### PR TITLE
docs: point pynec-accel install at the fixed 1.7.4.post1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,12 +328,19 @@ momwire is still fully functional; install it only if you want to cross-check
 against NEC2.
 
 ```bash
-# The self-contained wheel from the python-necpp fork's release (OpenBLAS
-# vendored). The fork is distributed as `pynec-accel` (the import name stays
-# `import PyNEC`); --no-index avoids upstream PyNEC/pynec on PyPI, whose builds
-# are broken on current Python and lack the fork's BLAS/OpenMP work.
+# Wheel from the python-necpp fork's release (OpenBLAS + libgfortran vendored).
+# The fork is distributed as `pynec-accel` (the import name stays `import
+# PyNEC`); --no-index avoids upstream PyNEC/pynec on PyPI, whose builds are
+# broken on current Python and lack the fork's BLAS/OpenMP work.
+#
+# Use >= 1.7.4.post1 (release v1.7.4-accel.5 or later). Earlier builds vendored
+# their own libgomp, which clashes with momwire's system libgomp via a static-
+# TLS limit and silently knocks momwire's C++ accelerator onto its slow pure-
+# Python path whenever both backends load in one process. 1.7.4.post1 binds the
+# system libgomp instead, so it needs a system libgomp at runtime (universal on
+# glibc Linux — the GCC OpenMP runtime).
 pip install pynec-accel --no-index \
-    --find-links https://github.com/stevenmburns/python-necpp/releases/expanded_assets/v1.7.4-accel.3
+    --find-links https://github.com/stevenmburns/python-necpp/releases/expanded_assets/v1.7.4-accel.5
 ```
 
 **4. Install AntennaKNoBs**


### PR DESCRIPTION
The install snippet in the README pointed at release `v1.7.4-accel.3`, whose wheels **vendor their own libgomp**. That second libgomp clashes with momwire's system libgomp (glibc static-TLS limit) and **silently** knocks momwire's C++ accelerator onto its slow pure-Python path whenever both backends load in one process (every CLI run, the web server).

Bumps the pointer to `v1.7.4-accel.5` (`pynec-accel 1.7.4.post1`), which de-vendors libgomp (python-necpp#11) so both backends share one OpenMP runtime. Adds a note that the wheel now needs a system libgomp at runtime (universal on glibc Linux).

Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)