### PR TITLE
site: point docs at antennaknobs.fly.dev (drop temp host)

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -5,7 +5,7 @@ import starlight from "@astrojs/starlight";
 // The live tuner (the FastAPI workbench) currently runs on its temporary
 // Fly hostname. Swap this for https://app.antennaknobs.dev (or the apex) once
 // DNS is wired up — it's referenced from the home hero and the Web docs.
-const TUNER_URL = "https://antennaknobs-4b980q.fly.dev/";
+const TUNER_URL = "https://antennaknobs.fly.dev/";
 
 // https://astro.build/config
 export default defineConfig({

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -6,7 +6,7 @@ hero:
   tagline: Turn a knob, watch the antenna. A browser-based wire-antenna MoM simulator — no install, no NEC deck to hand-write.
   actions:
     - text: Open the live tuner
-      link: https://antennaknobs-4b980q.fly.dev/
+      link: https://antennaknobs.fly.dev/
       icon: external
       variant: primary
     - text: Quickstart

--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -6,7 +6,7 @@ description: The built-in antenna designs, by family — each one a readable Ant
 Every built-in design is an [`AntennaBuilder`](/concepts/model/) whose source is
 meant to be read and copied. Address them as `family.name` (the same names
 `python -m antennaknobs list` prints), and open any in the [live
-tuner](https://antennaknobs-4b980q.fly.dev/) to drag its knobs. Many are modelled
+tuner](https://antennaknobs.fly.dev/) to drag its knobs. Many are modelled
 after L. B. Cebik (W4RNL)'s articles.
 
 ## Dipoles

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -20,7 +20,7 @@ handshake.
 ## The hosted instance
 
 A hosted tuner is running at
-**[antennaknobs-4b980q.fly.dev](https://antennaknobs-4b980q.fly.dev/)** (a single
+**[antennaknobs.fly.dev](https://antennaknobs.fly.dev/)** (a single
 FastAPI process serving the API, the `/ws` live-solve channel, and the built
 React SPA). It's deployed as a container on Fly.io; the repo's `docs/deploy.md`
 is the runbook.

--- a/site/src/content/docs/start/welcome.md
+++ b/site/src/content/docs/start/welcome.md
@@ -32,6 +32,6 @@ re-solve and redraw in real time.
 
 The live tuner is running here — open it, pick a design, and drag a knob:
 
-👉 **[antennaknobs-4b980q.fly.dev](https://antennaknobs-4b980q.fly.dev/)**
+👉 **[antennaknobs.fly.dev](https://antennaknobs.fly.dev/)**
 
 Then come back for the [Quickstart](/start/quickstart/) to drive it from Python.


### PR DESCRIPTION
## Summary
The docs linked the live tuner via the auto-generated `antennaknobs-4b980q.fly.dev` host. Switch all references to the clean `antennaknobs.fly.dev` app: the `TUNER_URL` const in `astro.config.mjs`, the home hero, and the welcome / web / catalog pages.

Builds clean (11 pages).

## Test plan
- [ ] All "open the tuner" links/CTAs point at `https://antennaknobs.fly.dev/`
- [ ] No `4b980q` references remain in `site/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)