### PR TITLE
Call the project a simulator, not a tuner

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,7 +2,7 @@ name: Deploy docs site to Fly.io
 
 # Push-to-deploy for the static docs site (the antennaknobs-docs Fly app). Fires
 # on pushes to main that touch site/, building + releasing on Fly's remote
-# builders. Separate from the live-tuner deploy (fly-deploy.yml) and gated on its
+# builders. Separate from the live-simulator deploy (fly-deploy.yml) and gated on its
 # own app-scoped secret (FLY_API_TOKEN_DOCS) so the two never cross-trigger.
 on:
   push:

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,8 +1,8 @@
-name: Deploy tuner to Fly.io
+name: Deploy simulator to Fly.io
 
-# Push-to-deploy for the live tuner (the antennaknobs Fly app). On a push to main
+# Push-to-deploy for the live simulator (the antennaknobs Fly app). On a push to main
 # that touches the app or its deploy config, build on Fly's remote builders and
-# release. Gated on an app-scoped secret (FLY_API_TOKEN_TUNER), separate from the
+# release. Gated on an app-scoped secret (FLY_API_TOKEN_SIMULATOR), separate from the
 # docs site's deploy (deploy-docs.yml / FLY_API_TOKEN_DOCS) so the two never
 # cross-trigger. NOTE: if a Fly dashboard GitHub integration is also connected to
 # this app, disconnect it — otherwise both it and this workflow deploy on push.
@@ -20,7 +20,7 @@ on:
 
 # Never run two deploys at once; cancel an in-flight one if a newer push lands.
 concurrency:
-  group: fly-deploy-tuner
+  group: fly-deploy-simulator
   cancel-in-progress: true
 
 jobs:
@@ -33,10 +33,10 @@ jobs:
       - name: Check for Fly token
         id: token
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_TUNER }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_SIMULATOR }}
         run: |
           if [ -z "$FLY_API_TOKEN" ]; then
-            echo "::notice::FLY_API_TOKEN_TUNER not set — skipping tuner deploy."
+            echo "::notice::FLY_API_TOKEN_SIMULATOR not set — skipping simulator deploy."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -48,4 +48,4 @@ jobs:
         if: steps.token.outputs.skip != 'true'
         run: flyctl deploy --remote-only
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_TUNER }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_SIMULATOR }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Multi-stage build for the antennaknobs web workbench (the live tuner).
+# Multi-stage build for the antennaknobs web workbench (the live simulator).
 #
 # Stage 1 builds the React/Vite SPA to src/antennaknobs/web/static.
 # Stage 2 is a slim Python runtime that installs the package + its C++ engine

--- a/docs/cloudflare-dns.md
+++ b/docs/cloudflare-dns.md
@@ -7,7 +7,7 @@ There are two Fly apps:
 
 | App | What | Public hostname |
 | --- | --- | --- |
-| `antennaknobs` | the live tuner (FastAPI) | `antennaknobs.fly.dev` |
+| `antennaknobs` | the live simulator (FastAPI) | `antennaknobs.fly.dev` |
 | `antennaknobs-docs` | the docs site (static, nginx) | `antennaknobs-docs.fly.dev` |
 
 ## 0. Prerequisites
@@ -24,7 +24,7 @@ Fly IPs rarely change, but always confirm before editing DNS:
 
 ```bash
 flyctl ips list -a antennaknobs-docs   # docs site
-flyctl ips list -a antennaknobs        # tuner
+flyctl ips list -a antennaknobs        # simulator
 ```
 
 As of last setup:
@@ -42,7 +42,7 @@ Tell Fly which hostnames it should serve, so it provisions a TLS cert:
 flyctl certs add antennaknobs.dev -a antennaknobs-docs
 # optional extras:
 flyctl certs add www.antennaknobs.dev -a antennaknobs-docs
-flyctl certs add app.antennaknobs.dev -a antennaknobs       # tuner on a subdomain
+flyctl certs add app.antennaknobs.dev -a antennaknobs       # simulator on a subdomain
 ```
 
 `flyctl certs show <hostname> -a <app>` prints the exact records Fly recommends.
@@ -123,8 +123,8 @@ should return `200`.
 
 ## 5. After DNS is live
 
-- Update the docs' tuner link if you move the tuner onto a custom domain: it's
-  the `TUNER_URL` constant in `site/astro.config.mjs` (plus the literal links in
+- Update the docs' simulator link if you move the simulator onto a custom domain: it's
+  the `SIMULATOR_URL` constant in `site/astro.config.mjs` (plus the literal links in
   the home/welcome/web/catalog pages). A push to `main` redeploys the docs via
   the `deploy-docs.yml` Action.
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,4 +1,4 @@
-# Deploy runbook — the live tuner on Fly.io
+# Deploy runbook — the live simulator on Fly.io
 
 This deploys the web workbench (`antennaknobs.web.server:app` — the API, the
 `/ws` live-solve WebSocket, and the built React SPA) as a single persistent
@@ -25,7 +25,7 @@ Confirm the container serves the app before touching Fly:
 ```bash
 docker build -t antennaknobs-web .
 docker run --rm -p 8000:8000 antennaknobs-web
-# open http://127.0.0.1:8000 — the tuner should load and knobs should solve
+# open http://127.0.0.1:8000 — the simulator should load and knobs should solve
 curl -fsS http://127.0.0.1:8000/healthz   # -> ok
 ```
 
@@ -58,7 +58,7 @@ fly open                            # opens https://<app>.fly.dev
 fly logs                            # tail if anything misbehaves
 ```
 
-At this point the live tuner is reachable at `https://<app>.fly.dev`. **Test it
+At this point the live simulator is reachable at `https://<app>.fly.dev`. **Test it
 remotely from your own machine and confirm dragging a knob feels responsive
 before adding the custom domains** — this is the moment to measure the real
 round-trip.

--- a/docs/design-audit.md
+++ b/docs/design-audit.md
@@ -1,6 +1,6 @@
 # SPA design audit — AntennaKNoBs web workbench
 
-Audit of the React/Vite single-page tuner (`src/antennaknobs/web/frontend/`):
+Audit of the React/Vite single-page app (`src/antennaknobs/web/frontend/`):
 `App.tsx` (~5.5k lines) + `styles.css` (~1.7k lines). Scope is **visual design,
 UX, and accessibility** of the rendered chrome — not the canvas plot maths.
 

--- a/docs/website-content-plan.md
+++ b/docs/website-content-plan.md
@@ -31,8 +31,8 @@ so there is one canonical URL per topic. `.com` links *into* `.dev` for depth.
 ## antennaknobs.com — the front door
 
 ```
-/                     Hero: live tuner embed + one-line pitch + two CTAs
-/gallery              Design catalog as cards → "open in the tuner"
+/                     Hero: live simulator embed + one-line pitch + two CTAs
+/gallery              Design catalog as cards → "open in the simulator"
 /why                  Why antennaknobs (vs 4nec2 / EZNEC / PyNEC) — honest table
 /learn                On-ramp: "design your first antenna in 5 minutes"
 /about                Project, license (open source), credits, links to .dev
@@ -40,7 +40,7 @@ so there is one canonical URL per topic. `.com` links *into* `.dev` for depth.
 
 ### `/` — Home
 
-- **Above the fold:** an embedded live tuner instance (or, if cold-start is too
+- **Above the fold:** an embedded live simulator instance (or, if cold-start is too
   heavy, a looping screen capture) showing a dipole/Yagi with a knob being
   dragged and the polar pattern + SWR responding. Caption: *"This is the whole
   tool. No install."*
@@ -55,7 +55,7 @@ so there is one canonical URL per topic. `.com` links *into* `.dev` for depth.
 ### `/gallery` — Design catalog
 
 - Card grid; each card = geometry thumbnail + name + one-line use ("40m full-wave
-  loop", "2-element 10m Yagi") + **Open in the tuner** button (deep-links the
+  loop", "2-element 10m Yagi") + **Open in the simulator** button (deep-links the
   hosted app with that design preloaded).
 - Filter by band / type (dipole, Yagi, loop, vertical, bowtie, multiband).
 - Each card's "details" links to the design's page on `.dev` (source + knobs).
@@ -87,7 +87,7 @@ so there is one canonical URL per topic. `.com` links *into* `.dev` for depth.
 Hosts **both** the live app and the canonical docs.
 
 ```
-/app                  The hosted interactive tuner (the real product)
+/app                  The hosted interactive simulator (the real product)
 /docs/                Documentation root
   /docs/quickstart      pip install → first design in Python in 10 lines
   /docs/concepts        The model: AntennaBuilder, params/knobs, build_wires
@@ -101,7 +101,7 @@ Hosts **both** the live app and the canonical docs.
 /changelog            Release notes
 ```
 
-### `/app` — The hosted tuner
+### `/app` — The hosted simulator
 
 The live FastAPI + React app. Deep-linkable per design (so `.com/gallery` cards
 and `/docs/catalog` can point at it). This *is* the product; docs orbit it.
@@ -165,7 +165,7 @@ release notes.
 
 ## Build order (suggested)
 
-1. **`.dev/app` live + deep-linkable** — without the live tuner nothing else
+1. **`.dev/app` live + deep-linkable** — without the live simulator nothing else
    lands. Everything points here.
 2. **`.com/` home** wrapping that app in the pitch + CTAs.
 3. **`/docs/authoring` (five-ways)** + **`/docs/catalog`** — the highest-leverage

--- a/scripts/tune_hexbeam_5band_coupled.py
+++ b/scripts/tune_hexbeam_5band_coupled.py
@@ -1,4 +1,4 @@
-"""Coupled multi-band hexbeam_5band tuner.
+"""Coupled multi-band hexbeam_5band tuning script.
 
 Unlike scripts/tune_hexbeam_5band_band.py — which slices `bands` down
 to a single entry and tunes in isolation — this script keeps all five

--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -1,5 +1,5 @@
 # Build the static Astro/Starlight docs site, then serve it with nginx.
-# A separate, cheap Fly app from the live tuner: static files, scale-to-zero.
+# A separate, cheap Fly app from the live simulator: static files, scale-to-zero.
 # Deploy from this directory: `cd site && fly deploy` (see fly.toml).
 
 # ---- build ----

--- a/site/README.md
+++ b/site/README.md
@@ -36,7 +36,7 @@ astro.config.mjs       # Starlight config + sidebar
 
 ## Notes
 
-- The live tuner URL is defined once as `TUNER_URL` in `astro.config.mjs` and
+- The live simulator URL is defined once as `SIMULATOR_URL` in `astro.config.mjs` and
   referenced in the home hero / docs. **Swap it for the real domain** (e.g.
   `https://app.antennaknobs.dev`) once DNS is wired up.
 - Pages contain `TODO` comments marking content that should be **generated from

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -2,10 +2,10 @@
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
 
-// The live tuner (the FastAPI workbench) currently runs on its temporary
+// The live simulator (the FastAPI workbench) currently runs on its temporary
 // Fly hostname. Swap this for https://app.antennaknobs.dev (or the apex) once
 // DNS is wired up — it's referenced from the home hero and the Web docs.
-const TUNER_URL = "https://antennaknobs.fly.dev/";
+const SIMULATOR_URL = "https://antennaknobs.fly.dev/";
 
 // https://astro.build/config
 export default defineConfig({
@@ -28,7 +28,7 @@ export default defineConfig({
           items: [
             { label: "What is antennaknobs?", slug: "start/welcome" },
             { label: "Quickstart", slug: "start/quickstart" },
-            { label: "Open the live tuner", link: TUNER_URL, attrs: { target: "_blank" } },
+            { label: "Open the live simulator", link: SIMULATOR_URL, attrs: { target: "_blank" } },
           ],
         },
         {

--- a/site/fly.toml
+++ b/site/fly.toml
@@ -1,5 +1,5 @@
 # Fly.io config for the antennaknobs docs site (static Astro/Starlight build,
-# served by nginx). A separate, cheap app from the live tuner.
+# served by nginx). A separate, cheap app from the live simulator.
 #
 # Deploy from THIS directory so the build context is site/:
 #   cd site
@@ -16,7 +16,7 @@ primary_region = 'sjc'
   internal_port = 80
   force_https = true
   # Static files cold-start near-instantly, so scale to zero when idle — this
-  # keeps the docs app close to free, unlike the always-warm tuner.
+  # keeps the docs app close to free, unlike the always-warm simulator.
   auto_stop_machines = 'stop'
   auto_start_machines = true
   min_machines_running = 0

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -5,7 +5,7 @@ template: splash
 hero:
   tagline: Turn a knob, watch the antenna. A browser-based wire-antenna MoM simulator — no install, no NEC deck to hand-write.
   actions:
-    - text: Open the live tuner
+    - text: Open the live simulator
       link: https://antennaknobs.fly.dev/
       icon: external
       variant: primary

--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -6,7 +6,7 @@ description: The built-in antenna designs, by family — each one a readable Ant
 Every built-in design is an [`AntennaBuilder`](/concepts/model/) whose source is
 meant to be read and copied. Address them as `family.name` (the same names
 `python -m antennaknobs list` prints), and open any in the [live
-tuner](https://antennaknobs.fly.dev/) to drag its knobs. Many are modelled
+simulator](https://antennaknobs.fly.dev/) to drag its knobs. Many are modelled
 after L. B. Cebik (W4RNL)'s articles.
 
 ## Dipoles

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -1,6 +1,6 @@
 ---
 title: Web workbench
-description: The browser-based tuner — running it, and how it's served.
+description: The browser-based simulator — running it, and how it's served.
 ---
 
 The web workbench is the live, no-install face of antennaknobs: a panel of knobs
@@ -19,7 +19,7 @@ handshake.
 
 ## The hosted instance
 
-A hosted tuner is running at
+A hosted simulator is running at
 **[antennaknobs.fly.dev](https://antennaknobs.fly.dev/)** (a single
 FastAPI process serving the API, the `/ws` live-solve channel, and the built
 React SPA). It's deployed as a container on Fly.io; the repo's `docs/deploy.md`

--- a/site/src/content/docs/start/welcome.md
+++ b/site/src/content/docs/start/welcome.md
@@ -30,7 +30,7 @@ re-solve and redraw in real time.
 
 ## Try it now
 
-The live tuner is running here — open it, pick a design, and drag a knob:
+The live simulator is running here — open it, pick a design, and drag a knob:
 
 👉 **[antennaknobs.fly.dev](https://antennaknobs.fly.dev/)**
 


### PR DESCRIPTION
## Summary
An *antenna tuner* is a matchbox (Ls/Cs that match the feedline to the antenna). This project **simulates** antennas, so calling the web app "the live tuner" was a domain misnomer that would mislead hams. This renames the product-as-tuner usages to **simulator** and leaves the (correct) real-hardware-tuner references alone.

- **Website copy** (user-facing): hero + CTA buttons ("Open the live simulator"), `welcome`, `web`/`catalog` reference ("browser-based / hosted simulator").
- **Deploy/infra**: the Fly + docs deploy workflows, root + `site/` Dockerfiles, `docs/deploy.md`, `docs/cloudflare-dns.md`, `docs/website-content-plan.md`, and the `docs/design-audit.md` heading.
- **Identifiers**: site-internal `TUNER_URL` → `SIMULATOR_URL`; the coupled-hexbeam script's self-description "tuner" → "tuning script".
- **Deploy secret**: `fly-deploy.yml` now reads `FLY_API_TOKEN_SIMULATOR`. GitHub secrets can't be renamed, so the secret was recreated under the new name and the stale `FLY_API_TOKEN_TUNER` deleted — both done before this merges, so the post-merge deploy authenticates.

## Deliberately unchanged (correct usage — real hardware tuners, not the app)
The design docstrings (`g5rv`, `zepp`, `lazy_h`, `sterba`, `t2fd`, `invvee`, `bisquare`), `cebik-design-candidates.md`, and the cebik tests — these accurately describe antennas fed through a tuner/matchbox. `README.md` and the `CLAUDE.md` directive files already say "simulator"/"workbench".

## Test plan
- [x] `node --check site/astro.config.mjs` — clean; `SIMULATOR_URL` def + sidebar link consistent
- [x] `ruff check` / `ruff format --check` — clean
- [x] `FLY_API_TOKEN_SIMULATOR` secret set; stale `FLY_API_TOKEN_TUNER` deleted
- [ ] After merge: confirm the Fly deploy run authenticates against the renamed secret (not skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)