### PR TITLE
Website foundations: content plan + Fly.io deploy for the live tuner

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Keep the build context small and the image clean. The frontend is rebuilt in
+# stage 1 and the engine wheels come from TestPyPI, so none of the local build
+# artifacts, the momwire submodule checkout, or the dev venv are needed.
+.git
+.venv
+**/__pycache__/
+*.pyc
+*.egg-info/
+**/node_modules/
+# Rebuilt by the frontend stage; never ship a stale local bundle.
+src/antennaknobs/web/static/
+# momwire is installed as a wheel from TestPyPI, not built from the submodule.
+momwire/
+# Docs, tests, scratch, and CI are not part of the runtime image.
+docs/
+tests/
+scratch/
+scripts/
+.github/
+site/
+*.png
+NEXT_STEPS.md

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy to Fly.io
+
+# Push-to-deploy for the live tuner. On a push to main that touches the app or
+# its deploy config, build on Fly's remote builders and release. Fly has no
+# "connect a repo" dashboard like Render/Vercel; this workflow is the
+# equivalent. See docs/deploy.md for the one-time bootstrap (create the app +
+# add the FLY_API_TOKEN secret).
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - "fly.toml"
+      - "src/antennaknobs/**"
+      - "pyproject.toml"
+      - ".github/workflows/fly-deploy.yml"
+  workflow_dispatch: {}
+
+# Never run two deploys at once; cancel an in-flight one if a newer push lands.
+concurrency:
+  group: fly-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Stay green (not red) before the bootstrap is done: if the token secret
+      # is absent, skip the deploy with a notice instead of failing.
+      - name: Check for Fly token
+        id: token
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          if [ -z "$FLY_API_TOKEN" ]; then
+            echo "::notice::FLY_API_TOKEN not set — skipping deploy. Add it in repo Settings → Secrets to enable push-to-deploy (see docs/deploy.md)."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up flyctl
+        if: steps.token.outputs.skip != 'true'
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy
+        if: steps.token.outputs.skip != 'true'
+        run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,69 @@
+# Multi-stage build for the antennaknobs web workbench (the live tuner).
+#
+# Stage 1 builds the React/Vite SPA to src/antennaknobs/web/static.
+# Stage 2 is a slim Python runtime that installs the package + its C++ engine
+# wheels (momwire, pynec-accel) from TestPyPI and serves everything from one
+# uvicorn process (API + the /ws live-solve WebSocket + the static SPA).
+#
+# See docs/deploy.md for the build/run/deploy runbook.
+
+# ---- Stage 1: build the frontend -------------------------------------------
+# Vite 8 needs Node >=22.12 (or >=20.19); node:22 satisfies it.
+FROM node:22-bookworm-slim AS frontend
+
+# Mirror the repo path so vite's outDir ("../static") lands at
+# /app/src/antennaknobs/web/static — exactly where server.py looks for it.
+WORKDIR /app/src/antennaknobs/web/frontend
+
+# Install deps first (cached unless the lockfile changes).
+COPY src/antennaknobs/web/frontend/package.json src/antennaknobs/web/frontend/package-lock.json ./
+RUN npm ci
+
+# Then the sources, and build.
+COPY src/antennaknobs/web/frontend/ ./
+RUN npm run build   # writes /app/src/antennaknobs/web/static
+
+
+# ---- Stage 2: python runtime -----------------------------------------------
+FROM python:3.12-slim-bookworm AS runtime
+
+# libgomp1: the OpenMP runtime the C++ accelerators link against. Both momwire
+# (>=0.2.2) and pynec-accel (>=1.7.4.post1) de-vendor libgomp and link THIS
+# system copy, so they share one OpenMP runtime — no private-vendored static-TLS
+# clash, so no GLIBC_TUNABLES workaround is needed.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends libgomp1 \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+ENV PIP_NO_CACHE_DIR=1 \
+    PYTHONUNBUFFERED=1 \
+    PORT=8000
+
+# Package metadata + sources (an editable install keeps server.py's
+# _FRONTEND_DIR = <module>/static pointing at the bundle we copy in below).
+COPY pyproject.toml setup.py README.md ./
+COPY src/ ./src/
+
+# The built SPA from stage 1.
+COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/static
+
+# The C++ engine wheels live on TestPyPI; their scientific deps (numpy/scipy)
+# come from real PyPI. Install those FIRST so the editable install below sees
+# the momwire requirement already satisfied — and so the second install can use
+# real PyPI ONLY. (TestPyPI must NOT be an index for the `[web]` deps: it hosts a
+# stray, unbuildable `fastapi` sdist that shadows the real wheel and breaks the
+# build.)
+RUN pip install --upgrade pip \
+ && pip install \
+      --index-url https://test.pypi.org/simple/ \
+      --extra-index-url https://pypi.org/simple/ \
+      "momwire>=0.2.2" "pynec-accel>=1.7.4.post1" \
+ && pip install -e ".[web]"
+
+EXPOSE 8000
+
+# One worker: solves are CPU-bound and run in a threadpool, so extra uvicorn
+# workers would only contend for the same cores. --host 0.0.0.0 to accept the
+# proxy's traffic inside the container.
+CMD ["sh", "-c", "uvicorn antennaknobs.web.server:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,100 @@
+# Deploy runbook — the live tuner on Fly.io
+
+This deploys the web workbench (`antennaknobs.web.server:app` — the API, the
+`/ws` live-solve WebSocket, and the built React SPA) as a single persistent
+container on [Fly.io](https://fly.io). It uses the prebuilt TestPyPI engine
+wheels, so the image needs **no C++ toolchain**.
+
+Files involved: [`Dockerfile`](../Dockerfile), [`.dockerignore`](../.dockerignore),
+[`fly.toml`](../fly.toml).
+
+## 0. One-time prerequisites
+
+- Docker (to build/test the image locally).
+- The Fly CLI: `curl -L https://fly.io/install.sh | sh` (or `brew install flyctl`).
+- A Fly account + login. Run this in your shell so the browser auth completes:
+
+  ```
+  flyctl auth login
+  ```
+
+## 1. Build and test the image locally first
+
+Confirm the container serves the app before touching Fly:
+
+```bash
+docker build -t antennaknobs-web .
+docker run --rm -p 8000:8000 antennaknobs-web
+# open http://127.0.0.1:8000 — the tuner should load and knobs should solve
+curl -fsS http://127.0.0.1:8000/healthz   # -> ok
+```
+
+If the build fails on the engine wheels, check that `momwire` and
+`pynec-accel>=1.7.4.post1` resolve on TestPyPI for linux (the `pip install`
+step in the `Dockerfile`).
+
+## 2. First deploy
+
+`fly.toml` is already written, so you only need an app name and a region.
+
+```bash
+# If the name "antennaknobs" in fly.toml is taken, create your own and edit
+# the `app =` line to match:
+fly apps create antennaknobs        # or your chosen name
+
+# Pick the region nearest you (latency is dominated by the solve, but a short
+# network hop still helps — see the latency note below):
+fly platform regions                # list; edit primary_region in fly.toml
+
+fly deploy
+```
+
+`fly deploy` builds the `Dockerfile`, pushes the image, and boots one machine.
+When it finishes:
+
+```bash
+fly status                          # machine should be "started" + healthy
+fly open                            # opens https://<app>.fly.dev
+fly logs                            # tail if anything misbehaves
+```
+
+At this point the live tuner is reachable at `https://<app>.fly.dev`. **Test it
+remotely from your own machine and confirm dragging a knob feels responsive
+before adding the custom domains** — this is the moment to measure the real
+round-trip.
+
+## 3. Custom domains (after the app is verified live)
+
+For each of `antennaknobs.com` and `antennaknobs.dev` (or a subdomain like
+`app.antennaknobs.dev`):
+
+```bash
+fly certs add app.antennaknobs.dev
+fly certs show app.antennaknobs.dev   # prints the A/AAAA (or CNAME) target
+```
+
+Add the printed record at your registrar's DNS, then re-run `fly certs show`
+until the cert validates. (The marketing `.com` landing and `.dev` docs are
+static sites built separately — see `docs/website-content-plan.md`; only the
+live app needs this Fly service.)
+
+## 4. Day-to-day
+
+| Task | Command |
+|---|---|
+| Redeploy after a change | `fly deploy` |
+| Tail logs | `fly logs` |
+| Open a shell in the machine | `fly ssh console` |
+| Scale memory / CPU | edit `[[vm]]` in `fly.toml`, then `fly deploy` |
+| Add a region replica | `fly scale count 2 --region <r>` |
+
+## Latency note
+
+Perceived lag per knob turn ≈ one network round-trip + the server solve time.
+The **solve dominates** (free-space dipole-class solves are ~10–80 ms; real-ground
+Sommerfeld is ~100× slower). A regional Fly machine adds only ~5–40 ms RTT over a
+persistent WebSocket, so typical tuning totals well under the ~100 ms "feels
+instant" threshold. If it ever feels sluggish, the levers are: debounce knob
+events client-side, lean on the existing solve cache, default to the fast ground
+approximation while dragging, and keep `min_machines_running = 1` so there's no
+cold start.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -78,11 +78,34 @@ until the cert validates. (The marketing `.com` landing and `.dev` docs are
 static sites built separately — see `docs/website-content-plan.md`; only the
 live app needs this Fly service.)
 
-## 4. Day-to-day
+## 4. Push-to-deploy via GitHub Actions (optional, recommended)
+
+Fly has no "connect a repo" dashboard like Render/Vercel — but
+[`.github/workflows/fly-deploy.yml`](../.github/workflows/fly-deploy.yml) gives
+the same result: every push to `main` that touches the app or its deploy config
+builds on Fly's remote builders and releases. One-time bootstrap (after the app
+exists from step 2):
+
+```bash
+# A scoped deploy token for this app:
+fly tokens create deploy -a antennaknobs   # use your app name
+```
+
+Copy the printed token and add it as a repo secret named **`FLY_API_TOKEN`**
+(GitHub → repo Settings → Secrets and variables → Actions → New repository
+secret). Until that secret exists, the workflow runs green but **skips** the
+deploy with a notice — so it never fails CI before you're ready. Once set, a
+merge to `main` deploys automatically; `workflow_dispatch` lets you trigger a
+deploy by hand from the Actions tab.
+
+The first deploy should still be the manual `fly deploy` from step 2 (it creates
+and warms the machine); the workflow handles redeploys thereafter.
+
+## 5. Day-to-day
 
 | Task | Command |
 |---|---|
-| Redeploy after a change | `fly deploy` |
+| Redeploy after a change | `fly deploy` (or just push to `main`) |
 | Tail logs | `fly logs` |
 | Open a shell in the machine | `fly ssh console` |
 | Scale memory / CPU | edit `[[vm]]` in `fly.toml`, then `fly deploy` |

--- a/docs/website-content-plan.md
+++ b/docs/website-content-plan.md
@@ -1,0 +1,184 @@
+# Website content plan — antennaknobs.com & antennaknobs.dev
+
+Status: draft for review. A page-by-page content plan for the two domains.
+Anchored on the positioning in
+[`market-research-antenna-simulators.md`](./market-research-antenna-simulators.md)
+(note: that doc predates the rename — read `antenna_designer` → **antennaknobs**,
+`pysim` → **momwire**).
+
+## The one-sentence pitch
+
+> An open-source, browser-based wire-antenna MoM simulator: grab a knob, watch
+> the pattern, SWR, and impedance move in real time — paid-tier modeling quality
+> (multi-basis MoM, H-matrix acceleration, NEC-2 cross-validation) for free, with
+> no platform lock-in.
+
+Everything below is in service of one idea: **nobody else leads with a live,
+no-install "drag a knob, see the physics move" demo.** Both domains open with it.
+
+## Audience tiering
+
+| Domain | Primary audience | Voice |
+|---|---|---|
+| **antennaknobs.com** | hams + RF/EE students (broad) | plain-language, results-first, minimal jargon |
+| **antennaknobs.dev** | Python devs + contributors | precise, code-shaped, canonical docs home |
+
+Rule: anything code-shaped (API, authoring, contributing) lives **only** on `.dev`,
+so there is one canonical URL per topic. `.com` links *into* `.dev` for depth.
+
+---
+
+## antennaknobs.com — the front door
+
+```
+/                     Hero: live tuner embed + one-line pitch + two CTAs
+/gallery              Design catalog as cards → "open in the tuner"
+/why                  Why antennaknobs (vs 4nec2 / EZNEC / PyNEC) — honest table
+/learn                On-ramp: "design your first antenna in 5 minutes"
+/about                Project, license (open source), credits, links to .dev
+```
+
+### `/` — Home
+
+- **Above the fold:** an embedded live tuner instance (or, if cold-start is too
+  heavy, a looping screen capture) showing a dipole/Yagi with a knob being
+  dragged and the polar pattern + SWR responding. Caption: *"This is the whole
+  tool. No install."*
+- **One-line pitch** (above) + sub-line naming the audience: *"For ham operators,
+  RF students, and anyone who'd rather turn a knob than hand-write a NEC deck."*
+- **Two CTAs:** `Try it in your browser →` (the hosted app on .dev) and a copy box
+  `pip install antennaknobs`.
+- **Three proof tiles** drawn from the differentiators: *Multi-basis MoM* ·
+  *H-matrix acceleration for big arrays* · *Cross-checked against NEC-2*.
+- **Strip of gallery thumbnails** → `/gallery`.
+
+### `/gallery` — Design catalog
+
+- Card grid; each card = geometry thumbnail + name + one-line use ("40m full-wave
+  loop", "2-element 10m Yagi") + **Open in the tuner** button (deep-links the
+  hosted app with that design preloaded).
+- Filter by band / type (dipole, Yagi, loop, vertical, bowtie, multiband).
+- Each card's "details" links to the design's page on `.dev` (source + knobs).
+
+### `/why` — Why antennaknobs
+
+- The honest comparison table from the market research (Tier-2/Tier-3 row): method,
+  interface, platform, price, license. Lead with the three real differentiators
+  (multi-basis, H-matrix, web UI + cross-validation) and **state the gaps too**
+  (approximate finite-ground, no conductor loss yet, polar cuts not 3D surface) —
+  honesty is itself a differentiator vs. the commercial pitches.
+- Positioning statement verbatim.
+
+### `/learn` — First antenna in 5 minutes
+
+- A guided, screenshot-driven walk: pick a dipole → tune length to resonance
+  watching SWR → read the pattern → export the dimensions. No code.
+- Ends with two doors: *"Want the physics?"* → `.dev` concepts; *"Want to script
+  it?"* → `.dev` quickstart.
+
+### `/about`
+
+- What it is, who's behind it, MIT/OSS license, repo link, how to cite, contact.
+
+---
+
+## antennaknobs.dev — the workshop
+
+Hosts **both** the live app and the canonical docs.
+
+```
+/app                  The hosted interactive tuner (the real product)
+/docs/                Documentation root
+  /docs/quickstart      pip install → first design in Python in 10 lines
+  /docs/concepts        The model: AntennaBuilder, params/knobs, build_wires
+  /docs/authoring       Three ways to describe geometry (coords / Transform / Drone)
+  /docs/catalog         Every design rendered with its source + live knobs
+  /docs/solver          The MoM engine: bases, H-matrix, accuracy & validation
+  /docs/web             Running the web UI / adapter / ParamSpec
+  /docs/cli             nec_export and command-line usage
+  /docs/api             Generated API reference
+/contributing         How to add a design, run tests, submit a PR
+/changelog            Release notes
+```
+
+### `/app` — The hosted tuner
+
+The live FastAPI + React app. Deep-linkable per design (so `.com/gallery` cards
+and `/docs/catalog` can point at it). This *is* the product; docs orbit it.
+
+### `/docs/quickstart`
+
+`pip install antennaknobs`, then ~10 lines: import a `Builder`, set a couple of
+params, `build_wires()`, solve, print SWR/impedance. The "it's real Python"
+moment.
+
+### `/docs/concepts` — The model
+
+- `AntennaBuilder`: `default_params` / variant params, `ui_params`, the knob model
+  (`__getattr__`/`__setattr__` over `_params`), `FRAMEWORK_PARAMS`.
+- `build_wires()` contract: the edge list
+  `((x0,y0,z0),(x1,y1,z1), nsegs, excitation)`.
+- House conventions: **angles in degrees**, `_deg` suffix, the display-label /
+  tooltip story (why the knob says `slant°` but the param is `slant_deg`).
+
+### `/docs/authoring` — Many ways to express geometry  ⭐ centerpiece
+
+The teaching page that sells the design philosophy. Same delta loop, built every
+way, rendering identically:
+
+1. **Coordinates + a formula** (`delta_loop`) — apex-height closed form.
+2. **The Drone / 3D turtle** (`delta_loop_drone`) — fly, turn, pay out wire; the
+   pen-up/pen-down (`cut`/`pay_out`/`feed`), `yaw`/`pitch`/`roll`, `face`, `close`.
+3. **Drone + labelled nodes** (`delta_loop_marked`) — `mark`/`line_to`, trig-free.
+4. **Point-finder + reflection + `build_path`** (`delta_loop_reflected`) — Drone
+   reads off one corner, `ry` mirrors the rest.
+5. **Numeric solve** (`delta_loop_solved`) — `brentq` inverts a build-and-measure
+   model from a `length_factor`.
+
+Show the five scripts side by side with the identical rendered geometry under
+each. Message: *pick the expression that fits how you think; the framework
+doesn't care.* Cross-link `Drone` and `Transform` API.
+
+### `/docs/catalog` — Designs with source
+
+Every design: rendered geometry, the live knobs, and the actual `Builder` source
+(these are meant to be **starting points for new designs**, so the source is the
+point). Grouped by family (dipoles, Yagis, loops, verticals, bowties, multiband).
+
+### `/docs/solver` — The engine & accuracy
+
+- The MoM core (momwire): triangular / sinusoidal / B-spline bases; H-matrix/ACA +
+  GMRES; `ArrayBlock`/`HMatrix` for large arrays.
+- **The benchmark** (the 10-design engine comparison already in the repo) →
+  accuracy & performance plots. This is the credibility page for skeptics.
+- The two-engine cross-validation (momwire vs. PyNEC reference).
+- Honest caveats from `NEXT_STEPS.md` (PEC wires, approximate finite ground,
+  polar cuts vs. 3D surface).
+
+### `/docs/web`, `/docs/cli`, `/docs/api`, `/contributing`, `/changelog`
+
+Reference + process pages: the web adapter & `_auto_paramspec`/ParamSpec model,
+`nec_export` CLI, generated API ref, how to add a design and run the test suite,
+release notes.
+
+---
+
+## Build order (suggested)
+
+1. **`.dev/app` live + deep-linkable** — without the live tuner nothing else
+   lands. Everything points here.
+2. **`.com/` home** wrapping that app in the pitch + CTAs.
+3. **`/docs/authoring` (five-ways)** + **`/docs/catalog`** — the highest-leverage
+   teaching content, and it's already written in code.
+4. **`.com/gallery`** + **`/docs/solver` benchmark** — depth and credibility.
+5. **`/why`, `/learn`, quickstart, contributing** — fill in the on-ramps.
+
+## Open questions
+
+- **Hosting the live app:** is `.dev/app` a persistently-running instance, or do we
+  ship a WASM/static build so the demo can't cold-start? (Decides whether `.com`
+  embeds live or a captured loop.)
+- **Docs tooling:** MkDocs Material, Docusaurus, or Astro Starlight? (Astro pairs
+  well if we want the marketing `.com` and docs `.dev` to share components.)
+- **Domain redirect policy:** does bare `antennaknobs.dev` redirect to `/app`,
+  `/docs`, or a thin landing? (I'd send it to `/app`.)

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,37 @@
+# Fly.io deploy config for the antennaknobs web workbench.
+#
+# `app` must be globally unique on Fly — if "antennaknobs" is taken, run
+# `fly apps create <name>` with another name and update this line (or let
+# `fly launch` pick one). Set `primary_region` to the Fly region nearest your
+# users; list them with `fly platform regions`. See docs/deploy.md.
+
+app = "antennaknobs"
+primary_region = "sjc"   # San Jose — change to your nearest region
+
+[build]
+  dockerfile = "Dockerfile"
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  # Keep one machine warm so the first knob turn has no cold-start lag
+  # (importing numpy/scipy/momwire + the first solve takes a few seconds).
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+  # WebSockets ride the same HTTP service — the /ws live-solve channel needs no
+  # special config; Fly proxies the upgrade through to internal_port.
+
+  [[http_service.checks]]
+    method = "GET"
+    path = "/healthz"
+    interval = "15s"
+    timeout = "5s"
+    grace_period = "20s"   # let the app import + warm before first probe
+
+[[vm]]
+  # Shared CPU is fine for bursty single-user solves; 2 GB gives numpy/scipy/
+  # momwire and the solve cache headroom (1 GB is tight). Step up to a
+  # performance VM if concurrent users stretch the solve times.
+  size = "shared-cpu-1x"
+  memory = "2gb"


### PR DESCRIPTION
## Summary
- **`docs/website-content-plan.md`** — page-by-page content plan for `antennaknobs.com` (broad front door: hams + RF/EE students) and `antennaknobs.dev` (the workshop: hosts the live tuner + canonical docs). Tiered-audience structure, anchored on the positioning in `docs/market-research-antenna-simulators.md` and on assets the repo already has (the five-ways delta loop, the design catalog, the engine benchmark). Decisions baked in: **monorepo** (`site/` alongside the existing app + docs), **Astro Starlight** for `.com` + `.dev`.
- **`Dockerfile`** — multi-stage build for the web workbench: a Node stage builds the React/Vite SPA, a slim Python runtime installs `momwire` + `pynec-accel>=1.7.4.post1` wheels from TestPyPI (no C++ toolchain in the image) and serves API + the `/ws` live-solve WebSocket + the static SPA from one uvicorn process. An editable install keeps `server.py`'s `_FRONTEND_DIR` pointed at the built bundle.
- **`fly.toml`** — persistent (Option A) deploy: a warm machine (`min_machines_running = 1`, no cold-start lag), a `/healthz` check, WS-friendly `http_service`, 2 GB shared-CPU.
- **`.dockerignore`** + **`docs/deploy.md`** — small build context and a build → run-locally → `fly deploy` → custom-domain runbook.

## Notes
- **The image build is unverified by an actual `docker build`** — there was no Docker in the authoring environment. Every path the Dockerfile touches was checked to exist (`package-lock.json`, `setup.py`, `README.md`, the `_FRONTEND_DIR` contract, the open `/healthz` route), and the TestPyPI install line matches the README, but the local `docker build`/`docker run` in `docs/deploy.md` step 1 is the real verification.
- The marketing `.com` + `.dev` docs sites (Astro Starlight `site/`) are **not** in this PR — this is the plan + the live-app deploy only. Site scaffolding is the next piece.

## Test plan
- [ ] `docker build -t antennaknobs-web .` succeeds (engine wheels resolve for linux on TestPyPI)
- [ ] `docker run --rm -p 8000:8000 antennaknobs-web` serves the tuner at http://127.0.0.1:8000 and knobs solve
- [ ] `curl -fsS http://127.0.0.1:8000/healthz` returns ok
- [ ] `fly deploy` boots a healthy machine; live tuner reachable at `https://<app>.fly.dev`
- [ ] knob-drag feels responsive remotely (measure real round-trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)