### PR TITLE
Make antennaknobs pip-installable (CLI + library + web API) and publish to TestPyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,72 @@
+name: publish
+
+# Build and publish the antennaknobs distribution. antennaknobs is pure Python
+# (no compiled extension — momwire/PyNEC carry the C++), so this produces a
+# single universal py3-none-any wheel plus an sdist; there is no per-platform
+# wheel matrix and no cibuildwheel.
+#
+# Triggers:
+#   - push tag v*: build, publish to TestPyPI (Trusted Publishing), and attach
+#     the wheel + sdist to the GitHub Release.
+#   - workflow_dispatch: build the dist on a branch to validate packaging
+#     (sdist/wheel contents) without publishing — the publish/release jobs are
+#     tag-gated, so a manual run only exercises `build`.
+on:
+  workflow_dispatch:
+  push:
+    tags: ["v*"]
+
+jobs:
+  build:
+    name: build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        # No submodules: the dist is pure Python and does not build momwire.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build
+        run: pipx run build
+      - name: Check metadata
+        run: pipx run twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+
+  publish-testpypi:
+    name: publish to TestPyPI
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist
+          skip-existing: true
+
+  release:
+    name: attach wheel + sdist to release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - name: Attach to the GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.0.1"
+version = "0.1.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]
@@ -16,19 +16,23 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-# Core runtime deps: imported unconditionally by src/antennaknobs (numpy/scipy
-# math throughout; matplotlib for the draw/sweep/pattern plots; icecream for the
-# CLI/sweep debug tracing; scikit-rf for Touchstone/network handling in sweep).
+# Core runtime deps, imported unconditionally:
+#   - momwire — the built-in MoM engine (`from momwire import ...` across the
+#     engines/CLI). Now that momwire publishes its own wheels, it is a real
+#     declared dependency so `pip install antennaknobs` resolves it from the
+#     same index. The vendored git submodule remains for co-development (install
+#     it editable to override the wheel); a development checkout that does
+#     `pip install -e ./momwire` first satisfies this pin and pip won't refetch.
+#   - numpy/scipy math throughout; matplotlib for the draw/sweep/pattern plots;
+#     icecream for the CLI/sweep debug tracing; scikit-rf for Touchstone/network
+#     handling in sweep.
 #
-# Deliberately NOT listed here:
-#   - momwire — the built-in MoM engine. Provided by the vendored git submodule
-#     (installed editable: `pip install -e ./momwire`) or its own wheel; not yet
-#     on a durable index, and antennaknobs is only ever installed from a clone
-#     that carries the submodule, so pinning it here would just break that flow.
-#   - PyNEC — the optional NEC2 backend, which is GPL-2.0-or-later. It is
-#     installed separately from the python-necpp fork's release wheel (see
-#     README) and must never be declared a dependency of this MIT package.
+# Deliberately NOT listed: PyNEC — the optional NEC2 backend, GPL-2.0-or-later.
+# It is installed separately from the python-necpp fork's release wheel (the
+# `pynec-accel` distribution; see README) and must never be declared a
+# dependency of this MIT package.
 dependencies = [
+    "momwire>=0.1.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,19 @@
-from setuptools import setup
+from setuptools import find_packages, setup
+
+# antennaknobs uses a src-layout (src/antennaknobs, with the antennaknobs.engines
+# subpackage); the web API server lives at the repo root as the `web` package
+# (with its web.examples antenna registry). Discover both and map each top-level
+# package to its directory — a plain packages=["antennaknobs"] would silently
+# drop antennaknobs.engines and all of web from a built wheel (editable installs
+# mask this because they put the source roots on sys.path wholesale).
+#
+# web/user_design_assets/ is not a package (no __init__); it holds TEMPLATE.py +
+# CLAUDE.md that web/user_designs.py copies into the user folder on first run, so
+# it ships as package data of the `web` package.
+packages = find_packages(where="src") + find_packages(include=["web", "web.*"])
 
 setup(
-    packages=["antennaknobs"],
-    package_dir={"": "src/"},
+    packages=packages,
+    package_dir={"antennaknobs": "src/antennaknobs", "web": "web"},
+    package_data={"web": ["user_design_assets/*"]},
 )

--- a/src/antennaknobs/designs/__init__.py
+++ b/src/antennaknobs/designs/__init__.py
@@ -1,0 +1,8 @@
+"""Built-in antenna design catalog.
+
+Each design is a Builder module under a family subpackage
+(``antennaknobs.designs.<family>.<name>``) and is addressed by the CLI/web as
+``<family>.<name>`` (e.g. ``dipoles.invvee``). This is a regular package (not an
+implicit namespace package) so the whole catalog ships in the built wheel;
+user-authored designs live in the separate ``user`` namespace, not here.
+"""

--- a/src/antennaknobs/designs/arrays/__init__.py
+++ b/src/antennaknobs/designs/arrays/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in arrays antenna designs."""

--- a/src/antennaknobs/designs/beams/__init__.py
+++ b/src/antennaknobs/designs/beams/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in beams antenna designs."""

--- a/src/antennaknobs/designs/broadband/__init__.py
+++ b/src/antennaknobs/designs/broadband/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in broadband antenna designs."""

--- a/src/antennaknobs/designs/dipoles/__init__.py
+++ b/src/antennaknobs/designs/dipoles/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in dipoles antenna designs."""

--- a/src/antennaknobs/designs/loops/__init__.py
+++ b/src/antennaknobs/designs/loops/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in loops antenna designs."""

--- a/src/antennaknobs/designs/multiband/__init__.py
+++ b/src/antennaknobs/designs/multiband/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in multiband antenna designs."""

--- a/src/antennaknobs/designs/specialty/__init__.py
+++ b/src/antennaknobs/designs/specialty/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in specialty antenna designs."""

--- a/src/antennaknobs/designs/verticals/__init__.py
+++ b/src/antennaknobs/designs/verticals/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in verticals antenna designs."""

--- a/src/antennaknobs/designs/wire/__init__.py
+++ b/src/antennaknobs/designs/wire/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in wire antenna designs."""

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,0 +1,11 @@
+"""antennaknobs web API server.
+
+A FastAPI app (``web.server:app``) plus its antenna-example registry
+(``web.examples``) and the adapter that bridges antennaknobs's Builders to the
+JSON/WebSocket contract the frontend consumes. The React frontend under
+``web/frontend`` is a separate build and is not part of this package.
+
+This ``__init__`` exists so ``web`` is a real importable package when
+antennaknobs is installed from a wheel (not just from a source checkout with
+the repo root on ``sys.path``).
+"""

--- a/web/adapter.py
+++ b/web/adapter.py
@@ -71,9 +71,11 @@ from .examples._base import (
 C_LIGHT = 299_792_458.0
 
 DESIGNS_PKG = "antennaknobs.designs"
-DESIGNS_DIR = (
-    pathlib.Path(__file__).resolve().parents[1] / "src" / "antennaknobs" / "designs"
-)
+# Resolve the designs directory from the installed package, never a path relative
+# to this file: web/ and src/antennaknobs/ are siblings in a source checkout, but
+# once installed from a wheel they are separate top-level packages with no `src/`
+# in between. __path__ points at the real location in both layouts.
+DESIGNS_DIR = pathlib.Path(importlib.import_module(DESIGNS_PKG).__path__[0])
 
 _MOMWIRE_MODELS = {
     "triangular": TriangularSolver,


### PR DESCRIPTION
## Summary
Turns antennaknobs into a proper distributable package so it can be deployed with `pip install` instead of a git checkout + submodule + editable. antennaknobs is pure Python (momwire/PyNEC carry the C++), so this is **one universal `py3-none-any` wheel** + sdist — no per-platform matrix.

### Packaging correctness (the old `setup.py` only worked for editable installs)
- **`setup.py`:** discover all packages, not just top-level `antennaknobs`. A *built wheel* was silently dropping `antennaknobs.engines` **and the entire `web` API**. Now uses `find_packages` over `src/` (antennaknobs + the designs catalog) and the top-level `web` + `web.examples`, with `web/user_design_assets` shipped as package data (TEMPLATE.py + CLAUDE.md are copied at runtime).
- **Design catalog:** added `__init__.py` to `src/antennaknobs/designs` and its **9 family subpackages** (arrays, beams, broadband, dipoles, loops, multiband, specialty, verticals, wire). They were implicit namespace packages — importable in a checkout but omitted from a regular-package wheel, which would have shipped antennaknobs with **zero designs**. User designs use a separate `"user"` namespace, so this is safe.
- **`web/__init__.py`:** so `web` is a real package in the wheel (it relied on the repo root being on `sys.path`).
- **`web/adapter.py`:** resolve `DESIGNS_DIR` from the installed package (`importlib __path__`) instead of a hardcoded `../src/antennaknobs/designs` path that only exists in a source checkout.

### Dependency + version
- Declare **`momwire>=0.1.0`** (now that it publishes wheels) so a standalone `pip install antennaknobs` resolves the engine. The vendored submodule stays for co-development; an editable momwire satisfies the pin. **PyNEC stays optional/undeclared** (GPL).
- Bump `0.0.1 → 0.1.0` and the momwire submodule to its `v0.1.0` commit.

### Publishing
- Add **`.github/workflows/publish.yml`**: build sdist+wheel, `twine check`, and on a `v*` tag publish to TestPyPI via Trusted Publishing + attach to the GitHub Release. Requires a TestPyPI **pending publisher** for `antennaknobs` (workflow `publish.yml`).

## Test plan
- [x] Built the wheel; installed into a clean venv resolving **momwire from TestPyPI**; from a neutral dir confirmed `import antennaknobs` + `import web.server` (FastAPI app), **68 designs** listed, web registry populated (**68 examples**), `user_design_assets` present, and a momwire solve.
- [x] Editable/dev flow still resolves designs from `src/` (68 designs/examples, solve OK).
- [x] ruff clean.
- [ ] CI green.

## Notes
- **TestPyPI install footgun:** `--extra-index-url test.pypi` can pull broken *sdists* of common deps (e.g. fastapi) off TestPyPI. The robust recipe keeps PyPI primary and only momwire/antennaknobs come from TestPyPI. A durable, frictionless install ultimately wants **real PyPI** (which needs momwire on real PyPI too).
- **`web` is a top-level package name.** Fine for this TestPyPI validation, but it's a namespace-collision risk; before any real-PyPI release it should move under `antennaknobs.web` (a ~10-file import refactor, deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)