### PR TITLE
Simplify pynec-accel + momwire install prose (drop license-label noise)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 # Stage 1 builds the React/Vite SPA to src/antennaknobs/web/static.
 # Stage 2 is a slim Python runtime that installs the package + its C++ engine
 # wheels from PyPI and serves everything from one uvicorn process (API + the /ws
-# live-solve WebSocket + the static SPA). momwire (MIT) installs with the core;
-# pynec-accel (optional, GPL-2.0) is a separate, standalone install step.
+# live-solve WebSocket + the static SPA). The momwire engine installs with the
+# core; the optional NEC2 backend pynec-accel is a separate install step.
 #
 # See docs/deploy.md for the build/run/deploy runbook.
 
@@ -49,17 +49,16 @@ COPY src/ ./src/
 # The built SPA from stage 1.
 COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/static
 
-# Install momwire (the MIT C++ engine, a declared dependency) first so the
-# editable install below sees its requirement already satisfied, then the package
-# with the web extra. All from PyPI (the default index).
+# Install momwire (the C++ engine, a declared dependency) first so the editable
+# install below sees its requirement already satisfied, then the package with the
+# web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
  && pip install "momwire>=0.2.2" \
  && pip install -e ".[web]"
 
-# Optional NEC2 cross-validation backend — pynec-accel is GPL-2.0, NOT a
-# dependency of this MIT package, and installed as its OWN standalone step (never
-# in the same pip command as the MIT packages). antennaknobs runs fully on
-# momwire alone; this only enables the PyNEC cross-check.
+# Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in
+# its own step. antennaknobs runs fully on momwire alone; this adds the NEC2
+# engine as an alternative.
 RUN pip install "pynec-accel>=1.7.4.post1"
 
 EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ User-authored designs (in the `user.*` namespace) appear here too; filter with
 
 ### From PyPI (prebuilt wheels — no toolchain)
 
-`antennaknobs` and its MIT C++ engine `momwire` are published to **PyPI** with
+`antennaknobs` and its C++ engine `momwire` are published to **PyPI** with
 prebuilt wheels, so a plain install needs no compiler:
 
 ```bash
@@ -300,14 +300,10 @@ pip install --upgrade pip
 pip install "antennaknobs[web]"
 ```
 
-The optional NEC2 cross-validation backend **`pynec-accel`** is **GPL-2.0** — it
-is *not* a dependency of antennaknobs and is installed as a **separate** step,
-never in the same `pip install` command as the MIT packages. antennaknobs is
-fully functional on momwire alone; install pynec-accel only to cross-check
-against NEC2:
+Optionally, add the **NEC2 solver** (PyNEC) as an alternative to momwire:
 
 ```bash
-# optional, GPL-2.0 (Linux / Windows / macOS-arm64 wheels)
+# optional NEC2 solver (Linux / Windows / macOS-arm64 wheels)
 pip install pynec-accel
 ```
 

--- a/site/src/content/docs/start/quickstart.md
+++ b/site/src/content/docs/start/quickstart.md
@@ -5,7 +5,7 @@ description: Install antennaknobs and solve your first antenna in a few lines of
 
 ## Install
 
-`antennaknobs` and its MIT engine `momwire` are published to PyPI with prebuilt
+`antennaknobs` and its engine `momwire` are published to PyPI with prebuilt
 wheels — a plain install needs no compiler:
 
 ```bash
@@ -16,10 +16,12 @@ pip install "antennaknobs[web]"
 ```
 
 :::note
-`momwire` (the solver) comes along as a dependency. The optional NEC-2
-cross-validation backend `pynec-accel` is **GPL-2.0** — not a dependency of
-antennaknobs — so install it on its own, never in the same command:
-`pip install pynec-accel`. antennaknobs is fully functional without it.
+`momwire` (the solver) comes along as a dependency. Optionally, add the NEC2
+solver (PyNEC) as an alternative to momwire:
+
+```bash
+pip install pynec-accel
+```
 :::
 
 ## Launch the web workbench


### PR DESCRIPTION
## Summary
Make the user-facing install steps say only what an installer needs. License labels are a contributor/distribution concern, not install-instruction noise — and the legal separation that protects the MIT package lives in the **package metadata** (pynec-accel is not a declared dependency) and the **LICENSE files**, not in prose.

- **README "From PyPI" + quickstart**: present `pynec-accel` simply as an **optional NEC2 solver (PyNEC), an alternative to momwire**, with the command in a code box. Drop "MIT engine", the GPL labels, "never in the same pip command", and the redundant "fully functional without it".
- **Dockerfile**: drop MIT/GPL labels from the build comments; keep the separate `pynec-accel` install step (it's just not a dependency).
- The GPL/MIT separation stays documented in the README **backends** section and the LICENSE files.

## Test plan
- [ ] CI (ruff + build) green
- [ ] `pip install pynec-accel` renders in a code box in the quickstart note

🤖 Generated with [Claude Code](https://claude.com/claude-code)