### PR TITLE
Differential + common-mode 2-wire transmission-line element (pysim)

### DIFF
--- a/src/antenna_designer/engines/pynec.py
+++ b/src/antenna_designer/engines/pynec.py
@@ -3,6 +3,7 @@ import PyNEC as nec
 
 from ..engine import FarField, SimulationEngine, WireCurrents
 from ..network import (
+    DiffTL,
     Driven,
     Load,
     PortAtEdge,
@@ -231,6 +232,12 @@ class PyNECEngine(SimulationEngine):
                 self.c.tl_card(tag_a, seg_a, tag_b, seg_b, br.z0, br.length, 0, 0, 0, 0)
             elif isinstance(br, Load):
                 continue  # already emitted above
+            elif isinstance(br, DiffTL):
+                raise NotImplementedError(
+                    "DiffTL (4-terminal differential transmission line) is not "
+                    "expressible as a NEC2 tl_card, whose ports are pinned to "
+                    "single segments. Use PysimEngine for differential lines."
+                )
             elif isinstance(br, TwoPort):
                 raise NotImplementedError(
                     "TwoPort on PyNECEngine: sketched but not cross-engine "

--- a/src/antenna_designer/engines/pysim.py
+++ b/src/antenna_designer/engines/pysim.py
@@ -11,6 +11,7 @@ from ..engine import FarField, SimulationEngine, WireCurrents
 from ..geometry import flat_wires_to_polylines
 from ..network import (
     TL,
+    DiffTL,
     Driven,
     Load,
     PortAtEdge,
@@ -232,6 +233,56 @@ class PysimEngine(SimulationEngine):
         scale = 1.0 / (1j * z0 * s)
         return scale * np.array([[c, -1.0], [-1.0, c]], dtype=np.complex128)
 
+    def _difftl_admittance_4x4(
+        self, z0, length, wavelength, transposed=False, z0_cm=None
+    ):
+        """4-terminal nodal admittance of a 2-conductor lossless line.
+
+        Unlike `_tl_admittance_2x2`, whose two ports are each pinned to a
+        single antenna segment, this models a genuine 2-conductor (twisted-
+        pair) line whose two ports are each a pair of independent terminals
+        — the thing NEC2's `tl_card` cannot express.
+
+        Terminals are ordered (a_pos, a_neg, b_pos, b_neg). A real 2-wire
+        line carries two independent modes, decomposed by the power-
+        preserving mixed-mode transform:
+
+            differential:  V_d = V_pos - V_neg,      I_d = (I_pos - I_neg)/2
+            common:        V_c = (V_pos + V_neg)/2,  I_c =  I_pos + I_neg
+
+        Each mode is its own lossless line. The differential mode (impedance
+        `z0`) carries the phasing current that cancels in the far field; it
+        is lifted to four terminals by M_d (rows V_d at ports A,B) as
+        Mᵀ·Y_d·M. The common mode (impedance `z0_cm`) is the through-current
+        the two conductors carry in parallel — what keeps a galvanic wire's
+        current continuous across a junction; it is lifted by
+        P_c = [[½,½,0,0],[0,0,½,½]] as P_cᵀ·Y_c·P_c. The full stamp is the
+        sum, so the element reproduces both currents a real conductor pair
+        carries — not just the differential one.
+
+        `z0_cm=None` gives the pure-differential element (rank-2 stamp; the
+        common mode floats). `transposed=True` swaps the b-port terminals —
+        the half-twist — which flips the differential A<->B coupling sign;
+        the common mode is symmetric under that swap and is unaffected.
+
+        The half-wave singularity of `_tl_admittance_2x2` is inherited by
+        both modes (same physical length); callers carry a small offset.
+        """
+        y_d = self._tl_admittance_2x2(z0, length, wavelength)
+        m_d = np.array(
+            [[1.0, -1.0, 0.0, 0.0], [0.0, 0.0, 1.0, -1.0]], dtype=np.complex128
+        )
+        if transposed:
+            m_d[1] = np.array([0.0, 0.0, -1.0, 1.0], dtype=np.complex128)
+        y4 = m_d.T @ y_d @ m_d
+        if z0_cm is not None:
+            y_c = self._tl_admittance_2x2(z0_cm, length, wavelength)
+            p_c = np.array(
+                [[0.5, 0.5, 0.0, 0.0], [0.0, 0.0, 0.5, 0.5]], dtype=np.complex128
+            )
+            y4 = y4 + p_c.T @ y_c @ p_c
+        return y4
+
     def _apply_tls(self, Y, wavelength):
         """Y + per-TL stamps at the corresponding feed-index pairs."""
         Y = Y.copy()
@@ -358,6 +409,19 @@ class PysimEngine(SimulationEngine):
                 a, b = self._port_to_idx[br.a], self._port_to_idx[br.b]
                 y_tl = self._tl_admittance_2x2(br.z0, br.length, wavelength)
                 Y_full[np.ix_([a, b], [a, b])] += y_tl
+            elif isinstance(br, DiffTL):
+                idx = [
+                    self._port_to_idx[p]
+                    for p in (br.a_pos, br.a_neg, br.b_pos, br.b_neg)
+                ]
+                y4 = self._difftl_admittance_4x4(
+                    br.z0,
+                    br.length,
+                    wavelength,
+                    transposed=br.transposed,
+                    z0_cm=br.z0_cm,
+                )
+                Y_full[np.ix_(idx, idx)] += y4
             elif isinstance(br, Load):
                 continue  # already applied to the real-port Y
             elif isinstance(br, TwoPort):

--- a/src/antenna_designer/network.py
+++ b/src/antenna_designer/network.py
@@ -64,6 +64,40 @@ class TL:
     length: float
 
 
+@dataclass(frozen=True)
+class DiffTL:
+    """Differential (twisted-pair) lossless transmission line.
+
+    Where `TL` couples two single-ended ports (each pinned to one antenna
+    segment), `DiffTL` is a genuine 2-conductor line whose two ports are
+    each a *differential pair* of independent real ports:
+        port A = (a_pos, a_neg),  port B = (b_pos, b_neg).
+    This is the 4-terminal element NEC2's `tl_card` cannot express, so it
+    is pysim-only (PyNECEngine raises on it).
+
+    transposed=True applies the physical half-twist of the pair (swap the
+    b-port terminals), flipping the A<->B coupling sign — the phase
+    inversion that keeps a Sterba curtain's sections co-phased.
+
+    z0 is the differential-mode impedance. z0_cm, if given, adds the
+    common-mode line (the two conductors in parallel) — the through-current
+    a real wire pair carries that a pure-differential line omits. Leave it
+    None for the pure-differential element.
+
+    Inherits the half-wave singularity of the ideal line; pick `length`
+    slightly off kλ/2.
+    """
+
+    a_pos: str
+    a_neg: str
+    b_pos: str
+    b_neg: str
+    z0: float
+    length: float
+    transposed: bool = False
+    z0_cm: float | None = None
+
+
 # Reserved for follow-up PR — sketched here so the discriminated-union
 # pattern is established but not consumed yet by any engine.
 @dataclass(frozen=True)
@@ -114,7 +148,16 @@ class TwoPort:
     c: float | None = None
 
 
-Branch = Union[TL, Load, TwoPort]
+Branch = Union[TL, DiffTL, Load, TwoPort]
+
+
+def _branch_port_refs(br):
+    """Port names a branch references, regardless of branch type."""
+    if isinstance(br, DiffTL):
+        return (br.a_pos, br.a_neg, br.b_pos, br.b_neg)
+    if hasattr(br, "a"):  # TL, TwoPort
+        return (br.a, br.b)
+    return (br.port,)  # Load
 
 
 def _series_rlc_impedance(r, l, c, omega):
@@ -223,8 +266,7 @@ class Network:
                 )
         port_names = set(self.ports)
         for br in self.branches:
-            refs = (br.a, br.b) if hasattr(br, "a") else (br.port,)
-            for ref in refs:
+            for ref in _branch_port_refs(br):
                 if ref not in port_names:
                     raise ValueError(f"branch {br!r} references unknown port {ref!r}")
         for src in self.sources:

--- a/tests/test_pysim_engine.py
+++ b/tests/test_pysim_engine.py
@@ -215,6 +215,154 @@ def test_pysim_tl_admittance_half_wave_singular():
         e._tl_admittance_2x2(z0=50.0, length=2.0, wavelength=4.0)
 
 
+def test_pysim_difftl_admittance_quarter_wave():
+    """4-terminal stamp of a *differential* quarter-wave line, Z0=50.
+
+    Terminals are ordered (a_pos, a_neg, b_pos, b_neg). The two differential
+    ports are A = V(a_pos)-V(a_neg) and B = V(b_pos)-V(b_neg); the line's 2x2
+    differential admittance is the same lossless-line Y as the single-ended
+    TL, lifted to four terminals by M = [[1,-1,0,0],[0,0,1,-1]] as
+    Stamp = Mᵀ · Y2 · M. For a quarter-wave Z0=50 line, Y2 = [[0, j/50],
+    [j/50, 0]], so the cross-coupling constant is c = j/50."""
+    from antenna_designer.designs.freq_based.invvee import (
+        Builder as InvBuilder,
+    )
+
+    e = PysimEngine(InvBuilder())
+    wl = 4.0  # length = wl/4 -> theta = pi/2
+    Y4 = e._difftl_admittance_4x4(z0=50.0, length=1.0, wavelength=wl, transposed=False)
+    c = 1j / 50
+    expected = np.array(
+        [
+            [0, 0, c, -c],
+            [0, 0, -c, c],
+            [c, -c, 0, 0],
+            [-c, c, 0, 0],
+        ],
+        dtype=np.complex128,
+    )
+    assert np.allclose(Y4, expected, atol=1e-12), Y4
+
+
+def test_pysim_difftl_transposed_flips_cross_coupling():
+    """Transposing one port swaps its two terminals — that's the half-twist.
+    It flips the sign of the A<->B cross-coupling blocks while leaving the
+    self blocks (each port's own admittance) unchanged."""
+    from antenna_designer.designs.freq_based.invvee import (
+        Builder as InvBuilder,
+    )
+
+    e = PysimEngine(InvBuilder())
+    wl = 4.0
+    Y = e._difftl_admittance_4x4(z0=50.0, length=1.0, wavelength=wl, transposed=False)
+    Yt = e._difftl_admittance_4x4(z0=50.0, length=1.0, wavelength=wl, transposed=True)
+    assert np.allclose(Yt[:2, 2:], -Y[:2, 2:], atol=1e-12)
+    assert np.allclose(Yt[2:, :2], -Y[2:, :2], atol=1e-12)
+    assert np.allclose(Yt[:2, :2], Y[:2, :2], atol=1e-12)
+    assert np.allclose(Yt[2:, 2:], Y[2:, 2:], atol=1e-12)
+
+
+def test_pysim_difftl_common_mode_stamp_quarter_wave():
+    """Adding z0_cm adds the common-mode line on top of the differential
+    one. For a quarter-wave common line, Y_c = [[0, j/Zc],[j/Zc,0]], lifted
+    by P_c=[[½,½,0,0],[0,0,½,½]] as P_cᵀ·Y_c·P_c — a hand value of
+    (j/4Zc)·[[0,0,1,1],[0,0,1,1],[1,1,0,0],[1,1,0,0]]."""
+    from antenna_designer.designs.freq_based.invvee import (
+        Builder as InvBuilder,
+    )
+
+    e = PysimEngine(InvBuilder())
+    wl = 4.0
+    Y_diff = e._difftl_admittance_4x4(z0=50.0, length=1.0, wavelength=wl)
+    Y_full = e._difftl_admittance_4x4(z0=50.0, length=1.0, wavelength=wl, z0_cm=200.0)
+    cm = Y_full - Y_diff
+    c = 1j / (4 * 200.0)
+    expected = c * np.array(
+        [[0, 0, 1, 1], [0, 0, 1, 1], [1, 1, 0, 0], [1, 1, 0, 0]],
+        dtype=np.complex128,
+    )
+    assert np.allclose(cm, expected, atol=1e-12), cm
+
+
+def _difftl_demo_builder(transposed=False):
+    """Minimal antenna exercising the full DiffTL network path: a driven
+    dipole plus a coupled 2-wire vertical pair whose top and bottom ends form
+    two differential ports joined by a DiffTL (length off λ/2 to avoid the
+    line singularity)."""
+    from types import MappingProxyType
+
+    from antenna_designer import AntennaBuilder
+    from antenna_designer.network import DiffTL, Driven, Network, PortAtEdge
+
+    h = 0.5 * (299.792458 / 28.47) * 0.95
+    eps = 0.1
+    tups = [
+        ((0, -2.6, 7), (0, -eps, 7), 21, None, None),
+        ((0, -eps, 7), (0, eps, 7), 3, None, "feed"),
+        ((0, eps, 7), (0, 2.6, 7), 21, None, None),
+    ]
+    for yy, nt, nb in [(-0.1, "a_pos", "b_pos"), (0.1, "a_neg", "b_neg")]:
+        tups.append(((1, yy, 7.0), (1, yy, 7.15), 1, None, nb))
+        tups.append(((1, yy, 7.15), (1, yy, 7.0 + h - 0.15), 11, None, None))
+        tups.append(((1, yy, 7.0 + h - 0.15), (1, yy, 7.0 + h), 1, None, nt))
+    net = Network(
+        ports={n: PortAtEdge(n) for n in ("feed", "a_pos", "a_neg", "b_pos", "b_neg")},
+        branches=[
+            DiffTL(
+                "a_pos",
+                "a_neg",
+                "b_pos",
+                "b_neg",
+                z0=400.0,
+                length=h,
+                transposed=transposed,
+            )
+        ],
+        sources=[Driven("feed")],
+    )
+
+    class B(AntennaBuilder):
+        default_params = MappingProxyType({"design_freq": 28.47, "freq": 28.47})
+
+        def build_wires(self):
+            return tups
+
+        def build_network(self):
+            return net
+
+    return B()
+
+
+def test_difftl_network_rejects_unknown_ref():
+    from antenna_designer.network import DiffTL, Driven, Network, PortAtEdge
+
+    with pytest.raises(ValueError, match="unknown port"):
+        Network(
+            ports={k: PortAtEdge(k) for k in ("feed", "a", "b", "c")},
+            branches=[DiffTL("a", "b", "c", "missing", z0=50.0, length=1.0)],
+            sources=[Driven("feed")],
+        )
+
+
+def test_difftl_solves_end_to_end_on_pysim():
+    z = PysimEngine(_difftl_demo_builder(), ground=None).impedance()[0]
+    assert np.isfinite(z.real) and np.isfinite(z.imag)
+    assert 10 < z.real < 200, z
+
+
+def test_difftl_transposed_changes_the_solve():
+    z = PysimEngine(_difftl_demo_builder(transposed=False), ground=None).impedance()[0]
+    zt = PysimEngine(_difftl_demo_builder(transposed=True), ground=None).impedance()[0]
+    assert not np.isclose(z, zt), (z, zt)
+
+
+def test_difftl_raises_on_pynec():
+    """NEC2's tl_card pins each port to one segment, so a 4-terminal
+    differential line is inexpressible — PyNECEngine must say so clearly."""
+    with pytest.raises(NotImplementedError, match="DiffTL"):
+        PyNECEngine(_difftl_demo_builder(), ground=None)
+
+
 def test_pysim_engine_declares_far_field_support():
     assert PysimEngine.supports_far_field is True
 


### PR DESCRIPTION
## Summary
- Adds a **4-terminal balanced transmission-line element** that NEC2's `tl_card` cannot express — its ports are pinned to single segments, so a differential pair spanning two conductors is inexpressible. `PysimEngine` synthesises it from the existing single-ended N-port Y via a mixed-mode port transform, so **no pysim solver change** is needed.
- `network.py`: new `DiffTL(a_pos, a_neg, b_pos, b_neg, z0, length, transposed, z0_cm)` branch + `Network` validation of its four port refs.
- `engines/pysim.py`: `_difftl_admittance_4x4` stamps both line modes into the port-Y matrix — the **differential** mode `Mᵀ·Y_d·M` (the phasing current that cancels in the far field; `transposed` flips the A↔B coupling for the half-twist) and the optional **common** mode `P_cᵀ·Y_c·P_c` (the through-current a real conductor pair carries).
- `engines/pynec.py`: raises a clear `NotImplementedError` (a 4-terminal differential line is inexpressible as a `tl_card`).

### Background
This came out of a Sterba-curtain modelling study. Replacing the curtain's vertical phasing pairs with ideal lines decomposes their role into three effects: **twist → phasing** (differential mode), **through-current → continuity** (common mode), and **near-field coupling** (needs real geometry). The element reproduces the first two exactly (single-ended ~4 dBi → differential ~6.5 → +common ~7.0); the last ~3.5 dB to the all-wires 10.5 dBi is spatial coupling an ideal line can't provide. The element stands on its own for any antenna with genuine balanced feedlines.

## Test plan
- [x] Hand-checked unit tests: quarter-wave differential 4-terminal stamp, common-mode stamp, and the transpose sign-flip
- [x] `Network` rejects an unknown `DiffTL` port ref
- [x] End-to-end `DiffTL` solve on `PysimEngine` returns a finite, sensible impedance; transpose changes the solve
- [x] `PyNECEngine` raises on `DiffTL`
- [x] Full pysim-engine suite green (67 passed); `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)