### PR TITLE
GUI: band dropdown + full HF/6m bands tunable, and 3-across band controls

### DIFF
--- a/web/examples/_base.py
+++ b/web/examples/_base.py
@@ -217,11 +217,19 @@ DEFAULT_SWEEP_POLICY = SweepPolicy()
 
 
 DEFAULT_HF_BANDS: tuple[BandSpec, ...] = (
+    # Full HF amateur set + 6m, low to high. The band dropdown scales to any
+    # number, so designs (especially design_freq-scaled ones) can be placed and
+    # tuned anywhere from 160m up. (key, label, snap-freq, slider-min, -max MHz)
+    BandSpec("160m", "160m", 1.900, 1.800, 2.000),
+    BandSpec("80m", "80m", 3.750, 3.500, 4.000),
+    BandSpec("40m", "40m", 7.150, 7.000, 7.300),
+    BandSpec("30m", "30m", 10.125, 10.100, 10.150),
     BandSpec("20m", "20m", 14.300, 14.000, 14.350),
     BandSpec("17m", "17m", 18.1575, 18.068, 18.168),
     BandSpec("15m", "15m", 21.383, 21.000, 21.450),
     BandSpec("12m", "12m", 24.970, 24.890, 24.990),
     BandSpec("10m", "10m", 28.470, 28.000, 29.700),
+    BandSpec("6m", "6m", 50.150, 50.000, 54.000),
 )
 
 

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -2614,27 +2614,29 @@ export function App() {
                 <span>design freq</span>
                 <span>{designFreq.toFixed(3)} MHz</span>
               </label>
-              <div className="geometry-tabs band-tabs" role="tablist">
-                {currentBands.map((b) => (
-                  <button
-                    key={b.key}
-                    role="tab"
-                    aria-selected={activeKey === b.key}
-                    className={activeKey === b.key ? "active" : ""}
-                    onClick={() => selectBand(b.key)}
-                  >
-                    {b.label}
-                  </button>
-                ))}
+              <div className="band-row">
+                <select
+                  className="band-select"
+                  value={active.key}
+                  onChange={(e) => selectBand(e.target.value)}
+                >
+                  {currentBands.map((b) => (
+                    <option key={b.key} value={b.key}>
+                      {b.label}
+                    </option>
+                  ))}
+                </select>
+                <input
+                  type="range"
+                  min={active.min_mhz}
+                  max={active.max_mhz}
+                  step={0.005}
+                  value={designFreq}
+                  onInput={(e) =>
+                    updateDesignFreq(Number((e.target as HTMLInputElement).value))
+                  }
+                />
               </div>
-              <input
-                type="range"
-                min={active.min_mhz}
-                max={active.max_mhz}
-                step={0.005}
-                value={designFreq}
-                onInput={(e) => updateDesignFreq(Number((e.target as HTMLInputElement).value))}
-              />
             </div>
           );
         })()}
@@ -2725,41 +2727,39 @@ export function App() {
           </label>
           {/* Multi-band examples override meas_freq_range_mhz so the
               slider spans every band rather than ±25% of one design freq. */}
-          {currentBands.length > 0 && (
-            <div className="geometry-tabs band-tabs" role="tablist">
-              {currentBands.map((b) => {
-                const active = bandContaining(measFreq) === b.key;
-                return (
-                  <button
-                    key={b.key}
-                    role="tab"
-                    aria-selected={active}
-                    className={active ? "active" : ""}
-                    onClick={() => selectMeasBand(b.key)}
-                  >
+          <div className="band-row">
+            {currentBands.length > 0 && (
+              <select
+                className="band-select"
+                value={bandContaining(measFreq) ?? currentBands[0].key}
+                disabled={linkMeas}
+                onChange={(e) => selectMeasBand(e.target.value)}
+              >
+                {currentBands.map((b) => (
+                  <option key={b.key} value={b.key}>
                     {b.label}
-                  </button>
-                );
-              })}
-            </div>
-          )}
-          <input
-            type="range"
-            min={
-              currentExample?.meas_freq_range_mhz
-                ? currentExample.meas_freq_range_mhz[0]
-                : Math.max(0.5, designFreq * 0.8)
-            }
-            max={
-              currentExample?.meas_freq_range_mhz
-                ? currentExample.meas_freq_range_mhz[1]
-                : Math.min(60, designFreq * 1.25)
-            }
-            step={0.005}
-            value={measFreq}
-            disabled={linkMeas}
-            onInput={(e) => setMeasFreq(Number((e.target as HTMLInputElement).value))}
-          />
+                  </option>
+                ))}
+              </select>
+            )}
+            <input
+              type="range"
+              min={
+                currentExample?.meas_freq_range_mhz
+                  ? currentExample.meas_freq_range_mhz[0]
+                  : Math.max(0.5, designFreq * 0.8)
+              }
+              max={
+                currentExample?.meas_freq_range_mhz
+                  ? currentExample.meas_freq_range_mhz[1]
+                  : Math.min(60, designFreq * 1.25)
+              }
+              step={0.005}
+              value={measFreq}
+              disabled={linkMeas}
+              onInput={(e) => setMeasFreq(Number((e.target as HTMLInputElement).value))}
+            />
+          </div>
           <label className="link-toggle">
             <input
               type="checkbox"

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -1783,6 +1783,17 @@ export function App() {
 
   const currentBands: BandSpec[] = currentExample?.bands ?? [];
 
+  // Anchor for the measurement-freq slider window: the snap-freq of the band
+  // measFreq currently sits in, falling back to designFreq when it's between
+  // bands. This lets the meas-freq dropdown jump to any band (e.g. 40m) and
+  // have the slider actually reach it, instead of staying pinned to a window
+  // around the design frequency (which would strand a fixed-metre 40m antenna
+  // near 14 MHz). design_freq-scaled designs are unaffected: there the band's
+  // snap-freq equals designFreq, so the window is identical to before.
+  const measBandAnchor =
+    currentBands.find((b) => b.key === bandContaining(measFreq))?.freq_mhz ??
+    designFreq;
+
   // When the active example changes (or first loads), snap band /
   // designFreq / measFreq to the band whose [min, max] window contains
   // the design's native freq (from the schema's freq ParamSpec). If
@@ -2747,12 +2758,12 @@ export function App() {
               min={
                 currentExample?.meas_freq_range_mhz
                   ? currentExample.meas_freq_range_mhz[0]
-                  : Math.max(0.5, designFreq * 0.8)
+                  : Math.max(0.5, measBandAnchor * 0.8)
               }
               max={
                 currentExample?.meas_freq_range_mhz
                   ? currentExample.meas_freq_range_mhz[1]
-                  : Math.min(60, designFreq * 1.25)
+                  : Math.min(60, measBandAnchor * 1.25)
               }
               step={0.005}
               value={measFreq}

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -494,14 +494,19 @@ function ParamForm({
                   <div className="param-group-header">
                     {item.label_template.replace("{i}", String(i))}
                   </div>
-                  <ParamForm
-                    schema={item.params}
-                    values={instances[i]}
-                    onChange={onChange}
-                    pathPrefix={[...pathPrefix, item.name, i]}
-                    disabledFields={disabledFields}
-                    useKnobs={useKnobs}
-                  />
+                  {/* Wrap the band's controls in their own .param-grid so they
+                      pack 3-across just like the top-level rail. Without this
+                      the nested ParamForm block-stacks one control per row. */}
+                  <div className={`param-grid${useKnobs ? " is-knobs" : ""}`}>
+                    <ParamForm
+                      schema={item.params}
+                      values={instances[i]}
+                      onChange={onChange}
+                      pathPrefix={[...pathPrefix, item.name, i]}
+                      disabledFields={disabledFields}
+                      useKnobs={useKnobs}
+                    />
+                  </div>
                 </div>
               ))}
             </div>

--- a/web/frontend/src/styles.css
+++ b/web/frontend/src/styles.css
@@ -403,6 +403,42 @@ button:focus-visible,
   box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
+/* Band selector: a compact <select> on the same row as the freq slider, so the
+   band list scales to any number of amateur bands without a wide tab strip. */
+.band-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+.band-row input[type="range"] {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.band-select {
+  flex: 0 0 auto;
+  background: var(--inset);
+  color: var(--fg);
+  border: 1px solid var(--border-control);
+  border-radius: var(--r-sm);
+  padding: var(--space-3) var(--space-4);
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  cursor: pointer;
+}
+.band-select:hover {
+  border-color: var(--border-hover);
+}
+.band-select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.band-select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .geometry-filter {
   flex: 1;
   background: var(--inset);

--- a/web/user_design_assets/CLAUDE.md
+++ b/web/user_design_assets/CLAUDE.md
@@ -34,7 +34,9 @@ this folder, run e.g. `antennaknobs draw --builder user.my_dipole` (or
 Every key becomes a slider in the UI, accessed in `build_wires` as
 `self.<key>`. Conventions:
 
-- `freq` — measurement frequency in **MHz**. Always include it.
+- `freq` — measurement frequency in **MHz** (seeds the meas-freq slider).
+  Always include it, and set it to your target band (e.g. `7.1` for 40m). See
+  the tuning note under `build_wires` about pairing this with `design_freq`.
 - Lengths/positions are in **metres**.
 - Add a nested `"ui_params": MappingProxyType({...})` for UI hints. The most
   useful is `"default_view"`: `"xy"` (top-down), `"xz"`, or `"yz"` (side).
@@ -62,12 +64,24 @@ small `eps` (e.g. 0.01 m) apart, with the radiator arms running outward from
 those two points. Wires connect where they share an endpoint, so the arms and
 the feed segment must share their centre points exactly. See `TEMPLATE.py`.
 
-**Frequency-scaled geometry (optional):** to size an antenna from a design
-frequency instead of fixed metres, add a `design_freq` param (MHz) and a
-`length_factor` (a multiplier near 1.0), then compute
-`wavelength = 299.792458 / self.design_freq` and build dimensions as
-fractions of `wavelength * self.length_factor`. This is how most built-in
-designs work and gives you a clean per-band tuning knob.
+**Tuning on a band — use `design_freq` (strongly recommended).** To place an
+antenna on a band *and be able to tune it there*, add a `design_freq` param
+(MHz) plus a `length_factor` (a multiplier near 1.0), compute
+`wavelength = 299.792458 / self.design_freq`, and build every dimension as a
+fraction of `wavelength * self.length_factor`. This does two things at once:
+it scales the geometry to the chosen frequency, **and** it makes the app's band
+selector and the measurement-frequency slider follow `design_freq`. So a design
+with `design_freq = 7.1` lands on 40m and tunes on 40m. This is how the built-in
+designs work.
+
+**Why this matters (the 40m trap):** without a `design_freq`, the geometry is
+fixed metres and the measurement-frequency window stays parked near 14 MHz
+(20m). A fixed-metre 40m antenna therefore *cannot be tuned on 40m* — the meas
+slider won't reach 7 MHz. So if the user asks for any band other than 20–10m,
+prefer `design_freq`. If you must keep fixed dimensions, instead widen the
+measurement slider to the target band by adding
+`"meas_freq_range": (low_mhz, high_mhz)` to `ui_params` (e.g. `(6.5, 8.0)` for
+40m).
 
 ## Arrays of identical elements (advanced)
 

--- a/web/user_design_assets/TEMPLATE.py
+++ b/web/user_design_assets/TEMPLATE.py
@@ -35,12 +35,19 @@ class Builder(AntennaBuilder):
     # Optional friendly name shown in the UI. Without it, the file name is used.
     label = "Example dipole"
 
-    # The knobs. Every entry here becomes a slider in the UI. ``freq`` (the
-    # measurement frequency in MHz) is special and should always be present.
+    # The knobs. Every entry here becomes a slider in the UI.
+    #
+    # This dipole is sized from ``design_freq`` rather than fixed metres, which
+    # is the recommended pattern: ``design_freq`` scales the geometry AND drives
+    # the app's band selector + measurement-freq slider, so the antenna lands on
+    # its band and can be tuned there. Change ``design_freq`` to retune to any
+    # band (e.g. 7.1 for 40m). A fixed-metre design instead strands the
+    # measurement frequency near 14 MHz -- see CLAUDE.md ("the 40m trap").
     default_params = MappingProxyType(
         {
-            "freq": 28.5,  # MHz -- where you measure SWR / impedance
-            "half_length": 2.5,  # metres -- length of each arm (~1/4 wave on 10 m)
+            "design_freq": 14.1,  # MHz -- the band this antenna is cut for (20m)
+            "freq": 14.1,  # MHz -- where you measure SWR / impedance
+            "length_factor": 0.96,  # fine length trim near 1.0 (drag to resonate)
             "height": 10.0,  # metres -- height above ground
             # Optional UI hints. "default_view" sets the first 2-D view:
             # "xy" (top-down), "xz" or "yz" (from the side).
@@ -58,7 +65,11 @@ class Builder(AntennaBuilder):
           * ``feed`` is ``1 + 0j`` on the ONE segment driven by the
             transmitter, and ``None`` on every other wire.
         """
-        h = self.half_length
+        # Size each arm from the design frequency: a half-wave dipole is about
+        # lambda/2 tip-to-tip, so each arm is ~lambda/4. ``length_factor`` trims
+        # it to resonance (real wire runs a few % short of the ideal).
+        wavelength = 299.792458 / self.design_freq  # metres
+        h = (wavelength / 4.0) * self.length_factor  # each arm, metres
         z = self.height
         eps = 0.01  # tiny half-gap at the centre where the feed point sits
 

--- a/web/user_designs.py
+++ b/web/user_designs.py
@@ -38,12 +38,17 @@ _ASSETS = Path(__file__).resolve().parent / "user_design_assets"
 
 
 def ensure_scaffold() -> None:
-    """Create the default user folder with a ``TEMPLATE.py`` + ``CLAUDE.md``
-    the first time, so there's something to copy and Claude Code has context.
+    """Create the default user folder and keep its reference assets current.
+
+    ``TEMPLATE.py`` and ``CLAUDE.md`` are shipped documentation, not user
+    content — the workflow is copy-then-rename, so they're safe to refresh from
+    the packaged copies on every startup. That's what lets an *existing* install
+    pick up updated authoring guidance (e.g. the design_freq tuning note) after
+    an upgrade, not just brand-new folders. Any other ``*.py`` in the folder is
+    a user design and is never touched.
+
     Idempotent and best-effort — never raises into startup."""
     d = default_user_dir()
-    if d.exists():
-        return
     try:
         d.mkdir(parents=True, exist_ok=True)
         for asset in ("TEMPLATE.py", "CLAUDE.md"):


### PR DESCRIPTION
## Summary
A set of UI + design-authoring fixes centered on making the frequency band selection work beyond 20m–10m, plus a layout fix for multiband controls.

- **Band controls pack 3-across inside bands** — a multiband antenna's per-band controls had no `.param-grid` wrapper, so they block-stacked while the top-level rail packed 3-across. Now they match.
- **Band selector is a dropdown on the slider's row** — the 5-tab strip couldn't fit more than ~5 bands in the 320px rail. Replaced with a compact `<select>` sharing one row with the freq slider (`.band-row` / `.band-select`), so the band list scales to any number.
- **All HF + 6m bands, and meas-freq can reach them** — `DEFAULT_HF_BANDS` broadened from 20m–10m to 160m–6m. The measurement-freq window now anchors on the *selected* band rather than always on `design_freq`, so a fixed-metre 40m antenna can actually slide the meas freq to 7 MHz (before, it was stranded near 14 MHz).
- **Design-authoring guidance → `design_freq`** — `CLAUDE.md` now strongly recommends `design_freq` (it scales geometry *and* makes the band selector + meas slider follow it), documents "the 40m trap," and gives the `ui_params['meas_freq_range']` escape hatch for fixed designs. `TEMPLATE.py` rewritten to size itself from `design_freq` so a copy tunes on its band out of the box.
- **Scaffold refresh** — `ensure_scaffold()` now re-copies the two reference assets (`TEMPLATE.py` + `CLAUDE.md`) on every startup, so existing installs get updated guidance after an upgrade; user-authored designs are untouched.

## Why
The meas-freq window followed `design_freq`, so a generated fixed-metre 40m antenna couldn't be tuned (meas freq pinned near 14 MHz). This fixes it end-to-end: the band is offered, selecting it re-centers the window, and the authoring guidance/template steer new designs to `design_freq`.

## Test plan
- [x] Frontend builds clean (`tsc --noEmit && vite build`).
- [x] Rewritten `TEMPLATE.py` builds correct geometry (~5.1 m arm at 14.1 MHz, one feed) and loads through full discovery (`test_scaffold_creates_assets` passes).
- [x] ruff clean (check + format) across the repo.
- [ ] Manual: `npm run dev`, pick a `design_freq` design → band dropdown lists 160m–6m; selecting 40m tunes both freqs there; multiband per-band controls sit 3-across.
- [ ] CI green.

## Note
The scaffold now overwrites `CLAUDE.md`/`TEMPLATE.py` on every startup (they're copy-then-rename reference docs). If hand-editing those in place should be supported, switch to refresh-only-if-unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)