### PR TITLE
Export knob values as paste-ready Python (CLI + web)

### DIFF
--- a/src/antennaknobs/__init__.py
+++ b/src/antennaknobs/__init__.py
@@ -19,6 +19,8 @@ __all__ = [
     "optimize",
     "pattern",
     "pattern3d",
+    "params_source",
+    "builder_params_source",
     "cli",
 ]
 
@@ -35,6 +37,7 @@ from .sim import Antenna
 from .opt import optimize
 from .sweep import sweep, sweep_freq, sweep_gain, sweep_patterns, resolve_range, gen_xs
 from .far_field import compare_patterns, plot_patterns, pattern, pattern3d
+from .serialize import params_source, builder_params_source
 from .cli import cli
 
 # Re-enable Builder debug prints (now `logger.debug` calls under

--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -11,6 +11,7 @@ from . import (
     optimize,
 )
 from .engines import PyNECEngine, MomwireEngine
+from .serialize import builder_params_source
 from .user_designs import USER_NS, iter_design_files, resolve_user_design
 
 from momwire import (
@@ -205,6 +206,19 @@ def get_builder(nm):
 
 def get_builders(nms):
     return (get_builder(nm) for nm in nms)
+
+
+def emit_params_name(builder_spec):
+    """Variable name for a serialised param block emitted from ``builder_spec``.
+
+    A ``name:variant`` spec emits ``<variant>_params`` (so the block drops
+    straight back beside the variant it came from); a bare name or ``:default``
+    emits ``default_params``.
+    """
+    _, _, variant = builder_spec.partition(":")
+    if variant and variant != "default":
+        return f"{variant}_params"
+    return "default_params"
 
 
 def parse_ground(s):
@@ -502,8 +516,57 @@ def cli(arguments=None):
             resonance=args.resonance,
             engine=engine,
         )
-        print(opt_builder)
+        print()
+        print("# Optimized knobs — paste over the design's params block:")
+        print(
+            builder_params_source(
+                opt_builder,
+                name=emit_params_name(args.builder),
+                default_precision=6,
+            )
+        )
         compare_patterns([engine(builder()), engine(opt_builder)], fn=args.fn)
+
+    p.set_defaults(func=f)
+
+    p = subparsers.add_parser(
+        "params", help="Print a design's knob values as paste-ready Python"
+    )
+    p.add_argument(
+        "--builder",
+        type=str,
+        default="dipoles.invvee:dipole",
+        help="Antenna builder (name or name:variant) to dump.",
+    )
+    p.add_argument(
+        "--name",
+        type=str,
+        default=None,
+        help="Variable name for the emitted block "
+        "(default: <variant>_params, or default_params).",
+    )
+    p.add_argument(
+        "--no-ui",
+        dest="no_ui",
+        default=False,
+        action="store_true",
+        help="Omit the ui_params block (knob values only).",
+    )
+    p.add_argument(
+        "--wrap",
+        choices=["dict", "mappingproxy"],
+        default="dict",
+        help="Wrap the block in MappingProxyType to match the catalog style.",
+    )
+
+    def f(args):
+        builder = get_builder(args.builder)
+        name = args.name or emit_params_name(args.builder)
+        print(
+            builder_params_source(
+                builder(), name=name, include_ui=not args.no_ui, wrap=args.wrap
+            )
+        )
 
     p.set_defaults(func=f)
 

--- a/src/antennaknobs/serialize.py
+++ b/src/antennaknobs/serialize.py
@@ -1,0 +1,183 @@
+"""Serialise a Builder's knob values back to paste-ready Python source.
+
+After a UI tuning session or a CLI ``optimize`` run you hold a set of knob
+values you want to commit into a design's ``default_params`` (or a named
+variant). This turns those values into a copy-pasteable assignment block — the
+missing piece that hand-rolled tuning scripts used to format inline.
+
+The public entry points are :func:`params_source` (format any param mapping)
+and :func:`builder_params_source` (pull the live params off a Builder instance,
+drop framework-only keys, and apply each knob's ``ui_params`` display
+precision).
+
+Floats default to the shortest round-tripping ``repr`` so the emitted source is
+paste-safe — it never silently rounds an optimiser result away. A knob that
+declares ``precision`` or ``step`` in ``ui_params`` is rendered at that display
+precision instead, which keeps tuned knobs clean without losing the others.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from typing import Any
+
+
+def _precision_for_step(step: float) -> int:
+    """Decimal places for a value stepped by ``step``.
+
+    Mirror of ``web.adapter._precision_for_step``, duplicated here so this
+    module stays free of the web/solver import chain.
+    """
+    if step <= 0.0:
+        return 3
+    return min(6, max(0, -math.floor(math.log10(step))) + 1)
+
+
+def _precision_map(ui_params: Any) -> dict[str, int]:
+    """Per-knob decimal precision derived from a design's ``ui_params``.
+
+    An explicit ``precision`` wins; otherwise it's inferred from the knob's
+    ``step``. Knobs with neither (and the reserved non-knob ``ui_params`` keys,
+    which aren't mappings) are omitted, so they fall back to the caller's
+    default.
+    """
+    out: dict[str, int] = {}
+    if not isinstance(ui_params, Mapping):
+        return out
+    for key, spec in ui_params.items():
+        if not isinstance(spec, Mapping):
+            continue
+        if "precision" in spec:
+            out[key] = int(spec["precision"])
+        elif "step" in spec:
+            out[key] = _precision_for_step(float(spec["step"]))
+    return out
+
+
+def _fmt_float(value: float, precision: int | None) -> str:
+    """Render a float as Python source. ``None`` precision keeps the shortest
+    round-tripping repr; an int rounds to that many decimals, trimming trailing
+    zeros but always leaving one (so it still reads as a float)."""
+    if precision is None:
+        return repr(float(value))
+    s = f"{value:.{precision}f}"
+    if "." in s:
+        s = s.rstrip("0")
+        if s.endswith("."):
+            s += "0"
+    return s
+
+
+def _fmt_value(value: Any, *, precision: int | None, indent: int, level: int) -> str:
+    """Recursively format an arbitrary param value as indented Python source.
+
+    Mappings, lists and tuples are expanded one item per line; scalars fall
+    back to ``repr`` (which is already valid source for str/complex/bool/int).
+    """
+    # bool is an int subclass — check it first so True/False don't render as 1/0.
+    if isinstance(value, bool):
+        return repr(value)
+    if isinstance(value, int):
+        return repr(value)
+    if isinstance(value, float):
+        return _fmt_float(value, precision)
+
+    inner = " " * (indent * (level + 1))
+    closing = " " * (indent * level)
+
+    if isinstance(value, Mapping):
+        if not value:
+            return "{}"
+        lines = ["{"]
+        for k, v in value.items():
+            rendered = _fmt_value(
+                v, precision=precision, indent=indent, level=level + 1
+            )
+            lines.append(f"{inner}{k!r}: {rendered},")
+        lines.append(f"{closing}}}")
+        return "\n".join(lines)
+
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return "[]" if isinstance(value, list) else "()"
+        open_b, close_b = ("[", "]") if isinstance(value, list) else ("(", ")")
+        lines = [open_b]
+        for v in value:
+            rendered = _fmt_value(
+                v, precision=precision, indent=indent, level=level + 1
+            )
+            lines.append(f"{inner}{rendered},")
+        lines.append(f"{closing}{close_b}")
+        return "\n".join(lines)
+
+    return repr(value)
+
+
+def params_source(
+    params: Mapping[str, Any],
+    *,
+    name: str = "default_params",
+    precision: Mapping[str, int] | None = None,
+    default_precision: int | None = None,
+    include_ui: bool = True,
+    indent: int = 4,
+    wrap: str = "dict",
+) -> str:
+    """Format a param mapping as a paste-ready ``<name> = {...}`` block.
+
+    ``precision`` maps individual top-level knob names to a decimal precision;
+    knobs absent from it use ``default_precision`` (``None`` → shortest
+    round-trip). Set ``include_ui=False`` to drop the reserved ``ui_params``
+    block. ``wrap="mappingproxy"`` emits ``MappingProxyType({...})`` to match
+    the catalog's frozen-params convention (the caller must import it).
+    """
+    precision = precision or {}
+    pad = " " * indent
+    body_lines = []
+    for k, v in params.items():
+        if k == "ui_params" and not include_ui:
+            continue
+        if isinstance(v, float) and not isinstance(v, bool):
+            rendered = _fmt_float(v, precision.get(k, default_precision))
+        else:
+            rendered = _fmt_value(
+                v, precision=default_precision, indent=indent, level=1
+            )
+        body_lines.append(f"{pad}{k!r}: {rendered},")
+    body = "\n".join(body_lines)
+    if wrap == "mappingproxy":
+        return f"{name} = MappingProxyType({{\n{body}\n}})"
+    if wrap != "dict":
+        raise ValueError(f"unknown wrap {wrap!r}; expected 'dict' or 'mappingproxy'")
+    return f"{name} = {{\n{body}\n}}"
+
+
+def builder_params_source(
+    builder: Any,
+    *,
+    name: str = "default_params",
+    include_ui: bool = True,
+    default_precision: int | None = None,
+    wrap: str = "dict",
+) -> str:
+    """Serialise a live Builder instance's knobs to paste-ready source.
+
+    Framework-only params (``nominal_nsegs`` & friends) are dropped — they're
+    not design knobs — and each knob's ``ui_params`` display precision is
+    applied so tuned values read cleanly. ``default_precision`` rounds the knobs
+    that *don't* declare a display precision: leave it ``None`` to dump existing
+    literals losslessly, or set it (e.g. 6 after an optimise run) to trim the
+    optimiser's sub-tolerance digits.
+    """
+    framework = type(builder).FRAMEWORK_PARAMS
+    params = {k: v for k, v in builder._params.items() if k not in framework}
+    precision = _precision_map(params.get("ui_params"))
+    return params_source(
+        params,
+        name=name,
+        precision=precision,
+        default_precision=default_precision,
+        include_ui=include_ui,
+        wrap=wrap,
+    )

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -1191,6 +1191,39 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             ]
         return out
 
+    def params_source(req: dict) -> str:
+        # Overlay the request's live knob values onto the chosen variant's
+        # params (which still carry ui_params and the design's real nesting —
+        # bands tuples etc.), then serialise. Knob-values-only by default
+        # (include_ui), matching the manual "copy the printed values" workflow
+        # this replaces; pass include_ui=true to emit a wholesale block.
+        from antennaknobs.serialize import _precision_map
+        from antennaknobs.serialize import params_source as _emit
+
+        variant = req.get("variant")
+        base = dict(_variant_params(cls, variant))  # retains ui_params
+        ui = base.get("ui_params")
+        nested = req.get("params") or {}
+        for k in list(base.keys()):
+            if k == "ui_params":
+                continue
+            if k in req:
+                base[k] = _rehydrate_param(base[k], req[k])
+            elif k in nested:
+                base[k] = _rehydrate_param(base[k], nested[k])
+        name = (
+            f"{variant}_params"
+            if variant and variant != "default"
+            else "default_params"
+        )
+        return _emit(
+            base,
+            name=name,
+            precision=_precision_map(ui),
+            include_ui=bool(req.get("include_ui", False)),
+            wrap="mappingproxy" if req.get("wrap") == "mappingproxy" else "dict",
+        )
+
     def nec_export(req: dict) -> str:
         # Same builder construction as pynec_solve, then serialise to a NEC2
         # card deck. Ground/freq mirror what the live solve uses so the
@@ -1262,6 +1295,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         pynec_build=pynec_build,
         pynec_pattern_excite=pynec_pattern_excite,
         nec_export=nec_export,
+        params_source=params_source,
         multi_feed=field_multi_feed,
         param_schema=param_schema,
         bands=bands,

--- a/src/antennaknobs/web/examples/_base.py
+++ b/src/antennaknobs/web/examples/_base.py
@@ -310,6 +310,11 @@ class AntennaExample:
     # request (params/variant/freq/ground). None when the design has no
     # faithful native-NEC representation (TL/DiffTL/virtual-driver networks).
     nec_export: Optional[Callable[[dict], str]] = None
+    # Serialise the request's current knob values back to a paste-ready
+    # Python `default_params = {...}` (or named-variant) block, so the UI can
+    # offer a "Copy Python" action that drops straight into a design file.
+    # None when the design can't be serialised.
+    params_source: Optional[Callable[[dict], str]] = None
     # When set, pattern() calls this to excite the NEC context (e.g.
     # multi-source drive for bowtie's 1×2 array). When None, pattern()
     # uses the default single-feed excitation reading b["feed_seg"] /

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1565,6 +1565,8 @@ export function App() {
   // Tools (gear) dropdown in the header. Tucked away because it holds
   // occasional actions like the NEC deck export, not per-solve controls.
   const [gearMenuOpen, setGearMenuOpen] = useState(false);
+  // Transient "Copied ✓" confirmation on the Copy-params menu item.
+  const [copiedParams, setCopiedParams] = useState(false);
 
   // Schema-driven parameter controls. Each registered example bundles
   // its parameter schema in web/examples/<name>.py; the backend serves
@@ -2318,6 +2320,38 @@ export function App() {
     }
   }
 
+  // Copy the current knob values as a paste-ready Python `default_params`
+  // (or `<variant>_params`) block. Replaces the old workflow of hand-copying
+  // the values printed on screen back into a design file. The backend reuses
+  // the same variant + live-knob overlay as the solve, so what you copy is
+  // exactly the antenna on screen.
+  async function copyParams() {
+    try {
+      const resp = await fetch("/params_source", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildRequest()),
+      });
+      const data = await resp.json();
+      if (!resp.ok || data.available === false || data.error) {
+        window.alert(data.error ?? "Copy params is unavailable for this design.");
+        return;
+      }
+      const src: string = data.source;
+      try {
+        await navigator.clipboard.writeText(src);
+        setCopiedParams(true);
+        window.setTimeout(() => setCopiedParams(false), 1500);
+      } catch {
+        // Clipboard API blocked (e.g. insecure context) — fall back to a
+        // prompt the user can copy from by hand.
+        window.prompt("Copy these params:", src);
+      }
+    } catch (e) {
+      window.alert(`Copy params failed: ${e}`);
+    }
+  }
+
   const currentBands: BandSpec[] = currentExample?.bands ?? [];
 
   // Anchor for the measurement-freq slider window: the snap-freq of the band
@@ -3030,6 +3064,15 @@ export function App() {
                     onClick={() => setGearMenuOpen(false)}
                   />
                   <div className="gear-menu" role="menu">
+                    <button
+                      type="button"
+                      className="gear-menu-item"
+                      role="menuitem"
+                      onClick={copyParams}
+                      title="Copy the current knob values as a paste-ready Python default_params block"
+                    >
+                      {copiedParams ? "Copied ✓" : "Copy params (Python)"}
+                    </button>
                     <button
                       type="button"
                       className="gear-menu-item"

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -766,6 +766,27 @@ async def export_nec_endpoint(req: dict):
     )
 
 
+@app.post("/params_source")
+async def params_source_endpoint(req: dict):
+    """Serialise the current knob values to a paste-ready Python params block.
+
+    Reuses the same variant + live-knob overlay as the solve path, so the
+    emitted ``default_params`` (or ``<variant>_params``) block matches the
+    antenna on screen. Knob-values-only by default; pass ``include_ui: true``
+    for a wholesale block and ``wrap: "mappingproxy"`` to match catalog style.
+    Returns ``{"available": False}`` for a design that can't be serialised.
+    """
+    geometry = req.get("geometry", next(iter(EXAMPLES)))
+    ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
+    if ex.params_source is None:
+        return {"available": False}
+    try:
+        source = await run_in_threadpool(ex.params_source, req)
+    except Exception as exc:  # noqa: BLE001 — a user design's params can be odd
+        return {"geometry": geometry, "error": user_designs.format_solve_error(exc)}
+    return {"geometry": geometry, "available": True, "source": source}
+
+
 @app.post("/geometry")
 async def geometry_endpoint(req: dict):
     """Fast geometry-only snapshot of the selected antenna: wire positions +

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,0 +1,178 @@
+"""Tests for antennaknobs.serialize — knob values → paste-ready Python source.
+
+Every emitted block must be valid Python that, when executed, reproduces the
+input values (up to the requested display precision). The round-trip is checked
+by ``exec``-ing the source and comparing the resulting binding.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+
+import pytest
+
+from antennaknobs.serialize import (
+    builder_params_source,
+    params_source,
+)
+
+
+def _eval_block(src: str, name: str = "default_params"):
+    """Exec an emitted assignment block and return the bound value."""
+    ns: dict = {"MappingProxyType": MappingProxyType}
+    exec(src, ns)
+    return ns[name]
+
+
+def test_simple_dict_round_trips():
+    params = {"freq": 14.0, "base": 10.0, "length_factor": 0.97}
+    src = params_source(params)
+    assert src.startswith("default_params = {")
+    assert _eval_block(src) == params
+
+
+def test_emitted_source_is_valid_python_and_named():
+    src = params_source({"freq": 28.57}, name="opt_params")
+    assert src.startswith("opt_params = {")
+    assert _eval_block(src, "opt_params") == {"freq": 28.57}
+
+
+def test_floats_default_to_shortest_round_trip():
+    # No precision metadata: the exact value must survive, not be rounded away.
+    params = {"halfdriver": 2.4597430629596713}
+    out = _eval_block(params_source(params))
+    assert out["halfdriver"] == 2.4597430629596713
+
+
+def test_per_knob_precision_rounds_for_display():
+    params = {"z0_match": 450.123456, "match_len_frac": 0.461234}
+    src = params_source(params, precision={"z0_match": 1, "match_len_frac": 3})
+    assert "'z0_match': 450.1," in src
+    assert "'match_len_frac': 0.461," in src
+
+
+def test_default_precision_applies_when_no_per_knob_entry():
+    src = params_source({"x": 0.123456789}, default_precision=4)
+    assert "'x': 0.1235," in src
+
+
+def test_trailing_zeros_trimmed_but_keeps_one_decimal():
+    src = params_source({"a": 14.0, "b": 1.2000}, precision={"a": 4, "b": 4})
+    assert "'a': 14.0," in src
+    assert "'b': 1.2," in src
+
+
+def test_ints_bools_strings_render_natively():
+    params = {"n": 5, "daisy_chain": True, "view": "xz"}
+    src = params_source(params)
+    assert "'n': 5," in src
+    assert "'daisy_chain': True," in src  # not 1
+    assert "'view': 'xz'," in src
+    assert _eval_block(src) == params
+
+
+def test_complex_excitation_round_trips():
+    params = {"drive": 1 + 0j}
+    out = _eval_block(params_source(params))
+    assert out["drive"] == 1 + 0j
+
+
+def test_nested_ui_params_round_trips():
+    params = {
+        "freq": 14.0,
+        "ui_params": {
+            "default_view": "xz",
+            "z0_match": {"min": 200.0, "max": 600.0},
+        },
+    }
+    out = _eval_block(params_source(params))
+    assert out == params
+
+
+def test_include_ui_false_drops_ui_params():
+    params = {"freq": 14.0, "ui_params": {"default_view": "xz"}}
+    src = params_source(params, include_ui=False)
+    assert "ui_params" not in src
+    assert _eval_block(src) == {"freq": 14.0}
+
+
+def test_bands_tuple_of_dicts_round_trips():
+    params = {
+        "n_bands": 2,
+        "bands": (
+            {"freq": 14.3, "halfdriver_factor": 1.071},
+            {"freq": 21.383, "halfdriver_factor": 1.071},
+        ),
+    }
+    out = _eval_block(params_source(params))
+    assert out == params
+    # tuple stays a tuple, not silently widened to a list
+    assert isinstance(out["bands"], tuple)
+
+
+def test_mappingproxy_wrap():
+    src = params_source({"freq": 14.0}, wrap="mappingproxy")
+    assert src.startswith("default_params = MappingProxyType({")
+    assert _eval_block(src) == MappingProxyType({"freq": 14.0})
+
+
+def test_unknown_wrap_raises():
+    with pytest.raises(ValueError, match="unknown wrap"):
+        params_source({"freq": 14.0}, wrap="tuple")
+
+
+# --- builder_params_source ----------------------------------------------------
+
+
+def test_builder_params_source_drops_framework_params():
+    import antennaknobs as ant
+
+    class Builder(ant.AntennaBuilder):
+        default_params = MappingProxyType({"freq": 14.0, "base": 10.0})
+
+        def build_wires(self):
+            return []
+
+    b = Builder()
+    # nominal_nsegs is a framework param merged into _params; it must not leak.
+    assert "nominal_nsegs" in b._params
+    src = builder_params_source(b)
+    assert "nominal_nsegs" not in src
+    assert _eval_block(src) == {"freq": 14.0, "base": 10.0}
+
+
+def test_builder_params_source_applies_ui_precision():
+    import antennaknobs as ant
+
+    class Builder(ant.AntennaBuilder):
+        default_params = MappingProxyType(
+            {
+                "z0_match": 450.0,
+                "ui_params": MappingProxyType(
+                    {"z0_match": {"step": 1.0, "precision": 1}}
+                ),
+            }
+        )
+
+        def build_wires(self):
+            return []
+
+    b = Builder()
+    b.z0_match = 451.98765
+    src = builder_params_source(b)
+    assert "'z0_match': 452.0," in src
+
+
+def test_builder_params_source_reflects_runtime_edits():
+    import antennaknobs as ant
+
+    class Builder(ant.AntennaBuilder):
+        default_params = MappingProxyType({"length_factor": 1.0})
+
+        def build_wires(self):
+            return []
+
+    b = Builder()
+    b.length_factor = 0.965
+    out = _eval_block(builder_params_source(b))
+    assert out["length_factor"] == 0.965

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -91,6 +91,63 @@ def test_healthz_returns_ok(client: TestClient):
 
 
 # ---------------------------------------------------------------------------
+# /params_source — "Copy Python" export of the live knob values
+# ---------------------------------------------------------------------------
+
+
+def _eval_params_block(src: str):
+    from types import MappingProxyType
+
+    ns: dict = {"MappingProxyType": MappingProxyType}
+    exec(src, ns)
+    return ns["default_params"]
+
+
+def test_params_source_reflects_live_knob_values(client: TestClient):
+    r = client.post(
+        "/params_source",
+        json={
+            "geometry": "broadband.g5rv",
+            "variant": "default",
+            "z0_match": 512.5,
+            "match_len_frac": 0.41,
+        },
+    )
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload["available"] is True
+    block = _eval_params_block(payload["source"])
+    # The overlaid slider values must come back out, not the design defaults.
+    assert block["z0_match"] == 512.5
+    assert block["match_len_frac"] == 0.41
+    # Knob-values-only by default — no ui_params noise.
+    assert "ui_params" not in block
+
+
+def test_params_source_include_ui_and_mappingproxy(client: TestClient):
+    r = client.post(
+        "/params_source",
+        json={
+            "geometry": "broadband.g5rv",
+            "include_ui": True,
+            "wrap": "mappingproxy",
+        },
+    )
+    payload = r.json()
+    assert payload["source"].startswith("default_params = MappingProxyType({")
+    block = _eval_params_block(payload["source"])
+    assert "ui_params" in block
+
+
+def test_params_source_names_block_after_variant(client: TestClient):
+    payload = client.post(
+        "/params_source",
+        json={"geometry": "specialty.hentenna", "variant": "z100"},
+    ).json()
+    assert payload["source"].startswith("z100_params = {")
+
+
+# ---------------------------------------------------------------------------
 # /examples — schema serialization, used by the frontend on mount
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Closes the ergonomic gap where, after a UI session or a CLI `optimize` run, you had to hand-copy the printed knob values back into a design file. Now both surfaces emit a paste-ready `default_params = {...}` (or `<variant>_params`) block.

- **New `antennaknobs.serialize`** — `params_source()` / `builder_params_source()` turn a param mapping (or a live Builder's knobs) into copy-pasteable source. Floats default to shortest round-trip (never silently rounded); a knob's `ui_params` precision/step tightens its display, and an optional `default_precision` trims an optimiser's sub-tolerance digits. Handles nested `ui_params`, `bands` tuples-of-dicts, complex excitations, and a `MappingProxyType` wrap to match catalog style.
- **CLI** — `optimize` prints the block (rounded to 6 dp) instead of the old comma-separated `__str__` log line; new `params` subcommand dumps any design/variant's knobs (`--name` / `--no-ui` / `--wrap`).
- **Web** — `POST /params_source` plus a gear-menu **"Copy params (Python)"** button. The backend overlays the request's live knobs onto the chosen variant's params (which still carry `ui_params` + the design's real nesting) and reuses the serializer. Knob-values-only by default; `include_ui` / `wrap` options available. Clipboard copy with a transient "Copied ✓", falling back to a prompt when the clipboard API is blocked.

## Test plan
- [x] `tests/test_serialize.py` — 16 round-trip / precision / wrap / builder tests
- [x] `tests/test_web_server.py::test_params_source_*` — endpoint reflects live knobs, `include_ui`/`mappingproxy`, variant naming
- [x] Full `tests/` suite (1325 passed); ruff check + format clean
- [x] Frontend `tsc --noEmit` + `vite build` clean
- [ ] Manual: click **Copy params (Python)** in the web UI, paste into a design file, confirm it loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)