### PR TITLE
feat: shared NetworkReducer + correct PyNEC transmission-line support

### DIFF
--- a/src/antenna_designer/designs/freq_based/sterba_tl.py
+++ b/src/antenna_designer/designs/freq_based/sterba_tl.py
@@ -28,7 +28,7 @@ Note on the half-wave TL: this engine's nodal TL admittance
 1/(jZ0 sin βl)·[[cos βl,-1],[-1,cos βl]] is SINGULAR at βl = π (length =
 λ/2). The phasing lines are nominally λ/2, so `length_factor` defaults to
 0.99 (TL length ≈ 0.495 λ) to sit just off the singularity. lf = 1.0
-exactly will raise in `_tl_admittance_2x2`; keep lf away from 1.0.
+exactly will raise in `network_reduce.tl_admittance_2x2`; keep lf away from 1.0.
 """
 
 from ... import AntennaBuilder

--- a/src/antenna_designer/engines/pynec.py
+++ b/src/antenna_designer/engines/pynec.py
@@ -9,20 +9,14 @@ from ..network import (
     PortAtEdge,
     PortVirtual,
     TL,
-    TwoPort,
 )
+from ..network_reduce import C_LIGHT, NetworkReducer
+
+WIRE_RADIUS = 0.0005
+COPPER_CONDUCTIVITY = 5.8e7
 
 
 DEFAULT_GROUND = ("finite", 10.0, 0.002)  # (kind, dielectric, conductivity)
-
-
-def _seg_midpoint(p0, p1, n_seg, sub_idx):
-    """Centre of segment `sub_idx` (1-based) on the wire from p0 to p1
-    discretised into n_seg uniform segments. NEC2's tl_card / ex_card
-    refer to sub-segments by this index."""
-    p0 = np.asarray(p0, dtype=float)
-    p1 = np.asarray(p1, dtype=float)
-    return p0 + ((sub_idx - 0.5) / n_seg) * (p1 - p0)
 
 
 class PyNECEngine(SimulationEngine):
@@ -49,7 +43,17 @@ class PyNECEngine(SimulationEngine):
         self.tls = [] if self._network is not None else builder.build_tls()
         self.ground = ground
         self.excitation_pairs = None
-        self._build_geometry()
+        # Loads alone are handled natively (ld_card) and accurately by NEC, so
+        # only divert to the multiport-Y + NetworkReducer path for what NEC
+        # *can't* do natively: transmission lines (TL/DiffTL) and virtual
+        # drivers. Those skip the baked NEC context entirely — impedance uses
+        # per-port solves and far-field/current build an excitation-resolved
+        # context on demand. Load-only and plain designs keep the native path.
+        self._use_reducer = self._network is not None and self._network_uses_reducer()
+        if self._use_reducer:
+            self._init_network()
+        else:
+            self._build_geometry()
 
     def __del__(self):
         # Release the nec_context handle if construction got that far.
@@ -83,16 +87,15 @@ class PyNECEngine(SimulationEngine):
             if ev is not None and self._network is None:
                 self.excitation_pairs.append((idx, mid_seg, ev))
 
-        # Synthesise stub wires for virtual ports (extends self.tups so the
-        # tag space picks up where the user-supplied wires left off). Must
-        # happen before geometry_complete().
         self._network_port_loc = {}
-        if self._network is not None:
-            self._synthesise_virtual_stubs(geo)
 
         self.c.geometry_complete(0)
 
         if self._network is not None:
+            # Only Load-only networks reach here; TL/DiffTL/virtual-driver
+            # networks take the NetworkReducer path and never build this
+            # context.
+            self._resolve_network_ports()
             self._emit_network_cards()
         else:
             for idx1, seg1, idx2, seg2, impedance, length in self.tls:
@@ -104,19 +107,11 @@ class PyNECEngine(SimulationEngine):
         for tag, sub_index, voltage in self.excitation_pairs:
             self.c.ex_card(0, tag, sub_index, 0, voltage.real, voltage.imag, 0, 0, 0, 0)
 
-    def _synthesise_virtual_stubs(self, geo):
-        """For each PortVirtual referenced by a TL branch, add a short stub
-        wire (~λ/100, single segment) anchored above the centroid of its
-        TL-connected real-port feed points. NEC2's tl_card needs both
-        endpoints on real segments; the stub is the minimum geometry that
-        carries the driver node without polluting radiation.
-
-        Resolves every PortAtEdge to its (tag, sub_seg) in the same pass so
-        downstream branch/source emission only consults self._network_port_loc.
-        """
-        net = self._network
-        # Real ports: resolve via the name → (tag, mid_seg) map built above.
-        for name, port in net.ports.items():
+    def _resolve_network_ports(self):
+        """Resolve every PortAtEdge to its (tag, sub_seg) for native ld_card /
+        ex_card emission. Only reached for Load-only networks; TL/DiffTL and
+        virtual-driver networks take the NetworkReducer path instead."""
+        for name, port in self._network.ports.items():
             if isinstance(port, PortAtEdge):
                 if name not in self._feed_name_to_loc:
                     raise ValueError(
@@ -127,124 +122,37 @@ class PyNECEngine(SimulationEngine):
                 tag, mid_seg, _p0, _p1, _ns = self._feed_name_to_loc[name]
                 self._network_port_loc[name] = (tag, mid_seg)
 
-        # Collect, per virtual port, the set of real ports it's TL-connected to.
-        virtual_neighbours = {
-            name: [] for name, p in net.ports.items() if isinstance(p, PortVirtual)
-        }
-        for br in net.branches:
-            if not isinstance(br, TL):
-                continue
-            ends = (br.a, br.b)
-            virt_ends = [e for e in ends if isinstance(net.ports[e], PortVirtual)]
-            real_ends = [e for e in ends if isinstance(net.ports[e], PortAtEdge)]
-            if len(virt_ends) == 2:
-                raise ValueError(
-                    f"TL between two virtual ports ({br.a!r}, {br.b!r}) has no "
-                    "real-segment endpoints; cannot map to NEC2 tl_card"
-                )
-            for v in virt_ends:
-                virtual_neighbours[v].extend(real_ends)
-
-        # Only compute stub geometry if we actually have virtual ports to
-        # synthesise stubs for. Designs with only PortAtEdge ports (e.g.
-        # trap_fan_dipole) shouldn't be required to declare a design_freq
-        # they don't otherwise use.
-        if not virtual_neighbours:
-            return
-
-        wavelength = 299.792458 / self.builder.design_freq
-        stub_len = wavelength / 100.0
-        next_tag = len(self.tups) + 1
-
-        for name, neighbours in virtual_neighbours.items():
-            if not neighbours:
-                raise ValueError(
-                    f"virtual port {name!r} has no TL branches; can't synthesise "
-                    "a stub wire without at least one real-port neighbour"
-                )
-            # Centroid of neighbour feed midpoints.
-            mids = np.stack(
-                [
-                    _seg_midpoint(
-                        *self._feed_name_to_loc[r][2:5],
-                        sub_idx=self._feed_name_to_loc[r][1],
-                    )
-                    for r in neighbours
-                ]
-            )
-            c = mids.mean(axis=0)
-            # Offset 2 stub-lengths above the highest neighbour midpoint in z,
-            # so the stub doesn't collide with the antenna geometry.
-            z_top = mids[:, 2].max()
-            base = np.array([c[0], c[1], z_top + 2.0 * stub_len])
-            tip = base + np.array([0.0, 0.0, stub_len])
-            # Single-segment stub (parity "odd" is already satisfied).
-            geo.wire(
-                next_tag,
-                1,
-                base[0],
-                base[1],
-                base[2],
-                tip[0],
-                tip[1],
-                tip[2],
-                0.0005,
-                1.0,
-                1.0,
-            )
-            self._network_port_loc[name] = (next_tag, 1)
-            next_tag += 1
-
     def _emit_network_cards(self):
-        """Translate Network branches into tl_card / ld_card calls and Network
-        sources into ex_card calls. Called after geometry_complete().
+        """Emit a Load-only network as native NEC2 ld_cards + ex_cards. Called
+        after geometry_complete(). (TL/DiffTL/virtual-driver networks never
+        reach here — they go through the multiport-Y NetworkReducer path.)
 
-        Load branches are emitted as NEC2 type-0 ld_cards (short series RLC
-        on a single segment). NEC2's convention: a zero value for R, L, or C
-        means that element isn't present in the load — same semantics as the
-        Load dataclass's optional fields.
+        Load branches become ld_cards (type 0 = series RLC, type 1 = parallel
+        RLC) on a single segment; a zero R/L/C means that element is absent,
+        matching the Load dataclass's optional fields.
         """
         net = self._network
-        # ld_cards first — conventional ordering; loading affects the MoM
-        # solution that the TL/EX stages then read from.
         for br in net.branches:
-            if isinstance(br, Load):
-                port = net.ports[br.port]
-                if not isinstance(port, PortAtEdge):
-                    raise ValueError(
-                        f"Load on virtual port {br.port!r}: a Load is a series "
-                        "impedance on an antenna segment, which only PortAtEdge has"
-                    )
-                tag, seg = self._network_port_loc[br.port]
-                r = float(br.r) if br.r is not None else 0.0
-                l = float(br.l) if br.l is not None else 0.0
-                c = float(br.c) if br.c is not None else 0.0
-                if r == 0.0 and l == 0.0 and c == 0.0:
-                    continue
-                # NEC2 ld_card type 0 = series RLC, type 1 = parallel RLC.
-                # Both apply on a single segment [seg, seg] on `tag`.
-                ldtyp = 1 if br.parallel else 0
-                self.c.ld_card(ldtyp, tag, seg, seg, r, l, c)
-        for br in net.branches:
-            if isinstance(br, TL):
-                tag_a, seg_a = self._network_port_loc[br.a]
-                tag_b, seg_b = self._network_port_loc[br.b]
-                self.c.tl_card(tag_a, seg_a, tag_b, seg_b, br.z0, br.length, 0, 0, 0, 0)
-            elif isinstance(br, Load):
-                continue  # already emitted above
-            elif isinstance(br, DiffTL):
+            if not isinstance(br, Load):
                 raise NotImplementedError(
-                    "DiffTL (4-terminal differential transmission line) is not "
-                    "expressible as a NEC2 tl_card, whose ports are pinned to "
-                    "single segments. Use PysimEngine for differential lines."
+                    f"{type(br).__name__} reached PyNEC's native network path; "
+                    "only Load is handled natively (TL/DiffTL/virtual-driver "
+                    "networks use the NetworkReducer path)"
                 )
-            elif isinstance(br, TwoPort):
-                raise NotImplementedError(
-                    "TwoPort on PyNECEngine: sketched but not cross-engine "
-                    "validated. See issue #65 piece (B)."
+            port = net.ports[br.port]
+            if not isinstance(port, PortAtEdge):
+                raise ValueError(
+                    f"Load on virtual port {br.port!r}: a Load is a series "
+                    "impedance on an antenna segment, which only PortAtEdge has"
                 )
-            else:
-                raise NotImplementedError(f"branch type {type(br).__name__}")
+            tag, seg = self._network_port_loc[br.port]
+            r = float(br.r) if br.r is not None else 0.0
+            l = float(br.l) if br.l is not None else 0.0
+            c = float(br.c) if br.c is not None else 0.0
+            if r == 0.0 and l == 0.0 and c == 0.0:
+                continue
+            ldtyp = 1 if br.parallel else 0
+            self.c.ld_card(ldtyp, tag, seg, seg, r, l, c)
         for src in net.sources:
             if not isinstance(src, Driven):
                 raise NotImplementedError(f"unknown source type: {src!r}")
@@ -252,18 +160,142 @@ class PyNECEngine(SimulationEngine):
             v = complex(src.voltage)
             self.excitation_pairs.append((tag, seg, v))
 
-    def _apply_ground_card(self):
+    def _apply_ground_card(self, c=None):
+        c = c if c is not None else self.c
         g = self.ground
         if g is None or g == "free":
             return  # no gn_card -> free space
         if g == "pec":
-            self.c.gn_card(1, 0, 0, 0, 0, 0, 0, 0)
+            c.gn_card(1, 0, 0, 0, 0, 0, 0, 0)
             return
         if isinstance(g, tuple) and len(g) == 3 and g[0] == "finite":
             _, eps_r, sigma = g
-            self.c.gn_card(0, 0, eps_r, sigma, 0, 0, 0, 0)
+            c.gn_card(0, 0, eps_r, sigma, 0, 0, 0, 0)
             return
         raise ValueError(f"unrecognised ground spec: {g!r}")
+
+    # ----- network-spec path: multiport Y + shared NetworkReducer -----
+    #
+    # NEC2's tl_card can't represent a virtual driver behind a line (it needs
+    # both endpoints on real segments, and a synthesised dummy stub injects a
+    # huge parasitic reactance that the line fails to transform away). So for
+    # `build_network()` designs we don't emit tl_cards at all: we extract the
+    # antenna's multiport short-circuit Y at the real ports and hand it to the
+    # engine-agnostic NetworkReducer (the EZNEC approach — transmission lines
+    # as a circuit post-process on the field solution). Shared with pysim.
+
+    def _network_uses_reducer(self):
+        """True iff the network needs the Y-matrix reduction path — i.e. it
+        has a transmission line (TL/DiffTL) or a virtual driver. Load-only
+        networks are handled natively by NEC's ld_card."""
+        net = self._network
+        if any(isinstance(b, (TL, DiffTL)) for b in net.branches):
+            return True
+        return any(isinstance(p, PortVirtual) for p in net.ports.values())
+
+    def _init_network(self):
+        """Build the port-index map (real PortAtEdge ports first, virtual
+        ports after) and the NetworkReducer. Validates that every PortAtEdge
+        names an edge in build_wires()."""
+        net = self._network
+        if any(isinstance(b, DiffTL) for b in net.branches):
+            # The multiport-Y + NetworkReducer path *can* express a DiffTL
+            # (NEC2's tl_card cannot), but DiffTL on PyNEC isn't cross-
+            # validated yet — keep it PysimEngine-only for now.
+            raise NotImplementedError(
+                "DiffTL (4-terminal differential transmission line) on "
+                "PyNECEngine is not enabled; use PysimEngine for differential "
+                "lines."
+            )
+        named = {t[4] for t in self.tups if len(t) >= 5 and t[4] is not None}
+        self._real_port_names = [
+            n for n, p in net.ports.items() if isinstance(p, PortAtEdge)
+        ]
+        for name in self._real_port_names:
+            if name not in named:
+                raise ValueError(
+                    f"network port {name!r} is a PortAtEdge but no edge in "
+                    f"build_wires() carries that name; named edges: {sorted(named)}"
+                )
+        port_to_idx = {n: i for i, n in enumerate(self._real_port_names)}
+        next_idx = len(self._real_port_names)
+        for name, port in net.ports.items():
+            if isinstance(port, PortVirtual):
+                port_to_idx[name] = next_idx
+                next_idx += 1
+        self._reducer = NetworkReducer(net, port_to_idx, next_idx)
+
+    def _make_real_context(self):
+        """A fresh nec_context with only the real build_wires() geometry, wire
+        conductivity, and ground — no virtual stubs, no tl_cards. Returns
+        (context, {edge_name: (tag, mid_seg)})."""
+        c = nec.nec_context()
+        geo = c.get_geometry()
+        loc = {}
+        for idx, t in enumerate(self.tups, start=1):
+            p0, p1, n_seg = t[0], t[1], t[2]
+            name = t[4] if len(t) >= 5 else None
+            geo.wire(
+                idx,
+                n_seg,
+                p0[0],
+                p0[1],
+                p0[2],
+                p1[0],
+                p1[1],
+                p1[2],
+                WIRE_RADIUS,
+                1.0,
+                1.0,
+            )
+            if name is not None:
+                loc[name] = (idx, (n_seg + 1) // 2)
+        c.geometry_complete(0)
+        c.ld_card(5, 0, 0, 0, COPPER_CONDUCTIVITY, 0.0, 0.0)
+        self._apply_ground_card(c)
+        return c, loc
+
+    @staticmethod
+    def _port_current(sc, tag, seg):
+        """Complex current in sub-segment `seg` (1-based) of wire `tag`."""
+        matches = [k for k, t in enumerate(sc.get_current_segment_tag()) if t == tag]
+        return sc.get_current()[matches[seg - 1]]
+
+    def _compute_y_matrix(self, wavelength):
+        """Multiport short-circuit Y at the real ports, via one NEC solve per
+        port: drive that port's gap at 1 V (the other named ports stay
+        continuous = shorted) and read the resulting current at every port —
+        column j of Y. The geometry's interaction matrix is refactored once
+        per solve; small antennas make the N solves cheap."""
+        freq = C_LIGHT / wavelength / 1e6
+        names = self._real_port_names
+        n = len(names)
+        Y = np.zeros((n, n), dtype=np.complex128)
+        for j, drv in enumerate(names):
+            c, loc = self._make_real_context()
+            tag, seg = loc[drv]
+            c.ex_card(0, tag, seg, 0, 1.0, 0.0, 0, 0, 0, 0)
+            c.fr_card(0, 1, freq, 0)
+            c.xq_card(0)
+            sc = c.get_structure_currents(0)
+            for i, name in enumerate(names):
+                Y[i, j] = self._port_current(sc, *loc[name])
+            del c
+        return Y
+
+    def _excited_real_context(self, wavelength):
+        """Fresh real-geometry context driven at the network-resolved real-
+        port voltages (each real port a delta-gap at its resolved V), so
+        far-field / current readouts reflect the network. fr_card is left to
+        the caller."""
+        Y = self._compute_y_matrix(wavelength)
+        V = self._reducer.resolve_voltages(self._reducer.apply_branches(Y, wavelength))
+        c, loc = self._make_real_context()
+        for i, name in enumerate(self._real_port_names):
+            tag, seg = loc[name]
+            v = complex(V[i])
+            c.ex_card(0, tag, seg, 0, v.real, v.imag, 0, 0, 0, 0)
+        return c
 
     def _set_freq_and_execute(self):
         self.c.fr_card(0, 1, self.builder.freq, 0)
@@ -289,6 +321,9 @@ class PyNECEngine(SimulationEngine):
         return zs
 
     def impedance(self, sum_currents=False):
+        if self._use_reducer:
+            wl = C_LIGHT / (self.builder.freq * 1e6)
+            return self._reducer.driven_impedance(self._compute_y_matrix(wl), wl)
         self._set_freq_and_execute()
         return self._impedances_at(0, sum_currents=sum_currents)
 
@@ -296,6 +331,12 @@ class PyNECEngine(SimulationEngine):
         freqs = np.asarray(freqs, dtype=float)
         if freqs.ndim != 1 or freqs.size == 0:
             raise ValueError("freqs must be a 1-D non-empty array")
+        if self._use_reducer:
+            zs = np.empty((freqs.size, self._reducer.n_driven), dtype=np.complex128)
+            for k, f in enumerate(freqs):
+                wl = C_LIGHT / (float(f) * 1e6)
+                zs[k] = self._reducer.driven_impedance(self._compute_y_matrix(wl), wl)
+            return zs
         if freqs.size == 1:
             del_freq = 0.0
         else:
@@ -320,6 +361,8 @@ class PyNECEngine(SimulationEngine):
         currents are the average of the two adjacent NEC segment-centre
         currents, with boundary knots zeroed (open-wire BC). The pysim web
         backend uses the same averaging convention."""
+        if self._use_reducer:
+            self.c = self._excited_real_context(C_LIGHT / (self.builder.freq * 1e6))
         self._set_freq_and_execute()
         sc = self.c.get_structure_currents(0)
         all_tags = list(sc.get_current_segment_tag())
@@ -346,6 +389,8 @@ class PyNECEngine(SimulationEngine):
         return out
 
     def far_field(self, *, n_theta=90, n_phi=360, del_theta=1, del_phi=1):
+        if self._use_reducer:
+            self.c = self._excited_real_context(C_LIGHT / (self.builder.freq * 1e6))
         self._set_freq_and_execute()
         return self._collect_pattern(
             n_theta=n_theta, n_phi=n_phi, del_theta=del_theta, del_phi=del_phi

--- a/src/antenna_designer/engines/pysim.py
+++ b/src/antenna_designer/engines/pysim.py
@@ -9,17 +9,8 @@ from pysim import TriangularPySim
 
 from ..engine import FarField, SimulationEngine, WireCurrents
 from ..geometry import flat_wires_to_polylines
-from ..network import (
-    TL,
-    DiffTL,
-    Driven,
-    Load,
-    PortAtEdge,
-    PortVirtual,
-    TwoPort,
-    load_impedance,
-    load_series_admittance,
-)
+from ..network import PortAtEdge, PortVirtual
+from ..network_reduce import NetworkReducer, tl_admittance_2x2
 
 
 def _parity_for_solver(solver, solver_kwargs):
@@ -150,13 +141,14 @@ class PysimEngine(SimulationEngine):
             self._init_network()
 
     def _init_network(self):
-        """Build port-index maps and validate that every PortAtEdge resolves
-        to a translated feed name. Real ports come first (matching pysim's
-        feed list); virtual ports are appended after."""
+        """Build the port-index map (real feeds first, virtual ports after)
+        and the engine-agnostic NetworkReducer that stamps the branches and
+        reduces to driven-port impedance. Validates that every PortAtEdge
+        resolves to a translated feed name."""
         net = self._network
         feed_name_to_idx = {n: i for i, n in enumerate(self._feed_names) if n}
 
-        self._port_to_idx = {}
+        port_to_idx = {}
         for name, port in net.ports.items():
             if isinstance(port, PortAtEdge):
                 if name not in feed_name_to_idx:
@@ -165,39 +157,16 @@ class PysimEngine(SimulationEngine):
                         f"build_wires() carries that name; named edges: "
                         f"{sorted(feed_name_to_idx)}"
                     )
-                self._port_to_idx[name] = feed_name_to_idx[name]
+                port_to_idx[name] = feed_name_to_idx[name]
 
         # Virtual ports are indexed after the real feeds.
         next_idx = len(self._feeds)
         for name, port in net.ports.items():
             if isinstance(port, PortVirtual):
-                self._port_to_idx[name] = next_idx
+                port_to_idx[name] = next_idx
                 next_idx += 1
-        self._n_total_ports = next_idx
 
-        # 0-based driven port indices and their applied voltages.
-        self._driven_port_idx = []
-        self._driven_voltages = []
-        for src in net.sources:
-            if not isinstance(src, Driven):
-                raise NotImplementedError(f"unknown source type: {src!r}")
-            self._driven_port_idx.append(self._port_to_idx[src.port])
-            self._driven_voltages.append(complex(src.voltage))
-
-        # A Load on a port modifies the MoM Z-diagonal of that segment via
-        # Sherman-Morrison (equivalent to NEC2's ld_card on segment k). The
-        # right boundary condition at a loaded port is V_external = 0 (no
-        # source attached to the segment's external terminal) — NOT
-        # I_external = 0, which is the right BC for TL passive ports. With
-        # I_ext = 0 forced, the Sherman-Morrison update's effect on the
-        # driven-port impedance cancels out algebraically (you can derive
-        # it: V_passive picks up a factor (1 − α·Y_kk) that divides out).
-        # So track loaded ports separately and pin their V = 0 in the
-        # reduction. They take precedence over the floating-passive default.
-        self._loaded_port_idx = set()
-        for br in net.branches:
-            if isinstance(br, Load):
-                self._loaded_port_idx.add(self._port_to_idx[br.port])
+        self._reducer = NetworkReducer(net, port_to_idx, next_idx)
 
     def _make_solver(self, *, wavelength):
         return self._solver(
@@ -215,81 +184,14 @@ class PysimEngine(SimulationEngine):
     def _wavelength_for(freq_mhz):
         return C_LIGHT / (freq_mhz * 1e6)
 
-    def _tl_admittance_2x2(self, z0, length, wavelength):
-        """Lossless ideal-TL nodal admittance between its two terminals.
-
-        For electrical length θ = 2π·length/λ:
-            Y_TL = 1/(j Z0 sin θ) · [[cos θ, -1], [-1, cos θ]]
-        Singular at sin θ = 0 (TL is a half-wavelength multiple); raise
-        rather than return garbage so callers can pick a different length.
-        """
-        theta = 2.0 * np.pi * length / wavelength
-        s, c = np.sin(theta), np.cos(theta)
-        if abs(s) < 1e-12:
-            raise ValueError(
-                f"TL length {length} is ~kλ/2 at f={C_LIGHT / wavelength / 1e6:.4f} MHz "
-                "(sin βl ≈ 0); admittance is singular"
-            )
-        scale = 1.0 / (1j * z0 * s)
-        return scale * np.array([[c, -1.0], [-1.0, c]], dtype=np.complex128)
-
-    def _difftl_admittance_4x4(
-        self, z0, length, wavelength, transposed=False, z0_cm=None
-    ):
-        """4-terminal nodal admittance of a 2-conductor lossless line.
-
-        Unlike `_tl_admittance_2x2`, whose two ports are each pinned to a
-        single antenna segment, this models a genuine 2-conductor (twisted-
-        pair) line whose two ports are each a pair of independent terminals
-        — the thing NEC2's `tl_card` cannot express.
-
-        Terminals are ordered (a_pos, a_neg, b_pos, b_neg). A real 2-wire
-        line carries two independent modes, decomposed by the power-
-        preserving mixed-mode transform:
-
-            differential:  V_d = V_pos - V_neg,      I_d = (I_pos - I_neg)/2
-            common:        V_c = (V_pos + V_neg)/2,  I_c =  I_pos + I_neg
-
-        Each mode is its own lossless line. The differential mode (impedance
-        `z0`) carries the phasing current that cancels in the far field; it
-        is lifted to four terminals by M_d (rows V_d at ports A,B) as
-        Mᵀ·Y_d·M. The common mode (impedance `z0_cm`) is the through-current
-        the two conductors carry in parallel — what keeps a galvanic wire's
-        current continuous across a junction; it is lifted by
-        P_c = [[½,½,0,0],[0,0,½,½]] as P_cᵀ·Y_c·P_c. The full stamp is the
-        sum, so the element reproduces both currents a real conductor pair
-        carries — not just the differential one.
-
-        `z0_cm=None` gives the pure-differential element (rank-2 stamp; the
-        common mode floats). `transposed=True` swaps the b-port terminals —
-        the half-twist — which flips the differential A<->B coupling sign;
-        the common mode is symmetric under that swap and is unaffected.
-
-        The half-wave singularity of `_tl_admittance_2x2` is inherited by
-        both modes (same physical length); callers carry a small offset.
-        """
-        y_d = self._tl_admittance_2x2(z0, length, wavelength)
-        m_d = np.array(
-            [[1.0, -1.0, 0.0, 0.0], [0.0, 0.0, 1.0, -1.0]], dtype=np.complex128
-        )
-        if transposed:
-            m_d[1] = np.array([0.0, 0.0, -1.0, 1.0], dtype=np.complex128)
-        y4 = m_d.T @ y_d @ m_d
-        if z0_cm is not None:
-            y_c = self._tl_admittance_2x2(z0_cm, length, wavelength)
-            p_c = np.array(
-                [[0.5, 0.5, 0.0, 0.0], [0.0, 0.0, 0.5, 0.5]], dtype=np.complex128
-            )
-            y4 = y4 + p_c.T @ y_c @ p_c
-        return y4
-
     def _apply_tls(self, Y, wavelength):
-        """Y + per-TL stamps at the corresponding feed-index pairs."""
+        """Y + per-TL stamps at the corresponding feed-index pairs (legacy
+        build_tls() path; the network-spec path goes through NetworkReducer)."""
         Y = Y.copy()
         for tag1, _s1, tag2, _s2, z0, length in self._tls:
             a = self._tag_to_feed[tag1]
             b = self._tag_to_feed[tag2]
-            y_tl = self._tl_admittance_2x2(z0, length, wavelength)
+            y_tl = tl_admittance_2x2(z0, length, wavelength)
             Y[np.ix_([a, b], [a, b])] += y_tl
         return Y
 
@@ -326,144 +228,6 @@ class PysimEngine(SimulationEngine):
             dtype=np.complex128,
         )
 
-    def _apply_loads(self, Y, omega):
-        """Apply every Load branch as a Sherman-Morrison rank-1 update on
-        the real-port Y — the network-level equivalent of NEC2's `ld_card`
-        modifying the segment's MoM Z[k,k].
-
-        The update has two algebraically-identical forms, dual under
-        Z_L ↔ y_L = 1/Z_L:
-
-            impedance:   Y − Z_L/(1 + Z_L·Y_kk) · outer(Y[:,k], Y[k,:])
-            admittance:  Y − 1/(y_L + Y_kk)     · outer(Y[:,k], Y[k,:])
-
-        Each Load mode has a resonance where one form divides by an
-        intermediate infinity while the other stays finite, so we pick the
-        form whose denominator is bounded at that mode's resonance:
-
-          - Parallel-LC trap: Z_L→∞ at ω₀ (open circuit). Use the
-            ADMITTANCE form — y_L is the tank admittance, →0 at ω₀, giving
-            coefficient 1/Y_kk (the open-circuit Schur complement).
-          - Series-LC: Z_L→0 at ω₀ (short circuit = unbroken wire). Use the
-            IMPEDANCE form — coefficient →0, i.e. no stamp.
-
-        This way neither path ever forms or tests for infinity.
-        """
-        Y = Y.copy()
-        for br in self._network.branches:
-            if not isinstance(br, Load):
-                continue
-            port = self._network.ports[br.port]
-            if not isinstance(port, PortAtEdge):
-                raise ValueError(
-                    f"Load on virtual port {br.port!r}: a Load is a series "
-                    "impedance on an antenna segment, which only PortAtEdge has"
-                )
-            k = self._port_to_idx[br.port]
-            y_col = Y[:, k].copy()
-
-            if br.parallel:
-                # Admittance form: y_L is the parallel-LC tank admittance,
-                # cleanly 0 at trap resonance (the open-circuit point).
-                y_l = load_series_admittance(br, omega)
-                denom = y_l + Y[k, k]
-                if abs(denom) < 1e-15:
-                    raise ValueError(
-                        f"Load on port {br.port!r}: y_L + Y[k,k] ≈ 0 (singular)"
-                    )
-                Y -= np.outer(y_col, y_col) / denom
-            else:
-                # Impedance form: Z_L is 0 at series-LC resonance (a short
-                # = unbroken wire), where the coefficient vanishes anyway.
-                z_l = load_impedance(br, omega)
-                if z_l == 0:
-                    continue
-                denom = 1.0 + z_l * Y[k, k]
-                if abs(denom) < 1e-15:
-                    raise ValueError(
-                        f"Load on port {br.port!r}: 1 + Z_L·Y[k,k] ≈ 0 (singular)"
-                    )
-                Y -= (z_l / denom) * np.outer(y_col, y_col)
-        return Y
-
-    def _apply_branches(self, Y, wavelength):
-        """Pad Y to include virtual ports, then stamp every network branch.
-
-        Y comes from pysim with shape (n_real, n_real); we return a
-        (n_total, n_total) augmented matrix with zeros in the virtual-port
-        rows/cols (no antenna admittance) plus the branch contributions.
-
-        Order matters: Load branches modify the antenna's real-port Y first
-        (matching ld_card's effect inside the MoM), then TL branches stamp
-        on the loaded Y. A TL connected to a loaded port sees the external
-        side of the load.
-        """
-        omega = 2.0 * np.pi * C_LIGHT / wavelength
-        Y = self._apply_loads(Y, omega)
-        n_total = self._n_total_ports
-        Y_full = np.zeros((n_total, n_total), dtype=np.complex128)
-        n_real = Y.shape[0]
-        Y_full[:n_real, :n_real] = Y
-        for br in self._network.branches:
-            if isinstance(br, TL):
-                a, b = self._port_to_idx[br.a], self._port_to_idx[br.b]
-                y_tl = self._tl_admittance_2x2(br.z0, br.length, wavelength)
-                Y_full[np.ix_([a, b], [a, b])] += y_tl
-            elif isinstance(br, DiffTL):
-                idx = [
-                    self._port_to_idx[p]
-                    for p in (br.a_pos, br.a_neg, br.b_pos, br.b_neg)
-                ]
-                y4 = self._difftl_admittance_4x4(
-                    br.z0,
-                    br.length,
-                    wavelength,
-                    transposed=br.transposed,
-                    z0_cm=br.z0_cm,
-                )
-                Y_full[np.ix_(idx, idx)] += y4
-            elif isinstance(br, Load):
-                continue  # already applied to the real-port Y
-            elif isinstance(br, TwoPort):
-                raise NotImplementedError(
-                    "TwoPort on PysimEngine: sketched but not cross-engine "
-                    "validated. See issue #65 piece (B)."
-                )
-            else:
-                raise NotImplementedError(f"branch type {type(br).__name__}")
-        return Y_full
-
-    def _resolve_network_voltages(self, Y_total):
-        """Return the (n_total,) voltage vector after solving the network:
-        driven ports at their applied voltages, every other port floating
-        with I_ext = 0."""
-        n = Y_total.shape[0]
-        driven = list(self._driven_port_idx)
-        # Loaded ports get V = 0 forced (correct BC for "no external source
-        # on a wire-interior segment"; see _init_network for the derivation).
-        floating = [
-            i for i in range(n) if i not in driven and i not in self._loaded_port_idx
-        ]
-        v_driven = np.array(self._driven_voltages, dtype=np.complex128)
-        V = np.zeros(n, dtype=np.complex128)
-        V[driven] = v_driven
-        # V[loaded] = 0 by zeros init.
-        if floating:
-            # I_ext = 0 at floating ports: Y_ff V_f = -Y_fd V_d - Y_fl V_l.
-            # V_l = 0 so the last term drops; same form as before.
-            Y_ff = Y_total[np.ix_(floating, floating)]
-            Y_fd = Y_total[np.ix_(floating, driven)]
-            V[floating] = np.linalg.solve(Y_ff, -Y_fd @ v_driven)
-        return V
-
-    def _impedance_from_network_y(self, Y_total):
-        """Driven-port impedance: solve the network for V (loaded ports
-        pinned at V=0, floating ports satisfying I_ext=0, driven ports at
-        their applied V), then read I_driven = (Y_total @ V)_driven."""
-        V = self._resolve_network_voltages(Y_total)
-        I = Y_total @ V
-        return [complex(V[i] / I[i]) for i in self._driven_port_idx]
-
     def _solved_excited(self, wavelength):
         """Build the excitation-resolved solver and run compute_impedance
         once per (wavelength, feed-voltage) tuple, caching on the engine
@@ -487,8 +251,7 @@ class PysimEngine(SimulationEngine):
         wavelength = self._wavelength_for(self.builder.freq)
         if self._network is not None:
             Y = self._compute_y_matrix(wavelength)
-            Y_total = self._apply_branches(Y, wavelength)
-            return self._impedance_from_network_y(Y_total)
+            return self._reducer.driven_impedance(Y, wavelength)
         if self._tls:
             Y = self._compute_y_matrix(wavelength)
             Y_total = self._apply_tls(Y, wavelength)
@@ -509,11 +272,12 @@ class PysimEngine(SimulationEngine):
             Y_swept = np.asarray(
                 s.compute_y_matrix_swept(k_array), dtype=np.complex128
             )  # (n_k, n_real, n_real)
-            n_driven = len(self._driven_port_idx)
-            zs = np.empty((freqs.size, n_driven), dtype=np.complex128)
+            zs = np.empty((freqs.size, self._reducer.n_driven), dtype=np.complex128)
             for ki, freq in enumerate(freqs):
-                Y_total = self._apply_branches(Y_swept[ki], self._wavelength_for(freq))
-                zs[ki] = self._impedance_from_network_y(Y_total)
+                Y_total = self._reducer.apply_branches(
+                    Y_swept[ki], self._wavelength_for(freq)
+                )
+                zs[ki] = self._reducer.impedance_from_y(Y_total)
             return zs
         if self._tls:
             # Batched Y at every frequency, then per-k TL stamping (βL is
@@ -549,8 +313,8 @@ class PysimEngine(SimulationEngine):
         coefficient is zero and `compute_impedance`'s V/I returns NaN."""
         if self._network is not None:
             Y = self._compute_y_matrix(wavelength)
-            Y_total = self._apply_branches(Y, wavelength)
-            V_full = self._resolve_network_voltages(Y_total)
+            Y_total = self._reducer.apply_branches(Y, wavelength)
+            V_full = self._reducer.resolve_voltages(Y_total)
             feeds_resolved = [
                 (w, arc, complex(V_full[i]))
                 for i, (w, arc, _v) in enumerate(self._feeds)

--- a/src/antenna_designer/network.py
+++ b/src/antenna_designer/network.py
@@ -190,7 +190,7 @@ def load_series_admittance(br, omega):
     """Series-branch admittance y_load = 1/Z_load of a Load branch at ω.
 
     This is the natural quantity for the Sherman-Morrison port-Y stamp
-    (see PysimEngine._apply_loads): the stamp coefficient is
+    (see network_reduce.NetworkReducer.apply_loads): the stamp coefficient is
     1/(y_load + Y_kk), which stays finite exactly where Z_load blows up.
 
     Parallel mode: y_load IS the parallel-LC tank admittance,

--- a/src/antenna_designer/network_reduce.py
+++ b/src/antenna_designer/network_reduce.py
@@ -1,0 +1,283 @@
+"""Engine-agnostic reduction of a port-based `Network` spec to driven-port
+impedances, on top of a raw multiport antenna admittance matrix.
+
+Both PysimEngine and PyNECEngine assemble the antenna's short-circuit Y at
+the real (`PortAtEdge`) ports, then hand it here with a port-name -> matrix-
+index map. This module stamps the network branches (`TL` / `DiffTL` / `Load`)
+into the Y matrix and reduces it to the driven-port impedance(s). The only
+engine-specific work is producing that raw Y and the index map; the linear
+algebra here is identical regardless of which MoM solver produced Y.
+
+This is the EZNEC-style approach: model transmission lines as a circuit
+post-process on top of the field solution, rather than via NEC2's native
+`tl_card`.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .network import (
+    TL,
+    DiffTL,
+    Driven,
+    Load,
+    PortAtEdge,
+    TwoPort,
+    load_impedance,
+    load_series_admittance,
+)
+
+C_LIGHT = 299_792_458.0
+
+
+def tl_admittance_2x2(z0, length, wavelength):
+    """Lossless ideal-TL nodal admittance between its two terminals.
+
+    For electrical length θ = 2π·length/λ:
+        Y_TL = 1/(j Z0 sin θ) · [[cos θ, -1], [-1, cos θ]]
+    Singular at sin θ = 0 (TL is a half-wavelength multiple); raise
+    rather than return garbage so callers can pick a different length.
+    """
+    theta = 2.0 * np.pi * length / wavelength
+    s, c = np.sin(theta), np.cos(theta)
+    if abs(s) < 1e-12:
+        raise ValueError(
+            f"TL length {length} is ~kλ/2 at f={C_LIGHT / wavelength / 1e6:.4f} MHz "
+            "(sin βl ≈ 0); admittance is singular"
+        )
+    scale = 1.0 / (1j * z0 * s)
+    return scale * np.array([[c, -1.0], [-1.0, c]], dtype=np.complex128)
+
+
+def difftl_admittance_4x4(z0, length, wavelength, transposed=False, z0_cm=None):
+    """4-terminal nodal admittance of a 2-conductor lossless line.
+
+    Unlike `tl_admittance_2x2`, whose two ports are each pinned to a single
+    antenna segment, this models a genuine 2-conductor (twisted-pair) line
+    whose two ports are each a pair of independent terminals — the thing
+    NEC2's `tl_card` cannot express.
+
+    Terminals are ordered (a_pos, a_neg, b_pos, b_neg). A real 2-wire line
+    carries two independent modes, decomposed by the power-preserving
+    mixed-mode transform:
+
+        differential:  V_d = V_pos - V_neg,      I_d = (I_pos - I_neg)/2
+        common:        V_c = (V_pos + V_neg)/2,  I_c =  I_pos + I_neg
+
+    Each mode is its own lossless line. The differential mode (impedance
+    `z0`) carries the phasing current that cancels in the far field; it is
+    lifted to four terminals by M_d (rows V_d at ports A,B) as Mᵀ·Y_d·M. The
+    common mode (impedance `z0_cm`) is the through-current the two conductors
+    carry in parallel — what keeps a galvanic wire's current continuous
+    across a junction; it is lifted by P_c = [[½,½,0,0],[0,0,½,½]] as
+    P_cᵀ·Y_c·P_c. The full stamp is the sum, so the element reproduces both
+    currents a real conductor pair carries — not just the differential one.
+
+    `z0_cm=None` gives the pure-differential element (rank-2 stamp; the
+    common mode floats). `transposed=True` swaps the b-port terminals — the
+    half-twist — which flips the differential A<->B coupling sign; the common
+    mode is symmetric under that swap and is unaffected.
+
+    The half-wave singularity of `tl_admittance_2x2` is inherited by both
+    modes (same physical length); callers carry a small offset.
+    """
+    y_d = tl_admittance_2x2(z0, length, wavelength)
+    m_d = np.array([[1.0, -1.0, 0.0, 0.0], [0.0, 0.0, 1.0, -1.0]], dtype=np.complex128)
+    if transposed:
+        m_d[1] = np.array([0.0, 0.0, -1.0, 1.0], dtype=np.complex128)
+    y4 = m_d.T @ y_d @ m_d
+    if z0_cm is not None:
+        y_c = tl_admittance_2x2(z0_cm, length, wavelength)
+        p_c = np.array(
+            [[0.5, 0.5, 0.0, 0.0], [0.0, 0.0, 0.5, 0.5]], dtype=np.complex128
+        )
+        y4 = y4 + p_c.T @ y_c @ p_c
+    return y4
+
+
+class NetworkReducer:
+    """Stamps a `Network`'s branches onto a raw real-port Y and reduces to
+    the driven-port impedance(s).
+
+    Construct with the network spec, a ``port_to_idx`` mapping every port
+    name (real and virtual) to its row/column in the augmented Y matrix, and
+    ``n_total_ports`` (real feeds + virtual ports). Real ports must occupy
+    indices ``0..n_real-1`` in the same order as the raw Y handed to
+    :meth:`apply_branches`; virtual ports come after.
+    """
+
+    def __init__(self, network, port_to_idx, n_total_ports):
+        self.network = network
+        self.port_to_idx = port_to_idx
+        self.n_total_ports = n_total_ports
+
+        # 0-based driven port indices and their applied voltages.
+        self.driven_port_idx = []
+        self.driven_voltages = []
+        for src in network.sources:
+            if not isinstance(src, Driven):
+                raise NotImplementedError(f"unknown source type: {src!r}")
+            self.driven_port_idx.append(port_to_idx[src.port])
+            self.driven_voltages.append(complex(src.voltage))
+
+        # A Load on a port modifies the MoM Z-diagonal of that segment via
+        # Sherman-Morrison (equivalent to NEC2's ld_card on segment k). The
+        # right boundary condition at a loaded port is V_external = 0 (no
+        # source attached to the segment's external terminal) — NOT
+        # I_external = 0, which is the right BC for TL passive ports. With
+        # I_ext = 0 forced, the Sherman-Morrison update's effect on the
+        # driven-port impedance cancels out algebraically (you can derive
+        # it: V_passive picks up a factor (1 − α·Y_kk) that divides out).
+        # So track loaded ports separately and pin their V = 0 in the
+        # reduction. They take precedence over the floating-passive default.
+        self.loaded_port_idx = set()
+        for br in network.branches:
+            if isinstance(br, Load):
+                self.loaded_port_idx.add(port_to_idx[br.port])
+
+    @property
+    def n_driven(self):
+        return len(self.driven_port_idx)
+
+    def apply_loads(self, Y, omega):
+        """Apply every Load branch as a Sherman-Morrison rank-1 update on
+        the real-port Y — the network-level equivalent of NEC2's `ld_card`
+        modifying the segment's MoM Z[k,k].
+
+        The update has two algebraically-identical forms, dual under
+        Z_L ↔ y_L = 1/Z_L:
+
+            impedance:   Y − Z_L/(1 + Z_L·Y_kk) · outer(Y[:,k], Y[k,:])
+            admittance:  Y − 1/(y_L + Y_kk)     · outer(Y[:,k], Y[k,:])
+
+        Each Load mode has a resonance where one form divides by an
+        intermediate infinity while the other stays finite, so we pick the
+        form whose denominator is bounded at that mode's resonance:
+
+          - Parallel-LC trap: Z_L→∞ at ω₀ (open circuit). Use the
+            ADMITTANCE form — y_L is the tank admittance, →0 at ω₀, giving
+            coefficient 1/Y_kk (the open-circuit Schur complement).
+          - Series-LC: Z_L→0 at ω₀ (short circuit = unbroken wire). Use the
+            IMPEDANCE form — coefficient →0, i.e. no stamp.
+
+        This way neither path ever forms or tests for infinity.
+        """
+        Y = Y.copy()
+        for br in self.network.branches:
+            if not isinstance(br, Load):
+                continue
+            port = self.network.ports[br.port]
+            if not isinstance(port, PortAtEdge):
+                raise ValueError(
+                    f"Load on virtual port {br.port!r}: a Load is a series "
+                    "impedance on an antenna segment, which only PortAtEdge has"
+                )
+            k = self.port_to_idx[br.port]
+            y_col = Y[:, k].copy()
+
+            if br.parallel:
+                # Admittance form: y_L is the parallel-LC tank admittance,
+                # cleanly 0 at trap resonance (the open-circuit point).
+                y_l = load_series_admittance(br, omega)
+                denom = y_l + Y[k, k]
+                if abs(denom) < 1e-15:
+                    raise ValueError(
+                        f"Load on port {br.port!r}: y_L + Y[k,k] ≈ 0 (singular)"
+                    )
+                Y -= np.outer(y_col, y_col) / denom
+            else:
+                # Impedance form: Z_L is 0 at series-LC resonance (a short
+                # = unbroken wire), where the coefficient vanishes anyway.
+                z_l = load_impedance(br, omega)
+                if z_l == 0:
+                    continue
+                denom = 1.0 + z_l * Y[k, k]
+                if abs(denom) < 1e-15:
+                    raise ValueError(
+                        f"Load on port {br.port!r}: 1 + Z_L·Y[k,k] ≈ 0 (singular)"
+                    )
+                Y -= (z_l / denom) * np.outer(y_col, y_col)
+        return Y
+
+    def apply_branches(self, Y, wavelength):
+        """Pad Y to include virtual ports, then stamp every network branch.
+
+        Y is the raw real-port admittance, shape (n_real, n_real); the
+        return is a (n_total, n_total) augmented matrix with zeros in the
+        virtual-port rows/cols (no antenna admittance) plus the branch
+        contributions.
+
+        Order matters: Load branches modify the antenna's real-port Y first
+        (matching ld_card's effect inside the MoM), then TL branches stamp
+        on the loaded Y. A TL connected to a loaded port sees the external
+        side of the load.
+        """
+        omega = 2.0 * np.pi * C_LIGHT / wavelength
+        Y = self.apply_loads(Y, omega)
+        n_total = self.n_total_ports
+        Y_full = np.zeros((n_total, n_total), dtype=np.complex128)
+        n_real = Y.shape[0]
+        Y_full[:n_real, :n_real] = Y
+        for br in self.network.branches:
+            if isinstance(br, TL):
+                a, b = self.port_to_idx[br.a], self.port_to_idx[br.b]
+                y_tl = tl_admittance_2x2(br.z0, br.length, wavelength)
+                Y_full[np.ix_([a, b], [a, b])] += y_tl
+            elif isinstance(br, DiffTL):
+                idx = [
+                    self.port_to_idx[p]
+                    for p in (br.a_pos, br.a_neg, br.b_pos, br.b_neg)
+                ]
+                y4 = difftl_admittance_4x4(
+                    br.z0,
+                    br.length,
+                    wavelength,
+                    transposed=br.transposed,
+                    z0_cm=br.z0_cm,
+                )
+                Y_full[np.ix_(idx, idx)] += y4
+            elif isinstance(br, Load):
+                continue  # already applied to the real-port Y
+            elif isinstance(br, TwoPort):
+                raise NotImplementedError(
+                    "TwoPort: sketched but not cross-engine validated. "
+                    "See issue #65 piece (B)."
+                )
+            else:
+                raise NotImplementedError(f"branch type {type(br).__name__}")
+        return Y_full
+
+    def resolve_voltages(self, Y_total):
+        """Return the (n_total,) voltage vector after solving the network:
+        driven ports at their applied voltages, loaded ports pinned at V=0,
+        every other port floating with I_ext = 0."""
+        n = Y_total.shape[0]
+        driven = list(self.driven_port_idx)
+        floating = [
+            i for i in range(n) if i not in driven and i not in self.loaded_port_idx
+        ]
+        v_driven = np.array(self.driven_voltages, dtype=np.complex128)
+        V = np.zeros(n, dtype=np.complex128)
+        V[driven] = v_driven
+        # V[loaded] = 0 by zeros init.
+        if floating:
+            # I_ext = 0 at floating ports: Y_ff V_f = -Y_fd V_d - Y_fl V_l.
+            # V_l = 0 so the last term drops.
+            Y_ff = Y_total[np.ix_(floating, floating)]
+            Y_fd = Y_total[np.ix_(floating, driven)]
+            V[floating] = np.linalg.solve(Y_ff, -Y_fd @ v_driven)
+        return V
+
+    def impedance_from_y(self, Y_total):
+        """Driven-port impedance: solve the network for V (loaded ports
+        pinned at V=0, floating ports satisfying I_ext=0, driven ports at
+        their applied V), then read I_driven = (Y_total @ V)_driven."""
+        V = self.resolve_voltages(Y_total)
+        I = Y_total @ V
+        return [complex(V[i] / I[i]) for i in self.driven_port_idx]
+
+    def driven_impedance(self, Y_real, wavelength):
+        """Convenience: stamp branches onto the raw real-port Y and reduce
+        to the driven-port impedance(s) in one call."""
+        return self.impedance_from_y(self.apply_branches(Y_real, wavelength))

--- a/tests/test_pysim_engine.py
+++ b/tests/test_pysim_engine.py
@@ -192,13 +192,10 @@ def test_pysim_tl_admittance_quarter_wave():
     """Hand-checked Y_TL for a quarter-wave TL with Z0=50: at θ=π/2,
     Y_TL = (1/(j50)) [[0,-1],[-1,0]] = [[0, j/50], [j/50, 0]].
     A unit-length TL of length λ/4 satisfies sin(βl)=1, cos(βl)=0."""
-    from antenna_designer.designs.freq_based.invvee import (
-        Builder as InvBuilder,
-    )
+    from antenna_designer.network_reduce import tl_admittance_2x2
 
-    e = PysimEngine(InvBuilder())
     wl = 4.0  # arbitrary; TL length = wl/4 gives θ=π/2
-    Y_tl = e._tl_admittance_2x2(z0=50.0, length=1.0, wavelength=wl)
+    Y_tl = tl_admittance_2x2(z0=50.0, length=1.0, wavelength=wl)
     expected = np.array([[0, 1j / 50], [1j / 50, 0]], dtype=np.complex128)
     assert np.allclose(Y_tl, expected, atol=1e-12), Y_tl
 
@@ -206,13 +203,10 @@ def test_pysim_tl_admittance_quarter_wave():
 def test_pysim_tl_admittance_half_wave_singular():
     """A half-wavelength TL gives sin(βl)=0 — the admittance is singular.
     Raise instead of returning nans so callers can adjust geometry."""
-    from antenna_designer.designs.freq_based.invvee import (
-        Builder as InvBuilder,
-    )
+    from antenna_designer.network_reduce import tl_admittance_2x2
 
-    e = PysimEngine(InvBuilder())
     with pytest.raises(ValueError, match="singular"):
-        e._tl_admittance_2x2(z0=50.0, length=2.0, wavelength=4.0)
+        tl_admittance_2x2(z0=50.0, length=2.0, wavelength=4.0)
 
 
 def test_pysim_difftl_admittance_quarter_wave():
@@ -224,13 +218,10 @@ def test_pysim_difftl_admittance_quarter_wave():
     TL, lifted to four terminals by M = [[1,-1,0,0],[0,0,1,-1]] as
     Stamp = Mᵀ · Y2 · M. For a quarter-wave Z0=50 line, Y2 = [[0, j/50],
     [j/50, 0]], so the cross-coupling constant is c = j/50."""
-    from antenna_designer.designs.freq_based.invvee import (
-        Builder as InvBuilder,
-    )
+    from antenna_designer.network_reduce import difftl_admittance_4x4
 
-    e = PysimEngine(InvBuilder())
     wl = 4.0  # length = wl/4 -> theta = pi/2
-    Y4 = e._difftl_admittance_4x4(z0=50.0, length=1.0, wavelength=wl, transposed=False)
+    Y4 = difftl_admittance_4x4(z0=50.0, length=1.0, wavelength=wl, transposed=False)
     c = 1j / 50
     expected = np.array(
         [
@@ -248,14 +239,11 @@ def test_pysim_difftl_transposed_flips_cross_coupling():
     """Transposing one port swaps its two terminals — that's the half-twist.
     It flips the sign of the A<->B cross-coupling blocks while leaving the
     self blocks (each port's own admittance) unchanged."""
-    from antenna_designer.designs.freq_based.invvee import (
-        Builder as InvBuilder,
-    )
+    from antenna_designer.network_reduce import difftl_admittance_4x4
 
-    e = PysimEngine(InvBuilder())
     wl = 4.0
-    Y = e._difftl_admittance_4x4(z0=50.0, length=1.0, wavelength=wl, transposed=False)
-    Yt = e._difftl_admittance_4x4(z0=50.0, length=1.0, wavelength=wl, transposed=True)
+    Y = difftl_admittance_4x4(z0=50.0, length=1.0, wavelength=wl, transposed=False)
+    Yt = difftl_admittance_4x4(z0=50.0, length=1.0, wavelength=wl, transposed=True)
     assert np.allclose(Yt[:2, 2:], -Y[:2, 2:], atol=1e-12)
     assert np.allclose(Yt[2:, :2], -Y[2:, :2], atol=1e-12)
     assert np.allclose(Yt[:2, :2], Y[:2, :2], atol=1e-12)
@@ -267,14 +255,11 @@ def test_pysim_difftl_common_mode_stamp_quarter_wave():
     one. For a quarter-wave common line, Y_c = [[0, j/Zc],[j/Zc,0]], lifted
     by P_c=[[½,½,0,0],[0,0,½,½]] as P_cᵀ·Y_c·P_c — a hand value of
     (j/4Zc)·[[0,0,1,1],[0,0,1,1],[1,1,0,0],[1,1,0,0]]."""
-    from antenna_designer.designs.freq_based.invvee import (
-        Builder as InvBuilder,
-    )
+    from antenna_designer.network_reduce import difftl_admittance_4x4
 
-    e = PysimEngine(InvBuilder())
     wl = 4.0
-    Y_diff = e._difftl_admittance_4x4(z0=50.0, length=1.0, wavelength=wl)
-    Y_full = e._difftl_admittance_4x4(z0=50.0, length=1.0, wavelength=wl, z0_cm=200.0)
+    Y_diff = difftl_admittance_4x4(z0=50.0, length=1.0, wavelength=wl)
+    Y_full = difftl_admittance_4x4(z0=50.0, length=1.0, wavelength=wl, z0_cm=200.0)
     cm = Y_full - Y_diff
     c = 1j / (4 * 200.0)
     expected = c * np.array(

--- a/tests/test_pysim_engine.py
+++ b/tests/test_pysim_engine.py
@@ -932,38 +932,35 @@ def test_network_spec_rejects_port_at_edge_with_no_named_edge():
         PysimEngine(BadBuilder())
 
 
-def test_pynec_network_dispatch_runs_delta_looparray_network():
-    """delta_looparray_network on PyNECEngine. With build_network() now
-    consumed, the engine synthesises a stub wire for the central virtual
-    driver, emits tl_cards from network.branches, ex_card from sources.
-
-    No strict numerical match to the legacy `delta_looparray_with_tls` is
-    expected — the segment-vs-basis port convention issue from #63 makes
-    both PyNEC variants of this design produce wonky impedances at default
-    params. The point is to verify the network-spec dispatch ran and the
-    network and legacy PyNEC results are in the same ballpark (same
-    physical antenna, modulo a tiny stub-wire difference)."""
+def test_pynec_network_matches_pysim_on_delta_looparray():
+    """delta_looparray_network on PyNECEngine now goes through multiport-Y
+    extraction + the shared NetworkReducer (the EZNEC approach), NOT NEC2's
+    tl_card with a synthesised dummy stub. That dummy stub used to inject a
+    huge parasitic reactance the line failed to transform away, giving a
+    wildly wrong impedance (~100 - j33000); the reducer path instead agrees
+    with PysimEngine to within the two MoM formulations' inherent few-percent
+    difference, for both impedance and far-field gain."""
     from antenna_designer.designs.freq_based.delta_looparray_network import (
         Builder as NetBuilder,
     )
-    from antenna_designer.designs.freq_based.delta_looparray_with_tls import (
-        Builder as LegacyBuilder,
-    )
 
-    (z_net,) = PyNECEngine(NetBuilder(), ground=None).impedance()
-    (z_leg,) = PyNECEngine(LegacyBuilder(), ground=None).impedance()
-    assert np.isfinite(z_net.real) and np.isfinite(z_net.imag), z_net
-    # Same antenna, just different stub-wire placement: order-of-magnitude
-    # agreement is enough to confirm the dispatch wired through correctly.
-    ratio = abs(z_net) / abs(z_leg)
-    assert 0.3 < ratio < 3.0, (
-        f"network and legacy PyNEC results diverged too far: "
-        f"net={z_net}, legacy={z_leg}, |ratio|={ratio:.2f}"
-    )
+    (z_nec,) = PyNECEngine(NetBuilder(), ground=None).impedance()
+    (z_ps,) = PysimEngine(NetBuilder(), ground=None).impedance()
+    assert np.isfinite(z_nec.real) and np.isfinite(z_nec.imag), z_nec
+    assert abs(z_nec - z_ps) / abs(z_ps) < 0.05, f"nec={z_nec}, pysim={z_ps}"
+
+    kw = dict(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
+    g_nec = PyNECEngine(NetBuilder(), ground=None).far_field(**kw).max_gain
+    g_ps = PysimEngine(NetBuilder(), ground=None).far_field(**kw).max_gain
+    assert abs(g_nec - g_ps) < 0.3, (g_nec, g_ps)
 
 
-def test_pynec_network_rejects_virtual_to_virtual_tl():
-    """TL between two PortVirtuals has no NEC2 mapping — reject at construction."""
+def test_pynec_virtual_to_virtual_tl_supported():
+    """A TL between two PortVirtuals has no NEC2 tl_card mapping, but the
+    multiport-Y + NetworkReducer path handles it fine — intermediate virtual
+    nodes are just rows in the network Y matrix. It yields a finite impedance
+    agreeing with PysimEngine (was a hard ValueError under the old tl_card
+    dispatch)."""
     from antenna_designer import AntennaBuilder
     from antenna_designer.network import Driven, Network, PortAtEdge, PortVirtual, TL
     from types import MappingProxyType
@@ -988,8 +985,10 @@ def test_pynec_network_rejects_virtual_to_virtual_tl():
                 sources=[Driven(port="a")],
             )
 
-    with pytest.raises(ValueError, match="TL between two virtual ports"):
-        PyNECEngine(Builder(), ground=None)
+    z_nec = PyNECEngine(Builder(), ground=None).impedance()[0]
+    z_ps = PysimEngine(Builder(), ground=None).impedance()[0]
+    assert np.isfinite(z_nec.real) and np.isfinite(z_nec.imag), z_nec
+    assert abs(z_nec - z_ps) / abs(z_ps) < 0.05, (z_nec, z_ps)
 
 
 def test_pynec_load_branch_resistor_adds_to_impedance():
@@ -1117,8 +1116,9 @@ def test_pynec_load_branch_rejects_virtual_port():
                 sources=[Driven(port="drv")],
             )
 
+    eng = PyNECEngine(Builder(), ground=None)
     with pytest.raises(ValueError, match="Load on virtual port"):
-        PyNECEngine(Builder(), ground=None)
+        eng.impedance()
 
 
 def test_pynec_network_rejects_port_at_edge_with_no_named_edge():


### PR DESCRIPTION
Gives `PyNECEngine` correct transmission-line / virtual-driver support by sharing the network reduction with `PysimEngine`, the EZNEC way — model transmission lines as a circuit post-process on the field solution rather than via NEC2's `tl_card`.

## Step 1 — extract `NetworkReducer` (pure refactor)
New module `antenna_designer/network_reduce.py`:
- `tl_admittance_2x2`, `difftl_admittance_4x4` — free functions (canonical home; pysim engine + unit tests import these).
- `NetworkReducer(network, port_to_idx, n_total_ports)` — `apply_loads`, `apply_branches`, `resolve_voltages`, `impedance_from_y`, `driven_impedance`.

`PysimEngine` keeps only the engine-specific work (raw multiport Y from the solver + the name→index map) and delegates stamping/reduction to the reducer. The legacy `build_tls()` path reuses the shared `tl_admittance_2x2`. No behavior change.

## Step 2 — route PyNEC's network path through the reducer
Background: NEC2's `tl_card` can't represent a virtual driver behind a line — a synthesised dummy stub injects a huge parasitic reactance the line fails to transform away, so `delta_looparray_network` on PyNEC read **~100 − j33000** (a measured no-op `tl_card`, independent of `z0`/length).

`PyNECEngine` now:
- `_compute_y_matrix` — multiport short-circuit Y at the real ports via one NEC solve per port (drive its gap at 1 V, others continuous/shorted, read all port currents).
- `_make_real_context` / `_excited_real_context` — fresh real-geometry contexts (no stubs/`tl_card`s) for Y extraction and network-resolved far-field / current readouts.
- `_network_uses_reducer` gate — only TL/DiffTL or virtual-driver networks take the reducer path; **Load-only networks keep NEC's native `ld_card`** (preserves `trap_dipole` cross-engine agreement).

`impedance` / `impedance_sweep` / `far_field` / `current_distribution` route network designs through the reducer.

### Result
`delta_looparray_network` on PyNEC: **54.84 − j3.58** vs PysimEngine 55.24 − j3.20 (<1%, was garbage), tracks TL length correctly, far-field max gain within ~0.1 dB. The old dispatch test (which asserted the network path stayed in the legacy `tl_card`'s wonky ballpark) now asserts PyNEC↔pysim parity.

## Validation
- 617 `tests/` + 78 web-server tests pass; `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
