### PR TITLE
fix(web): use wss:// for the live-solve WebSocket on HTTPS

### DIFF
--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1414,7 +1414,10 @@ type PatternData = {
   measurement_freq_mhz: number;
 };
 
-const WS_URL = `ws://${window.location.host}/ws`;
+// Match the page's scheme: a wss:// upgrade is required on HTTPS pages (e.g. the
+// deployed site behind Fly's force_https), where browsers block insecure ws://
+// as mixed content. Plain ws:// only works on http:// (local dev).
+const WS_URL = `${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.host}/ws`;
 
 type View = "antenna" | "azimuth" | "elevation" | "smith";
 const VIEWS: { id: View; label: string }[] = [


### PR DESCRIPTION
## Summary
- The frontend hardcoded the live-solve WebSocket as `ws://${window.location.host}/ws`. On an HTTPS page — i.e. the deployed site behind Fly's `force_https` — browsers block insecure `ws://` as mixed content. The blocked WebSocket throws right after mount, so the app paints the correct content once and then **blanks to the empty gray canvas**. Local dev was unaffected because it runs over `http://localhost`.
- Fix: derive the scheme from `window.location.protocol`, upgrading to `wss://` on HTTPS pages.

This is why the deployed tuner "flashes the right content then goes blank" — on any HTTPS browser, not just mobile.

## Test plan
- [ ] Deployed HTTPS site (`https://…fly.dev/`) loads the tuner and a knob drag re-solves (WebSocket connects over `wss://`)
- [ ] Local `http://localhost:8000` still works (`ws://`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)