### PR TITLE
Add Cebik (W4RNL) antenna design family (8 models)

### DIFF
--- a/src/antenna_designer/designs/cebik/PLAN.md
+++ b/src/antenna_designer/designs/cebik/PLAN.md
@@ -1,0 +1,73 @@
+# Cebik (W4RNL) design candidates
+
+Source material: L. B. Cebik's antenna articles and books, archived at
+<https://antenna2.github.io/cebik/> (the "Cebik website"), the
+*Antennas Made of Wires* Vols 1–3 on the Internet Archive, his antenneX
+back-issues, and his ARRL *Antenna Handbook* chapters (LPDA, log-periodic).
+
+## Selection principle
+
+"Interesting" = **different from what's already modeled**. The existing
+catalog already covers: dipoles (inv-vee, fan, trap, folded, turnstile,
+short-loaded), loops (delta + diamond, slanted, arrays, turnstile),
+parasitic beams (Yagi, hexbeam, Moxon), bowties + arrays, verticals
+(ground-plane, raised), and horizontally-polarized wire curtains (Sterba,
+hentenna, hourglass). The Extended Double Zepp is already present as
+variants of `freq_based/invvee.py`.
+
+The candidates below deliberately target categories the catalog lacks.
+
+## Candidates
+
+### Tier 1 — build first (distinct, iconic, clearly modelable)
+
+1. **Half-square** (`half_square.py`) — VERTICALLY polarized wire antenna:
+   two λ/4 vertical legs joined by a λ/2 horizontal top wire, end/corner
+   fed. ~3.8 dBi bidirectional broadside, low takeoff angle. *Gap filled:*
+   first vertically-polarized wire array (existing verticals are single
+   ground-plane radiators). Single feed, simple geometry.
+
+2. **Bobtail curtain** (`bobtail.py`) — the iconic W4RNL VP curtain: three
+   λ/4 verticals on ~λ/2 spacing, joined by a ~1λ top wire, fed at the
+   base of the center vertical. ~5–7 dBi broadside, very low angle. Natural
+   extension of the half-square; requires a ground model.
+
+3. **Cubical quad (2-element beam)** (`quad.py`) — a driven full-wave SQUARE
+   loop + a parasitic reflector loop. *Gap filled:* the catalog has delta
+   (triangle) and diamond loops but no square quad beam — the classic
+   loop-beam topology. Horizontally polarized, ~7 dBi forward.
+
+4. **Lazy-H** (`lazy_h.py`) — two collinear elements stacked λ/2 apart and
+   fed IN PHASE via a phasing harness. *Gap filled:* vertical stacking of
+   collinear radiators (existing arrays phase identical elements
+   side-by-side). Exercises `build_tls()`/`build_network()` in a new way.
+
+### Tier 2 — stretch goals (very different design methodology)
+
+5. **LPDA — log-periodic dipole array** (`lpda.py`) — N dipoles scaled by
+   τ (tau) and σ (sigma) with a transposed (phase-alternating) feed boom.
+   *Gap filled:* frequency-INDEPENDENT wideband array; a completely
+   different design math from every resonant antenna here. Most complex
+   (transposed feeder phasing across many elements).
+
+6. **HB9CV / ZL-Special** (`hb9cv.py`) — a 2-element ALL-DRIVEN phased beam
+   (~135° phasing line between two driven elements). *Gap filled:* contrast
+   to the parasitic Yagi — both elements driven, gain from phasing not
+   parasitics.
+
+### Tier 3 — traveling-wave / broadband (needs resistive termination)
+
+The framework's `network.Load` supports lumped R loads, so terminated
+types are feasible:
+
+7. **Terminated rhombic** (`rhombic.py`) — four long wires in a diamond with
+   a terminating resistor for unidirectional, traveling-wave operation.
+   *Gap filled:* non-resonant traveling-wave antenna.
+
+8. **T2FD — terminated tilted folded dipole** (`t2fd.py`) — folded dipole
+   with a series terminating resistor for broadband, low-Q response.
+   *Gap filled:* deliberately broadband (sacrifices gain for bandwidth).
+
+## Status
+
+Scaffold only. Models to be implemented after priority is confirmed.

--- a/src/antenna_designer/designs/cebik/PLAN.md
+++ b/src/antenna_designer/designs/cebik/PLAN.md
@@ -70,4 +70,24 @@ types are feasible:
 
 ## Status
 
-Scaffold only. Models to be implemented after priority is confirmed.
+All eight implemented, verified against the MKL-backed PyNEC solver, and
+covered by physics regression tests in `tests/test_cebik_designs.py`. Each
+auto-registers in the web examples registry (so it also picks up the generic
+schema tests) and is reachable from the CLI as `cebik.<name>`. Verified
+free-space figures at the 28.57 MHz family default:
+
+| design        | headline result                                            |
+|---------------|------------------------------------------------------------|
+| half_square   | 4.7 dBi, ~62 ohm corner feed, VP bidirectional broadside   |
+| bobtail       | 6.4 dBi peak, ~30 dB end nulls, high-Z base feed           |
+| quad          | 7.0 dBi forward, resonant driver ~132 ohm                  |
+| lazy_h        | 8.1 dBi (stacking gain), HP broadside, high-Z tuner feed   |
+| lpda          | ~6-9 dBi forward across ~24-32 MHz (feed-Z caveat in file) |
+| hb9cv         | ~6.8 dBi endfire, ~50 ohm inductive (F/B caveat in file)   |
+| rhombic       | 8 dBi, ~18 dB F/B, unidirectional; Z ~ termination         |
+| t2fd          | SWR < 1.8 over 14-56 MHz; broadband, low gain by design    |
+
+Two models carry documented modeling caveats (see their module docstrings):
+the LPDA's ideal lossless crossed feeder gives an unreliable feedpoint
+impedance, and the HB9CV's single-ended crossed TL reaches only ~8 dB F/B
+(the deep ZL null wants a true differential transposed line / pysim DiffTL).

--- a/src/antenna_designer/designs/cebik/__init__.py
+++ b/src/antenna_designer/designs/cebik/__init__.py
@@ -1,0 +1,8 @@
+# Cebik (W4RNL) design family.
+#
+# A collection of antenna models adapted from L. B. Cebik's (W4RNL)
+# articles and books ("Antennas Made of Wires" Vols 1-3, antenneX, ARRL
+# Antenna Handbook chapters), archived at https://antenna2.github.io/cebik/.
+#
+# These are chosen to fill gaps in the existing design catalog -- see
+# PLAN.md in this directory for the candidate list and rationale.

--- a/src/antenna_designer/designs/cebik/bobtail.py
+++ b/src/antenna_designer/designs/cebik/bobtail.py
@@ -1,0 +1,109 @@
+"""Bobtail curtain: a 3-element vertically-polarised broadside array
+(L. B. Cebik, W4RNL).
+
+The bobtail is the electrical big brother of the half-square: THREE roughly
+1/4-wavelength vertical radiators, spaced about 1/2 wavelength apart, joined
+along the top by a continuous ~1-wavelength phasing wire. All three verticals
+end up driven in phase, so the array is VERTICALLY POLARISED and fires
+bidirectionally broadside to the plane of the wires, with a tighter pattern
+and a few dB more gain than the half-square (~5.1 dBi, max at a low ~19 deg
+elevation over ground).
+
+Only the centre vertical is physically fed -- at its base, the classic
+"matching tank at the bottom of the centre wire" point. This is a high,
+reactive impedance (hundreds of ohms and up), which is why the real antenna
+uses a parallel-tuned tank rather than a direct coax feed. The two OUTER
+verticals are passive, open at the bottom, and excited entirely through the
+top phasing wire.
+
+Cebik's 40 m proportions: verticals ~0.243 wl, half-span (centre-to-outer)
+~0.541 wl, so the full top wire is ~1.083 wl.
+
+Geometry, in the framework's (x, y, z) convention:
+  - y : the long axis (the three verticals sit at y = -span, 0, +span)
+  - z : height; leg bottoms at `base`, top wire at `base + vert`
+  - x : firing axis; radiation is broadside off +/- x
+The structure is planar in x = 0.
+
+    C1=========C2=========C3    z = base + vert   (top wire, ~1.08 wl)
+    |          |          |
+    |          |          |     three verticals, ~0.243 wl
+    |          F          |
+    A1         A2         A3     z = base   (outer ends open; centre base-fed)
+"""
+
+from ... import AntennaBuilder
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.57,
+            "freq": 28.57,
+            # Height of the open leg ends above ground.
+            "base": 3.0,
+            # Vertical-radiator length as a fraction of a wavelength
+            # (Cebik's 40 m model: ~0.243 wl).
+            "vert_frac": 0.243,
+            # Half-span: centre-to-outer horizontal spacing as a fraction of
+            # a wavelength (~0.541 wl) -> full top wire ~1.083 wl.
+            "span_frac": 0.541,
+            # Overall scale knob. Unlike the half-square, the base feed is
+            # inherently high-Z and reactive (tank-matched), so this is not
+            # tuned for resonance -- length_factor ~1.0 is Cebik's max-gain
+            # proportion; peak gain/pattern, not X->0, is the design target.
+            "length_factor": 1.0,
+            "ui_params": MappingProxyType(
+                {
+                    # High, reactive feed (tank-matched in practice); reference
+                    # SWR to a representative open-wire/tank impedance.
+                    "target_z0": 300.0,
+                    "default_view": "yz",
+                    "length_factor": {
+                        "min": 0.9,
+                        "max": 1.1,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        eps = 0.05
+
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+
+        vert = self.vert_frac * wavelength * self.length_factor
+        span = self.span_frac * wavelength * self.length_factor
+
+        z_bot = self.base
+        z_top = self.base + vert
+
+        def nsegs(length):
+            n = max(3, round(self.nominal_nsegs * length / quarter))
+            return n if n % 2 == 1 else n + 1
+
+        tups = []
+
+        # Top phasing wire: -span -> 0 -> +span, split at the centre so the
+        # centre vertical shares the junction node.
+        tups.append(((0.0, -span, z_top), (0.0, 0.0, z_top), nsegs(span), None))
+        tups.append(((0.0, 0.0, z_top), (0.0, span, z_top), nsegs(span), None))
+
+        # Outer verticals (passive, open at the bottom).
+        tups.append(((0.0, -span, z_top), (0.0, -span, z_bot), nsegs(vert), None))
+        tups.append(((0.0, span, z_top), (0.0, span, z_bot), nsegs(vert), None))
+
+        # Centre vertical: passive from the top down to just above the base,
+        # then a one-segment driven gap at the base (the matching-tank point).
+        feed = 2 * eps
+        tups.append(
+            ((0.0, 0.0, z_top), (0.0, 0.0, z_bot + feed), nsegs(vert - feed), None)
+        )
+        tups.append(((0.0, 0.0, z_bot + feed), (0.0, 0.0, z_bot), 1, 1 + 0j))
+
+        return tups

--- a/src/antenna_designer/designs/cebik/half_square.py
+++ b/src/antenna_designer/designs/cebik/half_square.py
@@ -1,0 +1,111 @@
+"""Half-square: a vertically-polarised wire antenna (L. B. Cebik, W4RNL).
+
+The half-square is "two (roughly) 1/4-wavelength vertical legs connected by a
+(roughly) 1/2-wavelength horizontal wire" -- a rectangle missing its bottom
+side. Electrically it is a ~1-wavelength conductor (1/4 + 1/2 + 1/4) bent into
+that shape, with the two open leg-ends as voltage (current-null) points. The
+current maxima sit at the two top corners, so the radiation is dominated by
+the two vertical legs fed in phase: the antenna is VERTICALLY POLARISED and
+fires bidirectionally broadside to the plane of the wire, with deep nulls off
+the ends (Cebik: side rejection "from 10 to well over 15 dB") and a low
+takeoff angle that makes it a modest DX antenna.
+
+Cebik's max-gain proportions are frequency-independent: the horizontal:vertical
+length ratio is about 1.6:1 (top ~0.454 wl, legs ~0.283 wl), giving ~4.6-4.7
+dBi free-space gain. We feed at one top corner -- the current maximum -- which
+is a low, near-resonant impedance (~65 ohm in Cebik's models) rather than the
+high-impedance end feed of the classic "feed the bottom of one leg" version.
+
+Geometry, in the framework's (x, y, z) convention:
+  - y : the long axis (the horizontal top wire runs along y)
+  - z : height; leg bottoms at `base`, top wire at `base + vert`
+  - x : firing axis; the antenna radiates broadside off +/- x
+The structure is planar in x = 0.
+
+    C===============D     z = base + vert   (top wire, ~0.454 wl)
+    |               |
+    F               |     legs ~0.283 wl; feed F just below corner C
+    |               |
+    A               B     z = base          (open leg ends, voltage nulls)
+"""
+
+from ... import AntennaBuilder
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.57,
+            "freq": 28.57,
+            # Height of the open leg ends above ground. Low for a VP DX
+            # antenna; the top wire sits `vert` higher.
+            "base": 3.0,
+            # Leg (vertical) length as a fraction of a wavelength. Cebik's
+            # max-gain proportion is ~0.283 wl.
+            "vert_frac": 0.283,
+            # Top-wire (horizontal) length as a fraction of a wavelength,
+            # ~0.454 wl -> a horizontal:vertical ratio of ~1.6:1.
+            "horiz_frac": 0.454,
+            # Overall scale knob the optimiser tunes for resonance (X -> 0).
+            "length_factor": 1.0,
+            "ui_params": MappingProxyType(
+                {
+                    # Fed at a current maximum -> low impedance; reference SWR
+                    # to a typical 50 ohm line.
+                    "target_z0": 50.0,
+                    # Planar in x=0; the y (top) and z (legs) spans are the
+                    # two largest, so the yz view shows the antenna face-on.
+                    "default_view": "yz",
+                    "length_factor": {
+                        "min": 0.9,
+                        "max": 1.1,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        eps = 0.05
+
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+
+        vert = self.vert_frac * wavelength * self.length_factor
+        horiz = self.horiz_frac * wavelength * self.length_factor
+
+        y_left, y_right = -horiz / 2, horiz / 2
+        z_bot = self.base
+        z_top = self.base + vert
+
+        # Keep the per-segment length roughly uniform across wires of
+        # different lengths (good NEC practice at the corner junctions):
+        # scale each wire's segment count by its length relative to a
+        # quarter wave. Odd counts so the centre falls on a segment.
+        def nsegs(length):
+            n = max(3, round(self.nominal_nsegs * length / quarter))
+            return n if n % 2 == 1 else n + 1
+
+        # A short feed gap just below the left top corner, at the current
+        # maximum. One segment carries the excitation (cf. moxon.py).
+        feed = 2 * eps
+        A = (0.0, y_left, z_bot)
+        F = (0.0, y_left, z_top - feed)
+        C = (0.0, y_left, z_top)
+        D = (0.0, y_right, z_top)
+        B = (0.0, y_right, z_bot)
+
+        tups = []
+        # Left leg (bottom -> just below corner), passive.
+        tups.append((A, F, nsegs(vert - feed), None))
+        # Feed segment at the corner, driven.
+        tups.append((F, C, 1, 1 + 0j))
+        # Top wire, passive.
+        tups.append((C, D, nsegs(horiz), None))
+        # Right leg (corner -> bottom), passive.
+        tups.append((D, B, nsegs(vert), None))
+
+        return tups

--- a/src/antenna_designer/designs/cebik/hb9cv.py
+++ b/src/antenna_designer/designs/cebik/hb9cv.py
@@ -1,0 +1,131 @@
+"""ZL-Special / HB9CV: a 2-element all-driven phased beam (L. B. Cebik, W4RNL).
+
+Unlike a Yagi -- where one element is driven and the second is a parasite --
+BOTH elements here are driven, through a short CROSSED ("half-twist") phasing
+line. The crossing supplies a 180-degree reversal and the line's ~45-degree
+electrical length subtracts ~45 degrees, so the two elements run roughly 135
+degrees out of phase. With ~1/8-wavelength spacing that phasing produces an
+endfire pattern -- forward gain comparable to a 2-element Yagi but with a very
+deep, sharply tuned front-to-back null (Cebik models 25-45+ dB). This fills
+the "phased driven array" gap: gain from feed phasing, not from a parasite.
+
+Cebik's proportions (straight dipoles, 10 m): spacing ~0.12-0.15 wl, phasing
+line length ~= the spacing (~45 deg electrical), characteristic impedance
+~67 ohm. Equal-length elements work and make the beam reversible; the front
+element is made slightly short here so the feed lands near 50 ohm. The line
+is modeled as an ideal crossed TL (negative z0, NEC2 convention); at VF = 1
+its physical length equals the spacing, which is the wanted ~45 deg.
+
+Geometry, in the framework's (x, y, z) convention:
+  - x : boom axis; rear element at x = -spacing, front at x = 0; beam --> +x
+  - y : the dipole length axis (both horizontal, centre at y = 0)
+  - z : constant height `base`
+Horizontally polarised. Fed at the front element; the crossed phasing line
+carries drive to the rear.
+
+CAVEAT -- front-to-back: the phasing line is modeled as a single-ended IDEAL
+crossed TL between the two element centres. That gets the forward gain
+(~6.8 dBi), the endfire direction, and the ~50 ohm inductive feed right, but
+the very deep F/B null Cebik reports (25-45 dB) needs a precise simultaneous
+phase-AND-current-magnitude match that the single-ended ideal line does not
+reach -- it tops out near ~8 dB here. The genuinely deep null wants a true
+2-conductor transposed line (the pysim DiffTL, cf. sterba_difftl) or a fine
+multi-variable optimisation. Treat F/B as "real but shallow" in this model.
+"""
+
+from ... import AntennaBuilder
+from ...network import Driven, Network, PortAtEdge, TL
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.57,
+            "freq": 28.57,
+            "base": 7.0,
+            # Element half-lengths as fractions of a quarter wave (~half-wave
+            # dipoles). Rear slightly longer, front slightly shorter -- the
+            # small asymmetry that, with the phasing, sets up the F/B null.
+            "rear_factor": 1.03,
+            "front_factor": 0.99,
+            # Element spacing as a fraction of a wavelength (~1/8 wl).
+            "spacing_frac": 0.13,
+            # Crossed phasing-line length as a fraction of a wavelength
+            # (~= spacing -> ~45 deg electrical at VF = 1).
+            "phasing_frac": 0.14,
+            # Phasing-line characteristic impedance (ohm); modeled crossed.
+            "z0": 50.0,
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 50.0,
+                    "default_view": "xy",
+                    "rear_factor": {
+                        "min": 0.95,
+                        "max": 1.08,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                    "front_factor": {
+                        "min": 0.9,
+                        "max": 1.03,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                    "spacing_frac": {
+                        "min": 0.08,
+                        "max": 0.2,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                    "phasing_frac": {
+                        "min": 0.08,
+                        "max": 0.25,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        eps = 0.05
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+
+        spacing = self.spacing_frac * wavelength
+        h_rear = quarter * self.rear_factor
+        h_front = quarter * self.front_factor
+        z = self.base
+
+        def nsegs(length):
+            m = max(3, round(self.nominal_nsegs * length / quarter))
+            return m if m % 2 == 1 else m + 1
+
+        def dipole(x, h, name):
+            L = (x, -h, z)
+            C0 = (x, -eps, z)
+            C1 = (x, eps, z)
+            R = (x, h, z)
+            arm = nsegs(h - eps)
+            return [
+                (L, C0, arm, None, None),
+                (C0, C1, 1, None, name),
+                (C1, R, arm, None, None),
+            ]
+
+        tups = []
+        tups.extend(dipole(-spacing, h_rear, "rear"))
+        tups.extend(dipole(0.0, h_front, "front"))
+        return tups
+
+    def build_network(self):
+        wavelength = 299.792458 / self.design_freq
+        length = self.phasing_frac * wavelength
+        return Network(
+            ports={"rear": PortAtEdge("rear"), "front": PortAtEdge("front")},
+            # Crossed (negative z0) phasing line between the two driven elements.
+            branches=[TL(a="rear", b="front", z0=-self.z0, length=length)],
+            sources=[Driven(port="front", voltage=1 + 0j)],
+        )

--- a/src/antenna_designer/designs/cebik/hb9cv.py
+++ b/src/antenna_designer/designs/cebik/hb9cv.py
@@ -13,8 +13,8 @@ Cebik's proportions (straight dipoles, 10 m): spacing ~0.12-0.15 wl, phasing
 line length ~= the spacing (~45 deg electrical), characteristic impedance
 ~67 ohm. Equal-length elements work and make the beam reversible; the front
 element is made slightly short here so the feed lands near 50 ohm. The line
-is modeled as an ideal crossed TL (negative z0, NEC2 convention); at VF = 1
-its physical length equals the spacing, which is the wanted ~45 deg.
+is modeled as an ideal crossed TL (the TL `transposed` flag); at VF = 1 its
+physical length equals the spacing, which is the wanted ~45 deg.
 
 Geometry, in the framework's (x, y, z) convention:
   - x : boom axis; rear element at x = -spacing, front at x = 0; beam --> +x
@@ -125,7 +125,9 @@ class Builder(AntennaBuilder):
         length = self.phasing_frac * wavelength
         return Network(
             ports={"rear": PortAtEdge("rear"), "front": PortAtEdge("front")},
-            # Crossed (negative z0) phasing line between the two driven elements.
-            branches=[TL(a="rear", b="front", z0=-self.z0, length=length)],
+            # Crossed ("half-twist") phasing line between the two driven elements.
+            branches=[
+                TL(a="rear", b="front", z0=self.z0, length=length, transposed=True)
+            ],
             sources=[Driven(port="front", voltage=1 + 0j)],
         )

--- a/src/antenna_designer/designs/cebik/lazy_h.py
+++ b/src/antenna_designer/designs/cebik/lazy_h.py
@@ -1,0 +1,100 @@
+"""Lazy-H: two stacked collinear elements fed in phase (L. B. Cebik, W4RNL).
+
+Two horizontal wires, each ~1 wavelength long, mounted one above the other and
+separated by ~1/2 wavelength, fed IN PHASE. Each 1 wl wire behaves as a
+collinear pair of half-waves (broadside gain over a single dipole); stacking
+two of them in phase adds the vertical-stacking gain and narrows the elevation
+lobe. The array is HORIZONTALLY POLARISED and bidirectional broadside off both
+faces of the "H".
+
+In Cebik's build each element is centre-fed with parallel line, and equal
+lengths of that line run to a common junction -- so both elements see equal,
+in-phase drive, and the junction is the (high-impedance) feedpoint taken to an
+antenna tuner via 300-600 ohm open-wire line. The phasing harness exists only
+to impose equal in-phase excitation; by the array's symmetry that is exactly
+what two equal in-phase centre feeds produce, so we model it that way (cf.
+the multi-feed convention in freq_based/hexbeam_5band). This fills the
+vertical-stacking gap: the catalog's other arrays phase elements side-by-side,
+not collinear elements stacked in height.
+
+Geometry, in the framework's (x, y, z) convention:
+  - y : the long axis (both 1 wl wires run along y)
+  - z : height; lower wire at `base`, upper at `base + spacing`
+  - x : firing axis; radiation is broadside off +/- x
+The structure is planar in x = 0.
+
+    ===================F===================   z = base + spacing  (upper 1 wl)
+
+    ===================F===================   z = base            (lower 1 wl)
+                  (F = in-phase centre feed)
+"""
+
+from ... import AntennaBuilder
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.57,
+            "freq": 28.57,
+            # Height of the lower element above ground.
+            "base": 7.0,
+            # Element length as a fraction of a wavelength (~1.0 wl each).
+            "elem_frac": 1.0,
+            # Vertical stacking distance as a fraction of a wavelength
+            # (~0.5 wl between the two elements).
+            "spacing_frac": 0.5,
+            "ui_params": MappingProxyType(
+                {
+                    # High-Z junction fed via open-wire line + tuner.
+                    "target_z0": 300.0,
+                    "default_view": "yz",
+                    "elem_frac": {
+                        "min": 0.8,
+                        "max": 1.3,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                    "spacing_frac": {
+                        "min": 0.3,
+                        "max": 0.75,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        eps = 0.05
+
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+
+        elem = self.elem_frac * wavelength
+        spacing = self.spacing_frac * wavelength
+        half = elem / 2
+
+        def nsegs(length):
+            n = max(3, round(self.nominal_nsegs * length / quarter))
+            return n if n % 2 == 1 else n + 1
+
+        def element(z):
+            """A 1 wl horizontal wire along y at height z, centre-fed in
+            phase (one-segment driven gap at y = 0)."""
+            L = (0.0, -half, z)
+            R = (0.0, half, z)
+            C0 = (0.0, -eps, z)
+            C1 = (0.0, eps, z)
+            return [
+                (L, C0, nsegs(half - eps), None),
+                (C0, C1, 1, 1 + 0j),
+                (C1, R, nsegs(half - eps), None),
+            ]
+
+        tups = []
+        tups.extend(element(self.base))  # lower element
+        tups.extend(element(self.base + spacing))  # upper element
+        return tups

--- a/src/antenna_designer/designs/cebik/lpda.py
+++ b/src/antenna_designer/designs/cebik/lpda.py
@@ -17,11 +17,10 @@ Two constants describe the array (with the band edges):
 with the optimum sigma_opt = 0.243*tau - 0.051. The half apex angle follows
 from cot(alpha) = 4*sigma/(1 - tau).
 
-The transposed feeder is modeled the canonical NEC way: ideal transmission
-lines join adjacent element centres, every one CROSSED (negative
-characteristic impedance in NEC2's tl_card convention) to supply the
-180-degree section-to-section phase reversal. The array is driven at the
-front (shortest) element.
+The transposed feeder is modeled with ideal transmission lines joining
+adjacent element centres, every one CROSSED (the TL `transposed` flag -- a
+port-B polarity inversion) to supply the 180-degree section-to-section
+phase reversal. The array is driven at the front (shortest) element.
 
 CAVEAT -- feedpoint impedance: the feeder is modeled as a cascade of IDEAL,
 LOSSLESS crossed transmission lines. That cascade has internal resonances
@@ -148,10 +147,17 @@ class Builder(AntennaBuilder):
         ports = {f"d{k}": PortAtEdge(f"d{k}") for k in range(n)}
         branches = []
         # Crossed feeder section between adjacent element centres. Length =
-        # physical boom spacing; negative z0 = transposed (NEC2 convention).
+        # physical boom spacing; transposed=True gives the 180-degree
+        # section-to-section phase reversal of the transposed feeder.
         for k in range(n - 1):
             branches.append(
-                TL(a=f"d{k}", b=f"d{k + 1}", z0=-z0, length=x[k + 1] - x[k])
+                TL(
+                    a=f"d{k}",
+                    b=f"d{k + 1}",
+                    z0=z0,
+                    length=x[k + 1] - x[k],
+                    transposed=True,
+                )
             )
         # Driven at the front (shortest) element.
         return Network(

--- a/src/antenna_designer/designs/cebik/lpda.py
+++ b/src/antenna_designer/designs/cebik/lpda.py
@@ -1,0 +1,161 @@
+"""Log-periodic dipole array (LPDA) (L. B. Cebik, W4RNL; ARRL Antenna Book
+LPDA chapter).
+
+A frequency-INDEPENDENT array: a row of parallel dipoles whose lengths and
+spacings shrink geometrically toward the front by a constant ratio tau, fed
+by a TRANSPOSED (phase-alternating) feeder boom. At any frequency in the
+design band only the two or three dipoles near a half-wavelength form the
+"active region" and radiate as a small driver/reflector/director group; the
+active region slides along the array with frequency, so gain, pattern, and
+feed impedance stay roughly constant over a very wide band. The beam fires
+toward the SHORT (apex) end. This is a completely different design law from
+every resonant antenna in the catalog.
+
+Two constants describe the array (with the band edges):
+  tau   = l(n+1)/l(n) = d(n+1)/d(n)        element scaling ratio (< 1)
+  sigma = d(n) / (2 * l(n))                relative spacing constant
+with the optimum sigma_opt = 0.243*tau - 0.051. The half apex angle follows
+from cot(alpha) = 4*sigma/(1 - tau).
+
+The transposed feeder is modeled the canonical NEC way: ideal transmission
+lines join adjacent element centres, every one CROSSED (negative
+characteristic impedance in NEC2's tl_card convention) to supply the
+180-degree section-to-section phase reversal. The array is driven at the
+front (shortest) element.
+
+CAVEAT -- feedpoint impedance: the feeder is modeled as a cascade of IDEAL,
+LOSSLESS crossed transmission lines. That cascade has internal resonances
+that NEC2's tl_card does not damp, so the computed driving-point impedance is
+unreliable (it can swing wildly and even show a negative real part at
+scattered in-band frequencies). A real LPDA's feeder loss plus a termination
+stub behind the longest element suppress this. The robust, physically
+meaningful outputs of this model are the GAIN and the forward PATTERN, which
+stay LPDA-like (~6-9 dBi, fires toward the apex) across the whole band; treat
+the SWR/impedance readout as indicative only.
+
+Geometry, in the framework's (x, y, z) convention:
+  - x : boom axis; longest element at the back (x=0), shortest at the
+        front (max x); the beam fires toward +x
+  - y : the dipole length axis (all elements horizontal, centre at y=0)
+  - z : constant height `base`
+Horizontally polarised.
+
+      d0      d1   d2  d3 ...                          (lengths shrink by tau)
+    |         |        |    |   <- crossed feeder ->  F (driven, front)
+   back (low freq)                              front (high freq), beam --> +x
+"""
+
+from ... import AntennaBuilder
+from ...network import Driven, Network, PortAtEdge, TL
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            # Operating/test frequency. The band runs from `freq_low_factor`
+            # * design_freq upward; design_freq sits inside the active region.
+            "design_freq": 28.57,
+            "freq": 28.57,
+            "base": 10.0,
+            # Highest band edge as a fraction of design_freq: the shortest
+            # (front) element is a half wave here. >1 so design_freq sits
+            # just inside the top of the band, at the front of the active
+            # region where the feed is -- the longer elements extend the
+            # band downward.
+            "freq_high_factor": 1.15,
+            # Element scaling ratio and relative spacing constant. sigma near
+            # the optimum sigma_opt = 0.243*tau - 0.051 (~0.168 for tau=0.9)
+            # for good gain; lower sigma compresses the array and drops gain.
+            "tau": 0.9,
+            "sigma": 0.14,
+            # Number of dipole elements.
+            "n_elements": 10,
+            # Feeder (boom) characteristic impedance in ohms; modeled crossed.
+            "z0": 100.0,
+            # Overall length trim of the active region.
+            "length_factor": 1.0,
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 50.0,
+                    "default_view": "xy",
+                    "n_elements": {"min": 4, "max": 16, "step": 1},
+                    "tau": {"min": 0.8, "max": 0.95, "step": 0.001, "precision": 4},
+                    "sigma": {"min": 0.03, "max": 0.18, "step": 0.001, "precision": 4},
+                    "length_factor": {
+                        "min": 0.85,
+                        "max": 1.05,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                }
+            ),
+        }
+    )
+
+    def _layout(self):
+        """Element half-lengths h[n] and boom positions x[n], longest (n=0)
+        at the back. Shared by build_wires and build_network."""
+        c = 299.792458
+        n = int(self.n_elements)
+        tau = self.tau
+        sigma = self.sigma
+
+        lam_high = c / (self.freq_high_factor * self.design_freq)
+        l_min = 0.5 * lam_high * self.length_factor  # shortest (front) element
+
+        # k = 0 longest (back) ... k = n-1 shortest (front).
+        lengths = [l_min / tau ** (n - 1 - k) for k in range(n)]
+        half = [le / 2 for le in lengths]
+        # spacing d_k = 2*sigma*l_k between element k and k+1
+        x = [0.0]
+        for k in range(n - 1):
+            x.append(x[-1] + 2 * sigma * lengths[k])
+        return half, x
+
+    def build_wires(self):
+        eps = 0.05
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+        half, x = self._layout()
+        n = int(self.n_elements)
+        z = self.base
+
+        def nsegs(length):
+            m = max(3, round(self.nominal_nsegs * length / quarter))
+            return m if m % 2 == 1 else m + 1
+
+        tups = []
+        for k in range(n):
+            h = half[k]
+            xk = x[k]
+            L = (xk, -h, z)
+            C0 = (xk, -eps, z)
+            C1 = (xk, eps, z)
+            R = (xk, h, z)
+            arm = nsegs(h - eps)
+            # left arm, named centre gap (a feeder port), right arm
+            tups.append((L, C0, arm, None, None))
+            tups.append((C0, C1, 1, None, f"d{k}"))
+            tups.append((C1, R, arm, None, None))
+        return tups
+
+    def build_network(self):
+        half, x = self._layout()
+        n = int(self.n_elements)
+        z0 = self.z0
+
+        ports = {f"d{k}": PortAtEdge(f"d{k}") for k in range(n)}
+        branches = []
+        # Crossed feeder section between adjacent element centres. Length =
+        # physical boom spacing; negative z0 = transposed (NEC2 convention).
+        for k in range(n - 1):
+            branches.append(
+                TL(a=f"d{k}", b=f"d{k + 1}", z0=-z0, length=x[k + 1] - x[k])
+            )
+        # Driven at the front (shortest) element.
+        return Network(
+            ports=ports,
+            branches=branches,
+            sources=[Driven(port=f"d{n - 1}", voltage=1 + 0j)],
+        )

--- a/src/antenna_designer/designs/cebik/quad.py
+++ b/src/antenna_designer/designs/cebik/quad.py
@@ -1,0 +1,128 @@
+"""Two-element cubical quad beam (L. B. Cebik, W4RNL).
+
+A parasitic beam built from full-wave LOOPS instead of linear elements: a
+driven square loop of ~1 wavelength circumference plus a slightly larger
+parasitic reflector loop (~1.06 wl) spaced ~0.15 wl behind it. The driver is
+fed at the centre of its bottom wire, so the horizontal bottom (and top)
+wires carry the in-phase current maxima and the beam is HORIZONTALLY
+POLARISED, firing broadside to the loop planes (toward the driver, away from
+the reflector).
+
+This fills the loop-beam gap in the catalog: the existing delta (triangle)
+and diamond loops are single radiators, not the square-loop driver/reflector
+beam. Versus a 2-element Yagi the quad gives a little more gain for its
+boom length and a lower feed impedance.
+
+Cebik's wideband 20 m proportions (frequency-independent ratios):
+  driver    circumference 1.010 wl (side 0.2525 wl)
+  reflector circumference 1.065 wl (side 0.2663 wl)
+  spacing   0.155 wl
+giving ~6.6-7.5 dBi forward gain across the band.
+
+Geometry, in the framework's (x, y, z) convention:
+  - x : boom axis; reflector behind at x = -spacing, driver at x = 0,
+        beam fires toward +x
+  - y : horizontal width of each square loop
+  - z : height; both loop bottoms at `base`
+The loops lie in planes of constant x.
+
+       reflector (x=-spacing)      driver (x=0)
+        TL----TR                    TL----TR        z = base + side
+        |      |                    |      |
+        |      |                    |      |
+        BL----BR                    BL--F--BR        z = base
+                          beam --> +x
+"""
+
+from ... import AntennaBuilder
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.57,
+            "freq": 28.57,
+            # Height of the loop bottom wires above ground.
+            "base": 7.0,
+            # Loop circumferences as fractions of a wavelength. Driver near
+            # 1.0 wl (resonant); reflector larger -> inductive -> reflector.
+            "driver_circ": 1.010,
+            "reflector_circ": 1.065,
+            # Driver-reflector spacing as a fraction of a wavelength.
+            "spacing_factor": 0.155,
+            "ui_params": MappingProxyType(
+                {
+                    # Quad driver feed is ~60-130 ohm; reference SWR to 50.
+                    "target_z0": 50.0,
+                    # Boom along x, loops span y/z; the xz view shows the
+                    # driver-reflector spacing edge-on.
+                    "default_view": "xz",
+                    "driver_circ": {
+                        "min": 0.95,
+                        "max": 1.08,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                    "reflector_circ": {
+                        "min": 1.0,
+                        "max": 1.15,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                    "spacing_factor": {
+                        "min": 0.1,
+                        "max": 0.3,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        eps = 0.05
+
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+
+        side_d = self.driver_circ * wavelength / 4
+        side_r = self.reflector_circ * wavelength / 4
+        spacing = self.spacing_factor * wavelength
+
+        def nsegs(length):
+            n = max(3, round(self.nominal_nsegs * length / quarter))
+            return n if n % 2 == 1 else n + 1
+
+        def square_loop(x, side, fed):
+            """A square loop in the plane of constant x, bottom wire at
+            z = base. If `fed`, a one-segment driven gap sits at the centre
+            of the bottom wire (horizontal polarisation)."""
+            half = side / 2
+            z0, z1 = self.base, self.base + side
+            BL = (x, -half, z0)
+            BR = (x, half, z0)
+            TR = (x, half, z1)
+            TL = (x, -half, z1)
+            ns = nsegs(side)
+            wires = []
+            if fed:
+                # bottom wire: BL -> (-eps) -> [feed] -> (+eps) -> BR
+                C0 = (x, -eps, z0)
+                C1 = (x, eps, z0)
+                wires.append((BL, C0, nsegs(half - eps), None))
+                wires.append((C0, C1, 1, 1 + 0j))
+                wires.append((C1, BR, nsegs(half - eps), None))
+            else:
+                wires.append((BL, BR, ns, None))
+            # remaining three sides (passive for both loops)
+            wires.append((BR, TR, ns, None))
+            wires.append((TR, TL, ns, None))
+            wires.append((TL, BL, ns, None))
+            return wires
+
+        tups = []
+        tups.extend(square_loop(-spacing, side_r, fed=False))  # reflector
+        tups.extend(square_loop(0.0, side_d, fed=True))  # driver
+        return tups

--- a/src/antenna_designer/designs/cebik/rhombic.py
+++ b/src/antenna_designer/designs/cebik/rhombic.py
@@ -1,0 +1,119 @@
+"""Terminated rhombic: a traveling-wave directional long-wire (L. B. Cebik,
+W4RNL, "Long-Wire Antennas" / "The Terminated Vee-Beam and Rhombic").
+
+Four long wires (each 1-4 wavelengths) arranged as a horizontal diamond. The
+antenna is fed at one acute apex and TERMINATED at the opposite apex with a
+non-inductive resistor (~600-800 ohm). The resistor absorbs the forward
+traveling wave when it reaches the far apex, so almost no wave reflects back:
+the current is a progressive (traveling) wave rather than a standing wave, and
+the pattern is UNIDIRECTIONAL toward the terminated end. This is the catalog's
+first non-resonant antenna -- its behaviour is set by wire length and the
+termination, not by resonance, so it is inherently broadband (the driving-point
+impedance stays near the termination value across a wide band).
+
+The legs each make a small "tilt" angle with the main axis so that the
+long-wire radiation lobes of the four legs add along the axis. Gain runs a few
+dB over a dipole with a 10-15 dB front-to-back ratio; roughly half the input
+power is dissipated in the terminating resistor (the price of the clean
+unidirectional, broadband pattern).
+
+Geometry, in the framework's (x, y, z) convention:
+  - x : main axis; feed apex at x=0, terminated apex at x=2d; beam --> +x
+  - y : transverse; the side apexes sit at (d, +/-w)
+  - z : constant height `base` (a horizontal antenna over ground)
+with d = L*cos(tilt), w = L*sin(tilt), L the leg length. Horizontally
+polarised.
+
+              (d, +w)
+             /        \\
+   feed --> 0          2d --> [R termination], beam --> +x
+             \\        /
+              (d, -w)
+"""
+
+from ... import AntennaBuilder
+from ...network import Driven, Load, Network, PortAtEdge
+import math
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.57,
+            "freq": 28.57,
+            # Height above ground (a horizontal traveling-wave antenna).
+            "base": 10.0,
+            # Leg length as a fraction of a wavelength (each of the 4 legs).
+            "leg_factor": 3.0,
+            # Tilt angle (leg to main axis), degrees. Small -> long, narrow
+            # diamond; tuned so the long-wire lobes add along the axis.
+            "tilt_deg": 18.0,
+            # Terminating resistance (ohm) at the far apex; absorbs the
+            # forward wave to make the pattern unidirectional.
+            "term_r": 700.0,
+            "ui_params": MappingProxyType(
+                {
+                    # Driving-point impedance tracks the termination (~700 ohm),
+                    # fed via open-wire line; reference SWR there.
+                    "target_z0": 700.0,
+                    "default_view": "xy",
+                    "leg_factor": {
+                        "min": 1.0,
+                        "max": 5.0,
+                        "step": 0.05,
+                        "precision": 3,
+                    },
+                    "tilt_deg": {
+                        "min": 8.0,
+                        "max": 35.0,
+                        "step": 0.5,
+                        "precision": 2,
+                    },
+                    "term_r": {"min": 400.0, "max": 1000.0, "step": 10.0},
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        g = 0.05  # half-gap at the feed / termination apexes
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+
+        L = self.leg_factor * wavelength
+        tilt = math.radians(self.tilt_deg)
+        d = L * math.cos(tilt)
+        w = L * math.sin(tilt)
+        z = self.base
+
+        def nsegs(length):
+            m = max(3, round(self.nominal_nsegs * length / quarter))
+            return m if m % 2 == 1 else m + 1
+
+        leg = nsegs(L)
+        FU = (0.0, g, z)  # feed apex, upper terminal
+        FL = (0.0, -g, z)  # feed apex, lower terminal
+        SU = (d, w, z)  # upper side apex
+        SD = (d, -w, z)  # lower side apex
+        TU = (2 * d, g, z)  # terminated apex, upper terminal
+        TL = (2 * d, -g, z)  # terminated apex, lower terminal
+
+        return [
+            # feed gap at the rear apex (driven via build_network)
+            (FU, FL, 1, None, "feed"),
+            # four legs
+            (FU, SU, leg, None, None),  # rear upper
+            (FL, SD, leg, None, None),  # rear lower
+            (SU, TU, leg, None, None),  # front upper
+            (SD, TL, leg, None, None),  # front lower
+            # termination gap at the far apex (resistor via build_network)
+            (TU, TL, 1, None, "term"),
+        ]
+
+    def build_network(self):
+        return Network(
+            ports={"feed": PortAtEdge("feed"), "term": PortAtEdge("term")},
+            branches=[Load(port="term", r=self.term_r)],
+            sources=[Driven(port="feed", voltage=1 + 0j)],
+        )

--- a/src/antenna_designer/designs/cebik/t2fd.py
+++ b/src/antenna_designer/designs/cebik/t2fd.py
@@ -1,0 +1,127 @@
+"""T2FD -- Terminated Tilted Folded Dipole (G2BCX; modeled per L. B. Cebik,
+W4RNL, "broadband wire antennas").
+
+A folded dipole (two close-spaced parallel wires, shorted at both ends) fed at
+the centre of one wire, with a non-inductive TERMINATING RESISTOR at the centre
+of the other wire -- diametrically opposite the feed. The resistor damps the
+folded dipole's resonances, so instead of one sharp resonance the antenna
+presents a moderate, slowly-varying impedance over a very wide frequency range
+(several octaves): a deliberately BROADBAND, low-Q antenna. The price, as with
+the rhombic, is efficiency -- a good fraction of the input power is burned in
+the resistor, especially where the antenna is electrically short -- so gain is
+below a resonant dipole's. The "tilted" of the name is a deployment choice (the
+wire is slung at a slope) that mixes polarisation and smooths the azimuth
+pattern; it does not change the broadband impedance behaviour.
+
+This fills the broadband / low-Q gap: every other antenna in the catalog is
+either resonant or a sharply-tuned traveling-wave type optimised for gain;
+the T2FD trades gain for a flat SWR curve and no-tuner multiband use.
+
+Geometry, in the framework's (x, y, z) convention:
+  - y : the long axis (folded-dipole length), tilted up by `tilt_deg`
+  - x : the small fold spacing (kept horizontal)
+  - z : height; the centre sits at `base`
+Feed at the centre of the near wire; terminating resistor at the centre of the
+far wire.
+
+    short |==================|==================| short   <- far wire (term R)
+          |       feed                          |
+    short |========= F =======|================| short    <- near wire (feed)
+"""
+
+from ... import AntennaBuilder
+from ...network import Driven, Load, Network, PortAtEdge
+import math
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.57,
+            "freq": 28.57,
+            "base": 10.0,
+            # Overall length as a fraction of a wavelength at design_freq.
+            # ~0.6 wl puts design_freq inside the flat region; the antenna
+            # stays broadband well above and somewhat below it.
+            "length_frac": 0.6,
+            # Fold spacing as a fraction of a wavelength (close-spaced pair).
+            "spacing_frac": 0.008,
+            # Deployment tilt of the long axis from horizontal, degrees.
+            "tilt_deg": 30.0,
+            # Terminating resistance (ohm) at the far-wire centre. Tuned with
+            # the geometry for a flat SWR curve; fed through a balun.
+            "term_r": 820.0,
+            "ui_params": MappingProxyType(
+                {
+                    # The terminated geometry settles near ~850 ohm across
+                    # the band; reference SWR there (fed via a balun).
+                    "target_z0": 850.0,
+                    "default_view": "yz",
+                    "length_frac": {
+                        "min": 0.3,
+                        "max": 0.8,
+                        "step": 0.005,
+                        "precision": 3,
+                    },
+                    "spacing_frac": {
+                        "min": 0.004,
+                        "max": 0.03,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                    "tilt_deg": {"min": 0.0, "max": 45.0, "step": 1.0, "precision": 1},
+                    "term_r": {"min": 200.0, "max": 800.0, "step": 10.0},
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        eps = 0.05
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+
+        D = self.length_frac * wavelength
+        s = self.spacing_frac * wavelength
+        half = D / 2
+        tilt = math.radians(self.tilt_deg)
+
+        def nsegs(length):
+            m = max(3, round(self.nominal_nsegs * length / quarter))
+            return m if m % 2 == 1 else m + 1
+
+        def P(x, y):
+            # Place in a plane tilted about the x-axis: the long axis (y)
+            # slopes up by `tilt`; the fold spacing (x) stays horizontal.
+            return (x, y * math.cos(tilt), y * math.sin(tilt) + self.base)
+
+        arm = nsegs(half - eps)
+        short = nsegs(s)
+
+        # near wire (feed) at x=0; far wire (termination) at x=s
+        nL, nR = P(0.0, -half), P(0.0, half)
+        nF0, nF1 = P(0.0, -eps), P(0.0, eps)
+        fL, fR = P(s, -half), P(s, half)
+        fT0, fT1 = P(s, -eps), P(s, eps)
+
+        return [
+            # near (feed) wire: left arm, feed gap, right arm
+            (nL, nF0, arm, None, None),
+            (nF0, nF1, 1, None, "feed"),
+            (nF1, nR, arm, None, None),
+            # far (termination) wire: left arm, load gap, right arm
+            (fL, fT0, arm, None, None),
+            (fT0, fT1, 1, None, "term"),
+            (fT1, fR, arm, None, None),
+            # end shorts joining the two wires
+            (nL, fL, short, None, None),
+            (nR, fR, short, None, None),
+        ]
+
+    def build_network(self):
+        return Network(
+            ports={"feed": PortAtEdge("feed"), "term": PortAtEdge("term")},
+            branches=[Load(port="term", r=self.term_r)],
+            sources=[Driven(port="feed", voltage=1 + 0j)],
+        )

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -360,3 +360,71 @@ def test_rhombic_has_terminating_load_and_feed():
     assert loads[0].port == "term" and loads[0].r == 700.0
     (src,) = net.sources
     assert isinstance(src, Driven) and src.port == "feed"
+
+
+# ---------------------------------------------------------------------------
+# T2FD (terminated tilted folded dipole)
+# ---------------------------------------------------------------------------
+
+
+def _swr(z, z0):
+    g = abs((z - z0) / (z + z0))
+    return (1 + g) / (1 - g)
+
+
+_T2FD_BAND = (14.0, 18.0, 22.0, 28.57, 36.0, 45.0, 56.0)
+
+
+def test_t2fd_broadband_low_swr():
+    """The defining T2FD behaviour: a flat SWR curve over a 4:1 frequency
+    range (here referenced to the ~850 ohm the terminated geometry settles
+    to), unlike a resonant antenna."""
+    from antenna_designer.designs.cebik.t2fd import Builder
+
+    z0 = 850.0
+    swrs = [
+        _swr(_z(Builder(dict(Builder.default_params, freq=f))), z0) for f in _T2FD_BAND
+    ]
+    assert max(swrs) < 2.5, dict(zip(_T2FD_BAND, swrs))
+
+
+def test_t2fd_termination_flattens_the_response():
+    """Removing the resistor (R -> huge) restores sharp resonances: the
+    unterminated max-SWR over the band is far worse than terminated."""
+    from antenna_designer.designs.cebik.t2fd import Builder
+
+    z0 = 850.0
+
+    def band_max(r):
+        return max(
+            _swr(_z(Builder(dict(Builder.default_params, freq=f, term_r=r))), z0)
+            for f in _T2FD_BAND
+        )
+
+    assert band_max(820.0) < 2.5
+    assert band_max(1e9) > 10.0  # huge anti-resonant spike without the load
+
+
+def test_t2fd_gain_is_reduced_by_loss():
+    """Power burned in the terminating resistor drops gain below a resonant
+    dipole's ~2.1 dBi -- the bandwidth/efficiency trade."""
+    from antenna_designer.designs.cebik.t2fd import Builder
+
+    ff = _far_field(Builder())
+    assert ff.max_gain < 2.0
+
+
+def test_t2fd_folded_with_termination():
+    """Folded pair (two end shorts), one driven feed, one resistive Load."""
+    from antenna_designer.designs.cebik.t2fd import Builder
+    from antenna_designer.network import Driven, Load
+
+    tups = Builder().build_wires()
+    feeds = [t for t in tups if len(t) == 5 and t[4] == "feed"]
+    terms = [t for t in tups if len(t) == 5 and t[4] == "term"]
+    assert len(feeds) == 1 and len(terms) == 1
+    net = Builder().build_network()
+    (load,) = [br for br in net.branches if isinstance(br, Load)]
+    assert load.port == "term"
+    (src,) = net.sources
+    assert isinstance(src, Driven) and src.port == "feed"

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -258,7 +258,7 @@ def test_lpda_feeder_is_crossed_and_front_driven():
     net = b.build_network()
     tls = [br for br in net.branches if isinstance(br, TL)]
     assert len(tls) == b.n_elements - 1
-    assert all(tl.z0 < 0 for tl in tls)  # all transposed
+    assert all(tl.transposed and tl.z0 > 0 for tl in tls)  # all crossed
     (src,) = net.sources
     assert isinstance(src, Driven)
     assert src.port == f"d{b.n_elements - 1}"  # frontmost / shortest
@@ -293,14 +293,14 @@ def test_hb9cv_feed_resistive_inductive():
 
 
 def test_hb9cv_both_driven_via_one_crossed_line():
-    """No parasite: a single crossed (negative-z0) phasing line couples the
+    """No parasite: a single crossed (transposed) phasing line couples the
     two driven element centres; the source sits on the front element."""
     from antenna_designer.designs.cebik.hb9cv import Builder
     from antenna_designer.network import TL, Driven
 
     net = Builder().build_network()
     tls = [br for br in net.branches if isinstance(br, TL)]
-    assert len(tls) == 1 and tls[0].z0 < 0
+    assert len(tls) == 1 and tls[0].transposed and tls[0].z0 > 0
     assert {tls[0].a, tls[0].b} == {"rear", "front"}
     (src,) = net.sources
     assert isinstance(src, Driven) and src.port == "front"

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -116,3 +116,47 @@ def test_bobtail_only_centre_element_is_fed():
     # The fed gap sits on the centre vertical (y = 0).
     (x0, y0, _), (x1, y1, _), _, _ = feeds[0]
     assert y0 == 0.0 and y1 == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Cubical quad beam
+# ---------------------------------------------------------------------------
+
+
+def test_quad_forward_gain():
+    """~7 dBi forward (Cebik: 6.6-7.5 dBi for the wideband 2-el quad)."""
+    from antenna_designer.designs.cebik.quad import Builder
+
+    ff = _far_field(Builder())
+    assert ff.max_gain > 6.5
+
+
+def test_quad_driver_near_resonant():
+    """Driver loop ~1.01 wl is near resonance at the default scale."""
+    from antenna_designer.designs.cebik.quad import Builder
+
+    z = _z(Builder())
+    assert abs(z.imag) < 35.0
+
+
+def test_quad_fires_toward_driver_with_front_to_back():
+    """Beam fires +x (toward the driver, away from the reflector at -x)."""
+    from antenna_designer.designs.cebik.quad import Builder
+
+    ff = _far_field(Builder())
+    rings = np.array(ff.rings)
+    front = rings[:, 0].max()  # +x
+    back = rings[:, 180].max()  # -x
+    assert front - back > 6.0
+
+
+def test_quad_has_two_loops_one_fed():
+    """Reflector (passive) + driver (one fed gap) = 2 four-sided loops."""
+    from antenna_designer.designs.cebik.quad import Builder
+
+    tups = Builder().build_wires()
+    feeds = [t for t in tups if t[3] is not None]
+    assert len(feeds) == 1
+    # Reflector sits behind the driver (more negative x).
+    xs = sorted({round(t[0][0], 6) for t in tups})
+    assert len(xs) == 2 and xs[0] < xs[1]

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -160,3 +160,55 @@ def test_quad_has_two_loops_one_fed():
     # Reflector sits behind the driver (more negative x).
     xs = sorted({round(t[0][0], 6) for t in tups})
     assert len(xs) == 2 and xs[0] < xs[1]
+
+
+# ---------------------------------------------------------------------------
+# Lazy-H
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_h_stacking_gain():
+    """Two stacked in-phase 1 wl elements give ~8 dBi free-space -- well
+    above a single ~1 wl element's ~4 dBi (the vertical-stacking gain)."""
+    from antenna_designer.designs.cebik.lazy_h import Builder
+
+    ff = _far_field(Builder())
+    assert ff.max_gain > 7.0
+
+
+def test_lazy_h_broadside_horizontal():
+    """Bidirectional broadside off +/-x with deep end nulls."""
+    from antenna_designer.designs.cebik.lazy_h import Builder
+
+    ff = _far_field(Builder())
+    rings = np.array(ff.rings)
+    row = rings[60]
+    broadside = max(row[0], row[180])
+    end_on = max(row[90], row[270])
+    assert broadside - end_on > 15.0
+
+
+def test_lazy_h_two_in_phase_feeds():
+    """Two centre feeds, both at y=0, both driven in phase (1+0j); by
+    symmetry they present equal feed impedance."""
+    from antenna_designer.designs.cebik.lazy_h import Builder
+
+    feeds = [t for t in Builder().build_wires() if t[3] is not None]
+    assert len(feeds) == 2
+    assert all(f[3] == 1 + 0j for f in feeds)
+    assert all(f[0][1] == -0.05 and f[1][1] == 0.05 for f in feeds)
+    zs = PyNECEngine(Builder(), ground=None).impedance()
+    assert abs(zs[0] - zs[1]) < 1.0  # symmetric -> equal
+
+
+def test_lazy_h_wider_spacing_adds_gain():
+    """Expanding the stack toward ~5/8 wl raises gain (W2EEY expansion)."""
+    from antenna_designer.designs.cebik.lazy_h import Builder
+
+    g_half = _far_field(
+        Builder(dict(Builder.default_params, spacing_frac=0.5))
+    ).max_gain
+    g_wide = _far_field(
+        Builder(dict(Builder.default_params, spacing_frac=0.625))
+    ).max_gain
+    assert g_wide > g_half

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -68,3 +68,51 @@ def test_half_square_length_factor_tunes_reactance():
     x_mid = _z(Builder(dict(Builder.default_params, length_factor=1.00))).imag
     x_hi = _z(Builder(dict(Builder.default_params, length_factor=1.04))).imag
     assert x_lo < x_mid < x_hi
+
+
+# ---------------------------------------------------------------------------
+# Bobtail curtain
+# ---------------------------------------------------------------------------
+
+
+def test_bobtail_gain_exceeds_half_square():
+    """Three-element curtain: ~5+ dBi broadside, more than the half-square's
+    ~4.7 (Cebik: ~5.1-5.2 dBi)."""
+    from antenna_designer.designs.cebik.bobtail import Builder
+
+    ff = _far_field(Builder())
+    assert ff.max_gain > 5.0
+
+
+def test_bobtail_broadside_directivity():
+    """Vertically-polarised, sharply bidirectional broadside off +/-x with
+    very deep end nulls (3 in-phase verticals)."""
+    from antenna_designer.designs.cebik.bobtail import Builder
+
+    ff = _far_field(Builder())
+    rings = np.array(ff.rings)
+    row = rings[60]
+    broadside = max(row[0], row[180])
+    end_on = max(row[90], row[270])
+    assert broadside - end_on > 20.0
+
+
+def test_bobtail_feed_is_high_impedance():
+    """Base feed of the centre element is a high, reactive point (Cebik:
+    hundreds to thousands of ohms, tank-matched)."""
+    from antenna_designer.designs.cebik.bobtail import Builder
+
+    z = _z(Builder())
+    assert z.real > 500.0
+    assert abs(z.imag) > 1000.0
+
+
+def test_bobtail_only_centre_element_is_fed():
+    """Exactly one driven gap; the outer verticals are passive."""
+    from antenna_designer.designs.cebik.bobtail import Builder
+
+    feeds = [t for t in Builder().build_wires() if t[3] is not None]
+    assert len(feeds) == 1
+    # The fed gap sits on the centre vertical (y = 0).
+    (x0, y0, _), (x1, y1, _), _, _ = feeds[0]
+    assert y0 == 0.0 and y1 == 0.0

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -1,0 +1,70 @@
+"""Physics regression tests for the Cebik (W4RNL) design family.
+
+Each test pins the published Cebik behaviour (resonant impedance, gain,
+polarisation/pattern shape) via the PyNEC engine so a geometry regression
+in build_wires() is caught. Free-space (ground=None) is used for the
+impedance/gain numbers because it removes soil-model dependence; pattern
+shape (broadside vs end-on) is checked there too.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from antenna_designer.engines import PyNECEngine
+
+
+def _z(builder, ground=None):
+    return PyNECEngine(builder, ground=ground).impedance()[0]
+
+
+def _far_field(builder, ground=None):
+    return PyNECEngine(builder, ground=ground).far_field(
+        n_theta=90, n_phi=360, del_theta=1, del_phi=1
+    )
+
+
+# ---------------------------------------------------------------------------
+# Half-square
+# ---------------------------------------------------------------------------
+
+
+def test_half_square_resonant_and_low_z():
+    """Corner-fed half-square: ~65 ohm, near-resonant at length_factor=1
+    (Cebik's max-gain proportions)."""
+    from antenna_designer.designs.cebik.half_square import Builder
+
+    z = _z(Builder())
+    assert 50.0 < z.real < 80.0
+    assert abs(z.imag) < 20.0  # near resonance at the default scale
+
+
+def test_half_square_gain_matches_cebik():
+    """~4.6-4.7 dBi free-space per Cebik's published models."""
+    from antenna_designer.designs.cebik.half_square import Builder
+
+    ff = _far_field(Builder())
+    assert 4.0 < ff.max_gain < 5.5
+
+
+def test_half_square_is_broadside_with_end_nulls():
+    """Vertically-polarised, bidirectional broadside off +/-x with deep
+    nulls off the ends (Cebik: >10 dB side rejection)."""
+    from antenna_designer.designs.cebik.half_square import Builder
+
+    ff = _far_field(Builder())
+    rings = np.array(ff.rings)  # [theta][phi], dBi
+    row = rings[60]  # ~30 deg elevation
+    broadside = max(row[0], row[180])
+    end_on = max(row[90], row[270])
+    assert broadside - end_on > 8.0
+
+
+def test_half_square_length_factor_tunes_reactance():
+    """Reactance climbs monotonically with length_factor through resonance."""
+    from antenna_designer.designs.cebik.half_square import Builder
+
+    x_lo = _z(Builder(dict(Builder.default_params, length_factor=0.96))).imag
+    x_mid = _z(Builder(dict(Builder.default_params, length_factor=1.00))).imag
+    x_hi = _z(Builder(dict(Builder.default_params, length_factor=1.04))).imag
+    assert x_lo < x_mid < x_hi

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -304,3 +304,59 @@ def test_hb9cv_both_driven_via_one_crossed_line():
     assert {tls[0].a, tls[0].b} == {"rear", "front"}
     (src,) = net.sources
     assert isinstance(src, Driven) and src.port == "front"
+
+
+# ---------------------------------------------------------------------------
+# Terminated rhombic
+# ---------------------------------------------------------------------------
+
+
+def test_rhombic_unidirectional_when_terminated():
+    """The terminating resistor makes the traveling-wave pattern
+    unidirectional toward the terminated apex (+x)."""
+    from antenna_designer.designs.cebik.rhombic import Builder
+
+    ff = _far_field(Builder())
+    rings = np.array(ff.rings)
+    front = rings[:, 0].max()  # +x toward termination
+    back = rings[:, 180].max()
+    assert ff.max_gain > 6.0
+    assert front - back > 12.0
+
+
+def test_rhombic_termination_creates_the_directivity():
+    """Remove the termination (R -> huge) and the F/B collapses: the
+    progressive wave is gone and the pattern goes ~bidirectional."""
+    from antenna_designer.designs.cebik.rhombic import Builder
+
+    def fb(r):
+        b = Builder(dict(Builder.default_params, term_r=r))
+        rings = np.array(_far_field(b).rings)
+        return rings[:, 0].max() - rings[:, 180].max()
+
+    assert fb(700.0) > 12.0
+    assert fb(1e9) < 5.0
+
+
+def test_rhombic_impedance_tracks_termination():
+    """Traveling-wave antenna: the driving-point R sits near the
+    termination value, and it scales with it (broadband behaviour)."""
+    from antenna_designer.designs.cebik.rhombic import Builder
+
+    z600 = _z(Builder(dict(Builder.default_params, term_r=600.0)))
+    z800 = _z(Builder(dict(Builder.default_params, term_r=800.0)))
+    assert 450.0 < z600.real < 750.0
+    assert z800.real > z600.real  # tracks the termination upward
+
+
+def test_rhombic_has_terminating_load_and_feed():
+    """One driven feed apex and one resistive Load at the far apex."""
+    from antenna_designer.designs.cebik.rhombic import Builder
+    from antenna_designer.network import Driven, Load
+
+    net = Builder().build_network()
+    loads = [br for br in net.branches if isinstance(br, Load)]
+    assert len(loads) == 1
+    assert loads[0].port == "term" and loads[0].r == 700.0
+    (src,) = net.sources
+    assert isinstance(src, Driven) and src.port == "feed"

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -262,3 +262,45 @@ def test_lpda_feeder_is_crossed_and_front_driven():
     (src,) = net.sources
     assert isinstance(src, Driven)
     assert src.port == f"d{b.n_elements - 1}"  # frontmost / shortest
+
+
+# ---------------------------------------------------------------------------
+# HB9CV / ZL-Special (2-element all-driven phased beam)
+# ---------------------------------------------------------------------------
+
+
+def test_hb9cv_forward_gain_and_endfire():
+    """~6-7 dBi (like a 2-el Yagi) firing toward the front (+x). F/B is real
+    but shallow in this ideal-crossed-TL model -- see module docstring."""
+    from antenna_designer.designs.cebik.hb9cv import Builder
+
+    ff = _far_field(Builder())
+    rings = np.array(ff.rings)
+    front = rings[:, 0].max()
+    back = rings[:, 180].max()
+    assert ff.max_gain > 6.0
+    assert front - back > 5.0
+
+
+def test_hb9cv_feed_resistive_inductive():
+    """Cebik: feed ~40-55 ohm resistive with inductive reactance. Both
+    elements are driven through a single crossed phasing line."""
+    from antenna_designer.designs.cebik.hb9cv import Builder
+
+    z = _z(Builder())
+    assert z.real > 15.0  # positive, real driving-point R
+    assert z.imag > 0.0  # inductive (needs series-cap cancellation)
+
+
+def test_hb9cv_both_driven_via_one_crossed_line():
+    """No parasite: a single crossed (negative-z0) phasing line couples the
+    two driven element centres; the source sits on the front element."""
+    from antenna_designer.designs.cebik.hb9cv import Builder
+    from antenna_designer.network import TL, Driven
+
+    net = Builder().build_network()
+    tls = [br for br in net.branches if isinstance(br, TL)]
+    assert len(tls) == 1 and tls[0].z0 < 0
+    assert {tls[0].a, tls[0].b} == {"rear", "front"}
+    (src,) = net.sources
+    assert isinstance(src, Driven) and src.port == "front"

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -212,3 +212,53 @@ def test_lazy_h_wider_spacing_adds_gain():
         Builder(dict(Builder.default_params, spacing_frac=0.625))
     ).max_gain
     assert g_wide > g_half
+
+
+# ---------------------------------------------------------------------------
+# LPDA (log-periodic dipole array)
+# ---------------------------------------------------------------------------
+
+
+def test_lpda_broadband_forward_gain():
+    """The defining LPDA behaviour: ~6-9 dBi forward gain held across a wide
+    band, firing toward the apex (+x). (Feedpoint impedance is not asserted
+    -- the ideal lossless crossed feeder makes it unreliable; see module
+    docstring.)"""
+    from antenna_designer.designs.cebik.lpda import Builder
+
+    for fr in (24.0, 26.0, 28.57, 30.0):
+        b = Builder(dict(Builder.default_params, freq=fr))
+        ff = _far_field(b)
+        rings = np.array(ff.rings)
+        front = rings[:, 0].max()  # +x, toward the apex
+        back = rings[:, 180].max()
+        assert ff.max_gain > 5.5, (fr, ff.max_gain)
+        assert front > back, (fr, front, back)
+
+
+def test_lpda_elements_scale_by_tau():
+    """Element half-lengths form a geometric sequence with ratio tau."""
+    from antenna_designer.designs.cebik.lpda import Builder
+
+    b = Builder()
+    half, x = b._layout()
+    ratios = [half[k + 1] / half[k] for k in range(len(half) - 1)]
+    assert all(abs(r - b.tau) < 1e-9 for r in ratios)
+    # boom positions strictly increase toward the front
+    assert all(x[k + 1] > x[k] for k in range(len(x) - 1))
+
+
+def test_lpda_feeder_is_crossed_and_front_driven():
+    """Every feeder section is crossed (negative z0) and the source sits on
+    the front (shortest) element."""
+    from antenna_designer.designs.cebik.lpda import Builder
+    from antenna_designer.network import TL, Driven
+
+    b = Builder()
+    net = b.build_network()
+    tls = [br for br in net.branches if isinstance(br, TL)]
+    assert len(tls) == b.n_elements - 1
+    assert all(tl.z0 < 0 for tl in tls)  # all transposed
+    (src,) = net.sources
+    assert isinstance(src, Driven)
+    assert src.port == f"d{b.n_elements - 1}"  # frontmost / shortest


### PR DESCRIPTION
Adds `designs/cebik/` — eight antenna models adapted from L. B. Cebik's
(W4RNL) articles (sourced from the antenna2.github.io/cebik archive),
chosen to fill gaps in the existing catalog. Each is verified against the
PyNEC solver with physics regression tests in `tests/test_cebik_designs.py`,
auto-registers in the web examples registry, and is reachable from the CLI
as `cebik.<name>`.

| Model | Gap filled | Headline (free space, 28.57 MHz) |
|---|---|---|
| `half_square` | first VP wire antenna | 4.7 dBi, ~62 Ω corner feed, VP broadside |
| `bobtail` | 3-element VP curtain | 6.4 dBi, ~30 dB end nulls |
| `quad` | square-loop **beam** (vs delta/diamond loops) | 7.0 dBi fwd, resonant driver |
| `lazy_h` | collinear **stacking** (vs side-by-side) | 8.1 dBi, HP broadside |
| `lpda` | frequency-**independent** array | ~6–9 dBi fwd across the band |
| `hb9cv` | **all-driven** phased beam (vs parasitic Yagi) | ~6.8 dBi endfire, ~50 Ω |
| `rhombic` | **traveling-wave** directional | 8 dBi, ~18 dB F/B, unidirectional |
| `t2fd` | **broadband / low-Q** | SWR < 1.8 over 14–56 MHz |

### Notes
- `lpda` and `hb9cv` use the `TL(transposed=True)` flag (added in #89) for their crossed feeders.
- Two documented modeling caveats (in the module docstrings): the LPDA's ideal lossless crossed-feeder cascade gives an unreliable feedpoint impedance (gain/pattern are the valid outputs); the HB9CV's single-ended crossed TL reaches only ~8 dB F/B (the deep ZL null wants a true differential transposed line / pysim `DiffTL`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)