### PR TITLE
chore: bump antennaknobs to 0.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.10.0"
+version = "0.11.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]


### PR DESCRIPTION
Version bump for the 0.11.0 minor release.

Ships since 0.10.0:
- **Sticky knob selection** — a physical dial (or the arrow keys) keeps driving the selected knob after DOM focus leaves it (#204).
- **Cloudflare Web Analytics** — beacon on the docs site rolls up antennaknobs.dev + .com into one dashboard (#206).
- **`[dev]` extra** — `pip install -e ".[dev]"` for local ruff (#205).
- **CI** — Fly simulator deploy retries transient builder failures (#203).

After merge, tagging `v0.11.0` publishes to PyPI and deploys the simulator + docs site (with the analytics beacon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)