### PR TITLE
docs: Copy-params and pattern-compare in the web + CLI reference

### DIFF
--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -1,12 +1,12 @@
 ---
 title: Command line
-description: Driving antennaknobs from the terminal — list, draw, sweep, pattern, optimize, compare, and .nec export.
+description: Driving antennaknobs from the terminal — list, draw, sweep, pattern, optimize, compare, params, and .nec export.
 ---
 
 antennaknobs has a command-line interface for batch work. The subcommands:
 
 ```text
-python -m antennaknobs {draw,sweep,optimize,pattern,compare_patterns,export,list}
+python -m antennaknobs {draw,sweep,optimize,pattern,compare_patterns,params,export,list}
 ```
 
 | Command | What it does |
@@ -17,6 +17,7 @@ python -m antennaknobs {draw,sweep,optimize,pattern,compare_patterns,export,list
 | `pattern` | Plot the far-field pattern |
 | `compare_patterns` | Overlay the patterns of several antennas / engines |
 | `optimize` | Optimize an antenna's parameters |
+| `params` | Print a design's knob values as paste-ready Python |
 | `export` | Export the design to a NEC-2 `.nec` card deck |
 
 ## Naming a design
@@ -67,6 +68,34 @@ python -m antennaknobs compare_patterns \
   --builders beams.moxon beams.moxon \
   --engines pynec momwire:bspline --fn check.png
 ```
+
+Alongside the overlaid plot, `compare_patterns` prints a metrics table — peak
+gain (dBi), takeoff angle, front-to-back, and −3 dB azimuth/elevation
+beamwidths — one row per antenna, so the comparison comes with numbers, not just
+shapes:
+
+```text
+design            peak dBi  takeoff°    F/B dB    az bw°    el bw°
+----------------------------------------------------------------
+dipoles.invvee        1.93         1       0.0        85        89
+beams.yagi            8.89         1       8.2        60        42
+```
+
+## Copying params back to code
+
+After tuning — in the workbench or with `optimize` — turn the knob values back
+into source you can paste into a design file. `params` prints a design's (or a
+`name:variant`'s) current values as a `default_params = {...}` block:
+
+```bash
+python -m antennaknobs params --builder beams.yagi
+python -m antennaknobs params --builder specialty.hentenna:z100 --wrap mappingproxy
+```
+
+Useful flags: `--name <var>` (name the emitted block), `--no-ui` (knob values
+only, drop the `ui_params` block), and `--wrap mappingproxy` (match the
+catalog's frozen-params style). An `optimize` run ends by printing the same
+paste-ready block for its result, so the tuned values go straight into code.
 
 ## Exporting to NEC
 

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -109,6 +109,35 @@ current antenna across a range of N values and plots the resulting feed-point
 impedance, so you can see where the curve flattens out. Details and how to read
 it: [Segments & convergence](/reference/solver/#segments--convergence).
 
+## Comparing patterns
+
+On the **azimuth** and **elevation** pattern views a **📌 Pin pattern** button
+(top-left of the plot) freezes the current radiation pattern as a dimmed,
+dashed **ghost** overlaid on the live one. Pin it, then change knobs — or switch
+to a completely different design — and the live lobe redraws over the pinned
+ghost so you can see the effect directly.
+
+- **Pins survive a design switch**, so you can overlay one antenna's pattern on
+  another's — a Yagi's beam against a dipole's figure-8, say — not just two
+  tunings of the same design.
+- Each pinned trace recomputes for whichever cut (azimuth or elevation) and
+  cut-angle you're viewing, so it always shares the live plot's geometry.
+- A **compare table** appears alongside with a row per pattern — peak gain
+  (dBi), takeoff angle, front-to-back, and −3 dB azimuth beamwidth — so the
+  overlaid shapes come with the numbers that matter. **clear** removes all
+  pins; the **✕** on a row removes one.
+
+## Copying params back to code
+
+The **gear menu** (⚙, top of the sidebar) has **Copy params (Python)**, which
+copies the current knob values to the clipboard as a paste-ready
+`default_params = {...}` block (a `<variant>_params` block when you're on a
+named variant). Drop it straight into a design file to bake in whatever you
+dialed in — no more transcribing values off the screen by hand.
+
+The same gear menu also has **Download .nec deck**, which exports the design as
+a NEC-2 card deck for xnec2c / 4nec2 / EZNEC.
+
 ## How a knob turn works
 
 A knob change sends one message over the `/ws` WebSocket; the server re-solves in


### PR DESCRIPTION
Website docs for the two shipped pre-release features, for review before the release.

## Web workbench (`reference/web.md`)
- **Comparing patterns** — the 📌 Pin pattern ghost overlay (survives design switches → cross-antenna compare; recomputes for the active cut) and the peak / takeoff / F-B / az-beamwidth compare table, with clear / ✕ controls.
- **Copying params back to code** — the gear-menu **Copy params (Python)** button (plus the existing **Download .nec deck**).

## Command line (`reference/cli.md`)
- `params` added to the subcommand list + table.
- **Copying params back to code** — `params` with `--name` / `--no-ui` / `--wrap`, and the paste-ready block `optimize` now prints.
- A sample of the metrics table `compare_patterns` prints alongside the plot.

Scope: **shipped features only** (from PRs #198 and #199). The parked A/B live-compare (draft #200) is intentionally *not* documented.

## Test plan
- [x] `npm run build` in `site/` succeeds (14 pages)
- [ ] Skim the rendered **Web workbench** and **Command line** pages for wording/accuracy before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)