### PR TITLE
feat: add tl_length_factor and widen length_factor on sterba_difftl

### DIFF
--- a/src/antenna_designer/designs/freq_based/sterba_difftl.py
+++ b/src/antenna_designer/designs/freq_based/sterba_difftl.py
@@ -24,9 +24,11 @@ the radiators — the last ~3.5 dB genuinely needs real conductors. Use
 differential-line element.
 
 z0 is the differential-mode impedance (defaulted near the best-gain value,
-not the physical ~526 ohm), z0_cm the common-mode impedance; length is the
-half-wave riser height, kept off exactly lambda/2 via length_factor=0.99
-to dodge the ideal-line singularity.
+not the physical ~526 ohm), z0_cm the common-mode impedance. Each DiffTL's
+electrical length is `h * tl_length_factor`, where h is the half-wave riser
+height (kept off exactly lambda/2 via length_factor=0.99 to dodge the ideal-
+line singularity); tl_length_factor (default 1.0) phase-trims the lines
+independently of the wire geometry.
 """
 
 from ... import AntennaBuilder
@@ -42,26 +44,41 @@ class Builder(AntennaBuilder):
             "design_freq": 28.47,
             "freq": 28.47,
             "base": 7.0,
-            # Off exactly 1.0 so the half-wave DiffTLs miss the nodal-
-            # admittance singularity at length = lambda/2.
+            # Default off exactly 1.0 so the half-wave DiffTLs miss the
+            # nodal-admittance singularity at length = lambda/2. The slider
+            # range now spans 1.0; the singularity is at the *product*
+            # length_factor * tl_length_factor == 1.0, so when running
+            # length_factor at 1.0 keep tl_length_factor off 1.0 (or vice
+            # versa) to stay clear of it.
             "length_factor": 0.99,
             "n_cells": 3,  # odd; interior DiffTLs = n_cells + 1
             "spacing": 0.04,
             "z0": 150.0,  # differential-mode impedance (near best gain)
             "z0_cm": 80.0,  # common-mode impedance
+            # Multiplies the riser height h to set each DiffTL's electrical
+            # length, decoupled from the physical geometry. 1.0 -> length = h
+            # (the half-wave riser); tweak to phase-trim the lines without
+            # moving any wires.
+            "tl_length_factor": 1.0,
             "ui_params": MappingProxyType(
                 {
                     "target_z0": 75.0,  # ~70 ohm driving point (measured)
                     "sweep_policy": {"band_locked": True},
                     "length_factor": {
                         "min": 0.96,
-                        "max": 0.999,
+                        "max": 1.05,
                         "step": 0.001,
                         "precision": 4,
                     },
                     "n_cells": {"min": 1, "max": 7, "step": 2},
                     "z0": {"min": 50.0, "max": 600.0, "step": 5.0},
                     "z0_cm": {"min": 30.0, "max": 600.0, "step": 5.0},
+                    "tl_length_factor": {
+                        "min": 0.8,
+                        "max": 1.2,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
                 }
             ),
         }
@@ -174,7 +191,7 @@ class Builder(AntennaBuilder):
                     f"j{j}_Ab",
                     f"j{j}_Bb",
                     z0=self.z0,
-                    length=h,
+                    length=h * self.tl_length_factor,
                     transposed=False,
                     z0_cm=self.z0_cm,
                 )


### PR DESCRIPTION
Decouple each DiffTL's electrical length from the physical riser height on the `sterba_difftl` design.

## Changes
- **`tl_length_factor`** (default `1.0`): multiplies the riser height `h` to set each DiffTL's `length`, so the line's electrical length is tunable independently of the wire geometry. Exposed in the GUI at the same `0.001` step / precision-4 granularity as `length_factor`.
- **Widened `length_factor`** slider to `0.96–1.05` (matching the all-wires `sterba`), up from the old `0.999` cap. Now that the half-wave singularity can be dodged via either factor, the geometry no longer needs to be capped below 1.0.

## Singularity note
The ideal-line singularity sits at `length_factor * tl_length_factor == 1.0`. With the default `tl_length_factor = 1.0`, running `length_factor` at exactly `1.000` lands on it — keep one of the two factors off `1.0` to stay clear. The docstring/comment spell this out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)