### PR TITLE
perf: lazy-import matplotlib off the cold-start path

### DIFF
--- a/src/antennaknobs/builder.py
+++ b/src/antennaknobs/builder.py
@@ -1,11 +1,10 @@
 from .core import save_or_show
 import numpy as np
 
-import matplotlib.pyplot as plt
-
-# from matplotlib.collections import LineCollection
-# from mpl_toolkits.mplot3d import axes3d
-from mpl_toolkits.mplot3d.art3d import Line3DCollection
+# matplotlib (pyplot + the mplot3d Line3DCollection) is imported lazily inside
+# draw() below — it costs ~0.1 s to import and only the drawing path needs it,
+# so keeping it off module import keeps `import antennaknobs` and web startup
+# (which never plots) lean.
 
 
 class AntennaBuilder:
@@ -65,6 +64,8 @@ class AntennaBuilder:
 
     @staticmethod
     def draw(tups, fn=None):
+        import matplotlib.pyplot as plt
+        from mpl_toolkits.mplot3d.art3d import Line3DCollection
 
         # Edges are 4-tuples (p0, p1, nsegs, excitation) or 5-tuples with a
         # trailing port name (named-edge designs like sterba_tl and the

--- a/src/antennaknobs/far_field.py
+++ b/src/antennaknobs/far_field.py
@@ -4,7 +4,9 @@ from .engine import SimulationEngine
 
 import numpy as np
 
-import matplotlib.pyplot as plt
+# matplotlib.pyplot is imported lazily inside the plotting functions below
+# (plot_patterns / pattern / pattern3d) — it costs ~0.1 s to import and only the
+# plotting paths need it, so it stays off `import antennaknobs` and web startup.
 
 
 def _as_engine(obj):
@@ -67,6 +69,8 @@ def plot_patterns(
     azimuth_f=0,
     azimuth_r=180,
 ):
+    import matplotlib.pyplot as plt
+
     fig, axes = plt.subplots(
         ncols=2, subplot_kw={"projection": "polar"}, figsize=(12, 8)
     )
@@ -157,6 +161,7 @@ def compare_patterns(
 
 
 def pattern(builder_or_engine, elevation_angle=15, fn=None):
+    import matplotlib.pyplot as plt
 
     rings, max_gain, min_gain, thetas, phis = get_pattern_rings(builder_or_engine)
 
@@ -189,6 +194,8 @@ def pattern(builder_or_engine, elevation_angle=15, fn=None):
 
 
 def pattern3d(builder_or_engine, fn=None):
+    import matplotlib.pyplot as plt
+
     a = _as_engine(builder_or_engine)
     ff = a.far_field(n_theta=30, n_phi=60, del_theta=3, del_phi=6)
     del a

--- a/src/antennaknobs/sweep.py
+++ b/src/antennaknobs/sweep.py
@@ -5,13 +5,12 @@ from icecream import ic
 
 import numpy as np
 
-import matplotlib.pyplot as plt
-
-# NOTE: scikit-rf (skrf) is imported lazily inside sweep()'s Smith-chart branch,
-# not here. Its package import is ~0.8 s (it pulls pandas + most of skrf), and
-# it's only needed when actually drawing a Smith chart — so loading it at module
-# import would tax every `import antennaknobs`, every CLI command, and web
-# startup for a feature most runs never touch.
+# NOTE: matplotlib.pyplot and scikit-rf (skrf) are imported lazily inside the
+# plotting functions below, not at module top. Both are import-heavy
+# (matplotlib ~0.1 s; skrf ~0.8 s, pulling pandas + most of skrf) and only
+# needed when actually drawing — loading them here would tax every
+# `import antennaknobs`, every CLI command, and web startup (which never plots)
+# for a feature most runs never touch.
 
 
 def build_and_get_elevation(antenna_builder, *, engine=Antenna):
@@ -52,6 +51,7 @@ def sweep_freq(
     fn=None,
     engine=Antenna,
 ):
+    import matplotlib.pyplot as plt
 
     rng = resolve_range(antenna_builder.freq, rng, center, fraction)
 
@@ -140,6 +140,7 @@ def sweep_gain(
     fn=None,
     engine=Antenna,
 ):
+    import matplotlib.pyplot as plt
 
     xs = gen_xs(getattr(antenna_builder, nm), rng, center, fraction, npoints)
 
@@ -175,6 +176,7 @@ def sweep(
     fn=None,
     engine=Antenna,
 ):
+    import matplotlib.pyplot as plt
 
     xs = gen_xs(getattr(antenna_builder, nm), rng, center, fraction, npoints)
 


### PR DESCRIPTION
## Summary
`matplotlib.pyplot` (and the mplot3d `Line3DCollection`) were imported at the top of `builder.py`, `far_field.py`, and `sweep.py` purely for plotting. matplotlib's import is ~0.1 s and `antennaknobs/__init__` pulls these modules in, so the cost hit **every `import antennaknobs` and web startup** — even though the web server returns JSON and **never plots**, and CLI commands like `list` never draw.

**Change:** move the import into the 7 functions that actually plot (`draw`; `plot_patterns`/`pattern`/`pattern3d`; `sweep_freq`/`sweep_gain`/`sweep`). `core.save_or_show` already takes `plt` as a parameter, so no change there.

## Impact (measured) — combined with the earlier skrf deferral
| | original | after skrf | after matplotlib |
|---|---|---|---|
| `import antennaknobs` | ~1.3 s | 0.79 s | **0.48 s** |
| `import web.server` (uvicorn startup) | 1.84 s | 1.22 s | **0.71 s** |

matplotlib is no longer in `sys.modules` after import; it loads on the first plot.

## Test plan
- [x] matplotlib not eagerly loaded (neither `import antennaknobs` nor `import web.server`).
- [x] All 7 plotting paths still render: draw, pattern, pattern3d, plot_patterns, sweep (+ Smith chart), sweep_gain, sweep_freq.
- [x] ruff clean; plotting test suites pass.
- [ ] CI green.

## Remaining levers
After this, the big remaining imports are `momwire` (~260 ms, the engine — deferring it to first-solve is invasive) and `fastapi` (~246 ms, web-only, not deferrable since the `app` is module-level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)