### PR TITLE
fandipole: multi-band UI with per-band link, band-locked sweep, and ParamGroupSpec variants

### DIFF
--- a/src/antenna_designer/designs/fandipole.py
+++ b/src/antenna_designer/designs/fandipole.py
@@ -30,6 +30,14 @@ class Builder(AntennaBuilder):
             # linkMeas toggle.
             "ui_params": MappingProxyType(
                 {
+                    # Anchor the sweep on measFreq and lock it to the
+                    # amateur band containing the anchor — for fandipole
+                    # the user wants the sweep to span exactly the band
+                    # they're currently tuning, not a wide ±5% window.
+                    "sweep_policy": {
+                        "anchor": "meas_freq",
+                        "band_locked": True,
+                    },
                     "length_20": {"link_meas_freq_to_param": "freq_20"},
                     "length_17": {"link_meas_freq_to_param": "freq_17"},
                     "length_15": {"link_meas_freq_to_param": "freq_15"},

--- a/src/antenna_designer/designs/fandipole.py
+++ b/src/antenna_designer/designs/fandipole.py
@@ -23,6 +23,25 @@ class Builder(AntennaBuilder):
             "freq_12": 24.97,
             "freq_10": 28.47,
             "slope": 0.5,
+            # Touching length_NN signals the user is tuning the NN-m
+            # band, so jump the measurement-frequency slider to that
+            # band's freq_NN. The freq_NN sliders self-link so dragging
+            # one updates measFreq in lockstep. Gated by the frontend's
+            # linkMeas toggle.
+            "ui_params": MappingProxyType(
+                {
+                    "length_20": {"link_meas_freq_to_param": "freq_20"},
+                    "length_17": {"link_meas_freq_to_param": "freq_17"},
+                    "length_15": {"link_meas_freq_to_param": "freq_15"},
+                    "length_12": {"link_meas_freq_to_param": "freq_12"},
+                    "length_10": {"link_meas_freq_to_param": "freq_10"},
+                    "freq_20": {"link_meas_freq_to_param": "freq_20"},
+                    "freq_17": {"link_meas_freq_to_param": "freq_17"},
+                    "freq_15": {"link_meas_freq_to_param": "freq_15"},
+                    "freq_12": {"link_meas_freq_to_param": "freq_12"},
+                    "freq_10": {"link_meas_freq_to_param": "freq_10"},
+                }
+            ),
         }
     )
 

--- a/src/antenna_designer/designs/freq_based/fandipole.py
+++ b/src/antenna_designer/designs/freq_based/fandipole.py
@@ -9,49 +9,106 @@ logger = logging.getLogger(__name__)
 
 C_LIGHT_MHZ_M = 299.792458
 
+# Max bands the cone geometry supports — fixes the spoke layout so
+# variants with fewer active bands can still share a single bands tuple
+# of this length (cleaner variant overlay on the frontend).
+_MAX_BANDS = 5
+
+
+# Canonical per-band defaults. Variants pick a subset (n_bands of these
+# slots become the active bands) but always carry a length-5 tuple so
+# selectVariant's wholesale overlay of `bands` keeps the frontend's
+# preallocated group instances aligned with max_repeats.
+_BAND_20M = {"freq": 14.300, "length_factor": 0.4892}
+_BAND_17M = {"freq": 18.1575, "length_factor": 0.4994}
+_BAND_15M = {"freq": 21.383, "length_factor": 0.4984}
+_BAND_12M = {"freq": 24.97, "length_factor": 0.4971}
+_BAND_10M = {"freq": 28.47, "length_factor": 0.5004}
+
 
 class Builder(AntennaBuilder):
     # Each band's element is a half-wave dipole sized to its own band
-    # frequency: half_length = length_factor_NN × (c / freq_NN). The
-    # factor ≈ 0.5 (slight end-effect shortening on the higher bands).
-    # design_freq is here to satisfy the freq_based.* convention — the
-    # adapter wires it into the design-freq UI control — but the
-    # geometry pulls each arm's length from its own freq_NN so the
-    # cone-shared feed remains tuneable per band.
+    # frequency: half_length = length_factor × (c / freq). The factor
+    # ≈ 0.5 (slight end-effect shortening on the higher bands). The
+    # cone-spoke layout is fixed at _MAX_BANDS spokes; n_bands controls
+    # how many of `bands` get realised, so the same Builder backs the
+    # 5-band, 17/15 pair, and 12/10 pair variants.
     default_params = MappingProxyType(
         {
             "design_freq": 14.300,
             "freq": 28.57,
             "base": 7.0,
-            "length_factor_20": 0.4892,
-            "length_factor_17": 0.4994,
-            "length_factor_15": 0.4984,
-            "length_factor_12": 0.4971,
-            "length_factor_10": 0.5004,
-            "freq_20": 14.300,
-            "freq_17": 18.1575,
-            "freq_15": 21.383,
-            "freq_12": 24.97,
-            "freq_10": 28.47,
             "slope": 0.5,
+            "n_bands": _MAX_BANDS,
+            "bands": (_BAND_20M, _BAND_17M, _BAND_15M, _BAND_12M, _BAND_10M),
             "ui_params": MappingProxyType(
                 {
                     "sweep_policy": {
                         "anchor": "meas_freq",
                         "band_locked": True,
                     },
-                    "length_factor_20": {"link_meas_freq_to_param": "freq_20"},
-                    "length_factor_17": {"link_meas_freq_to_param": "freq_17"},
-                    "length_factor_15": {"link_meas_freq_to_param": "freq_15"},
-                    "length_factor_12": {"link_meas_freq_to_param": "freq_12"},
-                    "length_factor_10": {"link_meas_freq_to_param": "freq_10"},
-                    "freq_20": {"link_meas_freq_to_param": "freq_20"},
-                    "freq_17": {"link_meas_freq_to_param": "freq_17"},
-                    "freq_15": {"link_meas_freq_to_param": "freq_15"},
-                    "freq_12": {"link_meas_freq_to_param": "freq_12"},
-                    "freq_10": {"link_meas_freq_to_param": "freq_10"},
+                    # Group config: tuple-of-dicts in default_params
+                    # becomes a ParamGroupSpec in the schema. The dict
+                    # under the same key gives the adapter the group's
+                    # label_template, repeat_count name, max_repeats,
+                    # link_meas_freq_to_param, plus per-leaf override
+                    # hints (precision, range, step).
+                    "bands": {
+                        "label_template": "band {i}",
+                        "repeat_count": "n_bands",
+                        "max_repeats": _MAX_BANDS,
+                        "link_meas_freq_to_param": "freq",
+                        "freq": {
+                            "min": 13.5,
+                            "max": 30.2,
+                            "step": 0.001,
+                            "precision": 3,
+                            "unit": " MHz",
+                        },
+                        "length_factor": {
+                            "min": 0.40,
+                            "max": 0.55,
+                            "step": 0.0005,
+                            "precision": 4,
+                        },
+                    },
+                    "n_bands": {
+                        "min": 1,
+                        "max": _MAX_BANDS,
+                        "step": 1,
+                    },
                 }
             ),
+        }
+    )
+
+    # Explicit alias so the variant selector lists the 5-band
+    # configuration even if the user is already on a pair variant.
+    five_band_params = default_params
+
+    # 17m/15m pair — the two active bands first, remaining slots padded
+    # with the other bands so bumping n_bands back up reveals a sensible
+    # 5-band fall-back instead of empty placeholders.
+    pair_17_15_params = MappingProxyType(
+        {
+            "design_freq": 18.1575,
+            "freq": 21.383,
+            "base": 7.0,
+            "slope": 0.5,
+            "n_bands": 2,
+            "bands": (_BAND_17M, _BAND_15M, _BAND_20M, _BAND_12M, _BAND_10M),
+        }
+    )
+
+    # 12m/10m pair.
+    pair_12_10_params = MappingProxyType(
+        {
+            "design_freq": 24.97,
+            "freq": 28.47,
+            "base": 7.0,
+            "slope": 0.5,
+            "n_bands": 2,
+            "bands": (_BAND_12M, _BAND_10M, _BAND_20M, _BAND_17M, _BAND_15M),
         }
     )
 
@@ -61,12 +118,20 @@ class Builder(AntennaBuilder):
         radius = 0.12
         t0 = radius * math.sqrt(2)
 
-        n = 5
+        n_bands = int(self.n_bands)
+        if not 1 <= n_bands <= _MAX_BANDS:
+            raise ValueError(f"n_bands must be in [1, {_MAX_BANDS}], got {n_bands}")
+        active_bands = tuple(self.bands)[:n_bands]
 
+        # Spoke layout uses the geometric max so individual spokes
+        # always sit at the same azimuth across variants. (Re-laying
+        # out per-n_bands would rotate the antenna under the user
+        # whenever they toggled n_bands.)
+        n = _MAX_BANDS
         lst = [
             (math.cos(math.pi * i / 180), math.sin(math.pi * i / 180))
             for i in range(360 // (2 * n), 360, 360 // n)
-        ]
+        ][:n_bands]
 
         def build_path(lst, ns, ex):
             return ((a, b, ns, ex) for a, b in zip(lst[:-1], lst[1:]))
@@ -95,17 +160,11 @@ class Builder(AntennaBuilder):
             logger.debug("t0: %s dists from C: %s", t0, [dist(C, a) for a in A])
             logger.debug("radius: %s dists from S: %s", radius, [dist(S, a) for a in A])
 
-        # Per-band physical length = length_factor_NN × λ_NN, where
-        # λ_NN = c / freq_NN. Ordered low-to-high freq (20m → 10m) to
-        # match the spoke ordering in `lst`.
-        band_specs = [
-            (self.length_factor_10, self.freq_10),
-            (self.length_factor_12, self.freq_12),
-            (self.length_factor_15, self.freq_15),
-            (self.length_factor_17, self.freq_17),
-            (self.length_factor_20, self.freq_20),
+        # Per-band physical length = length_factor × (c / freq).
+        lengths = [
+            float(b["length_factor"]) * (C_LIGHT_MHZ_M / float(b["freq"]))
+            for b in active_bands
         ]
-        lengths = [factor * (C_LIGHT_MHZ_M / freq) for factor, freq in band_specs]
 
         ls = [(q / 2 - dist(S, a)) for (q, a) in zip(lengths, A)]
 
@@ -114,7 +173,7 @@ class Builder(AntennaBuilder):
         Ay = [ry(p) for p in A]
         By = [ry(p) for p in B]
 
-        for i in range(n):
+        for i in range(n_bands):
             wire_length = dist(S, A[i]) + dist(A[i], B[i])
             logger.debug(
                 "%d length %s %s %s",
@@ -133,7 +192,7 @@ class Builder(AntennaBuilder):
         n_seg1 = 3
 
         tups = []
-        for i in range(n):
+        for i in range(n_bands):
             tups.extend(build_path([S, A[i], B[i]], n_seg0, None))
             tups.extend(build_path([T, Ay[i], By[i]], n_seg0, None))
         tups.append((T, S, n_seg1, 1 + 0j))

--- a/src/antenna_designer/designs/freq_based/fandipole.py
+++ b/src/antenna_designer/designs/freq_based/fandipole.py
@@ -2,47 +2,49 @@ import logging
 import math
 from types import MappingProxyType
 
-from antenna_designer import AntennaBuilder
+from ... import AntennaBuilder
 
 logger = logging.getLogger(__name__)
 
 
+C_LIGHT_MHZ_M = 299.792458
+
+
 class Builder(AntennaBuilder):
+    # Each band's element is a half-wave dipole sized to its own band
+    # frequency: half_length = length_factor_NN × (c / freq_NN). The
+    # factor ≈ 0.5 (slight end-effect shortening on the higher bands).
+    # design_freq is here to satisfy the freq_based.* convention — the
+    # adapter wires it into the design-freq UI control — but the
+    # geometry pulls each arm's length from its own freq_NN so the
+    # cone-shared feed remains tuneable per band.
     default_params = MappingProxyType(
         {
+            "design_freq": 14.300,
             "freq": 28.57,
             "base": 7.0,
-            "length_20": 10.2551,
-            "length_17": 8.2461,
-            "length_15": 6.9880,
-            "length_12": 5.9681,
-            "length_10": 5.2691,
+            "length_factor_20": 0.4892,
+            "length_factor_17": 0.4994,
+            "length_factor_15": 0.4984,
+            "length_factor_12": 0.4971,
+            "length_factor_10": 0.5004,
             "freq_20": 14.300,
             "freq_17": 18.1575,
             "freq_15": 21.383,
             "freq_12": 24.97,
             "freq_10": 28.47,
             "slope": 0.5,
-            # Touching length_NN signals the user is tuning the NN-m
-            # band, so jump the measurement-frequency slider to that
-            # band's freq_NN. The freq_NN sliders self-link so dragging
-            # one updates measFreq in lockstep. Gated by the frontend's
-            # linkMeas toggle.
             "ui_params": MappingProxyType(
                 {
-                    # Anchor the sweep on measFreq and lock it to the
-                    # amateur band containing the anchor — for fandipole
-                    # the user wants the sweep to span exactly the band
-                    # they're currently tuning, not a wide ±5% window.
                     "sweep_policy": {
                         "anchor": "meas_freq",
                         "band_locked": True,
                     },
-                    "length_20": {"link_meas_freq_to_param": "freq_20"},
-                    "length_17": {"link_meas_freq_to_param": "freq_17"},
-                    "length_15": {"link_meas_freq_to_param": "freq_15"},
-                    "length_12": {"link_meas_freq_to_param": "freq_12"},
-                    "length_10": {"link_meas_freq_to_param": "freq_10"},
+                    "length_factor_20": {"link_meas_freq_to_param": "freq_20"},
+                    "length_factor_17": {"link_meas_freq_to_param": "freq_17"},
+                    "length_factor_15": {"link_meas_freq_to_param": "freq_15"},
+                    "length_factor_12": {"link_meas_freq_to_param": "freq_12"},
+                    "length_factor_10": {"link_meas_freq_to_param": "freq_10"},
                     "freq_20": {"link_meas_freq_to_param": "freq_20"},
                     "freq_17": {"link_meas_freq_to_param": "freq_17"},
                     "freq_15": {"link_meas_freq_to_param": "freq_15"},
@@ -93,13 +95,17 @@ class Builder(AntennaBuilder):
             logger.debug("t0: %s dists from C: %s", t0, [dist(C, a) for a in A])
             logger.debug("radius: %s dists from S: %s", radius, [dist(S, a) for a in A])
 
-        lengths = [
-            self.length_10,
-            self.length_12,
-            self.length_15,
-            self.length_17,
-            self.length_20,
+        # Per-band physical length = length_factor_NN × λ_NN, where
+        # λ_NN = c / freq_NN. Ordered low-to-high freq (20m → 10m) to
+        # match the spoke ordering in `lst`.
+        band_specs = [
+            (self.length_factor_10, self.freq_10),
+            (self.length_factor_12, self.freq_12),
+            (self.length_factor_15, self.freq_15),
+            (self.length_factor_17, self.freq_17),
+            (self.length_factor_20, self.freq_20),
         ]
+        lengths = [factor * (C_LIGHT_MHZ_M / freq) for factor, freq in band_specs]
 
         ls = [(q / 2 - dist(S, a)) for (q, a) in zip(lengths, A)]
 
@@ -147,27 +153,3 @@ class Builder(AntennaBuilder):
             )
 
         return new_tups
-
-
-if __name__ == "__main__":
-
-    def tofeet_inches(m):
-        f, i = divmod(m / 0.0254, 12)
-
-        ii, frac16 = divmod(i * 16, 16)
-
-        frac16 = int(frac16 + 0.5)
-
-        g = math.gcd(frac16, 16)
-        factor = 1 / 1.05
-
-        return f"{m * 100:.1f} ({m * 100 * factor + 1:.1f}) ({489.3 + 90 - (m * 100 * factor + 1):.1f}) cm {f:.0f} ft {i:.3f} in ({ii:.0f} {frac16 // g}/{16 // g} in)"
-
-    params = Builder.default_params
-
-    bands = [20, 17, 15, 12, 10]
-    lengths = [f"length_{b}" for b in bands]
-
-    for b in bands:
-        length = f"length_{b}"
-        print(f"Quarter wave element on {b}m: {tofeet_inches(params[length] / 2)}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,7 @@ def test_cli_draw():
         "rawdipole",
         "freq_based.yagi",
         "freq_based.invvee",
-        "fandipole",
+        "freq_based.fandipole",
     ]:
         ant.cli(f"draw --builder {design}{o}".split())
 

--- a/tests/test_fandipole.py
+++ b/tests/test_fandipole.py
@@ -25,7 +25,10 @@ def test_fandipole_sweep_length_20():
     params = dict(Builder.default_params)
     params["freq"] = 14.3
     ant.sweep(
-        Builder(params), "length_factor_20", rng=(10.5, 12), fn="fandipole_sweep_length_20.pdf"
+        Builder(params),
+        "length_factor_20",
+        rng=(10.5, 12),
+        fn="fandipole_sweep_length_20.pdf",
     )
 
 
@@ -70,7 +73,10 @@ def test_fandipole_sweep_length_12():
 
     params["freq"] = 24.97
     ant.sweep(
-        Builder(params), "length_factor_12", rng=(3, 6), fn="fandipole_sweep_length_12.pdf"
+        Builder(params),
+        "length_factor_12",
+        rng=(3, 6),
+        fn="fandipole_sweep_length_12.pdf",
     )
 
 
@@ -91,7 +97,10 @@ def test_fandipole_sweep_length_10():
 
     params["freq"] = 28.57
     ant.sweep(
-        Builder(params), "length_factor_10", rng=(3, 6), fn="fandipole_sweep_length_10.pdf"
+        Builder(params),
+        "length_factor_10",
+        rng=(3, 6),
+        fn="fandipole_sweep_length_10.pdf",
     )
 
 
@@ -107,7 +116,9 @@ def test_fandipole_pattern3d():
 
 @pytest.mark.skip(reason="Takes too long has unstable params")
 def test_fandipole_optimize():
-    params = ant.optimize(Builder(), ["length_factor_10", "length_factor_12"], z0=50, resonance=True)
+    params = ant.optimize(
+        Builder(), ["length_factor_10", "length_factor_12"], z0=50, resonance=True
+    )
     ic(params)
 
     assert all(abs(params[k] - v) < 0.01 for k, v in Builder.default_params.items())

--- a/tests/test_fandipole.py
+++ b/tests/test_fandipole.py
@@ -1,6 +1,6 @@
 import pytest
 import antenna_designer as ant
-from antenna_designer.designs.fandipole import Builder
+from antenna_designer.designs.freq_based.fandipole import Builder
 from icecream import ic
 
 
@@ -25,7 +25,7 @@ def test_fandipole_sweep_length_20():
     params = dict(Builder.default_params)
     params["freq"] = 14.3
     ant.sweep(
-        Builder(params), "length_20", rng=(10.5, 12), fn="fandipole_sweep_length_20.pdf"
+        Builder(params), "length_factor_20", rng=(10.5, 12), fn="fandipole_sweep_length_20.pdf"
     )
 
 
@@ -35,7 +35,7 @@ def test_fandipole_sweep_length17():
     params["freq"] = 18.1575
     ant.sweep(
         Builder(params),
-        "length_17",
+        "length_factor_17",
         rng=(11.3 * 17 / 20 - 1, 11.3 * 17 / 20 + 1),
         fn="fandipole_sweep_length_17.pdf",
     )
@@ -47,7 +47,7 @@ def test_fandipole_sweep_length_15():
     params["freq"] = 21.383
     ant.sweep(
         Builder(params),
-        "length_15",
+        "length_factor_15",
         rng=(11.3 * 15 / 20 - 1, 11.3 * 15 / 20 + 1),
         fn="fandipole_sweep_length_15.pdf",
     )
@@ -60,17 +60,17 @@ def test_fandipole_sweep_length_12():
     params = {
         "base": 7,
         "freq": 28.57,
-        "length_10": 3.550404757728437,
-        "length_12": 4.165365028613822,
-        "length_15": 6.687555534770612,
-        "length_17": 7.875750399295038,
-        "length_20": 10,
+        "length_factor_10": 3.550404757728437,
+        "length_factor_12": 4.165365028613822,
+        "length_factor_15": 6.687555534770612,
+        "length_factor_17": 7.875750399295038,
+        "length_factor_20": 10,
         "slope": 0.604,
     }
 
     params["freq"] = 24.97
     ant.sweep(
-        Builder(params), "length_12", rng=(3, 6), fn="fandipole_sweep_length_12.pdf"
+        Builder(params), "length_factor_12", rng=(3, 6), fn="fandipole_sweep_length_12.pdf"
     )
 
 
@@ -81,17 +81,17 @@ def test_fandipole_sweep_length_10():
     params = {
         "base": 7,
         "freq": 28.57,
-        "length_10": 3.550404757728437,
-        "length_12": 4.165365028613822,
-        "length_15": 6.687555534770612,
-        "length_17": 7.875750399295038,
-        "length_20": 10,
+        "length_factor_10": 3.550404757728437,
+        "length_factor_12": 4.165365028613822,
+        "length_factor_15": 6.687555534770612,
+        "length_factor_17": 7.875750399295038,
+        "length_factor_20": 10,
         "slope": 0.604,
     }
 
     params["freq"] = 28.57
     ant.sweep(
-        Builder(params), "length_10", rng=(3, 6), fn="fandipole_sweep_length_10.pdf"
+        Builder(params), "length_factor_10", rng=(3, 6), fn="fandipole_sweep_length_10.pdf"
     )
 
 
@@ -107,7 +107,7 @@ def test_fandipole_pattern3d():
 
 @pytest.mark.skip(reason="Takes too long has unstable params")
 def test_fandipole_optimize():
-    params = ant.optimize(Builder(), ["length_10", "length_12"], z0=50, resonance=True)
+    params = ant.optimize(Builder(), ["length_factor_10", "length_factor_12"], z0=50, resonance=True)
     ic(params)
 
     assert all(abs(params[k] - v) < 0.01 for k, v in Builder.default_params.items())
@@ -121,11 +121,11 @@ def test_fandipole_seq_optimize():
     gold_params = {
         "base": 7,
         "freq": 28.57,
-        "length_10": 3.550404757728437,
-        "length_12": 4.165365028613822,
-        "length_15": 6.687555534770612,
-        "length_17": 7.875750399295038,
-        "length_20": 10,
+        "length_factor_10": 3.550404757728437,
+        "length_factor_12": 4.165365028613822,
+        "length_factor_15": 6.687555534770612,
+        "length_factor_17": 7.875750399295038,
+        "length_factor_20": 10,
         "slope": 0.604,
     }
 
@@ -136,8 +136,8 @@ def test_fandipole_seq_optimize():
             freq,
             nm,
         ) in (  # (14.3, 'length_20'), (18.1575, 'length_17'), (21.383, 'length_15'),
-            (24.97, "length_12"),
-            (28.57, "length_10"),
+            (24.97, "length_factor_12"),
+            (28.57, "length_factor_10"),
         ):
             params["freq"] = freq
             params = ant.optimize(Builder(params), [nm], z0=50, resonance=False)

--- a/tests/test_fandipole_schema.py
+++ b/tests/test_fandipole_schema.py
@@ -1,24 +1,17 @@
-"""Schema-level checks for fandipole's ui_params.
+"""Schema-level checks for fandipole's ui_params + variants.
 
 Covers the wiring between Builder.default_params['ui_params'] and the
-web adapter's derived ParamSpec / SweepPolicy: the length_factor_NN
-sliders must carry a link_meas_freq_to_param pointing at the matching
-freq_NN, the freq_NN sliders must self-link, and the sweep policy must
-come through anchored on measFreq with band_locked=True.
+web adapter's derived ParamSpec/ParamGroupSpec/SweepPolicy: the bands
+tuple-of-dicts must surface as a repeating group whose freq leaf drives
+measFreq, the sweep policy must arrive anchored on measFreq with
+band_locked=True, and the three intended variants must be discovered
+with the expected n_bands counts.
 """
 
 import web.examples  # noqa: F401  — registers examples; primes the adapter
 from antenna_designer.designs.freq_based.fandipole import Builder
 from web.adapter import _derive_schema, _make_example
-
-
-_BAND_PAIRS = [
-    ("length_factor_20", "freq_20"),
-    ("length_factor_17", "freq_17"),
-    ("length_factor_15", "freq_15"),
-    ("length_factor_12", "freq_12"),
-    ("length_factor_10", "freq_10"),
-]
+from web.examples._base import ParamGroupSpec, ParamSpec
 
 
 def _schema_by_name():
@@ -26,21 +19,39 @@ def _schema_by_name():
     return {s.name: s for s in schema}
 
 
-def test_length_sliders_link_to_matching_freq():
-    specs = _schema_by_name()
-    for length_name, freq_name in _BAND_PAIRS:
-        assert specs[length_name].link_meas_freq_to_param == freq_name
+def test_bands_emerges_as_group():
+    by_name = _schema_by_name()
+    bands = by_name["bands"]
+    assert isinstance(bands, ParamGroupSpec)
+    assert bands.repeat_count == "n_bands"
+    assert bands.max_repeats == 5
+    assert bands.link_meas_freq_to_param == "freq"
+    assert "{i}" in bands.label_template
 
 
-def test_freq_sliders_self_link():
-    specs = _schema_by_name()
-    for _, freq_name in _BAND_PAIRS:
-        assert specs[freq_name].link_meas_freq_to_param == freq_name
+def test_bands_inner_params_are_freq_and_length_factor():
+    bands = _schema_by_name()["bands"]
+    leaf_names = {p.name for p in bands.params}
+    assert leaf_names == {"freq", "length_factor"}
+    for p in bands.params:
+        assert isinstance(p, ParamSpec)
 
 
-def test_unrelated_param_has_no_meas_link():
-    specs = _schema_by_name()
-    assert specs["slope"].link_meas_freq_to_param is None
+def test_bands_default_overrides_seed_five_bands_in_canonical_order():
+    bands = _schema_by_name()["bands"]
+    assert len(bands.default_overrides) == 5
+    freqs = [d["freq"] for d in bands.default_overrides]
+    # 20m → 10m, canonical ordering.
+    assert freqs == [14.300, 18.1575, 21.383, 24.97, 28.47]
+
+
+def test_n_bands_scalar_present_for_repeat_count():
+    by_name = _schema_by_name()
+    n_bands = by_name["n_bands"]
+    assert isinstance(n_bands, ParamSpec)
+    assert n_bands.kind == "int"
+    assert n_bands.max == 5
+    assert n_bands.min == 1
 
 
 def test_sweep_policy_is_band_locked_on_meas_freq():
@@ -49,14 +60,46 @@ def test_sweep_policy_is_band_locked_on_meas_freq():
     assert ex.sweep_policy.band_locked is True
 
 
-def test_bands_cover_each_freq_default():
-    # The band-locked sweep only kicks in when measFreq sits inside a
-    # configured band. Guard against a future refactor that drops the
-    # default HF bands from the fandipole example, which would silently
-    # break the per-band sweep snap.
+def test_variants_cover_five_band_and_pair_variants():
     ex = _make_example("fandipole", Builder)
-    for _, freq_name in _BAND_PAIRS:
-        f = float(Builder.default_params[freq_name])
+    assert set(ex.variants) >= {"default", "five_band", "pair_17_15", "pair_12_10"}
+    assert ex.variant_values["pair_17_15"]["n_bands"] == 2
+    assert ex.variant_values["pair_12_10"]["n_bands"] == 2
+    assert ex.variant_values["five_band"]["n_bands"] == 5
+
+
+def test_pair_variants_keep_full_bands_tuple_for_clean_overlay():
+    # Variants always carry a length-5 bands array so the frontend's
+    # wholesale-overlay variant switch stays aligned with the schema's
+    # max_repeats-preallocated instances; n_bands selects how many
+    # render but the others are available if the user bumps the count.
+    ex = _make_example("fandipole", Builder)
+    for v in ("pair_17_15", "pair_12_10", "five_band"):
+        assert len(ex.variant_values[v]["bands"]) == 5
+
+
+def test_pair_17_15_first_two_active_bands_are_17m_and_15m():
+    ex = _make_example("fandipole", Builder)
+    bands = ex.variant_values["pair_17_15"]["bands"]
+    assert bands[0]["freq"] == 18.1575
+    assert bands[1]["freq"] == 21.383
+
+
+def test_pair_12_10_first_two_active_bands_are_12m_and_10m():
+    ex = _make_example("fandipole", Builder)
+    bands = ex.variant_values["pair_12_10"]["bands"]
+    assert bands[0]["freq"] == 24.97
+    assert bands[1]["freq"] == 28.47
+
+
+def test_bands_cover_each_seeded_freq():
+    # band_locked sweep only kicks in when measFreq sits inside a
+    # configured band. Guard against a future refactor that drops the
+    # default HF bands from the fandipole example.
+    ex = _make_example("fandipole", Builder)
+    bands = _schema_by_name()["bands"]
+    for d in bands.default_overrides:
+        f = float(d["freq"])
         assert any(b.min_mhz <= f <= b.max_mhz for b in ex.bands), (
-            f"{freq_name}={f} falls outside every band in ex.bands"
+            f"freq {f} falls outside every band in ex.bands"
         )

--- a/tests/test_fandipole_schema.py
+++ b/tests/test_fandipole_schema.py
@@ -1,23 +1,23 @@
 """Schema-level checks for fandipole's ui_params.
 
 Covers the wiring between Builder.default_params['ui_params'] and the
-web adapter's derived ParamSpec / SweepPolicy: the length_NN sliders
-must carry a link_meas_freq_to_param pointing at the matching freq_NN,
-the freq_NN sliders must self-link, and the sweep policy must come
-through anchored on measFreq with band_locked=True.
+web adapter's derived ParamSpec / SweepPolicy: the length_factor_NN
+sliders must carry a link_meas_freq_to_param pointing at the matching
+freq_NN, the freq_NN sliders must self-link, and the sweep policy must
+come through anchored on measFreq with band_locked=True.
 """
 
 import web.examples  # noqa: F401  — registers examples; primes the adapter
-from antenna_designer.designs.fandipole import Builder
+from antenna_designer.designs.freq_based.fandipole import Builder
 from web.adapter import _derive_schema, _make_example
 
 
 _BAND_PAIRS = [
-    ("length_20", "freq_20"),
-    ("length_17", "freq_17"),
-    ("length_15", "freq_15"),
-    ("length_12", "freq_12"),
-    ("length_10", "freq_10"),
+    ("length_factor_20", "freq_20"),
+    ("length_factor_17", "freq_17"),
+    ("length_factor_15", "freq_15"),
+    ("length_factor_12", "freq_12"),
+    ("length_factor_10", "freq_10"),
 ]
 
 

--- a/tests/test_fandipole_schema.py
+++ b/tests/test_fandipole_schema.py
@@ -1,0 +1,62 @@
+"""Schema-level checks for fandipole's ui_params.
+
+Covers the wiring between Builder.default_params['ui_params'] and the
+web adapter's derived ParamSpec / SweepPolicy: the length_NN sliders
+must carry a link_meas_freq_to_param pointing at the matching freq_NN,
+the freq_NN sliders must self-link, and the sweep policy must come
+through anchored on measFreq with band_locked=True.
+"""
+
+import web.examples  # noqa: F401  — registers examples; primes the adapter
+from antenna_designer.designs.fandipole import Builder
+from web.adapter import _derive_schema, _make_example
+
+
+_BAND_PAIRS = [
+    ("length_20", "freq_20"),
+    ("length_17", "freq_17"),
+    ("length_15", "freq_15"),
+    ("length_12", "freq_12"),
+    ("length_10", "freq_10"),
+]
+
+
+def _schema_by_name():
+    schema = _derive_schema(Builder.default_params)
+    return {s.name: s for s in schema}
+
+
+def test_length_sliders_link_to_matching_freq():
+    specs = _schema_by_name()
+    for length_name, freq_name in _BAND_PAIRS:
+        assert specs[length_name].link_meas_freq_to_param == freq_name
+
+
+def test_freq_sliders_self_link():
+    specs = _schema_by_name()
+    for _, freq_name in _BAND_PAIRS:
+        assert specs[freq_name].link_meas_freq_to_param == freq_name
+
+
+def test_unrelated_param_has_no_meas_link():
+    specs = _schema_by_name()
+    assert specs["slope"].link_meas_freq_to_param is None
+
+
+def test_sweep_policy_is_band_locked_on_meas_freq():
+    ex = _make_example("fandipole", Builder)
+    assert ex.sweep_policy.anchor == "meas_freq"
+    assert ex.sweep_policy.band_locked is True
+
+
+def test_bands_cover_each_freq_default():
+    # The band-locked sweep only kicks in when measFreq sits inside a
+    # configured band. Guard against a future refactor that drops the
+    # default HF bands from the fandipole example, which would silently
+    # break the per-band sweep snap.
+    ex = _make_example("fandipole", Builder)
+    for _, freq_name in _BAND_PAIRS:
+        f = float(Builder.default_params[freq_name])
+        assert any(b.min_mhz <= f <= b.max_mhz for b in ex.bands), (
+            f"{freq_name}={f} falls outside every band in ex.bands"
+        )

--- a/tests/test_pysim_engine.py
+++ b/tests/test_pysim_engine.py
@@ -255,7 +255,7 @@ def test_translator_handles_hentenna_tee_junctions():
 def test_translator_handles_fandipole_high_degree_junctions():
     """Fandipole has two degree-6 nodes (S, T): feed wire + 5 spokes
     on each side. 5 polylines per side + 1 feed = 11 polylines."""
-    from antenna_designer.designs.fandipole import Builder as F
+    from antenna_designer.designs.freq_based.fandipole import Builder as F
 
     out = flat_wires_to_polylines(F().build_wires())
     assert len(out["polylines"]) == 11
@@ -292,7 +292,7 @@ def test_pysim_sinusoidal_fandipole_runs():
     a plausible value, the multi-wire geometry has too many freedoms
     to set a tight tolerance here."""
     from pysim import SinusoidalPySim
-    from antenna_designer.designs.fandipole import Builder as F
+    from antenna_designer.designs.freq_based.fandipole import Builder as F
 
     z = PysimEngine(F(), solver=SinusoidalPySim).impedance()[0]
     assert 20 < z.real < 200, z

--- a/web/adapter.py
+++ b/web/adapter.py
@@ -44,6 +44,7 @@ from .examples._base import (
     DEFAULT_SWEEP_POLICY,
     AntennaExample,
     BandSpec,
+    ParamGroupSpec,
     ParamSpec,
     SweepPolicy,
 )
@@ -168,7 +169,70 @@ def _auto_paramspec(name: str, default: Any, override: dict | None) -> ParamSpec
     return None
 
 
-def _derive_schema(default_params: dict) -> tuple[ParamSpec, ...]:
+def _group_spec_from_default(
+    name: str,
+    default_value: tuple | list,
+    ui_override: dict,
+    all_default_params: dict,
+) -> ParamGroupSpec | None:
+    """Build a ParamGroupSpec from a tuple/list-of-dicts default value.
+
+    The default value's length seeds default_overrides for the group's
+    instances; the inner ParamSpecs come from auto-deriving each key of
+    the first instance dict (with optional per-leaf overrides supplied
+    under the same ui_override dict, keyed by leaf name).
+
+    `ui_override` is the dict stored under `ui_params[<group_name>]`.
+    Recognised keys: label_template, repeat_count, max_repeats,
+    link_meas_freq_to_param, plus any leaf-name → override-dict pairs.
+    Falls back to sensible defaults when missing.
+    """
+    if not default_value or not all(isinstance(d, dict) for d in default_value):
+        return None
+    template = default_value[0]
+    if not template:
+        return None
+
+    repeat_count = ui_override.get("repeat_count")
+    if repeat_count is None:
+        # Heuristic: prefer n_<name> (n_bands for bands), then n_<singular>.
+        for cand in (f"n_{name}", f"n_{name.rstrip('s')}"):
+            if cand in all_default_params:
+                repeat_count = cand
+                break
+    if not isinstance(repeat_count, str):
+        # No count param → can't render a repeating group.
+        return None
+
+    max_repeats = int(ui_override.get("max_repeats", len(default_value)))
+    label_template = str(ui_override.get("label_template", f"{name} {{i}}"))
+    link = ui_override.get("link_meas_freq_to_param")
+
+    inner_params: list[ParamSpec] = []
+    for leaf_name, leaf_default in template.items():
+        leaf_override = ui_override.get(leaf_name)
+        if leaf_override is None or not isinstance(leaf_override, dict):
+            leaf_override = {}
+        spec = _auto_paramspec(leaf_name, leaf_default, dict(leaf_override))
+        if spec is not None:
+            inner_params.append(spec)
+    if not inner_params:
+        return None
+
+    default_overrides = tuple(dict(d) for d in default_value)
+
+    return ParamGroupSpec(
+        name=name,
+        label_template=label_template,
+        repeat_count=repeat_count,
+        max_repeats=max_repeats,
+        params=tuple(inner_params),
+        default_overrides=default_overrides,
+        link_meas_freq_to_param=str(link) if isinstance(link, str) else None,
+    )
+
+
+def _derive_schema(default_params: dict) -> tuple:
     ui = dict(default_params.get("ui_params") or {})
     specs: list[ParamSpec] = []
     for key, default in default_params.items():
@@ -186,6 +250,24 @@ def _derive_schema(default_params: dict) -> tuple[ParamSpec, ...]:
         # request). Skipping it here too prevents the auto-derived
         # schema slider from duplicating that control.
         if key in ("freq", "design_freq"):
+            continue
+        # Repeating-group default: tuple/list of dicts → ParamGroupSpec.
+        # The ui_params override (if any) carries the group-level
+        # config (label_template, repeat_count, max_repeats,
+        # link_meas_freq_to_param) plus per-leaf override dicts.
+        if (
+            isinstance(default, (tuple, list))
+            and default
+            and all(isinstance(x, dict) for x in default)
+        ):
+            group_override = ui.get(key)
+            if not isinstance(group_override, dict):
+                group_override = {}
+            group_spec = _group_spec_from_default(
+                key, default, group_override, default_params
+            )
+            if group_spec is not None:
+                specs.append(group_spec)
             continue
         override = ui.get(key)
         if override is not None and not isinstance(override, dict):

--- a/web/adapter.py
+++ b/web/adapter.py
@@ -143,6 +143,10 @@ def _auto_paramspec(name: str, default: Any, override: dict | None) -> ParamSpec
             spec_kwargs["linked_to_design_freq"] = bool(
                 override.pop("linked_to_design_freq")
             )
+        if "link_meas_freq_to_param" in override:
+            spec_kwargs["link_meas_freq_to_param"] = str(
+                override.pop("link_meas_freq_to_param")
+            )
         return ParamSpec(**spec_kwargs)
 
     if isinstance(default, str):

--- a/web/adapter.py
+++ b/web/adapter.py
@@ -455,6 +455,17 @@ def _make_example(name: str, cls) -> AntennaExample:
             lo_factor=float(sweep_pol_raw[1]),
             hi_factor=float(sweep_pol_raw[2]),
         )
+    elif isinstance(sweep_pol_raw, dict):
+        # Dict form lets ui_params opt into named fields (band_locked,
+        # ...) without having to supply every positional. Anchor +
+        # factors fall back to the dataclass defaults when absent.
+        defaults = DEFAULT_SWEEP_POLICY
+        sweep_policy = SweepPolicy(
+            anchor=str(sweep_pol_raw.get("anchor", defaults.anchor)),
+            lo_factor=float(sweep_pol_raw.get("lo_factor", defaults.lo_factor)),
+            hi_factor=float(sweep_pol_raw.get("hi_factor", defaults.hi_factor)),
+            band_locked=bool(sweep_pol_raw.get("band_locked", defaults.band_locked)),
+        )
     else:
         sweep_policy = DEFAULT_SWEEP_POLICY
 

--- a/web/examples/_base.py
+++ b/web/examples/_base.py
@@ -82,6 +82,16 @@ class ParamSpec:
     global designFreq state on the frontend. Fan_dipole uses it on
     `bands[0].freq` so the first band's frequency stays the antenna's
     design frequency without a separate global slider.
+
+    `link_meas_freq_to_param` is the flat-schema sibling of
+    ParamGroupSpec.link_meas_freq_to_param: when this scalar slider
+    moves, push the current value of the named sibling param into the
+    global measFreq state (gated by the frontend's linkMeas toggle).
+    Used by multi-band antennas with parallel `length_NN` / `freq_NN`
+    params so dragging length_20 jumps the measurement-freq slider to
+    the 20m band's freq. A self-reference (param links to itself, e.g.
+    freq_20 → freq_20) is the natural way to mark "this slider's own
+    value is a measurement-frequency anchor".
     """
 
     name: str
@@ -98,6 +108,7 @@ class ParamSpec:
     range_from_enum_option: Optional[dict] = None
     on_change_set: Optional[dict] = None
     linked_to_design_freq: bool = False
+    link_meas_freq_to_param: Optional[str] = None
     sweepable: bool = False
 
 

--- a/web/examples/_base.py
+++ b/web/examples/_base.py
@@ -203,6 +203,14 @@ class SweepPolicy:
     anchor: str = "design_freq"  # "design_freq" | "meas_freq"
     lo_factor: float = 0.8
     hi_factor: float = 1.25
+    # When True, the frontend snaps the sweep range to the [min_mhz,
+    # max_mhz] of the band whose range contains the current anchor
+    # frequency (typically measFreq for multi-band antennas). Falls
+    # back to lo_factor/hi_factor multiplicatively if the anchor sits
+    # outside every band. Used by fandipole so the sweep trace stays
+    # inside the amateur band the user is currently tuning instead of
+    # bleeding into the adjacent bands.
+    band_locked: bool = False
 
 
 DEFAULT_SWEEP_POLICY = SweepPolicy()

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -37,6 +37,11 @@ type SchemaParamSpec = {
   range_from_enum_option?: { param: string; min_key: string; max_key: string } | null;
   on_change_set?: { set: string; from_enum_key: string } | null;
   linked_to_design_freq?: boolean;
+  // Flat-schema sibling of the group-level link: when this scalar
+  // changes, push the current value of the named sibling param into
+  // measFreq. Self-reference is allowed (and used by freq_NN params
+  // in multi-band antennas).
+  link_meas_freq_to_param?: string | null;
 };
 
 type SchemaParamGroupSpec = {
@@ -948,28 +953,51 @@ export function App() {
       obj[head] = setIn(obj[head], rest);
       return obj;
     };
-    let newRoot: ParamValueBag | null = null;
-    setParamValues((prev) => {
-      newRoot = setIn(prev[geometry] ?? {}, path) as ParamValueBag;
-      return { ...prev, [geometry]: newRoot };
-    });
+    // Compute the new geometry bag eagerly (outside the setter) so the
+    // meas-freq follow logic below can read newRoot reliably. React's
+    // useState eager-bailout optimization runs the updater synchronously
+    // only when no updates are queued; rapid slider drags batch
+    // multiple updates, so a `newRoot` captured inside the updater
+    // closure is null on the fast path — which manifests as the linked
+    // measFreq snap working on slow drags but not on fast ones.
+    const newRoot = setIn(paramValues[geometry] ?? {}, path) as ParamValueBag;
+    setParamValues((prev) => ({
+      ...prev,
+      [geometry]: setIn(prev[geometry] ?? {}, path) as ParamValueBag,
+    }));
 
-    // Schema-driven meas-freq follow: if the change touched a leaf
-    // inside a group instance, and that group declares
-    // `link_meas_freq_to_param`, push the instance's value of that
-    // sibling param into measFreq. Lets multi-band antennas track
-    // whichever band the user is currently tuning when linkMeas is on.
-    if (!linkMeas || newRoot == null || path.length < 3) return;
+    // Schema-driven meas-freq follow. Two variants:
+    //   * group leaf: `path = [groupName, instanceIdx, leafName]` and
+    //     the group declares `link_meas_freq_to_param` — push that
+    //     instance's value of the named sibling into measFreq.
+    //   * flat scalar: `path = [paramName]` and the ParamSpec declares
+    //     `link_meas_freq_to_param` — push the current value of the
+    //     named sibling (possibly itself) into measFreq. Used by
+    //     multi-band antennas with parallel length_NN / freq_NN flat
+    //     sliders (antenna_designer's fandipole).
+    if (!linkMeas) return;
+    const ex = currentExample;
+    if (!ex) return;
+    if (path.length === 1 && typeof path[0] === "string") {
+      const paramName = path[0];
+      const spec = ex.param_schema.find(
+        (s) => !isGroup(s) && s.name === paramName,
+      ) as SchemaParamSpec | undefined;
+      const linked = spec?.link_meas_freq_to_param;
+      if (!linked) return;
+      const freqValue = newRoot[linked];
+      if (typeof freqValue === "number") setMeasFreq(freqValue);
+      return;
+    }
+    if (path.length < 3) return;
     const groupName = path[0];
     const instanceIdx = path[1];
     if (typeof groupName !== "string" || typeof instanceIdx !== "number") return;
-    const ex = currentExample;
-    if (!ex) return;
     const group = ex.param_schema.find(
       (s) => isGroup(s) && s.name === groupName,
     ) as SchemaParamGroupSpec | undefined;
     if (!group || !group.link_meas_freq_to_param) return;
-    const instances = (newRoot as ParamValueBag)[groupName];
+    const instances = newRoot[groupName];
     if (!Array.isArray(instances)) return;
     const inst = instances[instanceIdx];
     if (!inst) return;

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -83,6 +83,7 @@ type SweepPolicy = {
   anchor: "design_freq" | "meas_freq";
   lo_factor: number;
   hi_factor: number;
+  band_locked?: boolean;
 };
 
 type BandSpec = {
@@ -1402,8 +1403,25 @@ export function App() {
     const N = slowGround ? 21 : 41;
     const policy = currentExample?.sweep_policy;
     const sweepAnchor = policy?.anchor === "meas_freq" ? measFreq : designFreq;
-    const fLo = Math.max(0.5, sweepAnchor * (policy?.lo_factor ?? 0.8));
-    const fHi = Math.min(60, sweepAnchor * (policy?.hi_factor ?? 1.25));
+    // Band-locked sweep: when the active band contains the anchor,
+    // snap the sweep range to that band's [min_mhz, max_mhz] so the
+    // trace stays inside the band the user is tuning instead of
+    // bleeding into adjacent ones. Falls through to the multiplicative
+    // window if the anchor sits outside every band.
+    let fLo: number;
+    let fHi: number;
+    const bandLocked = policy?.band_locked
+      ? currentBands.find(
+          (b) => sweepAnchor >= b.min_mhz && sweepAnchor <= b.max_mhz,
+        )
+      : undefined;
+    if (bandLocked) {
+      fLo = bandLocked.min_mhz;
+      fHi = bandLocked.max_mhz;
+    } else {
+      fLo = Math.max(0.5, sweepAnchor * (policy?.lo_factor ?? 0.8));
+      fHi = Math.min(60, sweepAnchor * (policy?.hi_factor ?? 1.25));
+    }
     const freqs = Array.from({ length: N }, (_, i) =>
       Math.exp(Math.log(fLo) + (i / (N - 1)) * (Math.log(fHi) - Math.log(fLo))),
     );

--- a/web/server.py
+++ b/web/server.py
@@ -701,6 +701,7 @@ def examples_endpoint():
             "range_from_enum_option": item.range_from_enum_option,
             "on_change_set": item.on_change_set,
             "linked_to_design_freq": item.linked_to_design_freq,
+            "link_meas_freq_to_param": item.link_meas_freq_to_param,
         }
 
     out = []

--- a/web/server.py
+++ b/web/server.py
@@ -762,6 +762,7 @@ def examples_endpoint():
                     "anchor": ex.sweep_policy.anchor,
                     "lo_factor": ex.sweep_policy.lo_factor,
                     "hi_factor": ex.sweep_policy.hi_factor,
+                    "band_locked": ex.sweep_policy.band_locked,
                 },
             }
         )


### PR DESCRIPTION
## Summary

- Adds a flat-schema `ParamSpec.link_meas_freq_to_param` so a scalar slider can declare which sibling drives measFreq on every change (gated by linkMeas). Threads it through the adapter, server serializer, and frontend handler — with a React eager-bailout fix so the snap fires on fast slider drags, not just slow ones.
- Adds `SweepPolicy.band_locked`: when set, the frontend snaps the sweep range to the [min_mhz, max_mhz] of the band whose range contains the sweep anchor, falling back to the multiplicative window when outside any band. `ui_params['sweep_policy']` now accepts a dict form so antennas opt in without restating positionals.
- Moves fandipole into `designs/freq_based/` and reparameterizes each band element on `length_factor × (c / freq)` (half-wave dipole anchored to its own band frequency).
- Migrates fandipole's flat per-band sliders to a single `bands` `ParamGroupSpec` (tuple-of-dicts default → group with `default_overrides`) gated by an `n_bands` int. Adds three variants: `default`/`five_band`, `pair_17_15`, `pair_12_10`. All variants carry the full 5-entry bands tuple so bumping n_bands after a variant switch reveals sensible fallback bands.

## Test plan

- [x] `pytest tests/` — 93 pass, 24 skipped (no new skips).
- [x] `tsc --noEmit` on `web/frontend/` — clean.
- [x] New `tests/test_fandipole_schema.py` covers the group shape, inner spec identities, default-override ordering, n_bands bounds, sweep policy, and the three variants' n_bands + first-active-band freqs.
- [ ] Manual: launch the dev server, switch between fandipole variants, drag length_factor / freq sliders within a band, confirm measFreq snaps to that band's freq and the sweep trace stays inside [min, max] of the active amateur band.
- [ ] Manual: bump n_bands on a pair variant, confirm fallback bands render with sensible defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)