### PR TITLE
Load branch + PyNEC build_network() dispatch (issue #65 pieces A & C)

### DIFF
--- a/src/antenna_designer/designs/freq_based/short_dipole_loaded.py
+++ b/src/antenna_designer/designs/freq_based/short_dipole_loaded.py
@@ -1,0 +1,55 @@
+"""Center-loaded shortened dipole — the Load-branch showcase for issue #65.
+
+A half-wave dipole shortened to `length_factor` × λ/2 has a small radiation
+resistance plus a large capacitive reactance. Adding a series inductor at
+the feed (a "loading coil") cancels the capacitive reactance and pulls
+the input impedance toward resonance. Both Pysim's Sherman-Morrison rank-1
+Y update and PyNEC's ld_card produce the same shift, which makes this the
+natural cross-engine cross-check for the Load branch.
+
+`inductance_uH` is whatever cancels the reactance of the unloaded short
+dipole at `design_freq` — recompute it if you change `length_factor`.
+"""
+
+from ... import AntennaBuilder
+from ...network import Driven, Load, Network, PortAtEdge
+
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.0,
+            "freq": 28.0,
+            # Total length as a fraction of λ/2. <1.0 shortens the dipole.
+            "length_factor": 0.5,
+            # Series inductor (µH) at the feed point. ~4.65 µH cancels the
+            # ~−820 Ω capacitive reactance of the 0.5·λ/2 short dipole at
+            # 28 MHz; both engines land within ±15 Ω of zero reactance.
+            "inductance_uH": 4.65,
+        }
+    )
+
+    def build_wires(self):
+        wavelength = 299.792458 / self.design_freq
+        half_arm = 0.25 * wavelength * self.length_factor
+        # Single straight wire spanning the dipole, feed at the centre.
+        # No `ev` — the Network supplies the source; `name` marks the
+        # segment for PortAtEdge resolution.
+        return [
+            (
+                (0, -half_arm, 5),
+                (0, half_arm, 5),
+                21,
+                None,
+                "feed",
+            )
+        ]
+
+    def build_network(self):
+        return Network(
+            ports={"feed": PortAtEdge("feed")},
+            branches=[Load(port="feed", l=self.inductance_uH * 1e-6)],
+            sources=[Driven(port="feed", voltage=1 + 0j)],
+        )

--- a/src/antenna_designer/engines/pynec.py
+++ b/src/antenna_designer/engines/pynec.py
@@ -181,19 +181,44 @@ class PyNECEngine(SimulationEngine):
             next_tag += 1
 
     def _emit_network_cards(self):
-        """Translate Network branches into tl_card calls and Network sources
-        into ex_card calls. Called after geometry_complete()."""
+        """Translate Network branches into tl_card / ld_card calls and Network
+        sources into ex_card calls. Called after geometry_complete().
+
+        Load branches are emitted as NEC2 type-0 ld_cards (short series RLC
+        on a single segment). NEC2's convention: a zero value for R, L, or C
+        means that element isn't present in the load — same semantics as the
+        Load dataclass's optional fields.
+        """
         net = self._network
+        # ld_cards first — conventional ordering; loading affects the MoM
+        # solution that the TL/EX stages then read from.
+        for br in net.branches:
+            if isinstance(br, Load):
+                port = net.ports[br.port]
+                if not isinstance(port, PortAtEdge):
+                    raise ValueError(
+                        f"Load on virtual port {br.port!r}: a Load is a series "
+                        "impedance on an antenna segment, which only PortAtEdge has"
+                    )
+                tag, seg = self._network_port_loc[br.port]
+                r = float(br.r) if br.r is not None else 0.0
+                l = float(br.l) if br.l is not None else 0.0
+                c = float(br.c) if br.c is not None else 0.0
+                if r == 0.0 and l == 0.0 and c == 0.0:
+                    continue
+                # ldtyp=0: short series RLC at segments [seg, seg] on tag.
+                self.c.ld_card(0, tag, seg, seg, r, l, c)
         for br in net.branches:
             if isinstance(br, TL):
                 tag_a, seg_a = self._network_port_loc[br.a]
                 tag_b, seg_b = self._network_port_loc[br.b]
                 self.c.tl_card(tag_a, seg_a, tag_b, seg_b, br.z0, br.length, 0, 0, 0, 0)
-            elif isinstance(br, (Load, TwoPort)):
+            elif isinstance(br, Load):
+                continue  # already emitted above
+            elif isinstance(br, TwoPort):
                 raise NotImplementedError(
-                    f"{type(br).__name__} on PyNECEngine is a follow-up piece of "
-                    "issue #65 (ld_card / nt_card translation); use PysimEngine "
-                    "for now"
+                    "TwoPort on PyNECEngine is a follow-up piece of issue #65 "
+                    "(nt_card translation); use PysimEngine for now"
                 )
             else:
                 raise NotImplementedError(f"branch type {type(br).__name__}")

--- a/src/antenna_designer/engines/pynec.py
+++ b/src/antenna_designer/engines/pynec.py
@@ -2,9 +2,19 @@ import numpy as np
 import PyNEC as nec
 
 from ..engine import FarField, SimulationEngine, WireCurrents
+from ..network import Driven, Load, PortAtEdge, PortVirtual, TL, TwoPort
 
 
 DEFAULT_GROUND = ("finite", 10.0, 0.002)  # (kind, dielectric, conductivity)
+
+
+def _seg_midpoint(p0, p1, n_seg, sub_idx):
+    """Centre of segment `sub_idx` (1-based) on the wire from p0 to p1
+    discretised into n_seg uniform segments. NEC2's tl_card / ex_card
+    refer to sub-segments by this index."""
+    p0 = np.asarray(p0, dtype=float)
+    p1 = np.asarray(p1, dtype=float)
+    return p0 + ((sub_idx - 0.5) / n_seg) * (p1 - p0)
 
 
 class PyNECEngine(SimulationEngine):
@@ -25,7 +35,10 @@ class PyNECEngine(SimulationEngine):
         """
         super().__init__(builder)
         self.tups = self._coerce_wire_tuples(builder.build_wires())
-        self.tls = builder.build_tls()
+        self._network = builder.build_network()
+        # build_tls() is only consulted when there's no Network spec; with a
+        # Network, the engine drives ex_card/tl_card calls off the spec instead.
+        self.tls = [] if self._network is not None else builder.build_tls()
         self.ground = ground
         self.excitation_pairs = None
         self._build_geometry()
@@ -42,24 +55,154 @@ class PyNECEngine(SimulationEngine):
         self.c = nec.nec_context()
         geo = self.c.get_geometry()
 
+        # Walk build_wires(): emit `geo.wire` cards, collect ex_card pairs from
+        # any tuple with a non-None `ev`, and remember (tag, mid_seg) for every
+        # named edge so the network path can resolve PortAtEdge later.
         self.excitation_pairs = []
-        for idx, (p0, p1, n_seg, ev) in enumerate(self.tups, start=1):
+        self._feed_name_to_loc = {}
+        for idx, t in enumerate(self.tups, start=1):
+            p0, p1, n_seg, ev = t[0], t[1], t[2], t[3]
+            name = t[4] if len(t) >= 5 else None
             geo.wire(
                 idx, n_seg, p0[0], p0[1], p0[2], p1[0], p1[1], p1[2], 0.0005, 1.0, 1.0
             )
-            if ev is not None:
-                self.excitation_pairs.append((idx, (n_seg + 1) // 2, ev))
+            mid_seg = (n_seg + 1) // 2
+            if name is not None:
+                self._feed_name_to_loc[name] = (idx, mid_seg, p0, p1, n_seg)
+            # In the network path the spec drives ex_card emission; ignore ev's
+            # (they're typically placeholders to keep a segment marked at the
+            # feed edge for the geometry translator).
+            if ev is not None and self._network is None:
+                self.excitation_pairs.append((idx, mid_seg, ev))
+
+        # Synthesise stub wires for virtual ports (extends self.tups so the
+        # tag space picks up where the user-supplied wires left off). Must
+        # happen before geometry_complete().
+        self._network_port_loc = {}
+        if self._network is not None:
+            self._synthesise_virtual_stubs(geo)
 
         self.c.geometry_complete(0)
 
-        for idx1, seg1, idx2, seg2, impedance, length in self.tls:
-            self.c.tl_card(idx1, seg1, idx2, seg2, impedance, length, 0, 0, 0, 0)
+        if self._network is not None:
+            self._emit_network_cards()
+        else:
+            for idx1, seg1, idx2, seg2, impedance, length in self.tls:
+                self.c.tl_card(idx1, seg1, idx2, seg2, impedance, length, 0, 0, 0, 0)
 
         self.c.ld_card(5, 0, 0, 0, conductivity, 0.0, 0.0)
         self._apply_ground_card()
 
         for tag, sub_index, voltage in self.excitation_pairs:
             self.c.ex_card(0, tag, sub_index, 0, voltage.real, voltage.imag, 0, 0, 0, 0)
+
+    def _synthesise_virtual_stubs(self, geo):
+        """For each PortVirtual referenced by a TL branch, add a short stub
+        wire (~λ/100, single segment) anchored above the centroid of its
+        TL-connected real-port feed points. NEC2's tl_card needs both
+        endpoints on real segments; the stub is the minimum geometry that
+        carries the driver node without polluting radiation.
+
+        Resolves every PortAtEdge to its (tag, sub_seg) in the same pass so
+        downstream branch/source emission only consults self._network_port_loc.
+        """
+        net = self._network
+        # Real ports: resolve via the name → (tag, mid_seg) map built above.
+        for name, port in net.ports.items():
+            if isinstance(port, PortAtEdge):
+                if name not in self._feed_name_to_loc:
+                    raise ValueError(
+                        f"network port {name!r} is a PortAtEdge but no edge in "
+                        f"build_wires() carries that name; named edges: "
+                        f"{sorted(self._feed_name_to_loc)}"
+                    )
+                tag, mid_seg, _p0, _p1, _ns = self._feed_name_to_loc[name]
+                self._network_port_loc[name] = (tag, mid_seg)
+
+        # Collect, per virtual port, the set of real ports it's TL-connected to.
+        virtual_neighbours = {
+            name: [] for name, p in net.ports.items() if isinstance(p, PortVirtual)
+        }
+        for br in net.branches:
+            if not isinstance(br, TL):
+                continue
+            ends = (br.a, br.b)
+            virt_ends = [e for e in ends if isinstance(net.ports[e], PortVirtual)]
+            real_ends = [e for e in ends if isinstance(net.ports[e], PortAtEdge)]
+            if len(virt_ends) == 2:
+                raise ValueError(
+                    f"TL between two virtual ports ({br.a!r}, {br.b!r}) has no "
+                    "real-segment endpoints; cannot map to NEC2 tl_card"
+                )
+            for v in virt_ends:
+                virtual_neighbours[v].extend(real_ends)
+
+        wavelength = 299.792458 / self.builder.design_freq
+        stub_len = wavelength / 100.0
+        next_tag = len(self.tups) + 1
+
+        for name, neighbours in virtual_neighbours.items():
+            if not neighbours:
+                raise ValueError(
+                    f"virtual port {name!r} has no TL branches; can't synthesise "
+                    "a stub wire without at least one real-port neighbour"
+                )
+            # Centroid of neighbour feed midpoints.
+            mids = np.stack(
+                [
+                    _seg_midpoint(
+                        *self._feed_name_to_loc[r][2:5],
+                        sub_idx=self._feed_name_to_loc[r][1],
+                    )
+                    for r in neighbours
+                ]
+            )
+            c = mids.mean(axis=0)
+            # Offset 2 stub-lengths above the highest neighbour midpoint in z,
+            # so the stub doesn't collide with the antenna geometry.
+            z_top = mids[:, 2].max()
+            base = np.array([c[0], c[1], z_top + 2.0 * stub_len])
+            tip = base + np.array([0.0, 0.0, stub_len])
+            # Single-segment stub (parity "odd" is already satisfied).
+            geo.wire(
+                next_tag,
+                1,
+                base[0],
+                base[1],
+                base[2],
+                tip[0],
+                tip[1],
+                tip[2],
+                0.0005,
+                1.0,
+                1.0,
+            )
+            self._network_port_loc[name] = (next_tag, 1)
+            next_tag += 1
+
+    def _emit_network_cards(self):
+        """Translate Network branches into tl_card calls and Network sources
+        into ex_card calls. Called after geometry_complete()."""
+        net = self._network
+        for br in net.branches:
+            if isinstance(br, TL):
+                tag_a, seg_a = self._network_port_loc[br.a]
+                tag_b, seg_b = self._network_port_loc[br.b]
+                self.c.tl_card(tag_a, seg_a, tag_b, seg_b, br.z0, br.length, 0, 0, 0, 0)
+            elif isinstance(br, (Load, TwoPort)):
+                raise NotImplementedError(
+                    f"{type(br).__name__} on PyNECEngine is a follow-up piece of "
+                    "issue #65 (ld_card / nt_card translation); use PysimEngine "
+                    "for now"
+                )
+            else:
+                raise NotImplementedError(f"branch type {type(br).__name__}")
+        for src in net.sources:
+            if not isinstance(src, Driven):
+                raise NotImplementedError(f"unknown source type: {src!r}")
+            tag, seg = self._network_port_loc[src.port]
+            v = complex(src.voltage)
+            self.excitation_pairs.append((tag, seg, v))
 
     def _apply_ground_card(self):
         g = self.ground
@@ -135,7 +278,8 @@ class PyNECEngine(SimulationEngine):
         all_cur = sc.get_current()
 
         out = []
-        for tag_idx, (p0, p1, n_seg, _ev) in enumerate(self.tups, start=1):
+        for tag_idx, t in enumerate(self.tups, start=1):
+            p0, p1, n_seg = t[0], t[1], t[2]
             seg_idxs = [i for i, t in enumerate(all_tags) if t == tag_idx]
             cur_per_seg = np.array([all_cur[i] for i in seg_idxs], dtype=np.complex128)
             knots = np.linspace(p0, p1, n_seg + 1)

--- a/src/antenna_designer/engines/pysim.py
+++ b/src/antenna_designer/engines/pysim.py
@@ -9,7 +9,19 @@ from pysim import TriangularPySim
 
 from ..engine import FarField, SimulationEngine, WireCurrents
 from ..geometry import flat_wires_to_polylines
-from ..network import TL, Driven, PortAtEdge, PortVirtual
+from ..network import TL, Driven, Load, PortAtEdge, PortVirtual
+
+
+def _series_rlc_impedance(r, l, c, omega):
+    """Series R + jωL + 1/(jωC). Any of r/l/c may be None (omitted term)."""
+    z = 0.0 + 0.0j
+    if r is not None:
+        z += r
+    if l is not None:
+        z += 1j * omega * l
+    if c is not None:
+        z += 1.0 / (1j * omega * c)
+    return z
 
 
 def _parity_for_solver(solver, solver_kwargs):
@@ -251,13 +263,53 @@ class PysimEngine(SimulationEngine):
             dtype=np.complex128,
         )
 
+    def _apply_loads(self, Y, omega):
+        """Apply every Load branch as a Sherman-Morrison rank-1 update on
+        the real-port Y. Series Z_L inserted at port k transforms
+
+            Y' = Y − Z_L · Y[:,k] · Y[k,:] / (1 + Z_L · Y[k,k])
+
+        which is the network-level equivalent of NEC2's `ld_card` modifying
+        the segment's MoM Z[k,k] (derived via Sherman-Morrison on Z_mom +
+        Z_L·e_k·e_k^T). Same physics, no solver hook required.
+        """
+        Y = Y.copy()
+        for br in self._network.branches:
+            if not isinstance(br, Load):
+                continue
+            port = self._network.ports[br.port]
+            if not isinstance(port, PortAtEdge):
+                raise ValueError(
+                    f"Load on virtual port {br.port!r}: a Load is a series "
+                    "impedance on an antenna segment, which only PortAtEdge has"
+                )
+            z_l = _series_rlc_impedance(br.r, br.l, br.c, omega)
+            if z_l == 0:
+                continue
+            k = self._port_to_idx[br.port]
+            y_col = Y[:, k].copy()
+            denom = 1.0 + z_l * Y[k, k]
+            if abs(denom) < 1e-15:
+                raise ValueError(
+                    f"Load on port {br.port!r}: 1 + Z_L·Y[k,k] ≈ 0 (singular)"
+                )
+            Y -= (z_l / denom) * np.outer(y_col, y_col)
+        return Y
+
     def _apply_branches(self, Y, wavelength):
         """Pad Y to include virtual ports, then stamp every network branch.
 
         Y comes from pysim with shape (n_real, n_real); we return a
         (n_total, n_total) augmented matrix with zeros in the virtual-port
         rows/cols (no antenna admittance) plus the branch contributions.
+
+        Order matters: Load branches modify the antenna's real-port Y first
+        (matching ld_card's effect inside the MoM), then TL/TwoPort branches
+        stamp on the loaded Y. A TL connected to a loaded port sees the
+        external side of the load.
         """
+        omega = 2.0 * np.pi * C_LIGHT / wavelength
+        Y = self._apply_loads(Y, omega)
         n_total = self._n_total_ports
         Y_full = np.zeros((n_total, n_total), dtype=np.complex128)
         n_real = Y.shape[0]
@@ -267,6 +319,8 @@ class PysimEngine(SimulationEngine):
                 a, b = self._port_to_idx[br.a], self._port_to_idx[br.b]
                 y_tl = self._tl_admittance_2x2(br.z0, br.length, wavelength)
                 Y_full[np.ix_([a, b], [a, b])] += y_tl
+            elif isinstance(br, Load):
+                continue  # already applied to the real-port Y
             else:
                 raise NotImplementedError(f"branch type {type(br).__name__}")
         return Y_full

--- a/tests/test_pysim_engine.py
+++ b/tests/test_pysim_engine.py
@@ -747,11 +747,51 @@ def test_pynec_network_rejects_virtual_to_virtual_tl():
         PyNECEngine(Builder(), ground=None)
 
 
-def test_pynec_network_rejects_load_branch():
-    """Load (ld_card backport) is a follow-up; raise NotImplementedError so
-    users get a clear pointer rather than silent omission."""
+def test_pynec_load_branch_resistor_adds_to_impedance():
+    """Load(r=R) on a PyNEC-driven dipole should shift driving-point Z by
+    exactly R — ld_card type-0 inserts a series R+L+C at the segment. This
+    is the cross-engine cross-check for piece (A) on the PyNEC side."""
     from antenna_designer import AntennaBuilder
     from antenna_designer.network import Driven, Load, Network, PortAtEdge
+    from types import MappingProxyType
+
+    class Builder(AntennaBuilder):
+        default_params = MappingProxyType({"freq": 28.0, "design_freq": 28.0})
+
+        def __init__(self, with_load=True):
+            super().__init__()
+            self._with_load = with_load
+
+        def build_wires(self):
+            return [((0, -2.5, 5), (0, 2.5, 5), 21, None, "feed")]
+
+        def build_network(self):
+            branches = [Load(port="feed", r=50.0)] if self._with_load else []
+            return Network(
+                ports={"feed": PortAtEdge("feed")},
+                branches=branches,
+                sources=[Driven(port="feed", voltage=1 + 0j)],
+            )
+
+    (z_bare,) = PyNECEngine(Builder(with_load=False), ground=None).impedance()
+    (z_loaded,) = PyNECEngine(Builder(with_load=True), ground=None).impedance()
+    # NEC2 distributes the load across the loaded segment, with a small
+    # discretisation error vs the analytical +R shift. Half an ohm at 50 Ω
+    # is well within ld_card's typical accuracy.
+    assert abs((z_loaded - z_bare) - 50.0) < 0.5, (z_bare, z_loaded)
+
+
+def test_pynec_load_branch_rejects_virtual_port():
+    """Load on a PortVirtual is rejected — same check as PysimEngine."""
+    from antenna_designer import AntennaBuilder
+    from antenna_designer.network import (
+        Driven,
+        Load,
+        Network,
+        PortAtEdge,
+        PortVirtual,
+        TL,
+    )
     from types import MappingProxyType
 
     class Builder(AntennaBuilder):
@@ -762,12 +802,18 @@ def test_pynec_network_rejects_load_branch():
 
         def build_network(self):
             return Network(
-                ports={"feed": PortAtEdge("feed")},
-                branches=[Load(port="feed", r=50)],
-                sources=[Driven(port="feed")],
+                ports={
+                    "feed": PortAtEdge("feed"),
+                    "drv": PortVirtual("drv"),
+                },
+                branches=[
+                    TL(a="drv", b="feed", z0=50, length=1.0),
+                    Load(port="drv", r=10),
+                ],
+                sources=[Driven(port="drv")],
             )
 
-    with pytest.raises(NotImplementedError, match="Load"):
+    with pytest.raises(ValueError, match="Load on virtual port"):
         PyNECEngine(Builder(), ground=None)
 
 

--- a/tests/test_pysim_engine.py
+++ b/tests/test_pysim_engine.py
@@ -687,6 +687,113 @@ def test_network_spec_rejects_port_at_edge_with_no_named_edge():
         PysimEngine(BadBuilder())
 
 
+def _load_dipole_builder(load_branch=None, name_feed=False):
+    """Synthetic half-wave dipole at 28 MHz with one named feed edge.
+    When `load_branch` is given, build_network() returns a Network with that
+    Load and a Driven on the same port. Otherwise build_network()=None and
+    the engine falls through to the plain-feed path."""
+    from antenna_designer import AntennaBuilder
+    from antenna_designer.network import Driven, Network, PortAtEdge
+    from types import MappingProxyType
+
+    class Builder(AntennaBuilder):
+        default_params = MappingProxyType({"freq": 28.0, "design_freq": 28.0})
+
+        def build_wires(self):
+            # ~λ/2 at 28 MHz is ~5.35m; half-arms of 2.5m straddling origin.
+            ex = 1 + 0j
+            if load_branch is None and not name_feed:
+                return [((0, -2.5, 5), (0, 2.5, 5), 21, ex)]
+            return [((0, -2.5, 5), (0, 2.5, 5), 21, ex, "feed")]
+
+        def build_network(self):
+            if load_branch is None:
+                return None
+            return Network(
+                ports={"feed": PortAtEdge("feed")},
+                branches=[load_branch],
+                sources=[Driven(port="feed", voltage=1 + 0j)],
+            )
+
+    return Builder()
+
+
+def test_load_branch_resistor_adds_to_impedance():
+    """Load(r=R) on the driven port should shift driving-point Z by exactly R
+    — Sherman-Morrison on a 1-port reduces to Z' = Z + Z_L."""
+    from antenna_designer.network import Load
+
+    z_bare = PysimEngine(_load_dipole_builder(name_feed=True)).impedance()[0]
+    z_loaded = PysimEngine(_load_dipole_builder(Load(port="feed", r=50.0))).impedance()[
+        0
+    ]
+    assert abs((z_loaded - z_bare) - 50.0) < 1e-6, (z_bare, z_loaded)
+
+
+def test_load_branch_series_lc_at_resonance_zero_impact():
+    """A series LC tuned to be resonant at the operating freq has Z_L=0 →
+    no shift in driving-point Z."""
+    from antenna_designer.network import Load
+
+    f_hz = 28.0e6
+    l = 1e-6
+    c = 1.0 / ((2 * np.pi * f_hz) ** 2 * l)  # ω²LC = 1
+    z_bare = PysimEngine(_load_dipole_builder(name_feed=True)).impedance()[0]
+    z_loaded = PysimEngine(
+        _load_dipole_builder(Load(port="feed", l=l, c=c))
+    ).impedance()[0]
+    assert abs(z_loaded - z_bare) < 1e-3, (z_bare, z_loaded)
+
+
+def test_load_branch_inductor_adds_reactance():
+    """Load(l=L) adds jωL to driving-point Z — pure reactive shift."""
+    from antenna_designer.network import Load
+
+    l = 1e-6
+    omega = 2 * np.pi * 28.0e6
+    z_bare = PysimEngine(_load_dipole_builder(name_feed=True)).impedance()[0]
+    z_loaded = PysimEngine(_load_dipole_builder(Load(port="feed", l=l))).impedance()[0]
+    assert abs((z_loaded - z_bare).real) < 1e-6, (z_bare, z_loaded)
+    assert abs((z_loaded - z_bare).imag - omega * l) < 1e-3, (z_bare, z_loaded)
+
+
+def test_load_branch_rejects_virtual_port():
+    """Load on a PortVirtual has no antenna segment to load → ValueError."""
+    from antenna_designer import AntennaBuilder
+    from antenna_designer.network import (
+        Driven,
+        Load,
+        Network,
+        PortAtEdge,
+        PortVirtual,
+        TL,
+    )
+    from types import MappingProxyType
+
+    class Builder(AntennaBuilder):
+        default_params = MappingProxyType({"freq": 28.0, "design_freq": 28.0})
+
+        def build_wires(self):
+            return [((0, -2.5, 5), (0, 2.5, 5), 21, 1 + 0j, "feed")]
+
+        def build_network(self):
+            return Network(
+                ports={
+                    "feed": PortAtEdge("feed"),
+                    "drv": PortVirtual("drv"),
+                },
+                branches=[
+                    TL(a="drv", b="feed", z0=50, length=1.0),
+                    Load(port="drv", r=10),
+                ],
+                sources=[Driven(port="drv")],
+            )
+
+    eng = PysimEngine(Builder())
+    with pytest.raises(ValueError, match="Load on virtual port"):
+        eng.impedance()
+
+
 def test_translator_rejects_loop_without_feed():
     """A pure cycle with no excited segment can't be handled (parasitic
     coupling not yet implemented). Should raise a clear NotImplementedError

--- a/tests/test_pysim_engine.py
+++ b/tests/test_pysim_engine.py
@@ -687,6 +687,118 @@ def test_network_spec_rejects_port_at_edge_with_no_named_edge():
         PysimEngine(BadBuilder())
 
 
+def test_pynec_network_dispatch_runs_delta_looparray_network():
+    """delta_looparray_network on PyNECEngine. With build_network() now
+    consumed, the engine synthesises a stub wire for the central virtual
+    driver, emits tl_cards from network.branches, ex_card from sources.
+
+    No strict numerical match to the legacy `delta_looparray_with_tls` is
+    expected — the segment-vs-basis port convention issue from #63 makes
+    both PyNEC variants of this design produce wonky impedances at default
+    params. The point is to verify the network-spec dispatch ran and the
+    network and legacy PyNEC results are in the same ballpark (same
+    physical antenna, modulo a tiny stub-wire difference)."""
+    from antenna_designer.designs.freq_based.delta_looparray_network import (
+        Builder as NetBuilder,
+    )
+    from antenna_designer.designs.freq_based.delta_looparray_with_tls import (
+        Builder as LegacyBuilder,
+    )
+
+    (z_net,) = PyNECEngine(NetBuilder(), ground=None).impedance()
+    (z_leg,) = PyNECEngine(LegacyBuilder(), ground=None).impedance()
+    assert np.isfinite(z_net.real) and np.isfinite(z_net.imag), z_net
+    # Same antenna, just different stub-wire placement: order-of-magnitude
+    # agreement is enough to confirm the dispatch wired through correctly.
+    ratio = abs(z_net) / abs(z_leg)
+    assert 0.3 < ratio < 3.0, (
+        f"network and legacy PyNEC results diverged too far: "
+        f"net={z_net}, legacy={z_leg}, |ratio|={ratio:.2f}"
+    )
+
+
+def test_pynec_network_rejects_virtual_to_virtual_tl():
+    """TL between two PortVirtuals has no NEC2 mapping — reject at construction."""
+    from antenna_designer import AntennaBuilder
+    from antenna_designer.network import Driven, Network, PortAtEdge, PortVirtual, TL
+    from types import MappingProxyType
+
+    class Builder(AntennaBuilder):
+        default_params = MappingProxyType({"freq": 28.0, "design_freq": 28.0})
+
+        def build_wires(self):
+            return [((0, -2.5, 5), (0, 2.5, 5), 21, None, "feed")]
+
+        def build_network(self):
+            return Network(
+                ports={
+                    "feed": PortAtEdge("feed"),
+                    "a": PortVirtual("a"),
+                    "b": PortVirtual("b"),
+                },
+                branches=[
+                    TL(a="a", b="b", z0=50, length=1.0),  # virtual ↔ virtual
+                    TL(a="a", b="feed", z0=50, length=1.0),
+                ],
+                sources=[Driven(port="a")],
+            )
+
+    with pytest.raises(ValueError, match="TL between two virtual ports"):
+        PyNECEngine(Builder(), ground=None)
+
+
+def test_pynec_network_rejects_load_branch():
+    """Load (ld_card backport) is a follow-up; raise NotImplementedError so
+    users get a clear pointer rather than silent omission."""
+    from antenna_designer import AntennaBuilder
+    from antenna_designer.network import Driven, Load, Network, PortAtEdge
+    from types import MappingProxyType
+
+    class Builder(AntennaBuilder):
+        default_params = MappingProxyType({"freq": 28.0, "design_freq": 28.0})
+
+        def build_wires(self):
+            return [((0, -2.5, 5), (0, 2.5, 5), 21, None, "feed")]
+
+        def build_network(self):
+            return Network(
+                ports={"feed": PortAtEdge("feed")},
+                branches=[Load(port="feed", r=50)],
+                sources=[Driven(port="feed")],
+            )
+
+    with pytest.raises(NotImplementedError, match="Load"):
+        PyNECEngine(Builder(), ground=None)
+
+
+def test_pynec_network_rejects_port_at_edge_with_no_named_edge():
+    """PortAtEdge("loop1") with no `loop1` edge in build_wires() should
+    raise a clear error at engine construction time — mirror of the
+    PysimEngine check."""
+    from antenna_designer import AntennaBuilder
+    from antenna_designer.network import Driven, Network, PortAtEdge, PortVirtual, TL
+    from types import MappingProxyType
+
+    class Builder(AntennaBuilder):
+        default_params = MappingProxyType({"freq": 28.0, "design_freq": 28.0})
+
+        def build_wires(self):
+            return [((0, -2.5, 5), (0, 2.5, 5), 21, 1 + 0j)]  # no name
+
+        def build_network(self):
+            return Network(
+                ports={
+                    "loop1": PortAtEdge("loop1"),
+                    "drv": PortVirtual("drv"),
+                },
+                branches=[TL(a="drv", b="loop1", z0=50, length=1.0)],
+                sources=[Driven(port="drv")],
+            )
+
+    with pytest.raises(ValueError, match="no edge in build_wires"):
+        PyNECEngine(Builder(), ground=None)
+
+
 def _load_dipole_builder(load_branch=None, name_feed=False):
     """Synthetic half-wave dipole at 28 MHz with one named feed edge.
     When `load_branch` is given, build_network() returns a Network with that

--- a/tests/test_pysim_engine.py
+++ b/tests/test_pysim_engine.py
@@ -781,6 +781,65 @@ def test_pynec_load_branch_resistor_adds_to_impedance():
     assert abs((z_loaded - z_bare) - 50.0) < 0.5, (z_bare, z_loaded)
 
 
+def test_short_dipole_loaded_cross_engine_impedance():
+    """Showcase for the Load branch: a 0.5·λ/2 shortened dipole at 28 MHz
+    with a series loading coil at the feed point. Pysim's Sherman-Morrison
+    Y stamp and PyNEC's ld_card should agree to within their baseline
+    free-space dipole tolerance (~1-2 Ω R, tens of Ω X)."""
+    from antenna_designer.designs.freq_based.short_dipole_loaded import (
+        Builder as ShortB,
+    )
+
+    b = ShortB()
+    (z_ps,) = PysimEngine(b).impedance()
+    (z_nec,) = PyNECEngine(b, ground=None).impedance()
+    # R agreement matches the dipole baseline cross-check.
+    assert abs(z_ps.real - z_nec.real) < 2.0, (z_ps, z_nec)
+    # Reactance: each engine reaches the same loaded Z within ~25 Ω,
+    # which is dominated by the underlying short-dipole reactance offset
+    # (the Load shift itself is identical between engines: each adds ωL
+    # to whatever the bare antenna's X was).
+    assert abs(z_ps.imag - z_nec.imag) < 30.0, (z_ps, z_nec)
+
+
+def test_short_dipole_loaded_pattern_similar_lower_gain_than_full():
+    """A center-loaded shortened dipole radiates the same broadside-peak
+    pattern as a full-length dipole but with ~0.4 dB less peak gain
+    (closer to the ideal short-dipole directivity of 1.76 dBi vs the
+    half-wave's 2.15 dBi). Confirmed on both engines."""
+    from antenna_designer.designs.freq_based.short_dipole_loaded import (
+        Builder as ShortB,
+    )
+
+    short = ShortB()
+    # Same Builder, length_factor=1 + no load → full-length unloaded dipole.
+    full = ShortB()
+    full.length_factor = 1.0
+    full.inductance_uH = 0.0
+
+    for engine_cls, kwargs in [(PysimEngine, {}), (PyNECEngine, {"ground": None})]:
+        ff_s = engine_cls(short, **kwargs).far_field(
+            n_theta=90, n_phi=360, del_theta=1, del_phi=1
+        )
+        ff_f = engine_cls(full, **kwargs).far_field(
+            n_theta=90, n_phi=360, del_theta=1, del_phi=1
+        )
+        # Less peak gain — the user's hypothesis. ~0.3-0.4 dB range observed.
+        assert ff_s.max_gain < ff_f.max_gain, (engine_cls.__name__, ff_s, ff_f)
+        assert 0.1 < (ff_f.max_gain - ff_s.max_gain) < 1.0, (
+            engine_cls.__name__,
+            ff_s.max_gain,
+            ff_f.max_gain,
+        )
+        # Same pattern shape: short and full dipole patterns should be
+        # highly correlated bin-by-bin (just shifted in absolute level).
+        # >0.99 corr ⇒ "same shape" to a tight tolerance.
+        rings_s = np.asarray(ff_s.rings).ravel()
+        rings_f = np.asarray(ff_f.rings).ravel()
+        corr = np.corrcoef(rings_s, rings_f)[0, 1]
+        assert corr > 0.99, f"{engine_cls.__name__}: pattern correlation {corr:.4f}"
+
+
 def test_pynec_load_branch_rejects_virtual_port():
     """Load on a PortVirtual is rejected — same check as PysimEngine."""
     from antenna_designer import AntennaBuilder


### PR DESCRIPTION
## Summary

Issue #65 follow-ups — Load branch and the PyNEC dispatch layer:

- **Load branch (piece A)** consumed by both engines. PysimEngine applies a Sherman-Morrison rank-1 update on the real-port Y (equivalent to NEC2's `ld_card` on the MoM Z[k,k]; no solver hook required). PyNECEngine emits NEC2 type-0 `ld_card`s. Load on `PortVirtual` is rejected on both sides.
- **PyNEC `build_network()` dispatch (piece C).** PyNECEngine now permissively unpacks 5-tuple `build_wires()`, dispatches on `build_network()`, synthesises ~λ/100 single-segment stub wires above the centroid of each `PortVirtual`'s TL-connected real ports, and translates `Network` branches/sources into `tl_card`/`ld_card`/`ex_card` calls. TL between two virtual ports is rejected (Q5). `TwoPort` raises NotImplementedError with a clear pointer (deferred to a follow-up branch).
- **Showcase design** `short_dipole_loaded`: 0.5·λ/2 shortened dipole with a 4.65 µH series feed-point coil. Both engines agree on impedance to ~1.3 Ω R / ~24 Ω X, both report ~0.3-0.4 dB less peak gain than the full unloaded dipole on the same Builder, and pattern correlation between short-loaded and full is >0.99. Validates the user-facing hypothesis that center-loading preserves pattern shape but trims peak gain.

## Test plan

- [x] `pytest tests/test_pysim_engine.py` — 54 pass (43 baseline + 11 new across pysim Load, PyNEC dispatch, PyNEC Load, and the showcase)
- [x] `pytest tests/` — 538 pass
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)