### PR TITLE
Pannable mobile layout in landscape, not just portrait

### DIFF
--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1802,9 +1802,14 @@ canvas {
    horizontally: the controls fill the screen, and you swipe right to a
    full-size output rectangle. Scroll-snap rests the pan on either pane.
    Breakpoint ~700px: the two-pane needs ≈320px rail + ≈360px usable output to
-   be comfortable, so only below that do we switch to the pannable layout
-   (landscape phones and tablets keep the normal two-pane). */
-@media (max-width: 700px) {
+   be comfortable, so only below that do we switch to the pannable layout.
+   We ALSO switch on a short, touch viewport (max-height 500px + a coarse
+   pointer) so a phone in LANDSCAPE — wider than 700px but only ~400px tall,
+   where the two-pane's output stage gets squashed flat — gets the same wide
+   pannable rectangle you swipe across in portrait. Large landscape tablets
+   (height > 500px) keep the roomy two-pane. */
+@media (max-width: 700px),
+       (max-height: 500px) and (pointer: coarse) {
   .app {
     /* Controls nearly fill the viewport (capped so a sliver of the stage peeks
        as a "swipe right" affordance); the stage is a wide, monitor-aspect


### PR DESCRIPTION
## Summary
On a phone the workbench switches from the desktop two-pane to a single-column **pannable** layout: controls fill the screen and you swipe right to a wide, monitor-aspect output rectangle. That only triggered at `max-width: 700px` — so a phone in **landscape** (wider than 700px, but only ~400px tall) fell into the cramped desktop two-pane with a squashed output stage.

This also triggers the pannable layout on a **short, touch viewport** (`max-height: 500px and pointer: coarse`), so landscape phones get the same big pannable rectangle as portrait. Targeting stays precise: large landscape **tablets** (height > 500px) and short **mouse** windows keep the roomy two-pane.

CSS-only (`styles.css`), one media-query clause + the explanatory comment.

## Verification
Rendered under CDP mobile emulation (`mobile:true` → `pointer: coarse`):
- **Portrait** (390×844): unchanged — controls fill screen, stage peeks at the right edge.
- **Landscape** (844×390): now shows the sidebar + the wide pannable output stage (was the cramped two-pane before).

## Test plan
- [ ] On a real phone, rotate to landscape on `app.antennaknobs.dev` (after the next release): controls + a big pannable output rectangle, same as portrait.
- [ ] Desktop and landscape tablet still show the two-pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)