### PR TITLE
Exclude python-necpp submodule from ruff lint

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -7,4 +7,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v1
         with:
-          args: "check --exclude python-necpp/"
+          args: "check"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,5 +21,8 @@ classifiers = [
 Homepage = "https://github.com/stevenmburns/antenna_designer"
 Issues = "https://github.com/stevenmburns/antenna_designer/issues"
 
+[tool.ruff]
+extend-exclude = ["python-necpp"]
+
 [tool.ruff.lint]
 ignore = ["E741"]


### PR DESCRIPTION
## Summary
- Add `extend-exclude = ["python-necpp"]` under `[tool.ruff]` in `pyproject.toml` so local `ruff check` no longer trips on the submodule's legacy Python 2 code
- Drop the now-redundant `--exclude python-necpp/` CLI flag from `.github/workflows/ruff.yml` — the exclusion now lives in one place and applies to both local and CI runs

## Test plan
- [ ] `ruff check` from the repo root passes (no submodule noise)
- [ ] The Ruff GitHub Actions workflow still passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)