### PR TITLE
Web UI: instant antenna switch (preview + no stale results) and array-block default

### DIFF
--- a/src/antenna_designer/engines/pysim.py
+++ b/src/antenna_designer/engines/pysim.py
@@ -365,6 +365,27 @@ class PysimEngine(SimulationEngine):
             )
         return out
 
+    def geometry_distribution(self):
+        """Per-wire knot positions with zero currents — a cheap geometry-only
+        snapshot that skips the (possibly slow) MoM solve.
+
+        Same shape as `current_distribution()` so the web layer can pack it
+        with the same helper, but it only reads `_polylines` / `_edge_segments`
+        (both built in `__init__`), so it returns in milliseconds even for
+        large arrays. The UI uses it to draw a newly-selected antenna's shape
+        immediately, then fills in the heatmap/waveforms when the real solve
+        lands."""
+        out = []
+        for w_idx, polyline in enumerate(self._polylines):
+            knots = _polyline_knots(polyline, self._edge_segments[w_idx])
+            out.append(
+                WireCurrents(
+                    knot_positions=np.ascontiguousarray(knots),
+                    knot_currents=np.zeros(knots.shape[0], dtype=np.complex128),
+                )
+            )
+        return out
+
     def _segment_dipoles(self, sim, coeffs):
         """Returns (mid, dr, i_mid) — concatenated per-segment midpoints,
         edge vectors, and midpoint currents from the MoM solution."""

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -455,6 +455,42 @@ def test_pattern_endpoint_pysim_returns_unavailable(client: TestClient):
     assert r.json() == {"available": False}
 
 
+def test_geometry_endpoint_returns_wires_without_solving(client: TestClient):
+    # The fast antenna-shape preview: wires + feed marker, zero currents, and
+    # no impedance/far-field (those come from the live solve). Geometry is
+    # solver-independent, so it answers even with solver=pynec.
+    r = client.post(
+        "/geometry",
+        json={
+            "geometry": "freq_based.invvee",
+            "design_freq_mhz": 28.47,
+            "measurement_freq_mhz": 28.47,
+            "solver": "pynec",
+        },
+    )
+    assert r.status_code == 200
+    out = r.json()
+    assert out["geometry"] == "freq_based.invvee"
+    assert out["preview"] is True
+    assert out["solver"] == "pysim"
+    assert len(out["wires"]) >= 1
+    # Geometry only — every current is zero, and the solve never ran.
+    assert "z_in_re" not in out
+    for w in out["wires"]:
+        assert len(w["knot_positions"]) > 0
+        assert all(c == 0 for c in w["knot_currents_re"])
+        assert all(c == 0 for c in w["knot_currents_im"])
+    assert "feed_position" in out
+
+
+def test_geometry_endpoint_falls_back_when_geometry_unknown(client: TestClient):
+    r = client.post("/geometry", json={"geometry": "does.not.exist"})
+    assert r.status_code == 200
+    out = r.json()
+    # Falls back to the first registered example rather than erroring.
+    assert "wires" in out and len(out["wires"]) >= 1
+
+
 # ---------------------------------------------------------------------------
 # _solve_z_only — pure helper inlined from converge's per-point loop.
 # ---------------------------------------------------------------------------

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -483,6 +483,20 @@ def test_geometry_endpoint_returns_wires_without_solving(client: TestClient):
     assert "feed_position" in out
 
 
+def test_examples_carry_default_backend(client: TestClient):
+    # Every example exposes default_backend (str | null). Grid arrays recommend
+    # the array-block accelerator; single-element designs keep the UI default
+    # (null) so their basis/results are unchanged.
+    payload = client.get("/examples").json()
+    by_name = {e["name"]: e for e in payload["examples"]}
+    for e in payload["examples"]:
+        assert "default_backend" in e
+        assert e["default_backend"] in (None, "arrayblock")
+    assert by_name["bowtiearray2x4"]["default_backend"] == "arrayblock"
+    # A plain single-element design keeps the default.
+    assert by_name["bowtie"]["default_backend"] is None
+
+
 def test_geometry_endpoint_falls_back_when_geometry_unknown(client: TestClient):
     r = client.post("/geometry", json={"geometry": "does.not.exist"})
     assert r.status_code == 200

--- a/web/adapter.py
+++ b/web/adapter.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import importlib
 import pathlib
 import time
+from functools import lru_cache
 from typing import Any
 
 import numpy as np
@@ -717,6 +718,53 @@ def _auto_default_view(cls) -> str:
     return "".join(sorted(s[0] for s in spans[:2]))
 
 
+@lru_cache(maxsize=None)
+def _recommended_backend(cls) -> str | None:
+    """Recommend a default solver for the design, or None to let the UI keep
+    its own default (the dense Triangular path).
+
+    Returns "arrayblock" for true grid arrays — multiple electrically separate
+    elements with at least one repeated shape — where the element-aware block
+    solver is dramatically faster than the dense default (e.g. bowtiearray2x4:
+    ~1 s vs ~8 s). Single-element designs, and multi-element designs whose
+    elements are all distinct (Yagi-style), keep the dense default so their
+    basis/results are unchanged. Detection is geometry-only (no solve) and any
+    failure falls back to None.
+
+    Memoised per design class: it already runs only once per design at registry
+    build (the result is baked into the immutable `AntennaExample`, which the
+    /examples endpoint and the frontend read at runtime — a slider change never
+    re-runs it), but `lru_cache` makes that a hard guarantee regardless of
+    call site.
+    """
+    try:
+        from pysim.array_block import _wire_to_element
+
+        builder = _build_builder(cls, {})
+        eng = _make_pysim_engine({}, builder)
+        polylines = [np.asarray(p, dtype=float) for p in eng._polylines]
+    except Exception:
+        return None
+    if len(polylines) < 2:
+        return None
+    wire_elem, n_elem = _wire_to_element(polylines)
+    if n_elem < 2:
+        return None
+    # Signature each element by its points recentred on its own centroid; a
+    # repeated shape (fewer distinct signatures than elements) marks a real
+    # array — exactly what array-block accelerates via per-shape block reuse.
+    sigs = set()
+    for e in range(n_elem):
+        pts = np.vstack(
+            [polylines[w] for w in range(len(polylines)) if wire_elem[w] == e]
+        )
+        pts = pts - pts.mean(axis=0)
+        key = np.round(pts / 1e-4).astype(np.int64)
+        key = key[np.lexsort(key.T)]
+        sigs.add(key.tobytes())
+    return "arrayblock" if len(sigs) < n_elem else None
+
+
 def _make_example(name: str, cls) -> AntennaExample:
     dp = dict(cls.default_params)
     ui = dict(dp.get("ui_params") or {})
@@ -1018,6 +1066,7 @@ def _make_example(name: str, cls) -> AntennaExample:
         pysim_solve=pysim_solve,
         pysim_sweep=pysim_sweep,
         pysim_geometry=pysim_geometry,
+        default_backend=_recommended_backend(cls),
         pynec_solve=pynec_solve,
         pynec_build=pynec_build,
         pynec_pattern_excite=pynec_pattern_excite,

--- a/web/adapter.py
+++ b/web/adapter.py
@@ -835,6 +835,37 @@ def _make_example(name: str, cls) -> AntennaExample:
             ]
         return out
 
+    def pysim_geometry(req: dict) -> dict:
+        # Geometry-only snapshot: build the engine (cheap — geometry is
+        # resolved in the constructor) and read its wire knot positions
+        # without solving. The frontend draws this immediately on antenna
+        # selection so a large design's shape shows up right away instead of
+        # waiting tens of seconds for the MoM solve. Mirrors pysim_solve's
+        # builder setup but returns zero currents and omits impedance / far
+        # field (the live solve fills those in).
+        design_freq = float(req.get("design_freq_mhz", _design_freq_default(req)))
+        meas_freq = float(req.get("measurement_freq_mhz", design_freq))
+        builder = _build_builder(cls, req)
+        builder.freq = meas_freq
+        if has_design_freq:
+            builder.design_freq = design_freq
+        eng = _make_pysim_engine(req, builder)
+        geom = eng.geometry_distribution()
+        feed_wire_idx, feed_knot_idx = _feed_indices(eng, geom)
+        return {
+            "geometry": name,
+            "wires": _pack_wires(geom),
+            "feed_wire_index": feed_wire_idx,
+            "feed_knot_index": feed_knot_idx,
+            "feed_position": _feed_position(eng, geom),
+            "design_freq_mhz": design_freq,
+            "measurement_freq_mhz": meas_freq,
+            "lambda_design_m": C_LIGHT / (design_freq * 1e6),
+            "ground": bool(req.get("ground", False)),
+            "z0_ohms": target_z0,
+            "preview": True,
+        }
+
     def pynec_build(req: dict) -> dict:
         # web.pynec_backend.pattern() expects this to return a build
         # dict with at least:
@@ -986,6 +1017,7 @@ def _make_example(name: str, cls) -> AntennaExample:
         label=name.replace("_", " "),
         pysim_solve=pysim_solve,
         pysim_sweep=pysim_sweep,
+        pysim_geometry=pysim_geometry,
         pynec_solve=pynec_solve,
         pynec_build=pynec_build,
         pynec_pattern_excite=pynec_pattern_excite,

--- a/web/examples/_base.py
+++ b/web/examples/_base.py
@@ -272,6 +272,10 @@ class AntennaExample:
     label: str
     pysim_solve: SolveFn
     pysim_sweep: SweepFn
+    # Geometry-only snapshot (wires, feed marker; no solve, no currents) for a
+    # fast antenna-shape preview while the real solve runs. Optional so an
+    # example without one degrades to "no preview".
+    pysim_geometry: Optional[SolveFn] = None
     pynec_build: Optional[PynecBuildFn] = None
     pynec_solve: Optional[SolveFn] = None
     # Render the geometry as a NEC2 .nec card deck (str) for the current

--- a/web/examples/_base.py
+++ b/web/examples/_base.py
@@ -276,6 +276,11 @@ class AntennaExample:
     # fast antenna-shape preview while the real solve runs. Optional so an
     # example without one degrades to "no preview".
     pysim_geometry: Optional[SolveFn] = None
+    # Recommended default solver backend for this design (e.g. "arrayblock" for
+    # grid arrays, where it's far faster than the dense default). None lets the
+    # UI keep its own default. Surfaced in the /examples schema; the frontend
+    # seeds the active slot's backend from it on antenna selection.
+    default_backend: Optional[str] = None
     pynec_build: Optional[PynecBuildFn] = None
     pynec_solve: Optional[SolveFn] = None
     # Render the geometry as a NEC2 .nec card deck (str) for the current

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -1513,10 +1513,10 @@ export function App() {
     if (!sweepEnabled) {
       return;
     }
-    sweepTimerRef.current = window.setTimeout(() => {
-      runSweep();
-      sweepTimerRef.current = null;
-    }, 500);
+    // runSweep itself waits for the live solve to finish before it starts
+    // (see its guard), so the dwell effectively begins once the heatmap solve
+    // has returned rather than competing with it.
+    sweepTimerRef.current = window.setTimeout(runSweep, 500);
     return () => {
       if (sweepTimerRef.current) window.clearTimeout(sweepTimerRef.current);
     };
@@ -1545,10 +1545,8 @@ export function App() {
     if (!convergeEnabled) {
       return;
     }
-    convergeTimerRef.current = window.setTimeout(() => {
-      runConverge();
-      convergeTimerRef.current = null;
-    }, 500);
+    // Like the sweep, runConverge waits for the live solve before starting.
+    convergeTimerRef.current = window.setTimeout(runConverge, 500);
     return () => {
       if (convergeTimerRef.current) window.clearTimeout(convergeTimerRef.current);
     };
@@ -1583,6 +1581,17 @@ export function App() {
   ]);
 
   async function runSweep() {
+    // Hold off until the live /ws solve (the one that fills in the heatmap,
+    // impedance, and far field) has returned. Its 41 background freq solves
+    // would otherwise share CPU with it and stretch the time-to-heatmap — the
+    // pain that motivated this on large arrays. Re-poll until the main solve is
+    // idle, then proceed; the input-change effect cancels this timer on the
+    // next change, so rapid edits still debounce.
+    if (inFlightRef.current || pendingRef.current) {
+      sweepTimerRef.current = window.setTimeout(runSweep, 200);
+      return;
+    }
+    sweepTimerRef.current = null;
     sweepAbortRef.current?.abort();
     const controller = new AbortController();
     sweepAbortRef.current = controller;
@@ -1692,6 +1701,14 @@ export function App() {
   }
 
   async function runConverge() {
+    // Same as runSweep: defer the converge ladder (another batch of solves)
+    // until the live solve has returned, so it never competes with the solve
+    // that draws the heatmap.
+    if (inFlightRef.current || pendingRef.current) {
+      convergeTimerRef.current = window.setTimeout(runConverge, 200);
+      return;
+    }
+    convergeTimerRef.current = null;
     convergeAbortRef.current?.abort();
     const controller = new AbortController();
     convergeAbortRef.current = controller;

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -122,6 +122,11 @@ type ExampleDescriptor = {
   /** The freq this antenna is naturally designed for. Used by the
    *  band-snap-on-example-change effect; null = no preferred freq. */
   default_freq_mhz: number | null;
+  /** Recommended solver backend for this design (e.g. "arrayblock" for grid
+   *  arrays). The active slot's backend is seeded from this on selection
+   *  unless the user has manually picked a backend. null = keep the UI
+   *  default. */
+  default_backend: Backend | null;
   /** True when the Builder has a `design_freq` param that scales
    *  geometry (freq_based.* designs). When false, the design-freq
    *  band-tab row is hidden because dragging it would be a no-op. */
@@ -1114,6 +1119,9 @@ export function App() {
   // and tune each one independently from its gear menu.
   const [activeSlot, setActiveSlot] = useState<Slot>("A");
   const [slots, setSlots] = useState<Record<Slot, SlotConfig>>(DEFAULT_SLOTS);
+  // Set once the user picks a backend by hand; after that we stop auto-seeding
+  // the per-antenna recommended solver so their choice sticks.
+  const backendTouchedRef = useRef(false);
   const [gearOpen, setGearOpen] = useState<Slot | null>(null);
   const activeConfig = slots[activeSlot];
   const backend = activeConfig.backend;
@@ -1222,6 +1230,21 @@ export function App() {
   // Explicit user override sticks until the next geometry change.
   useEffect(() => {
     if (currentExample) setCameraProjection(currentExample.default_view);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentExample?.name]);
+
+  // Seed the active slot's solver from the example's recommendation on antenna
+  // selection — e.g. grid arrays default to the array-block accelerator, which
+  // is ~8x faster than the dense Triangular default. Only *upgrades* a dense
+  // pysim backend; an explicit PyNEC pick, an already-accelerated backend, or
+  // any hand-picked choice (backendTouchedRef) is left untouched.
+  useEffect(() => {
+    const rec = currentExample?.default_backend;
+    if (!rec || backendTouchedRef.current || !BACKEND_ORDER.includes(rec)) return;
+    const cur = slots[activeSlot].backend;
+    const upgradable =
+      cur === "triangular" || cur === "sinusoidal" || cur === "bspline";
+    if (upgradable && cur !== rec) setSlotBackend(activeSlot, rec);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentExample?.name]);
 
@@ -2298,7 +2321,10 @@ export function App() {
             slot={gearOpen}
             backend={slots[gearOpen].backend}
             opts={slots[gearOpen].opts}
-            onChangeBackend={(b) => setSlotBackend(gearOpen, b)}
+            onChangeBackend={(b) => {
+              backendTouchedRef.current = true;
+              setSlotBackend(gearOpen, b);
+            }}
             onPatch={(patch) => updateSlotOpts(gearOpen, patch)}
             onReset={() => resetSlot(gearOpen)}
             onClose={() => setGearOpen(null)}

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -1194,6 +1194,12 @@ export function App() {
   // measFreq still follows designFreq via the linkMeas useEffect below.
 
   const [result, setResult] = useState<SolveResponse | null>(null);
+  // Geometry-only snapshot of the just-selected antenna (wires + feed marker,
+  // no currents), fetched fast so a large design's shape renders immediately
+  // instead of waiting tens of seconds for the full solve. Superseded by
+  // `result` the moment the real solve lands; only consulted while result is
+  // null (i.e. right after an antenna switch).
+  const [preview, setPreview] = useState<SolveResponse | null>(null);
   const [status, setStatus] = useState<"connecting" | "open" | "closed">("connecting");
   const [rttMs, setRttMs] = useState<number | null>(null);
   const [sweep, setSweep] = useState<SweepData | null>(null);
@@ -1267,6 +1273,12 @@ export function App() {
   const patternAbortRef = useRef<AbortController | null>(null);
   const convergeTimerRef = useRef<number | null>(null);
   const convergeAbortRef = useRef<AbortController | null>(null);
+  const previewAbortRef = useRef<AbortController | null>(null);
+  // Latest selected antenna, mirrored into a ref so the (mount-once) WebSocket
+  // onmessage handler can drop responses for an antenna the user already
+  // switched away from. Updated every render — cheap and always current.
+  const geometryRef = useRef(geometry);
+  geometryRef.current = geometry;
 
   const wsRef = useRef<WebSocket | null>(null);
   const inFlightRef = useRef(false);
@@ -1447,6 +1459,39 @@ export function App() {
     designFreq, measFreq,
     groundEnabled, groundFast, heightM,
   ]);
+
+  // Antenna switch: drop the previous antenna's results immediately so nothing
+  // stale lingers (the old geometry/impedance/far-field would otherwise stay on
+  // screen for the tens of seconds a large array takes to solve), then fetch a
+  // fast geometry-only preview so the NEW antenna's shape draws right away. The
+  // live /ws solve (fired by the effect above) replaces the preview with the
+  // real currents/impedance/far-field when it lands. Keyed on `geometry` alone:
+  // param/freq tweaks on the *same* antenna keep updating in place (no flicker),
+  // matching the prior behaviour for the fast designs where this isn't a pain.
+  useEffect(() => {
+    setResult(null);
+    setPreview(null);
+    previewAbortRef.current?.abort();
+    const controller = new AbortController();
+    previewAbortRef.current = controller;
+    fetch("/geometry", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(buildRequest()),
+      signal: controller.signal,
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data && data.wires && !controller.signal.aborted) {
+          setPreview(data as SolveResponse);
+        }
+      })
+      .catch(() => {
+        /* aborted or offline — the live solve will still render the antenna */
+      });
+    return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [geometry]);
 
   // Debounced sweep across measurement freq. Re-runs whenever any antenna
   // parameter changes. Single-band geometries sweep around designFreq, so
@@ -1826,7 +1871,12 @@ export function App() {
       setRttMs(performance.now() - sendStartRef.current);
       const data: SolveResponse = JSON.parse(ev.data);
       inFlightRef.current = false;
-      setResult(data);
+      // Drop a response for an antenna the user already switched away from: a
+      // slow in-flight solve for the previous selection must not stomp the new
+      // antenna's geometry preview (and briefly show the wrong antenna). The
+      // pending solve below still fires so the current selection gets solved.
+      const stale = !!data.geometry && data.geometry !== geometryRef.current;
+      if (!stale) setResult(data);
       // If controls changed while waiting, fire the next solve immediately.
       if (pendingRef.current) {
         pendingRef.current = null;
@@ -2257,6 +2307,7 @@ export function App() {
                   size={thumbSize}
                   fill={false}
                   result={result}
+                  preview={preview}
                   sweep={sweep}
                   converge={converge}
                   pattern={pattern}
@@ -2345,6 +2396,7 @@ export function App() {
             size={chartSize}
             fill={view === "antenna"}
             result={result}
+            preview={preview}
             sweep={sweep}
             converge={converge}
             pattern={pattern}
@@ -2709,6 +2761,7 @@ function ViewPanel({
   size,
   fill,
   result,
+  preview,
   sweep,
   converge,
   pattern,
@@ -2726,6 +2779,7 @@ function ViewPanel({
   size: number;
   fill: boolean;
   result: SolveResponse | null;
+  preview: SolveResponse | null;
   sweep: SweepData | null;
   converge: ConvergeData | null;
   pattern: PatternData | null;
@@ -2740,14 +2794,18 @@ function ViewPanel({
   multiFeed: boolean;
 }) {
   if (view === "antenna") {
+    // Fall back to the geometry-only preview while the real solve is in
+    // flight, but with the current heatmap/waveform overlays forced off —
+    // the preview has no currents, so only the bare wires + feed are drawn.
+    const showingPreview = !result && !!preview;
     return (
       <div className={fill ? "antenna-fill" : "antenna-thumb"}
            style={fill ? undefined : { width: size, height: size }}>
         <CurrentCanvas
-          result={result}
+          result={result ?? preview}
           projection={cameraProjection}
-          showHeatmap={showHeatmap}
-          showEnvelope={showEnvelope}
+          showHeatmap={showingPreview ? false : showHeatmap}
+          showEnvelope={showingPreview ? false : showEnvelope}
         />
       </div>
     );

--- a/web/frontend/vite.config.ts
+++ b/web/frontend/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       "/sweep": { target: "http://127.0.0.1:8000", changeOrigin: true },
       "/converge": { target: "http://127.0.0.1:8000", changeOrigin: true },
       "/pattern": { target: "http://127.0.0.1:8000", changeOrigin: true },
+      "/geometry": { target: "http://127.0.0.1:8000", changeOrigin: true },
       "/examples": { target: "http://127.0.0.1:8000", changeOrigin: true },
       "/export_nec": { target: "http://127.0.0.1:8000", changeOrigin: true },
     },

--- a/web/frontend/vite.config.ts
+++ b/web/frontend/vite.config.ts
@@ -1,19 +1,46 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+// Dev-server proxy. Instead of enumerating every backend route (which meant a
+// new route silently 404'd into the SPA fallback until someone remembered to
+// add it here — this bit us repeatedly), we proxy *everything* to the backend
+// and bypass only the requests Vite must serve itself: the SPA document, its
+// own dev-client internals (/@vite, /@react-refresh, /@fs, /@id), app source
+// under /src, pre-bundled deps under /node_modules, and any static asset (a
+// path with a file extension). Everything else — every extensionless GET and
+// every non-GET — is a backend API call and is forwarded automatically, so new
+// JSON routes need no change here.
+//
+// The app WebSocket stays an explicit entry: it's the only upgrade route, and
+// keeping it separate leaves Vite's own HMR socket untouched.
 export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
     proxy: {
       "/ws": { target: "ws://127.0.0.1:8000", ws: true, changeOrigin: true },
-      "/healthz": { target: "http://127.0.0.1:8000", changeOrigin: true },
-      "/sweep": { target: "http://127.0.0.1:8000", changeOrigin: true },
-      "/converge": { target: "http://127.0.0.1:8000", changeOrigin: true },
-      "/pattern": { target: "http://127.0.0.1:8000", changeOrigin: true },
-      "/geometry": { target: "http://127.0.0.1:8000", changeOrigin: true },
-      "/examples": { target: "http://127.0.0.1:8000", changeOrigin: true },
-      "/export_nec": { target: "http://127.0.0.1:8000", changeOrigin: true },
+      "/": {
+        target: "http://127.0.0.1:8000",
+        changeOrigin: true,
+        bypass(req) {
+          const url = req.url || "";
+          // Only GETs can be Vite-owned; any other method is an API call.
+          if (req.method === "GET") {
+            const accept = req.headers.accept || "";
+            if (
+              accept.includes("text/html") || // SPA document / navigations
+              url === "/" ||
+              url.startsWith("/@") || // /@vite, /@react-refresh, /@fs, /@id
+              url.startsWith("/src/") || // app source modules
+              url.startsWith("/node_modules/") || // pre-bundled deps
+              /\.\w+($|\?)/.test(url) // static assets: .js/.css/.svg/...
+            ) {
+              return url; // let Vite serve it
+            }
+          }
+          return undefined; // forward to the backend
+        },
+      },
     },
   },
 });

--- a/web/server.py
+++ b/web/server.py
@@ -689,6 +689,24 @@ async def export_nec_endpoint(req: dict):
     )
 
 
+@app.post("/geometry")
+async def geometry_endpoint(req: dict):
+    """Fast geometry-only snapshot of the selected antenna: wire positions +
+    feed marker, no MoM solve. The frontend fetches this the instant the user
+    picks a new antenna so the shape renders immediately (large arrays take
+    tens of seconds to solve); the live /ws solve then supplies currents,
+    impedance, and far field. Geometry is solver-independent, so this always
+    uses the pysim builder path regardless of the request's `solver`.
+    """
+    geometry = req.get("geometry", next(iter(EXAMPLES)))
+    ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
+    if ex.pysim_geometry is None:
+        return {"available": False}
+    out = await run_in_threadpool(ex.pysim_geometry, req)
+    out["solver"] = "pysim"
+    return out
+
+
 @app.get("/healthz")
 def healthz():
     return {"ok": True}

--- a/web/server.py
+++ b/web/server.py
@@ -810,6 +810,7 @@ def examples_endpoint():
                 ),
                 "default_view": ex.default_view,
                 "default_freq_mhz": ex.default_freq_mhz,
+                "default_backend": ex.default_backend,
                 "has_design_freq": ex.has_design_freq,
                 "variants": list(ex.variants),
                 "variant_values": dict(ex.variant_values),


### PR DESCRIPTION
## Summary
Makes switching antennas in the web UI feel instant and stops slow designs from showing stale data, plus auto-selects the fast solver for arrays. Bumps the `pysim` submodule to `32cf008` (PR #91 swept-impedance fix, required by the array-block default).

- **Instant geometry preview on switch** — a new `POST /geometry` returns wires + feed marker with no MoM solve (~5 ms even for bowtiearray2x4). On antenna selection the old results clear immediately and the new antenna's shape draws right away (no heatmap/waveforms until the real solve lands). `PysimEngine.geometry_distribution()` reads geometry straight from the polylines; a stale-WS-response guard stops a previous antenna's slow solve from stomping the preview.
- **Auto-proxy all dev API routes** — replace the Vite proxy allowlist (which silently 404'd each new route into the SPA) with a catch-all that proxies everything except Vite's own assets. New routes need no config change.
- **Hold the freq-sweep/converge until the live solve returns** — they no longer run dozens of background solves alongside the one that draws the heatmap, so time-to-heatmap isn't starved on slow designs.
- **Default grid arrays to the array-block solver** — `default_backend` (detected once per design, memoised) seeds the active slot's backend for true grid arrays (~1 s vs ~8 s for bowtiearray2x4); only *upgrades* a dense pysim default, leaving explicit PyNEC / already-fast / hand-picked choices alone.

## Test plan
- [x] Full web suite (778) + new `/geometry` and `default_backend` tests pass
- [x] `ruff check` / `ruff format --check` clean; frontend `tsc --noEmit` clean
- [x] Geometry preview verified <10 ms; array detection flags the 24 array designs, leaves the other 44 on the default
- [x] Proxy verified by curl through Vite (SPA + new routes both route correctly)
- [x] bowtiearray2x4 ends up on array-block (~1 s) out of the box; sweep no longer crashes (pysim #91)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)