### PR TITLE
Quiet build_wires debug prints behind a logger

### DIFF
--- a/src/antenna_designer/__init__.py
+++ b/src/antenna_designer/__init__.py
@@ -34,3 +34,18 @@ from .opt import optimize
 from .sweep import sweep, sweep_freq, sweep_gain, sweep_patterns, resolve_range, gen_xs
 from .far_field import compare_patterns, plot_patterns, pattern, pattern3d
 from .cli import cli
+
+# Re-enable Builder debug prints (now `logger.debug` calls under
+# `antenna_designer.designs.*`) when the env var is set:
+#   ANTENNA_DESIGNER_LOG=debug python -m antenna_designer ...
+# Unset → default WARNING level keeps the live UI quiet.
+#
+# We pin the root logger at WARNING and only flip the antenna_designer
+# namespace; otherwise basicConfig(level=DEBUG) bleeds into matplotlib,
+# PIL, and every other library that uses the stdlib logger.
+import logging as _logging  # noqa: E402
+import os as _os  # noqa: E402
+
+if _level := _os.getenv("ANTENNA_DESIGNER_LOG"):
+    _logging.basicConfig(level=_logging.WARNING)
+    _logging.getLogger("antenna_designer").setLevel(_level.upper())

--- a/src/antenna_designer/designs/fandipole.py
+++ b/src/antenna_designer/designs/fandipole.py
@@ -1,7 +1,10 @@
-from antenna_designer import AntennaBuilder
+import logging
 import math
 from types import MappingProxyType
-# from icecream import ic
+
+from antenna_designer import AntennaBuilder
+
+logger = logging.getLogger(__name__)
 
 
 class Builder(AntennaBuilder):
@@ -58,9 +61,10 @@ class Builder(AntennaBuilder):
         def dist(p0, p1):
             return math.sqrt(sum((x0 - x1) ** 2 for x0, x1 in zip(p0, p1)))
 
-        print(f"t0: {t0} dist: {dist(S, C)}")
-        print(f"t0: {t0} dists from C: {[dist(C, a) for a in A]}")
-        print(f"radius: {radius} dists from S: {[dist(S, a) for a in A]}")
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("t0: %s dist: %s", t0, dist(S, C))
+            logger.debug("t0: %s dists from C: %s", t0, [dist(C, a) for a in A])
+            logger.debug("radius: %s dists from S: %s", radius, [dist(S, a) for a in A])
 
         lengths = [
             self.length_10,
@@ -79,9 +83,12 @@ class Builder(AntennaBuilder):
 
         for i in range(n):
             wire_length = dist(S, A[i]) + dist(A[i], B[i])
-
-            print(
-                f"{i} length {wire_length} {lengths[i] / 2} {(wire_length - lengths[i] / 2) / lengths[i]}"
+            logger.debug(
+                "%d length %s %s %s",
+                i,
+                wire_length,
+                lengths[i] / 2,
+                (wire_length - lengths[i] / 2) / lengths[i],
             )
 
         n_seg0 = 21

--- a/src/antenna_designer/designs/freq_based/delta_loop.py
+++ b/src/antenna_designer/designs/freq_based/delta_loop.py
@@ -1,7 +1,10 @@
-from ... import AntennaBuilder
+import logging
 import math
-
 from types import MappingProxyType
+
+from ... import AntennaBuilder
+
+logger = logging.getLogger(__name__)
 
 
 class Builder(AntennaBuilder):
@@ -77,8 +80,13 @@ class Builder(AntennaBuilder):
 
         B, T = ry(A), ry(S)
 
-        print(f"theta = {self.angle_radians * 180 / math.pi:.1f}")
-        print(f"wires AB = {dist(A, B):.3f} AS = {dist(A, S):.3f} BT ={dist(B, T):.3f}")
+        logger.debug("theta = %.1f", self.angle_radians * 180 / math.pi)
+        logger.debug(
+            "wires AB = %.3f AS = %.3f BT = %.3f",
+            dist(A, B),
+            dist(A, S),
+            dist(B, T),
+        )
 
         tups = []
 

--- a/src/antenna_designer/designs/twoband_fan_dipole.py
+++ b/src/antenna_designer/designs/twoband_fan_dipole.py
@@ -1,8 +1,11 @@
-from antenna_designer import AntennaBuilder
+import logging
 import math
 from math import sqrt
 from types import MappingProxyType
-# from icecream import ic
+
+from antenna_designer import AntennaBuilder
+
+logger = logging.getLogger(__name__)
 
 
 class Builder(AntennaBuilder):
@@ -276,8 +279,12 @@ class Builder(AntennaBuilder):
         wire12 = dist(S, G) + dist(G, A)
         wire10 = dist(S, H) + dist(H, B)
 
-        print(
-            f"wire12: {wire12} {self.length_12 / 2} wire10: {wire10} {self.length_10 / 2} "
+        logger.debug(
+            "wire12: %s %s wire10: %s %s",
+            wire12,
+            self.length_12 / 2,
+            wire10,
+            self.length_10 / 2,
         )
 
         tups = []
@@ -326,7 +333,6 @@ if __name__ == "__main__":
     params = Builder.default_params
     print(f"Quarter wave element on 12m: {tofeet_inches(params['length_12'] / 2)}")
     print(f"Quarter wave element on 10m: {tofeet_inches(params['length_10'] / 2)}")
-
     print(f"Ratio of 12m element to single band invvee: {params['length_12'] / 5.8408}")
     print(
         f"Ratio of 12m element to 10m element: {params['length_12'] / params['length_10']}"


### PR DESCRIPTION
## Summary
- Convert the `print(f"…")` calls inside `build_wires()` for fandipole, twoband_fan_dipole, and freq_based.delta_loop into `logger.debug` calls under a per-module `logging.getLogger(__name__)`. These were firing on every live UI solve and visibly slowing the slider animation.
- `src/antenna_designer/__init__.py` reads `ANTENNA_DESIGNER_LOG`; when set, it pins the root logger at WARNING (so matplotlib / PIL stay quiet) and flips only the `antenna_designer` namespace to the requested level. So `ANTENNA_DESIGNER_LOG=debug python -m antenna_designer draw --builder fandipole --fn /dev/null` brings the original messages back, prefixed with their module name; the default UI/CLI run is silent.
- The `if __name__ == "__main__":` "report on this file" blocks at the bottom of fandipole.py / twoband_fan_dipole.py keep `print` — those exist specifically to be seen when the user runs the file directly.

## Test plan
- [ ] `ruff check` + `ruff format --check` pass.
- [ ] `pytest tests/ --ignore=tests/subdir` reports 83 passed / 24 skipped.
- [ ] Default `python -m antenna_designer draw --builder fandipole --fn /dev/null` shows no `t0:` / `length` lines.
- [ ] `ANTENNA_DESIGNER_LOG=debug python -m antenna_designer draw --builder fandipole --fn /dev/null` brings them back, prefixed with `DEBUG:antenna_designer.designs.fandipole:`, with no matplotlib DEBUG noise mixed in.
- [ ] Reload the UI, drag a fandipole or freq_based.delta_loop slider, backend log stays quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)