### PR TITLE
Add a reactive knob optimizer (per-knob menu + always-on tuning)

### DIFF
--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -746,6 +746,7 @@ function ParamForm({
   onChange,
   pathPrefix = [],
   disabledFields,
+  opt,
 }: {
   schema: SchemaItem[];
   values: ParamValueBag;
@@ -756,6 +757,12 @@ function ParamForm({
   // depends on the active backend (e.g. daisy_chain only works on
   // PyNEC; momwire engines don't support transmission lines yet).
   disabledFields?: Set<string>;
+  // Optimiser integration (top-level rail only). `settings` overrides a knob's
+  // effective min/max/step; `onContext` opens that knob's right-click menu.
+  opt?: {
+    settings: Record<string, KnobOpt>;
+    onContext: (name: string, e: React.MouseEvent) => void;
+  };
 }) {
   return (
     <>
@@ -887,8 +894,19 @@ function ParamForm({
         // Every float/int param is a rotary knob: label on top, dial in the
         // middle, value on the bottom. (The slider alternative and its toggle
         // were retired — knobs are the brand.)
+        // Per-knob optimiser override: display extents + manual step come from
+        // the knob's menu when set, and `vary` marks it a free variable.
+        const ko = opt?.settings[item.name];
+        const knobMin = ko ? ko.dispMin : effMin;
+        const knobMax = ko ? ko.dispMax : effMax;
+        const knobStep = ko?.step ?? item.step ?? 0.001;
         return (
-          <div key={item.name} className="field field-knob" style={layoutStyle(item.layout)}>
+          <div
+            key={item.name}
+            className={`field field-knob${ko?.vary ? " is-opt-var" : ""}`}
+            style={layoutStyle(item.layout)}
+            onContextMenu={opt ? (e) => opt.onContext(item.name, e) : undefined}
+          >
             <span
               className="knob-label"
               title={item.name === item.label ? item.label : `${item.label} · param: ${item.name}`}
@@ -897,9 +915,9 @@ function ParamForm({
             </span>
             <Knob
               value={currentNum}
-              min={effMin}
-              max={effMax}
-              step={item.step ?? 0.001}
+              min={knobMin}
+              max={knobMax}
+              step={knobStep}
               precision={item.kind === "int" ? 0 : item.precision}
               unit={item.unit}
               label={item.label}
@@ -1465,6 +1483,41 @@ function useThumbColumnSize(
 type Theme = "light" | "dark";
 const ThemeContext = createContext<Theme>("light");
 
+// Response from POST /optimize.
+type OptMetrics = { z_in_re: number; z_in_im: number; z0_ohms: number; swr: number };
+type OptimizeResult = {
+  objective: string;
+  params: Record<string, number>;
+  objective_before: number;
+  objective_after: number;
+  metrics_before: OptMetrics;
+  metrics_after: OptMetrics;
+  n_evals: number;
+  improved: boolean;
+};
+type OptObjective = "swr" | "resonance" | "match_z0";
+const OPT_OBJECTIVE_LABELS: Record<OptObjective, string> = {
+  swr: "SWR",
+  resonance: "Resonance",
+  match_z0: "Match Z₀",
+};
+// The two objectives offered in the compact control next to meas-freq.
+const OPT_OBJECTIVES: OptObjective[] = ["resonance", "swr"];
+
+// Per-knob optimisation settings (per geometry, per param name). `vary` marks
+// the knob as a free variable the optimiser may change; opt extents bound the
+// search; display extents are the knob's own slider range; step is the manual
+// turn granularity (the optimiser itself is continuous). Absent for a knob =
+// schema defaults.
+type KnobOpt = {
+  vary: boolean;
+  optMin: number;
+  optMax: number;
+  dispMin: number;
+  dispMax: number;
+  step: number;
+};
+
 export function App() {
   const [geometry, setGeometry] = useState<string>("");
 
@@ -1517,6 +1570,30 @@ export function App() {
   // when this map has no entry — `default` for designs that declare
   // it, otherwise whatever the example shipped first.
   const [variantByGeom, setVariantByGeom] = useState<Record<string, string>>({});
+
+  // --- Reactive knob optimiser (POST /optimize) ---
+  // Master enable + objective live in the compact control by meas-freq; per-knob
+  // "vary" + extents + step live in each knob's right-click menu (knobOpt).
+  const [optEnabled, setOptEnabled] = useState(false);
+  const [optObjective, setOptObjective] = useState<OptObjective>("resonance");
+  const [knobOpt, setKnobOpt] = useState<Record<string, Record<string, KnobOpt>>>({});
+  // Open knob context menu: which param + anchor position.
+  const [knobMenu, setKnobMenu] = useState<{ name: string; x: number; y: number } | null>(
+    null,
+  );
+  const [optRunning, setOptRunning] = useState(false);
+  const [optResult, setOptResult] = useState<OptimizeResult | null>(null);
+  const [optError, setOptError] = useState<string | null>(null);
+  const optAbortRef = useRef<AbortController | null>(null);
+  // Per-knob settings persist per geometry (knobOpt is keyed by geometry); just
+  // close any open menu / clear the last result / abort any in-flight run when
+  // the antenna changes.
+  useEffect(() => {
+    optAbortRef.current?.abort();
+    setKnobMenu(null);
+    setOptResult(null);
+    setOptError(null);
+  }, [geometry]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1992,6 +2069,138 @@ export function App() {
     }
     return base;
   }
+
+  // Run the optimiser once: POST the current solve request + the free knobs
+  // (from each knob's menu) and objective, then apply the returned params to the
+  // knobs (re-solving via the normal onChange path). Warm-started from the
+  // current values; a newer run aborts the previous so stale results are
+  // dropped. Always uses the momwire engine server-side.
+  async function runOptimize() {
+    const settings = knobOpt[geometry] ?? {};
+    const free = Object.entries(settings)
+      .filter(([, o]) => o.vary)
+      .map(([name, o]) => ({ name, min: o.optMin, max: o.optMax }));
+    if (free.length === 0) return;
+    optAbortRef.current?.abort();
+    const ctrl = new AbortController();
+    optAbortRef.current = ctrl;
+    setOptRunning(true);
+    setOptError(null);
+    try {
+      const resp = await fetch("/optimize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        signal: ctrl.signal,
+        body: JSON.stringify({
+          ...buildRequest(),
+          // Reactive runs are warm-started, so a modest eval cap keeps them snappy.
+          optimize: { free, objective: optObjective, max_evals: 40 },
+        }),
+      });
+      const data = await resp.json();
+      if (ctrl.signal.aborted) return; // superseded by a newer run
+      if (data.error) {
+        setOptError(String(data.error));
+      } else {
+        setOptResult(data as OptimizeResult);
+        for (const [name, val] of Object.entries((data as OptimizeResult).params)) {
+          setParamAtPath([name], val);
+        }
+      }
+    } catch (e) {
+      if (!ctrl.signal.aborted) setOptError(String(e));
+    } finally {
+      if (optAbortRef.current === ctrl) {
+        optAbortRef.current = null;
+        setOptRunning(false);
+      }
+    }
+  }
+
+  // Reactive optimisation. When enabled with >=1 free knob, re-tune shortly
+  // after the user pauses on any *fixed* input. The trigger is a signature of
+  // everything the optimiser depends on EXCEPT the free knobs' values — the
+  // optimiser writes those, so including them would loop. Turning it on produces
+  // a fresh signature, so it also tunes immediately on enable.
+  const optFixedSig = useMemo(() => {
+    if (!optEnabled) return "";
+    const settings = knobOpt[geometry] ?? {};
+    const free = Object.entries(settings).filter(([, o]) => o.vary);
+    if (free.length === 0) return "";
+    const freeSet = new Set(free.map(([n]) => n));
+    const fixed: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(currentValues)) {
+      if (!freeSet.has(k)) fixed[k] = v;
+    }
+    return JSON.stringify({
+      geometry,
+      objective: optObjective,
+      backend,
+      designFreq,
+      measFreq,
+      bounds: free.map(([n, o]) => [n, o.optMin, o.optMax]),
+      fixed,
+    });
+    // currentValuesKey stands in for currentValues' contents in the deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    optEnabled,
+    knobOpt,
+    geometry,
+    optObjective,
+    backend,
+    designFreq,
+    measFreq,
+    currentValuesKey,
+  ]);
+
+  useEffect(() => {
+    if (!optFixedSig) return;
+    const t = setTimeout(() => {
+      runOptimize();
+    }, 400);
+    return () => clearTimeout(t);
+    // runOptimize captured here reflects the state at this signature; re-running
+    // only when the signature changes is intentional.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [optFixedSig]);
+
+  // The effective per-knob optimiser settings: the stored entry, or seeded from
+  // the schema (extents = slider bounds, step = schema step, not varying).
+  function knobOptFor(name: string): KnobOpt {
+    const existing = knobOpt[geometry]?.[name];
+    if (existing) return existing;
+    const s = currentExample?.param_schema.find(
+      (x): x is SchemaParamSpec => !isGroup(x) && x.name === name,
+    );
+    const min = s?.min ?? 0;
+    const max = s?.max ?? 1;
+    return {
+      vary: false,
+      optMin: min,
+      optMax: max,
+      dispMin: min,
+      dispMax: max,
+      step: s?.step ?? 0.001,
+    };
+  }
+  function updateKnobOpt(name: string, patch: Partial<KnobOpt>) {
+    const base = knobOptFor(name);
+    setKnobOpt((prev) => ({
+      ...prev,
+      [geometry]: { ...(prev[geometry] ?? {}), [name]: { ...base, ...patch } },
+    }));
+  }
+
+  // Close the knob menu on Escape.
+  useEffect(() => {
+    if (!knobMenu) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setKnobMenu(null);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [knobMenu]);
 
   // Export the current design as a NEC2 .nec card deck and trigger a
   // browser download. The backend reuses the same builder construction as
@@ -2807,6 +3016,16 @@ export function App() {
               disabledFields={
                 backend !== "pynec" ? new Set(["daisy_chain"]) : undefined
               }
+              // Per-knob optimiser hooks: effective min/max/step come from the
+              // knob's menu settings (overriding schema), and right-click opens
+              // that menu.
+              opt={{
+                settings: knobOpt[geometry] ?? {},
+                onContext: (name, e) => {
+                  e.preventDefault();
+                  setKnobMenu({ name, x: e.clientX, y: e.clientY });
+                },
+              }}
             />
           </div>
         )}
@@ -2854,6 +3073,86 @@ export function App() {
           );
         })()}
 
+        {/* Per-knob optimiser menu (right-click a knob): vary toggle + extents +
+            turn step. Position-fixed at the click point. */}
+        {knobMenu &&
+          currentExample &&
+          (() => {
+            const name = knobMenu.name;
+            const ko = knobOptFor(name);
+            const s = currentExample.param_schema.find(
+              (x): x is SchemaParamSpec => !isGroup(x) && x.name === name,
+            );
+            const num = (v: number) => (Number.isFinite(v) ? v : 0);
+            const set = (patch: Partial<KnobOpt>) => updateKnobOpt(name, patch);
+            return (
+              <>
+                <div
+                  className="knob-menu-backdrop"
+                  onClick={() => setKnobMenu(null)}
+                  onContextMenu={(e) => {
+                    e.preventDefault();
+                    setKnobMenu(null);
+                  }}
+                />
+                <div
+                  className="knob-menu"
+                  style={{ left: knobMenu.x, top: knobMenu.y }}
+                  onContextMenu={(e) => e.preventDefault()}
+                >
+                  <div className="knob-menu-title">{s?.label ?? name}</div>
+                  <label className="knob-menu-vary">
+                    <input
+                      type="checkbox"
+                      checked={ko.vary}
+                      onChange={(e) => set({ vary: e.target.checked })}
+                    />
+                    Optimize this knob
+                  </label>
+                  <div className="knob-menu-row">
+                    <span>Optimize range</span>
+                    <input
+                      type="number"
+                      step="any"
+                      value={num(ko.optMin)}
+                      onChange={(e) => set({ optMin: Number(e.target.value) })}
+                    />
+                    <input
+                      type="number"
+                      step="any"
+                      value={num(ko.optMax)}
+                      onChange={(e) => set({ optMax: Number(e.target.value) })}
+                    />
+                  </div>
+                  <div className="knob-menu-row">
+                    <span>Display range</span>
+                    <input
+                      type="number"
+                      step="any"
+                      value={num(ko.dispMin)}
+                      onChange={(e) => set({ dispMin: Number(e.target.value) })}
+                    />
+                    <input
+                      type="number"
+                      step="any"
+                      value={num(ko.dispMax)}
+                      onChange={(e) => set({ dispMax: Number(e.target.value) })}
+                    />
+                  </div>
+                  <div className="knob-menu-row">
+                    <span>Turn step</span>
+                    <input
+                      type="number"
+                      step="any"
+                      value={num(ko.step)}
+                      onChange={(e) => set({ step: Number(e.target.value) })}
+                    />
+                  </div>
+                </div>
+              </>
+            );
+          })()}
+
         {/* Measurement freq = the rig's tuning control: a weighted VFO dial +
             frequency-counter readout. Band select + lock sit to the LEFT of the
             readout/dial to keep the field compact. "lock to design freq"
@@ -2883,6 +3182,39 @@ export function App() {
               />
               lock
             </label>
+            {/* Reactive optimiser: enable + objective. Mark knobs to vary via
+                their right-click menu; turning a fixed knob re-tunes. */}
+            <div className="opt-control" title="reactive optimisation">
+              <label className="link-toggle">
+                <input
+                  type="checkbox"
+                  checked={optEnabled}
+                  onChange={(e) => setOptEnabled(e.target.checked)}
+                />
+                opt{optRunning ? <span className="opt-pip">●</span> : null}
+              </label>
+              {optEnabled && (
+                <select
+                  className="opt-objective"
+                  value={optObjective}
+                  onChange={(e) => setOptObjective(e.target.value as OptObjective)}
+                >
+                  {OPT_OBJECTIVES.map((k) => (
+                    <option key={k} value={k}>
+                      {OPT_OBJECTIVE_LABELS[k]}
+                    </option>
+                  ))}
+                </select>
+              )}
+              {optEnabled && optResult && (
+                <span className="opt-readout" title="SWR after optimisation">
+                  SWR {optResult.metrics_after.swr.toFixed(2)}
+                </span>
+              )}
+              {optEnabled && optError && (
+                <span className="opt-readout opt-readout-err">{optError}</span>
+              )}
+            </div>
           </div>
           <div className="vfo-main">
             <div className="freq-lcd" title={`${measFreq.toFixed(3)} MHz`}>

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1534,3 +1534,92 @@ canvas {
     opacity: 0.5;
   }
 }
+
+/* --- Reactive knob optimiser --- */
+/* A knob marked as a free optimisation variable. */
+.field-knob.is-opt-var .knob-cap,
+.field-knob.is-opt-var .mockdial {
+  box-shadow: 0 0 0 2px var(--accent);
+}
+.field-knob.is-opt-var .knob-label::after {
+  content: " ⟳";
+  color: var(--accent);
+}
+
+/* Compact enable + objective control next to the meas-freq band/lock. */
+.opt-control {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+.opt-control .opt-objective {
+  font-size: var(--text-xs);
+  padding: 0 var(--space-1);
+}
+.opt-pip {
+  color: var(--accent);
+  margin-left: 2px;
+  animation: opt-blink 1s steps(2, start) infinite;
+}
+@keyframes opt-blink {
+  to {
+    opacity: 0.2;
+  }
+}
+.opt-readout {
+  font-size: var(--text-xs);
+  color: var(--muted);
+  white-space: nowrap;
+}
+.opt-readout-err {
+  color: var(--danger, #c0392b);
+}
+
+/* Per-knob right-click menu. */
+.knob-menu-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+}
+.knob-menu {
+  position: fixed;
+  z-index: 41;
+  min-width: 200px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-2, 6px);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.3);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+}
+.knob-menu-title {
+  font-weight: 600;
+  color: var(--fg);
+  border-bottom: 1px solid var(--border);
+  padding-bottom: var(--space-2);
+}
+.knob-menu-vary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+  color: var(--fg);
+}
+.knob-menu-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--muted);
+}
+.knob-menu-row > span:first-child {
+  flex: 1;
+  min-width: 0;
+}
+.knob-menu-row input[type="number"] {
+  width: 5em;
+  font-size: var(--text-xs);
+}

--- a/src/antennaknobs/web/optimize.py
+++ b/src/antennaknobs/web/optimize.py
@@ -1,0 +1,145 @@
+"""Knob optimisation: vary a chosen subset of params within user-set bounds to
+optimise an electrical objective (impedance match / SWR, resonance, …).
+
+Deliberately free of any web framework. The objective is evaluated through an
+injected ``solve_fn(req) -> response`` callback, so the same code runs:
+  - under the FastAPI ``/optimize`` endpoint, wired to a registry example's
+    cheap impedance-only ``momwire_solve`` (no far-field — we only read Z), and
+  - under unit tests, wired to a builder/example solve directly or to a stub.
+
+The optimiser is a bounded Nelder–Mead (derivative-free — each objective eval is
+a full MoM solve, so finite-difference gradients would be wasteful) started from
+the params' current values. It's a *local* search: it refines the operating
+point the user is already near, which matches the "nudge these knobs to tune
+this" workflow. A global pass (differential_evolution) can be layered on later.
+
+Request shape (the bits this module reads), in addition to a normal solve req:
+    optimize = {
+        "free": [{"name": "length_factor", "min": 0.9, "max": 1.1}, ...],
+        "objective": "swr" | "resonance" | "match_z0",
+        "max_evals": <int, optional cap>,
+    }
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from scipy.optimize import minimize
+
+# Objective keys the UI can offer. Each maps a solve response -> a scalar to
+# MINIMISE (so a perfect match / resonance is 0).
+OBJECTIVES = ("swr", "resonance", "match_z0")
+
+
+def _swr(z_re: float, z_im: float, z0: float) -> float:
+    """Voltage SWR of impedance Z against a real reference Z0. 1.0 = perfect
+    match; clamped just below the open-circuit singularity so a totally
+    mismatched candidate returns a large-but-finite penalty the optimiser can
+    still descend from."""
+    z = complex(z_re, z_im)
+    denom = z + z0
+    gamma = 1.0 if denom == 0 else abs((z - z0) / denom)
+    gamma = min(gamma, 1.0 - 1e-9)
+    return (1.0 + gamma) / (1.0 - gamma)
+
+
+def _objective_value(out: dict, key: str) -> float:
+    z0 = float(out.get("z0_ohms", 50.0))
+    z_re = float(out["z_in_re"])
+    z_im = float(out["z_in_im"])
+    if key == "resonance":
+        return abs(z_im)  # cancel reactance
+    if key == "match_z0":
+        return abs(complex(z_re, z_im) - z0)  # complex distance to Z0
+    return _swr(z_re, z_im, z0)  # default: minimise SWR
+
+
+def _metrics(out: dict) -> dict:
+    """The handful of numbers the UI shows before/after, derived from one solve."""
+    z0 = float(out.get("z0_ohms", 50.0))
+    z_re = float(out["z_in_re"])
+    z_im = float(out["z_in_im"])
+    return {
+        "z_in_re": z_re,
+        "z_in_im": z_im,
+        "z0_ohms": z0,
+        "swr": _swr(z_re, z_im, z0),
+    }
+
+
+def optimize(
+    base_req: dict,
+    free: list[dict],
+    objective: str = "swr",
+    *,
+    solve_fn: Callable[[dict], dict],
+    max_evals: int | None = None,
+) -> dict:
+    """Optimise ``objective`` over the ``free`` params within their bounds.
+
+    ``free`` is a list of ``{"name", "min", "max"}``. ``solve_fn`` takes a solve
+    request and returns a response carrying ``z_in_re``/``z_in_im``/``z0_ohms``.
+    Returns the best params found plus before/after objective + metrics.
+    """
+    if not free:
+        raise ValueError("no free params selected to optimise")
+    if objective not in OBJECTIVES:
+        objective = "swr"
+
+    names = [f["name"] for f in free]
+    lo = [float(f["min"]) for f in free]
+    hi = [float(f["max"]) for f in free]
+
+    # Start from each param's current value, clipped into its bound.
+    x0 = []
+    for name, lob, hib in zip(names, lo, hi):
+        cur = float(base_req.get(name, 0.5 * (lob + hib)))
+        x0.append(min(max(cur, lob), hib))
+
+    n_evals = 0
+
+    def _solve_at(x) -> dict:
+        nonlocal n_evals
+        req = dict(base_req)
+        for name, v in zip(names, x):
+            req[name] = float(v)
+        n_evals += 1
+        return solve_fn(req)
+
+    def f(x) -> float:
+        return _objective_value(_solve_at(x), objective)
+
+    out0 = _solve_at(x0)
+
+    # Cap the work: each eval is a full solve. ~40 per free param, hard-capped so
+    # a wide search can't run away. The UI can override via max_evals.
+    maxfev = int(max_evals) if max_evals else min(200, 40 * len(free))
+    res = minimize(
+        f,
+        x0,
+        method="Nelder-Mead",
+        bounds=list(zip(lo, hi)),
+        options={"maxfev": maxfev, "xatol": 1e-4, "fatol": 1e-5},
+    )
+
+    # res.x can sit a hair outside bounds after the final reflection; clip.
+    x_best = [min(max(float(v), lob), hib) for v, lob, hib in zip(res.x, lo, hi)]
+    out1 = _solve_at(x_best)
+
+    before = _objective_value(out0, objective)
+    after = _objective_value(out1, objective)
+    # Only claim the optimum if it actually didn't get worse (Nelder–Mead can
+    # report success while terminating at the start point for a flat objective).
+    best_params = dict(zip(names, x_best)) if after <= before else dict(zip(names, x0))
+
+    return {
+        "objective": objective,
+        "params": {k: float(v) for k, v in best_params.items()},
+        "objective_before": before,
+        "objective_after": min(before, after),
+        "metrics_before": _metrics(out0),
+        "metrics_after": _metrics(out1 if after <= before else out0),
+        "n_evals": n_evals,
+        "improved": after < before,
+    }

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -700,6 +700,50 @@ async def geometry_endpoint(req: dict):
     return out
 
 
+@app.post("/optimize")
+async def optimize_endpoint(req: dict):
+    """Tune a chosen subset of knobs to optimise an electrical objective.
+
+    The request is a normal solve request plus an `optimize` block:
+        optimize = {
+          "free": [{"name", "min", "max"}, ...],   # which knobs + their bounds
+          "objective": "swr" | "resonance" | "match_z0",
+          "max_evals": <int, optional>,
+        }
+    Returns the best params found + before/after metrics. The objective is
+    evaluated at the request's measurement frequency through the geometry's
+    impedance-only momwire_solve (cheap — no far field), so a run is dozens of
+    quick solves rather than a far-field sweep. Always uses the momwire engine
+    regardless of the request's `solver` (PyNEC would be far too slow per eval).
+    """
+    from .optimize import OBJECTIVES, optimize as _optimize
+
+    opt = req.get("optimize") or {}
+    free = opt.get("free") or []
+    if not free:
+        return {"error": "select at least one knob to vary"}
+    objective = opt.get("objective", "swr")
+    if objective not in OBJECTIVES:
+        return {"error": f"unknown objective {objective!r}"}
+
+    geometry = req.get("geometry", next(iter(EXAMPLES)))
+    ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
+    base = {k: v for k, v in req.items() if k != "optimize"}
+    try:
+        result = await run_in_threadpool(
+            _optimize,
+            base,
+            free,
+            objective,
+            solve_fn=ex.momwire_solve,
+            max_evals=opt.get("max_evals"),
+        )
+    except Exception as exc:  # noqa: BLE001 — a user design's build_wires can raise
+        return {"geometry": geometry, "error": user_designs.format_solve_error(exc)}
+    result["geometry"] = geometry
+    return result
+
+
 @app.get("/healthz")
 def healthz():
     return {"ok": True}

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,0 +1,126 @@
+"""Unit tests for the knob optimiser (antennaknobs.web.optimize).
+
+The optimiser machinery is exercised with a *stub* solve_fn (a closed-form Z as
+a function of the free params) so the tests are fast and deterministic — no MoM
+solves. A separate slow-marked test runs one real geometry through it to confirm
+the wiring to momwire_solve.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from antennaknobs.web.optimize import _swr, optimize
+
+
+def test_swr_helper():
+    assert _swr(50.0, 0.0, 50.0) == pytest.approx(1.0)  # perfect match
+    assert _swr(100.0, 0.0, 50.0) == pytest.approx(2.0)  # 2:1
+    assert _swr(25.0, 0.0, 50.0) == pytest.approx(2.0)  # 2:1 the other way
+    assert _swr(50.0, 50.0, 50.0) > 2.0  # reactance worsens it
+    assert math.isfinite(_swr(1e9, 0.0, 50.0))  # open circuit stays finite
+
+
+def _linear_reactance(zero_at: float, z_re: float = 50.0):
+    """Stub solve_fn: X(x) crosses zero at `zero_at`, R fixed. So resonance
+    (|X|) and SWR are both minimised there (Z = z_re + 0j)."""
+
+    def solve(req: dict) -> dict:
+        x = float(req["x"])
+        return {"z_in_re": z_re, "z_in_im": 100.0 * (x - zero_at), "z0_ohms": 50.0}
+
+    return solve
+
+
+def test_optimize_finds_the_minimum():
+    res = optimize(
+        {"x": 0.80},
+        [{"name": "x", "min": 0.5, "max": 1.5}],
+        "resonance",
+        solve_fn=_linear_reactance(1.05),
+    )
+    assert res["params"]["x"] == pytest.approx(1.05, abs=1e-3)
+    assert res["objective_after"] == pytest.approx(0.0, abs=1e-1)
+    assert res["objective_after"] < res["objective_before"]
+    assert res["improved"] is True
+    assert res["n_evals"] > 2
+
+
+def test_optimize_clamps_to_bounds_when_optimum_is_outside():
+    # Reactance zero sits at 1.30 but the user constrained x to <= 1.00.
+    res = optimize(
+        {"x": 0.80},
+        [{"name": "x", "min": 0.5, "max": 1.0}],
+        "resonance",
+        solve_fn=_linear_reactance(1.30),
+    )
+    assert res["params"]["x"] == pytest.approx(1.0, abs=1e-3)  # pinned to the bound
+    assert 0.5 <= res["params"]["x"] <= 1.0
+
+
+def test_optimize_swr_objective_matches_z0():
+    # Same stub: at x=1.05, Z = 50 + 0j -> SWR 1.0.
+    res = optimize(
+        {"x": 0.80},
+        [{"name": "x", "min": 0.5, "max": 1.5}],
+        "swr",
+        solve_fn=_linear_reactance(1.05),
+    )
+    assert res["params"]["x"] == pytest.approx(1.05, abs=1e-2)
+    assert res["metrics_after"]["swr"] == pytest.approx(1.0, abs=0.05)
+
+
+def test_optimize_two_free_params():
+    # A 2-D bowl: |X| minimised where both params hit their targets.
+    def solve(req: dict) -> dict:
+        a, b = float(req["a"]), float(req["b"])
+        x_im = 100.0 * (a - 1.10) + 80.0 * (b - 0.90)
+        return {"z_in_re": 50.0, "z_in_im": x_im, "z0_ohms": 50.0}
+
+    res = optimize(
+        {"a": 1.0, "b": 1.0},
+        [{"name": "a", "min": 0.8, "max": 1.3}, {"name": "b", "min": 0.7, "max": 1.1}],
+        "resonance",
+        solve_fn=solve,
+    )
+    assert res["objective_after"] < res["objective_before"]
+    assert 0.8 <= res["params"]["a"] <= 1.3
+    assert 0.7 <= res["params"]["b"] <= 1.1
+
+
+def test_optimize_rejects_empty_free():
+    with pytest.raises(ValueError):
+        optimize({"x": 1.0}, [], "swr", solve_fn=_linear_reactance(1.0))
+
+
+def test_unknown_objective_falls_back_to_swr():
+    res = optimize(
+        {"x": 0.8},
+        [{"name": "x", "min": 0.5, "max": 1.5}],
+        "not_a_real_objective",
+        solve_fn=_linear_reactance(1.05),
+    )
+    assert res["objective"] == "swr"
+
+
+@pytest.mark.antenna_computation_check
+def test_optimize_real_geometry_improves_resonance():
+    """End-to-end through a real momwire solve (slow): tuning a length knob
+    should not worsen, and usually improves, the reactance."""
+    from antennaknobs.web.examples import REGISTRY
+
+    name = "broadband.g5rv"
+    ex = REGISTRY[name]
+    freq = ex.default_freq_mhz or 14.0
+    base = {"geometry": name, "measurement_freq_mhz": freq, "design_freq_mhz": freq}
+    res = optimize(
+        base,
+        [{"name": "length_factor", "min": 0.85, "max": 1.15}],
+        "resonance",
+        solve_fn=ex.momwire_solve,
+        max_evals=20,
+    )
+    assert res["objective_after"] <= res["objective_before"]
+    assert 0.85 <= res["params"]["length_factor"] <= 1.15


### PR DESCRIPTION
## Summary
- **`/optimize` backend** (`antennaknobs.web.optimize`): vary a chosen subset of knobs within user-set bounds to minimise an electrical objective — **SWR** (match), **resonance** (|X|), or **match Z₀**. Bounded Nelder–Mead from the params' current values (derivative-free — each eval is a full MoM solve), eval-capped (~40/knob, max 200). Framework-free (objective evaluated via an injected `solve_fn`), so it's unit-testable; the endpoint wires it to the geometry's cheap impedance-only `momwire_solve` (no far-field) in a threadpool.
- **Reactive in-context UI** (no dedicated panel): **right-click any knob** for its optimiser menu — vary checkbox, optimization range, display range, and turn step (settings persist per geometry; the knob reads its effective min/max/step from them, and a free knob gets an accent ring + ⟳). A compact **enable + objective** control sits with the meas-freq band/lock.
- **Always-on:** when enabled with ≥1 free knob, pausing on any *fixed* input re-tunes the free knobs — debounced 400 ms, **warm-started** from current values, newer runs **abort** older ones. Enabling tunes immediately; a blinking pip + SWR readout show progress/result. The trigger keys on a signature of the *fixed* inputs only, so the optimiser writing the free knobs can't loop.

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] `pytest tests/test_optimize.py` — 7 stub-driven unit tests (minimum-finding, bound clamping, objective selection, multi-param, empty-free guard); the real-geometry test is marked `antenna_computation_check` (off the PR lane)
- [x] `/optimize` end-to-end via TestClient: resonance drove |Im Z| ≈ −58 → 0, SWR ≈ 2.8 → 1.2
- [x] frontend `tsc --noEmit` + `vite build` clean; verified live (right-click → set extents → enable → reactive re-tune produced a real SWR readout)
- [ ] CI green (ruff + build)

## Notes
- Local search only (refines the current operating point); multi-freq/gain objectives and a global pass are deferred. Dragging a *free* knob doesn't auto-trigger — it just warm-starts the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
