### PR TITLE
Integrate HMatrixPySim hierarchical MoM solver into the engine + web

### DIFF
--- a/src/antenna_designer/engines/pysim.py
+++ b/src/antenna_designer/engines/pysim.py
@@ -25,7 +25,9 @@ def _parity_for_solver(solver, solver_kwargs):
         return "even"
     if name == "SinusoidalPySim":
         return "odd"
-    if name == "BSplinePySim":
+    if name in ("BSplinePySim", "HMatrixPySim"):
+        # HMatrixPySim is a BSplinePySim subclass (same basis), so it shares
+        # the degree-driven parity.
         degree = (solver_kwargs or {}).get("degree", 2)
         return "even" if int(degree) == 1 else "odd"
     return "any"

--- a/web/adapter.py
+++ b/web/adapter.py
@@ -43,7 +43,7 @@ from antenna_designer.builder import (
 )
 from antenna_designer.engines.pynec import PyNECEngine
 from antenna_designer.engines.pysim import PysimEngine
-from pysim import BSplinePySim, SinusoidalPySim, TriangularPySim
+from pysim import BSplinePySim, HMatrixPySim, SinusoidalPySim, TriangularPySim
 
 from .examples import register
 from .examples._base import (
@@ -67,6 +67,11 @@ _PYSIM_MODELS = {
     "triangular": TriangularPySim,
     "sinusoidal": SinusoidalPySim,
     "bspline": BSplinePySim,
+    # Hierarchical (H-matrix / ACA) accelerator — same B-spline basis as
+    # bspline; model_options forward verbatim (degree, aca_eta,
+    # aca_leaf_size, aca_tol, solve_tol, …). Ground/enrichment fall back to
+    # the dense bspline solve inside HMatrixPySim.
+    "hmatrix": HMatrixPySim,
 }
 
 


### PR DESCRIPTION
## Summary
- Bumps the `pysim` submodule to the `hierarchical-mom-engine` branch, which adds `HMatrixPySim` — a distance-based H-matrix / ACA accelerator for the B-spline MoM (see pysim PR #84).
- Teaches `engines/pysim.py`'s `_parity_for_solver` that `HMatrixPySim` shares `BSplinePySim`'s degree-driven segment parity. Without this the engine meshed the two solvers differently, which masqueraded as a ~1% solver error in apples-to-apples comparisons.
- Registers `HMatrixPySim` under the `hmatrix` key in the web adapter's `_PYSIM_MODELS`, so the server API accepts `pysim_model="hmatrix"` (model_options forward verbatim: degree, aca_eta, aca_leaf_size, aca_tol, solve_tol). The React frontend model picker is a separate surface and is intentionally left unchanged for now.

## Test plan
- [x] `pytest tests/test_pysim_engine.py tests/test_cebik_designs.py` — 160 passed
- [x] `pytest tests/test_web_server.py` — 80 passed
- [x] `ruff check .` clean
- [x] Manual: `PysimEngine(builder, solver=HMatrixPySim).impedance()` and `adapter._make_pysim_engine({"pysim_model":"hmatrix"}, ...)` match the dense bspline engine on rhombic (rel 1e-4) and bowtiearray2x4 (rel 2e-5)

> Note: depends on pysim PR #84 — merge that first, then this submodule bump points at a commit on pysim's `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)