### PR TITLE
Bump antennaknobs to 0.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]


### PR DESCRIPTION
## Summary
Minor release since 0.8.0:

- **API (breaking): `odd_nsegs` → `segs_for`** — rename `AntennaBuilder.odd_nsegs(length, ref)` to `segs_for(length, ref)` and stop forcing segment parity. Every solver already coerces each count to its basis' required parity at solve time, so the builder forcing odd was redundant and mildly counterproductive (it bumped the default triangular solver's count up by one). The Drone's `_seg` helper is de-odded to match. No backward-compat alias → breaking rename, hence a minor bump (pre-1.0). (#190)
- **Docs: "Write your first design" tutorial** — a progressive on-ramp growing one hardcoded wire into a band-tunable dipole. (#191)
- **Docs: README scrub** — knobs not sliders, and don't "tune" the antenna; plus a corrected "40 m trap" framing now that the meas-freq slider reaches any selected band. (#192)

## Test plan
- [x] `ruff` clean; full suite green on each merged PR (1306 passed for the rename)
- [x] version is the only change here (`pyproject.toml` 0.8.0 → 0.9.0)
- [ ] after merge: tag `v0.9.0` on main → triggers `publish.yml` (PyPI) + `fly-deploy.yml` (simulator) + `deploy-docs.yml` (ships the new tutorial live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)