### PR TITLE
Optimizer UX: pause on manual change of a marked knob + default to SWR

### DIFF
--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1612,6 +1612,10 @@ export function App() {
   const [optRunning, setOptRunning] = useState(false);
   const [optResult, setOptResult] = useState<OptimizeResult | null>(null);
   const [optError, setOptError] = useState<string | null>(null);
+  // When a user change to a knob marked for optimization auto-pauses the
+  // optimizer, this holds that knob's name for a brief "paused, you're
+  // changing X by hand" cue (cleared on re-enable / after a few seconds).
+  const [optPausedBy, setOptPausedBy] = useState<string | null>(null);
   const optAbortRef = useRef<AbortController | null>(null);
   // Per-knob settings persist per geometry (knobOpt is keyed by geometry); just
   // close any open menu / clear the last result / abort any in-flight run when
@@ -1791,6 +1795,29 @@ export function App() {
     if (!inst) return;
     const freqValue = inst[group.link_meas_freq_to_param];
     if (typeof freqValue === "number") setMeasFreq(freqValue);
+  }
+
+  // A user-originated knob change (drag / arrow key) — the optimizer's own
+  // write-back calls setParamAtPath directly and never routes through here, so
+  // this is exactly the "the human moved it" path. If the knob the user grabbed
+  // is one marked for optimization, hand them manual control: abort any
+  // in-flight optimize (so its write-back can't clobber this change) and switch
+  // Optimize off. Re-enabling resumes from the current values. (Fixed-knob
+  // changes fall through untouched, so the reactive optimizer still re-solves
+  // toward the objective on those.)
+  function handleUserParamChange(
+    path: (string | number)[],
+    value: number | string | boolean,
+  ) {
+    if (optEnabled && path.length === 1 && typeof path[0] === "string") {
+      const ko = (knobOpt[geometry] ?? {})[path[0]];
+      if (ko?.vary) {
+        optAbortRef.current?.abort();
+        setOptEnabled(false);
+        setOptPausedBy(path[0]);
+      }
+    }
+    setParamAtPath(path, value);
   }
   // Fan_dipole was hand-rolled here pre-PR — fanNBands / fanBandIds /
   // fanBandFreqs / fanHalfdriverFactors / fanSlope / fanConeRadius
@@ -2205,6 +2232,14 @@ export function App() {
     // only when the signature changes is intentional.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [optFixedSig, autoSim]);
+
+  // The "paused — changing X by hand" cue is a brief flash: clear it a few
+  // seconds after it appears so it doesn't linger while Optimize stays off.
+  useEffect(() => {
+    if (!optPausedBy) return;
+    const t = setTimeout(() => setOptPausedBy(null), 5000);
+    return () => clearTimeout(t);
+  }, [optPausedBy]);
 
   // The effective per-knob optimiser settings: the stored entry, or seeded from
   // the schema (extents = slider bounds, step = schema step, not varying).
@@ -3084,7 +3119,7 @@ export function App() {
             <ParamForm
               schema={currentExample.param_schema}
               values={currentValues}
-              onChange={setParamAtPath}
+              onChange={handleUserParamChange}
               // hexbeam_5band's daisy_chain mode emits NEC TL cards;
               // momwire engines reject any non-empty build_tls() so the
               // toggle has no effect there. Grey it out when the active
@@ -3291,8 +3326,11 @@ export function App() {
                   type="button"
                   className={`toggle-btn opt-toggle${optEnabled ? " is-on" : ""}`}
                   aria-pressed={optEnabled}
-                  onClick={() => setOptEnabled((v) => !v)}
-                  title="Reactive optimiser: vary the knobs you mark (right-click a knob) to hit the objective whenever a fixed knob changes."
+                  onClick={() => {
+                    setOptEnabled((v) => !v);
+                    setOptPausedBy(null);
+                  }}
+                  title="Reactive optimiser: vary the knobs you mark (right-click a knob) to hit the objective whenever a fixed knob changes. Changing a marked knob by hand pauses it — turn it back on to resume."
                 >
                   <span className="toggle-led" aria-hidden="true" />
                   Optimize
@@ -3347,6 +3385,14 @@ export function App() {
                   title={optError}
                 >
                   {optError}
+                </span>
+              )}
+              {!optEnabled && optPausedBy && (
+                <span
+                  className="opt-readout opt-paused"
+                  title="You changed a knob marked for optimization, so Optimize paused. Turn it back on to resume."
+                >
+                  Paused — changing {optPausedBy} by hand
                 </span>
               )}
             </div>

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1520,7 +1520,7 @@ const OPT_OBJECTIVE_LABELS: Record<OptObjective, string> = {
   match_z0: "Match Z₀",
 };
 // The two objectives offered in the compact control next to meas-freq.
-const OPT_OBJECTIVES: OptObjective[] = ["resonance", "swr"];
+const OPT_OBJECTIVES: OptObjective[] = ["swr", "resonance"];
 
 // Per-knob optimisation settings (per geometry, per param name). `vary` marks
 // the knob as a free variable the optimiser may change; opt extents bound the
@@ -1600,7 +1600,7 @@ export function App() {
   // Master enable + objective live in the compact control by meas-freq; per-knob
   // "vary" + extents + step live in each knob's right-click menu (knobOpt).
   const [optEnabled, setOptEnabled] = useState(false);
-  const [optObjective, setOptObjective] = useState<OptObjective>("resonance");
+  const [optObjective, setOptObjective] = useState<OptObjective>("swr");
   // The objective ("optimise for") picker lives in a small gear popover next to
   // the Optimize button, mirroring the solver-slot gear.
   const [optMenuOpen, setOptMenuOpen] = useState(false);

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1744,6 +1744,12 @@ canvas {
 .opt-readout-err {
   color: var(--danger, #c0392b);
 }
+/* Auto-pause cue: the optimizer stepped aside because the user grabbed a
+   marked knob. Use the "hot" accent so it reads as a deliberate, momentary
+   state change rather than an error. */
+.opt-paused {
+  color: var(--hot);
+}
 
 /* Per-knob right-click menu. */
 .knob-menu-backdrop {


### PR DESCRIPTION
## Summary
Fixes the confusing "optimization stops without meeting the objective" behavior.

**Before:** dragging a knob that's *selected for optimization* silently left the optimizer idle. Its reactive trigger deliberately excludes the free knobs' own values (so the optimizer's write-back can't loop), so a manual change to one didn't re-solve — you were stranded off-objective with no signal why. It looked broken.

**Now:** a user change (drag / arrow key) to a marked knob hands you manual control:
- aborts any in-flight optimize (so its write-back can't clobber your change),
- switches **Optimize off**, and
- flashes a brief **"Paused — changing `<knob>` by hand"** cue on the Optimize button (in the `--hot` accent, auto-clears after 5s).

Turn Optimize back on to resume from the current values (the existing enable path re-solves immediately). Marked-knob selections persist; only the master toggle flips.

## How user vs. optimizer changes are told apart
Structural, not heuristic: user changes route through the knob's `onChange` (`handleUserParamChange`), while the optimizer's write-back calls `setParamAtPath` **directly** — so the optimizer never trips its own auto-pause. Changing a *fixed* knob still re-solves toward the objective, unchanged.

## Verification
- `tsc --noEmit` clean; `vite build` succeeds (bundle contains the handler + cue).
- App loads with the rewired `onChange` (no runtime crash).
- The live drag-interaction is best confirmed in-browser (CSS/TSX, not covered by the Python CI).

## Test plan
- [ ] Mark a knob (right-click → Optimize this knob), enable Optimize, let it solve; then drag that knob → Optimize switches off + the "Paused — changing X by hand" cue appears; re-enabling resumes.
- [ ] Dragging a *fixed* knob with Optimize on still re-solves toward the objective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)