### PR TITLE
Add PysimEngine (impedance only); ground spec on PyNECEngine

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools numpy scipy pytest matplotlib icecream scikit.rf coverage
+        pip install setuptools numpy scipy pytest matplotlib icecream scikit.rf coverage pybind11
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
     - name: install swig3.0 (g++, buildtools and fortran already installed)
@@ -53,6 +53,10 @@ jobs:
         swig3.0 -Wall -v -c++ -python PyNEC.i
         python setup.py build
         python setup.py install
+
+    - name: Install pysim (vendored MoM engine)
+      run: |
+        pip install --no-build-isolation -e ./pysim
 
     - name: Test with pytest
       run: |

--- a/src/antenna_designer/engines/__init__.py
+++ b/src/antenna_designer/engines/__init__.py
@@ -1,3 +1,4 @@
 from .pynec import PyNECEngine
+from .pysim import PysimEngine
 
-__all__ = ["PyNECEngine"]
+__all__ = ["PyNECEngine", "PysimEngine"]

--- a/src/antenna_designer/engines/pynec.py
+++ b/src/antenna_designer/engines/pynec.py
@@ -4,13 +4,25 @@ import PyNEC as nec
 from ..engine import FarField, SimulationEngine
 
 
+DEFAULT_GROUND = ("finite", 10.0, 0.002)  # (kind, dielectric, conductivity)
+
+
 class PyNECEngine(SimulationEngine):
     supports_far_field = True
 
-    def __init__(self, builder):
+    def __init__(self, builder, *, ground=DEFAULT_GROUND):
+        """
+        ground:
+          None or "free"               — no gn_card (free space)
+          "pec"                        — perfectly conducting ground
+          ("finite", eps_r, sigma)     — Sommerfeld finite ground (default,
+                                         matches the historical hard-coded
+                                         eps_r=10, sigma=0.002)
+        """
         super().__init__(builder)
         self.tups = builder.build_wires()
         self.tls = builder.build_tls()
+        self.ground = ground
         self.excitation_pairs = None
         self._build_geometry()
 
@@ -22,8 +34,6 @@ class PyNECEngine(SimulationEngine):
 
     def _build_geometry(self):
         conductivity = 5.8e7  # Copper
-        ground_conductivity = 0.002
-        ground_dielectric = 10
 
         self.c = nec.nec_context()
         geo = self.c.get_geometry()
@@ -40,10 +50,23 @@ class PyNECEngine(SimulationEngine):
             self.c.tl_card(idx1, seg1, idx2, seg2, impedance, length, 0, 0, 0, 0)
 
         self.c.ld_card(5, 0, 0, 0, conductivity, 0.0, 0.0)
-        self.c.gn_card(0, 0, ground_dielectric, ground_conductivity, 0, 0, 0, 0)
+        self._apply_ground_card()
 
         for tag, sub_index, voltage in self.excitation_pairs:
             self.c.ex_card(0, tag, sub_index, 0, voltage.real, voltage.imag, 0, 0, 0, 0)
+
+    def _apply_ground_card(self):
+        g = self.ground
+        if g is None or g == "free":
+            return  # no gn_card -> free space
+        if g == "pec":
+            self.c.gn_card(1, 0, 0, 0, 0, 0, 0, 0)
+            return
+        if isinstance(g, tuple) and len(g) == 3 and g[0] == "finite":
+            _, eps_r, sigma = g
+            self.c.gn_card(0, 0, eps_r, sigma, 0, 0, 0, 0)
+            return
+        raise ValueError(f"unrecognised ground spec: {g!r}")
 
     def _set_freq_and_execute(self):
         self.c.fr_card(0, 1, self.builder.freq, 0)

--- a/src/antenna_designer/engines/pysim.py
+++ b/src/antenna_designer/engines/pysim.py
@@ -1,0 +1,64 @@
+"""pysim-backed SimulationEngine. Currently impedance-only; far-field is
+deferred to a follow-up PR that ports pysim's web/server.py directivity
+math into the engine."""
+from __future__ import annotations
+
+import numpy as np
+from pysim import TriangularPySim
+
+from ..engine import SimulationEngine
+from ..geometry import flat_wires_to_polylines
+
+C_LIGHT = 299_792_458.0
+
+
+class PysimEngine(SimulationEngine):
+    supports_far_field = False
+
+    def __init__(self, builder, *, solver=TriangularPySim, wire_radius=0.0005, n_qp_reg=4, n_qp_off=4):
+        super().__init__(builder)
+        if builder.build_tls():
+            raise NotImplementedError("transmission-line cards not supported by PysimEngine yet")
+
+        tups = builder.build_wires()
+        translated = flat_wires_to_polylines(tups)
+        self._polylines = translated["polylines"]
+        self._edge_segments = translated["edge_segments"]
+        self._feed_wire_index = translated["feed_wire_index"]
+        self._feed_arclength = translated["feed_arclength"]
+        self._feed_voltage = translated["feed_voltage"]
+        self._solver = solver
+        self._wire_radius = wire_radius
+        self._n_qp_reg = n_qp_reg
+        self._n_qp_off = n_qp_off
+
+    def _make_solver(self, *, wavelength):
+        return self._solver(
+            wires=self._polylines,
+            n_per_edge_per_wire=self._edge_segments,
+            feed_wire_index=self._feed_wire_index,
+            feed_arclength=self._feed_arclength,
+            wavelength=wavelength,
+            wire_radius=self._wire_radius,
+            n_qp_reg=self._n_qp_reg,
+            n_qp_off=self._n_qp_off,
+        )
+
+    @staticmethod
+    def _wavelength_for(freq_mhz):
+        return C_LIGHT / (freq_mhz * 1e6)
+
+    def impedance(self):
+        s = self._make_solver(wavelength=self._wavelength_for(self.builder.freq))
+        z, _coeffs = s.compute_impedance()
+        return [self._feed_voltage * z]
+
+    def impedance_sweep(self, freqs):
+        freqs = np.asarray(freqs, dtype=float)
+        if freqs.ndim != 1 or freqs.size == 0:
+            raise ValueError("freqs must be a 1-D non-empty array")
+        # All k-independent setup happens in the constructor; build once.
+        s = self._make_solver(wavelength=self._wavelength_for(freqs[0]))
+        k_array = 2.0 * np.pi * freqs * 1e6 / C_LIGHT
+        zs = s.compute_impedance_swept(k_array)
+        return (self._feed_voltage * zs).reshape(-1, 1)

--- a/src/antenna_designer/geometry.py
+++ b/src/antenna_designer/geometry.py
@@ -1,0 +1,160 @@
+"""Translate the flat (p0, p1, n_seg, excitation) wire list used by
+AntennaBuilder.build_wires() into the polyline + feed-arclength shape
+that pysim's TriangularPySim consumes.
+
+The flat list expresses connectivity implicitly: two tuples are part of
+the same electrical wire when they share an endpoint (within `eps`).
+pysim wants each electrical wire as one (M, 3) polyline with junction
+information explicit; this module recovers that graph and chains each
+connected component into a polyline.
+
+Limitations of the current translator (acceptable for the dipole-class
+designs we're cross-validating first; will be lifted as needed):
+  * Exactly one excited segment per geometry.
+  * No degree-3+ nodes (no tee junctions) and no closed loops — every
+    connected component must be a simple path with two degree-1 ends.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+def _round_point(p, eps):
+    # Quantize endpoints onto an eps-spaced grid so 1e-14 floating-point
+    # noise doesn't fragment what is logically a shared node.
+    return tuple(round(float(c) / eps) * eps for c in p)
+
+
+def flat_wires_to_polylines(tups, *, eps=1e-6):
+    """Convert flat wire tuples to pysim polyline form.
+
+    Parameters
+    ----------
+    tups : list of (p0, p1, n_seg, ev)
+        Same shape produced by AntennaBuilder.build_wires().
+    eps : float
+        Endpoint-coalescence tolerance (m).
+
+    Returns
+    -------
+    dict with keys
+        polylines           : list of (M, 3) np.ndarray
+        edge_segments       : list of list[int] — n_seg per edge per polyline
+        feed_wire_index     : int
+        feed_arclength      : float — distance along feed polyline to the
+                              midpoint of the excited segment, matching
+                              PyNEC's behaviour of feeding at segment
+                              `(n_seg+1)//2`.
+        feed_voltage        : complex — the excitation amplitude.
+    """
+    if not tups:
+        raise ValueError("no wires to translate")
+
+    # Build endpoint->node map and adjacency list.
+    node_of = {}
+    nodes = []  # list of np.ndarray(3,)
+    edges = []  # list of (a, b, n_seg, ev, tup_index)
+
+    def node_id(p):
+        key = _round_point(p, eps)
+        if key not in node_of:
+            node_of[key] = len(nodes)
+            nodes.append(np.asarray(p, dtype=float))
+        return node_of[key]
+
+    for i, (p0, p1, n_seg, ev) in enumerate(tups):
+        a = node_id(p0)
+        b = node_id(p1)
+        if a == b:
+            raise ValueError(f"tuple {i}: degenerate edge (p0==p1 within eps)")
+        edges.append((a, b, int(n_seg), ev, i))
+
+    adj = [[] for _ in nodes]
+    for ei, (a, b, _, _, _) in enumerate(edges):
+        adj[a].append((b, ei))
+        adj[b].append((a, ei))
+
+    for nid, neigh in enumerate(adj):
+        if len(neigh) > 2:
+            raise NotImplementedError(
+                f"node {nid} has degree {len(neigh)}; tee junctions are "
+                "not yet supported by the translator"
+            )
+
+    # Walk connected components into ordered polylines.
+    edge_seen = [False] * len(edges)
+    node_seen = [False] * len(nodes)
+
+    polylines = []
+    edge_segments = []
+    edge_to_polyline = {}  # tup_index -> (polyline_index, edge_index_within)
+
+    for start in range(len(nodes)):
+        if node_seen[start]:
+            continue
+        if len(adj[start]) == 0:
+            raise ValueError(f"node {start} is isolated")
+        if len(adj[start]) == 2:
+            # Interior node of a chain — wait until we hit an endpoint.
+            continue
+
+        # start has degree 1: walk the chain.
+        path_nodes = [start]
+        path_edges = []
+        prev = None
+        cur = start
+        while True:
+            node_seen[cur] = True
+            next_step = None
+            for nb, ei in adj[cur]:
+                if ei == prev or edge_seen[ei]:
+                    continue
+                next_step = (nb, ei)
+                break
+            if next_step is None:
+                break
+            nb, ei = next_step
+            edge_seen[ei] = True
+            path_edges.append(ei)
+            path_nodes.append(nb)
+            prev = ei
+            cur = nb
+
+        polylines.append(np.stack([nodes[n] for n in path_nodes], axis=0))
+        edge_segments.append([edges[ei][2] for ei in path_edges])
+        for k, ei in enumerate(path_edges):
+            edge_to_polyline[edges[ei][4]] = (len(polylines) - 1, k)
+
+    # Closed loops would leave node_seen=False everywhere along them.
+    if any(not s for s in node_seen):
+        raise NotImplementedError(
+            "closed loops in the wire graph are not supported"
+        )
+
+    # Locate the excitation and convert to (polyline_index, arclength).
+    excited = [(i, ev) for i, (_, _, _, ev, _) in enumerate(edges) if ev is not None]
+    if len(excited) == 0:
+        raise ValueError("no excitation found in wire list")
+    if len(excited) > 1:
+        raise NotImplementedError(
+            f"{len(excited)} excitations found; pysim engine currently "
+            "supports a single feed per geometry"
+        )
+
+    tup_index, voltage = excited[0]
+    feed_pl, feed_edge_idx = edge_to_polyline[tup_index]
+    polyline = polylines[feed_pl]
+    edge_lengths = np.linalg.norm(np.diff(polyline, axis=0), axis=1)
+
+    # PyNEC feeds at segment `(n_seg+1)//2` which is the middle segment
+    # 1-indexed; physically that's the centre of the wire. Reproduce that
+    # by feeding at the midpoint of the feed edge.
+    feed_arclength = float(edge_lengths[:feed_edge_idx].sum() + 0.5 * edge_lengths[feed_edge_idx])
+
+    return {
+        "polylines": polylines,
+        "edge_segments": edge_segments,
+        "feed_wire_index": feed_pl,
+        "feed_arclength": feed_arclength,
+        "feed_voltage": complex(voltage),
+    }

--- a/tests/test_pysim_engine.py
+++ b/tests/test_pysim_engine.py
@@ -1,0 +1,64 @@
+"""Tests for the pysim-backed SimulationEngine and the flat-wire-to-polyline
+geometry translator it sits on top of."""
+import numpy as np
+import pytest
+
+from antenna_designer.designs.dipole import Builder
+from antenna_designer.engines import PyNECEngine, PysimEngine
+from antenna_designer.geometry import flat_wires_to_polylines
+
+
+def test_translator_chains_dipole_into_single_polyline():
+    b = Builder()
+    out = flat_wires_to_polylines(b.build_wires())
+
+    assert len(out["polylines"]) == 1
+    polyline = out["polylines"][0]
+    assert polyline.shape == (4, 3), polyline.shape
+    assert out["edge_segments"] == [[21, 3, 21]]
+    assert out["feed_wire_index"] == 0
+
+    # Feed sits at the geometric centre of the dipole; the dipole spans
+    # -length/2 ... +length/2 about x=0, so arclength from the starting
+    # end to the feed midpoint is length/2.
+    assert out["feed_arclength"] == pytest.approx(b.length / 2.0, rel=1e-9)
+    assert out["feed_voltage"] == 1 + 0j
+
+
+def test_pysim_impedance_in_realistic_range():
+    z, = PysimEngine(Builder()).impedance()
+    assert z.real > 30 and z.real < 150, f"unrealistic R: {z}"
+    # Imaginary part can swing widely with formulation/ground, just sanity-
+    # check it stays in a plausible band rather than blowing up.
+    assert abs(z.imag) < 200, f"unrealistic X: {z}"
+
+
+def test_pysim_impedance_sweep_shape_and_monotone_resistance():
+    freqs = np.linspace(28.0, 29.0, 5)
+    zs = PysimEngine(Builder()).impedance_sweep(freqs)
+    assert zs.shape == (5, 1)
+    # Driver R rises smoothly across a sub-resonant span for a dipole.
+    real = zs[:, 0].real
+    assert np.all(np.diff(real) > 0), real
+
+
+def test_pysim_matches_pynec_in_free_space():
+    """Free-space cross-check between the two MoM engines on a dipole.
+    Disabling PyNEC's gn_card so both solve the same physical problem
+    (no ground, no Fresnel) brings real-part agreement well under 10%
+    and reactance close enough to confirm the translator's feed-point
+    mapping is correct."""
+    b = Builder()
+    z_nec, = PyNECEngine(b, ground=None).impedance()
+    z_pysim, = PysimEngine(b).impedance()
+    real_rel = abs(z_pysim.real - z_nec.real) / abs(z_nec.real)
+    assert real_rel < 0.10, f"real parts diverged: nec={z_nec}, pysim={z_pysim}"
+    # Reactance offsets between formulations are larger at sub-resonant
+    # dipole lengths; absolute, not relative, headroom is the right test.
+    assert abs(z_pysim.imag - z_nec.imag) < 20.0, f"reactance diverged: nec={z_nec}, pysim={z_pysim}"
+
+
+def test_pysim_engine_declares_no_far_field():
+    assert PysimEngine.supports_far_field is False
+    with pytest.raises(NotImplementedError):
+        PysimEngine(Builder()).far_field(n_theta=90, n_phi=360, del_theta=1, del_phi=1)


### PR DESCRIPTION
## Summary
Stage 2a of the multi-engine refactor. Adds a pysim-backed \`SimulationEngine\` and the geometry translator that lets it consume the same \`AntennaBuilder.build_wires()\` output as \`PyNECEngine\`. Pure additive change — every existing caller behaves identically.

- **\`geometry.flat_wires_to_polylines(tups)\`** — eps-quantized endpoint hashing → adjacency graph → ordered polyline per connected component. Locates the single excited segment and converts PyNEC's \`(tag, segment_index)\` feed to pysim's \`(wire_index, arclength)\`. Asserts max degree 2 (no tee junctions yet), no closed loops, exactly one feed.
- **\`engines.pysim.PysimEngine\`** — \`impedance()\` and \`impedance_sweep(freqs)\` via \`TriangularPySim\`. \`supports_far_field = False\` (raises \`NotImplementedError\` from the base class — to be flipped in stage 2b after porting pysim's directivity math out of the JS UI).
- **\`engines.pynec.PyNECEngine\` \`ground=\` parameter** — replaces the hardcoded \`gn_card(0, 0, 10, 0.002, ...)\`. Three shapes: \`None\`/\`"free"\` (no \`gn_card\`), \`"pec"\` (\`gn_card(1, ...)\`), \`("finite", eps_r, sigma)\` (Sommerfeld finite ground). Default is the old \`("finite", 10.0, 0.002)\` so backwards compatibility is unchanged.

## Cross-validation
Dipole at 28.57 MHz, both engines in free space:
| | R | X |
|---|---|---|
| PyNECEngine (ground=None) | 69.26 | −15.86 |
| PysimEngine               | 69.33 | −17.97 |
| **delta** | **0.09%** | **2.1 Ω** |

Free-space agreement under 1% on R is good independent confirmation that the geometry translator's feed-arclength mapping is correct.

## Test plan
- [x] \`pytest tests\` — 24 passed (19 existing + 5 new), 24 skipped.
- [x] Translator chains the dipole into one polyline with the correct \`[21, 3, 21]\` edge counts and arclength-to-feed.
- [x] Pysim impedance lies in a realistic range and the sweep returns the expected \`(n_freqs, 1)\` shape with monotone resistance below resonance.
- [x] Pysim's free-space dipole impedance lands within 10% of PyNEC's free-space dipole impedance.
- [x] \`PysimEngine.far_field(...)\` raises \`NotImplementedError\`.

## Not in this PR
- Far-field/pattern computation on \`PysimEngine\` (stage 2b).
- Tee-junction support in the geometry translator (no design currently in \`designs/\` needs it; will add when one does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)