### PR TITLE
Fix AntennaBuilder.draw for named-edge (5-tuple) designs

### DIFF
--- a/src/antenna_designer/builder.py
+++ b/src/antenna_designer/builder.py
@@ -66,8 +66,10 @@ class AntennaBuilder:
     @staticmethod
     def draw(tups, fn=None):
 
-        pairs = [(p0, p1) for p0, p1, _, _ in tups]
-        print(pairs)
+        # Edges are 4-tuples (p0, p1, nsegs, excitation) or 5-tuples with a
+        # trailing port name (named-edge designs like sterba_tl and the
+        # network builders); take the endpoints regardless of arity.
+        pairs = [(t[0], t[1]) for t in tups]
 
         lc = Line3DCollection(pairs, colors=(1, 0, 0, 1), linewidths=1)
 

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1,0 +1,33 @@
+"""Tests for AntennaBuilder.draw()."""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+from antenna_designer import AntennaBuilder
+
+
+def test_draw_handles_named_edge_designs(tmp_path):
+    """draw() used to hard-unpack 4-tuples (p0, p1, _, _), so it raised
+    "too many values to unpack" on every named-edge (5-tuple) design -- the
+    transmission-line / network builders such as freq_based.sterba_tl. It
+    must render those too, taking the endpoints regardless of tuple arity."""
+    from antenna_designer.designs.freq_based.sterba_tl import Builder
+
+    tups = Builder().build_wires()
+    assert any(len(t) == 5 for t in tups)  # this design uses named edges
+
+    out = tmp_path / "sterba_tl.png"
+    AntennaBuilder.draw(tups, fn=str(out))
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_draw_handles_plain_four_tuple_designs(tmp_path):
+    """The common 4-tuple case (no named edges) still works."""
+    from antenna_designer.designs.moxon import Builder
+
+    out = tmp_path / "moxon.png"
+    AntennaBuilder.draw(Builder().build_wires(), fn=str(out))
+    assert out.exists() and out.stat().st_size > 0


### PR DESCRIPTION
## Problem

`AntennaBuilder.draw` hard-unpacks 4-tuples:

```python
pairs = [(p0, p1) for p0, p1, _, _ in tups]
```

so `python -m antenna_designer draw --builder <design>` raises
`ValueError: too many values to unpack (expected 4, got 5)` for every
**named-edge (5-tuple)** design — the transmission-line / network builders
such as `freq_based.sterba_tl`, whose `build_wires()` emits
`(p0, p1, nsegs, excitation, name)` edges.

## Fix

Take the two endpoints regardless of tuple arity (`[(t[0], t[1]) for t in tups]`),
and drop a stray `print(pairs)` debug line.

## Tests

`tests/test_draw.py` renders both a 5-tuple design (`sterba_tl`) and a
4-tuple design (`moxon`) to a file and asserts success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)