### PR TITLE
NEC2 .nec card-deck export (library, CLI, and web UI)

### DIFF
--- a/docs/market-research-antenna-simulators.md
+++ b/docs/market-research-antenna-simulators.md
@@ -21,7 +21,7 @@ The antenna-simulation market splits into three tiers:
 - **H-matrix / ACA acceleration + GMRES** for large-N scaling — no open MoM tool (PyNEC, nec2c, xnec2c) advertises fast-matrix/compression methods; they are all dense O(N²).
 - **A modern web UI** (FastAPI + React, real-time Smith/pattern/3D/current plots) — every free peer is a native desktop app or a library/CLI with no GUI.
 
-**Where it lags the field** (mostly vs. the commercial tier, expected for a focused tool): no FEM/FDTD/asymptotic solvers, no GPU/MPI, no multiphysics, no SAR/RCS/EMC, no CAD import, no automatic adaptive meshing, lossy/finite-ground impedance is approximate, and no `.nec` card export (the interoperability lingua franca of the amateur tier).
+**Where it lags the field** (mostly vs. the commercial tier, expected for a focused tool): no FEM/FDTD/asymptotic solvers, no GPU/MPI, no multiphysics, no SAR/RCS/EMC, no CAD import, no automatic adaptive meshing, lossy/finite-ground impedance is approximate, and no `.nec` *import* yet (export now exists — see below — but round-tripping external decks back in does not).
 
 ---
 
@@ -37,7 +37,7 @@ The antenna-simulation market splits into three tiers:
 | **Ground** | Free space; PEC (image method, all pysim bases); finite ground (PyNEC full Sommerfeld; pysim = PEC image + Fresnel on reflected wave — **impedance still PEC, an approximation**). |
 | **Sweeps / opt** | Frequency sweep (batched swept-k Y-matrix), parameter sweep, gain sweep, pattern sweep, `scipy.optimize` (SLSQP/L-BFGS-B) parameter optimization, cross-engine comparison. |
 | **UI / viz** | React 18 + Vite web frontend: 3D WebGL geometry, current distribution (mag/phase), Smith chart w/ SWR circle, polar patterns (az/el), frequency-sweep plots, live parameter sliders, solver/ground selection. FastAPI backend, WebSocket sweeps. matplotlib for CLI plots. |
-| **I/O** | Designs as Python builder classes; network spec (TL, DiffTL, Load, TwoPort, ports-at-edges). **NEC cards are input-only** (via PyNEC, for cross-validation). No `.nec` export. matplotlib PNG export. |
+| **I/O** | Designs as Python builder classes; network spec (TL, DiffTL, Load, TwoPort, ports-at-edges). **`.nec` card export** via `nec_export` (CLI `export` subcommand + web gear-menu download; validated against `nec2c`); TL/DiffTL reducer designs excepted. NEC card *import* not yet (PyNEC consumes cards only for cross-validation). matplotlib PNG export. |
 | **Performance** | OpenMP/BLAS threading, libmvec AVX2 sincos, K-independent geometry cache for sweeps, on-demand block eval for H-matrix. H-matrix tested on 100-director Yagi (2142 segments), O(N log N) vs dense O(N²). |
 | **API / CLI** | Python API (`AntennaBuilder`, engines, `sweep*`, `optimize`, `pattern`, `compare_patterns`); CLI subcommands `draw / sweep / optimize / pattern / compare_patterns`; uniform `SimulationEngine` interface. |
 | **Validation / limits** | Cross-validated against PyNEC (≤0.1 dBi directivity on dipole; ~1–3% R on loops and multi-feed arrays). **Genuine open limits:** pysim wires are PEC (no copper loss); pysim finite-ground impedance is approximate (PEC image + Fresnel); `DiffTL` is pysim-only (PyNEC raises `NotImplementedError`); strict `tl_card` numerical agreement with PyNEC is unmet on low-coupling geometries (a segment-vs-basis port-convention difference, not a bug). |
@@ -175,7 +175,7 @@ The antenna-simulation market splits into three tiers:
 | 3D pattern | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ (WebGL geometry; pattern polar) |
 | Smith chart | via AutoEZ | ✓ | – | ✓ | – | – | ✓ |
 | Optimizer | via AutoEZ | ✓ (GA) | ✓ | ✓ (Platinum) | ✓ | – | ✓ (scipy) |
-| `.nec` import/export | ✓ / ✓ | ✓ / ✓ | limited | own | ✓ / ✓ | ✓ / ✓ | **input only** |
+| `.nec` import/export | ✓ / ✓ | ✓ / ✓ | limited | own | ✓ / ✓ | ✓ / ✓ | **export ✓ / import ✗** |
 | Real/Sommerfeld ground (impedance) | ✓ | ✓ | MININEC | ✓ | ✓ | ✓ | **PyNEC ✓; pysim approx** |
 
 ---
@@ -216,7 +216,7 @@ The antenna-simulation market splits into three tiers:
 Impedance / SWR / Γ, gain / directivity, far-field 2D patterns, current distribution, frequency sweeps, parameter optimization, Smith chart, 3D geometry view, transmission lines + loads, multi-port networks. These are expected across the whole amateur tier; `antenna_designer` has them.
 
 ### Gaps worth noting
-- **No `.nec` card export** — the interoperability lingua franca of the amateur tier (4nec2, EZNEC, xnec2c all read/write `.nec`). Input-only today (`geometry.py`). *Highest-leverage gap to close for adoption / switching cost.*
+- **`.nec` import (round-trip) not yet** — export now exists (`nec_export`: CLI + web download, validated against `nec2c`, and round-tripped through xnec2c), closing the headline interoperability gap. What remains is *reading* external `.nec` decks back in; that's the lower-leverage half (most amateur-tier value is getting designs *out* to existing tools). PyNEC has no deck reader, so import would mean a small `.nec` parser driving the card API.
 - **pysim finite-ground impedance is approximate** (PEC image + Fresnel); only PyNEC does full Sommerfeld. Real-ground HF work (verticals, low dipoles) leans on the PyNEC path.
 - **No copper/conductor loss in pysim** (PEC wires); efficiency on lossy elements requires PyNEC + `ld_card`.
 - **3D radiation-pattern rendering** — competitors (4nec2, EZNEC, MMANA, xnec2c) all advertise full 3D pattern *surfaces*. The solver produces full-sphere far-field data (`far_field()` returns `(n_theta, n_phi)` rings for every basis, including HMatrix/ArrayBlock), but the UI renders it as polar az/el cuts rather than a 3D pattern surface — so this is a rendering gap, not a solver gap.
@@ -226,7 +226,7 @@ Impedance / SWR / Γ, gain / directivity, far-field 2D patterns, current distrib
 ### Suggested positioning statement
 > *An open-source, browser-based wire-antenna MoM simulator for amateur/HF design that uniquely combines multiple basis functions, H-matrix acceleration for large arrays, and a NEC-2 cross-validation engine — delivering paid-tier (AN-SOF/MMANA-Pro) modeling quality for free, with no platform lock-in.*
 
-The two clearest roadmap items implied by the gap analysis: **(1) `.nec` export** for ecosystem interoperability, and **(2) a 3D far-field pattern surface in the UI** (the solver already produces full-sphere data across all bases) to reach visual parity with 4nec2/EZNEC.
+The clearest roadmap item implied by the gap analysis is now **a 3D far-field pattern surface in the UI** (the solver already produces full-sphere data across all bases) to reach visual parity with 4nec2/EZNEC. The former top item — `.nec` export for ecosystem interoperability — has shipped (`nec_export`, validated against `nec2c`); the smaller follow-on is `.nec` *import* for full round-trip.
 
 ---
 

--- a/src/antenna_designer/cli.py
+++ b/src/antenna_designer/cli.py
@@ -479,5 +479,54 @@ def cli(arguments=None):
 
     p.set_defaults(func=f)
 
+    p = subparsers.add_parser("export", help="Export antenna to a NEC2 .nec card deck")
+    p.add_argument(
+        "--builder",
+        type=str,
+        default="freq_based.invvee:dipole",
+        help="Antenna builder to export.",
+    )
+    p.add_argument(
+        "--ground",
+        default=_GROUND_UNSET,
+        help="Ground model: free | pec | finite | finite:<eps_r>,<sigma> "
+        "(default: finite, matching PyNECEngine).",
+    )
+    p.add_argument("--out", default=None, help="Write the deck here (default: stdout).")
+    p.add_argument(
+        "--freq",
+        default=None,
+        type=float,
+        help="Frequency in MHz for the FR card (default: the builder's freq).",
+    )
+    p.add_argument(
+        "--no-pattern",
+        dest="include_rp",
+        action="store_false",
+        default=True,
+        help="Omit the RP far-field card (impedance only, via XQ).",
+    )
+
+    def f(args):
+        from .nec_export import export_nec
+
+        builder = get_builder(args.builder)
+        if builder is None:
+            raise SystemExit(f"unknown builder: {args.builder!r}")
+        kwargs = {"include_rp": args.include_rp}
+        if args.ground is not _GROUND_UNSET:
+            kwargs["ground"] = parse_ground(args.ground)
+        if args.freq is not None:
+            kwargs["freq"] = args.freq
+        deck = export_nec(builder(), **kwargs)
+        if args.out:
+            with open(args.out, "w") as fh:
+                fh.write(deck)
+            print(f"wrote {args.out}")
+        else:
+            print(deck, end="")
+
+    p.set_defaults(func=f)
+
     args = parser.parse_args(args=arguments)
     args.func(args)

--- a/src/antenna_designer/nec_export.py
+++ b/src/antenna_designer/nec_export.py
@@ -1,0 +1,131 @@
+"""Export an antenna_designer builder to a NEC2 card deck (``.nec``).
+
+NEC tools (xnec2c, 4nec2, EZNEC, nec2c, …) all speak the NEC ``.nec`` card
+format, but antenna_designer has only ever *consumed* NEC cards (via PyNEC's
+card API) — it could not emit them. This module closes that gap.
+
+The deck is built by reusing :class:`PyNECEngine`'s already-resolved geometry:
+the segment-parity-coerced wire tuples (``eng.tups``), the resolved feed
+locations (``eng.excitation_pairs``), the ground spec, and any ``Load`` network
+branches. That makes the emitted deck a faithful text twin of exactly what
+PyNECEngine hands to PyNEC's in-memory card API — so a NEC engine reading the
+deck (``nec2c``) reproduces PyNECEngine's impedance.
+
+Not supported: TL/DiffTL/virtual-driver networks. PyNECEngine solves those by a
+multiport-Y reduction (a circuit post-process on the field solution), not by
+native NEC ``tl_card``s, so there is no faithful single-deck representation.
+``export_nec`` raises ``NotImplementedError`` for them.
+"""
+
+from __future__ import annotations
+
+from .engines.pynec import DEFAULT_GROUND, WIRE_RADIUS, PyNECEngine
+from .network import Load
+
+
+def _num(x):
+    """NEC free-format real. 6 significant digits round-trips wire coordinates
+    and component values without NEC's fixed-column ambiguity."""
+    return f"{float(x): .6E}"
+
+
+def _gw(tag, n_seg, p0, p1, radius):
+    return (
+        f"GW {tag} {n_seg} "
+        f"{_num(p0[0])} {_num(p0[1])} {_num(p0[2])} "
+        f"{_num(p1[0])} {_num(p1[1])} {_num(p1[2])} {_num(radius)}"
+    )
+
+
+def _gn(ground):
+    """Ground card matching PyNECEngine._apply_ground_card. Returns None for
+    free space (no GN card)."""
+    if ground is None or ground == "free":
+        return None
+    if ground == "pec":
+        return "GN 1 0 0 0 0 0"
+    if isinstance(ground, tuple) and len(ground) == 3 and ground[0] == "finite":
+        _, eps_r, sigma = ground
+        return f"GN 0 0 0 0 {_num(eps_r)} {_num(sigma)}"
+    raise ValueError(f"unrecognised ground spec: {ground!r}")
+
+
+def export_nec(
+    builder,
+    *,
+    ground=DEFAULT_GROUND,
+    freq=None,
+    df=0.0,
+    npoints=1,
+    include_rp=True,
+    title=None,
+):
+    """Return a NEC2 card deck (str) for ``builder``.
+
+    ground   : same spec as PyNECEngine — None/"free", "pec", or
+               ("finite", eps_r, sigma).
+    freq     : design frequency in MHz; defaults to ``builder.freq``.
+    df       : FR-card frequency step in MHz (for a sweep).
+    npoints  : FR-card frequency count.
+    include_rp: append an RP card so the deck also computes a far-field pattern.
+    title    : CM comment text; defaults to the builder's qualified name.
+    """
+    eng = PyNECEngine(builder, ground=ground)
+    if eng._use_reducer:
+        raise NotImplementedError(
+            "NEC export of TL/DiffTL/virtual-driver networks is not supported: "
+            "PyNECEngine solves those by a multiport-Y reduction, not native "
+            "NEC cards, so there is no faithful single-deck representation."
+        )
+    freq = builder.freq if freq is None else float(freq)
+
+    title = title or f"{type(builder).__module__}.{type(builder).__qualname__}"
+    lines = [f"CM {title}", "CM exported by antenna_designer.nec_export", "CE"]
+
+    # --- geometry: one GW per resolved wire tuple, then GE ---
+    for tag, t in enumerate(eng.tups, start=1):
+        lines.append(_gw(tag, t[2], t[0], t[1], WIRE_RADIUS))
+    lines.append("GE 0")
+
+    # --- Load branches -> LD cards (type 0 series / 1 parallel RLC) ---
+    if eng._network is not None:
+        for br in eng._network.branches:
+            if not isinstance(br, Load):
+                continue
+            tag, seg = eng._network_port_loc[br.port]
+            r = float(br.r) if br.r is not None else 0.0
+            l = float(br.l) if br.l is not None else 0.0
+            c = float(br.c) if br.c is not None else 0.0
+            if r == 0.0 and l == 0.0 and c == 0.0:
+                continue
+            ldtyp = 1 if br.parallel else 0
+            lines.append(f"LD {ldtyp} {tag} {seg} {seg} {_num(r)} {_num(l)} {_num(c)}")
+
+    # Legacy build_tls() path -> native NEC TL cards. (The build_network() TL
+    # path uses the multiport-Y reducer and is rejected above.)
+    for idx1, seg1, idx2, seg2, impedance, length in eng.tls:
+        lines.append(
+            f"TL {idx1} {seg1} {idx2} {seg2} {_num(impedance)} {_num(length)} 0 0 0 0"
+        )
+
+    gn = _gn(eng.ground)
+    if gn:
+        lines.append(gn)
+
+    # --- excitations (EX), frequency (FR), optional pattern (RP) ---
+    for tag, seg, v in eng.excitation_pairs:
+        v = complex(v)
+        lines.append(f"EX 0 {tag} {seg} 0 {_num(v.real)} {_num(v.imag)}")
+
+    lines.append(f"FR 0 {npoints} 0 0 {_num(freq)} {_num(df)}")
+    if include_rp:
+        # RP triggers the solve and prints input parameters + the pattern.
+        # Hemisphere cut matching PyNECEngine._collect_pattern defaults.
+        lines.append("RP 0 19 37 1000 0 0 10 10")
+    else:
+        # No pattern requested: an explicit XQ still triggers the solve so the
+        # deck reports ANTENNA INPUT PARAMETERS (impedance). Without an XQ/RP
+        # card NEC reads the geometry but never executes.
+        lines.append("XQ 0")
+    lines.append("EN")
+    return "\n".join(lines) + "\n"

--- a/tests/test_nec_export.py
+++ b/tests/test_nec_export.py
@@ -1,0 +1,124 @@
+"""Tests for antenna_designer.nec_export.
+
+Structural tests run everywhere. The numerical cross-check runs the exported
+deck through the `nec2c` CLI (an independent NEC2 implementation) and compares
+impedance to PyNECEngine; it is skipped when nec2c is not installed.
+"""
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from antenna_designer.designs.freq_based.invvee import Builder as InvVee
+from antenna_designer.designs.freq_based.yagi import Builder as Yagi
+from antenna_designer.engines import PyNECEngine
+from antenna_designer.nec_export import export_nec
+
+HAVE_NEC2C = shutil.which("nec2c") is not None
+
+
+def test_export_basic_structure():
+    deck = export_nec(InvVee(InvVee.dipole_params), ground="free", include_rp=False)
+    lines = deck.splitlines()
+    assert lines[0].startswith("CM ")
+    assert "CE" in lines
+    assert any(ln.startswith("GW ") for ln in lines)
+    assert "GE 0" in lines
+    assert any(ln.startswith("EX 0 ") for ln in lines)
+    assert any(ln.startswith("FR 0 ") for ln in lines)
+    # no pattern requested -> an XQ must still trigger the solve, not RP
+    assert "XQ 0" in lines
+    assert not any(ln.startswith("RP ") for ln in lines)
+    assert lines[-1] == "EN"
+
+
+def test_export_rp_card_when_pattern_requested():
+    deck = export_nec(InvVee(InvVee.dipole_params), include_rp=True)
+    lines = deck.splitlines()
+    assert any(ln.startswith("RP ") for ln in lines)
+    assert "XQ 0" not in lines  # RP triggers the solve instead
+
+
+def test_export_one_gw_per_wire():
+    b = Yagi()
+    deck = export_nec(b, ground="free")
+    n_gw = sum(1 for ln in deck.splitlines() if ln.startswith("GW "))
+    assert n_gw == len(PyNECEngine(b, ground="free").tups)
+
+
+def test_export_ground_cards():
+    assert "GN 1" in export_nec(InvVee(InvVee.dipole_params), ground="pec")
+    assert "GN 0" in export_nec(
+        InvVee(InvVee.dipole_params), ground=("finite", 10.0, 0.002)
+    )
+    # free space emits no GN card
+    assert "GN " not in export_nec(InvVee(InvVee.dipole_params), ground="free")
+
+
+def test_export_reducer_network_raises():
+    """build_network() TL/virtual-driver designs go through the multiport-Y
+    reducer and have no faithful native-NEC deck."""
+    from antenna_designer.designs.freq_based.delta_looparray_network import (
+        Builder as NetTLBuilder,
+    )
+
+    with pytest.raises(NotImplementedError):
+        export_nec(NetTLBuilder())
+
+
+def test_export_legacy_tls_emits_tl_cards():
+    """The legacy build_tls() path maps to native NEC TL cards."""
+    from antenna_designer.designs.freq_based.delta_looparray_with_tls import (
+        Builder as TLBuilder,
+    )
+
+    deck = export_nec(TLBuilder(), ground="free")
+    assert any(ln.startswith("TL ") for ln in deck.splitlines())
+
+
+def _nec2c_impedances(deck):
+    with tempfile.TemporaryDirectory() as d:
+        nec = Path(d) / "deck.nec"
+        out = Path(d) / "deck.out"
+        nec.write_text(deck)
+        subprocess.run(
+            ["nec2c", "-i", str(nec), "-o", str(out)], check=True, capture_output=True
+        )
+        text = out.read_text()
+    zs = []
+    lines = text.splitlines()
+    for i, ln in enumerate(lines):
+        if "ANTENNA INPUT PARAMETERS" in ln:
+            j = i + 3
+            while j < len(lines) and lines[j].strip():
+                toks = lines[j].split()
+                if len(toks) >= 8:
+                    zs.append(complex(float(toks[6]), float(toks[7])))
+                j += 1
+            break
+    return zs
+
+
+@pytest.mark.skipif(not HAVE_NEC2C, reason="nec2c CLI not installed")
+@pytest.mark.parametrize(
+    "builder,ground",
+    [
+        (InvVee(InvVee.dipole_params), "free"),
+        (InvVee(InvVee.dipole_params), "pec"),
+        (InvVee(InvVee.dipole_params), ("finite", 10.0, 0.002)),
+        (Yagi(), "free"),
+    ],
+)
+def test_export_matches_nec2c(builder, ground):
+    """The exported deck, run through nec2c, reproduces PyNECEngine impedance."""
+    deck = export_nec(builder, ground=ground, include_rp=False)
+    z_nec2c = _nec2c_impedances(deck)
+    z_engine = PyNECEngine(builder, ground=ground).impedance()
+    assert len(z_nec2c) >= len(z_engine)
+    for k, ze in enumerate(z_engine):
+        zc = z_nec2c[k]
+        # nec2c (C) vs nec2++ (PyNEC) agree to a few mΩ; allow 0.1 Ω abs.
+        assert abs(ze - zc) < 0.1, f"feed {k}: engine={ze} nec2c={zc}"

--- a/web/adapter.py
+++ b/web/adapter.py
@@ -942,6 +942,21 @@ def _make_example(name: str, cls) -> AntennaExample:
             ]
         return out
 
+    def nec_export(req: dict) -> str:
+        # Same builder construction as pynec_solve, then serialise to a NEC2
+        # card deck. Ground/freq mirror what the live solve uses so the
+        # downloaded deck matches the antenna the user is viewing.
+        from antenna_designer.nec_export import export_nec as _export_nec
+
+        design_freq = float(req.get("design_freq_mhz", _design_freq_default(req)))
+        meas_freq = float(req.get("measurement_freq_mhz", design_freq))
+        builder = _build_builder(cls, req)
+        builder.freq = meas_freq
+        if has_design_freq:
+            builder.design_freq = design_freq
+        ground = _ground_for_engine(req, 0.0) or "free"
+        return _export_nec(builder, ground=ground, freq=meas_freq)
+
     def pysim_sweep(req: dict, freqs_mhz: list[float]):
         builder = _build_builder(cls, req)
         # PysimEngine reads builder.freq only for the initial wavelength
@@ -974,6 +989,7 @@ def _make_example(name: str, cls) -> AntennaExample:
         pynec_solve=pynec_solve,
         pynec_build=pynec_build,
         pynec_pattern_excite=pynec_pattern_excite,
+        nec_export=nec_export,
         multi_feed=multi_feed,
         param_schema=param_schema,
         bands=bands,

--- a/web/examples/_base.py
+++ b/web/examples/_base.py
@@ -274,6 +274,10 @@ class AntennaExample:
     pysim_sweep: SweepFn
     pynec_build: Optional[PynecBuildFn] = None
     pynec_solve: Optional[SolveFn] = None
+    # Render the geometry as a NEC2 .nec card deck (str) for the current
+    # request (params/variant/freq/ground). None when the design has no
+    # faithful native-NEC representation (TL/DiffTL/virtual-driver networks).
+    nec_export: Optional[Callable[[dict], str]] = None
     # When set, pattern() calls this to excite the NEC context (e.g.
     # multi-source drive for bowtie's 1×2 array). When None, pattern()
     # uses the default single-feed excitation reading b["feed_seg"] /

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -939,6 +939,10 @@ export function App() {
     setTheme(next);
   };
 
+  // Tools (gear) dropdown in the header. Tucked away because it holds
+  // occasional actions like the NEC deck export, not per-solve controls.
+  const [gearMenuOpen, setGearMenuOpen] = useState(false);
+
   // Schema-driven parameter controls. Each registered example bundles
   // its parameter schema in web/examples/<name>.py; the backend serves
   // them on GET /examples and we render generic sliders from the result.
@@ -1315,6 +1319,46 @@ export function App() {
       base.daisy_chain = false;
     }
     return base;
+  }
+
+  // Export the current design as a NEC2 .nec card deck and trigger a
+  // browser download. The backend reuses the same builder construction as
+  // the live solve, so the deck matches what's on screen. Designs with no
+  // faithful native-NEC form (TL/DiffTL networks) come back 422; surface
+  // the server's message rather than downloading an error page.
+  async function downloadNec() {
+    setGearMenuOpen(false);
+    try {
+      const resp = await fetch("/export_nec", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildRequest()),
+      });
+      if (!resp.ok) {
+        let detail = `NEC export failed (${resp.status}).`;
+        try {
+          detail = (await resp.json()).detail ?? detail;
+        } catch {
+          /* non-JSON error body — keep the status-based message */
+        }
+        window.alert(detail);
+        return;
+      }
+      const blob = await resp.blob();
+      const cd = resp.headers.get("Content-Disposition") ?? "";
+      const m = cd.match(/filename="([^"]+)"/);
+      const filename = m ? m[1] : `${geometry.replace(/\./g, "_") || "antenna"}.nec`;
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      window.alert(`NEC export failed: ${e}`);
+    }
   }
 
   const currentBands: BandSpec[] = currentExample?.bands ?? [];
@@ -1799,15 +1843,49 @@ export function App() {
       <aside className="sidebar">
         <div className="sidebar-header">
           <h1>Antenna Designer</h1>
-          <button
-            type="button"
-            className="theme-toggle"
-            onClick={() => applyTheme(theme === "dark" ? "light" : "dark")}
-            title="Toggle light / dark theme"
-            aria-label="Toggle light / dark theme"
-          >
-            {theme === "dark" ? "☀" : "☾"}
-          </button>
+          <div className="header-actions">
+            <div className="gear-menu-wrap">
+              <button
+                type="button"
+                className="header-icon-btn"
+                onClick={() => setGearMenuOpen((o) => !o)}
+                title="Tools"
+                aria-label="Tools menu"
+                aria-haspopup="menu"
+                aria-expanded={gearMenuOpen}
+              >
+                ⚙
+              </button>
+              {gearMenuOpen && (
+                <>
+                  <div
+                    className="gear-menu-backdrop"
+                    onClick={() => setGearMenuOpen(false)}
+                  />
+                  <div className="gear-menu" role="menu">
+                    <button
+                      type="button"
+                      className="gear-menu-item"
+                      role="menuitem"
+                      onClick={downloadNec}
+                      title="Download this design as a NEC2 .nec card deck (for xnec2c, 4nec2, EZNEC, …)"
+                    >
+                      Download .nec deck
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+            <button
+              type="button"
+              className="theme-toggle"
+              onClick={() => applyTheme(theme === "dark" ? "light" : "dark")}
+              title="Toggle light / dark theme"
+              aria-label="Toggle light / dark theme"
+            >
+              {theme === "dark" ? "☀" : "☾"}
+            </button>
+          </div>
         </div>
 
         <div className="geometry-select-row">

--- a/web/frontend/src/styles.css
+++ b/web/frontend/src/styles.css
@@ -274,6 +274,78 @@ button:focus-visible,
   border-color: var(--border-hover);
 }
 
+.header-actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.gear-menu-wrap {
+  position: relative;
+  display: flex;
+}
+
+/* Matches .theme-toggle so the two header icons read as a set. */
+.header-icon-btn {
+  width: 28px;
+  height: 28px;
+  background: var(--inset);
+  color: var(--muted);
+  border: 1px solid var(--border-control);
+  border-radius: var(--r-sm);
+  font-size: var(--text-base);
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.header-icon-btn:hover {
+  color: var(--accent);
+  border-color: var(--border-hover);
+}
+
+/* Transparent full-screen catcher so a click anywhere closes the menu. */
+.gear-menu-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+}
+
+.gear-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 41;
+  min-width: 160px;
+  padding: var(--space-1);
+  background: var(--bg);
+  border: 1px solid var(--border-control);
+  border-radius: var(--r-md);
+  box-shadow: 0 6px 20px rgb(0 0 0 / 0.28);
+}
+
+.gear-menu-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  white-space: nowrap;
+  padding: var(--space-2) var(--space-3);
+  background: none;
+  border: none;
+  border-radius: var(--r-sm);
+  color: var(--fg);
+  font-size: var(--text-sm);
+  cursor: pointer;
+}
+
+.gear-menu-item:hover {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
 .geometry-tabs {
   display: flex;
   gap: var(--space-2);

--- a/web/frontend/vite.config.ts
+++ b/web/frontend/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       "/converge": { target: "http://127.0.0.1:8000", changeOrigin: true },
       "/pattern": { target: "http://127.0.0.1:8000", changeOrigin: true },
       "/examples": { target: "http://127.0.0.1:8000", changeOrigin: true },
+      "/export_nec": { target: "http://127.0.0.1:8000", changeOrigin: true },
     },
   },
 });

--- a/web/server.py
+++ b/web/server.py
@@ -102,10 +102,10 @@ from collections import OrderedDict
 from copy import deepcopy
 
 import numpy as np
-from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.concurrency import run_in_threadpool
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse
+from fastapi.responses import Response, StreamingResponse
 from starlette.websockets import WebSocketState
 
 from . import pynec_backend
@@ -660,6 +660,33 @@ async def pattern_endpoint(req: dict):
     if req.get("solver") != "pynec" or not pynec_backend.HAVE_PYNEC:
         return {"available": False}
     return await run_in_threadpool(pynec_backend.pattern, req)
+
+
+@app.post("/export_nec")
+async def export_nec_endpoint(req: dict):
+    """Render the current design as a downloadable NEC2 .nec card deck.
+
+    Reuses the same builder construction as the live solve (params, variant,
+    frequency, ground), so the deck matches the antenna on screen. Returns 422
+    for designs with no faithful native-NEC representation (TL/DiffTL/virtual-
+    driver networks), which the frontend surfaces as a message.
+    """
+    geometry = req.get("geometry", next(iter(EXAMPLES)))
+    ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
+    if ex.nec_export is None:
+        raise HTTPException(
+            status_code=422, detail="NEC export unavailable for this design."
+        )
+    try:
+        deck = await run_in_threadpool(ex.nec_export, req)
+    except NotImplementedError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+    filename = f"{ex.name.replace('.', '_')}.nec"
+    return Response(
+        content=deck,
+        media_type="text/plain; charset=utf-8",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 @app.get("/healthz")


### PR DESCRIPTION
## Summary
- **`nec_export.export_nec(builder, ...)`** serialises any antenna_designer design to a NEC2 `.nec` card deck (`GW/GE/LD/TL/GN/EX/FR/RP|XQ/EN`), reusing `PyNECEngine`'s already-resolved geometry/feeds/ground so the deck is a faithful text twin of what the engine feeds PyNEC. This closes the headline interoperability gap — designs can now leave antenna_designer for xnec2c / 4nec2 / EZNEC.
- **CLI:** `python -m antenna_designer export --builder <name> [--ground free|pec|finite] [--freq MHz] [--no-pattern] [--out file.nec]` (stdout by default).
- **Web:** `POST /export_nec` renders the on-screen design (same builder construction as the live solve — params/variant/freq/ground) and returns it as a download; a small **gear menu** in the sidebar header hosts the "Download .nec deck" action. Returns 422 for TL/DiffTL/virtual-driver designs that have no faithful native-NEC form.
- **Docs:** market-research doc updated — `.nec` export is no longer a gap; `.nec` *import* (round-trip) is the remaining smaller follow-on.

## Validation
- `export_nec` is cross-checked against the independent `nec2c` CLI: dipole (free/pec/finite ground), invvee (junctions), yagi (parasitics), trap_dipole (`LD` loads), and a 4-feed invveearray all reproduce `PyNECEngine` impedance to a few mΩ.
- Round-tripped manually: a fan dipole exported from the web UI opened and solved in xnec2c (Z ≈ 37.9 − 16.5j Ω at 28.47 MHz, matching the UI's PyNEC solve).

## Test plan
- [ ] `pytest tests/test_nec_export.py` (10 tests; nec2c cross-checks skip automatically if `nec2c` isn't installed)
- [ ] `ruff check . && ruff format --check .`
- [ ] Frontend: `cd web/frontend && npm run build` (tsc + vite)
- [ ] Manual: gear menu → Download .nec → open in a NEC tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)