### PR TITLE
Add second Cebik (W4RNL) antenna design batch (8 models)

### DIFF
--- a/src/antenna_designer/designs/cebik/PLAN.md
+++ b/src/antenna_designer/designs/cebik/PLAN.md
@@ -91,3 +91,43 @@ Two models carry documented modeling caveats (see their module docstrings):
 the LPDA's ideal lossless crossed feeder gives an unreliable feedpoint
 impedance, and the HB9CV's single-ended crossed TL reaches only ~8 dB F/B
 (the deep ZL null wants a true differential transposed line / pysim DiffTL).
+
+## Batch 2 (PR #91)
+
+A second eight-model set, again chosen to hit categories the catalog (now
+including batch 1) still lacked. All free-space, self-contained, MKL-PyNEC
+verified, with regression tests in `tests/test_cebik_designs.py`:
+
+| design            | gap filled / headline result                              |
+|-------------------|-----------------------------------------------------------|
+| w8jk              | 180-deg all-driven flat-top: ~5.8 dBi bidirectional       |
+|                   | endfire, deep broadside + overhead nulls (array action)   |
+| phased_verticals  | 90-deg cardioid: feed-phase steering, ~5.2 dBi, ~6-7 dB   |
+|                   | F/B (current-forcing network deepens it; see caveat)      |
+| inverted_l        | bent/top-loaded vertical on elevated radials: resonant    |
+|                   | ~18 ohm, VP low-angle                                     |
+| ocf_dipole        | off-centre (Windom) feed: R rises ~3x off centre to       |
+|                   | ~230 ohm (the defining OCF physics)                       |
+| vbeam             | resonant long-wire V: ~5 dBi along the bisector, deep     |
+|                   | broadside null (standing-wave sibling of the rhombic)     |
+| bisquare          | 2 wl VP loop curtain: VP broadside, ~3.4 dBi free-space   |
+|                   | (the gain reputation is a low-mount over-ground effect)   |
+| jpole             | stub-matched end-fed half-wave: omni VP ~2 dBi, SWR < 2   |
+| discone           | broadband vertical (disc+cone wire cage): SWR < 3 over    |
+|                   | ~34-65 MHz above the cone cutoff, low-angle omni          |
+
+Design-method notes learned this round:
+- VP/ground-mounted antennas (inverted_l, the verticals) are best modelled
+  with a small ELEVATED-RADIAL counterpoise in free space (cf.
+  `designs/vertical.py`) rather than a PEC/finite ground card: a wire whose
+  base sits exactly on a PEC plane gave a pathological ~-10 kohm feed
+  reactance, whereas radials give a clean, deterministic feedpoint.
+- A two-element cardioid fed by VOLTAGE sources only reaches ~5-7 dB F/B
+  because the two driving-point impedances differ, so equal voltages give
+  unequal currents; `phased_verticals` exposes a tuned complex `front_voltage`
+  (~-1.2j) to partly compensate. A genuinely deep null needs a current-forcing
+  feed network (Christman/Lewallen) — same family of caveat as hb9cv.
+- A single-wire Franklin collinear was prototyped and dropped: with only two
+  half-wave sections a centre feed already makes them in-phase (it degenerates
+  to lazy_h's 1 wl element), and the multi-section phase-reversed curtain is
+  already covered by `freq_based/sterba`. The discone took its slot instead.

--- a/src/antenna_designer/designs/cebik/bisquare.py
+++ b/src/antenna_designer/designs/cebik/bisquare.py
@@ -1,0 +1,98 @@
+"""Bi-square: a two-wavelength loop worked as a vertical broadside curtain
+(L. B. Cebik, W4RNL).
+
+Take the half-square (a 1 wl conductor) and double it into a 2 wl loop with
+four HALF-wave sides, hung as a square standing on one corner (a diamond) and
+fed at the bottom corner. Current reverses every half wavelength -- i.e. at
+every corner -- so by symmetry the horizontal (left/right) field components of
+the four slanting sides cancel while the VERTICAL components add: the bi-square
+is VERTICALLY POLARISED and fires bidirectionally broadside to the plane of the
+loop. In free space its gain is modest (a couple of dB over a dipole), but
+mounted low it is a strong LOW-ANGLE VP performer, the best-known member of
+Cebik's "self-contained vertical" (SCV) loop family.
+
+This fills the "vertical loop curtain" gap: the catalog's loops (delta,
+diamond, quad) are ~1 wl radiators or horizontally polarised beams; the
+bi-square is a 2 wl VP curtain needing no ground plane. Cebik's max-pattern
+proportion runs the sides a touch over a half wave (~0.55 wl here).
+
+Geometry, in the framework's (x, y, z) convention:
+  - z : height; the loop's tall vertical extent is what makes it VP
+  - y : the left/right corners splay to +/- y
+  - x : firing axis; broadside off +/- x (planar in x = 0)
+
+                    o  top corner             z = base + 2*hd
+                   / \\
+       left corner o   o right corner         z = base + hd
+                   \\ /
+                    F  bottom corner (fed)     z = base
+"""
+
+from ... import AntennaBuilder
+from types import MappingProxyType
+import math
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.57,
+            "freq": 28.57,
+            # Height of the bottom (fed) corner above ground.
+            "base": 4.0,
+            # Side length as a fraction of a wavelength (~half-wave per side;
+            # four sides -> ~2 wl loop). ~0.55 wl is the modelled max-pattern
+            # proportion.
+            "side_frac": 0.55,
+            # Overall scale knob (peak gain / pattern, not a low-Z resonance,
+            # is the design target -- the corner feed is high and reactive).
+            "length_factor": 1.0,
+            "ui_params": MappingProxyType(
+                {
+                    # Corner-fed 2 wl loop -> high, reactive feed; open-wire +
+                    # tuner in practice.
+                    "target_z0": 300.0,
+                    "default_view": "yz",
+                    "length_factor": {
+                        "min": 0.9,
+                        "max": 1.1,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        eps = 0.05
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+
+        side = self.side_frac * wavelength * self.length_factor
+        # Square standing on a corner: the half-diagonal is side / sqrt(2).
+        hd = side / math.sqrt(2)
+
+        Bc = (0.0, 0.0, self.base)  # bottom corner (fed)
+        Rc = (0.0, hd, self.base + hd)  # right corner
+        Tc = (0.0, 0.0, self.base + 2 * hd)  # top corner
+        Lc = (0.0, -hd, self.base + hd)  # left corner
+
+        def nsegs(length):
+            n = max(3, round(self.nominal_nsegs * length / quarter))
+            return n if n % 2 == 1 else n + 1
+
+        ns = nsegs(side)
+        feed = 2 * eps
+        # Feed gap on the lower-right side, a short `feed` distance up from the
+        # bottom corner along the Bc -> Rc direction (unit (0, 1, 1)/sqrt(2)).
+        u = hd / side  # = 1/sqrt(2)
+        F = (0.0, feed * u, self.base + feed * u)
+
+        tups = []
+        tups.append((Bc, F, 1, 1 + 0j))  # one-segment driven gap at the corner
+        tups.append((F, Rc, nsegs(side - feed), None))
+        tups.append((Rc, Tc, ns, None))  # upper-right side
+        tups.append((Tc, Lc, ns, None))  # upper-left side
+        tups.append((Lc, Bc, ns, None))  # lower-left side
+        return tups

--- a/src/antenna_designer/designs/cebik/discone.py
+++ b/src/antenna_designer/designs/cebik/discone.py
@@ -1,0 +1,128 @@
+"""Discone: a broadband vertical (disc + cone), modelled as a wire cage
+(L. B. Cebik, W4RNL).
+
+A horizontal DISC sits above the apex of a downward-opening CONE; the coax
+feeds across the small gap between the disc centre and the cone apex. The cone
+behaves like a fat, tapered monopole and the disc like its ground/counterpoise,
+and because both are tapered the antenna stays usefully matched (~VSWR < 2-3)
+over roughly a 4:1 frequency range starting a little above the frequency where
+the cone slant height is a quarter wavelength. It radiates VERTICALLY
+POLARISED and omnidirectionally in azimuth, like a vertical monopole but
+WIDEBAND -- the standard scanner / VHF-UHF utility antenna.
+
+This fills the "wideband vertical / frequency-independent omni" gap: the
+catalog's verticals are resonant quarter-waves and its only other broadband
+member, the t2fd, is a (lossy, terminated) horizontal dipole. We approximate
+the solid disc and cone by a cage of radial WIRES (the usual NEC modelling
+trick); the disc doubles as a self-contained counterpoise, so no ground card
+is needed.
+
+Geometry, in the framework's (x, y, z) convention:
+  - z : vertical; the disc is the horizontal cage at the top, the cone hangs
+        below it, fed across the apex gap -- VERTICALLY POLARISED
+  - x, y : the disc radials and cone slant wires spread in azimuth
+
+        disc:  ----o----o----o----   (horizontal radial cage)   z = base
+                       \\ | /
+                        \\|/  feed gap (apex)
+                        /|\\
+                       / | \\
+        cone:         o  o  o         (downward radial cage)     z < base
+"""
+
+from ... import AntennaBuilder
+import math
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.57,
+            "freq": 28.57,
+            # Height of the disc (and feedpoint) above ground.
+            "base": 8.0,
+            # Cone slant-wire length as a fraction of a wavelength at the design
+            # frequency. ~1/4 wl sets the LOW-frequency corner; the antenna
+            # works upward from there.
+            "cone_frac": 0.27,
+            # Half-angle of the cone from vertical, in degrees (~30 deg is the
+            # classic ~60-degree-included discone cone).
+            "cone_half_angle_deg": 30.0,
+            # Disc radius as a fraction of the cone BASE radius -- the textbook
+            # "disc diameter ~ 0.7 * cone base diameter" rule.
+            "disc_ratio": 0.7,
+            # Number of radial wires in each cage (disc and cone).
+            "n_wires": 12,
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 50.0,
+                    # Vertical radiator; the xz view reads the elevation.
+                    "default_view": "xz",
+                    # Broadband by design: let the GUI sweep run wide rather
+                    # than band-locking to 10 m.
+                    "cone_frac": {
+                        "min": 0.2,
+                        "max": 0.35,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                    "disc_ratio": {
+                        "min": 0.5,
+                        "max": 1.0,
+                        "step": 0.01,
+                        "precision": 3,
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        eps = 0.05
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+
+        cone = self.cone_frac * wavelength
+        ang = math.radians(self.cone_half_angle_deg)
+        cone_r = cone * math.sin(ang)  # cone base radius
+        cone_h = cone * math.cos(ang)  # cone vertical drop
+        disc_r = self.disc_ratio * cone_r  # disc radius (~0.7 * cone base r)
+        m = int(self.n_wires)
+
+        z_disc = self.base  # disc plane (cone apex just below)
+        z_apex = self.base - 2 * eps  # cone apex
+        z_cone_base = self.base - cone_h
+
+        def nsegs(length):
+            n = max(3, round(self.nominal_nsegs * length / quarter))
+            return n if n % 2 == 1 else n + 1
+
+        tups = []
+        # Feed: a one-segment driven gap between the disc centre and the cone
+        # apex (the coax point of a discone).
+        tups.append(((0.0, 0.0, z_disc), (0.0, 0.0, z_apex), 1, 1 + 0j))
+
+        for i in range(m):
+            phi = 2 * math.pi / m * i
+            c, s = math.cos(phi), math.sin(phi)
+            # Disc radial: horizontal, out from the centre.
+            tups.append(
+                (
+                    (0.0, 0.0, z_disc),
+                    (disc_r * c, disc_r * s, z_disc),
+                    nsegs(disc_r),
+                    None,
+                )
+            )
+            # Cone slant wire: down and out from the apex.
+            tups.append(
+                (
+                    (0.0, 0.0, z_apex),
+                    (cone_r * c, cone_r * s, z_cone_base),
+                    nsegs(cone),
+                    None,
+                )
+            )
+
+        return tups

--- a/src/antenna_designer/designs/cebik/inverted_l.py
+++ b/src/antenna_designer/designs/cebik/inverted_l.py
@@ -1,0 +1,100 @@
+"""Inverted-L: a bent, top-loaded vertical (L. B. Cebik, W4RNL).
+
+A quarter-wavelength (or a bit more) of wire run straight up from the
+feedpoint and then bent horizontally for the remainder -- the shape of an
+upside-down "L". The vertical riser does most of the radiating (mostly
+VERTICALLY POLARISED, low takeoff angle); the horizontal top section acts
+largely as top-loading/capacitance that lets the riser be shorter than a full
+quarter wave while keeping the feed near resonance. It is the classic
+"no-room-for-a-full-vertical" low-band antenna.
+
+This fills the "bent / top-loaded monopole" gap: the catalog's verticals
+(vertical, raised_vertical) are straight whips; the inverted-L bends the top
+over. Like the framework's `vertical`, we give it a small set of elevated
+RADIALS as its counterpoise and model it in free space (self-contained, no
+ground card); a real install works it against earth or a buried radial field
+whose loss adds a few ohms of feed resistance.
+
+Geometry, in the framework's (x, y, z) convention:
+  - z : the riser axis, fed at its base against the radial counterpoise
+  - y : the horizontal top-wire axis
+  - x : the radials spread in x/y; the riser+top section are planar in x = 0
+
+       (0, horiz, vert) o------------------o   horizontal top section
+                                            |
+                                            |    vertical riser
+                          radials           |
+                       \\     |     /        F   (base feed)
+                        \\    |    /     ____/
+"""
+
+from ... import AntennaBuilder
+import math
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.57,
+            "freq": 28.57,
+            # Height of the radial counterpoise (and feedpoint) above ground.
+            "base": 5.0,
+            # Vertical riser height as a fraction of a wavelength.
+            "vert_frac": 0.17,
+            # Horizontal top section length as a fraction of a wavelength.
+            # vert + horiz ~ 0.255 wl total: the bent, top-loaded geometry
+            # resonates a good bit shorter than a straight quarter-wave whip.
+            "horiz_frac": 0.085,
+            # Overall scale knob the optimiser tunes for resonance (X -> 0).
+            "length_factor": 1.0,
+            "ui_params": MappingProxyType(
+                {
+                    # Top-loaded monopole feed -> low R (~25-45 ohm).
+                    "target_z0": 50.0,
+                    # Riser along z, top wire along y -> yz view is face-on.
+                    "default_view": "yz",
+                    "length_factor": {
+                        "min": 0.85,
+                        "max": 1.2,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        eps = 0.05
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+
+        vert = self.vert_frac * wavelength * self.length_factor
+        horiz = self.horiz_frac * wavelength * self.length_factor
+        z = self.base
+
+        def nsegs(length):
+            n = max(3, round(self.nominal_nsegs * length / quarter))
+            return n if n % 2 == 1 else n + 1
+
+        n_seg_radials = 5
+        n_radials = 4
+        radial_len = quarter  # quarter-wave radials, like a ground-plane vert
+
+        tups = []
+        # Base feed: a one-segment driven gap at the foot of the riser, against
+        # the radial counterpoise (cf. designs/vertical.py).
+        tups.append(((0.0, 0.0, z), (0.0, 0.0, z + eps), 1, 1 + 0j))
+        # Vertical riser, then the horizontal top section.
+        tups.append(((0.0, 0.0, z + eps), (0.0, 0.0, z + vert), nsegs(vert), None))
+        tups.append(((0.0, 0.0, z + vert), (0.0, horiz, z + vert), nsegs(horiz), None))
+
+        # Elevated radials spreading from the feedpoint in the x/y plane.
+        for i in range(n_radials):
+            theta = 2 * math.pi / n_radials * i
+            rx = radial_len * math.cos(theta)
+            ry = radial_len * math.sin(theta)
+            tups.append(((0.0, 0.0, z), (rx, ry, z), n_seg_radials, None))
+
+        return tups

--- a/src/antenna_designer/designs/cebik/jpole.py
+++ b/src/antenna_designer/designs/cebik/jpole.py
@@ -1,0 +1,114 @@
+"""J-pole: an end-fed half-wave matched by a quarter-wave stub (L. B. Cebik,
+W4RNL).
+
+An end-fed half-wave radiator presents a very high impedance at its base, so it
+cannot take coax directly. The J-pole solves that with a quarter-wave parallel
+("J") matching section -- a shorted stub that transforms the high radiator-base
+impedance down to ~50 ohm at a tap a short way up from the short. The
+half-wave radiator stands on top of the stub and does all the radiating:
+VERTICALLY POLARISED, omnidirectional in azimuth, ~2 dBi like any vertical
+half-wave, but ground-independent (no radials -- the stub is the counterpoise).
+
+This fills the "stub-matched end-fed vertical" gap: the catalog's verticals are
+all base-fed quarter-wave monopoles; the J-pole is the self-contained,
+end-fed-half-wave topology, and a clean test of feeding across two close wires.
+
+Geometry, in the framework's (x, y, z) convention:
+  - z : the vertical axis -- the lambda/4 stub at the bottom, then the
+        lambda/2 radiator continuing up one stub leg
+  - x : the two stub legs sit at x = 0 and x = gap (close together)
+  - y : 0 (planar in y = 0)
+
+           | radiator (lambda/2)        z = base + Q + H
+           |
+           |  o   <- stub top (open on the short leg)
+        leg|  | leg              lambda/4 stub
+           F==|   <- feed tap across the two legs
+           |__|   <- bottom short                z = base
+"""
+
+from ... import AntennaBuilder
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.57,
+            "freq": 28.57,
+            # Height of the bottom short above ground.
+            "base": 4.0,
+            # Radiator length as a fraction of a wavelength (~half-wave).
+            "radiator_frac": 0.49,
+            # Matching-stub length as a fraction of a wavelength (~1/4).
+            "stub_frac": 0.25,
+            # Stub leg-to-leg spacing as a fraction of a wavelength.
+            "spacing_frac": 0.02,
+            # Feed-tap height up the stub as a fraction of the stub length;
+            # transforms the match toward 50 ohm (low tap -> low R).
+            "tap_frac": 0.05,
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 50.0,
+                    # Stub legs span x, structure rises in z -> xz view.
+                    "default_view": "xz",
+                    "radiator_frac": {
+                        "min": 0.45,
+                        "max": 0.55,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                    "tap_frac": {
+                        "min": 0.03,
+                        "max": 0.3,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+
+        radiator = self.radiator_frac * wavelength
+        stub = self.stub_frac * wavelength
+        gap = self.spacing_frac * wavelength
+        tap = self.tap_frac * stub
+
+        z_short = self.base
+        z_tap = self.base + tap
+        z_stub_top = self.base + stub
+        z_rad_top = z_stub_top + radiator
+
+        def nsegs(length):
+            n = max(3, round(self.nominal_nsegs * length / quarter))
+            return n if n % 2 == 1 else n + 1
+
+        # Leg A at x = 0 carries the radiator on top; leg B at x = gap is the
+        # short open-ended stub leg.
+        tups = []
+        # Bottom short bar bridging the two legs.
+        tups.append(((0.0, 0.0, z_short), (gap, 0.0, z_short), 1, None))
+
+        # Leg A: short -> tap node -> stub top, then the radiator continues up.
+        tups.append(((0.0, 0.0, z_short), (0.0, 0.0, z_tap), nsegs(tap), None))
+        tups.append(
+            ((0.0, 0.0, z_tap), (0.0, 0.0, z_stub_top), nsegs(stub - tap), None)
+        )
+        tups.append(
+            ((0.0, 0.0, z_stub_top), (0.0, 0.0, z_rad_top), nsegs(radiator), None)
+        )
+
+        # Leg B: short -> tap node -> stub top (open).
+        tups.append(((gap, 0.0, z_short), (gap, 0.0, z_tap), nsegs(tap), None))
+        tups.append(
+            ((gap, 0.0, z_tap), (gap, 0.0, z_stub_top), nsegs(stub - tap), None)
+        )
+
+        # Feed: a one-segment driven gap bridging the two legs at the tap.
+        tups.append(((0.0, 0.0, z_tap), (gap, 0.0, z_tap), 1, 1 + 0j))
+
+        return tups

--- a/src/antenna_designer/designs/cebik/ocf_dipole.py
+++ b/src/antenna_designer/designs/cebik/ocf_dipole.py
@@ -1,0 +1,97 @@
+"""Off-Center-Fed dipole (Windom): a half-wave fed away from the middle
+(L. B. Cebik, W4RNL).
+
+A resonant half-wave wire fed at the centre shows ~70 ohm. As the feedpoint
+slides toward one end the resistive impedance climbs smoothly -- ~100 ohm part
+way out, ~200 ohm near the one-third point, ~300 ohm and up further still --
+while staying essentially resistive at resonance. The OCF (the modern,
+two-wire-feed descendant of the 1929 single-wire Windom) exploits that: feeding
+about a THIRD of the way from one end lands near 200-300 ohm, a 4:1 or 6:1
+balun step from coax, and -- because the same off-centre point is also near a
+current loop on several harmonics -- gives a multiband doublet.
+
+This fills the "off-centre feed" gap: every other dipole in the catalog
+(invvee, fan, trap, folded) is centre-fed. The defining, testable physics here
+is the feedpoint impedance's dependence on feed POSITION, not the (ordinary
+dipole) pattern.
+
+Geometry, in the framework's (x, y, z) convention:
+  - y : the wire axis; total length ~half-wave, the feed gap offset toward -y
+  - x, z : the wire sits at x = 0, z = base
+  - HORIZONTALLY POLARISED, ordinary dipole figure-8 broadside off +/- x.
+
+    o------------F=================================o      z = base
+    |<-- ~1/3 -->|<------------- ~2/3 ------------->|
+"""
+
+from ... import AntennaBuilder
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.57,
+            "freq": 28.57,
+            "base": 7.0,
+            # Total wire length as a fraction of a wavelength (~resonant
+            # half-wave; slightly short for end effects).
+            "length_frac": 0.485,
+            # Feed position as a fraction of the total length measured from the
+            # near (-y) end. ~0.18 (just under a fifth of the way in) lands near
+            # the classic ~200 ohm Windom point on a thin free-space wire; the
+            # textbook "one-third from the end" is nearer 100 ohm here.
+            "feed_frac": 0.18,
+            "ui_params": MappingProxyType(
+                {
+                    # OCF feed is high-ish; reference SWR to a 4:1-balun 200 ohm.
+                    "target_z0": 200.0,
+                    "default_view": "xy",
+                    "length_frac": {
+                        "min": 0.44,
+                        "max": 0.52,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                    "feed_frac": {
+                        "min": 0.1,
+                        "max": 0.5,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        eps = 0.05
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+
+        length = self.length_frac * wavelength
+        z = self.base
+
+        # Wire spans y = -length/2 .. +length/2; feedpoint a fraction
+        # `feed_frac` of the length in from the -y end.
+        y_left = -length / 2
+        y_right = length / 2
+        y_feed = y_left + self.feed_frac * length
+
+        def nsegs(seg_len):
+            n = max(3, round(self.nominal_nsegs * seg_len / quarter))
+            return n if n % 2 == 1 else n + 1
+
+        L = (0.0, y_left, z)
+        F0 = (0.0, y_feed - eps, z)
+        F1 = (0.0, y_feed + eps, z)
+        R = (0.0, y_right, z)
+
+        left_arm = (y_feed - eps) - y_left
+        right_arm = y_right - (y_feed + eps)
+
+        tups = []
+        tups.append((L, F0, nsegs(left_arm), None))  # short arm (to -y end)
+        tups.append((F0, F1, 1, 1 + 0j))  # off-centre feed
+        tups.append((F1, R, nsegs(right_arm), None))  # long arm (to +y end)
+        return tups

--- a/src/antenna_designer/designs/cebik/phased_verticals.py
+++ b/src/antenna_designer/designs/cebik/phased_verticals.py
@@ -1,0 +1,113 @@
+"""Two-element phased vertical array -- the 90-degree cardioid (L. B. Cebik,
+W4RNL).
+
+Two vertical radiators spaced a quarter wavelength apart and fed 90 degrees
+out of phase. The spatial quarter-wave delay and the electrical 90-degree feed
+phase add in the direction of the lagging element and cancel behind the
+leading one, so the bidirectional figure-8 of a single vertical collapses into
+a UNIDIRECTIONAL CARDIOID: ~3 dB of forward gain and a deep rearward null
+(Cebik / Christman models reach 15-25+ dB front-to-back). This is the
+canonical steered VP array and the basis of the four-square.
+
+This fills the "phased vertical / cardioid" gap: the catalog's other VP wire
+antennas (half_square, bobtail) are fixed broadside curtains; here the pattern
+is steered by FEED PHASE. We model each radiator as a self-contained vertical
+half-wave DIPOLE (so the array needs no ground plane and the cardioid is
+visible in free space); the classic field version uses quarter-wave MONOPOLES
+of half this height worked against a radial ground screen -- electrically the
+same array, imaged in the ground.
+
+Phasing: with the elements at x = 0 (rear) and x = +spacing (front), feeding
+the FRONT element 90 degrees LAGGING (voltage -j) steers the main lobe to +x
+and nulls -x.
+
+Geometry, in the framework's (x, y, z) convention:
+  - z : the radiator (vertical) axis -- VERTICALLY POLARISED
+  - x : array/firing axis; rear element at x = 0, front at x = +spacing,
+        cardioid main lobe toward +x with the null toward -x
+  - y : 0 for both elements
+
+      rear (x=0)        front (x=spacing)
+        |                   |
+        |  V = 1            |  V = -j      (front lags 90 deg)
+        F                   F
+        |                   |       cardioid main lobe --> +x
+"""
+
+from ... import AntennaBuilder
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.57,
+            "freq": 28.57,
+            # Height of the lower tip of each vertical dipole.
+            "base": 5.0,
+            # Radiator length as a fraction of a wavelength (~half-wave
+            # vertical dipole; the monopole version is half this over ground).
+            "elem_frac": 0.5,
+            # Element spacing as a fraction of a wavelength (~1/4 -> cardioid).
+            "spacing_frac": 0.25,
+            # Complex drive on the FRONT element relative to the rear (which is
+            # 1+0j). Ideal theory wants -j (90 deg lag, equal magnitude); the
+            # value here is tuned against the modelled mutual coupling so the
+            # currents -- not just the voltages -- come out 90 deg apart and
+            # equal, which is what actually deepens the rearward null. The 1.2
+            # magnitude compensates the front element's lower driving-point
+            # current (from the mutual coupling) so the null deepens past the
+            # ~5 dB a naive equal-voltage feed gives.
+            "front_voltage": -1.2j,
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 50.0,
+                    # Array axis x, radiators along z -> the xz view is face-on.
+                    "default_view": "xz",
+                    "elem_frac": {
+                        "min": 0.4,
+                        "max": 0.6,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                    "spacing_frac": {
+                        "min": 0.15,
+                        "max": 0.35,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        eps = 0.05
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+
+        elem = self.elem_frac * wavelength
+        spacing = self.spacing_frac * wavelength
+        half = elem / 2
+        zc = self.base + half  # geometric centre height of each vertical
+
+        def nsegs(length):
+            n = max(3, round(self.nominal_nsegs * length / quarter))
+            return n if n % 2 == 1 else n + 1
+
+        def vertical(x, voltage):
+            """A vertical (z-axis) half-wave dipole at x, centre-fed."""
+            B = (x, 0.0, zc - half)
+            T = (x, 0.0, zc + half)
+            C0 = (x, 0.0, zc - eps)
+            C1 = (x, 0.0, zc + eps)
+            return [
+                (B, C0, nsegs(half - eps), None),
+                (C0, C1, 1, voltage),
+                (C1, T, nsegs(half - eps), None),
+            ]
+
+        tups = []
+        tups.extend(vertical(0.0, 1 + 0j))  # rear, reference phase
+        tups.extend(vertical(spacing, complex(self.front_voltage)))  # front lobe
+        return tups

--- a/src/antenna_designer/designs/cebik/vbeam.py
+++ b/src/antenna_designer/designs/cebik/vbeam.py
@@ -1,0 +1,102 @@
+"""Resonant V-beam: two long wires splayed into a V (L. B. Cebik, W4RNL).
+
+A single long wire (1 wavelength or more) is not broadside like a dipole -- its
+main lobes swing toward the wire's own axis, making a shallow cone a fixed
+angle off the wire. Put two such long wires together at an apex, opening them by
+twice that angle, and the forward lobes of the two legs line up along the
+bisector and ADD: a bidirectional beam off both ends of the V's centreline,
+HORIZONTALLY POLARISED, with more gain than a dipole for the wire used. It is
+the standing-wave (resonant, un-terminated) sibling of the terminated rhombic
+-- which is just two V-beams placed nose to nose with a load.
+
+This fills the "resonant long-wire array" gap directly alongside the existing
+terminated `rhombic`: same wire family, but bidirectional (no termination, no
+DC path to burn the back lobe).
+
+Cebik / long-wire theory: for ~1 wl legs the lobe sits ~36 degrees off each
+wire, so the included apex angle is ~2 * 36 = ~72 degrees (each leg ~36 degrees
+off the bisector). Longer legs want a narrower apex and give more gain.
+
+Geometry, in the framework's (x, y, z) convention:
+  - x : the bisector / firing axis; the apex sits at -x, the legs open toward
+        +x, and the beam fires bidirectionally off +/- x
+  - y : the two legs splay symmetrically to +/- y
+  - z : constant height `base` (the V lies in a horizontal plane)
+
+              o  (leg end, +y)
+             /
+        F===<            apex feed at -x, opening toward +x
+             \\
+              o  (leg end, -y)        beam <--> +/- x (along the bisector)
+"""
+
+from ... import AntennaBuilder
+from types import MappingProxyType
+import math
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.57,
+            "freq": 28.57,
+            "base": 7.0,
+            # Leg length as a fraction of a wavelength (each wire). Longer ->
+            # more gain, narrower apex.
+            "leg_frac": 1.0,
+            # Half the included apex angle, in degrees: each leg sits this far
+            # off the bisector. ~36 deg suits ~1 wl legs.
+            "half_apex_deg": 36.0,
+            "ui_params": MappingProxyType(
+                {
+                    # Long-wire apex feed is high and reactive; open-wire fed.
+                    "target_z0": 300.0,
+                    # Legs splay in x/y -> the xy view is face-on.
+                    "default_view": "xy",
+                    "leg_frac": {
+                        "min": 0.75,
+                        "max": 2.0,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                    "half_apex_deg": {
+                        "min": 20.0,
+                        "max": 55.0,
+                        "step": 0.1,
+                        "precision": 2,
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        eps = 0.05
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+
+        leg = self.leg_frac * wavelength
+        theta = math.radians(self.half_apex_deg)
+        dx = math.cos(theta)
+        dy = math.sin(theta)
+        z = self.base
+
+        def nsegs(length):
+            n = max(3, round(self.nominal_nsegs * length / quarter))
+            return n if n % 2 == 1 else n + 1
+
+        # Apex near the origin, legs opening toward +x at +/- theta off the
+        # bisector. A one-segment driven gap bridges the two inner ends.
+        inner_p = (eps * dx, eps * dy, z)  # toward +y leg
+        inner_m = (eps * dx, -eps * dy, z)  # toward -y leg
+        end_p = (leg * dx, leg * dy, z)
+        end_m = (leg * dx, -leg * dy, z)
+
+        arm = nsegs(leg - eps)
+
+        tups = []
+        # Driven gap across the apex between the two legs' inner ends.
+        tups.append((inner_m, inner_p, 1, 1 + 0j))
+        tups.append((inner_p, end_p, arm, None))  # +y leg
+        tups.append((inner_m, end_m, arm, None))  # -y leg
+        return tups

--- a/src/antenna_designer/designs/cebik/w8jk.py
+++ b/src/antenna_designer/designs/cebik/w8jk.py
@@ -1,0 +1,105 @@
+"""W8JK flat-top beam: a 2-element all-driven 180-degree array (L. B. Cebik,
+W4RNL, after John Kraus W8JK).
+
+Two horizontal wires run parallel, close-spaced (~1/8 wavelength), and are fed
+180 degrees OUT OF PHASE -- in the real antenna by a parallel feeder with one
+side given a half-twist between the two element centres. The out-of-phase,
+close-spaced pair radiates BIDIRECTIONALLY endfire (off the +/- x ends of the
+boom, in the plane of the wires) with a deep broadside null. Using "extended"
+elements longer than a half-wave (~0.64 wl each, the Kraus extended-double-Zepp
+length) puts the collinear gain on top of the array gain, so the flat-top beats
+a plain dipole by several dB while staying dead simple and feedline-tunable.
+
+This fills the "out-of-phase driven array" gap: the catalog's lazy_h feeds two
+elements IN phase (broadside), the hb9cv feeds them ~135 degrees apart
+(unidirectional endfire); the W8JK is the 180-degree, bidirectional member of
+the family. Because the two elements are mirror images across the y-z plane and
+are driven with equal-and-opposite voltages, the antisymmetric excitation
+forces equal-magnitude, opposite-phase currents -- exactly the 180-degree
+phasing the half-twist feeder produces -- so we model it as two centre feeds at
++1 and -1 rather than as an explicit crossed line.
+
+Cebik / Kraus proportions: elements 0.5-1.25 wl long (0.64 wl "extended" here),
+spacing 1/8 to 1/2 wl (0.125 wl here). HORIZONTALLY POLARISED.
+
+Geometry, in the framework's (x, y, z) convention:
+  - y : the element length axis (both wires run along y)
+  - x : boom/firing axis; the two wires sit at x = -spacing/2 and +spacing/2,
+        and the beam fires bidirectionally off +/- x
+  - z : constant height `base`
+
+    x = -s/2   ====================F====================   (rear,  V = -1)
+    x = +s/2   ====================F====================   (front, V = +1)
+                          beam <--> +/- x   (broadside null off +/- y)
+"""
+
+from ... import AntennaBuilder
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.57,
+            "freq": 28.57,
+            "base": 7.0,
+            # Element length as a fraction of a wavelength. ~0.64 wl is the
+            # Kraus "extended" length that adds collinear gain.
+            "elem_frac": 0.64,
+            # Element-to-element spacing as a fraction of a wavelength (~1/8).
+            "spacing_frac": 0.125,
+            "ui_params": MappingProxyType(
+                {
+                    # Out-of-phase close-spaced feed -> low, reactive driving
+                    # point; in practice tuned via the parallel feeder. Use a
+                    # representative open-wire reference.
+                    "target_z0": 100.0,
+                    # Wires span y, boom along x -> the xy view is face-on.
+                    "default_view": "xy",
+                    "elem_frac": {
+                        "min": 0.5,
+                        "max": 1.25,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                    "spacing_frac": {
+                        "min": 0.1,
+                        "max": 0.5,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        eps = 0.05
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+
+        elem = self.elem_frac * wavelength
+        spacing = self.spacing_frac * wavelength
+        half = elem / 2
+        z = self.base
+
+        def nsegs(length):
+            n = max(3, round(self.nominal_nsegs * length / quarter))
+            return n if n % 2 == 1 else n + 1
+
+        def element(x, voltage):
+            """A horizontal wire along y at (x, z), centre-fed with `voltage`."""
+            L = (x, -half, z)
+            R = (x, half, z)
+            C0 = (x, -eps, z)
+            C1 = (x, eps, z)
+            return [
+                (L, C0, nsegs(half - eps), None),
+                (C0, C1, 1, voltage),
+                (C1, R, nsegs(half - eps), None),
+            ]
+
+        tups = []
+        tups.extend(element(-spacing / 2, -1 + 0j))  # rear, anti-phase
+        tups.extend(element(spacing / 2, 1 + 0j))  # front
+        return tups

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -428,3 +428,372 @@ def test_t2fd_folded_with_termination():
     assert load.port == "term"
     (src,) = net.sources
     assert isinstance(src, Driven) and src.port == "feed"
+
+
+# ---------------------------------------------------------------------------
+# Batch 2 — W8JK, phased verticals, inverted-L, OCF, V-beam, bi-square,
+# J-pole, discone (a second Cebik/W4RNL set filling further catalog gaps).
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# W8JK flat-top beam (180-degree all-driven array)
+# ---------------------------------------------------------------------------
+
+
+def test_w8jk_bidirectional_endfire_gain():
+    """~5.8 dBi firing equally off both +/- x ends (Kraus extended elements);
+    the two anti-phase, close-spaced elements make a bidirectional endfire
+    beam, not a unidirectional one."""
+    from antenna_designer.designs.cebik.w8jk import Builder
+
+    ff = _far_field(Builder())
+    rings = np.array(ff.rings)
+    front = rings[:, 0].max()  # +x
+    back = rings[:, 180].max()  # -x
+    assert ff.max_gain > 5.5
+    assert abs(front - back) < 1.0  # bidirectional
+
+
+def test_w8jk_broadside_and_overhead_nulls():
+    """The array signature: deep nulls off the ends (+/- y, broadside to the
+    boom) AND overhead (theta = 0, broadside to the array axis) -- the latter
+    is what a single dipole would NOT have, proving the 180-deg array action."""
+    from antenna_designer.designs.cebik.w8jk import Builder
+
+    ff = _far_field(Builder())
+    rings = np.array(ff.rings)
+    lobe = rings[:, 0].max()  # the +x endfire lobe
+    side = rings[:, 90].max()  # +y broadside
+    overhead = rings[0].max()  # straight up
+    assert lobe - side > 15.0
+    assert lobe - overhead > 15.0
+
+
+def test_w8jk_two_antiphase_feeds():
+    """Exactly two centre feeds, driven 180 degrees out of phase (+1 and -1),
+    one per element -- the defining all-driven, out-of-phase topology."""
+    from antenna_designer.designs.cebik.w8jk import Builder
+
+    feeds = [t for t in Builder().build_wires() if t[3] is not None]
+    assert len(feeds) == 2
+    volts = sorted(complex(f[3]).real for f in feeds)
+    assert volts[0] == -1.0 and volts[1] == 1.0  # anti-phase
+
+
+# ---------------------------------------------------------------------------
+# Two-element phased vertical array (90-degree cardioid)
+# ---------------------------------------------------------------------------
+
+
+def test_phased_verticals_cardioid_front_to_back():
+    """The 90-deg feed phasing steers the pattern unidirectionally toward +x
+    with a deep rearward null (~6-7 dB F/B here; a current-forcing network
+    deepens it further) -- not the figure-8 of a single vertical."""
+    from antenna_designer.designs.cebik.phased_verticals import Builder
+
+    ff = _far_field(Builder())
+    rings = np.array(ff.rings)
+    front = rings[:, 0].max()
+    back = rings[:, 180].max()
+    assert ff.max_gain > 4.5
+    assert front - back > 5.0
+
+
+def test_phased_verticals_phase_does_the_steering():
+    """Drive the two verticals IN phase instead and the unidirectional cardioid
+    collapses -- proving the directivity comes from the FEED PHASE, not the
+    geometry."""
+    from antenna_designer.designs.cebik.phased_verticals import Builder
+
+    in_phase = Builder(dict(Builder.default_params, front_voltage=1 + 0j))
+    rings = np.array(_far_field(in_phase).rings)
+    fb = rings[:, 0].max() - rings[:, 180].max()
+    assert abs(fb) < 2.0  # symmetric again
+
+
+def test_phased_verticals_two_feeds_front_quadrature():
+    """Two vertical (z-axis) feeds; the rear is the +1 reference and the front
+    is driven near 90 degrees out of phase (a dominant imaginary part)."""
+    from antenna_designer.designs.cebik.phased_verticals import Builder
+
+    feeds = [t for t in Builder().build_wires() if t[3] is not None]
+    assert len(feeds) == 2
+    # vertical elements: both feed gaps run along z
+    assert all(f[0][2] != f[1][2] for f in feeds)
+    rear, front = (complex(f[3]) for f in feeds)
+    assert rear == 1 + 0j
+    assert abs(front.imag) > abs(front.real)  # near quadrature
+
+
+# ---------------------------------------------------------------------------
+# Inverted-L (bent, top-loaded vertical)
+# ---------------------------------------------------------------------------
+
+
+def test_inverted_l_resonant_low_impedance():
+    """Top-loaded short vertical: near-resonant (small X) at a low feed
+    resistance over its radial counterpoise."""
+    from antenna_designer.designs.cebik.inverted_l import Builder
+
+    z = _z(Builder())
+    assert 8.0 < z.real < 45.0
+    assert abs(z.imag) < 25.0
+
+
+def test_inverted_l_vertical_low_angle_radiation():
+    """Mostly vertically polarised: the pattern peaks toward the horizon and
+    is deeply nulled overhead -- the signature of a vertical, not a horizontal
+    wire."""
+    from antenna_designer.designs.cebik.inverted_l import Builder
+
+    rings = np.array(_far_field(Builder()).rings)
+    horizon = rings[80:].max()  # near the horizon (theta ~ 90)
+    overhead = rings[:5].max()  # near zenith (theta ~ 0)
+    assert horizon - overhead > 5.0
+
+
+def test_inverted_l_has_riser_top_and_radials():
+    """One base feed, a vertical riser, a horizontal top section (the bend),
+    and a radial counterpoise."""
+    from antenna_designer.designs.cebik.inverted_l import Builder
+
+    tups = Builder().build_wires()
+    feeds = [t for t in tups if t[3] is not None]
+    assert len(feeds) == 1
+    # a horizontal top wire (constant z, runs along y) exists
+    horiz = [
+        t
+        for t in tups
+        if abs(t[0][2] - t[1][2]) < 1e-9 and abs(t[0][1] - t[1][1]) > 1e-6
+    ]
+    assert horiz, "expected a horizontal top section"
+
+
+# ---------------------------------------------------------------------------
+# Off-Center-Fed dipole (Windom)
+# ---------------------------------------------------------------------------
+
+
+def test_ocf_impedance_rises_off_center():
+    """The defining OCF physics: sliding the feed off-centre raises the
+    (resistive) feed impedance well above the ~70 ohm centre value."""
+    from antenna_designer.designs.cebik.ocf_dipole import Builder
+
+    r_off = _z(Builder()).real
+    r_ctr = _z(Builder(dict(Builder.default_params, feed_frac=0.5))).real
+    assert r_off > 1.8 * r_ctr
+    assert 150.0 < r_off < 350.0  # near the classic ~200-300 ohm Windom point
+
+
+def test_ocf_near_resonant():
+    """At the design length the off-centre feed is near resonance (small X),
+    so the elevated impedance is essentially resistive."""
+    from antenna_designer.designs.cebik.ocf_dipole import Builder
+
+    assert abs(_z(Builder()).imag) < 60.0
+
+
+def test_ocf_feed_is_off_center():
+    """Geometry: a single feed with unequal arms (short arm toward -y end)."""
+    from antenna_designer.designs.cebik.ocf_dipole import Builder
+
+    tups = Builder().build_wires()
+    feeds = [t for t in tups if t[3] is not None]
+    assert len(feeds) == 1
+    y_feed = feeds[0][0][1]
+    assert y_feed < -0.05  # offset from the centre (y = 0) toward -y
+
+
+# ---------------------------------------------------------------------------
+# Resonant V-beam
+# ---------------------------------------------------------------------------
+
+
+def test_vbeam_fires_along_the_bisector():
+    """Two ~1 wl legs splayed at the apex put gain (~5 dBi) along the
+    bisector (+/- x) with a deep null off the broadside (+/- y) -- the
+    long-wire lobes of the two legs aligning."""
+    from antenna_designer.designs.cebik.vbeam import Builder
+
+    rings = np.array(_far_field(Builder()).rings)
+    fwd = rings[:, 0].max()  # +x bisector
+    back = rings[:, 180].max()  # -x bisector
+    side = rings[:, 90].max()  # +y broadside
+    assert _far_field(Builder()).max_gain > 4.5
+    assert fwd - side > 4.0
+    assert back - side > 3.0
+
+
+def test_vbeam_high_reactive_apex_feed():
+    """Long-wire apex feed: high resistance and strongly reactive (open-wire
+    fed in practice), unlike a resonant dipole."""
+    from antenna_designer.designs.cebik.vbeam import Builder
+
+    z = _z(Builder())
+    assert z.real > 500.0
+    assert abs(z.imag) > 500.0
+
+
+def test_vbeam_two_legs_one_apex_feed():
+    """One driven apex gap and two legs of equal length opening symmetrically
+    in +/- y."""
+    from antenna_designer.designs.cebik.vbeam import Builder
+
+    tups = Builder().build_wires()
+    feeds = [t for t in tups if t[3] is not None]
+    assert len(feeds) == 1
+    ends = [t[1] for t in tups if t[3] is None]
+    ys = sorted(e[1] for e in ends)
+    assert ys[0] < 0 < ys[-1]  # legs splay to both +/- y
+    assert abs(abs(ys[0]) - abs(ys[-1])) < 1e-6  # symmetric
+
+
+# ---------------------------------------------------------------------------
+# Bi-square (2 wl vertical loop curtain)
+# ---------------------------------------------------------------------------
+
+
+def test_bisquare_vertical_broadside():
+    """Vertically polarised, fires broadside to the loop plane (off +/- x) with
+    the in-plane (+/- y) endfire suppressed -- the in-phase vertical components
+    adding while the horizontals cancel."""
+    from antenna_designer.designs.cebik.bisquare import Builder
+
+    ff = _far_field(Builder())
+    rings = np.array(ff.rings)
+    broadside = rings[:, 0].max()  # +x
+    end_on = rings[:, 90].max()  # +y
+    assert ff.max_gain > 3.0
+    assert broadside - end_on > 2.0
+
+
+def test_bisquare_high_reactive_corner_feed():
+    """A 2 wl loop fed at a corner is a high, reactive feedpoint (open-wire +
+    tuner), not a 50 ohm match."""
+    from antenna_designer.designs.cebik.bisquare import Builder
+
+    z = _z(Builder())
+    assert abs(z.imag) > 200.0
+
+
+def test_bisquare_is_a_four_sided_loop_one_feed():
+    """Four half-wave sides forming one closed loop, with a single driven gap
+    at the bottom corner (z minimum)."""
+    from antenna_designer.designs.cebik.bisquare import Builder
+
+    tups = Builder().build_wires()
+    feeds = [t for t in tups if t[3] is not None]
+    assert len(feeds) == 1
+    zmin = min(min(t[0][2], t[1][2]) for t in tups)
+    assert abs(feeds[0][0][2] - zmin) < 1e-6  # fed at the bottom corner
+
+
+# ---------------------------------------------------------------------------
+# J-pole (end-fed half-wave + quarter-wave matching stub)
+# ---------------------------------------------------------------------------
+
+
+def test_jpole_omnidirectional_vertical():
+    """A vertical end-fed half-wave: ~2 dBi, omnidirectional in azimuth (small
+    ripple around the peak-elevation ring)."""
+    from antenna_designer.designs.cebik.jpole import Builder
+
+    ff = _far_field(Builder())
+    rings = np.array(ff.rings)
+    ti = int(np.argmax(rings.max(axis=1)))  # elevation ring of peak gain
+    az = rings[ti]
+    assert 1.5 < ff.max_gain < 2.6
+    assert az.max() - az.min() < 1.5  # omnidirectional in azimuth
+
+
+def test_jpole_stub_matches_to_coax():
+    """The quarter-wave stub transforms the very high end-fed impedance down to
+    a coax-friendly match (SWR < 2.5 to 50 ohm at the tuned tap)."""
+    from antenna_designer.designs.cebik.jpole import Builder
+
+    assert _swr(_z(Builder()), 50.0) < 2.5
+
+
+def test_jpole_radiator_continues_above_the_stub():
+    """Topology: the half-wave radiator stands on top of one stub leg, so the
+    structure's top is a half-wave above the stub top; the feed bridges the two
+    close stub legs (different x)."""
+    from antenna_designer.designs.cebik.jpole import Builder
+
+    tups = Builder().build_wires()
+    feeds = [t for t in tups if t[3] is not None]
+    assert len(feeds) == 1
+    # feed bridges the two legs -> its endpoints differ in x
+    assert abs(feeds[0][0][0] - feeds[0][1][0]) > 1e-6
+    # the radiator reaches well above the stub top
+    wl = 299.792458 / Builder().design_freq
+    ztop = max(max(t[0][2], t[1][2]) for t in tups)
+    zbot = min(min(t[0][2], t[1][2]) for t in tups)
+    assert (ztop - zbot) > 0.6 * wl  # stub (~1/4) + radiator (~1/2)
+
+
+# ---------------------------------------------------------------------------
+# Discone (broadband vertical)
+# ---------------------------------------------------------------------------
+
+
+_DISCONE_BAND = (34.0, 40.0, 50.0, 65.0)  # above the ~28.6 MHz cone cutoff
+
+
+def test_discone_broadband_match():
+    """The defining discone behaviour: a usable match held across a wide band
+    ABOVE the cone's quarter-wave cutoff (here ~2:1, 34-65 MHz), unlike a
+    resonant vertical."""
+    from antenna_designer.designs.cebik.discone import Builder
+
+    swrs = [
+        _swr(_z(Builder(dict(Builder.default_params, freq=f))), 50.0)
+        for f in _DISCONE_BAND
+    ]
+    assert max(swrs) < 3.0, dict(zip(_DISCONE_BAND, swrs))
+
+
+def test_discone_match_beats_a_resonant_vertical_off_band():
+    """A resonant antenna's SWR explodes when you move ~2:1 in frequency; the
+    discone's barely moves. Compare the band-edge spread."""
+    from antenna_designer.designs.cebik.discone import Builder
+    from antenna_designer.designs.cebik.jpole import Builder as JBuilder
+
+    def spread(B, lo, hi, z0):
+        return _swr(_z(B(dict(B.default_params, freq=hi))), z0) - _swr(
+            _z(B(dict(B.default_params, freq=lo))), z0
+        )
+
+    # the resonant J-pole degrades far more across a 34->65 MHz move than the
+    # broadband discone does.
+    assert abs(spread(Builder, 34.0, 65.0, 50.0)) < abs(
+        spread(JBuilder, 34.0, 65.0, 50.0)
+    )
+
+
+def test_discone_omni_low_angle_in_band():
+    """In-band it is a vertical: omnidirectional in azimuth and low takeoff
+    (peak gain near the horizon)."""
+    from antenna_designer.designs.cebik.discone import Builder
+
+    b = Builder(dict(Builder.default_params, freq=50.0))
+    rings = np.array(_far_field(b).rings)
+    ti = int(np.argmax(rings.max(axis=1)))
+    az = rings[ti]
+    assert ti > 75  # peak near the horizon (theta ~ 90)
+    assert az.max() - az.min() < 1.0  # omnidirectional
+
+
+def test_discone_has_disc_and_cone_one_feed():
+    """A disc cage (horizontal radials) above a cone cage (downward radials),
+    fed across the apex gap -- exactly one driven segment."""
+    from antenna_designer.designs.cebik.discone import Builder
+
+    tups = Builder().build_wires()
+    feeds = [t for t in tups if t[3] is not None]
+    assert len(feeds) == 1
+    n = int(Builder().n_wires)
+    # m disc radials (horizontal) + m cone wires (sloping down) + 1 feed
+    horiz = [t for t in tups if abs(t[0][2] - t[1][2]) < 1e-9 and t[3] is None]
+    assert len(horiz) == n  # the disc radials


### PR DESCRIPTION
A second eight-model Cebik/W4RNL set, each filling a category the catalog (including batch 1, #90) still lacked. All are free-space / self-contained, MKL-PyNEC verified, auto-register as `cebik.<name>`, and carry physics regression tests in `tests/test_cebik_designs.py` (24 new tests; full suite 913 green).

| design | gap filled / headline (28.57 MHz, free space) |
|---|---|
| `w8jk` | 180° all-driven flat-top beam: ~5.8 dBi **bidirectional** endfire with deep broadside **and overhead** nulls (the array signature). Completes the driven-phased family: lazy_h (0°), hb9cv (135°), this (180°). |
| `phased_verticals` | 90° **cardioid**: feed-phase-steered VP array, ~5.2 dBi, ~6–7 dB F/B. Tunable complex `front_voltage`. |
| `inverted_l` | bent/top-loaded vertical on an elevated-radial counterpoise: resonant ~18 Ω, VP low-angle. |
| `ocf_dipole` | off-centre-fed **Windom**: feed R rises ~3× off centre to ~230 Ω (the defining OCF physics). |
| `vbeam` | resonant long-wire **V**: ~5 dBi along the bisector, deep broadside null (standing-wave sibling of the rhombic). |
| `bisquare` | 2 λ **VP loop curtain** (SCV family): VP broadside, ~3.4 dBi free-space. |
| `jpole` | stub-matched **end-fed half-wave**: omni VP ~2 dBi, SWR < 2. |
| `discone` | **broadband vertical** (disc+cone wire cage): SWR < 3 over ~34–65 MHz above the cone cutoff, low-angle omni. Fills the wideband-omni gap. |

### Modelling notes (also in `PLAN.md`)
- **Ground-mounted verticals** (`inverted_l`) use a small **elevated-radial counterpoise in free space** (cf. `designs/vertical.py`) instead of a PEC/finite ground card — a wire whose base sits exactly on a PEC plane gave a pathological ~−10 kΩ feed reactance, while radials give a clean, deterministic feedpoint.
- The **cardioid** reaches only ~5–7 dB F/B with pure voltage drive (the two driving-point impedances differ, so equal voltages give unequal currents); a genuinely deep null needs a current-forcing network (Christman/Lewallen) — same caveat family as hb9cv.
- A single-wire **Franklin collinear** was prototyped and dropped: two half-wave sections are already in-phase under a centre feed (it degenerates to lazy_h's 1 λ element), and the multi-section phase-reversed curtain is already covered by `freq_based/sterba`. The discone took its slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)