### PR TITLE
ci: push-to-deploy the docs site via GitHub Actions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,45 @@
+name: Deploy docs site to Fly.io
+
+# Push-to-deploy for the static docs site (the antennaknobs-docs Fly app). Fires
+# on pushes to main that touch site/, building + releasing on Fly's remote
+# builders. Separate from the live-tuner deploy (fly-deploy.yml) and gated on its
+# own app-scoped secret (FLY_API_TOKEN_DOCS) so the two never cross-trigger.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - ".github/workflows/deploy-docs.yml"
+  workflow_dispatch: {}
+
+concurrency:
+  group: fly-deploy-docs
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Stay green (not red) if the secret is missing: skip with a notice.
+      - name: Check for Fly token
+        id: token
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DOCS }}
+        run: |
+          if [ -z "$FLY_API_TOKEN" ]; then
+            echo "::notice::FLY_API_TOKEN_DOCS not set — skipping docs deploy."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up flyctl
+        if: steps.token.outputs.skip != 'true'
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy docs
+        if: steps.token.outputs.skip != 'true'
+        working-directory: site
+        run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DOCS }}


### PR DESCRIPTION
## Summary
Wires up push-to-deploy for the static docs site (`antennaknobs-docs` Fly app) via GitHub Actions:
- `deploy-docs.yml` runs `flyctl deploy --remote-only` from `site/` on pushes to `main` that touch `site/**` (or the workflow itself), building on Fly's remote builders.
- Authenticated with an **app-scoped** deploy token stored as `FLY_API_TOKEN_DOCS` — deliberately separate from the tuner's `FLY_API_TOKEN`, so this never cross-triggers the (dashboard-managed) tuner deploy.
- Skip-green guard if the secret is ever missing.

The `FLY_API_TOKEN_DOCS` secret is already set on the repo. Merging this PR touches the workflow path, so the first deploy fires on merge — proving the pipeline.

## Test plan
- [ ] Merge triggers the "Deploy docs site to Fly.io" workflow and it deploys `antennaknobs-docs`
- [ ] A later `site/`-only change auto-deploys; non-`site/` changes don't
- [ ] The tuner deploy is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)