### PR TITLE
site: deploy docs site as a cheap static Fly app

### DIFF
--- a/site/.dockerignore
+++ b/site/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.astro
+.DS_Store
+npm-debug.log*
+fly.toml

--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -1,0 +1,17 @@
+# Build the static Astro/Starlight docs site, then serve it with nginx.
+# A separate, cheap Fly app from the live tuner: static files, scale-to-zero.
+# Deploy from this directory: `cd site && fly deploy` (see fly.toml).
+
+# ---- build ----
+FROM node:22-bookworm-slim AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build      # type-checks then emits the static site to /app/dist
+
+# ---- serve ----
+FROM nginx:1.27-alpine AS serve
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80

--- a/site/fly.toml
+++ b/site/fly.toml
@@ -1,0 +1,33 @@
+# Fly.io config for the antennaknobs docs site (static Astro/Starlight build,
+# served by nginx). A separate, cheap app from the live tuner.
+#
+# Deploy from THIS directory so the build context is site/:
+#   cd site
+#   fly apps create antennaknobs-docs   # first time only
+#   fly deploy
+
+app = 'antennaknobs-docs'
+primary_region = 'sjc'
+
+[build]
+  dockerfile = 'Dockerfile'
+
+[http_service]
+  internal_port = 80
+  force_https = true
+  # Static files cold-start near-instantly, so scale to zero when idle — this
+  # keeps the docs app close to free, unlike the always-warm tuner.
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [[http_service.checks]]
+    method = 'GET'
+    path = '/'
+    interval = '30s'
+    timeout = '5s'
+    grace_period = '5s'
+
+[[vm]]
+  size = 'shared-cpu-1x'
+  memory = '256mb'

--- a/site/nginx.conf
+++ b/site/nginx.conf
@@ -1,0 +1,23 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Astro emits directory-style pages (/path/index.html). Resolve clean URLs
+    # (with or without a trailing slash), then fall through to the static 404.
+    location / {
+        try_files $uri $uri/ $uri.html =404;
+    }
+
+    error_page 404 /404.html;
+
+    # Fingerprinted build assets never change — cache them hard.
+    location /_astro/ {
+        try_files $uri =404;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}


### PR DESCRIPTION
## Summary
Adds a static-serve stack so the Astro/Starlight docs site can run as a **separate, cheap Fly app** (`antennaknobs-docs`), distinct from the always-warm live tuner:
- **`site/Dockerfile`** — multi-stage: node builds the static site → `nginx:alpine` serves `dist/`.
- **`site/nginx.conf`** — resolves Astro's directory-style clean URLs (with/without trailing slash), a static `404.html`, and long-cache headers for fingerprinted `/_astro/` assets.
- **`site/fly.toml`** — `internal_port = 80`, **scale-to-zero** (`auto_stop_machines = 'stop'`, `min_machines_running = 0`) since static cold-start is instant, on a `256mb` `shared-cpu-1x` → near-free.
- **`site/.dockerignore`**.

## Deploy
From the `site/` directory (so the build context is `site/`):
```bash
cd site
fly apps create antennaknobs-docs   # first time
fly deploy
```

## Notes
- `dist/` structure verified locally (root `index.html`, `404.html`, directory pages, `_astro/` assets) — the nginx config matches it. The image `docker build` runs on Fly's remote builders.
- Separate from the tuner app; doesn't touch the tuner's deploy.

## Test plan
- [ ] `cd site && fly deploy` builds and the app serves the home + docs over HTTPS
- [ ] Clean URLs (e.g. `/concepts/authoring/`) and the 404 page resolve
- [ ] Machine stops when idle and restarts on request

🤖 Generated with [Claude Code](https://claude.com/claude-code)