### PR TITLE
docs(web): describe sticky knob selection + physical-dial support

### DIFF
--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -33,8 +33,13 @@ VFO dial; the rest are smaller). Three ways to change one:
 - **Drag** — press on the knob and move the mouse **vertically** (up to
   increase, down to decrease). Horizontal motion is ignored, so a natural hand
   motion won't fight you.
-- **Arrow keys** — focus a knob (click or tab to it) and press **↑ / ↓** to step
-  it by one increment — the precise way to nudge a value.
+- **Keyboard / physical dial** — click a knob (or tab to it) to **select** it;
+  it stays highlighted as the *armed* knob. Then **↑ / →** and **↓ / ←** step by
+  one increment, **Page Up / Down** by ten, **Home / End** jump to the range
+  ends, and **Enter** opens the value to type a number exactly. The selection is
+  **sticky** — it survives clicking away (onto the 3D view, say), so a physical
+  USB dial that emits arrow keys keeps driving the armed knob without having to
+  hold keyboard focus on it. **Esc** disarms.
 - **Right-click menu** — right-click a knob for its settings:
   - **Turn step** — how much one drag-notch / arrow press moves the value.
   - **Display range** — the min/max the knob sweeps between.


### PR DESCRIPTION
The **Driving a knob** section only documented focus + ↑/↓, which undersells the sticky-selection feature shipped in 0.11.0 (#204).

Updates the keyboard bullet to cover:
- clicking/tabbing a knob **arms** it (stays highlighted),
- the full key set — ↑/→ and ↓/← step by one, Page Up/Down by ten, Home/End jump to the ends, Enter types a value,
- the **sticky** selection surviving focus loss, so a **physical USB dial** emitting arrow keys keeps driving the armed knob,
- Esc to disarm.

## Test plan
- [x] `npm run build` succeeds; the new copy renders on `/reference/web/`
- [ ] Skim the rendered page before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)