### PR TITLE
Integrate ArrayBlockPySim array-block solver into PysimEngine

### DIFF
--- a/src/antenna_designer/cli.py
+++ b/src/antenna_designer/cli.py
@@ -12,7 +12,13 @@ from . import (
 )
 from .engines import PyNECEngine, PysimEngine
 
-from pysim import TriangularPySim, SinusoidalPySim, BSplinePySim
+from pysim import (
+    TriangularPySim,
+    SinusoidalPySim,
+    BSplinePySim,
+    HMatrixPySim,
+    ArrayBlockPySim,
+)
 
 from icecream import ic
 
@@ -29,6 +35,8 @@ PYSIM_BASES = {
     "triangular": TriangularPySim,
     "sinusoidal": SinusoidalPySim,
     "bspline": BSplinePySim,
+    "hmatrix": HMatrixPySim,
+    "arrayblock": ArrayBlockPySim,
 }
 
 

--- a/src/antenna_designer/engines/pysim.py
+++ b/src/antenna_designer/engines/pysim.py
@@ -25,9 +25,12 @@ def _parity_for_solver(solver, solver_kwargs):
         return "even"
     if name == "SinusoidalPySim":
         return "odd"
-    if name in ("BSplinePySim", "HMatrixPySim"):
-        # HMatrixPySim is a BSplinePySim subclass (same basis), so it shares
-        # the degree-driven parity.
+    if name in ("BSplinePySim", "HMatrixPySim", "ArrayBlockPySim"):
+        # HMatrixPySim and ArrayBlockPySim are BSplinePySim subclasses (same
+        # basis), so they share the degree-driven parity. Getting this right
+        # matters for cross-solver comparison: a mismatched parity would build
+        # a *different* mesh and silently invalidate any A/B against the dense
+        # bspline path.
         degree = (solver_kwargs or {}).get("degree", 2)
         return "even" if int(degree) == 1 else "odd"
     return "any"

--- a/tests/test_engine_spec.py
+++ b/tests/test_engine_spec.py
@@ -69,7 +69,13 @@ def test_make_factory_binds_ground_and_solver():
 
 
 def test_pysim_bases_keys():
-    assert set(PYSIM_BASES) == {"triangular", "sinusoidal", "bspline"}
+    assert set(PYSIM_BASES) == {
+        "triangular",
+        "sinusoidal",
+        "bspline",
+        "hmatrix",
+        "arrayblock",
+    }
 
 
 O = " --fn /dev/null"

--- a/tests/test_pysim_engine.py
+++ b/tests/test_pysim_engine.py
@@ -1438,3 +1438,40 @@ def test_translator_rejects_geometry_with_no_excitation():
     ]
     with pytest.raises(ValueError, match="no excitation"):
         flat_wires_to_polylines(tups)
+
+
+@pytest.mark.parametrize(
+    "design_module",
+    [
+        "antenna_designer.designs.invveearray",
+        "antenna_designer.designs.bowtiearray2x4",
+    ],
+)
+def test_pysim_arrayblock_matches_dense_bspline(design_module):
+    """The element-aware array-block solver must reproduce the dense bspline
+    per-port impedance on the array designs. Both go through PysimEngine, so
+    this also pins the parity wiring: a wrong parity for ArrayBlockPySim would
+    build a different mesh and the impedances would diverge."""
+    from importlib import import_module
+    from pysim import BSplinePySim, ArrayBlockPySim
+
+    b = import_module(design_module).Builder()
+    kw = {"solver_kwargs": {"degree": 2}}
+    z_dense = PysimEngine(b, solver=BSplinePySim, **kw).impedance()
+    z_block = PysimEngine(b, solver=ArrayBlockPySim, **kw).impedance()
+    assert len(z_dense) == len(z_block) > 1
+    for i, (zd, zb) in enumerate(zip(z_dense, z_block)):
+        assert abs(zd - zb) / abs(zd) < 1e-3, f"feed {i}: {zd} vs {zb}"
+
+
+def test_pysim_arrayblock_parity_matches_bspline():
+    """ArrayBlockPySim shares BSplinePySim's degree-driven parity (a regression
+    guard for the _parity_for_solver wiring)."""
+    from pysim import BSplinePySim, ArrayBlockPySim
+    from antenna_designer.engines.pysim import _parity_for_solver
+
+    for degree in (1, 2):
+        kw = {"degree": degree}
+        assert _parity_for_solver(ArrayBlockPySim, kw) == _parity_for_solver(
+            BSplinePySim, kw
+        )

--- a/web/adapter.py
+++ b/web/adapter.py
@@ -43,7 +43,13 @@ from antenna_designer.builder import (
 )
 from antenna_designer.engines.pynec import PyNECEngine
 from antenna_designer.engines.pysim import PysimEngine
-from pysim import BSplinePySim, HMatrixPySim, SinusoidalPySim, TriangularPySim
+from pysim import (
+    ArrayBlockPySim,
+    BSplinePySim,
+    HMatrixPySim,
+    SinusoidalPySim,
+    TriangularPySim,
+)
 
 from .examples import register
 from .examples._base import (
@@ -72,6 +78,12 @@ _PYSIM_MODELS = {
     # aca_leaf_size, aca_tol, solve_tol, …). Ground/enrichment fall back to
     # the dense bspline solve inside HMatrixPySim.
     "hmatrix": HMatrixPySim,
+    # Element-aware array-block accelerator (sibling of hmatrix) for arrays of
+    # identical/few-shape elements: dense per-shape self-blocks + low-rank
+    # coupling, block-Jacobi GMRES. Same B-spline basis and model_options as
+    # bspline/hmatrix (degree, aca_tol, solve_tol, …); on a single connected
+    # structure it degrades to one element and matches the dense bspline solve.
+    "arrayblock": ArrayBlockPySim,
 }
 
 

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -520,25 +520,52 @@ type SolveResponse = {
   z0_ohms?: number;
 };
 
-// Backend selector — three PySim model variants + PyNEC. Per-backend
+// Backend selector — PySim model variants + PyNEC. Per-backend
 // `model_options` are forwarded to server.py's _make_pysim_sim.
-type Backend = "triangular" | "sinusoidal" | "bspline" | "pynec";
+type Backend =
+  | "triangular"
+  | "sinusoidal"
+  | "bspline"
+  | "hmatrix"
+  | "arrayblock"
+  | "pynec";
 
 const BACKEND_LABEL: Record<Backend, string> = {
   triangular: "Triangular",
   sinusoidal: "Sinusoidal",
   bspline: "B-spline",
+  hmatrix: "H-matrix (ACA)",
+  arrayblock: "Array-block",
   pynec: "PyNEC",
 };
 
-const BACKEND_ORDER: Backend[] = ["triangular", "sinusoidal", "bspline", "pynec"];
+const BACKEND_ORDER: Backend[] = [
+  "triangular",
+  "sinusoidal",
+  "bspline",
+  "hmatrix",
+  "arrayblock",
+  "pynec",
+];
 
-// All three pysim models have the PEC image-method ground; PyNEC uses
-// its own Sommerfeld / reflection-coefficient ground. Kept as an explicit
-// list so future backends without ground support can be excluded by name.
+// hmatrix (hierarchical H-matrix / ACA) and arrayblock (element-aware block
+// solver for arrays) are accelerators built on the same B-spline basis as
+// bspline; they share its options and request shape, and fall back to the
+// dense bspline path for ground/enrichment.
+const BSPLINE_FAMILY: Backend[] = ["bspline", "hmatrix", "arrayblock"];
+function isBSplineFamily(b: Backend): boolean {
+  return BSPLINE_FAMILY.includes(b);
+}
+
+// Every pysim model has the PEC image-method ground; PyNEC uses its own
+// Sommerfeld / reflection-coefficient ground. Kept as an explicit list so
+// future backends without ground support can be excluded by name.
 function backendSupportsGround(b: Backend): boolean {
   return (
-    b === "triangular" || b === "bspline" || b === "sinusoidal" || b === "pynec"
+    b === "triangular" ||
+    b === "sinusoidal" ||
+    isBSplineFamily(b) ||
+    b === "pynec"
   );
 }
 
@@ -575,30 +602,38 @@ type BSplineOpts = CommonOpts & {
 };
 type PyNECOpts = CommonOpts;
 
+// hmatrix and arrayblock share BSplineOpts (same basis + knobs); the ACA
+// tolerances use the solver defaults.
 type BackendOptsMap = {
   triangular: TriangularOpts;
   sinusoidal: SinusoidalOpts;
   bspline: BSplineOpts;
+  hmatrix: BSplineOpts;
+  arrayblock: BSplineOpts;
   pynec: PyNECOpts;
+};
+
+const BSPLINE_DEFAULT_OPTS: BSplineOpts = {
+  nPerWire: 30,
+  wireRadius: 0.0005,
+  degree: 2,
+  nQpPair: 4,
+  feedSmoothingFactor: null,
+  useSingularEnrichment: false,
+  enrichmentVariant: "raw",
+  tikhonovLambda: 0.1,
+  autoTapRatioThreshold: 0.3,
+  nQpSing: 32,
+  enrichmentMinK: 3,
+  nQpSource: 16,
 };
 
 const DEFAULT_BACKEND_OPTS: BackendOptsMap = {
   triangular: { nPerWire: 30, wireRadius: 0.0005, nQpReg: 4, nQpOff: 4 },
   sinusoidal: { nPerWire: 30, wireRadius: 0.0005, nQpConst: 8 },
-  bspline: {
-    nPerWire: 30,
-    wireRadius: 0.0005,
-    degree: 2,
-    nQpPair: 4,
-    feedSmoothingFactor: null,
-    useSingularEnrichment: false,
-    enrichmentVariant: "raw",
-    tikhonovLambda: 0.1,
-    autoTapRatioThreshold: 0.3,
-    nQpSing: 32,
-    enrichmentMinK: 3,
-    nQpSource: 16,
-  },
+  bspline: { ...BSPLINE_DEFAULT_OPTS },
+  hmatrix: { ...BSPLINE_DEFAULT_OPTS },
+  arrayblock: { ...BSPLINE_DEFAULT_OPTS },
   pynec: { nPerWire: 30, wireRadius: 0.0005 },
 };
 
@@ -647,7 +682,9 @@ function modelOptionsForRequest(
     const o = opts as SinusoidalOpts;
     return { n_qp_const: o.nQpConst };
   }
-  if (backend === "bspline") {
+  if (isBSplineFamily(backend)) {
+    // bspline, hmatrix, and arrayblock all take the B-spline kwargs; the
+    // accelerators read additional aca_tol/solve_tol from their own defaults.
     const o = opts as BSplineOpts;
     return {
       degree: o.degree,
@@ -671,7 +708,12 @@ type SolveRequest = {
    *  → backend falls back to default_params. */
   variant?: string;
   solver: "pysim" | "pynec";
-  pysim_model?: "triangular" | "sinusoidal" | "bspline";
+  pysim_model?:
+    | "triangular"
+    | "sinusoidal"
+    | "bspline"
+    | "hmatrix"
+    | "arrayblock";
   model_options?: Record<string, unknown>;
   n_per_wire: number;
   design_freq_mhz: number;
@@ -1253,7 +1295,7 @@ export function App() {
       // enrichment off in the request when ground is active so the user
       // gets a sensible solve instead of a server error; the gear shows
       // an inline note.
-      if (backend === "bspline" && groundActive) {
+      if (isBSplineFamily(backend) && groundActive) {
         opts.use_singular_enrichment = false;
       }
       base.model_options = opts;
@@ -2354,7 +2396,7 @@ function BackendConfigModal({
             />
           )}
 
-          {backend === "bspline" && (
+          {isBSplineFamily(backend) && (
             <BSplineFields
               opts={opts as BSplineOpts}
               onPatch={(p) => onPatch(p as never)}


### PR DESCRIPTION
Engine integration for the element-aware array-block solver (`ArrayBlockPySim`),
which lands in the pysim submodule via stevenmburns/pysim#86.

## Changes
- `_parity_for_solver` recognises `ArrayBlockPySim` (degree-driven parity, same
  as `BSplinePySim`/`HMatrixPySim`). **Critical:** a mismatched parity silently
  builds a different mesh and invalidates any cross-solver comparison against
  the dense bspline path.
- Register `arrayblock` (and `hmatrix`) in the CLI pysim basis map.
- Integration tests: `arrayblock` per-port Z matches dense bspline on
  `invveearray` and `bowtiearray2x4` to <1e-3; a parity-wiring regression guard.
- Bump the `pysim` submodule to the `array-block-solver` tip (P0–P4b).

## Merge order
Depends on stevenmburns/pysim#86. Merge that first, then I'll repoint the
submodule at the merged pysim `main` commit before merging this — otherwise the
submodule pointer would reference the (soon-deleted) pysim branch commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)