### PR TITLE
Fix packaging: declare core deps, complete web extra, correct PyNEC install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,18 +45,19 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools numpy scipy pytest matplotlib icecream scikit.rf coverage pybind11 fastapi httpx
+        pip install setuptools numpy scipy pytest matplotlib icecream scikit-rf coverage pybind11 fastapi httpx
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
     - name: Install PyNEC from the python-necpp release wheel
       # PyNEC is no longer built from a submodule — install the self-contained
       # wheel (OpenBLAS vendored via scipy-openblas32) from the python-necpp
-      # fork's GitHub Release. --no-index so upstream PyNEC on PyPI (broken
-      # builds on current Python, missing our BLAS/OpenMP work) can never
+      # fork's GitHub Release. The fork's distribution name is `pynec-accel`
+      # (import name stays `PyNEC`). --no-index so upstream PyNEC/pynec on PyPI
+      # (broken builds on current Python, missing our BLAS/OpenMP work) can never
       # shadow it; numpy is already installed above.
       run: |
-        pip install PyNEC --no-index \
-          --find-links https://github.com/stevenmburns/python-necpp/releases/expanded_assets/v1.7.4-accel.1
+        pip install pynec-accel --no-index \
+          --find-links https://github.com/stevenmburns/python-necpp/releases/expanded_assets/v1.7.4-accel.3
 
     - name: Install momwire (vendored MoM engine)
       # momwire is still a submodule; its C++ accelerator builds from source here.

--- a/README.md
+++ b/README.md
@@ -317,10 +317,11 @@ against NEC2.
 
 ```bash
 # The self-contained wheel from the python-necpp fork's release (OpenBLAS
-# vendored). --no-index avoids upstream PyNEC on PyPI, whose builds are broken
-# on current Python and lack the fork's BLAS/OpenMP work.
-pip install PyNEC --no-index \
-    --find-links https://github.com/stevenmburns/python-necpp/releases/expanded_assets/v1.7.4-accel.1
+# vendored). The fork is distributed as `pynec-accel` (the import name stays
+# `import PyNEC`); --no-index avoids upstream PyNEC/pynec on PyPI, whose builds
+# are broken on current Python and lack the fork's BLAS/OpenMP work.
+pip install pynec-accel --no-index \
+    --find-links https://github.com/stevenmburns/python-necpp/releases/expanded_assets/v1.7.4-accel.3
 ```
 
 **4. Install AntennaKNoBs**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,17 +16,40 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+# Core runtime deps: imported unconditionally by src/antennaknobs (numpy/scipy
+# math throughout; matplotlib for the draw/sweep/pattern plots; icecream for the
+# CLI/sweep debug tracing; scikit-rf for Touchstone/network handling in sweep).
+#
+# Deliberately NOT listed here:
+#   - momwire — the built-in MoM engine. Provided by the vendored git submodule
+#     (installed editable: `pip install -e ./momwire`) or its own wheel; not yet
+#     on a durable index, and antennaknobs is only ever installed from a clone
+#     that carries the submodule, so pinning it here would just break that flow.
+#   - PyNEC — the optional NEC2 backend, which is GPL-2.0-or-later. It is
+#     installed separately from the python-necpp fork's release wheel (see
+#     README) and must never be declared a dependency of this MIT package.
+dependencies = [
+    "numpy>=1.21",
+    "scipy>=1.7",
+    "matplotlib>=3.5",
+    "icecream>=2.1",
+    "scikit-rf>=0.24",
+]
 
 [project.optional-dependencies]
-# Web UI: the FastAPI server (web.server:app) needs an ASGI server with
-# WebSocket support — the live-solve channel at /ws is a WS upgrade.
-# Bare `uvicorn` ships without ws support and fails the handshake at
-# runtime; `uvicorn[standard]` pulls in websockets + httptools + uvloop
-# (uvloop is no-op on Windows).
-# psutil powers _physical_cpu_count() in web.server — portable across
-# Windows/macOS/Linux. Falls back to os.cpu_count() if missing, which
-# misfires on chips without HT (pins to half the actual cores).
-web = ["uvicorn[standard]", "psutil"]
+# Web UI: web/server.py is a FastAPI app served by uvicorn.
+#   - fastapi (+ its starlette core) is the web framework itself — imported
+#     directly by web/server.py, so it must be declared here, not assumed.
+#   - uvicorn[standard] is the ASGI server. The live-solve channel at /ws is a
+#     WebSocket upgrade, so the server needs WS support: bare `uvicorn` ships
+#     without it and fails the handshake at runtime. `uvicorn[standard]` already
+#     pulls in websockets (+ httptools + uvloop, uvloop a no-op on Windows), but
+#     we also list `websockets` explicitly so the /ws dependency is visible and
+#     pinned even if uvicorn's extra ever changes.
+#   - psutil powers _physical_cpu_count() in web.server — portable across
+#     Windows/macOS/Linux. Falls back to os.cpu_count() if missing, which
+#     misfires on chips without HT (pins to half the actual cores).
+web = ["fastapi", "uvicorn[standard]", "websockets", "psutil"]
 
 [project.urls]
 Homepage = "https://github.com/stevenmburns/antennaknobs"


### PR DESCRIPTION
## Summary
A clean `pip install` of antennaknobs was broken — the package imported several third-party libraries it never declared, so installs only worked if those happened to be present transitively. Surfaced while standing up a fresh venv for the complete (momwire + pynec-accel) system.

- **Add the missing `[project].dependencies`:** `numpy`, `scipy`, `matplotlib`, `icecream`, `scikit-rf` — all imported unconditionally by `src/antennaknobs`. Before this only numpy/scipy arrived (transitively via momwire); `matplotlib`, `icecream`, `scikit-rf` each failed at import. `momwire` (submodule-provided) and `PyNEC` (optional, GPL-2.0) are intentionally left undeclared.
- **Complete the `[web]` extra:** add `fastapi` (imported directly by `web/server.py` but never declared) and pin `websockets` explicitly. The `/ws` live-solve channel is a WebSocket upgrade; `uvicorn[standard]` already pulls `websockets` in, but listing it makes the requirement visible and resilient to uvicorn's extra changing.
- **Correct the PyNEC install:** the fork's distribution is now `pynec-accel` (import name stays `PyNEC`), and the pin was a stale `v1.7.4-accel.1` whose wheels predate the rename. `pip install PyNEC ... accel.1` only resolved by PEP 503 name-normalization luck; against current releases it silently falls back to a from-source build. README + CI now point at `pynec-accel` / `v1.7.4-accel.3`.
- **Fix** a `scikit.rf` → `scikit-rf` typo in the CI dep list.

## Test plan
- [x] Fresh venv: `pip install -e ./momwire && pip install -e ".[web]"` now pulls **every** dep with no manual installs (verified matplotlib/icecream/scikit-rf/fastapi/websockets/starlette all present).
- [x] `python -m antennaknobs --help` and `import web.server` (FastAPI app + websockets) both work.
- [x] Both engines solve: `--engine momwire:triangular` and `--engine pynec` on `dipoles.invvee`.
- [x] `pynec-accel` installs as a **wheel** (no source build) from the corrected `accel.3` pin.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)