### PR TITLE
Remove the python-necpp submodule from antenna_designer (install PyNEC from the wheel)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,42 +33,22 @@ jobs:
         pip install setuptools numpy scipy pytest matplotlib icecream scikit.rf coverage pybind11 fastapi httpx
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
-    - name: Install swig + LAPACKE/OpenBLAS + autotools
-      # The fork's PyNEC links a real LAPACK backend. Use lapacke (reference
-      # LAPACKE + OpenBLAS pthread) — plain apt packages, unlike the default
-      # ATLAS or the MKL backend. Do NOT add libatlas-base-dev: it Provides
-      # the same libblas/liblapack alternatives as liblapacke-dev and the two
-      # conflict on Ubuntu. autoconf/automake/libtool/m4 are needed because the
-      # necpp build regenerates the (now-gitignored) libtool macros via
-      # libtoolize.
+    - name: Install PyNEC from the python-necpp release wheel
+      # PyNEC is no longer built from a submodule — install the self-contained
+      # wheel (OpenBLAS vendored via scipy-openblas32) from the python-necpp
+      # fork's GitHub Release. --no-index so upstream PyNEC on PyPI (broken
+      # builds on current Python, missing our BLAS/OpenMP work) can never
+      # shadow it; numpy is already installed above.
       run: |
-        sudo apt-get update -qq
-        sudo apt-get install -y swig3.0 autoconf automake libtool m4 \
-          libopenblas-pthread-dev liblapacke-dev
-
-    - name: Compile PyNEC (lapacke backend)
-      # LAPACK code path is enabled by setup.py -D macros, so necpp_src's
-      # configure stays --without-lapack (it only generates config.h).
-      env:
-        PYNEC_BACKEND: lapacke
-      run: |
-        git submodule init
-        git submodule update --remote
-        cd python-necpp
-        git submodule init
-        git submodule update --remote
-        cd PyNEC
-        ln -s ../necpp_src .
-        pushd ../necpp_src
-        make -f Makefile.git
-        ./configure --without-lapack
-        popd
-        swig3.0 -Wall -v -c++ -python PyNEC.i
-        python setup.py build
-        python setup.py install
+        pip install PyNEC --no-index \
+          --find-links https://github.com/stevenmburns/python-necpp/releases/expanded_assets/v1.7.4-accel.1
 
     - name: Install pysim (vendored MoM engine)
+      # pysim is still a submodule; its C++ accelerator builds from source here.
+      # --remote tracks pysim's main; --no-build-isolation so setup.py sees the
+      # numpy + pybind11 installed above.
       run: |
+        git submodule update --init --remote pysim
         pip install --no-build-isolation -e ./pysim
 
     - name: Test with pytest
@@ -80,77 +60,3 @@ jobs:
       uses: py-cov-action/python-coverage-comment-action@v3
       with:
         GITHUB_TOKEN: ${{ github.token }}
-
-  build-mkl:
-    # Same build + tests as `build`, but links PyNEC against Intel MKL (the
-    # production backend). Verifies the MKL link path still builds and that
-    # necpp's LAPACKE_zgetrf/zgetrs calls resolve against MKL's mkl_lapacke.h.
-    #
-    # Gated to push-to-main only: MKL isn't pre-installed on GitHub runners and
-    # the ~1 GB intel-oneapi-mkl-classic-devel install adds ~3 min per run, so
-    # running it per-PR would burn CI minutes for marginal coverage. The
-    # post-merge run on main catches MKL-path regressions without slowing PRs.
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.12
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.12"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools numpy scipy pytest matplotlib icecream scikit.rf coverage pybind11 fastapi httpx
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-
-    - name: Install swig + autotools + Intel oneAPI MKL classic
-      run: |
-        wget -qO- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
-          | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
-        echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" \
-          | sudo tee /etc/apt/sources.list.d/oneAPI.list
-        sudo apt-get update -qq
-        sudo apt-get install -y swig3.0 autoconf automake libtool m4 \
-          intel-oneapi-mkl-classic-devel
-
-    - name: Compile PyNEC (MKL backend)
-      env:
-        PYNEC_BACKEND: mkl
-        MKLROOT: /opt/intel/oneapi/mkl/latest
-      run: |
-        git submodule init
-        git submodule update --remote
-        cd python-necpp
-        git submodule init
-        git submodule update --remote
-        cd PyNEC
-        ln -s ../necpp_src .
-        pushd ../necpp_src
-        make -f Makefile.git
-        ./configure --without-lapack
-        popd
-        swig3.0 -Wall -v -c++ -python PyNEC.i
-        python setup.py build
-        python setup.py install
-
-    - name: Verify PyNEC is linked against MKL
-      run: |
-        so=$(python -c "import _PyNEC; print(_PyNEC.__file__)")
-        ldd "$so" | grep -q libmkl_core || { echo "ERROR: PyNEC not linked against MKL"; ldd "$so"; exit 1; }
-        echo "OK — PyNEC is linked against MKL:"
-        ldd "$so" | grep -i mkl
-
-    - name: Install pysim (vendored MoM engine)
-      run: |
-        pip install --no-build-isolation -e ./pysim
-
-    - name: Test with pytest
-      # OPENBLAS_NUM_THREADS=1 keeps numpy/scipy's idle BLAS pool from
-      # contending with MKL for cores during the solve.
-      env:
-        OPENBLAS_NUM_THREADS: "1"
-      run: |
-        pip install -e .
-        python -m pytest tests/  # -m puts CWD on sys.path so the top-level web/ package imports

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "python-necpp"]
-	path = python-necpp
-	url = https://github.com/stevenmburns/python-necpp.git
 [submodule "pysim"]
 	path = pysim
 	url = https://github.com/stevenmburns/pysim.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,10 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninterative apt-get -qq install \
     python3-pip \
     python3-venv \
     python3-dev \
-    # C++ Dependencies
+    # C++ build deps for the pysim accelerator (PyNEC ships as a prebuilt wheel)
     g++ \
-    gfortran \
-    swig3.0 \
     git \
     build-essential \
-    automake \
-    libtool \
 &&    apt-get -qq clean
 
 FROM antenna_designer_base AS antenna_designer_base_with_python
@@ -29,7 +25,7 @@ RUN \
     /bin/bash -c "python3 -m venv /opt/.venv && \
     source /opt/.venv/bin/activate && \
     pip install --upgrade pip -q && \
-    pip install setuptools numpy scipy pytest matplotlib icecream scikit-rf -q"
+    pip install setuptools numpy scipy pytest matplotlib icecream scikit-rf coverage pybind11 fastapi httpx -q"
 
 FROM antenna_designer_base_with_python AS antenna_designer
 
@@ -37,21 +33,8 @@ COPY . /opt/antenna_designer
 
 RUN \
     /bin/bash -c "source /opt/.venv/bin/activate && \
-    cd /opt && \
-    cd antenna_designer && \
-    git submodule init && \
-    git submodule update --remote && \
-    pushd python-necpp && \    
-    git submodule init && \
-    git submodule update --remote && \
-    cd PyNEC && \
-    ln -s ../necpp_src . && \
-    pushd ../necpp_src && \
-    make -f Makefile.git && \
-    ./configure --without-lapack && \
-    popd && \
-    swig3.0 -Wall -v -c++ -python PyNEC.i && \
-    python setup.py build && \
-    python setup.py install && \
-    popd && \
+    cd /opt/antenna_designer && \
+    pip install PyNEC --no-index --find-links https://github.com/stevenmburns/python-necpp/releases/expanded_assets/v1.7.4-accel.1 && \
+    git submodule update --init pysim && \
+    pip install --no-build-isolation -e ./pysim && \
     pip install -e ."

--- a/README.md
+++ b/README.md
@@ -132,14 +132,10 @@ sudo apt-get install \
     python3-pip \
     python3-venv \
     python3-dev \
-    # C++ Dependencies
+    # C++ build deps for the pysim accelerator (PyNEC ships as a prebuilt wheel)
     g++ \
-    gfortran \
-    swig3.0 \
-    git \
     build-essential \
-    automake \
-    libtool
+    git
 ```
 
 2. Create a virtual environment and collect python dependencies
@@ -150,25 +146,23 @@ pip install --upgrade pip
 pip install setuptools numpy scipy pytest matplotlib icecream scikit-rf
 ```
 
-3. Clone repo, update the submodules (for python-necpp) and install from sources (can't do just a pip install PyNEC). Do this in the virtual environment.
+3. Clone the repo and install the two engines (PyNEC + pysim). Do this in the virtual environment.
 ```bash
 git clone https://github.com/stevenmburns/antenna_designer
 cd antenna_designer
-git submodule init
-git submodule update --remote
-pushd python-necpp
-git submodule init
-git submodule update --remote
-cd PyNEC
-ln -sfn ../necpp_src .
-pushd ../necpp_src
-make -f Makefile.git
-/configure --without-lapack
-popd
-swig3.0 -Wall -v -c++ -python PyNEC.i
-python setup.py build
-python setup.py install
-popd
+
+# PyNEC: install the self-contained wheel from the python-necpp fork's release
+# (OpenBLAS is vendored, so no BLAS/SWIG/autotools toolchain is needed).
+# --no-index avoids upstream PyNEC on PyPI, whose builds are broken on current
+# Python and which lacks the fork's BLAS/OpenMP work.
+pip install PyNEC --no-index \
+    --find-links https://github.com/stevenmburns/python-necpp/releases/expanded_assets/v1.7.4-accel.1
+
+# pysim (the MoM engine) is still a git submodule; its C++ accelerator builds
+# from source (needs g++ + pybind11; install pybind11 if you haven't).
+pip install pybind11
+git submodule update --init pysim
+pip install --no-build-isolation -e ./pysim
 ```
 
 4. Install an editable version of this repo (inside virtual enviroment and in the cloned repository directory)
@@ -192,7 +186,7 @@ To run some of the test in docker, try:
 docker run -it stevenmburns/antenna_designer /bin/bash -c "source /opt/.venv/bin/activate && cd /opt/antenna_designer && pytest -vv --durations=0 -- tests/" 
 ```
 
-The tests (including a build of python-necpp from sources) are also running in Github Actions on every push and pull request:
+The tests are also running in Github Actions on every push and pull request (PyNEC from the release wheel, pysim built from its submodule):
 
 [![Test Python package](https://github.com/stevenmburns/antenna_design/actions/workflows/test.yml/badge.svg)](https://github.com/stevenmburns/antenna_design/actions/workflows/test.yml)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ Issues = "https://github.com/stevenmburns/antenna_designer/issues"
 
 [tool.ruff]
 # pysim is a submodule with its own config.
-extend-exclude = ["python-necpp", "pysim"]
+extend-exclude = ["pysim"]
 
 [tool.ruff.lint]
 ignore = ["E741"]


### PR DESCRIPTION
## Summary
Stage B of retiring the PyNEC submodules (Stage A removed it from pysim). PyNEC now installs as a self-contained wheel (OpenBLAS vendored via scipy-openblas32) from the [python-necpp fork](https://github.com/stevenmburns/python-necpp)'s GitHub Release, so antenna_designer no longer compiles NEC2++ from a submodule. No further PyNEC development is expected.

- **Remove the `python-necpp` submodule** (`.gitmodules` keeps only `pysim`).
- **`test.yml`**: replace the swig/OpenBLAS/autotools apt install + the source compile with a PyNEC wheel install (`--no-index --find-links`). pysim still builds from its submodule (explicit init). **Drop the `build-mkl` job** — MKL build coverage belongs in python-necpp's own CI.
- **`Dockerfile`**: same swap (PyNEC wheel, not source build); add the pysim editable install + the `pybind11`/`fastapi`/`httpx`/`coverage` deps CI uses so the image matches CI. *(Not built locally — mirrors the validated CI steps.)*
- **`README`**: install steps now pip-install the PyNEC wheel and build pysim from its submodule; drop the now-unneeded swig/gfortran/automake/libtool system deps.
- **`pyproject.toml`**: drop `python-necpp` from the ruff `extend-exclude` (`pysim` stays — still a submodule).

The **pysim submodule is intentionally left in place**; removing it is a separate later stage.

## Test plan
- [ ] CI `build` job green: PyNEC installs from the release wheel, pysim builds from its submodule, `pytest tests/` passes with coverage
- [ ] No `build-mkl` job runs on push-to-main (removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)