### PR TITLE
Re-feed bobtail at a current maximum (coax-direct ~50 ohm)

### DIFF
--- a/src/antenna_designer/designs/cebik/PLAN.md
+++ b/src/antenna_designer/designs/cebik/PLAN.md
@@ -79,7 +79,7 @@ free-space figures at the 28.57 MHz family default:
 | design        | headline result                                            |
 |---------------|------------------------------------------------------------|
 | half_square   | 4.7 dBi, ~62 ohm corner feed, VP bidirectional broadside   |
-| bobtail       | 6.4 dBi peak, ~30 dB end nulls, high-Z base feed           |
+| bobtail       | 6.4 dBi peak, deep end nulls, ~50 ohm current-max tap feed |
 | quad          | 7.0 dBi forward, resonant driver ~132 ohm                  |
 | lazy_h        | 8.1 dBi (stacking gain), HP broadside, high-Z tuner feed   |
 | lpda          | ~6-9 dBi forward across ~24-32 MHz (feed-Z caveat in file) |
@@ -91,6 +91,19 @@ Two models carry documented modeling caveats (see their module docstrings):
 the LPDA's ideal lossless crossed feeder gives an unreliable feedpoint
 impedance, and the HB9CV's single-ended crossed TL reaches only ~8 dB F/B
 (the deep ZL null wants a true differential transposed line / pysim DiffTL).
+
+**Bobtail feedpoint revision (post-merge):** the bobtail was originally
+base-fed at the classic "tank" point (the bottom of the centre vertical). That
+is a current null -> a high, strongly-reactive impedance (~5000-8000j) that, a
+segment-convergence + multi-basis study showed, neither converges with
+segmentation nor agrees between solver bases (NEC2/sinusoidal ~5000, rooftop
+~2700, bspl-d2 ~3500 ohm) -- the textbook ill-conditioned high-Z feedpoint
+Cebik warned about, and a unun can't fix it because it scales the large
+reactance too. We re-fed it like `half_square`: tapped at a current MAXIMUM
+(`feed_height_frac` up the centre vertical), giving a coax-direct ~50 ohm that
+all four engines agree on (45-49 ohm) at identical gain/pattern. Gain and
+pattern were basis-stable throughout; only the feed Z was unreliable -- exactly
+Cebik's "model for gain/pattern, treat high-Z feeds as approximate" guidance.
 
 ## Batch 2 (PR #91)
 

--- a/src/antenna_designer/designs/cebik/bobtail.py
+++ b/src/antenna_designer/designs/cebik/bobtail.py
@@ -6,15 +6,26 @@ The bobtail is the electrical big brother of the half-square: THREE roughly
 along the top by a continuous ~1-wavelength phasing wire. All three verticals
 end up driven in phase, so the array is VERTICALLY POLARISED and fires
 bidirectionally broadside to the plane of the wires, with a tighter pattern
-and a few dB more gain than the half-square (~5.1 dBi, max at a low ~19 deg
+and a few dB more gain than the half-square (~6.4 dBi here, max at a low
 elevation over ground).
 
-Only the centre vertical is physically fed -- at its base, the classic
-"matching tank at the bottom of the centre wire" point. This is a high,
-reactive impedance (hundreds of ohms and up), which is why the real antenna
-uses a parallel-tuned tank rather than a direct coax feed. The two OUTER
-verticals are passive, open at the bottom, and excited entirely through the
-top phasing wire.
+Only the centre vertical is fed; the two OUTER verticals are passive, open at
+the bottom, and excited entirely through the top phasing wire.
+
+FEEDPOINT -- where we tap the centre vertical. The classic bobtail is fed at
+the BASE of the centre wire ("the matching tank at the bottom"), which sits at
+a current NULL: the impedance there is high (thousands of ohms) and strongly
+reactive, so the real antenna resonates it out with a parallel-tuned tank, not
+a broadband unun. That base point is also a poor MODELLING point -- being a
+current minimum, the computed Z is ill-conditioned (it neither converges with
+segmentation nor agrees between solver bases), exactly the high-impedance-
+feedpoint hazard Cebik warned about. So, like the catalog's `half_square`
+(which feeds its top corner rather than a leg end), we instead tap the centre
+vertical partway up, at a CURRENT MAXIMUM: `feed_height_frac` of the way from
+the base to the top. At the default mid-element tap the driving point is a low,
+near-resonant ~50 ohm -- coax-direct, well-conditioned, and identical in gain
+and pattern to the base-fed version (the feed only taps the standing wave; it
+does not change the radiation). A real shunt/gamma-fed coax bobtail does this.
 
 Cebik's 40 m proportions: verticals ~0.243 wl, half-span (centre-to-outer)
 ~0.541 wl, so the full top wire is ~1.083 wl.
@@ -27,9 +38,9 @@ The structure is planar in x = 0.
 
     C1=========C2=========C3    z = base + vert   (top wire, ~1.08 wl)
     |          |          |
-    |          |          |     three verticals, ~0.243 wl
-    |          F          |
-    A1         A2         A3     z = base   (outer ends open; centre base-fed)
+    |          F          |     three verticals, ~0.243 wl; centre tapped
+    |          |          |     at a current max (feed_height_frac up)
+    A1         A2         A3     z = base   (outer ends open; A2 = open base)
 """
 
 from ... import AntennaBuilder
@@ -49,20 +60,30 @@ class Builder(AntennaBuilder):
             # Half-span: centre-to-outer horizontal spacing as a fraction of
             # a wavelength (~0.541 wl) -> full top wire ~1.083 wl.
             "span_frac": 0.541,
-            # Overall scale knob. Unlike the half-square, the base feed is
-            # inherently high-Z and reactive (tank-matched), so this is not
-            # tuned for resonance -- length_factor ~1.0 is Cebik's max-gain
-            # proportion; peak gain/pattern, not X->0, is the design target.
+            # Tap height of the feed on the centre vertical, as a fraction of
+            # its length from the base (0 = base/current-null/high-Z tank
+            # point, 1 = top/junction). ~0.5 taps a current maximum -> ~50 ohm.
+            "feed_height_frac": 0.5,
+            # Overall scale knob. length_factor ~1.0 is Cebik's max-gain
+            # proportion; near the mid tap it is also near-resonant (X -> 0).
             "length_factor": 1.0,
             "ui_params": MappingProxyType(
                 {
-                    # High, reactive feed (tank-matched in practice); reference
-                    # SWR to a representative open-wire/tank impedance.
-                    "target_z0": 300.0,
+                    # Mid-element current-max tap -> low, near-resonant feed;
+                    # reference SWR to 50 ohm coax.
+                    "target_z0": 50.0,
                     "default_view": "yz",
                     "length_factor": {
                         "min": 0.9,
                         "max": 1.1,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                    # Tap position: stay off the ill-conditioned base (0) and
+                    # top-junction (1) extremes.
+                    "feed_height_frac": {
+                        "min": 0.25,
+                        "max": 0.85,
                         "step": 0.001,
                         "precision": 4,
                     },
@@ -98,12 +119,15 @@ class Builder(AntennaBuilder):
         tups.append(((0.0, -span, z_top), (0.0, -span, z_bot), nsegs(vert), None))
         tups.append(((0.0, span, z_top), (0.0, span, z_bot), nsegs(vert), None))
 
-        # Centre vertical: passive from the top down to just above the base,
-        # then a one-segment driven gap at the base (the matching-tank point).
+        # Centre vertical: a one-segment driven gap tapped `feed_height_frac`
+        # of the way up (a current maximum), with passive wire above and below.
+        # zf is the lower edge of the gap.
         feed = 2 * eps
+        zf = z_bot + self.feed_height_frac * (vert - feed)
         tups.append(
-            ((0.0, 0.0, z_top), (0.0, 0.0, z_bot + feed), nsegs(vert - feed), None)
+            ((0.0, 0.0, z_top), (0.0, 0.0, zf + feed), nsegs(z_top - (zf + feed)), None)
         )
-        tups.append(((0.0, 0.0, z_bot + feed), (0.0, 0.0, z_bot), 1, 1 + 0j))
+        tups.append(((0.0, 0.0, zf + feed), (0.0, 0.0, zf), 1, 1 + 0j))
+        tups.append(((0.0, 0.0, zf), (0.0, 0.0, z_bot), nsegs(zf - z_bot), None))
 
         return tups

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -97,14 +97,26 @@ def test_bobtail_broadside_directivity():
     assert broadside - end_on > 20.0
 
 
-def test_bobtail_feed_is_high_impedance():
-    """Base feed of the centre element is a high, reactive point (Cebik:
-    hundreds to thousands of ohms, tank-matched)."""
+def test_bobtail_feed_is_coax_friendly():
+    """Tapped at a current maximum on the centre vertical (not the classic
+    high-Z base/tank point), the driving point is a low, near-resonant ~50 ohm
+    that takes coax directly."""
     from antenna_designer.designs.cebik.bobtail import Builder
 
     z = _z(Builder())
-    assert z.real > 500.0
-    assert abs(z.imag) > 1000.0
+    assert 35.0 < z.real < 70.0
+    assert abs(z.imag) < 30.0
+
+
+def test_bobtail_tap_position_sets_impedance():
+    """Sliding the tap toward the base (a current null) raises the feed
+    resistance -- the standing-wave transformation that lets feed_height_frac
+    pick the match, the same trick a shunt/gamma feed uses."""
+    from antenna_designer.designs.cebik.bobtail import Builder
+
+    r_mid = _z(Builder()).real  # default tap (~0.5) -> ~50 ohm
+    r_low = _z(Builder(dict(Builder.default_params, feed_height_frac=0.3))).real
+    assert r_low > r_mid + 20.0
 
 
 def test_bobtail_only_centre_element_is_fed():


### PR DESCRIPTION
## Why
Follow-up to the engine cross-check (#90/#91 designs). The bobtail was base-fed at the classic high-Z **"tank" point** — the bottom of the centre vertical, a **current null**. A segment-convergence + multi-basis study showed that feedpoint is **ill-conditioned**:

| basis family | feed Z |
|---|---|
| NEC2 / pysim-sinusoidal | ~4900−7800j (still climbing with N) |
| rooftop (triangular, bspl-d1) | ~2700−5990j (converged) |
| quadratic (bspl-d2) | ~3500−6600j (drifting) |

It neither converges with segmentation nor agrees between solver bases, and the large reactance can't be cancelled by a 49:1/64:1 unun (which scales R *and* X — leaving SWR ≈ 6–7). This is the textbook high-impedance-feedpoint hazard Cebik documented: **gain/pattern reliable, high-Z feed not** (gain was 6.44 dBi across every engine and N).

## What
Re-fed it like `half_square` already does (corner/current-max instead of a high-Z end): tap the centre vertical at a **current maximum** via a new `feed_height_frac` param (default 0.5, mid-element).

Result — same antenna, well-conditioned feed:
- Driving point **48.8 − 13.9j** (~50 Ω, SWR ≈ 1.3), coax-direct, no tank.
- **All four engines now agree:** pynec 48.8−13.9j · sinus 45.7−16.8j · triang 45.2−18.7j · bspl-d2 45.3−17.8j.
- **Gain/pattern unchanged** (6.46 dBi, deep end nulls) — the feed only taps the standing wave.
- `feed_height_frac` also tunes the match (toward the base raises R), like a shunt/gamma feed.

## Tests / docs
- Replace `test_bobtail_feed_is_high_impedance` → `test_bobtail_feed_is_coax_friendly` (~50 Ω, low X).
- Add `test_bobtail_tap_position_sets_impedance` (tap position sets R).
- Docstring + `PLAN.md` record the rationale and the convergence finding.
- Full suite: 914 passing, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)