### PR TITLE
Disable ruff auto-fix for F401 (unused imports)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,9 @@ extend-exclude = ["python-necpp"]
 
 [tool.ruff.lint]
 ignore = ["E741"]
+# Keep "imported but unused" as a warning instead of auto-stripping.
+# Without this, multi-pass edits (add imports first, then add code that
+# uses them) can have the import deleted between edits — by the editor's
+# format-on-save, the project's auto-fix hook, or a pre-commit run —
+# producing a broken next edit. Manual cleanup of unused imports is fine.
+unfixable = ["F401"]


### PR DESCRIPTION
## Summary
- Adds `unfixable = ["F401"]` under `[tool.ruff.lint]` in `pyproject.toml`. F401 ("imported but unused") is still reported, just not auto-fixed.
- Prevents format-on-save hooks and `ruff check --fix` from silently deleting imports between multi-step edits — a footgun where Edit #1 adds an import, the hook deletes it as "unused", Edit #2 adds the code that needs it, runtime fails with NameError.
- Pattern lifted from `claude-driving-point-synthesis`; worth standardizing across all Python projects.

## Test plan
- [ ] `ruff check` still passes
- [ ] CI still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)