### PR TITLE
Compare radiation patterns in the UI (pin/ghost overlay) + pattern metrics

### DIFF
--- a/src/antennaknobs/__init__.py
+++ b/src/antennaknobs/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "Array1x4GroupedBuilder",
     "plot_patterns",
     "compare_patterns",
+    "pattern_metrics",
     "resolve_range",
     "gen_xs",
     "sweep",
@@ -36,7 +37,13 @@ from .drone import Drone
 from .sim import Antenna
 from .opt import optimize
 from .sweep import sweep, sweep_freq, sweep_gain, sweep_patterns, resolve_range, gen_xs
-from .far_field import compare_patterns, plot_patterns, pattern, pattern3d
+from .far_field import (
+    compare_patterns,
+    pattern_metrics,
+    plot_patterns,
+    pattern,
+    pattern3d,
+)
 from .serialize import params_source, builder_params_source
 from .cli import cli
 

--- a/src/antennaknobs/far_field.py
+++ b/src/antennaknobs/far_field.py
@@ -59,6 +59,103 @@ def get_elevation(a):
     return ff.rings, ff.max_gain, ff.min_gain, ff.thetas, ff.phis
 
 
+def _beamwidth_wrapped(angles, gains, peak_idx, threshold):
+    """−3 dB-style width through a peak in a *wrapped* cut (azimuth: φ 0→360
+    with a duplicated endpoint). Returns the angular width (deg) where the
+    trace stays at/above `threshold` either side of the peak, the crossings
+    found by linear interpolation between 1° samples. A trace that never drops
+    below threshold (omnidirectional) returns the full 360°."""
+    g = np.asarray(gains[:-1], float)  # drop the duplicated φ=360 sample
+    ang = np.asarray(angles[:-1], float)
+    n = len(g)
+    if n == 0 or np.all(g >= threshold):
+        return 360.0
+    pk = int(peak_idx) % n
+
+    def walk(direction):
+        dist = 0.0
+        i = pk
+        for _ in range(n):
+            j = (i + direction) % n
+            step = ((ang[j] - ang[i]) * direction) % 360.0 or 360.0 / n
+            if g[j] < threshold:
+                frac = (g[i] - threshold) / (g[i] - g[j])
+                return dist + frac * step
+            dist += step
+            i = j
+        return None
+
+    right, left = walk(+1), walk(-1)
+    if right is None or left is None:
+        return 360.0
+    return right + left
+
+
+def _beamwidth_linear(angles, gains, peak_idx, threshold):
+    """−3 dB-style width through a peak in a *non-wrapped* cut (elevation:
+    bounded to the 0°–90° hemisphere). Same interpolation as the wrapped case,
+    but a side that runs into the array edge without crossing returns the
+    distance to the edge, so the result is a lower bound for a lobe that hugs
+    the horizon or zenith."""
+    g = np.asarray(gains, float)
+    ang = np.asarray(angles, float)
+    n = len(g)
+    if n == 0 or np.all(g >= threshold):
+        return abs(float(ang[-1] - ang[0])) if n else 0.0
+
+    def walk(direction):
+        dist = 0.0
+        i = int(peak_idx)
+        while 0 <= i + direction < n:
+            j = i + direction
+            step = abs(float(ang[j] - ang[i]))
+            if g[j] < threshold:
+                frac = (g[i] - threshold) / (g[i] - g[j])
+                return dist + frac * step
+            dist += step
+            i = j
+        return dist  # ran into the edge — truncated lower bound
+
+    return walk(+1) + walk(-1)
+
+
+def pattern_metrics(ff, *, beamwidth_db=3.0):
+    """Summarise a `FarField` into scalar metrics for comparing antennas.
+
+    Returns a dict with:
+      * `peak_gain_dbi`    — maximum gain over the whole pattern (dBi)
+      * `takeoff_deg`      — elevation angle of the peak (90 − θ)
+      * `azimuth_deg`      — azimuth of the peak
+      * `front_to_back_db` — peak minus the gain at the same elevation, 180°
+                             away in azimuth
+      * `az_beamwidth_deg` — −`beamwidth_db` width through the peak in the
+                             azimuth ring at the peak's elevation
+      * `el_beamwidth_deg` — −`beamwidth_db` width through the peak in the
+                             elevation column at the peak's azimuth (a lower
+                             bound when the lobe meets the 0°/90° limit)
+    """
+    rings = np.asarray(ff.rings, float)
+    thetas = np.asarray(ff.thetas, float)
+    phis = np.asarray(ff.phis, float)
+    ti, pi = np.unravel_index(int(np.argmax(rings)), rings.shape)
+    peak = float(rings[ti, pi])
+    ring = rings[ti]
+
+    back_az = (float(phis[pi]) + 180.0) % 360.0
+    bi = int(np.argmin(np.abs(((phis - back_az + 180.0) % 360.0) - 180.0)))
+    front_to_back = peak - float(ring[bi])
+
+    thr = peak - beamwidth_db
+    return {
+        "peak_gain_dbi": peak,
+        "takeoff_deg": float(90.0 - thetas[ti]),
+        "azimuth_deg": float(phis[pi]),
+        "front_to_back_db": front_to_back,
+        "az_beamwidth_deg": _beamwidth_wrapped(phis, ring, pi, thr),
+        "el_beamwidth_deg": _beamwidth_linear(90.0 - thetas, rings[:, pi], ti, thr),
+    }
+
+
 def plot_patterns(
     rings_lst,
     names,
@@ -101,8 +198,6 @@ def plot_patterns(
         azimuth_r += delta_azimuth
         azimuth_r %= n - 1
 
-    print(n, azimuth_f, azimuth_r)
-
     assert 0 <= azimuth_f < n - 1
     assert 0 <= azimuth_r < n - 1
 
@@ -122,6 +217,28 @@ def plot_patterns(
     save_or_show(plt, fn)
 
 
+def _print_metrics_table(names, metrics_lst):
+    """Print an aligned metrics table comparing the antennas, so a
+    `compare_patterns` run (and the optimize before/after) reports the numbers
+    that make the overlaid plot actionable, not just the shapes."""
+    cols = [
+        ("peak dBi", "peak_gain_dbi", "{:.2f}"),
+        ("takeoff°", "takeoff_deg", "{:.0f}"),
+        ("F/B dB", "front_to_back_db", "{:.1f}"),
+        ("az bw°", "az_beamwidth_deg", "{:.0f}"),
+        ("el bw°", "el_beamwidth_deg", "{:.0f}"),
+    ]
+    name_w = max([len("design")] + [len(str(n)) for n in names])
+    header = "design".ljust(name_w) + "  " + "  ".join(h.rjust(8) for h, _, _ in cols)
+    print(header)
+    print("-" * len(header))
+    for nm, m in zip(names, metrics_lst):
+        row = str(nm).ljust(name_w)
+        for _, key, fmt in cols:
+            row += "  " + fmt.format(m[key]).rjust(8)
+        print(row)
+
+
 def compare_patterns(
     builders_or_engines,
     elevation_angle=15,
@@ -129,6 +246,7 @@ def compare_patterns(
     builder_names=None,
     azimuth_f=0,
     azimuth_r=180,
+    show_metrics=True,
 ):
     """Plot azimuth + elevation cuts for a sequence of antennas.
 
@@ -138,15 +256,25 @@ def compare_patterns(
     an explicit `builder_names=[...]` to control legend labels; absent
     that, engine instances get their class name (e.g. "PyNECEngine",
     "MomwireEngine") and bare builders fall back to "Unknown" for
-    backwards compatibility."""
+    backwards compatibility. With `show_metrics` (default) a peak-gain /
+    takeoff / F-B / beamwidth table is printed alongside the plot."""
     if builder_names is None:
         builder_names = [_default_name(b) for b in builders_or_engines]
 
     rings_lst = []
+    metrics_lst = []
+    thetas = phis = None
 
     for item in builders_or_engines:
-        rings, max_gain, min_gain, thetas, phis = get_pattern_rings(item)
-        rings_lst.append(rings)
+        a = _as_engine(item)
+        ff = a.far_field(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
+        del a
+        rings_lst.append(ff.rings)
+        metrics_lst.append(pattern_metrics(ff))
+        thetas, phis = ff.thetas, ff.phis
+
+    if show_metrics:
+        _print_metrics_table(builder_names, metrics_lst)
 
     plot_patterns(
         rings_lst,

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -1224,6 +1224,24 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             wrap="mappingproxy" if req.get("wrap") == "mappingproxy" else "dict",
         )
 
+    def far_field_metrics(req: dict) -> dict:
+        # Scalar metrics for the pattern-compare table. Uses the same builder
+        # setup as momwire_solve and the momwire engine (so the numbers match
+        # the client-derived lobe on screen), then summarises the full grid.
+        from antennaknobs.far_field import pattern_metrics
+
+        design_freq = float(req.get("design_freq_mhz", _design_freq_default(req)))
+        meas_freq = float(req.get("measurement_freq_mhz", design_freq))
+        builder = _build_builder(cls, req)
+        builder.freq = meas_freq
+        if has_design_freq:
+            builder.design_freq = design_freq
+        eng = _make_momwire_engine(req, builder)
+        ff = eng.far_field(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
+        metrics = pattern_metrics(ff)
+        metrics["measurement_freq_mhz"] = meas_freq
+        return metrics
+
     def nec_export(req: dict) -> str:
         # Same builder construction as pynec_solve, then serialise to a NEC2
         # card deck. Ground/freq mirror what the live solve uses so the
@@ -1296,6 +1314,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         pynec_pattern_excite=pynec_pattern_excite,
         nec_export=nec_export,
         params_source=params_source,
+        far_field_metrics=far_field_metrics,
         multi_feed=field_multi_feed,
         param_schema=param_schema,
         bands=bands,

--- a/src/antennaknobs/web/examples/_base.py
+++ b/src/antennaknobs/web/examples/_base.py
@@ -315,6 +315,11 @@ class AntennaExample:
     # offer a "Copy Python" action that drops straight into a design file.
     # None when the design can't be serialised.
     params_source: Optional[Callable[[dict], str]] = None
+    # Compute scalar far-field metrics (peak gain, takeoff, F/B, beamwidths)
+    # for the request's antenna, so the UI can show a side-by-side table when
+    # comparing pinned patterns. Always the momwire engine (matches the
+    # client-derived lobe on screen). None when the design can't be evaluated.
+    far_field_metrics: Optional[Callable[[dict], dict]] = None
     # When set, pattern() calls this to excite the NEC context (e.g.
     # multi-source drive for bowtie's 1×2 array). When None, pattern()
     # uses the default single-feed excitation reading b["feed_seg"] /

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1975,6 +1975,12 @@ export function App() {
   // NEC's rp_card pattern, fetched on a debounce so we don't fire one per
   // slider tick. Overlaid on the cuts as a comparison line.
   const [pattern, setPattern] = useState<PatternData | null>(null);
+  // Pinned far-field overlays for cross-antenna pattern comparison, plus the
+  // live antenna's metrics for the side-by-side table. A monotonic counter
+  // gives each pin a stable React key.
+  const [pinnedPatterns, setPinnedPatterns] = useState<PinnedPattern[]>([]);
+  const [liveMetrics, setLiveMetrics] = useState<PatternMetrics | null>(null);
+  const pinSeq = useRef(0);
   const [view, setView] = useState<View>("antenna");
   const [cameraProjection, setCameraProjection] = useState<Projection>("xy");
   // When the user switches antennas, reset the camera to that example's
@@ -2438,6 +2444,67 @@ export function App() {
   // The latest control values, used to send a new request when the prior one
   // completes (drops intermediate values rather than queuing them all up).
   const controlsRef = useRef<SolveRequest>(buildRequest());
+
+  // --- Pattern compare (pin / ghost overlay) --------------------------------
+  // Fetch the scalar far-field metrics for a request (peak gain, takeoff, F/B,
+  // beamwidths). Returns null when the design can't be evaluated or on error.
+  async function fetchMetrics(req: SolveRequest): Promise<PatternMetrics | null> {
+    try {
+      const resp = await fetch("/pattern_metrics", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(req),
+      });
+      const data = await resp.json();
+      return data.available ? (data.metrics as PatternMetrics) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  // Pin the current pattern: snapshot the solve response (for the ghost trace)
+  // and fetch its metrics (for the table). The snapshot is frozen — it won't
+  // change as the live knobs move, which is the whole point of comparing.
+  function pinCurrentPattern() {
+    if (!result) return;
+    const id = `pin-${pinSeq.current++}`;
+    const label = `${currentExample?.label ?? geometry} @ ${measFreq.toFixed(2)} MHz`;
+    setPinnedPatterns((ps) => [...ps, { id, label, result, metrics: null }]);
+    const req = controlsRef.current;
+    fetchMetrics(req).then((m) =>
+      setPinnedPatterns((ps) =>
+        ps.map((p) => (p.id === id ? { ...p, metrics: m } : p)),
+      ),
+    );
+  }
+
+  function removePin(id: string) {
+    setPinnedPatterns((ps) => ps.filter((p) => p.id !== id));
+  }
+
+  // Keep the live antenna's metrics fresh for the table, but only while a
+  // comparison is actually on screen (≥1 pin and a pattern view) — the metrics
+  // need a full far-field solve, so don't pay for it otherwise. Debounced so it
+  // doesn't fire on every knob tick.
+  const pinCount = pinnedPatterns.length;
+  const comparing = pinCount > 0 && (view === "azimuth" || view === "elevation");
+  useEffect(() => {
+    if (!comparing || !result) {
+      setLiveMetrics(null);
+      return;
+    }
+    let cancelled = false;
+    const h = window.setTimeout(() => {
+      fetchMetrics(controlsRef.current).then((m) => {
+        if (!cancelled) setLiveMetrics(m);
+      });
+    }, 300);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(h);
+    };
+    // result identity changes per solve; that's the cue to refresh.
+  }, [comparing, result]);
 
   // Reset the "solve anyway" approval whenever the design or solver changes, so
   // an inappropriate combo is re-evaluated (and re-warned) rather than riding a
@@ -3659,6 +3726,7 @@ export function App() {
                   sweep={sweep}
                   converge={converge}
                   pattern={pattern}
+                  pinnedPatterns={[]}
                   measFreqMhz={measFreq}
                   sweepRunning={sweepRunning}
                   convergeRunning={convergeRunning}
@@ -3809,6 +3877,37 @@ export function App() {
               <span className="cut-overlay-value">{elevAzDeg}°</span>
             </div>
           )}
+          {(view === "azimuth" || view === "elevation") && (
+            <div className="compare-overlay">
+              <button
+                type="button"
+                className="pin-btn"
+                onClick={pinCurrentPattern}
+                disabled={!result}
+                title="Pin the current pattern as a ghost overlay, to compare another antenna or tuning against it"
+              >
+                📌 Pin pattern
+              </button>
+              {pinnedPatterns.length > 0 && (
+                <>
+                  <button
+                    type="button"
+                    className="pin-clear"
+                    onClick={() => setPinnedPatterns([])}
+                    title="Remove all pinned patterns"
+                  >
+                    clear
+                  </button>
+                  <PatternCompareTable
+                    live={liveMetrics}
+                    liveLabel={`${currentExample?.label ?? geometry} @ ${measFreq.toFixed(2)} MHz`}
+                    pinned={pinnedPatterns}
+                    onRemove={removePin}
+                  />
+                </>
+              )}
+            </div>
+          )}
           <ViewPanel
             view={view}
             size={chartSize}
@@ -3818,6 +3917,7 @@ export function App() {
             sweep={sweep}
             converge={converge}
             pattern={pattern}
+            pinnedPatterns={pinnedPatterns}
             measFreqMhz={measFreq}
             sweepRunning={sweepRunning}
             convergeRunning={convergeRunning}
@@ -4262,6 +4362,7 @@ function ViewPanel({
   sweep,
   converge,
   pattern,
+  pinnedPatterns,
   measFreqMhz,
   sweepRunning,
   convergeRunning,
@@ -4282,6 +4383,7 @@ function ViewPanel({
   sweep: SweepData | null;
   converge: ConvergeData | null;
   pattern: PatternData | null;
+  pinnedPatterns: PinnedPattern[];
   measFreqMhz: number;
   sweepRunning: boolean;
   convergeRunning: boolean;
@@ -4318,6 +4420,7 @@ function ViewPanel({
       <FarFieldChart
         result={result}
         pattern={pattern}
+        pinned={pinnedPatterns}
         size={size}
         cut="xy"
         azElevDeg={azElevDeg}
@@ -4330,6 +4433,7 @@ function ViewPanel({
       <FarFieldChart
         result={result}
         pattern={pattern}
+        pinned={pinnedPatterns}
         size={size}
         cut="yz"
         azElevDeg={azElevDeg}
@@ -4356,9 +4460,283 @@ function ViewPanel({
 
 type FarFieldCut = "xy" | "yz";
 
+// Scalar far-field metrics from /pattern_metrics, shown in the compare table.
+type PatternMetrics = {
+  peak_gain_dbi: number;
+  takeoff_deg: number;
+  azimuth_deg: number;
+  front_to_back_db: number;
+  az_beamwidth_deg: number;
+  el_beamwidth_deg: number;
+  measurement_freq_mhz?: number;
+};
+
+// A pinned far-field snapshot: the full solve response (so its cut traces
+// recompute through the same math as the live one, in whatever cut the user is
+// viewing) plus a label, and the metrics fetched for the table. Pins survive
+// design switches, so you can overlay one antenna's pattern on another's.
+type PinnedPattern = {
+  id: string;
+  label: string;
+  result: SolveResponse;
+  metrics: PatternMetrics | null;
+};
+
+function PatternCompareTable({
+  live,
+  liveLabel,
+  pinned,
+  onRemove,
+}: {
+  live: PatternMetrics | null;
+  liveLabel: string;
+  pinned: PinnedPattern[];
+  onRemove: (id: string) => void;
+}) {
+  const fmt = (v: number | undefined, d: number) =>
+    v === undefined || v === null ? "—" : v.toFixed(d);
+  // Live row's swatch reads the lobe CSS var so it matches the orange lobe in
+  // either theme; pinned rows use their fixed canvas ghost colors.
+  const rows = [
+    {
+      key: "live",
+      bg: "rgba(var(--plot-lobe-rgb), 0.95)",
+      label: liveLabel,
+      m: live,
+      onX: undefined as undefined | (() => void),
+    },
+    ...pinned.map((p, i) => {
+      const [r, g, b] = GHOST_COLORS[i % GHOST_COLORS.length];
+      return {
+        key: p.id,
+        bg: `rgba(${r}, ${g}, ${b}, 0.95)`,
+        label: p.label,
+        m: p.metrics,
+        onX: () => onRemove(p.id),
+      };
+    }),
+  ];
+  return (
+    <table className="compare-table">
+      <thead>
+        <tr>
+          <th>design</th>
+          <th>peak</th>
+          <th>takeoff</th>
+          <th>F/B</th>
+          <th>az bw</th>
+          <th />
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.key}>
+            <td className="compare-name">
+              <span className="compare-swatch" style={{ background: row.bg }} />
+              {row.label}
+            </td>
+            <td>{fmt(row.m?.peak_gain_dbi, 1)}</td>
+            <td>{row.m ? `${fmt(row.m.takeoff_deg, 0)}°` : "—"}</td>
+            <td>{fmt(row.m?.front_to_back_db, 1)}</td>
+            <td>{row.m ? `${fmt(row.m.az_beamwidth_deg, 0)}°` : "—"}</td>
+            <td>
+              {row.onX && (
+                <button
+                  type="button"
+                  className="compare-x"
+                  onClick={row.onX}
+                  title="Remove this pinned pattern"
+                >
+                  ✕
+                </button>
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+// Directions sampled around each polar cut. Module-level so the trace helper
+// and the chart agree.
+const FARFIELD_N_DIR = 180;
+
+// Compute the per-direction gain (dBi) of one solve response along a polar cut,
+// reproducing the live lobe math (moment integral over all segments, PEC image
+// + Fresnel reflection when ground is on). Returns the N_DIR-length dBi samples
+// and the peak, or null when there's nothing to draw. Both the live trace and
+// every pinned ghost go through this, so they're guaranteed consistent.
+function computeCutDbi(
+  result: SolveResponse,
+  cut: FarFieldCut,
+  azElevDeg: number,
+  elevAzDeg: number,
+): { dbi: number[]; peakDbi: number } | null {
+  const azElevRad = (azElevDeg * Math.PI) / 180;
+  const azSinT = Math.cos(azElevRad);
+  const azCosT = Math.sin(azElevRad);
+  const elevAzRad = (elevAzDeg * Math.PI) / 180;
+  const elevAzCos = Math.cos(elevAzRad);
+  const elevAzSin = Math.sin(elevAzRad);
+  const groundOn = !!result.ground;
+  const N_DIR = FARFIELD_N_DIR;
+  const k = result.k_meas_m_inv ?? 0;
+  const epsRe = result.ground_eps_r ?? 1;
+  const epsIm = result.ground_eps_im ?? 0;
+
+  let nSeg = 0;
+  for (const w of result.wires) {
+    const pts = w.sample_positions ?? w.knot_positions;
+    nSeg += pts.length - 1;
+  }
+  if (nSeg === 0) return null;
+  const dx = new Float64Array(nSeg);
+  const dy = new Float64Array(nSeg);
+  const dz = new Float64Array(nSeg);
+  const midx = new Float64Array(nSeg);
+  const midy = new Float64Array(nSeg);
+  const midz = new Float64Array(nSeg);
+  const Ire = new Float64Array(nSeg);
+  const Iim = new Float64Array(nSeg);
+  let off = 0;
+  for (const w of result.wires) {
+    const pts = w.sample_positions ?? w.knot_positions;
+    const cre = w.sample_currents_re ?? w.knot_currents_re;
+    const cim = w.sample_currents_im ?? w.knot_currents_im;
+    for (let n = 0; n < pts.length - 1; n++) {
+      const a = pts[n];
+      const b = pts[n + 1];
+      dx[off] = b[0] - a[0];
+      dy[off] = b[1] - a[1];
+      dz[off] = b[2] - a[2];
+      midx[off] = 0.5 * (a[0] + b[0]);
+      midy[off] = 0.5 * (a[1] + b[1]);
+      midz[off] = 0.5 * (a[2] + b[2]);
+      Ire[off] = 0.5 * (cre[n] + cre[n + 1]);
+      Iim[off] = 0.5 * (cim[n] + cim[n + 1]);
+      off++;
+    }
+  }
+
+  const mag2s = new Array<number>(N_DIR);
+  let maxMag2 = 0;
+  for (let pi = 0; pi < N_DIR; pi++) {
+    const t = (2 * Math.PI * pi) / N_DIR;
+    const ct = Math.cos(t);
+    const st = Math.sin(t);
+    const rx = cut === "xy" ? azSinT * ct : elevAzCos * ct;
+    const ry = cut === "xy" ? azSinT * st : elevAzSin * ct;
+    const rz = cut === "xy" ? azCosT : st;
+    if (groundOn && rz < 0) {
+      mag2s[pi] = 0;
+      continue;
+    }
+    let mxRe = 0, mxIm = 0, myRe = 0, myIm = 0, mzRe = 0, mzIm = 0;
+    let ixRe = 0, ixIm = 0, iyRe = 0, iyIm = 0, izRe = 0, izIm = 0;
+    for (let n = 0; n < nSeg; n++) {
+      const phase = k * (rx * midx[n] + ry * midy[n] + rz * midz[n]);
+      const cph = Math.cos(phase);
+      const sph = Math.sin(phase);
+      const ire = Ire[n] * cph - Iim[n] * sph;
+      const iim = Ire[n] * sph + Iim[n] * cph;
+      mxRe += ire * dx[n];
+      mxIm += iim * dx[n];
+      myRe += ire * dy[n];
+      myIm += iim * dy[n];
+      mzRe += ire * dz[n];
+      mzIm += iim * dz[n];
+      if (groundOn) {
+        const phaseI = k * (rx * midx[n] + ry * midy[n] - rz * midz[n]);
+        const cphI = Math.cos(phaseI);
+        const sphI = Math.sin(phaseI);
+        const ireI = Ire[n] * cphI - Iim[n] * sphI;
+        const iimI = Ire[n] * sphI + Iim[n] * cphI;
+        ixRe += ireI * -dx[n]; ixIm += iimI * -dx[n];
+        iyRe += ireI * -dy[n]; iyIm += iimI * -dy[n];
+        izRe += ireI *  dz[n]; izIm += iimI *  dz[n];
+      }
+    }
+    const mDotRre = mxRe * rx + myRe * ry + mzRe * rz;
+    const mDotRim = mxIm * rx + myIm * ry + mzIm * rz;
+    let pxRe = mxRe - mDotRre * rx;
+    let pxIm = mxIm - mDotRim * rx;
+    let pyRe = myRe - mDotRre * ry;
+    let pyIm = myIm - mDotRim * ry;
+    let pzRe = mzRe - mDotRre * rz;
+    let pzIm = mzIm - mDotRim * rz;
+    if (groundOn) {
+      const iDotRre = ixRe * rx + iyRe * ry + izRe * rz;
+      const iDotRim = ixIm * rx + iyIm * ry + izIm * rz;
+      const qxRe = ixRe - iDotRre * rx;
+      const qxIm = ixIm - iDotRim * rx;
+      const qyRe = iyRe - iDotRre * ry;
+      const qyIm = iyIm - iDotRim * ry;
+      const qzRe = izRe - iDotRre * rz;
+      const qzIm = izIm - iDotRim * rz;
+      const s = Math.sqrt(rx * rx + ry * ry);
+      let hx: number, hy: number, hz: number;
+      let vx: number, vy: number, vz: number;
+      if (s > 1e-9) {
+        hx = -ry / s; hy = rx / s; hz = 0;
+        vx = -rx * rz / s; vy = -ry * rz / s; vz = s;
+      } else {
+        hx = 1; hy = 0; hz = 0;
+        vx = 0; vy = 1; vz = 0;
+      }
+      const qhRe = qxRe * hx + qyRe * hy + qzRe * hz;
+      const qhIm = qxIm * hx + qyIm * hy + qzIm * hz;
+      const qvRe = qxRe * vx + qyRe * vy + qzRe * vz;
+      const qvIm = qxIm * vx + qyIm * vy + qzIm * vz;
+      const cosTi = rz;
+      const sin2Ti = s * s;
+      const aRe = epsRe - sin2Ti;
+      const aIm = epsIm;
+      const aMag = Math.hypot(aRe, aIm);
+      const QRe = Math.sqrt(0.5 * (aMag + aRe));
+      const QIm = Math.sign(aIm || 1) * Math.sqrt(Math.max(0, 0.5 * (aMag - aRe)));
+      const numHRe = cosTi - QRe, numHIm = -QIm;
+      const denHRe = cosTi + QRe, denHIm = QIm;
+      const denH2 = denHRe * denHRe + denHIm * denHIm;
+      const rhoHRe = (numHRe * denHRe + numHIm * denHIm) / denH2;
+      const rhoHIm = (numHIm * denHRe - numHRe * denHIm) / denH2;
+      const ecRe = epsRe * cosTi, ecIm = epsIm * cosTi;
+      const numVRe = ecRe - QRe, numVIm = ecIm - QIm;
+      const denVRe = ecRe + QRe, denVIm = ecIm + QIm;
+      const denV2 = denVRe * denVRe + denVIm * denVIm;
+      const rhoVRe = (numVRe * denVRe + numVIm * denVIm) / denV2;
+      const rhoVIm = (numVIm * denVRe - numVRe * denVIm) / denV2;
+      const rvqRe = rhoVRe * qvRe - rhoVIm * qvIm;
+      const rvqIm = rhoVRe * qvIm + rhoVIm * qvRe;
+      const rhqRe = rhoHRe * qhRe - rhoHIm * qhIm;
+      const rhqIm = rhoHRe * qhIm + rhoHIm * qhRe;
+      pxRe += rvqRe * vx - rhqRe * hx;
+      pxIm += rvqIm * vx - rhqIm * hx;
+      pyRe += rvqRe * vy - rhqRe * hy;
+      pyIm += rvqIm * vy - rhqIm * hy;
+      pzRe += rvqRe * vz - rhqRe * hz;
+      pzIm += rvqIm * vz - rhqIm * hz;
+    }
+    const mag2 =
+      pxRe * pxRe + pxIm * pxIm +
+      pyRe * pyRe + pyIm * pyIm +
+      pzRe * pzRe + pzIm * pzIm;
+    mag2s[pi] = mag2;
+    if (mag2 > maxMag2) maxMag2 = mag2;
+  }
+  if (maxMag2 <= 0) return null;
+  const norm =
+    result.directivity_norm && result.directivity_norm > 0
+      ? result.directivity_norm
+      : 1 / maxMag2;
+  const dbi = mag2s.map((m) => (norm * m > 0 ? 10 * Math.log10(norm * m) : -Infinity));
+  return { dbi, peakDbi: 10 * Math.log10(norm * maxMag2) };
+}
+
 function FarFieldChart({
   result,
   pattern,
+  pinned,
   size,
   cut,
   azElevDeg,
@@ -4366,6 +4744,7 @@ function FarFieldChart({
 }: {
   result: SolveResponse | null;
   pattern: PatternData | null;
+  pinned: PinnedPattern[];
   size: number;
   cut: FarFieldCut;
   azElevDeg: number;
@@ -4396,7 +4775,6 @@ function FarFieldChart({
     const cy = size / 2;
     const R = size / 2 - 14;
 
-    const groundOn = !!result?.ground;
     // Azimuth cut: cone above horizon at elevation azElevDeg. With ground
     // off, the conventional setting is 0° (the xy plane). With ground on,
     // 0° is grazing and Fresnel kills the pattern, so something like 15°
@@ -4477,228 +4855,58 @@ function FarFieldChart({
 
     if (!result) return;
 
-    // Planar cut: r̂(t) = u·cos t + v·sin t, where (u, v) are the two world
-    // basis vectors in the cut plane (xy: (x̂, ŷ); yz: (ŷ, ẑ)). For each
-    // direction compute the moment integral over ALL wires:
-    //   M(r̂) = Σ_segments I_mid · (r_{n+1} − r_n) · exp(jk r̂·r_mid)
-    // and take |M_perp|² (component perpendicular to r̂).
-    //
-    // With a ground plane, also accumulate the PEC-image moment (segments
-    // mirrored through z=0, horizontal current direction flipped) and apply
-    // Fresnel coefficients per ray to get the reflected wave. Above-horizon
-    // only; rays into the ground contribute nothing.
-    const N_DIR = 180;
-    // Wavenumber and complex ground permittivity are precomputed by the
-    // server (`k_meas_m_inv`, `ground_eps_im`) so this renderer stays
-    // free of physics constants. Fallbacks keep older responses working.
-    const k = result.k_meas_m_inv ?? 0;
-    const epsRe = result.ground_eps_r ?? 1;
-    const epsIm = result.ground_eps_im ?? 0;
+    const N_DIR = FARFIELD_N_DIR;
 
-    // Flatten per-segment quantities across every wire. Prefer the finer-
-    // grained sample arrays (knots interleaved with segment midpoints) when
-    // the backend supplies them; that way non-tent bases (B-spline d=2,
-    // sinusoidal three-term) and the B-spline enrichment shape — all of
-    // which carry intra-segment curvature the knot-only samples drop — get
-    // resolved at twice the cadence. PyNEC stays on the knot path.
-    let nSeg = 0;
-    for (const w of result.wires) {
-      const pts = w.sample_positions ?? w.knot_positions;
-      nSeg += pts.length - 1;
-    }
-    const dx = new Float64Array(nSeg);
-    const dy = new Float64Array(nSeg);
-    const dz = new Float64Array(nSeg);
-    const midx = new Float64Array(nSeg);
-    const midy = new Float64Array(nSeg);
-    const midz = new Float64Array(nSeg);
-    const Ire = new Float64Array(nSeg);
-    const Iim = new Float64Array(nSeg);
-    let off = 0;
-    for (const w of result.wires) {
-      const pts = w.sample_positions ?? w.knot_positions;
-      const cre = w.sample_currents_re ?? w.knot_currents_re;
-      const cim = w.sample_currents_im ?? w.knot_currents_im;
-      for (let n = 0; n < pts.length - 1; n++) {
-        const a = pts[n];
-        const b = pts[n + 1];
-        dx[off] = b[0] - a[0];
-        dy[off] = b[1] - a[1];
-        dz[off] = b[2] - a[2];
-        midx[off] = 0.5 * (a[0] + b[0]);
-        midy[off] = 0.5 * (a[1] + b[1]);
-        midz[off] = 0.5 * (a[2] + b[2]);
-        Ire[off] = 0.5 * (cre[n] + cre[n + 1]);
-        Iim[off] = 0.5 * (cim[n] + cim[n + 1]);
-        off++;
+    // Draw one dBi trace around the polar cut. The live lobe closes + fills;
+    // pinned ghosts are an open dashed stroke so the live trace reads on top.
+    const strokeTrace = (
+      dbi: number[],
+      o: { stroke: string; fill?: string; width: number; dash?: number[] },
+    ) => {
+      ctx.beginPath();
+      for (let pi = 0; pi <= N_DIR; pi++) {
+        const t = (2 * Math.PI * pi) / N_DIR;
+        const frac = dbiToFrac(dbi[pi % N_DIR]);
+        const px = cx + Math.cos(t) * frac * R;
+        // Canvas y flips: +y on canvas is down, so we negate to put +y at top.
+        const py = cy - Math.sin(t) * frac * R;
+        if (pi === 0) ctx.moveTo(px, py);
+        else ctx.lineTo(px, py);
       }
-    }
-
-    const mag2s = new Array<number>(N_DIR);
-    let maxMag2 = 0;
-
-    for (let pi = 0; pi < N_DIR; pi++) {
-      const t = (2 * Math.PI * pi) / N_DIR;
-      const ct = Math.cos(t);
-      const st = Math.sin(t);
-      // xy cut: cone at the chosen elevation. yz cut: vertical great circle
-      // through the chosen azimuth bearing (cos t · (cos φ, sin φ) on the
-      // horizontal plane, plus sin t on z).
-      const rx = cut === "xy" ? azSinT * ct : elevAzCos * ct;
-      const ry = cut === "xy" ? azSinT * st : elevAzSin * ct;
-      const rz = cut === "xy" ? azCosT : st;
-
-      // Rays into the ground (rz < 0) carry no far field.
-      if (groundOn && rz < 0) {
-        mag2s[pi] = 0;
-        continue;
+      ctx.closePath();
+      if (o.fill) {
+        ctx.fillStyle = o.fill;
+        ctx.fill();
       }
+      if (o.dash) ctx.setLineDash(o.dash);
+      ctx.strokeStyle = o.stroke;
+      ctx.lineWidth = o.width;
+      ctx.stroke();
+      if (o.dash) ctx.setLineDash([]);
+    };
 
-      let mxRe = 0, mxIm = 0, myRe = 0, myIm = 0, mzRe = 0, mzIm = 0;
-      // Image moment accumulators (only used when groundOn).
-      let ixRe = 0, ixIm = 0, iyRe = 0, iyIm = 0, izRe = 0, izIm = 0;
-      for (let n = 0; n < nSeg; n++) {
-        const phase = k * (rx * midx[n] + ry * midy[n] + rz * midz[n]);
-        const cph = Math.cos(phase);
-        const sph = Math.sin(phase);
-        // I_mid * exp(jphase)
-        const ire = Ire[n] * cph - Iim[n] * sph;
-        const iim = Ire[n] * sph + Iim[n] * cph;
-        mxRe += ire * dx[n];
-        mxIm += iim * dx[n];
-        myRe += ire * dy[n];
-        myIm += iim * dy[n];
-        mzRe += ire * dz[n];
-        mzIm += iim * dz[n];
+    // Pinned ghosts first (dimmed, dashed), so the live lobe sits on top. Each
+    // recomputes its own cut from its stored solve, so it tracks the cut and
+    // angle sliders just like the live trace.
+    pinned.forEach((p, i) => {
+      const tr = computeCutDbi(p.result, cut, azElevDeg, elevAzDeg);
+      if (!tr) return;
+      const [r, g, b] = GHOST_COLORS[i % GHOST_COLORS.length];
+      strokeTrace(tr.dbi, {
+        stroke: `rgba(${r}, ${g}, ${b}, 0.8)`,
+        width: 1,
+        dash: [5, 3],
+      });
+    });
 
-        if (groundOn) {
-          // Image position: (x, y, -z). Image current dir: (-dx, -dy, +dz).
-          const phaseI = k * (rx * midx[n] + ry * midy[n] - rz * midz[n]);
-          const cphI = Math.cos(phaseI);
-          const sphI = Math.sin(phaseI);
-          const ireI = Ire[n] * cphI - Iim[n] * sphI;
-          const iimI = Ire[n] * sphI + Iim[n] * cphI;
-          ixRe += ireI * -dx[n]; ixIm += iimI * -dx[n];
-          iyRe += ireI * -dy[n]; iyIm += iimI * -dy[n];
-          izRe += ireI *  dz[n]; izIm += iimI *  dz[n];
-        }
-      }
-      // Direct M_perp = M − (M·r̂) r̂
-      const mDotRre = mxRe * rx + myRe * ry + mzRe * rz;
-      const mDotRim = mxIm * rx + myIm * ry + mzIm * rz;
-      let pxRe = mxRe - mDotRre * rx;
-      let pxIm = mxIm - mDotRim * rx;
-      let pyRe = myRe - mDotRre * ry;
-      let pyIm = myIm - mDotRim * ry;
-      let pzRe = mzRe - mDotRre * rz;
-      let pzIm = mzIm - mDotRim * rz;
-
-      if (groundOn) {
-        // Image M_perp.
-        const iDotRre = ixRe * rx + iyRe * ry + izRe * rz;
-        const iDotRim = ixIm * rx + iyIm * ry + izIm * rz;
-        const qxRe = ixRe - iDotRre * rx;
-        const qxIm = ixIm - iDotRim * rx;
-        const qyRe = iyRe - iDotRre * ry;
-        const qyIm = iyIm - iDotRim * ry;
-        const qzRe = izRe - iDotRre * rz;
-        const qzIm = izIm - iDotRim * rz;
-
-        // Polarization basis at r̂. ĥ = ẑ × r̂ / |·|, v̂ = r̂ × ĥ.
-        // Degenerate at the zenith (s≈0); pick arbitrary axes — both pol
-        // coefficients agree there, so the choice doesn't affect the sum.
-        const s = Math.sqrt(rx * rx + ry * ry);
-        let hx: number, hy: number, hz: number;
-        let vx: number, vy: number, vz: number;
-        if (s > 1e-9) {
-          hx = -ry / s; hy = rx / s; hz = 0;
-          vx = -rx * rz / s; vy = -ry * rz / s; vz = s;
-        } else {
-          hx = 1; hy = 0; hz = 0;
-          vx = 0; vy = 1; vz = 0;
-        }
-
-        // Decompose image perp onto (ĥ, v̂) — complex scalars.
-        const qhRe = qxRe * hx + qyRe * hy + qzRe * hz;
-        const qhIm = qxIm * hx + qyIm * hy + qzIm * hz;
-        const qvRe = qxRe * vx + qyRe * vy + qzRe * vz;
-        const qvIm = qxIm * vx + qyIm * vy + qzIm * vz;
-
-        // Fresnel reflection coefficients (complex). cos θᵢ = rz, sin²θᵢ = s².
-        // ε̃ − sin²θᵢ is complex; sqrt of complex follows the principal branch.
-        const cosTi = rz;
-        const sin2Ti = s * s;
-        const aRe = epsRe - sin2Ti;
-        const aIm = epsIm;
-        // Principal-branch √(a + jb)
-        const aMag = Math.hypot(aRe, aIm);
-        const QRe = Math.sqrt(0.5 * (aMag + aRe));
-        const QIm = Math.sign(aIm || 1) * Math.sqrt(Math.max(0, 0.5 * (aMag - aRe)));
-        // ρ_h = (cosTi − Q) / (cosTi + Q)
-        const numHRe = cosTi - QRe, numHIm = -QIm;
-        const denHRe = cosTi + QRe, denHIm = QIm;
-        const denH2 = denHRe * denHRe + denHIm * denHIm;
-        const rhoHRe = (numHRe * denHRe + numHIm * denHIm) / denH2;
-        const rhoHIm = (numHIm * denHRe - numHRe * denHIm) / denH2;
-        // ρ_v = (ε̃·cosTi − Q) / (ε̃·cosTi + Q)
-        const ecRe = epsRe * cosTi, ecIm = epsIm * cosTi;
-        const numVRe = ecRe - QRe, numVIm = ecIm - QIm;
-        const denVRe = ecRe + QRe, denVIm = ecIm + QIm;
-        const denV2 = denVRe * denVRe + denVIm * denVIm;
-        const rhoVRe = (numVRe * denVRe + numVIm * denVIm) / denV2;
-        const rhoVIm = (numVIm * denVRe - numVRe * denVIm) / denV2;
-
-        // Reflected: M_refl = ρ_v · q_v · v̂ − ρ_h · q_h · ĥ.
-        // The (−ρ_h) sign folds the PEC image's pre-applied horizontal flip
-        // back out, so ρ_h=−1 reproduces the PEC reflection exactly.
-        const rvqRe = rhoVRe * qvRe - rhoVIm * qvIm;
-        const rvqIm = rhoVRe * qvIm + rhoVIm * qvRe;
-        const rhqRe = rhoHRe * qhRe - rhoHIm * qhIm;
-        const rhqIm = rhoHRe * qhIm + rhoHIm * qhRe;
-        pxRe += rvqRe * vx - rhqRe * hx;
-        pxIm += rvqIm * vx - rhqIm * hx;
-        pyRe += rvqRe * vy - rhqRe * hy;
-        pyIm += rvqIm * vy - rhqIm * hy;
-        pzRe += rvqRe * vz - rhqRe * hz;
-        pzIm += rvqIm * vz - rhqIm * hz;
-      }
-
-      const mag2 =
-        pxRe * pxRe + pxIm * pxIm +
-        pyRe * pyRe + pyIm * pyIm +
-        pzRe * pzRe + pzIm * pzIm;
-      mag2s[pi] = mag2;
-      if (mag2 > maxMag2) maxMag2 = mag2;
-    }
-
-    if (maxMag2 <= 0) return;
-
-    // Absolute directivity: D(φ) = directivity_norm · |M_perp(π/2, φ)|².
-    // If the server omitted the norm (older response), fall back to a
-    // per-frame relative scale that puts the peak at 0 dBi.
-    const norm =
-      result.directivity_norm && result.directivity_norm > 0
-        ? result.directivity_norm
-        : 1 / maxMag2;
-
-    ctx.beginPath();
-    for (let pi = 0; pi <= N_DIR; pi++) {
-      const t = (2 * Math.PI * pi) / N_DIR;
-      const D = norm * mag2s[pi % N_DIR];
-      const dBi = D > 0 ? 10 * Math.log10(D) : -Infinity;
-      const frac = dbiToFrac(dBi);
-      const px = cx + Math.cos(t) * frac * R;
-      // Canvas y flips: +y on canvas is down, so we negate to put +y at top.
-      const py = cy - Math.sin(t) * frac * R;
-      if (pi === 0) ctx.moveTo(px, py);
-      else ctx.lineTo(px, py);
-    }
-    ctx.closePath();
-    ctx.fillStyle = `rgba(${PC.lobeRgb}, 0.12)`;
-    ctx.fill();
-    ctx.strokeStyle = `rgba(${PC.lobeRgb}, 0.9)`;
-    ctx.lineWidth = 1.5;
-    ctx.stroke();
+    // Live lobe (filled).
+    const live = computeCutDbi(result, cut, azElevDeg, elevAzDeg);
+    if (!live) return;
+    strokeTrace(live.dbi, {
+      stroke: `rgba(${PC.lobeRgb}, 0.9)`,
+      fill: `rgba(${PC.lobeRgb}, 0.12)`,
+      width: 1.5,
+    });
 
     // NEC exact-pattern overlay (dashed cyan line) when available. Bilinear
     // interpolation off the (θ, φ) grid; rays below horizon are skipped so
@@ -4762,13 +4970,13 @@ function FarFieldChart({
     }
 
     // Peak dBi annotation (top-right corner).
-    const peakDbi = 10 * Math.log10(norm * maxMag2);
+    const peakDbi = live.peakDbi;
     ctx.fillStyle = PC.labelStrong;
     ctx.font = "10px ui-monospace, monospace";
     const peakText = `peak ${peakDbi >= 0 ? "+" : ""}${peakDbi.toFixed(1)} dBi`;
     const tw = ctx.measureText(peakText).width;
     ctx.fillText(peakText, size - tw - 6, 14);
-  }, [result, pattern, size, cut, azElevDeg, elevAzDeg, theme]);
+  }, [result, pattern, pinned, size, cut, azElevDeg, elevAzDeg, theme]);
 
   return <canvas ref={canvasRef} className="farfield" />;
 }
@@ -4783,6 +4991,15 @@ const FEED_COLORS: [number, number, number][] = [
   [255, 196, 102],  // amber
   [140, 230, 140],  // green
   [255, 130, 200],  // pink
+];
+
+// Swatch colors for pinned far-field ghost overlays. Distinct from the live
+// lobe (orange) and the NEC overlay (cyan); they wrap past the 4th pin.
+const GHOST_COLORS: [number, number, number][] = [
+  [140, 230, 140],  // green
+  [255, 130, 200],  // pink
+  [180, 160, 255],  // violet
+  [120, 220, 220],  // teal
 ];
 
 function feedColor(i: number, alpha = 0.85): string {

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1408,6 +1408,90 @@ input[type=checkbox] {
   font-variant-numeric: tabular-nums;
 }
 
+/* Pattern-compare controls, overlaid top-left on the far-field plots: a Pin
+   button plus the side-by-side metrics table of the live + pinned antennas. */
+.compare-overlay {
+  position: absolute;
+  top: var(--space-6);
+  left: var(--space-6);
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-2);
+}
+.pin-btn,
+.pin-clear {
+  font-size: var(--text-xs);
+  color: var(--fg);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: var(--space-1) var(--space-3);
+  cursor: pointer;
+  box-shadow: 0 2px 10px var(--shadow);
+}
+.pin-btn:hover,
+.pin-clear:hover {
+  border-color: var(--muted-2);
+}
+.pin-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.pin-clear {
+  align-self: flex-end;
+  padding: 0 var(--space-2);
+}
+.compare-table {
+  border-collapse: collapse;
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+  color: var(--fg);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  box-shadow: 0 2px 10px var(--shadow);
+  overflow: hidden;
+}
+.compare-table th,
+.compare-table td {
+  padding: 2px var(--space-3);
+  text-align: right;
+  white-space: nowrap;
+}
+.compare-table thead th {
+  color: var(--muted-2);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 500;
+}
+.compare-table .compare-name {
+  text-align: left;
+  max-width: 16ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.compare-swatch {
+  display: inline-block;
+  width: 9px;
+  height: 3px;
+  margin-right: var(--space-2);
+  vertical-align: middle;
+  border-radius: 1px;
+}
+.compare-x {
+  border: none;
+  background: none;
+  color: var(--muted-2);
+  cursor: pointer;
+  padding: 0 2px;
+  font-size: var(--text-xs);
+}
+.compare-x:hover {
+  color: var(--fg);
+}
+
 /* Solve readout floated over the lower-left of the centered carousel view.
    Inherits the .readout card look (bg/border/radius/mono); this just pins it
    to the corner as a compact HUD and keeps it clear of the canvas content. */

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -787,6 +787,26 @@ async def params_source_endpoint(req: dict):
     return {"geometry": geometry, "available": True, "source": source}
 
 
+@app.post("/pattern_metrics")
+async def pattern_metrics_endpoint(req: dict):
+    """Scalar far-field metrics for the current antenna, for the compare table.
+
+    Reuses the same builder + momwire engine as the live solve, so the metrics
+    match the lobe drawn on screen. Returns ``{available, metrics}`` where
+    metrics carries peak_gain_dbi / takeoff_deg / azimuth_deg /
+    front_to_back_db / az_beamwidth_deg / el_beamwidth_deg (+ the freq).
+    """
+    geometry = req.get("geometry", next(iter(EXAMPLES)))
+    ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
+    if ex.far_field_metrics is None:
+        return {"available": False}
+    try:
+        metrics = await run_in_threadpool(ex.far_field_metrics, req)
+    except Exception as exc:  # noqa: BLE001 — a user design's build_wires can raise
+        return {"geometry": geometry, "error": user_designs.format_solve_error(exc)}
+    return {"geometry": geometry, "available": True, "metrics": metrics}
+
+
 @app.post("/geometry")
 async def geometry_endpoint(req: dict):
     """Fast geometry-only snapshot of the selected antenna: wire positions +

--- a/tests/test_pattern_metrics.py
+++ b/tests/test_pattern_metrics.py
@@ -1,0 +1,105 @@
+"""Tests for antennaknobs.far_field pattern metrics.
+
+The metrics are computed from a `FarField` (rings[θ][φ] in dBi). Tests build
+synthetic FarFields with known peaks / lobes so the expected metrics are exact
+or analytically known, rather than depending on a solver.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from antennaknobs.engine import FarField
+from antennaknobs.far_field import (
+    _beamwidth_linear,
+    _beamwidth_wrapped,
+    pattern_metrics,
+)
+
+
+def _make_ff(rings):
+    rings = np.asarray(rings, float)
+    n_theta, n_phi = rings.shape
+    thetas = np.arange(n_theta, dtype=float)
+    phis = np.arange(n_phi, dtype=float)
+    return FarField(
+        rings=rings.tolist(),
+        max_gain=float(rings.max()),
+        min_gain=float(rings.min()),
+        thetas=thetas,
+        phis=phis,
+    )
+
+
+# --- beamwidth helpers --------------------------------------------------------
+
+
+def test_wrapped_beamwidth_of_parabolic_lobe():
+    # g(φ) = 10 − 0.003333·d², d = circular distance from 0°. g hits 10−3=7 at
+    # d = 30°, so the −3 dB width is 60°.
+    phis = np.arange(361, dtype=float)
+    d = np.minimum(phis, 360.0 - phis)
+    g = 10.0 - (3.0 / 900.0) * d**2
+    bw = _beamwidth_wrapped(phis, g, peak_idx=0, threshold=7.0)
+    assert bw == pytest.approx(60.0, abs=0.5)
+
+
+def test_wrapped_beamwidth_omnidirectional_is_full_circle():
+    phis = np.arange(361, dtype=float)
+    g = np.full_like(phis, 5.0)
+    assert _beamwidth_wrapped(phis, g, peak_idx=0, threshold=2.0) == 360.0
+
+
+def test_linear_beamwidth_of_parabolic_lobe():
+    # Elevation angles 90..1 (decreasing); lobe peaks at 45° with a 3 dB
+    # half-width of 20° → 40° total.
+    thetas = np.arange(90, dtype=float)
+    el = 90.0 - thetas
+    g = 10.0 - (3.0 / 400.0) * (el - 45.0) ** 2
+    peak_idx = int(np.argmax(g))
+    bw = _beamwidth_linear(el, g, peak_idx, threshold=7.0)
+    assert bw == pytest.approx(40.0, abs=1.0)
+
+
+# --- pattern_metrics ----------------------------------------------------------
+
+
+def test_peak_takeoff_and_azimuth_locate_the_maximum():
+    rings = np.full((90, 361), -50.0)
+    rings[75, 0] = 12.0  # θ=75 → elevation 15°, azimuth 0°
+    m = pattern_metrics(_make_ff(rings))
+    assert m["peak_gain_dbi"] == 12.0
+    assert m["takeoff_deg"] == pytest.approx(15.0)
+    assert m["azimuth_deg"] == pytest.approx(0.0)
+
+
+def test_front_to_back_uses_same_elevation_opposite_azimuth():
+    rings = np.full((90, 361), -50.0)
+    rings[75, 0] = 10.0  # front
+    rings[75, 180] = -8.0  # back, same elevation
+    m = pattern_metrics(_make_ff(rings))
+    assert m["front_to_back_db"] == pytest.approx(18.0)
+
+
+def test_front_to_back_wraps_when_peak_past_180():
+    rings = np.full((90, 361), -40.0)
+    rings[60, 300] = 6.0  # peak azimuth 300° → back lobe at 120°
+    rings[60, 120] = -4.0
+    m = pattern_metrics(_make_ff(rings))
+    assert m["azimuth_deg"] == pytest.approx(300.0)
+    assert m["front_to_back_db"] == pytest.approx(10.0)
+
+
+def test_metrics_keys_present():
+    rings = np.full((90, 361), -30.0)
+    rings[80, 90] = 3.0
+    m = pattern_metrics(_make_ff(rings))
+    assert set(m) == {
+        "peak_gain_dbi",
+        "takeoff_deg",
+        "azimuth_deg",
+        "front_to_back_db",
+        "az_beamwidth_deg",
+        "el_beamwidth_deg",
+    }

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -148,6 +148,47 @@ def test_params_source_names_block_after_variant(client: TestClient):
 
 
 # ---------------------------------------------------------------------------
+# /pattern_metrics — scalar far-field metrics for the compare table
+# ---------------------------------------------------------------------------
+
+
+def test_pattern_metrics_returns_expected_keys(client: TestClient):
+    r = client.post(
+        "/pattern_metrics",
+        json={
+            "geometry": "beams.yagi",
+            "variant": "default",
+            "measurement_freq_mhz": 28.4,
+            "design_freq_mhz": 28.4,
+        },
+    )
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload["available"] is True
+    m = payload["metrics"]
+    for key in (
+        "peak_gain_dbi",
+        "takeoff_deg",
+        "azimuth_deg",
+        "front_to_back_db",
+        "az_beamwidth_deg",
+        "el_beamwidth_deg",
+    ):
+        assert key in m and isinstance(m[key], (int, float))
+    # A yagi is a forward-gain beam: positive peak gain and a real F/B.
+    assert m["peak_gain_dbi"] > 0.0
+    assert m["front_to_back_db"] > 0.0
+
+
+def test_pattern_metrics_tracks_the_measurement_frequency(client: TestClient):
+    payload = client.post(
+        "/pattern_metrics",
+        json={"geometry": "beams.yagi", "measurement_freq_mhz": 21.1},
+    ).json()
+    assert payload["metrics"]["measurement_freq_mhz"] == 21.1
+
+
+# ---------------------------------------------------------------------------
 # /examples — schema serialization, used by the frontend on mount
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Adds the ability to compare radiation patterns **in the web UI**, not just the CLI — the second of the two pre-launch features.

- **Pin / ghost overlay (web).** A "📌 Pin pattern" action on the azimuth/elevation views snapshots the current solve response. The far-field chart redraws each pin as a dimmed dashed ghost through the *same* cut math as the live lobe, so pins track the cut-angle sliders. **Pins survive design switches**, so you can overlay one antenna's pattern on another's — true cross-antenna comparison, not just variants within a design. The lobe-from-currents math is extracted into a module-level `computeCutDbi()` shared by the live trace and every ghost.
- **`pattern_metrics` helper (shared).** `far_field.pattern_metrics(ff)` → peak gain (dBi), takeoff angle, azimuth, front-to-back, and −3 dB azimuth/elevation beamwidths (interpolated crossings; azimuth wraps, elevation is edge-bounded). Reused by:
  - the CLI `compare_patterns` (and `optimize` before/after), which now prints an aligned metrics table next to the plot;
  - `POST /pattern_metrics` (momwire engine, so the numbers match the on-screen lobe), feeding a side-by-side **compare table** in the UI for the live antenna + each pin.
- Removes a stray `print(n, ...)` debug line left in `plot_patterns`.

Per the agreed scope, this ships the pin/ghost overlay; the heavier **A/B live-compare** (two fully live, independently-editable configs) is deliberately left for a follow-on. The dropped variant-only overlay isn't needed — pins already cover variants and arbitrary antennas.

## Test plan
- [x] `tests/test_pattern_metrics.py` — 7 tests: beamwidth helpers on synthetic parabolic/omni lobes; peak/takeoff/azimuth/F-B on constructed patterns (incl. azimuth wrap)
- [x] `tests/test_web_server.py::test_pattern_metrics_*` — endpoint keys, positive gain/F-B for a yagi, freq tracking
- [x] Full `tests/` suite (1334 passed); ruff check + format clean
- [x] Frontend `tsc --noEmit` + `vite build` clean; Pin button + compare-table present in built bundle
- [x] Live `/pattern_metrics` matches the CLI table (dipole 1.93 dBi / F/B 0 vs yagi 8.89 dBi / F/B 8.2)
- [ ] Manual in-browser: pin a yagi, switch to a dipole, confirm the ghost + metrics row overlay correctly (pending — Chrome extension wasn't connected this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)