### PR TITLE
Go live on custom domains: update DNS runbook + simulator links

### DIFF
--- a/docs/cloudflare-dns.md
+++ b/docs/cloudflare-dns.md
@@ -1,20 +1,36 @@
 # Cloudflare DNS setup for the Fly.io apps
 
 A runbook for pointing the `antennaknobs` domains at the Fly apps via
-Cloudflare-managed DNS, and validating the Fly TLS certs.
+Cloudflare-managed DNS, and validating the Fly TLS certs. This documents the
+**as-built** setup: both zones mirror each other across two Fly apps.
 
 There are two Fly apps:
 
-| App | What | Public hostname |
+| App | What | Fly hostname |
 | --- | --- | --- |
 | `antennaknobs` | the live simulator (FastAPI) | `antennaknobs.fly.dev` |
 | `antennaknobs-docs` | the docs site (static, nginx) | `antennaknobs-docs.fly.dev` |
 
+## As-built layout
+
+Two zones, `antennaknobs.dev` and `antennaknobs.com`, are configured **identically
+(mirrored)**:
+
+| Hostname | Serves | Fly app |
+| --- | --- | --- |
+| `antennaknobs.dev` (apex) | docs site | `antennaknobs-docs` |
+| `app.antennaknobs.dev` | simulator | `antennaknobs` |
+| `antennaknobs.com` (apex) | docs site | `antennaknobs-docs` |
+| `app.antennaknobs.com` | simulator | `antennaknobs` |
+
+The apex serves the docs; the simulator lives on the `app.` subdomain. `.com`
+is a straight mirror of `.dev`.
+
 ## 0. Prerequisites
 
-- The zone (`antennaknobs.dev` / `antennaknobs.com`) must already be **active on
+- Both zones (`antennaknobs.dev`, `antennaknobs.com`) must be **active on
   Cloudflare** — i.e. the registrar's nameservers point at Cloudflare. Check in
-  the Cloudflare dashboard that the zone shows "Active". If not, add the site to
+  the Cloudflare dashboard that each zone shows "Active". If not, add the site to
   Cloudflare and update the nameservers at the registrar first.
 - `flyctl` installed and logged in (`flyctl auth whoami`).
 
@@ -23,8 +39,8 @@ There are two Fly apps:
 Fly IPs rarely change, but always confirm before editing DNS:
 
 ```bash
-flyctl ips list -a antennaknobs-docs   # docs site
-flyctl ips list -a antennaknobs        # simulator
+flyctl ips list -a antennaknobs-docs   # docs site (serves the apexes)
+flyctl ips list -a antennaknobs        # simulator (serves app.*)
 ```
 
 As of last setup:
@@ -36,16 +52,25 @@ As of last setup:
 
 ## 2. Add the Fly cert(s)
 
-Tell Fly which hostnames it should serve, so it provisions a TLS cert:
+Tell Fly which hostnames each app should serve, so it provisions a TLS cert. The
+as-built set is four hostnames across the two apps:
 
 ```bash
+# Apexes -> docs app
 flyctl certs add antennaknobs.dev -a antennaknobs-docs
-# optional extras:
-flyctl certs add www.antennaknobs.dev -a antennaknobs-docs
-flyctl certs add app.antennaknobs.dev -a antennaknobs       # simulator on a subdomain
+flyctl certs add antennaknobs.com -a antennaknobs-docs
+
+# app.* subdomains -> simulator
+flyctl certs add app.antennaknobs.dev -a antennaknobs
+flyctl certs add app.antennaknobs.com -a antennaknobs
+
+# optional www, if you want it:
+# flyctl certs add www.antennaknobs.dev -a antennaknobs-docs
+# flyctl certs add www.antennaknobs.com -a antennaknobs-docs
 ```
 
-`flyctl certs show <hostname> -a <app>` prints the exact records Fly recommends.
+`flyctl certs add` prints the exact A/AAAA records Fly wants (they match the
+table in §3). `flyctl certs show <hostname> -a <app>` reprints them later.
 
 ## 3. Create the records in Cloudflare
 
@@ -53,54 +78,64 @@ flyctl certs add app.antennaknobs.dev -a antennaknobs       # simulator on a sub
 > Set every Fly record to **DNS only (grey cloud), NOT proxied**. Fly does its
 > own TLS/SNI routing, and a proxied (orange-cloud) record resolves to
 > Cloudflare's IPs — which breaks Fly's ACME cert validation and its routing.
-> Keep them grey-cloud (at minimum until the cert is validated).
+> Keep them grey-cloud.
 
-### Recommended records
+### Records (per zone — create the same four in **both** `.dev` and `.com`)
 
 | Type | Name | Value | Proxy |
 | --- | --- | --- | --- |
-| `A` | `antennaknobs.dev` (`@`) | `66.241.124.199` | DNS only |
-| `AAAA` | `antennaknobs.dev` (`@`) | `2a09:8280:1::137:a070:0` | DNS only |
+| `A` | `@` (apex) | `66.241.124.199` | DNS only |
+| `AAAA` | `@` (apex) | `2a09:8280:1::137:a070:0` | DNS only |
+| `A` | `app` | `66.241.125.41` | DNS only |
+| `AAAA` | `app` | `2a09:8280:1::137:614b:0` | DNS only |
 
-Optional:
+`@` is the bare apex (Cloudflare auto-expands it); `app` becomes
+`app.<zone>`. That's 8 records total across the two zones.
+
+Optional `www` (point at whichever app you certified it on):
 
 | Type | Name | Value | Proxy |
 | --- | --- | --- | --- |
 | `CNAME` | `www` | `antennaknobs-docs.fly.dev` | DNS only |
-| `CNAME` | `app` | `antennaknobs.fly.dev` | DNS only |
-
-(For `antennaknobs.com`, repeat the apex `A`/`AAAA` pointing at whichever app
-should serve it — docs for now, or the marketing site later.)
 
 ### Option A — Cloudflare dashboard (manual)
 
-Zone → **DNS** → **Records** → **Add record**, one per row above. For the apex,
-set Name to `@`. Toggle the cloud icon to **grey (DNS only)**.
+For each zone: **DNS** → **Records** → **Add record**, one per row above. For the
+apex, set Name to `@`. Toggle the cloud icon to **grey (DNS only)** before
+saving. Repeat for the second zone.
 
 ### Option B — Cloudflare API (scripted)
 
 Create a **scoped** API token: Cloudflare → My Profile → **API Tokens** →
-Create Token → **Edit zone DNS** template → Permissions `Zone:DNS:Edit`, Zone
-Resources = the specific zone(s). Then:
+Create Token → **Edit zone DNS** template → Permissions `Zone:DNS:Edit`
+(+ `Zone:Zone:Read` for the zone-id lookup), Zone Resources = **both** zones.
+Then, per zone:
 
 ```bash
 # Provide the token WITHOUT putting it in shell history / the terminal scrollback:
 #   umask 077 && printf '%s' 'YOUR_TOKEN' > ~/.cf-token
 export CF_TOKEN="$(cat ~/.cf-token)"
-ZONE="antennaknobs.dev"
 
-# Look up the zone id
-ZID=$(curl -s -H "Authorization: Bearer $CF_TOKEN" \
-  "https://api.cloudflare.com/client/v4/zones?name=$ZONE" | \
-  python3 -c 'import sys,json;print(json.load(sys.stdin)["result"][0]["id"])')
+for ZONE in antennaknobs.dev antennaknobs.com; do
+  # Look up the zone id
+  ZID=$(curl -s -H "Authorization: Bearer $CF_TOKEN" \
+    "https://api.cloudflare.com/client/v4/zones?name=$ZONE" | \
+    python3 -c 'import sys,json;print(json.load(sys.stdin)["result"][0]["id"])')
 
-# Apex A + AAAA -> the docs app, DNS only (proxied=false)
-for rec in 'A 66.241.124.199' 'AAAA 2a09:8280:1::137:a070:0'; do
-  set -- $rec
-  curl -s -X POST -H "Authorization: Bearer $CF_TOKEN" -H "Content-Type: application/json" \
-    "https://api.cloudflare.com/client/v4/zones/$ZID/dns_records" \
-    --data "{\"type\":\"$1\",\"name\":\"$ZONE\",\"content\":\"$2\",\"ttl\":1,\"proxied\":false}"
-  echo
+  # apex -> docs app; app.* -> simulator; all DNS only (proxied=false)
+  for rec in \
+    "A    @   66.241.124.199" \
+    "AAAA @   2a09:8280:1::137:a070:0" \
+    "A    app 66.241.125.41" \
+    "AAAA app 2a09:8280:1::137:614b:0"; do
+    set -- $rec
+    TYPE=$1; HOST=$2; VAL=$3
+    NAME=$([ "$HOST" = "@" ] && echo "$ZONE" || echo "$HOST.$ZONE")
+    curl -s -X POST -H "Authorization: Bearer $CF_TOKEN" -H "Content-Type: application/json" \
+      "https://api.cloudflare.com/client/v4/zones/$ZID/dns_records" \
+      --data "{\"type\":\"$TYPE\",\"name\":\"$NAME\",\"content\":\"$VAL\",\"ttl\":1,\"proxied\":false}"
+    echo
+  done
 done
 
 rm -f ~/.cf-token   # clean up the token when done
@@ -108,33 +143,40 @@ rm -f ~/.cf-token   # clean up the token when done
 
 ## 4. Validate
 
-```bash
-flyctl certs check antennaknobs.dev -a antennaknobs-docs
-```
-
-Re-run until it reports verified (DNS propagation is usually seconds–minutes on
-Cloudflare). Then:
+Certs flip to `Issued` once Fly sees the DNS:
 
 ```bash
-curl -sS -o /dev/null -w "%{http_code}\n" https://antennaknobs.dev/
+flyctl certs list -a antennaknobs-docs   # antennaknobs.dev, antennaknobs.com
+flyctl certs list -a antennaknobs        # app.antennaknobs.dev, app.antennaknobs.com
 ```
 
-should return `200`.
+Re-run until each reports `Issued` (DNS propagation is usually seconds–minutes on
+Cloudflare). Then confirm each hostname serves a 200 over HTTPS:
+
+```bash
+for u in https://antennaknobs.dev/ https://app.antennaknobs.dev/ \
+         https://antennaknobs.com/ https://app.antennaknobs.com/; do
+  echo -n "$u -> "; curl -sS -o /dev/null -w "%{http_code}\n" "$u"
+done
+```
+
+All four should return `200`, the apexes routing to `66.241.124.199` (docs) and
+the `app.*` hosts to `66.241.125.41` (simulator).
 
 ## 5. After DNS is live
 
-- Update the docs' simulator link if you move the simulator onto a custom domain: it's
+- Update the docs' simulator link if you move the simulator's public hostname: it's
   the `SIMULATOR_URL` constant in `site/astro.config.mjs` (plus the literal links in
   the home/welcome/web/catalog pages). A push to `main` redeploys the docs via
   the `deploy-docs.yml` Action.
 
 ## Notes / gotchas
 
-- **Apex + shared IPv4:** the docs app uses a *shared* Fly IPv4, which routes
-  HTTPS fine via SNI, but plain `http://` on the apex (port 80) can't be routed
-  by SNI and won't redirect cleanly. For flawless apex redirects, allocate a
-  dedicated IPv4: `flyctl ips allocate-v4 -a antennaknobs-docs` (~$2/mo) and use
-  that as the `A` record.
+- **Apex + shared IPv4:** both apexes use the docs app's *shared* Fly IPv4, which
+  routes HTTPS fine via SNI, but plain `http://` on the apex (port 80) can't be
+  routed by SNI and won't redirect cleanly. For flawless apex redirects, allocate
+  a dedicated IPv4: `flyctl ips allocate-v4 -a antennaknobs-docs` (~$2/mo) and use
+  that as the apex `A` record in both zones.
 - Keep records **grey-cloud**. If you later want Cloudflare's proxy/CDN in front,
   set the zone's SSL/TLS mode to **Full (strict)** first, and expect to re-check
   the Fly cert.

--- a/site/README.md
+++ b/site/README.md
@@ -37,8 +37,9 @@ astro.config.mjs       # Starlight config + sidebar
 ## Notes
 
 - The live simulator URL is defined once as `SIMULATOR_URL` in `astro.config.mjs` and
-  referenced in the home hero / docs. **Swap it for the real domain** (e.g.
-  `https://app.antennaknobs.dev`) once DNS is wired up.
+  referenced in the home hero / docs. It points at the custom domain
+  `https://app.antennaknobs.dev`. If the simulator's public hostname ever moves,
+  change it there.
 - Pages contain `TODO` comments marking content that should be **generated from
   the package** (the catalog, API reference, benchmark plots) so docs stay in
   sync with the code rather than being hand-maintained.

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -2,10 +2,10 @@
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
 
-// The live simulator (the FastAPI workbench) currently runs on its temporary
-// Fly hostname. Swap this for https://app.antennaknobs.dev (or the apex) once
-// DNS is wired up — it's referenced from the home hero and the Web docs.
-const SIMULATOR_URL = "https://antennaknobs.fly.dev/";
+// The live simulator (the FastAPI workbench), served on its custom domain.
+// (The Fly app is still reachable at antennaknobs.fly.dev, but app.antennaknobs.dev
+// is the canonical public URL.) Referenced from the home hero and the Web docs.
+const SIMULATOR_URL = "https://app.antennaknobs.dev/";
 
 // https://astro.build/config
 export default defineConfig({

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -6,7 +6,7 @@ hero:
   tagline: Turn a knob, watch the antenna. A browser-based wire-antenna MoM simulator — no install, no NEC deck to hand-write.
   actions:
     - text: Open the live simulator
-      link: https://antennaknobs.fly.dev/
+      link: https://app.antennaknobs.dev/
       icon: external
       variant: primary
     - text: Quickstart

--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -6,7 +6,7 @@ description: The built-in antenna designs, by family — each one a readable Ant
 Every built-in design is an [`AntennaBuilder`](/concepts/model/) whose source is
 meant to be read and copied. Address them as `family.name` (the same names
 `python -m antennaknobs list` prints), and open any in the [live
-simulator](https://antennaknobs.fly.dev/) to drag its knobs. Many are modelled
+simulator](https://app.antennaknobs.dev/) to drag its knobs. Many are modelled
 after L. B. Cebik (W4RNL)'s articles.
 
 ## Dipoles

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -20,7 +20,7 @@ handshake.
 ## The hosted instance
 
 A hosted simulator is running at
-**[antennaknobs.fly.dev](https://antennaknobs.fly.dev/)** (a single
+**[app.antennaknobs.dev](https://app.antennaknobs.dev/)** (a single
 FastAPI process serving the API, the `/ws` live-solve channel, and the built
 React SPA). It's deployed as a container on Fly.io; the repo's `docs/deploy.md`
 is the runbook.

--- a/site/src/content/docs/start/welcome.md
+++ b/site/src/content/docs/start/welcome.md
@@ -32,6 +32,6 @@ re-solve and redraw in real time.
 
 The live simulator is running here — open it, pick a design, and drag a knob:
 
-👉 **[antennaknobs.fly.dev](https://antennaknobs.fly.dev/)**
+👉 **[app.antennaknobs.dev](https://app.antennaknobs.dev/)**
 
 Then come back for the [Quickstart](/start/quickstart/) to drive it from Python.


### PR DESCRIPTION
## Summary
- **DNS runbook (`docs/cloudflare-dns.md`)** rewritten to match the as-built setup: both `antennaknobs.dev` and `antennaknobs.com` are mirrored — apex → docs app, `app.*` subdomain → simulator app. Adds an "As-built layout" table, the four `flyctl certs add` commands, the per-zone record set (8 records total), and a two-zone API script.
- **Site simulator links** now point at the canonical `https://app.antennaknobs.dev/` instead of the temporary `antennaknobs.fly.dev`: `SIMULATOR_URL` in `astro.config.mjs`, the home hero, and the welcome / web-reference / catalog pages. `site/README` note refreshed (DNS is wired up).
- Background: both custom domains are live with Fly certs `Issued` and all four hostnames serving 200 over valid TLS; the stray `antennaknobs-4b980q` Fly app was destroyed.

## Test plan
- [ ] CI build passes (Astro site builds with the new links)
- [ ] After merge, `deploy-docs.yml` redeploys the docs site
- [ ] `https://antennaknobs.dev` and the "Open the live simulator" link resolve to `app.antennaknobs.dev` (200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)