### PR TITLE
docs(site): Cloudflare Web Analytics beacon rolling up .dev + .com

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -44,6 +44,21 @@ export default defineConfig({
             href: "https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap",
           },
         },
+        // Cloudflare Web Analytics beacon. The apex zones antennaknobs.dev and
+        // antennaknobs.com serve this one docs build, so a single token rolls
+        // both domains' traffic into one dashboard. The token is a public
+        // client-side id (ships in every page), not a secret. It lives here in
+        // the site <head> — rather than being auto-injected by Cloudflare —
+        // because the Fly DNS records are grey-cloud (DNS-only, required for
+        // Fly's TLS/SNI routing), so CF never proxies the request to inject it.
+        {
+          tag: "script",
+          attrs: {
+            defer: true,
+            src: "https://static.cloudflareinsights.com/beacon.min.js",
+            "data-cf-beacon": '{"token": "a7ed2b6512b5461fbd0beac3d6e13d71"}',
+          },
+        },
       ],
       sidebar: [
         {


### PR DESCRIPTION
## Summary
Adds a Cloudflare Web Analytics beacon to the docs site `<head>` so **antennaknobs.dev** and **antennaknobs.com** — which serve the *same* build from the `antennaknobs-docs` Fly app — report pageview metrics into a **single dashboard**.

- One public beacon token on the shared build → both apex domains roll up together.
- It has to live in the site head (not Cloudflare auto-injection) because the Fly DNS records are grey-cloud / DNS-only (required for Fly's TLS), so CF never proxies the request.
- The token is a public client-side id (ships in every page), not a secret.

**Search/SEO metrics were already consolidated** — every page (on both domains) emits `<link rel="canonical">` + `og:url` → `antennaknobs.dev` and the sitemap lists only `.dev`, via Astro's `site` config. This PR closes the remaining gap: pageview analytics.

## Test plan
- [x] `npm run build` succeeds; the beacon appears on all 14 built pages with the correct token
- [ ] After the next release deploy, confirm hits show up in the Cloudflare Web Analytics dashboard from both `antennaknobs.dev` and `antennaknobs.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)