### PR TITLE
Cache live /solve responses and dedup per-tick MoM solves

### DIFF
--- a/src/antenna_designer/engines/pysim.py
+++ b/src/antenna_designer/engines/pysim.py
@@ -400,6 +400,25 @@ class PysimEngine(SimulationEngine):
         I = Y_total @ V
         return [complex(V[i] / I[i]) for i in self._driven_port_idx]
 
+    def _solved_excited(self, wavelength):
+        """Build the excitation-resolved solver and run compute_impedance
+        once per (wavelength, feed-voltage) tuple, caching on the engine
+        instance. Lets impedance(), current_distribution(), and far_field()
+        share one MoM solve when the live UI tick calls them in sequence.
+
+        Cache lives for this engine instance only; the server constructs a
+        fresh PysimEngine each tick, so nothing leaks across requests.
+        """
+        sim = self._make_excited_solver(wavelength=wavelength)
+        v_key = tuple((complex(v).real, complex(v).imag) for *_, v in sim.feeds)
+        key = (float(wavelength), v_key)
+        cached = getattr(self, "_solved_cache", None)
+        if cached is not None and cached[0] == key:
+            return cached[1]
+        z, coeffs = sim.compute_impedance()
+        self._solved_cache = (key, (sim, coeffs, z))
+        return sim, coeffs, z
+
     def impedance(self):
         wavelength = self._wavelength_for(self.builder.freq)
         if self._network is not None:
@@ -410,8 +429,7 @@ class PysimEngine(SimulationEngine):
             Y = self._compute_y_matrix(wavelength)
             Y_total = self._apply_tls(Y, wavelength)
             return self._impedance_from_y(Y_total)
-        s = self._make_solver(wavelength=wavelength)
-        z, _coeffs = s.compute_impedance()
+        _sim, _coeffs, z = self._solved_excited(wavelength)
         # Single-feed path returns a scalar; multi-feed returns an array.
         # Match PyNECEngine's list-of-Z return shape.
         z_arr = np.atleast_1d(z)
@@ -494,10 +512,7 @@ class PysimEngine(SimulationEngine):
         )
 
     def current_distribution(self):
-        sim = self._make_excited_solver(
-            wavelength=self._wavelength_for(self.builder.freq)
-        )
-        _z, coeffs = sim.compute_impedance()
+        sim, coeffs, _z = self._solved_excited(self._wavelength_for(self.builder.freq))
         knot_currents = sim.currents_at_knots(coeffs)
         out = []
         for w_idx, polyline in enumerate(self._polylines):
@@ -606,50 +621,7 @@ class PysimEngine(SimulationEngine):
         k = 2.0 * np.pi / wavelength
         freq_hz = self.builder.freq * 1e6
 
-        if self._network is not None:
-            # Same trick as the legacy TL path: extract Y at the real ports,
-            # pad to include virtual ports, stamp the branches, solve for
-            # the resolved real-port voltages, then re-solve the MoM once
-            # with every real feed at its true V so basis coefficients
-            # reflect the branch-induced port voltages.
-            Y = self._compute_y_matrix(wavelength)
-            Y_total = self._apply_branches(Y, wavelength)
-            V_full = self._resolve_network_voltages(Y_total)
-            feeds_resolved = [
-                (w, arc, complex(V_full[i]))
-                for i, (w, arc, _v) in enumerate(self._feeds)
-            ]
-            sim = self._solver(
-                wires=self._polylines,
-                n_per_edge_per_wire=self._edge_segments,
-                feeds=feeds_resolved,
-                wavelength=wavelength,
-                wire_radius=self._wire_radius,
-                ground_z=self._ground_z,
-                junctions=self._junctions or None,
-                **self._solver_kwargs,
-            )
-        elif self._tls:
-            # Legacy TL path: same pattern but everything's a real port.
-            Y = self._compute_y_matrix(wavelength)
-            Y_total = self._apply_tls(Y, wavelength)
-            V, _ = self._resolve_feed_voltages(Y_total)
-            feeds_resolved = [
-                (w, arc, complex(V[i])) for i, (w, arc, _v) in enumerate(self._feeds)
-            ]
-            sim = self._solver(
-                wires=self._polylines,
-                n_per_edge_per_wire=self._edge_segments,
-                feeds=feeds_resolved,
-                wavelength=wavelength,
-                wire_radius=self._wire_radius,
-                ground_z=self._ground_z,
-                junctions=self._junctions or None,
-                **self._solver_kwargs,
-            )
-        else:
-            sim = self._make_solver(wavelength=wavelength)
-        _z, coeffs = sim.compute_impedance()
+        sim, coeffs, _z = self._solved_excited(wavelength)
         mid, dr, i_mid = self._segment_dipoles(sim, coeffs)
 
         # Cell-centred integration grid for ∫|M_perp|² dΩ. With ground the

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -770,3 +770,209 @@ def test_compute_directivity_norm_ground_on_stays_finite_and_positive():
     server._compute_directivity_norm(with_ground, n_theta=15, n_phi=30)
     assert with_ground["directivity_norm"] > 0
     assert np.isfinite(with_ground["directivity_norm"])
+
+
+# ---------------------------------------------------------------------------
+# Cache-key allowlist tests
+#
+# The /ws live-tick cache in server.solve() hashes the request to skip
+# repeat solves. Two correctness hazards:
+#
+#  (a) A new field is added to the request that DOES affect the physics,
+#      but it isn't reflected in the key — the cache silently returns a
+#      stale answer.
+#  (b) A new field is added that does NOT affect the physics (a UI-only
+#      hint, a client timestamp) — the key changes on every tick and the
+#      cache effectively never hits.
+#
+# These tests pin a representative request and explicitly enumerate which
+# fields are "physical" (must influence the key) vs "ignored" (must not).
+# When a new field shows up that isn't in either list, the test fails
+# with a message telling the author exactly what to do.
+# ---------------------------------------------------------------------------
+
+
+# Representative live request — the shape the React client posts on the
+# /ws socket for an interactive solve. Update this when the frontend
+# request shape changes; that update is the cue to also revisit the
+# physical/ignored split below.
+_CANONICAL_REQ = {
+    "geometry": "freq_based.fandipole",
+    "solver": "pysim",
+    "pysim_model": "bspline",
+    "model_options": {
+        "degree": 2,
+        "use_singular_enrichment": True,
+        "enrichment_variant": "auto",
+        "tikhonov_lambda": 1e-3,
+    },
+    "wire_radius": 0.0005,
+    "ground": False,
+    "n_per_wire": 21,
+    "variant": None,
+    "design_freq_mhz": 14.300,
+    "measurement_freq_mhz": 14.300,
+    "params": {},
+    # A representative builder param the adapter pulls from the top level.
+    "base": 7.0,
+    "slope": 0.5,
+    "n_bands": 5,
+}
+
+# Top-level fields known to influence the solve numerics. Each MUST cause
+# the canonical key to change when perturbed.
+_PHYSICAL_FIELDS = frozenset(
+    {
+        "geometry",
+        "solver",
+        "pysim_model",
+        "model_options",
+        "wire_radius",
+        "ground",
+        "n_per_wire",
+        "variant",
+        "design_freq_mhz",
+        "measurement_freq_mhz",
+        "params",
+        "base",
+        "slope",
+        "n_bands",
+    }
+)
+
+# Top-level fields known NOT to influence the solve numerics. Adding any
+# of these to the request MUST NOT change the canonical key — otherwise
+# every tick is a cache miss. Members must also be in server's
+# _CACHE_KEY_BLOCKLIST.
+_IGNORED_FIELDS = frozenset(
+    {
+        "_request_id",
+        "_client_ts",
+    }
+)
+
+
+def test_cache_key_field_coverage_is_exhaustive():
+    """The canonical request's top-level keys must be fully classified.
+
+    If this fails, the canonical request has grown a field that isn't
+    declared physical or ignored. Pick one:
+
+      - If the field changes the physics, add it to _PHYSICAL_FIELDS
+        (it's already in the key via the catch-all hash; this just makes
+        intent explicit and gives the perturbation test something to
+        verify).
+      - If the field is UI-only (timestamps, render hints, client ids),
+        add it to _IGNORED_FIELDS *and* to server._CACHE_KEY_BLOCKLIST,
+        otherwise it will torch the cache hit rate.
+    """
+    seen = set(_CANONICAL_REQ.keys())
+    classified = _PHYSICAL_FIELDS | _IGNORED_FIELDS
+    unclassified = seen - classified
+    stale = (
+        classified - seen - _IGNORED_FIELDS
+    )  # ignored fields don't have to be in canonical
+    assert not unclassified, (
+        f"unclassified request fields in canonical request: {sorted(unclassified)}. "
+        f"Add each to _PHYSICAL_FIELDS or _IGNORED_FIELDS (and _CACHE_KEY_BLOCKLIST)."
+    )
+    assert not stale, (
+        f"fields declared physical but missing from canonical request: {sorted(stale)}. "
+        f"Either remove from _PHYSICAL_FIELDS or add to _CANONICAL_REQ."
+    )
+
+
+def test_cache_key_blocklist_matches_ignored_fields():
+    """Ignored fields must also be in server._CACHE_KEY_BLOCKLIST.
+
+    Otherwise the blocklist is a lie: a field declared ignored here would
+    still be hashed into the key in production.
+    """
+    missing = _IGNORED_FIELDS - server._CACHE_KEY_BLOCKLIST
+    assert not missing, (
+        f"fields in _IGNORED_FIELDS but not in server._CACHE_KEY_BLOCKLIST: "
+        f"{sorted(missing)}. Add them to server._CACHE_KEY_BLOCKLIST so the "
+        f"canonical-key builder actually strips them."
+    )
+
+
+@pytest.mark.parametrize("field", sorted(_PHYSICAL_FIELDS))
+def test_cache_key_changes_when_physical_field_perturbed(field):
+    """Perturbing a physical field MUST change the canonical key.
+
+    If this fails on field X, the canonicalizer is dropping X — either it
+    was added to _CACHE_KEY_BLOCKLIST by mistake, or the hashing function
+    isn't reaching it (e.g. lives inside a non-dict / non-list container
+    that quantise() doesn't recurse into).
+    """
+    base_key = server._canonical_solve_key(_CANONICAL_REQ)
+    perturbed = dict(_CANONICAL_REQ)
+    v = perturbed[field]
+    if isinstance(v, bool):
+        perturbed[field] = not v
+    elif isinstance(v, (int, float)):
+        perturbed[field] = v + 1
+    elif isinstance(v, str):
+        perturbed[field] = v + "_x"
+    elif isinstance(v, dict):
+        perturbed[field] = {**v, "__probe__": 999}
+    elif v is None:
+        perturbed[field] = "non_none"
+    else:
+        perturbed[field] = ("__probe__", v)
+    new_key = server._canonical_solve_key(perturbed)
+    assert new_key != base_key, (
+        f"perturbing physical field {field!r} did NOT change the cache key. "
+        f"The canonicalizer is failing to capture this field; cache will return "
+        f"stale results when {field!r} changes between calls."
+    )
+
+
+@pytest.mark.parametrize("field", sorted(_IGNORED_FIELDS))
+def test_cache_key_unchanged_when_ignored_field_added(field):
+    """Adding an ignored field MUST NOT change the canonical key.
+
+    If this fails on field X, X is in _IGNORED_FIELDS but server's
+    blocklist isn't stripping it — every request that carries X will
+    miss the cache. Add X to server._CACHE_KEY_BLOCKLIST.
+    """
+    base_key = server._canonical_solve_key(_CANONICAL_REQ)
+    with_field = dict(_CANONICAL_REQ)
+    with_field[field] = "anything"
+    assert server._canonical_solve_key(with_field) == base_key, (
+        f"adding ignored field {field!r} changed the cache key — the blocklist "
+        f"is not stripping it. Add {field!r} to server._CACHE_KEY_BLOCKLIST."
+    )
+
+
+def test_cache_key_quantises_floats_below_step():
+    """Floats within _CACHE_FLOAT_QUANT must collapse to the same key.
+
+    Slider positions are coarser than this quant; without quantisation,
+    back-and-forth scrubs to nominally-identical values would miss.
+    """
+    base = dict(_CANONICAL_REQ)
+    nudged = dict(_CANONICAL_REQ)
+    nudged["design_freq_mhz"] = (
+        base["design_freq_mhz"] + server._CACHE_FLOAT_QUANT * 0.1
+    )
+    assert server._canonical_solve_key(base) == server._canonical_solve_key(nudged)
+
+
+def test_cache_key_recurses_into_model_options():
+    """Sanity: per-solver kwargs inside model_options must contribute to
+    the key. Otherwise switching bspline degrees or toggling singular
+    enrichment via model_options.use_singular_enrichment would return
+    a stale answer."""
+    base_key = server._canonical_solve_key(_CANONICAL_REQ)
+    for k, alt in [
+        ("degree", 1),
+        ("use_singular_enrichment", False),
+        ("enrichment_variant", "off"),
+        ("tikhonov_lambda", 1e-2),
+    ]:
+        mutant = dict(_CANONICAL_REQ)
+        mutant["model_options"] = {**_CANONICAL_REQ["model_options"], k: alt}
+        assert server._canonical_solve_key(mutant) != base_key, (
+            f"model_options.{k} change did not alter the cache key"
+        )

--- a/web/server.py
+++ b/web/server.py
@@ -95,8 +95,11 @@ os.environ.setdefault("GOMP_SPINCOUNT", "0")
 
 # ruff: noqa: E402 — imports below must follow the env-var setup above so
 # OpenBLAS picks up the thread count at its own import time.
+import hashlib
 import json
 import time
+from collections import OrderedDict
+from copy import deepcopy
 
 import numpy as np
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
@@ -370,7 +373,44 @@ def _polyline_knots(polyline: np.ndarray, npe_list: list[int]) -> np.ndarray:
     return np.vstack(parts)
 
 
-def solve(req: dict) -> dict:
+_SOLVE_CACHE: "OrderedDict[str, dict]" = OrderedDict()
+_SOLVE_CACHE_MAX = 100
+
+# Request fields that are pure metadata and never change the physics. Pop
+# them before hashing so noisy frontend additions (timestamps, request ids)
+# don't shred the hit rate. Anything else in `req` is treated as load-
+# bearing — preferring "extra miss" over "wrong hit".
+_CACHE_KEY_BLOCKLIST = frozenset(
+    {
+        "_request_id",
+        "_client_ts",
+    }
+)
+
+# Quantisation grid for floats in the cache key. Slider grids in the UI
+# are coarser than 1e-6, so this still lets back-and-forth scrubs land on
+# identical values; finer than user-perceivable change so two genuinely
+# different requests don't collide.
+_CACHE_FLOAT_QUANT = 1e-6
+
+
+def _canonical_solve_key(req: dict) -> str:
+    def quantise(x):
+        if isinstance(x, float):
+            return round(x / _CACHE_FLOAT_QUANT) * _CACHE_FLOAT_QUANT
+        if isinstance(x, dict):
+            return {
+                k: quantise(v) for k, v in x.items() if k not in _CACHE_KEY_BLOCKLIST
+            }
+        if isinstance(x, (list, tuple)):
+            return [quantise(v) for v in x]
+        return x
+
+    blob = json.dumps(quantise(req), sort_keys=True, default=str).encode()
+    return hashlib.blake2b(blob, digest_size=16).hexdigest()
+
+
+def _solve_uncached(req: dict) -> dict:
     geometry = req.get("geometry", next(iter(EXAMPLES)))
     use_pynec = req.get("solver") == "pynec" and pynec_backend.HAVE_PYNEC
     if use_pynec:
@@ -383,6 +423,28 @@ def solve(req: dict) -> dict:
     out["solver"] = "pysim"
     _attach_derived_em_fields(out)
     _compute_directivity_norm(out)
+    return out
+
+
+def solve(req: dict) -> dict:
+    key = _canonical_solve_key(req)
+    hit = _SOLVE_CACHE.get(key)
+    if hit is not None:
+        _SOLVE_CACHE.move_to_end(key)
+        t0 = time.perf_counter()
+        out = deepcopy(hit)
+        # Overwrite the cached solve_ms with the actual cost of producing
+        # this response (the lookup + deepcopy) — otherwise the frontend's
+        # "solve time" indicator shows a stale value from whichever earlier
+        # tick first populated this cache entry.
+        out["solve_ms"] = (time.perf_counter() - t0) * 1e3
+        out["cache_hit"] = True
+        return out
+    out = _solve_uncached(req)
+    out["cache_hit"] = False
+    _SOLVE_CACHE[key] = deepcopy(out)
+    while len(_SOLVE_CACHE) > _SOLVE_CACHE_MAX:
+        _SOLVE_CACHE.popitem(last=False)
     return out
 
 


### PR DESCRIPTION
## Summary
- **Dedup the per-tick MoM solve.** `PysimEngine.impedance()` / `current_distribution()` / `far_field()` previously each built a fresh solver and called `compute_impedance()` independently — 2–3 full solves per UI tick. They now route through `_solved_excited()` which caches `(sim, coeffs, z)` on the engine instance keyed on `(wavelength, feed-voltage tuple)`. On the 5-band fandipole (n_basis=435), `current_distribution()` after `impedance()` drops from ~720 ms to ~5 ms.
- **LRU cache the /solve response.** `web.server.solve()` is wrapped in a 100-entry blake2b-keyed cache over the canonicalised request (recursive float quantisation, blocklist for UI-only fields, deepcopy on store and return). Same-input ticks return in ~0.3 ms — fits the back-and-forth scrub pattern the UI naturally produces. `cache_hit` is surfaced on the response for telemetry.
- **Allowlist tests guard the cache key.** Every top-level field in a representative request must be declared physical (must change the key when perturbed) or ignored (must not), and the blocklist must actually strip the ignored ones. Failure messages spell out which list to update, so adding a frontend field can't silently torch the hit rate or return stale impedance.

## Test plan
- [x] `pytest tests/test_pysim_engine.py` — 60 passed, including the network/TL paths the dedup touches
- [x] `pytest tests/test_web_server.py -k cache_key` — 20 cache-key allowlist tests pass
- [x] Smoke: cold solve ~75 ms, repeat-same-request ~0.3 ms, perturb-then-revert hits the cache again, `z_in_re` byte-stable across hits
- [ ] Manual scrub of a length-factor slider in the UI to confirm the perceived latency drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)