### PR TITLE
chore: bump antennaknobs to 0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.9.0"
+version = "0.10.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]


### PR DESCRIPTION
Version bump for the 0.10.0 minor release.

Ships since 0.9.0:
- **Copy params as Python** — CLI `params` subcommand, `optimize` emits a paste-ready `default_params` block, and a web "Copy params (Python)" gear-menu button (#198).
- **Pattern compare** — pin/ghost pattern overlays in the web UI (survive design switches) + a shared `pattern_metrics` helper feeding a CLI metrics table and the UI compare table (#199).
- **Docs** — web + CLI reference pages for both features (#201).

After this merges, tagging `v0.10.0` triggers the publish workflow (PyPI + GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)