### PR TITLE
Explicit-feedpoint Sterba: can feeds replace the inner verticals?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ node_modules/
 web/frontend/dist/
 web/frontend/.vite/
 .claude/
+scripts/sterba_center_driven_pattern.png

--- a/scripts/sterba_center_driven_experiment.py
+++ b/scripts/sterba_center_driven_experiment.py
@@ -1,0 +1,144 @@
+"""Experiment: center-feed each riser-less Sterba section so its net current
+moment matches the all-wires reference — and recover the gain.
+
+Counterpart to sterba_driven_experiment.py (which fed the section *ends* — free
+wire-ends where current must vanish — and reached only ~3 dBi). Here each of the
+10 horizontal sections is fed at its center.
+
+The quantity that sets the broadside field is each section's net current moment
+M_y = ∫ I·dy (at broadside the curtain's wires are all at x≈0, so the field is
+∝ |Σ M_y|). So we match *that*, not the midpoint current: matching the midpoint
+current gets the half-wave sections right but flips the quarter-wave end
+sections 180° (their midpoint isn't their antinode), costing ~3 dB. Because the
+far field is linear in the feed voltages, M_y = G·V for a section-moment
+response matrix G, so we solve V = G⁻¹·M_y,ref.
+
+    .venv/bin/python scripts/sterba_center_driven_experiment.py [out.png]
+"""
+
+import sys
+
+import numpy as np
+
+from antenna_designer.designs.freq_based import sterba, sterba_center_driven
+from antenna_designer.engines import PysimEngine
+from antenna_designer.far_field import plot_patterns
+
+FF_KW = dict(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
+GROUND = None  # free space, vs the reference's 10.501 dBi
+
+
+def _broadside_coherence(cd):
+    """|Σ I·dy| / Σ|I·dy| over horizontal segments: ~1 co-phased, ~0 scattered."""
+    num, den = 0 + 0j, 0.0
+    for wc in cd:
+        P, I = wc.knot_positions, wc.knot_currents
+        for k in range(len(P) - 1):
+            d = P[k + 1] - P[k]
+            if abs(d[1]) > max(abs(d[0]), abs(d[2])):
+                m = 0.5 * (I[k] + I[k + 1]) * d[1]
+                num += m
+                den += abs(m)
+    return abs(num) / den if den else float("nan")
+
+
+def _section_extents(b):
+    """[(name, x, z, y0, y1)] for each horizontal section of the riser-less
+    curtain (same order as section_specs)."""
+    out = []
+    i = 0
+    for p0, p1, _ns, _ev in b._all_wires_tups():
+        if b._is_interior_riser(p0, p1):
+            continue
+        if abs(p0[2] - p1[2]) < 1e-9 and abs(p1[1] - p0[1]) > 0.01:
+            out.append(
+                (f"s{i}", 0.5 * (p0[0] + p1[0]), 0.5 * (p0[2] + p1[2]), p0[1], p1[1])
+            )
+            i += 1
+    return out
+
+
+def _section_moment(cd, x, z, y0, y1):
+    """Net y-current moment M_y = Σ I·dy of the horizontal segments belonging
+    to one section (binned by x, z and y-range)."""
+    my = 0 + 0j
+    lo, hi = min(y0, y1) - 0.3, max(y0, y1) + 0.3
+    for wc in cd:
+        P, I = wc.knot_positions, wc.knot_currents
+        for k in range(len(P) - 1):
+            d = P[k + 1] - P[k]
+            m = 0.5 * (P[k] + P[k + 1])
+            if (
+                abs(d[1]) > max(abs(d[0]), abs(d[2]))
+                and abs(m[2] - z) < 0.5
+                and abs(m[0] - x) < 0.03
+                and lo < m[1] < hi
+            ):
+                my += 0.5 * (I[k] + I[k + 1]) * d[1]
+    return my
+
+
+def _moments(cd, exts):
+    return np.array([_section_moment(cd, x, z, y0, y1) for _n, x, z, y0, y1 in exts])
+
+
+def _drive(builder_cls, ports, V):
+    p = dict(builder_cls.default_params)
+    p["feed_voltages"] = {nm: complex(V[i]) for i, nm in enumerate(ports)}
+    return PysimEngine(builder_cls(p), ground=GROUND)
+
+
+def main():
+    out = sys.argv[1] if len(sys.argv) > 1 else "sterba_center_driven_pattern.png"
+
+    eng_ref = PysimEngine(sterba.Builder(), ground=GROUND)
+    ff_ref = eng_ref.far_field(**FF_KW)
+    cd_ref = eng_ref.current_distribution()
+
+    b0 = sterba_center_driven.Builder()
+    exts = _section_extents(b0)
+    ports = [nm for nm, _c in b0.section_specs()]
+    n = len(ports)
+
+    # Reference per-section net moments (the match target).
+    My_ref = _moments(cd_ref, exts)
+
+    # Section-moment response matrix: G[:, j] = moments when only port j is at 1 V.
+    G = np.empty((n, n), dtype=np.complex128)
+    for j in range(n):
+        e_j = np.zeros(n, dtype=np.complex128)
+        e_j[j] = 1.0
+        G[:, j] = _moments(
+            _drive(sterba_center_driven.Builder, ports, e_j).current_distribution(),
+            exts,
+        )
+
+    V = np.linalg.solve(G, My_ref)
+    eng = _drive(sterba_center_driven.Builder, ports, V)
+    cd = eng.current_distribution()
+    ff = eng.far_field(**FF_KW)
+
+    moment_err = np.max(np.abs(_moments(cd, exts) - My_ref)) / np.max(np.abs(My_ref))
+    print(f"sections fed (at center)     : {n}")
+    print(f"cond(G)                      : {np.linalg.cond(G):.2e}")
+    print(f"section net-moment match err : {moment_err:.2e} (M_y = G·V round-trip)")
+    print(
+        f"broadside coherence (driven) : {_broadside_coherence(cd):.3f} "
+        f"(reference {_broadside_coherence(cd_ref):.3f}; 1=co-phased)"
+    )
+    print(f"max_gain (center-driven)     : {ff.max_gain:.3f} dBi")
+    print(f"max_gain (all-wires ref)     : {ff_ref.max_gain:.3f} dBi")
+    print(f"gap                          : {ff.max_gain - ff_ref.max_gain:+.3f} dB")
+
+    plot_patterns(
+        [ff_ref.rings, ff.rings],
+        ["all wires", "center-driven"],
+        ff_ref.thetas,
+        ff_ref.phis,
+        fn=out,
+    )
+    print(f"\nwrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sterba_driven_experiment.py
+++ b/scripts/sterba_driven_experiment.py
@@ -1,0 +1,148 @@
+"""Experiment: can explicit feedpoints replace the Sterba's inner verticals?
+
+Delete the 8 interior risers, then drive each junction's 4 ports (j_At, j_Bt,
+j_Ab, j_Bb) so they carry the *current* (amplitude + phase) the all-wires
+reference carries at those points. Because the system is linear (I = Y·V), we
+solve V = Y⁻¹·I_target and apply those voltages. If co-phased independently-fed
+radiators reproduce the reference's ~10.5 dBi, the verticals were pure phasing;
+the shortfall measures their own radiation/coupling.
+
+Run incrementally, one junction pair at a time:
+    .venv/bin/python scripts/sterba_driven_experiment.py 2
+    .venv/bin/python scripts/sterba_driven_experiment.py 2 3
+    .venv/bin/python scripts/sterba_driven_experiment.py            # all four
+"""
+
+import sys
+
+import numpy as np
+
+from antenna_designer.designs.freq_based import sterba, sterba_driven
+from antenna_designer.engines import PysimEngine
+
+FF_KW = dict(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
+GROUND = None  # free space, to compare against the reference's 10.501 dBi
+
+
+def _broadside_coherence(cd):
+    """How coherently the horizontal radiators add toward broadside.
+
+    The curtain fires in ±x; the broadside field is ∝ |Σ_k I_k·dy_k| over the
+    y-directed (horizontal) segments. Normalising by Σ|I_k·dy_k| gives a 0..1
+    coherence: ~1 when every section is co-phased (they add), ~0 when phases
+    are scattered (they cancel). This is the quantity the gain ultimately
+    depends on, with phase handled correctly (complex sum, no wrap artefacts)."""
+    num = 0 + 0j
+    den = 0.0
+    for wc in cd:
+        P, I = wc.knot_positions, wc.knot_currents
+        for k in range(len(P) - 1):
+            d = P[k + 1] - P[k]
+            if abs(d[1]) > max(abs(d[0]), abs(d[2])):  # horizontal (along y)
+                m = 0.5 * (I[k] + I[k + 1]) * d[1]
+                num += m
+                den += abs(m)
+    return abs(num) / den if den else float("nan")
+
+
+def _shared_params(active):
+    p = dict(sterba_driven.Builder.default_params)
+    p["active_junctions"] = active
+    return p
+
+
+def reference_sampler():
+    """Run the all-wires reference once; return (max_gain, sample(coord))
+    where sample returns the complex current at the knot nearest coord."""
+    ref = sterba.Builder()
+    # Keep geometry identical to the driven variant (same defaults already).
+    eng = PysimEngine(ref, ground=GROUND)
+    gain = eng.far_field(**FF_KW).max_gain
+    cd = eng.current_distribution()
+    print(
+        f"all-wires reference: max_gain = {gain:.3f} dBi, "
+        f"broadside coherence = {_broadside_coherence(cd):.3f}"
+    )
+    pos = np.vstack([wc.knot_positions for wc in cd])
+    cur = np.concatenate([wc.knot_currents for wc in cd])
+
+    def sample(coord):
+        d = np.linalg.norm(pos - np.asarray(coord), axis=1)
+        k = int(np.argmin(d))
+        return cur[k], float(d[k])
+
+    return gain, sample
+
+
+def run(active, ref_gain, sample):
+    p = _shared_params(active)
+    b0 = sterba_driven.Builder(p)
+    _, jname = b0._junction_names()
+    name_to_pt = {nm: pt for pt, nm in jname.items()}
+
+    # Pass 1: target currents from the reference at each active port.
+    eng0 = PysimEngine(b0, ground=GROUND)
+    wl = 299.792458 / b0.design_freq
+    Y = eng0._compute_y_matrix(wl)
+    port_to_idx = eng0._reducer.port_to_idx
+    ports = sorted(port_to_idx)
+
+    I_target = np.zeros(Y.shape[0], dtype=np.complex128)
+    max_d = 0.0
+    for nm in ports:
+        i_ref, d = sample(name_to_pt[nm])
+        I_target[port_to_idx[nm]] = i_ref
+        max_d = max(max_d, d)
+
+    # Pass 2: voltages that produce those currents (mutual coupling included).
+    V = np.linalg.solve(Y, I_target)
+    I_check = Y @ V
+    match_err = np.max(np.abs(I_check - I_target)) / np.max(np.abs(I_target))
+    cond = np.linalg.cond(Y)
+
+    # Pass 3: evaluate the driven design.
+    p2 = _shared_params(active)
+    p2["feed_voltages"] = {nm: complex(V[port_to_idx[nm]]) for nm in ports}
+    b = sterba_driven.Builder(p2)
+    eng = PysimEngine(b, ground=GROUND)
+    gain = eng.far_field(**FF_KW).max_gain
+    coh = _broadside_coherence(eng.current_distribution())
+
+    label = "all" if active is None else ",".join(map(str, active))
+    print(f"\n=== active junctions: {label}  ({len(ports)} feedpoints) ===")
+    print(
+        f"  reference current-sample max offset : {max_d:.3f} m (want « half-wave 5.27 m)"
+    )
+    print(f"  cond(Y)                             : {cond:.2e}")
+    print(
+        f"  port current-match error            : {match_err:.2e} (V = Y⁻¹ I round-trip)"
+    )
+    print(
+        f"  |I_target| range                    : "
+        f"{np.abs(I_target).min():.3e} .. {np.abs(I_target).max():.3e}"
+    )
+    print(
+        f"  broadside coherence (driven)        : {coh:.3f} (reference ≈ 0.90; 1=co-phased)"
+    )
+    print(f"  max_gain (driven)                   : {gain:.3f} dBi")
+    print(f"  max_gain (all-wires reference)      : {ref_gain:.3f} dBi")
+    print(f"  gap                                 : {gain - ref_gain:+.3f} dB")
+    return gain
+
+
+def main():
+    args = sys.argv[1:]
+    active = [int(a) for a in args] if args else None
+
+    ref_gain, sample = reference_sampler()
+
+    if active is not None:
+        run(active, ref_gain, sample)
+    else:
+        # Default: the full incremental sweep.
+        for a in ([2], [2, 3], [1, 2, 3, 4]):
+            run(a, ref_gain, sample)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sterba_riser_masked_pattern.py
+++ b/scripts/sterba_riser_masked_pattern.py
@@ -1,0 +1,98 @@
+"""Custom far field of the all-wires Sterba with the 8 interior riser currents
+ignored.
+
+The inner verticals carry *large* currents (~2.5e-3, comparable to the peak),
+but the A/B pair at each junction is ~180° out of phase, so their radiation
+cancels. This script proves it: it solves the real all-wires antenna, then
+recomputes the far field with the interior-riser segment currents zeroed. If
+the verticals truly only phase the curtain (and don't radiate), both the
+pattern and the max gain should be essentially unchanged.
+
+Implementation: subclass PysimEngine and mask the riser segments in
+`_segment_dipoles`, which `far_field` uses for BOTH the radiated-power
+normalisation and the pattern grid — so the directivity stays self-consistent.
+
+    .venv/bin/python scripts/sterba_riser_masked_pattern.py [out.png]
+"""
+
+import sys
+
+import numpy as np
+
+from antenna_designer.designs.freq_based.sterba import Builder
+from antenna_designer.engines import PysimEngine
+from antenna_designer.far_field import plot_patterns
+
+FF_KW = dict(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
+
+
+def _interior_junction_ys(b):
+    wavelength = 299.792458 / b.design_freq
+    h = 0.5 * wavelength * b.length_factor
+    q = 0.5 * h
+    n = int(b.n_cells)
+    yb = [0.0, q] + [q + k * h for k in range(1, n + 1)] + [2 * q + n * h]
+    return np.array([yb[k] for k in range(1, n + 2)]), h  # the n+1 interior junctions
+
+
+class RiserMaskedEngine(PysimEngine):
+    """PysimEngine that drops the interior vertical-riser segment currents from
+    the far-field integration (everything else — including the solve — is
+    identical to the parent)."""
+
+    def __init__(self, builder, **kw):
+        super().__init__(builder, **kw)
+        self._jys, self._h = _interior_junction_ys(builder)
+        self.masked_segments = 0
+        self.masked_current_l1 = 0.0
+
+    def _segment_dipoles(self, sim, coeffs):
+        mid, dr, i_mid = super()._segment_dipoles(sim, coeffs)
+        vertical = (np.abs(dr[:, 2]) > np.abs(dr[:, 1])) & (
+            np.abs(dr[:, 2]) > np.abs(dr[:, 0])
+        )
+        near_junction = (
+            np.min(np.abs(mid[:, 1][:, None] - self._jys[None, :]), axis=1) < 0.1
+        )
+        mask = vertical & near_junction  # the 8 interior risers (A and B × n+1)
+        self.masked_segments = int(mask.sum())
+        self.masked_current_l1 = float(np.abs(i_mid[mask]).sum())
+        i_mid = i_mid.copy()
+        i_mid[mask] = 0.0
+        return mid, dr, i_mid
+
+
+def main():
+    out = sys.argv[1] if len(sys.argv) > 1 else "sterba_riser_masked_pattern.png"
+
+    b = Builder()
+    full = PysimEngine(b, ground=None)
+    masked = RiserMaskedEngine(Builder(), ground=None)
+
+    ff_full = full.far_field(**FF_KW)
+    ff_mask = masked.far_field(**FF_KW)
+
+    print(f"interior riser segments zeroed : {masked.masked_segments}")
+    print(
+        f"riser current (Σ|I_mid|)       : {masked.masked_current_l1:.4e}  "
+        f"(large — not negligible by magnitude)"
+    )
+    print(f"max_gain  all wires            : {ff_full.max_gain:.4f} dBi")
+    print(f"max_gain  risers ignored       : {ff_mask.max_gain:.4f} dBi")
+    print(
+        f"Δ max_gain                     : {ff_mask.max_gain - ff_full.max_gain:+.4f} dB"
+    )
+
+    # Overlaid azimuth + elevation cuts, all-wires vs risers-ignored.
+    plot_patterns(
+        [ff_full.rings, ff_mask.rings],
+        ["all wires", "risers ignored"],
+        ff_full.thetas,
+        ff_full.phis,
+        fn=out,
+    )
+    print(f"\nwrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/antenna_designer/designs/freq_based/sterba_center_driven.py
+++ b/src/antenna_designer/designs/freq_based/sterba_center_driven.py
@@ -1,0 +1,116 @@
+"""Sterba curtain, center-fed-section variant.
+
+Like `sterba_driven`, this deletes the 8 interior risers — but instead of
+feeding the section *ends* (the junction ports, which become free wire ends
+where current must vanish), it puts one feedpoint at the **center** of each
+horizontal section. The riser-mask experiment proved the far field is set
+entirely by the horizontal current distribution; an isolated half-wave
+section's natural center-fed mode is a co-phased half-sine, which is exactly
+what the reference sections look like. So driving each section's center with
+the reference's center current (amplitude + phase) should reproduce the
+reference distribution — and thus the ~10.5 dBi gain — if the verticals are
+purely a phasing mechanism.
+
+As with `sterba_driven`, voltages are supplied via `feed_voltages`; the driver
+script solves V = Y⁻¹·I_target so the section-center currents match the
+reference. End risers are kept (they are not among the 8 inner verticals).
+PysimEngine-only.
+"""
+
+from ...network import Driven, Network, PortAtEdge
+from . import sterba_difftl
+
+from types import MappingProxyType
+
+
+class Builder(sterba_difftl.Builder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.47,
+            "freq": 28.47,
+            "base": 7.0,
+            "length_factor": 1.0,  # match the all-wires reference geometry
+            "n_cells": 3,
+            "spacing": 0.04,
+            # Per-section drive voltages, {section_name -> complex}. None ->
+            # placeholder 1+0j (used to extract Y; the script solves for the
+            # real voltages).
+            "feed_voltages": None,
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 75.0,
+                    "sweep_policy": {"band_locked": True},
+                    "length_factor": {
+                        "min": 0.96,
+                        "max": 1.05,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                    "n_cells": {"min": 1, "max": 7, "step": 2},
+                }
+            ),
+        }
+    )
+
+    def _is_interior_riser(self, p0, p1):
+        h, _, _, yb = self._geom()
+        Ltot = yb[-1]
+        ddx = abs(p1[0] - p0[0])
+        dy = abs(p1[1] - p0[1])
+        dz = abs(p1[2] - p0[2])
+        y = 0.5 * (p0[1] + p1[1])
+        return dz > 0.5 * h and ddx < 0.01 and dy < 0.01 and 0.01 < y < Ltot - 0.01
+
+    def section_specs(self):
+        """Ordered [(name, center_xyz)] for each horizontal section of the
+        riser-less curtain — the same iteration order build_wires uses, so the
+        names line up. Center is the section midpoint (the current antinode)."""
+        specs = []
+        i = 0
+        for p0, p1, _ns, _ev in self._all_wires_tups():
+            if self._is_interior_riser(p0, p1):
+                continue
+            is_horiz = abs(p0[2] - p1[2]) < 1e-9 and abs(p1[1] - p0[1]) > 0.01
+            if is_horiz:
+                c = (
+                    0.5 * (p0[0] + p1[0]),
+                    0.5 * (p0[1] + p1[1]),
+                    0.5 * (p0[2] + p1[2]),
+                )
+                specs.append((f"s{i}", c))
+                i += 1
+        return specs
+
+    def build_wires(self):
+        h, _, _, _ = self._geom()
+        pe = h / self.nominal_nsegs
+        out = []
+        i = 0
+        for p0, p1, ns, _ev in self._all_wires_tups():
+            if self._is_interior_riser(p0, p1):
+                continue  # one of the 8 inner risers — deleted
+            is_horiz = abs(p0[2] - p1[2]) < 1e-9 and abs(p1[1] - p0[1]) > 0.01
+            if is_horiz:
+                name = f"s{i}"
+                i += 1
+                x, z = p0[0], p0[2]
+                cy = 0.5 * (p0[1] + p1[1])
+                s = 1.0 if p1[1] > p0[1] else -1.0
+                a, b = cy - s * pe / 2, cy + s * pe / 2
+                # left | short named center edge | right
+                for ya, yb_, nm in ((p0[1], a, None), (a, b, name), (b, p1[1], None)):
+                    seglen = abs(yb_ - ya)
+                    nseg = 3 if nm else max(3, round(self.nominal_nsegs * seglen / h))
+                    out.append(((x, ya, z), (x, yb_, z), nseg, None, nm))
+            else:
+                out.append((p0, p1, ns, None, None))
+        return out
+
+    def build_network(self):
+        fv = dict(self.feed_voltages) if self.feed_voltages else {}
+        ports = {}
+        sources = []
+        for name, _c in self.section_specs():
+            ports[name] = PortAtEdge(name)
+            sources.append(Driven(port=name, voltage=fv.get(name, 1 + 0j)))
+        return Network(ports=ports, branches=[], sources=sources)

--- a/src/antenna_designer/designs/freq_based/sterba_driven.py
+++ b/src/antenna_designer/designs/freq_based/sterba_driven.py
@@ -1,0 +1,150 @@
+"""Sterba curtain, explicit-feedpoint variant.
+
+A research variant of `freq_based.sterba` that, like `sterba_difftl`, removes
+the 8 interior vertical riser wires — but instead of stitching each vertical
+*pair* back together with a `DiffTL`, it leaves the horizontal sections
+electrically disconnected and drives them **directly**: an explicit feedpoint
+is placed at each of the 4 ports a vertical pair exposes at a junction —
+two top (`j_At`, `j_Bt`) and two bottom (`j_Ab`, `j_Bb`).
+
+The experiment: are the inner verticals purely a phasing mechanism? If so,
+deleting them and driving each section's junction-ends with the *current*
+(amplitude + phase) the all-wires reference carried there should reproduce the
+reference's far field. The reference is a continuous wire with no source at
+these points, so "matching the reference" means matching its **port currents**,
+not applying its numbers as voltages. Since the system is linear (I = Y·V), the
+driver script solves V = Y⁻¹·I_target and feeds those voltages back in via
+`feed_voltages` — this design just exposes the ports and applies whatever
+voltages it is handed.
+
+Build it up one junction at a time with `active_junctions`: a single central
+pair first (to confirm the feedpoint mechanism solves at all), then more, up to
+all n_cells+1. Sections at inactive junctions stay as plain floating (parasitic)
+wires. PysimEngine-only (multi-feed network, like `sterba_difftl`).
+"""
+
+from ...network import Driven, Network, PortAtEdge
+from . import sterba_difftl
+
+from types import MappingProxyType
+
+
+class Builder(sterba_difftl.Builder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.47,
+            "freq": 28.47,
+            "base": 7.0,
+            # Match the all-wires reference geometry exactly (it runs at 1.0),
+            # so the reference currents we inject correspond to identical
+            # horizontal sections. No DiffTL here, so the ideal-line
+            # half-wave singularity that forced difftl to 0.99 doesn't apply.
+            "length_factor": 1.0,
+            "n_cells": 3,  # odd; interior junctions (= riser pairs) = n_cells + 1
+            "spacing": 0.04,
+            # Which junctions (1..n_cells+1) get explicit feedpoints. None = all.
+            # The incremental knob: start [2] (one central pair), then grow.
+            "active_junctions": None,
+            # Per-port drive voltages, {port_name -> complex}. Empty/None ->
+            # placeholder 1+0j on every active port (used only to extract the
+            # multi-port Y; the script then solves for the real voltages).
+            "feed_voltages": None,
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 75.0,
+                    "sweep_policy": {"band_locked": True},
+                    "length_factor": {
+                        "min": 0.96,
+                        "max": 1.05,
+                        "step": 0.001,
+                        "precision": 4,
+                    },
+                    "n_cells": {"min": 1, "max": 7, "step": 2},
+                }
+            ),
+        }
+    )
+
+    def _active_set(self):
+        """Set of active junction indices (1..n_cells+1)."""
+        _, _, n, _ = self._geom()
+        if self.active_junctions is None:
+            return set(range(1, n + 2))
+        active = {int(j) for j in self.active_junctions}
+        assert active <= set(range(1, n + 2)), (
+            f"active_junctions {sorted(active)} out of range 1..{n + 1}"
+        )
+        return active
+
+    def _active_jname(self):
+        """Junction-terminal point -> port name, restricted to active junctions."""
+        _, jname = self._junction_names()
+        active = self._active_set()
+        return {
+            pt: nm for pt, nm in jname.items() if int(nm[1:].split("_")[0]) in active
+        }
+
+    def build_wires(self):
+        """Riser-less geometry. All 8 interior risers are removed; only the
+        junction terminals of *active* junctions are split into short named
+        port edges. No central feed — every section is driven solely through
+        its junction-end ports."""
+        h, q, n, yb = self._geom()
+        Ltot = yb[-1]
+        jname = self._active_jname()
+        pe = h / self.nominal_nsegs
+
+        def key(p):
+            return (round(p[0], 4), round(p[1], 4), round(p[2], 4))
+
+        def is_riser(p0, p1):
+            ddx = abs(p1[0] - p0[0])
+            dy = abs(p1[1] - p0[1])
+            dz = abs(p1[2] - p0[2])
+            y = 0.5 * (p0[1] + p1[1])
+            return dz > 0.5 * h and ddx < 0.01 and dy < 0.01 and 0.01 < y < Ltot - 0.01
+
+        out = []
+        for p0, p1, ns, _ev in self._all_wires_tups():
+            if is_riser(p0, p1):
+                continue  # one of the 8 inner risers — deleted
+            ln = jname.get(key(p0))
+            rn = jname.get(key(p1))
+            dy = p1[1] - p0[1]
+            if abs(dy) > 0.01 and (ln or rn):
+                # Split this horizontal so its active-junction end(s) become
+                # short named port edges the feedpoint attaches to.
+                x, z = p0[0], p0[2]
+                s = 1.0 if dy > 0 else -1.0
+                cur = p0[1]
+                segs = []
+                if ln:
+                    segs.append((p0[1], p0[1] + s * pe, ln))
+                    cur = p0[1] + s * pe
+                end = (p1[1] - s * pe) if rn else p1[1]
+                segs.append((cur, end, None))
+                cur = end
+                if rn:
+                    segs.append((cur, p1[1], rn))
+                for ya, yb_, nm in segs:
+                    seglen = abs(yb_ - ya)
+                    nseg = 3 if nm else max(3, round(self.nominal_nsegs * seglen / h))
+                    out.append(((x, ya, z), (x, yb_, z), nseg, None, nm))
+            else:
+                out.append((p0, p1, ns, None, None))
+        return out
+
+    def build_network(self):
+        """One driven feedpoint per port of each active junction. No branches:
+        a pure multi-feed network (NetworkReducer pins driven ports at their
+        applied voltage and floats the rest)."""
+        active = sorted(self._active_set())
+        fv = dict(self.feed_voltages) if self.feed_voltages else {}
+        ports = {}
+        sources = []
+        for j in active:
+            for t in ("At", "Bt", "Ab", "Bb"):
+                name = f"j{j}_{t}"
+                ports[name] = PortAtEdge(name)
+                sources.append(Driven(port=name, voltage=fv.get(name, 1 + 0j)))
+        return Network(ports=ports, branches=[], sources=sources)

--- a/tests/test_design_schemas.py
+++ b/tests/test_design_schemas.py
@@ -69,6 +69,13 @@ def test_schema_covers_every_non_freq_default_param(name):
         if isinstance(val, str):
             # String defaults need an enum_options override to surface.
             continue
+        if val is None:
+            # None carries no type info, so the adapter emits no auto-UI
+            # (web/adapter.py _param_spec_from_default returns None for
+            # complex/None/exotic). Used by programmatic-only params such as
+            # sterba_driven.feed_voltages / active_junctions, set via the
+            # request body rather than a slider.
+            continue
         assert key in slider_names, f"{name}: missing slider for {key!r}"
 
 

--- a/tests/test_sterba_center_driven.py
+++ b/tests/test_sterba_center_driven.py
@@ -1,0 +1,41 @@
+"""Tests for the center-fed-section Sterba variant (freq_based.sterba_center_driven).
+
+The design deletes the 8 interior risers and exposes the center of each of the
+10 horizontal sections as a feedpoint. These check the build/solve mechanism;
+the gain result (≈ the all-wires reference, once each section's net moment is
+matched) is measured by scripts/sterba_center_driven_experiment.py.
+"""
+
+import numpy as np
+
+from antenna_designer.designs.freq_based import sterba_center_driven
+from antenna_designer.engines import PysimEngine
+
+FF_KW = dict(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
+
+
+def test_ten_sections_named_edges_match_ports():
+    b = sterba_center_driven.Builder()
+    specs = b.section_specs()
+    assert len(specs) == 10  # n_cells=3: 5 horizontal sections per conductor × 2
+    named = {t[4] for t in b.build_wires() if len(t) >= 5 and t[4]}
+    assert named == set(b.build_network().ports) == {nm for nm, _c in specs}
+
+
+def test_section_feeds_sit_at_section_centers():
+    """Each named edge is short and centered on its section midpoint (so the
+    delta-gap feed drives the section at its current antinode for half-waves)."""
+    b = sterba_center_driven.Builder()
+    centers = dict(b.section_specs())
+    for t in b.build_wires():
+        if len(t) >= 5 and t[4]:
+            mid_y = 0.5 * (t[0][1] + t[1][1])
+            assert abs(mid_y - centers[t[4]][1]) < 1e-6
+
+
+def test_builds_and_solves_to_finite_z_and_gain():
+    eng = PysimEngine(sterba_center_driven.Builder(), ground=None)
+    zs = eng.impedance()
+    assert len(zs) == 10
+    assert all(np.isfinite(z.real) and np.isfinite(z.imag) for z in zs)
+    assert np.isfinite(eng.far_field(**FF_KW).max_gain)

--- a/tests/test_sterba_driven.py
+++ b/tests/test_sterba_driven.py
@@ -1,0 +1,89 @@
+"""Tests for the explicit-feedpoint Sterba variant (freq_based.sterba_driven).
+
+The design deletes the 8 interior risers and exposes the 4 ports of each
+junction as independent feedpoints. These tests check the *mechanism* — that
+placing feedpoints at those ports builds and solves — and the linear-algebra
+contract the experiment relies on: voltages V = Y⁻¹·I_target reproduce any
+target port currents. (Whether that recovers the curtain's gain is a physics
+question the driver script measures, not something pinned here.)
+"""
+
+import numpy as np
+import pytest
+
+from antenna_designer.designs.freq_based import sterba_driven
+from antenna_designer.engines import PysimEngine
+
+FF_KW = dict(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
+
+
+def _builder(active, feed_voltages=None):
+    p = dict(sterba_driven.Builder.default_params)
+    p["active_junctions"] = active
+    p["feed_voltages"] = feed_voltages
+    return sterba_driven.Builder(p)
+
+
+@pytest.mark.parametrize("active", [[2], [2, 3], [1, 2, 3, 4]])
+def test_named_edges_match_network_ports(active):
+    """Every network PortAtEdge must be backed by a named edge in build_wires
+    (the engine asserts this); and there are exactly 4 ports per junction."""
+    b = _builder(active)
+    named = {t[4] for t in b.build_wires() if len(t) >= 5 and t[4]}
+    ports = set(b.build_network().ports)
+    assert named == ports
+    assert len(ports) == 4 * len(active)
+
+
+def test_single_junction_solves_to_finite_z_and_gain():
+    """The user's 'can it be done': one vertical pair (4 feedpoints) builds,
+    solves to finite driving-point impedances, and yields a finite far field."""
+    eng = PysimEngine(_builder([2]), ground=None)
+    zs = eng.impedance()
+    assert len(zs) == 4
+    assert all(np.isfinite(z.real) and np.isfinite(z.imag) for z in zs)
+    ff = eng.far_field(**FF_KW)
+    assert np.isfinite(ff.max_gain)
+
+
+def test_current_match_round_trip():
+    """V = Y⁻¹·I_target reproduces the target port currents (the contract the
+    experiment uses to inject the reference currents). Well-conditioned, so
+    the round-trip is exact to solver precision."""
+    b = _builder([1, 2, 3, 4])
+    eng = PysimEngine(b, ground=None)
+    wl = 299.792458 / b.design_freq
+    Y = eng._compute_y_matrix(wl)
+
+    rng = np.random.default_rng(0)
+    n = Y.shape[0]
+    I_target = rng.standard_normal(n) + 1j * rng.standard_normal(n)
+    V = np.linalg.solve(Y, I_target)
+
+    assert np.linalg.cond(Y) < 1e3  # feedpoints are independent, not degenerate
+    assert np.allclose(Y @ V, I_target, atol=1e-10)
+
+
+def test_applied_voltages_realize_the_target_port_currents():
+    """Feeding the solved voltages back through the design reproduces the
+    target port currents in the actual network reduction (not just the bare Y
+    algebra). With I_target = 1 A at every port, the driving-point Z = V/I
+    returned by impedance() must equal the applied voltages (since I = 1)."""
+    b0 = _builder([2])
+    eng0 = PysimEngine(b0, ground=None)
+    wl = 299.792458 / b0.design_freq
+    Y = eng0._compute_y_matrix(wl)
+    pti = eng0._reducer.port_to_idx
+
+    I_target = np.ones(Y.shape[0], dtype=np.complex128)  # 1 A into every port
+    V = np.linalg.solve(Y, I_target)
+
+    fv = {nm: complex(V[i]) for nm, i in pti.items()}
+    eng = PysimEngine(_builder([2], feed_voltages=fv), ground=None)
+    zs = eng.impedance()
+
+    # impedance() returns V/I per driven port in source order (j, then At/Bt/
+    # Ab/Bb); I = 1 A, so Z must equal the applied voltage at each port.
+    order = [f"j2_{t}" for t in ("At", "Bt", "Ab", "Bb")]
+    z_expected = [V[pti[nm]] for nm in order]
+    assert np.allclose(zs, z_expected, rtol=1e-6, atol=1e-9)


### PR DESCRIPTION
## Summary
Three research variants of the Sterba curtain that investigate whether the 8 interior vertical risers are purely a phasing mechanism — and whether explicit feedpoints can replace them. PysimEngine-only (multi-feed networks, like `sterba_difftl`). All additive; no existing code touched.

- **`sterba_driven`** — deletes the 8 inner risers and drives each junction's 4 ports as independent feedpoints, matching the reference port currents (`V = Y⁻¹·I_target`). Builds up one vertical pair at a time. **Finding: solves cleanly but does NOT recover the gain (~3 dBi vs 10.5).** A deleted riser leaves a free wire-end where current must vanish, so a feedpoint there end-feeds the section into its own resonance — the phases scatter (broadside coherence 0.10).
- **`sterba_riser_masked_pattern.py`** — solves the real all-wires Sterba, then recomputes the far field with the 8 interior-riser segment currents zeroed. **Finding: 176 riser segments carrying Σ|I| ≈ 0.29 (comparable to the radiators) contribute essentially nothing — max gain 10.501 → 10.546 dBi, pattern unchanged.** The A/B pair at each junction is ~180° out of phase, so their radiation cancels: the verticals phase the curtain, they don't radiate.
- **`sterba_center_driven`** — deletes the 8 inner risers and feeds each of the 10 horizontal sections at its **center**, matching each section's net current moment `M_y = ∫I·dy` (`V = G⁻¹·M_y,ref`). **Finding: 10.412 dBi vs the 10.501 reference (gap −0.089 dB), coherence 0.968, pattern overlays the reference.** Confirms the verticals are purely a phasing mechanism — delete them, drive each radiator's center with the right net moment, and the full gain comes back.

The arc: end-feed fails → risers don't radiate (only phase) → center-feed with matched moments recovers the gain.

## Test plan
- [x] `pytest tests/test_sterba_driven.py tests/test_sterba_center_driven.py` (9 pass): build/solve to finite Z + gain, current-match and moment-match round-trips, named-edge/port consistency
- [x] Existing `tests/test_pysim_engine.py` difftl/far-field tests still green
- [x] `ruff check` and `ruff format --check` clean
- [ ] `python scripts/sterba_driven_experiment.py` — incremental sweep, ~3 dBi
- [ ] `python scripts/sterba_riser_masked_pattern.py` — Δgain +0.045 dB
- [ ] `python scripts/sterba_center_driven_experiment.py` — 10.41 dBi, pattern overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)