### PR TITLE
Bump antennaknobs to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.5.1"
+version = "0.6.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]


### PR DESCRIPTION
## Summary
Minor release since 0.5.1:
- **Hosted-only live-engine solve-size cap** (new feature, off by default locally).
- **CLI default → momwire** so a plain `pip install` CLI works without `pynec-accel`.
- **Docs**: workbench usage, Drone/Transform API reference, the Claude Code authoring guide, and README/site pitch + consistency.

After merge, tagging `v0.6.0` triggers tag-to-deploy: **publish** → PyPI, **fly-deploy** → simulator, **deploy-docs** → docs.

## Test plan
- [ ] Merge, then `git tag v0.6.0 && git push origin v0.6.0`
- [ ] `publish.yml` uploads to https://pypi.org/project/antennaknobs/0.6.0/
- [ ] simulator + docs redeploy; the hosted cap activates (fly.toml `ANTENNAKNOBS_HOSTED=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)