### PR TITLE
Translator: closed-loop support via cut-at-excited-edge

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -17,61 +17,29 @@ Cross-validation at design freq, free space, against PyNEC: ≤ 0.1 dBi peak dir
 
 These are the topologies `PysimEngine` currently rejects. PyNECEngine is unaffected — these only matter if you're cross-validating with pysim or using it as the production backend.
 
-| limitation | affected designs (today) | severity |
+| limitation | affected designs (today) | status |
 |---|---|---|
-| pure closed loops (no degree-1 endpoint, no degree-3+ junction in any component) | `bowtie`, `freq_based.delta_loop`, `freq_based.diamond_loop`, `freq_based.inv_delta_loop`, `freq_based.folded_invvee`, `freq_based.delta_loop_slanted{,2,3}` | translator-only fix, no upstream pysim work needed |
+| ~~pure closed loops~~ | ~~bowtie, delta_loop, diamond_loop, inv_delta_loop, folded_invvee, delta_loop_slanted{,2,3}~~ | **done** — cut-at-feed-edge in `flat_wires_to_polylines` |
 | multiple excitations (`ex_card` voltage on more than one segment) | every array design — `invveearray`, `moxonarray`, `yagiarray`, `bowtiearray*`, `delta_looparray*`, `hentenna_array`, `hourglass_array`, `folded_invveearray`, `diamond_loop_turnstile` | deeper PysimEngine + likely upstream pysim change |
 | transmission-line cards (`tl_card`) | `freq_based.delta_looparray_with_tls` | upstream pysim has no equivalent today |
 
-## Next branch: closed-loop support in the translator
+## ~~Next branch: closed-loop support in the translator~~ — landed
 
-**Goal**: lift the "closed loops with no junctions/endpoints" `NotImplementedError` in `flat_wires_to_polylines` so `bowtie` and the delta/diamond loops can be solved by `PysimEngine`.
+Implementation: after the existing junction/endpoint walker finishes, any unwalked edges belong to pure-cycle components. The translator floods each cycle, locates its excited edge, and cuts there — emitting the excited edge as a single-edge polyline and the rest of the loop as a second polyline running the long way back. Both cut endpoints become 2-entry junctions so pysim's KCL closes the loop.
 
-### What "closed loop" means here
+Surprise relative to the plan: **bowtie is a pure cycle, not a degree-3 case**. The two triangles share corners at `(±y, 0)` but each triangle only contributes one edge incident at the shared corner, leaving those corners degree-2. The whole bowtie is a single 10-edge cycle with one excited segment (the lower triangle's centre gap) and one passive segment (the upper triangle's centre gap, no `ex_card`). It falls out of the same cut-at-excited-edge path with no special handling.
 
-A connected component in the wire graph where every node has degree 2 — no degree-1 free ends, no degree-3+ junctions. The current walker can't start because it iterates only boundary nodes. The excitation lives on one of the loop's edges.
+Cross-validation at design freq, free space (R, X in Ω):
 
-Concrete shape, from `bowtie.build_wires()`:
+| design | PyNEC | pysim Sinusoidal | pysim Triangular |
+|---|---|---|---|
+| bowtie | 188.6, +16.3 | 186.1, +14.2 | 187.7, +13.9 |
+| delta_loop | 113.4, +46.1 | 110.5, +43.9 | 110.5, +42.7 |
+| diamond_loop | 219.7, +60.1 | 216.8, +58.0 | 220.7, +57.6 |
 
-```
-A → B → C → D → E → A     (closed loop, all nodes degree 2)
-                  ^
-                  feed gap somewhere along this chain
-```
+Both pysim bases agree with PyNEC to ~1–3 % R and a few Ω X on the closed-loop designs (tighter than the hentenna because there are no degree-3 junctions adding extra basis-family bias). All six previously-blocked closed-loop designs now translate cleanly; the remaining 16 blocked designs are *all* multi-feed arrays (no more closed-loop blockers in the codebase).
 
-(Bowtie is actually two triangles sharing a feed gap, so it has *two* loops sharing two nodes — degenerate-tee territory. Single delta loop is the canonical pure-cycle case.)
-
-### Approach
-
-1. **Detect pure cycles**. After the existing junction/endpoint walker finishes, any remaining unwalked edges belong to pure-cycle components. Group those edges by connected component.
-
-2. **Choose a cut point** in each cycle. Two reasonable rules; pick whichever makes feed placement cleanest:
-
-   - **Cut at the excited edge** if the cycle contains the feed. The excited tuple becomes its own polyline (start ↔ end of the feed edge), and a *second* polyline runs the long way around the loop, connecting the same two nodes. The two polylines share both endpoints, which makes those endpoints degree-2 junctions in pysim's `junctions=` sense. Cleanest because the feed-arclength computation is identical to the open-polyline case.
-
-   - **Cut at an arbitrary node** if the cycle has no feed (parasitic loop coupling). Same junction-pair pattern; feed handling unchanged.
-
-3. **Emit the junction list**. The two cut endpoints each get a 2-element junction record `[(loop_polyline_0, "start"), (loop_polyline_1, "start")]` and `[(loop_polyline_0, "end"), (loop_polyline_1, "end")]`. Pysim's KCL Lagrange multiplier rows then enforce current continuity around the loop.
-
-4. **Compose with existing junction logic**. The translator already handles arbitrary-degree junctions for the non-cycle case (hentenna, fandipole). The cycle case is conceptually "two polylines sharing both endpoints" — the existing junction emission code should compose if we just append to the `junctions` dict already in flight.
-
-### Bowtie wrinkle
-
-Bowtie's two triangles share a common feed-gap edge: degree-2 nodes everywhere within each triangle, but the two feed-gap endpoints are each degree-3 (one edge of each triangle plus the feed gap). So it's already a junction-bearing component, not a pure cycle — the current translator's degree check should already accept it, and the failure mode reported in the inventory is the *no-boundary* check tripping because there are still no degree-1 nodes. Need to soften that check: "has at least one boundary node OR was reachable via junctions". Bowtie should fall out of step 1 for free once the walker considers junction nodes as valid starting points for cycle traversal too.
-
-Verify on bowtie specifically — it may need no special handling beyond making the no-boundary error less paranoid.
-
-### Tests
-
-- Translator structure check on `bowtie`, `freq_based.delta_loop`, `freq_based.diamond_loop`: expected polyline / junction counts.
-- Loose impedance bound for SinusoidalPySim vs PyNECEngine (free space) on `delta_loop`. Delta loops are textbook ~100 Ω at resonance; a < 15 % R / < 15 Ω X bound should be safe.
-- Existing dipole/hentenna/fandipole tests continue to pass — the cycle code path doesn't touch them.
-
-### Out of scope for that branch
-
-- Multi-feed arrays (bucket 2 above). Separate PR, needs upstream pysim work.
-- `tl_card` (bucket 3). Separate concern; likely "document as PyNEC-only" rather than implement.
-- Auto-refining short feed segments. The fandipole's `n_seg1=1` feed-gap trick that breaks Triangular but works under Sinusoidal is a basis-selection question, not a geometry-translation question.
+Parasitic-only loops (a cycle with no excited segment, no other component) raise a clear `NotImplementedError` rather than crashing inside pysim. Loops with multiple excitations also raise specifically. Neither case appears in `designs/`.
 
 ## Other follow-ups (lower priority)
 

--- a/src/antenna_designer/geometry.py
+++ b/src/antenna_designer/geometry.py
@@ -130,11 +130,86 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
             junction_ends[path_nodes[0]].append((polyline_idx, "start"))
             junction_ends[path_nodes[-1]].append((polyline_idx, "end"))
 
-    # Closed loops with no boundary node would leave edges unseen.
-    if not all(edge_seen):
-        raise NotImplementedError(
-            "closed loops with no junctions/endpoints are not supported"
+    # Pure-cycle components — every node degree 2, no boundary to start
+    # the walk from — are left untouched by the loop above. Cut each at
+    # its excited edge: the excited edge becomes one polyline (A→B), the
+    # rest of the cycle becomes a second polyline walked B→A the long
+    # way. The two cut nodes A and B are each registered as 2-entry
+    # junctions so pysim's KCL enforces current continuity around the
+    # loop.
+    while not all(edge_seen):
+        seed = next(i for i, seen in enumerate(edge_seen) if not seen)
+        # Flood the component reachable from `seed` through unseen edges.
+        comp_edges = []
+        stack = [seed]
+        in_comp = {seed}
+        while stack:
+            ei = stack.pop()
+            comp_edges.append(ei)
+            edge_seen[ei] = True
+            a, b, _, _, _ = edges[ei]
+            for endpoint in (a, b):
+                for _nb, eo in adj[endpoint]:
+                    if eo not in in_comp and not edge_seen[eo]:
+                        in_comp.add(eo)
+                        stack.append(eo)
+
+        excited_in_comp = [ei for ei in comp_edges if edges[ei][3] is not None]
+        if not excited_in_comp:
+            raise NotImplementedError(
+                "closed loop with no excited segment is not supported "
+                "(parasitic-only loops are not yet handled)"
+            )
+        if len(excited_in_comp) > 1:
+            raise NotImplementedError(
+                f"closed loop with {len(excited_in_comp)} excited segments "
+                "is not supported"
+            )
+
+        feed_ei = excited_in_comp[0]
+        cut_a, cut_b, feed_n_seg, _, feed_tup_idx = edges[feed_ei]
+
+        # Polyline 0 (feed): the excited edge alone, A → B.
+        feed_pl_idx = len(polylines)
+        polylines.append(np.stack([nodes[cut_a], nodes[cut_b]], axis=0))
+        edge_segments.append([feed_n_seg])
+        edge_to_polyline[feed_tup_idx] = (feed_pl_idx, 0)
+
+        # Polyline 1 (long way): walk B → ... → A via the remaining edges.
+        # The cut nodes are now polyline boundaries; the walker stops there.
+        is_boundary[cut_a] = True
+        is_boundary[cut_b] = True
+        junction_ends.setdefault(cut_a, [])
+        junction_ends.setdefault(cut_b, [])
+
+        # Undo the flood-fill's seen marks on the cycle remainder so the
+        # walker can traverse them. Keep the feed edge marked since it's
+        # already become polyline 0.
+        for ei in comp_edges:
+            if ei != feed_ei:
+                edge_seen[ei] = False
+
+        first = next(
+            (eo for _nb, eo in adj[cut_b] if eo != feed_ei and not edge_seen[eo]),
+            None,
         )
+        # In a pure cycle every node has degree 2, so there's exactly one
+        # remaining edge at cut_b after consuming the feed.
+        assert first is not None, "cycle cut left no continuation"
+        path_nodes, path_edges = walk_from(cut_b, first)
+        loop_pl_idx = len(polylines)
+        polylines.append(np.stack([nodes[n] for n in path_nodes], axis=0))
+        edge_segments.append([edges[e][2] for e in path_edges])
+        for k, e in enumerate(path_edges):
+            edge_to_polyline[edges[e][4]] = (loop_pl_idx, k)
+
+        # Register the cut endpoints as junctions: feed polyline has
+        # path [A, B] so its start=A, end=B; loop polyline was walked
+        # B → A so its start=B, end=A.
+        junction_ends[cut_a].append((feed_pl_idx, "start"))
+        junction_ends[cut_a].append((loop_pl_idx, "end"))
+        junction_ends[cut_b].append((feed_pl_idx, "end"))
+        junction_ends[cut_b].append((loop_pl_idx, "start"))
 
     # Junctions = nodes where >= 2 polylines meet. Single-end records
     # (degree-1 free ends) and lone polyline starts aren't junctions.

--- a/tests/test_pysim_engine.py
+++ b/tests/test_pysim_engine.py
@@ -264,3 +264,65 @@ def test_pysim_sinusoidal_fandipole_runs():
     z = PysimEngine(F(), solver=SinusoidalPySim).impedance()[0]
     assert 20 < z.real < 200, z
     assert abs(z.imag) < 200, z
+
+
+def test_translator_handles_bowtie_closed_cycle():
+    """Bowtie is a single 10-edge closed cycle (each triangle's corners
+    share one edge per triangle, leaving every node degree-2). Cut at
+    the excited edge: feed becomes a 1-edge polyline, the rest becomes
+    a 9-edge polyline running the long way back."""
+    from antenna_designer.designs.bowtie import Builder as BT
+    out = flat_wires_to_polylines(BT().build_wires())
+    assert len(out["polylines"]) == 2
+    # Both polylines share both endpoints (the cut points), so both
+    # cut nodes are 2-entry junctions.
+    assert sorted(len(j) for j in out["junctions"]) == [2, 2]
+    feed_pl = out["polylines"][out["feed_wire_index"]]
+    assert feed_pl.shape == (2, 3)
+
+
+def test_translator_handles_delta_loop_pure_cycle():
+    from antenna_designer.designs.freq_based.delta_loop import Builder as DL
+    out = flat_wires_to_polylines(DL().build_wires())
+    assert len(out["polylines"]) == 2
+    assert sorted(len(j) for j in out["junctions"]) == [2, 2]
+    # Delta loop has 4 edges total: 1 becomes the feed polyline, 3 the loop.
+    assert sorted(len(s) for s in out["edge_segments"]) == [1, 3]
+
+
+def test_pysim_sinusoidal_delta_loop_close_to_pynec():
+    """Closed-loop cross-validation: PyNEC and Sinusoidal agree on a
+    canonical pure-cycle geometry. Tighter bound than the hentenna test
+    because there are no tee junctions adding extra basis-family bias."""
+    from pysim import SinusoidalPySim
+    from antenna_designer.designs.freq_based.delta_loop import Builder as DL
+    b = DL()
+    z_nec = PyNECEngine(b, ground=None).impedance()[0]
+    z_ps = PysimEngine(b, solver=SinusoidalPySim).impedance()[0]
+    assert abs(z_ps.real - z_nec.real) / abs(z_nec.real) < 0.05
+    assert abs(z_ps.imag - z_nec.imag) < 5.0
+
+
+def test_pysim_triangular_bowtie_runs():
+    """Triangular handles the bowtie because its feed gap is n_seg=3
+    (interior tent basis available). Verifies the closed-loop path
+    doesn't trip Triangular's feed-basis lookup."""
+    from antenna_designer.designs.bowtie import Builder as BT
+    z = PysimEngine(BT()).impedance()[0]
+    assert 100 < z.real < 300, z
+    assert abs(z.imag) < 100, z
+
+
+def test_translator_rejects_loop_without_feed():
+    """A pure cycle with no excited segment can't be handled (parasitic
+    coupling not yet implemented). Should raise a clear NotImplementedError
+    rather than crashing inside pysim."""
+    # Synthesise a 4-tuple cycle around a square, no excitation.
+    tups = [
+        ((0, 0, 0), (1, 0, 0), 5, None),
+        ((1, 0, 0), (1, 1, 0), 5, None),
+        ((1, 1, 0), (0, 1, 0), 5, None),
+        ((0, 1, 0), (0, 0, 0), 5, None),
+    ]
+    with pytest.raises(NotImplementedError, match="closed loop"):
+        flat_wires_to_polylines(tups)


### PR DESCRIPTION
## Summary
Lifts the "closed loops with no junctions/endpoints" \`NotImplementedError\` in \`flat_wires_to_polylines\`, unlocking the last topology bucket the translator was rejecting that has a tractable fix (no upstream pysim work needed). Multi-feed arrays remain — that's a deeper change scoped against pysim's single-source assumption.

After the existing junction/endpoint walker finishes, any unwalked edges form pure-cycle components. The translator floods each cycle, locates its excited edge, and cuts there — emitting the excited edge as a single-edge polyline and the rest of the loop as a second polyline walked the long way back to the cut endpoints. Both cut endpoints become 2-entry junctions so pysim's KCL enforces current continuity around the loop.

**Surprise relative to the NEXT_STEPS.md plan**: bowtie is a pure cycle, not a degree-3 case. The two triangles share corners at \`(±y, 0)\` but each triangle only contributes one edge incident at the shared corner, so those corners stay degree-2. The whole bowtie is a single 10-edge cycle with one excited segment (lower centre gap) and one passive segment (upper centre gap). Falls out of the same cut-at-excited-edge path with no special handling.

## Cross-validation at design freq, free space

| design | PyNEC | pysim Sinusoidal | pysim Triangular |
|---|---|---|---|
| bowtie | 188.6 + j16.3 | 186.1 + j14.2 | 187.7 + j13.9 |
| delta_loop | 113.4 + j46.1 | 110.5 + j43.9 | 110.5 + j42.7 |
| diamond_loop | 219.7 + j60.1 | 216.8 + j58.0 | 220.7 + j57.6 |

~1-3 % R / few-Ω X across all three on both pysim bases — tighter than the hentenna because there are no tee junctions adding extra basis-family bias.

## Newly unblocked
\`bowtie\`, \`freq_based.delta_loop\`, \`freq_based.diamond_loop\`, \`freq_based.inv_delta_loop\`, \`freq_based.folded_invvee\`, \`freq_based.delta_loop_slanted{,2,3}\`. All translate cleanly and produce sensible impedances under both Triangular and Sinusoidal.

## Remaining blocks
16 designs, *all* multi-feed arrays (\`invveearray\`, \`moxonarray\`, \`yagiarray\`, the bowtie/delta_loop arrays, \`hentenna_array\`, \`hourglass_array\`, \`folded_invveearray\`, \`diamond_loop_turnstile\`). That's bucket 2 from NEXT_STEPS.md — separate PR, needs a pysim-side change to support multi-feed solves. Closed-loop bucket is now empty.

## Defensive error handling
- Parasitic-only loop (cycle with no excited segment): clear \`NotImplementedError("closed loop with no excited segment …")\` rather than crashing inside pysim.
- Loop with multiple excitations: specific \`NotImplementedError\` mentioning the count.

Neither case appears in \`designs/\` today.

## Test plan
- [x] \`pytest tests\` — 44 passed (39 prior + 5 new), 24 skipped.
- [x] Translator structure for \`bowtie\` (10-edge cycle → 2 polylines, both with 2-entry junctions) and \`delta_loop\` (4-edge cycle → 2 polylines of sizes [1, 3]).
- [x] Sinusoidal vs PyNEC on \`delta_loop\` — < 5 % R, < 5 Ω X.
- [x] Triangular runs cleanly on \`bowtie\` (feed segment is \`n_seg=3\`, has interior tent basis).
- [x] Synthetic 4-tuple square loop with no feed: raises \`NotImplementedError\` mentioning "closed loop".

## Updates
\`NEXT_STEPS.md\` marks the closed-loop bucket done and records the bowtie-is-actually-pure-cycle finding so future archeology doesn't repeat the analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)