### PR TITLE
Live/Paused simulation toggle + measurement-freq control redesign

### DIFF
--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1596,6 +1596,9 @@ export function App() {
   // "vary" + extents + step live in each knob's right-click menu (knobOpt).
   const [optEnabled, setOptEnabled] = useState(false);
   const [optObjective, setOptObjective] = useState<OptObjective>("resonance");
+  // The objective ("optimise for") picker lives in a small gear popover next to
+  // the Optimize button, mirroring the solver-slot gear.
+  const [optMenuOpen, setOptMenuOpen] = useState(false);
   const [knobOpt, setKnobOpt] = useState<Record<string, Record<string, KnobOpt>>>({});
   // Open knob context menu: which param + anchor position.
   const [knobMenu, setKnobMenu] = useState<{ name: string; x: number; y: number } | null>(
@@ -3225,12 +3228,13 @@ export function App() {
           })()}
 
         {/* Measurement freq = the rig's tuning control: a weighted VFO dial +
-            frequency-counter readout. Band select + lock sit to the LEFT of the
-            readout/dial to keep the field compact. "lock to design freq"
-            disables the dial. */}
+            frequency-counter readout. Top line: band select + the LCD. Below:
+            the Live/Optimize toggles stacked at the left of the dial, with the
+            lock pinned to the dial's lower-right corner ("lock to design freq"
+            disables the dial). */}
         <h2 className="group-label">measurement freq</h2>
         <div className={`field vfo-field${linkMeas ? " is-locked" : ""}`}>
-          <div className="vfo-aux">
+          <div className="vfo-top">
             {currentBands.length > 0 && (
               <select
                 className="band-select"
@@ -3246,16 +3250,6 @@ export function App() {
                 ))}
               </select>
             )}
-            <label className="link-toggle" title="lock to design freq">
-              <input
-                type="checkbox"
-                checked={linkMeas}
-                onChange={(e) => toggleLink(e.target.checked)}
-              />
-              lock
-            </label>
-          </div>
-          <div className="vfo-main">
             <div className="freq-lcd" title={`${measFreq.toFixed(3)} MHz`}>
               <span className="lcd-digits">
                 <span className="lcd-ghost">
@@ -3265,80 +3259,133 @@ export function App() {
               </span>
               <span className="lcd-unit">MHz</span>
             </div>
-            <Knob
-              variant="vfo"
-              value={measFreq}
-              min={
-                currentExample?.meas_freq_range_mhz
-                  ? currentExample.meas_freq_range_mhz[0]
-                  : Math.max(0.5, measBandAnchor * 0.8)
-              }
-              max={
-                currentExample?.meas_freq_range_mhz
-                  ? currentExample.meas_freq_range_mhz[1]
-                  : Math.min(60, measBandAnchor * 1.25)
-              }
-              step={0.005}
-              precision={3}
-              unit=" MHz"
-              label="measurement frequency"
-              onChange={setMeasFreq}
-              disabled={linkMeas}
-            />
           </div>
-        </div>
 
-        {/* Live / Optimize: two matching push-button toggles (depressed = on).
-            Live gates auto-solving on knob turns; Optimize gates the reactive
-            tuner. The objective select + last-SWR readout follow Optimize. */}
-        <div className="sim-controls">
-          <button
-            type="button"
-            className={`toggle-btn${autoSim ? " is-on" : ""}`}
-            aria-pressed={autoSim}
-            onClick={() => setAutoSim((v) => !v)}
-            title={
-              autoSim
-                ? "Live: knob changes re-solve automatically. Click to pause and edit without solving."
-                : "Paused: edit the design freely; the engine is held. Click to resume and solve."
-            }
-          >
-            <span className="toggle-led" aria-hidden="true" />
-            {autoSim ? "Live" : "Paused"}
-          </button>
-          <button
-            type="button"
-            className={`toggle-btn${optEnabled ? " is-on" : ""}`}
-            aria-pressed={optEnabled}
-            onClick={() => setOptEnabled((v) => !v)}
-            title="Reactive optimiser: vary the knobs you mark (right-click a knob) to hit the objective whenever a fixed knob changes."
-          >
-            <span className="toggle-led" aria-hidden="true" />
-            Optimize
-            {optRunning ? <span className="opt-pip">●</span> : null}
-          </button>
-          {optEnabled && (
-            <select
-              className="opt-objective"
-              aria-label="optimise for"
-              value={optObjective}
-              onChange={(e) => setOptObjective(e.target.value as OptObjective)}
-            >
-              {OPT_OBJECTIVES.map((k) => (
-                <option key={k} value={k}>
-                  {OPT_OBJECTIVE_LABELS[k]}
-                </option>
-              ))}
-            </select>
-          )}
-          {optEnabled && optResult && (
-            <span className="opt-readout" title="SWR after optimisation">
-              SWR {optResult.metrics_after.swr.toFixed(2)}
-            </span>
-          )}
-          {optEnabled && optError && (
-            <span className="opt-readout opt-readout-err">{optError}</span>
-          )}
+          <div className="vfo-body">
+            {/* Live / Optimize: two matching push-button toggles (depressed =
+                on), stacked at the left of the dial. Live gates auto-solving on
+                knob turns; Optimize gates the reactive tuner. The objective
+                ("optimise for") picker is the gear next to Optimize. */}
+            <div className="sim-controls">
+              <button
+                type="button"
+                className={`toggle-btn${autoSim ? " is-on" : ""}`}
+                aria-pressed={autoSim}
+                onClick={() => setAutoSim((v) => !v)}
+                title={
+                  autoSim
+                    ? "Live: knob changes re-solve automatically. Click to pause and edit without solving."
+                    : "Paused: edit the design freely; the engine is held. Click to resume and solve."
+                }
+              >
+                <span className="toggle-led" aria-hidden="true" />
+                {autoSim ? "Live" : "Paused"}
+              </button>
+              <div className="opt-cell">
+                <button
+                  type="button"
+                  className={`toggle-btn opt-toggle${optEnabled ? " is-on" : ""}`}
+                  aria-pressed={optEnabled}
+                  onClick={() => setOptEnabled((v) => !v)}
+                  title="Reactive optimiser: vary the knobs you mark (right-click a knob) to hit the objective whenever a fixed knob changes."
+                >
+                  <span className="toggle-led" aria-hidden="true" />
+                  Optimize
+                  {optRunning ? <span className="opt-pip">●</span> : null}
+                </button>
+                <button
+                  type="button"
+                  className="opt-gear-btn"
+                  aria-label="Optimisation method"
+                  aria-haspopup="menu"
+                  aria-expanded={optMenuOpen}
+                  title={`Optimise for: ${OPT_OBJECTIVE_LABELS[optObjective]}`}
+                  onClick={() => setOptMenuOpen((o) => !o)}
+                >
+                  ⚙
+                </button>
+                {optMenuOpen && (
+                  <>
+                    <div
+                      className="gear-menu-backdrop"
+                      onClick={() => setOptMenuOpen(false)}
+                    />
+                    <div className="opt-menu" role="menu">
+                      <div className="opt-menu-title">Optimise for</div>
+                      {OPT_OBJECTIVES.map((k) => (
+                        <button
+                          key={k}
+                          type="button"
+                          role="menuitemradio"
+                          aria-checked={optObjective === k}
+                          className={`gear-menu-item${optObjective === k ? " is-active" : ""}`}
+                          onClick={() => {
+                            setOptObjective(k);
+                            setOptMenuOpen(false);
+                          }}
+                        >
+                          {OPT_OBJECTIVE_LABELS[k]}
+                        </button>
+                      ))}
+                    </div>
+                  </>
+                )}
+              </div>
+              {optEnabled && optResult && (
+                <span className="opt-readout" title="SWR after optimisation">
+                  SWR {optResult.metrics_after.swr.toFixed(2)}
+                </span>
+              )}
+              {optEnabled && optError && (
+                <span
+                  className="opt-readout opt-readout-err"
+                  title={optError}
+                >
+                  {optError}
+                </span>
+              )}
+            </div>
+
+            <div className="vfo-dial">
+              <Knob
+                variant="vfo"
+                value={measFreq}
+                min={
+                  currentExample?.meas_freq_range_mhz
+                    ? currentExample.meas_freq_range_mhz[0]
+                    : Math.max(0.5, measBandAnchor * 0.8)
+                }
+                max={
+                  currentExample?.meas_freq_range_mhz
+                    ? currentExample.meas_freq_range_mhz[1]
+                    : Math.min(60, measBandAnchor * 1.25)
+                }
+                step={0.005}
+                precision={3}
+                unit=" MHz"
+                label="measurement frequency"
+                onChange={setMeasFreq}
+                disabled={linkMeas}
+              />
+              <button
+                type="button"
+                className="vfo-lock"
+                aria-pressed={linkMeas}
+                aria-label="Lock measurement frequency to the design frequency"
+                title={
+                  linkMeas
+                    ? "Locked to the design frequency — the dial is fixed. Click to unlock and tune freely."
+                    : "Lock the measurement frequency to the design frequency."
+                }
+                onClick={() => toggleLink(!linkMeas)}
+              >
+                <svg className="lock-glyph" viewBox="0 0 16 16" aria-hidden="true">
+                  <rect x="3.5" y="7.2" width="9" height="6.3" rx="1.3" />
+                  <path className="shackle" d="M5.3 7.2V5a2.7 2.7 0 0 1 5.4 0v2.2" />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
 
         <h2 className="group-label">simulation</h2>

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -534,6 +534,11 @@ function Knob({
             style={fillColor ? { stroke: fillColor } : undefined}
             d={arc(Rarc, startDeg, ang)}
           />
+          {/* Focus ring drawn in SVG space so it's a true circle centered on the
+              dial (50,50) — the wrapper's box-shadow ring would be an ellipse on
+              the VFO's non-square 112×99 box. Just outside the gauge arc (Rarc).
+              Shown on keyboard focus via .vfo-focus-ring CSS. */}
+          {isVfo && <circle className="vfo-focus-ring" cx="50" cy="50" r="50.5" />}
           {isVfo ? (
             // The whole knob body spins; the band arc behind it stays put — a
             // fixed scale with a turning dial, exactly like a transceiver VFO.

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1585,6 +1585,13 @@ export function App() {
   const [variantByGeom, setVariantByGeom] = useState<Record<string, string>>({});
 
   // --- Reactive knob optimiser (POST /optimize) ---
+  // Live simulation: when on, knob/freq changes auto-solve (and the optimiser
+  // runs). When off ("Paused"), edits update the geometry but the engine is held
+  // — the user keeps changing the design, then clicks Live to resume and solve.
+  // This replaces the old fire-and-forget "Cancel" on the solver-mismatch prompt,
+  // which left the plots blank with no obvious way back. Defaults on.
+  const [autoSim, setAutoSim] = useState(true);
+
   // Master enable + objective live in the compact control by meas-freq; per-knob
   // "vary" + extents + step live in each knob's right-click menu (knobOpt).
   const [optEnabled, setOptEnabled] = useState(false);
@@ -1959,9 +1966,14 @@ export function App() {
     controlsRef.current = buildRequest();
     requestSolve();
   }
-  // "Cancel": dismiss the warning without solving.
-  function dismissWarning() {
+  // "Pause simulation": stop auto-solving so the user can keep editing the design
+  // without the engine running, instead of the old "Cancel" that just hid the
+  // prompt and left the plots blank with no way forward. Approves this solver too,
+  // so clicking Live to resume continues the simulation rather than re-warning.
+  function pauseSimulation() {
+    approvedComboRef.current = true;
     setSolverWarning(false);
+    setAutoSim(false);
   }
   // Cancel an IN-FLIGHT solve: stop waiting and discard its result. The server
   // keeps computing (its /ws loop is sequential and a running MoM solve can't be
@@ -2173,7 +2185,10 @@ export function App() {
   ]);
 
   useEffect(() => {
-    if (!optFixedSig) return;
+    // Paused (Live off) holds the optimiser too — it drives engine solves, so it
+    // must respect the same gate as the main solve. Resuming re-runs this effect
+    // (autoSim is a dep) and re-tunes.
+    if (!optFixedSig || !autoSim) return;
     const t = setTimeout(() => {
       runOptimize();
     }, 400);
@@ -2181,7 +2196,7 @@ export function App() {
     // runOptimize captured here reflects the state at this signature; re-running
     // only when the signature changes is intentional.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [optFixedSig]);
+  }, [optFixedSig, autoSim]);
 
   // The effective per-knob optimiser settings: the stored entry, or seeded from
   // the schema (extents = slider bounds, step = schema step, not varying).
@@ -2361,6 +2376,14 @@ export function App() {
     // the next switch resets it to null.
     if (previewReady !== geometry) return;
     controlsRef.current = buildRequest();
+    // Paused: keep controlsRef fresh (so resuming sends the latest design) but
+    // don't solve, and suppress the combo warning — nothing is running to warn
+    // about. Toggling Live back on re-runs this effect (autoSim is a dep) and
+    // solves the current state.
+    if (!autoSim) {
+      setSolverWarning(false);
+      return;
+    }
     // Withhold the solve when the design/solver combo is a poor match and the
     // user hasn't approved it — show a warning instead. The app never switches
     // the solver itself; the user does that in the gear menu, which changes
@@ -2375,6 +2398,7 @@ export function App() {
     requestSolve();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
+    autoSim,
     geometry, previewReady, backend, backendOptsKey,
     currentValuesKey,
     designFreq, measFreq,
@@ -3230,40 +3254,6 @@ export function App() {
               />
               lock
             </label>
-            {/* Reactive optimiser: enable + objective. Mark knobs to vary via
-                their right-click menu; turning a fixed knob re-tunes. */}
-            <div className="opt-control" title="reactive optimisation">
-              <label className="link-toggle">
-                <input
-                  type="checkbox"
-                  checked={optEnabled}
-                  onChange={(e) => setOptEnabled(e.target.checked)}
-                />
-                opt{optRunning ? <span className="opt-pip">●</span> : null}
-              </label>
-              {optEnabled && (
-                <select
-                  className="opt-objective"
-                  aria-label="optimise for"
-                  value={optObjective}
-                  onChange={(e) => setOptObjective(e.target.value as OptObjective)}
-                >
-                  {OPT_OBJECTIVES.map((k) => (
-                    <option key={k} value={k}>
-                      {OPT_OBJECTIVE_LABELS[k]}
-                    </option>
-                  ))}
-                </select>
-              )}
-              {optEnabled && optResult && (
-                <span className="opt-readout" title="SWR after optimisation">
-                  SWR {optResult.metrics_after.swr.toFixed(2)}
-                </span>
-              )}
-              {optEnabled && optError && (
-                <span className="opt-readout opt-readout-err">{optError}</span>
-              )}
-            </div>
           </div>
           <div className="vfo-main">
             <div className="freq-lcd" title={`${measFreq.toFixed(3)} MHz`}>
@@ -3296,6 +3286,59 @@ export function App() {
               disabled={linkMeas}
             />
           </div>
+        </div>
+
+        {/* Live / Optimize: two matching push-button toggles (depressed = on).
+            Live gates auto-solving on knob turns; Optimize gates the reactive
+            tuner. The objective select + last-SWR readout follow Optimize. */}
+        <div className="sim-controls">
+          <button
+            type="button"
+            className={`toggle-btn${autoSim ? " is-on" : ""}`}
+            aria-pressed={autoSim}
+            onClick={() => setAutoSim((v) => !v)}
+            title={
+              autoSim
+                ? "Live: knob changes re-solve automatically. Click to pause and edit without solving."
+                : "Paused: edit the design freely; the engine is held. Click to resume and solve."
+            }
+          >
+            <span className="toggle-led" aria-hidden="true" />
+            {autoSim ? "Live" : "Paused"}
+          </button>
+          <button
+            type="button"
+            className={`toggle-btn${optEnabled ? " is-on" : ""}`}
+            aria-pressed={optEnabled}
+            onClick={() => setOptEnabled((v) => !v)}
+            title="Reactive optimiser: vary the knobs you mark (right-click a knob) to hit the objective whenever a fixed knob changes."
+          >
+            <span className="toggle-led" aria-hidden="true" />
+            Optimize
+            {optRunning ? <span className="opt-pip">●</span> : null}
+          </button>
+          {optEnabled && (
+            <select
+              className="opt-objective"
+              aria-label="optimise for"
+              value={optObjective}
+              onChange={(e) => setOptObjective(e.target.value as OptObjective)}
+            >
+              {OPT_OBJECTIVES.map((k) => (
+                <option key={k} value={k}>
+                  {OPT_OBJECTIVE_LABELS[k]}
+                </option>
+              ))}
+            </select>
+          )}
+          {optEnabled && optResult && (
+            <span className="opt-readout" title="SWR after optimisation">
+              SWR {optResult.metrics_after.swr.toFixed(2)}
+            </span>
+          )}
+          {optEnabled && optError && (
+            <span className="opt-readout opt-readout-err">{optError}</span>
+          )}
         </div>
 
         <h2 className="group-label">simulation</h2>
@@ -3422,7 +3465,8 @@ export function App() {
               {backend === "arrayblock" || backend === "hmatrix"
                 ? "This accelerator is overkill on a single-element design — a dense solver (e.g. Triangular) is faster here. "
                 : "This is a large array — a dense solver can be very slow. Array-block is far faster. "}
-              Change the solver in the gear menu, or solve anyway.
+              Change the solver in the gear menu, solve anyway, or pause to keep
+              editing.
             </span>
             <div className="solver-suggest-actions">
               <button
@@ -3435,9 +3479,10 @@ export function App() {
               <button
                 type="button"
                 className="solver-suggest-secondary"
-                onClick={dismissWarning}
+                onClick={pauseSimulation}
+                title="Stop auto-solving so you can keep editing; click Live to resume."
               >
-                Cancel
+                Pause simulation
               </button>
             </div>
           </div>

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -790,6 +790,21 @@ button:focus-visible,
   border-radius: 50%;
   box-shadow: 0 0 0 3px var(--accent-soft);
 }
+/* The VFO box is 112×99 (cropped), so the round box-shadow ring above renders
+   as an off-centre ellipse. Suppress it and use the in-SVG .vfo-focus-ring
+   circle instead, which is concentric with the dial. */
+.knob.is-vfo:focus-visible {
+  box-shadow: none;
+}
+.vfo-focus-ring {
+  fill: none;
+  stroke: var(--accent-soft);
+  stroke-width: 3.5;
+  opacity: 0;
+}
+.knob.is-vfo:focus-visible .vfo-focus-ring {
+  opacity: 1;
+}
 .knob svg {
   display: block;
   width: 100%;
@@ -908,8 +923,10 @@ button:focus-visible,
 }
 .vfo-dial {
   position: relative;
-  margin-left: var(--space-4); /* toggles at the left, dial just right of them */
-  margin-right: auto; /* leave the empty space on the right for the lock */
+  margin-left: auto; /* toggles at the left; push the dial toward the right */
+  /* inset == the lock's right:-16px overhang, so the lock's right edge lands on
+     the field's right edge (aligned with the frequency readout above). */
+  margin-right: var(--space-6);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -1576,17 +1593,13 @@ canvas {
 }
 
 /* --- Reactive knob optimiser --- */
-/* A knob marked as a free optimisation variable. The cap is an SVG <circle>, so
-   it takes an SVG stroke (box-shadow does not apply to SVG shapes) — this also
-   keeps the variable marker off the wrapper's box-shadow focus ring, so the two
-   states no longer stack into a muddy double outline. */
+/* A knob marked as a free optimisation variable. The accent ring on the cap (an
+   SVG <circle>, so it takes an SVG stroke — box-shadow does not apply to SVG
+   shapes) is the sole marker; a trailing label glyph was dropped because it
+   could overlap neighbouring labels in the packed knob grid. */
 .field-knob.is-opt-var .knob-cap {
   stroke: var(--accent);
   stroke-width: 2;
-}
-.field-knob.is-opt-var .knob-label::after {
-  content: " ⟳";
-  color: var(--accent);
 }
 
 /* --- Live / Optimize push-button toggles ------------------------------------

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1701,7 +1701,10 @@ canvas {
 .opt-menu {
   position: absolute;
   top: calc(100% + 4px);
-  right: 0;
+  /* The opt-cell sits at the left edge of the rail, so anchor the popover to the
+     LEFT and let it open rightward into the panel — anchoring right:0 ran it off
+     the left edge, where the sidebar's overflow-x:hidden clipped it. */
+  left: 0;
   z-index: 41;
   min-width: 160px;
   padding: var(--space-1);

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -880,25 +880,72 @@ button:focus-visible,
 }
 
 /* measurement-freq VFO field: caption, LCD counter, dial, band select, lock */
-/* compact layout: band select + lock on the left, LCD + dial on the right */
+/* stacked layout: top line = band select + LCD; body = the Live/Optimize
+   toggles at the left of the weighted dial, with the lock pinned to the dial's
+   lower-right corner. */
 .vfo-field {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-5);
-}
-.vfo-aux {
   display: flex;
   flex-direction: column;
   align-items: stretch;
   gap: var(--space-4);
 }
-.vfo-main {
+.vfo-top {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+.vfo-top .band-select {
+  flex: 0 0 auto;
+  max-width: 120px;
+}
+.vfo-top .freq-lcd {
+  margin-left: auto; /* push the readout to the right edge */
+}
+.vfo-body {
+  display: flex;
+  align-items: center;
+  gap: var(--space-5);
+}
+.vfo-dial {
+  position: relative;
+  margin-left: var(--space-4); /* toggles at the left, dial just right of them */
+  margin-right: auto; /* leave the empty space on the right for the lock */
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--space-3);
+}
+/* the lock: a bare icon (no button chrome) tucked at the dial's lower-right,
+   in the empty space beside the gauge so it stays clear of the arc. */
+.vfo-lock {
+  position: absolute;
+  right: -16px;
+  bottom: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+}
+.vfo-lock:hover {
+  color: var(--fg);
+}
+.vfo-lock[aria-pressed="true"] {
+  color: var(--accent);
+}
+.lock-glyph {
+  width: 12px;
+  height: 12px;
+}
+.lock-glyph rect {
+  fill: currentColor;
+}
+.lock-glyph .shackle {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.6;
 }
 /* light bench-counter LCD: dark numerals over faint "off" segments */
 .freq-lcd {
@@ -937,14 +984,6 @@ button:focus-visible,
 }
 .vfo-field.is-locked .lcd-live {
   color: var(--muted);
-}
-.vfo-aux .band-select {
-  max-width: 130px;
-}
-/* the lock toggle sits in the left aux column; "lock" label + full tooltip */
-.vfo-aux .link-toggle {
-  font-size: var(--text-xs);
-  white-space: nowrap;
 }
 .knob-edit {
   width: 54px;
@@ -1556,17 +1595,18 @@ canvas {
    knob turns; Optimize gates the reactive tuner. Both share this look. */
 .sim-controls {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
+  flex-direction: column; /* Live on top of Optimize, at the left of the dial */
+  align-items: stretch;
   gap: var(--space-3);
+  flex: 0 0 auto;
 }
 .toggle-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: var(--space-3);
-  min-width: 84px;
-  padding: var(--space-4) var(--space-6);
+  gap: var(--space-2);
+  min-width: 58px;
+  padding: var(--space-2) var(--space-4);
   background: var(--inset);
   color: var(--muted);
   border: 1px solid var(--border-control);
@@ -1614,9 +1654,61 @@ canvas {
   background: var(--accent);
   box-shadow: 0 0 4px var(--accent);
 }
-.sim-controls .opt-objective {
+/* Optimize + its objective gear share a cell, attached like the solver-slot
+   tab+gear. The gear opens a small popover to pick what to optimise for. */
+.opt-cell {
+  position: relative;
+  display: flex;
+}
+.opt-cell .opt-toggle {
+  flex: 1;
+  min-width: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-right: none;
+}
+.opt-gear-btn {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 var(--space-3);
+  background: var(--inset);
+  color: var(--muted);
+  border: 1px solid var(--border-control);
+  border-radius: 0 var(--r-sm) var(--r-sm) 0;
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+}
+.opt-gear-btn:hover {
+  color: var(--accent);
+  border-color: var(--border-hover);
+}
+.opt-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 41;
+  min-width: 160px;
+  padding: var(--space-1);
+  background: var(--panel);
+  border: 1px solid var(--border-control);
+  border-radius: var(--r-md);
+  box-shadow: 0 6px 20px var(--shadow-strong);
+}
+.opt-menu-title {
+  font-family: var(--font-mono);
   font-size: var(--text-xs);
-  padding: 0 var(--space-1);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted-2);
+  padding: var(--space-2) var(--space-3) var(--space-1);
+}
+.opt-menu .gear-menu-item.is-active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 600;
 }
 .opt-pip {
   color: var(--accent);
@@ -1735,9 +1827,12 @@ canvas {
     width: 40px;
     height: 40px;
   }
-  .band-select,
-  .opt-objective {
+  .band-select {
     min-height: 40px;
+  }
+  .vfo-lock,
+  .opt-gear-btn {
+    min-width: 36px;
   }
 }
 

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1550,14 +1550,71 @@ canvas {
   color: var(--accent);
 }
 
-/* Compact enable + objective control next to the meas-freq band/lock. */
-.opt-control {
+/* --- Live / Optimize push-button toggles ------------------------------------
+   A row of bench-style push buttons under the VFO. Depressed (inset shadow +
+   accent fill + lit LED) = engaged; raised = off. Live gates auto-solving on
+   knob turns; Optimize gates the reactive tuner. Both share this look. */
+.sim-controls {
   display: flex;
-  align-items: center;
-  gap: var(--space-2);
   flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
 }
-.opt-control .opt-objective {
+.toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  min-width: 84px;
+  padding: var(--space-4) var(--space-6);
+  background: var(--inset);
+  color: var(--muted);
+  border: 1px solid var(--border-control);
+  border-radius: var(--r-sm);
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 1px 0 var(--shadow); /* a hair of raise when off */
+}
+.toggle-btn:hover {
+  color: var(--fg);
+  border-color: var(--border-hover);
+}
+.toggle-btn.is-on {
+  background: var(--accent-active);
+  color: var(--accent);
+  border-color: var(--accent-border);
+  box-shadow: inset 0 2px 4px var(--shadow); /* pressed in */
+}
+.toggle-btn:active {
+  transform: translateY(1px);
+}
+/* keyboard focus ring, layered over the raised/pressed shadow so the state
+   still reads while focused (the .is-on rule alone would otherwise win the
+   box-shadow cascade and hide the ring). */
+.toggle-btn:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 1px 0 var(--shadow), 0 0 0 3px var(--accent-soft);
+}
+.toggle-btn.is-on:focus-visible {
+  box-shadow: inset 0 2px 4px var(--shadow), 0 0 0 3px var(--accent-soft);
+}
+/* indicator LED: dim/hollow when off, lit accent (with a glow) when on */
+.toggle-led {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--track);
+  box-shadow: inset 0 0 0 1px var(--border-control);
+}
+.toggle-btn.is-on .toggle-led {
+  background: var(--accent);
+  box-shadow: 0 0 4px var(--accent);
+}
+.sim-controls .opt-objective {
   font-size: var(--text-xs);
   padding: 0 var(--space-1);
 }


### PR DESCRIPTION
## Summary
Replaces the dead-end "Cancel" on the solver-mismatch prompt with an explicit, persistent simulation gate, and reorganises the measurement-freq controls around it.

- **Live/Paused toggle + Cancel fix** — the solver-mismatch prompt's "Cancel" used to just hide the dialog without solving, leaving the heatmap / current / Smith / far-field plots blank with no way back. There's now a persistent `autoSim` gate driven by a **Live** push-button (depressed = on): Live = knob/freq changes auto-solve; Paused = edits update the design but the engine is held, then click Live to resume and solve the current state. The prompt's secondary button is now **Pause simulation** (pauses + approves the solver so resuming continues instead of re-warning). The optimiser respects the same gate.
- **Measurement-freq layout redesign** — band select moves to the top line beside the frequency LCD; **Live** stacks over **Optimize** (matching toggle buttons) at the left of the dial; the objective ("optimise for") picker moves into a small gear popover attached to Optimize (mirroring the solver-slot gear); the lock becomes a bare padlock icon tucked at the dial's lower-right with a tooltip.
- **Polish** — dial+lock aligned so the lock's right edge meets the readout's right edge; the VFO keyboard-focus ring is now drawn inside the SVG so it's a true circle concentric with the dial (the old wrapper `box-shadow` was an off-centre ellipse on the 112×99 box); the optimisation-variable knob marker is now just the accent ring on the cap (the trailing label glyph was dropped to avoid overlapping neighbouring labels).

## Test plan
- [x] `tsc --noEmit && vite build` — clean
- [x] `ruff check` / `ruff format --check` — clean (changes are TS/CSS only)
- [x] Rendered the new layout in headless Chrome at each step (lock clearance, alignment, concentric focus ring)
- [ ] Click through: pause via the toggle and via the prompt; confirm plots hold then fill on resume; gear popover picks the objective; lock disables the dial

🤖 Generated with [Claude Code](https://claude.com/claude-code)