### PR TITLE
Raw-string ASCII-art docstrings to silence SyntaxWarning

### DIFF
--- a/src/antenna_designer/designs/freq_based/delta_loop.py
+++ b/src/antenna_designer/designs/freq_based/delta_loop.py
@@ -64,7 +64,7 @@ class Builder(AntennaBuilder):
         d = driver
         h = (cos_theta * (d - 2 * eps) + 2 * eps) / (2 * (cos_theta + 1))
 
-        """
+        r"""
          B-----------------A
           \         theta /
            \             /

--- a/src/antenna_designer/designs/freq_based/delta_loop_slanted.py
+++ b/src/antenna_designer/designs/freq_based/delta_loop_slanted.py
@@ -63,7 +63,7 @@ class Builder(AntennaBuilder):
         d = driver
         h = (cos_theta * (d - 2 * eps) + 2 * eps) / (2 * (cos_theta + 1))
 
-        """
+        r"""
          B-----------------A
           \         theta /
            \             /

--- a/src/antenna_designer/designs/freq_based/delta_looparray_with_tls.py
+++ b/src/antenna_designer/designs/freq_based/delta_looparray_with_tls.py
@@ -46,7 +46,7 @@ class Builder(AntennaBuilder):
         d = driver
         h = (cos_theta * (d - 2 * eps) + 2 * eps) / (2 * (cos_theta + 1))
 
-        """
+        r"""
          B-----------------A
           \         theta /
            \             /

--- a/src/antenna_designer/designs/freq_based/diamond_loop.py
+++ b/src/antenna_designer/designs/freq_based/diamond_loop.py
@@ -58,7 +58,7 @@ class Builder(AntennaBuilder):
         d = driver
         h = d * cos_theta / 4 - eps * cos_theta / 2 + eps / 2
 
-        """
+        r"""
                   B 
                  / \
                 /   \

--- a/src/antenna_designer/designs/freq_based/diamond_loop_turnstile.py
+++ b/src/antenna_designer/designs/freq_based/diamond_loop_turnstile.py
@@ -41,7 +41,7 @@ class Builder(AntennaBuilder):
         d = driver
         h = d * cos_theta / 4 - eps * cos_theta / 2 + eps / 2
 
-        """
+        r"""
                   B 
                  / \
                 /   \

--- a/src/antenna_designer/designs/freq_based/hourglass.py
+++ b/src/antenna_designer/designs/freq_based/hourglass.py
@@ -33,7 +33,7 @@ class Builder(AntennaBuilder):
         n_seg0 = self.nominal_nsegs
         n_seg1 = max(3, self.nominal_nsegs // 7)
 
-        """
+        r"""
  C----------------------------A
   \                          /
    \                        /

--- a/src/antenna_designer/designs/freq_based/hourglass_slant.py
+++ b/src/antenna_designer/designs/freq_based/hourglass_slant.py
@@ -40,7 +40,7 @@ class Builder(AntennaBuilder):
         n_seg0 = self.nominal_nsegs
         n_seg1 = max(3, self.nominal_nsegs // 7)
 
-        """
+        r"""
     Add an invvee like slant, 0 degrees is horizontal
 
  C-------------AA-------------A


### PR DESCRIPTION
## Summary
- Seven design docstrings draw geometry with backslashes (e.g. `\         theta /`) inside regular strings. Python 3.12+ flags `\ ` as an invalid escape and 3.14 keeps warning that these will become syntax errors.
- Prefix each opening triple-quote with `r` so the backslashes are literal. The rendered docstring is identical.

## Test plan
- [ ] `python -W error::SyntaxWarning -c "import antenna_designer.designs"` — no warnings
- [ ] `pytest tests/` — still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)