### PR TITLE
Add transposed flag to single-ended TL

### DIFF
--- a/src/antenna_designer/network.py
+++ b/src/antenna_designer/network.py
@@ -56,12 +56,19 @@ class TL:
 
     The electrical length βl is computed at solve time from the antenna's
     operating wavelength. Both endpoints can be either real or virtual.
+
+    transposed: crossed ("half-twist") line — inverts port B's polarity,
+    flipping the sign of the off-diagonal transfer terms. This is the
+    phase reversal a transposed-feeder array (LPDA, ZL-Special) needs.
+    Prefer it over a negative z0, which would wrongly negate the diagonal
+    self terms too.
     """
 
     a: str  # port name
     b: str
     z0: float
     length: float
+    transposed: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/antenna_designer/network_reduce.py
+++ b/src/antenna_designer/network_reduce.py
@@ -31,13 +31,20 @@ from .network import (
 C_LIGHT = 299_792_458.0
 
 
-def tl_admittance_2x2(z0, length, wavelength):
+def tl_admittance_2x2(z0, length, wavelength, transposed=False):
     """Lossless ideal-TL nodal admittance between its two terminals.
 
     For electrical length θ = 2π·length/λ:
         Y_TL = 1/(j Z0 sin θ) · [[cos θ, -1], [-1, cos θ]]
     Singular at sin θ = 0 (TL is a half-wavelength multiple); raise
     rather than return garbage so callers can pick a different length.
+
+    `transposed=True` models a crossed ("half-twist") line: port B's
+    polarity is inverted, which flips the sign of the off-diagonal
+    (transfer) terms only. This is the nodal-model equivalent of NEC2's
+    negative-Z0 tl_card crossing, used by transposed-feeder arrays (LPDA,
+    ZL-Special). Note it is NOT the same as a negative z0, which would
+    (wrongly) negate the diagonal self terms too.
     """
     theta = 2.0 * np.pi * length / wavelength
     s, c = np.sin(theta), np.cos(theta)
@@ -47,7 +54,8 @@ def tl_admittance_2x2(z0, length, wavelength):
             "(sin βl ≈ 0); admittance is singular"
         )
     scale = 1.0 / (1j * z0 * s)
-    return scale * np.array([[c, -1.0], [-1.0, c]], dtype=np.complex128)
+    off = 1.0 if transposed else -1.0
+    return scale * np.array([[c, off], [off, c]], dtype=np.complex128)
 
 
 def difftl_admittance_4x4(z0, length, wavelength, transposed=False, z0_cm=None):
@@ -222,7 +230,9 @@ class NetworkReducer:
         for br in self.network.branches:
             if isinstance(br, TL):
                 a, b = self.port_to_idx[br.a], self.port_to_idx[br.b]
-                y_tl = tl_admittance_2x2(br.z0, br.length, wavelength)
+                y_tl = tl_admittance_2x2(
+                    br.z0, br.length, wavelength, transposed=br.transposed
+                )
                 Y_full[np.ix_([a, b], [a, b])] += y_tl
             elif isinstance(br, DiffTL):
                 idx = [

--- a/tests/test_pysim_engine.py
+++ b/tests/test_pysim_engine.py
@@ -200,6 +200,21 @@ def test_pysim_tl_admittance_quarter_wave():
     assert np.allclose(Y_tl, expected, atol=1e-12), Y_tl
 
 
+def test_pysim_tl_admittance_transposed_flips_offdiagonal_only():
+    """A crossed/transposed line inverts port B's polarity: only the
+    off-diagonal (transfer) terms flip sign; the diagonal (self) terms are
+    unchanged. (NOT the same as a negative z0, which negates everything.)"""
+    from antenna_designer.network_reduce import tl_admittance_2x2
+
+    # θ = π/3 so cos≠0 and the diagonal is non-trivial to compare.
+    wl, length, z0 = 6.0, 1.0, 50.0
+    y = tl_admittance_2x2(z0, length, wl)
+    yt = tl_admittance_2x2(z0, length, wl, transposed=True)
+    assert np.allclose(np.diag(yt), np.diag(y), atol=1e-12)  # self terms same
+    assert np.allclose(yt[0, 1], -y[0, 1], atol=1e-12)  # transfer flipped
+    assert np.allclose(yt[1, 0], -y[1, 0], atol=1e-12)
+
+
 def test_pysim_tl_admittance_half_wave_singular():
     """A half-wavelength TL gives sin(βl)=0 — the admittance is singular.
     Raise instead of returning nans so callers can adjust geometry."""


### PR DESCRIPTION
## Motivation

When `build_network()`'s PyNEC path moved off NEC2's `tl_card` onto the shared nodal `NetworkReducer`, the **"negative z0 = crossed line"** `tl_card` convention was lost. In the nodal stamp

```
Y_TL = 1/(j·z0·sinθ) · [[cosθ, -1], [-1, cosθ]]
```

a negative `z0` negates the **whole** matrix — including the diagonal (self) terms — which is physically wrong, not a transposition.

## Change

Add an explicit `transposed: bool = False` flag to the single-ended `TL` (mirroring the existing `DiffTL.transposed`). It flips **only the off-diagonal transfer terms** (`[[c, +1], [+1, c]]`) — port B's polarity inversion — which is the correct nodal-model crossing used by transposed-feeder arrays (LPDA, ZL-Special / HB9CV). It works on both the PyNEC and pysim reducer paths.

Defaults to `False`, so all existing `TL` behavior is unchanged.

## Tests

Adds `test_pysim_tl_admittance_transposed_flips_offdiagonal_only` pinning that the diagonal self terms are unchanged and only the transfer terms flip sign (distinct from a negative z0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)