### PR TITLE
Drone: forward_to_plane factor + a fully-flown trig-free delta loop

### DIFF
--- a/src/antennaknobs/designs/loops/delta_loop_flown.py
+++ b/src/antennaknobs/designs/loops/delta_loop_flown.py
@@ -1,0 +1,83 @@
+"""A delta loop flown *entirely* by the Drone, with NO explicit trig in the
+script -- not even the closed-form apex height, and no ``ry`` reflection. Every
+leg's length is discovered by flying to a plane, including the top edge, which
+uses ``forward_to_plane(..., factor=2)`` to cross the symmetry plane ``y = 0``
+and land on the mirrored corner in a single command.
+
+The flight, given the feed height, the top height and the apex tilt:
+
+    S --up the right slant--> A   (fly to the plane z = top)
+    A --across the top------> B   (fly to the symmetry plane y = 0, factor=2)
+    B --down the left slant-> T   (fly to the plane z = base)
+    T --feed gap------------> S   (close)
+
+The point of this variant is the *tradeoff* it exposes: the construction could
+hardly be simpler -- no cos/sin/tan anywhere, the drone's matrices and the plane
+solves carry all of it -- but the **parameterization pays for it**. You give the
+two heights and the tilt; you do NOT set the loop's size or its resonance
+directly. The perimeter is whatever falls out of ``(base, top, angle_deg)``, so
+to tune resonance you nudge ``top`` and re-measure. The shipped ``delta_loop``
+hands that knob back by solving the apex height in closed form (explicit trig) so
+you can size by total wire length outright. Simple to build vs. convenient to
+design with are different axes -- this loop trades the second for the first.
+
+The loop is vertical (planar in x = 0), fed by a short driven gap at the bottom.
+"""
+
+from types import MappingProxyType
+
+from ... import AntennaBuilder, Drone
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.47,
+            "freq": 28.47,
+            # Feed-gap height (the bottom point of the loop).
+            "base": 7.0,
+            # Top-edge height. The vertical extent (top - base) and the tilt set
+            # the size; the perimeter is emergent, not a knob.
+            "top": 10.0,
+            # Slant tilt from horizontal (60 deg -> the classic ~equilateral
+            # delta loop). Given to the drone as a plain yaw -- no trig here.
+            "angle_deg": 60.0,
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 100.0,
+                    "default_view": "yz",  # loop lies in the x = 0 plane
+                    "top": {"min": 8.5, "max": 11.5},
+                    "angle_deg": {"min": 45.0, "max": 75.0},
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        eps = 0.05
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+        n_body = self.nominal_nsegs
+        n_feed = max(3, self.nominal_nsegs // 7)
+
+        S = (0.0, eps, self.base)  # right feed terminal
+        drone = Drone(position=S, nominal_nsegs=n_body, ref=quarter)
+
+        # Nose out along the top edge with world +x as "up" so every yaw stays
+        # in the loop plane (x = 0), then tilt up onto the right slant. No
+        # direction cosines by hand -- the drone's rotation holds them.
+        drone.face(heading=(0.0, 1.0, 0.0), up=(1.0, 0.0, 0.0))
+        drone.yaw(self.angle_deg)
+
+        drone.pay_out()
+        drone.forward_to_plane((0.0, 0.0, 1.0, self.top))  # S -> A: up to the top
+        drone.yaw(180.0 - self.angle_deg)  # exterior angle at the top-right corner A
+        # A -> B: fly across the top to the symmetry plane y = 0 and the same
+        # distance past it, landing on B without computing the top's width.
+        drone.forward_to_plane((0.0, 1.0, 0.0, 0.0), factor=2.0)
+        drone.yaw(180.0 - self.angle_deg)  # exterior angle at the top-left corner B
+        drone.forward_to_plane((0.0, 0.0, 1.0, self.base))  # B -> T: down to the feed
+        drone.feed(1 + 0j)
+        drone.close(nsegs=n_feed)  # T -> S: the driven feed gap, fly home
+
+        return drone.wires()

--- a/src/antennaknobs/drone.py
+++ b/src/antennaknobs/drone.py
@@ -120,7 +120,7 @@ class Drone:
         self.pose = self.pose.postmult(Transform.translate(dist, 0, 0))
         return self
 
-    def forward_to_plane(self, plane, nsegs=None):
+    def forward_to_plane(self, plane, nsegs=None, factor=1.0):
         """Fly along the nose until the path meets ``plane``, laying an edge if
         the pen is down -- ``forward`` whose distance is solved for rather than
         given. Handy for trimming a leg to a boundary (a ground plane, a
@@ -133,6 +133,15 @@ class Drone:
         ``n_hat . x == d``; e.g. ``(0, 0, 1, 5)`` is the horizontal plane
         ``z = 5`` and ``(0, 0, 2, 5)`` is the same plane (``d`` is a true
         distance, not scaled by the normal's length).
+
+        ``factor`` scales the solved distance: the default ``1.0`` stops *at*
+        the plane; ``2.0`` flies to the plane and an equal distance past it.
+        When the nose crosses the plane **squarely** (heading parallel to the
+        plane normal), ``factor=2`` lands exactly on the mirror image of the
+        start point -- so a segment straddling a symmetry plane (e.g. the top
+        edge of a symmetric loop) can be laid without computing its length or
+        reflecting a corner. For an oblique crossing it is simply a proportional
+        overshoot along the nose, not a geometric reflection.
 
         Raises ``ValueError`` if the normal is zero, if the nose is parallel to
         the plane (no intersection), or if the plane lies behind the nose (you
@@ -155,8 +164,9 @@ class Drone:
         t = (d - float(np.dot(n, p0))) / denom
         if t < -1e-12:
             raise ValueError("plane lies behind the nose; cannot extend forward to it")
-        if t > 1e-12:
-            self.forward(t, nsegs)
+        dist = t * factor
+        if dist > 1e-12:
+            self.forward(dist, nsegs)
         return self
 
     def move_to(self, position):

--- a/tests/test_drone.py
+++ b/tests/test_drone.py
@@ -12,6 +12,7 @@ from antennaknobs.designs.loops.delta_loop_marked import Builder as DeltaLoopMar
 from antennaknobs.designs.loops.delta_loop_reflected import (
     Builder as DeltaLoopReflected,
 )
+from antennaknobs.designs.loops.delta_loop_flown import Builder as DeltaLoopFlown
 from antennaknobs.designs.loops.delta_loop_plane import Builder as DeltaLoopPlane
 from antennaknobs.designs.loops.delta_loop_solved import Builder as DeltaLoopSolved
 from antennaknobs.designs.loops.horizontal_loop_drone import Builder as HLoopDrone
@@ -158,6 +159,27 @@ def test_forward_to_plane_rejects_zero_normal():
         Drone().pay_out().forward_to_plane((0.0, 0.0, 0.0, 1.0))
 
 
+def test_forward_to_plane_factor_reaches_the_mirror_when_perpendicular():
+    # Nose +x at the origin, plane x = 3. factor=2 flies to the plane and an
+    # equal distance past it -- squarely, so it lands on the mirror image
+    # (6, 0, 0), laying one edge the full length.
+    d = Drone(ref=1.0).pay_out()
+    d.forward_to_plane((1.0, 0.0, 0.0, 3.0), factor=2.0)
+    assert d.position == pytest.approx((6.0, 0.0, 0.0))
+    p0, p1, _ns, _ex = d.wires()[0]
+    assert p0 == pytest.approx((0.0, 0.0, 0.0))
+    assert p1 == pytest.approx((6.0, 0.0, 0.0))
+
+
+def test_forward_to_plane_factor_is_proportional_overshoot_when_oblique():
+    # Heading +x toward the tilted plane whose x-intercept is 2 (normal (1,1,0),
+    # d = sqrt(2)). factor=2 flies 2 * 2 = 4 ALONG THE NOSE to (4, 0, 0) -- not
+    # the geometric mirror of the origin across that plane (which is (2, 2, 0)).
+    d = Drone(ref=1.0).pay_out()
+    d.forward_to_plane((1.0, 1.0, 0.0, math.sqrt(2.0)), factor=2.0)
+    assert d.position == pytest.approx((4.0, 0.0, 0.0))
+
+
 def _key(edges):
     """Edges as an order- and direction-independent multiset (the drone may
     traverse a segment either way)."""
@@ -301,6 +323,48 @@ def test_delta_loop_plane_is_a_closed_symmetric_delta_loop():
 
     counts = Counter((round(p[1], 6), round(p[2], 6)) for e in ws for p in (e[0], e[1]))
     assert set(counts.values()) == {2}
+
+
+def test_delta_loop_flown_is_a_closed_symmetric_delta_loop():
+    # Built entirely by flying to planes (no explicit trig, no ry reflection):
+    # the top edge is laid with forward_to_plane(..., factor=2) across y = 0.
+    b = DeltaLoopFlown()
+    ws = b.build_wires()
+
+    # Same four-edge topology as the sibling delta loops.
+    assert len(ws) == 4
+    driven = [e for e in ws if e[3] is not None]
+    assert len(driven) == 1 and driven[0][3] == 1 + 0j
+
+    # Vertical loop, planar in x = 0.
+    assert {round(p[0], 9) for e in ws for p in (e[0], e[1])} == {0.0}
+
+    # The top edge sits at `top`; the feed gap straddles y = 0 at `base`.
+    top_z = max(p[2] for e in ws for p in (e[0], e[1]))
+    assert top_z == pytest.approx(b.default_params["top"])
+    (fy0, fy1) = (driven[0][0][1], driven[0][1][1])
+    assert sorted([round(fy0, 9), round(fy1, 9)]) == [-0.05, 0.05]
+    assert driven[0][0][2] == pytest.approx(b.default_params["base"])
+
+    # Symmetric about y = 0 (feed/pattern stay symmetric).
+    yz = {(round(p[1], 6), round(p[2], 6)) for e in ws for p in (e[0], e[1])}
+    assert {(-y, z) for (y, z) in yz} == yz
+
+    # Connected closed loop: every node shared by exactly two edges.
+    from collections import Counter
+
+    counts = Counter((round(p[1], 6), round(p[2], 6)) for e in ws for p in (e[0], e[1]))
+    assert set(counts.values()) == {2}
+
+
+def test_delta_loop_flown_size_tracks_top_height():
+    # No perimeter knob: the loop grows with the vertical extent (top - base).
+    def top_width(top):
+        ws = DeltaLoopFlown(dict(DeltaLoopFlown.default_params, top=top)).build_wires()
+        ys = [p[1] for e in ws for p in (e[0], e[1])]
+        return max(ys) - min(ys)
+
+    assert top_width(11.0) > top_width(10.0) > top_width(9.0)
 
 
 def test_delta_loop_plane_size_tracks_length_factor():


### PR DESCRIPTION
## What & why

Adds a small, docs-independent capability to the `Drone` turtle and a design that exercises it.

### `forward_to_plane(plane, nsegs=None, factor=1.0)`
An optional `factor` that scales the solved distance:
- `factor=1.0` (default) — unchanged; stops **at** the plane. All existing `forward_to_plane` tests still pass.
- `factor=2.0` — fly to the plane and an **equal distance past** it. When the nose crosses the plane **squarely** (heading ∥ normal), it lands exactly on the **mirror image** of the start point — so an edge straddling a symmetry plane can be laid without computing its length or reflecting a corner.

Heading-respecting by design: an oblique crossing is a proportional overshoot *along the nose*, **not** a geometric reflection. Both cases are tested and the caveat is documented.

### `delta_loop_flown`
A delta loop built **entirely by flying to planes** — up the right slant to `z=top`, across the top via `forward_to_plane(y=0, factor=2)`, down the left slant to `z=base`, close the feed — with **no explicit trig and no `ry` reflection**. Produces a clean symmetric full-wave loop (~1.006 λ).

It's kept as an honest illustration of a tradeoff: trivial to construct, but parameterized by `(base, top, angle_deg)` with the **perimeter emergent** rather than a direct knob — the resonance control the shipped `delta_loop` buys back with its apex-height formula. *Simple to build* and *convenient to design with* are different axes.

## Notes
- No docs changes — where (and whether) this appears in the authoring tutorial is deferred to the separate tutorial rework.
- The load-bearing `delta_loop.Builder` and every other design are untouched.

## Verification
- `pytest tests/` — **1349 passed** (existing `forward_to_plane` behavior unchanged; new design registers cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)