### PR TITLE
Fix feed-point marker shift and PyNEC current gap across solver bases

### DIFF
--- a/src/antenna_designer/engines/pynec.py
+++ b/src/antenna_designer/engines/pynec.py
@@ -412,10 +412,12 @@ class PyNECEngine(SimulationEngine):
 
     def current_distribution(self):
         """Per-tuple knot positions + complex currents. Each build_wires()
-        tuple becomes one wire entry with n_seg+1 knot positions; per-knot
-        currents are the average of the two adjacent NEC segment-centre
-        currents, with boundary knots zeroed (open-wire BC). The pysim web
-        backend uses the same averaging convention."""
+        tuple becomes one wire entry with n_seg+1 knot positions; interior
+        knots are the average of the two adjacent NEC segment-centre
+        currents. Boundary knots are zeroed at genuine free ends (open-wire
+        BC) but carry the adjacent segment-centre current at junctions, where
+        the current is physically continuous through the shared endpoint.
+        Mirrors web.pynec_backend._segment_centers_to_knot_currents."""
         if self._use_reducer:
             self.c = self._excited_real_context(C_LIGHT / (self.builder.freq * 1e6))
         self._set_freq_and_execute()
@@ -426,6 +428,19 @@ class PyNECEngine(SimulationEngine):
         all_tags = list(sc.get_current_segment_tag())
         all_cur = sc.get_current()
 
+        # A wire end shared with another tuple is a junction (current
+        # continuous through it); an unshared end is a free end (I -> 0).
+        # Without this, a 1-segment feed stub — both ends junctions — would
+        # render zero current along its whole length even though it sits at a
+        # current maximum, opening a visible gap at the feed.
+        def _key(p):
+            return tuple(np.round(np.asarray(p, dtype=float), 6))
+
+        endpoint_count: dict = {}
+        for t in self.tups:
+            for p in (t[0], t[1]):
+                endpoint_count[_key(p)] = endpoint_count.get(_key(p), 0) + 1
+
         out = []
         for tag_idx, t in enumerate(self.tups, start=1):
             p0, p1, n_seg = t[0], t[1], t[2]
@@ -435,9 +450,11 @@ class PyNECEngine(SimulationEngine):
             knot_cur = np.zeros(n_seg + 1, dtype=np.complex128)
             if n_seg >= 2:
                 knot_cur[1:-1] = 0.5 * (cur_per_seg[:-1] + cur_per_seg[1:])
-            elif n_seg == 1:
-                # 1-segment wire: no interior knot, leave boundaries at 0.
-                pass
+            if cur_per_seg.shape[0] >= 1:
+                if endpoint_count.get(_key(p0), 0) >= 2:
+                    knot_cur[0] = cur_per_seg[0]
+                if endpoint_count.get(_key(p1), 0) >= 2:
+                    knot_cur[-1] = cur_per_seg[-1]
             out.append(
                 WireCurrents(
                     knot_positions=knots,

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -60,6 +60,26 @@ def test_half_square_is_broadside_with_end_nulls():
     assert broadside - end_on > 8.0
 
 
+def test_half_square_feed_wire_carries_current_free_ends_null():
+    """The corner feed is a dedicated 1-segment driven edge, so both its
+    knots are junctions. current_distribution must carry the segment current
+    onto those boundary knots (continuous through a junction) rather than
+    zeroing them, which would render a zero-current gap right at the feed —
+    the current maximum. The two open leg ends, by contrast, are genuine free
+    ends and stay at the current null Cebik describes."""
+    from antenna_designer.designs.cebik.half_square import Builder
+
+    cur = PyNECEngine(Builder(), ground=None).current_distribution()
+    # Tuple order from build_wires: 0=left leg, 1=feed stub, 2=top, 3=right leg.
+    feed = np.abs(cur[1].knot_currents)
+    assert cur[1].knot_positions.shape[0] == 2  # 1-segment feed edge
+    assert feed.min() > 1e-4  # both junction knots carry current, no gap
+    # Open leg ends (knot 0 of the left leg, last knot of the right leg) are
+    # free ends -> current null.
+    assert abs(cur[0].knot_currents[0]) < 1e-9
+    assert abs(cur[3].knot_currents[-1]) < 1e-9
+
+
 def test_half_square_length_factor_tunes_reactance():
     """Reactance climbs monotonically with length_factor through resonance."""
     from antenna_designer.designs.cebik.half_square import Builder

--- a/web/adapter.py
+++ b/web/adapter.py
@@ -402,8 +402,8 @@ def _pack_wires(currents) -> list[dict]:
     ]
 
 
-def _feed_indices(engine, currents) -> tuple[int, int]:
-    """Pick a (wire, knot) for the feed marker.
+def _primary_feed(engine):
+    """(polyline_idx, arclength) of the driven feed, or None.
 
     PysimEngine exposes `_feeds = [(polyline_idx, arclength, voltage)]`
     post-translator. For network-spec designs the geometry translator
@@ -415,7 +415,7 @@ def _feed_indices(engine, currents) -> tuple[int, int]:
     feeds = getattr(engine, "_feeds", None) or []
     feed_names = getattr(engine, "_feed_names", None) or []
     if not feeds:
-        return 0, 0
+        return None
     feed_idx = 0
     network = getattr(engine, "_network", None)
     if network is not None and network.sources:
@@ -426,6 +426,30 @@ def _feed_indices(engine, currents) -> tuple[int, int]:
         if driven_name in feed_names:
             feed_idx = feed_names.index(driven_name)
     pl_idx, arclen, _v = feeds[feed_idx]
+    return int(pl_idx), float(arclen)
+
+
+def _interp_polyline(knots, cum, arclen):
+    """3D point at `arclen` along a polyline (knots + cumulative arclength)."""
+    arclen = min(max(arclen, 0.0), float(cum[-1]))
+    seg = int(np.searchsorted(cum, arclen, side="right")) - 1
+    seg = min(max(seg, 0), len(knots) - 2)
+    span = cum[seg + 1] - cum[seg]
+    t = 0.0 if span <= 0 else (arclen - cum[seg]) / span
+    return (knots[seg] + t * (knots[seg + 1] - knots[seg])).tolist()
+
+
+def _feed_indices(engine, currents) -> tuple[int, int]:
+    """Pick a (wire, knot) for the feed marker — the knot nearest the feed.
+
+    Kept for the feed_knot_index the frontend uses to read feed current and
+    split the current envelope. The visible marker dot uses `_feed_position`
+    instead (exact, not snapped to a knot).
+    """
+    pf = _primary_feed(engine)
+    if pf is None:
+        return 0, 0
+    pl_idx, arclen = pf
     if pl_idx >= len(currents):
         return 0, 0
     knots = currents[pl_idx].knot_positions
@@ -434,8 +458,29 @@ def _feed_indices(engine, currents) -> tuple[int, int]:
     # Cumulative arclength along the polyline.
     deltas = np.linalg.norm(np.diff(knots, axis=0), axis=1)
     cum = np.concatenate([[0.0], np.cumsum(deltas)])
-    j = int(np.argmin(np.abs(cum - float(arclen))))
-    return int(pl_idx), j
+    j = int(np.argmin(np.abs(cum - arclen)))
+    return pl_idx, j
+
+
+def _feed_position(engine, currents):
+    """Exact 3D feed point for the primary feed — the physical location the
+    solver actually feeds, independent of where segment knots fall. Avoids
+    the half-segment marker shift from snapping to the nearest knot, which
+    lands on an endpoint when the feed edge has no interior knot (e.g. a
+    1-segment driven stub under odd-parity bases like sinusoidal/Bspline=2).
+    """
+    pf = _primary_feed(engine)
+    if pf is None:
+        return None
+    pl_idx, arclen = pf
+    if pl_idx >= len(currents):
+        return None
+    knots = currents[pl_idx].knot_positions
+    if knots.shape[0] < 2:
+        return knots[0].tolist() if knots.shape[0] else None
+    deltas = np.linalg.norm(np.diff(knots, axis=0), axis=1)
+    cum = np.concatenate([[0.0], np.cumsum(deltas)])
+    return _interp_polyline(knots, cum, arclen)
 
 
 def _pynec_feed_indices(builder, currents) -> tuple[int, int]:
@@ -470,6 +515,38 @@ def _pynec_feed_indices(builder, currents) -> tuple[int, int]:
         k = currents[i].knot_positions.shape[0]
         return i, k // 2
     return 0, 0
+
+
+def _pynec_feed_position(builder, currents):
+    """Exact 3D feed point for PyNEC: the midpoint of the driven segment.
+    NEC feeds at segment (n_seg+1)//2, so on a 1-segment feed edge the feed
+    sits at the edge midpoint — not the wire's centre knot (`k//2`), which
+    lands on an endpoint for a 2-knot wire. Mirrors `_pynec_feed_indices`'
+    driven-tuple selection.
+    """
+    tuples = list(builder.build_wires())
+    driven_name = None
+    if hasattr(builder, "build_network"):
+        net = builder.build_network()
+        if net is not None and net.sources:
+            driven_name = net.sources[0].port
+    for i, t in enumerate(tuples):
+        ev = t[3]
+        name = t[4] if len(t) >= 5 else None
+        if driven_name is not None:
+            if name != driven_name:
+                continue
+        elif ev is None:
+            continue
+        if i >= len(currents):
+            return None
+        knots = currents[i].knot_positions
+        n_seg = knots.shape[0] - 1
+        if n_seg < 1:
+            return knots[0].tolist() if knots.shape[0] else None
+        mid_seg = (n_seg + 1) // 2  # 1-indexed driven segment
+        return (0.5 * (knots[mid_seg - 1] + knots[mid_seg])).tolist()
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -704,6 +781,7 @@ def _make_example(name: str, cls) -> AntennaExample:
             "wires": _pack_wires(currents),
             "feed_wire_index": feed_wire_idx,
             "feed_knot_index": feed_knot_idx,
+            "feed_position": _feed_position(eng, currents),
             "z_in_re": float(z_primary.real),
             "z_in_im": float(z_primary.imag),
             "design_freq_mhz": design_freq,
@@ -814,6 +892,7 @@ def _make_example(name: str, cls) -> AntennaExample:
             "wires": _pack_wires(currents),
             "feed_wire_index": feed_wire_idx,
             "feed_knot_index": feed_knot_idx,
+            "feed_position": _pynec_feed_position(builder, currents),
             "z_in_re": float(z_primary.real),
             "z_in_im": float(z_primary.imag),
             "design_freq_mhz": design_freq,

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -443,6 +443,8 @@ function ResultPanel({
 type FeedEntry = {
   wire_index: number;
   knot_index: number;
+  /** Exact 3D feed point; preferred over the knot lookup for the marker dot. */
+  feed_position?: [number, number, number];
   z_re: number;
   z_im: number;
   v_re: number;
@@ -454,6 +456,9 @@ type SolveResponse = {
   wires: Wire[];
   feed_wire_index: number;
   feed_knot_index: number;
+  /** Exact 3D feed point for the primary feed; the marker dot uses this so
+   *  it stays on the true feed regardless of solver-basis parity. */
+  feed_position?: [number, number, number];
   z_in_re: number;
   z_in_im: number;
   /** Multi-feed geometries (bowtie 1×2 array) populate this; single-feed
@@ -3720,14 +3725,17 @@ function CurrentCanvas({
         : [{
             wire_index: feedWireIdx,
             knot_index: result.feed_knot_index,
+            feed_position: result.feed_position,
             v_re: 1, v_im: 0,
             z_re: result.z_in_re, z_im: result.z_in_im,
           }];
       for (let fi = 0; fi < feedList.length; fi++) {
         const f = feedList[fi];
         const w_ = result.wires[f.wire_index];
-        if (!w_) continue;
-        const feed = project(w_.knot_positions[f.knot_index]);
+        // Prefer the exact feed point; fall back to the nearest knot.
+        const pos3d = f.feed_position ?? (w_ ? w_.knot_positions[f.knot_index] : undefined);
+        if (!pos3d) continue;
+        const feed = project(pos3d);
         ctx!.fillStyle = "#ffd166";
         ctx!.beginPath();
         ctx!.arc(feed.x, feed.y, 5 * s, 0, Math.PI * 2);


### PR DESCRIPTION
## Summary
- **Marker shift was a rendering artifact, not a physics difference.** Every solver feeds the same physical point (for `cebik.half_square`, the midpoint of the 1-segment driven edge at the top corner). The displayed dot snapped the feed to the *nearest drawn knot*, so it jumped up to half a segment when the feed edge had no interior knot there — different directions for triangular (even parity, knot on feed), sinusoidal/Bspline=2 (odd parity, no interior knot → endpoint), and PyNEC (`k//2` → opposite endpoint).
- **Fix 1 (`fe8c016`):** add an exact `feed_position` to the solve payload (pysim: interpolate along the polyline at the feed arclength; PyNEC: midpoint of the driven segment) and render the marker there, falling back to the nearest knot. `feed_knot_index` is kept for the feed-current readout and current-envelope split.
- **Fix 2 (`45da063`):** `PyNECEngine.current_distribution` zeroed *every* wire's boundary knots as an open-wire BC. That's only right at genuine free ends; at a junction the current is continuous. The 1-segment feed stub has two junction ends, so it rendered zero current end-to-end — the "gap" opening up at the feed. Now junctions carry the adjacent segment current while true free ends (the open leg tips) stay at their current null. This matches the intent in the tested-but-orphaned `web.pynec_backend._segment_centers_to_knot_currents` helper the live path never used.
- Net effect: all four engines now report `feed_position` z≈5.92 for half_square, and the PyNEC feed wire carries continuous current.

## Test plan
- [x] Full Python suite: 1057 passed (incl. new `test_half_square_feed_wire_carries_current_free_ends_null`)
- [x] `ruff check` / `ruff format --check` clean on changed files
- [x] Frontend `tsc --noEmit` clean
- [ ] Manual UI check: switch half_square between Triangular / Bspline=2 / Sinusoidal / PyNEC and confirm the feed dot stays put and the PyNEC current display no longer shows a gap at the feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)