### PR TITLE
Bump antennaknobs to 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.6.0"
+version = "0.7.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]


### PR DESCRIPTION
## Summary
Minor release since 0.6.0 — three web-workbench UX features:
- **Pannable mobile layout in landscape** (not just portrait).
- **Optimizer pauses on a manual change** to a marked knob (clear "Paused — changing X by hand" cue; re-enable to resume).
- **Optimizer objective defaults to SWR**.

After merge, tagging `v0.7.0` triggers tag-to-deploy: publish → PyPI, fly-deploy → simulator, deploy-docs → docs.

## Test plan
- [ ] Merge, then `git tag v0.7.0 && git push origin v0.7.0`
- [ ] `publish.yml` uploads to https://pypi.org/project/antennaknobs/0.7.0/
- [ ] simulator + docs redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)