### PR TITLE
Handle LC trap loads at exact resonance instead of raising

### DIFF
--- a/docs/status/2026-06-14-trap-fan-dipole.md
+++ b/docs/status/2026-06-14-trap-fan-dipole.md
@@ -13,7 +13,7 @@ broken by a parallel-LC trap. Spoke 0 covers 17m/12m; spoke 1 covers
 |---|---|---|
 | `slope` | 0.68 | inverted-vee descent angle |
 | `n_bands` | 2 | locked (UI exposes 1..2 but build_wires requires 2) |
-| `trap0_freq_shift` | 0.999 | ~no-op, dodges the framework's `y==0` bug at exact LC-resonance |
+| `trap0_freq_shift` | 1.0 | no shift (the `y==0` framework bug that forced 0.999 is now fixed — see follow-up) |
 | `trap1_freq_shift` | 0.95 | puts 10m into a mode-jump regime where Re(Z)≈50 Ω |
 | band 0 `full_freq` | 18.16 MHz | 17m |
 | band 0 `trap_freq` | 24.97 MHz | 12m |
@@ -85,8 +85,10 @@ Sensitivity to ±1 cm length error: max SWR ≤ 1.17 on any band.
   band-1 trap is slightly past resonance at 10m, the outer extension
   joins the radiating section, and 10m's Re(Z) jumps from ~42 Ω to
   ~50 Ω — drops 10m SWR from 1.20 to 1.02.
-- **trap0_freq_shift=0.999** is a defensive dodge of a framework bug
-  in `network.load_impedance()` — see "Framework issues" below.
+- **trap0_freq_shift was briefly set to 0.999** as a defensive dodge of
+  a framework bug in `network.load_impedance()` (see "Framework issues").
+  That bug is now fixed, so the default is back to a clean 1.0 and band 0
+  runs at exact LC-resonance.
 
 ### Choice of simulation basis
 
@@ -116,15 +118,20 @@ Sensitivity to ±1 cm length error: max SWR ≤ 1.17 on any band.
 
 ## Framework issues / follow-ups
 
-1. **`network.load_impedance()` y==0 guard** — fires whenever a
-   parallel-LC tank's L*C*ω² lands at *exactly* 1 in float arithmetic.
-   The physical interpretation is Z=∞ (segment current=0); the engine
-   should handle this rather than crash. Our `_resonant_C_pF()`
-   construction *deliberately* sets up exact resonance, so this case
-   is on the happy path of the design intent.
-   Defensive workaround in this design: `trap0_freq_shift=0.999`
-   forces a 0.1% offset that breaks the bit-exact equality. The
-   actual fix belongs in `network.py`.
+1. **`network.load_impedance()` y==0 guard** — FIXED (follow-up commit).
+   The guard fired whenever a parallel-LC tank's L*C*ω² landed at
+   *exactly* 1 in float arithmetic — i.e. the trap's design resonance,
+   where Z=∞ (segment current interrupted, the open-circuit trap point).
+   That is the *intended* operating point, not an error. Root cause was
+   purely representational: the code formed Z_load = 1/y_tank and then
+   the consumer formed 1/(1+Z_load·Y_kk), so the infinity appeared in an
+   intermediate even though the final stamp is finite. Fix: added
+   `load_series_admittance()` returning y_load = 1/Z_load directly (= the
+   tank admittance, cleanly 0 at resonance), and reworked
+   `PysimEngine._apply_loads` to the dual Sherman-Morrison form
+   `Y -= outer / (y_load + Y_kk)` — algebraically identical for finite
+   loads, finite at resonance (coefficient → 1/Y_kk). The defensive
+   `trap0_freq_shift=0.999` was reverted to 1.0.
 
 2. **`n_bands` schema test contract** — the `test_schema_covers_every_
    non_freq_default_param` and `test_param_schema_specs_are_typed_
@@ -144,5 +151,5 @@ Sensitivity to ±1 cm length error: max SWR ≤ 1.17 on any band.
 
 ## What's *not* in this PR
 
-- The `opt.py` far-field gate — separate branch `opt-skip-far-field`.
-- A fix for `network.py`'s `y == 0` guard — TODO.
+- The `opt.py` far-field gate — separate branch `opt-skip-far-field`
+  (merged as PR #70).

--- a/src/antenna_designer/designs/freq_based/trap_fan_dipole.py
+++ b/src/antenna_designer/designs/freq_based/trap_fan_dipole.py
@@ -147,13 +147,7 @@ class Builder(AntennaBuilder):
             # resonance lands slightly off after a length retune — moving
             # the trap a few percent shifts the inner-stub electrical
             # length without touching the geometry. Default 1.0 = no shift.
-            # 0.999 not 1.0 to dodge `network.load_impedance()`'s exact-
-            # equality `y == 0` guard at the trap's LC-resonance. With shift
-            # = 1.0 exactly and the C derived from L via _resonant_C_pF(),
-            # float arithmetic lands ω²LC at exactly 1, triggering the
-            # ValueError. 0.999 puts ω₀ at 24.945 MHz instead of 24.97 — a
-            # 0.1% offset, far less than the trap's resonance bandwidth.
-            "trap0_freq_shift": 0.999,
+            "trap0_freq_shift": 1.0,
             # Set slightly below 1.0 so band-1's trap is just past resonance
             # at 10m. The trap doesn't fully open, the outer extension joins
             # in, and the inner sits in a different mode (~0.40·λ/2 instead

--- a/src/antenna_designer/engines/pysim.py
+++ b/src/antenna_designer/engines/pysim.py
@@ -17,6 +17,7 @@ from ..network import (
     PortVirtual,
     TwoPort,
     load_impedance,
+    load_series_admittance,
 )
 
 
@@ -276,13 +277,26 @@ class PysimEngine(SimulationEngine):
 
     def _apply_loads(self, Y, omega):
         """Apply every Load branch as a Sherman-Morrison rank-1 update on
-        the real-port Y. Series Z_L inserted at port k transforms
+        the real-port Y — the network-level equivalent of NEC2's `ld_card`
+        modifying the segment's MoM Z[k,k].
 
-            Y' = Y − Z_L · Y[:,k] · Y[k,:] / (1 + Z_L · Y[k,k])
+        The update has two algebraically-identical forms, dual under
+        Z_L ↔ y_L = 1/Z_L:
 
-        which is the network-level equivalent of NEC2's `ld_card` modifying
-        the segment's MoM Z[k,k] (derived via Sherman-Morrison on Z_mom +
-        Z_L·e_k·e_k^T). Same physics, no solver hook required.
+            impedance:   Y − Z_L/(1 + Z_L·Y_kk) · outer(Y[:,k], Y[k,:])
+            admittance:  Y − 1/(y_L + Y_kk)     · outer(Y[:,k], Y[k,:])
+
+        Each Load mode has a resonance where one form divides by an
+        intermediate infinity while the other stays finite, so we pick the
+        form whose denominator is bounded at that mode's resonance:
+
+          - Parallel-LC trap: Z_L→∞ at ω₀ (open circuit). Use the
+            ADMITTANCE form — y_L is the tank admittance, →0 at ω₀, giving
+            coefficient 1/Y_kk (the open-circuit Schur complement).
+          - Series-LC: Z_L→0 at ω₀ (short circuit = unbroken wire). Use the
+            IMPEDANCE form — coefficient →0, i.e. no stamp.
+
+        This way neither path ever forms or tests for infinity.
         """
         Y = Y.copy()
         for br in self._network.branches:
@@ -294,17 +308,31 @@ class PysimEngine(SimulationEngine):
                     f"Load on virtual port {br.port!r}: a Load is a series "
                     "impedance on an antenna segment, which only PortAtEdge has"
                 )
-            z_l = load_impedance(br, omega)
-            if z_l == 0:
-                continue
             k = self._port_to_idx[br.port]
             y_col = Y[:, k].copy()
-            denom = 1.0 + z_l * Y[k, k]
-            if abs(denom) < 1e-15:
-                raise ValueError(
-                    f"Load on port {br.port!r}: 1 + Z_L·Y[k,k] ≈ 0 (singular)"
-                )
-            Y -= (z_l / denom) * np.outer(y_col, y_col)
+
+            if br.parallel:
+                # Admittance form: y_L is the parallel-LC tank admittance,
+                # cleanly 0 at trap resonance (the open-circuit point).
+                y_l = load_series_admittance(br, omega)
+                denom = y_l + Y[k, k]
+                if abs(denom) < 1e-15:
+                    raise ValueError(
+                        f"Load on port {br.port!r}: y_L + Y[k,k] ≈ 0 (singular)"
+                    )
+                Y -= np.outer(y_col, y_col) / denom
+            else:
+                # Impedance form: Z_L is 0 at series-LC resonance (a short
+                # = unbroken wire), where the coefficient vanishes anyway.
+                z_l = load_impedance(br, omega)
+                if z_l == 0:
+                    continue
+                denom = 1.0 + z_l * Y[k, k]
+                if abs(denom) < 1e-15:
+                    raise ValueError(
+                        f"Load on port {br.port!r}: 1 + Z_L·Y[k,k] ≈ 0 (singular)"
+                    )
+                Y -= (z_l / denom) * np.outer(y_col, y_col)
         return Y
 
     def _apply_branches(self, Y, wavelength):

--- a/src/antenna_designer/network.py
+++ b/src/antenna_designer/network.py
@@ -143,19 +143,44 @@ def _parallel_rlc_admittance(r, l, c, omega):
     return y
 
 
+def load_series_admittance(br, omega):
+    """Series-branch admittance y_load = 1/Z_load of a Load branch at ω.
+
+    This is the natural quantity for the Sherman-Morrison port-Y stamp
+    (see PysimEngine._apply_loads): the stamp coefficient is
+    1/(y_load + Y_kk), which stays finite exactly where Z_load blows up.
+
+    Parallel mode: y_load IS the parallel-LC tank admittance,
+        y = 1/R + 1/(jωL) + jωC,
+    which goes cleanly to 0 at ω₀ = 1/√(LC) — the trap-resonance open
+    circuit. No singularity: the "infinite impedance" only ever appeared
+    when we formed Z_load = 1/y and then took 1/Z_load again.
+
+    Series mode: y_load = 1/(R + jωL + 1/(jωC)); returns complex inf when
+    the series impedance is exactly 0 (series-LC short circuit), which the
+    caller treats as "no series element" (the wire is unbroken)."""
+    if br.parallel:
+        return _parallel_rlc_admittance(br.r, br.l, br.c, omega)
+    z = _series_rlc_impedance(br.r, br.l, br.c, omega)
+    if z == 0:
+        return complex(float("inf"), 0.0)
+    return 1.0 / z
+
+
 def load_impedance(br, omega):
     """Effective series impedance of a Load branch at angular ω.
     Series mode: Z = R + jωL + 1/(jωC).
     Parallel mode: Z = 1 / (1/R + 1/(jωL) + jωC) — equals the parallel-LC
-    tank impedance, diverging at ω₀ = 1/√(LC) (the trap idiom)."""
+    tank impedance, diverging at ω₀ = 1/√(LC) (the trap idiom).
+
+    Returns complex inf at parallel-LC resonance rather than raising —
+    Z→∞ is the physically-intended open circuit of a trap. Consumers that
+    stamp the load into a port-Y matrix should prefer
+    `load_series_admittance`, which avoids forming this infinity at all."""
     if br.parallel:
         y = _parallel_rlc_admittance(br.r, br.l, br.c, omega)
         if y == 0:
-            raise ValueError(
-                f"Load {br!r} parallel-mode admittance is 0 (LC at exact "
-                "resonance with no R); the load impedance is infinite. Add "
-                "a finite r, or evaluate off-resonance."
-            )
+            return complex(float("inf"), 0.0)
         return 1.0 / y
     return _series_rlc_impedance(br.r, br.l, br.c, omega)
 

--- a/tests/test_pysim_engine.py
+++ b/tests/test_pysim_engine.py
@@ -975,24 +975,63 @@ def test_trap_dipole_low_band_loaded_into_resonance():
     assert 30 < z_nec.real < 200, z_nec
 
 
-def test_trap_dipole_parallel_lc_resonance_singularity_raises():
-    """At exactly f_high with no parallel R, the parallel-LC admittance
-    is 0 and the stamp is singular. Pysim should raise a clear error
-    rather than silently produce garbage."""
+def test_trap_dipole_parallel_lc_resonance_is_finite():
+    """At exactly f_high with no parallel R, the parallel-LC tank admittance
+    is 0 (Z→∞, the trap open circuit). This is the *intended* operating
+    point of a trap, not an error: the admittance-form Sherman-Morrison
+    stamp resolves the 0/∞ analytically (coefficient → 1/Y_kk, the
+    open-circuit Schur complement). Pysim must produce a finite impedance
+    here — no raise, no NaN/Inf."""
     from antenna_designer.designs.freq_based.trap_dipole import Builder
 
     b = Builder()
-    b.freq = b.design_freq  # exactly at trap resonance
-    # Verify the trap_C calculation lands exactly on resonance for this f.
-    # If the singularity check fires it means Load spotted Y → 0; if
-    # the impedance returns finite, floating-point drift kept us off the
-    # singular point. Either is acceptable — the test just confirms no
-    # silent NaN/Inf propagation.
-    try:
-        (z,) = PysimEngine(b).impedance()
-        assert np.isfinite(z.real) and np.isfinite(z.imag), z
-    except ValueError as e:
-        assert "parallel-mode admittance is 0" in str(e), str(e)
+    b.freq = b.design_freq  # exactly at trap resonance — tank admittance → 0
+    (z,) = PysimEngine(b).impedance()
+    assert np.isfinite(z.real) and np.isfinite(z.imag), z
+
+
+def test_load_series_admittance_parallel_lc_zero_at_resonance():
+    """The parallel-LC tank admittance is exactly 0 at ω₀=1/√(LC) — the
+    open-circuit trap point — and load_impedance returns +inf there rather
+    than raising."""
+    import math
+
+    from antenna_designer.network import (
+        Load,
+        load_impedance,
+        load_series_admittance,
+    )
+
+    L = 5e-6
+    C = 1.0 / (L * (2 * math.pi * 28e6) ** 2)  # resonant at 28 MHz
+    omega0 = 1.0 / math.sqrt(L * C)
+    br = Load(port="t", l=L, c=C, parallel=True)
+
+    y = load_series_admittance(br, omega0)
+    assert abs(y) < 1e-6, y  # tank admittance ≈ 0 at resonance
+
+    z = load_impedance(br, omega0)
+    assert math.isinf(z.real), z  # Z = 1/y → ∞ (no raise)
+
+    # Off resonance the tank is reactive and finite.
+    y_off = load_series_admittance(br, omega0 * 1.1)
+    assert abs(y_off) > 1e-6, y_off
+
+
+def test_load_series_admittance_series_short_is_inf():
+    """A series-LC load at its resonance is a short (Z=0); its series
+    admittance is reported as inf so the stamp consumer skips it."""
+    import math
+
+    from antenna_designer.network import Load, load_series_admittance
+
+    L = 5e-6
+    C = 1.0 / (L * (2 * math.pi * 28e6) ** 2)
+    omega0 = 1.0 / math.sqrt(L * C)
+    br = Load(port="t", l=L, c=C, parallel=False)  # series mode
+
+    y = load_series_admittance(br, omega0)
+    assert math.isinf(y.real), y
 
 
 def _load_dipole_builder(load_branch=None, name_feed=False):


### PR DESCRIPTION
## Summary
- A parallel-LC trap is *meant* to present Z→∞ at its resonant frequency (the open circuit that interrupts the segment's current), but `network.load_impedance()` raised `ValueError` there and the Pysim stamp would have divided by an intermediate infinity. The `trap_fan_dipole` design had to dodge this with a 0.1%-off `trap0_freq_shift=0.999`.
- The singularity was purely representational. The Sherman-Morrison rank-1 stamp has two algebraically-identical dual forms (impedance `Z_L/(1+Z_L·Y_kk)` and admittance `1/(y_L+Y_kk)`); each Load mode has a resonance where one form blows up and the other stays finite. `_apply_loads` now dispatches on `br.parallel` and uses the non-singular form: **admittance** for the parallel-LC trap (Z→∞, y→0 → coefficient `1/Y_kk`), **impedance** for series-LC (Z→0 → coefficient 0). Neither path ever forms or tests for infinity.
- Added `network.load_series_admittance()` (returns `y_L = 1/Z_load`, = the tank admittance for a parallel trap, cleanly 0 at resonance). `load_impedance` no longer raises (returns complex inf at parallel resonance) and points callers at the admittance entry point.
- Reverted the `trap_fan_dipole` workaround: `trap0_freq_shift` back to 1.0, band 0 runs at exact LC-resonance (12m lands at Z≈51.5−0.3j, SWR 1.03). Updated the status doc to mark the bug fixed.

## Test plan
- [x] Full suite passes (`pytest tests/`, 635 tests)
- [x] `ruff check` + `ruff format --check` clean
- [x] Renamed `test_..._singularity_raises` → asserts a *finite* result at exact trap resonance
- [x] New unit tests: `load_series_admittance` is 0 at parallel-LC resonance, inf at series-LC resonance
- [x] Verified a series-LC load at its resonance (Z=0) gives Z_in identical to the bare unloaded wire (short = unbroken segment)
- [x] trap_fan_dipole SWR50 unchanged: 17m 1.03, 15m 1.04, 12m 1.03, 10m 1.07

🤖 Generated with [Claude Code](https://claude.com/claude-code)