### PR TITLE
User-authored antenna designs (local plugin folder)

### DIFF
--- a/src/antenna_designer/cli.py
+++ b/src/antenna_designer/cli.py
@@ -81,13 +81,23 @@ def resolve_class(s):
         return res
 
     # Designs live under a family subpackage (designs/<family>/<name>.py).
-    # Basenames are globally unique, so a bare name like "moxon" can still be
-    # resolved by searching each family — the family prefix ("beams.moxon")
-    # is accepted by the branch above but not required.
+    # A bare name like "moxon" can still be resolved by searching each family
+    # — the family prefix ("beams.moxon") is accepted by the branch above but
+    # not required. Basenames are unique today, but if two families ever
+    # define the same name, refuse to guess: report both and make the caller
+    # qualify it (the qualified form resolves in the branch above).
+    matches = []
     for fam in _design_families():
         cand = ["antenna_designer", "designs", fam] + lst
         if (res := try_to_resolve_list(cand)) is not None:
-            return res
+            matches.append((fam, res))
+    if len(matches) > 1:
+        qualified = ", ".join(f"{fam}.{'.'.join(lst)}" for fam, _ in matches)
+        raise ValueError(
+            f"ambiguous design {s!r}: matches {qualified} — qualify it with the family"
+        )
+    if matches:
+        return matches[0][1]
 
     return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,19 @@
+"""Shared pytest setup.
+
+- Force a headless matplotlib backend so plot tests run without a display.
+- Expose `needs_pynec`, a skip marker for tests that require the optional
+  PyNEC engine (unavailable e.g. on Windows).
+- Point the user-design folder at a throwaway temp dir for the whole test
+  session, set *before* any `import web.server` (which scaffolds the folder
+  at import time). Keeps the suite from writing TEMPLATE.py / CLAUDE.md into
+  the developer's real ~/.antenna_designer. Individual tests can still
+  override ANTENNA_DESIGNER_USER_DIR via monkeypatch — user_designs reads it
+  fresh on every refresh().
+"""
+
 import importlib.util
 import os
+import tempfile
 
 os.environ.setdefault("MPLBACKEND", "Agg")
 
@@ -8,6 +22,11 @@ import matplotlib  # noqa: E402
 matplotlib.use("Agg", force=True)
 
 import pytest  # noqa: E402
+
+os.environ.setdefault(
+    "ANTENNA_DESIGNER_USER_DIR",
+    tempfile.mkdtemp(prefix="antenna_designer_userdesigns_test_"),
+)
 
 HAS_PYNEC = importlib.util.find_spec("PyNEC") is not None
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,3 +1,5 @@
+import pytest
+
 from antenna_designer.designs.dipoles.invvee import Builder
 # from icecream import ic
 
@@ -27,6 +29,37 @@ def test_resolve_class():
     assert check(resolve_class("subdir.moxon.Builder"))
 
     assert check(resolve_class("dipoles.invvee"))
+
+
+def test_resolve_class_ambiguous_bare_name(monkeypatch):
+    """A bare name that resolves under more than one family must error with
+    the candidates rather than silently picking the first."""
+    import importlib
+    import types as _types
+
+    # The package re-exports a cli() function, shadowing the submodule
+    # attribute — fetch the actual module object explicitly.
+    cli = importlib.import_module("antenna_designer.cli")
+
+    monkeypatch.setattr(cli, "_design_families", lambda: ["fam_a", "fam_b"])
+
+    class _B:
+        pass
+
+    def fake_import(name):
+        if name in (
+            "antenna_designer.designs.fam_a.dupe",
+            "antenna_designer.designs.fam_b.dupe",
+        ):
+            m = _types.ModuleType(name)
+            m.Builder = _B
+            return m
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(cli, "import_module", fake_import)
+
+    with pytest.raises(ValueError, match="ambiguous"):
+        cli.resolve_class("dupe")
 
 
 def test_unit_params():

--- a/tests/test_user_designs.py
+++ b/tests/test_user_designs.py
@@ -1,0 +1,132 @@
+"""User-authored design discovery, live reload, error surfacing, scaffolding.
+
+See web/user_designs.py — local users drop a Builder file in their user dir
+and it registers under `user.<filename>` with no restart.
+"""
+
+import pytest
+
+import web.examples  # noqa: F401 — bootstraps the adapter + REGISTRY
+from web import user_designs
+from web.examples import REGISTRY
+
+VALID = """
+from types import MappingProxyType
+from antenna_designer import AntennaBuilder
+
+class Builder(AntennaBuilder):
+    label = "Test dipole"
+    default_params = MappingProxyType({"freq": 14.0, "half_length": 5.0})
+
+    def build_wires(self):
+        h = self.half_length
+        n = self.nominal_nsegs
+        return [
+            ((0.0, -h, 0.0), (0.0, -0.01, 0.0), n, None),
+            ((0.0, 0.01, 0.0), (0.0, h, 0.0), n, None),
+            ((0.0, -0.01, 0.0), (0.0, 0.01, 0.0), 1, 1 + 0j),
+        ]
+"""
+
+BROKEN_BUILD = """
+from types import MappingProxyType
+from antenna_designer import AntennaBuilder
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType({"freq": 14.0})
+
+    def build_wires(self):
+        return undefined_name  # NameError when geometry is built
+"""
+
+NO_BUILDER = "x = 1\n"
+
+
+@pytest.fixture
+def userdir(tmp_path, monkeypatch):
+    """A clean temp user-design dir; strips any user.* from the shared
+    REGISTRY before and after so tests don't leak into each other."""
+    monkeypatch.setenv("ANTENNA_DESIGNER_USER_DIR", str(tmp_path))
+
+    def _clear():
+        for k in [k for k in REGISTRY if k.startswith("user.")]:
+            del REGISTRY[k]
+
+    _clear()
+    yield tmp_path
+    _clear()
+
+
+def test_valid_design_registers(userdir):
+    (userdir / "my_dipole.py").write_text(VALID)
+    errors = user_designs.refresh()
+    assert errors == []
+    assert "user.my_dipole" in REGISTRY
+    assert REGISTRY["user.my_dipole"].name == "user.my_dipole"
+
+
+def test_broken_geometry_reports_error_without_crashing(userdir):
+    (userdir / "oops.py").write_text(BROKEN_BUILD)
+    errors = user_designs.refresh()
+    assert "user.oops" not in REGISTRY
+    assert len(errors) == 1
+    assert errors[0]["name"] == "user.oops"
+    assert "NameError" in errors[0]["message"]
+
+
+def test_missing_builder_reports_error(userdir):
+    (userdir / "nobuilder.py").write_text(NO_BUILDER)
+    errors = user_designs.refresh()
+    assert "user.nobuilder" not in REGISTRY
+    assert any("Builder" in e["message"] for e in errors)
+
+
+def test_one_bad_design_does_not_block_a_good_one(userdir):
+    (userdir / "good.py").write_text(VALID)
+    (userdir / "bad.py").write_text(BROKEN_BUILD)
+    errors = user_designs.refresh()
+    assert "user.good" in REGISTRY
+    assert {e["name"] for e in errors} == {"user.bad"}
+
+
+def test_reload_picks_up_edits(userdir):
+    f = userdir / "d.py"
+    f.write_text(VALID)
+    assert user_designs.refresh() == []
+    assert "user.d" in REGISTRY
+
+    f.write_text(BROKEN_BUILD)  # break it
+    errors = user_designs.refresh()
+    assert "user.d" not in REGISTRY
+    assert errors and errors[0]["name"] == "user.d"
+
+    f.write_text(VALID)  # fix it
+    assert user_designs.refresh() == []
+    assert "user.d" in REGISTRY
+
+
+def test_template_file_is_skipped(userdir):
+    (userdir / "TEMPLATE.py").write_text(VALID)
+    user_designs.refresh()
+    assert "user.TEMPLATE" not in REGISTRY
+
+
+def test_scaffold_creates_assets(tmp_path, monkeypatch):
+    target = tmp_path / "designs"
+    monkeypatch.setenv("ANTENNA_DESIGNER_USER_DIR", str(target))
+    user_designs.ensure_scaffold()
+    assert (target / "TEMPLATE.py").is_file()
+    assert (target / "CLAUDE.md").is_file()
+
+    # The shipped template must itself be a loadable design (copied under a
+    # non-TEMPLATE name, since TEMPLATE.py is skipped by discovery).
+    (target / "example_from_template.py").write_text(
+        (target / "TEMPLATE.py").read_text()
+    )
+    errors = user_designs.refresh()
+    try:
+        assert "user.example_from_template" in REGISTRY
+        assert not any(e["name"] == "user.example_from_template" for e in errors)
+    finally:
+        for k in [k for k in REGISTRY if k.startswith("user.")]:
+            del REGISTRY[k]

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -142,17 +142,21 @@ type ExampleDescriptor = {
   sweep_policy: SweepPolicy;
 };
 
+// A user design that failed to load, reported by GET /examples.
+type DesignLoadError = { name: string; file: string; message: string };
+
 // Design names are `family.design` (e.g. "dipoles.invvee"). The selector
 // groups by that family prefix; this fixes display order + labels and keeps
 // any unknown family rendering last under its bare name.
 const FAMILY_ORDER = [
-  "dipoles", "loops", "verticals", "beams", "wire",
+  "user", "dipoles", "loops", "verticals", "beams", "wire",
   "broadband", "multiband", "specialty", "arrays",
 ] as const;
 const FAMILY_LABELS: Record<string, string> = {
-  dipoles: "Dipoles", loops: "Loops", verticals: "Verticals", beams: "Beams",
-  wire: "Wire / traveling-wave", broadband: "Broadband", multiband: "Multiband",
-  specialty: "Specialty", arrays: "Arrays",
+  user: "Your designs", dipoles: "Dipoles", loops: "Loops",
+  verticals: "Verticals", beams: "Beams", wire: "Wire / traveling-wave",
+  broadband: "Broadband", multiband: "Multiband", specialty: "Specialty",
+  arrays: "Arrays",
 };
 // Extra search keywords so cryptic or historically-named designs are findable
 // by something other than their terse name (the old pre-regroup names live
@@ -1006,6 +1010,9 @@ export function App() {
   // repeat-count down and back up preserves the values.
   const [examples, setExamples] = useState<ExampleDescriptor[]>([]);
   const [examplesError, setExamplesError] = useState<string | null>(null);
+  // User designs that failed to load (bad Python, no Builder, geometry error).
+  // Surfaced from /examples so the author / Claude can see and fix them.
+  const [loadErrors, setLoadErrors] = useState<DesignLoadError[]>([]);
   // Free-text filter for the antenna selector — matches name / label /
   // family / keywords so users can find a design without knowing its family.
   const [geomFilter, setGeomFilter] = useState<string>("");
@@ -1025,6 +1032,7 @@ export function App() {
         const list: ExampleDescriptor[] = j.examples ?? [];
         setExamples(list);
         setExamplesError(null);
+        setLoadErrors(Array.isArray(j.errors) ? j.errors : []);
         // Walk each example's schema and pre-seed defaults — including
         // pre-allocated group instance arrays — so the sliders have
         // something to render against on first show.
@@ -2180,6 +2188,25 @@ export function App() {
         {examplesError && (
           <div className="examples-error">
             Failed to load /examples: {examplesError}
+          </div>
+        )}
+        {loadErrors.length > 0 && (
+          <div className="design-load-errors" role="alert">
+            <div className="design-load-errors-title">
+              {loadErrors.length} design
+              {loadErrors.length === 1 ? "" : "s"} failed to load
+            </div>
+            <ul>
+              {loadErrors.map((err) => (
+                <li key={err.name}>
+                  <code>{err.name}</code> — {err.message}
+                  <span className="design-load-errors-file">{err.file}</span>
+                </li>
+              ))}
+            </ul>
+            <div className="design-load-errors-hint">
+              Fix the file and refresh. See CLAUDE.md in your designs folder.
+            </div>
           </div>
         )}
 

--- a/web/frontend/src/styles.css
+++ b/web/frontend/src/styles.css
@@ -428,6 +428,48 @@ button:focus-visible,
   font-size: var(--text-sm);
 }
 
+.design-load-errors {
+  margin: var(--space-4) 0;
+  padding: var(--space-4) var(--space-5);
+  border: 1px solid var(--danger-border);
+  border-radius: var(--r-sm);
+  background: var(--danger-bg);
+  color: var(--danger);
+  font-size: var(--text-sm);
+}
+
+.design-load-errors-title {
+  font-weight: 600;
+  margin-bottom: var(--space-2);
+}
+
+.design-load-errors ul {
+  margin: 0;
+  padding-left: var(--space-5);
+}
+
+.design-load-errors li {
+  margin: var(--space-2) 0;
+}
+
+.design-load-errors code {
+  font-family: var(--font-mono);
+}
+
+.design-load-errors-file {
+  display: block;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  word-break: break-all;
+}
+
+.design-load-errors-hint {
+  margin-top: var(--space-2);
+  color: var(--muted);
+  font-size: var(--text-xs);
+}
+
 .geometry-tabs button {
   flex: 1;
   background: var(--inset);

--- a/web/server.py
+++ b/web/server.py
@@ -109,8 +109,14 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response, StreamingResponse
 from starlette.websockets import WebSocketState
 
-from . import pynec_backend
+from . import pynec_backend, user_designs
 from .examples import REGISTRY as EXAMPLES
+
+# Scaffold the user-design folder (TEMPLATE.py + CLAUDE.md on first run) and
+# load any existing user designs into the registry at startup. They are also
+# refreshed on every GET /examples so edits appear without a restart.
+user_designs.ensure_scaffold()
+user_designs.refresh()
 
 
 # Target per-chunk wall time for the adaptive pysim /sweep chunking. The
@@ -710,7 +716,11 @@ def examples_endpoint():
     its `multi_feed` flag (affects the response handling for arrays of
     feeds) plus a result_schema that may mix scalar ResultFieldSpec
     rows with ResultGroupSpec repeat groups.
+
+    Reloads user designs first (live edits without a restart) and returns
+    any that failed to load under `errors`, so the UI can show them.
     """
+    load_errors = user_designs.refresh()
 
     def _serialize_schema_item(item) -> dict:
         # Discriminate by attribute: ParamGroupSpec has `params`, ParamSpec
@@ -812,7 +822,7 @@ def examples_endpoint():
             }
         )
     out.sort(key=lambda e: e["label"])
-    return {"examples": out}
+    return {"examples": out, "errors": load_errors}
 
 
 @app.websocket("/ws")

--- a/web/user_design_assets/CLAUDE.md
+++ b/web/user_design_assets/CLAUDE.md
@@ -1,0 +1,89 @@
+# Designing antennas in this folder
+
+This folder holds **your** antenna designs for the Antenna Designer app.
+Each `.py` file here is one antenna. Drop a file in, refresh the web page,
+and it shows up under **"Your designs"**.
+
+If you're reading this as Claude Code: the user wants you to write or edit an
+antenna design in this folder. Follow the contract below exactly, then tell
+them to refresh the page (and to check the "failed to load" panel if their
+design has an error).
+
+## The contract
+
+A design file must:
+
+1. **Be named** `lowercase_with_underscores.py`. The file name becomes the
+   antenna's name in the app (`my_dipole.py` → `user.my_dipole`). No spaces,
+   no dots except the `.py` extension, one antenna per file.
+2. **Define a class named exactly `Builder`** that subclasses `AntennaBuilder`.
+3. **Import only** from `antenna_designer` and the Python standard library.
+   Do **not** import other design files — keep each one self-contained.
+4. Provide a **`default_params`** mapping (use `MappingProxyType(...)`) and a
+   **`build_wires(self)`** method.
+
+Start from `TEMPLATE.py` in this folder — copy it, rename it, edit it.
+
+## `default_params`
+
+Every key becomes a slider in the UI, accessed in `build_wires` as
+`self.<key>`. Conventions:
+
+- `freq` — measurement frequency in **MHz**. Always include it.
+- Lengths/positions are in **metres**.
+- Add a nested `"ui_params": MappingProxyType({...})` for UI hints. The most
+  useful is `"default_view"`: `"xy"` (top-down), `"xz"`, or `"yz"` (side).
+- A class-level `label = "Pretty Name"` sets the display name (optional).
+
+Slider bounds and step are auto-derived (±50% around the default, fine
+resolution). You usually don't need to specify them.
+
+## `build_wires(self)`
+
+Return a list of straight wire segments. Each entry is:
+
+```python
+(start, end, n_segments, feed)
+```
+
+- `start`, `end` — `(x, y, z)` tuples in metres.
+- `n_segments` — how finely to subdivide that wire. Use `self.nominal_nsegs`
+  for the main radiator; fewer for short stubs (`max(1, self.nominal_nsegs // 7)`).
+- `feed` — `1 + 0j` on the **single** segment the transmitter drives, `None`
+  everywhere else. Exactly one segment in the whole antenna is the feed.
+
+**Feed convention:** put the feed on a tiny segment between two points a
+small `eps` (e.g. 0.01 m) apart, with the radiator arms running outward from
+those two points. Wires connect where they share an endpoint, so the arms and
+the feed segment must share their centre points exactly. See `TEMPLATE.py`.
+
+**Frequency-scaled geometry (optional):** to size an antenna from a design
+frequency instead of fixed metres, add a `design_freq` param (MHz) and a
+`length_factor` (a multiplier near 1.0), then compute
+`wavelength = 299.792458 / self.design_freq` and build dimensions as
+fractions of `wavelength * self.length_factor`. This is how most built-in
+designs work and gives you a clean per-band tuning knob.
+
+## Arrays of identical elements (advanced)
+
+For a phased array of N copies of one element, `antenna_designer` exposes
+`Array1x2Builder`, `Array1x4Builder`, `Array2x2Builder`, `Array2x4Builder`.
+These wrap an element `Builder`. For a first design, stick to a single
+`build_wires`; reach for arrays only once a single element works.
+
+## How to check your work
+
+1. Save the file. **Refresh the web page** (no server restart needed).
+2. The antenna appears under "Your designs". If it doesn't, look at the
+   **"designs that failed to load"** panel — it shows the file, the error
+   type, and the line number. Fix and refresh again.
+3. Pick it in the selector and look at the geometry plot, the SWR curve, and
+   the impedance. Adjust `default_params` and `build_wires` until the
+   resonance and pattern look right.
+
+## Good prompts to give Claude Code
+
+- "Make me a 40-meter off-center-fed dipole fed 1/3 from one end."
+- "Design a 2-element 20-meter quad loop, driven element plus a reflector."
+- "Take my_dipole.py and add an adjustable height-above-ground slider."
+- "My design loads but resonates at 32 MHz — shorten it to hit 28.5 MHz."

--- a/web/user_design_assets/TEMPLATE.py
+++ b/web/user_design_assets/TEMPLATE.py
@@ -1,0 +1,81 @@
+"""A complete, working example antenna. Copy it and make it your own.
+
+HOW TO USE THIS FILE
+--------------------
+1. Copy it to a new file in this same folder, e.g. ``my_dipole.py``. The
+   file name (lowercase, words joined by underscores) becomes the antenna's
+   name in the app: ``my_dipole.py`` shows up as "user.my_dipole".
+2. Change the numbers in ``default_params`` and the geometry in
+   ``build_wires``.
+3. Refresh the web page. Your antenna appears under "Your designs". If you
+   made a mistake, the page shows the error so you can fix it.
+
+NOT A PYTHON PROGRAMMER?
+------------------------
+Open Claude Code in this folder and just ask, for example:
+    "make me a 40-meter off-center-fed dipole"
+The CLAUDE.md file next to this one tells Claude everything it needs to
+write a valid design and check its work.
+
+THE RULES (keep it this simple)
+-------------------------------
+- One file = one antenna. The file name is the antenna name
+  (lowercase_with_underscores.py, no spaces, no dots except ``.py``).
+- Define a class named exactly ``Builder`` that subclasses ``AntennaBuilder``.
+- Stay self-contained: only import from ``antenna_designer`` and the Python
+  standard library. Don't import other antenna files.
+"""
+
+from types import MappingProxyType
+
+from antenna_designer import AntennaBuilder
+
+
+class Builder(AntennaBuilder):
+    # Optional friendly name shown in the UI. Without it, the file name is used.
+    label = "Example dipole"
+
+    # The knobs. Every entry here becomes a slider in the UI. ``freq`` (the
+    # measurement frequency in MHz) is special and should always be present.
+    default_params = MappingProxyType(
+        {
+            "freq": 28.5,  # MHz -- where you measure SWR / impedance
+            "half_length": 2.5,  # metres -- length of each arm (~1/4 wave on 10 m)
+            "height": 10.0,  # metres -- height above ground
+            # Optional UI hints. "default_view" sets the first 2-D view:
+            # "xy" (top-down), "xz" or "yz" (from the side).
+            "ui_params": MappingProxyType({"default_view": "xz"}),
+        }
+    )
+
+    def build_wires(self):
+        """Return the antenna as a list of straight wire segments.
+
+        Each entry is ``(start, end, n_segments, feed)``:
+          * ``start`` / ``end`` are ``(x, y, z)`` points in metres,
+          * ``n_segments`` is how finely to divide that wire (more = finer,
+            slower) -- ``self.nominal_nsegs`` is a sensible default,
+          * ``feed`` is ``1 + 0j`` on the ONE segment driven by the
+            transmitter, and ``None`` on every other wire.
+        """
+        h = self.half_length
+        z = self.height
+        eps = 0.01  # tiny half-gap at the centre where the feed point sits
+
+        arm_segs = self.nominal_nsegs
+        feed_segs = max(1, self.nominal_nsegs // 7)
+
+        # A center-fed dipole lying along the y axis at height z:
+        #
+        #   tip(-h) ---- arm ---- (-eps)[ feed ](+eps) ---- arm ---- tip(+h)
+        #
+        left_tip = (0.0, -h, z)
+        right_tip = (0.0, h, z)
+        feed_lo = (0.0, -eps, z)
+        feed_hi = (0.0, eps, z)
+
+        return [
+            (left_tip, feed_lo, arm_segs, None),  # left arm
+            (feed_hi, right_tip, arm_segs, None),  # right arm
+            (feed_lo, feed_hi, feed_segs, 1 + 0j),  # the driven feed gap
+        ]

--- a/web/user_designs.py
+++ b/web/user_designs.py
@@ -1,0 +1,138 @@
+"""Discovery and live-reload of user-authored antenna designs.
+
+For a local install, a ham (or Claude Code on their behalf) drops a ``.py``
+file defining a ``Builder`` into their user design folder; it shows up in the
+web UI under the ``user`` family with no server restart. The authoring
+contract lives in ``user_design_assets/TEMPLATE.py`` and ``CLAUDE.md``, which
+are copied into the user folder on first run.
+
+User designs live *outside* the installed package (so a ``pip`` upgrade never
+clobbers them) and are loaded by file path, then registered under
+``user.<filename>`` — a namespace that can never collide with or shadow a
+built-in family design.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import sys
+import traceback
+from pathlib import Path
+
+from . import adapter
+from .examples import REGISTRY
+
+USER_NS = "user"
+_ASSETS = Path(__file__).resolve().parent / "user_design_assets"
+_MODULE_PREFIX = "antenna_designer._user_designs"
+
+
+def default_user_dir() -> Path:
+    """The primary user-design folder: ``$ANTENNA_DESIGNER_USER_DIR`` if set,
+    else ``~/.antenna_designer/designs``."""
+    env = os.environ.get("ANTENNA_DESIGNER_USER_DIR")
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".antenna_designer" / "designs"
+
+
+def user_design_dirs() -> list[Path]:
+    """Folders scanned for user designs, in priority order: the default (or
+    the env override) plus ``./antenna_designs`` if it exists in the cwd."""
+    dirs = [default_user_dir()]
+    seen = {d.resolve() for d in dirs if d.exists()}
+    local = Path.cwd() / "antenna_designs"
+    if local.is_dir() and local.resolve() not in seen:
+        dirs.append(local)
+    return dirs
+
+
+def ensure_scaffold() -> None:
+    """Create the default user folder with a ``TEMPLATE.py`` + ``CLAUDE.md``
+    the first time, so there's something to copy and Claude Code has context.
+    Idempotent and best-effort — never raises into startup."""
+    d = default_user_dir()
+    if d.exists():
+        return
+    try:
+        d.mkdir(parents=True, exist_ok=True)
+        for asset in ("TEMPLATE.py", "CLAUDE.md"):
+            src = _ASSETS / asset
+            if src.is_file():
+                shutil.copyfile(src, d / asset)
+    except OSError as exc:  # read-only home, permissions, … — log and move on
+        print(f"[user_designs] could not scaffold {d}: {exc!r}")
+
+
+def _load_builder(path: Path):
+    """Import a single user file by path and return its ``Builder`` class.
+    Re-executes the file on every call, so edits are picked up live."""
+    modname = f"{_MODULE_PREFIX}.{path.stem}"
+    spec = importlib.util.spec_from_file_location(modname, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"could not create import spec for {path.name}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[modname] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except BaseException:
+        sys.modules.pop(modname, None)
+        raise
+    cls = getattr(mod, "Builder", None)
+    if cls is None:
+        raise AttributeError(
+            "no `Builder` class found — define `class Builder(AntennaBuilder): ...`"
+        )
+    return cls
+
+
+def _format_error(path: Path, exc: Exception) -> str:
+    """A short, user-facing message pointing at the line in *their* file."""
+    tb = traceback.extract_tb(exc.__traceback__)
+    here = [fr for fr in tb if fr.filename == str(path)]
+    where = f" (line {here[-1].lineno})" if here else ""
+    return f"{type(exc).__name__}: {exc}{where}"
+
+
+def refresh() -> list[dict]:
+    """Reload every user design into ``REGISTRY`` under ``user.<filename>``,
+    replacing any previously-loaded user designs.
+
+    Returns a list of ``{"name", "file", "message"}`` for files that failed to
+    load — surfaced in the UI so the author (or Claude) can fix them. A broken
+    file never takes down the rest.
+    """
+    for key in [k for k in REGISTRY if k.startswith(f"{USER_NS}.")]:
+        del REGISTRY[key]
+
+    errors: list[dict] = []
+    seen: set[str] = set()
+    for d in user_design_dirs():
+        if not d.is_dir():
+            continue
+        for path in sorted(d.glob("*.py")):
+            stem = path.stem
+            if stem.startswith("_") or stem == "TEMPLATE":
+                continue
+            name = f"{USER_NS}.{stem}"
+            if name in seen:
+                continue  # first folder in priority order wins
+            seen.add(name)
+            try:
+                cls = _load_builder(path)
+                # Smoke-test: construct, then actually build the geometry so a
+                # typo / bad shape in build_wires surfaces here (at load, in
+                # the UI panel) instead of only when the design is solved.
+                cls().build_wires()
+                REGISTRY[name] = adapter._make_example(name, cls)
+            except Exception as exc:  # noqa: BLE001 — surface, don't crash
+                errors.append(
+                    {
+                        "name": name,
+                        "file": str(path),
+                        "message": _format_error(path, exc),
+                    }
+                )
+    return errors


### PR DESCRIPTION
## Summary
Lets a local user — or Claude Code on their behalf — add their own antennas by dropping a `Builder` file into a user folder. This is the headline feature for releasing the tool to the ham community: a sandbox where non-programmers can design (or have Claude design) antennas without touching the repo.

- **Discovery + live reload** (`web/user_designs.py`): scans `$ANTENNA_DESIGNER_USER_DIR` (default `~/.antenna_designer/designs`) plus `./antenna_designs`, loads each `*.py` by file path, and registers it under the reserved **`user.`** family (can't collide with or shadow a built-in). Designs live *outside* the installed package, so a `pip` upgrade never clobbers them. Re-scanned on every `GET /examples`, so the loop is: edit file → refresh page → done. No restart.
- **Load-time validation + error surfacing**: each design is smoke-tested (construct **and** `build_wires()`), so a typo surfaces at load — not only at solve. One bad file never blocks the rest. `/examples` returns a parallel `errors` list and the frontend shows a "designs that failed to load" panel (name, message, line).
- **First-run scaffolding**: drops a heavily-commented `TEMPLATE.py` (a real working dipole) and a Claude-Code-forward `CLAUDE.md` (the authoring contract + suggested prompts) into the user folder.
- **Selector**: user designs group under "Your designs" at the top.
- **Hardening**: `resolve_class` now errors on an ambiguous bare name (lists candidates) instead of silently first-winning — user designs are exactly when basename uniqueness can break.
- **Test isolation**: `tests/conftest.py` redirects the user dir to a temp path so the suite never writes to the real `~/.antenna_designer`.

## Test plan
- [x] `test_user_designs.py`: valid registers, broken geometry reports an error without crashing, missing `Builder` reported, one bad file doesn't block a good one, reload picks up edits, `TEMPLATE.py` skipped, scaffold writes assets and the shipped template loads
- [x] `resolve_class` ambiguous-bare-name test
- [x] Full suite green: 1163 passed, 4 skipped; `ruff check` + `ruff format --check` clean; frontend builds (tsc + vite)
- [x] End-to-end `/examples`: a valid user file loads as `user.<name>`; a typo'd file reports `NameError … (line N)` in `errors`
- [x] Manual: start the server fresh → `~/.antenna_designer/designs/` is created with `TEMPLATE.py` + `CLAUDE.md`; copy/edit a design → refresh → it appears under "Your designs"; introduce a typo → the failed-to-load panel shows it

🤖 Generated with [Claude Code](https://claude.com/claude-code)