### PR TITLE
Docs: Drone/Transform API reference + Claude Code authoring guide

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -59,6 +59,10 @@ export default defineConfig({
           items: [
             { label: "The model", slug: "concepts/model" },
             { label: "Many ways to express geometry", slug: "concepts/authoring" },
+            {
+              label: "Writing designs with Claude Code",
+              slug: "concepts/authoring-with-claude",
+            },
           ],
         },
         {
@@ -67,6 +71,7 @@ export default defineConfig({
             { label: "Design catalog", slug: "reference/catalog" },
             { label: "The solver & accuracy", slug: "reference/solver" },
             { label: "Web workbench", slug: "reference/web" },
+            { label: "Drone & Transform API", slug: "reference/drone-transform" },
             { label: "Command line", slug: "reference/cli" },
           ],
         },

--- a/site/src/content/docs/concepts/authoring-with-claude.md
+++ b/site/src/content/docs/concepts/authoring-with-claude.md
@@ -1,0 +1,104 @@
+---
+title: Writing designs with Claude Code
+description: Drop your own antenna into the workbench — and let Claude Code write the Python for you from the seeded contract.
+---
+
+The workbench loads **your** designs alongside the built-ins. Each `.py` file in
+your designs folder becomes one antenna under **"Your designs"** (the `user.*`
+namespace) — drop a file in, refresh the page, and it shows up. Because each
+design is just a small Python class, [Claude Code](https://claude.com/claude-code)
+can write or edit one for you from a contract that's seeded right into the folder.
+
+## Your designs folder
+
+On first run the app creates **`~/.antennaknobs/designs/`** (override with the
+`ANTENNAKNOBS_USER_DIR` environment variable) and seeds two reference files into
+it:
+
+- **`TEMPLATE.py`** — a complete, working example dipole. Copy it, rename it, edit
+  it.
+- **`CLAUDE.md`** — the authoring contract, written *for Claude Code*. It's the
+  context that lets Claude write a correct design on the first try.
+
+Both are refreshed from the package on every startup (they're documentation, not
+your content), so an upgrade brings the latest authoring guidance. Your own
+`*.py` files are never touched.
+
+A design is also a first-class CLI antenna: once `my_dipole.py` is in the folder,
+`antennaknobs draw --builder user.my_dipole` (or `sweep`, `pattern`, …) works,
+and `antennaknobs list` shows it.
+
+## The workflow
+
+1. **Open Claude Code in the folder:**
+   ```bash
+   cd ~/.antennaknobs/designs
+   claude
+   ```
+   Claude reads the seeded `CLAUDE.md` as context automatically.
+2. **Ask for an antenna in plain language** — for example:
+   - *"Make me a 40-meter off-center-fed dipole fed 1/3 from one end."*
+   - *"Design a 2-element 20-meter quad loop — driven element plus a reflector."*
+   - *"Take my_dipole.py and add an adjustable height-above-ground slider."*
+   - *"My design loads but resonates at 32 MHz — shorten it to hit 28.5 MHz."*
+3. **Refresh the web page.** The antenna appears under "Your designs." If it
+   doesn't, the **"designs that failed to load"** panel shows the file, the error,
+   and the line number — paste that back to Claude and iterate.
+4. **Tune it** with the knobs, the SWR curve, and the impedance readout until the
+   resonance and pattern look right.
+
+## The contract (what Claude follows)
+
+The seeded `CLAUDE.md` is authoritative; in brief, a design file must:
+
+- Be named `lowercase_with_underscores.py` — the name becomes the antenna's name
+  (`my_dipole.py` → `user.my_dipole`).
+- Define a class **`Builder`** subclassing `AntennaBuilder`.
+- Provide a **`default_params`** mapping (every key becomes a knob, read as
+  `self.<key>` in the build) and a **`build_wires(self)`** method returning
+  `(start, end, n_segments, feed)` tuples — exactly **one** segment carries the
+  feed `1 + 0j`, the rest `None`.
+- Import only from `antennaknobs` and the standard library.
+
+```python
+from types import MappingProxyType
+from antennaknobs import AntennaBuilder
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 14.1,   # MHz — the band this is cut for
+            "freq": 14.1,          # MHz — measurement frequency
+            "length_factor": 0.96,
+            "height": 10.0,        # metres
+            "ui_params": MappingProxyType({"default_view": "xz"}),
+        }
+    )
+
+    def build_wires(self):
+        wavelength = 299.792458 / self.design_freq
+        h = (wavelength / 4.0) * self.length_factor
+        z, eps = self.height, 0.01
+        arm = self.nominal_nsegs
+        return [
+            ((0.0, -h, z), (0.0, -eps, z), arm, None),       # left arm
+            ((0.0, eps, z), (0.0, h, z), arm, None),         # right arm
+            ((0.0, -eps, z), (0.0, eps, z), 1, 1 + 0j),      # driven feed gap
+        ]
+```
+
+:::tip[The `design_freq` rule — avoid the "40 m trap"]
+To put an antenna on a band *and keep it tunable there*, size every dimension as
+a fraction of `wavelength = 299.792458 / self.design_freq` (times a
+`length_factor` near 1.0). That scales the geometry **and** makes the band
+selector and the measurement-freq slider follow `design_freq`. Skip it and the
+geometry is fixed metres while the meas slider stays parked near 14 MHz — so a
+fixed-metre 40 m antenna can't actually be tuned on 40 m.
+:::
+
+For path-shaped geometry (loops, vees, rhombics), `build_wires` can fly a
+[`Drone`](/reference/drone-transform/) instead of computing corners by hand —
+return `drone.wires()`. Arrays of identical elements have dedicated builders
+(`Array1x2Builder`, `Array2x2Builder`, …); reach for those only once a single
+element works.

--- a/site/src/content/docs/reference/drone-transform.md
+++ b/site/src/content/docs/reference/drone-transform.md
@@ -1,0 +1,181 @@
+---
+title: Drone & Transform API
+description: The 3D turtle (Drone) and the homogeneous-transform helpers (Transform, TransformStack) for authoring antenna geometry as a flight path.
+---
+
+Most designs build their wire list from absolute corner coordinates. For
+path-shaped antennas — loops, inverted-vee arms, rhombics, zig-zags — it's often
+clearer to **describe the walk**: fly a leg, turn, fly the next, paying out wire
+as you go. `Drone` is that 3D turtle; `Transform` / `TransformStack` are the
+coordinate-frame helpers underneath it (and useful on their own for placing
+elements). All three compile to the same edge list `build_wires` returns:
+
+```python
+((x0, y0, z0), (x1, y1, z1), nsegs, excitation)
+```
+
+so they're purely an alternate **authoring** style — nothing downstream changes.
+See [Many ways to express geometry](/concepts/authoring/) for where this fits
+among the other idioms.
+
+## `Drone`
+
+```python
+from antennaknobs import Drone
+```
+
+A pen-carrying drone that carries a pose (position + orientation) and lays wire
+as it flies.
+
+**Body frame:** local **+x** is *forward* (the nose), **+z** is *up* (the yaw
+axis), **+y** is *left* — a right-handed frame. Turns are **body-relative** (like
+a turtle's left/right, generalized to 3D), so they're relative to the current
+heading, not the world axes.
+
+### Constructor
+
+```python
+Drone(position=(0.0, 0.0, 0.0), *, nominal_nsegs=21, ref=1.0)
+```
+
+- **`position`** — starting world position `(x, y, z)`.
+- **`nominal_nsegs`** — the segment count a wire of length `ref` receives. Longer
+  wires get proportionally more (see [auto-segmentation](#auto-segmentation)).
+- **`ref`** — the reference length for that scaling, usually a quarter
+  wavelength. Matches `AntennaBuilder`'s convention.
+
+### Pen control
+
+The pen is *up* (moving without wire) or *down* (laying wire). Each method
+returns `self`, so calls chain.
+
+| Method | Effect |
+| --- | --- |
+| `pay_out()` | Lower the pen — subsequent `forward()` lays **structural** wire. |
+| `feed(excitation=1+0j)` | Lower the pen for the **driven** segment — wire laid carries the source `excitation`. |
+| `cut()` | Raise the pen — subsequent `forward()` moves without wire. |
+
+### Movement
+
+| Method | Effect |
+| --- | --- |
+| `forward(dist, nsegs=None)` | Fly `dist` (m) along the nose; lays an edge if the pen is down. `nsegs` overrides the auto count. |
+| `jump(dist)` | Fly `dist` along the nose **without** wire (pen ignored). |
+| `move_to(position)` | Relocate to `position`, keeping orientation; lays no wire. |
+| `close(nsegs=None)` | Fly straight back to where the current pen-down stroke began, laying the closing edge (a loop's last side, or its feed gap). No-op if the pen is up or already home. |
+
+### Turns (body-relative, **degrees**)
+
+| Method | Axis |
+| --- | --- |
+| `yaw(deg)` | Turn left/right about local **+z** (up). |
+| `pitch(deg)` | Nose up/down about local **+y** (left). |
+| `roll(deg)` | Bank about local **+x** (the nose). |
+| `face(heading, up=(0,0,1))` | Point the nose along `heading` with the given `up`, keeping position. `up` is orthogonalized against `heading` (they must not be parallel). Handy to start a planar figure: face an in-plane heading with the plane normal as `up`, then `yaw` turns stay in that plane. |
+
+### Labelled nodes
+
+For the one edge whose length you'd otherwise have to solve for (e.g. the top of
+a triangle once you've flown to both corners), drop a pin and connect to it — no
+trig:
+
+| Method | Effect |
+| --- | --- |
+| `mark(label)` | Pin the current position under `label`. |
+| `line_to(label, nsegs=None)` | Lay a wire from here to a previously `mark()`ed node (with the current pen), then move there — the drone works out the straight segment itself. |
+
+### Reading state
+
+| Member | Value |
+| --- | --- |
+| `position` *(property)* | Current world position `(x, y, z)`. |
+| `heading` *(property)* | World-space unit vector the nose points along. |
+| `wires()` | The accumulated edge list, in `build_wires` shape. |
+
+### Auto-segmentation
+
+When `forward()` / `close()` / `line_to()` aren't given an explicit `nsegs`, the
+drone picks `max(3, round(nominal_nsegs · |length| / ref))`, forced **odd** so a
+center-fed segment has a true middle.
+
+### Example — a vertical delta loop
+
+From `designs/loops/delta_loop_drone.py`: a downward-pointing triangle in the
+x = 0 plane. `face()` sets the nose along a slant with the plane normal (+x) as
+"up", so every `yaw()` stays in-plane — no explicit trig.
+
+```python
+import math
+from antennaknobs import Drone
+
+drone = Drone(position=S, nominal_nsegs=n_body, ref=quarter)
+drone.face(heading=(0.0, cos_theta, math.sin(theta)), up=(1.0, 0.0, 0.0))
+
+drone.pay_out()
+drone.forward(side, nsegs=n_body)   # S -> A  (right side)
+drone.yaw(180 - self.angle_deg)     # exterior angle at A
+drone.forward(top, nsegs=n_body)    # A -> B  (top edge)
+drone.yaw(180 - self.angle_deg)     # exterior angle at B
+drone.forward(side, nsegs=n_body)   # B -> T  (left side)
+drone.feed(1 + 0j)
+drone.close(nsegs=n_feed)           # T -> S  (driven feed gap, fly home)
+
+return drone.wires()
+```
+
+Other idiomatic examples in the catalog: `horizontal_loop_drone.py` (a planar
+square via four `yaw(90).forward(side)` legs), `delta_loop_marked.py`
+(`mark`/`line_to` to bridge the top edge), and `delta_loop_reflected.py` (the
+drone as a pure **point finder** — fly pen-up and read `.position`).
+
+## `Transform`
+
+```python
+from antennaknobs import Transform
+```
+
+A 4×4 homogeneous transform (rotation + translation). All rotation factories take
+**degrees**.
+
+| Member | Returns / effect |
+| --- | --- |
+| `Transform(A=identity)` | Wrap a 4×4 matrix `A`. |
+| `Transform.translate(x, y, z)` | Translation-only transform *(static)*. |
+| `Transform.rotX(deg)` / `rotY(deg)` / `rotZ(deg)` | Rotation about a world axis, in degrees *(static)*. |
+| `Transform.inverse(tr)` | The inverse of `tr` *(static)*. |
+| `t.hit(coords)` | Apply `t` to a point `coords=(x, y, z)`; returns the transformed `(x, y, z)`. |
+| `t.premult(other)` | Return `other @ t` (apply `t` first, then `other`). |
+| `t.postmult(other)` | Return `t @ other` (apply `other` second). |
+
+## `TransformStack`
+
+```python
+from antennaknobs import TransformStack
+```
+
+A stack of composed frames — push nested transforms to build up a coordinate
+frame (e.g. place an array element within the array's frame), read points
+through the top.
+
+| Method | Effect |
+| --- | --- |
+| `TransformStack()` | New stack holding the identity frame. |
+| `push(tr)` | Compose `tr` onto the current top frame and push it. |
+| `pop()` | Remove the top frame. |
+| `hit(v)` | Transform point `v` through the current top frame. |
+
+### Example — stacked frames
+
+From `designs/specialty/hentenna.py`: lift to the base height, tilt the whole
+structure, then read local points through the composed frame.
+
+```python
+from antennaknobs import Transform, TransformStack
+
+st = TransformStack()
+st.push(Transform.translate(0, 0, b))     # to base height
+st.push(Transform.rotX(-self.slant_deg))  # tilt the structure
+
+def build_path(lst, ns, ex):
+    return ((st.hit(a), st.hit(b), ns, ex) for a, b in zip(lst[:-1], lst[1:]))
+```


### PR DESCRIPTION
## Summary
The last two content gaps (items 5 + 7), as two new pages added to the sidebar.

- **`reference/drone-transform.md`** — API reference for the geometry-authoring helpers:
  - **`Drone`** (the 3D turtle): body-frame convention, constructor, pen control (`pay_out`/`feed`/`cut`), movement (`forward`/`jump`/`move_to`/`close`), body-relative turns (`yaw`/`pitch`/`roll`/`face`), labelled nodes (`mark`/`line_to`), state (`position`/`heading`/`wires`), and auto-segmentation — with a worked delta-loop example.
  - **`Transform`** and **`TransformStack`** — factories, `hit`/`premult`/`postmult`, `push`/`pop`, with a stacked-frame example.
  - Signatures taken verbatim from source; top-level imports verified.
- **`concepts/authoring-with-claude.md`** — drop your own design into the workbench and let Claude Code write it: the `~/.antennaknobs/designs` folder + seeded `CLAUDE.md`/`TEMPLATE.py`, the `user.*` discovery + refresh-on-reload flow, the `Builder`/`build_wires` contract with a minimal example, and the `design_freq` tuning rule (the "40 m trap").

## Test plan
- [x] `npm run build` (astro check + build) green — 13 pages (2 new)
- [x] `from antennaknobs import Drone, Transform, TransformStack` works (documented import path)
- [x] All cross-page links resolve in the built HTML; both pages reachable from the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)