### PR TITLE
pysim multi-feed support

### DIFF
--- a/src/antenna_designer/engines/pysim.py
+++ b/src/antenna_designer/engines/pysim.py
@@ -74,9 +74,7 @@ class PysimEngine(SimulationEngine):
         translated = flat_wires_to_polylines(tups)
         self._polylines = translated["polylines"]
         self._edge_segments = translated["edge_segments"]
-        self._feed_wire_index = translated["feed_wire_index"]
-        self._feed_arclength = translated["feed_arclength"]
-        self._feed_voltage = translated["feed_voltage"]
+        self._feeds = translated["feeds"]
         self._junctions = translated["junctions"]
         self._solver = solver
         self._wire_radius = wire_radius
@@ -88,8 +86,7 @@ class PysimEngine(SimulationEngine):
         return self._solver(
             wires=self._polylines,
             n_per_edge_per_wire=self._edge_segments,
-            feed_wire_index=self._feed_wire_index,
-            feed_arclength=self._feed_arclength,
+            feeds=self._feeds,
             wavelength=wavelength,
             wire_radius=self._wire_radius,
             ground_z=self._ground_z,
@@ -104,7 +101,10 @@ class PysimEngine(SimulationEngine):
     def impedance(self):
         s = self._make_solver(wavelength=self._wavelength_for(self.builder.freq))
         z, _coeffs = s.compute_impedance()
-        return [self._feed_voltage * z]
+        # Single-feed path returns a scalar; multi-feed returns an array.
+        # Match PyNECEngine's list-of-Z return shape.
+        z_arr = np.atleast_1d(z)
+        return [complex(zi) for zi in z_arr]
 
     def impedance_sweep(self, freqs):
         freqs = np.asarray(freqs, dtype=float)
@@ -114,7 +114,12 @@ class PysimEngine(SimulationEngine):
         s = self._make_solver(wavelength=self._wavelength_for(freqs[0]))
         k_array = 2.0 * np.pi * freqs * 1e6 / C_LIGHT
         zs = s.compute_impedance_swept(k_array)
-        return (self._feed_voltage * zs).reshape(-1, 1)
+        # Single-feed: (n_k,); multi-feed: (n_k, n_feeds). Normalise to
+        # (n_k, n_feeds) to match PyNECEngine.
+        zs = np.asarray(zs)
+        if zs.ndim == 1:
+            zs = zs.reshape(-1, 1)
+        return zs
 
     def _segment_dipoles(self, sim, coeffs):
         """Returns (mid, dr, i_mid) — concatenated per-segment midpoints,

--- a/src/antenna_designer/geometry.py
+++ b/src/antenna_designer/geometry.py
@@ -14,7 +14,8 @@ Supported topologies:
     OR at least one junction (degree >= 3); pure cycles aren't handled.
   * Any number of junctions of any degree (tees, X's, hentenna-style
     multi-junction, fandipole-style multi-spoke feeds).
-  * Exactly one excited segment per geometry.
+  * One or more excited segments per geometry (each becomes a delta-gap
+    feed in the returned `feeds` list).
 """
 from __future__ import annotations
 
@@ -33,10 +34,16 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
     Returns a dict with keys:
         polylines       : list of (M, 3) np.ndarray
         edge_segments   : list of list[int] — n_seg per edge per polyline
-        feed_wire_index : int — polyline holding the excited segment
-        feed_arclength  : float — distance along the feed polyline to
-                          the midpoint of the excited segment
-        feed_voltage    : complex
+        feeds           : list of (polyline_idx, arclength, voltage) —
+                          one entry per excited tuple, in registration
+                          order. Suitable to pass directly to
+                          TriangularPySim(feeds=...).
+        feed_wire_index : int — polyline holding the first excited
+                          segment (back-compat: feeds[0][0])
+        feed_arclength  : float — arclength of the first feed
+                          (back-compat: feeds[0][1])
+        feed_voltage    : complex — voltage of the first feed
+                          (back-compat: feeds[0][2])
         junctions       : list of list[(wire_idx, "start"|"end")] —
                           shared-node groups, suitable to pass directly
                           to TriangularPySim(junctions=...). Empty list
@@ -215,33 +222,34 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
     # (degree-1 free ends) and lone polyline starts aren't junctions.
     junctions = [ends for ends in junction_ends.values() if len(ends) >= 2]
 
-    # Locate the excitation and convert to (polyline_index, arclength).
-    excited = [(i, ev) for i, (_, _, _, ev, _) in enumerate(edges) if ev is not None]
-    if len(excited) == 0:
-        raise ValueError("no excitation found in wire list")
-    if len(excited) > 1:
-        raise NotImplementedError(
-            f"{len(excited)} excitations found; pysim engine currently "
-            "supports a single feed per geometry"
+    # Locate the excitation(s) and convert each to (polyline_idx,
+    # arclength, voltage). PyNEC feeds at segment `(n_seg+1)//2` of the
+    # excited tuple — the middle segment 1-indexed, i.e. the physical
+    # midpoint of the wire. The excited tuple is one edge of its
+    # polyline; feed at that edge's midpoint.
+    feeds = []
+    for tup_index, edge in enumerate(edges):
+        voltage = edge[3]
+        if voltage is None:
+            continue
+        feed_pl, feed_edge_idx = edge_to_polyline[tup_index]
+        polyline = polylines[feed_pl]
+        edge_lengths = np.linalg.norm(np.diff(polyline, axis=0), axis=1)
+        feed_arclength = float(
+            edge_lengths[:feed_edge_idx].sum() + 0.5 * edge_lengths[feed_edge_idx]
         )
+        feeds.append((feed_pl, feed_arclength, complex(voltage)))
 
-    tup_index, voltage = excited[0]
-    feed_pl, feed_edge_idx = edge_to_polyline[tup_index]
-    polyline = polylines[feed_pl]
-    edge_lengths = np.linalg.norm(np.diff(polyline, axis=0), axis=1)
-    # PyNEC feeds at segment `(n_seg+1)//2` of the excited tuple — the
-    # middle segment 1-indexed, i.e. the physical midpoint of the wire.
-    # The excited tuple is one edge of its polyline; feed at that edge's
-    # midpoint.
-    feed_arclength = float(
-        edge_lengths[:feed_edge_idx].sum() + 0.5 * edge_lengths[feed_edge_idx]
-    )
+    if not feeds:
+        raise ValueError("no excitation found in wire list")
 
     return {
         "polylines": polylines,
         "edge_segments": edge_segments,
-        "feed_wire_index": feed_pl,
-        "feed_arclength": feed_arclength,
-        "feed_voltage": complex(voltage),
+        "feeds": feeds,
+        # Back-compat scalars — first feed.
+        "feed_wire_index": feeds[0][0],
+        "feed_arclength": feeds[0][1],
+        "feed_voltage": feeds[0][2],
         "junctions": junctions,
     }

--- a/tests/test_pysim_engine.py
+++ b/tests/test_pysim_engine.py
@@ -363,6 +363,25 @@ def test_pysim_multifeed_bowtie_1x2_phased_matches_pynec():
     assert abs(z_nec[0] - z_nec[1]) > 10.0
 
 
+def test_pysim_multifeed_far_field_matches_pynec():
+    """Bowtie 1×2 phased-array peak directivity, two backends. In-phase
+    drive gives a broadside lobe; 90° drive squints. Both must agree
+    with PyNEC because the far-field integrand is just the superposed
+    multi-source current pattern — a feed-ordering or voltage-sign bug
+    in the multi-feed RHS would show up as a different lobe shape and
+    a different peak. 0.1 dBi headroom matches the single-feed dipole
+    test; observed delta is ~0.02 dBi on both phasings."""
+    from antenna_designer.designs.bowtiearray1x2 import Builder as B12
+    for phase_lr_deg in (0.0, 90.0):
+        b = B12()
+        b.phase_lr = phase_lr_deg
+        ff_p = PysimEngine(b).far_field(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
+        ff_n = PyNECEngine(b, ground=None).far_field(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
+        assert abs(ff_p.max_gain - ff_n.max_gain) < 0.1, (
+            f"phase={phase_lr_deg}: pysim={ff_p.max_gain}, pynec={ff_n.max_gain}"
+        )
+
+
 def test_pysim_multifeed_impedance_sweep_shape():
     """Multi-feed impedance_sweep must return (n_freqs, n_feeds) to
     match PyNECEngine's shape contract."""

--- a/tests/test_pysim_engine.py
+++ b/tests/test_pysim_engine.py
@@ -313,6 +313,65 @@ def test_pysim_triangular_bowtie_runs():
     assert abs(z.imag) < 100, z
 
 
+def test_translator_emits_one_feed_per_excited_tuple():
+    """Multi-feed builders (arrays) should produce one entry in `feeds`
+    per excited wire tuple, with voltages from the builder phasors."""
+    from antenna_designer.designs.bowtiearray1x2 import Builder as B12
+    b = B12()
+    b.phase_lr = 90.0
+    out = flat_wires_to_polylines(b.build_wires())
+    assert len(out["feeds"]) == 2
+    v0, v1 = out["feeds"][0][2], out["feeds"][1][2]
+    # First feed is V=1+0j; second is the phase_lr phasor at 90°.
+    assert abs(v0 - (1 + 0j)) < 1e-12
+    assert abs(v1 - 1j) < 1e-12
+    # Back-compat scalars point at the first feed.
+    assert out["feed_wire_index"] == out["feeds"][0][0]
+    assert out["feed_arclength"] == out["feeds"][0][1]
+    assert out["feed_voltage"] == out["feeds"][0][2]
+
+
+def test_pysim_multifeed_bowtie_1x2_matches_pynec():
+    """Symmetric in-phase drive on the bowtie 1×2 phased array: per-feed
+    Z from PysimEngine must agree with PyNEC, and the two feeds should
+    return ~equal Z by symmetry. 5% relative + 3 Ω absolute slack covers
+    the basis-vs-NEC gap that pysim's own bowtie-1×2 parity test uses."""
+    from antenna_designer.designs.bowtiearray1x2 import Builder as B12
+    b = B12()
+    z_ps = PysimEngine(b).impedance()
+    z_nec = PyNECEngine(b, ground=None).impedance()
+    assert len(z_ps) == len(z_nec) == 2
+    for zp, zn in zip(z_ps, z_nec):
+        assert abs(zp - zn) < 0.05 * abs(zn) + 3.0, (zp, zn)
+    # In-phase symmetric drive → the two ports see the same Z.
+    assert abs(z_ps[0] - z_ps[1]) < 1.0
+
+
+def test_pysim_multifeed_bowtie_1x2_phased_matches_pynec():
+    """90° phasing makes Z₀ ≠ Z₁ via mutual coupling. Catches feed-
+    ordering / voltage-sign bugs that a symmetric drive would mask."""
+    from antenna_designer.designs.bowtiearray1x2 import Builder as B12
+    b = B12()
+    b.phase_lr = 90.0
+    z_ps = PysimEngine(b).impedance()
+    z_nec = PyNECEngine(b, ground=None).impedance()
+    for zp, zn in zip(z_ps, z_nec):
+        assert abs(zp - zn) < 0.05 * abs(zn) + 3.0, (zp, zn)
+    # Asymmetry must actually appear, otherwise both backends could
+    # be silently degenerate.
+    assert abs(z_ps[0] - z_ps[1]) > 10.0
+    assert abs(z_nec[0] - z_nec[1]) > 10.0
+
+
+def test_pysim_multifeed_impedance_sweep_shape():
+    """Multi-feed impedance_sweep must return (n_freqs, n_feeds) to
+    match PyNECEngine's shape contract."""
+    from antenna_designer.designs.bowtiearray1x2 import Builder as B12
+    freqs = np.linspace(28.0, 29.0, 4)
+    zs = PysimEngine(B12()).impedance_sweep(freqs)
+    assert zs.shape == (4, 2), zs.shape
+
+
 def test_translator_rejects_loop_without_feed():
     """A pure cycle with no excited segment can't be handled (parasitic
     coupling not yet implemented). Should raise a clear NotImplementedError


### PR DESCRIPTION
## Summary
- Bump pysim submodule to origin/main (14 upstream commits: bspline/sinusoidal/triangular multi-feed, bowtie 1×2 web demo)
- Extend `flat_wires_to_polylines` to emit a `feeds=[(wire, arc, voltage), ...]` list instead of rejecting >1 excited tuple
- Forward the feeds list into the pysim solver and normalise `PysimEngine.impedance` / `impedance_sweep` to PyNECEngine's `list` / `(n_freqs, n_feeds)` shape
- Add PyNEC parity tests on the bowtie 1×2 phased array — both in-phase (symmetric) and 90° (asymmetric per-feed Z from mutual coupling)

All 13 array designs (bowtiearray, bowtiearray1x2/2x4, moxonarray, delta_looparray*, folded_invveearray, hentenna_array, hourglass_array, invveearray, yagiarray) now solve through pysim. Single-feed back-compat preserved.

## Test plan
- [x] `pytest tests/` — 81 passed, 24 skipped
- [x] Bowtie 1×2 in-phase: pysim vs PyNEC within ~1 Ω / 2.5 Ω on a 184 Ω port
- [x] Bowtie 1×2 90°-phased: asymmetric Z₀ ≠ Z₁ reproduced on both backends (Δ ≈ 47 Ω)

🤖 Generated with [Claude Code](https://claude.com/claude-code)