### PR TITLE
Drop vestigial del_z from Array1x2Builder and its designs

### DIFF
--- a/src/antennaknobs/builder.py
+++ b/src/antennaknobs/builder.py
@@ -435,19 +435,23 @@ class Array1x2Builder(AntennaBuilder):
 
         phasor_lr = self._phasor("phase_lr")
 
+        # A 1x2 array is a single row of two elements offset to ∓del_y — the
+        # left at unit drive, the right at the phase_lr phasor. There is NO z
+        # iteration: with one row the elements keep the element builder's own z
+        # (their `base`), and there is no array z-spacing. (The 2x2/1x4/2x4
+        # builders DO iterate z; this one was originally copied from the 2x2 and
+        # carried a vestigial single-entry z-loop + `del_z` that only rigidly
+        # shifted the whole array — inert in free space — now removed.)
         new_tups = []
         for yoff, ph0 in ((-self.del_y, 1), (self.del_y, phasor_lr)):
-            for zoff, tups, ph1 in ((self.del_z, tups_top, 1),):
-                for (x0, y0, z0), (x1, y1, z1), ns, ex in tups:
-                    new_tups.extend(
-                        [
-                            (
-                                (x0, y0 + yoff, z0 + zoff),
-                                (x1, y1 + yoff, z1 + zoff),
-                                ns,
-                                ph0 * ph1 if ex is not None else ex,
-                            )
-                        ]
+            for (x0, y0, z0), (x1, y1, z1), ns, ex in tups_top:
+                new_tups.append(
+                    (
+                        (x0, y0 + yoff, z0),
+                        (x1, y1 + yoff, z1),
+                        ns,
+                        ph0 if ex is not None else ex,
                     )
+                )
 
         return new_tups

--- a/src/antennaknobs/designs/arrays/bowtiearray1x2.py
+++ b/src/antennaknobs/designs/arrays/bowtiearray1x2.py
@@ -12,7 +12,6 @@ class Builder(Array1x2Builder):
             "base": 7.0,
             "length_top": 5.53,
             "del_y": 4.0,
-            "del_z": 2.0,
             "phase_lr": 0.0,
         }
     )

--- a/src/antennaknobs/designs/arrays/delta_looparray.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray.py
@@ -13,12 +13,15 @@ class Builder(Array1x2Builder):
             "angle_deg_top": 61.2377,
             "base": 7.0,
             "del_y": 4.0,
-            "del_z": 0.0,
             "phase_lr": 0.0,
         }
     )
 
-    dy35_dz2_params = MappingProxyType(
+    # Alternate element spacings (the loop tuning was re-optimised per del_y).
+    # These were formerly suffixed `_dz2`; the del_z=2 they carried was an inert
+    # rigid lift on this single-row 1x2 array (see Array1x2Builder) and has been
+    # removed, so the variants are named by their distinguishing del_y.
+    dy35_params = MappingProxyType(
         {
             "design_freq": 28.47,
             "freq": 28.47,
@@ -26,12 +29,11 @@ class Builder(Array1x2Builder):
             "angle_deg_top": 65.0422,
             "base": 7.0,
             "del_y": 3.5,
-            "del_z": 2,
             "phase_lr": 0.0,
         }
     )
 
-    dy45_dz2_params = MappingProxyType(
+    dy45_params = MappingProxyType(
         {
             "design_freq": 28.47,
             "freq": 28.47,
@@ -39,12 +41,11 @@ class Builder(Array1x2Builder):
             "angle_deg_top": 63.2603,
             "base": 7.0,
             "del_y": 4.5,
-            "del_z": 2,
             "phase_lr": 0.0,
         }
     )
 
-    dy3_dz2_params = MappingProxyType(
+    dy3_params = MappingProxyType(
         {
             "design_freq": 28.47,
             "freq": 28.47,
@@ -52,7 +53,6 @@ class Builder(Array1x2Builder):
             "angle_deg_top": 63.2603,
             "base": 7.0,
             "del_y": 3,
-            "del_z": 2,
             "phase_lr": 0.0,
         }
     )

--- a/src/antennaknobs/designs/arrays/hentenna_array.py
+++ b/src/antennaknobs/designs/arrays/hentenna_array.py
@@ -14,7 +14,6 @@ class Builder(Array1x2Builder):
             "width_factor_top": 0.1880,
             "base": 10.0,
             "del_y": 4.0,
-            "del_z": 0.0,
             "phase_lr": 0.0,
         }
     )

--- a/src/antennaknobs/designs/arrays/hourglass_array.py
+++ b/src/antennaknobs/designs/arrays/hourglass_array.py
@@ -14,7 +14,6 @@ class Builder(Array1x2Builder):
             "waist_factor_top": 0.6071,
             "base": 10.0,
             "del_y": 4.0,
-            "del_z": 0.0,
             "phase_lr": 0.0,
         }
     )

--- a/tests/test_design_schemas.py
+++ b/tests/test_design_schemas.py
@@ -253,7 +253,7 @@ def test_hentenna_slant_z100_overrides_default_factors():
         ("loops.inv_delta_loop", {"default", "z100", "z200"}),
         ("specialty.hentenna", {"default", "z50", "z100"}),
         ("loops.delta_loop_slanted", {"default", "slant0", "slant30"}),
-        ("arrays.delta_looparray", {"default", "dy3_dz2", "dy35_dz2", "dy45_dz2"}),
+        ("arrays.delta_looparray", {"default", "dy3", "dy35", "dy45"}),
     ],
 )
 def test_variant_family(name, expected):


### PR DESCRIPTION
## Summary
`Array1x2Builder` was copied from the 2×2 builder and kept the 2×2's nested z-loop — but with a single entry `((self.del_z, tups_top, 1),)`. With one element row that loop does nothing except rigidly shift the whole array by `del_z` in z: inert in free space (the core has no ground), redundant with each element's own `base`, and never an array z-spacing. Copy-paste residue.

- **Builder:** rewrite the 1×2 `build_wires` to place the two elements at ∓`del_y` (left = unit drive, right = the `phase_lr` phasor) with no z offset.
- **Designs:** remove the `del_z` param from the four designs that use the 1×2 builder (`bowtiearray1x2`, `delta_looparray`, `hentenna_array`, `hourglass_array`). `bowtiearray1x2` defaulted `del_z=2.0` and `delta_looparray`'s variants set `del_z=2` — both inert lifts, so impedance / far-field are unchanged in free space (translation-invariant; verified Z stays symmetric and the PyNEC parity tests pass).
- **Variant rename:** `delta_looparray`'s `dy35_dz2` / `dy45_dz2` / `dy3_dz2` → `dy35` / `dy45` / `dy3` (they differ only by `del_y`). Updates the one schema test that pins the set.
- The 2×2 / 1×4 / 2×4 / 1×4-grouped builders genuinely iterate z and keep `del_z` — untouched.

## Note
This lowers `bowtiearray1x2` and the `dz2` variants by 2 m (the removed lift). Physically inert in free space; a possible follow-up is to make `base` mean the top of the antenna and grow downward, deferred for later.

## Test plan
- [x] `pytest test_design_schemas test_web_server test_momwire_engine test_nec_export test_opt_nested_params` — 1022 passed
- [x] `ruff check` / `ruff format --check` — clean
- [x] `bowtiearray1x2` per-feed Z verified symmetric (183.19+32.28j), PyNEC free-space parity tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)