### PR TITLE
Bump antennaknobs to 0.5.1 for first real-PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.5.0"
+version = "0.5.1"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]


### PR DESCRIPTION
## Summary
First real-PyPI release needs a fresh version: `v0.5.0` is already tagged (at a commit whose `publish.yml` targeted TestPyPI). Bump `0.5.0 → 0.5.1`.

After merge, tagging `v0.5.1` triggers the tag-to-deploy workflows: **publish** (→ real PyPI), **fly-deploy** (simulator Docker, now pulling momwire + pynec-accel from real PyPI), and **deploy-docs**.

## Test plan
- [ ] Merge, then push `v0.5.1`
- [ ] `publish.yml` uploads to https://pypi.org/project/antennaknobs/
- [ ] Fly Docker build resolves both engines from real PyPI; simulator + docs redeploy
- [ ] Clean `pip install "antennaknobs[web]"` works from real PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)