### PR TITLE
feat: non-resonant doublet fed by ideal TL vs real 2-wire feeder

### DIFF
--- a/src/antenna_designer/designs/freq_based/doublet_2wire.py
+++ b/src/antenna_designer/designs/freq_based/doublet_2wire.py
@@ -1,0 +1,95 @@
+"""Non-resonant doublet fed by a *real* two-wire open-wire line to a tuner.
+
+The geometric counterpart to `doublet_tl`: instead of modelling the open-wire
+feeder as an ideal `network.TL`, the two feeder conductors are real parallel
+wires with geometry. They drop from the dipole's centre down to a delta-gap
+feed at the bottom (the tuner output), so the feeder carries a genuine
+transmission-line current *and* radiates / couples in the near field — the
+effects an ideal line omits.
+
+Topology (framework x, y, z convention):
+  - y : the doublet's long axis (the flat-top) and the feeder spacing
+  - z : height; flat-top at `base`, feeder drops to `base - feeder_factor·λ`
+  - x : unused
+
+Current path is one continuous loop: +y tip → +y arm → down the +y feeder
+wire → feed edge (driven) → up the −y feeder wire → −y arm → −y tip. The feed
+edge at the bottom is the tuner output; its impedance is what the tuner must
+match. SWR is referenced to the line impedance (`ui_params["target_z0"]`).
+
+`spacing` (default ≈ 7.4 cm with the 0.5 mm default wire radius) sets the
+line's characteristic impedance to ≈ 600 Ω, matching `doublet_tl`'s default
+`z0` so the two can be compared directly. length_factor is the total doublet
+length in wavelengths (default 1.28λ EDZ); feeder_factor is the feeder's
+physical length in wavelengths (≈ electrical length for air-spaced line).
+
+Compare against `doublet_tl`: the impedances and patterns agree to the extent
+that the ideal line is a good model — differences are exactly the feeder's
+radiation and near-field coupling. Runs on either engine.
+"""
+
+from ... import AntennaBuilder
+
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.47,
+            "freq": 28.47,
+            "base": 10.0,
+            "length_factor": 1.28,  # total doublet length in λ (EDZ)
+            "feeder_factor": 0.3,  # feeder physical length in λ
+            # Conductor spacing -> ~600 Ω with the 0.5 mm default wire radius
+            # (z0 = 120·acosh(spacing / 2·radius)); matches doublet_tl's z0.
+            "spacing": 0.074,
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 600.0,
+                    "sweep_policy": {"band_locked": True},
+                    "length_factor": {
+                        "min": 0.4,
+                        "max": 2.0,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                    "feeder_factor": {
+                        "min": 0.05,
+                        "max": 0.6,
+                        "step": 0.005,
+                        "precision": 3,
+                    },
+                    "spacing": {
+                        "min": 0.02,
+                        "max": 0.30,
+                        "step": 0.002,
+                        "precision": 3,
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        wavelength = 299.792458 / self.design_freq
+        half = 0.5 * self.length_factor * wavelength
+        z = self.base
+        sp = 0.5 * self.spacing  # half conductor spacing in y
+        h = self.feeder_factor * wavelength  # feeder drop length
+        zb = z - h  # feeder bottom (tuner output)
+
+        n0 = self.nominal_nsegs
+        n1 = max(3, n0 // 7)
+        n_feed = max(3, round(n0 * h / (0.5 * wavelength)))
+
+        # Continuous loop: arms at the top, two feeder wires dropping to a
+        # delta-gap feed at the bottom. Endpoints are shared so the translator
+        # chains them into one structure.
+        return [
+            ((0.0, sp, z), (0.0, half, z), n0, None),  # +y arm
+            ((0.0, -half, z), (0.0, -sp, z), n0, None),  # -y arm
+            ((0.0, sp, z), (0.0, sp, zb), n_feed, None),  # +y feeder wire
+            ((0.0, -sp, zb), (0.0, -sp, z), n_feed, None),  # -y feeder wire
+            ((0.0, -sp, zb), (0.0, sp, zb), n1, 1 + 0j),  # feed edge (tuner)
+        ]

--- a/src/antenna_designer/designs/freq_based/doublet_tl.py
+++ b/src/antenna_designer/designs/freq_based/doublet_tl.py
@@ -1,0 +1,118 @@
+"""Non-resonant doublet fed by an open-wire line (modelled as a TL) to a tuner.
+
+A doublet is a centre-fed flat-top whose length is deliberately *not* λ/2 on
+the operating band, so its feedpoint impedance is high and reactive; in
+practice it is fed with open-wire / ladder line down to an antenna tuner
+that resolves the match. Here the feeder is one `network.TL` (a single-ended
+lossless line — the element that correctly feeds a collinear centre-fed
+dipole), running from a virtual driver (the tuner output) up to the dipole's
+centre feed edge.
+
+Topology (framework x, y, z convention):
+  - y : the doublet's long axis; one continuous flat-top, centre-fed
+  - z : height (`base`); the wire is horizontal
+  - x : unused
+
+The driving-point impedance is read at the bottom of the feeder — **what the
+tuner has to match.** As with `sterba`, the tuner itself is not modelled as a
+circuit; SWR is referenced to the feeder impedance (`ui_params["target_z0"]`),
+i.e. the open-wire-line SWR (constant along a lossless line) the tuner then
+absorbs. Vary `feeder_factor` to watch the feedpoint impedance rotate along
+the line (a quarter-wave feeder inverts it).
+
+length_factor is the total doublet length in wavelengths (default 1.28λ, the
+classic Extended-Double-Zepp non-resonant length, ~100−j600 Ω at the
+feedpoint). feeder_factor is the feeder's electrical length in wavelengths,
+kept inside (0, ½) to stay off the ideal-line kλ/2 singularity. z0 is the
+feeder (open-wire line) impedance.
+
+This is the all-validated-elements cousin of the DiffTL experiments: a single
+TL feeds the collinear dipole's through-current correctly, where an ideal
+4-terminal DiffTL cannot (the dipole radiates via the common/through mode, not
+the differential mode a DiffTL drives). Driven via the network spec on
+PysimEngine; the TL→tuner virtual-driver translation is the same one
+`delta_looparray_network` uses. Compare with `doublet_2wire`, the real-wire
+feeder version.
+"""
+
+from ... import AntennaBuilder
+from ...network import Driven, Network, PortAtEdge, PortVirtual, TL
+
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.47,
+            "freq": 28.47,
+            "base": 10.0,
+            # Total doublet length in wavelengths. 1.28λ is the classic
+            # Extended Double Zepp — deliberately non-resonant, so the
+            # feedpoint is high and reactive and genuinely wants a tuner.
+            "length_factor": 1.28,
+            # Feeder electrical length in wavelengths. Kept in (0, 0.5) so
+            # the ideal TL stays off its kλ/2 admittance singularity.
+            "feeder_factor": 0.3,
+            "z0": 600.0,  # open-wire / ladder-line impedance
+            "ui_params": MappingProxyType(
+                {
+                    # SWR referenced to the feeder impedance: the open-wire-
+                    # line SWR (constant along a lossless line) that the tuner
+                    # at the bottom then matches out.
+                    "target_z0": 600.0,
+                    "sweep_policy": {"band_locked": True},
+                    "length_factor": {
+                        "min": 0.4,
+                        "max": 2.0,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                    # Stop short of 0.5λ: at exactly kλ/2 the ideal line is
+                    # singular (sin βl = 0).
+                    "feeder_factor": {
+                        "min": 0.05,
+                        "max": 0.45,
+                        "step": 0.005,
+                        "precision": 3,
+                    },
+                    "z0": {"min": 200.0, "max": 600.0, "step": 5.0},
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        wavelength = 299.792458 / self.design_freq
+        half = 0.5 * self.length_factor * wavelength
+        z = self.base
+        eps = 0.05  # half-width of the centre feed edge
+
+        n_seg0 = self.nominal_nsegs
+        n_seg1 = max(3, n_seg0 // 7)
+
+        # One continuous flat-top along y, centre-fed: two arms plus a short
+        # bridging feed edge spanning the gap (the standard delta-gap that
+        # drives the dipole's through-current). The TL attaches at "feed".
+        return [
+            ((0.0, eps, z), (0.0, half, z), n_seg0, None, None),
+            ((0.0, -half, z), (0.0, -eps, z), n_seg0, None, None),
+            ((0.0, -eps, z), (0.0, eps, z), n_seg1, None, "feed"),
+        ]
+
+    def build_network(self):
+        wavelength = 299.792458 / self.design_freq
+        feeder_len = self.feeder_factor * wavelength
+        return Network(
+            ports={
+                "feed": PortAtEdge("feed"),
+                "tuner": PortVirtual("tuner"),
+            },
+            branches=[
+                # Single-ended open-wire feeder from the tuner output up to the
+                # dipole centre. The TL transforms the (high, reactive)
+                # feedpoint impedance down the line to whatever the tuner sees.
+                TL(a="tuner", b="feed", z0=self.z0, length=feeder_len),
+            ],
+            sources=[Driven(port="tuner", voltage=1 + 0j)],
+        )

--- a/tests/test_pysim_engine.py
+++ b/tests/test_pysim_engine.py
@@ -475,6 +475,28 @@ def test_difftl_reproduces_tl_array_impedance_sweep():
     assert np.allclose(zs_tl[:, 0], zs_diff[:, 0], atol=1e-9), (zs_tl, zs_diff)
 
 
+def test_doublet_ideal_tl_vs_real_2wire_feeder_agree():
+    """A non-resonant doublet fed by an ideal TL (doublet_tl) and by a real
+    parallel-wire feeder of the same ~600Ω / 0.3λ (doublet_2wire) should give
+    nearly the same tuner-side impedance — the ideal line is a good model of
+    the real feeder. The residual difference is the real feeder's radiation /
+    near-field coupling, which also makes its gain marginally higher."""
+    from antenna_designer.designs.freq_based import doublet_2wire, doublet_tl
+
+    z_tl = PysimEngine(doublet_tl.Builder(), ground=None).impedance()[0]
+    z_2w = PysimEngine(doublet_2wire.Builder(), ground=None).impedance()[0]
+    # Both transform the same high/reactive feedpoint down ~0.3λ of 600Ω line.
+    assert abs(z_tl - z_2w) / abs(z_tl) < 0.10, (z_tl, z_2w)
+    assert z_tl.real > 50 and z_2w.real > 50, (z_tl, z_2w)
+
+    kw = dict(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
+    g_tl = PysimEngine(doublet_tl.Builder(), ground=None).far_field(**kw).max_gain
+    g_2w = PysimEngine(doublet_2wire.Builder(), ground=None).far_field(**kw).max_gain
+    # Same radiator, similar pattern; the real feeder radiates a touch more.
+    assert abs(g_tl - g_2w) < 0.5, (g_tl, g_2w)
+    assert g_2w >= g_tl, (g_tl, g_2w)
+
+
 def test_pysim_engine_declares_far_field_support():
     assert PysimEngine.supports_far_field is True
 


### PR DESCRIPTION
Two new `freq_based` designs modelling a non-resonant 1.28λ (Extended Double Zepp) doublet fed with open-wire line to a tuner, plus a comparison test.

## Designs
- **`doublet_tl`** — feeder is one `network.TL` (ideal single-ended line). The TL correctly feeds the collinear dipole's through-current; `Zin` at the virtual tuner port is what the tuner must match, SWR referenced to the line `z0`.
- **`doublet_2wire`** — the same feeder as **two real parallel wires** with geometry, dropping to a delta-gap feed. Includes the feeder radiation / near-field coupling the ideal line omits. Conductor spacing defaulted (~7.4 cm at the 0.5 mm default wire radius) to ~600 Ω to match `doublet_tl`.

## Why TL and not DiffTL
An ideal 4-terminal `DiffTL` *cannot* feed a collinear center-fed dipole: the dipole radiates via the **common/through mode**, while a `DiffTL` drives the **differential mode**, and the ideal line has no geometry to convert between them. A single-ended `TL` is the correct element here. (`DiffTL` shines on parallel-conductor radiators like `sterba`.)

## Comparison (free space, pysim)
| | ideal TL | real 2-wire |
|---|---|---|
| Zin @ 0.3λ feeder, 1.28λ | 195 + j975 | 183 + j920 |
| max gain @ 1.28λ | 5.07 dBi | 5.14 dBi |

Impedances agree within a few percent; gains within ~0.1 dB, with the real feeder *slightly higher* (its own radiation). The test locks this in: <10% Zin, <0.5 dB gain, and 2-wire gain ≥ TL gain.

## Note
The network→PyNEC virtual-driver path is unreliable in this environment (the existing `delta_looparray_network` shows the same ~−33000j artifact), so `doublet_tl` is scoped to PysimEngine in its docstring. `doublet_2wire` (plain geometry) runs on both engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)