### PR TITLE
CLI: named param variants via builder:variant syntax

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -41,8 +41,33 @@ Both pysim bases agree with PyNEC to ~1–3 % R and a few Ω X on the closed-loo
 
 Parasitic-only loops (a cycle with no excited segment, no other component) raise a clear `NotImplementedError` rather than crashing inside pysim. Loops with multiple excitations also raise specifically. Neither case appears in `designs/`.
 
-## Other follow-ups (lower priority)
+## Next branches (rough priority order)
 
-- **CLI `--basis triangular|sinusoidal|bspline` flag** on the analysis subcommands. Today `--engine pysim` always uses Triangular; choosing Sinusoidal requires the Python API. Straightforward add — mirror how `--ground` is plumbed.
-- **Far-field for the new designs**. Stage 2b validated the pattern math on the dipole; once tee-junction geometries are stable, re-run the directivity cross-check on hentenna and fandipole and add a corresponding test.
-- **Multi-feed PysimEngine**. Two viable shapes: (a) N independent solves, superposing per-feed for the impedance matrix Y; (b) genuine multi-source solve in pysim, requires upstream changes. Worth a design sketch before either.
+### 1. Cross-engine pattern comparison in the CLI
+
+Today `compare --engine pysim --builders dipole invvee` runs both builders through *one* engine. The Python API already lets `compare_patterns` take a heterogeneous list of engine instances; the gap is just CLI plumbing. Extend the `compare` subcommand to accept `--engines pynec pysim` and take the cross-product with `--builders` (labels become `dipole/pynec`, `dipole/pysim`, …). Same change naturally subsumes the previously-listed `--basis triangular|sinusoidal|bspline` follow-up: spell engine choices as `pynec`, `pysim:triangular`, `pysim:sinusoidal`, `pysim:bspline` so the basis is part of the engine identity rather than a separate orthogonal flag. Small, no upstream changes, immediate cross-validation value.
+
+### 2. Named parameter variants per builder
+
+Designs currently export one default param dict per module. Real usage (different bands, different element counts, swept-then-frozen configurations) wants multiple named variants checked into the same file. Proposal:
+
+- A design module can expose a `VARIANTS: dict[str, dict]` mapping name → param dict alongside the existing default. The default stays the unnamed variant.
+- Builder selector syntax on the CLI becomes `builder[:variant]`, e.g. `dipole:80m`, `hentenna:wide`. No colon → default variant (back-compatible).
+- The builder registry resolves `name:variant` to `(builder_callable, params_override)` and threads the override through the existing builder API.
+
+Open question: should variants compose with per-flag overrides (`--set length=5.2`)? The two solve different problems — named variants are for reproducible saved configurations, ad-hoc overrides are for sweeping. Probably both, but named variants first.
+
+### 3. Multi-feed PysimEngine (and where the interface code should live)
+
+This is the dominant blocker — 16 of the currently-rejected designs are multi-feed arrays. Two viable shapes, unchanged from before:
+
+- **(a) N independent solves, superpose for Y.** Drive each feed in turn with the others open/shorted (the choice matters for what Y means), recover the multi-port impedance matrix column-by-column. Works entirely above pysim's existing single-source API. Cheapest path; the answer is exact for linear MoM.
+- **(b) Genuine multi-source solve in pysim.** Requires upstream changes — basis assembly and the RHS construction need to know about multiple excitations simultaneously. More natural and avoids N solves, but couples our roadmap to a pysim release.
+
+Worth a design sketch before either. Recommend prototyping (a) first because it's reversible and validates the multi-port plumbing in `antenna_designer` independently of upstream churn.
+
+**Where the interface code lives.** Once multi-feed works, a real question opens up: the geometry translator (`flat_wires_to_polylines`, the closed-loop cut, the multi-port Y assembly) is antenna-agnostic and would benefit any pysim user, not just us. Tempting to move it upstream. **Don't do this yet** — moving code across repos creates an API contract that's expensive to iterate against, and we're still discovering the right shape (multi-feed will almost certainly reshape the translator's interface). Revisit after multi-feed lands and the translator's signature has been stable for a release or two.
+
+### 4. Far-field for the new designs
+
+Stage 2b validated the pattern math on the dipole; once tee-junction geometries are stable, re-run the directivity cross-check on hentenna and fandipole and add a corresponding test. Lower priority — falls out naturally as a side effect of #1 once the CLI can compare engines on these designs.

--- a/src/antenna_designer/cli.py
+++ b/src/antenna_designer/cli.py
@@ -54,8 +54,42 @@ def resolve_class(s):
     return try_to_resolve_list(['antenna_designer', 'designs'] + lst)
 
 
+def list_variants(cls):
+    """Return all variant names for a Builder class. A variant is any class
+    attribute whose name ends in '_params' and is a Mapping; the variant name
+    is the attribute name with '_params' stripped."""
+    from collections.abc import Mapping
+    out = []
+    for nm in dir(cls):
+        if not nm.endswith('_params'):
+            continue
+        if not isinstance(getattr(cls, nm), Mapping):
+            continue
+        out.append(nm[:-len('_params')])
+    return sorted(out)
+
+
 def get_builder(nm):
-    return resolve_class(nm)
+    """Resolve a builder spec into a zero-arg factory.
+
+    Spec is "name" or "name:variant". A variant binds the named '<variant>_params'
+    class attribute as the builder's params; absent or ':default' uses default_params.
+    """
+    name, _, variant = nm.partition(':')
+    cls = resolve_class(name)
+    if cls is None:
+        return None
+    if not variant or variant == 'default':
+        return cls
+    attr = f'{variant}_params'
+    params = getattr(cls, attr, None)
+    if params is None:
+        available = ', '.join(list_variants(cls)) or '(none)'
+        raise ValueError(
+            f"builder {name!r} has no variant {variant!r}; available: {available}"
+        )
+    return partial(cls, params=params)
+
 
 def get_builders(nms):
     return (get_builder(nm) for nm in nms)

--- a/src/antenna_designer/designs/freq_based/delta_loop.py
+++ b/src/antenna_designer/designs/freq_based/delta_loop.py
@@ -4,7 +4,7 @@ import math
 from types import MappingProxyType
 
 class Builder(AntennaBuilder):
-  params_100ohms = MappingProxyType({
+  z100_params = MappingProxyType({
     'design_freq': 28.47,
     'freq': 28.47,
     'base': 7,
@@ -12,7 +12,7 @@ class Builder(AntennaBuilder):
     'angle_radians': 1.0889,
   })
 
-  params_200ohms = MappingProxyType({
+  z200_params = MappingProxyType({
     'design_freq': 28.47,
     'freq': 28.47,
     'base': 7,

--- a/src/antenna_designer/designs/freq_based/diamond_loop.py
+++ b/src/antenna_designer/designs/freq_based/diamond_loop.py
@@ -4,7 +4,7 @@ import math
 from types import MappingProxyType
 
 class Builder(AntennaBuilder):
-  params_100ohms = MappingProxyType({
+  z100_params = MappingProxyType({
     'design_freq': 28.47,
     'freq': 28.47,
     'base': 7,
@@ -12,7 +12,7 @@ class Builder(AntennaBuilder):
     'angle_radians': 0.8981,
   })
 
-  params_200ohms = MappingProxyType({
+  z200_params = MappingProxyType({
     'design_freq': 28.47,
     'freq': 28.47,
     'base': 7,

--- a/src/antenna_designer/designs/freq_based/hentenna.py
+++ b/src/antenna_designer/designs/freq_based/hentenna.py
@@ -6,7 +6,7 @@ from types import MappingProxyType
 
 
 class Builder(AntennaBuilder):
-  params_100 = MappingProxyType({
+  z100_params = MappingProxyType({
     'design_freq': 28.47,
     'freq': 28.47,
     'base': 10,
@@ -15,7 +15,7 @@ class Builder(AntennaBuilder):
     'width_factor': 0.1841,
   })
 
-  params_50 = MappingProxyType({
+  z50_params = MappingProxyType({
     'design_freq': 28.47,
     'freq': 28.47,
     'base': 10,
@@ -24,7 +24,7 @@ class Builder(AntennaBuilder):
     'width_factor': 0.1378,   
   })
   
-  default_params = params_50
+  default_params = z50_params
 
   def build_wires(self):
     eps = 0.05

--- a/src/antenna_designer/designs/freq_based/hentenna_slant.py
+++ b/src/antenna_designer/designs/freq_based/hentenna_slant.py
@@ -8,7 +8,7 @@ from types import MappingProxyType
 
 
 class Builder(AntennaBuilder):
-  params_50 = MappingProxyType({
+  z50_params = MappingProxyType({
     'design_freq': 28.47,
     'freq': 28.47,
     'base': 10,
@@ -18,7 +18,7 @@ class Builder(AntennaBuilder):
     'slant_degrees': 30,
   })
   
-  default_params = params_50
+  default_params = z50_params
 
   def build_wires(self):
     eps = 0.05

--- a/src/antenna_designer/designs/freq_based/inv_delta_loop.py
+++ b/src/antenna_designer/designs/freq_based/inv_delta_loop.py
@@ -4,7 +4,7 @@ import math
 from types import MappingProxyType
 
 class Builder(AntennaBuilder):
-  params_100ohms = MappingProxyType({
+  z100_params = MappingProxyType({
     'design_freq': 28.47,
     'freq': 28.47,
     'base': 7,
@@ -12,7 +12,7 @@ class Builder(AntennaBuilder):
     'angle_radians': 1.1284,
   })
 
-  params_200ohms = MappingProxyType({
+  z200_params = MappingProxyType({
     'design_freq': 28.47,
     'freq': 28.47,
     'base': 7,

--- a/src/antenna_designer/designs/twoband_fan_dipole.py
+++ b/src/antenna_designer/designs/twoband_fan_dipole.py
@@ -6,7 +6,7 @@ from types import MappingProxyType
 
 class Builder(AntennaBuilder):
 
-  default_params_07 = MappingProxyType({
+  s07_params = MappingProxyType({
     'freq': 28.57,
     'freq_10': 28.57,
     'freq_12': 24.97,
@@ -22,7 +22,7 @@ class Builder(AntennaBuilder):
 
 
 
-  default_params_05 = MappingProxyType({
+  s05_params = MappingProxyType({
     'freq': 28.57,
     'freq_10': 28.57,
     'freq_12': 24.97,
@@ -36,7 +36,7 @@ class Builder(AntennaBuilder):
     'eps': 0.01
   })
 
-  default_params_03 = MappingProxyType({
+  s03_params = MappingProxyType({
     'freq': 28.57,
     'freq_10': 28.57,
     'freq_12': 24.97,
@@ -50,7 +50,7 @@ class Builder(AntennaBuilder):
     'eps': 0.01
   })
 
-  default_params_025 = MappingProxyType({
+  s025_params = MappingProxyType({
     'freq': 24.97,
     'freq_10': 28.57,
     'freq_12': 24.97,
@@ -65,7 +65,7 @@ class Builder(AntennaBuilder):
   })
 
 
-  default_params_02 = MappingProxyType({
+  s02_params = MappingProxyType({
     'freq': 24.97,
     'freq_10': 28.57,
     'freq_12': 24.97,
@@ -79,7 +79,7 @@ class Builder(AntennaBuilder):
     'eps': 0.01
   })
 
-  default_params_015 = MappingProxyType({
+  s015_params = MappingProxyType({
     'freq': 24.97,
     'freq_10': 28.57,
     'freq_12': 24.97,
@@ -93,7 +93,7 @@ class Builder(AntennaBuilder):
     'eps': 0.01
   })
 
-  default_params_01 = MappingProxyType({
+  s01_params = MappingProxyType({
     'freq': 24.97,
     'freq_10': 28.57,
     'freq_12': 24.97,
@@ -107,7 +107,7 @@ class Builder(AntennaBuilder):
     'eps': 0.01
   })
 
-  default_params_01_001 = MappingProxyType({
+  s01_eps001_params = MappingProxyType({
     'freq': 24.97,
     'freq_10': 28.57,
     'freq_12': 24.97,
@@ -121,7 +121,7 @@ class Builder(AntennaBuilder):
     'eps': 0.001
   })
 
-  default_params_current_physical = MappingProxyType({
+  current_physical_params = MappingProxyType({
     'freq': 28.47,
     'freq_10': 29.3,
     'freq_12': 26.6,

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -6,59 +6,59 @@ from antenna_designer.designs.freq_based import hentenna, delta_loop
 
 
 def test_no_colon_uses_default_params():
-    factory = get_builder('hexbeam')
+    factory = get_builder("hexbeam")
     inst = factory()
     assert dict(inst._params) == dict(hexbeam.Builder.default_params)
 
 
 def test_explicit_default_variant():
-    factory = get_builder('hexbeam:default')
+    factory = get_builder("hexbeam:default")
     inst = factory()
     assert dict(inst._params) == dict(hexbeam.Builder.default_params)
 
 
 def test_named_variant_resolves():
-    factory = get_builder('hexbeam:opt')
+    factory = get_builder("hexbeam:opt")
     inst = factory()
     assert dict(inst._params) == dict(hexbeam.Builder.opt_params)
 
 
 def test_variant_on_moxon_original():
-    factory = get_builder('moxon:original')
+    factory = get_builder("moxon:original")
     inst = factory()
     assert dict(inst._params) == dict(moxon.Builder.original_params)
 
 
 def test_renamed_twoband_variant():
-    factory = get_builder('twoband_fan_dipole:s07')
+    factory = get_builder("twoband_fan_dipole:s07")
     inst = factory()
     assert dict(inst._params) == dict(twoband_fan_dipole.Builder.s07_params)
 
 
 def test_renamed_freq_based_variant():
-    factory = get_builder('freq_based.hentenna:z100')
+    factory = get_builder("freq_based.hentenna:z100")
     inst = factory()
     assert dict(inst._params) == dict(hentenna.Builder.z100_params)
 
 
 def test_renamed_loop_variant():
-    factory = get_builder('freq_based.delta_loop:z200')
+    factory = get_builder("freq_based.delta_loop:z200")
     inst = factory()
     assert dict(inst._params) == dict(delta_loop.Builder.z200_params)
 
 
 def test_unknown_variant_raises_with_available():
     with pytest.raises(ValueError) as exc:
-        get_builder('hexbeam:does_not_exist')
+        get_builder("hexbeam:does_not_exist")
     msg = str(exc.value)
-    assert 'does_not_exist' in msg
-    assert 'opt' in msg
-    assert 'default' in msg
+    assert "does_not_exist" in msg
+    assert "opt" in msg
+    assert "default" in msg
 
 
 def test_list_variants_for_hexbeam():
-    assert list_variants(hexbeam.Builder) == ['default', 'opt']
+    assert list_variants(hexbeam.Builder) == ["default", "opt"]
 
 
 def test_list_variants_for_moxon():
-    assert list_variants(moxon.Builder) == ['default', 'opt', 'original']
+    assert list_variants(moxon.Builder) == ["default", "opt", "original"]

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -1,0 +1,64 @@
+import pytest
+
+from antenna_designer.cli import get_builder, list_variants
+from antenna_designer.designs import hexbeam, moxon, twoband_fan_dipole
+from antenna_designer.designs.freq_based import hentenna, delta_loop
+
+
+def test_no_colon_uses_default_params():
+    factory = get_builder('hexbeam')
+    inst = factory()
+    assert dict(inst._params) == dict(hexbeam.Builder.default_params)
+
+
+def test_explicit_default_variant():
+    factory = get_builder('hexbeam:default')
+    inst = factory()
+    assert dict(inst._params) == dict(hexbeam.Builder.default_params)
+
+
+def test_named_variant_resolves():
+    factory = get_builder('hexbeam:opt')
+    inst = factory()
+    assert dict(inst._params) == dict(hexbeam.Builder.opt_params)
+
+
+def test_variant_on_moxon_original():
+    factory = get_builder('moxon:original')
+    inst = factory()
+    assert dict(inst._params) == dict(moxon.Builder.original_params)
+
+
+def test_renamed_twoband_variant():
+    factory = get_builder('twoband_fan_dipole:s07')
+    inst = factory()
+    assert dict(inst._params) == dict(twoband_fan_dipole.Builder.s07_params)
+
+
+def test_renamed_freq_based_variant():
+    factory = get_builder('freq_based.hentenna:z100')
+    inst = factory()
+    assert dict(inst._params) == dict(hentenna.Builder.z100_params)
+
+
+def test_renamed_loop_variant():
+    factory = get_builder('freq_based.delta_loop:z200')
+    inst = factory()
+    assert dict(inst._params) == dict(delta_loop.Builder.z200_params)
+
+
+def test_unknown_variant_raises_with_available():
+    with pytest.raises(ValueError) as exc:
+        get_builder('hexbeam:does_not_exist')
+    msg = str(exc.value)
+    assert 'does_not_exist' in msg
+    assert 'opt' in msg
+    assert 'default' in msg
+
+
+def test_list_variants_for_hexbeam():
+    assert list_variants(hexbeam.Builder) == ['default', 'opt']
+
+
+def test_list_variants_for_moxon():
+    assert list_variants(moxon.Builder) == ['default', 'opt', 'original']


### PR DESCRIPTION
## Summary
- Adds `name:variant` builder syntax to the CLI: any `<variant>_params` class attribute is now a selectable parameter set (e.g. `--builder hexbeam:opt`, `--builders twoband_fan_dipole:s07 twoband_fan_dipole:s05`).
- Resolver lives in `cli.get_builder`; no colon (or `:default`) preserves existing behavior. Unknown variant raises with the available list.
- Renames non-conforming param attrs so every variant ends in `_params`: `default_params_<s>` → `<s>_params` (twoband_fan_dipole), `params_50/100` → `z50/z100_params` (freq_based hentenna{,_slant}), `params_<n>ohms` → `z<n>_params` (delta_loop, inv_delta_loop, diamond_loop).
- Reorganizes NEXT_STEPS.md into a prioritized "Next branches" section.

## Test plan
- [x] 10 new tests in `tests/test_variants.py` cover default, explicit `:default`, named variant resolution, error path, and `list_variants()`.
- [x] Full suite (54 passed, 24 skipped) green after the renames.
- [ ] Manual: `python -m antenna_designer compare_patterns --builders hexbeam:default hexbeam:opt` renders both with labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)