### PR TITLE
Knob-redesign web UI + antennaknobs v0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -546,6 +546,143 @@ function Knob({
   );
 }
 
+// Searchable antenna picker: merges the old filter box + grouped <select> into
+// one combobox (type to filter, ▾ to open) so it fits on one line beside the
+// variant select. Keeps the family grouping the native <optgroup> list had.
+function GeometryCombobox({
+  groups,
+  selected,
+  currentLabel,
+  filter,
+  setFilter,
+  onSelect,
+}: {
+  groups: { fam: string; label: string; items: ExampleDescriptor[] }[];
+  selected: string;
+  currentLabel: string;
+  filter: string;
+  setFilter: (s: string) => void;
+  onSelect: (name: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState(0);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const flat = groups.flatMap((g) => g.items);
+
+  // Close (and clear the filter) on an outside click.
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        setFilter("");
+      }
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open, setFilter]);
+
+  const choose = (name: string) => {
+    onSelect(name);
+    setFilter("");
+    setOpen(false);
+    inputRef.current?.blur();
+  };
+
+  const onKey = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setOpen(true);
+      setActive((i) => Math.min(flat.length - 1, i + 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActive((i) => Math.max(0, i - 1));
+    } else if (e.key === "Enter") {
+      if (open && flat[active]) {
+        e.preventDefault();
+        choose(flat[active].name);
+      }
+    } else if (e.key === "Escape") {
+      setOpen(false);
+      setFilter("");
+      inputRef.current?.blur();
+    }
+  };
+
+  return (
+    <div className="combobox" ref={rootRef}>
+      <input
+        ref={inputRef}
+        className="geometry-filter combobox-input"
+        type="text"
+        role="combobox"
+        aria-expanded={open}
+        aria-label="antenna"
+        placeholder="search antennas…"
+        value={open ? filter : currentLabel}
+        onChange={(e) => {
+          setFilter(e.target.value);
+          setOpen(true);
+          setActive(0);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={onKey}
+      />
+      <span
+        className="combobox-caret"
+        aria-hidden="true"
+        onMouseDown={(e) => {
+          e.preventDefault();
+          if (open) {
+            setOpen(false);
+          } else {
+            inputRef.current?.focus();
+            setOpen(true);
+          }
+        }}
+      >
+        ▾
+      </span>
+      {open && (
+        <ul className="combobox-list" role="listbox">
+          {flat.length === 0 ? (
+            <li className="combobox-empty">no antennas match</li>
+          ) : (
+            groups.map((g) => (
+              <li key={g.fam} className="combobox-group">
+                <div className="combobox-group-label">{g.label}</div>
+                <ul>
+                  {g.items.map((ex) => {
+                    const idx = flat.indexOf(ex);
+                    return (
+                      <li
+                        key={ex.name}
+                        role="option"
+                        aria-selected={ex.name === selected}
+                        className={`combobox-option${
+                          ex.name === selected ? " is-selected" : ""
+                        }${idx === active ? " is-active" : ""}`}
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          choose(ex.name);
+                        }}
+                        onMouseEnter={() => setActive(idx)}
+                      >
+                        {ex.label}
+                      </li>
+                    );
+                  })}
+                </ul>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}
+
 function ParamForm({
   schema,
   values,
@@ -1384,9 +1521,6 @@ export function App() {
       }))
       .sort((a, b) => familyRank(a.fam) - familyRank(b.fam));
   })();
-  const geomMatchCount = examples.filter((ex) =>
-    matchesQuery(ex, geomQuery),
-  ).length;
   const currentVariant =
     variantByGeom[geometry] ?? currentExample?.variants?.[0] ?? "default";
 
@@ -2532,46 +2666,32 @@ export function App() {
           </div>
         </div>
 
-        <div className="geometry-select-row">
-          <label className="geometry-select-label" htmlFor="geometry-filter">
-            antenna
-          </label>
-          <input
-            id="geometry-filter"
-            className="geometry-filter"
-            type="search"
-            placeholder="search name, family, keyword…"
-            value={geomFilter}
-            onChange={(e) => setGeomFilter(e.target.value)}
-            aria-label="filter antennas"
+        <div className="antenna-row">
+          <GeometryCombobox
+            groups={geomGroups}
+            selected={geometry}
+            currentLabel={currentExample?.label ?? ""}
+            filter={geomFilter}
+            setFilter={setGeomFilter}
+            onSelect={setGeometry}
           />
+          {currentExample && currentExample.variants.length > 1 && (
+            <select
+              id="variant-select"
+              className="geometry-select variant-select"
+              value={currentVariant}
+              onChange={(e) => selectVariant(e.target.value)}
+              aria-label="variant"
+              title="variant"
+            >
+              {currentExample.variants.map((v) => (
+                <option key={v} value={v}>
+                  {v}
+                </option>
+              ))}
+            </select>
+          )}
         </div>
-        <div className="geometry-select-row">
-          <select
-            id="geometry-select"
-            className="geometry-select"
-            value={geometry}
-            onChange={(e) => setGeometry(e.target.value)}
-            size={geomQuery ? Math.min(12, geomMatchCount + geomGroups.length) : undefined}
-          >
-            {geomGroups.map((g) => (
-              <optgroup key={g.fam} label={g.label}>
-                {g.items.map((ex) => (
-                  <option key={ex.name} value={ex.name}>
-                    {ex.label}
-                  </option>
-                ))}
-              </optgroup>
-            ))}
-          </select>
-        </div>
-        {geomQuery && (
-          <div className="geometry-filter-hint">
-            {geomMatchCount === 0
-              ? "no antennas match — showing current selection only"
-              : `${geomMatchCount} match${geomMatchCount === 1 ? "" : "es"}`}
-          </div>
-        )}
         {examplesError && (
           <div className="examples-error">
             Failed to load /examples: {examplesError}
@@ -2597,25 +2717,6 @@ export function App() {
           </div>
         )}
 
-        {currentExample && currentExample.variants.length > 1 && (
-          <div className="field">
-            <label htmlFor="variant-select">
-              <span>variant</span>
-            </label>
-            <select
-              id="variant-select"
-              className="geometry-select"
-              value={currentVariant}
-              onChange={(e) => selectVariant(e.target.value)}
-            >
-              {currentExample.variants.map((v) => (
-                <option key={v} value={v}>
-                  {v}
-                </option>
-              ))}
-            </select>
-          </div>
-        )}
 
         {currentExample && (
           <div className="param-grid is-knobs">

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -270,6 +270,16 @@ function findLinkedDesignFreq(
   return null;
 }
 
+// Blend two #rrggbb colors; t=0 -> a, t=1 -> b. Used to warm the knob's value
+// arc from --accent toward --hot as it nears max (an "energizing" cue).
+function mixHex(a: string, b: string, t: number): string {
+  const ch = (s: string, i: number) => parseInt(s.slice(i, i + 2), 16);
+  const r = Math.round(ch(a, 1) + (ch(b, 1) - ch(a, 1)) * t);
+  const g = Math.round(ch(a, 3) + (ch(b, 3) - ch(a, 3)) * t);
+  const bl = Math.round(ch(a, 5) + (ch(b, 5) - ch(a, 5)) * t);
+  return `rgb(${r}, ${g}, ${bl})`;
+}
+
 // A dependency-free rotary knob — a drop-in alternative to the range
 // slider for float/int params. Semantically a slider (role="slider"), so
 // it stays keyboard- and screen-reader-accessible: vertical drag, scroll
@@ -287,6 +297,10 @@ function Knob({
   unit,
   label,
   onChange,
+  startDeg = -135,
+  sweepDeg = 270,
+  variant = "param",
+  disabled = false,
 }: {
   value: number;
   min: number;
@@ -296,10 +310,26 @@ function Knob({
   unit: string | null;
   label: string;
   onChange: (v: number) => void;
+  // Dial geometry in clock-angle degrees (0 = 12 o'clock, +CW). The default is
+  // the classic 270° gauge sweeping clockwise from 7:30 (lower-left) to 4:30.
+  // Pass startDeg=90, sweepDeg=-(max-min) for a CCW dial starting at 3 o'clock
+  // (elevation: -90 quarter-arc; azimuth: -360 full circle) — degrees then map
+  // 1:1 onto the dial face.
+  startDeg?: number;
+  sweepDeg?: number;
+  // "vfo" = the big weighted measurement-freq tuning dial: knurled skirt +
+  // finger dimple on an eased rotor, outer band arc that warms toward the edge.
+  // "param" = the compact setup/cut dials (clean accent, no warming).
+  variant?: "param" | "vfo";
+  // Locked (e.g. measurement freq while "lock to design freq" is on): dims the
+  // dial and ignores drag/wheel/keys.
+  disabled?: boolean;
 }) {
   const wrapRef = useRef<HTMLDivElement>(null);
   const dragRef = useRef<{ y: number; v: number } | null>(null);
   const [editing, setEditing] = useState(false);
+  const [dragging, setDragging] = useState(false);
+  const isVfo = variant === "vfo";
 
   const span = max - min || 1;
   const clamp = (v: number) => Math.min(max, Math.max(min, v));
@@ -312,10 +342,8 @@ function Knob({
   };
 
   const frac = Math.min(1, Math.max(0, (value - min) / span));
-  const SWEEP = 270;
-  const START = -135;
-  const ang = START + frac * SWEEP;
-  const R = 38;
+  const ang = startDeg + frac * sweepDeg;
+  const Rarc = isVfo ? 42 : 38;
   const polar = (deg: number, r: number): [number, number] => {
     const a = (deg * Math.PI) / 180;
     return [50 + r * Math.sin(a), 50 - r * Math.cos(a)];
@@ -323,10 +351,21 @@ function Knob({
   const arc = (r: number, a0: number, a1: number): string => {
     const [x0, y0] = polar(a0, r);
     const [x1, y1] = polar(a1, r);
-    const large = Math.abs(a1 - a0) > 180 ? 1 : 0;
-    return `M ${x0.toFixed(2)} ${y0.toFixed(2)} A ${r} ${r} 0 ${large} 1 ${x1.toFixed(2)} ${y1.toFixed(2)}`;
+    const delta = a1 - a0;
+    const large = Math.abs(delta) > 180 ? 1 : 0;
+    // Sweep-flag follows the traversal direction: clockwise (SVG +angle) for an
+    // increasing clock-angle, counter-clockwise for a decreasing one. Lets a
+    // negative sweepDeg (CCW dials: elevation, azimuth) bend the correct way.
+    const sweep = delta >= 0 ? 1 : 0;
+    return `M ${x0.toFixed(2)} ${y0.toFixed(2)} A ${r} ${r} 0 ${large} ${sweep} ${x1.toFixed(2)} ${y1.toFixed(2)}`;
   };
-  const [px, py] = polar(ang, R - 3);
+  // Param-knob indicator notch across the cap face (center-out), at value.
+  const [nx0, ny0] = polar(ang, 3);
+  const [nx1, ny1] = polar(ang, 14);
+  // Only the VFO's band arc warms --accent -> --hot over the top ~40% of travel
+  // ("redlining" near the band edge). Small knobs stay a clean accent.
+  const warm = Math.max(0, (frac - 0.6) / 0.4);
+  const fillColor = isVfo ? mixHex("#2f5fb0", "#cf7a22", warm) : undefined;
 
   // Scroll wheel: ±step per detent (×10 with Shift). Attached natively so
   // we can preventDefault — React's onWheel is passive and can't stop the
@@ -335,6 +374,7 @@ function Knob({
     const el = wrapRef.current;
     if (!el) return;
     const onWheel = (e: WheelEvent) => {
+      if (disabled) return;
       e.preventDefault();
       const dir = e.deltaY < 0 ? 1 : -1;
       const mult = e.shiftKey ? 10 : 1;
@@ -345,12 +385,13 @@ function Knob({
     };
     el.addEventListener("wheel", onWheel, { passive: false });
     return () => el.removeEventListener("wheel", onWheel);
-  }, [value, step, min, max, precision, onChange]);
+  }, [value, step, min, max, precision, onChange, disabled]);
 
   const onPointerDown = (e: React.PointerEvent) => {
-    if (editing) return;
+    if (editing || disabled) return;
     (e.target as Element).setPointerCapture(e.pointerId);
     dragRef.current = { y: e.clientY, v: value };
+    setDragging(true);
     wrapRef.current?.focus();
     e.preventDefault();
   };
@@ -363,10 +404,12 @@ function Knob({
   };
   const endDrag = (e: React.PointerEvent) => {
     dragRef.current = null;
+    setDragging(false);
     (e.target as Element).releasePointerCapture?.(e.pointerId);
   };
 
   const onKeyDown = (e: React.KeyboardEvent) => {
+    if (disabled) return;
     let next: number | null = null;
     switch (e.key) {
       case "ArrowUp":
@@ -409,15 +452,16 @@ function Knob({
   const p = Math.max(0, precision);
   return (
     <div
-      className="knob"
+      className={`knob${isVfo ? " is-vfo" : ""}${disabled ? " is-disabled" : ""}`}
       ref={wrapRef}
       role="slider"
-      tabIndex={editing ? -1 : 0}
+      tabIndex={editing || disabled ? -1 : 0}
       aria-label={label}
       aria-valuemin={min}
       aria-valuemax={max}
       aria-valuenow={value}
       aria-valuetext={`${value.toFixed(p)}${unit ?? ""}`}
+      aria-disabled={disabled || undefined}
       onKeyDown={onKeyDown}
     >
       {editing ? (
@@ -438,23 +482,64 @@ function Knob({
         />
       ) : (
         <svg
-          viewBox="0 0 100 100"
+          // The VFO's 270° gauge opens at the bottom (~6 o'clock) and its
+          // content stops by y≈82, so crop the empty bottom off the box rather
+          // than reserve a full square. NOT for the others: the azimuth dial is
+          // a full circle that uses the bottom.
+          viewBox={isVfo ? "0 0 100 88" : "0 0 100 100"}
           onPointerDown={onPointerDown}
           onPointerMove={onPointerMove}
           onPointerUp={endDrag}
           onPointerCancel={endDrag}
           onDoubleClick={() => setEditing(true)}
         >
-          <path className="knob-track" d={arc(R, START, START + SWEEP)} />
-          <path className="knob-fill" d={arc(R, START, ang)} />
-          <line
-            className="knob-ptr"
-            x1="50"
-            y1="50"
-            x2={px.toFixed(2)}
-            y2={py.toFixed(2)}
+          <path
+            className="knob-track"
+            d={arc(Rarc, startDeg, startDeg + sweepDeg)}
           />
-          <circle className="knob-hub" cx="50" cy="50" r="6" />
+          <path
+            className="knob-fill"
+            style={fillColor ? { stroke: fillColor } : undefined}
+            d={arc(Rarc, startDeg, ang)}
+          />
+          {isVfo ? (
+            // The whole knob body spins; the band arc behind it stays put — a
+            // fixed scale with a turning dial, exactly like a transceiver VFO.
+            <g
+              className={`knob-rotor${dragging ? " no-ease" : ""}`}
+              style={{ transform: `rotate(${ang.toFixed(2)}deg)` }}
+            >
+              <circle className="knob-cap" cx="50" cy="50" r="30" />
+              {Array.from({ length: 30 }, (_, i) => {
+                const a = (i * 360) / 30;
+                const [sx0, sy0] = polar(a, 27.5);
+                const [sx1, sy1] = polar(a, 32);
+                return (
+                  <line
+                    key={i}
+                    className="knob-skirt"
+                    x1={sx0.toFixed(2)}
+                    y1={sy0.toFixed(2)}
+                    x2={sx1.toFixed(2)}
+                    y2={sy1.toFixed(2)}
+                  />
+                );
+              })}
+              <line className="knob-notch" x1="50" y1="39" x2="50" y2="24" />
+              <circle className="knob-dimple" cx="50" cy="30" r="3.4" />
+            </g>
+          ) : (
+            <>
+              <circle className="knob-cap" cx="50" cy="50" r="15" />
+              <line
+                className="knob-notch"
+                x1={nx0.toFixed(2)}
+                y1={ny0.toFixed(2)}
+                x2={nx1.toFixed(2)}
+                y2={ny1.toFixed(2)}
+              />
+            </>
+          )}
         </svg>
       )}
     </div>
@@ -467,7 +552,6 @@ function ParamForm({
   onChange,
   pathPrefix = [],
   disabledFields,
-  useKnobs = false,
 }: {
   schema: SchemaItem[];
   values: ParamValueBag;
@@ -478,8 +562,6 @@ function ParamForm({
   // depends on the active backend (e.g. daisy_chain only works on
   // PyNEC; momwire engines don't support transmission lines yet).
   disabledFields?: Set<string>;
-  // Render float/int params as rotary knobs instead of range sliders.
-  useKnobs?: boolean;
 }) {
   return (
     <>
@@ -499,14 +581,13 @@ function ParamForm({
                   {/* Wrap the band's controls in their own .param-grid so they
                       pack 3-across just like the top-level rail. Without this
                       the nested ParamForm block-stacks one control per row. */}
-                  <div className={`param-grid${useKnobs ? " is-knobs" : ""}`}>
+                  <div className="param-grid is-knobs">
                     <ParamForm
                       schema={item.params}
                       values={instances[i]}
                       onChange={onChange}
                       pathPrefix={[...pathPrefix, item.name, i]}
                       disabledFields={disabledFields}
-                      useKnobs={useKnobs}
                     />
                   </div>
                 </div>
@@ -609,47 +690,23 @@ function ParamForm({
           item.kind === "int"
             ? String(Math.round(currentNum))
             : currentNum.toFixed(item.precision);
-        // Knobs stack vertically — label on top, dial in the middle, value
-        // on the bottom — so the label and value don't share a cramped row
-        // above the dial. Sliders keep the name+value label row above the
-        // track.
-        if (useKnobs) {
-          return (
-            <div key={item.name} className="field field-knob">
-              <span className="knob-label" title={item.label}>{item.label}</span>
-              <Knob
-                value={currentNum}
-                min={effMin}
-                max={effMax}
-                step={item.step ?? 0.001}
-                precision={item.kind === "int" ? 0 : item.precision}
-                unit={item.unit}
-                label={item.label}
-                onChange={(v) => onChange([...pathPrefix, item.name], v)}
-              />
-              <span className="knob-value">{shown}{item.unit ?? ""}</span>
-            </div>
-          );
-        }
+        // Every float/int param is a rotary knob: label on top, dial in the
+        // middle, value on the bottom. (The slider alternative and its toggle
+        // were retired — knobs are the brand.)
         return (
-          <div key={item.name} className="field">
-            <label>
-              <span title={item.label}>{item.label}</span>
-              <span>{shown}{item.unit ?? ""}</span>
-            </label>
-            <input
-              type="range"
+          <div key={item.name} className="field field-knob">
+            <span className="knob-label" title={item.label}>{item.label}</span>
+            <Knob
+              value={currentNum}
               min={effMin}
               max={effMax}
               step={item.step ?? 0.001}
-              value={currentNum}
-              onInput={(e) =>
-                onChange(
-                  [...pathPrefix, item.name],
-                  Number((e.target as HTMLInputElement).value),
-                )
-              }
+              precision={item.kind === "int" ? 0 : item.precision}
+              unit={item.unit}
+              label={item.label}
+              onChange={(v) => onChange([...pathPrefix, item.name], v)}
             />
+            <span className="knob-value">{shown}{item.unit ?? ""}</span>
           </div>
         );
       })}
@@ -1238,21 +1295,6 @@ export function App() {
   // Tools (gear) dropdown in the header. Tucked away because it holds
   // occasional actions like the NEC deck export, not per-solve controls.
   const [gearMenuOpen, setGearMenuOpen] = useState(false);
-
-  // Render parameter controls as rotary knobs instead of range sliders.
-  // Opt-in (persisted) — knobs are on-brand and compact but a precision
-  // regression for some users, so sliders stay the default.
-  const [useKnobs, setUseKnobs] = useState<boolean>(
-    () => localStorage.getItem("useKnobs") === "1",
-  );
-  const toggleKnobs = (next: boolean) => {
-    try {
-      localStorage.setItem("useKnobs", next ? "1" : "0");
-    } catch {
-      /* storage disabled — in-memory toggle still works */
-    }
-    setUseKnobs(next);
-  };
 
   // Schema-driven parameter controls. Each registered example bundles
   // its parameter schema in web/examples/<name>.py; the backend serves
@@ -2576,35 +2618,11 @@ export function App() {
         )}
 
         {currentExample && (
-          <div
-            className="knob-toggle"
-            role="group"
-            aria-label="Parameter control style"
-          >
-            <button
-              type="button"
-              className={!useKnobs ? "active" : ""}
-              onClick={() => toggleKnobs(false)}
-            >
-              Sliders
-            </button>
-            <button
-              type="button"
-              className={useKnobs ? "active" : ""}
-              onClick={() => toggleKnobs(true)}
-            >
-              Knobs
-            </button>
-          </div>
-        )}
-
-        {currentExample && (
-          <div className={`param-grid${useKnobs ? " is-knobs" : ""}`}>
+          <div className="param-grid is-knobs">
             <ParamForm
               schema={currentExample.param_schema}
               values={currentValues}
               onChange={setParamAtPath}
-              useKnobs={useKnobs}
               // hexbeam_5band's daisy_chain mode emits NEC TL cards;
               // momwire engines reject any non-empty build_tls() so the
               // toggle has no effect there. Grey it out when the active
@@ -2740,46 +2758,55 @@ export function App() {
           )}
         </div>
 
-        <div className="field">
-          <label>
-            <span>measurement freq</span>
-            <span>{measFreq.toFixed(3)} MHz</span>
-          </label>
-          {/* Multi-band examples override meas_freq_range_mhz so the
-              slider spans every band rather than ±25% of one design freq. */}
-          <div className="band-row">
-            {currentBands.length > 0 && (
-              <select
-                className="band-select"
-                value={bandContaining(measFreq) ?? currentBands[0].key}
-                disabled={linkMeas}
-                onChange={(e) => selectMeasBand(e.target.value)}
-              >
-                {currentBands.map((b) => (
-                  <option key={b.key} value={b.key}>
-                    {b.label}
-                  </option>
-                ))}
-              </select>
-            )}
-            <input
-              type="range"
-              min={
-                currentExample?.meas_freq_range_mhz
-                  ? currentExample.meas_freq_range_mhz[0]
-                  : Math.max(0.5, measBandAnchor * 0.8)
-              }
-              max={
-                currentExample?.meas_freq_range_mhz
-                  ? currentExample.meas_freq_range_mhz[1]
-                  : Math.min(60, measBandAnchor * 1.25)
-              }
-              step={0.005}
-              value={measFreq}
-              disabled={linkMeas}
-              onInput={(e) => setMeasFreq(Number((e.target as HTMLInputElement).value))}
-            />
+        {/* Measurement freq is the rig's tuning control → a weighted VFO dial
+            with a frequency-counter readout, in place of a slider. The dial
+            spans the band (multi-band examples override meas_freq_range_mhz).
+            "lock to design freq" disables the dial. */}
+        <div className={`field vfo-field${linkMeas ? " is-locked" : ""}`}>
+          <span className="vfo-cap">measurement freq</span>
+          <div className="freq-lcd" title={`${measFreq.toFixed(3)} MHz`}>
+            <span className="lcd-digits">
+              <span className="lcd-ghost">
+                {measFreq.toFixed(3).replace(/\d/g, "8")}
+              </span>
+              <span className="lcd-live">{measFreq.toFixed(3)}</span>
+            </span>
+            <span className="lcd-unit">MHz</span>
           </div>
+          <Knob
+            variant="vfo"
+            value={measFreq}
+            min={
+              currentExample?.meas_freq_range_mhz
+                ? currentExample.meas_freq_range_mhz[0]
+                : Math.max(0.5, measBandAnchor * 0.8)
+            }
+            max={
+              currentExample?.meas_freq_range_mhz
+                ? currentExample.meas_freq_range_mhz[1]
+                : Math.min(60, measBandAnchor * 1.25)
+            }
+            step={0.005}
+            precision={3}
+            unit=" MHz"
+            label="measurement frequency"
+            onChange={setMeasFreq}
+            disabled={linkMeas}
+          />
+          {currentBands.length > 0 && (
+            <select
+              className="band-select"
+              value={bandContaining(measFreq) ?? currentBands[0].key}
+              disabled={linkMeas}
+              onChange={(e) => selectMeasBand(e.target.value)}
+            >
+              {currentBands.map((b) => (
+                <option key={b.key} value={b.key}>
+                  {b.label}
+                </option>
+              ))}
+            </select>
+          )}
           <label className="link-toggle">
             <input
               type="checkbox"
@@ -2792,34 +2819,49 @@ export function App() {
 
         <div className="group-label">far-field cuts</div>
 
-        <div className="field">
-          <label>
-            <span>azimuth at elevation</span>
-            <span>{azElevDeg.toFixed(0)}°</span>
-          </label>
-          <input
-            type="range"
-            min={0}
-            max={89}
-            step={1}
-            value={azElevDeg}
-            onInput={(e) => setAzElevDeg(Number((e.target as HTMLInputElement).value))}
-          />
-        </div>
-
-        <div className="field">
-          <label>
-            <span>elevation at azimuth</span>
-            <span>{elevAzDeg.toFixed(0)}°</span>
-          </label>
-          <input
-            type="range"
-            min={0}
-            max={359}
-            step={1}
-            value={elevAzDeg}
-            onInput={(e) => setElevAzDeg(Number((e.target as HTMLInputElement).value))}
-          />
+        <div className="cut-knobs">
+          <div className="field field-knob">
+            <span
+              className="knob-label"
+              title="elevation at which the azimuth-plane cut is taken"
+            >
+              elevation
+            </span>
+            <Knob
+              value={azElevDeg}
+              min={0}
+              max={89}
+              step={1}
+              precision={0}
+              unit="°"
+              label="cut elevation"
+              onChange={setAzElevDeg}
+              startDeg={90}
+              sweepDeg={-89}
+            />
+            <span className="knob-value">{azElevDeg.toFixed(0)}°</span>
+          </div>
+          <div className="field field-knob">
+            <span
+              className="knob-label"
+              title="azimuth bearing at which the elevation-plane cut is taken"
+            >
+              azimuth
+            </span>
+            <Knob
+              value={elevAzDeg}
+              min={0}
+              max={359}
+              step={1}
+              precision={0}
+              unit="°"
+              label="cut azimuth"
+              onChange={setElevAzDeg}
+              startDeg={90}
+              sweepDeg={-359}
+            />
+            <span className="knob-value">{elevAzDeg.toFixed(0)}°</span>
+          </div>
         </div>
 
         <div className={`readout${stale ? " stale" : ""}`}>

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -2922,53 +2922,6 @@ export function App() {
           )}
         </div>
 
-        <div className="group-label">far-field cuts</div>
-
-        <div className="cut-knobs">
-          <div className="field field-knob">
-            <span
-              className="knob-label"
-              title="elevation at which the azimuth-plane cut is taken"
-            >
-              elevation
-            </span>
-            <Knob
-              value={azElevDeg}
-              min={0}
-              max={89}
-              step={1}
-              precision={0}
-              unit="°"
-              label="cut elevation"
-              onChange={setAzElevDeg}
-              startDeg={90}
-              sweepDeg={-89}
-            />
-            <span className="knob-value">{azElevDeg.toFixed(0)}°</span>
-          </div>
-          <div className="field field-knob">
-            <span
-              className="knob-label"
-              title="azimuth bearing at which the elevation-plane cut is taken"
-            >
-              azimuth
-            </span>
-            <Knob
-              value={elevAzDeg}
-              min={0}
-              max={359}
-              step={1}
-              precision={0}
-              unit="°"
-              label="cut azimuth"
-              onChange={setElevAzDeg}
-              startDeg={90}
-              sweepDeg={-359}
-            />
-            <span className="knob-value">{elevAzDeg.toFixed(0)}°</span>
-          </div>
-        </div>
-
         <div className={`readout${stale ? " stale" : ""}`}>
           <div className="row">
             <span>R</span>
@@ -3159,6 +3112,51 @@ export function App() {
                 />
                 converge sweep
               </label>
+            </div>
+          )}
+          {/* The cut-angle knob lives on the plot it drives: the azimuth
+              (xy) cut is taken at elevation azElevDeg; the elevation (yz) cut
+              is taken at azimuth bearing elevAzDeg. CCW dials from 3 o'clock. */}
+          {view === "azimuth" && (
+            <div
+              className="cut-overlay"
+              title="elevation at which this azimuth cut is taken"
+            >
+              <span className="cut-overlay-label">elevation</span>
+              <Knob
+                value={azElevDeg}
+                min={0}
+                max={89}
+                step={1}
+                precision={0}
+                unit="°"
+                label="cut elevation"
+                onChange={setAzElevDeg}
+                startDeg={90}
+                sweepDeg={-89}
+              />
+              <span className="cut-overlay-value">{azElevDeg}°</span>
+            </div>
+          )}
+          {view === "elevation" && (
+            <div
+              className="cut-overlay"
+              title="azimuth bearing at which this elevation cut is taken"
+            >
+              <span className="cut-overlay-label">azimuth</span>
+              <Knob
+                value={elevAzDeg}
+                min={0}
+                max={359}
+                step={1}
+                precision={0}
+                unit="°"
+                label="cut azimuth"
+                onChange={setElevAzDeg}
+                startDeg={90}
+                sweepDeg={-359}
+              />
+              <span className="cut-overlay-value">{elevAzDeg}°</span>
             </div>
           )}
           <ViewPanel

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -1841,7 +1841,12 @@ export function App() {
   // and the |I| envelope curve overlay. Either or both can be turned off;
   // the wires and feed marker are always drawn.
   const [showHeatmap, setShowHeatmap] = useState(true);
-  const [showEnvelope, setShowEnvelope] = useState(true);
+  const [showEnvelope, setShowEnvelope] = useState(false);
+  // Wire labels and feed names can crowd dense geometries (and PyNEC returns
+  // many more wires than the momwire engines), so let them be toggled. Wire
+  // labels default OFF — they're the noisiest, especially on PyNEC.
+  const [showWireLabels, setShowWireLabels] = useState(false);
+  const [showFeedNames, setShowFeedNames] = useState(true);
   const { ref: slideRef, size: chartSize } = useSlideSize(720);
   const thumbStripRef = useRef<HTMLDivElement>(null);
   const thumbSize = useThumbColumnSize(thumbStripRef, 280);
@@ -3086,6 +3091,28 @@ export function App() {
                 />
                 current waveforms
               </label>
+              <label
+                className="overlay-checkbox"
+                title="Draw the per-wire labels (off to declutter dense geometries)"
+              >
+                <input
+                  type="checkbox"
+                  checked={showWireLabels}
+                  onChange={(e) => setShowWireLabels(e.target.checked)}
+                />
+                wire labels
+              </label>
+              <label
+                className="overlay-checkbox"
+                title="Draw the 'feed' name beside each feedpoint marker"
+              >
+                <input
+                  type="checkbox"
+                  checked={showFeedNames}
+                  onChange={(e) => setShowFeedNames(e.target.checked)}
+                />
+                feed labels
+              </label>
             </div>
           )}
           {view === "smith" && (
@@ -3176,6 +3203,8 @@ export function App() {
             cameraProjection={cameraProjection}
             showHeatmap={showHeatmap}
             showEnvelope={showEnvelope}
+            showWireLabels={showWireLabels}
+            showFeedNames={showFeedNames}
             multiFeed={effectiveMultiFeed}
           />
         </div>
@@ -3559,6 +3588,8 @@ function ViewPanel({
   cameraProjection,
   showHeatmap,
   showEnvelope,
+  showWireLabels = false,
+  showFeedNames = true,
   multiFeed,
 }: {
   view: View;
@@ -3577,6 +3608,8 @@ function ViewPanel({
   cameraProjection: Projection;
   showHeatmap: boolean;
   showEnvelope: boolean;
+  showWireLabels?: boolean;
+  showFeedNames?: boolean;
   multiFeed: boolean;
 }) {
   if (view === "antenna") {
@@ -3592,6 +3625,8 @@ function ViewPanel({
           projection={cameraProjection}
           showHeatmap={showingPreview ? false : showHeatmap}
           showEnvelope={showingPreview ? false : showEnvelope}
+          showWireLabels={showWireLabels}
+          showFeedNames={showFeedNames}
         />
       </div>
     );
@@ -4533,11 +4568,15 @@ function CurrentCanvas({
   projection,
   showHeatmap,
   showEnvelope,
+  showWireLabels,
+  showFeedNames,
 }: {
   result: SolveResponse | null;
   projection: Projection;
   showHeatmap: boolean;
   showEnvelope: boolean;
+  showWireLabels: boolean;
+  showFeedNames: boolean;
 }) {
   const theme = useContext(ThemeContext); // repaint on theme toggle (dep below)
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -4729,7 +4768,7 @@ function CurrentCanvas({
         }
 
         // Wire label near the leftmost knot for multi-wire geometries.
-        if (result.wires.length > 1) {
+        if (showWireLabels && result.wires.length > 1) {
           const lp = project(wire.knot_positions[0]);
           ctx!.fillStyle = PC.label;
           ctx!.font = `${labelFontPx}px ui-monospace, monospace`;
@@ -4761,11 +4800,13 @@ function CurrentCanvas({
         ctx!.beginPath();
         ctx!.arc(feed.x, feed.y, 5 * s, 0, Math.PI * 2);
         ctx!.fill();
-        ctx!.font = `${feedFontPx}px ui-monospace, monospace`;
-        const label = feedList.length > 1
-          ? `feed ${fi} ∠${Math.round(Math.atan2(f.v_im, f.v_re) * 180 / Math.PI)}°`
-          : "feed";
-        ctx!.fillText(label, feed.x + 8 * s, feed.y - 8 * s);
+        if (showFeedNames) {
+          ctx!.font = `${feedFontPx}px ui-monospace, monospace`;
+          const label = feedList.length > 1
+            ? `feed ${fi} ∠${Math.round(Math.atan2(f.v_im, f.v_re) * 180 / Math.PI)}°`
+            : "feed";
+          ctx!.fillText(label, feed.x + 8 * s, feed.y - 8 * s);
+        }
       }
 
       // λ/4 scale bar, centered horizontally under the antenna.
@@ -4793,7 +4834,7 @@ function CurrentCanvas({
     const obs = new ResizeObserver(onResize);
     obs.observe(canvas);
     return () => obs.disconnect();
-  }, [result, projection, showHeatmap, showEnvelope, theme]);
+  }, [result, projection, showHeatmap, showEnvelope, showWireLabels, showFeedNames, theme]);
 
   return <canvas ref={canvasRef} />;
 }

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -2679,6 +2679,69 @@ export function App() {
           );
         })()}
 
+        {/* Measurement freq = the rig's tuning control: a weighted VFO dial +
+            frequency-counter readout. Band select + lock sit to the LEFT of the
+            readout/dial to keep the field compact. "lock to design freq"
+            disables the dial. */}
+        <div className="group-label">measurement freq</div>
+        <div className={`field vfo-field${linkMeas ? " is-locked" : ""}`}>
+          <div className="vfo-aux">
+            {currentBands.length > 0 && (
+              <select
+                className="band-select"
+                value={bandContaining(measFreq) ?? currentBands[0].key}
+                disabled={linkMeas}
+                onChange={(e) => selectMeasBand(e.target.value)}
+              >
+                {currentBands.map((b) => (
+                  <option key={b.key} value={b.key}>
+                    {b.label}
+                  </option>
+                ))}
+              </select>
+            )}
+            <label className="link-toggle" title="lock to design freq">
+              <input
+                type="checkbox"
+                checked={linkMeas}
+                onChange={(e) => toggleLink(e.target.checked)}
+              />
+              lock
+            </label>
+          </div>
+          <div className="vfo-main">
+            <div className="freq-lcd" title={`${measFreq.toFixed(3)} MHz`}>
+              <span className="lcd-digits">
+                <span className="lcd-ghost">
+                  {measFreq.toFixed(3).replace(/\d/g, "8")}
+                </span>
+                <span className="lcd-live">{measFreq.toFixed(3)}</span>
+              </span>
+              <span className="lcd-unit">MHz</span>
+            </div>
+            <Knob
+              variant="vfo"
+              value={measFreq}
+              min={
+                currentExample?.meas_freq_range_mhz
+                  ? currentExample.meas_freq_range_mhz[0]
+                  : Math.max(0.5, measBandAnchor * 0.8)
+              }
+              max={
+                currentExample?.meas_freq_range_mhz
+                  ? currentExample.meas_freq_range_mhz[1]
+                  : Math.min(60, measBandAnchor * 1.25)
+              }
+              step={0.005}
+              precision={3}
+              unit=" MHz"
+              label="measurement frequency"
+              onChange={setMeasFreq}
+              disabled={linkMeas}
+            />
+          </div>
+        </div>
+
         <div className="group-label">simulation</div>
 
         <div className="field">
@@ -2756,65 +2819,6 @@ export function App() {
               fast ground (reflection coefficient)
             </label>
           )}
-        </div>
-
-        {/* Measurement freq is the rig's tuning control → a weighted VFO dial
-            with a frequency-counter readout, in place of a slider. The dial
-            spans the band (multi-band examples override meas_freq_range_mhz).
-            "lock to design freq" disables the dial. */}
-        <div className={`field vfo-field${linkMeas ? " is-locked" : ""}`}>
-          <span className="vfo-cap">measurement freq</span>
-          <div className="freq-lcd" title={`${measFreq.toFixed(3)} MHz`}>
-            <span className="lcd-digits">
-              <span className="lcd-ghost">
-                {measFreq.toFixed(3).replace(/\d/g, "8")}
-              </span>
-              <span className="lcd-live">{measFreq.toFixed(3)}</span>
-            </span>
-            <span className="lcd-unit">MHz</span>
-          </div>
-          <Knob
-            variant="vfo"
-            value={measFreq}
-            min={
-              currentExample?.meas_freq_range_mhz
-                ? currentExample.meas_freq_range_mhz[0]
-                : Math.max(0.5, measBandAnchor * 0.8)
-            }
-            max={
-              currentExample?.meas_freq_range_mhz
-                ? currentExample.meas_freq_range_mhz[1]
-                : Math.min(60, measBandAnchor * 1.25)
-            }
-            step={0.005}
-            precision={3}
-            unit=" MHz"
-            label="measurement frequency"
-            onChange={setMeasFreq}
-            disabled={linkMeas}
-          />
-          {currentBands.length > 0 && (
-            <select
-              className="band-select"
-              value={bandContaining(measFreq) ?? currentBands[0].key}
-              disabled={linkMeas}
-              onChange={(e) => selectMeasBand(e.target.value)}
-            >
-              {currentBands.map((b) => (
-                <option key={b.key} value={b.key}>
-                  {b.label}
-                </option>
-              ))}
-            </select>
-          )}
-          <label className="link-toggle">
-            <input
-              type="checkbox"
-              checked={linkMeas}
-              onChange={(e) => toggleLink(e.target.checked)}
-            />
-            lock to design freq
-          </label>
         </div>
 
         <div className="group-label">far-field cuts</div>

--- a/web/frontend/src/styles.css
+++ b/web/frontend/src/styles.css
@@ -460,6 +460,96 @@ button:focus-visible,
   box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
+/* one-line antenna picker: searchable combobox + inline variant select */
+.antenna-row {
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-3);
+  margin: var(--space-2) 0 var(--space-4);
+}
+.combobox {
+  position: relative;
+  flex: 1 1 0; /* grow from a 0 basis so its text width can't crowd the variant */
+  min-width: 0;
+}
+.combobox-input {
+  width: 100%;
+  box-sizing: border-box; /* keep padding inside the box so it can't overflow
+                             right and paint over the variant select */
+  padding-right: 26px; /* room for the caret */
+}
+.combobox-caret {
+  position: absolute;
+  right: 9px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--muted);
+  font-size: 10px;
+  cursor: pointer;
+  user-select: none;
+}
+.combobox-list {
+  position: absolute;
+  top: calc(100% + 3px);
+  left: 0;
+  right: 0;
+  z-index: 30;
+  max-height: 300px;
+  overflow-y: auto;
+  margin: 0;
+  padding: var(--space-2);
+  list-style: none;
+  background: var(--panel);
+  border: 1px solid var(--border-control);
+  border-radius: var(--r-sm);
+  box-shadow: 0 8px 22px var(--shadow);
+}
+.combobox-group + .combobox-group {
+  margin-top: var(--space-2);
+}
+.combobox-group > ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.combobox-group-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted-2);
+  padding: var(--space-2) var(--space-3) var(--space-1);
+}
+.combobox-option {
+  padding: var(--space-3);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: var(--text-base);
+  color: var(--fg);
+}
+.combobox-option.is-active {
+  background: var(--inset);
+}
+.combobox-option.is-selected {
+  color: var(--accent);
+  font-weight: 600;
+}
+.combobox-option.is-selected.is-active {
+  background: var(--accent-soft);
+}
+.combobox-empty {
+  padding: var(--space-4) var(--space-3);
+  color: var(--muted);
+  font-size: var(--text-sm);
+}
+.variant-select {
+  flex: 0 0 auto;
+  min-width: 104px; /* always fits "default" + the dropdown arrow */
+  max-width: 45%;
+  font-size: var(--text-sm);
+  padding: var(--space-4) var(--space-3);
+}
+
 .geometry-filter-hint {
   color: var(--muted);
   font-family: var(--font-mono);

--- a/web/frontend/src/styles.css
+++ b/web/frontend/src/styles.css
@@ -978,6 +978,10 @@ button:focus-visible,
 .param-grid .field-bool,
 .param-grid .param-group {
   grid-column: 1 / -1;
+  /* The is-knobs grid sets justify-items:center, which would otherwise shrink
+     these full-width spanners to their content width (collapsing a band group's
+     nested grid to one column). Force them to fill the row. */
+  justify-self: stretch;
 }
 .param-grid.is-knobs .field {
   align-items: center;

--- a/web/frontend/src/styles.css
+++ b/web/frontend/src/styles.css
@@ -1319,6 +1319,34 @@ input[type=checkbox] {
   gap: var(--space-4);
 }
 
+/* far-field cut-angle knob, overlaid bottom-right on the plot it drives */
+.cut-overlay {
+  position: absolute;
+  bottom: var(--space-6);
+  right: var(--space-6);
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: var(--space-3) var(--space-4) var(--space-2);
+  box-shadow: 0 2px 10px var(--shadow);
+}
+.cut-overlay-label {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted-2);
+}
+.cut-overlay-value {
+  font-size: var(--text-xs);
+  color: var(--fg);
+  font-variant-numeric: tabular-nums;
+}
+
 .projection-toggle {
   display: flex;
   gap: var(--space-2);

--- a/web/frontend/src/styles.css
+++ b/web/frontend/src/styles.css
@@ -789,17 +789,25 @@ button:focus-visible,
 }
 
 /* measurement-freq VFO field: caption, LCD counter, dial, band select, lock */
+/* compact layout: band select + lock on the left, LCD + dial on the right */
 .vfo-field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-5);
+}
+.vfo-aux {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--space-4);
+}
+.vfo-main {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--space-4);
-}
-.vfo-cap {
-  font-size: var(--text-xs);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--muted-2);
+  gap: var(--space-3);
 }
 /* light bench-counter LCD: dark numerals over faint "off" segments */
 .freq-lcd {
@@ -839,8 +847,13 @@ button:focus-visible,
 .vfo-field.is-locked .lcd-live {
   color: var(--muted);
 }
-.vfo-field .band-select {
-  max-width: 200px;
+.vfo-aux .band-select {
+  max-width: 130px;
+}
+/* the lock toggle sits in the left aux column; "lock" label + full tooltip */
+.vfo-aux .link-toggle {
+  font-size: var(--text-xs);
+  white-space: nowrap;
 }
 .knob-edit {
   width: 54px;

--- a/web/frontend/src/styles.css
+++ b/web/frontend/src/styles.css
@@ -704,28 +704,143 @@ button:focus-visible,
   width: 100%;
   height: 100%;
   cursor: ns-resize; /* signals vertical drag */
+  overflow: visible; /* let the raised cap's shadow spill past the viewBox */
+  transition: transform 120ms ease-out;
+}
+.knob:hover svg {
+  transform: translateY(-1px); /* subtle lift on hover */
+}
+.knob:active svg {
+  transform: scale(0.95); /* press-in on grab — tactile feedback */
 }
 .knob-track {
   fill: none;
   stroke: var(--track);
-  stroke-width: 7;
+  stroke-width: 6;
   stroke-linecap: round;
 }
 .knob-fill {
   fill: none;
-  stroke: var(--accent);
-  stroke-width: 7;
+  stroke: var(--accent); /* overridden inline per value: warms toward --hot */
+  stroke-width: 6;
   stroke-linecap: round;
 }
-.knob-ptr {
+/* the metal cap — a disc raised off the panel by its drop shadow */
+.knob-cap {
+  fill: var(--panel);
+  stroke: var(--border-control);
+  stroke-width: 1;
+  filter: drop-shadow(0 2px 2.5px var(--shadow));
+}
+/* indicator line across the cap face, pointing at the value */
+.knob-notch {
   stroke: var(--fg);
   stroke-width: 3;
   stroke-linecap: round;
 }
-.knob-hub {
-  fill: var(--panel);
+
+/* --- VFO: the big weighted measurement-freq tuning dial --- */
+.knob.is-vfo {
+  width: 112px;
+  height: 99px; /* 112 * 88/100 — matches the cropped viewBox, no letterbox */
+}
+/* the knob body spins as a unit; the band arc behind it stays fixed */
+.knob-rotor {
+  transform-box: view-box;
+  transform-origin: 50px 50px;
+  transition: transform 280ms cubic-bezier(0.22, 0.61, 0.36, 1); /* weighty */
+}
+.knob-rotor.no-ease {
+  transition: none; /* track the finger 1:1 while dragging */
+}
+.knob.is-vfo .knob-cap {
+  fill: var(--inset);
   stroke: var(--border-control);
-  stroke-width: 1.5;
+  stroke-width: 1;
+  filter: drop-shadow(0 3px 4px var(--shadow)); /* heavier — sits proud */
+}
+.knob-skirt {
+  stroke: var(--muted-2);
+  stroke-width: 1.4;
+  stroke-linecap: round;
+  opacity: 0.5; /* knurled-rim texture */
+}
+.knob-dimple {
+  fill: var(--bg);
+  stroke: var(--border-control);
+  stroke-width: 0.8; /* recessed finger grip */
+}
+.knob.is-vfo .knob-notch {
+  stroke: var(--accent);
+  stroke-width: 2.5;
+}
+.knob.is-vfo .knob-fill {
+  stroke-width: 5;
+}
+.knob.is-disabled {
+  opacity: 0.4;
+  pointer-events: none; /* locked to design freq */
+}
+@media (prefers-reduced-motion: reduce) {
+  .knob svg,
+  .knob-rotor {
+    transition: none;
+  }
+}
+
+/* measurement-freq VFO field: caption, LCD counter, dial, band select, lock */
+.vfo-field {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-4);
+}
+.vfo-cap {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted-2);
+}
+/* light bench-counter LCD: dark numerals over faint "off" segments */
+.freq-lcd {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 7px;
+  background: var(--inset);
+  border: 1px solid var(--border-control);
+  border-radius: var(--r-sm);
+  padding: 6px 13px;
+  box-shadow: inset 0 1px 3px var(--shadow);
+}
+.lcd-digits {
+  position: relative;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: 2px;
+  font-variant-numeric: tabular-nums;
+}
+.lcd-ghost {
+  color: var(--track);
+  opacity: 0.6; /* the unlit segments */
+}
+.lcd-live {
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: var(--fg);
+}
+.lcd-unit {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+.vfo-field.is-locked .lcd-live {
+  color: var(--muted);
+}
+.vfo-field .band-select {
+  max-width: 200px;
 }
 .knob-edit {
   width: 54px;
@@ -795,29 +910,12 @@ button:focus-visible,
   color: var(--fg);
 }
 
-/* sliders <-> knobs control-style toggle */
-.knob-toggle {
-  display: inline-flex;
-  gap: var(--space-1);
-  margin-bottom: var(--space-4);
-  padding: var(--space-1);
-  background: var(--inset);
-  border: 1px solid var(--border-control);
-  border-radius: var(--r-sm);
-}
-.knob-toggle button {
-  font: inherit;
-  font-size: var(--text-xs);
-  color: var(--muted);
-  background: transparent;
-  border: none;
-  border-radius: 4px;
-  padding: var(--space-2) var(--space-4);
-  cursor: pointer;
-}
-.knob-toggle button.active {
-  background: var(--accent-active);
-  color: var(--fg);
+/* the two far-field cut dials sit side by side, centered under the group label */
+.cut-knobs {
+  display: flex;
+  gap: var(--space-7);
+  justify-content: center;
+  margin: var(--space-3) 0 var(--space-5);
 }
 
 /* range sliders */


### PR DESCRIPTION
Reworks the interactive web UI around the **knob** brand, then bumps antennaknobs to **0.4.0** (on top of the momwire v0.2.0 submodule bump already on main).

## What changed (6 feature commits)
- **Knob redesign** — measurement freq becomes a weighted **VFO tuning dial** + frequency-counter readout; elevation/azimuth become dedicated CCW knobs; the small param knobs get a tactile cap/notch/shadow treatment; the sliders↔knobs toggle is retired (knobs only). Design freq stays a slider.
- **Compact measurement-freq field**, lifted above the simulation section.
- **One-line antenna combobox** — searchable picker (keeps family grouping) + inline variant select, replacing the old 3-row filter/select/variant stack.
- **Far-field cut knobs moved onto their plot views** — the elevation knob lives on the Azimuth plot, the azimuth knob on the Elevation plot.
- **Multiband per-band knobs pack 3-wide again** (grid `justify-self` fix).
- **Antenna-canvas overlay toggles** — wire labels + feed labels checkboxes; wire labels and current-waveforms default **off** to declutter (PyNEC returns one wire per straight GW card).

Only `web/frontend/src/{App.tsx,styles.css}` change for the UI; `tsc` + `vite build` green throughout.

## Release
- Bumps `antennaknobs` `0.3.0 → 0.4.0`.
- The `momwire` submodule is at `d5bce1b` (v0.2.0 + build/metadata fixes), already on `main`.
- Tagging `v0.4.0` after merge builds the frontend into the wheel and publishes to TestPyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)