### PR TITLE
Fix array-backend and default-view auto-detection

### DIFF
--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -476,6 +476,39 @@ def test_examples_carry_default_backend(client: TestClient):
     assert by_name["arrays.bowtiearray2x4"]["default_backend"] == "arrayblock"
     # A plain single-element design keeps the default.
     assert by_name["specialty.bowtie"]["default_backend"] is None
+    # Regression: a Yagi is NOT a grid array — its equal-length directors used
+    # to collapse to one signature and trip the "any repeated shape" test. The
+    # recommendation now requires repetition to dominate (>= half the elements),
+    # so a Yagi (and a plain dipole) keep the dense default.
+    assert by_name["beams.yagi"]["default_backend"] is None
+    assert by_name["dipoles.invvee"]["default_backend"] is None
+
+
+def test_deferred_design_view_is_null_then_arrives_with_preview():
+    # Regression: a deferred (user) design with no default_view override must
+    # report default_view=None in the schema — NOT a hardcoded "xy" that makes
+    # the camera snap to the wrong plane and then flip when the auto-detected
+    # view arrives with the first geometry preview.
+    from types import MappingProxyType
+
+    from web import adapter
+    from antennaknobs.designs.dipoles.invvee import Builder as Inv
+
+    ui = {
+        k: v
+        for k, v in dict(dict(Inv.default_params).get("ui_params") or {}).items()
+        if k != "default_view"
+    }
+    dp = dict(Inv.default_params)
+    dp["ui_params"] = MappingProxyType(ui)
+
+    class NoView(Inv):
+        default_params = MappingProxyType(dp)
+
+    ex = adapter._make_example("user.noview", NoView, defer_hints=True)
+    assert ex.default_view is None  # schema holds; camera stays put
+    g = ex.momwire_geometry({})  # the builder runs here
+    assert g["default_view"] in {"xy", "yz", "xz"}  # real view rides the preview
 
 
 def test_geometry_endpoint_falls_back_when_geometry_unknown(client: TestClient):

--- a/web/adapter.py
+++ b/web/adapter.py
@@ -794,11 +794,18 @@ def _recommended_backend(cls) -> str | None:
     if len(polylines) < 2:
         return None
     wire_elem, n_elem = _wire_to_element(polylines)
-    if n_elem < 2:
+    # array-block only pays off for a genuine grid array: several elements where
+    # ONE shape repeats many times (so per-shape block reuse dominates). Require
+    # at least 4 elements — below that the speedup is marginal and 2-element
+    # symmetric things (a split dipole, a 1x2) are ambiguous.
+    if n_elem < 4:
         return None
-    # Signature each element by its points recentred on its own centroid; a
-    # repeated shape (fewer distinct signatures than elements) marks a real
-    # array — exactly what array-block accelerates via per-shape block reuse.
+    # Signature each element by its points recentred on its own centroid, then
+    # require repetition to *dominate*: at least half the elements must be
+    # duplicates of another (len(sigs) * 2 <= n_elem). The earlier test
+    # (len(sigs) < n_elem) fired on a single repeated pair, which wrongly tagged
+    # Yagis (their equal-length directors collapse to one signature while the
+    # driven element and reflector stay distinct) as arrays.
     sigs = set()
     for e in range(n_elem):
         pts = np.vstack(
@@ -808,7 +815,7 @@ def _recommended_backend(cls) -> str | None:
         key = np.round(pts / 1e-4).astype(np.int64)
         key = key[np.lexsort(key.T)]
         sigs.add(key.tobytes())
-    return "arrayblock" if len(sigs) < n_elem else None
+    return "arrayblock" if len(sigs) * 2 <= n_elem else None
 
 
 def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExample:
@@ -1162,7 +1169,11 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         field_multi_feed = (
             bool(multi_feed_override) if multi_feed_override is not None else False
         )
-        field_default_view = str(view_override) if view_override is not None else "xy"
+        # No view override and hints deferred → leave it None rather than
+        # guessing "xy". The frontend keeps the current camera until the first
+        # geometry/solve response carries the real auto-detected view, instead
+        # of snapping to a wrong "xy" and then flipping when the preview lands.
+        field_default_view = str(view_override) if view_override is not None else None
         field_default_backend = None
     else:
         h = hints()

--- a/web/examples/_base.py
+++ b/web/examples/_base.py
@@ -331,7 +331,11 @@ class AntennaExample:
     # arms run along y and droop in z, like inverted_v / fan_dipole;
     # also the vertical-loop hentenna). The user can still override
     # via the projection buttons; this just sets the starting view.
-    default_view: str = "xy"
+    # None for a deferred (user) design with no override: the real view is
+    # auto-detected and arrives with the first geometry/solve response, so the
+    # frontend holds the current camera until then instead of snapping to a
+    # provisional value.
+    default_view: Optional[str] = None
     # The frequency this antenna is naturally designed for, in MHz.
     # Used by the frontend to snap the band selector + design-freq /
     # meas-freq sliders to the right starting value when the example

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -118,7 +118,9 @@ type ExampleDescriptor = {
   result_schema: ResultSchemaItem[];
   bands: BandSpec[];
   meas_freq_range_mhz: [number, number] | null;
-  default_view: Projection;
+  /** Null for a deferred (user) design with no override — the real view is
+   *  auto-detected and arrives with the first geometry/solve response. */
+  default_view: Projection | null;
   /** The freq this antenna is naturally designed for. Used by the
    *  band-snap-on-example-change effect; null = no preferred freq. */
   default_freq_mhz: number | null;
@@ -1593,8 +1595,15 @@ export function App() {
   // When the user switches antennas, reset the camera to that example's
   // natural starting view (declared on the backend via default_view).
   // Explicit user override sticks until the next geometry change.
+  //
+  // A deferred (user) design reports default_view === null — its real view is
+  // auto-detected and arrives with the first geometry preview (handled where
+  // the preview lands, below). Holding the current camera until then avoids
+  // snapping to a wrong provisional view and flipping when the preview arrives.
   useEffect(() => {
-    if (currentExample) setCameraProjection(currentExample.default_view);
+    if (currentExample?.default_view) {
+      setCameraProjection(currentExample.default_view);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentExample?.name]);
 


### PR DESCRIPTION
## Summary
Two geometry auto-detection heuristics were misfiring (diagnosed from the OCF view + dipole-as-array reports).

### 1. Array-backend recommender flagged non-arrays
`_recommended_backend` returned `arrayblock` whenever **any** single element shape repeated (`len(sigs) < n_elem`). Confirmed on `beams.yagi`: its two equal-length directors collapse to one signature → flagged, contradicting the function's own docstring ("Yagi-style → keep dense default"). A user dipole modeled as two disconnected identical arms would trip it too.

**Fix:** require repetition to *dominate* — `n_elem >= 4 and len(sigs) * 2 <= n_elem` (≥4 elements, ≥half of them duplicates). Validated across the catalog: all 13 genuine grid/curtain arrays still recommend array-block; `beams.yagi`, dipoles, and 2-element designs now keep the dense default. (Note: `bowtiearray1x2` no longer auto-recommends array-block under the `n_elem≥4` floor — trivial to relax if you want 2-element arrays back.)

### 2. User designs opened on the wrong view
The detector (`_auto_default_view`) was always correct (`yz` for a y-axis OCF). The bug: **deferred (user) designs hardcoded `default_view="xy"`** in the `/examples` schema, so the camera snapped to `xy` on selection, then **flipped to `yz`** when the geometry preview landed — which is why adding an explicit override "fixed" it.

**Fix:** deferred designs report `default_view: null`; the frontend only sets the camera from the schema when present, otherwise holds it until the preview carries the real auto-detected view. No flip, no per-design override needed. (Built-in designs are unchanged — they prime hints eagerly.)

## Test plan
- [x] `_recommended_backend` swept across the whole catalog — Yagi/dipoles → None, real arrays → arrayblock.
- [x] Deferred OCF: schema `default_view` is None; geometry response carries `yz`.
- [x] New regression tests (yagi/dipole `default_backend=None`; deferred-view null-then-preview).
- [x] Full affected suites pass (870 passed, 5 skipped); ruff clean; frontend builds (tsc).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)