### PR TITLE
Declare ruff via an opt-in [dev] extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,14 @@ web = ["fastapi", "uvicorn[standard]", "websockets", "psutil"]
 #     the pynec-backed tests skip when it's absent.
 test = ["antennaknobs[web]", "pytest", "coverage", "httpx2"]
 
+# Local developer tooling — install with `pip install -e ".[dev]"`.
+#   - ruff is the linter/formatter, configured under [tool.ruff] below. It is a
+#     purely local convenience: CI lints via astral-sh/ruff-action (.github/
+#     workflows/ruff.yml), which installs its own ruff, so ruff is deliberately
+#     NOT in [project] or the runtime/test extras — end users and the `.[test]`
+#     CI install never pull it in.
+dev = ["ruff"]
+
 [project.urls]
 Homepage = "https://github.com/stevenmburns/antennaknobs"
 Issues = "https://github.com/stevenmburns/antennaknobs/issues"


### PR DESCRIPTION
## Summary
- Adds a `dev = ["ruff"]` optional-dependency extra so a fresh clone can install the linter reproducibly with `pip install -e ".[dev]"`. Ruff is configured under `[tool.ruff]` but was previously undeclared, so it had to be installed by hand.
- Deliberately kept out of `[project]` dependencies and the `web`/`test` extras: CI lints via `astral-sh/ruff-action` (which installs its own ruff), and neither end users nor the `.[test]` CI install should ever pull a linter.

## Test plan
- [ ] `pip install -e ".[dev]"` installs ruff
- [ ] `pip install -e ".[test]"` still does NOT pull ruff (dev extra is opt-in only)
- [ ] `ruff check .` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)