### PR TITLE
tests: /ws websocket endpoint coverage via TestClient

### DIFF
--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -412,6 +412,62 @@ def test_pattern_endpoint_pysim_returns_unavailable(client: TestClient):
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# /ws — websocket endpoint. TestClient.websocket_connect gives a synchronous
+# context manager around the live route.
+# ---------------------------------------------------------------------------
+
+
+def test_ws_endpoint_round_trips_a_solve(client: TestClient):
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(
+            __import__("json").dumps(
+                {
+                    "geometry": "dipole",
+                    "measurement_freq_mhz": 14.0,
+                    "pysim_model": "triangular",
+                }
+            )
+        )
+        result = __import__("json").loads(ws.receive_text())
+    assert result["solver"] == "pysim"
+    assert result["geometry"] == "dipole"
+    assert "wires" in result
+    assert result["z_in_re"] > 0
+
+
+def test_ws_endpoint_handles_multiple_requests_on_one_socket(client: TestClient):
+    # The endpoint's outer `while True` loop must keep serving once the
+    # first solve returns; the React frontend reuses the same socket
+    # for every slider drag.
+    req = __import__("json").dumps(
+        {
+            "geometry": "dipole",
+            "measurement_freq_mhz": 14.0,
+            "pysim_model": "triangular",
+        }
+    )
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(req)
+        first = __import__("json").loads(ws.receive_text())
+        ws.send_text(req)
+        second = __import__("json").loads(ws.receive_text())
+    assert first["geometry"] == "dipole"
+    assert second["geometry"] == "dipole"
+    # Same request → deterministic same z_in.
+    assert first["z_in_re"] == pytest.approx(second["z_in_re"])
+    assert first["z_in_im"] == pytest.approx(second["z_in_im"])
+
+
+def test_ws_endpoint_returns_cleanly_on_client_disconnect(client: TestClient):
+    # Opening + closing the socket without sending anything has to hit
+    # the outer WebSocketDisconnect path (receive_text raises). The
+    # endpoint must catch it cleanly — no exception leaking out of the
+    # context manager.
+    with client.websocket_connect("/ws"):
+        pass  # context exit closes the socket
+
+
 def test_solve_z_only_returns_primary_z_and_no_feeds_for_dipole():
     z, feeds_z = server._solve_z_only(
         {

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -413,6 +413,108 @@ def test_pattern_endpoint_pysim_returns_unavailable(client: TestClient):
 
 
 # ---------------------------------------------------------------------------
+# PyNEC paths — same endpoints, solver="pynec" branch. Each test runs one
+# real NEC solve on dipole; sub-second on the CI box.
+# ---------------------------------------------------------------------------
+
+
+# Skip the whole PyNEC-path section when PyNEC didn't build (it's a hard
+# dep on CI, but local devs without swig+gfortran shouldn't see a hard
+# failure). pynec_backend.HAVE_PYNEC is the same flag the dispatcher uses.
+pynec_required = pytest.mark.skipif(
+    not __import__("web.pynec_backend", fromlist=["HAVE_PYNEC"]).HAVE_PYNEC,
+    reason="PyNEC not built in this environment",
+)
+
+
+@pynec_required
+def test_solve_dispatches_to_pynec_when_requested():
+    out = server.solve(
+        {
+            "geometry": "dipole",
+            "solver": "pynec",
+            "measurement_freq_mhz": 14.0,
+        }
+    )
+    assert out["geometry"] == "dipole"
+    assert "wires" in out
+    # _attach_derived_em_fields + _compute_directivity_norm wrap both
+    # solver branches; their outputs must show up regardless of which
+    # backend ran.
+    assert out["k_meas_m_inv"] > 0
+    assert out["directivity_norm"] > 0
+    # Real dipole at 14 MHz: real Z roughly order 73 Ω; very loose bound
+    # so a future PyNEC version bump doesn't trip the test.
+    assert 10 < out["z_in_re"] < 500
+
+
+@pynec_required
+def test_sweep_endpoint_with_pynec_streams_per_point(client: TestClient):
+    freqs = [13.8, 14.0, 14.2]
+    r = client.post(
+        "/sweep",
+        json={
+            "geometry": "dipole",
+            "solver": "pynec",
+            "freqs_mhz": freqs,
+            "measurement_freq_mhz": 14.0,
+        },
+    )
+    assert r.status_code == 200
+    recs = _ndjson_records(r.text)
+    assert len(recs) == len(freqs) + 1
+    *points, terminator = recs
+    assert terminator == {"done": True, "solver": "pynec"}
+    for f, rec in zip(freqs, points):
+        assert rec["freq_mhz"] == f
+        assert rec["solver"] == "pynec"
+        assert isinstance(rec["z_re"], float) and isinstance(rec["z_im"], float)
+
+
+@pynec_required
+def test_pattern_endpoint_with_pynec_returns_full_grid(client: TestClient):
+    # /pattern routes through pynec_backend.pattern → rp_card → gain
+    # extraction. Asserts the grid shape the frontend reads (46 thetas
+    # × 73 phis) is what comes back, and that all gains are finite
+    # (NaN/Inf would imply a botched ex_card or fr_card sequence).
+    r = client.post(
+        "/pattern",
+        json={
+            "geometry": "dipole",
+            "solver": "pynec",
+            "measurement_freq_mhz": 14.0,
+        },
+    )
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload["available"] is True
+    assert payload["geometry"] == "dipole"
+    assert len(payload["theta_deg"]) == 46
+    assert len(payload["phi_deg"]) == 73
+    assert len(payload["gain_dbi"]) == 46
+    assert len(payload["gain_dbi"][0]) == 73
+    # NEC reports -999.99 dBi at radiation nulls as a sentinel — filter
+    # those before bounds-checking. Anything outside (-200, 30) on the
+    # non-null cells implies a malformed solve, not a real antenna.
+    flat = [g for row in payload["gain_dbi"] for g in row]
+    real_gains = [g for g in flat if g > -900]
+    assert real_gains, "NEC returned no non-null gain cells"
+    assert all(-200 < g < 30 for g in real_gains)
+    # Peak gain for a half-wave dipole is ~2.15 dBi (in free space).
+    # Loose ceiling guards against accidental dBW vs dBi mixups.
+    assert max(real_gains) < 10
+
+
+@pynec_required
+def test_sweep_endpoint_pynec_empty_freqs_returns_only_done(client: TestClient):
+    r = client.post(
+        "/sweep", json={"geometry": "dipole", "solver": "pynec", "freqs_mhz": []}
+    )
+    recs = _ndjson_records(r.text)
+    assert recs == [{"done": True, "solver": "pynec"}]
+
+
+# ---------------------------------------------------------------------------
 # /ws — websocket endpoint. TestClient.websocket_connect gives a synchronous
 # context manager around the live route.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Three TestClient-driven tests for the \`/ws\` route:

- **Round-trip**: send a solve request, receive the response, assert dipole geometry + solver/wires/z_in_re fields match what \`/solve\` returns over HTTP.
- **Multi-request**: re-using one socket across two solves stays consistent with the React frontend's pattern of reusing one socket across every slider drag.
- **Clean disconnect**: opening then closing without sending exercises the outer \`WebSocketDisconnect\` path.

## Coverage
\`web/server.py\`: **83% → 87%**.

The remaining gaps in \`ws_endpoint\` (state-check + send_text exception branches at lines 732/735–736) are disconnect races that would need an injected solve delay to exercise deterministically — not worth chasing for two return statements.

## Test plan
- [x] \`pytest tests/test_web_server.py -k ws_endpoint\` — 3 passed, slowest 0.07s
- [x] \`pytest tests/\` — 534 passed
- [x] \`ruff check .\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)