### PR TITLE
Delta loop, more ways: drone idioms, reflection, and a numeric solve

### DIFF
--- a/src/antennaknobs/designs/loops/delta_loop_marked.py
+++ b/src/antennaknobs/designs/loops/delta_loop_marked.py
@@ -1,0 +1,93 @@
+"""A delta loop built a third way: reparameterized by slant *angle* and *side
+length*, with NO trig in the script.
+
+``delta_loop`` (and its drone twin ``delta_loop_drone``) size the triangle from
+a perimeter ``length_factor`` and then solve an apex-height formula
+``h = (cos·(d-2eps)+2eps)/(2(cos+1))`` for the corner coordinates. That closed
+form is the "scary trig" this version avoids.
+
+The reparameterization: give the two equal slanted sides directly (their length
+``side`` and their tilt ``angle_deg`` from vertical). Then the only edge whose
+length still needs trig is the horizontal *top* -- so we don't compute it. We
+fly each slant with the 3D-turtle ``Drone`` (``yaw`` by the angle, ``forward``
+by the side -- the sin/cos lives inside the Drone, never in this script), drop a
+labelled pin at the right corner, fly the left slant, and ``line_to`` that pin
+to lay the top. The Drone works out the top segment from the two corner
+positions it has been tracking.
+
+The loop is vertical, in the plane x = 0, fed by a short driven gap centred at
+the bottom (height ``base``) and opening upward:
+
+        L-----------R      top, drawn corner-to-corner (line_to a marked node)
+         \\         /
+          \\       /        two equal slants, each flown from (angle, side)
+           \\     /
+            T~~~~S          short driven feed gap at the bottom, on the y axis
+"""
+
+from types import MappingProxyType
+
+from ... import AntennaBuilder, Drone
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.47,
+            "freq": 28.47,
+            # Height of the bottom feed gap above ground.
+            "base": 7.0,
+            # Each slanted side is a third of a wavelength times this (three
+            # ~equal sides -> a ~1 wl perimeter full-wave loop). Tunes resonance.
+            "length_factor": 1.0,
+            # Tilt of each slant from vertical. 30deg -> a 60deg apex, the
+            # classic near-equilateral delta loop.
+            "angle_deg": 30.0,
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 100.0,
+                    "default_view": "yz",  # loop lies in the x = 0 plane
+                    "length_factor": {"min": 0.85, "max": 1.15},
+                    "angle_deg": {"min": 10.0, "max": 60.0},
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        eps = 0.05
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+        side = (wavelength / 3.0) * self.length_factor
+
+        # Bottom feed gap: a short horizontal segment centred on the y axis at
+        # height `base`. Its two ends seed the slants; T is just S mirrored, so
+        # no trig -- and everything above is flown by the drone.
+        S = (0.0, eps, self.base)  # right end of the feed gap
+        T = (0.0, -eps, self.base)  # left end
+
+        drone = Drone(nominal_nsegs=self.nominal_nsegs, ref=quarter)
+
+        # Right slant: from S, nose straight up, tilt `angle_deg` toward +y,
+        # fly one side up to the right top corner; pin it as "R".
+        drone.move_to(S).mark("S")
+        drone.face(heading=(0.0, 0.0, 1.0), up=(1.0, 0.0, 0.0))
+        drone.yaw(-self.angle_deg)
+        drone.pay_out().forward(side)  # S -> R
+        drone.mark("R")
+
+        # Left slant: same from T, tilted the other way, up to the left corner.
+        drone.cut().move_to(T)
+        drone.face(heading=(0.0, 0.0, 1.0), up=(1.0, 0.0, 0.0))
+        drone.yaw(self.angle_deg)
+        drone.pay_out().forward(side)  # T -> L
+
+        # Top wire: connect the left corner to the pinned right corner. The
+        # drone computes the segment -- no trig for the top's length.
+        drone.line_to("R")  # L -> R
+
+        # Feed: the short driven gap across the bottom, T -> S (one segment).
+        drone.cut().move_to(T)
+        drone.feed(1 + 0j).line_to("S", nsegs=1)  # T -> S
+
+        return drone.wires()

--- a/src/antennaknobs/designs/loops/delta_loop_reflected.py
+++ b/src/antennaknobs/designs/loops/delta_loop_reflected.py
@@ -1,0 +1,79 @@
+"""A delta loop built as a hybrid: the Drone is a trig-free *point finder*, and
+the codebase's own ``ry`` reflection + ``build_path`` do the assembly.
+
+This is the most hybrid of the delta-loop variants. Like ``delta_loop_marked``
+it is parameterized by the slant ``angle_deg`` and side length (no apex-height
+formula), but it leans on three idioms at once:
+
+  - the **Drone** flies (laying no wire) up the right slant to read off the top
+    corner ``A`` -- the one point that would otherwise need trig; the sin/cos
+    lives in the Drone's matrices, never in this script;
+  - **reflection** across the y = 0 plane (``ry``) mirrors the right half to get
+    the left corner ``B`` and feed terminal ``T`` for free;
+  - **build_path** (the same helper ``delta_loop`` uses) stitches the four
+    points into the S->A->B->T perimeter plus the T->S feed.
+
+        B-----------A      top (A found by the Drone, B = ry(A))
+         \\         /
+          \\       /
+           \\     /
+            T~~~~S          feed gap; S seeds the Drone, T = ry(S)
+"""
+
+from types import MappingProxyType
+
+from ... import AntennaBuilder, Drone
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.47,
+            "freq": 28.47,
+            "base": 7.0,  # height of the bottom feed gap
+            "length_factor": 1.0,  # each slant = (wavelength / 3) * this
+            "angle_deg": 30.0,  # slant tilt from vertical (30 -> 60 apex)
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 100.0,
+                    "default_view": "yz",  # loop lies in the x = 0 plane
+                    "length_factor": {"min": 0.85, "max": 1.15},
+                    "angle_deg": {"min": 10.0, "max": 60.0},
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        eps = 0.05
+        wavelength = 299.792458 / self.design_freq
+        side = (wavelength / 3.0) * self.length_factor
+        n_seg0 = self.nominal_nsegs
+        n_seg1 = max(3, self.nominal_nsegs // 7)
+
+        def build_path(lst, ns, ex):
+            return ((a, b, ns, ex) for a, b in zip(lst[:-1], lst[1:]))
+
+        def ry(p):
+            return p[0], -p[1], p[2]
+
+        # S is the right end of the bottom feed gap. Fly the drone (pen up, no
+        # wire) from S up the right slant to read off the top corner A -- the
+        # only point that would otherwise need trig.
+        S = (0.0, eps, self.base)
+        A = (
+            Drone(position=S)
+            .face(heading=(0.0, 0.0, 1.0), up=(1.0, 0.0, 0.0))
+            .yaw(-self.angle_deg)
+            .forward(side)
+            .position
+        )
+
+        # The left half is the right half mirrored across the y = 0 plane.
+        B, T = ry(A), ry(S)
+
+        # build_path stitches the points into edges.
+        tups = []
+        tups.extend(build_path([S, A, B, T], n_seg0, None))  # perimeter
+        tups.extend(build_path([T, S], n_seg1, 1 + 0j))  # driven feed gap
+        return tups

--- a/src/antennaknobs/designs/loops/delta_loop_solved.py
+++ b/src/antennaknobs/designs/loops/delta_loop_solved.py
@@ -1,0 +1,82 @@
+"""A delta loop built the same hybrid way as ``delta_loop_reflected`` (Drone as
+a trig-free point finder + ``ry`` reflection + ``build_path``), but parameterized
+by ``length_factor`` -- and the side length is found NUMERICALLY.
+
+``delta_loop`` solves a closed-form apex-height formula to make the perimeter
+equal ``length_factor * wavelength``. Here we don't derive that formula at all:
+we build the loop for a trial ``side``, MEASURE its total wire length, and hand
+the residual to a scipy root finder to recover the ``side`` that hits the
+target. The geometry function is the model; scipy inverts it.
+
+So none of the trig (or algebra) lives in this script -- the Drone computes the
+corner, ``math.dist`` measures the wires, and ``brentq`` does the inversion.
+"""
+
+import math
+from types import MappingProxyType
+
+from ... import AntennaBuilder, Drone
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.47,
+            "freq": 28.47,
+            "base": 7.0,  # height of the bottom feed gap
+            # Total wire length as a multiple of a wavelength (~1 -> full-wave
+            # loop). The side length is solved to hit this exactly.
+            "length_factor": 1.0,
+            "angle_deg": 30.0,  # slant tilt from vertical (30 -> 60 apex)
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 100.0,
+                    "default_view": "yz",  # loop lies in the x = 0 plane
+                    "length_factor": {"min": 0.85, "max": 1.15},
+                    "angle_deg": {"min": 10.0, "max": 60.0},
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        eps = 0.05
+        wavelength = 299.792458 / self.design_freq
+        n_seg0 = self.nominal_nsegs
+        n_seg1 = max(3, self.nominal_nsegs // 7)
+
+        def build_path(lst, ns, ex):
+            return [(a, b, ns, ex) for a, b in zip(lst[:-1], lst[1:])]
+
+        def ry(p):
+            return p[0], -p[1], p[2]
+
+        def geometry(side):
+            # Same construction as delta_loop_reflected: the Drone flies pen-up
+            # to find the top corner A, reflection mirrors the left half, and
+            # build_path stitches the perimeter and feed.
+            S = (0.0, eps, self.base)
+            A = (
+                Drone(position=S)
+                .face(heading=(0.0, 0.0, 1.0), up=(1.0, 0.0, 0.0))
+                .yaw(-self.angle_deg)
+                .forward(side)
+                .position
+            )
+            B, T = ry(A), ry(S)
+            return build_path([S, A, B, T], n_seg0, None) + build_path(
+                [T, S], n_seg1, 1 + 0j
+            )
+
+        def total_wire_length(side):
+            return sum(math.dist(p0, p1) for p0, p1, _ns, _ex in geometry(side))
+
+        # Invert numerically: find the side whose loop has total wire length
+        # length_factor * wavelength. The length grows monotonically with side,
+        # so [tiny, a couple of wavelengths] brackets the single root.
+        from scipy.optimize import brentq
+
+        target = self.length_factor * wavelength
+        side = brentq(lambda s: total_wire_length(s) - target, 1e-3, 2.0 * wavelength)
+
+        return geometry(side)

--- a/src/antennaknobs/drone.py
+++ b/src/antennaknobs/drone.py
@@ -56,6 +56,7 @@ class Drone:
         self.ref = ref
         self._pen = None  # None = up; ("ex", value) when down
         self._origin = None  # world position where the current stroke began
+        self._nodes = {}  # labelled positions, dropped by mark()
         self.edges = []
 
     # -- state ----------------------------------------------------------
@@ -134,6 +135,27 @@ class Drone:
         if math.dist(p0, self._origin) > 1e-12:
             self._emit(p0, tuple(self._origin), nsegs)
         self.move_to(self._origin)
+        return self
+
+    # -- labelled nodes -------------------------------------------------
+    def mark(self, label):
+        """Drop a labelled pin at the current position for a later line_to()."""
+        self._nodes[label] = self.position
+        return self
+
+    def line_to(self, label, nsegs=None):
+        """Lay a wire from the current position to a previously mark()ed node
+        (with the current pen), then move there. The drone works out the
+        straight segment itself, so the caller needs no trig to connect two
+        points -- handy for the one edge of a figure whose length would
+        otherwise have to be solved for (e.g. the top of a triangle once both
+        corners have been flown to). ``close()`` is the special case of this
+        for the stroke's start node."""
+        target = self._nodes[label]
+        p0 = self.position
+        if math.dist(p0, target) > 1e-12:
+            self._emit(p0, tuple(target), nsegs)
+        self.move_to(target)
         return self
 
     # -- turns (body-relative) -----------------------------------------

--- a/tests/test_drone.py
+++ b/tests/test_drone.py
@@ -9,6 +9,9 @@ from antennaknobs import Drone
 from antennaknobs.designs.loops.delta_loop import Builder as DeltaLoop
 from antennaknobs.designs.loops.delta_loop_drone import Builder as DeltaLoopDrone
 from antennaknobs.designs.loops.delta_loop_marked import Builder as DeltaLoopMarked
+from antennaknobs.designs.loops.delta_loop_reflected import (
+    Builder as DeltaLoopReflected,
+)
 from antennaknobs.designs.loops.horizontal_loop_drone import Builder as HLoopDrone
 
 
@@ -201,3 +204,31 @@ def test_delta_loop_marked_is_a_symmetric_delta_loop():
 
     counts = Counter((round(p[1], 6), round(p[2], 6)) for p in pts)
     assert set(counts.values()) == {2}
+
+
+def _undirected(builder):
+    """{(sorted endpoint pair, is_driven)} for a design's wires, ignoring
+    edge order, direction, and segment count."""
+    out = set()
+    for p0, p1, _ns, ex in builder.build_wires():
+        a = tuple(round(c, 9) for c in p0)
+        b = tuple(round(c, 9) for c in p1)
+        out.add((tuple(sorted([a, b])), ex is not None))
+    return out
+
+
+def test_delta_loop_reflected_uses_build_path_topology():
+    ws = DeltaLoopReflected().build_wires()
+    # build_path([S, A, B, T]) -> 3 perimeter edges; build_path([T, S]) -> feed.
+    assert len(ws) == 4
+    driven = [e for e in ws if e[3] is not None]
+    assert len(driven) == 1 and driven[0][3] == 1 + 0j
+    # The feed uses the original delta_loop n_seg1 = max(3, nominal // 7).
+    assert driven[0][2] == max(3, DeltaLoopReflected().nominal_nsegs // 7)
+
+
+def test_delta_loop_reflected_agrees_with_marked():
+    # Three constructions of the same antenna: the labelled-node version and
+    # the reflection+build_path version must produce the same loop (same nodes,
+    # same undirected edges, same driven edge) -- only segmentation differs.
+    assert _undirected(DeltaLoopReflected()) == _undirected(DeltaLoopMarked())

--- a/tests/test_drone.py
+++ b/tests/test_drone.py
@@ -8,6 +8,7 @@ import pytest
 from antennaknobs import Drone
 from antennaknobs.designs.loops.delta_loop import Builder as DeltaLoop
 from antennaknobs.designs.loops.delta_loop_drone import Builder as DeltaLoopDrone
+from antennaknobs.designs.loops.delta_loop_marked import Builder as DeltaLoopMarked
 from antennaknobs.designs.loops.horizontal_loop_drone import Builder as HLoopDrone
 
 
@@ -155,3 +156,48 @@ def test_horizontal_loop_drone_feed_is_symmetric():
     # And the whole loop is invariant under that reflection (x, y) -> (y, x).
     pts = {(round(p[0], 6), round(p[1], 6)) for e in wires for p in (e[0], e[1])}
     assert {(y, x) for (x, y) in pts} == pts
+
+
+def test_mark_and_line_to_connects_to_a_pinned_node():
+    d = Drone(ref=1.0)
+    d.pay_out().mark("a")  # pin the origin
+    d.forward(2.0)  # -> (2, 0, 0)
+    d.yaw(90).forward(2.0)  # -> (2, 2, 0)
+    d.line_to("a")  # lay (2,2,0) -> (0,0,0) and move there
+    last = d.wires()[-1]
+    assert last[0] == pytest.approx((2.0, 2.0, 0.0))
+    assert last[1] == pytest.approx((0.0, 0.0, 0.0))
+    assert d.position == pytest.approx((0.0, 0.0, 0.0))
+
+
+def test_delta_loop_marked_is_a_symmetric_delta_loop():
+    ws = DeltaLoopMarked().build_wires()
+    assert len(ws) == 4
+    pts = [p for e in ws for p in (e[0], e[1])]
+
+    # Vertical loop, planar in x = 0.
+    assert {round(p[0], 9) for p in pts} == {0.0}
+
+    # Exactly one one-segment driven feed.
+    driven = [e for e in ws if e[3] is not None]
+    assert len(driven) == 1 and driven[0][2] == 1 and driven[0][3] == 1 + 0j
+
+    # Symmetric about the y = 0 plane (so the feed/pattern stay symmetric).
+    yz = {(round(p[1], 6), round(p[2], 6)) for p in pts}
+    assert {(-y, z) for (y, z) in yz} == yz
+
+    # Two equal slanted sides and a horizontal top.
+    top_z = max(p[2] for p in pts)
+    structural = [e for e in ws if e[3] is None]
+    top = [e for e in structural if e[0][2] == top_z and e[1][2] == top_z]
+    slants = [e for e in structural if e not in top]
+    assert len(top) == 1 and len(slants) == 2
+    assert math.dist(slants[0][0], slants[0][1]) == pytest.approx(
+        math.dist(slants[1][0], slants[1][1])
+    )
+
+    # Connected closed loop: every node is shared by exactly two edges.
+    from collections import Counter
+
+    counts = Counter((round(p[1], 6), round(p[2], 6)) for p in pts)
+    assert set(counts.values()) == {2}

--- a/tests/test_drone.py
+++ b/tests/test_drone.py
@@ -12,6 +12,7 @@ from antennaknobs.designs.loops.delta_loop_marked import Builder as DeltaLoopMar
 from antennaknobs.designs.loops.delta_loop_reflected import (
     Builder as DeltaLoopReflected,
 )
+from antennaknobs.designs.loops.delta_loop_solved import Builder as DeltaLoopSolved
 from antennaknobs.designs.loops.horizontal_loop_drone import Builder as HLoopDrone
 
 
@@ -232,3 +233,24 @@ def test_delta_loop_reflected_agrees_with_marked():
     # the reflection+build_path version must produce the same loop (same nodes,
     # same undirected edges, same driven edge) -- only segmentation differs.
     assert _undirected(DeltaLoopReflected()) == _undirected(DeltaLoopMarked())
+
+
+def test_delta_loop_solved_hits_target_perimeter():
+    # The side length is found numerically so the total wire length equals
+    # length_factor * wavelength -- no apex formula, the solver inverts the
+    # build-and-measure model.
+    wl = 299.792458 / DeltaLoopSolved.default_params["design_freq"]
+    for lf in (0.9, 1.0, 1.1):
+        ws = DeltaLoopSolved(
+            dict(DeltaLoopSolved.default_params, length_factor=lf)
+        ).build_wires()
+        total = sum(math.dist(p0, p1) for p0, p1, _ns, _ex in ws)
+        assert total == pytest.approx(lf * wl, abs=1e-6)
+
+    # Same symmetric build_path topology as the other delta loops.
+    ws = DeltaLoopSolved().build_wires()
+    assert len(ws) == 4
+    driven = [e for e in ws if e[3] is not None]
+    assert len(driven) == 1 and driven[0][3] == 1 + 0j
+    yz = {(round(p[1], 6), round(p[2], 6)) for e in ws for p in (e[0], e[1])}
+    assert {(-y, z) for (y, z) in yz} == yz


### PR DESCRIPTION
## Summary
Several more ways to build the delta loop, all reparameterized off the apex-height formula. With `delta_loop` (coordinate) and `delta_loop_drone` (pure-drone twin) already on main, the catalog now shows the delta loop built **five ways** — a gallery of "many ways to express the same geometry."

### `delta_loop_marked` — Drone + labelled nodes
The top is the only edge whose length needs trig, so we fly to *both* corners and connect them. New Drone primitives `mark(label)` / `line_to(label)` (with `close()` now their origin special case). Parameterized by slant `angle_deg` + side length.

### `delta_loop_reflected` — Drone as a point finder + reflection + `build_path`
The Drone flies **pen-up** (no wire) just to read off the top corner `A`; `ry` reflects the right half to `B`/`T`; `build_path` stitches the perimeter + feed. Cross-check test: produces the **same loop** as `delta_loop_marked`.

### `delta_loop_solved` — numeric inversion for the side
Same hybrid as reflected, but parameterized by `length_factor` (total wire length = `length_factor × wavelength`). Instead of deriving a formula, it **builds the loop for a trial side, measures the total wire length, and uses `scipy.optimize.brentq`** to solve for the side that hits the target. The geometry function is the model; the solver inverts it.

In all three, **no trig (or algebra) lives in the design script** — the Drone computes corners, `math.dist` measures, `brentq` inverts.

## Verified
All closed, planar (`x=0`), symmetric about `y=0`. `delta_loop_reflected` agrees with `delta_loop_marked` node-for-node; `delta_loop_solved` hits its target perimeter to 1e-6 across `length_factor`s.

## Test plan
- [x] `tests/test_drone.py`: `mark`/`line_to`; `delta_loop_marked` structural; `delta_loop_reflected` `build_path` topology + agreement with marked; `delta_loop_solved` perimeter target + structure.
- [x] Full suite: 1264 passed, 4 skipped; ruff clean. All three designs register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)