### PR TITLE
Design audit of the web SPA + fixes (a11y, token drift, optimiser ring)

### DIFF
--- a/docs/design-audit.md
+++ b/docs/design-audit.md
@@ -1,0 +1,105 @@
+# SPA design audit — AntennaKNoBs web workbench
+
+Audit of the React/Vite single-page tuner (`src/antennaknobs/web/frontend/`):
+`App.tsx` (~5.5k lines) + `styles.css` (~1.7k lines). Scope is **visual design,
+UX, and accessibility** of the rendered chrome — not the canvas plot maths.
+
+Date: 2026-06-28. Reviewer: design pass on `spa-design-audit`.
+
+## Verdict
+
+The SPA is **already well-built**, not a rough draft. It has a real,
+token-driven design system (a single `:root` set drives both the DOM chrome and
+the `<canvas>` plots), light/dark theming, a deliberate spacing/radius/type
+scale, and genuine accessibility foundations (the rotary knob is a correct ARIA
+`slider`; `prefers-reduced-motion` is honoured; focus-visible rings are
+consistent; one contrast token was already bumped to 4.5:1). The findings below
+are **refinements, not rescues** — most are small, and they cluster in the two
+most recently-added surfaces (the reactive optimiser's knob-menu and
+opt-control), which drifted from the system the rest of the app follows.
+
+## Strengths (keep these)
+
+- **One source of truth for theme.** `:root` tokens drive chrome + canvas; dark
+  theme overrides *only* token values, so the whole app + plots retheme from one
+  block. This is the right architecture and it's followed almost everywhere.
+- **Scales are real and snapped.** `--space-1..7`, `--r-sm/md/lg`,
+  `--text-lg/base/sm/xs` — ad-hoc px values were deliberately rounded into these.
+- **Loading states are tasteful.** The solve bar is dwell-gated (≈300 ms) so
+  quick solves never flash it, and stale panels dim with an eased transition.
+- **The knob is accessible.** `role="slider"` with `aria-valuemin/max/now/text`,
+  keyboard handling, and `aria-disabled`. Comboboxes use `role="combobox"` /
+  `listbox` / `option` with `aria-expanded` and accessible names.
+- **Motion is restrained and reversible**, with a global reduced-motion escape.
+
+## Findings (prioritised)
+
+### P1 — Accessibility
+
+1. **Unlabeled `<select>`s.** Several selects have no accessible name (no
+   wrapping `<label>`, no `aria-label`): the two band selects
+   (`styles.css`-classed `band-select`, `App.tsx:3096` and `:3210`) and the
+   optimiser objective select (`opt-objective`, `App.tsx:3243`). A screen reader
+   announces them as an unnamed combobox. The antenna picker and variant select
+   *do* set `aria-label`, so this is an easy, mechanical fix — add
+   `aria-label="band"` / `aria-label="optimise for"`.
+2. **Flat heading outline.** There is exactly one `<h1>` and **zero `<h2>`**.
+   Section headers ("measurement freq", "simulation") render as
+   `<div class="group-label">`, so assistive-tech heading navigation and the
+   document outline see a single node. Promote group labels to `<h2>`/`<h3>`
+   (style stays identical via the existing class) so the rail is navigable by
+   heading.
+3. **`title=` carries non-decorative information.** 28 `title` attributes hold
+   real semantics — ground-model parameters (εr/σ), solver trade-offs, the
+   "fast ground" caveat. `title` is invisible to keyboard and touch users and is
+   announced inconsistently by screen readers. For the load-bearing ones (the
+   ground/solver explanations), move the text into visible helper copy or an
+   accessible popover; keep `title` only for redundant "Switch to X" hints.
+
+### P2 — Design-system drift (consistency)
+
+4. **Undefined radius token.** `.knob-menu` uses `border-radius:
+   var(--radius-2, 6px)` (`styles.css:1591`) — `--radius-2` is **never defined**
+   (the scale is `--r-sm/md/lg`), so it silently falls back to a hardcoded 6px.
+   Should be `var(--r-sm)`.
+5. **Off-scale elevation/shadows.** Three overlays hardcode black shadows
+   instead of the theme-aware `var(--shadow)`: gear-menu
+   (`rgb(0 0 0 / 0.28)`, `:340`), stage-readout (`rgba(0,0,0,0.28)`, `:1365`),
+   knob-menu (`rgba(0,0,0,0.3)`, `:1592`). These won't track the light/dark
+   `--shadow` value (light theme uses a blue-tinted `rgba(30,55,95,0.16)`).
+   Consider a small elevation scale (`--shadow-1/2/3`) and route all overlays
+   through it.
+6. **Two inline `fontSize: 12` literals** (`App.tsx:3336`, `:3829`) bypass
+   `--text-sm`. Minor, but they're the only type-scale escapes in the JSX.
+
+### P2 — Optimiser UI integration
+
+7. **Free-variable ring competes with the focus ring.** A knob marked as an
+   optimiser variable gets `box-shadow: 0 0 0 2px var(--accent)`
+   (`styles.css:1540`); the keyboard focus ring is `0 0 0 3px var(--accent-soft)`.
+   When a free-variable knob is focused, the two rings stack and read as a muddy
+   double outline. Differentiate the "is a variable" state from focus — e.g. a
+   ring on the *cap* + the existing `⟳` glyph for the variable state, reserving
+   the box-shadow purely for focus.
+
+### P3 — Touch / responsive
+
+8. **Sub-44px tap targets.** The header icon buttons (theme toggle, tools gear)
+   are 28×28px and the band selects are compact; below ~44px they're fiddly on
+   the phone layout the app explicitly supports (the `max-width:700px` pannable
+   mode). Bump the icon buttons toward 36–40px on coarse pointers
+   (`@media (pointer: coarse)`).
+9. **Colour-only signal in the heatmap and some readouts.** The current-density
+   ramp encodes magnitude by colour alone; the `val-hot` readout partly mitigates
+   with `font-weight:600` but still leans on hue. Fine for the data viz, worth a
+   note for the readouts — keep the weight/affix cue so SWR state isn't hue-only.
+
+## Suggested order of work
+
+1. The P1 a11y fixes (1–3) — small, high-leverage, and a few are one-line
+   `aria-label`s.
+2. The token-drift trio (4–6) — pure search-and-replace, zero behaviour change.
+3. The optimiser ring (7) and touch targets (8) — small visual tweaks.
+
+None of these are architectural. The system is sound; this is polish on a
+mature surface.

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -3095,6 +3095,7 @@ export function App() {
               <div className="band-row">
                 <select
                   className="band-select"
+                  aria-label="band"
                   value={active.key}
                   onChange={(e) => selectBand(e.target.value)}
                 >
@@ -3203,12 +3204,13 @@ export function App() {
             frequency-counter readout. Band select + lock sit to the LEFT of the
             readout/dial to keep the field compact. "lock to design freq"
             disables the dial. */}
-        <div className="group-label">measurement freq</div>
+        <h2 className="group-label">measurement freq</h2>
         <div className={`field vfo-field${linkMeas ? " is-locked" : ""}`}>
           <div className="vfo-aux">
             {currentBands.length > 0 && (
               <select
                 className="band-select"
+                aria-label="measurement band"
                 value={bandContaining(measFreq) ?? currentBands[0].key}
                 disabled={linkMeas}
                 onChange={(e) => selectMeasBand(e.target.value)}
@@ -3242,6 +3244,7 @@ export function App() {
               {optEnabled && (
                 <select
                   className="opt-objective"
+                  aria-label="optimise for"
                   value={optObjective}
                   onChange={(e) => setOptObjective(e.target.value as OptObjective)}
                 >
@@ -3295,7 +3298,7 @@ export function App() {
           </div>
         </div>
 
-        <div className="group-label">simulation</div>
+        <h2 className="group-label">simulation</h2>
 
         <div className="field">
           <label>
@@ -3310,6 +3313,7 @@ export function App() {
                   <button
                     role="tab"
                     aria-selected={activeSlot === s}
+                    aria-label={`Solver slot ${s}: ${BACKEND_LABEL[cfg.backend]}, N=${cfg.opts.nPerWire}`}
                     className={`backend-tab-btn ${activeSlot === s ? "active" : ""}`}
                     title={`${BACKEND_LABEL[cfg.backend]}, N=${cfg.opts.nPerWire}`}
                     onClick={() => setActiveSlot(s)}
@@ -3333,7 +3337,7 @@ export function App() {
 
         {!backendSupportsGround(backend) && groundEnabled && (
           <div className="field" title="This backend doesn't model ground; ignored until you switch to one that does.">
-            <em style={{ color: "var(--muted)", fontSize: 12 }}>
+            <em style={{ color: "var(--muted)", fontSize: "var(--text-sm)" }}>
               ground plane ignored for {BACKEND_LABEL[backend]}
             </em>
           </div>
@@ -3390,7 +3394,7 @@ export function App() {
         )}
       </aside>
 
-      <main className="stage">
+      <main className="stage" aria-label="Antenna output views">
         {/* Indeterminate progress bar: appears once a solve outlasts the dwell
             and lingers out its min-visible window (showBusy), so it never
             flashes — the dim/label (stale) clear earlier, when the result lands. */}
@@ -3826,7 +3830,7 @@ function BackendConfigModal({
           )}
 
           {backend === "pynec" && (
-            <em style={{ color: "var(--muted)", fontSize: 12 }}>
+            <em style={{ color: "var(--muted)", fontSize: "var(--text-sm)" }}>
               PyNEC has no extra solver knobs here — ground type / fast ground
               live in the main panel.
             </em>

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -45,6 +45,7 @@
   --track: #c6d2e0;
   --grid: rgba(47, 95, 176, 0.07);
   --shadow: rgba(30, 55, 95, 0.16);
+  --shadow-strong: rgba(30, 55, 95, 0.30); /* popovers/menus — proud of raised cards */
 
   /* radius scale — one small token set instead of ad-hoc 5..10px */
   --r-sm: 6px;  /* inputs, selects, tabs, buttons */
@@ -135,6 +136,7 @@
   --track: #2a313d;
   --grid: rgba(120, 170, 230, 0.06);
   --shadow: rgba(0, 0, 0, 0.5);
+  --shadow-strong: rgba(0, 0, 0, 0.6); /* popovers/menus — proud of raised cards */
 
   /* canvas plot tokens — carried verbatim from the original dark theme */
   --plot-bg: #0d1015;
@@ -337,7 +339,7 @@ button:focus-visible,
   background: var(--bg);
   border: 1px solid var(--border-control);
   border-radius: var(--r-md);
-  box-shadow: 0 6px 20px rgb(0 0 0 / 0.28);
+  box-shadow: 0 6px 20px var(--shadow-strong);
 }
 
 .gear-menu-item {
@@ -727,20 +729,19 @@ button:focus-visible,
   font-family: var(--font-mono);
 }
 
+/* Section headers in the rail. Rendered as <h2> for a navigable heading outline;
+   the class restores the label look (mono/uppercase/normal weight) over the
+   browser's bold-heading default. */
 .group-label {
   font-family: var(--font-mono);
   font-size: var(--text-xs);
+  font-weight: 400;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--muted);
   margin: var(--space-2) 0 -4px;
   padding-top: var(--space-5);
   border-top: 1px solid var(--border);
-}
-
-.group-label:first-of-type {
-  border-top: none;
-  padding-top: 0;
 }
 
 .field {
@@ -1362,7 +1363,7 @@ input[type=checkbox] {
   min-width: 172px;
   max-width: 240px;
   line-height: 1.6;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.28);
+  box-shadow: 0 4px 16px var(--shadow-strong);
   pointer-events: none; /* a passive HUD — never intercept drags on the view */
 }
 
@@ -1536,10 +1537,13 @@ canvas {
 }
 
 /* --- Reactive knob optimiser --- */
-/* A knob marked as a free optimisation variable. */
-.field-knob.is-opt-var .knob-cap,
-.field-knob.is-opt-var .mockdial {
-  box-shadow: 0 0 0 2px var(--accent);
+/* A knob marked as a free optimisation variable. The cap is an SVG <circle>, so
+   it takes an SVG stroke (box-shadow does not apply to SVG shapes) — this also
+   keeps the variable marker off the wrapper's box-shadow focus ring, so the two
+   states no longer stack into a muddy double outline. */
+.field-knob.is-opt-var .knob-cap {
+  stroke: var(--accent);
+  stroke-width: 2;
 }
 .field-knob.is-opt-var .knob-label::after {
   content: " ⟳";
@@ -1588,8 +1592,8 @@ canvas {
   min-width: 200px;
   background: var(--panel);
   border: 1px solid var(--border);
-  border-radius: var(--radius-2, 6px);
-  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.3);
+  border-radius: var(--r-sm);
+  box-shadow: 0 6px 24px var(--shadow-strong);
   padding: var(--space-3);
   display: flex;
   flex-direction: column;
@@ -1661,6 +1665,22 @@ canvas {
        across it. */
     min-width: var(--mobile-stage-w);
     scroll-snap-align: start;
+  }
+}
+
+/* Coarse pointers (touch): grow the small icon buttons and compact selects
+   toward a ~40px hit target — the 28px header icons and the xs-padded selects
+   are fiddly to tap on the phone layout above. Pointer-media (not width) so a
+   touch laptop benefits and a narrow mouse window doesn't bloat. */
+@media (pointer: coarse) {
+  .theme-toggle,
+  .header-icon-btn {
+    width: 40px;
+    height: 40px;
+  }
+  .band-select,
+  .opt-objective {
+    min-height: 40px;
   }
 }
 


### PR DESCRIPTION
## Summary
A design pass over the React/Vite tuner SPA, with the findings written up and then fixed.

- **`docs/design-audit.md`** — a token-driven design review. Verdict: the SPA is already a mature, token-driven design system; findings are refinements that cluster in the recently-added optimiser surfaces, not rescues.
- **Accessibility:** named the three unlabeled `<select>`s (design band, measurement band, optimise-for); promoted the rail section headers to `<h2>` for a navigable heading outline (class restores the label look over the bold-heading default; dropped a `:first-of-type` border rule that never matched the old `<div>`s); named the `<main>` output stage as a landmark; gave the solver-slot tab a real accessible name carrying the `N=` count that was previously `title`-only.
- **Design-system drift:** added a theme-aware `--shadow-strong` and routed the gear-menu / stage-readout / knob-menu shadows through it instead of hardcoded black `rgba()`; fixed the knob-menu's undefined `var(--radius-2)` → `var(--r-sm)`; replaced two inline `fontSize: 12` literals with `var(--text-sm)`.
- **Optimiser UI:** the `is-opt-var` free-variable marker used `box-shadow` on an SVG `<circle>` (a no-op — SVG shapes ignore `box-shadow`), so the ring never actually rendered and `.mockdial` was a dead selector. Switched to an SVG `stroke` on the cap: it renders, is circular, and stays off the wrapper's box-shadow focus ring so the two states no longer collide.
- **Touch:** grew the 28px header icon buttons and compact selects to a ~40px hit target under `@media (pointer: coarse)`.

## Deliberately out of scope
- Explanatory `title` tooltips (ground εr/σ, fast-ground trade-off) were kept as supplementary — their load-bearing facts are already in adjacent visible text; moving them to visible copy/popovers is a content decision left to the maintainer.
- Colour-only signal: `val-hot` already pairs hue with `font-weight: 600`, and the current-density ramp is legitimate data-viz — unchanged.

## Test plan
- [x] `tsc --noEmit && vite build` — clean
- [x] `ruff check` / `ruff format --check` — clean (changes are TS/CSS only)
- [ ] Spot-check light/dark + a screen reader: selects announce names, rail headings navigable, optimiser-variable knob shows a circular accent ring distinct from the focus ring

🤖 Generated with [Claude Code](https://claude.com/claude-code)