### PR TITLE
Rename odd_nsegs → segs_for and stop forcing segment parity

### DIFF
--- a/site/src/content/docs/reference/drone-transform.md
+++ b/site/src/content/docs/reference/drone-transform.md
@@ -96,8 +96,10 @@ trig:
 ### Auto-segmentation
 
 When `forward()` / `close()` / `line_to()` aren't given an explicit `nsegs`, the
-drone picks `max(3, round(nominal_nsegs · |length| / ref))`, forced **odd** so a
-center-fed segment has a true middle.
+drone picks `max(3, round(nominal_nsegs · |length| / ref))`. It does **not**
+force a parity — each solver wants a different one (odd for sinusoidal / B-spline
+degree-2 / PyNEC, even for triangular / B-spline degree-1) so the feed lands
+cleanly, and the engine coerces every count to its own parity at solve time.
 
 ### Example — a vertical delta loop
 

--- a/src/antennaknobs/builder.py
+++ b/src/antennaknobs/builder.py
@@ -62,16 +62,23 @@ class AntennaBuilder:
         a dummy stub wire, branches refer to ports by name, etc."""
         return None
 
-    def odd_nsegs(self, length, ref):
+    def segs_for(self, length, ref):
         """Mesh segment count for a wire of the given `length`.
 
         Scales `self.nominal_nsegs` (the segment count for a reference-length
         wire) by `length / ref`, so longer wires get proportionally more
         segments and the segment length stays roughly constant. `ref` is
-        usually a quarter-wavelength. Floored at 3 and forced odd so a
-        center-fed element has a true center segment for the feed/excitation."""
-        n = max(3, round(self.nominal_nsegs * length / ref))
-        return n if n % 2 == 1 else n + 1
+        usually a quarter-wavelength; the count is floored at 3.
+
+        Parity is intentionally NOT forced here. Each solver wants a particular
+        segment parity so the feed lands on (or symmetrically across) the
+        center — sinusoidal, B-spline degree-2 and PyNEC want odd; triangular
+        and B-spline degree-1 want even — and every engine coerces each count
+        to its own parity at solve time (`SimulationEngine.coerce_n_seg`).
+        Returning the natural count and letting the solver round is why this is
+        `segs_for`, not the old `odd_nsegs`: baking in odd here would just make
+        a triangular solve bump the count up by one."""
+        return max(3, round(self.nominal_nsegs * length / ref))
 
     def _phasor(self, name):
         """Unit phasor exp(j·phase) for a degrees-valued phase param (e.g.

--- a/src/antennaknobs/designs/beams/hb9cv.py
+++ b/src/antennaknobs/designs/beams/hb9cv.py
@@ -96,7 +96,7 @@ class Builder(AntennaBuilder):
             C0 = (x, -eps, z)
             C1 = (x, eps, z)
             R = (x, h, z)
-            arm = self.odd_nsegs(h - eps, quarter)
+            arm = self.segs_for(h - eps, quarter)
             return [
                 (L, C0, arm, None, None),
                 (C0, C1, 1, None, name),

--- a/src/antennaknobs/designs/broadband/discone.py
+++ b/src/antennaknobs/designs/broadband/discone.py
@@ -105,7 +105,7 @@ class Builder(AntennaBuilder):
                 (
                     (0.0, 0.0, z_disc),
                     (disc_r * c, disc_r * s, z_disc),
-                    self.odd_nsegs(disc_r, quarter),
+                    self.segs_for(disc_r, quarter),
                     None,
                 )
             )
@@ -114,7 +114,7 @@ class Builder(AntennaBuilder):
                 (
                     (0.0, 0.0, z_apex),
                     (cone_r * c, cone_r * s, z_cone_base),
-                    self.odd_nsegs(cone, quarter),
+                    self.segs_for(cone, quarter),
                     None,
                 )
             )

--- a/src/antennaknobs/designs/broadband/g5rv.py
+++ b/src/antennaknobs/designs/broadband/g5rv.py
@@ -100,7 +100,7 @@ class Builder(AntennaBuilder):
         C0 = (0.0, -eps, z)
         C1 = (0.0, eps, z)
         R = (0.0, half, z)
-        arm = self.odd_nsegs(half - eps, quarter)
+        arm = self.segs_for(half - eps, quarter)
         # Centre-fed doublet; the named centre gap "feed" is the antenna-side
         # port the matched line connects to (no direct voltage source here).
         return [

--- a/src/antennaknobs/designs/broadband/lpda.py
+++ b/src/antennaknobs/designs/broadband/lpda.py
@@ -126,7 +126,7 @@ class Builder(AntennaBuilder):
             C0 = (xk, -eps, z)
             C1 = (xk, eps, z)
             R = (xk, h, z)
-            arm = self.odd_nsegs(h - eps, quarter)
+            arm = self.segs_for(h - eps, quarter)
             # left arm, named centre gap (a feeder port), right arm
             tups.append((L, C0, arm, None, None))
             tups.append((C0, C1, 1, None, f"d{k}"))

--- a/src/antennaknobs/designs/broadband/t2fd.py
+++ b/src/antennaknobs/designs/broadband/t2fd.py
@@ -90,8 +90,8 @@ class Builder(AntennaBuilder):
             # slopes up by `tilt`; the fold spacing (x) stays horizontal.
             return (x, y * math.cos(tilt), y * math.sin(tilt) + self.base)
 
-        arm = self.odd_nsegs(half - eps, quarter)
-        short = self.odd_nsegs(s, quarter)
+        arm = self.segs_for(half - eps, quarter)
+        short = self.segs_for(s, quarter)
 
         # near wire (feed) at x=0; far wire (termination) at x=s
         nL, nR = P(0.0, -half), P(0.0, half)

--- a/src/antennaknobs/designs/dipoles/koch_dipole.py
+++ b/src/antennaknobs/designs/dipoles/koch_dipole.py
@@ -109,7 +109,7 @@ class Builder(AntennaBuilder):
                 (
                     (0.0, ya, z + za),
                     (0.0, yb, z + zb),
-                    self.odd_nsegs(seg, quarter),
+                    self.segs_for(seg, quarter),
                     None,
                 )
             )
@@ -122,7 +122,7 @@ class Builder(AntennaBuilder):
                 (
                     (0.0, ya, z + za),
                     (0.0, yb, z + zb),
-                    self.odd_nsegs(seg, quarter),
+                    self.segs_for(seg, quarter),
                     None,
                 )
             )

--- a/src/antennaknobs/designs/dipoles/ocf_dipole.py
+++ b/src/antennaknobs/designs/dipoles/ocf_dipole.py
@@ -84,10 +84,10 @@ class Builder(AntennaBuilder):
 
         tups = []
         tups.append(
-            (L, F0, self.odd_nsegs(left_arm, quarter), None)
+            (L, F0, self.segs_for(left_arm, quarter), None)
         )  # short arm (to -y end)
         tups.append((F0, F1, 1, 1 + 0j))  # off-centre feed
         tups.append(
-            (F1, R, self.odd_nsegs(right_arm, quarter), None)
+            (F1, R, self.segs_for(right_arm, quarter), None)
         )  # long arm (to +y end)
         return tups

--- a/src/antennaknobs/designs/loops/bisquare.py
+++ b/src/antennaknobs/designs/loops/bisquare.py
@@ -82,7 +82,7 @@ class Builder(AntennaBuilder):
         Tc = (0.0, 0.0, self.base + 2 * hd)  # top corner
         Lc = (0.0, -hd, self.base + hd)  # left corner
 
-        ns = self.odd_nsegs(side, quarter)
+        ns = self.segs_for(side, quarter)
         feed = 2 * eps
         # Feed gap on the lower-right side, a short `feed` distance up from the
         # bottom corner along the Bc -> Rc direction (unit (0, 1, 1)/sqrt(2)).
@@ -91,7 +91,7 @@ class Builder(AntennaBuilder):
 
         tups = []
         tups.append((Bc, F, 1, 1 + 0j))  # one-segment driven gap at the corner
-        tups.append((F, Rc, self.odd_nsegs(side - feed, quarter), None))
+        tups.append((F, Rc, self.segs_for(side - feed, quarter), None))
         tups.append((Rc, Tc, ns, None))  # upper-right side
         tups.append((Tc, Lc, ns, None))  # upper-left side
         tups.append((Lc, Bc, ns, None))  # lower-left side

--- a/src/antennaknobs/designs/loops/horizontal_loop.py
+++ b/src/antennaknobs/designs/loops/horizontal_loop.py
@@ -100,12 +100,12 @@ class Builder(AntennaBuilder):
         tups = []
         # Side A->D split into: A->gap-start (passive), gap (driven, 1 seg),
         # gap-end->D (passive). The remaining three sides close the loop.
-        tups.append((A, F0, self.odd_nsegs(h - feed / 2.0, quarter), None))
+        tups.append((A, F0, self.segs_for(h - feed / 2.0, quarter), None))
         tups.append((F0, F1, 1, 1 + 0j))  # one-segment driven gap
-        tups.append((F1, D, self.odd_nsegs(h - feed / 2.0, quarter), None))
-        tups.append((D, C, self.odd_nsegs(side, quarter), None))  # top side
-        tups.append((C, B, self.odd_nsegs(side, quarter), None))  # right side
+        tups.append((F1, D, self.segs_for(h - feed / 2.0, quarter), None))
+        tups.append((D, C, self.segs_for(side, quarter), None))  # top side
+        tups.append((C, B, self.segs_for(side, quarter), None))  # right side
         tups.append(
-            (B, A, self.odd_nsegs(side, quarter), None)
+            (B, A, self.segs_for(side, quarter), None)
         )  # bottom side, closes the loop
         return tups

--- a/src/antennaknobs/designs/loops/quad.py
+++ b/src/antennaknobs/designs/loops/quad.py
@@ -95,15 +95,15 @@ class Builder(AntennaBuilder):
             BR = (x, half, z0)
             TR = (x, half, z1)
             TL = (x, -half, z1)
-            ns = self.odd_nsegs(side, quarter)
+            ns = self.segs_for(side, quarter)
             wires = []
             if fed:
                 # bottom wire: BL -> (-eps) -> [feed] -> (+eps) -> BR
                 C0 = (x, -eps, z0)
                 C1 = (x, eps, z0)
-                wires.append((BL, C0, self.odd_nsegs(half - eps, quarter), None))
+                wires.append((BL, C0, self.segs_for(half - eps, quarter), None))
                 wires.append((C0, C1, 1, 1 + 0j))
-                wires.append((C1, BR, self.odd_nsegs(half - eps, quarter), None))
+                wires.append((C1, BR, self.segs_for(half - eps, quarter), None))
             else:
                 wires.append((BL, BR, ns, None))
             # remaining three sides (passive for both loops)

--- a/src/antennaknobs/designs/verticals/bobtail.py
+++ b/src/antennaknobs/designs/verticals/bobtail.py
@@ -108,12 +108,12 @@ class Builder(AntennaBuilder):
             (
                 (0.0, -span, z_top),
                 (0.0, 0.0, z_top),
-                self.odd_nsegs(span, quarter),
+                self.segs_for(span, quarter),
                 None,
             )
         )
         tups.append(
-            ((0.0, 0.0, z_top), (0.0, span, z_top), self.odd_nsegs(span, quarter), None)
+            ((0.0, 0.0, z_top), (0.0, span, z_top), self.segs_for(span, quarter), None)
         )
 
         # Outer verticals (passive, open at the bottom).
@@ -121,7 +121,7 @@ class Builder(AntennaBuilder):
             (
                 (0.0, -span, z_top),
                 (0.0, -span, z_bot),
-                self.odd_nsegs(vert, quarter),
+                self.segs_for(vert, quarter),
                 None,
             )
         )
@@ -129,7 +129,7 @@ class Builder(AntennaBuilder):
             (
                 (0.0, span, z_top),
                 (0.0, span, z_bot),
-                self.odd_nsegs(vert, quarter),
+                self.segs_for(vert, quarter),
                 None,
             )
         )
@@ -143,7 +143,7 @@ class Builder(AntennaBuilder):
             (
                 (0.0, 0.0, z_top),
                 (0.0, 0.0, zf + feed),
-                self.odd_nsegs(z_top - (zf + feed), quarter),
+                self.segs_for(z_top - (zf + feed), quarter),
                 None,
             )
         )
@@ -152,7 +152,7 @@ class Builder(AntennaBuilder):
             (
                 (0.0, 0.0, zf),
                 (0.0, 0.0, z_bot),
-                self.odd_nsegs(zf - z_bot, quarter),
+                self.segs_for(zf - z_bot, quarter),
                 None,
             )
         )

--- a/src/antennaknobs/designs/verticals/bruce.py
+++ b/src/antennaknobs/designs/verticals/bruce.py
@@ -136,7 +136,7 @@ class Builder(AntennaBuilder):
                     (
                         (0.0, ya, za),
                         (0.0, ya, zf),
-                        self.odd_nsegs(zf - za, quarter),
+                        self.segs_for(zf - za, quarter),
                         None,
                     )
                 )
@@ -145,13 +145,13 @@ class Builder(AntennaBuilder):
                     (
                         (0.0, ya, zf + 2 * eps),
                         (0.0, yb, zb),
-                        self.odd_nsegs(zb - (zf + 2 * eps), quarter),
+                        self.segs_for(zb - (zf + 2 * eps), quarter),
                         None,
                     )
                 )
             else:
                 tups.append(
-                    ((0.0, ya, za), (0.0, yb, zb), self.odd_nsegs(seg, quarter), None)
+                    ((0.0, ya, za), (0.0, yb, zb), self.segs_for(seg, quarter), None)
                 )
 
         return tups

--- a/src/antennaknobs/designs/verticals/four_square.py
+++ b/src/antennaknobs/designs/verticals/four_square.py
@@ -122,9 +122,9 @@ class Builder(AntennaBuilder):
             C0 = (x, y, zc - eps)
             C1 = (x, y, zc + eps)
             return [
-                (B, C0, self.odd_nsegs(half - eps, quarter), None),
+                (B, C0, self.segs_for(half - eps, quarter), None),
                 (C0, C1, 1, voltage),
-                (C1, T, self.odd_nsegs(half - eps, quarter), None),
+                (C1, T, self.segs_for(half - eps, quarter), None),
             ]
 
         side = complex(self.side_mag) * (-1j)

--- a/src/antennaknobs/designs/verticals/half_square.py
+++ b/src/antennaknobs/designs/verticals/half_square.py
@@ -94,12 +94,12 @@ class Builder(AntennaBuilder):
 
         tups = []
         # Left leg (bottom -> just below corner), passive.
-        tups.append((A, F, self.odd_nsegs(vert - feed, quarter), None))
+        tups.append((A, F, self.segs_for(vert - feed, quarter), None))
         # Feed segment at the corner, driven.
         tups.append((F, C, 1, 1 + 0j))
         # Top wire, passive.
-        tups.append((C, D, self.odd_nsegs(horiz, quarter), None))
+        tups.append((C, D, self.segs_for(horiz, quarter), None))
         # Right leg (corner -> bottom), passive.
-        tups.append((D, B, self.odd_nsegs(vert, quarter), None))
+        tups.append((D, B, self.segs_for(vert, quarter), None))
 
         return tups

--- a/src/antennaknobs/designs/verticals/inverted_l.py
+++ b/src/antennaknobs/designs/verticals/inverted_l.py
@@ -85,7 +85,7 @@ class Builder(AntennaBuilder):
             (
                 (0.0, 0.0, z + eps),
                 (0.0, 0.0, z + vert),
-                self.odd_nsegs(vert, quarter),
+                self.segs_for(vert, quarter),
                 None,
             )
         )
@@ -93,7 +93,7 @@ class Builder(AntennaBuilder):
             (
                 (0.0, 0.0, z + vert),
                 (0.0, horiz, z + vert),
-                self.odd_nsegs(horiz, quarter),
+                self.segs_for(horiz, quarter),
                 None,
             )
         )

--- a/src/antennaknobs/designs/verticals/jpole.py
+++ b/src/antennaknobs/designs/verticals/jpole.py
@@ -87,13 +87,13 @@ class Builder(AntennaBuilder):
 
         # Leg A: short -> tap node -> stub top, then the radiator continues up.
         tups.append(
-            ((0.0, 0.0, z_short), (0.0, 0.0, z_tap), self.odd_nsegs(tap, quarter), None)
+            ((0.0, 0.0, z_short), (0.0, 0.0, z_tap), self.segs_for(tap, quarter), None)
         )
         tups.append(
             (
                 (0.0, 0.0, z_tap),
                 (0.0, 0.0, z_stub_top),
-                self.odd_nsegs(stub - tap, quarter),
+                self.segs_for(stub - tap, quarter),
                 None,
             )
         )
@@ -101,20 +101,20 @@ class Builder(AntennaBuilder):
             (
                 (0.0, 0.0, z_stub_top),
                 (0.0, 0.0, z_rad_top),
-                self.odd_nsegs(radiator, quarter),
+                self.segs_for(radiator, quarter),
                 None,
             )
         )
 
         # Leg B: short -> tap node -> stub top (open).
         tups.append(
-            ((gap, 0.0, z_short), (gap, 0.0, z_tap), self.odd_nsegs(tap, quarter), None)
+            ((gap, 0.0, z_short), (gap, 0.0, z_tap), self.segs_for(tap, quarter), None)
         )
         tups.append(
             (
                 (gap, 0.0, z_tap),
                 (gap, 0.0, z_stub_top),
-                self.odd_nsegs(stub - tap, quarter),
+                self.segs_for(stub - tap, quarter),
                 None,
             )
         )

--- a/src/antennaknobs/designs/verticals/phased_verticals.py
+++ b/src/antennaknobs/designs/verticals/phased_verticals.py
@@ -94,9 +94,9 @@ class Builder(AntennaBuilder):
             C0 = (x, 0.0, zc - eps)
             C1 = (x, 0.0, zc + eps)
             return [
-                (B, C0, self.odd_nsegs(half - eps, quarter), None),
+                (B, C0, self.segs_for(half - eps, quarter), None),
                 (C0, C1, 1, voltage),
-                (C1, T, self.odd_nsegs(half - eps, quarter), None),
+                (C1, T, self.segs_for(half - eps, quarter), None),
             ]
 
         tups = []

--- a/src/antennaknobs/designs/wire/lazy_h.py
+++ b/src/antennaknobs/designs/wire/lazy_h.py
@@ -81,9 +81,9 @@ class Builder(AntennaBuilder):
             C0 = (0.0, -eps, z)
             C1 = (0.0, eps, z)
             return [
-                (L, C0, self.odd_nsegs(half - eps, quarter), None),
+                (L, C0, self.segs_for(half - eps, quarter), None),
                 (C0, C1, 1, 1 + 0j),
-                (C1, R, self.odd_nsegs(half - eps, quarter), None),
+                (C1, R, self.segs_for(half - eps, quarter), None),
             ]
 
         tups = []

--- a/src/antennaknobs/designs/wire/longwire.py
+++ b/src/antennaknobs/designs/wire/longwire.py
@@ -93,10 +93,10 @@ class Builder(AntennaBuilder):
 
         tups = []
         # Left half (end -> -eps), passive.
-        tups.append((left_end, gap_m, self.odd_nsegs(half - eps, quarter), None))
+        tups.append((left_end, gap_m, self.segs_for(half - eps, quarter), None))
         # Driven feed gap across the centre.
         tups.append((gap_m, gap_p, 1, 1 + 0j))
         # Right half (+eps -> end), passive.
-        tups.append((gap_p, right_end, self.odd_nsegs(half - eps, quarter), None))
+        tups.append((gap_p, right_end, self.segs_for(half - eps, quarter), None))
 
         return tups

--- a/src/antennaknobs/designs/wire/rhombic.py
+++ b/src/antennaknobs/designs/wire/rhombic.py
@@ -87,7 +87,7 @@ class Builder(AntennaBuilder):
         w = L * math.sin(tilt)
         z = self.base
 
-        leg = self.odd_nsegs(L, quarter)
+        leg = self.segs_for(L, quarter)
         FU = (0.0, eps, z)  # feed apex, upper terminal
         FL = (0.0, -eps, z)  # feed apex, lower terminal
         SU = (d, w, z)  # upper side apex

--- a/src/antennaknobs/designs/wire/vbeam.py
+++ b/src/antennaknobs/designs/wire/vbeam.py
@@ -86,7 +86,7 @@ class Builder(AntennaBuilder):
         end_p = (leg * dx, leg * dy, z)
         end_m = (leg * dx, -leg * dy, z)
 
-        arm = self.odd_nsegs(leg - eps, quarter)
+        arm = self.segs_for(leg - eps, quarter)
 
         tups = []
         # Driven gap across the apex between the two legs' inner ends.

--- a/src/antennaknobs/designs/wire/w8jk.py
+++ b/src/antennaknobs/designs/wire/w8jk.py
@@ -86,9 +86,9 @@ class Builder(AntennaBuilder):
             C0 = (x, -eps, z)
             C1 = (x, eps, z)
             return [
-                (L, C0, self.odd_nsegs(half - eps, quarter), None),
+                (L, C0, self.segs_for(half - eps, quarter), None),
                 (C0, C1, 1, voltage),
-                (C1, R, self.odd_nsegs(half - eps, quarter), None),
+                (C1, R, self.segs_for(half - eps, quarter), None),
             ]
 
         tups = []

--- a/src/antennaknobs/designs/wire/zepp.py
+++ b/src/antennaknobs/designs/wire/zepp.py
@@ -104,7 +104,7 @@ class Builder(AntennaBuilder):
             (
                 (0.0, eps, z),
                 (0.0, length, z),
-                self.odd_nsegs(length - eps, quarter),
+                self.segs_for(length - eps, quarter),
                 None,
             ),
         ]

--- a/src/antennaknobs/drone.py
+++ b/src/antennaknobs/drone.py
@@ -96,8 +96,10 @@ class Drone:
 
     # -- segmentation ---------------------------------------------------
     def _seg(self, length):
-        n = max(3, round(self.nominal_nsegs * abs(length) / self.ref))
-        return n if n % 2 == 1 else n + 1
+        # Parity is the solver's job — every engine coerces each count to its
+        # basis' required parity at solve time — so we don't force odd here
+        # (matching AntennaBuilder.segs_for).
+        return max(3, round(self.nominal_nsegs * abs(length) / self.ref))
 
     def _emit(self, p0, p1, nsegs):
         if self._pen is not None:


### PR DESCRIPTION
## Summary
`odd_nsegs` was a misnomer. Only **sinusoidal / B-spline degree-2 / PyNEC** want an odd segment count for a clean center feed — **triangular** (the default dense solver) and **B-spline degree-1** want **even**. And every engine *already* coerces each count to its own basis' parity at solve time (`SimulationEngine.coerce_n_seg`), so forcing odd in the builder was redundant and mildly counterproductive: a forced-odd 41 just got bumped to 42 on a triangular solve.

- Rename `AntennaBuilder.odd_nsegs(length, ref)` → **`segs_for(length, ref)`**, returning the natural `max(3, round(nominal_nsegs * length / ref))` with **no parity forcing** — the solver rounds, as it already does.
- Apply the same de-odding to the Drone's twin `_seg` helper (consistency).
- Update all **23 design call sites** and the Drone auto-segmentation reference docs.
- No backward-compat alias (pre-1.0; the seeded authoring contract never referenced `odd_nsegs` — it steers users to `self.nominal_nsegs`).

## Why it's safe
The per-solver coercion is the single source of truth for parity and is independently tested (`test_momwire_triangular_coerces_to_even_parity`). Dropping the builder's odd-forcing means even-parity solvers now mesh to the natural count directly instead of natural+1 — the intended improvement.

## Test plan
- [x] `pytest tests/` — **1306 passed** (no impedance/pattern drift; coercion preserves the clean feed on every solver)
- [x] `ruff check` clean
- [ ] merge this **before** the "Write your first design" tutorial PR, which documents `segs_for`

🤖 Generated with [Claude Code](https://claude.com/claude-code)