### PR TITLE
fix(web): use psutil for physical core count

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,10 @@ classifiers = [
 # Bare `uvicorn` ships without ws support and fails the handshake at
 # runtime; `uvicorn[standard]` pulls in websockets + httptools + uvloop
 # (uvloop is no-op on Windows).
-web = ["uvicorn[standard]"]
+# psutil powers _physical_cpu_count() in web.server — portable across
+# Windows/macOS/Linux. Falls back to os.cpu_count() if missing, which
+# misfires on chips without HT (pins to half the actual cores).
+web = ["uvicorn[standard]", "psutil"]
 
 [project.urls]
 Homepage = "https://github.com/stevenmburns/antenna_designer"

--- a/web/server.py
+++ b/web/server.py
@@ -51,31 +51,21 @@ def _physical_cpu_count() -> int:
     core contend for execution units rather than overlap. Ad-hoc bench on
     KBL-R 4C/8T showed 4-thread runs ~15% faster than 8-thread runs of the
     swept-ground hot path. Pin to physical-core count to skip that loss.
+
+    Uses psutil for a portable answer (Windows/macOS/Linux). The previous
+    /proc/cpuinfo + "assume 2 HT siblings" fallback misfired on chips
+    without HT (e.g. Intel N-series E-core SoCs), pinning to half the
+    actual core count.
     """
     try:
-        cores = set()
-        phys, coreid = None, None
-        with open("/proc/cpuinfo") as f:
-            for line in f:
-                key, _, val = line.partition(":")
-                key = key.strip()
-                val = val.strip()
-                if key == "physical id":
-                    phys = val
-                elif key == "core id":
-                    coreid = val
-                elif not line.strip() and phys is not None and coreid is not None:
-                    cores.add((phys, coreid))
-                    phys, coreid = None, None
-        if phys is not None and coreid is not None:
-            cores.add((phys, coreid))
-        if cores:
-            return len(cores)
-    except OSError:
+        import psutil
+
+        n = psutil.cpu_count(logical=False)
+        if n:
+            return n
+    except ImportError:
         pass
-    # Fallback: assume 2 HT siblings per core on x86. Wrong on chips without
-    # HT, but in that case the caller can override via the env var.
-    return max(1, (os.cpu_count() or 1) // 2)
+    return max(1, os.cpu_count() or 1)
 
 
 _NPROC = str(_physical_cpu_count())


### PR DESCRIPTION
## Summary
- `web/server.py:_physical_cpu_count()` previously read `/proc/cpuinfo` (Linux-only) and fell back to `os.cpu_count() // 2` everywhere else, assuming \"non-Linux means x86 with 2 HT siblings per core.\" That assumption misfires on chips without HT — Intel N-series E-core SoCs report cores == logical, so the fallback pinned OMP/MKL to half the actual core count (2/4 on the N150 I'm developing on). Also wrong on any Windows host with HT off and on macOS.
- Swap to `psutil.cpu_count(logical=False)`. Portable, right answer on Win/macOS/Linux.
- Add `psutil` to the `web` extra so `pip install -e .[web]` picks it up. Falls back to `os.cpu_count()` if psutil isn't installed — closer to right than the old halving for non-HT chips.

Verified: on Intel N150 (4 cores, no HT) the new code reports **4** vs the old fallback's **2**.

## Test plan
- [ ] On Linux CI with HT: still reports physical core count (psutil and the old /proc/cpuinfo path agree).
- [ ] On Windows/N150: reports 4, not 2.
- [ ] `pip install -e .[web]` installs psutil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)