### PR TITLE
Port hexbeam_5band, opt variants, and nested-path CLI for tuning

### DIFF
--- a/scripts/tune_hexbeam_5band_band.py
+++ b/scripts/tune_hexbeam_5band_band.py
@@ -1,0 +1,121 @@
+"""Tune one band's shape factors to Z = z0 + 0j on PyNEC.
+
+Default target is 50+0j and the default knobs are halfdriver_factor +
+t0_factor — two degrees of freedom for a 2-D target (resistance and
+reactance). Add --resonance to fall back to |Im(Z)|-only (one knob is
+enough for that).
+
+Usage:
+    .venv/bin/python scripts/tune_hexbeam_5band_band.py --band 0
+    .venv/bin/python scripts/tune_hexbeam_5band_band.py --band 2 \\
+        --param halfdriver_factor tipspacer_factor --z0 50
+
+Sets n_bands=1 and slices `bands` to the single requested band so the
+solver computes one impedance per call. Prints the optimised factor(s)
+so you can paste them back into _BAND_xx in the design file.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from scipy.optimize import minimize
+
+from antenna_designer.designs.freq_based.hexbeam_5band import Builder
+from antenna_designer.engines.pynec import PyNECEngine
+
+
+def tune(
+    band_idx: int,
+    param_names: list[str],
+    freq_mhz: float | None,
+    z0: float,
+    resonance_only: bool,
+) -> dict:
+    b = Builder()
+    full_bands = tuple(b.bands)
+    band = dict(full_bands[band_idx])
+    if freq_mhz is not None:
+        band["freq"] = freq_mhz
+
+    # Strip the multi-band setup down to just the band we're tuning.
+    b.n_bands = 1
+    b.bands = (band,)
+    b.freq = band["freq"]
+    b.design_freq = band["freq"]
+
+    x0 = [band[p] for p in param_names]
+    bounds = [(x * 0.7, x * 1.3) for x in x0]
+
+    def objective(xs):
+        new_band = dict(band)
+        for name, x in zip(param_names, xs):
+            new_band[name] = float(x)
+        b.bands = (new_band,)
+        eng = PyNECEngine(b, ground=None)
+        (z,) = eng.impedance()
+        del eng
+        # Resonance mode targets just |Im(Z)| (one DOF is enough).
+        # Default targets Z = z0 + 0j — two DOFs needed; |z - z0|
+        # naturally weights resistance and reactance equally in Ω.
+        loss = abs(z.imag) if resonance_only else abs(z - z0)
+        print(
+            f"  {dict(zip(param_names, xs))} → "
+            f"Z=({z.real:.2f} {z.imag:+.2f}j) Ω  loss={loss:.3f}"
+        )
+        return loss
+
+    target = f"Z = {z0:.1f} + 0j Ω" if not resonance_only else "Im(Z) = 0"
+    print(
+        f"Tuning band {band_idx} at {band['freq']:.3f} MHz on knobs {param_names} → {target}"
+    )
+    if not resonance_only and len(param_names) < 2:
+        print(
+            "  WARNING: hitting both R and X needs two DOFs — "
+            "consider --param halfdriver_factor t0_factor"
+        )
+    result = minimize(
+        objective,
+        x0=x0,
+        method="Powell",
+        bounds=bounds,
+        options={"maxiter": 100, "xtol": 1e-4, "disp": True},
+    )
+    final = {name: float(x) for name, x in zip(param_names, result.x)}
+    print(f"\nOptimised: {final}")
+    return final
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--band", type=int, required=True, help="Band index 0..4")
+    ap.add_argument(
+        "--param",
+        nargs="+",
+        default=["halfdriver_factor", "t0_factor"],
+        help="Per-band knobs to tune (default: halfdriver_factor t0_factor — "
+        "two DOFs for matching Z = z0 + 0j)",
+    )
+    ap.add_argument(
+        "--freq",
+        type=float,
+        default=None,
+        help="Override the band's freq (MHz) before tuning",
+    )
+    ap.add_argument(
+        "--z0",
+        type=float,
+        default=50.0,
+        help="Target resistance in Ω (default: 50)",
+    )
+    ap.add_argument(
+        "--resonance",
+        action="store_true",
+        help="Optimise |Im(Z)| only, ignore resistance — one knob is enough",
+    )
+    args = ap.parse_args()
+    tune(args.band, args.param, args.freq, args.z0, args.resonance)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tune_hexbeam_5band_coupled.py
+++ b/scripts/tune_hexbeam_5band_coupled.py
@@ -1,0 +1,162 @@
+"""Coupled multi-band hexbeam_5band tuner.
+
+Unlike scripts/tune_hexbeam_5band_band.py — which slices `bands` down
+to a single entry and tunes in isolation — this script keeps all five
+bands active throughout and tunes one band's shape factors at a time,
+sweeping band-by-band for several passes until each band's driving-
+point Z lands close to z0 + 0j.
+
+Algorithm:
+  1. Start from opt_params (the single-band-tuned starting point).
+  2. For each pass, walk bands 0..4 in order. For each band:
+       - Set meas_freq to that band's freq.
+       - Minimise |Z[band_idx] - z0| over (halfdriver_factor, t0_factor)
+         of *that band only*, with the other four bands fixed at their
+         current values. Z[band_idx] is the band's driving-point Z in
+         the 5-port multi-feed solve, so the optimiser sees the actual
+         inter-band coupling.
+       - Update bands[band_idx] in place; the next band's tune sees
+         the updated geometry.
+  3. After each pass, log max|Z - z0|. Stop when it drops below tol or
+     we hit max_passes.
+  4. Print the final bands tuple as paste-ready Python.
+
+Usage:
+    .venv/bin/python scripts/tune_hexbeam_5band_coupled.py
+    .venv/bin/python scripts/tune_hexbeam_5band_coupled.py --passes 8 --tol 0.3
+
+Tune at PyNEC, free space. ~5 PyNEC solves per Powell step × ~40 steps
+per band × 5 bands × N passes — expect ~1–3 minutes per pass.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from scipy.optimize import minimize
+
+from antenna_designer.designs.freq_based.hexbeam_5band import Builder
+from antenna_designer.engines.pynec import PyNECEngine
+
+
+def _solve_all(b: Builder) -> list[complex]:
+    eng = PyNECEngine(b, ground=None)
+    zs = eng.impedance()
+    del eng
+    return zs
+
+
+def _max_distance_from_target(zs: list[complex], z0: float) -> float:
+    return max(abs(z - z0) for z in zs)
+
+
+def tune_band_in_place(
+    b: Builder,
+    band_idx: int,
+    param_names: list[str],
+    z0: float,
+    verbose: bool,
+) -> None:
+    """Mutate b.bands[band_idx] toward Z[band_idx] = z0 + 0j with the
+    other bands held at their current values. Uses Powell within a
+    ±30% bound on each knob."""
+    cur_bands = [dict(bd) for bd in b.bands]
+    band = cur_bands[band_idx]
+    x0 = [band[p] for p in param_names]
+    bounds = [(x * 0.7, x * 1.3) for x in x0]
+    b.freq = float(band["freq"])
+
+    def objective(xs):
+        for name, x in zip(param_names, xs):
+            band[name] = float(x)
+        cur_bands[band_idx] = band
+        b.bands = tuple(cur_bands)
+        zs = _solve_all(b)
+        z = zs[band_idx]
+        loss = abs(z - z0)
+        if verbose:
+            kvs = ", ".join(f"{n}={x:.5f}" for n, x in zip(param_names, xs))
+            print(
+                f"    [band {band_idx}] {kvs} → "
+                f"Z={z.real:7.3f}{z.imag:+7.3f}j  loss={loss:6.3f}"
+            )
+        return loss
+
+    minimize(
+        objective,
+        x0=x0,
+        method="Powell",
+        bounds=bounds,
+        options={"maxiter": 60, "xtol": 1e-4, "disp": False},
+    )
+
+
+def run(passes: int, tol: float, z0: float, param_names: list[str], verbose: bool):
+    b = Builder(params=dict(Builder.opt_params))
+    n_bands = int(b.n_bands)
+    print(f"Starting from opt_params; tuning {n_bands} bands → Z = {z0:.1f} + 0j Ω")
+
+    initial_zs = []
+    for i in range(n_bands):
+        b.freq = float(b.bands[i]["freq"])
+        initial_zs.append(_solve_all(b)[i])
+    print("Initial driving-point Z (all bands present, opt_params):")
+    for i, z in enumerate(initial_zs):
+        print(
+            f"  band {i} @ {b.bands[i]['freq']:>7.3f} MHz: "
+            f"Z = {z.real:6.2f}{z.imag:+6.2f}j Ω"
+        )
+
+    for pass_idx in range(passes):
+        print(f"\n--- pass {pass_idx + 1}/{passes} ---")
+        for band_idx in range(n_bands):
+            tune_band_in_place(b, band_idx, param_names, z0, verbose)
+
+        zs = []
+        for i in range(n_bands):
+            b.freq = float(b.bands[i]["freq"])
+            zs.append(_solve_all(b)[i])
+        print("After pass driving-point Z:")
+        for i, z in enumerate(zs):
+            print(
+                f"  band {i} @ {b.bands[i]['freq']:>7.3f} MHz: "
+                f"Z = {z.real:6.2f}{z.imag:+6.2f}j Ω"
+            )
+        worst = _max_distance_from_target(zs, z0)
+        print(f"worst |Z - z0|: {worst:.3f} Ω")
+        if worst < tol:
+            print(f"converged: worst |Z - z0| < tol ({tol})")
+            break
+
+    print("\n# Paste into hexbeam_5band.py as opt2_params or replace opt_params:")
+    print("(")
+    for bd in b.bands:
+        print(
+            "    {{"
+            f'"freq": {bd["freq"]}, '
+            f'"halfdriver_factor": {bd["halfdriver_factor"]:.5f}, '
+            f'"tipspacer_factor": {bd["tipspacer_factor"]}, '
+            f't0_factor": {bd["t0_factor"]:.5f}'
+            "}},"
+        )
+    print(")")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--passes", type=int, default=4, help="Max band-cycle passes")
+    ap.add_argument("--tol", type=float, default=0.5, help="Stop when worst |Z-z0| < tol")
+    ap.add_argument("--z0", type=float, default=50.0)
+    ap.add_argument(
+        "--param",
+        nargs="+",
+        default=["halfdriver_factor", "t0_factor"],
+        help="Per-band knobs to tune",
+    )
+    ap.add_argument("--quiet", action="store_true", help="Suppress per-step output")
+    args = ap.parse_args()
+    run(args.passes, args.tol, args.z0, args.param, not args.quiet)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tune_hexbeam_5band_coupled.py
+++ b/scripts/tune_hexbeam_5band_coupled.py
@@ -128,16 +128,16 @@ def run(passes: int, tol: float, z0: float, param_names: list[str], verbose: boo
             print(f"converged: worst |Z - z0| < tol ({tol})")
             break
 
-    print("\n# Paste into hexbeam_5band.py as opt2_params or replace opt_params:")
+    print("\n# Paste into hexbeam_5band.py:")
     print("(")
     for bd in b.bands:
         print(
-            "    {{"
+            "    {"
             f'"freq": {bd["freq"]}, '
             f'"halfdriver_factor": {bd["halfdriver_factor"]:.5f}, '
             f'"tipspacer_factor": {bd["tipspacer_factor"]}, '
-            f't0_factor": {bd["t0_factor"]:.5f}'
-            "}},"
+            f'"t0_factor": {bd["t0_factor"]:.5f}'
+            "},"
         )
     print(")")
 
@@ -145,7 +145,9 @@ def run(passes: int, tol: float, z0: float, param_names: list[str], verbose: boo
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--passes", type=int, default=4, help="Max band-cycle passes")
-    ap.add_argument("--tol", type=float, default=0.5, help="Stop when worst |Z-z0| < tol")
+    ap.add_argument(
+        "--tol", type=float, default=0.5, help="Stop when worst |Z-z0| < tol"
+    )
     ap.add_argument("--z0", type=float, default=50.0)
     ap.add_argument(
         "--param",

--- a/src/antenna_designer/designs/freq_based/hexbeam_5band.py
+++ b/src/antenna_designer/designs/freq_based/hexbeam_5band.py
@@ -116,6 +116,44 @@ def _band_anchors(halfdriver, tipspacer_factor, t0_factor):
     }
 
 
+# Per-band shape factors after a sequential single-band tune against
+# Z = 50 + 0j on PyNEC (free space, no ground). One band at a time with
+# n_bands=1 — scripts/tune_hexbeam_5band_band.py. Inter-band coupling
+# wasn't modelled in this pass; expect Z to drift a few ohms when all
+# five bands coexist. Use as a starting point for full 5-band joint
+# tuning.
+_BAND_20M_OPT = {
+    "freq": 14.300,
+    "halfdriver_factor": 1.0533,
+    "tipspacer_factor": 0.1312,
+    "t0_factor": 0.1448,
+}
+_BAND_17M_OPT = {
+    "freq": 18.1575,
+    "halfdriver_factor": 1.0556,
+    "tipspacer_factor": 0.1312,
+    "t0_factor": 0.1431,
+}
+_BAND_15M_OPT = {
+    "freq": 21.383,
+    "halfdriver_factor": 1.0572,
+    "tipspacer_factor": 0.1312,
+    "t0_factor": 0.1417,
+}
+_BAND_12M_OPT = {
+    "freq": 24.97,
+    "halfdriver_factor": 1.0590,
+    "tipspacer_factor": 0.1312,
+    "t0_factor": 0.1403,
+}
+_BAND_10M_OPT = {
+    "freq": 28.47,
+    "halfdriver_factor": 1.0582,
+    "tipspacer_factor": 0.1312,
+    "t0_factor": 0.1379,
+}
+
+
 class Builder(AntennaBuilder):
     default_params = MappingProxyType(
         {
@@ -179,6 +217,26 @@ class Builder(AntennaBuilder):
                         "label": "Daisy-chain feed (PyNEC only)",
                     },
                 }
+            ),
+        }
+    )
+
+    # Sequential single-band tune against Z = 50 + 0j on PyNEC.
+    # See _BAND_*_OPT comment and scripts/tune_hexbeam_5band_band.py.
+    opt_params = MappingProxyType(
+        {
+            "design_freq": 14.300,
+            "freq": 14.300,
+            "base": 7.0,
+            "z_spacing": 0.2,
+            "daisy_chain": False,
+            "n_bands": _MAX_BANDS,
+            "bands": (
+                _BAND_20M_OPT,
+                _BAND_17M_OPT,
+                _BAND_15M_OPT,
+                _BAND_12M_OPT,
+                _BAND_10M_OPT,
             ),
         }
     )

--- a/src/antenna_designer/designs/freq_based/hexbeam_5band.py
+++ b/src/antenna_designer/designs/freq_based/hexbeam_5band.py
@@ -154,6 +154,45 @@ _BAND_10M_OPT = {
 }
 
 
+# Coupled-mode tune from scripts/tune_hexbeam_5band_coupled.py — bands
+# stay present at every objective evaluation so the optimiser sees real
+# inter-band coupling. Four passes converged with worst |Z - 50| ≈ 7.7 Ω
+# on band 1 (resistance stuck at ~42; reactance went to ~0 everywhere).
+# Better starting point than _BAND_*_OPT for the joint solve, but you'd
+# need a 3-knob tune (add tipspacer_factor) or relax R to push closer
+# to a perfect 50+0j match.
+_BAND_20M_COUPLED = {
+    "freq": 14.300,
+    "halfdriver_factor": 1.04834,
+    "tipspacer_factor": 0.1312,
+    "t0_factor": 0.14394,
+}
+_BAND_17M_COUPLED = {
+    "freq": 18.1575,
+    "halfdriver_factor": 1.05036,
+    "tipspacer_factor": 0.1312,
+    "t0_factor": 0.14025,
+}
+_BAND_15M_COUPLED = {
+    "freq": 21.383,
+    "halfdriver_factor": 1.04961,
+    "tipspacer_factor": 0.1312,
+    "t0_factor": 0.14056,
+}
+_BAND_12M_COUPLED = {
+    "freq": 24.97,
+    "halfdriver_factor": 1.04908,
+    "tipspacer_factor": 0.1312,
+    "t0_factor": 0.14045,
+}
+_BAND_10M_COUPLED = {
+    "freq": 28.47,
+    "halfdriver_factor": 1.06693,
+    "tipspacer_factor": 0.1312,
+    "t0_factor": 0.14665,
+}
+
+
 class Builder(AntennaBuilder):
     default_params = MappingProxyType(
         {
@@ -237,6 +276,25 @@ class Builder(AntennaBuilder):
                 _BAND_15M_OPT,
                 _BAND_12M_OPT,
                 _BAND_10M_OPT,
+            ),
+        }
+    )
+
+    # Coupled multi-band tune; see _BAND_*_COUPLED comment.
+    opt_coupled_params = MappingProxyType(
+        {
+            "design_freq": 14.300,
+            "freq": 14.300,
+            "base": 7.0,
+            "z_spacing": 0.2,
+            "daisy_chain": False,
+            "n_bands": _MAX_BANDS,
+            "bands": (
+                _BAND_20M_COUPLED,
+                _BAND_17M_COUPLED,
+                _BAND_15M_COUPLED,
+                _BAND_12M_COUPLED,
+                _BAND_10M_COUPLED,
             ),
         }
     )

--- a/src/antenna_designer/designs/freq_based/hexbeam_5band.py
+++ b/src/antenna_designer/designs/freq_based/hexbeam_5band.py
@@ -1,0 +1,278 @@
+"""Stacked hexbeam: up to 5 concentric hexbeam shapes stacked along z,
+each sized to its own band's wavelength and driven by its own feed.
+
+Each band reuses the single-band hexbeam geometry (driver hex with t0/t1
+tip segments, reflector hex, 1-segment T->S feed gap). Per-band sizing
+follows the pysim convention: halfdriver = halfdriver_factor * lambda/4.
+Bands stack along z at z = base + (n_bands - 1 - i) * z_spacing, so
+band 0 (longest wavelength) sits on top and band N-1 sits at base —
+the usual physical convention for stacked Yagi/hexbeam towers.
+
+Two feed modes are exposed via daisy_chain:
+  * False (default) — multi-feed: every band driven independently with
+    V = 1+0j. The response carries one entry in feeds[] per band so the
+    Smith chart shows per-band driving-point Z.
+  * True — daisy-chain: only band 0 is driven externally; the lower
+    bands couple via 50ohm TL jumpers of length z_spacing between
+    successive feeds. build_tls() emits the jumper specs. Pysim engines
+    don't support TLs yet; the frontend greys out the toggle when a
+    pysim slot is active.
+"""
+
+import math
+from types import MappingProxyType
+
+from ... import AntennaBuilder
+
+C_LIGHT_MHZ_M = 299.792458
+
+_MAX_BANDS = 5
+
+# Per-band canonical defaults. Each band carries its own freq plus the
+# three shape factors that scale the hexbeam against its wavelength.
+# Variants pick a subset (n_bands of these become active) but the tuple
+# always has length _MAX_BANDS so variant overlay stays aligned with the
+# frontend's preallocated group instances.
+_BAND_20M = {
+    "freq": 14.300,
+    "halfdriver_factor": 1.071,
+    "tipspacer_factor": 0.1312,
+    "t0_factor": 0.1243,
+}
+_BAND_17M = {
+    "freq": 18.1575,
+    "halfdriver_factor": 1.071,
+    "tipspacer_factor": 0.1312,
+    "t0_factor": 0.1243,
+}
+_BAND_15M = {
+    "freq": 21.383,
+    "halfdriver_factor": 1.071,
+    "tipspacer_factor": 0.1312,
+    "t0_factor": 0.1243,
+}
+_BAND_12M = {
+    "freq": 24.97,
+    "halfdriver_factor": 1.071,
+    "tipspacer_factor": 0.1312,
+    "t0_factor": 0.1243,
+}
+_BAND_10M = {
+    "freq": 28.47,
+    "halfdriver_factor": 1.071,
+    "tipspacer_factor": 0.1312,
+    "t0_factor": 0.1243,
+}
+
+# Feed-gap half-spacing in meters between T and S knots. Matches the
+# single-band hexbeam (designs/hexbeam.py:28).
+_FEED_GAP = 0.05
+
+
+def _band_anchors(halfdriver, tipspacer_factor, t0_factor):
+    """Hex anchors for one band at z=0. Lifted from designs/hexbeam.py
+    so the 5-band file stays self-contained — if a third user appears,
+    factor into a shared helper module."""
+    radius = halfdriver / (2 - t0_factor - tipspacer_factor)
+    tipspacer = radius * tipspacer_factor
+    t0 = radius * t0_factor
+    t1 = radius - tipspacer - t0
+
+    sin30 = 0.5
+    cos30 = math.sqrt(3) / 2
+
+    def rx(p):
+        return -p[0], p[1], p[2]
+
+    def ry(p):
+        return p[0], -p[1], p[2]
+
+    A = (radius * cos30, radius * sin30, 0)
+    B = (A[0] - t1 * cos30, A[1] + t1 * sin30, 0)
+    D = (0, radius, 0)
+    C = (D[0] + t0 * cos30, D[1] - t0 * sin30, 0)
+    E = rx(A)
+    F = ry(E)
+    G = ry(D)
+    H = ry(C)
+    II = ry(B)
+    J = ry(A)
+    S = (_FEED_GAP * cos30, _FEED_GAP * sin30, 0)
+    T = ry(S)
+
+    return {
+        "S": S,
+        "A": A,
+        "B": B,
+        "C": C,
+        "D": D,
+        "E": E,
+        "F": F,
+        "G": G,
+        "H": H,
+        "I": II,
+        "J": J,
+        "T": T,
+    }
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 14.300,
+            "freq": 14.300,
+            "base": 7.0,
+            "z_spacing": 0.2,
+            "daisy_chain": False,
+            "n_bands": _MAX_BANDS,
+            "bands": (_BAND_20M, _BAND_17M, _BAND_15M, _BAND_12M, _BAND_10M),
+            "ui_params": MappingProxyType(
+                {
+                    "sweep_policy": {
+                        "anchor": "meas_freq",
+                        "band_locked": True,
+                    },
+                    "bands": {
+                        "label_template": "band {i}",
+                        "repeat_count": "n_bands",
+                        "max_repeats": _MAX_BANDS,
+                        "link_meas_freq_to_param": "freq",
+                        "freq": {
+                            "min": 13.5,
+                            "max": 30.2,
+                            "step": 0.001,
+                            "precision": 3,
+                            "unit": " MHz",
+                        },
+                        "halfdriver_factor": {
+                            "min": 0.9,
+                            "max": 1.2,
+                            "step": 0.001,
+                            "precision": 4,
+                        },
+                        "tipspacer_factor": {
+                            "min": 0.05,
+                            "max": 0.30,
+                            "step": 0.001,
+                            "precision": 4,
+                        },
+                        "t0_factor": {
+                            "min": 0.05,
+                            "max": 0.30,
+                            "step": 0.001,
+                            "precision": 4,
+                        },
+                    },
+                    "n_bands": {
+                        "min": 1,
+                        "max": _MAX_BANDS,
+                        "step": 1,
+                    },
+                    "z_spacing": {
+                        "min": 0.05,
+                        "max": 3.0,
+                        "step": 0.01,
+                        "precision": 2,
+                        "unit": " m",
+                    },
+                    "daisy_chain": {
+                        "label": "Daisy-chain feed (PyNEC only)",
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        n_bands = int(self.n_bands)
+        if not 1 <= n_bands <= _MAX_BANDS:
+            raise ValueError(f"n_bands must be in [1, {_MAX_BANDS}], got {n_bands}")
+        active_bands = tuple(self.bands)[:n_bands]
+
+        n_seg0 = self.nominal_nsegs
+        # Tip segments stay short; floor at 1 matches single-band hexbeam
+        # (designs/hexbeam.py:66 leaves the tip count at 1 too).
+        n_seg_tip = max(1, self.nominal_nsegs // 21)
+        n_seg_feed = 1  # the T->S feed gap is always one segment
+
+        tups = []
+        # build_wires() emits, per band, six edges from the driver hex,
+        # one tip edge on the reflector, three reflector edges, one more
+        # reflector tip, and finally the 1-segment feed across T->S.
+        # The feed tuple's index inside the flat list is recorded so
+        # build_tls() can wire daisy-chain jumpers between successive
+        # feeds without re-running build_wires().
+        self._feed_wire_indices = []
+
+        for band_idx, band in enumerate(active_bands):
+            wavelength = C_LIGHT_MHZ_M / float(band["freq"])
+            halfdriver = float(band["halfdriver_factor"]) * wavelength / 4.0
+            anchors = _band_anchors(
+                halfdriver,
+                float(band["tipspacer_factor"]),
+                float(band["t0_factor"]),
+            )
+
+            # z-stagger: band 0 sits on top.
+            zoff = self.base + (n_bands - 1 - band_idx) * self.z_spacing
+
+            def at_z(p):
+                return (p[0], p[1], p[2] + zoff)
+
+            S = at_z(anchors["S"])
+            A = at_z(anchors["A"])
+            B = at_z(anchors["B"])
+            C = at_z(anchors["C"])
+            D = at_z(anchors["D"])
+            E = at_z(anchors["E"])
+            F = at_z(anchors["F"])
+            G = at_z(anchors["G"])
+            H = at_z(anchors["H"])
+            II = at_z(anchors["I"])
+            J = at_z(anchors["J"])
+            T = at_z(anchors["T"])
+
+            def build_path(lst, ns):
+                return [(a, b, ns, None) for a, b in zip(lst[:-1], lst[1:])]
+
+            tups.extend(build_path([S, A, B], n_seg0))
+            tups.extend(build_path([C, D], n_seg_tip))
+            tups.extend(build_path([D, E, F, G], n_seg0))
+            tups.extend(build_path([G, H], n_seg_tip))
+            tups.extend(build_path([II, J, T], n_seg0))
+            # The feed wire (one per band). Daisy-chain mode strips the
+            # excitation on bands 1..N-1 inside build_tls; multi-feed
+            # mode leaves every band's excitation in place.
+            tups.append((T, S, n_seg_feed, 1 + 0j))
+            self._feed_wire_indices.append(len(tups))  # 1-indexed NEC tag
+
+        if self.daisy_chain:
+            # Daisy-chain mode: only band 0 stays excited. The TL jumpers
+            # added in build_tls() couple bands 1..N-1 to their upstream
+            # neighbour.
+            for idx in self._feed_wire_indices[1:]:
+                p0, p1, ns, _ = tups[idx - 1]
+                tups[idx - 1] = (p0, p1, ns, None)
+
+        return tups
+
+    def build_tls(self):
+        """50ohm jumpers between successive band feeds in daisy-chain mode.
+        Each tuple is (idx1, seg1, idx2, seg2, impedance, length) — the
+        shape PyNECEngine.tl_card expects. Pysim engines reject any
+        non-empty list (engines/pysim.py:90), which the frontend should
+        guard against by greying out the toggle when a pysim slot is
+        active."""
+        if not getattr(self, "daisy_chain", False):
+            return []
+        # build_wires must run first to populate _feed_wire_indices.
+        if not hasattr(self, "_feed_wire_indices"):
+            self.build_wires()
+        feeds = self._feed_wire_indices
+        # Feed wire has n_seg_feed=1 segment, so the centre segment is
+        # always 1.
+        seg = 1
+        tls = []
+        for i in range(len(feeds) - 1):
+            tls.append((feeds[i], seg, feeds[i + 1], seg, 50.0, self.z_spacing))
+        return tls

--- a/src/antenna_designer/opt.py
+++ b/src/antenna_designer/opt.py
@@ -7,6 +7,81 @@ import numpy as np
 from scipy.optimize import minimize
 
 
+def _parse_path(name: str):
+    """`bands.0.halfdriver_factor` → ['bands', 0, 'halfdriver_factor'].
+    Integer-looking segments become ints so they index tuples/lists; the
+    rest stay strings for attr or dict access."""
+    parts = []
+    for p in name.split("."):
+        if p.lstrip("-").isdigit():
+            parts.append(int(p))
+        else:
+            parts.append(p)
+    return parts
+
+
+def _get_path(obj, name):
+    """Walk a dotted path. Tries dict-key, sequence-index, then attribute
+    at each step — so it works against Builder attrs, the bands tuple,
+    and per-band dicts in one expression."""
+    for p in _parse_path(name):
+        if isinstance(obj, dict):
+            obj = obj[p]
+        elif isinstance(obj, (list, tuple)):
+            obj = obj[int(p)]
+        else:
+            obj = getattr(obj, p)
+    return obj
+
+
+def _set_path(obj, name, value):
+    """Functional update: dicts and tuples are rebuilt on the way back
+    up so the original `bands` tuple in the class's default_params (a
+    shared MappingProxyType reference) never gets mutated under one
+    Builder instance.
+
+    The outermost call writes back to the Builder via setattr — which
+    AntennaBuilder routes into _params — leaving class-level defaults
+    untouched."""
+    path = _parse_path(name)
+
+    def _recur(cur, idx):
+        if idx == len(path) - 1:
+            leaf = path[idx]
+            if isinstance(cur, dict):
+                return {**cur, leaf: value}
+            if isinstance(cur, tuple):
+                i = int(leaf)
+                return tuple(value if k == i else v for k, v in enumerate(cur))
+            if isinstance(cur, list):
+                i = int(leaf)
+                new = list(cur)
+                new[i] = value
+                return new
+            setattr(cur, leaf, value)
+            return cur
+        head = path[idx]
+        if isinstance(cur, dict):
+            new_child = _recur(cur[head], idx + 1)
+            return {**cur, head: new_child}
+        if isinstance(cur, tuple):
+            i = int(head)
+            new_child = _recur(cur[i], idx + 1)
+            return tuple(new_child if k == i else v for k, v in enumerate(cur))
+        if isinstance(cur, list):
+            i = int(head)
+            new_child = _recur(cur[i], idx + 1)
+            new = list(cur)
+            new[i] = new_child
+            return new
+        child = getattr(cur, head)
+        new_child = _recur(child, idx + 1)
+        setattr(cur, head, new_child)
+        return cur
+
+    _recur(obj, 0)
+
+
 def optimize(
     antenna_builder,
     independent_variable_names,
@@ -22,7 +97,7 @@ def optimize(
     def objective(independent_variables):
 
         for v, nm in zip(independent_variables, independent_variable_names):
-            setattr(antenna_builder, nm, v)
+            _set_path(antenna_builder, nm, v)
 
         a = engine(antenna_builder)
         zs = a.impedance()
@@ -60,7 +135,7 @@ def optimize(
     #'Nelder-Mead', tol=0.001
     #'Powell', options={'maxiter':100, 'disp': True, 'xtol': 0.0001}
 
-    x0 = tuple(getattr(antenna_builder, nm) for nm in independent_variable_names)
+    x0 = tuple(_get_path(antenna_builder, nm) for nm in independent_variable_names)
     if bounds is None:
         if fractions is None or len(fractions) != len(x0):
             frac = 5 / 3 if fractions is None else fractions[0]
@@ -80,7 +155,7 @@ def optimize(
     print(result)
 
     for x, nm in zip(result.x, independent_variable_names):
-        setattr(antenna_builder, nm, x)
+        _set_path(antenna_builder, nm, x)
 
     print(objective(result.x))
 

--- a/tests/test_hexbeam_5band.py
+++ b/tests/test_hexbeam_5band.py
@@ -1,0 +1,154 @@
+"""hexbeam_5band Builder: per-band z-stagger, multi-feed shape, daisy-
+chain TL list. Ports the multi-band convention from pysim's
+hexbeam_5band example into antenna_designer's Builder pattern."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from antenna_designer.designs.freq_based.hexbeam_5band import Builder
+
+
+def _feeds(tups):
+    return [(i + 1, t) for i, t in enumerate(tups) if t[3] is not None]
+
+
+def test_default_is_five_bands_multi_feed():
+    b = Builder()
+    tups = b.build_wires()
+    feeds = _feeds(tups)
+    assert b.n_bands == 5
+    assert b.daisy_chain is False
+    assert len(feeds) == 5
+    assert b.build_tls() == []
+
+
+def test_n_bands_slicing_drops_higher_bands():
+    b = Builder()
+    b.n_bands = 3
+    tups = b.build_wires()
+    feeds = _feeds(tups)
+    assert len(feeds) == 3
+    # Same per-band tuple count → exactly n_bands × per_band_tuples.
+    b5 = Builder()
+    assert len(tups) == len(b5.build_wires()) * 3 // 5
+
+
+def test_n_bands_out_of_range_raises():
+    b = Builder()
+    b.n_bands = 0
+    with pytest.raises(ValueError):
+        b.build_wires()
+    b.n_bands = 6
+    with pytest.raises(ValueError):
+        b.build_wires()
+
+
+def test_z_stagger_band0_on_top():
+    """Band 0 (longest wavelength) sits at the highest z; band N-1 at base."""
+    b = Builder()
+    b.n_bands = 3
+    b.z_spacing = 1.5
+    b.base = 10.0
+    tups = b.build_wires()
+    # The feed tuple is the last edge added per band; its endpoints
+    # share the same z as the rest of that band.
+    feeds = _feeds(tups)
+    zs = [feed[1][0][2] for feed in feeds]  # z of T knot
+    # Bands emitted in order 0,1,2 → z descends.
+    assert zs[0] > zs[1] > zs[2]
+    assert math.isclose(zs[0] - zs[1], 1.5)
+    assert math.isclose(zs[1] - zs[2], 1.5)
+    assert math.isclose(zs[-1], 10.0)
+
+
+def test_daisy_chain_strips_excitation_from_lower_bands():
+    b = Builder()
+    b.daisy_chain = True
+    tups = b.build_wires()
+    feeds = _feeds(tups)
+    # Only band 0 (the first feed) keeps a non-None excitation.
+    assert len(feeds) == 1
+
+
+def test_daisy_chain_emits_tl_jumpers():
+    b = Builder()
+    b.daisy_chain = True
+    b.z_spacing = 1.2
+    tls = b.build_tls()
+    assert len(tls) == 4  # N-1 jumpers for 5 bands
+    # Shape PyNECEngine consumes: (idx1, seg1, idx2, seg2, Z, length).
+    for jumper in tls:
+        assert len(jumper) == 6
+        assert jumper[4] == 50.0
+        assert jumper[5] == pytest.approx(1.2)
+    # Each jumper connects successive feed wires; with the build_wires
+    # convention each band emits the same number of tuples so feed
+    # indices increment uniformly.
+    feed_idxs = [j[0] for j in tls] + [tls[-1][2]]
+    diffs = [b - a for a, b in zip(feed_idxs[:-1], feed_idxs[1:])]
+    assert len(set(diffs)) == 1  # uniform stride between feeds
+
+
+def test_daisy_chain_disabled_returns_empty_tls():
+    b = Builder()
+    assert b.daisy_chain is False
+    assert b.build_tls() == []
+
+
+def test_per_band_freq_scales_geometry():
+    """Halving the band freq should roughly double its radius (linear in λ)."""
+    b = Builder()
+    b.n_bands = 2
+    # Use the per-band freq override path: override the second band to
+    # double the first's wavelength.
+    bands = (
+        {
+            "freq": 28.0,
+            "halfdriver_factor": 1.0,
+            "tipspacer_factor": 0.13,
+            "t0_factor": 0.13,
+        },
+        {
+            "freq": 14.0,
+            "halfdriver_factor": 1.0,
+            "tipspacer_factor": 0.13,
+            "t0_factor": 0.13,
+        },
+    )
+    b.bands = bands
+    tups = b.build_wires()
+    # Take the second-edge-of-each-band (S→A on the driver path); its
+    # length should scale with wavelength.
+    # Band 0's S→A edge is at tuple index 0; band 1's at index 10
+    # (single-band emits 10 tuples).
+    per_band = len(tups) // 2
+    s0 = tups[0]
+    s1 = tups[per_band]
+    dist0 = math.dist(s0[0], s0[1])
+    dist1 = math.dist(s1[0], s1[1])
+    # Band 1 has half the freq → λ doubles → radius doubles.
+    assert dist1 / dist0 == pytest.approx(2.0, rel=0.05)
+
+
+def test_registered_in_web_examples():
+    """Adapter auto-discovers the new design and reports multi_feed."""
+    from web.examples import REGISTRY
+
+    ex = REGISTRY.get("freq_based.hexbeam_5band")
+    assert ex is not None
+    assert ex.multi_feed is True
+
+
+def test_nominal_nsegs_scales_radiator_edges():
+    """Standard convergence-flow contract: bumping nominal_nsegs scales
+    the long radiator edges and leaves the feed gap at 1."""
+    b = Builder()
+    b.nominal_nsegs = 41
+    tups = b.build_wires()
+    seg_counts = {t[2] for t in tups}
+    assert 41 in seg_counts  # major radiator scaled with N
+    feeds = _feeds(tups)
+    assert all(f[1][2] == 1 for f in feeds)  # feed gaps stay 1

--- a/tests/test_opt_nested_params.py
+++ b/tests/test_opt_nested_params.py
@@ -1,0 +1,69 @@
+"""Nested-path support for opt.py's --params: dotted names like
+'bands.0.halfdriver_factor' walk Builder attrs, tuples, and dicts.
+Without this, the multi-band hexbeam_5band couldn't be tuned through
+the CLI."""
+
+from __future__ import annotations
+
+import pytest
+
+from antenna_designer.designs.freq_based.hexbeam_5band import Builder
+from antenna_designer.opt import _get_path, _set_path, _parse_path
+
+
+def test_parse_path_keeps_strings_and_promotes_ints():
+    assert _parse_path("freq") == ["freq"]
+    assert _parse_path("bands.0.halfdriver_factor") == ["bands", 0, "halfdriver_factor"]
+    assert _parse_path("a.-1.b") == ["a", -1, "b"]
+
+
+def test_get_path_walks_dict_and_tuple_and_attr():
+    b = Builder()
+    assert _get_path(b, "n_bands") == 5
+    assert _get_path(b, "bands.0.freq") == 14.300
+    assert _get_path(b, "bands.4.halfdriver_factor") == pytest.approx(1.071)
+
+
+def test_set_path_does_not_leak_into_class_defaults():
+    """Two separate Builder instances must not see each other's mutations
+    — the class-level `bands` tuple is a shared reference, so the set
+    helper has to rebuild the tuple functionally and write it back to
+    only this instance."""
+    b1 = Builder()
+    b2 = Builder()
+    _set_path(b1, "bands.0.halfdriver_factor", 1.234)
+    assert _get_path(b1, "bands.0.halfdriver_factor") == 1.234
+    # b2 must still see the class default — no leak through the shared
+    # default_params tuple.
+    assert _get_path(b2, "bands.0.halfdriver_factor") == pytest.approx(1.071)
+    # And the class default itself stays put.
+    assert Builder.default_params["bands"][0]["halfdriver_factor"] == pytest.approx(
+        1.071
+    )
+
+
+def test_set_path_updates_top_level_attr():
+    b = Builder()
+    _set_path(b, "n_bands", 3)
+    assert b.n_bands == 3
+
+
+def test_set_path_then_get_path_roundtrip():
+    b = Builder()
+    _set_path(b, "bands.2.t0_factor", 0.111)
+    assert _get_path(b, "bands.2.t0_factor") == 0.111
+    # Other band entries unchanged.
+    assert _get_path(b, "bands.0.t0_factor") == pytest.approx(0.1243)
+
+
+def test_set_path_works_through_optimize_signature():
+    """The actual call site in opt.objective uses _set_path for each
+    independent_variable_name on every objective evaluation. Verify a
+    typical dotted name round-trips."""
+    b = Builder()
+    names = ["bands.0.halfdriver_factor", "bands.0.t0_factor"]
+    values = [1.05, 0.15]
+    for v, nm in zip(values, names):
+        _set_path(b, nm, v)
+    assert _get_path(b, names[0]) == 1.05
+    assert _get_path(b, names[1]) == 0.15

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -210,11 +210,17 @@ function ParamForm({
   values,
   onChange,
   pathPrefix = [],
+  disabledFields,
 }: {
   schema: SchemaItem[];
   values: ParamValueBag;
   onChange: (path: (string | number)[], value: number | string | boolean) => void;
   pathPrefix?: (string | number)[];
+  // Param names that should render as disabled even though they're
+  // visible in the schema. Used to grey out controls whose effect
+  // depends on the active backend (e.g. daisy_chain only works on
+  // PyNEC; pysim engines don't support transmission lines yet).
+  disabledFields?: Set<string>;
 }) {
   return (
     <>
@@ -236,6 +242,7 @@ function ParamForm({
                     values={instances[i]}
                     onChange={onChange}
                     pathPrefix={[...pathPrefix, item.name, i]}
+                    disabledFields={disabledFields}
                   />
                 </div>
               ))}
@@ -275,12 +282,16 @@ function ParamForm({
 
         if (item.kind === "bool") {
           const checked = Boolean(currentRaw ?? item.default);
+          const isDisabled = disabledFields?.has(item.name) ?? false;
           return (
             <div key={item.name} className="field field-bool">
-              <label className="field-bool-label">
+              <label
+                className={`field-bool-label${isDisabled ? " field-disabled" : ""}`}
+              >
                 <input
                   type="checkbox"
                   checked={checked}
+                  disabled={isDisabled}
                   onChange={(e) =>
                     onChange(
                       [...pathPrefix, item.name],
@@ -1211,6 +1222,15 @@ export function App() {
     // `bands: [{band_id, freq, length_factor}, ...]` array; the backend
     // unpacks it in _bands_from_request().
     Object.assign(base, currentValues);
+    // hexbeam_5band's daisy_chain feed mode uses NEC TL cards; pysim
+    // engines reject any non-empty build_tls(). The daisy_chain gear
+    // is greyed out when a pysim slot is active (see the disabled prop
+    // on the schema control), and we belt-and-suspenders force the
+    // request to daisy_chain=false here so a stale value from a
+    // previously-active pynec slot doesn't slip through.
+    if (backend !== "pynec" && "daisy_chain" in base) {
+      base.daisy_chain = false;
+    }
     return base;
   }
 
@@ -1743,6 +1763,15 @@ export function App() {
             schema={currentExample.param_schema}
             values={currentValues}
             onChange={setParamAtPath}
+            // hexbeam_5band's daisy_chain mode emits NEC TL cards;
+            // pysim engines reject any non-empty build_tls() so the
+            // toggle has no effect there. Grey it out when the active
+            // slot's backend is pysim — the request-build side also
+            // forces daisy_chain=false so a stale value doesn't slip
+            // through.
+            disabledFields={
+              backend !== "pynec" ? new Set(["daisy_chain"]) : undefined
+            }
           />
         )}
 

--- a/web/frontend/src/styles.css
+++ b/web/frontend/src/styles.css
@@ -551,6 +551,11 @@ input[type=range]:disabled {
   cursor: not-allowed;
 }
 
+.field-disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 .stage {
   position: relative;
   display: flex;


### PR DESCRIPTION
## Summary
- Ports `hexbeam_5band` from the pysim UI as an antenna_designer Builder under `freq_based/`. Five concentric hexbeams stacked along z, each sized to its own wavelength; multi-feed by default, with an optional NEC-only daisy-chain mode that emits 50Ω TL jumpers from `build_tls()`.
- Frontend greys out the daisy-chain toggle when the active slot is pysim (PysimEngine rejects non-empty `build_tls()`), and belt-and-suspenders forces `daisy_chain=false` in the outgoing request.
- Extends `opt.optimize()` to support dotted nested paths in `--params` (e.g. `bands.0.halfdriver_factor`), with a functional setter so per-band edits don't leak into the class-level `default_params` tuple via the shared reference.
- Two `opt_*` variants: `opt_params` (sequential single-band tune) and `opt_coupled_params` (band-by-band tune with all five present so the optimiser sees inter-band coupling). After 4 passes the coupled tune lands all 5 bands at SWR ≤ 1.18.

## Test plan
- [ ] `pytest tests/` — 565 passing locally
- [ ] In the UI, select `freq_based.hexbeam_5band`. Default solve shows 5 trails on the Smith chart.
- [ ] Switch variant to `opt_coupled`. Reactance near zero at each band's freq; SWR ≤ 1.18.
- [ ] Tick daisy-chain on a PyNEC slot, solve — Smith chart drops to 1 trail.
- [ ] Switch active slot to triangular/sinusoidal/bspline — daisy-chain checkbox visibly greyed (45% opacity) and solve still works.
- [ ] CLI smoke: `python -m antenna_designer optimize --builder freq_based.hexbeam_5band:opt_coupled --engine pynec --params bands.1.halfdriver_factor bands.1.t0_factor bands.1.tipspacer_factor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)