### PR TITLE
Translator: tee/multi-junction support; PysimEngine: swappable solver

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,0 +1,80 @@
+# Next steps — antenna_designer
+
+Living roadmap of what's done and what's left on the multi-engine refactor. Updated as work lands.
+
+## Where we are
+
+`antenna_designer` exposes two simulation backends behind a common `SimulationEngine` interface:
+
+- **`PyNECEngine`** — the original NEC2/PyNEC path. Default backend. Supports free space / PEC / finite-Sommerfeld ground via the `ground=` parameter, multi-element arrays, transmission-line cards (`tl_card`), and arbitrary segment counts. This is the production backend; nothing here is restricted relative to the historical behaviour.
+- **`PysimEngine`** — the pure-Python MoM solvers from the vendored `pysim/` submodule, accessed through a flat-wire-to-polyline geometry translator (`antenna_designer/geometry.py`). Selectable solver (`TriangularPySim` default, `SinusoidalPySim`, `BSplinePySim`) via the engine's `solver=` kwarg.
+
+Selection is uniform across the Python API and the CLI: `compare_patterns([engine_instance, ...])` for ad-hoc comparisons; `engine=` factory kwarg on `sweep` / `sweep_freq` / `sweep_gain` / `sweep_patterns` / `optimize`; `--engine pynec|pysim --ground free|pec|finite|finite:eps,sigma` on every analysis subcommand.
+
+Cross-validation at design freq, free space, against PyNEC: ≤ 0.1 dBi peak directivity agreement on the dipole; ≤ 0.005 dBi on PEC ground. Sinusoidal lands within ~10 % R and ~10 Ω X of PyNEC on the hentenna's tee-junction geometry.
+
+## Known geometry limitations
+
+These are the topologies `PysimEngine` currently rejects. PyNECEngine is unaffected — these only matter if you're cross-validating with pysim or using it as the production backend.
+
+| limitation | affected designs (today) | severity |
+|---|---|---|
+| pure closed loops (no degree-1 endpoint, no degree-3+ junction in any component) | `bowtie`, `freq_based.delta_loop`, `freq_based.diamond_loop`, `freq_based.inv_delta_loop`, `freq_based.folded_invvee`, `freq_based.delta_loop_slanted{,2,3}` | translator-only fix, no upstream pysim work needed |
+| multiple excitations (`ex_card` voltage on more than one segment) | every array design — `invveearray`, `moxonarray`, `yagiarray`, `bowtiearray*`, `delta_looparray*`, `hentenna_array`, `hourglass_array`, `folded_invveearray`, `diamond_loop_turnstile` | deeper PysimEngine + likely upstream pysim change |
+| transmission-line cards (`tl_card`) | `freq_based.delta_looparray_with_tls` | upstream pysim has no equivalent today |
+
+## Next branch: closed-loop support in the translator
+
+**Goal**: lift the "closed loops with no junctions/endpoints" `NotImplementedError` in `flat_wires_to_polylines` so `bowtie` and the delta/diamond loops can be solved by `PysimEngine`.
+
+### What "closed loop" means here
+
+A connected component in the wire graph where every node has degree 2 — no degree-1 free ends, no degree-3+ junctions. The current walker can't start because it iterates only boundary nodes. The excitation lives on one of the loop's edges.
+
+Concrete shape, from `bowtie.build_wires()`:
+
+```
+A → B → C → D → E → A     (closed loop, all nodes degree 2)
+                  ^
+                  feed gap somewhere along this chain
+```
+
+(Bowtie is actually two triangles sharing a feed gap, so it has *two* loops sharing two nodes — degenerate-tee territory. Single delta loop is the canonical pure-cycle case.)
+
+### Approach
+
+1. **Detect pure cycles**. After the existing junction/endpoint walker finishes, any remaining unwalked edges belong to pure-cycle components. Group those edges by connected component.
+
+2. **Choose a cut point** in each cycle. Two reasonable rules; pick whichever makes feed placement cleanest:
+
+   - **Cut at the excited edge** if the cycle contains the feed. The excited tuple becomes its own polyline (start ↔ end of the feed edge), and a *second* polyline runs the long way around the loop, connecting the same two nodes. The two polylines share both endpoints, which makes those endpoints degree-2 junctions in pysim's `junctions=` sense. Cleanest because the feed-arclength computation is identical to the open-polyline case.
+
+   - **Cut at an arbitrary node** if the cycle has no feed (parasitic loop coupling). Same junction-pair pattern; feed handling unchanged.
+
+3. **Emit the junction list**. The two cut endpoints each get a 2-element junction record `[(loop_polyline_0, "start"), (loop_polyline_1, "start")]` and `[(loop_polyline_0, "end"), (loop_polyline_1, "end")]`. Pysim's KCL Lagrange multiplier rows then enforce current continuity around the loop.
+
+4. **Compose with existing junction logic**. The translator already handles arbitrary-degree junctions for the non-cycle case (hentenna, fandipole). The cycle case is conceptually "two polylines sharing both endpoints" — the existing junction emission code should compose if we just append to the `junctions` dict already in flight.
+
+### Bowtie wrinkle
+
+Bowtie's two triangles share a common feed-gap edge: degree-2 nodes everywhere within each triangle, but the two feed-gap endpoints are each degree-3 (one edge of each triangle plus the feed gap). So it's already a junction-bearing component, not a pure cycle — the current translator's degree check should already accept it, and the failure mode reported in the inventory is the *no-boundary* check tripping because there are still no degree-1 nodes. Need to soften that check: "has at least one boundary node OR was reachable via junctions". Bowtie should fall out of step 1 for free once the walker considers junction nodes as valid starting points for cycle traversal too.
+
+Verify on bowtie specifically — it may need no special handling beyond making the no-boundary error less paranoid.
+
+### Tests
+
+- Translator structure check on `bowtie`, `freq_based.delta_loop`, `freq_based.diamond_loop`: expected polyline / junction counts.
+- Loose impedance bound for SinusoidalPySim vs PyNECEngine (free space) on `delta_loop`. Delta loops are textbook ~100 Ω at resonance; a < 15 % R / < 15 Ω X bound should be safe.
+- Existing dipole/hentenna/fandipole tests continue to pass — the cycle code path doesn't touch them.
+
+### Out of scope for that branch
+
+- Multi-feed arrays (bucket 2 above). Separate PR, needs upstream pysim work.
+- `tl_card` (bucket 3). Separate concern; likely "document as PyNEC-only" rather than implement.
+- Auto-refining short feed segments. The fandipole's `n_seg1=1` feed-gap trick that breaks Triangular but works under Sinusoidal is a basis-selection question, not a geometry-translation question.
+
+## Other follow-ups (lower priority)
+
+- **CLI `--basis triangular|sinusoidal|bspline` flag** on the analysis subcommands. Today `--engine pysim` always uses Triangular; choosing Sinusoidal requires the Python API. Straightforward add — mirror how `--ground` is plumbed.
+- **Far-field for the new designs**. Stage 2b validated the pattern math on the dipole; once tee-junction geometries are stable, re-run the directivity cross-check on hentenna and fandipole and add a corresponding test.
+- **Multi-feed PysimEngine**. Two viable shapes: (a) N independent solves, superposing per-feed for the impedance matrix Y; (b) genuine multi-source solve in pysim, requires upstream changes. Worth a design sketch before either.

--- a/src/antenna_designer/engines/pysim.py
+++ b/src/antenna_designer/engines/pysim.py
@@ -42,21 +42,29 @@ class PysimEngine(SimulationEngine):
         *,
         solver=TriangularPySim,
         wire_radius=0.0005,
-        n_qp_reg=4,
-        n_qp_off=4,
+        solver_kwargs=None,
         ground=None,
         ground_z=0.0,
     ):
         """
+        solver:
+          A pysim solver class — TriangularPySim (default), SinusoidalPySim,
+          or BSplinePySim. Different bases trade speed vs impedance fidelity;
+          on the hentenna sinusoidal is typically closer to PyNEC at modest
+          segmentation than triangular.
+        solver_kwargs:
+          Dict of solver-specific kwargs passed straight to the constructor
+          (e.g. `{"n_qp_reg": 8, "n_qp_off": 8}` for TriangularPySim, or
+          `{"n_qp_const": 16}` for SinusoidalPySim). None = solver defaults.
         ground:
           None or "free"           — no ground (default)
           "pec"                    — PEC plane at z=ground_z (image method)
           ("finite", eps_r, sigma) — far-field uses PEC image + Fresnel
                                      coefficients on the reflected component;
                                      impedance solve still uses PEC because
-                                     TriangularPySim only models PEC ground.
-                                     Cross-validation against PyNEC's
-                                     gn_card(0,...) is approximate.
+                                     pysim only models PEC ground. Cross-
+                                     validation against PyNEC's gn_card(0,...)
+                                     is approximate.
         """
         super().__init__(builder)
         if builder.build_tls():
@@ -69,10 +77,10 @@ class PysimEngine(SimulationEngine):
         self._feed_wire_index = translated["feed_wire_index"]
         self._feed_arclength = translated["feed_arclength"]
         self._feed_voltage = translated["feed_voltage"]
+        self._junctions = translated["junctions"]
         self._solver = solver
         self._wire_radius = wire_radius
-        self._n_qp_reg = n_qp_reg
-        self._n_qp_off = n_qp_off
+        self._solver_kwargs = dict(solver_kwargs) if solver_kwargs else {}
         self._ground = _normalise_ground(ground)
         self._ground_z = ground_z if self._ground is not None else None
 
@@ -84,9 +92,9 @@ class PysimEngine(SimulationEngine):
             feed_arclength=self._feed_arclength,
             wavelength=wavelength,
             wire_radius=self._wire_radius,
-            n_qp_reg=self._n_qp_reg,
-            n_qp_off=self._n_qp_off,
             ground_z=self._ground_z,
+            junctions=self._junctions or None,
+            **self._solver_kwargs,
         )
 
     @staticmethod

--- a/src/antenna_designer/geometry.py
+++ b/src/antenna_designer/geometry.py
@@ -5,14 +5,16 @@ that pysim's TriangularPySim consumes.
 The flat list expresses connectivity implicitly: two tuples are part of
 the same electrical wire when they share an endpoint (within `eps`).
 pysim wants each electrical wire as one (M, 3) polyline with junction
-information explicit; this module recovers that graph and chains each
-connected component into a polyline.
+information (KCL at shared nodes) explicit; this module recovers the
+graph, decomposes it into maximal chains between junction/endpoint
+nodes, and emits the junction list.
 
-Limitations of the current translator (acceptable for the dipole-class
-designs we're cross-validating first; will be lifted as needed):
+Supported topologies:
+  * Each connected component must contain at least one degree-1 endpoint
+    OR at least one junction (degree >= 3); pure cycles aren't handled.
+  * Any number of junctions of any degree (tees, X's, hentenna-style
+    multi-junction, fandipole-style multi-spoke feeds).
   * Exactly one excited segment per geometry.
-  * No degree-3+ nodes (no tee junctions) and no closed loops — every
-    connected component must be a simple path with two degree-1 ends.
 """
 from __future__ import annotations
 
@@ -28,29 +30,22 @@ def _round_point(p, eps):
 def flat_wires_to_polylines(tups, *, eps=1e-6):
     """Convert flat wire tuples to pysim polyline form.
 
-    Parameters
-    ----------
-    tups : list of (p0, p1, n_seg, ev)
-        Same shape produced by AntennaBuilder.build_wires().
-    eps : float
-        Endpoint-coalescence tolerance (m).
-
-    Returns
-    -------
-    dict with keys
-        polylines           : list of (M, 3) np.ndarray
-        edge_segments       : list of list[int] — n_seg per edge per polyline
-        feed_wire_index     : int
-        feed_arclength      : float — distance along feed polyline to the
-                              midpoint of the excited segment, matching
-                              PyNEC's behaviour of feeding at segment
-                              `(n_seg+1)//2`.
-        feed_voltage        : complex — the excitation amplitude.
+    Returns a dict with keys:
+        polylines       : list of (M, 3) np.ndarray
+        edge_segments   : list of list[int] — n_seg per edge per polyline
+        feed_wire_index : int — polyline holding the excited segment
+        feed_arclength  : float — distance along the feed polyline to
+                          the midpoint of the excited segment
+        feed_voltage    : complex
+        junctions       : list of list[(wire_idx, "start"|"end")] —
+                          shared-node groups, suitable to pass directly
+                          to TriangularPySim(junctions=...). Empty list
+                          if every component is a simple path.
     """
     if not tups:
         raise ValueError("no wires to translate")
 
-    # Build endpoint->node map and adjacency list.
+    # Build endpoint->node map and per-tuple edge list.
     node_of = {}
     nodes = []  # list of np.ndarray(3,)
     edges = []  # list of (a, b, n_seg, ev, tup_index)
@@ -69,67 +64,81 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
             raise ValueError(f"tuple {i}: degenerate edge (p0==p1 within eps)")
         edges.append((a, b, int(n_seg), ev, i))
 
+    # adj[nid] = list of (other_node, edge_index), in registration order.
     adj = [[] for _ in nodes]
     for ei, (a, b, _, _, _) in enumerate(edges):
         adj[a].append((b, ei))
         adj[b].append((a, ei))
 
     for nid, neigh in enumerate(adj):
-        if len(neigh) > 2:
-            raise NotImplementedError(
-                f"node {nid} has degree {len(neigh)}; tee junctions are "
-                "not yet supported by the translator"
-            )
+        if len(neigh) == 0:
+            raise ValueError(f"node {nid} is isolated")
 
-    # Walk connected components into ordered polylines.
+    # Polyline boundaries are exactly the non-degree-2 nodes: degree-1
+    # ends an open polyline, degree>=3 is a junction that ends one
+    # polyline and starts another. Walk every edge out of every boundary
+    # node, threading through degree-2 nodes until the next boundary.
+    is_boundary = [len(a) != 2 for a in adj]
     edge_seen = [False] * len(edges)
-    node_seen = [False] * len(nodes)
 
     polylines = []
     edge_segments = []
-    edge_to_polyline = {}  # tup_index -> (polyline_index, edge_index_within)
+    # junction_ends[node_id] -> list of (polyline_index, "start"|"end").
+    # Filled as we walk; only meaningful for degree>=3 nodes, but we
+    # collect it for all boundary nodes and filter later.
+    junction_ends = {nid: [] for nid in range(len(nodes)) if is_boundary[nid]}
+    # tup_index -> (polyline_index, edge_index_within)
+    edge_to_polyline = {}
+
+    def walk_from(start_nid, first_edge):
+        path_nodes = [start_nid]
+        path_edges = []
+        prev_edge = None
+        cur = start_nid
+        next_edge = first_edge
+        while True:
+            edge_seen[next_edge] = True
+            path_edges.append(next_edge)
+            a, b, _, _, _ = edges[next_edge]
+            nxt = b if a == cur else a
+            path_nodes.append(nxt)
+            cur = nxt
+            if is_boundary[cur]:
+                return path_nodes, path_edges
+            prev_edge = next_edge
+            # Degree-2 interior: take the unique outgoing edge.
+            next_edge = None
+            for _nb, ei in adj[cur]:
+                if ei != prev_edge:
+                    next_edge = ei
+                    break
+            assert next_edge is not None, f"degree-2 node {cur} had no continuation"
 
     for start in range(len(nodes)):
-        if node_seen[start]:
+        if not is_boundary[start]:
             continue
-        if len(adj[start]) == 0:
-            raise ValueError(f"node {start} is isolated")
-        if len(adj[start]) == 2:
-            # Interior node of a chain — wait until we hit an endpoint.
-            continue
+        for _nb, ei in adj[start]:
+            if edge_seen[ei]:
+                continue
+            path_nodes, path_edges = walk_from(start, ei)
 
-        # start has degree 1: walk the chain.
-        path_nodes = [start]
-        path_edges = []
-        prev = None
-        cur = start
-        while True:
-            node_seen[cur] = True
-            next_step = None
-            for nb, ei in adj[cur]:
-                if ei == prev or edge_seen[ei]:
-                    continue
-                next_step = (nb, ei)
-                break
-            if next_step is None:
-                break
-            nb, ei = next_step
-            edge_seen[ei] = True
-            path_edges.append(ei)
-            path_nodes.append(nb)
-            prev = ei
-            cur = nb
+            polyline_idx = len(polylines)
+            polylines.append(np.stack([nodes[n] for n in path_nodes], axis=0))
+            edge_segments.append([edges[e][2] for e in path_edges])
+            for k, e in enumerate(path_edges):
+                edge_to_polyline[edges[e][4]] = (polyline_idx, k)
+            junction_ends[path_nodes[0]].append((polyline_idx, "start"))
+            junction_ends[path_nodes[-1]].append((polyline_idx, "end"))
 
-        polylines.append(np.stack([nodes[n] for n in path_nodes], axis=0))
-        edge_segments.append([edges[ei][2] for ei in path_edges])
-        for k, ei in enumerate(path_edges):
-            edge_to_polyline[edges[ei][4]] = (len(polylines) - 1, k)
-
-    # Closed loops would leave node_seen=False everywhere along them.
-    if any(not s for s in node_seen):
+    # Closed loops with no boundary node would leave edges unseen.
+    if not all(edge_seen):
         raise NotImplementedError(
-            "closed loops in the wire graph are not supported"
+            "closed loops with no junctions/endpoints are not supported"
         )
+
+    # Junctions = nodes where >= 2 polylines meet. Single-end records
+    # (degree-1 free ends) and lone polyline starts aren't junctions.
+    junctions = [ends for ends in junction_ends.values() if len(ends) >= 2]
 
     # Locate the excitation and convert to (polyline_index, arclength).
     excited = [(i, ev) for i, (_, _, _, ev, _) in enumerate(edges) if ev is not None]
@@ -145,11 +154,13 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
     feed_pl, feed_edge_idx = edge_to_polyline[tup_index]
     polyline = polylines[feed_pl]
     edge_lengths = np.linalg.norm(np.diff(polyline, axis=0), axis=1)
-
-    # PyNEC feeds at segment `(n_seg+1)//2` which is the middle segment
-    # 1-indexed; physically that's the centre of the wire. Reproduce that
-    # by feeding at the midpoint of the feed edge.
-    feed_arclength = float(edge_lengths[:feed_edge_idx].sum() + 0.5 * edge_lengths[feed_edge_idx])
+    # PyNEC feeds at segment `(n_seg+1)//2` of the excited tuple — the
+    # middle segment 1-indexed, i.e. the physical midpoint of the wire.
+    # The excited tuple is one edge of its polyline; feed at that edge's
+    # midpoint.
+    feed_arclength = float(
+        edge_lengths[:feed_edge_idx].sum() + 0.5 * edge_lengths[feed_edge_idx]
+    )
 
     return {
         "polylines": polylines,
@@ -157,4 +168,5 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
         "feed_wire_index": feed_pl,
         "feed_arclength": feed_arclength,
         "feed_voltage": complex(voltage),
+        "junctions": junctions,
     }

--- a/tests/test_pysim_engine.py
+++ b/tests/test_pysim_engine.py
@@ -208,3 +208,59 @@ def test_plot_patterns_pins_radial_floor(tmp_path):
     # exists; either way the file is on disk.
     assert out.exists() and out.stat().st_size > 0
     plt.close("all")
+
+
+def test_translator_handles_hentenna_tee_junctions():
+    """Hentenna has two degree-3 nodes (B, D); translator should
+    decompose into 3 polylines all running B→D, with one junction at
+    each."""
+    from antenna_designer.designs.freq_based.hentenna import Builder as H
+    out = flat_wires_to_polylines(H().build_wires())
+    assert len(out["polylines"]) == 3
+    assert len(out["junctions"]) == 2
+    # Two junctions, each with 3 polyline ends meeting.
+    assert sorted(len(j) for j in out["junctions"]) == [3, 3]
+
+
+def test_translator_handles_fandipole_high_degree_junctions():
+    """Fandipole has two degree-6 nodes (S, T): feed wire + 5 spokes
+    on each side. 5 polylines per side + 1 feed = 11 polylines."""
+    from antenna_designer.designs.fandipole import Builder as F
+    out = flat_wires_to_polylines(F().build_wires())
+    assert len(out["polylines"]) == 11
+    assert len(out["junctions"]) == 2
+    assert sorted(len(j) for j in out["junctions"]) == [6, 6]
+
+
+def test_pysim_sinusoidal_hentenna_impedance_close_to_pynec():
+    """Cross-validation on the hentenna (two tee junctions): pysim's
+    Sinusoidal basis agrees with PyNEC's free-space gn_card-disabled
+    solve to within ~10% on R and ~10 Ω on X. Triangular at the same
+    segmentation lands at a different impedance — the two basis
+    families converge to two different limits (PyNEC and Sinusoidal
+    to one, Triangular and BSpline to another), not to a common point.
+    A cross-engine bound against PyNEC therefore only makes sense for
+    Sinusoidal here. Picking a "more correct" pair is out of scope;
+    this test is just verifying that the translator's junction/feed
+    mapping is right."""
+    from pysim import SinusoidalPySim
+    from antenna_designer.designs.freq_based.hentenna import Builder as H
+    b = H()
+    z_nec = PyNECEngine(b, ground=None).impedance()[0]
+    z_ps = PysimEngine(b, solver=SinusoidalPySim).impedance()[0]
+    assert abs(z_ps.real - z_nec.real) / abs(z_nec.real) < 0.15
+    assert abs(z_ps.imag - z_nec.imag) < 15.0
+
+
+def test_pysim_sinusoidal_fandipole_runs():
+    """Fandipole has degree-6 junctions and a 1-segment feed gap. The
+    1-segment feed has zero interior knots so the Triangular tent basis
+    has no feed to land on; Sinusoidal's const-source basis lives on
+    segment centres and handles it. Just ensure it runs and produces
+    a plausible value, the multi-wire geometry has too many freedoms
+    to set a tight tolerance here."""
+    from pysim import SinusoidalPySim
+    from antenna_designer.designs.fandipole import Builder as F
+    z = PysimEngine(F(), solver=SinusoidalPySim).impedance()[0]
+    assert 20 < z.real < 200, z
+    assert abs(z.imag) < 200, z


### PR DESCRIPTION
## Summary
Generalises \`flat_wires_to_polylines\` to handle nodes of arbitrary degree, decomposing the wire graph into maximal polylines that run between junction/endpoint nodes. The output gains a \`junctions\` field matching pysim's \`[[(wire_idx, "start"|"end"), ...]]\` shape, plumbed straight into the pysim solvers' \`junctions=\` kwarg.

Unlocks the **hentenna** (two degree-3 junctions → 3 polylines) and the **fandipole** (two degree-6 junctions → 11 polylines), and any future design with tees or higher-degree feed manifolds.

\`PysimEngine\` constructor: collapsed \`n_qp_reg\` / \`n_qp_off\` into a generic \`solver_kwargs\` dict so \`SinusoidalPySim\` (takes \`n_qp_const\`) and \`BSplinePySim\` can be selected without per-solver constructor gymnastics. Default solver stays \`TriangularPySim\`.

## Cross-validation at design freq, both engines in free space

| design | PyNEC | pysim Triangular | pysim Sinusoidal |
|---|---|---|---|
| dipole | 69.26 − j15.86 | 69.33 − j17.97 | 68.06 − j17.01 |
| hentenna | 49.51 − j0.49 | 43.17 + j38.06 | 45.60 − j4.55 |
| fandipole | 64.10 + j29.66 | *n/a — 1-seg feed* | 56.23 + j27.69 |

**Important framing**: PyNEC and Sinusoidal converge to one limit on these geometries; Triangular and BSpline converge to a different limit. They aren't slow-convergent versions of the same answer — they're different MoM formulations landing at different fixed points. This PR doesn't claim either family is more correct. The translator's cross-validation rides on Sinusoidal only because that's where a bound against PyNEC means something.

Fandipole's 1-segment feed gap has zero interior knots, so the Triangular tent basis has no feed to land on (\`pysim\` raises \`argmin-of-empty\`). Sinusoidal's const-source basis lives on segment centres and handles it. Either bump the design's \`n_seg1\` to ≥ 3 or pick \`SinusoidalPySim\` for fandipole-class geometries.

## Test plan
- [x] \`pytest tests\` — 39 passed (35 prior + 4 new), 24 skipped.
- [x] Translator output structure: hentenna decomposes to 3 polylines with two degree-3 junctions; fandipole to 11 polylines with two degree-6 junctions.
- [x] Loose impedance bound for Sinusoidal vs PyNEC on hentenna (<15% R, <15 Ω X).
- [x] Fandipole runs through Sinusoidal and lands in a plausible range.
- [x] All prior tests still pass — dipole-class designs (no junctions) take the empty-junction-list path unchanged.

## Not in this PR
- Far-field cross-validation on the new designs (the geometry side is the load-bearing change here; pattern math was validated in stage 2b).
- A CLI \`--basis triangular|sinusoidal|bspline\` flag — straightforward, but a separate UX concern.
- Auto-refining the feed segment when it's too short for a given basis. Currently the user picks a basis that works for their geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)