### PR TITLE
Cache pip + ccache the pysim accelerator build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,18 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.12"
+        cache: pip
+        cache-dependency-path: pyproject.toml
+    - name: Set up ccache
+      # Caches object files for the pysim C++ accelerator (built from source in
+      # the "Install pysim" step). The action masquerades gcc/g++ on PATH, so
+      # setuptools' default compiler invocation routes through ccache with no
+      # CC/CXX overrides. Cold runs see no benefit; warm runs (the common case,
+      # when _accelerators.cpp is unchanged) skip the recompile.
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ccache-${{ runner.os }}-py312
+        max-size: 200M
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
Trim the AD `test` job toward the <2 min PR target (it was ~2m39s).

- **`setup-python` `cache: pip`** — reuse the downloaded-wheel cache across runs (numpy/scipy/matplotlib/etc.).
- **`hendrikmuhs/ccache-action`** — cache object files for the pysim C++ accelerator (built from source in the "Install pysim" step). The action masquerades `gcc`/`g++` on `PATH`, so setuptools routes the compile through ccache with no `CC`/`CXX` overrides. Cold runs see no benefit; warm runs (the common case — `_accelerators.cpp` unchanged) skip the recompile.

## Test plan
- [ ] Job still green
- [ ] Second run (warm caches) is meaningfully faster than the first; confirm ccache reports hits and pip restores from cache in the logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)