### PR TITLE
Default angle sliders to a 0.5° step

### DIFF
--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -229,9 +229,14 @@ def _auto_paramspec(name: str, default: Any, override: dict | None) -> ParamSpec
             unit = unit or "MHz"
             override["linked_to_design_freq"] = True  # keep around
         # Angle params read in degrees; show the ° unit on the slider so the
-        # label can drop the redundant `_deg` token (see _display_label).
+        # label can drop the redundant `_deg` token (see _display_label), and
+        # default to a 0.5° step (finer than the auto 1-2-5 step is overkill,
+        # coarser loses the half-degree tuning hams expect). A design's
+        # ui_params `step` still overrides; int-typed angles keep whole steps.
         if _is_degree_param(name):
             unit = unit or "°"
+            if kind != "int":
+                step = 0.5
         final_step = float(override.pop("step", step))
         # Derive display precision from the resolved step (matching its
         # decimals plus one digit of headroom), unless the design pinned a

--- a/tests/test_design_schemas.py
+++ b/tests/test_design_schemas.py
@@ -197,6 +197,22 @@ def test_degree_params_get_compact_label_and_unit():
     assert bowtie["length"].label == "length" and bowtie["length"].unit is None
 
 
+def test_degree_params_default_to_half_degree_step():
+    # Angle sliders default to a 0.5° step...
+    loop = {s.name: s for s in REGISTRY["loops.delta_loop"].param_schema}
+    assert loop["angle_deg"].step == 0.5
+    arr = {s.name: s for s in REGISTRY["arrays.bowtiearray2x4"].param_schema}
+    assert arr["angle_deg_itop"].step == 0.5
+
+    # ...but a design's explicit ui_params step still wins.
+    t2fd = {s.name: s for s in REGISTRY["broadband.t2fd"].param_schema}
+    assert t2fd["tilt_deg"].step == 1.0
+
+    # Non-angle params keep their auto-derived step (not the 0.5° default).
+    bowtie = {s.name: s for s in REGISTRY["specialty.bowtie"].param_schema}
+    assert bowtie["length"].step != 0.5
+
+
 def test_hentenna_slant_aspect_overrides_applied():
     schema = {s.name: s for s in REGISTRY["specialty.hentenna_slant"].param_schema}
     top = schema["top_aspect"]


### PR DESCRIPTION
## Summary
- Degree params (`_deg` keys) previously fell through to the generic 1-2-5 auto step, giving an over-fine angle step (e.g. `0.05°`). Default them to **`0.5°`** instead — the half-degree resolution that's actually useful for tuning.
- A design's explicit `ui_params` `step` still wins (`broadband.t2fd` `tilt_deg` stays `1.0`, `hentenna_slant` `slant_deg` stays `1.0`), and int-typed angles keep whole-degree steps.

One-line change in `_auto_paramspec` alongside the existing degree-unit handling.

## Test plan
- [x] `tests/test_design_schemas.py`: asserts `angle_deg` / `angle_deg_itop` / `gap_angle_deg` default to `step == 0.5`, that an explicit override (`t2fd.tilt_deg == 1.0`) still wins, and that non-angle params keep their auto step.
- [x] Full suite: 1213 passed, 4 skipped; ruff clean.