### PR TITLE
opt: skip far-field integration when opt_gain is off

### DIFF
--- a/src/antenna_designer/opt.py
+++ b/src/antenna_designer/opt.py
@@ -101,7 +101,11 @@ def optimize(
 
         a = engine(antenna_builder)
         zs = a.impedance()
-        _, max_gain, _, _, _ = get_elevation(a)
+        # Only compute the far-field pattern when opt_gain is on — get_elevation
+        # integrates over the full sphere and dominates per-iteration cost
+        # (>5× the impedance solve). For pure impedance / resonance objectives
+        # the computed max_gain is unused.
+        max_gain = get_elevation(a)[1] if opt_gain else 0.0
         del a
 
         for z in zs:


### PR DESCRIPTION
## Summary
- `opt.optimize()` was calling `get_elevation()` (full-sphere far-field pattern integration) on **every** objective evaluation, even when `opt_gain=False` and the returned `max_gain` was thrown away.
- Found via `py-spy` during a stalled trap_fan_dipole tuning run — ~80% of wall-clock time was inside `get_elevation` / `far_field`. The actual MoM impedance solve is much cheaper.
- One-line gate: only compute `max_gain` when `opt_gain=True`. **~5× speedup** on resonance / impedance-match tuning runs with no behavior change.

## Test plan
- [x] Full test suite passes (`pytest tests/`)
- [x] `ruff check` + `ruff format --check` pass
- [x] Verified `optimize(..., resonance=True, ...)` produces identical converged parameters (modulo Powell's internal tie-breaks) — only the time-per-iteration changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)