### PR TITLE
fix(web): pannable output stage on mobile

### DIFF
--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1623,3 +1623,37 @@ canvas {
   width: 5em;
   font-size: var(--text-xs);
 }
+
+/* ---- Mobile (phones / small tablets) ----------------------------------------
+   The desktop layout is a fixed two-pane grid (320px control rail + a 1fr
+   output stage) with overflow hidden everywhere. On a narrow phone the 320px
+   rail eats the width, the 1fr stage collapses to a sliver, and the output
+   carousel is clipped with no way to reach it. Below this breakpoint we instead
+   lay the two panes out as near-full-width columns and let `.app` pan
+   horizontally: the controls fill the screen, and you swipe right to a
+   full-size output rectangle. Scroll-snap rests the pan on either pane.
+   Breakpoint ~700px: the two-pane needs ≈320px rail + ≈360px usable output to
+   be comfortable, so only below that do we switch to the pannable layout
+   (landscape phones and tablets keep the normal two-pane). */
+@media (max-width: 700px) {
+  .app {
+    /* Controls nearly fill the viewport (capped so a sliver of the stage peeks
+       as a "swipe right" affordance); the stage is a full viewport-wide
+       rectangle. Their sum exceeds 100vw, so .app scrolls horizontally. */
+    grid-template-columns: min(340px, 86vw) 100vw;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scroll-snap-type: x proximity;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .sidebar {
+    scroll-snap-align: start;
+  }
+
+  .stage {
+    /* A real rectangle to pan to, the full width of the screen. */
+    min-width: 100vw;
+    scroll-snap-align: start;
+  }
+}


### PR DESCRIPTION
## Summary
- The frontend layout is a fixed two-pane grid — `.app { grid-template-columns: 320px 1fr; overflow: hidden }` — with **no mobile breakpoint** (only `prefers-reduced-motion` media queries exist). On a phone the 320px control rail eats the width, the `1fr` output `.stage` collapses to a sliver, and the output carousel is clipped with no way to pan to it.
- Adds a `max-width: 700px` media query that lays the two panes out as near-full-width columns and lets `.app` scroll horizontally: the controls fill the screen, and you **swipe right to a full viewport-wide output rectangle**. Scroll-snap rests the pan on either pane; a sliver of the stage peeks at rest as a "swipe right" affordance.

CSS-only; desktop and landscape/tablet (>700px) layout is unchanged.

## Test plan
- [ ] On a phone (≤700px), the controls render full-width and you can swipe/pan right to see the full output carousel
- [ ] Scroll-snap rests cleanly on controls or output
- [ ] Desktop (>700px) two-pane layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)