### PR TITLE
Add Drone.forward_to_plane and a top-down delta_loop_plane variant

### DIFF
--- a/site/src/content/docs/concepts/authoring.mdx
+++ b/site/src/content/docs/concepts/authoring.mdx
@@ -1,6 +1,6 @@
 ---
 title: Many ways to express geometry
-description: The same delta loop, built five different ways — from a coordinate formula to a 3D turtle to a numeric solve. Pick the expression that fits how you think.
+description: The same delta loop, built six different ways — from a coordinate formula to a 3D turtle to a numeric solve to a plane intersection. Pick the expression that fits how you think.
 ---
 
 import { Tabs, TabItem, Aside } from "@astrojs/starlight/components";
@@ -8,9 +8,9 @@ import { Tabs, TabItem, Aside } from "@astrojs/starlight/components";
 The only thing the solver sees is the [edge list from
 `build_wires()`](/concepts/model/#the-build_wires-contract). *How* you produce
 that list is entirely up to you — and there is rarely one right way. To make
-that concrete, the catalog ships the **same delta loop built five different
+that concrete, the catalog ships the **same delta loop built six different
 ways**, each rendering identical geometry. Pick the one that matches how you
-think about the shape; invent a sixth if none fit.
+think about the shape; invent a seventh if none fit.
 
 A delta loop is a triangle fed by a short gap at the bottom:
 
@@ -99,13 +99,33 @@ A delta loop is a triangle fed by a short gap at the bottom:
     No formula, no algebra — the drone computes the corner, `math.dist` measures
     the wires, and the solver does the inversion.
   </TabItem>
+
+  <TabItem label="6. Fly to a plane">
+    **`delta_loop_plane`** — build it *top-down* and let a plane intersection
+    find the feed. Start at the top centre, fly right to the corner, turn down
+    onto the slant, and `forward_to_plane` flies until the slant crosses the
+    feed plane `y = eps` (the plane `eps` from the centre line). Neither the
+    slant length nor the feed height is computed — both fall out of where the
+    slant meets the plane. Then it borrows #3 and #4 wholesale: named pins plus
+    a `ry` reflection close the loop.
+
+    ```python
+    R = drone.forward(half_top).position             # top corner (pen up)
+    drone.yaw(-(90 + angle_deg))                      # turn down the slant
+    S = drone.forward_to_plane((0, 1, 0, eps)).position  # land on the feed plane
+    L, T = ry(R), ry(S)                              # reflect across y = 0
+    ```
+
+    Because the build is anchored at the top, the feed height is *emergent* —
+    it lands wherever the slant reaches the plane.
+  </TabItem>
 </Tabs>
 
 <Aside type="tip" title="The point">
-  All five produce the same antenna. The progression — analytic → flown →
-  labelled → reflected → solved — is a tour of *how much you can lean on the
-  framework* instead of doing geometry by hand. Designs are meant to be starting
-  points; reach for whichever style makes your next antenna clearest.
+  All six produce the same shape. The progression — analytic → flown → labelled
+  → reflected → solved → flown-to-a-plane — is a tour of *how much you can lean
+  on the framework* instead of doing geometry by hand. Designs are meant to be
+  starting points; reach for whichever style makes your next antenna clearest.
 </Aside>
 
 ## The Drone
@@ -119,6 +139,7 @@ list `build_wires()` returns:
 | `pay_out()` / `cut()` | pen down / up (start / stop laying structural wire) |
 | `feed(excitation)` | like `pay_out`, but the wire is the driven segment |
 | `forward(dist)` / `jump(dist)` | fly along the nose, with / without laying wire |
+| `forward_to_plane(plane)` | fly along the nose until the path meets `plane=(nx, ny, nz, d)` (distance solved, not given) |
 | `yaw` / `pitch` / `roll` | turn in the body frame (degrees) |
 | `face(heading, up)` | point the nose along `heading` (handy to start a planar figure) |
 | `mark(label)` / `line_to(label)` | pin a node, then lay a wire straight to it |

--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -22,7 +22,7 @@ after L. B. Cebik (W4RNL)'s articles.
 
 ## Loops
 
-The delta loop is the catalog's teaching showpiece — it exists **five ways**, a
+The delta loop is the catalog's teaching showpiece — it exists **six ways**, a
 guided tour of how flexibly geometry can be expressed (see [Many ways to express
 geometry](/concepts/authoring/)):
 
@@ -33,6 +33,7 @@ geometry](/concepts/authoring/)):
 | `loops.delta_loop_marked` | `Drone` + labelled nodes (angle + side, trig-free) |
 | `loops.delta_loop_reflected` | `Drone` point-finder + reflection + `build_path` |
 | `loops.delta_loop_solved` | the reflected build, with the side solved by `brentq` |
+| `loops.delta_loop_plane` | top-down: `Drone.forward_to_plane` finds the feed where the slant crosses `y = eps`, then named nodes + reflection |
 
 Other loops: `loops.delta_loop_slanted`, `loops.inv_delta_loop`,
 `loops.horizontal_loop` (full-wave "loop skywire") and its `Drone` twin

--- a/site/src/content/docs/reference/drone-transform.md
+++ b/site/src/content/docs/reference/drone-transform.md
@@ -60,6 +60,7 @@ returns `self`, so calls chain.
 | Method | Effect |
 | --- | --- |
 | `forward(dist, nsegs=None)` | Fly `dist` (m) along the nose; lays an edge if the pen is down. `nsegs` overrides the auto count. |
+| `forward_to_plane(plane, nsegs=None)` | Fly along the nose **until the path meets `plane`** — a `forward()` whose distance is solved for, not given. Lays an edge if the pen is down. `plane` is a 4-tuple `(nx, ny, nz, d)`: the direction `(nx, ny, nz)` is the plane normal (normalized internally) and `d` is the signed distance from the origin along that unit normal, so the plane is `n̂·x == d` and `d` is a true distance regardless of the normal's length (`(0,0,1,5)` and `(0,0,2,5)` both mean `z = 5`). Raises if the normal is zero, the nose is parallel to the plane, or the plane is behind the nose; a no-op when already on it. |
 | `jump(dist)` | Fly `dist` along the nose **without** wire (pen ignored). |
 | `move_to(position)` | Relocate to `position`, keeping orientation; lays no wire. |
 | `close(nsegs=None)` | Fly straight back to where the current pen-down stroke began, laying the closing edge (a loop's last side, or its feed gap). No-op if the pen is up or already home. |
@@ -125,8 +126,11 @@ return drone.wires()
 
 Other idiomatic examples in the catalog: `horizontal_loop_drone.py` (a planar
 square via four `yaw(90).forward(side)` legs), `delta_loop_marked.py`
-(`mark`/`line_to` to bridge the top edge), and `delta_loop_reflected.py` (the
-drone as a pure **point finder** — fly pen-up and read `.position`).
+(`mark`/`line_to` to bridge the top edge), `delta_loop_reflected.py` (the
+drone as a pure **point finder** — fly pen-up and read `.position`), and
+`delta_loop_plane.py` (start at the top centre and `forward_to_plane` down a
+slant onto the feed plane `y = eps`, so the slant length and feed height fall
+out of the intersection rather than being computed).
 
 ## `Transform`
 

--- a/src/antennaknobs/designs/loops/delta_loop_plane.py
+++ b/src/antennaknobs/designs/loops/delta_loop_plane.py
@@ -1,0 +1,114 @@
+"""A delta loop built top-down, with the feed terminal *discovered* by flying a
+slant into a plane rather than computed.
+
+The other drone-built variants fix the bottom feed gap and grow the triangle
+upward (``delta_loop_marked`` flies each slant by its length; ``delta_loop_
+reflected`` flies pen-up to read off the top corner, then reflects). This one
+inverts that: it starts at the **top centre**, flies right to the top corner,
+turns down onto the slant, and lets ``Drone.forward_to_plane`` fly until it
+crosses the feed plane ``y = eps`` -- the plane ``eps`` from the loop's centre
+line. Neither the slant length nor the feed's height is computed in the script;
+both fall out of where the slant meets that plane. From there it borrows the
+*last two* variants' techniques wholesale: the two right-side vertices become
+**named pins** (``mark``/``line_to``) and their **reflections** across the
+``y = 0`` plane (``ry``) give the left side, so the four-edge loop closes with
+no trig at all in this module.
+
+The loop is vertical, in the plane x = 0, fed by a short driven gap at the
+bottom centre and opening upward:
+
+        R-----------L      top, flown corner-to-corner from the centre start
+         \\         /
+          \\       /        two equal slants; the right one is flown to the
+           \\     /         feed plane, the left is its reflection
+            T~~~~S          short driven feed gap straddling y = 0 (T = ry(S))
+
+Because the build is anchored at the *top* (param ``top``), the feed sits
+wherever the slant lands -- a little below ``top`` -- rather than at a fixed
+height; with the defaults it lands near 7 m, matching the sibling loops' base.
+"""
+
+from types import MappingProxyType
+
+from ... import AntennaBuilder, Drone
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.47,
+            "freq": 28.47,
+            # Height of the top edge -- the centre point the build starts from.
+            # The feed height is NOT set here; it is whatever height the slant
+            # has dropped to when it crosses the feed plane (see build_wires).
+            "top": 10.0,
+            # Scales the "go right" distance (half the top width), so it tunes
+            # the loop size for resonance. The slant length follows from it and
+            # the tilt angle via forward_to_plane.
+            "length_factor": 1.0,
+            # Tilt of each slant from vertical. 30 deg -> a 60 deg apex, the
+            # classic near-equilateral delta loop. The downward turn at the top
+            # corner is -(90 + angle_deg) deg (~ -120, i.e. a ~240/300 deg
+            # swing) so the nose points down the slant toward the feed plane.
+            "angle_deg": 30.0,
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 100.0,
+                    "default_view": "yz",  # loop lies in the x = 0 plane
+                    "length_factor": {"min": 0.85, "max": 1.15},
+                    "angle_deg": {"min": 10.0, "max": 60.0},
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        eps = 0.05
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+        # "Go right" distance: half the top width, wl-scaled so length_factor
+        # tunes the loop. The slant length and the feed height stay unknown to
+        # this script -- forward_to_plane discovers where the slant crosses the
+        # feed plane.
+        half_top = (wavelength / 6.0) * self.length_factor
+
+        n_seg0 = self.nominal_nsegs
+        n_seg1 = max(3, self.nominal_nsegs // 7)
+
+        def ry(p):
+            return p[0], -p[1], p[2]
+
+        drone = Drone(nominal_nsegs=self.nominal_nsegs, ref=quarter)
+
+        # Fly the right half pen-up to FIND its two vertices, no trig:
+        #   - start at the top centre, nose +y ("right"), up +x so every turn
+        #     stays in the x = 0 plane;
+        #   - fly half the top width to the top-right corner R;
+        #   - turn down onto the slant and fly until we cross the feed plane
+        #     y = eps (the plane eps from the centre line) to land on the
+        #     feed terminal S. forward_to_plane solves the slant length for us.
+        drone.move_to((0.0, 0.0, self.top))
+        drone.face(heading=(0.0, 1.0, 0.0), up=(1.0, 0.0, 0.0))
+        R = drone.forward(half_top).position
+        drone.yaw(-(90.0 + self.angle_deg))
+        S = drone.forward_to_plane((0.0, 1.0, 0.0, eps)).position
+
+        # The left half is the right half reflected across the y = 0 plane.
+        L, T = ry(R), ry(S)
+
+        # Complete the loop with named pins (the marked variant's idiom): pin
+        # all four corners, then stitch the perimeter S -> R -> L -> T with the
+        # pen down (the drone works out each segment's direction), and finally
+        # the short driven gap T -> S.
+        drone.cut().move_to(S).mark("S")
+        drone.move_to(R).mark("R")
+        drone.move_to(L).mark("L")
+        drone.move_to(T).mark("T")
+
+        drone.move_to(S).pay_out()
+        drone.line_to("R", nsegs=n_seg0)  # up the right slant
+        drone.line_to("L", nsegs=n_seg0)  # across the top
+        drone.line_to("T", nsegs=n_seg0)  # down the left slant
+        drone.cut().move_to(T).feed(1 + 0j).line_to("S", nsegs=n_seg1)  # feed gap
+
+        return drone.wires()

--- a/src/antennaknobs/drone.py
+++ b/src/antennaknobs/drone.py
@@ -118,6 +118,45 @@ class Drone:
         self.pose = self.pose.postmult(Transform.translate(dist, 0, 0))
         return self
 
+    def forward_to_plane(self, plane, nsegs=None):
+        """Fly along the nose until the path meets ``plane``, laying an edge if
+        the pen is down -- ``forward`` whose distance is solved for rather than
+        given. Handy for trimming a leg to a boundary (a ground plane, a
+        bounding box face, a reflector screen) without precomputing its length.
+
+        ``plane`` is a 4-tuple ``(nx, ny, nz, d)``: the direction
+        ``(nx, ny, nz)`` is the plane normal (normalized internally, so it need
+        not be a unit vector) and ``d`` is the signed distance from the origin
+        along that unit normal. The plane is the set of points ``x`` with
+        ``n_hat . x == d``; e.g. ``(0, 0, 1, 5)`` is the horizontal plane
+        ``z = 5`` and ``(0, 0, 2, 5)`` is the same plane (``d`` is a true
+        distance, not scaled by the normal's length).
+
+        Raises ``ValueError`` if the normal is zero, if the nose is parallel to
+        the plane (no intersection), or if the plane lies behind the nose (you
+        cannot extend *forward* to reach it). If the drone already sits on the
+        plane this is a no-op (no zero-length edge)."""
+        n = np.array(plane[:3], dtype=float)
+        nn = np.linalg.norm(n)
+        if nn < 1e-12:
+            raise ValueError("plane normal must be non-zero")
+        n /= nn
+        d = float(plane[3])
+
+        p0 = np.array(self.position, dtype=float)
+        # heading is the unit world image of local +x, so the solved parameter
+        # t is directly a forward distance along the nose.
+        h = np.array(self.heading, dtype=float)
+        denom = float(np.dot(n, h))
+        if abs(denom) < 1e-12:
+            raise ValueError("nose is parallel to the plane; it never intersects")
+        t = (d - float(np.dot(n, p0))) / denom
+        if t < -1e-12:
+            raise ValueError("plane lies behind the nose; cannot extend forward to it")
+        if t > 1e-12:
+            self.forward(t, nsegs)
+        return self
+
     def move_to(self, position):
         """Relocate to ``position`` keeping orientation; lays no wire."""
         A = self.pose.A.copy()

--- a/tests/test_drone.py
+++ b/tests/test_drone.py
@@ -12,6 +12,7 @@ from antennaknobs.designs.loops.delta_loop_marked import Builder as DeltaLoopMar
 from antennaknobs.designs.loops.delta_loop_reflected import (
     Builder as DeltaLoopReflected,
 )
+from antennaknobs.designs.loops.delta_loop_plane import Builder as DeltaLoopPlane
 from antennaknobs.designs.loops.delta_loop_solved import Builder as DeltaLoopSolved
 from antennaknobs.designs.loops.horizontal_loop_drone import Builder as HLoopDrone
 
@@ -266,6 +267,52 @@ def test_delta_loop_marked_is_a_symmetric_delta_loop():
 
     counts = Counter((round(p[1], 6), round(p[2], 6)) for p in pts)
     assert set(counts.values()) == {2}
+
+
+def test_delta_loop_plane_is_a_closed_symmetric_delta_loop():
+    eps = 0.05
+    b = DeltaLoopPlane()
+    ws = b.build_wires()
+
+    # Same four-edge topology as the sibling delta loops: three structural
+    # perimeter edges (two slants + the top) and one driven feed gap.
+    assert len(ws) == 4
+    driven = [e for e in ws if e[3] is not None]
+    assert len(driven) == 1 and driven[0][3] == 1 + 0j
+
+    # Vertical loop, planar in x = 0.
+    assert {round(p[0], 9) for e in ws for p in (e[0], e[1])} == {0.0}
+
+    # The top edge sits at the `top` param height.
+    top_z = max(p[2] for e in ws for p in (e[0], e[1]))
+    assert top_z == pytest.approx(b.default_params["top"])
+
+    # forward_to_plane landed the feed on the plane y = eps (eps from centre):
+    # the two driven-gap ends straddle the centre line at +/- eps.
+    (fy0, fy1) = (driven[0][0][1], driven[0][1][1])
+    assert sorted([round(fy0, 9), round(fy1, 9)]) == [-eps, eps]
+
+    # Symmetric about the y = 0 plane (so feed/pattern stay symmetric).
+    yz = {(round(p[1], 6), round(p[2], 6)) for e in ws for p in (e[0], e[1])}
+    assert {(-y, z) for (y, z) in yz} == yz
+
+    # Connected closed loop: every node shared by exactly two edges.
+    from collections import Counter
+
+    counts = Counter((round(p[1], 6), round(p[2], 6)) for e in ws for p in (e[0], e[1]))
+    assert set(counts.values()) == {2}
+
+
+def test_delta_loop_plane_size_tracks_length_factor():
+    # length_factor scales the "go right" distance, so the top widens with it.
+    def top_width(lf):
+        ws = DeltaLoopPlane(
+            dict(DeltaLoopPlane.default_params, length_factor=lf)
+        ).build_wires()
+        ys = [p[1] for e in ws for p in (e[0], e[1])]
+        return max(ys) - min(ys)
+
+    assert top_width(1.1) > top_width(1.0) > top_width(0.9)
 
 
 def _undirected(builder):

--- a/tests/test_drone.py
+++ b/tests/test_drone.py
@@ -96,6 +96,67 @@ def test_face_rejects_parallel_up():
         Drone().face(heading=(1.0, 0.0, 0.0), up=(2.0, 0.0, 0.0))
 
 
+def test_forward_to_plane_extends_to_axis_aligned_plane():
+    # Nose along +x at the origin; fly to the plane x = 3.
+    d = Drone(ref=1.0).pay_out()
+    d.forward_to_plane((1.0, 0.0, 0.0, 3.0))
+    p0, p1, _ns, ex = d.wires()[0]
+    assert p0 == pytest.approx((0.0, 0.0, 0.0))
+    assert p1 == pytest.approx((3.0, 0.0, 0.0))
+    assert ex is None
+    assert d.position == pytest.approx((3.0, 0.0, 0.0))
+
+
+def test_forward_to_plane_solves_the_oblique_distance():
+    # Heading +x toward a plane tilted 45 deg (normal (1,1,0)) at distance
+    # d = sqrt(2): n_hat . x = 1 => x = 2 on the x axis. The leg length is the
+    # solved 2.0, not d.
+    d = Drone(ref=1.0).pay_out()
+    d.forward_to_plane((1.0, 1.0, 0.0, math.sqrt(2.0)))
+    assert d.position == pytest.approx((2.0, 0.0, 0.0))
+    assert math.dist(*d.wires()[0][:2]) == pytest.approx(2.0)
+
+
+def test_forward_to_plane_d_is_a_true_distance_not_scaled_by_normal():
+    # (0,0,2,5) and (0,0,1,5) name the SAME plane z = 5 (d is the distance
+    # along the unit normal, independent of the passed normal's length).
+    for normal_z in (1.0, 2.0):
+        d = Drone(ref=1.0).face(heading=(0.0, 0.0, 1.0), up=(1.0, 0.0, 0.0))
+        d.pay_out().forward_to_plane((0.0, 0.0, normal_z, 5.0))
+        assert d.position == pytest.approx((0.0, 0.0, 5.0))
+
+
+def test_forward_to_plane_respects_the_pen():
+    # Pen up: move to the plane but lay no wire.
+    d = Drone(ref=1.0).forward_to_plane((1.0, 0.0, 0.0, 4.0))
+    assert d.wires() == []
+    assert d.position == pytest.approx((4.0, 0.0, 0.0))
+
+
+def test_forward_to_plane_already_on_plane_is_a_no_op():
+    d = Drone(position=(3.0, 0.0, 0.0), ref=1.0).pay_out()
+    d.forward_to_plane((1.0, 0.0, 0.0, 3.0))
+    assert d.wires() == []  # no zero-length edge
+    assert d.position == pytest.approx((3.0, 0.0, 0.0))
+
+
+def test_forward_to_plane_rejects_parallel_nose():
+    # Nose +x, plane normal +z: never intersects.
+    with pytest.raises(ValueError):
+        Drone().pay_out().forward_to_plane((0.0, 0.0, 1.0, 5.0))
+
+
+def test_forward_to_plane_rejects_plane_behind_nose():
+    # Nose +x at origin; plane x = -3 is behind: cannot extend forward to it.
+    with pytest.raises(ValueError):
+        Drone().pay_out().forward_to_plane((1.0, 0.0, 0.0, -3.0))
+
+
+def test_forward_to_plane_rejects_zero_normal():
+    with pytest.raises(ValueError):
+        Drone().pay_out().forward_to_plane((0.0, 0.0, 0.0, 1.0))
+
+
 def _key(edges):
     """Edges as an order- and direction-independent multiset (the drone may
     traverse a segment either way)."""


### PR DESCRIPTION
## Summary
- **`Drone.forward_to_plane(plane, nsegs=None)`**: a `forward()` whose distance is *solved for* rather than given — the drone flies along its nose until the path meets a plane, laying an edge if the pen is down. Useful for trimming a leg to a boundary (ground plane, bounding-box face, reflector screen) without precomputing its length.
- The plane is a 4-tuple `(nx, ny, nz, d)`: `(nx, ny, nz)` is the normal direction (normalized internally) and `d` is the signed distance from the origin along that unit normal, so `d` is a *true* distance regardless of the normal's length — `(0,0,1,5)` and `(0,0,2,5)` both mean `z = 5`. Raises `ValueError` on a zero normal, a nose parallel to the plane, or a plane behind the nose; no-op when already on the plane.
- **`designs/loops/delta_loop_plane.py`**: a sixth delta-loop variant built *top-down*. It starts at the top centre, flies right to the top corner, turns down onto the slant, and uses `forward_to_plane` to land on the feed terminal where the slant crosses the plane `y = eps` (eps from the centre line) — so neither the slant length nor the feed height is computed in the script. It then completes the loop with the last two variants' techniques: named pins (`mark`/`line_to`) and `ry`-reflection across `y = 0`, with no trig in the module.
- Because the build is anchored at the top (param `top`), the feed height is *emergent* (lands near 7 m with the defaults, matching the sibling loops' base) — a deliberate departure from the family's bottom-anchored `base` convention.

## Test plan
- [x] `pytest tests/test_drone.py` — 30 passed (8 new `forward_to_plane` cases covering axis-aligned/oblique/true-distance/pen-respect/no-op/3 error paths, plus 2 new `delta_loop_plane` topology + sizing tests)
- [x] `pytest tests/test_design_schemas.py` — 860 passed (catalog-wide sweep includes the new design)
- [x] `pytest tests/` — 1306 passed
- [x] `ruff check` and `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)