### PR TITLE
Drop _compute_y_via_n_solves workaround; use upstream pysim compute_y_matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ SWEEP_SLOPE
 __pycache__/
 PyNEC/
 *~
+# Emacs auto-save (#file#) and lock (.#file) files
+\#*\#
+.\#*
 TEST_RESULTS
 dist/
 build/

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -75,7 +75,7 @@ Same ballpark agreement as the closed-loop work (~few % R, a few Ω X). Cross-va
 
 ## ~~Next branch: `tl_card` support in PysimEngine~~ — landed
 
-`PysimEngine.impedance()` now handles transmission-line cards by extracting the multi-port Y matrix via **N independent solves** (one per port, V=1 at driven port, V=0 elsewhere), stamping each TL's 2×2 admittance contribution at its endpoint pair, then reducing back to the driven-port impedance via nodal analysis with passive-port currents constrained to zero. The N-solves approach was forced by an upstream limitation: pysim's `compute_y_matrix` doesn't yet support junctions, and every TL design has junctions (the delta loops).
+`PysimEngine.impedance()` handles transmission-line cards by extracting the multi-port Y matrix, stamping each TL's 2×2 admittance contribution at its endpoint pair, then reducing back to the driven-port impedance via nodal analysis with passive-port currents constrained to zero. The original implementation used **N independent solves** as a workaround for pysim's `compute_y_matrix` not supporting junctions; that's been lifted upstream and the engine now calls `compute_y_matrix` directly (one LU + N back-subs instead of N × factor cost).
 
 The path also fixed a latent `AttributeError` — `PysimEngine.__init__` used to call `builder.build_tls()` before `build_wires()` had run, blowing up on builders that populate `self.tls` inside `build_wires`. Order is reversed now.
 
@@ -83,7 +83,11 @@ The path also fixed a latent `AttributeError` — `PysimEngine.__init__` used to
 
 What this means going forward: the multi-port Y reduction is mathematically clean (verified: Y symmetric, passive-port `I_ext=0` constraint exact, `coeffs[m] = 1/Z` at the feed for single-port). Self-consistency tests are in `tests/test_pysim_engine.py`; strict PyNEC numerical agreement isn't currently achievable on the one available test fixture. If we ever land another TL design where loop-driver coupling is non-negligible, retry the comparison.
 
-`impedance_sweep` with TLs raises `NotImplementedError` — `compute_y_matrix_swept` exists upstream, but per-k stamping plus reduction is its own piece of code that no current design needs.
+`impedance_sweep` with TLs is implemented: batched Y over k via `compute_y_matrix_swept`, then per-k TL stamping (βl is frequency-dependent) and driven-port reduction. Matches per-k `impedance()` to ~1e-11 on `delta_looparray_with_tls`.
+
+## ~~Next branch: junction support in pysim's `compute_y_matrix`~~ — landed upstream
+
+Originally listed here as a follow-up. Landed in stevenmburns/pysim#78: both `compute_y_matrix` and `compute_y_matrix_swept` now handle junctions via a matrix-RHS Schur-complement KCL solve across all three solvers (triangular, bspline; sinusoidal already worked structurally). The N-solves workaround in `PysimEngine` has been deleted; the engine calls the upstream batched path directly.
 
 ## Next branches (rough priority order)
 
@@ -94,14 +98,6 @@ What this means going forward: the multi-port Y reduction is mathematically clea
 - Add a TL design where the in-antenna coupling between TL endpoints isn't near-zero, then re-run the comparison; agreement should be much tighter when the antenna's own Y has meaningful off-diagonal terms.
 - Implement segment-averaging at the TL endpoints (averaged current over the TL-end segment instead of basis coefficient at the midpoint). Closer to NEC2's convention; may reconcile.
 
-### 2. `impedance_sweep` with TLs
-
-`compute_y_matrix_swept` exists upstream — wire it up + per-k TL stamping + reduction. No current design needs this; add when one does.
-
-### 3. Junction support in pysim's `compute_y_matrix`
-
-The N-independent-solves path costs N× the LU factor cost. pysim's batched `compute_y_matrix` would do it in one factor + N back-substitutions, but currently rejects junctions. The Schur-complement KCL solve in `_solve_with_kcl` needs a matrix-RHS generalisation. Upstream change; only worth it if larger N-port problems appear.
-
-### 4. Far-field for the new designs
+### 2. Far-field for the new designs
 
 Stage 2b validated the pattern math on the dipole; once tee-junction geometries are stable, re-run the directivity cross-check on hentenna and fandipole and add a corresponding test. Lower priority — now that cross-engine `compare_patterns` is in the CLI, this is largely a "run it and write a test" task.

--- a/src/antenna_designer/engines/pysim.py
+++ b/src/antenna_designer/engines/pysim.py
@@ -200,36 +200,20 @@ class PysimEngine(SimulationEngine):
         I = Y_total @ V
         return [complex(V[i] / I[i]) for i in driven]
 
-    def _compute_y_via_n_solves(self, wavelength):
-        """Y matrix column-by-column via N independent solves with the j-th
-        column built from V_j=1, V_{k≠j}=0. Works through junctions (which
-        the solvers' batched `compute_y_matrix` doesn't yet handle)."""
-        n = len(self._feeds)
-        Y = np.empty((n, n), dtype=np.complex128)
-        for j in range(n):
-            feeds_j = [
-                (w, arc, 1.0 + 0j if k == j else 0.0 + 0j)
-                for k, (w, arc, _v) in enumerate(self._feeds)
-            ]
-            solver = self._solver(
-                wires=self._polylines,
-                n_per_edge_per_wire=self._edge_segments,
-                feeds=feeds_j,
-                wavelength=wavelength,
-                wire_radius=self._wire_radius,
-                ground_z=self._ground_z,
-                junctions=self._junctions or None,
-                **self._solver_kwargs,
-            )
-            _z, coeffs = solver.compute_impedance()
-            m_indices = solver._feed_basis_indices(solver._build_geometry())
-            Y[:, j] = [coeffs[m] for m in m_indices]
-        return Y
+    def _compute_y_matrix(self, wavelength):
+        """Multi-port short-circuit Y at the configured feeds. Builds one
+        solver with the full feed list and calls pysim's compute_y_matrix,
+        which since the junction-aware-y-matrix PR handles closed-loop /
+        tee-junction antennas correctly (one LU + N back-subs per Y)."""
+        return np.asarray(
+            self._make_solver(wavelength=wavelength).compute_y_matrix(),
+            dtype=np.complex128,
+        )
 
     def impedance(self):
         wavelength = self._wavelength_for(self.builder.freq)
         if self._tls:
-            Y = self._compute_y_via_n_solves(wavelength)
+            Y = self._compute_y_matrix(wavelength)
             Y_total = self._apply_tls(Y, wavelength)
             return self._impedance_from_y(Y_total)
         s = self._make_solver(wavelength=wavelength)
@@ -374,11 +358,11 @@ class PysimEngine(SimulationEngine):
         freq_hz = self.builder.freq * 1e6
 
         if self._tls:
-            # Run N-solve Y extraction, apply TLs, resolve passive port
+            # Run the batched Y extraction, apply TLs, resolve passive port
             # voltages, then re-solve once with every feed at its true V so
             # the basis coefficients reflect TL-induced loop drives (not
             # just driver-with-loops-shorted).
-            Y = self._compute_y_via_n_solves(wavelength)
+            Y = self._compute_y_matrix(wavelength)
             Y_total = self._apply_tls(Y, wavelength)
             V, _ = self._resolve_feed_voltages(Y_total)
             feeds_resolved = [

--- a/src/antenna_designer/engines/pysim.py
+++ b/src/antenna_designer/engines/pysim.py
@@ -227,17 +227,24 @@ class PysimEngine(SimulationEngine):
         freqs = np.asarray(freqs, dtype=float)
         if freqs.ndim != 1 or freqs.size == 0:
             raise ValueError("freqs must be a 1-D non-empty array")
-        if self._tls:
-            # compute_y_matrix_swept exists, but stamping TLs per-k and
-            # solving the driven-port reduction every frequency is its own
-            # piece of code. Not needed for any current design.
-            raise NotImplementedError(
-                "PysimEngine.impedance_sweep with transmission-line cards "
-                "is not implemented yet; use single-frequency impedance()"
-            )
-        # All k-independent setup happens in the constructor; build once.
         s = self._make_solver(wavelength=self._wavelength_for(freqs[0]))
         k_array = 2.0 * np.pi * freqs * 1e6 / C_LIGHT
+        if self._tls:
+            # Batched Y at every frequency, then per-k TL stamping (βL is
+            # frequency-dependent) and driven-port reduction. The Y assembly
+            # is amortised across frequencies via the upstream swept solve;
+            # the per-k post-processing is O(n_p³) and dwarfed by the solve.
+            Y_swept = np.asarray(
+                s.compute_y_matrix_swept(k_array), dtype=np.complex128
+            )  # (n_k, n_p, n_p)
+            n_driven = sum(
+                1 for i in range(Y_swept.shape[1]) if i not in self._tl_passive_feed_idx
+            )
+            zs = np.empty((freqs.size, n_driven), dtype=np.complex128)
+            for ki, freq in enumerate(freqs):
+                Y_total = self._apply_tls(Y_swept[ki], self._wavelength_for(freq))
+                zs[ki] = self._impedance_from_y(Y_total)
+            return zs
         zs = s.compute_impedance_swept(k_array)
         # Single-feed: (n_k,); multi-feed: (n_k, n_feeds). Normalise to
         # (n_k, n_feeds) to match PyNECEngine.

--- a/tests/test_pysim_engine.py
+++ b/tests/test_pysim_engine.py
@@ -128,7 +128,7 @@ def test_pysim_tl_card_runs_and_returns_finite_impedance():
     assert abs(z) < 1e4, f"unrealistic magnitude: {z}"
 
     wl = 299.792458 / b.freq
-    Y = e._compute_y_via_n_solves(wl)
+    Y = e._compute_y_matrix(wl)
     assert np.allclose(Y, Y.T, atol=1e-10), "Y matrix not symmetric (reciprocity)"
 
 
@@ -143,7 +143,7 @@ def test_pysim_tl_card_passive_port_floats_correctly():
     b = TLBuilder()
     e = PysimEngine(b)
     wl = 299.792458 / b.freq
-    Y = e._compute_y_via_n_solves(wl)
+    Y = e._compute_y_matrix(wl)
     Y_total = e._apply_tls(Y, wl)
 
     n = Y_total.shape[0]

--- a/tests/test_pysim_engine.py
+++ b/tests/test_pysim_engine.py
@@ -162,6 +162,32 @@ def test_pysim_tl_card_passive_port_floats_correctly():
     assert np.allclose(I[passive], 0, atol=1e-10), I[passive]
 
 
+def test_pysim_tl_impedance_sweep_matches_per_freq():
+    """impedance_sweep with TLs should match per-frequency impedance() calls
+    to within solver noise. Exercises the swept-Y → per-k TL stamp →
+    driven-port reduction path that was added once compute_y_matrix_swept
+    learned about junctions upstream."""
+    from antenna_designer.designs.freq_based.delta_looparray_with_tls import (
+        Builder as TLBuilder,
+    )
+
+    freqs = np.array([28.0, 28.47, 29.0])
+
+    # Per-freq reference
+    z_per = []
+    for f in freqs:
+        b = TLBuilder()
+        b.freq = f
+        z_per.append(PysimEngine(b).impedance()[0])
+
+    # Swept (engine constructed at any freq; impedance_sweep rebuilds per-k)
+    b = TLBuilder()
+    zs = PysimEngine(b).impedance_sweep(freqs)
+    assert zs.shape == (3, 1), zs.shape
+    for i, (zp, zs_i) in enumerate(zip(z_per, zs[:, 0])):
+        assert abs(zp - zs_i) < 1e-9, f"f={freqs[i]}: per={zp}, swept={zs_i}"
+
+
 def test_pysim_tl_admittance_quarter_wave():
     """Hand-checked Y_TL for a quarter-wave TL with Z0=50: at θ=π/2,
     Y_TL = (1/(j50)) [[0,-1],[-1,0]] = [[0, j/50], [j/50, 0]].


### PR DESCRIPTION
## Summary
- pysim now supports junctions in `compute_y_matrix` (stevenmburns/pysim#78), so PysimEngine's N-independent-solves workaround is obsolete. Replaced with a 4-line `_compute_y_matrix` that calls `solver.compute_y_matrix()` directly — one LU factor + (n_p + n_c) back-subs instead of N × (factor + solve).
- Bumped the `pysim` submodule pointer to the merge commit.
- For `delta_looparray_with_tls` (3 ports + closed-loop junctions), the new path returns bit-identical impedance (55.21−3.41j) to the previous workaround. All 573 tests pass.
- Added `.gitignore` entries for emacs auto-save (`#file#`) and lock (`.#file`) artifacts so they stop appearing in `git status`.

## Test plan
- [x] `pytest tests/` — 573/573 pass
- [x] `delta_looparray_with_tls` impedance check — bit-exact match with the previous workaround
- [x] `ruff check` + `ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)