### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]


### PR DESCRIPTION
## Summary
Bump `0.2.0 → 0.3.0` ahead of tagging `v0.3.0`. Ships since v0.2.0:
- **Fix:** array-backend + default-view auto-detection (#131) — Yagis/dipoles no longer flagged as arrays; user designs no longer flip to the wrong view.
- **Perf:** lazy-import scikit-rf (#132) + matplotlib (#133) — cold start `import antennaknobs` ~1.3s → 0.48s, `web.server` startup 1.84s → 0.71s.

## Test plan
- [ ] CI green; then tag `v0.3.0` to publish the bundled wheel to TestPyPI + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)