### PR TITLE
Phase 1 web UI backend: builder enumeration + FastAPI solve

### DIFF
--- a/src/antenna_designer/engine.py
+++ b/src/antenna_designer/engine.py
@@ -12,6 +12,19 @@ class FarField(NamedTuple):
     phis: np.ndarray
 
 
+class WireCurrents(NamedTuple):
+    """Per-wire knot positions + complex currents at the solve frequency.
+
+    Engines decompose geometry differently — PysimEngine returns one
+    entry per polyline (post-translator), PyNECEngine returns one entry
+    per build_wires() tuple. Callers (e.g. the web UI) treat each entry
+    as an independent rendering primitive rather than assuming the lists
+    are aligned across engines.
+    """
+    knot_positions: np.ndarray  # (M, 3) float
+    knot_currents: np.ndarray   # (M,)   complex
+
+
 class SimulationEngine(ABC):
     supports_far_field: ClassVar[bool] = False
 
@@ -29,4 +42,10 @@ class SimulationEngine(ABC):
     def far_field(self, *, n_theta, n_phi, del_theta, del_phi):
         raise NotImplementedError(
             f"{type(self).__name__} does not support far-field computation"
+        )
+
+    def current_distribution(self):
+        """Return list[WireCurrents] at the builder's frequency."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not expose currents yet"
         )

--- a/src/antenna_designer/engines/pynec.py
+++ b/src/antenna_designer/engines/pynec.py
@@ -1,7 +1,7 @@
 import numpy as np
 import PyNEC as nec
 
-from ..engine import FarField, SimulationEngine
+from ..engine import FarField, SimulationEngine, WireCurrents
 
 
 DEFAULT_GROUND = ("finite", 10.0, 0.002)  # (kind, dielectric, conductivity)
@@ -109,6 +109,34 @@ class PyNECEngine(SimulationEngine):
         self.c.fr_card(0, freqs.size, float(freqs[0]), del_freq)
         self.c.xq_card(0)
         return np.array([self._impedances_at(i, sum_currents=sum_currents) for i in range(freqs.size)])
+
+    def current_distribution(self):
+        """Per-tuple knot positions + complex currents. Each build_wires()
+        tuple becomes one wire entry with n_seg+1 knot positions; per-knot
+        currents are the average of the two adjacent NEC segment-centre
+        currents, with boundary knots zeroed (open-wire BC). The pysim web
+        backend uses the same averaging convention."""
+        self._set_freq_and_execute()
+        sc = self.c.get_structure_currents(0)
+        all_tags = list(sc.get_current_segment_tag())
+        all_cur = sc.get_current()
+
+        out = []
+        for tag_idx, (p0, p1, n_seg, _ev) in enumerate(self.tups, start=1):
+            seg_idxs = [i for i, t in enumerate(all_tags) if t == tag_idx]
+            cur_per_seg = np.array([all_cur[i] for i in seg_idxs], dtype=np.complex128)
+            knots = np.linspace(p0, p1, n_seg + 1)
+            knot_cur = np.zeros(n_seg + 1, dtype=np.complex128)
+            if n_seg >= 2:
+                knot_cur[1:-1] = 0.5 * (cur_per_seg[:-1] + cur_per_seg[1:])
+            elif n_seg == 1:
+                # 1-segment wire: no interior knot, leave boundaries at 0.
+                pass
+            out.append(WireCurrents(
+                knot_positions=knots,
+                knot_currents=knot_cur,
+            ))
+        return out
 
     def far_field(self, *, n_theta=90, n_phi=360, del_theta=1, del_phi=1):
         self._set_freq_and_execute()

--- a/src/antenna_designer/engines/pysim.py
+++ b/src/antenna_designer/engines/pysim.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import numpy as np
 from pysim import TriangularPySim
 
-from ..engine import FarField, SimulationEngine
+from ..engine import FarField, SimulationEngine, WireCurrents
 from ..geometry import flat_wires_to_polylines
 
 C_LIGHT = 299_792_458.0
@@ -120,6 +120,19 @@ class PysimEngine(SimulationEngine):
         if zs.ndim == 1:
             zs = zs.reshape(-1, 1)
         return zs
+
+    def current_distribution(self):
+        sim = self._make_solver(wavelength=self._wavelength_for(self.builder.freq))
+        _z, coeffs = sim.compute_impedance()
+        knot_currents = sim.currents_at_knots(coeffs)
+        out = []
+        for w_idx, polyline in enumerate(self._polylines):
+            knots = _polyline_knots(polyline, self._edge_segments[w_idx])
+            out.append(WireCurrents(
+                knot_positions=np.ascontiguousarray(knots),
+                knot_currents=np.ascontiguousarray(knot_currents[w_idx]),
+            ))
+        return out
 
     def _segment_dipoles(self, sim, coeffs):
         """Returns (mid, dr, i_mid) — concatenated per-segment midpoints,

--- a/src/antenna_designer/web_schema.py
+++ b/src/antenna_designer/web_schema.py
@@ -1,0 +1,204 @@
+"""Builder discovery + parameter-schema generation for the web UI.
+
+Walks the designs/ subpackage and emits a JSON-friendly description of
+every concrete Builder: its dotted name, its variants, and its slider
+schema (per-parameter default + suggested range).
+
+Range inference is heuristic by parameter name, with a generic ±50%
+fallback. Designs can override per-parameter by declaring an optional
+class attribute `param_ranges = {"key": (lo, hi), ...}` or
+`param_ranges = {"key": (lo, hi, step), ...}`.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from collections.abc import Mapping
+from importlib import import_module
+from typing import Any
+
+from . import __file__ as _pkg_init
+from .cli import list_variants
+
+_DESIGNS_ROOT = pathlib.Path(_pkg_init).parent / "designs"
+
+# Parameter-name-based range heuristics. Keys match by exact name first,
+# then by suffix (so `slope_top`, `slope_bot` etc. all map to `slope`).
+# Values are (min, max, step).
+_RANGE_BY_NAME: dict[str, tuple[float, float, float]] = {
+    "freq": (1.0, 60.0, 0.01),
+    "design_freq": (1.0, 60.0, 0.01),
+    "measurement_freq": (1.0, 60.0, 0.01),
+    "base": (0.5, 20.0, 0.05),
+    "length": (0.5, 30.0, 0.01),
+    "length_factor": (0.3, 1.5, 0.001),
+    "halfdriver_factor": (0.2, 0.6, 0.001),
+    "slope": (0.0, 1.5, 0.001),
+    "aspect_ratio": (0.1, 2.0, 0.001),
+    "angle_radians": (0.0, 1.5708, 0.001),
+    "angle_deg": (0.0, 90.0, 0.1),
+    "phase_lr": (0.0, 360.0, 1.0),
+    "phase_tb": (0.0, 360.0, 1.0),
+    "del_y": (0.5, 15.0, 0.05),
+    "del_z": (0.0, 10.0, 0.05),
+    "del_y0": (0.5, 15.0, 0.05),
+    "del_y1": (0.5, 15.0, 0.05),
+    "n_directors": (0, 30, 1),
+    "spacing_wavelengths": (0.05, 0.5, 0.001),
+}
+
+
+def _range_for(name: str, default: Any) -> tuple[float, float, float]:
+    """Pick (min, max, step) for a parameter by name, falling back to
+    ±50% around the default value."""
+    if name in _RANGE_BY_NAME:
+        return _RANGE_BY_NAME[name]
+    # Suffix fallback — slope_top → slope, length_top → length, etc.
+    for suffix in ("_top", "_bot", "_itop", "_ibot", "_otop", "_obot"):
+        if name.endswith(suffix):
+            stem = name[: -len(suffix)]
+            if stem in _RANGE_BY_NAME:
+                return _RANGE_BY_NAME[stem]
+    # Generic fallback.
+    try:
+        d = float(default)
+    except (TypeError, ValueError):
+        return (0.0, 1.0, 0.01)
+    if d == 0:
+        return (-1.0, 1.0, 0.01)
+    half = abs(d) * 0.5
+    lo, hi = d - half, d + half
+    if isinstance(default, int) and not isinstance(default, bool):
+        return (int(lo), int(hi), 1)
+    step = max(abs(d) / 200.0, 1e-4)
+    return (float(lo), float(hi), float(step))
+
+
+def _param_schema(cls: type, params: Mapping[str, Any]) -> list[dict]:
+    """Build the slider schema for one (class, variant-params) pair.
+
+    Honours an optional `param_ranges` class attribute that overrides
+    the heuristic for specific keys: {"key": (lo, hi)} or
+    {"key": (lo, hi, step)}.
+    """
+    overrides: Mapping[str, tuple] = getattr(cls, "param_ranges", {}) or {}
+    out = []
+    for key, default in params.items():
+        if isinstance(default, complex):
+            # Complex-valued params (e.g. excitation voltage) get two-input
+            # re/im treatment in the UI rather than a single slider.
+            out.append(
+                {
+                    "key": key,
+                    "default": {"re": float(default.real), "im": float(default.imag)},
+                    "is_complex": True,
+                }
+            )
+            continue
+        if key in overrides:
+            ov = overrides[key]
+            lo, hi = float(ov[0]), float(ov[1])
+            step = float(ov[2]) if len(ov) >= 3 else (hi - lo) / 200.0
+        else:
+            lo, hi, step = _range_for(key, default)
+        out.append(
+            {
+                "key": key,
+                "default": float(default)
+                if isinstance(default, (int, float))
+                else default,
+                "min": float(lo),
+                "max": float(hi),
+                "step": float(step),
+                "is_int": isinstance(default, int) and not isinstance(default, bool),
+            }
+        )
+    return out
+
+
+def _iter_design_modules() -> list[str]:
+    """Yield dotted module names (relative to antenna_designer.designs)
+    for every .py file under designs/, skipping package __init__s."""
+    names = []
+    for path in sorted(_DESIGNS_ROOT.rglob("*.py")):
+        if path.name == "__init__.py":
+            continue
+        rel = path.relative_to(_DESIGNS_ROOT).with_suffix("")
+        names.append(".".join(rel.parts))
+    return names
+
+
+def _try_concrete(cls: type) -> bool:
+    """A Builder is 'concrete' when zero-arg construction succeeds.
+    Excludes abstract array bases like Array1x2Builder that need an
+    element_builder positional arg."""
+    if not hasattr(cls, "default_params"):
+        return False
+    try:
+        cls()
+    except TypeError:
+        return False
+    except Exception:
+        return False
+    return True
+
+
+def list_builders() -> list[dict]:
+    """Enumerate every concrete Builder under antenna_designer.designs.
+
+    Returns a list of dicts:
+        {
+          "name": "freq_based.dipole_turnstile",
+          "variants": ["default", ...],
+          "params": [{key, default, min, max, step, is_int}, ...],
+        }
+    The 'params' field reflects the default-variant param set; variant
+    schemas can be fetched separately via builder_schema(name, variant).
+    """
+    out = []
+    for dotted in _iter_design_modules():
+        try:
+            mod = import_module(f"antenna_designer.designs.{dotted}")
+        except Exception:
+            continue
+        cls = getattr(mod, "Builder", None)
+        if cls is None or not _try_concrete(cls):
+            continue
+        variants = ["default", *[v for v in list_variants(cls) if v != "default"]]
+        try:
+            b = cls()
+        except Exception:
+            continue
+        out.append(
+            {
+                "name": dotted,
+                "variants": variants,
+                "params": _param_schema(cls, b._params),
+            }
+        )
+    return out
+
+
+def builder_schema(name: str, variant: str = "default") -> dict | None:
+    """Return one builder's schema, resolving the named variant."""
+    try:
+        mod = import_module(f"antenna_designer.designs.{name}")
+    except ModuleNotFoundError:
+        return None
+    cls = getattr(mod, "Builder", None)
+    if cls is None or not _try_concrete(cls):
+        return None
+    if variant and variant != "default":
+        attr = f"{variant}_params"
+        params_src = getattr(cls, attr, None)
+        if params_src is None:
+            return None
+        b = cls(params=dict(params_src))
+    else:
+        b = cls()
+    return {
+        "name": name,
+        "variant": variant,
+        "variants": ["default", *[v for v in list_variants(cls) if v != "default"]],
+        "params": _param_schema(cls, b._params),
+    }

--- a/tests/test_pysim_engine.py
+++ b/tests/test_pysim_engine.py
@@ -391,6 +391,18 @@ def test_pysim_multifeed_impedance_sweep_shape():
     assert zs.shape == (4, 2), zs.shape
 
 
+def test_current_distribution_peak_matches_one_over_z():
+    """Peak |I| over the geometry should equal |1/Z| within solver
+    rounding on both backends — Z = V/I with V=1, so the driving-point
+    current magnitude is |1/Z|."""
+    b = Builder()
+    for eng in (PysimEngine(b), PyNECEngine(b, ground=None)):
+        cd = eng.current_distribution()
+        peak = max(np.max(np.abs(w.knot_currents)) for w in cd)
+        z = eng.impedance()[0]
+        assert abs(peak - abs(1 / z)) < 0.02 * abs(1 / z), (peak, z)
+
+
 def test_translator_rejects_loop_without_feed():
     """A pure cycle with no excited segment can't be handled (parasitic
     coupling not yet implemented). Should raise a clear NotImplementedError

--- a/web/server.py
+++ b/web/server.py
@@ -1,0 +1,205 @@
+"""FastAPI backend for the antenna_designer web UI.
+
+Endpoints (Phase 1):
+    GET  /api/builders          — schema for every concrete Builder
+    GET  /api/builder/{name}    — schema for one builder + variant
+    POST /api/solve             — run a single-frequency solve
+
+Run with:
+    python -m uvicorn web.server:app --reload --port 8000
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+import numpy as np
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
+from antenna_designer.engines.pynec import PyNECEngine
+from antenna_designer.engines.pysim import PysimEngine
+from antenna_designer.web_schema import builder_schema, list_builders
+
+from pysim import BSplinePySim, SinusoidalPySim, TriangularPySim
+
+app = FastAPI(title="antenna_designer web UI")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+PYSIM_BASIS = {
+    "triangular": TriangularPySim,
+    "sinusoidal": SinusoidalPySim,
+    "bspline": BSplinePySim,
+}
+
+
+class SolveRequest(BaseModel):
+    builder: str = Field(..., description="Dotted builder name, e.g. 'dipole'")
+    variant: str = Field("default", description="Variant of default_params")
+    params: dict[str, Any] = Field(default_factory=dict, description="Param overrides")
+    engine: str = Field("pynec", description="'pynec' or 'pysim'")
+    pysim_basis: str = Field("triangular", description="triangular|sinusoidal|bspline")
+    ground: str | None = Field(None, description="None|'free'|'pec'|'finite:eps,sigma'")
+    far_field: bool = Field(True, description="Include far-field rings in response")
+
+
+def _resolve_builder_class(name: str) -> type:
+    try:
+        mod = import_module(f"antenna_designer.designs.{name}")
+    except ModuleNotFoundError:
+        raise HTTPException(404, f"unknown builder: {name}")
+    cls = getattr(mod, "Builder", None)
+    if cls is None:
+        raise HTTPException(404, f"no Builder class in {name}")
+    return cls
+
+
+def _build_builder(req: SolveRequest):
+    cls = _resolve_builder_class(req.builder)
+    if req.variant and req.variant != "default":
+        params_src = getattr(cls, f"{req.variant}_params", None)
+        if params_src is None:
+            raise HTTPException(400, f"unknown variant: {req.variant}")
+        params = dict(params_src)
+    else:
+        params = dict(cls.default_params)
+    # Overlay user-supplied params. Re-hydrate complex params from
+    # {"re": .., "im": ..} where the existing default is complex. Keys
+    # not declared in default_params (e.g. optional `phase_lr` on array
+    # builders) are applied after construction via setattr, matching the
+    # existing AntennaBuilder pattern.
+    extras: dict[str, Any] = {}
+    for k, v in req.params.items():
+        if k not in params:
+            extras[k] = v
+            continue
+        if isinstance(params[k], complex) and isinstance(v, dict):
+            params[k] = complex(float(v.get("re", 0.0)), float(v.get("im", 0.0)))
+        else:
+            params[k] = v
+    inst = cls(params=params)
+    for k, v in extras.items():
+        if isinstance(v, dict) and {"re", "im"} <= v.keys():
+            v = complex(float(v["re"]), float(v["im"]))
+        setattr(inst, k, v)
+    return inst
+
+
+def _parse_ground(s: str | None):
+    if s is None or s == "free":
+        return None
+    if s == "pec":
+        return "pec"
+    if s.startswith("finite:"):
+        try:
+            eps_s, sigma_s = s[len("finite:") :].split(",")
+            return ("finite", float(eps_s), float(sigma_s))
+        except ValueError:
+            raise HTTPException(400, f"bad ground spec: {s!r}")
+    raise HTTPException(400, f"unknown ground: {s!r}")
+
+
+def _make_engine(req: SolveRequest, builder):
+    ground = _parse_ground(req.ground)
+    if req.engine == "pynec":
+        # PyNEC's default ground is finite; here None means free space.
+        return PyNECEngine(builder, ground=ground if ground is not None else "free")
+    if req.engine == "pysim":
+        basis = PYSIM_BASIS.get(req.pysim_basis)
+        if basis is None:
+            raise HTTPException(400, f"unknown pysim basis: {req.pysim_basis}")
+        return PysimEngine(builder, solver=basis, ground=ground)
+    raise HTTPException(400, f"unknown engine: {req.engine}")
+
+
+def _pack_wires(builder, wire_currents):
+    """Combine builder.build_wires() tuples with engine current data.
+
+    Returns a list of {p0, p1, n_seg, feed_voltage} + a list of
+    {knot_positions, knot_currents_re, knot_currents_im} (the latter is
+    engine-specific in cardinality)."""
+    tups = builder.build_wires()
+    wires = [
+        {
+            "p0": list(map(float, p0)),
+            "p1": list(map(float, p1)),
+            "n_seg": int(n_seg),
+            "feed_voltage": (
+                None
+                if ev is None
+                else {"re": float(np.real(ev)), "im": float(np.imag(ev))}
+            ),
+        }
+        for (p0, p1, n_seg, ev) in tups
+    ]
+    currents = [
+        {
+            "knot_positions": w.knot_positions.tolist(),
+            "knot_currents_re": w.knot_currents.real.tolist(),
+            "knot_currents_im": w.knot_currents.imag.tolist(),
+        }
+        for w in wire_currents
+    ]
+    return wires, currents
+
+
+@app.get("/api/healthz")
+def healthz():
+    return {"ok": True}
+
+
+@app.get("/api/builders")
+def get_builders():
+    return {"builders": list_builders()}
+
+
+@app.get("/api/builder/{name:path}")
+def get_builder(name: str, variant: str = "default"):
+    s = builder_schema(name, variant)
+    if s is None:
+        raise HTTPException(404, f"unknown builder: {name}")
+    return s
+
+
+@app.post("/api/solve")
+def solve(req: SolveRequest):
+    builder = _build_builder(req)
+    eng = _make_engine(req, builder)
+
+    z_per_feed = [{"re": float(z.real), "im": float(z.imag)} for z in eng.impedance()]
+    currents = eng.current_distribution()
+    wires_json, currents_json = _pack_wires(builder, currents)
+
+    out: dict[str, Any] = {
+        "builder": req.builder,
+        "variant": req.variant,
+        "engine": req.engine,
+        "freq_mhz": float(builder.freq),
+        "z_per_feed": z_per_feed,
+        "wires": wires_json,
+        "currents": currents_json,
+    }
+
+    if req.far_field:
+        try:
+            ff = eng.far_field(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
+            out["far_field"] = {
+                "thetas": ff.thetas.tolist(),
+                "phis": ff.phis.tolist(),
+                "rings": ff.rings if isinstance(ff.rings, list) else ff.rings.tolist(),
+                "max_gain": float(ff.max_gain),
+                "min_gain": float(ff.min_gain),
+            }
+        except NotImplementedError:
+            out["far_field"] = None
+
+    return out


### PR DESCRIPTION
## Summary
- Adds `current_distribution()` to `SimulationEngine`, implemented on both PyNEC and pysim engines (per-knot positions + complex currents); PyNEC averages segment-centre currents onto knots using the same convention as pysim's web backend.
- New `antenna_designer.web_schema` module discovers every concrete `Builder` under `designs/**`, resolves variants, and builds a slider schema (named-range heuristics, per-class `param_ranges` override hook, complex-default re/im handling).
- New `web/server.py` (FastAPI): `GET /api/builders`, `GET /api/builder/{name}`, `POST /api/solve`. Solve dispatches to PyNEC or pysim (selectable basis), supports complex param round-trip and optional array-phasing kwargs like `phase_lr` via setattr-after-construct.
- This is Phase 1 only — backend foundation for a schema-driven UI; the React frontend (Phase 2) will be vendored from pysim and wired to these endpoints in a follow-up.

## Test plan
- [x] `pytest tests/` — 83 passed, 24 skipped
- [x] In-process TestClient smoke test: enumerates 38 concrete builders, solves dipole on both engines, solves bowtiearray1x2 at 90° phasing (asymmetric Z₀ ≠ Z₁), solves freq_based.dipole_turnstile with param override, fetches `delta_looparray:dy35_dz2` variant schema, returns 404 on unknown builder
- [x] `ruff check` + format pass on new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)