### PR TITLE
Quarantine the per-design solver catalog from PR CI; coverage on main only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,9 @@ jobs:
       with:
         key: ccache-${{ runner.os }}-py312
         max-size: 200M
+        # create the gcc/g++ -> ccache shims on PATH; without this the action
+        # caches ccache but nothing routes through it (the compile isn't cached).
+        create-symlink: true
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -63,12 +66,24 @@ jobs:
         git submodule update --init --remote pysim
         pip install --no-build-isolation -e ./pysim
 
-    - name: Test with pytest
-      run: |
-        pip install -e .
-        coverage run --source=src/ -m pytest tests/
+    - name: Install antenna_designer
+      run: pip install -e .
+
+    - name: Fast lane (PRs) — no per-design solver catalog, no coverage
+      # Skips the antenna_computation_check tests (the per-design solver
+      # catalogs). Keeps representative engine/solver coverage + all
+      # load/schema/unit tests. No coverage instrumentation on PRs.
+      if: github.event_name == 'pull_request'
+      run: pytest -m "not antenna_computation_check" tests/
+
+    - name: Full suite + coverage (push to main only)
+      # The complete suite, including the per-design solver catalogs, with
+      # coverage instrumentation. Runs once per merge to main, not per PR.
+      if: github.event_name == 'push'
+      run: coverage run --source=src/ -m pytest tests/
 
     - name: Coverage comment
+      if: github.event_name == 'push'
       uses: py-cov-action/python-coverage-comment-action@v3
       with:
         GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,10 @@ jobs:
       # catalogs). Keeps representative engine/solver coverage + all
       # load/schema/unit tests. No coverage instrumentation on PRs.
       if: github.event_name == 'pull_request'
-      run: pytest -m "not antenna_computation_check" tests/
+      # `python -m pytest` (not bare `pytest`) so CWD is on sys.path and the
+      # top-level `web/` package imports — same reason the main-lane command
+      # below uses the `-m pytest` form.
+      run: python -m pytest -m "not antenna_computation_check" tests/
 
     - name: Full suite + coverage (push to main only)
       # The complete suite, including the per-design solver catalogs, with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,18 @@ web = ["uvicorn[standard]"]
 Homepage = "https://github.com/stevenmburns/antenna_designer"
 Issues = "https://github.com/stevenmburns/antenna_designer/issues"
 
+[tool.pytest.ini_options]
+markers = [
+    # Tests that run an antenna solver across a *catalog* of named designs
+    # (e.g. tests/test_cebik_designs.py) — the same solve code path repeated
+    # design after design. Representative solver/engine coverage stays
+    # unmarked and runs on every PR; this marker quarantines the per-design
+    # repetition to the full main-only run, so the registry can grow toward
+    # many designs without inflating PR feedback. Deselect with
+    # `-m "not antenna_computation_check"`.
+    "antenna_computation_check: solves a named design as part of broad per-design catalog coverage (run on main, not per-PR)",
+]
+
 [tool.ruff]
 # pysim is a submodule with its own config.
 extend-exclude = ["pysim"]

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -14,6 +14,11 @@ import pytest
 
 pytest.importorskip("PyNEC")
 
+# Whole-file: every test here solves a named Cebik design via the PyNEC engine
+# (per-design catalog coverage). Quarantined off the per-PR fast lane and run
+# in the full main-only suite. See the marker definition in pyproject.toml.
+pytestmark = pytest.mark.antenna_computation_check
+
 from antenna_designer.engines import PyNECEngine  # noqa: E402
 
 


### PR DESCRIPTION
## Summary
PR CI was re-running the solver across the whole Cebik design catalog **and** running full coverage on every push — redundant for results reviewed ~once a fortnight, and the part that balloons as the registry grows toward hundreds of designs.

The principle: **keep representative solver/engine coverage on every PR, but stop re-running the solver design-after-design; cover the registry by loading.**

- Add the **`antenna_computation_check`** marker (registered in `pyproject.toml`) for tests that solve a named design as part of broad per-design catalog coverage. Mark **`tests/test_cebik_designs.py`** whole-file (88 tests, holds all three >5 s outliers).
- **Fast lane (`pull_request`)**: `pytest -m "not antenna_computation_check"`, **no coverage**. Keeps the engine code-path coverage (`test_pysim_engine.py` — TL/diff-TL/far-field/multifeed/PyNEC-agreement) and all load/schema/unit tests. **Local: 1094 tests in ~63 s, down from 1182 in ~127 s.**
- **Full suite + coverage (`push` to `main` only)**: complete suite incl. the catalog, with coverage + the comment action — once per merge, not per PR.
- Fix the **ccache** action (`create-symlink: true`) — it was caching ccache but nothing routed through it (a no-op).

Registry coverage is unchanged: `test_design_schemas.py` loads/validates every registered design (no solve).

Possible **second pass** (not in this PR): the mixed files `test_web_server.py` / `test_cli.py` have a few multi-second solves that could also move to main-only if you want the PR even leaner.

## Test plan
- [ ] PR run executes the fast lane only (no coverage step, catalog deselected) and is well under 2 min
- [ ] After merge, the push-to-main run executes the full suite + posts coverage
- [ ] ccache reports cache hits on the warm (post-merge / next-PR) run

🤖 Generated with [Claude Code](https://claude.com/claude-code)