### PR TITLE
Website brand parity with the app's Blueprint theme + AntennaKNoBs branding

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig({
   site: "https://antennaknobs.dev",
   integrations: [
     starlight({
-      title: "antennaknobs",
+      title: "AntennaKNoBs",
       tagline: "Turn a knob, watch the antenna.",
       social: [
         {
@@ -22,6 +22,29 @@ export default defineConfig({
         },
       ],
       customCss: ["./src/styles/custom.css"],
+      // Load IBM Plex Sans / Mono (the app's typefaces) — same source as the
+      // app's index.html. custom.css points --sl-font / --sl-font-mono at them.
+      head: [
+        {
+          tag: "link",
+          attrs: { rel: "preconnect", href: "https://fonts.googleapis.com" },
+        },
+        {
+          tag: "link",
+          attrs: {
+            rel: "preconnect",
+            href: "https://fonts.gstatic.com",
+            crossorigin: true,
+          },
+        },
+        {
+          tag: "link",
+          attrs: {
+            rel: "stylesheet",
+            href: "https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap",
+          },
+        },
+      ],
       sidebar: [
         {
           label: "Start here",

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -1,8 +1,9 @@
 ---
-title: antennaknobs
+title: AntennaKNoBs
 description: A browser-based wire-antenna method-of-moments simulator. Turn a knob, watch the radiation pattern, SWR, and impedance move in real time.
 template: splash
 hero:
+  title: AntennaKNoBs
   tagline: Turn a knob, watch the antenna. A browser-based wire-antenna MoM simulator — no install, no NEC deck to hand-write.
   actions:
     - text: Open the live simulator

--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -1,12 +1,72 @@
-/* antennaknobs brand accent. Starlight derives the rest of the palette from
-   these. Tweak freely — this is just a starting point. */
+/* Brand parity with the live app's "Blueprint" theme.
+ *
+ * The app (src/antennaknobs/web/frontend/src/styles.css) is driven by a single
+ * :root token set. This file maps that palette onto Starlight's theming
+ * variables (the --sl-* gray ramp + accent + fonts), so the docs share the
+ * app's instrument-panel look. Values are lifted from the app's light and dark
+ * token blocks. Fonts (IBM Plex Sans / Mono) are loaded via the `head` config
+ * in astro.config.mjs.
+ *
+ * Starlight derives most semantic colors (text, bg, hairlines, code) from the
+ * gray ramp + white/black + accent below; overriding those endpoints retints
+ * the whole site coherently. */
+
 :root {
-  --sl-color-accent-low: #11243a;
-  --sl-color-accent: #2b7fff;
-  --sl-color-accent-high: #b9d6ff;
+  /* Match the app's typography. */
+  --sl-font: "IBM Plex Sans", system-ui, -apple-system, "Segoe UI", sans-serif;
+  --sl-font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 }
+
+/* ---- Dark theme (Starlight's default) — app [data-theme="dark"] palette ---- */
+:root,
+:root[data-theme="dark"] {
+  /* accent — the app's signal cyan (--accent #76d0ff) */
+  --sl-color-accent-low: #15323f;
+  --sl-color-accent: #2f7d9e;
+  --sl-color-accent-high: #9fdcff;
+
+  /* gray ramp: white = headings → black = page bg, lifted from the app's
+     dark surfaces (--bg/--panel/--stage) and ink (--fg/--muted/--border). */
+  --sl-color-white: #eef1f6; /* headings */
+  --sl-color-gray-1: #e6e9ef; /* --fg */
+  --sl-color-gray-2: #c4ccd8; /* body text */
+  --sl-color-gray-3: #9aa3b2; /* --muted */
+  --sl-color-gray-4: #5d6675;
+  --sl-color-gray-5: #343c4a; /* --border-control */
+  --sl-color-gray-6: #232932; /* nav / sidebar surface */
+  --sl-color-gray-7: #181b22; /* --panel */
+  --sl-color-black: #0f1115; /* --bg (page) */
+}
+
+/* ---- Light theme — app :root (light) palette ---- */
 :root[data-theme="light"] {
-  --sl-color-accent-low: #c3d9ff;
-  --sl-color-accent: #1f6fe5;
-  --sl-color-accent-high: #0a2a5c;
+  /* accent — the app's blueprint blue (--accent #2f5fb0) */
+  --sl-color-accent-low: #c9dbf5;
+  --sl-color-accent: #2f5fb0;
+  --sl-color-accent-high: #163a72;
+
+  /* gray ramp inverted for light: white = strong text → black = page bg. */
+  --sl-color-white: #0e1b2e; /* headings / strong text */
+  --sl-color-gray-1: #152439; /* --fg */
+  --sl-color-gray-2: #2c3a50; /* body text */
+  --sl-color-gray-3: #5d6e85; /* --muted */
+  --sl-color-gray-4: #8294ab;
+  --sl-color-gray-5: #c6d2e0; /* --border */
+  --sl-color-gray-6: #e0e8f1; /* nav / sidebar surface */
+  --sl-color-gray-7: #eef3f9; /* --readout-bg */
+  --sl-color-black: #e9eff6; /* --inset → soft blueprint page tint */
+}
+
+/* Hero byline — the "by KK7KNB" callsign attribution under the AntennaKNoBs
+   title, mirroring the app's brand block (App.tsx `.brand .byline`). Splash
+   homepage only (the hero <h1 data-page-title>). */
+.hero h1[data-page-title]::after {
+  content: "by KK7KNB";
+  display: block;
+  margin-top: 0.55rem;
+  font-family: var(--sl-font-mono);
+  font-size: 1rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  color: var(--sl-color-gray-3);
 }


### PR DESCRIPTION
## Summary
Bring the live app's "Blueprint" look to the Starlight docs site (Layer A — styling only, no new deps, still Starlight + Astro).

- **`custom.css`**: map the app's light/dark surfaces, ink, borders, and accent onto Starlight's `--sl-*` gray ramp + accent (both themes). Add the `by KK7KNB` callsign byline under the hero title, mirroring the app's brand block.
- **`astro.config.mjs`**: site title → **AntennaKNoBs**; load IBM Plex Sans/Mono (the app's typefaces) via the `head` config.
- **`index.mdx`**: hero/page title → **AntennaKNoBs**.

Display branding only — the `antennaknobs` package/import/CLI/URL names stay lowercase. Light and dark themes verified via screenshots.

## Note
Merging does **not** deploy (the docs site is tag-to-deploy) — these styles go live on the next `v*` release tag.

## Test plan
- [ ] CI (ruff + build) green
- [ ] Site builds; light + dark themes render the Blueprint palette + IBM Plex fonts + the AntennaKNoBs/KK7KNB branding

🤖 Generated with [Claude Code](https://claude.com/claude-code)