### PR TITLE
Float solve readout as a lower-left HUD over the carousel

### DIFF
--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -2977,63 +2977,6 @@ export function App() {
           )}
         </div>
 
-        <div className={`readout${stale ? " stale" : ""}`}>
-          <div className="row">
-            <span>R</span>
-            <span className="val">{result ? `${result.z_in_re.toFixed(2)} Ω` : "—"}</span>
-          </div>
-          <div className="row">
-            <span>X</span>
-            <span className={result && Math.abs(result.z_in_im) < 2 ? "val val-hot" : "val"}>
-              {result ? `${result.z_in_im.toFixed(2)} Ω` : "—"}
-            </span>
-          </div>
-          {currentExample && (
-            <ResultPanel
-              schema={currentExample.result_schema}
-              result={result as Record<string, unknown> | null}
-            />
-          )}
-          {effectiveMultiFeed && result?.feeds && result.feeds.length > 1 && (
-            <div className="feeds-table">
-              <div className="feeds-table-header">per-feed Z (V/I)</div>
-              {result.feeds.map((f, i) => (
-                <div className="row" key={`feed-z-${i}`}>
-                  <span>
-                    feed {i} ∠{Math.round(Math.atan2(f.v_im, f.v_re) * 180 / Math.PI)}°
-                  </span>
-                  <span className="val">
-                    {f.z_re.toFixed(1)} {f.z_im >= 0 ? "+" : "−"} j
-                    {Math.abs(f.z_im).toFixed(1)} Ω
-                  </span>
-                </div>
-              ))}
-            </div>
-          )}
-          <div className="row">
-            <span>|I_feed|</span>
-            <span className="val">
-              {result ? feedMag(result).toExponential(3) : "—"}
-            </span>
-          </div>
-          <div className="row">
-            <span>solve</span>
-            <span className="val">{result ? `${result.solve_ms.toFixed(1)} ms` : "—"}</span>
-          </div>
-          <div className="row">
-            <span>SWR ({(result?.z0_ohms ?? 50).toFixed(0)} Ω)</span>
-            <span className="val">
-              {result
-                ? formatSwr(result.z_in_re, result.z_in_im, result.z0_ohms ?? 50)
-                : "—"}
-            </span>
-          </div>
-          <div className="row">
-            <span>rtt</span>
-            <span className="val">{rttMs != null ? `${rttMs.toFixed(1)} ms` : "—"}</span>
-          </div>
-        </div>
-
         {gearOpen && (
           <BackendConfigModal
             slot={gearOpen}
@@ -3257,6 +3200,65 @@ export function App() {
             showFeedNames={showFeedNames}
             multiFeed={effectiveMultiFeed}
           />
+          {/* Solve readout, pinned to the lower-left of whichever view the
+              carousel is centered on. Floats over the canvas as a HUD so the
+              left input rail stays inputs-only. */}
+          <div className={`readout stage-readout${stale ? " stale" : ""}`}>
+            <div className="row">
+              <span>R</span>
+              <span className="val">{result ? `${result.z_in_re.toFixed(2)} Ω` : "—"}</span>
+            </div>
+            <div className="row">
+              <span>X</span>
+              <span className={result && Math.abs(result.z_in_im) < 2 ? "val val-hot" : "val"}>
+                {result ? `${result.z_in_im.toFixed(2)} Ω` : "—"}
+              </span>
+            </div>
+            {currentExample && (
+              <ResultPanel
+                schema={currentExample.result_schema}
+                result={result as Record<string, unknown> | null}
+              />
+            )}
+            {effectiveMultiFeed && result?.feeds && result.feeds.length > 1 && (
+              <div className="feeds-table">
+                <div className="feeds-table-header">per-feed Z (V/I)</div>
+                {result.feeds.map((f, i) => (
+                  <div className="row" key={`feed-z-${i}`}>
+                    <span>
+                      feed {i} ∠{Math.round(Math.atan2(f.v_im, f.v_re) * 180 / Math.PI)}°
+                    </span>
+                    <span className="val">
+                      {f.z_re.toFixed(1)} {f.z_im >= 0 ? "+" : "−"} j
+                      {Math.abs(f.z_im).toFixed(1)} Ω
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+            <div className="row">
+              <span>|I_feed|</span>
+              <span className="val">
+                {result ? feedMag(result).toExponential(3) : "—"}
+              </span>
+            </div>
+            <div className="row">
+              <span>solve</span>
+              <span className="val">{result ? `${result.solve_ms.toFixed(1)} ms` : "—"}</span>
+            </div>
+            <div className="row">
+              <span>SWR ({(result?.z0_ohms ?? 50).toFixed(0)} Ω)</span>
+              <span className="val">
+                {result
+                  ? formatSwr(result.z_in_re, result.z_in_im, result.z0_ohms ?? 50)
+                  : "—"}
+              </span>
+            </div>
+            <div className="row">
+              <span>rtt</span>
+              <span className="val">{rttMs != null ? `${rttMs.toFixed(1)} ms` : "—"}</span>
+            </div>
+          </div>
         </div>
         <div className="status">
           ws: {status}

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1351,6 +1351,21 @@ input[type=checkbox] {
   font-variant-numeric: tabular-nums;
 }
 
+/* Solve readout floated over the lower-left of the centered carousel view.
+   Inherits the .readout card look (bg/border/radius/mono); this just pins it
+   to the corner as a compact HUD and keeps it clear of the canvas content. */
+.stage-readout {
+  position: absolute;
+  bottom: var(--space-6);
+  left: var(--space-6);
+  z-index: 2;
+  min-width: 172px;
+  max-width: 240px;
+  line-height: 1.6;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.28);
+  pointer-events: none; /* a passive HUD — never intercept drags on the view */
+}
+
 .projection-toggle {
   display: flex;
   gap: var(--space-2);


### PR DESCRIPTION
## Summary
- Moves the solve readout (R/X, per-feed Z, |I_feed|, solve time, SWR, rtt) out of the left input sidebar and pins it to the lower-left corner of the centered carousel view, floating over the canvas as a HUD.
- Left input rail is now inputs-only; the readout overlay keeps the `.readout` card styling but is compact, drop-shadowed, and `pointer-events: none` so drags pass through to the view underneath.
- The existing canvas overlays stay clear of it — they're all on the right (top-right antenna/Smith overlay, bottom-right cut-overlay and ws-status).

## Test plan
- [ ] `npm run build` in `src/antennaknobs/web/frontend` succeeds
- [ ] Run the dev server; readout appears bottom-left over every view (antenna, Smith, sweep, pattern) and updates on solve
- [ ] Dragging/rotating the antenna view works through the readout (pointer-events pass-through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)