### PR TITLE
CLI defaults to momwire + README/site pitch & consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ second backend and solve the same design both ways to trust the answer.
 
 ## The live web workbench
 
+It's live at **[app.antennaknobs.dev](https://app.antennaknobs.dev/)** — open
+it, pick a design, and drag a knob (no install).
+
 The workbench is the fastest way to feel a design. Pick an antenna, and its
 parameters appear as a panel of sliders — the *knobs*. Drag one and every view
 updates live over a WebSocket: the solver re-runs and the browser redraws.
@@ -95,7 +98,7 @@ point — agreement between independent engines is your confidence check.
 | | **PyNEC** | **momwire** |
 |---|---|---|
 | What | Python binding to the compiled C++ **NEC2** engine | In-house **method-of-moments** engines, pure-Python core with optional C++ accelerators |
-| Basis | NEC2 thin-wire (pulse/sinusoidal) | Multiple families: triangular (tent), sinusoidal, B-spline, H-matrix, array-block |
+| Basis | NEC2 thin-wire (pulse/sinusoidal) | Three bases — triangular (tent), sinusoidal, B-spline — plus H-matrix and array-block accelerators built on them |
 | Speed | Very fast single-frequency solves | Fast; C++ accelerators (pybind11) for assembly/quadrature, pure-Python fallback |
 | Ground | Sommerfeld–Norton finite ground (default) | PEC image method; free space by default |
 | Install | Prebuilt wheel from the `python-necpp` fork release (OpenBLAS vendored) | C++ accelerator built from the `momwire` submodule |
@@ -104,13 +107,13 @@ point — agreement between independent engines is your confidence check.
 **Selecting an engine** (CLI):
 
 ```bash
---engine pynec                 # NEC2 via PyNEC
---engine momwire                 # momwire, default triangular basis
+--engine momwire                 # momwire (default), default triangular basis
 --engine momwire:triangular      # piecewise-linear (tent) basis  — the momwire default
 --engine momwire:sinusoidal      # NEC2-style three-term basis (cross-validator)
 --engine momwire:bspline         # degree-1/2 B-spline Galerkin basis
 --engine momwire:hmatrix         # B-spline + hierarchical-matrix (ACA) acceleration
 --engine momwire:arrayblock      # element-aware block solver for arrays
+--engine pynec                   # NEC2 via PyNEC (needs the optional pynec-accel)
 ```
 
 In Python, instantiate an engine directly:
@@ -142,6 +145,10 @@ builds its wires from them. Because the geometry is *computed* from parameters
 in ordinary Python, you specify physical coordinates a minimal number of times —
 the rest follow by reflection and relative position. (Most antenna tools make
 you type six absolute coordinates per wire.)
+
+For path-shaped geometry (loops, vees, rhombics) you can describe the *walk*
+instead of the coordinates, with the `Drone` 3D-turtle — see the
+[Drone & Transform reference](https://antennaknobs.dev/reference/drone-transform/).
 
 Here is the built-in Moxon beam (`beams.moxon`), abbreviated. Four parameters
 describe the rectangle; helper functions negate coordinates (`rx`, `ry`) and
@@ -281,7 +288,11 @@ Roughly 70 built-in designs across nine families — run
 | `specialty` | hentenna, bowtie, helix, hourglass |
 
 User-authored designs (in the `user.*` namespace) appear here too; filter with
-`list --builtin-only` / `list --user-only`.
+`list --builtin-only` / `list --user-only`. Drop a Python file in
+`~/.antennaknobs/designs/` and it shows up in the workbench — see
+[Writing designs with Claude Code](https://antennaknobs.dev/concepts/authoring-with-claude/)
+for the contract and how to have Claude Code write one from a plain-language
+description.
 
 ---
 
@@ -304,7 +315,7 @@ Optionally, add the **NEC2 solver** (PyNEC) as an alternative to momwire:
 
 ```bash
 # optional NEC2 solver (Linux / Windows / macOS-arm64 wheels)
-pip install pynec-accel
+pip install "pynec-accel>=1.7.4.post2"
 ```
 
 Then launch the workbench with `uvicorn antennaknobs.web.server:app` (see
@@ -474,6 +485,13 @@ pytest -vv --durations=0 -- tests/
 (For the web workbench's frontend dev server, also `brew install node`.)
 
 ---
+
+## Acknowledgments
+
+Most of this codebase — the `AntennaBuilder` framework, the design catalog, the
+momwire engine bindings, the web workbench, and these docs — was written with
+**[Claude Code](https://claude.com/claude-code)**, Anthropic's agentic coding
+tool, working from KK7KNB's direction and antenna-engineering judgment.
 
 ## License
 

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -24,12 +24,19 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## The whole pitch, in one line
 
-Almost every antenna tool on the web is a static formula calculator or a
-desktop app you have to install. antennaknobs is the one you open in a browser,
-grab a knob, and watch the physics respond — the radiation pattern, SWR, and
-impedance update live as you drag.
+antennaknobs describes an antenna **as Python code** — a small parametric
+*builder*, its geometry computed from named knobs — then lets you explore it two
+ways: drive it from a script (sweep, optimize, compare, export a NEC deck), or
+open it in a browser and **turn the knobs live**, watching the radiation
+pattern, SWR, and impedance respond as you drag. Most antenna tools are a static
+formula calculator or a desktop app you have to install; this is neither.
 
 <CardGrid stagger>
+  <Card title="Antennas as Python code" icon="pencil">
+    Describe an antenna once as a small parametric builder — geometry computed
+    from named knobs — then sweep, optimize, compare, or open it in the browser.
+    Most tools make you hand-place every coordinate.
+  </Card>
   <Card title="Multi-basis MoM" icon="seti:python">
     Triangular, sinusoidal, and B-spline bases in one engine — basis quality
     that otherwise costs four figures in commercial tools.

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -43,16 +43,19 @@ Useful `pattern` flags: `--fn out.png` (write to a file instead of the screen),
 The `--engine` flag selects the solver:
 
 ```bash
---engine pynec                   # the NEC-2 reference backend (default)
---engine momwire                 # momwire, default (triangular) basis
+--engine momwire                 # momwire (default), default (triangular) basis
 --engine momwire:triangular      # piecewise-linear (tent) basis
 --engine momwire:sinusoidal      # NEC-2-style three-term basis
 --engine momwire:bspline         # B-spline Galerkin basis
+--engine momwire:hmatrix         # B-spline + hierarchical-matrix (ACA) acceleration
+--engine momwire:arrayblock      # element-aware block solver for arrays
+--engine pynec                   # the NEC-2 reference backend (needs pynec-accel)
 ```
 
-See [The solver & accuracy](/reference/solver/) for which engine to reach for —
-including the accelerated `hmatrix` and `arrayblock` solvers for large
-single-wire structures and arrays.
+`momwire` is the default so a plain install works without the optional
+`pynec-accel` package. See [The solver & accuracy](/reference/solver/) for which
+engine to reach for — including when the accelerated `hmatrix` / `arrayblock`
+solvers pay off.
 
 ## Comparing engines
 

--- a/site/src/content/docs/start/quickstart.md
+++ b/site/src/content/docs/start/quickstart.md
@@ -20,7 +20,7 @@ pip install "antennaknobs[web]"
 solver (PyNEC) as an alternative to momwire:
 
 ```bash
-pip install pynec-accel
+pip install "pynec-accel>=1.7.4.post2"
 ```
 :::
 

--- a/site/src/content/docs/start/welcome.md
+++ b/site/src/content/docs/start/welcome.md
@@ -35,3 +35,10 @@ The live simulator is running here — open it, pick a design, and drag a knob:
 👉 **[app.antennaknobs.dev](https://app.antennaknobs.dev/)**
 
 Then come back for the [Quickstart](/start/quickstart/) to drive it from Python.
+
+:::note[Built with Claude Code]
+Most of antennaknobs — the framework, the design catalog, the web workbench, and
+these docs — was written with [Claude Code](https://claude.com/claude-code),
+Anthropic's agentic coding tool, working from KK7KNB's direction and
+antenna-engineering judgment.
+:::

--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -322,19 +322,20 @@ def cli(arguments=None):
                 "--engines",
                 type=str,
                 nargs="+",
-                default=["pynec"],
+                default=["momwire"],
                 help="One or more simulation backends. Each spec is "
-                '"pynec" or "momwire[:triangular|sinusoidal|bspline]". '
+                '"momwire[:triangular|sinusoidal|bspline]" or "pynec". '
                 "Cross-products with --builders.",
             )
         else:
             p.add_argument(
                 "--engine",
                 type=str,
-                default="pynec",
-                help="Simulation backend: pynec | momwire | "
-                "momwire:triangular | momwire:sinusoidal | momwire:bspline "
-                "(default: pynec).",
+                default="momwire",
+                help="Simulation backend: momwire | "
+                "momwire:triangular | momwire:sinusoidal | momwire:bspline | "
+                "pynec (default: momwire). pynec needs the optional pynec-accel "
+                "package; momwire is always available.",
             )
         p.add_argument(
             "--ground",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,3 +100,18 @@ def test_cli_engine_flag():
     ant.cli(
         f"sweep --builder {dipole} --npoints 3 --engine momwire --ground free{o}".split()
     )
+
+
+def test_cli_default_engine_works_without_pynec(monkeypatch):
+    """The default engine must be one that's always installed (momwire), so a
+    plain `pip install antennaknobs` (no pynec-accel) has a working CLI. With
+    pynec absent, a command run WITHOUT --engine must still solve, not raise
+    "unknown engine 'pynec'"."""
+    import importlib
+
+    # `antennaknobs.cli` the attribute is the re-exported function; grab the
+    # actual module to reach ENGINE_CLASSES.
+    cli_mod = importlib.import_module("antennaknobs.cli")
+    monkeypatch.delitem(cli_mod.ENGINE_CLASSES, "pynec", raising=False)
+    dipole = "dipoles.invvee:dipole"
+    ant.cli(f"pattern --builder {dipole} --ground free{o}".split())


### PR DESCRIPTION
## Summary
Resolves the README ↔ site consistency audit, fixes a real first-run bug, and surfaces the headline differentiator + authorship. Two commits:

### `fix(cli)`: default `--engine` to momwire
The CLI defaulted `--engine`/`--engines` to **`pynec`** — the optional, separately-installed GPL backend. So a plain `pip install "antennaknobs[web]"` (no `pynec-accel`) failed on any solve command without `--engine`, with `unknown engine 'pynec'; available: momwire` — contradicting the documented "momwire alone is fully functional; pynec is optional." Now defaults to **momwire** (always installed). Regression test: with pynec absent from `ENGINE_CLASSES`, a default-engine command still solves.

### `docs`: pitch + consistency
- **Site pitch** (`index.mdx`): lead with **"antennas as Python code"** — the parametric-builder differentiator the homepage omitted (it led browser-first) — in the one-liner and as the first feature card.
- **Credit Claude Code**: an Acknowledgments section (README) + a note on the welcome page.
- **CLI default**: README + `cli.md` mark momwire as default, list it first; `cli.md` gains `hmatrix`/`arrayblock` examples.
- **README discoverability**: live URL `app.antennaknobs.dev` in the workbench section; pointers to the Drone/Transform reference and the authoring-with-Claude guide; bases-vs-accelerators wording split to match the solver page.
- **Pin** the optional `pynec-accel` to `>=1.7.4.post2` in the quick-install blocks (README + quickstart).

## Test plan
- [x] `test_cli / test_engine_spec / test_segment_convergence` pass; new default-engine regression test added
- [x] `npm run build` (astro check + build) green — 13 pages; new pitch + card render
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)