### PR TITLE
Publish antennaknobs to real PyPI + simplify install docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ name: publish
 # wheel matrix and no cibuildwheel.
 #
 # Triggers:
-#   - push tag v*: build, publish to TestPyPI (Trusted Publishing), and attach
+#   - push tag v*: build, publish to PyPI (Trusted Publishing), and attach
 #     the wheel + sdist to the GitHub Release.
 #   - workflow_dispatch: build the dist on a branch to validate packaging
 #     (sdist/wheel contents) without publishing — the publish/release jobs are
@@ -48,8 +48,13 @@ jobs:
           name: dist
           path: dist/*
 
-  publish-testpypi:
-    name: publish to TestPyPI
+  publish-pypi:
+    # Publish to PyPI via Trusted Publishing (OIDC) — no stored token. Requires a
+    # trusted/pending publisher on pypi.org for project `antennaknobs`: owner
+    # stevenmburns, repo antennaknobs, workflow publish.yml, no environment.
+    # Omitting repository-url defaults the action to https://upload.pypi.org/legacy/.
+    # skip-existing makes a re-run of an already-published version a no-op.
+    name: publish to PyPI
     needs: build
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
@@ -60,10 +65,9 @@ jobs:
         with:
           name: dist
           path: dist
-      - name: Publish to TestPyPI
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: https://test.pypi.org/legacy/
           packages-dir: dist
           skip-existing: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@
 #
 # Stage 1 builds the React/Vite SPA to src/antennaknobs/web/static.
 # Stage 2 is a slim Python runtime that installs the package + its C++ engine
-# wheels (momwire, pynec-accel) from TestPyPI and serves everything from one
-# uvicorn process (API + the /ws live-solve WebSocket + the static SPA).
+# wheels from PyPI and serves everything from one uvicorn process (API + the /ws
+# live-solve WebSocket + the static SPA). momwire (MIT) installs with the core;
+# pynec-accel (optional, GPL-2.0) is a separate, standalone install step.
 #
 # See docs/deploy.md for the build/run/deploy runbook.
 
@@ -48,18 +49,18 @@ COPY src/ ./src/
 # The built SPA from stage 1.
 COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/static
 
-# The C++ engine wheels live on TestPyPI; their scientific deps (numpy/scipy)
-# come from real PyPI. Install those FIRST so the editable install below sees
-# the momwire requirement already satisfied — and so the second install can use
-# real PyPI ONLY. (TestPyPI must NOT be an index for the `[web]` deps: it hosts a
-# stray, unbuildable `fastapi` sdist that shadows the real wheel and breaks the
-# build.)
+# Install momwire (the MIT C++ engine, a declared dependency) first so the
+# editable install below sees its requirement already satisfied, then the package
+# with the web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install \
-      --index-url https://test.pypi.org/simple/ \
-      --extra-index-url https://pypi.org/simple/ \
-      "momwire>=0.2.2" "pynec-accel>=1.7.4.post1" \
+ && pip install "momwire>=0.2.2" \
  && pip install -e ".[web]"
+
+# Optional NEC2 cross-validation backend — pynec-accel is GPL-2.0, NOT a
+# dependency of this MIT package, and installed as its OWN standalone step (never
+# in the same pip command as the MIT packages). antennaknobs runs fully on
+# momwire alone; this only enables the PyNEC cross-check.
+RUN pip install "pynec-accel>=1.7.4.post1"
 
 EXPOSE 8000
 

--- a/README.md
+++ b/README.md
@@ -287,28 +287,28 @@ User-authored designs (in the `user.*` namespace) appear here too; filter with
 
 ## Install
 
-### From TestPyPI (prebuilt wheels — no toolchain)
+### From PyPI (prebuilt wheels — no toolchain)
 
-All three packages are published to **TestPyPI**: `antennaknobs`, its engine
-`momwire` (C++ accelerator wheels), and the optional NEC2 backend `pynec-accel`.
-TestPyPI doesn't host the usual scientific deps (numpy/scipy/fastapi/…), so point
-pip at TestPyPI for these packages and at real PyPI for everything else:
+`antennaknobs` and its MIT C++ engine `momwire` are published to **PyPI** with
+prebuilt wheels, so a plain install needs no compiler:
 
 ```bash
 python3 -m venv .venv && source .venv/bin/activate
 pip install --upgrade pip
 
 # antennaknobs + the web workbench; momwire (the engine) comes along as a dep
-pip install \
-  --index-url https://test.pypi.org/simple/ \
-  --extra-index-url https://pypi.org/simple/ \
-  "antennaknobs[web]"
+pip install "antennaknobs[web]"
+```
 
-# optional: PyNEC cross-validation backend (GPL-2.0; Linux/Windows/macOS-arm64 wheels)
-pip install \
-  --index-url https://test.pypi.org/simple/ \
-  --extra-index-url https://pypi.org/simple/ \
-  pynec-accel
+The optional NEC2 cross-validation backend **`pynec-accel`** is **GPL-2.0** — it
+is *not* a dependency of antennaknobs and is installed as a **separate** step,
+never in the same `pip install` command as the MIT packages. antennaknobs is
+fully functional on momwire alone; install pynec-accel only to cross-check
+against NEC2:
+
+```bash
+# optional, GPL-2.0 (Linux / Windows / macOS-arm64 wheels)
+pip install pynec-accel
 ```
 
 Then launch the workbench with `uvicorn antennaknobs.web.server:app` (see
@@ -362,19 +362,16 @@ momwire is still fully functional; install it only if you want to cross-check
 against NEC2.
 
 ```bash
-# Wheel from the python-necpp fork's release (OpenBLAS + libgfortran vendored).
-# The fork is distributed as `pynec-accel` (the import name stays `import
-# PyNEC`); --no-index avoids upstream PyNEC/pynec on PyPI, whose builds are
-# broken on current Python and lack the fork's BLAS/OpenMP work.
+# The fork is published to PyPI as `pynec-accel` (a distinct name from upstream
+# PyNEC/pynec, whose builds are broken on current Python; the import name stays
+# `import PyNEC`). Its wheels vendor OpenBLAS + libgfortran.
 #
-# Use >= 1.7.4.post2 (release v1.7.4-accel.6 or later). Earlier builds vendored
-# their own libgomp, which clashes with momwire's system libgomp via a static-
-# TLS limit and silently knocks momwire's C++ accelerator onto its slow pure-
-# Python path whenever both backends load in one process. 1.7.4.post1 binds the
-# system libgomp instead, so it needs a system libgomp at runtime (universal on
-# glibc Linux — the GCC OpenMP runtime).
-pip install pynec-accel --no-index \
-    --find-links https://github.com/stevenmburns/python-necpp/releases/expanded_assets/v1.7.4-accel.6
+# Use >= 1.7.4.post2: earlier builds vendored their own libgomp, which clashes
+# with momwire's system libgomp via a static-TLS limit and silently knocks
+# momwire's C++ accelerator onto its slow pure-Python path whenever both backends
+# load in one process. post2 binds the system libgomp instead (universal on glibc
+# Linux — the GCC OpenMP runtime).
+pip install "pynec-accel>=1.7.4.post2"
 ```
 
 **4. Install AntennaKNoBs**
@@ -455,8 +452,7 @@ macOS wheels for **Apple Silicon (arm64), macOS 14+, Python 3.10–3.14** only �
 there are no Intel-Mac wheels, so on an Intel Mac skip PyNEC and use momwire alone.
 
 ```bash
-pip install pynec-accel --no-index \
-    --find-links https://github.com/stevenmburns/python-necpp/releases/expanded_assets/v1.7.4-accel.6
+pip install "pynec-accel>=1.7.4.post2"
 ```
 
 With **pynec-accel ≥ 1.7.4.post2** and **momwire ≥ 0.2.1**, neither wheel vendors

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -2,7 +2,7 @@
 
 This deploys the web workbench (`antennaknobs.web.server:app` — the API, the
 `/ws` live-solve WebSocket, and the built React SPA) as a single persistent
-container on [Fly.io](https://fly.io). It uses the prebuilt TestPyPI engine
+container on [Fly.io](https://fly.io). It uses the prebuilt PyPI engine
 wheels, so the image needs **no C++ toolchain**.
 
 Files involved: [`Dockerfile`](../Dockerfile), [`.dockerignore`](../.dockerignore),
@@ -30,8 +30,9 @@ curl -fsS http://127.0.0.1:8000/healthz   # -> ok
 ```
 
 If the build fails on the engine wheels, check that `momwire` and
-`pynec-accel>=1.7.4.post1` resolve on TestPyPI for linux (the `pip install`
-step in the `Dockerfile`).
+`pynec-accel>=1.7.4.post1` resolve on PyPI for linux (the `pip install`
+steps in the `Dockerfile` — momwire with the core, pynec-accel as its own
+optional GPL-2.0 step).
 
 ## 2. First deploy
 
@@ -88,7 +89,7 @@ push a `v*` tag, and three workflows fire off that one tagged commit:
 |---|---|---|
 | [`fly-deploy.yml`](../.github/workflows/fly-deploy.yml) | simulator (`antennaknobs`) | `FLY_API_TOKEN_SIMULATOR` |
 | [`deploy-docs.yml`](../.github/workflows/deploy-docs.yml) | docs site (`antennaknobs-docs`) | `FLY_API_TOKEN_DOCS` |
-| [`publish.yml`](../.github/workflows/publish.yml) | the package → TestPyPI + GitHub Release | — (Trusted Publishing) |
+| [`publish.yml`](../.github/workflows/publish.yml) | the package → PyPI + GitHub Release | — (Trusted Publishing) |
 
 So the tagged version number always names exactly what's live across the package,
 the simulator, and the docs — they ship as one consistent snapshot.

--- a/site/src/content/docs/start/quickstart.md
+++ b/site/src/content/docs/start/quickstart.md
@@ -5,22 +5,21 @@ description: Install antennaknobs and solve your first antenna in a few lines of
 
 ## Install
 
-The package and its engine wheels are published to TestPyPI; the scientific
-dependencies come from real PyPI:
+`antennaknobs` and its MIT engine `momwire` are published to PyPI with prebuilt
+wheels — a plain install needs no compiler:
 
 ```bash
 python3 -m venv .venv && source .venv/bin/activate
 pip install --upgrade pip
 
-pip install \
-  --index-url https://test.pypi.org/simple/ \
-  --extra-index-url https://pypi.org/simple/ \
-  "antennaknobs[web]"
+pip install "antennaknobs[web]"
 ```
 
 :::note
-`momwire` (the solver) comes along as a dependency. For the optional NEC-2
-cross-validation backend, also `pip install pynec-accel` from the same indexes.
+`momwire` (the solver) comes along as a dependency. The optional NEC-2
+cross-validation backend `pynec-accel` is **GPL-2.0** — not a dependency of
+antennaknobs — so install it on its own, never in the same command:
+`pip install pynec-accel`. antennaknobs is fully functional without it.
 :::
 
 ## Launch the web workbench


### PR DESCRIPTION
## Summary
Now that **momwire** (live, 0.2.3) and **pynec-accel** publish to real PyPI, move antennaknobs there too and drop the TestPyPI dual-index dance.

- **`publish.yml`**: `publish-testpypi` → `publish-pypi` — drop the `test.pypi.org` `repository-url` (defaults to `upload.pypi.org`). Trusted Publishing + `skip-existing` unchanged.
- **`Dockerfile`**: install from PyPI (no `--index-url`); split the engine install so the MIT core (`momwire` + `antennaknobs[web]`) and the optional **GPL-2.0** `pynec-accel` are **separate** pip steps — never the same command.
- **README / quickstart**: `From TestPyPI` → `From PyPI`; core install collapses to `pip install "antennaknobs[web]"`. `pynec-accel` is framed as optional, GPL-2.0, installed on its own line; source-build sections swap the GitHub-release `--find-links` for plain `pip install "pynec-accel>=1.7.4.post2"`.
- **`docs/deploy.md`**: TestPyPI → PyPI.
- **Submodule bump**: `momwire` pin → `b23d4bd` (the published 0.2.3 main).

**Licensing:** `pynec-accel` (GPL-2.0) stays out of antennaknobs' dependencies and is always a standalone, optional install; antennaknobs runs fully on `momwire` (MIT) alone.

## Sequencing (important)
The Dockerfile + README now install `pynec-accel` from real PyPI, so **`pynec-accel` must be published to real PyPI before antennaknobs is *tagged/released*** (the release tag builds the Docker image and publishes the package). Merging this PR is safe on its own — deploys/publishes are tag-gated.

## Test plan
- [ ] CI (ruff + tests) green
- [ ] pynec-accel published to real PyPI first
- [ ] After the antennaknobs release tag: `publish.yml` uploads to https://pypi.org/project/antennaknobs/, the Fly Docker build resolves both engines from PyPI, and a clean `pip install "antennaknobs[web]"` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)