### PR TITLE
Web UI: solve-progress indicator + ground/segment UX cleanups

### DIFF
--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -38,28 +38,6 @@ def test_physical_cpu_count_is_positive():
     assert server._physical_cpu_count() >= 1
 
 
-def test_read_ground_off_returns_zero_offset():
-    on, h, z = server._read_ground({})
-    assert on is False
-    assert h == 0.0
-    assert z == 0.0
-
-
-def test_read_ground_on_sets_z_offset_to_height():
-    on, h, z = server._read_ground({"ground": True, "height_m": 4.5})
-    assert on is True
-    assert h == 4.5
-    assert z == 4.5
-
-
-def test_read_ground_off_ignores_height():
-    # An explicit height with ground=False shouldn't displace the antenna —
-    # the geometry stays at its native z=0. The frontend toggles ground
-    # independently of the height slider.
-    _on, _h, z = server._read_ground({"ground": False, "height_m": 7.0})
-    assert z == 0.0
-
-
 def test_polyline_knots_dedup_shared_corners():
     poly = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0]])
     knots = server._polyline_knots(poly, [2, 3])

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -1210,6 +1210,13 @@ export function App() {
   const [preview, setPreview] = useState<SolveResponse | null>(null);
   const [status, setStatus] = useState<"connecting" | "open" | "closed">("connecting");
   const [rttMs, setRttMs] = useState<number | null>(null);
+  // True whenever a main solve is outstanding (in flight or queued) — i.e. the
+  // displayed analysis isn't current yet. `showBusy` is the *debounced* view of
+  // it: the progress bar / panel dimming only appear once a solve outlasts
+  // ~300 ms, so fast updates (cache hits, small designs) snap in cleanly
+  // without a flash of busy chrome.
+  const [solving, setSolving] = useState(false);
+  const [showBusy, setShowBusy] = useState(false);
   const [sweep, setSweep] = useState<SweepData | null>(null);
   const [sweepRunning, setSweepRunning] = useState(false);
   // Smith-chart overlay toggles. Both are debounced sweeps that re-fire
@@ -1297,6 +1304,9 @@ export function App() {
   const convergeTimerRef = useRef<number | null>(null);
   const convergeAbortRef = useRef<AbortController | null>(null);
   const previewAbortRef = useRef<AbortController | null>(null);
+  // Timestamp (performance.now) when the busy chrome last became visible, so
+  // the reveal effect can enforce a minimum-visible window. null = not shown.
+  const shownAtRef = useRef<number | null>(null);
   // Latest selected antenna, mirrored into a ref so the (mount-once) WebSocket
   // onmessage handler can drop responses for an antenna the user already
   // switched away from. Updated every render — cheap and always current.
@@ -1870,20 +1880,64 @@ export function App() {
     }
   }
 
+  // Mirror the solve refs into `solving` state so the UI can react. Called
+  // wherever inFlightRef/pendingRef change.
+  function syncSolving() {
+    setSolving(inFlightRef.current || pendingRef.current !== null);
+  }
+
+  // Busy-chrome reveal with two guards:
+  //  - dwell: only show once a solve has been outstanding >BUSY_DWELL_MS. 1 s
+  //    is the classic "flow of thought" threshold — below it users tolerate the
+  //    wait without feedback; at/above it the bar reassures them it's working.
+  //    A solve that finishes sooner clears the timer in cleanup, so the bar
+  //    never flips on for quick updates.
+  //  - min-visible: once shown, keep it up at least BUSY_MIN_VISIBLE_MS so a
+  //    solve that lands just past the dwell can't make it sub-perceptibly
+  //    flash.
+  const BUSY_DWELL_MS = 1000;
+  const BUSY_MIN_VISIBLE_MS = 400;
+  useEffect(() => {
+    if (solving) {
+      const t = window.setTimeout(() => {
+        shownAtRef.current = performance.now();
+        setShowBusy(true);
+      }, BUSY_DWELL_MS);
+      return () => window.clearTimeout(t);
+    }
+    // Solve finished. If the bar never showed (fast solve), hide immediately;
+    // otherwise hold it for the remainder of the minimum-visible window.
+    if (shownAtRef.current === null) {
+      setShowBusy(false);
+      return;
+    }
+    const remaining =
+      BUSY_MIN_VISIBLE_MS - (performance.now() - shownAtRef.current);
+    if (remaining <= 0) {
+      shownAtRef.current = null;
+      setShowBusy(false);
+      return;
+    }
+    const t = window.setTimeout(() => {
+      shownAtRef.current = null;
+      setShowBusy(false);
+    }, remaining);
+    return () => window.clearTimeout(t);
+  }, [solving]);
+
   function requestSolve() {
     const ws = wsRef.current;
     if (!ws || ws.readyState !== WebSocket.OPEN) {
       pendingRef.current = controlsRef.current;
-      return;
-    }
-    if (inFlightRef.current) {
+    } else if (inFlightRef.current) {
       // Coalesce: latest controls will be picked up when the response arrives.
       pendingRef.current = controlsRef.current;
-      return;
+    } else {
+      inFlightRef.current = true;
+      sendStartRef.current = performance.now();
+      ws.send(JSON.stringify(controlsRef.current));
     }
-    inFlightRef.current = true;
-    sendStartRef.current = performance.now();
-    ws.send(JSON.stringify(controlsRef.current));
+    syncSolving();
   }
 
   useEffect(() => {
@@ -1902,10 +1956,14 @@ export function App() {
     ws.onclose = () => {
       setStatus("closed");
       inFlightRef.current = false;
+      // No solve can progress while disconnected — drop the busy state so the
+      // bar doesn't spin under a "closed" status (reconnect re-arms it).
+      setSolving(false);
     };
     ws.onerror = () => {
       setStatus("closed");
       inFlightRef.current = false;
+      setSolving(false);
     };
     ws.onmessage = (ev) => {
       setRttMs(performance.now() - sendStartRef.current);
@@ -1922,6 +1980,7 @@ export function App() {
         pendingRef.current = null;
         requestSolve();
       }
+      syncSolving();
     };
     return () => ws.close();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -2259,7 +2318,7 @@ export function App() {
           />
         </div>
 
-        <div className="readout">
+        <div className={`readout${showBusy ? " stale" : ""}`}>
           <div className="row">
             <span>R</span>
             <span className="val">{result ? `${result.z_in_re.toFixed(2)} Ω` : "—"}</span>
@@ -2333,6 +2392,9 @@ export function App() {
       </aside>
 
       <main className="stage">
+        {/* Indeterminate progress bar: appears only once a solve outlasts the
+            ~300 ms dwell (showBusy), signalling the display isn't current yet. */}
+        <div className={`solve-bar${showBusy ? " active" : ""}`} aria-hidden />
         <div className="thumbstrip" ref={thumbStripRef}>
           {VIEWS.filter((v) => v.id !== view).map((v) => (
             <button
@@ -2369,7 +2431,10 @@ export function App() {
             </button>
           ))}
         </div>
-        <div className="carousel-slide" ref={slideRef}>
+        <div
+          className={`carousel-slide${showBusy ? " stale" : ""}`}
+          ref={slideRef}
+        >
           {view === "antenna" && (
             <div className="antenna-overlay">
               <div className="projection-toggle">
@@ -2454,7 +2519,10 @@ export function App() {
             multiFeed={currentExample?.multi_feed ?? false}
           />
         </div>
-        <div className="status">ws: {status}</div>
+        <div className="status">
+          ws: {status}
+          {showBusy && <span className="status-busy"> · solving…</span>}
+        </div>
       </main>
     </div>
     </ThemeContext.Provider>

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -2829,6 +2829,15 @@ function NumberField({
   step?: number;
   onChange: (v: number) => void;
 }) {
+  // Local text draft so the field can be emptied mid-edit. Binding the input
+  // straight to the number coerced "" → 0 on backspace (you couldn't clear it,
+  // and the forced 0 left a leading zero when you typed again). The draft holds
+  // raw text; a value is only committed when it parses, and re-syncs whenever
+  // `value` changes from outside (backend swap, auto-seed, reset).
+  const [draft, setDraft] = useState(String(value));
+  useEffect(() => {
+    setDraft(String(value));
+  }, [value]);
   return (
     <div className="field">
       <label>
@@ -2837,14 +2846,20 @@ function NumberField({
       </label>
       <input
         type="number"
-        value={value}
+        value={draft}
         min={min}
         max={max}
         step={step}
         onChange={(e) => {
-          const v = Number(e.target.value);
+          const text = e.target.value;
+          setDraft(text); // allow "", partial, or leading-zero input while typing
+          if (text.trim() === "") return; // empty: don't commit (no snap to 0)
+          const v = Number(text);
           if (!Number.isNaN(v)) onChange(v);
         }}
+        // Normalize on blur: drop any leading zeros / revert an empty field to
+        // the last committed value.
+        onBlur={() => setDraft(String(value))}
       />
     </div>
   );

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -726,7 +726,6 @@ type SolveRequest = {
   wire_radius: number;
   ground: boolean;
   ground_fast: boolean;
-  height_m: number;
   // V
   angle_deg?: number;
   halfdriver_factor?: number;
@@ -1169,10 +1168,9 @@ export function App() {
   const [designFreq, setDesignFreq] = useState(14.3);
   const [measFreq, setMeasFreq] = useState(14.3);
   const [linkMeas, setLinkMeas] = useState(true);
-  // Ground plane (PyNEC only). Geometry is lifted by heightM when enabled.
+  // PEC ground plane (image method at z = 0).
   const [groundEnabled, setGroundEnabled] = useState(false);
   const [groundFast, setGroundFast] = useState(false);
-  const [heightM, setHeightM] = useState(7.0);
   // Far-field cut angles. The azimuth plot slices the pattern at elevation
   // `azElevDeg`; the elevation plot slices the vertical plane at azimuth
   // bearing `elevAzDeg` (0° = +x). Defaults give the conventional views.
@@ -1334,7 +1332,6 @@ export function App() {
       wire_radius: wireRadius,
       ground: groundActive,
       ground_fast: groundActive && groundFast,
-      height_m: heightM,
     };
     if (backend !== "pynec") {
       base.pysim_model = backend;
@@ -1490,7 +1487,7 @@ export function App() {
     geometry, backend, backendOptsKey,
     currentValuesKey,
     designFreq, measFreq,
-    groundEnabled, groundFast, heightM,
+    groundEnabled, groundFast,
   ]);
 
   // Antenna switch: drop the previous antenna's results immediately so nothing
@@ -1558,7 +1555,7 @@ export function App() {
     geometry, backend, backendOptsKey,
     currentValuesKey,
     designFreq,
-    groundEnabled, groundFast, heightM,
+    groundEnabled, groundFast,
     sweepEnabled,
     currentExample?.sweep_policy.anchor === "meas_freq" ? measFreq : null,
   ]);
@@ -1588,7 +1585,7 @@ export function App() {
     geometry, backend, backendOptsKey,
     currentValuesKey,
     designFreq, measFreq,
-    groundEnabled, groundFast, heightM,
+    groundEnabled, groundFast,
     convergeEnabled,
   ]);
 
@@ -1610,7 +1607,7 @@ export function App() {
     geometry, backend, backendOptsKey,
     currentValuesKey,
     designFreq, measFreq,
-    groundEnabled, groundFast, heightM,
+    groundEnabled, groundFast,
   ]);
 
   async function runSweep() {
@@ -2216,23 +2213,6 @@ export function App() {
             </label>
           )}
         </div>
-
-        {groundEnabled && (
-          <div className="field">
-            <label>
-              <span>height above ground</span>
-              <span>{heightM.toFixed(2)} m</span>
-            </label>
-            <input
-              type="range"
-              min={0.5}
-              max={30}
-              step={0.1}
-              value={heightM}
-              onInput={(e) => setHeightM(Number((e.target as HTMLInputElement).value))}
-            />
-          </div>
-        )}
 
         <div className="field">
           <label>
@@ -3935,8 +3915,8 @@ function CurrentCanvas({
 
       // When ground is enabled and the vertical projection axis is z, expand
       // the visible vertical range to include z=0 so the ground reference
-      // line lands inside the canvas. Without this, high antennas
-      // (height_m ≳ λ/2) push the ground line off-screen.
+      // line lands inside the canvas. Without this, antennas sitting well
+      // above the plane push the ground line off-screen.
       let vEffMin = vMin, vEffMax = vMax;
       if (result.ground && vertAxis === 2) {
         vEffMin = Math.min(vMin, 0);

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -1922,6 +1922,14 @@ export function App() {
     return () => window.clearTimeout(t);
   }, [solving]);
 
+  // The progress bar (`showBusy`) honors the min-visible window so it can't
+  // flash, but the *dimming* and the "solving…" label mean "what you're
+  // looking at is stale" — so they must clear the instant the result lands,
+  // even while the bar lingers out its minimum. `solving` flips false
+  // immediately on result-land, so `showBusy && solving` is exactly that: dim
+  // only after the dwell (showBusy) AND while genuinely still solving.
+  const stale = showBusy && solving;
+
   function requestSolve() {
     const ws = wsRef.current;
     if (!ws || ws.readyState !== WebSocket.OPEN) {
@@ -2298,7 +2306,7 @@ export function App() {
           />
         </div>
 
-        <div className={`readout${showBusy ? " stale" : ""}`}>
+        <div className={`readout${stale ? " stale" : ""}`}>
           <div className="row">
             <span>R</span>
             <span className="val">{result ? `${result.z_in_re.toFixed(2)} Ω` : "—"}</span>
@@ -2372,8 +2380,9 @@ export function App() {
       </aside>
 
       <main className="stage">
-        {/* Indeterminate progress bar: appears only once a solve outlasts the
-            ~300 ms dwell (showBusy), signalling the display isn't current yet. */}
+        {/* Indeterminate progress bar: appears once a solve outlasts the dwell
+            and lingers out its min-visible window (showBusy), so it never
+            flashes — the dim/label (stale) clear earlier, when the result lands. */}
         <div className={`solve-bar${showBusy ? " active" : ""}`} aria-hidden />
         <div className="thumbstrip" ref={thumbStripRef}>
           {VIEWS.filter((v) => v.id !== view).map((v) => (
@@ -2412,7 +2421,7 @@ export function App() {
           ))}
         </div>
         <div
-          className={`carousel-slide${showBusy ? " stale" : ""}`}
+          className={`carousel-slide${stale ? " stale" : ""}`}
           ref={slideRef}
         >
           {view === "antenna" && (
@@ -2501,7 +2510,7 @@ export function App() {
         </div>
         <div className="status">
           ws: {status}
-          {showBusy && <span className="status-busy"> · solving…</span>}
+          {stale && <span className="status-busy"> · solving…</span>}
         </div>
       </main>
     </div>

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -638,8 +638,11 @@ const DEFAULT_BACKEND_OPTS: BackendOptsMap = {
   sinusoidal: { nPerWire: 30, wireRadius: 0.0005, nQpConst: 8 },
   bspline: { ...BSPLINE_DEFAULT_OPTS },
   hmatrix: { ...BSPLINE_DEFAULT_OPTS },
-  arrayblock: { ...BSPLINE_DEFAULT_OPTS },
-  pynec: { nPerWire: 30, wireRadius: 0.0005 },
+  // Arrays auto-select this; 21 segs/wire is the converged, correct-parity
+  // choice for B-spline d=2 (odd → interior knot at the feed). The old
+  // inherited 40 was both too many and the wrong (even) parity.
+  arrayblock: { ...BSPLINE_DEFAULT_OPTS, nPerWire: 21 },
+  pynec: { nPerWire: 21, wireRadius: 0.0005 },
 };
 
 // Three abstract solver slots. Each holds one backend choice and its
@@ -669,7 +672,7 @@ const DEFAULT_SLOTS: Record<Slot, SlotConfig> = {
   },
   C: {
     backend: "pynec",
-    opts: { ...DEFAULT_BACKEND_OPTS.pynec, nPerWire: 41 },
+    opts: { ...DEFAULT_BACKEND_OPTS.pynec },
   },
 };
 
@@ -1249,7 +1252,22 @@ export function App() {
     const cur = slots[activeSlot].backend;
     const upgradable =
       cur === "triangular" || cur === "sinusoidal" || cur === "bspline";
-    if (upgradable && cur !== rec) setSlotBackend(activeSlot, rec);
+    if (upgradable && cur !== rec) {
+      // Reset to the recommended backend's *own* defaults rather than carrying
+      // over the dense slot's segment count — arrays want array-block's 21
+      // segs/wire (converged, correct d=2 parity), not the inherited 40. Keep
+      // the user's wire radius.
+      setSlots((prev) => ({
+        ...prev,
+        [activeSlot]: {
+          backend: rec,
+          opts: {
+            ...DEFAULT_BACKEND_OPTS[rec],
+            wireRadius: prev[activeSlot].opts.wireRadius,
+          } as BackendOptsMap[Backend],
+        },
+      }));
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentExample?.name]);
 

--- a/web/frontend/src/styles.css
+++ b/web/frontend/src/styles.css
@@ -943,3 +943,67 @@ canvas {
   color: var(--muted);
   font-family: var(--font-mono);
 }
+
+.status-busy {
+  color: var(--accent);
+}
+
+/* Indeterminate "solving" bar across the top of the stage. Hidden (opacity 0)
+   until `.active`; only toggled after the ~300 ms dwell, so quick solves never
+   flash it. A narrow segment sweeps left→right. */
+.solve-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  z-index: 6;
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.solve-bar.active {
+  opacity: 1;
+}
+
+.solve-bar.active::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  height: 100%;
+  width: 35%;
+  background: var(--accent);
+  border-radius: 0 2px 2px 0;
+  animation: solve-bar-slide 1.1s ease-in-out infinite;
+}
+
+@keyframes solve-bar-slide {
+  0% {
+    left: -35%;
+  }
+  100% {
+    left: 100%;
+  }
+}
+
+/* Dim panels whose data is being recomputed (gated on the same dwell as the
+   bar). Transition lives on the base elements so it eases both in and out. */
+.carousel-slide,
+.readout {
+  transition: opacity 0.2s ease;
+}
+
+.carousel-slide.stale,
+.readout.stale {
+  opacity: 0.5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .solve-bar.active::before {
+    animation: none;
+    width: 100%;
+    opacity: 0.5;
+  }
+}

--- a/web/server.py
+++ b/web/server.py
@@ -359,18 +359,6 @@ _PEC_GROUND_EPS_R = 1.0e10
 _PEC_GROUND_SIGMA = 0.0
 
 
-def _read_ground(req: dict) -> tuple[bool, float, float]:
-    """Common request parsing: returns (ground_on, height_m, z_offset).
-
-    height_m is the antenna height above ground when ground_on=True; z_offset
-    is what each geometry helper adds to its native (z=0) coordinates.
-    """
-    ground_on = bool(req.get("ground", False))
-    height_m = float(req.get("height_m", 0.0))
-    z_offset = height_m if ground_on else 0.0
-    return ground_on, height_m, z_offset
-
-
 def _polyline_knots(polyline: np.ndarray, npe_list: list[int]) -> np.ndarray:
     """Concatenated per-edge knot positions, with shared corners deduped."""
     parts = []


### PR DESCRIPTION
## Summary
A batch of web-UI UX tweaks, all frontend except a small dead-code removal in the backend.

- **Solve-progress indicator** — when a solve is outstanding the display isn't current yet, so show an indeterminate top bar + dim the recomputed panels + a `· solving…` status label. Gated on a 1 s dwell so fast updates never flash, with a 400 ms min-visible window so it can't blink; the dim/label clear the instant the result lands (independent of the bar's min-visible).
- **Remove the unused "height above ground" slider** — its `height_m` request field was consumed by nothing downstream (the PEC image method runs at z=0; responses hardcode 0.0; the frontend never read it). Removed the slider, the request field, and the dead `server._read_ground` + its 3 unit tests.
- **Default auto-selected arrays (and PyNEC) to 21 segs/wire** — arrays upgraded to array-block were inheriting the dense Triangular slot's 40 (too many, and wrong parity for B-spline d=2, which wants odd). Array-block now defaults to 21 and the auto-upgrade resets to that backend's own defaults; PyNEC default dropped 41 → 21.
- **Fix NumberField clearing** — emptying a numeric field (e.g. segments/wire) snapped to `0` and left a leading zero on retype, because `Number("") === 0`. Now holds a text draft so the field can be empty mid-edit; commits only on a valid parse; normalizes on blur.

## Test plan
- [x] Full web suite (775) + schema tests pass; `ruff` clean; frontend `tsc --noEmit` clean
- [x] Indicator: fast solves show nothing; slow solves (cold Triangular array) show bar+dim after ~1 s, view un-dims the instant the result lands
- [x] `height_m` confirmed unused downstream repo-wide before removal
- [x] Selecting an array lands on Array-block @ N=21; PyNEC defaults to 21
- [x] Numeric fields can be fully cleared and retyped without a leading zero
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)