### PR TITLE
Make PyNEC optional so tests run on Windows

### DIFF
--- a/src/antenna_designer/cli.py
+++ b/src/antenna_designer/cli.py
@@ -21,9 +21,10 @@ from importlib import import_module
 from types import ModuleType
 
 ENGINE_CLASSES = {
-    "pynec": PyNECEngine,
     "pysim": PysimEngine,
 }
+if PyNECEngine is not None:
+    ENGINE_CLASSES["pynec"] = PyNECEngine
 
 PYSIM_BASES = {
     "triangular": TriangularPySim,

--- a/src/antenna_designer/engines/__init__.py
+++ b/src/antenna_designer/engines/__init__.py
@@ -1,4 +1,8 @@
-from .pynec import PyNECEngine
+try:
+    from .pynec import PyNECEngine
+except ImportError:
+    PyNECEngine = None
+
 from .pysim import PysimEngine
 
 __all__ = ["PyNECEngine", "PysimEngine"]

--- a/src/antenna_designer/sim.py
+++ b/src/antenna_designer/sim.py
@@ -1,3 +1,6 @@
-from .engines.pynec import PyNECEngine
+try:
+    from .engines.pynec import PyNECEngine
+except ImportError:
+    PyNECEngine = None
 
 Antenna = PyNECEngine

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import importlib.util
+import os
+
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg", force=True)
+
+import pytest  # noqa: E402
+
+HAS_PYNEC = importlib.util.find_spec("PyNEC") is not None
+
+needs_pynec = pytest.mark.skipif(
+    not HAS_PYNEC, reason="PyNEC not installed (engine unavailable on this platform)"
+)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 import antenna_designer as ant
 
+from conftest import needs_pynec
+
 o = " --fn /dev/null"
 # o = ''
 
@@ -20,6 +22,7 @@ def test_cli_draw():
         ant.cli(f"draw --builder {design}{o}".split())
 
 
+@needs_pynec
 def test_cli_sweep():
     ant.cli(f"sweep --param tipspacer_factor --builder moxon --npoints 2{o}".split())
     ant.cli(
@@ -43,6 +46,7 @@ def test_cli_sweep():
     )
 
 
+@needs_pynec
 def test_cli_optimize():
     ant.cli(
         f"optimize --params length_factor angle_radians --builder freq_based.invvee{o}".split()
@@ -52,11 +56,13 @@ def test_cli_optimize():
     )
 
 
+@needs_pynec
 def test_cli_pattern():
     ant.cli(f"pattern --builder freq_based.yagi{o}".split())
     ant.cli(f"pattern --builder freq_based.invvee --wireframe{o}".split())
 
 
+@needs_pynec
 def test_cli_compare_patterns():
     ant.cli(f"compare_patterns{o}".split())
     ant.cli(f"compare_patterns --builders freq_based.invvee moxon{o}".split())

--- a/tests/test_engine_spec.py
+++ b/tests/test_engine_spec.py
@@ -13,7 +13,10 @@ from antenna_designer.cli import (
 from antenna_designer.engines import PyNECEngine, PysimEngine
 from pysim import TriangularPySim, SinusoidalPySim, BSplinePySim
 
+from conftest import needs_pynec
 
+
+@needs_pynec
 def test_parse_pynec_no_basis():
     assert parse_engine_spec("pynec") == ("pynec", {})
 
@@ -51,6 +54,7 @@ def test_parse_pysim_unknown_basis_raises():
         parse_engine_spec("pysim:not_a_basis")
 
 
+@needs_pynec
 def test_make_factory_returns_class_when_no_kwargs():
     assert make_engine_factory("pynec", _GROUND_UNSET) is PyNECEngine
     assert make_engine_factory("pysim", _GROUND_UNSET) is PysimEngine
@@ -75,12 +79,14 @@ def test_pysim_bases_keys():
 O = " --fn /dev/null"
 
 
+@needs_pynec
 def test_cli_compare_patterns_multi_engine():
     ant.cli(
         f"compare_patterns --builders freq_based.invvee:dipole --engines pynec pysim{O}".split()
     )
 
 
+@needs_pynec
 def test_cli_compare_patterns_single_engine_still_works():
     ant.cli(
         f"compare_patterns --builders freq_based.invvee:dipole freq_based.invvee --engines pynec{O}".split()
@@ -122,6 +128,7 @@ def test_broadcast_mismatch_raises():
         broadcast_pairs(["a", "b"], ["x", "y", "z"])
 
 
+@needs_pynec
 def test_cli_compare_patterns_three_by_three_paired():
     ant.cli(
         f"compare_patterns --builders freq_based.invvee:dipole freq_based.invvee bowtie "

--- a/tests/test_pysim_engine.py
+++ b/tests/test_pysim_engine.py
@@ -8,6 +8,8 @@ from antenna_designer.designs.freq_based.invvee import Builder
 from antenna_designer.engines import PyNECEngine, PysimEngine
 from antenna_designer.geometry import flat_wires_to_polylines
 
+from conftest import needs_pynec
+
 
 def test_translator_chains_dipole_into_single_polyline():
     b = Builder(Builder.dipole_params)  # straight half-wave dipole
@@ -45,6 +47,7 @@ def test_pysim_impedance_sweep_shape_and_monotone_resistance():
     assert np.all(np.diff(real) > 0), real
 
 
+@needs_pynec
 def test_pysim_matches_pynec_in_free_space():
     """Free-space cross-check between the two MoM engines on a dipole.
     Disabling PyNEC's gn_card so both solve the same physical problem
@@ -63,6 +66,7 @@ def test_pysim_matches_pynec_in_free_space():
     )
 
 
+@needs_pynec
 @pytest.mark.parametrize(
     "design_module, max_dR, max_dX",
     [
@@ -219,6 +223,7 @@ def test_pysim_engine_declares_far_field_support():
     assert PysimEngine.supports_far_field is True
 
 
+@needs_pynec
 def test_pysim_far_field_shape_matches_pynec():
     """The FarField shape (rings dims, thetas/phis arrays) has to match
     PyNEC's so plot_patterns, compare_patterns etc. work for both."""
@@ -233,6 +238,7 @@ def test_pysim_far_field_shape_matches_pynec():
     assert len(ff_ps.rings[0]) == 361
 
 
+@needs_pynec
 def test_pysim_free_space_directivity_matches_pynec():
     """Free-space dipole peak directivity — same physical problem under
     two independent MoM solvers. 0.1 dBi headroom is generous for what
@@ -248,6 +254,7 @@ def test_pysim_free_space_directivity_matches_pynec():
     )
 
 
+@needs_pynec
 def test_pysim_pec_ground_directivity_matches_pynec():
     """PEC ground via image method on both sides. Tight agreement
     expected since the physics is identical."""
@@ -279,6 +286,7 @@ def test_pysim_finite_ground_returns_sane_values():
     assert np.all(np.isfinite([ff.max_gain, ff.min_gain]))
 
 
+@needs_pynec
 def test_compare_patterns_accepts_engine_instances(tmp_path):
     """End-to-end: compare_patterns with a mix of pre-built engines
     (so the caller picks ground / backend per item) should run to
@@ -298,6 +306,7 @@ def test_compare_patterns_accepts_engine_instances(tmp_path):
     assert out.exists() and out.stat().st_size > 0
 
 
+@needs_pynec
 def test_compare_patterns_backwards_compatible_with_bare_builders(tmp_path):
     """Passing AntennaBuilder instances (the historical API) must keep
     working — they get wrapped with the default Antenna alias."""
@@ -370,6 +379,7 @@ def test_sweep_gain_accepts_engine_factory(tmp_path):
     assert out.exists() and out.stat().st_size > 0
 
 
+@needs_pynec
 def test_plot_patterns_pins_radial_floor(tmp_path):
     """Without an rlim, matplotlib polar autoscale would smear a
     constant-radius elevation cut across the full radial range. Pin the
@@ -417,6 +427,7 @@ def test_translator_handles_fandipole_high_degree_junctions():
     assert sorted(len(j) for j in out["junctions"]) == [6, 6]
 
 
+@needs_pynec
 def test_pysim_sinusoidal_hentenna_impedance_close_to_pynec():
     """Cross-validation on the hentenna (two tee junctions): pysim's
     Sinusoidal basis agrees with PyNEC's free-space gn_card-disabled
@@ -479,6 +490,7 @@ def test_translator_handles_delta_loop_pure_cycle():
     assert sorted(len(s) for s in out["edge_segments"]) == [1, 3]
 
 
+@needs_pynec
 def test_pysim_sinusoidal_delta_loop_close_to_pynec():
     """Closed-loop cross-validation: PyNEC and Sinusoidal agree on a
     canonical pure-cycle geometry. Tighter bound than the hentenna test
@@ -523,6 +535,7 @@ def test_translator_emits_one_feed_per_excited_tuple():
     assert out["feed_voltage"] == out["feeds"][0][2]
 
 
+@needs_pynec
 def test_pysim_multifeed_bowtie_1x2_matches_pynec():
     """Symmetric in-phase drive on the bowtie 1×2 phased array: per-feed
     Z from PysimEngine must agree with PyNEC, and the two feeds should
@@ -540,6 +553,7 @@ def test_pysim_multifeed_bowtie_1x2_matches_pynec():
     assert abs(z_ps[0] - z_ps[1]) < 1.0
 
 
+@needs_pynec
 def test_pysim_multifeed_bowtie_1x2_phased_matches_pynec():
     """90° phasing makes Z₀ ≠ Z₁ via mutual coupling. Catches feed-
     ordering / voltage-sign bugs that a symmetric drive would mask."""
@@ -557,6 +571,7 @@ def test_pysim_multifeed_bowtie_1x2_phased_matches_pynec():
     assert abs(z_nec[0] - z_nec[1]) > 10.0
 
 
+@needs_pynec
 def test_pysim_multifeed_far_field_matches_pynec():
     """Bowtie 1×2 phased-array peak directivity, two backends. In-phase
     drive gives a broadside lobe; 90° drive squints. Both must agree
@@ -589,6 +604,7 @@ def test_pysim_multifeed_impedance_sweep_shape():
     assert zs.shape == (4, 2), zs.shape
 
 
+@needs_pynec
 def test_current_distribution_peak_matches_one_over_z():
     """Peak |I| over the geometry should equal |1/Z| within solver
     rounding on both backends — Z = V/I with V=1, so the driving-point
@@ -687,6 +703,7 @@ def test_network_spec_rejects_port_at_edge_with_no_named_edge():
         PysimEngine(BadBuilder())
 
 
+@needs_pynec
 def test_pynec_network_dispatch_runs_delta_looparray_network():
     """delta_looparray_network on PyNECEngine. With build_network() now
     consumed, the engine synthesises a stub wire for the central virtual
@@ -717,6 +734,7 @@ def test_pynec_network_dispatch_runs_delta_looparray_network():
     )
 
 
+@needs_pynec
 def test_pynec_network_rejects_virtual_to_virtual_tl():
     """TL between two PortVirtuals has no NEC2 mapping — reject at construction."""
     from antenna_designer import AntennaBuilder
@@ -747,6 +765,7 @@ def test_pynec_network_rejects_virtual_to_virtual_tl():
         PyNECEngine(Builder(), ground=None)
 
 
+@needs_pynec
 def test_pynec_load_branch_resistor_adds_to_impedance():
     """Load(r=R) on a PyNEC-driven dipole should shift driving-point Z by
     exactly R — ld_card type-0 inserts a series R+L+C at the segment. This
@@ -781,6 +800,7 @@ def test_pynec_load_branch_resistor_adds_to_impedance():
     assert abs((z_loaded - z_bare) - 50.0) < 0.5, (z_bare, z_loaded)
 
 
+@needs_pynec
 def test_short_dipole_loaded_cross_engine_impedance():
     """Showcase for the Load branch: a 0.5·λ/2 shortened dipole at 28 MHz
     with a series loading coil at the feed point. Pysim's Sherman-Morrison
@@ -802,6 +822,7 @@ def test_short_dipole_loaded_cross_engine_impedance():
     assert abs(z_ps.imag - z_nec.imag) < 30.0, (z_ps, z_nec)
 
 
+@needs_pynec
 def test_short_dipole_loaded_pattern_similar_lower_gain_than_full():
     """A center-loaded shortened dipole radiates the same broadside-peak
     pattern as a full-length dipole but with ~0.4 dB less peak gain
@@ -840,6 +861,7 @@ def test_short_dipole_loaded_pattern_similar_lower_gain_than_full():
         assert corr > 0.99, f"{engine_cls.__name__}: pattern correlation {corr:.4f}"
 
 
+@needs_pynec
 def test_pynec_load_branch_rejects_virtual_port():
     """Load on a PortVirtual is rejected — same check as PysimEngine."""
     from antenna_designer import AntennaBuilder
@@ -876,6 +898,7 @@ def test_pynec_load_branch_rejects_virtual_port():
         PyNECEngine(Builder(), ground=None)
 
 
+@needs_pynec
 def test_pynec_network_rejects_port_at_edge_with_no_named_edge():
     """PortAtEdge("loop1") with no `loop1` edge in build_wires() should
     raise a clear error at engine construction time — mirror of the
@@ -904,6 +927,7 @@ def test_pynec_network_rejects_port_at_edge_with_no_named_edge():
         PyNECEngine(Builder(), ground=None)
 
 
+@needs_pynec
 def test_trap_dipole_cross_engine_impedance_at_trap_resonance():
     """Trap dipole showcase tuned to design_freq=28 MHz. At trap resonance
     the parallel-LC tank goes Z→∞, interrupting the segment's current
@@ -952,6 +976,7 @@ def test_trap_dipole_trap_C_changes_impedance():
     assert abs(z_res - z_det) > 200, (z_res, z_det)
 
 
+@needs_pynec
 def test_trap_dipole_low_band_loaded_into_resonance():
     """At 14 MHz the parallel-LC trap is well below its 28 MHz resonance,
     so it looks inductive in series with the segment. That inductive

--- a/tests/test_segment_convergence.py
+++ b/tests/test_segment_convergence.py
@@ -9,7 +9,8 @@ import pytest
 from antenna_designer.designs.bowtie import Builder as BowtieBuilder
 from antenna_designer.designs.freq_based.invvee import Builder as InvVeeBuilder
 from antenna_designer.engine import SimulationEngine
-from antenna_designer.engines.pynec import PyNECEngine
+pytest.importorskip("PyNEC")
+from antenna_designer.engines.pynec import PyNECEngine  # noqa: E402
 from antenna_designer.engines.pysim import PysimEngine
 
 

--- a/tests/test_segment_convergence.py
+++ b/tests/test_segment_convergence.py
@@ -9,6 +9,7 @@ import pytest
 from antenna_designer.designs.bowtie import Builder as BowtieBuilder
 from antenna_designer.designs.freq_based.invvee import Builder as InvVeeBuilder
 from antenna_designer.engine import SimulationEngine
+
 pytest.importorskip("PyNEC")
 from antenna_designer.engines.pynec import PyNECEngine  # noqa: E402
 from antenna_designer.engines.pysim import PysimEngine

--- a/tests/test_sweep_freq.py
+++ b/tests/test_sweep_freq.py
@@ -1,6 +1,9 @@
 import antenna_designer as ant
 from antenna_designer.designs.freq_based.invvee import Builder
 
+from conftest import needs_pynec
 
+
+@needs_pynec
 def test_fandipole_sweep_freq():
     ant.sweep_freq(Builder(), z0=50, rng=(10, 30), npoints=2, fn="/dev/null")

--- a/tests/test_unit_sim.py
+++ b/tests/test_unit_sim.py
@@ -3,6 +3,8 @@ from antenna_designer.designs.freq_based.invvee import Builder
 
 from unittest.mock import patch
 
+from conftest import needs_pynec
+
 
 class FakeSC:
     def get_current_segment_tag(self):
@@ -28,6 +30,7 @@ def mock_geometry(self):
     self.excitation_pairs = [(2, 1, 1 + 0j), (4, 2, 0.5 + 0j)]
 
 
+@needs_pynec
 @patch("antenna_designer.Antenna._build_geometry", new=mock_geometry)
 def test_impedence_with_mock_Antenna():
 

--- a/web/adapter.py
+++ b/web/adapter.py
@@ -41,7 +41,10 @@ from antenna_designer.builder import (
     Array2x2Builder,
     Array2x4Builder,
 )
-from antenna_designer.engines.pynec import PyNECEngine
+try:
+    from antenna_designer.engines.pynec import PyNECEngine
+except ImportError:
+    PyNECEngine = None
 from antenna_designer.engines.pysim import PysimEngine
 from pysim import BSplinePySim, SinusoidalPySim, TriangularPySim
 

--- a/web/adapter.py
+++ b/web/adapter.py
@@ -41,6 +41,7 @@ from antenna_designer.builder import (
     Array2x2Builder,
     Array2x4Builder,
 )
+
 try:
     from antenna_designer.engines.pynec import PyNECEngine
 except ImportError:


### PR DESCRIPTION
## Summary
- Guard `import PyNEC` in `engines/__init__`, `sim`, `cli`, and `web/adapter` so the package and FastAPI server import cleanly when PyNEC isn't built (e.g. on Windows, where PyNEC's swig/autotools/gfortran toolchain isn't readily available).
- Add `tests/conftest.py` exposing a `needs_pynec` skip marker and forcing matplotlib's Agg backend to avoid Tk teardown errors when tests run together.
- Decorate the PyNEC-dependent tests so they skip cleanly when PyNEC is absent. `test_segment_convergence.py` uses `pytest.importorskip` (it imports PyNECEngine at module level).
- Result: on Windows without PyNEC, 595 tests pass and 41 PyNEC-dependent tests skip; the FastAPI backend (`/healthz`, `/examples`, `/sweep`, etc.) works against the pysim solver.

## Test plan
- [ ] On Linux CI with PyNEC built: full suite still runs (no tests should skip).
- [ ] On Windows without PyNEC: `pytest tests/` reports 595 passed / 41 skipped.
- [ ] `web.server:app` imports without PyNEC and `/sweep` round-trips against pysim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)