### PR TITLE
fix(web): floor the mobile pannable stage at a 1920x1080 canvas

### DIFF
--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1818,14 +1818,20 @@ canvas {
        (max-height: 500px) and (pointer: coarse) {
   .app {
     /* Controls nearly fill the viewport (capped so a sliver of the stage peeks
-       as a "swipe right" affordance); the stage is a wide, monitor-aspect
-       rectangle you pan across. Their sum far exceeds 100vw, so .app scrolls
-       horizontally. --mobile-stage-w keeps the grid column and the stage's
-       min-width in sync. */
-    --mobile-stage-w: 200vw;
+       as a "swipe right" affordance); the stage is a fixed monitor-sized canvas
+       you pan across in BOTH axes. We floor it at 1920x1080 CSS px so the output
+       always renders at a full desktop-monitor size regardless of the phone's
+       own dimensions — in portrait the old 200vw width was < 1920, and in
+       landscape the viewport-height stage (~400px tall) starved the vertical
+       thumbstrip (3 thumbs scaled to the stage height) down to tiny thumbnails.
+       The canvas exceeds the viewport on both axes, so .app scrolls both ways;
+       --mobile-stage-w/-h keep the grid track and the stage min-size in sync. */
+    --mobile-stage-w: max(200vw, 1920px);
+    --mobile-stage-h: max(100%, 1080px);
     grid-template-columns: min(340px, 86vw) var(--mobile-stage-w);
+    grid-template-rows: var(--mobile-stage-h);
     overflow-x: auto;
-    overflow-y: hidden;
+    overflow-y: auto;
     scroll-snap-type: x proximity;
     -webkit-overflow-scrolling: touch;
   }
@@ -1835,11 +1841,11 @@ canvas {
   }
 
   .stage {
-    /* ~2x the viewport width so the output carousel renders at roughly a
-       computer-monitor (landscape) aspect ratio, instead of the cramped,
-       near-portrait box a single viewport width produced. You pan horizontally
-       across it. */
+    /* A fixed >=1920x1080 monitor canvas: wide enough for the output carousel's
+       landscape aspect, and tall enough that the vertical thumbstrip renders
+       its 3 thumbnails at full size. You pan across it in both directions. */
     min-width: var(--mobile-stage-w);
+    min-height: var(--mobile-stage-h);
     scroll-snap-align: start;
   }
 }


### PR DESCRIPTION
## Problem

The pannable mobile layout sized the output stage at `200vw` wide and only as tall as the viewport. Two consequences:

- **Landscape phones**: the stage was only ~400px tall, so the vertical thumbstrip (3 thumbnails scaled to the stage *height* via `useThumbColumnSize`) collapsed to tiny ~50px thumbs.
- **Portrait phones**: `200vw` also fell short of a true 1920px-wide canvas on common phone widths.

## Fix

In the pannable media query (`styles.css`), floor the stage at a full **1920×1080** CSS-px monitor canvas in both orientations and let you pan it on **both** axes:

- `--mobile-stage-w: max(200vw, 1920px)`, `--mobile-stage-h: max(100%, 1080px)`
- `grid-template-rows: var(--mobile-stage-h)` + `overflow-y: auto` (was `hidden`) → vertical pan, not just horizontal
- `.stage` `min-width`/`min-height` driven by the same vars

At 1080px tall the thumbstrip renders its thumbnails at the full 280px cap.

## Verification

Measured the media-query body with a headless Chrome harness linking the real `styles.css`:

| Viewport | Layout | grid cols / rows | Stage | Thumb |
|---|---|---|---|---|
| phone-width | pannable | `340px 1920px` / `1080px`, overflow auto/auto | **1920×1080** | **280px** |
| 1400×900 | two-pane (unchanged) | `320px 1fr` / viewport | normal | 221px |

The landscape-phone trigger (`max-height:500px and pointer:coarse`) can't be exercised in headless Chrome (no coarse pointer), but it shares the *same rule body* via a comma selector and its trigger was already verified in ac57ecb8 (untouched here).

## Note / follow-up

Vertical pan happens at the `.app` level, so the sidebar now shares the tall scroll region rather than being its own viewport-height scroller. On a short landscape phone, reaching the bottom of a long sidebar scrolls the whole app down. If we'd prefer the sidebar to stay an independent scroller and only pan the stage internally, that's a more involved restructure — happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)