### PR TITLE
Add ui_param knob-layout mechanism and arrange knobs for 10 array/multiband designs

### DIFF
--- a/src/antennaknobs/designs/arrays/bowtiearray.py
+++ b/src/antennaknobs/designs/arrays/bowtiearray.py
@@ -17,6 +17,23 @@ class Builder(Array2x2Builder):
             "del_z": 2.0,
             "phase_lr": 0.0,
             "phase_tb": 0.0,
+            # slope / length as a top/bottom matrix in cols 1-2 (the 2x2
+            # sibling, bowtiearray2x4, adds inner/outer columns); array
+            # spacing on row 3, feed phasing on row 4.
+            "ui_params": MappingProxyType(
+                {
+                    "layout": {"columns": 3},
+                    "slope_top": {"layout": {"row": 1, "col": 1}},
+                    "length_top": {"layout": {"row": 1, "col": 2}},
+                    "slope_bot": {"layout": {"row": 2, "col": 1}},
+                    "length_bot": {"layout": {"row": 2, "col": 2}},
+                    "base": {"layout": {"row": 3, "col": 1}},
+                    "del_y": {"layout": {"row": 3, "col": 2}},
+                    "del_z": {"layout": {"row": 3, "col": 3}},
+                    "phase_lr": {"layout": {"row": 4, "col": 1}},
+                    "phase_tb": {"layout": {"row": 4, "col": 2}},
+                }
+            ),
         }
     )
 

--- a/src/antennaknobs/designs/arrays/bowtiearray2x4.py
+++ b/src/antennaknobs/designs/arrays/bowtiearray2x4.py
@@ -21,6 +21,34 @@ class Builder(Array2x4Builder):
             "del_z": 2.0,
             "phase_lr": 0.0,
             "phase_tb": 0.0,
+            # Lay the panel out to mirror the array's physical structure on a
+            # 4-column grid. The slope and length knobs are each a 2x2
+            # (rows = top/bottom, cols = outer/inner) block — slopes on the
+            # left half, matching lengths on the right — so the four element
+            # shapes line up where they sit in the array. Geometry spacing
+            # and feed phasing get their own rows underneath.
+            "ui_params": MappingProxyType(
+                {
+                    "layout": {"columns": 4},
+                    # slope block (cols 1-2: outer | inner)
+                    "slope_otop": {"layout": {"row": 1, "col": 1}},
+                    "slope_itop": {"layout": {"row": 1, "col": 2}},
+                    "slope_obot": {"layout": {"row": 2, "col": 1}},
+                    "slope_ibot": {"layout": {"row": 2, "col": 2}},
+                    # length block (cols 3-4: outer | inner)
+                    "length_otop": {"layout": {"row": 1, "col": 3}},
+                    "length_itop": {"layout": {"row": 1, "col": 4}},
+                    "length_obot": {"layout": {"row": 2, "col": 3}},
+                    "length_ibot": {"layout": {"row": 2, "col": 4}},
+                    # array spacing
+                    "base": {"layout": {"row": 3, "col": 1}},
+                    "del_y": {"layout": {"row": 3, "col": 2}},
+                    "del_z": {"layout": {"row": 3, "col": 3}},
+                    # feed phasing
+                    "phase_lr": {"layout": {"row": 4, "col": 1}},
+                    "phase_tb": {"layout": {"row": 4, "col": 2}},
+                }
+            ),
         }
     )
 

--- a/src/antennaknobs/designs/arrays/delta_looparray_1x4.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray_1x4.py
@@ -17,6 +17,22 @@ class Builder(Array1x4Builder):
             "del_y": 4.0,
             "del_z": 0.0,
             "phase_lr": 0.0,
+            # Per-element shape (length_factor / angle_radians) as an
+            # inner/outer matrix in cols 1-2; array spacing on row 3, feed
+            # phasing on row 4.
+            "ui_params": MappingProxyType(
+                {
+                    "layout": {"columns": 3},
+                    "length_factor_itop": {"layout": {"row": 1, "col": 1}},
+                    "angle_radians_itop": {"layout": {"row": 1, "col": 2}},
+                    "length_factor_otop": {"layout": {"row": 2, "col": 1}},
+                    "angle_radians_otop": {"layout": {"row": 2, "col": 2}},
+                    "base": {"layout": {"row": 3, "col": 1}},
+                    "del_y": {"layout": {"row": 3, "col": 2}},
+                    "del_z": {"layout": {"row": 3, "col": 3}},
+                    "phase_lr": {"layout": {"row": 4, "col": 1}},
+                }
+            ),
         }
     )
 

--- a/src/antennaknobs/designs/arrays/delta_looparray_1x4_grouped.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray_1x4_grouped.py
@@ -18,6 +18,23 @@ class Builder(Array1x4GroupedBuilder):
             "del_y1": 2.5,
             "del_z": 0.0,
             "phase_lr": 0.0,
+            # Per-element shape (length_factor / angle_radians) as an
+            # inner/outer matrix in cols 1-2; the two y-spacings (del_y0 /
+            # del_y1) for the grouped 1x4 sit with base on row 3.
+            "ui_params": MappingProxyType(
+                {
+                    "layout": {"columns": 3},
+                    "length_factor_itop": {"layout": {"row": 1, "col": 1}},
+                    "angle_radians_itop": {"layout": {"row": 1, "col": 2}},
+                    "length_factor_otop": {"layout": {"row": 2, "col": 1}},
+                    "angle_radians_otop": {"layout": {"row": 2, "col": 2}},
+                    "base": {"layout": {"row": 3, "col": 1}},
+                    "del_y0": {"layout": {"row": 3, "col": 2}},
+                    "del_y1": {"layout": {"row": 3, "col": 3}},
+                    "del_z": {"layout": {"row": 4, "col": 1}},
+                    "phase_lr": {"layout": {"row": 4, "col": 2}},
+                }
+            ),
         }
     )
 

--- a/src/antennaknobs/designs/arrays/delta_looparray_2x2.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray_2x2.py
@@ -18,6 +18,22 @@ class Builder(Array2x2Builder):
             "del_z": 2.0,
             "phase_lr": 0.0,
             "phase_tb": 0.0,
+            # Per-element shape (length_factor / angle_radians) as a top/bottom
+            # matrix in cols 1-2; array spacing on row 3, feed phasing on row 4.
+            "ui_params": MappingProxyType(
+                {
+                    "layout": {"columns": 3},
+                    "length_factor_top": {"layout": {"row": 1, "col": 1}},
+                    "angle_radians_top": {"layout": {"row": 1, "col": 2}},
+                    "length_factor_bot": {"layout": {"row": 2, "col": 1}},
+                    "angle_radians_bot": {"layout": {"row": 2, "col": 2}},
+                    "base": {"layout": {"row": 3, "col": 1}},
+                    "del_y": {"layout": {"row": 3, "col": 2}},
+                    "del_z": {"layout": {"row": 3, "col": 3}},
+                    "phase_lr": {"layout": {"row": 4, "col": 1}},
+                    "phase_tb": {"layout": {"row": 4, "col": 2}},
+                }
+            ),
         }
     )
 

--- a/src/antennaknobs/designs/arrays/folded_invveearray.py
+++ b/src/antennaknobs/designs/arrays/folded_invveearray.py
@@ -17,6 +17,22 @@ class Builder(Array2x2Builder):
             "del_z": 2.0,
             "phase_lr": 0.0,
             "phase_tb": 0.0,
+            # Per-element shape (length_factor / angle_radians) as a top/bottom
+            # matrix in cols 1-2; array spacing on row 3, feed phasing on row 4.
+            "ui_params": MappingProxyType(
+                {
+                    "layout": {"columns": 3},
+                    "length_factor_top": {"layout": {"row": 1, "col": 1}},
+                    "angle_radians_top": {"layout": {"row": 1, "col": 2}},
+                    "length_factor_bot": {"layout": {"row": 2, "col": 1}},
+                    "angle_radians_bot": {"layout": {"row": 2, "col": 2}},
+                    "base": {"layout": {"row": 3, "col": 1}},
+                    "del_y": {"layout": {"row": 3, "col": 2}},
+                    "del_z": {"layout": {"row": 3, "col": 3}},
+                    "phase_lr": {"layout": {"row": 4, "col": 1}},
+                    "phase_tb": {"layout": {"row": 4, "col": 2}},
+                }
+            ),
         }
     )
 

--- a/src/antennaknobs/designs/arrays/invveearray.py
+++ b/src/antennaknobs/designs/arrays/invveearray.py
@@ -43,6 +43,22 @@ class Builder(Array2x2Builder):
             "del_z": 2.0,
             "phase_lr": 0.0,
             "phase_tb": 0.0,
+            # Per-element shape (length_factor / angle_radians) as a top/bottom
+            # matrix in cols 1-2; array spacing on row 3, feed phasing on row 4.
+            "ui_params": MappingProxyType(
+                {
+                    "layout": {"columns": 3},
+                    "length_factor_top": {"layout": {"row": 1, "col": 1}},
+                    "angle_radians_top": {"layout": {"row": 1, "col": 2}},
+                    "length_factor_bot": {"layout": {"row": 2, "col": 1}},
+                    "angle_radians_bot": {"layout": {"row": 2, "col": 2}},
+                    "base": {"layout": {"row": 3, "col": 1}},
+                    "del_y": {"layout": {"row": 3, "col": 2}},
+                    "del_z": {"layout": {"row": 3, "col": 3}},
+                    "phase_lr": {"layout": {"row": 4, "col": 1}},
+                    "phase_tb": {"layout": {"row": 4, "col": 2}},
+                }
+            ),
         }
     )
 

--- a/src/antennaknobs/designs/arrays/moxonarray.py
+++ b/src/antennaknobs/designs/arrays/moxonarray.py
@@ -24,7 +24,32 @@ class Builder(Array2x2Builder):
             # Auto-view picks yz (y/z dominate from the 2x2 stacking),
             # but moxon-family geometry reads in xy — keep the array
             # consistent with the single moxon's view.
-            "ui_params": MappingProxyType({"default_view": "xy"}),
+            #
+            # Lay the panel out as two element columns: col 1 = the top
+            # element, col 2 = the bottom element; each row is one shape
+            # family (halfdriver / aspect_ratio / tipspacer / t0). The moxon
+            # param names are long, so a 2-wide grid keeps every label
+            # readable (a 4-wide family-per-column grid truncates them).
+            # Array spacing and feed phasing get their own rows beneath.
+            "ui_params": MappingProxyType(
+                {
+                    "default_view": "xy",
+                    "layout": {"columns": 2},
+                    "halfdriver_top": {"layout": {"row": 1, "col": 1}},
+                    "halfdriver_bot": {"layout": {"row": 1, "col": 2}},
+                    "aspect_ratio_top": {"layout": {"row": 2, "col": 1}},
+                    "aspect_ratio_bot": {"layout": {"row": 2, "col": 2}},
+                    "tipspacer_factor_top": {"layout": {"row": 3, "col": 1}},
+                    "tipspacer_factor_bot": {"layout": {"row": 3, "col": 2}},
+                    "t0_factor_top": {"layout": {"row": 4, "col": 1}},
+                    "t0_factor_bot": {"layout": {"row": 4, "col": 2}},
+                    "del_y": {"layout": {"row": 5, "col": 1}},
+                    "del_z": {"layout": {"row": 5, "col": 2}},
+                    "phase_lr": {"layout": {"row": 6, "col": 1}},
+                    "phase_tb": {"layout": {"row": 6, "col": 2}},
+                    "base": {"layout": {"row": 7, "col": 1}},
+                }
+            ),
         }
     )
 

--- a/src/antennaknobs/designs/arrays/yagiarray.py
+++ b/src/antennaknobs/designs/arrays/yagiarray.py
@@ -22,6 +22,27 @@ class Builder(Array2x2Builder):
             "reflector_factor": 1.05,
             "boom_factor": 0.2,
             "n_directors": 2,
+            # 3-column panel: the per-element shape (length_factor /
+            # angle_radians) forms a top/bottom matrix in cols 1-2; the
+            # shared Yagi element knobs (director count, reflector, boom) sit
+            # on their own row, with array spacing and phasing beneath.
+            "ui_params": MappingProxyType(
+                {
+                    "layout": {"columns": 3},
+                    "length_factor_top": {"layout": {"row": 1, "col": 1}},
+                    "angle_radians_top": {"layout": {"row": 1, "col": 2}},
+                    "length_factor_bot": {"layout": {"row": 2, "col": 1}},
+                    "angle_radians_bot": {"layout": {"row": 2, "col": 2}},
+                    "n_directors": {"layout": {"row": 3, "col": 1}},
+                    "reflector_factor": {"layout": {"row": 3, "col": 2}},
+                    "boom_factor": {"layout": {"row": 3, "col": 3}},
+                    "base": {"layout": {"row": 4, "col": 1}},
+                    "del_y": {"layout": {"row": 4, "col": 2}},
+                    "del_z": {"layout": {"row": 4, "col": 3}},
+                    "phase_lr": {"layout": {"row": 5, "col": 1}},
+                    "phase_tb": {"layout": {"row": 5, "col": 2}},
+                }
+            ),
         }
     )
 

--- a/src/antennaknobs/designs/multiband/twoband_fan_dipole.py
+++ b/src/antennaknobs/designs/multiband/twoband_fan_dipole.py
@@ -198,6 +198,25 @@ class Builder(AntennaBuilder):
             "gap_slope": 0.0,
             "s": 0.15,
             "eps": 0.015,
+            # 2-column panel, one column per band (10m | 12m): rows pair the
+            # band's freq / length / slope so the two bands read side by side.
+            # Feed-gap / coupling knobs (gap_slope, s, eps) sit on the rows
+            # below.
+            "ui_params": MappingProxyType(
+                {
+                    "layout": {"columns": 2},
+                    "freq_10": {"layout": {"row": 1, "col": 1}},
+                    "freq_12": {"layout": {"row": 1, "col": 2}},
+                    "length_10": {"layout": {"row": 2, "col": 1}},
+                    "length_12": {"layout": {"row": 2, "col": 2}},
+                    "slope_10": {"layout": {"row": 3, "col": 1}},
+                    "slope_12": {"layout": {"row": 3, "col": 2}},
+                    "gap_slope": {"layout": {"row": 4, "col": 1}},
+                    "s": {"layout": {"row": 4, "col": 2}},
+                    "eps": {"layout": {"row": 5, "col": 1}},
+                    "base": {"layout": {"row": 5, "col": 2}},
+                }
+            ),
         }
     )
 

--- a/tests/test_design_schemas.py
+++ b/tests/test_design_schemas.py
@@ -346,15 +346,23 @@ def test_auto_derived_length_factors_resolve_at_one_per_mille(name):
 # ---------------------------------------------------------------------------
 
 
-def test_layout_defaults_to_none():
-    """A param with no `layout` override carries layout=None (auto-flow),
-    and every shipped design defaults to auto-flow at both levels."""
+def test_layout_is_opt_in():
+    """Layout is opt-in: a param with no `layout` override carries
+    layout=None (auto-flow), and a design's grid layout is None unless it
+    declares a `ui_params["layout"]` dict. Per-param layout likewise only
+    appears where the design declared one under ui_params[<param>]."""
     assert _auto_paramspec("x", 1.0, None).layout is None
-    for ex in REGISTRY.values():
-        assert ex.layout is None
+    for name, ex in REGISTRY.items():
+        ui = dict(_builder_cls(name).default_params).get("ui_params") or {}
+        expects_grid = isinstance(ui.get("layout"), dict)
+        assert (ex.layout is not None) == expects_grid, name
         for s in ex.param_schema:
-            if not getattr(s, "params", None):  # scalar leaf
-                assert s.layout is None
+            if getattr(s, "params", None):  # group — leaves checked elsewhere
+                continue
+            declared = isinstance(ui.get(s.name), dict) and isinstance(
+                ui[s.name].get("layout"), dict
+            )
+            assert (s.layout is not None) == declared, (name, s.name)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_design_schemas.py
+++ b/tests/test_design_schemas.py
@@ -339,3 +339,71 @@ def test_auto_derived_length_factors_resolve_at_one_per_mille(name):
         # 1-2-5 snapping caps the relative step at ~0.167%; assert well
         # under the old 1% to lock in the resolution fix.
         assert s.step / abs(s.default) <= 0.0018, (name, s.name, s.step, s.default)
+
+
+# ---------------------------------------------------------------------------
+# ui_param layout — explicit row/col knob placement
+# ---------------------------------------------------------------------------
+
+
+def test_layout_defaults_to_none():
+    """A param with no `layout` override carries layout=None (auto-flow),
+    and every shipped design defaults to auto-flow at both levels."""
+    assert _auto_paramspec("x", 1.0, None).layout is None
+    for ex in REGISTRY.values():
+        assert ex.layout is None
+        for s in ex.param_schema:
+            if not getattr(s, "params", None):  # scalar leaf
+                assert s.layout is None
+
+
+@pytest.mark.parametrize(
+    "default, override",
+    [
+        (1.0, {"layout": {"row": 1, "col": 2, "col_span": 2}}),  # float
+        (3, {"layout": {"row": 2, "col": 1}}),  # int
+        (True, {"layout": {"col": 1}}),  # bool
+        ("a", {"enum_options": ({"value": "a", "label": "A"},), "layout": {"row": 3}}),
+    ],
+)
+def test_per_param_layout_passes_through_every_kind(default, override):
+    spec = _auto_paramspec("p", default, dict(override))
+    assert spec.layout == override["layout"]
+
+
+def test_non_dict_layout_is_ignored():
+    """A malformed layout value is dropped rather than crashing derivation."""
+    assert _auto_paramspec("p", 1.0, {"layout": "nope"}).layout is None
+
+
+def test_grid_level_layout_from_ui_params():
+    """Reserved ui_params['layout'] surfaces on AntennaExample.layout and
+    does not leak into the param schema as a phantom slider."""
+    from types import MappingProxyType
+
+    from antennaknobs import AntennaBuilder
+
+    class _LayoutBuilder(AntennaBuilder):
+        default_params = MappingProxyType(
+            {
+                "freq": 14.0,
+                "a": 1.0,
+                "b": 2.0,
+                "ui_params": MappingProxyType(
+                    {
+                        "layout": {"columns": 3},
+                        "a": {"layout": {"row": 1, "col": 1}},
+                    }
+                ),
+            }
+        )
+
+        def build_wires(self):
+            return [((0.0, 0.0, 0.0), (0.0, 1.0, 0.0), 3, None, None)]
+
+    ex = _make_example("layout_demo", _LayoutBuilder, defer_hints=True)
+    assert ex.layout == {"columns": 3}
+    assert "layout" not in {s.name for s in ex.param_schema}
+    by_name = {s.name: s for s in ex.param_schema}
+    assert by_name["a"].layout == {"row": 1, "col": 1}
+    assert by_name["b"].layout is None

--- a/web/adapter.py
+++ b/web/adapter.py
@@ -14,10 +14,16 @@ Reserved keys inside `ui_params`:
   bands            : tuple[BandSpec] — band tabs (default HF amateur set)
   sweep_policy     : (anchor, lo_factor, hi_factor)
   multi_feed       : bool — declare multi-feed response shape
+  layout           : dict {columns: int} — pin the knob grid to a fixed
+                     column count so per-param `layout` col positions are
+                     stable (default: responsive auto-flow packing)
   <param_name>     : dict of {min, max, step, unit, label, precision,
-                              kind, sweepable, enum_options}
+                              kind, sweepable, enum_options, layout}
                      — slider-bounds + metadata overrides for one param.
-                     Anything missing falls back to auto-derived defaults.
+                     `layout` is {row, col, row_span, col_span} (1-indexed
+                     CSS grid lines, all optional) to place this knob
+                     explicitly. Anything missing falls back to
+                     auto-derived defaults.
 
 Everything else in `default_params` becomes a `ParamSpec`. Numeric
 defaults become float sliders with auto bounds (±50% around default);
@@ -138,6 +144,11 @@ def _auto_paramspec(name: str, default: Any, override: dict | None) -> ParamSpec
     override = dict(override or {})
     label = override.pop("label", name)
     unit = override.pop("unit", None)
+    # Optional explicit grid placement for this knob (row/col/spans). Only a
+    # dict is meaningful; anything else is ignored so a typo can't crash the
+    # registry. Passed verbatim to ParamSpec.layout for every kind.
+    layout_raw = override.pop("layout", None)
+    layout = dict(layout_raw) if isinstance(layout_raw, dict) else None
     # Precision (decimal places shown on the slider label) defaults to None
     # here so the numeric branch can derive it from the resolved step. Any
     # non-numeric path falls back to 3, matching the historical default.
@@ -154,6 +165,7 @@ def _auto_paramspec(name: str, default: Any, override: dict | None) -> ParamSpec
             kind=kind,
             unit=unit,
             precision=precision,
+            layout=layout,
         )
 
     if isinstance(default, (int, float)) and not isinstance(default, bool):
@@ -220,6 +232,7 @@ def _auto_paramspec(name: str, default: Any, override: dict | None) -> ParamSpec
             precision=resolved_precision,
             unit=unit,
             sweepable=sweepable,
+            layout=layout,
         )
         if "linked_to_design_freq" in override:
             spec_kwargs["linked_to_design_freq"] = bool(
@@ -243,6 +256,7 @@ def _auto_paramspec(name: str, default: Any, override: dict | None) -> ParamSpec
             enum_options=tuple(opts),
             precision=precision,
             unit=unit,
+            layout=layout,
         )
 
     # complex, None, or anything exotic — skip the auto-UI; the request
@@ -857,6 +871,12 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             _hints["default_backend"] = _recommended_backend(cls)
         return _hints
 
+    # Grid-level layout config (reserved ui_params["layout"]). A dict today
+    # carrying {"columns": int}; ignore non-dicts so a stray value can't
+    # break registration. None keeps the responsive auto-flow grid.
+    layout_raw = ui.get("layout")
+    grid_layout = dict(layout_raw) if isinstance(layout_raw, dict) else None
+
     meas_range = (
         ui.get("meas_freq_range")
         if not isinstance(ui.get("meas_freq_range"), dict)
@@ -1205,6 +1225,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             v: _serialize_param_values(_strip_ui(_variant_params(cls, v)))
             for v in variants
         },
+        layout=grid_layout,
     )
 
 

--- a/web/examples/_base.py
+++ b/web/examples/_base.py
@@ -110,6 +110,15 @@ class ParamSpec:
     linked_to_design_freq: bool = False
     link_meas_freq_to_param: Optional[str] = None
     sweepable: bool = False
+    # Optional explicit placement in the param grid, opting this knob out
+    # of the default auto-flow packing. Shape: {"row", "col", "row_span",
+    # "col_span"} — all optional ints, 1-indexed (CSS grid lines). The
+    # frontend maps them straight onto grid-row / grid-column so a design
+    # can lay its knobs out in a deliberate row/column arrangement. Pairs
+    # with AntennaExample.layout["columns"], which fixes the grid's column
+    # count so these positions are stable rather than width-dependent.
+    # Authored under ui_params[<param>]["layout"]; None keeps auto-flow.
+    layout: Optional[dict] = None
 
 
 @dataclass(frozen=True)
@@ -364,3 +373,10 @@ class AntennaExample:
     # stripped. Single-variant designs ship {} since there's nothing
     # to switch between.
     variant_values: dict = field(default_factory=dict)
+    # Optional grid-level layout config for the top-level knob rail.
+    # Recognised key today: {"columns": int} — pins the param grid to a
+    # fixed column count so per-ParamSpec.layout col positions land
+    # predictably (the default auto-flow grid varies its column count with
+    # the rail width). None keeps the responsive auto-fill packing.
+    # Authored under the reserved ui_params["layout"] key.
+    layout: Optional[dict] = None

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
 } from "react";
+import type { CSSProperties } from "react";
 
 type Wire = {
   label: string;
@@ -50,6 +51,19 @@ type SchemaParamSpec = {
   // measFreq. Self-reference is allowed (and used by freq_NN params
   // in multi-band antennas).
   link_meas_freq_to_param?: string | null;
+  // Optional explicit placement in the param grid (1-indexed CSS grid
+  // lines). When present the field opts out of auto-flow and lands at the
+  // given row/col, optionally spanning multiple tracks. null = auto-flow.
+  layout?: KnobLayout | null;
+};
+
+// Per-knob grid placement. All fields optional; mapped onto inline
+// grid-row / grid-column. Pairs with ExampleDescriptor.layout.columns.
+type KnobLayout = {
+  row?: number | null;
+  col?: number | null;
+  row_span?: number | null;
+  col_span?: number | null;
 };
 
 type SchemaParamGroupSpec = {
@@ -142,6 +156,10 @@ type ExampleDescriptor = {
    *  variants. Complex-valued params arrive as {re, im}. */
   variant_values: { [variant: string]: { [key: string]: unknown } };
   sweep_policy: SweepPolicy;
+  /** Grid-level layout for the top-level knob rail. {columns: N} pins the
+   *  grid to a fixed column count so per-knob `layout.col` positions are
+   *  stable. null = responsive auto-flow packing. */
+  layout?: { columns?: number | null } | null;
 };
 
 // A user design that failed to load, reported by GET /examples.
@@ -683,6 +701,31 @@ function GeometryCombobox({
   );
 }
 
+// Translate a knob's optional layout hint into inline grid-placement
+// styles. Returns undefined when nothing is set so auto-flow fields stay
+// untouched. `col_span` / `row_span` use the CSS `span N` form; an explicit
+// `col` / `row` pins the start line (1-indexed). `col` + `col_span`
+// together place a spanning field at a fixed column.
+function layoutStyle(layout?: KnobLayout | null): CSSProperties | undefined {
+  if (!layout) return undefined;
+  const style: CSSProperties = {};
+  const colStart = layout.col ?? null;
+  const rowStart = layout.row ?? null;
+  const colSpan = layout.col_span ?? null;
+  const rowSpan = layout.row_span ?? null;
+  if (colStart != null) {
+    style.gridColumn = colSpan != null ? `${colStart} / span ${colSpan}` : `${colStart}`;
+  } else if (colSpan != null) {
+    style.gridColumn = `span ${colSpan}`;
+  }
+  if (rowStart != null) {
+    style.gridRow = rowSpan != null ? `${rowStart} / span ${rowSpan}` : `${rowStart}`;
+  } else if (rowSpan != null) {
+    style.gridRow = `span ${rowSpan}`;
+  }
+  return Object.keys(style).length ? style : undefined;
+}
+
 function ParamForm({
   schema,
   values,
@@ -767,7 +810,7 @@ function ParamForm({
           const checked = Boolean(currentRaw ?? item.default);
           const isDisabled = disabledFields?.has(item.name) ?? false;
           return (
-            <div key={item.name} className="field field-bool">
+            <div key={item.name} className="field field-bool" style={layoutStyle(item.layout)}>
               <label
                 className={`field-bool-label${isDisabled ? " field-disabled" : ""}`}
               >
@@ -791,7 +834,7 @@ function ParamForm({
         if (item.kind === "enum") {
           const opts = item.enum_options ?? [];
           return (
-            <div key={item.name} className="field field-enum">
+            <div key={item.name} className="field field-enum" style={layoutStyle(item.layout)}>
               <label>
                 <span>{item.label}</span>
               </label>
@@ -831,7 +874,7 @@ function ParamForm({
         // middle, value on the bottom. (The slider alternative and its toggle
         // were retired — knobs are the brand.)
         return (
-          <div key={item.name} className="field field-knob">
+          <div key={item.name} className="field field-knob" style={layoutStyle(item.layout)}>
             <span className="knob-label" title={item.label}>{item.label}</span>
             <Knob
               value={currentNum}
@@ -2724,7 +2767,14 @@ export function App() {
 
 
         {currentExample && (
-          <div className="param-grid is-knobs">
+          <div
+            className="param-grid is-knobs"
+            style={
+              currentExample.layout?.columns
+                ? { gridTemplateColumns: `repeat(${currentExample.layout.columns}, minmax(0, 1fr))` }
+                : undefined
+            }
+          >
             <ParamForm
               schema={currentExample.param_schema}
               values={currentValues}

--- a/web/server.py
+++ b/web/server.py
@@ -754,6 +754,7 @@ def examples_endpoint():
             "on_change_set": item.on_change_set,
             "linked_to_design_freq": item.linked_to_design_freq,
             "link_meas_freq_to_param": item.link_meas_freq_to_param,
+            "layout": item.layout,
         }
 
     out = []
@@ -817,6 +818,7 @@ def examples_endpoint():
                     "hi_factor": ex.sweep_policy.hi_factor,
                     "band_locked": ex.sweep_policy.band_locked,
                 },
+                "layout": ex.layout,
             }
         )
     out.sort(key=lambda e: e["label"])

--- a/web/user_design_assets/CLAUDE.md
+++ b/web/user_design_assets/CLAUDE.md
@@ -45,6 +45,22 @@ Every key becomes a slider in the UI, accessed in `build_wires` as
 Slider bounds and step are auto-derived (±50% around the default, fine
 resolution). You usually don't need to specify them.
 
+### Arranging the knobs (optional)
+
+By default knobs auto-flow into the panel. To place them deliberately, add
+a `"layout"` to a param's override dict — `{row, col, row_span, col_span}`,
+1-indexed, all optional — and pin the grid width with a panel-level
+`"layout": {"columns": N}` so the columns don't shift with the panel size:
+
+```python
+"ui_params": MappingProxyType({
+    "layout": {"columns": 2},                 # 2-column knob grid
+    "length": {"layout": {"row": 1, "col": 1}},
+    "height": {"layout": {"row": 1, "col": 2}},
+    "feed_z": {"layout": {"row": 2, "col": 1, "col_span": 2}},  # full-width
+}),
+```
+
 ## `build_wires(self)`
 
 Return a list of straight wire segments. Each entry is:


### PR DESCRIPTION
## Summary
- Add an opt-in `ui_param` **layout** mechanism so a design can place its knobs in a deliberate grid instead of the default auto-flow packing. Per-knob `layout` (`{row, col, row_span, col_span}`, 1-indexed CSS grid lines, authored under `ui_params[<param>]["layout"]`) plus a grid-level `ui_params["layout"] = {"columns": N}` that pins the panel to a fixed column count. Plumbed through adapter derivation → `/examples` serializer → frontend `ParamForm` (inline grid styles). Both default to `None`, so every existing design keeps today's auto-flow.
- Apply layouts to the 10 array/multiband designs whose parallel naming structure auto-flow scatters, arranging related knobs into matrices that mirror the antenna:
  - **bowtiearray2x4** (4 cols): slope/length as side-by-side 2×2 (top/bottom × inner/outer) blocks + spacing/phasing rows.
  - **moxonarray** (2 cols): top vs bottom element columns, one shape family per row (2-wide keeps its long labels readable).
  - **yagiarray**, **bowtiearray**, **invveearray**, **folded_invveearray**, **delta_looparray_2x2 / _1x4 / _1x4_grouped** (3 cols): per-element top/bottom (or inner/outer) shape matrix + array spacing/phasing block.
  - **twoband_fan_dipole** (2 cols): one column per band (10m | 12m), rows pairing freq/length/slope.
- Each layout was verified by rendering the knob grid against the real `styles.css` in headless Chrome at the 320px rail width to confirm labels fit their cells.
- Docs: the reserved-key list in `web/adapter.py` and the user-design `CLAUDE.md` both document the new `layout` key.

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] `pytest tests/test_design_schemas.py tests/test_web_server.py tests/test_variants.py tests/test_fandipole_schema.py` — 894 passed (incl. new layout opt-in / placement tests; `/examples` serialization)
- [ ] In the running app, select each of the 10 designs and confirm the knob panel renders in the intended arrangement with readable labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)
