### PR TITLE
docs: simplify tutorial Builder examples and tighten contributing copy

### DIFF
--- a/site/src/content/docs/concepts/authoring-with-claude.md
+++ b/site/src/content/docs/concepts/authoring-with-claude.md
@@ -61,20 +61,17 @@ The seeded `CLAUDE.md` is authoritative; in brief, a design file must:
 - Import only from `antennaknobs` and the standard library.
 
 ```python
-from types import MappingProxyType
 from antennaknobs import AntennaBuilder
 
 
 class Builder(AntennaBuilder):
-    default_params = MappingProxyType(
-        {
-            "design_freq": 14.1,   # MHz — the band this is cut for
-            "freq": 14.1,          # MHz — measurement frequency
-            "length_factor": 0.96,
-            "height": 10.0,        # metres
-            "ui_params": MappingProxyType({"default_view": "xz"}),
-        }
-    )
+    default_params = {
+        "design_freq": 14.1,   # MHz — the band this is cut for
+        "freq": 14.1,          # MHz — measurement frequency
+        "length_factor": 0.96,
+        "height": 10.0,        # metres
+        "ui_params": {"default_view": "xz"},
+    }
 
     def build_wires(self):
         wavelength = 299.792458 / self.design_freq

--- a/site/src/content/docs/concepts/first-builder.mdx
+++ b/site/src/content/docs/concepts/first-builder.mdx
@@ -21,12 +21,11 @@ A dipole is just a straight wire fed in the middle. Here it is, hardcoded — on
 wire, no geometry parameters at all:
 
 ```python
-from types import MappingProxyType
 from antennaknobs import AntennaBuilder
 
 
 class Builder(AntennaBuilder):
-    default_params = MappingProxyType({"freq": 14.0})  # MHz — the only knob
+    default_params = {"freq": 14.0}  # MHz — the only knob
 
     def build_wires(self):
         y = 5.0  # half-length in metres → a 10 m wire, tip to tip
@@ -92,12 +91,10 @@ add `base` to the params and use it as the `z` coordinate:
 
 ```python
 class Builder(AntennaBuilder):
-    default_params = MappingProxyType(
-        {
-            "freq": 14.0,   # MHz — measurement frequency
-            "base": 10.0,   # metres — height above ground
-        }
-    )
+    default_params = {
+        "freq": 14.0,   # MHz — measurement frequency
+        "base": 10.0,   # metres — height above ground
+    }
 
     def build_wires(self):
         y = 5.0
@@ -169,19 +166,16 @@ The last hardcoded number is `y`. Make it a knob and the antenna becomes
 adjustable — slide it longer to drop the resonant frequency, shorter to raise it:
 
 ```python
-from types import MappingProxyType
 from antennaknobs import AntennaBuilder
 
 
 class Builder(AntennaBuilder):
-    default_params = MappingProxyType(
-        {
-            "freq": 14.6,          # MHz — measurement frequency
-            "base": 10.0,          # metres — height above ground
-            "half_length": 5.0,    # metres — half the wire, tip to centre
-            "ui_params": MappingProxyType({"default_view": "xz"}),
-        }
-    )
+    default_params = {
+        "freq": 14.6,          # MHz — measurement frequency
+        "base": 10.0,          # metres — height above ground
+        "half_length": 5.0,    # metres — half the wire, tip to centre
+        "ui_params": {"default_view": "xz"},
+    }
 
     def build_wires(self):
         wavelength = 299.792458 / self.freq
@@ -211,20 +205,17 @@ quarter wavelength — times a `length_factor` near 1.0 that trims a real wire t
 true resonance:
 
 ```python
-from types import MappingProxyType
 from antennaknobs import AntennaBuilder
 
 
 class Builder(AntennaBuilder):
-    default_params = MappingProxyType(
-        {
-            "design_freq": 14.6,    # MHz — the band this antenna is cut for
-            "freq": 14.6,           # MHz — measurement frequency (starts on band)
-            "length_factor": 0.97,  # trims the half-wave to resonance (~97 %)
-            "base": 10.0,           # metres — height above ground
-            "ui_params": MappingProxyType({"default_view": "xz"}),
-        }
-    )
+    default_params = {
+        "design_freq": 14.6,    # MHz — the band this antenna is cut for
+        "freq": 14.6,           # MHz — measurement frequency (starts on band)
+        "length_factor": 0.97,  # trims the half-wave to resonance (~97 %)
+        "base": 10.0,           # metres — height above ground
+        "ui_params": {"default_view": "xz"},
+    }
 
     def build_wires(self):
         wavelength = 299.792458 / self.design_freq

--- a/site/src/content/docs/concepts/first-builder.mdx
+++ b/site/src/content/docs/concepts/first-builder.mdx
@@ -105,7 +105,7 @@ class Builder(AntennaBuilder):
 ```
 
 Every key in `default_params` is now a knob in the panel, read inside the build
-as `self.base`. Slide it and watch the pattern lift off the ground.
+as `self.base`. Slide it and watch the pattern lift off the ground. Make sure to enable ground modelling.
 
 ## 4. Segment the wire the right way
 

--- a/site/src/content/docs/concepts/model.md
+++ b/site/src/content/docs/concepts/model.md
@@ -11,16 +11,15 @@ from **parameters** (the knobs) to a **list of wires**.
 A design subclasses `AntennaBuilder` and declares its parameters:
 
 ```python
-from types import MappingProxyType
 from antennaknobs import AntennaBuilder
 
 class Builder(AntennaBuilder):
-    default_params = MappingProxyType({
+    default_params = {
         "design_freq": 28.47,
         "freq": 28.47,
         "length": 5.2,
         # ...
-    })
+    }
 
     def build_wires(self):
         ...

--- a/site/src/content/docs/project/contributing.md
+++ b/site/src/content/docs/project/contributing.md
@@ -4,8 +4,9 @@ description: How to add a design, run the tests, and submit changes.
 ---
 
 antennaknobs is open source on
-[GitHub](https://github.com/stevenmburns/antennaknobs). Contributions — new
-designs especially — are welcome.
+[GitHub](https://github.com/stevenmburns/antennaknobs). Contributions — in the
+form of new feature requests (issues) or new designs and fixes (pull requests) —
+are welcome.
 
 ## Adding a design
 


### PR DESCRIPTION
## Summary
- Drop `MappingProxyType` (and its `from types import MappingProxyType`) from the intro/concept tutorials (`first-builder`, `model`, `authoring-with-claude`), using plain `dict` literals instead — the immutability wrapper is a defensive measure, not a requirement (`builder.py` copies `default_params` into a fresh dict and never mutates the class attribute), so the examples stay runnable while reading simpler for beginners.
- `first-builder`: note that ground modelling must be enabled to see the pattern lift off the ground when raising the `base` knob.
- `contributing`: balance the em-dash and reframe PRs as new designs and fixes rather than just fixes.

## Test plan
- [ ] Docs build renders the updated `concepts/` and `project/contributing` pages without errors
- [ ] Tutorial code blocks copy-paste and load as valid Builders (plain-dict `default_params`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)