### PR TITLE
Variant selector: pick alternate *_params dicts per design

### DIFF
--- a/web/adapter.py
+++ b/web/adapter.py
@@ -219,7 +219,9 @@ def _build_builder(cls, req: dict):
     directly. A nested `params` dict is also accepted as a fallback for
     other clients.
     """
-    base = _strip_ui(dict(cls.default_params))
+    # Seed from the named variant (e.g. `opt_params`, `z50_params`).
+    # Unrecognised / absent → fall back to default_params.
+    base = _strip_ui(_variant_params(cls, req.get("variant")))
     nested = req.get("params") or {}
     for k in list(base.keys()):
         if k in req:
@@ -334,6 +336,63 @@ def _pynec_feed_indices(builder, currents) -> tuple[int, int]:
 # ---------------------------------------------------------------------------
 
 
+def _discover_variants(cls) -> tuple[str, ...]:
+    """Names of every class-level `<name>_params` attribute (the variant
+    convention used across the design library — e.g. `default_params`,
+    `opt_params`, `z50_params`, `current_physical_params`). The
+    returned list is suitable for a UI selector; the bare names (no
+    `_params` suffix) are what the frontend sends back in the request.
+
+    `default` is always first if present, so the UI lists it as the
+    canonical starting point regardless of class attribute order.
+    """
+    suffix = "_params"
+    found: list[str] = []
+    for attr in dir(cls):
+        if not attr.endswith(suffix) or attr.startswith("_"):
+            continue
+        v = getattr(cls, attr, None)
+        # MappingProxyType / dict only — skip e.g. a method that happens
+        # to end in _params.
+        if not hasattr(v, "keys"):
+            continue
+        name = attr[: -len(suffix)]
+        if name:
+            found.append(name)
+    # `default` first, rest in stable (alphabetical) order.
+    found.sort(key=lambda n: (n != "default", n))
+    return tuple(found)
+
+
+def _serialize_param_values(params: dict) -> dict:
+    """JSON-encode a params dict for shipping to the frontend.
+
+    Complex values become {"re": ..., "im": ...} (matches the same
+    shape `_rehydrate_param` accepts on the way back). Bool/int/float
+    pass through. Anything exotic (None, strings that aren't enum
+    options, etc.) passes through too — the frontend just ignores
+    keys it doesn't have sliders for.
+    """
+    out: dict = {}
+    for k, v in params.items():
+        if isinstance(v, complex):
+            out[k] = {"re": float(v.real), "im": float(v.imag)}
+        else:
+            out[k] = v
+    return out
+
+
+def _variant_params(cls, variant: str | None) -> dict:
+    """Return the seed params dict for the named variant. Falls back to
+    `default_params` when variant is None or doesn't resolve to an
+    attribute (stale frontend, unknown name)."""
+    if variant:
+        params = getattr(cls, f"{variant}_params", None)
+        if params is not None and hasattr(params, "keys"):
+            return dict(params)
+    return dict(cls.default_params)
+
+
 def _ui_scalar(default_params: dict, key: str, default):
     ui = default_params.get("ui_params") or {}
     if key in ui and not isinstance(ui[key], dict):
@@ -407,9 +466,18 @@ def _make_example(name: str, cls) -> AntennaExample:
 
     param_schema = _derive_schema(dp)
     has_design_freq = "design_freq" in dp
+    variants = _discover_variants(cls)
+
+    def _design_freq_default(req: dict) -> float:
+        # The active variant's `freq` is the right fallback when the
+        # request hasn't supplied design_freq_mhz yet — different
+        # variants of one design can target different bands (e.g.
+        # hexbeam's opt vs default).
+        vp = _variant_params(cls, req.get("variant"))
+        return float(vp.get("freq", 14.0))
 
     def pysim_solve(req: dict) -> dict:
-        design_freq = float(req.get("design_freq_mhz", dp.get("freq", 14.0)))
+        design_freq = float(req.get("design_freq_mhz", _design_freq_default(req)))
         meas_freq = float(req.get("measurement_freq_mhz", design_freq))
         builder = _build_builder(cls, req)
         builder.freq = meas_freq
@@ -468,7 +536,7 @@ def _make_example(name: str, cls) -> AntennaExample:
         #   _engine      — keep the PyNECEngine alive so the
         #                  underlying nec_context isn't released
         #                  before rp_card runs
-        design_freq = float(req.get("design_freq_mhz", dp.get("freq", 14.0)))
+        design_freq = float(req.get("design_freq_mhz", _design_freq_default(req)))
         meas_freq = float(req.get("measurement_freq_mhz", design_freq))
         builder = _build_builder(cls, req)
         builder.freq = meas_freq
@@ -504,7 +572,7 @@ def _make_example(name: str, cls) -> AntennaExample:
         # shape is identical so the frontend renders the result the
         # same way; the `solver` field gets stamped to "pynec" by
         # server.solve()'s outer wrapper.
-        design_freq = float(req.get("design_freq_mhz", dp.get("freq", 14.0)))
+        design_freq = float(req.get("design_freq_mhz", _design_freq_default(req)))
         meas_freq = float(req.get("measurement_freq_mhz", design_freq))
         builder = _build_builder(cls, req)
         builder.freq = meas_freq
@@ -547,7 +615,7 @@ def _make_example(name: str, cls) -> AntennaExample:
         # solve sees. See pysim_solve for the rationale.
         if has_design_freq:
             builder.design_freq = float(
-                req.get("design_freq_mhz", dp.get("freq", 14.0))
+                req.get("design_freq_mhz", _design_freq_default(req))
             )
         eng = _make_pysim_engine(req, builder)
         zs = np.asarray(eng.impedance_sweep(list(freqs_mhz)))
@@ -577,6 +645,11 @@ def _make_example(name: str, cls) -> AntennaExample:
         default_view=default_view,
         default_freq_mhz=float(dp["freq"]) if "freq" in dp else None,
         has_design_freq=has_design_freq,
+        variants=variants,
+        variant_values={
+            v: _serialize_param_values(_strip_ui(_variant_params(cls, v)))
+            for v in variants
+        },
     )
 
 

--- a/web/examples/_base.py
+++ b/web/examples/_base.py
@@ -305,3 +305,18 @@ class AntennaExample:
     # designs (top-level designs/) ignore design_freq, so the row
     # would just be a noop slider for them.
     has_design_freq: bool = False
+    # Alternate seed dicts available on the Builder — class-level
+    # attributes named `<variant>_params` (e.g. `default`, `opt`,
+    # `original`, `z50`, `z100`). The bare name is what the frontend
+    # sends back in the `variant` field of solve / sweep requests.
+    # `default` is always first when present so the UI lists it as
+    # the canonical starting point. Single-variant Builders ship
+    # ('default',) — the frontend can suppress the selector then.
+    variants: tuple[str, ...] = ("default",)
+    # Per-variant param values, keyed by variant name → {param_name:
+    # value}. The frontend uses this to reset schema sliders + design
+    # freq when the user picks a different variant. Complex-valued
+    # params are encoded as {"re": ..., "im": ...}; ui_params is
+    # stripped. Single-variant designs ship {} since there's nothing
+    # to switch between.
+    variant_values: dict = field(default_factory=dict)

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -112,6 +112,14 @@ type ExampleDescriptor = {
    *  geometry (freq_based.* designs). When false, the design-freq
    *  band-tab row is hidden because dragging it would be a no-op. */
   has_design_freq: boolean;
+  /** Alternate seed dicts on the Builder, e.g. ["default", "opt"].
+   *  The bare name is what the frontend sends back in `variant`.
+   *  Single-entry lists ("default") hide the selector. */
+  variants: string[];
+  /** Per-variant param values, keyed by variant name. Lets the UI
+   *  reset the schema sliders + design freq when the user switches
+   *  variants. Complex-valued params arrive as {re, im}. */
+  variant_values: { [variant: string]: { [key: string]: unknown } };
   sweep_policy: SweepPolicy;
 };
 
@@ -629,6 +637,9 @@ function modelOptionsForRequest(
 
 type SolveRequest = {
   geometry: string;
+  /** Which `<name>_params` dict on the Builder to seed from. Omitted
+   *  → backend falls back to default_params. */
+  variant?: string;
   solver: "pysim" | "pynec";
   pysim_model?: "triangular" | "sinusoidal" | "bspline";
   model_options?: Record<string, unknown>;
@@ -839,6 +850,11 @@ export function App() {
   const [examples, setExamples] = useState<ExampleDescriptor[]>([]);
   const [examplesError, setExamplesError] = useState<string | null>(null);
   const [paramValues, setParamValues] = useState<Record<string, ParamValueBag>>({});
+  // Per-geometry variant selection (which `<name>_params` dict on the
+  // Builder to seed from). Falls back to the example's variants[0]
+  // when this map has no entry — `default` for designs that declare
+  // it, otherwise whatever the example shipped first.
+  const [variantByGeom, setVariantByGeom] = useState<Record<string, string>>({});
 
   useEffect(() => {
     let cancelled = false;
@@ -879,6 +895,32 @@ export function App() {
 
   const currentExample = examples.find((e) => e.name === geometry);
   const currentValues = paramValues[geometry] ?? {};
+  const currentVariant =
+    variantByGeom[geometry] ?? currentExample?.variants?.[0] ?? "default";
+
+  // Switch to a different variant: overlay the variant's per-param
+  // values onto the existing slider state for this geometry (keeping
+  // schema-derived defaults for any key the variant doesn't supply),
+  // then snap designFreq / measFreq to the variant's `freq` so the
+  // band tabs follow too. Sweep / live solve will pick up `variant`
+  // via buildRequest on the next tick.
+  function selectVariant(nextVariant: string) {
+    if (!currentExample) return;
+    setVariantByGeom((prev) => ({ ...prev, [geometry]: nextVariant }));
+    const vv = currentExample.variant_values?.[nextVariant];
+    if (!vv) return;
+    setParamValues((prev) => {
+      const base = seedDefaults(currentExample.param_schema);
+      for (const k of Object.keys(base)) {
+        if (k in vv) base[k] = vv[k] as never;
+      }
+      return { ...prev, [geometry]: base };
+    });
+    if (typeof vv.freq === "number") {
+      setDesignFreq(vv.freq);
+      if (linkMeas) setMeasFreq(vv.freq);
+    }
+  }
   // Stable, primitive-only signature of the active antenna's params for
   // useEffect dependency arrays. Object identity isn't reliable because
   // setParamValues replaces the inner object on every onChange.
@@ -1112,6 +1154,7 @@ export function App() {
     const groundActive = groundEnabled && backendSupportsGround(backend);
     const base: SolveRequest = {
       geometry,
+      variant: currentVariant,
       solver: backend === "pynec" ? "pynec" : "pysim",
       n_per_wire: nPerWire,
       design_freq_mhz: designFreq,
@@ -1623,6 +1666,26 @@ export function App() {
         {examplesError && (
           <div className="examples-error">
             Failed to load /examples: {examplesError}
+          </div>
+        )}
+
+        {currentExample && currentExample.variants.length > 1 && (
+          <div className="field">
+            <label htmlFor="variant-select">
+              <span>variant</span>
+            </label>
+            <select
+              id="variant-select"
+              className="geometry-select"
+              value={currentVariant}
+              onChange={(e) => selectVariant(e.target.value)}
+            >
+              {currentExample.variants.map((v) => (
+                <option key={v} value={v}>
+                  {v}
+                </option>
+              ))}
+            </select>
           </div>
         )}
 

--- a/web/server.py
+++ b/web/server.py
@@ -755,6 +755,8 @@ def examples_endpoint():
                 "default_view": ex.default_view,
                 "default_freq_mhz": ex.default_freq_mhz,
                 "has_design_freq": ex.has_design_freq,
+                "variants": list(ex.variants),
+                "variant_values": dict(ex.variant_values),
                 "sweep_policy": {
                     "anchor": ex.sweep_policy.anchor,
                     "lo_factor": ex.sweep_policy.lo_factor,


### PR DESCRIPTION
## Summary
- Several Builders in the design library expose alternate seed dicts as class-level `<variant>_params` attributes (hexbeam.opt, moxon.original, freq_based.hentenna z50/z100, twoband_fan_dipole's 10 spacing sweeps, etc.). The web UI was always seeding from `default_params`; this wires up a per-design dropdown so the user can pick which variant to start from.
- Adapter discovers `*_params` per class, ships `variants: tuple[str, ...]` and `variant_values: dict[variant → {param → value}]` on each `AntennaExample`. `_build_builder` and the design-freq fallback honor the request's `variant` field; all four closures (pysim_solve, pysim_sweep, pynec_solve, pynec_build) pick up the change.
- Frontend adds a `variant` <select> above the params panel for multi-variant designs. Selecting one overlays the variant's per-param values onto the slider state and snaps designFreq/measFreq to the variant's `freq`. The chosen variant rides on every solve/sweep request.
- 11 designs gain the selector: hexbeam, moxon, invveearray, delta_looparray, twoband_fan_dipole, freq_based.delta_loop, .delta_loop_slanted, .diamond_loop, .hentenna, .hentenna_slant, .inv_delta_loop.

## Test plan
- [ ] `ruff check` + `ruff format --check` pass.
- [ ] `pytest tests/ --ignore=tests/subdir` still reports 83 passed / 24 skipped.
- [ ] UI: pick `hexbeam`, a "variant" dropdown appears with `default` / `opt`. Switching to `opt` re-seeds the schema sliders and Z jumps from ~50+j20 to ~16+j8.
- [ ] UI: pick `freq_based.hentenna`, switching `z50` → `z100` updates Z from ~43+j38 to ~94+j43.
- [ ] UI: pick a single-variant design (e.g. invvee), no variant dropdown shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)