### PR TITLE
Hosted-only solve-size cap to protect the shared instance

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -150,3 +150,33 @@ instant" threshold. If it ever feels sluggish, the levers are: debounce knob
 events client-side, lean on the existing solve cache, default to the fast ground
 approximation while dragging, and keep `min_machines_running = 1` so there's no
 cold start.
+
+## Live-engine size cap (hosted only)
+
+A solve builds a method-of-moments system whose dimension N ≈ the total wire
+segment count. The dense solvers — and PyNEC — form an N×N complex matrix
+(memory N²·16 bytes), so an unbounded N — a hand-edited request cranking
+"segments / wire", or a very large array — could exhaust a small box's RAM.
+
+This guard is **off by default**, so the package people `pip install` and run
+locally is **unlocked** (solve as big as your own machine allows). It turns on
+**only** when **`ANTENNAKNOBS_HOSTED=1`** is set — which this repo's `fly.toml`
+`[env]` does for the shared instance. Same wheel, unlocked locally and capped
+online. When on, the server rejects an oversized solve *before* the matrix is
+allocated, with a clear error in the UI.
+
+The caps target a single solve's matrix staying under **~800 MB** on the 2 GB
+Fly box (`basis = √(800·2²⁰/16) ≈ 7000` for a dense N×N). They're about
+**memory, not time** (PyNEC's ~N³ LU is slow long before it's large — a
+responsiveness concern, deliberately not guarded). The numbers come from
+measuring `arrays.bowtiearray2x4` (see `scripts/measure_solve_memory.py`): PyNEC
+tracks the full dense N×N (~1 GB at basis 8000); `arrayblock`'s block-low-rank
+uses ~0.6× of that, so it gets a proportionally higher cap. Override any of them
+in `fly.toml`'s `[env]` if the VM grows:
+
+| Env var | Default | Applies to |
+|---|---|---|
+| `ANTENNAKNOBS_HOSTED` | *(unset → off)* | **master switch** — set to `1` to enforce the caps below |
+| `ANTENNAKNOBS_MAX_BASIS` | `7000` | dense momwire (triangular / sinusoidal / bspline) — full N×N |
+| `ANTENNAKNOBS_MAX_BASIS_COMPRESSED` | `9000` | `arrayblock` / `hmatrix` (block-low-rank, ~0.6× dense memory) |
+| `ANTENNAKNOBS_MAX_BASIS_PYNEC` | `7000` | PyNEC (full dense N×N, same as dense momwire) |

--- a/fly.toml
+++ b/fly.toml
@@ -9,6 +9,13 @@ primary_region = 'sjc'
 [build]
   dockerfile = 'Dockerfile'
 
+[env]
+  # This is the shared, public instance — enforce the live-engine solve-size
+  # caps (server.py) so one oversized solve can't OOM the box. The package is
+  # unlocked by default; only this flag turns the caps on. Tune the limits with
+  # ANTENNAKNOBS_MAX_BASIS[_COMPRESSED|_PYNEC] if the VM size changes.
+  ANTENNAKNOBS_HOSTED = '1'
+
 [http_service]
   internal_port = 8000
   force_https = true

--- a/scripts/measure_solve_memory.py
+++ b/scripts/measure_solve_memory.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Measure a solve's peak memory (and time) vs segment count, per engine.
+
+This is how the live-engine size caps in ``web/server.py`` were derived: the
+caps bound a single solve's matrix memory so one oversized request can't OOM
+the shared box. Re-run it when the deployment VM size changes to re-pick them.
+
+Each N is measured in a *fresh subprocess* so ``ru_maxrss`` (peak RSS) reflects
+that one solve, not the high-water mark of every prior solve in the loop. The
+solve is called directly (not through the server), so the cap itself doesn't
+reject the very runs we're trying to measure.
+
+Usage:
+    python scripts/measure_solve_memory.py <geometry> <engine> <N> [<N> ...]
+
+    engine ∈ {triangular, sinusoidal, bspline, hmatrix, arrayblock, pynec}
+
+Example:
+    python scripts/measure_solve_memory.py arrays.bowtiearray2x4 arrayblock 21 41 81
+    python scripts/measure_solve_memory.py arrays.bowtiearray2x4 pynec 21 41 81 121
+"""
+
+import resource
+import subprocess
+import sys
+import time
+
+_WORKER = "--worker"
+
+
+def _measure_one(geometry: str, engine: str, n: int) -> None:
+    """Worker: run one solve and print a result line. Run in its own process."""
+    from antennaknobs.web.examples import REGISTRY
+
+    ex = REGISTRY[geometry]
+    use_pynec = engine == "pynec"
+    req = {
+        "geometry": geometry,
+        "n_per_wire": n,
+        "measurement_freq_mhz": 28.5,
+        "design_freq_mhz": 28.5,
+    }
+    if use_pynec:
+        req["solver"] = "pynec"
+        solve = ex.pynec_solve
+    else:
+        req["momwire_model"] = engine
+        solve = ex.momwire_solve
+
+    # momwire-basis proxy (the count the caps use). NEC's own segment count is
+    # close enough that PyNEC's RSS still tracks (basis**2 * 16) — see deploy.md.
+    basis = ex.count_basis(req)
+    rss_pre = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0  # MB
+    t0 = time.perf_counter()
+    out = solve(req)
+    dt_ms = (time.perf_counter() - t0) * 1e3
+    rss_peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0  # MB
+    dense_mb = (basis * basis * 16) / (1024 * 1024)
+    print(
+        f"N={n:4d}  basis~{basis:6d}  solve={dt_ms:9.0f} ms  "
+        f"peak={rss_peak:7.0f} MB  delta={rss_peak - rss_pre:7.0f} MB  "
+        f"dense_NxN~{dense_mb:7.0f} MB  "
+        f"Z={out['z_in_re']:.0f}{out['z_in_im']:+.0f}j",
+        flush=True,
+    )
+
+
+def main() -> None:
+    if len(sys.argv) >= 5 and sys.argv[1] == _WORKER:
+        _measure_one(sys.argv[2], sys.argv[3], int(sys.argv[4]))
+        return
+    if len(sys.argv) < 4:
+        print(__doc__)
+        sys.exit(2)
+    geometry, engine, *ns = sys.argv[1:]
+    print(f"# {geometry}  engine={engine}  (peak = total process RSS)")
+    for n in ns:
+        proc = subprocess.run(
+            [sys.executable, __file__, _WORKER, geometry, engine, n],
+            capture_output=True,
+            text=True,
+        )
+        line = next(
+            (ln for ln in proc.stdout.splitlines() if ln.startswith("N=")), None
+        )
+        print(line if line else f"N={n:>4}  FAILED\n{proc.stderr.strip()[-500:]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -964,6 +964,17 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         vp = _variant_params(cls, req.get("variant"))
         return float(vp.get("freq", 14.0))
 
+    def count_basis(req: dict):
+        """Total wire segments (≈ MoM basis functions, the N×N matrix dim) the
+        request would build. Geometry-only (cheap) — runs build_wires but no
+        solve. Returns None if the geometry can't be built; the real solve then
+        surfaces the underlying error instead of a spurious size rejection."""
+        try:
+            builder = _build_builder(cls, req)
+            return sum(int(w[2]) for w in builder.build_wires())
+        except Exception:
+            return None
+
     def momwire_solve(req: dict) -> dict:
         design_freq = float(req.get("design_freq_mhz", _design_freq_default(req)))
         meas_freq = float(req.get("measurement_freq_mhz", design_freq))
@@ -1245,6 +1256,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         momwire_solve=momwire_solve,
         momwire_sweep=momwire_sweep,
         momwire_geometry=momwire_geometry,
+        count_basis=count_basis,
         default_backend=field_default_backend,
         pynec_solve=pynec_solve,
         pynec_build=pynec_build,

--- a/src/antennaknobs/web/examples/_base.py
+++ b/src/antennaknobs/web/examples/_base.py
@@ -293,6 +293,12 @@ class AntennaExample:
     # fast antenna-shape preview while the real solve runs. Optional so an
     # example without one degrades to "no preview".
     momwire_geometry: Optional[SolveFn] = None
+    # Cheap geometry-only count of the wire segments (≈ MoM basis functions /
+    # matrix dimension N) a solve request would build, used to reject solves
+    # that would allocate an N×N matrix too large/slow for the live engine. None
+    # if the geometry can't be built (the real solve surfaces that error). Takes
+    # the same req dict as momwire_solve.
+    count_basis: Optional[Callable[[dict], Optional[int]]] = None
     # Recommended default solver backend for this design (e.g. "arrayblock" for
     # grid arrays, where it's far faster than the dense default). None lets the
     # UI keep its own default. Surfaced in the /examples schema; the frontend

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -370,6 +370,92 @@ def _polyline_knots(polyline: np.ndarray, npe_list: list[int]) -> np.ndarray:
 _SOLVE_CACHE: "OrderedDict[str, dict]" = OrderedDict()
 _SOLVE_CACHE_MAX = 100
 
+
+# --- Live-engine size guard (hosted only) ----------------------------------
+# A solve builds a method-of-moments system whose dimension N ≈ the total wire
+# segment count (one basis function per segment). The dense solvers — and PyNEC
+# — form an N×N complex128 matrix (memory N²·16 bytes), so an unbounded N (a
+# hand-edited request cranking "segments / wire", or a big array) can exhaust a
+# small box's RAM.
+#
+# This guard is OFF by default, so the package a user `pip install`s and runs
+# locally is unlocked — solve as big as your machine allows. It turns ON only
+# when ANTENNAKNOBS_HOSTED is set (truthy), which the shared instance does via
+# fly.toml's [env]. So the same wheel is unlocked locally and capped online.
+#
+# The caps are sized to keep a single solve's matrix under ~800 MB on the 2 GB
+# Fly box (basis = √(800·2²⁰/16) ≈ 7000 for a dense N×N). Measured on
+# arrays.bowtiearray2x4 (see scripts/measure_solve_memory.py): PyNEC's RSS
+# tracks the full dense N×N (~1 GB at basis 8000), while arrayblock's block-
+# low-rank uses ~0.6× of that — so it's allowed a proportionally higher cap.
+# Caps are about MEMORY, not solve time (PyNEC's ~N³ LU is slow long before it
+# is large; that's a responsiveness concern, deliberately not guarded here).
+# All env-overridable for self-hosting on bigger boxes.
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        v = int(os.environ.get(name, ""))
+    except ValueError:
+        return default
+    return v if v > 0 else default
+
+
+# The master switch: enforce the caps only on the shared/hosted instance.
+_HOSTED = _env_flag("ANTENNAKNOBS_HOSTED")
+
+_MAX_BASIS = _env_int("ANTENNAKNOBS_MAX_BASIS", 7000)  # dense momwire (~800 MB)
+_MAX_BASIS_COMPRESSED = _env_int("ANTENNAKNOBS_MAX_BASIS_COMPRESSED", 9000)
+_MAX_BASIS_PYNEC = _env_int("ANTENNAKNOBS_MAX_BASIS_PYNEC", 7000)
+_COMPRESSED_MODELS = frozenset({"arrayblock", "hmatrix"})
+
+
+class SolveTooLargeError(ValueError):
+    """A solve request exceeds the hosted live-engine segment-count cap."""
+
+
+def _check_solve_size(req: dict, *, use_pynec: bool) -> None:
+    """Reject a solve whose matrix would be too large for the hosted live engine.
+
+    No-op unless running hosted (ANTENNAKNOBS_HOSTED) — local instances are
+    unlocked. Best-effort: counts segments via the geometry-only ``count_basis``
+    hook (cheap — no solve). If the count can't be determined (geometry won't
+    build), return and let the normal solve path surface the real error.
+    """
+    if not _HOSTED:
+        return
+    geometry = req.get("geometry", next(iter(EXAMPLES)))
+    ex = EXAMPLES.get(geometry)
+    if ex is None or ex.count_basis is None:
+        return
+    n = ex.count_basis(req)
+    if n is None:
+        return
+    if use_pynec:
+        cap, engine, compressed = _MAX_BASIS_PYNEC, "PyNEC", False
+    elif req.get("momwire_model") in _COMPRESSED_MODELS:
+        cap = _MAX_BASIS_COMPRESSED
+        engine, compressed = str(req.get("momwire_model")), True
+    else:
+        cap, engine, compressed = _MAX_BASIS, "momwire", False
+    if n > cap:
+        # Dense momwire and PyNEC both form the full N×N matrix; point users at
+        # the compressed engines (which don't) for big arrays.
+        hint = (
+            ""
+            if compressed
+            else " — or switch to the array-block / H-matrix engine, which "
+            "handles larger arrays without a dense matrix"
+        )
+        raise SolveTooLargeError(
+            f"This solve needs ~{n} wire segments, over the live {engine} "
+            f"limit of {cap}. Reduce 'segments / wire (N)' or pick a smaller "
+            f"design{hint}."
+        )
+
+
 # Request fields that are pure metadata and never change the physics. Pop
 # them before hashing so noisy frontend additions (timestamps, request ids)
 # don't shred the hit rate. Anything else in `req` is treated as load-
@@ -407,6 +493,7 @@ def _canonical_solve_key(req: dict) -> str:
 def _solve_uncached(req: dict) -> dict:
     geometry = req.get("geometry", next(iter(EXAMPLES)))
     use_pynec = req.get("solver") == "pynec" and pynec_backend.HAVE_PYNEC
+    _check_solve_size(req, use_pynec=use_pynec)
     if use_pynec:
         out = pynec_backend.solve(req)
         _attach_derived_em_fields(out)
@@ -607,11 +694,14 @@ async def converge_endpoint(req: dict, request: Request):
             req_n = dict(req)
             req_n["n_per_wire"] = n
             try:
+                # Reject N values past the size cap (the convergence sweep is
+                # exactly where someone pushes N high); surfaced per-N below.
+                _check_solve_size(req_n, use_pynec=use_pynec)
                 z, feeds_z = await run_in_threadpool(_solve_z_only, req_n)
             except Exception as e:
                 # One-off solver failures (e.g. degenerate geometry at very
-                # small N) shouldn't abort the whole sweep — note the error
-                # for this N and keep going.
+                # small N) or a size rejection shouldn't abort the whole sweep —
+                # note the error for this N and keep going.
                 yield (
                     json.dumps(
                         {

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1148,3 +1148,103 @@ def test_cache_key_recurses_into_model_options():
         assert server._canonical_solve_key(mutant) != base_key, (
             f"model_options.{k} change did not alter the cache key"
         )
+
+
+# ---------------------------------------------------------------------------
+# Live-engine size guard (_check_solve_size). A solve's matrix dimension N ≈ the
+# total wire-segment count; the dense solvers (and PyNEC) form an N×N matrix, so
+# an oversized N must be rejected *before* any matrix fill. The guard is OFF by
+# default (local installs are unlocked) and only enforced when ANTENNAKNOBS_HOSTED
+# is set — which the tests below force via monkeypatch. The cap is engine-aware:
+# the compressed engines (arrayblock/hmatrix) skip the dense matrix and get a
+# higher cap.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def hosted(monkeypatch):
+    """Force the hosted size-guard on for a test (it's off by default)."""
+    monkeypatch.setattr(server, "_HOSTED", True)
+
+
+def _n_per_wire_for_basis(geom: str, target_basis: int) -> int:
+    """An n_per_wire that yields roughly ``target_basis`` segments for ``geom``
+    (basis scales ~linearly with n_per_wire), so the test is robust to the exact
+    cap values."""
+    k = REGISTRY[geom].count_basis({"geometry": geom, "n_per_wire": 100}) / 100.0
+    return max(1, round(target_basis / k))
+
+
+def test_count_basis_scales_with_segments():
+    ex = REGISTRY["dipoles.invvee"]
+    small = ex.count_basis({"geometry": "dipoles.invvee", "n_per_wire": 20})
+    big = ex.count_basis({"geometry": "dipoles.invvee", "n_per_wire": 200})
+    assert small is not None and big is not None
+    assert big > small  # more segments per wire → larger MoM system
+
+
+def test_size_guard_disabled_by_default_local_is_unlocked():
+    # With ANTENNAKNOBS_HOSTED unset (the default), even an absurd N is allowed —
+    # a local `pip install` instance is uncapped.
+    server._check_solve_size(
+        {
+            "geometry": "dipoles.invvee",
+            "n_per_wire": server._MAX_BASIS * 100,
+            "momwire_model": "triangular",
+        },
+        use_pynec=False,
+    )
+
+
+def test_check_solve_size_passes_for_normal_request(hosted):
+    # A modest segment count is well under every cap → no rejection.
+    server._check_solve_size(
+        {"geometry": "dipoles.invvee", "n_per_wire": 40, "momwire_model": "triangular"},
+        use_pynec=False,
+    )
+
+
+def test_check_solve_size_rejects_oversized_dense_but_allows_compressed(hosted):
+    geom = "dipoles.invvee"
+    # Aim the segment count between the dense and compressed caps so the dense
+    # engine rejects but the compressed one (higher cap) accepts.
+    target = (server._MAX_BASIS + server._MAX_BASIS_COMPRESSED) // 2
+    req = {
+        "geometry": geom,
+        "n_per_wire": _n_per_wire_for_basis(geom, target),
+        "momwire_model": "triangular",
+    }
+    basis = REGISTRY[geom].count_basis(req)
+    assert server._MAX_BASIS < basis <= server._MAX_BASIS_COMPRESSED, (
+        "test premise: basis must land between the dense and compressed caps"
+    )
+
+    # Dense engine rejects with a clear, actionable message.
+    with pytest.raises(server.SolveTooLargeError) as excinfo:
+        server._check_solve_size(req, use_pynec=False)
+    assert "segments / wire" in str(excinfo.value)
+
+    # The same N on a compressed engine is accepted (no dense matrix).
+    server._check_solve_size({**req, "momwire_model": "arrayblock"}, use_pynec=False)
+
+
+def test_solve_rejects_oversized_request_before_filling_matrix(hosted):
+    # The full solve() path raises the size error cheaply (geometry-only count,
+    # no expensive matrix fill).
+    with pytest.raises(server.SolveTooLargeError):
+        server.solve(
+            {
+                "geometry": "dipoles.invvee",
+                "n_per_wire": _n_per_wire_for_basis("dipoles.invvee", server._MAX_BASIS)
+                * 2,
+                "momwire_model": "triangular",
+            }
+        )
+
+
+def test_check_solve_size_unknown_geometry_does_not_falsely_reject(hosted):
+    # Unbuildable / unknown geometry → count unavailable → guard defers to the
+    # normal solve path instead of raising a spurious size error.
+    server._check_solve_size(
+        {"geometry": "does.not.exist", "n_per_wire": 999999}, use_pynec=False
+    )


### PR DESCRIPTION
## Summary
Bounds a single solve's MoM matrix so one oversized request can't OOM the shared Fly box — **without** capping anyone's local `pip install`.

**Hosted-only by design.** The guard is **off by default**; the package people install and run locally is unlocked. It turns on **only** when `ANTENNAKNOBS_HOSTED=1` — which this repo's `fly.toml` `[env]` sets for the shared instance. Same wheel, unlocked locally and capped online. Rejection happens *before* the matrix is allocated, surfaced in the existing error banner.

**Caps derived from measurement, not guesswork.** They target a single solve's matrix staying under **~800 MB** on the 2 GB Fly box. Measured peak RSS on `arrays.bowtiearray2x4` (`scripts/measure_solve_memory.py`):

| Engine | Memory per basis | Cap (env override) |
|---|---|---|
| dense momwire (triangular/sinusoidal/bspline) | full N×N | **7000** (`ANTENNAKNOBS_MAX_BASIS`) |
| PyNEC | full N×N — RSS ≈ `basis²·16`, ~1 GB at basis 8000 | **7000** (`ANTENNAKNOBS_MAX_BASIS_PYNEC`) |
| arrayblock / hmatrix | block-low-rank, ~0.6× dense (measured) | **9000** (`ANTENNAKNOBS_MAX_BASIS_COMPRESSED`) |

The caps bound **memory, not time** — PyNEC's ~N³ LU is slow long before it's large (a responsiveness concern, deliberately not guarded here).

## Details
- `AntennaExample.count_basis(req)` — geometry-only segment count (no solve). Adapter wires it in.
- `_check_solve_size` enforced in `_solve_uncached` (`/ws` + `/solve`) and per-N in `/converge`. Best-effort: an unbuildable geometry defers to the normal solve path. The dense/PyNEC message points users at the array-block / H-matrix engine.
- `fly.toml` sets `ANTENNAKNOBS_HOSTED=1`; `docs/deploy.md` documents the flag, caps, and provenance.
- `scripts/measure_solve_memory.py` re-derives the caps when the VM changes.

## Test plan
- [x] Tests: local-unlocked-by-default; count scaling; dense-reject vs compressed-allow; full `solve()` rejects pre-fill; unknown geometry safe
- [x] `test_web_server / test_design_schemas / test_segment_convergence / test_optimize` → 967 passed
- [x] ruff clean; measurement script reproduces the table above

🤖 Generated with [Claude Code](https://claude.com/claude-code)