### PR TITLE
Bundle the built frontend into the wheel and serve the UI at /

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         # No submodules: the dist is pure Python and does not build momwire.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: web/frontend/package-lock.json
+      - name: Build the React frontend
+        # Produces web/static (vite outDir) which setup.py ships as package
+        # data, so the wheel serves the browser UI with no Node at install time.
+        working-directory: web/frontend
+        run: |
+          npm ci
+          npm run build
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,8 @@ pg/
 node_modules/
 web/frontend/dist/
 web/frontend/.vite/
+# Built frontend bundle: produced by `npm run build` (vite outDir) and bundled
+# into the wheel as package data at publish time; never committed to source.
+web/static/
 .claude/
 scripts/sterba_center_driven_pattern.png

--- a/README.md
+++ b/README.md
@@ -48,13 +48,26 @@ solve per round-trip, so the solver is never buried under stale requests.
 
 ### Running it
 
-The workbench is a FastAPI backend plus a React (Vite) frontend. In development
-you run the two together (two terminals):
+The workbench is a FastAPI backend plus a React (Vite) frontend.
+
+**Installed (no Node needed).** A wheel install bundles the pre-built frontend,
+so one process serves the whole app:
+
+```bash
+pip install "antennaknobs[web]"
+uvicorn web.server:app                   # open http://127.0.0.1:8000
+```
+
+The backend serves the UI at `/` and the JSON/`/ws` API on the same origin;
+`/docs` is the interactive API explorer.
+
+**Development (two terminals, hot-reload).** When editing the frontend, run the
+Vite dev server alongside the backend so you get HMR:
 
 ```bash
 # Terminal 1 — backend (from the repo root, in your .venv)
 pip install -e ".[web]"
-uvicorn web.server:app --reload          # serves on http://127.0.0.1:8000
+uvicorn web.server:app --reload          # API on http://127.0.0.1:8000
 
 # Terminal 2 — frontend dev server
 cd web/frontend
@@ -63,10 +76,9 @@ npm run dev                              # open http://localhost:5173
 ```
 
 The Vite dev server proxies the API and the `/ws` live-solve channel to the
-backend on port 8000, so you only ever open `http://localhost:5173`.
-
-For a production bundle, `npm run build` (output in `web/frontend/dist/`) and
-serve it behind the FastAPI app.
+backend on port 8000, so you only ever open `http://localhost:5173`. (A source
+checkout has no pre-built bundle, so the backend alone runs API-only until you
+`npm run build` — which writes `web/static/`, the same bundle the wheel ships.)
 
 > The `[web]` extra pulls in `uvicorn[standard]`, which includes the WebSocket
 > support the live-solve channel needs — plain `uvicorn` fails the `/ws`

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,16 @@ from setuptools import find_packages, setup
 # web/user_design_assets/ is not a package (no __init__); it holds TEMPLATE.py +
 # CLAUDE.md that web/user_designs.py copies into the user folder on first run, so
 # it ships as package data of the `web` package.
+#
+# web/static/ is the built React frontend (vite `npm run build` output). It is
+# gitignored and produced at publish time; shipping it as package data is what
+# lets a wheel install serve the browser UI from server.py with no Node. A
+# source/editable install without a build simply has no web/static and runs
+# API-only (the dev workflow uses the Vite dev server instead).
 packages = find_packages(where="src") + find_packages(include=["web", "web.*"])
 
 setup(
     packages=packages,
     package_dir={"antennaknobs": "src/antennaknobs", "web": "web"},
-    package_data={"web": ["user_design_assets/*"]},
+    package_data={"web": ["user_design_assets/*", "static/**/*"]},
 )

--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -184,7 +184,13 @@ def get_builder(nm):
     name, _, variant = nm.partition(":")
     cls = resolve_class(name)
     if cls is None:
-        return None
+        # Fail with a clear message instead of returning None, which every
+        # caller would then call as `builder()` -> `TypeError: 'NoneType' object
+        # is not callable` (a confusing crash for a simple typo). SystemExit
+        # prints just the message to stderr and exits non-zero, no traceback.
+        raise SystemExit(
+            f"unknown builder {nm!r} — run `antennaknobs list` to see available designs"
+        )
     if not variant or variant == "default":
         return cls
     attr = f"{variant}_params"
@@ -591,8 +597,6 @@ def cli(arguments=None):
         from .nec_export import export_nec
 
         builder = get_builder(args.builder)
-        if builder is None:
-            raise SystemExit(f"unknown builder: {args.builder!r}")
         kwargs = {"include_rp": args.include_rp}
         if args.ground is not _GROUND_UNSET:
             kwargs["ground"] = parse_ground(args.ground)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,22 @@
+import pytest
+
 import antennaknobs as ant
 
 from conftest import needs_pynec
 
 o = " --fn /dev/null"
 # o = ''
+
+
+def test_cli_unknown_builder_is_clear_error():
+    # A mistyped builder must fail with a clear message + non-zero exit, not a
+    # `TypeError: 'NoneType' object is not callable` from calling the unresolved
+    # (None) builder. `draw` resolves the builder first, before any engine.
+    with pytest.raises(SystemExit) as exc:
+        ant.cli(f"draw --builder dipoles.invee{o}".split())
+    msg = str(exc.value)
+    assert "unknown builder" in msg
+    assert "dipoles.invee" in msg
 
 
 def test_cli_draw():

--- a/web/frontend/index.html
+++ b/web/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Antenna Designer</title>
+    <title>AntennaKNoBs</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -2416,7 +2416,10 @@ export function App() {
     <div className="app">
       <aside className="sidebar">
         <div className="sidebar-header">
-          <h1>Antenna Designer</h1>
+          <div className="brand">
+            <h1>AntennaKNoBs</h1>
+            <span className="byline">by KK7KNB</span>
+          </div>
           <div className="header-actions">
             <div className="gear-menu-wrap">
               <button

--- a/web/frontend/src/styles.css
+++ b/web/frontend/src/styles.css
@@ -245,12 +245,25 @@ button:focus-visible,
   gap: var(--space-4);
 }
 
+.brand {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
 .sidebar h1 {
   font-size: var(--text-lg);
   font-weight: 700;
   margin: 0;
   letter-spacing: -0.01em;
   color: var(--fg);
+}
+
+.byline {
+  font-size: var(--text-xs);
+  color: var(--muted);
+  letter-spacing: 0.01em;
 }
 
 .theme-toggle {

--- a/web/frontend/vite.config.ts
+++ b/web/frontend/vite.config.ts
@@ -15,6 +15,14 @@ import react from "@vitejs/plugin-react";
 // keeping it separate leaves Vite's own HMR socket untouched.
 export default defineConfig({
   plugins: [react()],
+  // Build the production bundle straight into the `web` Python package
+  // (web/static), so it ships as package data in the antennaknobs wheel and
+  // server.py can mount it at "/". emptyOutDir is required because the target
+  // is outside this Vite root (web/frontend).
+  build: {
+    outDir: "../static",
+    emptyOutDir: true,
+  },
   server: {
     port: 5173,
     proxy: {

--- a/web/server.py
+++ b/web/server.py
@@ -91,12 +91,14 @@ import json
 import time
 from collections import OrderedDict
 from copy import deepcopy
+from pathlib import Path
 
 import numpy as np
 from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.concurrency import run_in_threadpool
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response, StreamingResponse
+from fastapi.staticfiles import StaticFiles
 from starlette.websockets import WebSocketState
 
 from . import pynec_backend, user_designs
@@ -855,3 +857,18 @@ async def ws_endpoint(ws: WebSocket):
                 return
     except WebSocketDisconnect:
         return
+
+
+# Serve the built React frontend (web/static, produced by `npm run build` in
+# web/frontend) at "/". Mounted LAST so every API route and FastAPI's own
+# /docs + /openapi.json — all registered above — take precedence; the mount
+# only catches "/", the SPA's assets, and other unclaimed GETs. html=True
+# serves index.html for the root.
+#
+# Gated on the directory existing: a source checkout / editable install without
+# a frontend build (the dev workflow, where Vite serves the SPA on :5173 and
+# proxies here) simply runs API-only, while a wheel install — which ships the
+# built bundle as package data — serves the whole app from this one process.
+_FRONTEND_DIR = Path(__file__).resolve().parent / "static"
+if _FRONTEND_DIR.is_dir():
+    app.mount("/", StaticFiles(directory=_FRONTEND_DIR, html=True), name="frontend")


### PR DESCRIPTION
## Summary
Makes `pip install "antennaknobs[web]"` a complete, browser-ready app: a single `uvicorn web.server:app` process now serves the React UI at `/` alongside the JSON/WebSocket API — **no Node, no separate frontend host, no git checkout**. This is the standard way pip-installable web apps ship a JS frontend (Streamlit / Gradio / JupyterLab / Datasette all bundle pre-built static assets).

- **vite.config.ts:** build output → `web/static` (inside the `web` package) instead of `web/frontend/dist`.
- **server.py:** mount `StaticFiles(web/static, html=True)` at `/`, registered **last** so every API route plus FastAPI's `/docs` + `/openapi.json` take precedence. Gated on the directory existing, so a source/editable checkout without a build runs API-only (dev uses the Vite dev server on `:5173`, which proxies here).
- **setup.py:** ship `web/static/**/*` as package data.
- **publish.yml:** add a Node 20 step that runs `npm ci && npm run build` in `web/frontend` before the Python build, so the wheel carries the bundle.
- **.gitignore:** `web/static/` is a build artifact, never committed.
- **README:** document the installed (no-Node) run path vs the dev (HMR) path.

No frontend code change needed: it already uses same-origin relative URLs (`fetch("/sweep")`, `ws://${location.host}/ws`), so the bundled SPA talks to the backend it's served from.

## Test plan
- [x] Built frontend → `web/static/{index.html,assets/*}`; built wheel and confirmed those ship inside it.
- [x] Clean-venv install + `uvicorn web.server:app`: `GET /` → 200 `text/html` (the SPA), JS asset → 200, and `/healthz` + `/examples` + `/docs` still respond (mount does not shadow the API).
- [x] ruff clean.
- [ ] CI green (incl. the new npm build step on tag publish).

## Note
This is the bundled-frontend distribution (the recommended default). The git-checkout + `npm run dev` path stays for contributors who need HMR. A hosted instance / standalone `.exe` remain separate future options for the "no pip" audience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)