### PR TITLE
Add antenna-simulator market research and refresh NEXT_STEPS roadmap

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -7,103 +7,53 @@ Living roadmap of what's done and what's left on the multi-engine refactor. Upda
 `antenna_designer` exposes two simulation backends behind a common `SimulationEngine` interface:
 
 - **`PyNECEngine`** — the original NEC2/PyNEC path. Default backend. Supports free space / PEC / finite-Sommerfeld ground via the `ground=` parameter, multi-element arrays, transmission-line cards (`tl_card`), and arbitrary segment counts. This is the production backend; nothing here is restricted relative to the historical behaviour.
-- **`PysimEngine`** — the pure-Python MoM solvers from the vendored `pysim/` submodule, accessed through a flat-wire-to-polyline geometry translator (`antenna_designer/geometry.py`). Selectable solver (`TriangularPySim` default, `SinusoidalPySim`, `BSplinePySim`) via the engine's `solver=` kwarg.
+- **`PysimEngine`** — the pure-Python MoM solvers from the vendored `pysim/` submodule, accessed through a flat-wire-to-polyline geometry translator (`antenna_designer/geometry.py`). Selectable solver (`TriangularPySim` default, `SinusoidalPySim`, `BSplinePySim`, plus the large-N accelerators `HMatrixPySim` and `ArrayBlockPySim`) via the engine's `solver=` kwarg. `impedance()`, `impedance_sweep()`, `current_distribution()`, and `far_field()` are all supported across the bases.
 
 Selection is uniform across the Python API and the CLI: `compare_patterns([engine_instance, ...])` for ad-hoc comparisons; `engine=` factory kwarg on `sweep` / `sweep_freq` / `sweep_gain` / `sweep_patterns` / `optimize`; `--engine pynec|pysim --ground free|pec|finite|finite:eps,sigma` on every analysis subcommand.
 
-Cross-validation at design freq, free space, against PyNEC: ≤ 0.1 dBi peak directivity agreement on the dipole; ≤ 0.005 dBi on PEC ground. Sinusoidal lands within ~10 % R and ~10 Ω X of PyNEC on the hentenna's tee-junction geometry.
+Antenna topology and circuit elements both translate to pysim now: open chains with arbitrary junctions, pure closed loops (driven, parasitic, or terminated two-port), multi-feed arrays, and port-based networks (transmission lines + lumped R/L/C) via `build_network()`. Cross-validation at design freq, free space, against PyNEC: ≤ 0.1 dBi peak directivity agreement on the dipole; ≤ 0.005 dBi on PEC ground; ~1–3 % R / a few Ω X on closed loops and multi-feed arrays. Cross-validation tests live in `tests/test_pysim_engine.py`.
 
-## Known geometry limitations
+## Geometry & circuit support — current state
 
-These are the topologies `PysimEngine` currently rejects. PyNECEngine is unaffected — these only matter if you're cross-validating with pysim or using it as the production backend.
+Everything the translator previously rejected now works through `PysimEngine`. PyNECEngine was always unaffected.
 
-| limitation | affected designs (today) | status |
-|---|---|---|
-| ~~pure closed loops~~ | ~~bowtie, delta_loop, diamond_loop, inv_delta_loop, folded_invvee, delta_loop_slanted{,2,3}~~ | **done** — cut-at-feed-edge in `flat_wires_to_polylines` |
-| ~~multiple excitations (`ex_card` voltage on more than one segment)~~ | ~~every array design~~ | **done** — translator emits a `feeds` list, `PysimEngine.impedance()` returns per-port Z |
-| ~~transmission-line cards (`tl_card`)~~ | ~~`freq_based.delta_looparray_with_tls`~~ | **done** — `impedance()` only; sweep raises `NotImplementedError` |
+| topology / feature | status |
+|---|---|
+| open chains, arbitrary junctions (degree-2/3 tees) | **done** — junction walker + KCL in `flat_wires_to_polylines` |
+| pure closed loops (driven) | **done** — cut-at-port-edge (`8cc7945` lineage) |
+| **parasitic loops** (cycle with no excited/port edge) | **done** (`8cc7945`) — cut an arbitrary edge; it stays a passive polyline anchoring the two cut-node junctions |
+| **terminated / multi-port loops** (feed + termination) | **done** (`bcd64c4`) — extra port edges register as feeds by arclength inside the long-way polyline |
+| multiple excitations (`ex_card` on >1 segment) | **done** — translator emits a `feeds` list; `impedance()` returns per-port Z; `impedance_sweep` returns `(n_k, n_feeds)` |
+| transmission-line cards (`tl_card`), `impedance()` **and** `impedance_sweep()` | **done** (`c3535d4`, `1f899dc`) — multi-port Y extraction + nodal reduction; batched swept-k with frequency-dependent βl |
+| port-based network spec (`build_network`): TL + lumped R/L/C | **done** (`a09d548`, `6be1f5f`) — see "Landed" below |
+| differential / common-mode 2-wire TL (`DiffTL`) | **done** (`96336f8`) — pysim only; PyNECEngine raises `NotImplementedError` |
+| loaded-antenna far field (efficiency from resistive loads) | **done** (`bcd64c4`) — directivity → gain when loads present |
 
-## ~~Next branch: closed-loop support in the translator~~ — landed
+No topology in `designs/` is currently rejected by the translator.
 
-Implementation: after the existing junction/endpoint walker finishes, any unwalked edges belong to pure-cycle components. The translator floods each cycle, locates its excited edge, and cuts there — emitting the excited edge as a single-edge polyline and the rest of the loop as a second polyline running the long way back. Both cut endpoints become 2-entry junctions so pysim's KCL closes the loop.
+## Known limitations (genuinely open)
 
-Surprise relative to the plan: **bowtie is a pure cycle, not a degree-3 case**. The two triangles share corners at `(±y, 0)` but each triangle only contributes one edge incident at the shared corner, leaving those corners degree-2. The whole bowtie is a single 10-edge cycle with one excited segment (the lower triangle's centre gap) and one passive segment (the upper triangle's centre gap, no `ex_card`). It falls out of the same cut-at-excited-edge path with no special handling.
+- **Strict `tl_card` PyNEC cross-validation.** `PysimEngine.impedance()` runs cleanly on `delta_looparray_with_tls`, but the numerical answer doesn't match PyNEC (PyNEC: −77 −18255j; pysim: +55 −3j). Both engines are self-consistent across frequency and TL-length sweeps — this is a genuine modeling-convention difference, not numerical noise. Root cause: NEC2's `tl_card` treats TL endpoints as **segment-level** ports while pysim's post-processing treats them as **basis-level** ports (delta-gap at the wire midpoint). On this design the central driver is a 10 cm gap effectively decoupled from the loops (`Y[loop, driver] ≈ 3e-7`), so the TL transformation dominates and the segment-vs-basis distinction blows up the result. The Y reduction itself is verified clean (Y symmetric, passive-port `I_ext=0` exact, `coeffs[m] = 1/Z` for single-port). Two optional follow-ups: (a) add a TL design where loop↔driver coupling is non-negligible and re-compare — agreement should tighten; (b) implement segment-averaging at TL endpoints to match NEC2's convention.
+- **`PyNECEngine` does not implement `DiffTL`** — differential/common-mode TL is a pysim-only feature.
+- **`finite` ground in pysim is approximate** — PEC image + Fresnel on the reflected wave; the impedance is still the PEC result. Use PyNECEngine for full Sommerfeld finite-ground impedance.
+- **No conductor loss in pysim** — wires are PEC; lossy-element efficiency needs PyNECEngine + `ld_card`.
 
-Cross-validation at design freq, free space (R, X in Ω):
+## Landed (condensed changelog)
 
-| design | PyNEC | pysim Sinusoidal | pysim Triangular |
-|---|---|---|---|
-| bowtie | 188.6, +16.3 | 186.1, +14.2 | 187.7, +13.9 |
-| delta_loop | 113.4, +46.1 | 110.5, +43.9 | 110.5, +42.7 |
-| diamond_loop | 219.7, +60.1 | 216.8, +58.0 | 220.7, +57.6 |
+Historical branches, newest first. Each was a "next branch" entry; the engineering notes worth keeping are folded in.
 
-Both pysim bases agree with PyNEC to ~1–3 % R and a few Ω X on the closed-loop designs (tighter than the hentenna because there are no degree-3 junctions adding extra basis-family bias). All six previously-blocked closed-loop designs now translate cleanly; the remaining 16 blocked designs are *all* multi-feed arrays (no more closed-loop blockers in the codebase).
-
-Parasitic-only loops (a cycle with no excited segment, no other component) raise a clear `NotImplementedError` rather than crashing inside pysim. Loops with multiple excitations also raise specifically. Neither case appears in `designs/`.
-
-## ~~Next branch: cross-engine pattern comparison in the CLI~~ — landed
-
-The `compare_patterns` subcommand accepts `--engines` plural, with each spec spelled as `pynec`, `pysim`, or `pysim:triangular|sinusoidal|bspline` (basis is part of engine identity, not a separate flag). Builders × engines combine via **numpy-style broadcasting** in `broadcast_pairs` (cli.py), not literal Cartesian product: equal lengths zip pairwise, length-1 broadcasts against the other, other mismatches reject. Labels are `bname/espec` when both vary, otherwise whichever varies. Covered by `tests/test_engine_spec.py` (23 tests).
-
-Surprise relative to the plan: broadcasting beats cross-product because it lets you express specific pairings (`--builders A B C --engines E1 E2 E3` zips into 3 chosen pairs); a true Cartesian product would always yield 9. If we ever want both, add an opt-in `--cross-product` flag on top.
-
-## ~~Next branch: named parameter variants per builder~~ — landed
-
-The convention turned out simpler than the original `VARIANTS: dict[str, dict]` proposal: a Builder class exposes variants as class attributes whose name ends in `_params` and whose value is a `Mapping` (typically `MappingProxyType`). The unnamed default is `default_params`; named variants are `opt_params`, `s07_params`, `current_physical_params`, etc. CLI selector syntax is `builder[:variant]` (cli.py:90 `get_builder`); `:default` and no colon both pick `default_params`. `list_variants` discovers the available names for error messages.
-
-In practice this nests with the existing builder-resolution rules (local/library × explicit/implicit `Builder`), so `freq_based.invvee:dipole` works the same way `freq_based.invvee` does.
-
-Open question deferred: compositing variants with per-flag overrides (`--set length=5.2`). Not implemented; ad-hoc sweeping still goes through `sweep`/`optimize`.
-
-## ~~Next branch: multi-feed PysimEngine~~ — landed
-
-Discovered to already be working when re-auditing the design tree: 34/35 designs solve cleanly through `PysimEngine.impedance()`, including every multi-feed array previously listed as blocked (`invveearray`, `moxonarray`, `yagiarray`, `bowtiearray{,1x2,2x4}`, `delta_looparray{,_1x4,_1x4_grouped,_2x2}`, `hentenna_array`, `hourglass_array`, `folded_invveearray`, `diamond_loop_turnstile`). The geometry translator emits a `feeds: list[(polyline_idx, arclength, voltage)]` and `PysimEngine.impedance()` returns a list of per-port impedances; `impedance_sweep` normalises its return to `(n_k, n_feeds)` to match PyNECEngine.
-
-The only remaining limitation is `tl_card` (1 design: `delta_looparray_with_tls`).
-
-Cross-validation at design freq, free space (R, X in Ω) — sampled multi-feed arrays vs PyNEC:
-
-| design  | feeds | PyNEC range          | pysim Triangular range | max ΔR | max ΔX |
-|---------|-------|----------------------|------------------------|--------|--------|
-| invveearray | 4 | 48.0…55.4, −7.8…−3.0 | 47.1…54.8, −9.5…−4.8   | 0.95   | 1.82   |
-| moxonarray  | 4 | 43.8…44.3, −28.5…−24.9 | 39.9…40.4, −30.0…−26.4 | 3.95   | 1.51   |
-| yagiarray   | 4 | 81.6…81.9, +2.1     | 83.8…84.1, +0.7…+0.8  | 2.23   | 1.34   |
-
-Same ballpark agreement as the closed-loop work (~few % R, a few Ω X). Cross-validation tests live in `tests/test_pysim_engine.py`.
-
-**Where the interface code lives.** Same call as before: don't move the translator upstream yet. The shape just settled; let it bake.
-
-## ~~Next branch: `tl_card` support in PysimEngine~~ — landed
-
-`PysimEngine.impedance()` handles transmission-line cards by extracting the multi-port Y matrix, stamping each TL's 2×2 admittance contribution at its endpoint pair, then reducing back to the driven-port impedance via nodal analysis with passive-port currents constrained to zero. The original implementation used **N independent solves** as a workaround for pysim's `compute_y_matrix` not supporting junctions; that's been lifted upstream and the engine now calls `compute_y_matrix` directly (one LU + N back-subs instead of N × factor cost).
-
-The path also fixed a latent `AttributeError` — `PysimEngine.__init__` used to call `builder.build_tls()` before `build_wires()` had run, blowing up on builders that populate `self.tls` inside `build_wires`. Order is reversed now.
-
-**Cross-validation surprise.** PyNEC and pysim disagree wildly on `delta_looparray_with_tls` at default params (PyNEC: −77 −18255j; pysim: +55 −3j). Both engines stay self-consistent across frequency and TL length sweeps — this is a genuine modeling-convention difference, not numerical noise. The most likely root cause: NEC2's `tl_card` treats TL endpoints as **segment-level** ports (network attached to the segment as a whole) while my pysim post-processing treats them as **basis-level** ports (delta-gap at the wire midpoint). On simple geometries the two coincide; on this design the central driver is a 10cm gap with effectively zero coupling to the loops in the antenna's own Y matrix, so the TL transformation dominates and the segment-vs-basis distinction blows up the result. Reproducer: `Y[loop, driver] ≈ 3e-7` (essentially decoupled) — every Ω of driver impedance comes from how you stamp the TLs, so the conventions diverge maximally.
-
-What this means going forward: the multi-port Y reduction is mathematically clean (verified: Y symmetric, passive-port `I_ext=0` constraint exact, `coeffs[m] = 1/Z` at the feed for single-port). Self-consistency tests are in `tests/test_pysim_engine.py`; strict PyNEC numerical agreement isn't currently achievable on the one available test fixture. If we ever land another TL design where loop-driver coupling is non-negligible, retry the comparison.
-
-`impedance_sweep` with TLs is implemented: batched Y over k via `compute_y_matrix_swept`, then per-k TL stamping (βl is frequency-dependent) and driven-port reduction. Matches per-k `impedance()` to ~1e-11 on `delta_looparray_with_tls`.
-
-## ~~Next branch: junction support in pysim's `compute_y_matrix`~~ — landed upstream
-
-Originally listed here as a follow-up. Landed in stevenmburns/pysim#78: both `compute_y_matrix` and `compute_y_matrix_swept` now handle junctions via a matrix-RHS Schur-complement KCL solve across all three solvers (triangular, bspline; sinusoidal already worked structurally). The N-solves workaround in `PysimEngine` has been deleted; the engine calls the upstream batched path directly.
+- **Array-block solver** (`d136d68`) — `ArrayBlockPySim` integrated into `PysimEngine` (block-low-rank for phased arrays); shares BSpline segment parity (`a97f488`).
+- **Port-based network spec** (`a09d548`, `6be1f5f`, `5bbfecc`, `4dff155`, `6e024bc`) — `build_network()` returns named logical ports (`PortAtEdge`, `PortVirtual`, `Driven`) and 2-port branches (`TL`, `DiffTL`, `Load`, `TwoPort`); every branch stamps a frequency-dependent 2×2 admittance into Y. `Load` (series/parallel R/L/C, incl. LC traps at exact resonance) lands via a Sherman-Morrison Y stamp. ~15 designs use it (G5RV, Zepp, rhombic, LPDA, T2FD, HB9CV, trap dipole/fan, Sterba variants, etc.). This unblocked lumped-element designs (matching networks, traps, bandpass filters) that previously couldn't be modeled at all. `build_tls()` retained as the legacy path; `NetworkReducer` extracted engine-agnostic (`93b5883`).
+- **Differential TL** (`96336f8`, `14223c0`) — `DiffTL` 2-wire element with `transposed` flag (#89).
+- **`tl_card` in PysimEngine** (`c3535d4`, `6ba7e37`, `1f899dc`, `6c3ddb2`) — multi-port Y extraction + nodal reduction for `impedance()`, then batched swept-k for `impedance_sweep()` (matches per-k `impedance()` to ~1e-11). Junction support in pysim's `compute_y_matrix`/`compute_y_matrix_swept` landed upstream (stevenmburns/pysim#78), replacing the N-solves workaround.
+- **Closed-loop translator** — pure cycles open by cutting at the port edge (driven) or an arbitrary edge (parasitic); cut nodes become 2-entry junctions so pysim's KCL closes the loop. Surprise: bowtie is a single 10-edge cycle (shared corners stay degree-2), not a degree-3 case — falls out of the same path with no special handling.
+- **Multi-feed PysimEngine** — translator emits `feeds: list[(polyline_idx, arclength, voltage)]`; `impedance()` returns per-port Z. Validated against PyNEC on invveearray/moxonarray/yagiarray (≤ ~4 Ω ΔR).
+- **Cross-engine `compare_patterns` CLI** — `--engines pynec|pysim|pysim:triangular|sinusoidal|bspline`; builders × engines combine via numpy-style broadcasting (`broadcast_pairs`), not Cartesian product, so `--builders A B C --engines E1 E2 E3` zips into 3 chosen pairs. Covered by `tests/test_engine_spec.py`.
+- **Named parameter variants** — Builder classes expose variants as `*_params` class attributes (`MappingProxyType`); CLI selector `builder[:variant]`; `default_params` is the unnamed default.
+- **Engine infra** — `segment_parity` infra + parity coercion (`0d5c385`).
 
 ## Next branches (rough priority order)
 
-### 1. Port-based network spec (TL cleanup + lumped R/L/C) — [#65](https://github.com/stevenmburns/antenna_designer/issues/65)
-
-Replace `build_tls()` (NEC2-shaped: segment indices, requires a dummy stub wire) with `build_network()` returning named logical ports and 2-port branches. Same branch shape covers TLs **and** lumped R/L/C — every branch stamps a frequency-dependent 2×2 admittance into Y at the right port pair, which `_apply_tls` is already the prototype of.
-
-PysimEngine loses the dummy stub wire (virtual ports become Y-matrix rows only); PyNECEngine auto-generates the NEC2 hacks via `tl_card` / `ld_card` (segment loading) / `nt_card` (arbitrary 2-port Y between segments). Issue #65 has the full sketch plus seven open design questions to settle before implementation — naming convention for feed edges, ground reference semantics, backwards-compat with `build_tls()`, etc. **Biggest-impact next branch** — unblocks lumped-element designs (matching networks, traps, bandpass filters) which we currently can't model at all.
-
-### 2. Strict PyNEC cross-validation for `tl_card`
-
-`PysimEngine.impedance()` runs cleanly on `delta_looparray_with_tls` but the numerical answer doesn't match PyNEC (segment-vs-basis port convention — see the closed branch above). Two follow-ups, both optional:
-
-- Add a TL design where the in-antenna coupling between TL endpoints isn't near-zero, then re-run the comparison; agreement should be much tighter when the antenna's own Y has meaningful off-diagonal terms.
-- Implement segment-averaging at the TL endpoints (averaged current over the TL-end segment instead of basis coefficient at the midpoint). Closer to NEC2's convention; may reconcile.
-
-### 3. Far-field for the new designs
-
-Stage 2b validated the pattern math on the dipole; once tee-junction geometries are stable, re-run the directivity cross-check on hentenna and fandipole and add a corresponding test. Lower priority — now that cross-engine `compare_patterns` is in the CLI, this is largely a "run it and write a test" task.
+1. **Far-field validation tests for network/loop designs.** `far_field()` works across all bases and loaded-antenna gain is correct (`bcd64c4`); what's missing is a directivity cross-check + regression tests on the tee-junction and network designs (hentenna, fandipole, trap_fan_dipole). Largely a "run `compare_patterns` and write the test" task.
+2. **Strict `tl_card` PyNEC cross-validation** — see Known limitations. Optional; needs either a better-coupled TL test design or segment-averaging at TL endpoints.
+3. **Variant compositing with per-flag overrides** (`--set length=5.2`) — deferred. Ad-hoc parameter sweeping still goes through `sweep` / `optimize`.

--- a/docs/market-research-antenna-simulators.md
+++ b/docs/market-research-antenna-simulators.md
@@ -1,0 +1,245 @@
+# Antenna Simulator Market Research & Competitive Comparison
+
+**Date:** 2026-06-20
+**Subject:** Advertised features of antenna simulation software available on the web, compared against `antenna_designer`.
+
+> **Scope & method.** Capabilities for third-party tools are drawn from official vendor sites, product docs, GitHub, and reputable secondary sources (cited inline). They are **advertised / marketing claims**, not independently benchmarked. `antenna_designer` capabilities are taken from its own source code, docs, and tests (file-cited). Where a vendor gates pricing behind "contact sales," cost figures are flagged as third-party estimates.
+
+---
+
+## 1. Executive summary
+
+The antenna-simulation market splits into three tiers:
+
+1. **High-end commercial full-wave suites** — ANSYS HFSS, CST Studio Suite, Altair/Siemens FEKO, Remcom XFdtd, COMSOL RF, Keysight EMPro/ADS. Multi-solver (FEM/MoM/MLFMM/FDTD/asymptotic), GPU/HPC, multiphysics, CAD import, SAR/RCS/EMC. Quote-only licensing, commonly **$10K–$50K+/yr** (third-party estimates).
+2. **Amateur-radio / affordable MoM tools** — EZNEC (now free), 4nec2 (free), MMANA-GAL (free/€139), AN-SOF ($999–$1,599), xnec2c (GPL), cocoaNEC (free). Almost all are **NEC-2 / MININEC thin-wire MoM**, single basis function, desktop-GUI, platform-locked. **This is `antenna_designer`'s direct competitive tier.**
+3. **Open-source / Python EM ecosystem** — PyNEC/necpp/nec2c (wire MoM), openEMS (FDTD), gprMax (FDTD), Meep (FDTD, photonics-first), Sonnet Lite (planar MoM), scikit-rf (network analysis, *not* a solver), Antenna Magus (synthesis DB, *not* a solver).
+
+**Where `antenna_designer` stands.** It occupies the same numerical niche as one solver inside the big suites (a wire MoM, comparable to FEKO's MoM, HFSS's IE solver, or ADS Momentum). Within its actual competitive tier (free/affordable amateur tools and the open Python ecosystem) it has **three differentiators with essentially no equivalent in the open peer group**:
+
+- **Multiple basis functions** (triangular / sinusoidal / arbitrary-degree B-spline) vs. NEC's single fixed sinusoidal basis and AN-SOF's fixed triangular/pulse.
+- **H-matrix / ACA acceleration + GMRES** for large-N scaling — no open MoM tool (PyNEC, nec2c, xnec2c) advertises fast-matrix/compression methods; they are all dense O(N²).
+- **A modern web UI** (FastAPI + React, real-time Smith/pattern/3D/current plots) — every free peer is a native desktop app or a library/CLI with no GUI.
+
+**Where it lags the field** (mostly vs. the commercial tier, expected for a focused tool): no FEM/FDTD/asymptotic solvers, no GPU/MPI, no multiphysics, no SAR/RCS/EMC, no CAD import, no automatic adaptive meshing, lossy/finite-ground impedance is approximate, and no `.nec` card export (the interoperability lingua franca of the amateur tier).
+
+---
+
+## 2. `antenna_designer` capability baseline
+
+*Source: codebase inventory of `/home/smburns/antennas/antenna_designer` + `pysim` submodule.*
+
+| Dimension | What `antenna_designer` does |
+|---|---|
+| **Solvers** | Two independent engines: **PyNEC** (NEC-2 via `necpp` wrapper) and **pysim** (pure-Python MoM). pysim offers 3 basis families: **TriangularPySim**, **SinusoidalPySim** (NEC2-style 3-term), **BSplinePySim** (degree 1–2, KCL junctions, ground via images). Large-N accelerator solvers, selectable and integrated into `PysimEngine` (impedance, sweep, current, and far-field all supported): **HMatrixPySim** (ACA + GMRES + near-field preconditioner), **ArrayBlockPySim** (block-low-rank for arrays; integrated via PR 103). C++ pybind11 accelerators (`_accelerators.cpp`, libmvec SIMD sincos) for Z-matrix fill. |
+| **Geometry** | 69+ wire designs: dipoles, inverted-V, Yagis, loops (delta/diamond/horizontal), fan/trap dipoles, Moxon, hexbeam, Sterba, LPDA, hentenna, + 25 Cebik reference designs (bobtail, bruce, G5RV, half-square, J-pole, quad, rhombic, W8JK, Zepp…). Arrays (1×4, 2×2, 2×4, grouped). Junctions (KCL), closed loops (driven / parasitic / terminated two-port), bent wires, multi-feed, port-based networks (TL + lumped R/L/C via `build_network`). |
+| **Outputs** | Impedance Z, Γ, SWR, current distribution (knot positions/currents), far-field directivity/gain (dBi), 2D pattern rings, elevation/azimuth cuts, radiation efficiency (loaded antennas), multi-port short-circuit Y. |
+| **Ground** | Free space; PEC (image method, all pysim bases); finite ground (PyNEC full Sommerfeld; pysim = PEC image + Fresnel on reflected wave — **impedance still PEC, an approximation**). |
+| **Sweeps / opt** | Frequency sweep (batched swept-k Y-matrix), parameter sweep, gain sweep, pattern sweep, `scipy.optimize` (SLSQP/L-BFGS-B) parameter optimization, cross-engine comparison. |
+| **UI / viz** | React 18 + Vite web frontend: 3D WebGL geometry, current distribution (mag/phase), Smith chart w/ SWR circle, polar patterns (az/el), frequency-sweep plots, live parameter sliders, solver/ground selection. FastAPI backend, WebSocket sweeps. matplotlib for CLI plots. |
+| **I/O** | Designs as Python builder classes; network spec (TL, DiffTL, Load, TwoPort, ports-at-edges). **NEC cards are input-only** (via PyNEC, for cross-validation). No `.nec` export. matplotlib PNG export. |
+| **Performance** | OpenMP/BLAS threading, libmvec AVX2 sincos, K-independent geometry cache for sweeps, on-demand block eval for H-matrix. H-matrix tested on 100-director Yagi (2142 segments), O(N log N) vs dense O(N²). |
+| **API / CLI** | Python API (`AntennaBuilder`, engines, `sweep*`, `optimize`, `pattern`, `compare_patterns`); CLI subcommands `draw / sweep / optimize / pattern / compare_patterns`; uniform `SimulationEngine` interface. |
+| **Validation / limits** | Cross-validated against PyNEC (≤0.1 dBi directivity on dipole; ~1–3% R on loops and multi-feed arrays). **Genuine open limits:** pysim wires are PEC (no copper loss); pysim finite-ground impedance is approximate (PEC image + Fresnel); `DiffTL` is pysim-only (PyNEC raises `NotImplementedError`); strict `tl_card` numerical agreement with PyNEC is unmet on low-coupling geometries (a segment-vs-basis port-convention difference, not a bug). |
+| **License / platform** | Open-source Python; cross-platform (web UI = browser-based). |
+
+---
+
+## 3. Tier 1 — High-end commercial full-wave suites
+
+*All feature lists are vendor marketing claims. Pricing is quote-only everywhere; estimates are third-party.*
+
+### ANSYS HFSS (Ansys Electronics Desktop)
+- **Solvers:** 3D FEM w/ adaptive meshing (flagship); Integral Equation **MoM**; **SBR+** asymptotic (shooting-bouncing-rays) for electrically-large platforms; FEM Transient; hybrid FEM↔IE↔SBR+ and FE-BI; all built on Domain Decomposition Method (DDM) for HPC.
+- **Antennas:** finite-array DDM (mutual coupling, scan impedance, array edge effects), phased/5G mmWave arrays, encrypted 3D Components, installed/placement on aircraft/vehicles, RCS.
+- **Outputs:** S-params, impedance, gain/directivity, near/far field, scan impedance, RCS, co-site/EMI.
+- **Scale/opt:** Optimetrics + optiSLang (AI/ML design exploration), GPU (CUDA), Mesh Fusion parallel meshing, multiphysics (thermal/structural/Maxwell), Twin Builder circuit co-sim.
+- **Price:** quote-only; ~$10K–$50K+/yr (third-party).
+- Source: [ansys.com/products/electronics/ansys-hfss](https://www.ansys.com/products/electronics/ansys-hfss)
+
+### CST Studio Suite (Dassault SIMULIA)
+- **Solvers:** Time-domain **FIT** + **TLM**; Frequency-domain **FEM** (MOR); Integral Equation **MoM + MLFMM** with **Characteristic Mode Analysis**; Asymptotic **SBR**; Multilayer planar MoM.
+- **Antennas:** installed performance, small-antenna-on-large-structure (hybrid), planar/MMIC, scattering.
+- **Outputs:** multi-port S-params, near/far field, characteristic modes, EMC, SI/PI, RCS.
+- **Scale/opt:** built-in optimization, MPI cluster + GPU; multiphysics (thermal/mechanical/Lorentz); PCB SI/PI/EMC, cable-harness solver; Cadence/Zuken/Altium integration.
+- **Price:** quote-only.
+- Source: [3ds.com/.../cst-studio-suite](https://www.3ds.com/products/simulia/cst-studio-suite/electromagnetic-simulation-solvers)
+
+### Altair / Siemens FEKO *(advertised "market leader for antenna placement")*
+- **Solvers:** the broadest mix — **MoM**, **MLFMM**, **FEM**, **FDTD**, asymptotic **PO / LE-PO / RL-GO / UTD**, **Characteristic Mode Analysis**, true hybridization in one run.
+- **Antennas:** arrays (periodic BC), reflectors/horns, installed performance on electrically-large platforms (flagship), integrated windscreen antennas, radar, EMC.
+- **Outputs:** patterns/gain, near/far field, RCS, SAR, EMC/EMI, shielding, cable coupling, wireless coverage (WinProp).
+- **Scale/opt:** genetic-algorithm + other optimizers, MPI + OpenMP + multi-GPU CUDA, out-of-core; SPICE circuit co-sim.
+- **Price:** quote-only. *(Altair acquired by Siemens; now also under Simcenter branding.)*
+- Source: [help.altair.com/feko/...overview](https://help.altair.com/feko/topics/feko/user_guide/introduction/overview_feko_c.htm)
+
+### Remcom XFdtd
+- **Solvers:** full-wave **FDTD**; XACT conformal sub-cell meshing; PrOGrid optimized gridding.
+- **Antennas:** phased-array / **5G MIMO** w/ beam-steering optimization, mobile-device + hand-grip, biomedical/**SAR** w/ posable human models, placement/coupling.
+- **Outputs:** S-params, VSWR, impedance, active impedance, far-field gain/realized gain/**axial ratio**, near-field E/H/currents, SAR + thermal, efficiency.
+- **Scale/opt:** circuit/array optimizers, **XStream multi-GPU CUDA** + MPI; CAD import (STEP/IGES/STL/CATIA), Schematic Editor circuit solver, Optenni Lab matching.
+- **Price:** quote-only.
+- Source: [remcom.com/xfdtd-3d-em-simulation-software](https://www.remcom.com/xfdtd-3d-em-simulation-software)
+
+### COMSOL Multiphysics — RF Module
+- **Solvers:** **FEM** (order 1/2/3 vector elements) + **BEM** + hybrid FEM-BEM; frequency/transient/eigenfrequency; Model Order Reduction; PMLs; periodic/Floquet for arrays.
+- **Antennas:** arrays + array factor, microstrip patch, horns, fractal monopole, automotive radar, MRI/biomedical.
+- **Outputs:** S-params (Touchstone), impedance/matching, far-field patterns, directivity/gain, RCS, Smith plots, fields.
+- **Scale/opt:** parametric sweeps, Optimization Module, cluster computing; **headline = multiphysics** (RF heating, thermal, structural/thermal stress); CAD Import, LiveLink, Application Builder.
+- **Price:** quote-only (module add-on to base).
+- Source: [comsol.com/rf-module](https://www.comsol.com/rf-module)
+
+### Keysight EMPro / ADS (Momentum + RFPro) / Genesys
+- **Solvers:** EMPro 3D **FEM** + 3D **FDTD**; ADS **Momentum** 3D-planar **MoM** (full-wave + quasi-static); RFPro unifies FEM + planar MoM; Genesys EM = Momentum.
+- **Antennas:** planar antennas / far-field patterns, packaging/shielding/waveguide 3D effects, MMIC/RFIC/SI.
+- **Outputs:** S-params, surface currents, planar patterns, **SAR** (EMPro option).
+- **Scale/opt:** adaptive frequency sweep, GPU (EMPro); **headline = circuit-EM co-simulation** with no offline cleanup; Python scripting, CAD import.
+- **Price:** quote-only (element/bundle within PathWave/ADS).
+- Source: [keysight.com/.../empro-key-features](https://www.keysight.com/us/en/lib/resources/technical-specifications/empro-key-features-1741565.html)
+
+**Tier-1 solver matrix**
+
+| | HFSS | CST | FEKO | XFdtd | COMSOL | Keysight |
+|---|---|---|---|---|---|---|
+| FEM | ✓ | ✓ | ✓ | – | ✓ | ✓ |
+| MoM / MLFMM | ✓ (IE) | ✓ | ✓ (flagship) | – | (BEM) | ✓ (Momentum) |
+| FDTD / FIT / TLM | (transient) | ✓ | ✓ | ✓ (flagship) | (transient) | ✓ |
+| Asymptotic (PO/GO/UTD/SBR) | ✓ | ✓ | ✓ | – | – | – |
+| Characteristic Mode Analysis | – | ✓ | ✓ | – | – | – |
+| GPU acceleration | ✓ | ✓ | ✓ | ✓ | (platform) | ✓ |
+| Multiphysics | ✓ | ✓ | (limited) | (thermal) | ✓ (headline) | – |
+| Circuit co-sim | ✓ | ✓ | ✓ | ✓ | (LiveLink) | ✓ (headline) |
+| SAR / RCS | ✓ | ✓ | ✓ | ✓ | ✓ | (SAR) |
+
+---
+
+## 4. Tier 2 — Amateur-radio / affordable MoM tools *(direct competitors)*
+
+### The underlying engines (NEC-2 / NEC-4 / MININEC)
+- **NEC-2:** MoM solving EFIE (thin wires) + MFIE (surface patches). **Public domain, no license.** Ground: perfect + lossy/real (Sommerfeld-Norton) + radial-screen approximation. Limits: thin-wire kernel degrades for thick/closely-spaced wires; no insulated/buried wires.
+- **NEC-4:** adds accuracy for electrically-small/thick wires, **insulated + buried wires**, current sources, large-model memory. **Proprietary** (LLNL/UC), paid license + **US export control**.
+- **MININEC:** separate MoM lineage (used by MMANA-GAL); different ground/feedpoint behavior than NEC.
+- Source: [en.wikipedia.org/wiki/Numerical_Electromagnetics_Code](https://en.wikipedia.org/wiki/Numerical_Electromagnetics_Code), [softwarelicensing.llnl.gov/product/nec-v42](https://softwarelicensing.llnl.gov/product/nec-v42)
+
+### EZNEC / EZNEC Pro+ (W7EL) — **free since 2022, no support**
+- Engine: internal NEC-2D (Pro/2+) or NEC-4.2 (Pro/4+, needs LLNL license); can call NEC-5.
+- Ground: perfect, Real (Sommerfeld), High-Accuracy, MININEC-type.
+- Outputs: Z, SWR (+plot), gain/directivity, 2D + 3D far-field, current distribution, charge, near field, F/B, takeoff angle, average-gain test.
+- Loads/TL: traps + series/parallel R-L-C, transmission lines. `.NEC` import/export.
+- Viz: wireframe geometry, 2D/3D patterns, SWR plots. No native Smith chart (AutoEZ add-on adds optimization + plots).
+- Segments: historically 500 (std) / 1,500 (+) / up to 45,000 (Pro). **Windows only.**
+- Source: [eznec.com](https://www.eznec.com/)
+
+### 4nec2 (Arie Voors) — **free**
+- Engine: NEC-2 (+ NEC-4 command support). ~11,000 segments (memory-limited in practice).
+- Geometry: full NEC cards (GX/GM/GR/GA/GH transforms, surface patches), graphical structure editor + 3D preview, card text editor.
+- Outputs: Z, SWR, gain, F/B, F/R, efficiency, far + **near field**, current distribution.
+- **Optimizer:** built-in **genetic algorithm** (gain/resonance/SWR/efficiency/F/B/F/R/target-Z via SY variables). Frequency + variable sweeper.
+- Loads/TL: LD + TL cards. Viz: state-of-the-art 3D far/near field, 2D patterns, **Smith chart**.
+- I/O: `.nec`/`.txt` + **imports EZNEC `.ez`**. **Windows** (Linux/macOS via Wine).
+- Source: [qsl.net/4nec2](https://www.qsl.net/4nec2/)
+
+### MMANA-GAL (Basic free; Pro €139 / €699)
+- Engine: modified **MININEC-3** MoM (C++). *Not NEC* — different ground/feedpoint behavior.
+- Limits: Basic 512 wires / 8,192 segments; Pro 3,000 wires / 15,000 segments.
+- Outputs: Z, SWR-vs-f, gain, F/B, current distribution (CSV export), efficiency, 2D + 3D patterns.
+- Optimizer: element length/spacing optimization (min SWR / max gain). TL simulation, LC + Q-match, loads.
+- I/O: native `.maa`. **Windows.** No Smith chart emphasis.
+- Source: [gal-ana.de/basicmm/en](http://gal-ana.de/basicmm/en/)
+
+### AN-SOF (Golden Engineering) — **$999 (Gold) / $1,599 (Platinum); free 50-seg trial**
+- Engine: proprietary **Conformal MoM with Exact Kernel** — *only* tool advertising conformal MoM; models **curved wires natively** (helices/spirals/loops) without staircasing. Triangular basis + pulse testing.
+- Wire/surface: tapered + insulated wires, **microstrip/patch on dielectric/PCB**. Real ground.
+- Outputs: gain, efficiency, Z, **VSWR**, power, **RCS**, currents, near field 2D/3D color, far-field, **reflection on Smith charts**.
+- Optimization: engine in Platinum (configurable cost functions) + script optimizer. TL modeling.
+- **Windows.** Source: [antennasimulator.com/.../pricing](https://antennasimulator.com/index.php/pricing/)
+
+### xnec2c (KJ7LNW) — **free, GPL**
+- Engine: nec2c (NEC-2 in C), multi-threaded (`-j n`, near-linear); v4.3+ accelerated BLAS (ATLAS/OpenBLAS/MKL).
+- Outputs: far + near field, **3D pattern**, gain/Z/VSWR vs f, current/charge (color), F/B, interactive frequency pick.
+- Optimizer: built-in (SY symbolic vars, weighted fitness) + external GA (xnec2c-gao). `.nec` I/O.
+- **Linux / UNIX** (Flatpak). No Smith chart emphasis. Source: [github.com/KJ7LNW/xnec2c](https://github.com/KJ7LNW/xnec2c)
+
+### cocoaNEC (W7AY) — **free, macOS**
+- NEC-2 (+ optional NEC-4); spreadsheet + programming-language input modes; `.nec` card decks; multi-core; standard NEC outputs. Source: [w7ay.net/.../cocoaNEC](http://www.w7ay.net/site/Applications/cocoaNEC/)
+
+**Tier-2 comparison**
+
+| | EZNEC Pro+ | 4nec2 | MMANA-GAL | AN-SOF | xnec2c | cocoaNEC | **antenna_designer** |
+|---|---|---|---|---|---|---|---|
+| Engine | NEC-2/4 | NEC-2 | MININEC-3 | Conformal MoM | nec2c | NEC-2/4 | **NEC-2 + own multi-basis MoM** |
+| Basis functions | 1 (NEC) | 1 (NEC) | 1 (MININEC) | 1 (tri/pulse) | 1 (NEC) | 1 (NEC) | **3 (tri / sin / B-spline)** |
+| Large-N acceleration | – | – | – | – | BLAS threads | – | **H-matrix / ACA + GMRES** |
+| Platform | Windows | Windows | Windows | Windows | Linux | macOS | **Web (cross-platform)** |
+| Price | Free (no support) | Free | Free / €139 | $999+ | Free | Free | **Free / open-source** |
+| 3D pattern | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ (WebGL geometry; pattern polar) |
+| Smith chart | via AutoEZ | ✓ | – | ✓ | – | – | ✓ |
+| Optimizer | via AutoEZ | ✓ (GA) | ✓ | ✓ (Platinum) | ✓ | – | ✓ (scipy) |
+| `.nec` import/export | ✓ / ✓ | ✓ / ✓ | limited | own | ✓ / ✓ | ✓ / ✓ | **input only** |
+| Real/Sommerfeld ground (impedance) | ✓ | ✓ | MININEC | ✓ | ✓ | ✓ | **PyNEC ✓; pysim approx** |
+
+---
+
+## 5. Tier 3 — Open-source / Python ecosystem *(closest peer group)*
+
+- **PyNEC / necpp / nec2c** — the dominant Python **wire MoM** path (`pip install pynec`). NEC-2 physics, single sinusoidal basis, **dense matrix (no acceleration)**, library/CLI only (no GUI). Optimization via external scipy/GA (`antenna-optimizer` PyPI). GPL-2. **This is `antenna_designer`'s most direct peer** — and the one its multi-basis + H-matrix + web UI most clearly surpass. Source: [github.com/tmolteno/python-necpp](https://github.com/tmolteno/python-necpp)
+- **openEMS** — open-source 3D **FDTD** (EC-FDTD), Python/Octave/MATLAB API, NF2FF far-field, S-params/impedance, patterns. MT/SIMD/MPI (no GPU). GPL-3. No built-in optimizer/GUI. Source: [openems.de](https://www.openems.de/)
+- **gprMax** — Python/Cython **FDTD**, GPR-first but antenna-capable (transmission-line feed model, GPR antenna library). OpenMP + **CUDA GPU** + MPI. Source: [gprmax.com](https://www.gprmax.com/)
+- **Meep (MIT)** — Python/Scheme/C++ **FDTD**, photonics-first but has near-to-far-field + antenna pattern examples. MPI (no first-class GPU). GPL. Source: [github.com/NanoComp/meep](https://github.com/NanoComp/meep)
+- **Sonnet Lite** — free tier of commercial planar **MoM**; capped at 2 metal levels / 3 dielectrics / 4 ports / ~1,400 cells. S-params + current animation. GUI, Windows. Source: [sonnetsoftware.com/products/lite](https://www.sonnetsoftware.com/products/lite/)
+- **scikit-rf** — **NOT a field solver**: Python network-parameter (S/Z/Y) analysis, VNA calibration, Touchstone, Smith charts. BSD. Complementary post-processing peer. Source: [scikit-rf.org](https://scikit-rf.org/)
+- **Antenna Magus (Altair/SIMULIA)** — **NOT a solver**: 350+ design synthesis database, exports parametric models to FEKO/CST. Source: [3ds.com/.../antenna-magus](https://www.3ds.com/products/simulia/antenna-magus)
+
+| Tool | Method | Type | Interface | Acceleration | License |
+|---|---|---|---|---|---|
+| **PyNEC/necpp/nec2c** | MoM (wire, 1 basis) | Field solver | Python/C lib | none (dense) | GPL-2 |
+| openEMS | FDTD (3D vol.) | Field solver | Python/Octave + viewer | MT/SIMD/MPI | GPL-3 |
+| gprMax | FDTD (3D vol.) | Field solver | Python/Cython | OpenMP/CUDA/MPI | GPL |
+| Meep | FDTD (photonics) | Field solver | Python/Scheme/C++ | MPI | GPL |
+| Sonnet Lite | MoM (planar) | Field solver | GUI (capped) | – | Free/proprietary |
+| scikit-rf | network params | Analysis (not solver) | Python | – | BSD |
+| Antenna Magus | synthesis | Design DB | GUI → FEKO/CST | – | Proprietary |
+| **antenna_designer** | **MoM (wire, 3 bases)** | **Field solver** | **Web UI + Python/CLI** | **H-matrix/ACA + GMRES** | **Open-source** |
+
+---
+
+## 6. Positioning: differentiators, parity, and gaps
+
+### Genuine differentiators (vs. free/affordable peers)
+1. **Multi-basis MoM** — triangular / sinusoidal / B-spline in one engine. No free peer offers this; only commercial AN-SOF makes basis quality (conformal MoM) a selling point at $999+.
+2. **H-matrix / ACA acceleration + GMRES** — unique among open MoM tools (PyNEC, nec2c, xnec2c are all dense O(N²)). Demonstrated O(N log N) on a 2142-segment Yagi.
+3. **Web UI (FastAPI + React)** — cross-platform by default. Every free competitor is platform-locked desktop (Windows: EZNEC/4nec2/MMANA/AN-SOF, Linux: xnec2c, macOS: cocoaNEC) or GUI-less library (PyNEC, openEMS, Meep).
+4. **Two cross-validating engines in one tool** (PyNEC reference + pysim) — a built-in accuracy check most tools lack.
+5. **Open-source** while matching paid-tier modeling features (AN-SOF charges $999+; MMANA-GAL Pro €139).
+
+### Parity (table-stakes the tool already meets)
+Impedance / SWR / Γ, gain / directivity, far-field 2D patterns, current distribution, frequency sweeps, parameter optimization, Smith chart, 3D geometry view, transmission lines + loads, multi-port networks. These are expected across the whole amateur tier; `antenna_designer` has them.
+
+### Gaps worth noting
+- **No `.nec` card export** — the interoperability lingua franca of the amateur tier (4nec2, EZNEC, xnec2c all read/write `.nec`). Input-only today (`geometry.py`). *Highest-leverage gap to close for adoption / switching cost.*
+- **pysim finite-ground impedance is approximate** (PEC image + Fresnel); only PyNEC does full Sommerfeld. Real-ground HF work (verticals, low dipoles) leans on the PyNEC path.
+- **No copper/conductor loss in pysim** (PEC wires); efficiency on lossy elements requires PyNEC + `ld_card`.
+- **3D radiation-pattern rendering** — competitors (4nec2, EZNEC, MMANA, xnec2c) all advertise full 3D pattern *surfaces*. The solver produces full-sphere far-field data (`far_field()` returns `(n_theta, n_phi)` rings for every basis, including HMatrix/ArrayBlock), but the UI renders it as polar az/el cuts rather than a 3D pattern surface — so this is a rendering gap, not a solver gap.
+- **No FEM/FDTD/asymptotic, GPU/MPI, multiphysics, SAR/RCS/EMC, CAD import, auto-adaptive meshing** — Tier-1 features, out of scope for a focused wire-MoM tool, but worth stating explicitly so the positioning is honest.
+- **Remaining solver caveats** (per `NEXT_STEPS.md`): pysim wires are PEC (no conductor loss); finite-ground impedance is approximate; strict `tl_card` PyNEC numerical agreement is unmet on near-decoupled geometries (segment-vs-basis port convention).
+
+### Suggested positioning statement
+> *An open-source, browser-based wire-antenna MoM simulator for amateur/HF design that uniquely combines multiple basis functions, H-matrix acceleration for large arrays, and a NEC-2 cross-validation engine — delivering paid-tier (AN-SOF/MMANA-Pro) modeling quality for free, with no platform lock-in.*
+
+The two clearest roadmap items implied by the gap analysis: **(1) `.nec` export** for ecosystem interoperability, and **(2) a 3D far-field pattern surface in the UI** (the solver already produces full-sphere data across all bases) to reach visual parity with 4nec2/EZNEC.
+
+---
+
+## 7. Sources
+
+**Tier 1:** [HFSS](https://www.ansys.com/products/electronics/ansys-hfss) · [CST](https://www.3ds.com/products/simulia/cst-studio-suite/electromagnetic-simulation-solvers) · [FEKO](https://help.altair.com/feko/topics/feko/user_guide/introduction/overview_feko_c.htm) · [XFdtd](https://www.remcom.com/xfdtd-3d-em-simulation-software) · [COMSOL RF](https://www.comsol.com/rf-module) · [Keysight EMPro](https://www.keysight.com/us/en/lib/resources/technical-specifications/empro-key-features-1741565.html) · [Momentum](https://www.keysight.com/us/en/product/W3031E/pathwave-momentum.html)
+
+**Tier 2:** [NEC (Wikipedia)](https://en.wikipedia.org/wiki/Numerical_Electromagnetics_Code) · [LLNL NEC v4.2](https://softwarelicensing.llnl.gov/product/nec-v42) · [EZNEC](https://www.eznec.com/) · [4nec2](https://www.qsl.net/4nec2/) · [MMANA-GAL Basic](http://gal-ana.de/basicmm/en/) · [MMANA-GAL Pro](http://gal-ana.de/promm/) · [AN-SOF pricing](https://antennasimulator.com/index.php/pricing/) · [xnec2c](https://github.com/KJ7LNW/xnec2c) · [cocoaNEC](http://www.w7ay.net/site/Applications/cocoaNEC/) · [Cebik: NEC modeling](https://antenna2.github.io/cebik/content/model/nec.html)
+
+**Tier 3:** [PyNEC/necpp](https://github.com/tmolteno/python-necpp) · [pynec PyPI](https://pypi.org/project/pynec/1.7.3.6) · [openEMS](https://www.openems.de/) · [openEMS docs](https://docs.openems.de/intro.html) · [gprMax](https://www.gprmax.com/) · [Meep](https://github.com/NanoComp/meep) · [Sonnet Lite](https://www.sonnetsoftware.com/products/lite/) · [scikit-rf](https://scikit-rf.org/) · [Antenna Magus](https://www.3ds.com/products/simulia/antenna-magus) · [antenna-optimizer PyPI](https://pypi.org/project/antenna-optimizer/)
+
+*Pricing context (third-party estimates):* [ITQlick HFSS pricing](https://www.itqlick.com/ansys-hfss/pricing) · [EpsilonForge commercial EM comparison](https://www.epsilonforge.com/post/commercial-electromagnetic-software/)
+
+---
+
+*Caveats: All third-party feature lists are vendor marketing claims, not independently benchmarked. Commercial pricing is quote-only; figures are third-party estimates. 4nec2's official ~11,000-segment figure conflicts with third-party "tens of thousands" claims. EZNEC per-tier segment limits are from the pre-free product line. `antenna_designer` capabilities are current as of the 2026-06-20 `main` (post-PR-103) and reflect admitted limitations in `NEXT_STEPS.md`.*


### PR DESCRIPTION
## Summary
- Add `docs/market-research-antenna-simulators.md` — a competitive survey of advertised antenna-simulator features across three tiers (commercial full-wave suites, amateur NEC/MoM tools, open-source Python ecosystem), compared against `antenna_designer`'s actual capabilities, with positioning and gap analysis.
- Rewrite `NEXT_STEPS.md` to match the code: parasitic/terminated loops, multi-feed, `tl_card` impedance+sweep, `build_network` (TL + lumped R/L/C), `DiffTL`, and loaded-antenna far field have all landed.
- Remove stale "limitations" (including the contradictory `tl_card`-sweep `NotImplementedError` claim), condense the landed-branch narratives into a changelog, and trim the roadmap to what's genuinely open.
- Docs-only change — CI intentionally skipped via the commit-message directive.

## Test plan
- [x] Docs-only; no code paths touched, no tests required.
- [x] Verified all "landed" claims in the rewritten `NEXT_STEPS.md` against the source and git history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)