### PR TITLE
User-authored designs: CLI support, lazy registration, and on-select error surfacing

### DIFF
--- a/src/antenna_designer/cli.py
+++ b/src/antenna_designer/cli.py
@@ -11,6 +11,7 @@ from . import (
     optimize,
 )
 from .engines import PyNECEngine, PysimEngine
+from .user_designs import USER_NS, resolve_user_design
 
 from pysim import (
     TriangularPySim,
@@ -98,6 +99,14 @@ def resolve_class(s):
         )
     if matches:
         return matches[0][1]
+
+    # User-authored designs (local plugin folder), addressed explicitly as
+    # "user.<name>". Kept to its own namespace on purpose: a bare name never
+    # resolves to a user file, so a user design can't shadow a built-in. Load
+    # errors propagate so someone debugging their own file sees the real cause.
+    if len(lst) == 2 and lst[0] == USER_NS:
+        if (res := resolve_user_design(lst[1])) is not None:
+            return res
 
     return None
 

--- a/src/antenna_designer/cli.py
+++ b/src/antenna_designer/cli.py
@@ -11,7 +11,7 @@ from . import (
     optimize,
 )
 from .engines import PyNECEngine, PysimEngine
-from .user_designs import USER_NS, resolve_user_design
+from .user_designs import USER_NS, iter_design_files, resolve_user_design
 
 from pysim import (
     TriangularPySim,
@@ -131,6 +131,32 @@ def _design_families():
 
 
 _DESIGN_FAMILIES = None
+
+
+def list_builtin_designs() -> list[str]:
+    """Every built-in design as a sorted ``family.name`` dotted path.
+
+    A pure filesystem walk over ``antenna_designer.designs`` — every family
+    ``*.py`` defines a ``Builder``, so the listing matches what ``resolve_class``
+    can resolve, without importing the modules.
+    """
+    import os
+
+    import antenna_designer.designs as _d
+
+    names: list[str] = []
+    for root in list(getattr(_d, "__path__", [])):
+        for fam in os.listdir(root):
+            if fam.startswith(("_", ".")):
+                continue
+            fam_dir = os.path.join(root, fam)
+            if not os.path.isdir(fam_dir):
+                continue
+            for fn in os.listdir(fam_dir):
+                if not fn.endswith(".py") or fn.startswith("_"):
+                    continue
+                names.append(f"{fam}.{fn[:-3]}")
+    return sorted(set(names))
 
 
 def list_variants(cls):
@@ -579,6 +605,56 @@ def cli(arguments=None):
             print(f"wrote {args.out}")
         else:
             print(deck, end="")
+
+    p.set_defaults(func=f)
+
+    p = subparsers.add_parser(
+        "list", help="List available antenna designs (built-in and user)"
+    )
+    p.add_argument(
+        "filter",
+        nargs="?",
+        default=None,
+        help="Case-insensitive substring; only matching design names are shown.",
+    )
+    group = p.add_mutually_exclusive_group()
+    group.add_argument(
+        "--builtin-only", action="store_true", help="Only the built-in designs."
+    )
+    group.add_argument(
+        "--user-only", action="store_true", help="Only the user-authored designs."
+    )
+
+    def f(args):
+        from itertools import groupby
+
+        q = args.filter.lower() if args.filter else None
+
+        def keep(name):
+            return q is None or q in name.lower()
+
+        sections: list[tuple[str, list[str]]] = []
+        if not args.user_only:
+            names = [n for n in list_builtin_designs() if keep(n)]
+            for fam, grp in groupby(names, key=lambda n: n.split(".")[0]):
+                sections.append((fam, list(grp)))
+        if not args.builtin_only:
+            users = [f"{USER_NS}.{stem}" for stem, _ in iter_design_files()]
+            users = sorted(u for u in users if keep(u))
+            if users:
+                sections.append((USER_NS, users))
+
+        if not sections:
+            where = f" matching {args.filter!r}" if q else ""
+            print(f"no designs{where}")
+            return
+
+        for i, (fam, members) in enumerate(sections):
+            if i:
+                print()
+            print(f"{fam}")
+            for name in members:
+                print(f"  {name}")
 
     p.set_defaults(func=f)
 

--- a/src/antenna_designer/user_designs.py
+++ b/src/antenna_designer/user_designs.py
@@ -1,0 +1,106 @@
+"""Discovery and path-loading of user-authored antenna designs.
+
+Engine/UI-agnostic: pure filesystem + ``importlib`` with no dependency on the
+``web`` package, so both the CLI (``antenna_designer.cli``) and the web adapter
+resolve ``user.<name>`` designs from the same folders. The web layer
+(``web/user_designs.py``) adds REGISTRY registration, scaffolding, and
+error-panel formatting on top of this.
+
+User designs live *outside* the installed package (so a ``pip`` upgrade never
+clobbers them) and are loaded by file path. The ``user`` namespace can never
+collide with or shadow a built-in family design.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+USER_NS = "user"
+_MODULE_PREFIX = "antenna_designer._user_designs"
+
+
+def default_user_dir() -> Path:
+    """The primary user-design folder: ``$ANTENNA_DESIGNER_USER_DIR`` if set,
+    else ``~/.antenna_designer/designs``. Read fresh each call so tests can
+    redirect it via the environment."""
+    env = os.environ.get("ANTENNA_DESIGNER_USER_DIR")
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".antenna_designer" / "designs"
+
+
+def user_design_dirs() -> list[Path]:
+    """Folders scanned for user designs, in priority order: the default (or
+    the env override) plus ``./antenna_designs`` if it exists in the cwd."""
+    dirs = [default_user_dir()]
+    seen = {d.resolve() for d in dirs if d.exists()}
+    local = Path.cwd() / "antenna_designs"
+    if local.is_dir() and local.resolve() not in seen:
+        dirs.append(local)
+    return dirs
+
+
+def _is_design_file(path: Path) -> bool:
+    """Skip private files and the copied authoring template."""
+    stem = path.stem
+    return not (stem.startswith("_") or stem == "TEMPLATE")
+
+
+def load_builder(path: Path):
+    """Import a single user file by path and return its ``Builder`` class.
+    Re-executes the file on every call, so edits are picked up live."""
+    modname = f"{_MODULE_PREFIX}.{path.stem}"
+    spec = importlib.util.spec_from_file_location(modname, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"could not create import spec for {path.name}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[modname] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except BaseException:
+        sys.modules.pop(modname, None)
+        raise
+    cls = getattr(mod, "Builder", None)
+    if cls is None:
+        raise AttributeError(
+            "no `Builder` class found — define `class Builder(AntennaBuilder): ...`"
+        )
+    return cls
+
+
+def iter_design_files() -> Iterator[tuple[str, Path]]:
+    """Yield ``(stem, path)`` for each user design file across all folders,
+    first-folder-wins on a duplicate stem (matching the web's priority order)."""
+    seen: set[str] = set()
+    for d in user_design_dirs():
+        if not d.is_dir():
+            continue
+        for path in sorted(d.glob("*.py")):
+            if not _is_design_file(path):
+                continue
+            if path.stem in seen:
+                continue
+            seen.add(path.stem)
+            yield path.stem, path
+
+
+def find_design_file(stem: str) -> Path | None:
+    """The file backing user design ``stem``, or None if there is no such file."""
+    for s, path in iter_design_files():
+        if s == stem:
+            return path
+    return None
+
+
+def resolve_user_design(stem: str):
+    """Return the ``Builder`` class for user design ``stem``, or None if no
+    such file exists. Load errors (syntax error, missing ``Builder``) propagate
+    so someone debugging their own file sees the real cause."""
+    path = find_design_file(stem)
+    if path is None:
+        return None
+    return load_builder(path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,25 +24,31 @@ def test_cli_draw():
 
 @needs_pynec
 def test_cli_sweep():
-    ant.cli(f"sweep --param tipspacer_factor --builder moxon --npoints 2{o}".split())
     ant.cli(
-        f"sweep --gain --param tipspacer_factor --npoints 2 --builder moxon{o}".split()
+        f"sweep --param tipspacer_factor --builder beams.moxon --npoints 2{o}".split()
+    )
+    ant.cli(
+        f"sweep --gain --param tipspacer_factor --npoints 2 --builder beams.moxon{o}".split()
     )
 
     ant.cli(f"sweep --markers 28.57 --npoints 0{o}".split())
-    ant.cli(f"sweep --markers 28.57 --npoints 0 --builder invveearray{o}".split())
-    ant.cli(f"sweep --markers 28.57 --npoints 2 --builder invveearray{o}".split())
-    ant.cli(f"sweep --npoints 2 --builder invveearray{o}".split())
+    ant.cli(
+        f"sweep --markers 28.57 --npoints 0 --builder arrays.invveearray{o}".split()
+    )
+    ant.cli(
+        f"sweep --markers 28.57 --npoints 2 --builder arrays.invveearray{o}".split()
+    )
+    ant.cli(f"sweep --npoints 2 --builder arrays.invveearray{o}".split())
 
     ant.cli(f"sweep --markers 28.57 --npoints 0{o} --use_smithchart --z0=50".split())
     ant.cli(
-        f"sweep --markers 28.57 --npoints 0 --builder invveearray{o} --use_smithchart --z0=50".split()
+        f"sweep --markers 28.57 --npoints 0 --builder arrays.invveearray{o} --use_smithchart --z0=50".split()
     )
     ant.cli(
-        f"sweep --markers 28.57 --npoints 2 --builder invveearray{o} --use_smithchart --z0=50".split()
+        f"sweep --markers 28.57 --npoints 2 --builder arrays.invveearray{o} --use_smithchart --z0=50".split()
     )
     ant.cli(
-        f"sweep --npoints 2 --builder invveearray{o} --use_smithchart --z0=50".split()
+        f"sweep --npoints 2 --builder arrays.invveearray{o} --use_smithchart --z0=50".split()
     )
 
 
@@ -65,8 +71,8 @@ def test_cli_pattern():
 @needs_pynec
 def test_cli_compare_patterns():
     ant.cli(f"compare_patterns{o}".split())
-    ant.cli(f"compare_patterns --builders dipoles.invvee moxon{o}".split())
-    ant.cli(f"compare_patterns --builders dipoles.invvee hexbeam{o}".split())
+    ant.cli(f"compare_patterns --builders dipoles.invvee beams.moxon{o}".split())
+    ant.cli(f"compare_patterns --builders dipoles.invvee beams.hexbeam{o}".split())
 
 
 def test_cli_engine_flag():

--- a/tests/test_cli_user_designs.py
+++ b/tests/test_cli_user_designs.py
@@ -75,3 +75,41 @@ def test_resolve_user_design_helper(userdir):
     (userdir / "cli_dipole.py").write_text(VALID)
     assert user_designs.resolve_user_design("cli_dipole").__name__ == "Builder"
     assert user_designs.resolve_user_design("missing") is None
+
+
+def test_cli_list_includes_builtin_and_user(userdir, capsys):
+    (userdir / "cli_dipole.py").write_text(VALID)
+    ant.cli(["list"])
+    out = capsys.readouterr().out
+    assert "beams.moxon" in out
+    assert "user.cli_dipole" in out
+
+
+def test_cli_list_filter(userdir, capsys):
+    ant.cli(["list", "moxon"])
+    out = capsys.readouterr().out
+    assert "beams.moxon" in out
+    assert "arrays.moxonarray" in out
+    assert "dipoles.invvee" not in out
+
+
+def test_cli_list_user_only(userdir, capsys):
+    (userdir / "cli_dipole.py").write_text(VALID)
+    ant.cli(["list", "--user-only"])
+    out = capsys.readouterr().out
+    assert "user.cli_dipole" in out
+    assert "beams.moxon" not in out
+
+
+def test_cli_list_builtin_only(userdir, capsys):
+    (userdir / "cli_dipole.py").write_text(VALID)
+    ant.cli(["list", "--builtin-only"])
+    out = capsys.readouterr().out
+    assert "beams.moxon" in out
+    assert "user." not in out
+
+
+def test_cli_list_no_match(userdir, capsys):
+    ant.cli(["list", "definitely_not_a_design_xyz"])
+    out = capsys.readouterr().out
+    assert "no designs" in out

--- a/tests/test_cli_user_designs.py
+++ b/tests/test_cli_user_designs.py
@@ -1,0 +1,77 @@
+"""CLI resolution of user-authored designs.
+
+The web app registers user files under ``user.<name>`` in its REGISTRY; the
+CLI resolves the same ``user.<name>`` spec straight from the folder via
+``antenna_designer.user_designs`` (no web dependency). These cover the CLI /
+core path, separate from the web-registry behaviour in test_user_designs.py.
+"""
+
+import pytest
+
+import antenna_designer as ant
+from antenna_designer import user_designs
+from antenna_designer.cli import resolve_class
+
+VALID = """
+from types import MappingProxyType
+from antenna_designer import AntennaBuilder
+
+class Builder(AntennaBuilder):
+    label = "CLI test dipole"
+    default_params = MappingProxyType({"freq": 14.0, "half_length": 5.0})
+
+    def build_wires(self):
+        h = self.half_length
+        n = self.nominal_nsegs
+        return [
+            ((0.0, -h, 0.0), (0.0, -0.01, 0.0), n, None),
+            ((0.0, 0.01, 0.0), (0.0, h, 0.0), n, None),
+            ((0.0, -0.01, 0.0), (0.0, 0.01, 0.0), 1, 1 + 0j),
+        ]
+"""
+
+SYNTAX_ERROR = "class Builder(  # unterminated\n"
+
+
+@pytest.fixture
+def userdir(tmp_path, monkeypatch):
+    monkeypatch.setenv("ANTENNA_DESIGNER_USER_DIR", str(tmp_path))
+    return tmp_path
+
+
+def test_resolve_user_design_by_explicit_name(userdir):
+    (userdir / "cli_dipole.py").write_text(VALID)
+    cls = resolve_class("user.cli_dipole")
+    assert cls is not None
+    assert cls.__name__ == "Builder"
+
+
+def test_bare_name_does_not_resolve_user_design(userdir):
+    """A user file is reachable only through its `user.` namespace — a bare
+    name must not resolve to it (that's what keeps user files from shadowing
+    built-ins)."""
+    (userdir / "cli_dipole.py").write_text(VALID)
+    assert resolve_class("cli_dipole") is None
+
+
+def test_unknown_user_design_resolves_to_none(userdir):
+    assert resolve_class("user.does_not_exist") is None
+
+
+def test_cli_draw_runs_a_user_design(userdir):
+    (userdir / "cli_dipole.py").write_text(VALID)
+    ant.cli("draw --builder user.cli_dipole --fn /dev/null".split())
+
+
+def test_load_error_propagates_with_real_cause(userdir):
+    """A broken user file surfaces the actual error (so the author can fix it),
+    not a generic 'unknown builder'."""
+    (userdir / "broken.py").write_text(SYNTAX_ERROR)
+    with pytest.raises(SyntaxError):
+        resolve_class("user.broken")
+
+
+def test_resolve_user_design_helper(userdir):
+    (userdir / "cli_dipole.py").write_text(VALID)
+    assert user_designs.resolve_user_design("cli_dipole").__name__ == "Builder"
+    assert user_designs.resolve_user_design("missing") is None

--- a/tests/test_engine_spec.py
+++ b/tests/test_engine_spec.py
@@ -137,14 +137,14 @@ def test_broadcast_mismatch_raises():
 @needs_pynec
 def test_cli_compare_patterns_three_by_three_paired():
     ant.cli(
-        f"compare_patterns --builders dipoles.invvee:dipole dipoles.invvee bowtie "
+        f"compare_patterns --builders dipoles.invvee:dipole dipoles.invvee specialty.bowtie "
         f"--engines pynec pysim:triangular pysim:sinusoidal{O}".split()
     )
 
 
 def test_cli_compare_patterns_three_builders_one_engine():
     ant.cli(
-        f"compare_patterns --builders dipoles.invvee:dipole dipoles.invvee bowtie --engines pysim{O}".split()
+        f"compare_patterns --builders dipoles.invvee:dipole dipoles.invvee specialty.bowtie --engines pysim{O}".split()
     )
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -26,6 +26,11 @@ def test_resolve_class():
     assert check(resolve_class("freq_based_dipole"))
     assert not check(resolve_class("fail"))
 
+    # A bare, unqualified basename still resolves via the family-subpackage
+    # fallback (interactive convenience). Integration tests use the explicit
+    # "family.name" form; this keeps the fallback itself covered.
+    assert check(resolve_class("hexbeam"))
+
     assert check(resolve_class("subdir.moxon.Builder"))
 
     assert check(resolve_class("dipoles.invvee"))

--- a/tests/test_user_designs.py
+++ b/tests/test_user_designs.py
@@ -65,13 +65,18 @@ def test_valid_design_registers(userdir):
     assert REGISTRY["user.my_dipole"].name == "user.my_dipole"
 
 
-def test_broken_geometry_reports_error_without_crashing(userdir):
+def test_broken_geometry_loads_but_fails_on_solve(userdir):
+    # build_wires is no longer run at registration (lazy: the builder only runs
+    # when the design is selected/solved), so a geometry error does NOT block
+    # loading — the design registers, and the error surfaces on solve instead
+    # of in the load panel. Load-level errors (syntax/import/no-Builder) are
+    # still caught at registration; see the tests below.
     (userdir / "oops.py").write_text(BROKEN_BUILD)
     errors = user_designs.refresh()
-    assert "user.oops" not in REGISTRY
-    assert len(errors) == 1
-    assert errors[0]["name"] == "user.oops"
-    assert "NameError" in errors[0]["message"]
+    assert errors == []
+    assert "user.oops" in REGISTRY
+    with pytest.raises(NameError):
+        REGISTRY["user.oops"].pysim_solve({})
 
 
 def test_missing_builder_reports_error(userdir):
@@ -82,8 +87,9 @@ def test_missing_builder_reports_error(userdir):
 
 
 def test_one_bad_design_does_not_block_a_good_one(userdir):
+    # A load-level failure (no Builder) is isolated to its own file.
     (userdir / "good.py").write_text(VALID)
-    (userdir / "bad.py").write_text(BROKEN_BUILD)
+    (userdir / "bad.py").write_text(NO_BUILDER)
     errors = user_designs.refresh()
     assert "user.good" in REGISTRY
     assert {e["name"] for e in errors} == {"user.bad"}
@@ -95,7 +101,7 @@ def test_reload_picks_up_edits(userdir):
     assert user_designs.refresh() == []
     assert "user.d" in REGISTRY
 
-    f.write_text(BROKEN_BUILD)  # break it
+    f.write_text(NO_BUILDER)  # break it at load level (no Builder)
     errors = user_designs.refresh()
     assert "user.d" not in REGISTRY
     assert errors and errors[0]["name"] == "user.d"

--- a/tests/test_user_designs.py
+++ b/tests/test_user_designs.py
@@ -79,6 +79,18 @@ def test_broken_geometry_loads_but_fails_on_solve(userdir):
         REGISTRY["user.oops"].pysim_solve({})
 
 
+def test_format_solve_error_points_at_user_file(userdir):
+    # The on-solve error banner (server.py) formats exceptions via this helper;
+    # it should name the user's file + line, not framework internals.
+    (userdir / "boom.py").write_text(BROKEN_BUILD)
+    user_designs.refresh()
+    with pytest.raises(NameError) as ei:
+        REGISTRY["user.boom"].pysim_solve({})
+    msg = user_designs.format_solve_error(ei.value)
+    assert "NameError" in msg
+    assert "boom.py" in msg and "line" in msg
+
+
 def test_missing_builder_reports_error(userdir):
     (userdir / "nobuilder.py").write_text(NO_BUILDER)
     errors = user_designs.refresh()

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -16,7 +16,8 @@ import numpy as np
 import pytest
 from fastapi.testclient import TestClient
 
-from web import server
+from web import server, user_designs
+from web.examples import REGISTRY
 
 
 # ---------------------------------------------------------------------------
@@ -694,7 +695,6 @@ def test_phase_param_slider_range_spans_full_unit_circle():
         "antenna_designer.designs.arrays.bowtiearray"
     ).Builder.default_params
     assert "phase_lr" in schema and "phase_tb" in schema
-    from web.examples import REGISTRY
 
     by_name = {s.name: s for s in REGISTRY["arrays.bowtiearray"].param_schema}
     lr = by_name["phase_lr"]
@@ -813,6 +813,59 @@ def test_ws_endpoint_returns_cleanly_on_client_disconnect(client: TestClient):
     # context manager.
     with client.websocket_connect("/ws"):
         pass  # context exit closes the socket
+
+
+_BROKEN_USER_DESIGN = """
+from types import MappingProxyType
+from antenna_designer import AntennaBuilder
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType({"freq": 14.0})
+
+    def build_wires(self):
+        return 1 / 0  # ZeroDivisionError when geometry is built
+"""
+
+
+@pytest.fixture
+def broken_user_design():
+    """Install a user design that loads fine but raises in build_wires, so it
+    registers (geometry is deferred) yet fails on the first solve/geometry."""
+    d = user_designs.default_user_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    f = d / "wsboom.py"
+    f.write_text(_BROKEN_USER_DESIGN)
+    user_designs.refresh()
+    yield "user.wsboom"
+    f.unlink(missing_ok=True)
+    user_designs.refresh()
+    for k in [k for k in REGISTRY if k.startswith("user.")]:
+        del REGISTRY[k]
+
+
+def test_geometry_endpoint_surfaces_build_error(client, broken_user_design):
+    # A deferred user design that raises in build_wires fails at selection, not
+    # at load. /geometry must return the cause (200, not 500) so the frontend
+    # can show it instead of a blank stage.
+    r = client.post("/geometry", json={"geometry": broken_user_design})
+    assert r.status_code == 200
+    body = r.json()
+    assert "ZeroDivisionError" in body["error"]
+    assert "wsboom.py" in body["error"]
+
+
+def test_ws_solve_error_keeps_socket_alive(client, broken_user_design):
+    # A solve that raises must surface as an error frame, NOT tear down the
+    # socket — otherwise every subsequent slider-driven solve is lost.
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(__import__("json").dumps({"geometry": broken_user_design}))
+        bad = __import__("json").loads(ws.receive_text())
+        assert "ZeroDivisionError" in bad["error"]
+        # Same socket still serves a healthy design.
+        ws.send_text(__import__("json").dumps({"geometry": "dipoles.invvee"}))
+        good = __import__("json").loads(ws.receive_text())
+    assert good["geometry"] == "dipoles.invvee"
+    assert "wires" in good
 
 
 def test_solve_z_only_returns_primary_z_and_no_feeds_for_dipole():

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -684,6 +684,16 @@ def test_solve_response_carries_z0_ohms_for_array_design():
     assert out["z0_ohms"] == 100.0
 
 
+def test_geometry_preview_carries_default_backend(client: TestClient):
+    # The frontend seeds its solver from the preview's default_backend (and
+    # then fires the first solve), so the recommendation must ride on the
+    # /geometry response — array-block for a grid array, None otherwise.
+    arr = client.post("/geometry", json={"geometry": "arrays.bowtiearray2x4"}).json()
+    assert arr["default_backend"] == "arrayblock"
+    dip = client.post("/geometry", json={"geometry": "dipoles.invvee"}).json()
+    assert dip["default_backend"] is None
+
+
 def test_phase_param_slider_range_spans_full_unit_circle():
     # phase_lr / phase_tb default to 0.0; without the adapter's
     # phase_*-name special case the auto-derive falls back to (-1, 1)

--- a/web/adapter.py
+++ b/web/adapter.py
@@ -809,13 +809,45 @@ def _recommended_backend(cls) -> str | None:
     return "arrayblock" if len(sigs) < n_elem else None
 
 
-def _make_example(name: str, cls) -> AntennaExample:
+def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExample:
     dp = dict(cls.default_params)
     ui = dict(dp.get("ui_params") or {})
 
-    default_view = _ui_scalar(dp, "default_view", _auto_default_view(cls))
-    target_z0 = float(_ui_scalar(dp, "target_z0", _auto_target_z0(cls)))
-    multi_feed = bool(_ui_scalar(dp, "multi_feed", _auto_multi_feed(cls)))
+    # UI hints that need the built geometry — multi_feed, default_view, the
+    # array target_z0, and the recommended array-block backend — are derived
+    # by running the builder. They're computed once and memoised in `hints()`.
+    #
+    # Built-in designs prime them eagerly at registration (defer_hints=False)
+    # so /examples and the array-block seed are correct up front. User designs
+    # defer them (defer_hints=True): a slow or hanging build_wires never runs at
+    # startup or on a page refresh — only when that design is actually selected
+    # and solved, where the builder runs anyway and the closures fold the hints
+    # into the solve/geometry response. A design can pin any hint statically in
+    # ui_params to override the derived value.
+    view_override = _ui_scalar(dp, "default_view", None)
+    z0_override = _ui_scalar(dp, "target_z0", None)
+    multi_feed_override = _ui_scalar(dp, "multi_feed", None)
+
+    _hints: dict[str, Any] = {}
+
+    def hints() -> dict[str, Any]:
+        if not _hints:
+            _hints["default_view"] = (
+                str(view_override)
+                if view_override is not None
+                else _auto_default_view(cls)
+            )
+            _hints["target_z0"] = float(
+                z0_override if z0_override is not None else _auto_target_z0(cls)
+            )
+            _hints["multi_feed"] = bool(
+                multi_feed_override
+                if multi_feed_override is not None
+                else _auto_multi_feed(cls)
+            )
+            _hints["default_backend"] = _recommended_backend(cls)
+        return _hints
+
     meas_range = (
         ui.get("meas_freq_range")
         if not isinstance(ui.get("meas_freq_range"), dict)
@@ -901,7 +933,12 @@ def _make_example(name: str, cls) -> AntennaExample:
             "height_m": 0.0,
             "ground_eps_r": _PEC_GROUND_EPS_R,
             "ground_sigma": _PEC_GROUND_SIGMA,
-            "z0_ohms": target_z0,
+            "z0_ohms": hints()["target_z0"],
+            # Geometry-derived UI hints, folded into the response so user
+            # designs (which defer them) get correct values the moment they're
+            # selected, without running the builder at registration.
+            "multi_feed": hints()["multi_feed"],
+            "default_view": hints()["default_view"],
             # Fraction of input power actually radiated (1.0 unless the design
             # has resistive loads, e.g. a terminated rhombic / T2FD). The
             # server's far-field normaliser multiplies directivity by this so
@@ -909,7 +946,7 @@ def _make_example(name: str, cls) -> AntennaExample:
             # populated it on the engine.
             "radiation_efficiency": float(getattr(eng, "_excited_efficiency", 1.0)),
         }
-        if multi_feed and len(zs) > 1:
+        if hints()["multi_feed"] and len(zs) > 1:
             # Pull per-feed drive voltages off the engine so the frontend
             # can render each feed's phase indicator. PysimEngine stores
             # _feeds = [(polyline_idx, arclength, voltage)]; fall back to
@@ -954,7 +991,12 @@ def _make_example(name: str, cls) -> AntennaExample:
             "measurement_freq_mhz": meas_freq,
             "lambda_design_m": C_LIGHT / (design_freq * 1e6),
             "ground": bool(req.get("ground", False)),
-            "z0_ohms": target_z0,
+            "z0_ohms": hints()["target_z0"],
+            # Carry the geometry-derived hints on the fast preview too: it's the
+            # first request fired on selection, so a deferred user design gets
+            # its multi_feed / default_view here, before the live solve lands.
+            "multi_feed": hints()["multi_feed"],
+            "default_view": hints()["default_view"],
             "preview": True,
         }
 
@@ -1043,13 +1085,15 @@ def _make_example(name: str, cls) -> AntennaExample:
             "height_m": 0.0,
             "ground_eps_r": _PEC_GROUND_EPS_R,
             "ground_sigma": _PEC_GROUND_SIGMA,
-            "z0_ohms": target_z0,
+            "z0_ohms": hints()["target_z0"],
+            "multi_feed": hints()["multi_feed"],
+            "default_view": hints()["default_view"],
             # Same directivity->gain factor as the pysim path, so switching
             # engines in the UI keeps the far-field plot meaning GAIN.
             # current_distribution() set it from the solved load currents.
             "radiation_efficiency": float(getattr(eng, "_excited_efficiency", 1.0)),
         }
-        if multi_feed and len(zs) > 1:
+        if hints()["multi_feed"] and len(zs) > 1:
             # PyNECEngine.excitation_pairs is [(tag, sub_seg, voltage)];
             # pull the voltage off each so per-feed phase comes through.
             voltages = [v for _t, _s, v in (eng.excitation_pairs or [])]
@@ -1098,11 +1142,27 @@ def _make_example(name: str, cls) -> AntennaExample:
         primary = zs[:, 0]
         re = primary.real.tolist()
         im = primary.imag.tolist()
-        if multi_feed and zs.shape[1] > 1:
+        if hints()["multi_feed"] and zs.shape[1] > 1:
             feeds_re = zs.real.tolist()  # (n_freqs, n_feeds) list of lists
             feeds_im = zs.imag.tolist()
             return re, im, feeds_re, feeds_im
         return re, im
+
+    # Static fields served by /examples. Built-ins prime hints() now (eager,
+    # unchanged behaviour); user designs ship provisional values — overrides if
+    # declared, else neutral defaults — and the real values arrive with the
+    # first solve/geometry response (see the closures above).
+    if defer_hints:
+        field_multi_feed = (
+            bool(multi_feed_override) if multi_feed_override is not None else False
+        )
+        field_default_view = str(view_override) if view_override is not None else "xy"
+        field_default_backend = None
+    else:
+        h = hints()
+        field_multi_feed = h["multi_feed"]
+        field_default_view = h["default_view"]
+        field_default_backend = h["default_backend"]
 
     return AntennaExample(
         name=name,
@@ -1110,17 +1170,17 @@ def _make_example(name: str, cls) -> AntennaExample:
         pysim_solve=pysim_solve,
         pysim_sweep=pysim_sweep,
         pysim_geometry=pysim_geometry,
-        default_backend=_recommended_backend(cls),
+        default_backend=field_default_backend,
         pynec_solve=pynec_solve,
         pynec_build=pynec_build,
         pynec_pattern_excite=pynec_pattern_excite,
         nec_export=nec_export,
-        multi_feed=multi_feed,
+        multi_feed=field_multi_feed,
         param_schema=param_schema,
         bands=bands,
         meas_freq_range_mhz=tuple(meas_range) if meas_range else None,
         sweep_policy=sweep_policy,
-        default_view=default_view,
+        default_view=field_default_view,
         default_freq_mhz=float(dp["freq"]) if "freq" in dp else None,
         has_design_freq=has_design_freq,
         variants=variants,

--- a/web/adapter.py
+++ b/web/adapter.py
@@ -995,8 +995,12 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             # Carry the geometry-derived hints on the fast preview too: it's the
             # first request fired on selection, so a deferred user design gets
             # its multi_feed / default_view here, before the live solve lands.
+            # default_backend lets the frontend seed the array-block solver from
+            # the preview and then fire the first solve — no /examples-descriptor
+            # dependency, so this stays correct if a design's hints go lazy.
             "multi_feed": hints()["multi_feed"],
             "default_view": hints()["default_view"],
+            "default_backend": hints()["default_backend"],
             "preview": True,
         }
 

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -579,6 +579,10 @@ type SolveResponse = {
    *  prefer them over the example fields when present. */
   multi_feed?: boolean;
   default_view?: Projection;
+  /** Set when the solve/geometry request failed — e.g. a user design's
+   *  build_wires() raised. Carries a short, formatted message (type + file +
+   *  line). Mutually exclusive with a normal result payload. */
+  error?: string;
 };
 
 // Backend selector — PySim model variants + PyNEC. Per-backend
@@ -1300,6 +1304,11 @@ export function App() {
   // `result` the moment the real solve lands; only consulted while result is
   // null (i.e. right after an antenna switch).
   const [preview, setPreview] = useState<SolveResponse | null>(null);
+  // Set when the selected design fails to solve/build — most often a user
+  // design whose build_wires() raises. Geometry errors are deferred to
+  // selection now (the builder isn't run at registration), so this banner is
+  // where they surface. Cleared on every antenna switch.
+  const [solveError, setSolveError] = useState<string | null>(null);
   // Whether to render the per-feed (multi-feed) UI. Prefer the value the
   // server folds into the live solve / geometry response — authoritative for
   // user designs, which derive it lazily — and fall back to the example
@@ -1619,6 +1628,7 @@ export function App() {
   useEffect(() => {
     setResult(null);
     setPreview(null);
+    setSolveError(null);
     previewAbortRef.current?.abort();
     const controller = new AbortController();
     previewAbortRef.current = controller;
@@ -1630,7 +1640,15 @@ export function App() {
     })
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
-        if (data && data.wires && !controller.signal.aborted) {
+        if (!data || controller.signal.aborted) return;
+        if (data.error) {
+          // build_wires raised while building the preview — surface it; the
+          // live solve will report the same thing, but the preview gets here
+          // first so the user sees the cause without a blank stage.
+          setSolveError(data.error as string);
+          return;
+        }
+        if (data.wires) {
           setPreview(data as SolveResponse);
           // A deferred (user) design derives its natural view only when the
           // builder first runs — which is this preview. Snap the camera to it
@@ -2104,7 +2122,18 @@ export function App() {
       // antenna's geometry preview (and briefly show the wrong antenna). The
       // pending solve below still fires so the current selection gets solved.
       const stale = !!data.geometry && data.geometry !== geometryRef.current;
-      if (!stale) setResult(data);
+      if (!stale) {
+        if (data.error) {
+          // A solve that raised (e.g. a user design's build_wires) — show the
+          // message and clear stale plot data rather than rendering an empty
+          // result on top of the last antenna.
+          setSolveError(data.error);
+          setResult(null);
+        } else {
+          setSolveError(null);
+          setResult(data);
+        }
+      }
       // If controls changed while waiting, fire the next solve immediately.
       if (pendingRef.current) {
         pendingRef.current = null;
@@ -2551,6 +2580,16 @@ export function App() {
             and lingers out its min-visible window (showBusy), so it never
             flashes — the dim/label (stale) clear earlier, when the result lands. */}
         <div className={`solve-bar${showBusy ? " active" : ""}`} aria-hidden />
+        {solveError && (
+          <div className="solve-error" role="alert">
+            <span className="solve-error-title">This design failed to solve</span>
+            <code className="solve-error-message">{solveError}</code>
+            <span className="solve-error-hint">
+              Fix the design and adjust a control to retry. For user designs see
+              CLAUDE.md in your designs folder.
+            </span>
+          </div>
+        )}
         <div className="thumbstrip" ref={thumbStripRef}>
           {VIEWS.filter((v) => v.id !== view).map((v) => (
             <button

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -579,6 +579,11 @@ type SolveResponse = {
    *  prefer them over the example fields when present. */
   multi_feed?: boolean;
   default_view?: Projection;
+  /** Recommended solver backend for this design (e.g. "arrayblock" for grid
+   *  arrays). Carried on the geometry preview so the frontend can seed the
+   *  backend from it and *then* fire the first solve, instead of the descriptor
+   *  racing the preview. Absent / null = no recommendation. */
+  default_backend?: Backend | null;
   /** Set when the solve/geometry request failed — e.g. a user design's
    *  build_wires() raised. Carries a short, formatted message (type + file +
    *  line). Mutually exclusive with a normal result payload. */
@@ -1309,6 +1314,12 @@ export function App() {
   // selection now (the builder isn't run at registration), so this banner is
   // where they surface. Cleared on every antenna switch.
   const [solveError, setSolveError] = useState<string | null>(null);
+  // Name of the geometry whose preview has landed (and seeded the backend).
+  // Gates the first solve after an antenna switch: we want preview → seed
+  // backend → solve, not preview racing the solve. Reset to null on every
+  // switch; the preview's .then sets it. Slider drags on the *same* antenna
+  // keep solving freely (it stays equal to `geometry`).
+  const [previewReady, setPreviewReady] = useState<string | null>(null);
   // Whether to render the per-feed (multi-feed) UI. Prefer the value the
   // server folds into the live solve / geometry response — authoritative for
   // user designs, which derive it lazily — and fall back to the example
@@ -1350,23 +1361,27 @@ export function App() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentExample?.name]);
 
-  // Seed the active slot's solver from the example's recommendation on antenna
-  // selection — e.g. grid arrays default to the array-block accelerator, which
-  // is ~8x faster than the dense Triangular default. Only *upgrades* a dense
-  // pysim backend; an explicit PyNEC pick, an already-accelerated backend, or
-  // any hand-picked choice (backendTouchedRef) is left untouched.
-  useEffect(() => {
-    const rec = currentExample?.default_backend;
+  // Seed the active slot's solver from a design's recommendation — e.g. grid
+  // arrays default to the array-block accelerator, ~8x faster than the dense
+  // Triangular default. Called from the geometry preview's .then (which carries
+  // `default_backend`), so the backend is in place before the gated first solve
+  // fires — no descriptor-vs-preview race, and no dependency on /examples
+  // having the value (it works the same if a design's hints go lazy). Only
+  // *upgrades* a dense pysim backend; an explicit PyNEC pick, an already-
+  // accelerated backend, or any hand-picked choice (backendTouchedRef) is left
+  // untouched. The decision reads `prev` inside the updater so it's never stale.
+  function seedBackendFromPreview(rec: Backend | null | undefined) {
     if (!rec || backendTouchedRef.current || !BACKEND_ORDER.includes(rec)) return;
-    const cur = slots[activeSlot].backend;
-    const upgradable =
-      cur === "triangular" || cur === "sinusoidal" || cur === "bspline";
-    if (upgradable && cur !== rec) {
+    setSlots((prev) => {
+      const cur = prev[activeSlot].backend;
+      const upgradable =
+        cur === "triangular" || cur === "sinusoidal" || cur === "bspline";
+      if (!upgradable || cur === rec) return prev;
       // Reset to the recommended backend's *own* defaults rather than carrying
       // over the dense slot's segment count — arrays want array-block's 21
       // segs/wire (converged, correct d=2 parity), not the inherited 40. Keep
       // the user's wire radius.
-      setSlots((prev) => ({
+      return {
         ...prev,
         [activeSlot]: {
           backend: rec,
@@ -1375,10 +1390,9 @@ export function App() {
             wireRadius: prev[activeSlot].opts.wireRadius,
           } as BackendOptsMap[Backend],
         },
-      }));
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentExample?.name]);
+      };
+    });
+  }
 
   // Schema-driven design-freq link: when the active example has any
   // leaf marked `linked_to_design_freq`, sync the global designFreq
@@ -1607,11 +1621,16 @@ export function App() {
   const controlsRef = useRef<SolveRequest>(buildRequest());
 
   useEffect(() => {
+    // Hold the first solve after an antenna switch until that antenna's preview
+    // has landed and seeded the backend (previewReady === geometry). Param/freq
+    // tweaks on the *same* antenna keep solving freely — previewReady stays
+    // equal to geometry until the next switch resets it to null.
+    if (previewReady !== geometry) return;
     controlsRef.current = buildRequest();
     requestSolve();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    geometry, backend, backendOptsKey,
+    geometry, previewReady, backend, backendOptsKey,
     currentValuesKey,
     designFreq, measFreq,
     groundEnabled, groundFast,
@@ -1629,9 +1648,13 @@ export function App() {
     setResult(null);
     setPreview(null);
     setSolveError(null);
+    setPreviewReady(null); // close the solve gate until this antenna's preview lands
     previewAbortRef.current?.abort();
     const controller = new AbortController();
     previewAbortRef.current = controller;
+    // Capture the geometry this run is for, so the gate is released for the
+    // right antenna even if `geometry` changed by the time the fetch resolves.
+    const forGeometry = geometry;
     fetch("/geometry", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -1640,15 +1663,15 @@ export function App() {
     })
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
-        if (!data || controller.signal.aborted) return;
-        if (data.error) {
-          // build_wires raised while building the preview — surface it; the
-          // live solve will report the same thing, but the preview gets here
-          // first so the user sees the cause without a blank stage.
+        if (controller.signal.aborted) return;
+        if (data && data.error) {
+          // build_wires raised while building the preview — surface it and
+          // leave the gate closed: a live solve would just reproduce the same
+          // error, so there's nothing to render. (The error banner shows it.)
           setSolveError(data.error as string);
           return;
         }
-        if (data.wires) {
+        if (data && data.wires) {
           setPreview(data as SolveResponse);
           // A deferred (user) design derives its natural view only when the
           // builder first runs — which is this preview. Snap the camera to it
@@ -1657,10 +1680,21 @@ export function App() {
           // from currentExample.default_view, so there's no visible flip.
           const dv = (data as SolveResponse).default_view;
           if (dv) setCameraProjection(dv);
+          // Seed the solver backend from the preview *before* releasing the
+          // gate, batched in this same commit, so the first solve reads the
+          // seeded backend (arrays go straight to array-block, never a slow
+          // dense first solve).
+          seedBackendFromPreview((data as SolveResponse).default_backend);
         }
+        // Release the gate: preview resolved (with or without drawable wires,
+        // e.g. an `available:false` geometry) — let the first solve fire.
+        setPreviewReady(forGeometry);
       })
       .catch(() => {
-        /* aborted or offline — the live solve will still render the antenna */
+        // Aborted or offline. If this run wasn't superseded, still release the
+        // gate so the live solve renders the antenna (its own error path
+        // surfaces anything that goes wrong there).
+        if (!controller.signal.aborted) setPreviewReady(forGeometry);
       });
     return () => controller.abort();
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -573,6 +573,12 @@ type SolveResponse = {
    *  50 Ω when the server doesn't supply one. Bowtie array returns 100 Ω
    *  because each element is designed for a 100 Ω feedline. */
   z0_ohms?: number;
+  /** Geometry-derived UI hints folded into the solve/geometry response.
+   *  User designs defer these (the builder runs lazily on selection), so the
+   *  authoritative values arrive here rather than on the /examples descriptor;
+   *  prefer them over the example fields when present. */
+  multi_feed?: boolean;
+  default_view?: Projection;
 };
 
 // Backend selector — PySim model variants + PyNEC. Per-backend
@@ -1294,6 +1300,15 @@ export function App() {
   // `result` the moment the real solve lands; only consulted while result is
   // null (i.e. right after an antenna switch).
   const [preview, setPreview] = useState<SolveResponse | null>(null);
+  // Whether to render the per-feed (multi-feed) UI. Prefer the value the
+  // server folds into the live solve / geometry response — authoritative for
+  // user designs, which derive it lazily — and fall back to the example
+  // descriptor (eager built-ins) before the first response lands.
+  const effectiveMultiFeed =
+    result?.multi_feed ??
+    preview?.multi_feed ??
+    currentExample?.multi_feed ??
+    false;
   const [status, setStatus] = useState<"connecting" | "open" | "closed">("connecting");
   const [rttMs, setRttMs] = useState<number | null>(null);
   // True whenever a main solve is outstanding (in flight or queued) — i.e. the
@@ -1617,6 +1632,13 @@ export function App() {
       .then((data) => {
         if (data && data.wires && !controller.signal.aborted) {
           setPreview(data as SolveResponse);
+          // A deferred (user) design derives its natural view only when the
+          // builder first runs — which is this preview. Snap the camera to it
+          // here, once per selection (this effect is keyed on `geometry`). For
+          // eager built-ins the value matches the provisional one already set
+          // from currentExample.default_view, so there's no visible flip.
+          const dv = (data as SolveResponse).default_view;
+          if (dv) setCameraProjection(dv);
         }
       })
       .catch(() => {
@@ -2468,7 +2490,7 @@ export function App() {
               result={result as Record<string, unknown> | null}
             />
           )}
-          {currentExample?.multi_feed && result?.feeds && result.feeds.length > 1 && (
+          {effectiveMultiFeed && result?.feeds && result.feeds.length > 1 && (
             <div className="feeds-table">
               <div className="feeds-table-header">per-feed Z (V/I)</div>
               {result.feeds.map((f, i) => (
@@ -2558,7 +2580,7 @@ export function App() {
                   cameraProjection={cameraProjection}
                   showHeatmap={showHeatmap}
                   showEnvelope={showEnvelope}
-                  multiFeed={currentExample?.multi_feed ?? false}
+                  multiFeed={effectiveMultiFeed}
                 />
               </div>
               <div className="thumb-label">{v.label}</div>
@@ -2650,7 +2672,7 @@ export function App() {
             cameraProjection={cameraProjection}
             showHeatmap={showHeatmap}
             showEnvelope={showEnvelope}
-            multiFeed={currentExample?.multi_feed ?? false}
+            multiFeed={effectiveMultiFeed}
           />
         </div>
         <div className="status">

--- a/web/frontend/src/styles.css
+++ b/web/frontend/src/styles.css
@@ -470,6 +470,34 @@ button:focus-visible,
   font-size: var(--text-xs);
 }
 
+.solve-error {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: var(--space-3) 0;
+  padding: var(--space-4) var(--space-5);
+  border: 1px solid var(--danger-border);
+  border-radius: var(--r-sm);
+  background: var(--danger-bg);
+  color: var(--danger);
+  font-size: var(--text-sm);
+}
+
+.solve-error-title {
+  font-weight: 600;
+}
+
+.solve-error-message {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  word-break: break-word;
+}
+
+.solve-error-hint {
+  color: var(--muted);
+  font-size: var(--text-xs);
+}
+
 .geometry-tabs button {
   flex: 1;
   background: var(--inset);

--- a/web/server.py
+++ b/web/server.py
@@ -697,7 +697,13 @@ async def geometry_endpoint(req: dict):
     ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
     if ex.pysim_geometry is None:
         return {"available": False}
-    out = await run_in_threadpool(ex.pysim_geometry, req)
+    try:
+        out = await run_in_threadpool(ex.pysim_geometry, req)
+    except Exception as exc:  # noqa: BLE001 — a user design's build_wires can raise
+        # Geometry builds lazily on selection now, so a broken user design
+        # fails here rather than at load. Return the cause (200, not 500) so the
+        # frontend can show it in the solve-error banner instead of a blank stage.
+        return {"geometry": geometry, "error": user_designs.format_solve_error(exc)}
     out["solver"] = "pysim"
     return out
 
@@ -832,7 +838,16 @@ async def ws_endpoint(ws: WebSocket):
         while True:
             raw = await ws.receive_text()
             req = json.loads(raw)
-            result = await run_in_threadpool(solve, req)
+            try:
+                result = await run_in_threadpool(solve, req)
+            except Exception as exc:  # noqa: BLE001 — a user design's build_wires can raise
+                # A solve that raises must not tear down the socket (that drops
+                # every subsequent slider-driven solve). Send the cause so the
+                # frontend shows it in the solve-error banner, then keep serving.
+                result = {
+                    "geometry": req.get("geometry"),
+                    "error": user_designs.format_solve_error(exc),
+                }
             # The client can disconnect *during* the solve (rapid
             # slider drag tears down the React effect's WS and opens
             # a fresh one before our threadpool finishes). When that

--- a/web/user_design_assets/CLAUDE.md
+++ b/web/user_design_assets/CLAUDE.md
@@ -27,6 +27,7 @@ Start from `TEMPLATE.py` in this folder — copy it, rename it, edit it.
 The same file also works from the command line: once `my_dipole.py` is in
 this folder, run e.g. `antenna_designer draw --builder user.my_dipole` (or
 `sweep`, `pattern`, …). Always address it with the `user.` prefix.
+`antenna_designer list` shows every available design name (yours included).
 
 ## `default_params`
 

--- a/web/user_design_assets/CLAUDE.md
+++ b/web/user_design_assets/CLAUDE.md
@@ -24,6 +24,10 @@ A design file must:
 
 Start from `TEMPLATE.py` in this folder — copy it, rename it, edit it.
 
+The same file also works from the command line: once `my_dipole.py` is in
+this folder, run e.g. `antenna_designer draw --builder user.my_dipole` (or
+`sweep`, `pattern`, …). Always address it with the `user.` prefix.
+
 ## `default_params`
 
 Every key becomes a slider in the UI, accessed in `build_wires` as

--- a/web/user_designs.py
+++ b/web/user_designs.py
@@ -9,6 +9,7 @@ load errors for the "failed to load" UI panel.
 
 from __future__ import annotations
 
+import os
 import shutil
 import traceback
 from pathlib import Path
@@ -30,6 +31,7 @@ __all__ = [
     "user_design_dirs",
     "ensure_scaffold",
     "refresh",
+    "format_solve_error",
 ]
 
 _ASSETS = Path(__file__).resolve().parent / "user_design_assets"
@@ -57,6 +59,33 @@ def _format_error(path: Path, exc: Exception) -> str:
     tb = traceback.extract_tb(exc.__traceback__)
     here = [fr for fr in tb if fr.filename == str(path)]
     where = f" (line {here[-1].lineno})" if here else ""
+    return f"{type(exc).__name__}: {exc}{where}"
+
+
+def format_solve_error(exc: BaseException) -> str:
+    """Format a solve/geometry-time exception for the UI error banner.
+
+    Geometry now builds lazily on selection, so a user design's build_wires()
+    error surfaces here rather than in the load panel. Point at the deepest
+    frame inside a user-design folder when the failure came from someone's own
+    file (the common case); otherwise fall back to just type + message.
+    """
+    tb = traceback.extract_tb(exc.__traceback__)
+    dirs: list[str] = []
+    for d in user_design_dirs():
+        try:
+            dirs.append(str(d.resolve()))
+        except OSError:
+            dirs.append(str(d))
+    frame = None
+    for fr in tb:
+        try:
+            fp = str(Path(fr.filename).resolve())
+        except OSError:
+            fp = fr.filename
+        if any(fp == d or fp.startswith(d + os.sep) for d in dirs):
+            frame = fr  # keep the deepest (last) frame in a user folder
+    where = f" ({Path(frame.filename).name}, line {frame.lineno})" if frame else ""
     return f"{type(exc).__name__}: {exc}{where}"
 
 

--- a/web/user_designs.py
+++ b/web/user_designs.py
@@ -76,11 +76,16 @@ def refresh() -> list[dict]:
         name = f"{USER_NS}.{stem}"
         try:
             cls = load_builder(path)
-            # Smoke-test: construct, then actually build the geometry so a
-            # typo / bad shape in build_wires surfaces here (at load, in the UI
-            # panel) instead of only when the design is solved.
-            cls().build_wires()
-            REGISTRY[name] = adapter._make_example(name, cls)
+            # Construct (cheap — validates default_params) but do NOT run
+            # build_wires here: registration must not execute a user's geometry
+            # code, so a slow or hanging builder can't stall startup or a page
+            # refresh. defer_hints=True pushes every build_wires-derived hint to
+            # the first solve/geometry of this design. Geometry errors therefore
+            # surface on selection (via the solve/geometry error path) rather
+            # than in this load panel — import/syntax/construction errors still
+            # surface here.
+            cls()
+            REGISTRY[name] = adapter._make_example(name, cls, defer_hints=True)
         except Exception as exc:  # noqa: BLE001 — surface, don't crash
             errors.append(
                 {

--- a/web/user_designs.py
+++ b/web/user_designs.py
@@ -1,52 +1,38 @@
-"""Discovery and live-reload of user-authored antenna designs.
+"""Web-layer glue for user-authored antenna designs.
 
-For a local install, a ham (or Claude Code on their behalf) drops a ``.py``
-file defining a ``Builder`` into their user design folder; it shows up in the
-web UI under the ``user`` family with no server restart. The authoring
-contract lives in ``user_design_assets/TEMPLATE.py`` and ``CLAUDE.md``, which
-are copied into the user folder on first run.
-
-User designs live *outside* the installed package (so a ``pip`` upgrade never
-clobbers them) and are loaded by file path, then registered under
-``user.<filename>`` — a namespace that can never collide with or shadow a
-built-in family design.
+The discovery + path-loading core lives in ``antenna_designer.user_designs``
+(no web dependency, shared with the CLI). This module layers on the bits that
+are specific to the running web app: registering each design into ``REGISTRY``
+under ``user.<filename>``, scaffolding the folder on first run, and formatting
+load errors for the "failed to load" UI panel.
 """
 
 from __future__ import annotations
 
-import importlib.util
-import os
 import shutil
-import sys
 import traceback
 from pathlib import Path
+
+from antenna_designer.user_designs import (
+    USER_NS,
+    default_user_dir,
+    iter_design_files,
+    load_builder,
+    user_design_dirs,
+)
 
 from . import adapter
 from .examples import REGISTRY
 
-USER_NS = "user"
+__all__ = [
+    "USER_NS",
+    "default_user_dir",
+    "user_design_dirs",
+    "ensure_scaffold",
+    "refresh",
+]
+
 _ASSETS = Path(__file__).resolve().parent / "user_design_assets"
-_MODULE_PREFIX = "antenna_designer._user_designs"
-
-
-def default_user_dir() -> Path:
-    """The primary user-design folder: ``$ANTENNA_DESIGNER_USER_DIR`` if set,
-    else ``~/.antenna_designer/designs``."""
-    env = os.environ.get("ANTENNA_DESIGNER_USER_DIR")
-    if env:
-        return Path(env).expanduser()
-    return Path.home() / ".antenna_designer" / "designs"
-
-
-def user_design_dirs() -> list[Path]:
-    """Folders scanned for user designs, in priority order: the default (or
-    the env override) plus ``./antenna_designs`` if it exists in the cwd."""
-    dirs = [default_user_dir()]
-    seen = {d.resolve() for d in dirs if d.exists()}
-    local = Path.cwd() / "antenna_designs"
-    if local.is_dir() and local.resolve() not in seen:
-        dirs.append(local)
-    return dirs
 
 
 def ensure_scaffold() -> None:
@@ -64,28 +50,6 @@ def ensure_scaffold() -> None:
                 shutil.copyfile(src, d / asset)
     except OSError as exc:  # read-only home, permissions, … — log and move on
         print(f"[user_designs] could not scaffold {d}: {exc!r}")
-
-
-def _load_builder(path: Path):
-    """Import a single user file by path and return its ``Builder`` class.
-    Re-executes the file on every call, so edits are picked up live."""
-    modname = f"{_MODULE_PREFIX}.{path.stem}"
-    spec = importlib.util.spec_from_file_location(modname, path)
-    if spec is None or spec.loader is None:
-        raise ImportError(f"could not create import spec for {path.name}")
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules[modname] = mod
-    try:
-        spec.loader.exec_module(mod)
-    except BaseException:
-        sys.modules.pop(modname, None)
-        raise
-    cls = getattr(mod, "Builder", None)
-    if cls is None:
-        raise AttributeError(
-            "no `Builder` class found — define `class Builder(AntennaBuilder): ...`"
-        )
-    return cls
 
 
 def _format_error(path: Path, exc: Exception) -> str:
@@ -108,31 +72,21 @@ def refresh() -> list[dict]:
         del REGISTRY[key]
 
     errors: list[dict] = []
-    seen: set[str] = set()
-    for d in user_design_dirs():
-        if not d.is_dir():
-            continue
-        for path in sorted(d.glob("*.py")):
-            stem = path.stem
-            if stem.startswith("_") or stem == "TEMPLATE":
-                continue
-            name = f"{USER_NS}.{stem}"
-            if name in seen:
-                continue  # first folder in priority order wins
-            seen.add(name)
-            try:
-                cls = _load_builder(path)
-                # Smoke-test: construct, then actually build the geometry so a
-                # typo / bad shape in build_wires surfaces here (at load, in
-                # the UI panel) instead of only when the design is solved.
-                cls().build_wires()
-                REGISTRY[name] = adapter._make_example(name, cls)
-            except Exception as exc:  # noqa: BLE001 — surface, don't crash
-                errors.append(
-                    {
-                        "name": name,
-                        "file": str(path),
-                        "message": _format_error(path, exc),
-                    }
-                )
+    for stem, path in iter_design_files():
+        name = f"{USER_NS}.{stem}"
+        try:
+            cls = load_builder(path)
+            # Smoke-test: construct, then actually build the geometry so a
+            # typo / bad shape in build_wires surfaces here (at load, in the UI
+            # panel) instead of only when the design is solved.
+            cls().build_wires()
+            REGISTRY[name] = adapter._make_example(name, cls)
+        except Exception as exc:  # noqa: BLE001 — surface, don't crash
+            errors.append(
+                {
+                    "name": name,
+                    "file": str(path),
+                    "message": _format_error(path, exc),
+                }
+            )
     return errors


### PR DESCRIPTION
## Summary

Builds out the user-authored design feature across the CLI and web layers, and removes the startup cost / hang risk of running every builder eagerly.

**CLI / user-design plumbing**
- Resolve `user.<name>` designs from the CLI. The discovery + path-loading core moves into `antenna_designer.user_designs` (no web dependency); `web/user_designs.py` keeps only its REGISTRY/scaffold/error-panel glue. Bare names never resolve to a user file, so a user design can't shadow a built-in.
- CLI integration tests now address designs by explicit `family.name` instead of leaning on the bare-name family fallback (which keeps one positive unit test).
- New `antenna_designer list [filter] [--builtin-only|--user-only]` subcommand: enumerates every resolvable design as its canonical dotted path, grouped by family.

**Lazy registration**
- Registration no longer runs a user design's `build_wires()`. The four geometry-derived UI hints (`multi_feed`, `default_view`, array `target_z0`, array-block backend) are memoised in a per-example `hints()` closure and folded into the solve/geometry response. Built-ins prime eagerly (zero change to the shipped set, incl. array-block seeding); user designs defer — a slow or hanging builder can no longer stall server startup or a page refresh, only the solve of the design the user actually selected.
- The frontend prefers response-delivered hints over the (now-provisional) `/examples` descriptor.

**Error surfacing**
- Because geometry now builds on selection, a broken user design's `build_wires()` error surfaces on select rather than at load. `/geometry` and the `/ws` solve catch the exception and return `{error: "<type: msg (file, line)>"}`; the `/ws` socket stays alive after an error so a fixed design still solves. The frontend shows it in a solve-error banner. Load-level errors (syntax/import/no-`Builder`) are still caught at registration.

## Test plan
- [x] Full suite green (`pytest tests/`: 1177 passed, 4 skipped)
- [x] `ruff check` + `ruff format --check` clean repo-wide
- [x] Frontend `tsc --noEmit` + `vite build` clean
- [x] Verified deferred user design registers without running its builder; hints derived once per selection (not per slider tick)
- [x] Verified `/geometry` returns errors at 200 and `/ws` survives a solve error (subsequent solves still work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)