### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]


### PR DESCRIPTION
## Summary
Bump `0.1.0 → 0.2.0` ahead of tagging `v0.2.0`. This release adds:
- bundled browser UI in the wheel (`pip install "antennaknobs[web]"` + `uvicorn web.server:app` serves the whole app at `/`)
- the unknown-builder CLI guard (clear error instead of a `NoneType` crash)
- AntennaKNoBs branding (header + tab title + "by KK7KNB")

## Test plan
- [ ] CI green; then tag `v0.2.0` on the merge commit to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)