### PR TITLE
Bump antennaknobs to 0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.7.0"
+version = "0.8.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]


### PR DESCRIPTION
## Summary
Minor release since 0.7.0, bundling what's landed on `main`:

- **`Drone.forward_to_plane`** (#188) — extend a leg along the nose until it meets a plane `(nx, ny, nz, d)` (normal + signed distance from origin), the distance solved rather than given. Plus **`delta_loop_plane`**, a sixth delta-loop variant that uses it to find the feed terminal where the slant crosses `y = eps`, and reference + "many ways" tour docs for both.
- **Mobile canvas** (#187) — the pannable mobile layout now floors the output stage at a full 1920×1080 canvas in both orientations, so landscape no longer starves the vertical thumbstrip.

## Test plan
- [x] `ruff check` / `ruff format --check` clean
- [x] version is the only change (`pyproject.toml` 0.7.0 → 0.8.0)
- [ ] after merge: tag `v0.8.0` on main → triggers `publish.yml` (PyPI) + `fly-deploy.yml` + `deploy-docs.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)