### PR TITLE
CLI: cross-engine compare with broadcasting, pysim basis in engine spec

### DIFF
--- a/src/antenna_designer/cli.py
+++ b/src/antenna_designer/cli.py
@@ -4,6 +4,8 @@ from . import AntennaBuilder
 from . import sweep, sweep_gain, sweep_patterns, pattern, pattern3d, compare_patterns, optimize
 from .engines import PyNECEngine, PysimEngine
 
+from pysim import TriangularPySim, SinusoidalPySim, BSplinePySim
+
 from icecream import ic
 
 import argparse
@@ -13,6 +15,12 @@ from types import ModuleType
 ENGINE_CLASSES = {
     'pynec': PyNECEngine,
     'pysim': PysimEngine,
+}
+
+PYSIM_BASES = {
+    'triangular': TriangularPySim,
+    'sinusoidal': SinusoidalPySim,
+    'bspline': BSplinePySim,
 }
 
 
@@ -117,14 +125,40 @@ def parse_ground(s):
     raise argparse.ArgumentTypeError(f"unrecognised --ground: {s!r}")
 
 
-def make_engine_factory(engine_name, ground_spec):
-    cls = ENGINE_CLASSES[engine_name]
+def parse_engine_spec(spec):
+    """Parse an engine spec into (engine_name, kwargs_to_bind).
+
+    Forms: "pynec", "pysim", "pysim:triangular|sinusoidal|bspline".
+    """
+    name, _, basis = spec.partition(':')
+    if name not in ENGINE_CLASSES:
+        raise argparse.ArgumentTypeError(
+            f"unknown engine {name!r}; available: {', '.join(sorted(ENGINE_CLASSES))}"
+        )
+    if not basis:
+        return name, {}
+    if name != 'pysim':
+        raise argparse.ArgumentTypeError(
+            f"engine {name!r} does not accept a basis suffix (got {basis!r})"
+        )
+    if basis not in PYSIM_BASES:
+        raise argparse.ArgumentTypeError(
+            f"unknown pysim basis {basis!r}; available: {', '.join(sorted(PYSIM_BASES))}"
+        )
+    return name, {'solver': PYSIM_BASES[basis]}
+
+
+def make_engine_factory(engine_spec, ground_spec):
+    name, kwargs = parse_engine_spec(engine_spec)
+    cls = ENGINE_CLASSES[name]
     # PyNECEngine's default ground IS finite; pysim's default is free.
     # When the user passes --ground explicitly we always honour it;
     # when they don't, we use whatever the engine's own default is.
-    if ground_spec is _GROUND_UNSET:
+    if ground_spec is not _GROUND_UNSET:
+        kwargs['ground'] = ground_spec
+    if not kwargs:
         return cls
-    return partial(cls, ground=ground_spec)
+    return partial(cls, **kwargs)
 
 
 _GROUND_UNSET = object()
@@ -143,9 +177,17 @@ def cli(arguments=None):
         else:
             p.add_argument('--builder', type=str, default='dipole', help='Use this antenna builder.')
 
-    def add_engine_args(p):
-        p.add_argument('--engine', choices=sorted(ENGINE_CLASSES), default='pynec',
-                       help='Simulation backend (default: pynec).')
+    def add_engine_args(p, plural=False):
+        if plural:
+            p.add_argument('--engines', type=str, nargs='+', default=['pynec'],
+                           help='One or more simulation backends. Each spec is '
+                                '"pynec" or "pysim[:triangular|sinusoidal|bspline]". '
+                                'Cross-products with --builders.')
+        else:
+            p.add_argument('--engine', type=str, default='pynec',
+                           help='Simulation backend: pynec | pysim | '
+                                'pysim:triangular | pysim:sinusoidal | pysim:bspline '
+                                '(default: pynec).')
         p.add_argument('--ground', default=_GROUND_UNSET,
                        help='Ground model: free | pec | finite | finite:<eps_r>,<sigma> '
                             '(default: engine-specific — finite for pynec, free for pysim).')
@@ -227,12 +269,21 @@ def cli(arguments=None):
 
     p = subparsers.add_parser('compare_patterns', help='Display far field of multiple antennas')
     add_common(p, use_builders=True)
-    add_engine_args(p)
+    add_engine_args(p, plural=True)
     add_pattern_common(p)
     def f(args):
-        builders = get_builders(args.builders)
-        engine = engine_factory_from_args(args)
-        compare_patterns([engine(builder()) for builder in builders], elevation_angle=args.elevation_angle, fn=args.fn, builder_names=args.builders, azimuth_f=args.azimuth_f, azimuth_r=args.azimuth_r)
+        ground = args.ground if args.ground is _GROUND_UNSET else parse_ground(args.ground)
+        engines = [(spec, make_engine_factory(spec, ground)) for spec in args.engines]
+        multi_engine = len(engines) > 1
+        instances = []
+        labels = []
+        for bname in args.builders:
+            builder_factory = get_builder(bname)
+            for espec, eng in engines:
+                instances.append(eng(builder_factory()))
+                labels.append(f'{bname}/{espec}' if multi_engine else bname)
+        compare_patterns(instances, elevation_angle=args.elevation_angle, fn=args.fn,
+                         builder_names=labels, azimuth_f=args.azimuth_f, azimuth_r=args.azimuth_r)
     p.set_defaults(func=f)
 
     args = parser.parse_args(args=arguments)

--- a/src/antenna_designer/cli.py
+++ b/src/antenna_designer/cli.py
@@ -125,6 +125,25 @@ def parse_ground(s):
     raise argparse.ArgumentTypeError(f"unrecognised --ground: {s!r}")
 
 
+def broadcast_pairs(builders, engines):
+    """Numpy-style 1D broadcast of two sequences into a list of pairs.
+
+    Equal lengths zip pairwise; a length-1 sequence broadcasts against the
+    other. Any other length mismatch raises.
+    """
+    nb, ne = len(builders), len(engines)
+    if nb == ne:
+        return list(zip(builders, engines))
+    if nb == 1:
+        return [(builders[0], e) for e in engines]
+    if ne == 1:
+        return [(b, engines[0]) for b in builders]
+    raise argparse.ArgumentTypeError(
+        f"cannot broadcast {nb} builders against {ne} engines; "
+        "lengths must match or one side must be 1"
+    )
+
+
 def parse_engine_spec(spec):
     """Parse an engine spec into (engine_name, kwargs_to_bind).
 
@@ -273,15 +292,20 @@ def cli(arguments=None):
     add_pattern_common(p)
     def f(args):
         ground = args.ground if args.ground is _GROUND_UNSET else parse_ground(args.ground)
-        engines = [(spec, make_engine_factory(spec, ground)) for spec in args.engines]
-        multi_engine = len(engines) > 1
+        pairs = broadcast_pairs(args.builders, args.engines)
+        multi_engine = len(set(args.engines)) > 1
+        multi_builder = len(set(args.builders)) > 1
         instances = []
         labels = []
-        for bname in args.builders:
-            builder_factory = get_builder(bname)
-            for espec, eng in engines:
-                instances.append(eng(builder_factory()))
-                labels.append(f'{bname}/{espec}' if multi_engine else bname)
+        for bname, espec in pairs:
+            eng = make_engine_factory(espec, ground)
+            instances.append(eng(get_builder(bname)()))
+            if multi_engine and multi_builder:
+                labels.append(f'{bname}/{espec}')
+            elif multi_engine:
+                labels.append(espec)
+            else:
+                labels.append(bname)
         compare_patterns(instances, elevation_angle=args.elevation_angle, fn=args.fn,
                          builder_names=labels, azimuth_f=args.azimuth_f, azimuth_r=args.azimuth_r)
     p.set_defaults(func=f)

--- a/tests/test_engine_spec.py
+++ b/tests/test_engine_spec.py
@@ -1,0 +1,92 @@
+import argparse
+
+import pytest
+
+import antenna_designer as ant
+from antenna_designer.cli import (
+    PYSIM_BASES,
+    parse_engine_spec,
+    make_engine_factory,
+    _GROUND_UNSET,
+)
+from antenna_designer.engines import PyNECEngine, PysimEngine
+from pysim import TriangularPySim, SinusoidalPySim, BSplinePySim
+
+
+def test_parse_pynec_no_basis():
+    assert parse_engine_spec("pynec") == ("pynec", {})
+
+
+def test_parse_pysim_default():
+    assert parse_engine_spec("pysim") == ("pysim", {})
+
+
+@pytest.mark.parametrize(
+    "basis,cls",
+    [
+        ("triangular", TriangularPySim),
+        ("sinusoidal", SinusoidalPySim),
+        ("bspline", BSplinePySim),
+    ],
+)
+def test_parse_pysim_with_basis(basis, cls):
+    name, kw = parse_engine_spec(f"pysim:{basis}")
+    assert name == "pysim"
+    assert kw == {"solver": cls}
+
+
+def test_parse_unknown_engine_raises():
+    with pytest.raises(argparse.ArgumentTypeError):
+        parse_engine_spec("bogus")
+
+
+def test_parse_pynec_with_basis_raises():
+    with pytest.raises(argparse.ArgumentTypeError):
+        parse_engine_spec("pynec:triangular")
+
+
+def test_parse_pysim_unknown_basis_raises():
+    with pytest.raises(argparse.ArgumentTypeError):
+        parse_engine_spec("pysim:not_a_basis")
+
+
+def test_make_factory_returns_class_when_no_kwargs():
+    assert make_engine_factory("pynec", _GROUND_UNSET) is PyNECEngine
+    assert make_engine_factory("pysim", _GROUND_UNSET) is PysimEngine
+
+
+def test_make_factory_binds_solver():
+    factory = make_engine_factory("pysim:sinusoidal", _GROUND_UNSET)
+    assert factory.func is PysimEngine
+    assert factory.keywords == {"solver": SinusoidalPySim}
+
+
+def test_make_factory_binds_ground_and_solver():
+    factory = make_engine_factory("pysim:bspline", "pec")
+    assert factory.func is PysimEngine
+    assert factory.keywords == {"solver": BSplinePySim, "ground": "pec"}
+
+
+def test_pysim_bases_keys():
+    assert set(PYSIM_BASES) == {"triangular", "sinusoidal", "bspline"}
+
+
+O = " --fn /dev/null"
+
+
+def test_cli_compare_patterns_multi_engine():
+    ant.cli(f"compare_patterns --builders dipole --engines pynec pysim{O}".split())
+
+
+def test_cli_compare_patterns_single_engine_still_works():
+    ant.cli(f"compare_patterns --builders dipole invvee --engines pynec{O}".split())
+
+
+def test_cli_compare_patterns_pysim_basis():
+    ant.cli(
+        f"compare_patterns --builders dipole --engines pysim:triangular pysim:sinusoidal{O}".split()
+    )
+
+
+def test_cli_pattern_with_basis_spec():
+    ant.cli(f"pattern --builder dipole --engine pysim:sinusoidal{O}".split())

--- a/tests/test_engine_spec.py
+++ b/tests/test_engine_spec.py
@@ -7,6 +7,7 @@ from antenna_designer.cli import (
     PYSIM_BASES,
     parse_engine_spec,
     make_engine_factory,
+    broadcast_pairs,
     _GROUND_UNSET,
 )
 from antenna_designer.engines import PyNECEngine, PysimEngine
@@ -86,6 +87,49 @@ def test_cli_compare_patterns_pysim_basis():
     ant.cli(
         f"compare_patterns --builders dipole --engines pysim:triangular pysim:sinusoidal{O}".split()
     )
+
+
+def test_broadcast_equal_length():
+    assert broadcast_pairs(["a", "b", "c"], ["x", "y", "z"]) == [
+        ("a", "x"), ("b", "y"), ("c", "z")
+    ]
+
+
+def test_broadcast_single_engine():
+    assert broadcast_pairs(["a", "b", "c"], ["x"]) == [
+        ("a", "x"), ("b", "x"), ("c", "x")
+    ]
+
+
+def test_broadcast_single_builder():
+    assert broadcast_pairs(["a"], ["x", "y", "z"]) == [
+        ("a", "x"), ("a", "y"), ("a", "z")
+    ]
+
+
+def test_broadcast_mismatch_raises():
+    with pytest.raises(argparse.ArgumentTypeError):
+        broadcast_pairs(["a", "b"], ["x", "y", "z"])
+
+
+def test_cli_compare_patterns_three_by_three_paired():
+    ant.cli(
+        f"compare_patterns --builders dipole invvee bowtie "
+        f"--engines pynec pysim:triangular pysim:sinusoidal{O}".split()
+    )
+
+
+def test_cli_compare_patterns_three_builders_one_engine():
+    ant.cli(
+        f"compare_patterns --builders dipole invvee bowtie --engines pysim{O}".split()
+    )
+
+
+def test_cli_compare_patterns_mismatch_rejected():
+    with pytest.raises(argparse.ArgumentTypeError):
+        ant.cli(
+            f"compare_patterns --builders dipole invvee --engines pynec pysim:triangular pysim:sinusoidal{O}".split()
+        )
 
 
 def test_cli_pattern_with_basis_spec():


### PR DESCRIPTION
## Summary
- `compare_patterns` now takes `--engines` (plural) and broadcasts builders × engines numpy-style: equal-length zips pairwise, length-1 sides broadcast, any other mismatch raises.
- Engine spec syntax extended to include the pysim basis: `pynec` | `pysim` | `pysim:triangular` | `pysim:sinusoidal` | `pysim:bspline`. This subsumes the old `--basis` follow-up — basis is part of engine identity.
- Other subcommands (sweep, pattern, optimize) accept the basis-suffixed spec via the same parser.
- Labels collapse where one axis is singleton: engine-only when builder is fixed, builder-only when engine is fixed, `builder/engine` otherwise.

## Test plan
- [x] 23 new tests in `tests/test_engine_spec.py` cover spec parsing, broadcasting (paired, both broadcast directions, mismatch), and end-to-end CLI smoke tests.
- [x] Full suite: 77 passed / 24 skipped.
- [ ] Manual: `python -m antenna_designer compare_patterns --builders dipole --engines pynec pysim:triangular pysim:sinusoidal` renders three labeled curves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)