### PR TITLE
Multiple antenna design sessions as sidebar tabs

### DIFF
--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -1,6 +1,6 @@
 ---
 title: Web workbench
-description: The browser-based simulator — driving the knobs, optimizing, switching solvers, and how it's served.
+description: The browser-based simulator — driving the knobs, running several designs at once, optimizing, switching solvers, and how it's served.
 ---
 
 The web workbench is the live, no-install face of antennaknobs: a panel of knobs
@@ -113,6 +113,27 @@ longer moves the impedance — run a **convergence sweep**. It re-solves the
 current antenna across a range of N values and plots the resulting feed-point
 impedance, so you can see where the curve flattens out. Details and how to read
 it: [Segments & convergence](/reference/solver/#segments--convergence).
+
+## Design sessions (tabs)
+
+The sidebar is a **notebook**: the tabs across its top (**D1**, **D2**, …) are
+independent design sessions, each with its own geometry, knob values, design and
+measurement frequency, ground setting, solver slot, and results. Click **+** to
+open a new session — it starts fresh and solves on its own — switch by clicking a
+tab, and close one with the **✕** (the last remaining tab can't be closed).
+
+- Sessions are **fully independent**: changing a knob, the solver, or the ground
+  model in one leaves every other session exactly as you left it.
+- **Hover a tab** for its summary — design, solver, segment count, and ground
+  model — e.g. `dipoles.invvee · Triangular N=40 · free space`.
+- Switching to a session **re-solves** it, which is near-instant because the
+  server caches recent solves (see [How a knob turn works](#how-a-knob-turn-works)).
+- The light/dark theme is shared across all sessions; everything else is
+  per-session.
+
+Open the same design in two tabs to compare tunings, or load two different
+antennas — then pair it with [pattern pinning](#comparing-patterns) to overlay
+one session's radiation pattern on another's.
 
 ## Comparing patterns
 

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1552,6 +1552,77 @@ function useThumbColumnSize(
 
 type Theme = "light" | "dark";
 const ThemeContext = createContext<Theme>("light");
+// Theme is global (owned by the shell) but the toggle button lives in each
+// session's sidebar header; sessions reach the setter through this context so
+// the single button drives the one shared theme.
+const ThemeControlContext = createContext<(next: Theme) => void>(() => {});
+
+// The open design sessions and the controls to switch / add / close them. The
+// shell provides this; each session renders a <TabStrip> off it, so all
+// mounted sessions show the same tabs (only the active one is visible).
+type SessionMeta = { id: number };
+type SessionsCtx = {
+  sessions: SessionMeta[];
+  activeId: number;
+  add: () => void;
+  close: (id: number) => void;
+  setActive: (id: number) => void;
+};
+const SessionsContext = createContext<SessionsCtx>({
+  sessions: [],
+  activeId: 0,
+  add: () => {},
+  close: () => {},
+  setActive: () => {},
+});
+
+// The session tab strip, atop each session's sidebar. Global state comes from
+// SessionsContext, so every mounted session renders an identical strip.
+function TabStrip() {
+  const { sessions, activeId, add, close, setActive } =
+    useContext(SessionsContext);
+  return (
+    <div className="tab-strip" role="tablist" aria-label="Design sessions">
+      {sessions.map((s, i) => (
+        <div
+          key={s.id}
+          className={`tab ${s.id === activeId ? "active" : ""}`}
+        >
+          <button
+            type="button"
+            role="tab"
+            aria-selected={s.id === activeId}
+            className="tab-btn"
+            onClick={() => setActive(s.id)}
+            title={`Design ${i + 1}`}
+          >
+            Design {i + 1}
+          </button>
+          {sessions.length > 1 && (
+            <button
+              type="button"
+              className="tab-close"
+              onClick={() => close(s.id)}
+              aria-label={`Close design ${i + 1}`}
+              title={`Close design ${i + 1}`}
+            >
+              ×
+            </button>
+          )}
+        </div>
+      ))}
+      <button
+        type="button"
+        className="tab-add"
+        onClick={add}
+        aria-label="New design"
+        title="New design"
+      >
+        +
+      </button>
+    </div>
+  );
+}
 
 // Response from POST /optimize.
 type OptMetrics = { z_in_re: number; z_in_im: number; z0_ohms: number; swr: number };
@@ -1588,43 +1659,20 @@ type KnobOpt = {
   step: number;
 };
 
-export function App() {
+// One antenna design session: the entire left sidebar + right stage plus all
+// the state, effects, and the WebSocket that drive them. The shell (`App`,
+// below) mounts one instance per tab and passes `active` — true only for the
+// visible tab. An inactive session stays mounted, so its inputs survive, but
+// suspends its WebSocket, global key listeners, and background solves via the
+// `active` gates threaded through the effects below. Theme is global and lives
+// in the shell; the canvases here read it through ThemeContext.
+function DesignSession({ active }: { active: boolean }) {
   const [geometry, setGeometry] = useState<string>("");
 
-  // Theme is seeded from the <html data-theme> the no-flash script in
-  // index.html set (localStorage || prefers-color-scheme); the effect mirrors
-  // changes back to the attribute + storage. The 3 canvases read their colors
-  // from CSS vars via getComputedStyle, so they consume ThemeContext to repaint
-  // on toggle (see FarFieldChart/SmithChart/CurrentCanvas).
-  const [theme, setTheme] = useState<Theme>(() =>
-    document.documentElement.dataset.theme === "dark" ? "dark" : "light",
-  );
-  // Apply the attribute SYNCHRONOUSLY here, not in a post-render effect: React
-  // runs child effects before parent effects, so the canvases' draw effects
-  // would re-read getComputedStyle while the attribute still held the previous
-  // theme — lagging one toggle behind the (pure-CSS) chrome. Setting it eagerly
-  // means the attribute is already current when those effects re-run.
-  const applyTheme = (next: Theme) => {
-    document.documentElement.dataset.theme = next;
-    try {
-      localStorage.setItem("theme", next);
-    } catch {
-      /* storage disabled — in-memory toggle still works */
-    }
-    setTheme(next);
-  };
-
-  // Step 1 of the tabbed-sessions refactor. Every window listener, the
-  // WebSocket, and the background auto-poll effects below are gated on
-  // `active` so that a mounted-but-hidden instance (an inactive tab) holds no
-  // live socket, registers no global key listeners, and runs no background
-  // solves/sweeps/patterns — while its React state (the user's inputs) stays
-  // alive because the instance stays mounted. On re-activation each gated
-  // effect re-runs (`active` is in its deps) and reconnects / re-solves; the
-  // backend cache makes that the fast switch. Today there is a single,
-  // always-active instance, so this is a behaviour-preserving no-op; step 2
-  // turns `App` into `DesignSession` and `active` becomes a prop.
-  const active: boolean = true;
+  // Theme is global (shell-owned); the sidebar toggle reads the current value
+  // and writes through the control context so it drives the one shared theme.
+  const theme = useContext(ThemeContext);
+  const applyTheme = useContext(ThemeControlContext);
 
   // ---- Sticky knob selection (physical-dial support) ---------------------
   // `selectedKnob` drives the visible "armed" highlight; the ref mirror lets
@@ -3252,10 +3300,10 @@ export function App() {
   }, [active]);
 
   return (
-    <ThemeContext.Provider value={theme}>
     <KnobSelectionContext.Provider value={knobSelection}>
     <div className="app">
       <aside className="sidebar">
+        <TabStrip />
         <div className="sidebar-header">
           <div className="brand">
             <h1>AntennaKNoBs</h1>
@@ -4150,6 +4198,95 @@ export function App() {
       </main>
     </div>
     </KnobSelectionContext.Provider>
+  );
+}
+
+// App shell. Owns the two pieces of truly global state — the light/dark theme
+// and the list of open design sessions — and nothing else. Every session is a
+// mounted <DesignSession>; only the active one is shown (the rest are hidden
+// with CSS so their inputs survive). Switching flips `active`, which suspends
+// the outgoing session's socket/listeners/solves and resumes the incoming
+// one's (see the `active` gates in DesignSession).
+export function App() {
+  // Theme is seeded from the <html data-theme> the no-flash script in
+  // index.html set (localStorage || prefers-color-scheme). The 3 canvases read
+  // their colors from CSS vars via getComputedStyle, so they consume
+  // ThemeContext to repaint on toggle (see FarFieldChart/SmithChart/
+  // CurrentCanvas). The toggle button itself lives in each session's sidebar
+  // and writes back through ThemeControlContext.
+  const [theme, setTheme] = useState<Theme>(() =>
+    document.documentElement.dataset.theme === "dark" ? "dark" : "light",
+  );
+  // Apply the attribute SYNCHRONOUSLY here, not in a post-render effect: React
+  // runs child effects before parent effects, so the canvases' draw effects
+  // would re-read getComputedStyle while the attribute still held the previous
+  // theme — lagging one toggle behind the (pure-CSS) chrome. Setting it eagerly
+  // means the attribute is already current when those effects re-run.
+  const applyTheme = useCallback((next: Theme) => {
+    document.documentElement.dataset.theme = next;
+    try {
+      localStorage.setItem("theme", next);
+    } catch {
+      /* storage disabled — in-memory toggle still works */
+    }
+    setTheme(next);
+  }, []);
+
+  // Open sessions. Ids are stable and monotonic (never reused), so React keys
+  // each session to a fixed mount for its whole lifetime — the whole point:
+  // a session's inputs live in its component instance, so it must never be
+  // reconciled onto a different session's tree.
+  const [sessions, setSessions] = useState<SessionMeta[]>([{ id: 1 }]);
+  const [activeId, setActiveId] = useState(1);
+  const nextIdRef = useRef(2);
+
+  const add = useCallback(() => {
+    const id = nextIdRef.current++;
+    setSessions((prev) => [...prev, { id }]);
+    setActiveId(id);
+  }, []);
+
+  const close = useCallback((id: number) => {
+    setSessions((prev) => {
+      if (prev.length <= 1) return prev; // always keep one session open
+      const idx = prev.findIndex((s) => s.id === id);
+      const next = prev.filter((s) => s.id !== id);
+      // If the closed session was active, activate its neighbour (prefer the
+      // one to the left, matching browser-tab behaviour).
+      setActiveId((cur) =>
+        cur === id ? next[Math.max(0, idx - 1)].id : cur,
+      );
+      return next;
+    });
+  }, []);
+
+  const setActive = useCallback((id: number) => setActiveId(id), []);
+
+  const sessionsCtx = useMemo<SessionsCtx>(
+    () => ({ sessions, activeId, add, close, setActive }),
+    [sessions, activeId, add, close, setActive],
+  );
+
+  return (
+    <ThemeContext.Provider value={theme}>
+      <ThemeControlContext.Provider value={applyTheme}>
+        <SessionsContext.Provider value={sessionsCtx}>
+          <div className="sessions">
+            {sessions.map((s) => (
+              <div
+                key={s.id}
+                className="session-mount"
+                // Hidden — not unmounted — so an inactive session keeps its
+                // inputs. `hidden` also removes it from the a11y tree and stops
+                // its canvases painting.
+                hidden={s.id !== activeId}
+              >
+                <DesignSession active={s.id === activeId} />
+              </div>
+            ))}
+          </div>
+        </SessionsContext.Provider>
+      </ThemeControlContext.Provider>
     </ThemeContext.Provider>
   );
 }

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1614,6 +1614,18 @@ export function App() {
     setTheme(next);
   };
 
+  // Step 1 of the tabbed-sessions refactor. Every window listener, the
+  // WebSocket, and the background auto-poll effects below are gated on
+  // `active` so that a mounted-but-hidden instance (an inactive tab) holds no
+  // live socket, registers no global key listeners, and runs no background
+  // solves/sweeps/patterns — while its React state (the user's inputs) stays
+  // alive because the instance stays mounted. On re-activation each gated
+  // effect re-runs (`active` is in its deps) and reconnects / re-solves; the
+  // backend cache makes that the fast switch. Today there is a single,
+  // always-active instance, so this is a behaviour-preserving no-op; step 2
+  // turns `App` into `DesignSession` and `active` becomes a prop.
+  const active: boolean = true;
+
   // ---- Sticky knob selection (physical-dial support) ---------------------
   // `selectedKnob` drives the visible "armed" highlight; the ref mirror lets
   // the always-mounted global key listener read the latest selection without
@@ -1658,6 +1670,7 @@ export function App() {
   // keydown — avoids double-stepping) and when typing in a real field. Esc
   // disarms, freeing the arrow keys for normal page use again.
   useEffect(() => {
+    if (!active) return;
     const NAV = new Set([
       "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight",
       "PageUp", "PageDown", "Home", "End", "Enter",
@@ -1689,7 +1702,7 @@ export function App() {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, []);
+  }, [active]);
 
   // Tools (gear) dropdown in the header. Tucked away because it holds
   // occasional actions like the NEC deck export, not per-solve controls.
@@ -2193,6 +2206,7 @@ export function App() {
   const thumbSize = useThumbColumnSize(thumbStripRef, 280);
 
   useEffect(() => {
+    if (!active) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
       if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
@@ -2202,7 +2216,7 @@ export function App() {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [view]);
+  }, [view, active]);
 
   const sweepTimerRef = useRef<number | null>(null);
   const sweepAbortRef = useRef<AbortController | null>(null);
@@ -2360,7 +2374,7 @@ export function App() {
     // Paused (Live off) holds the optimiser too — it drives engine solves, so it
     // must respect the same gate as the main solve. Resuming re-runs this effect
     // (autoSim is a dep) and re-tunes.
-    if (!optFixedSig || !autoSim) return;
+    if (!optFixedSig || !autoSim || !active) return;
     const t = setTimeout(() => {
       runOptimize();
     }, 400);
@@ -2368,7 +2382,7 @@ export function App() {
     // runOptimize captured here reflects the state at this signature; re-running
     // only when the signature changes is intentional.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [optFixedSig, autoSim]);
+  }, [optFixedSig, autoSim, active]);
 
   // The "paused — changing X by hand" cue is a brief flash: clear it a few
   // seconds after it appears so it doesn't linger while Optimize stays off.
@@ -2407,13 +2421,13 @@ export function App() {
 
   // Close the knob menu on Escape.
   useEffect(() => {
-    if (!knobMenu) return;
+    if (!knobMenu || !active) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") setKnobMenu(null);
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [knobMenu]);
+  }, [knobMenu, active]);
 
   // Export the current design as a NEC2 .nec card deck and trigger a
   // browser download. The backend reuses the same builder construction as
@@ -2618,7 +2632,7 @@ export function App() {
   const pinCount = pinnedPatterns.length;
   const comparing = pinCount > 0 && (view === "azimuth" || view === "elevation");
   useEffect(() => {
-    if (!comparing || !result) {
+    if (!comparing || !result || !active) {
       setLiveMetrics(null);
       return;
     }
@@ -2633,7 +2647,7 @@ export function App() {
       window.clearTimeout(h);
     };
     // result identity changes per solve; that's the cue to refresh.
-  }, [comparing, result]);
+  }, [comparing, result, active]);
 
   // Reset the "solve anyway" approval whenever the design or solver changes, so
   // an inappropriate combo is re-evaluated (and re-warned) rather than riding a
@@ -2643,6 +2657,7 @@ export function App() {
   }, [geometry, backend, backendOptsKey]);
 
   useEffect(() => {
+    if (!active) return;
     // Hold the first solve after an antenna switch until that antenna's preview
     // has landed (previewReady === geometry). Param/freq tweaks on the *same*
     // antenna keep solving freely — previewReady stays equal to geometry until
@@ -2671,6 +2686,7 @@ export function App() {
     requestSolve();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
+    active,
     autoSim,
     geometry, previewReady, backend, backendOptsKey,
     currentValuesKey,
@@ -2754,7 +2770,7 @@ export function App() {
     }
     setSweep(null);
     setSweepRunning(false);
-    if (!sweepEnabled) {
+    if (!sweepEnabled || !active) {
       return;
     }
     // runSweep itself waits for the live solve to finish before it starts
@@ -2771,6 +2787,7 @@ export function App() {
     designFreq,
     groundEnabled, groundFast,
     sweepEnabled,
+    active,
     currentExample?.sweep_policy.anchor === "meas_freq" ? measFreq : null,
   ]);
 
@@ -2786,7 +2803,7 @@ export function App() {
     }
     setConverge(null);
     setConvergeRunning(false);
-    if (!convergeEnabled) {
+    if (!convergeEnabled || !active) {
       return;
     }
     // Like the sweep, runConverge waits for the live solve before starting.
@@ -2801,6 +2818,7 @@ export function App() {
     designFreq, measFreq,
     groundEnabled, groundFast,
     convergeEnabled,
+    active,
   ]);
 
   // Debounced NEC pattern fetch. PyNEC only — for momwire there's no rp_card
@@ -2808,7 +2826,7 @@ export function App() {
   useEffect(() => {
     if (patternTimerRef.current) window.clearTimeout(patternTimerRef.current);
     setPattern(null);
-    if (backend !== "pynec") return;
+    if (backend !== "pynec" || !active) return;
     patternTimerRef.current = window.setTimeout(() => {
       runPattern();
       patternTimerRef.current = null;
@@ -2822,6 +2840,7 @@ export function App() {
     currentValuesKey,
     designFreq, measFreq,
     groundEnabled, groundFast,
+    active,
   ]);
 
   async function runSweep() {
@@ -3164,6 +3183,7 @@ export function App() {
   }
 
   useEffect(() => {
+    if (!active) return;
     const ws = new WebSocket(WS_URL);
     wsRef.current = ws;
     ws.onopen = () => {
@@ -3229,7 +3249,7 @@ export function App() {
     };
     return () => ws.close();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [active]);
 
   return (
     <ThemeContext.Provider value={theme}>

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1567,6 +1567,10 @@ type SessionsCtx = {
   add: () => void;
   close: (id: number) => void;
   setActive: (id: number) => void;
+  // Per-session one-line summary (design · solver · segs · ground) for the tab
+  // hover, reported up from each session (which owns that state).
+  summaries: Record<number, string>;
+  reportSummary: (id: number, summary: string) => void;
 };
 const SessionsContext = createContext<SessionsCtx>({
   sessions: [],
@@ -1574,12 +1578,16 @@ const SessionsContext = createContext<SessionsCtx>({
   add: () => {},
   close: () => {},
   setActive: () => {},
+  summaries: {},
+  reportSummary: () => {},
 });
 
 // The session tab strip, atop each session's sidebar. Global state comes from
-// SessionsContext, so every mounted session renders an identical strip.
+// SessionsContext, so every mounted session renders an identical strip. Tabs
+// are labelled "D1", "D2", … to stay compact for many designs; the full
+// design/solver/segs/ground summary is on hover.
 function TabStrip() {
-  const { sessions, activeId, add, close, setActive } =
+  const { sessions, activeId, add, close, setActive, summaries } =
     useContext(SessionsContext);
   return (
     <div className="tab-strip" role="tablist" aria-label="Design sessions">
@@ -1594,9 +1602,9 @@ function TabStrip() {
             aria-selected={s.id === activeId}
             className="tab-btn"
             onClick={() => setActive(s.id)}
-            title={`Design ${i + 1}`}
+            title={summaries[s.id] ?? `Design ${i + 1}`}
           >
-            Design {i + 1}
+            D{i + 1}
           </button>
           {sessions.length > 1 && (
             <button
@@ -1666,13 +1674,16 @@ type KnobOpt = {
 // suspends its WebSocket, global key listeners, and background solves via the
 // `active` gates threaded through the effects below. Theme is global and lives
 // in the shell; the canvases here read it through ThemeContext.
-function DesignSession({ active }: { active: boolean }) {
+function DesignSession({ id, active }: { id: number; active: boolean }) {
   const [geometry, setGeometry] = useState<string>("");
 
   // Theme is global (shell-owned); the sidebar toggle reads the current value
   // and writes through the control context so it drives the one shared theme.
   const theme = useContext(ThemeContext);
   const applyTheme = useContext(ThemeControlContext);
+
+  // Report this session's one-line summary up to the shell for the tab hover.
+  const { reportSummary } = useContext(SessionsContext);
 
   // ---- Sticky knob selection (physical-dial support) ---------------------
   // `selectedKnob` drives the visible "armed" highlight; the ref mirror lets
@@ -2088,6 +2099,23 @@ function DesignSession({ active }: { active: boolean }) {
   // PEC ground plane (image method at z = 0).
   const [groundEnabled, setGroundEnabled] = useState(false);
   const [groundFast, setGroundFast] = useState(false);
+
+  // One-line tab-hover summary: design · solver N=segs · ground model. The
+  // ground wording follows the backend family (momwire = PEC image method,
+  // PyNEC = Sommerfeld, or its fast reflection-coefficient approximation), and
+  // reads "free space" when ground is off or unsupported by the active solver.
+  const groundActiveForSummary = groundEnabled && backendSupportsGround(backend);
+  const groundSummary = !groundActiveForSummary
+    ? "free space"
+    : backend === "pynec"
+      ? groundFast
+        ? "reflection-coef ground"
+        : "Sommerfeld ground"
+      : "PEC ground";
+  const tabSummary = `${(currentExample?.label ?? geometry) || "new design"} · ${BACKEND_LABEL[backend]} N=${nPerWire} · ${groundSummary}`;
+  useEffect(() => {
+    reportSummary(id, tabSummary);
+  }, [id, tabSummary, reportSummary]);
   // Far-field cut angles. The azimuth plot slices the pattern at elevation
   // `azElevDeg`; the elevation plot slices the vertical plane at azimuth
   // bearing `elevAzDeg` (0° = +x). Defaults give the conventional views.
@@ -4239,6 +4267,8 @@ export function App() {
   const [sessions, setSessions] = useState<SessionMeta[]>([{ id: 1 }]);
   const [activeId, setActiveId] = useState(1);
   const nextIdRef = useRef(2);
+  // Per-session tab-hover summaries, reported up from each session.
+  const [summaries, setSummaries] = useState<Record<number, string>>({});
 
   const add = useCallback(() => {
     const id = nextIdRef.current++;
@@ -4258,13 +4288,25 @@ export function App() {
       );
       return next;
     });
+    setSummaries((prev) => {
+      if (!(id in prev)) return prev;
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
   }, []);
 
   const setActive = useCallback((id: number) => setActiveId(id), []);
 
+  // Identity-guarded so a session re-reporting the same summary is a no-op
+  // (avoids a render loop from the reporting effect).
+  const reportSummary = useCallback((id: number, summary: string) => {
+    setSummaries((prev) => (prev[id] === summary ? prev : { ...prev, [id]: summary }));
+  }, []);
+
   const sessionsCtx = useMemo<SessionsCtx>(
-    () => ({ sessions, activeId, add, close, setActive }),
-    [sessions, activeId, add, close, setActive],
+    () => ({ sessions, activeId, add, close, setActive, summaries, reportSummary }),
+    [sessions, activeId, add, close, setActive, summaries, reportSummary],
   );
 
   return (
@@ -4281,7 +4323,7 @@ export function App() {
                 // its canvases painting.
                 hidden={s.id !== activeId}
               >
-                <DesignSession active={s.id === activeId} />
+                <DesignSession id={s.id} active={s.id === activeId} />
               </div>
             ))}
           </div>

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -219,6 +219,18 @@ button:focus-visible,
   box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
+/* Holds the mounted design sessions; the active one fills the viewport, the
+   rest are hidden (their inputs survive). Each session's `.app` grid is
+   height:100%. */
+.sessions {
+  height: 100%;
+  overflow: hidden;
+}
+
+.session-mount {
+  height: 100%;
+}
+
 .app {
   display: grid;
   grid-template-columns: 320px 1fr;
@@ -247,6 +259,95 @@ button:focus-visible,
   gap: var(--space-4);
 }
 
+/* Session tabs across the top of the sidebar column — a "notebook" whose pages
+   are the whole workspace. Sticky so they stay visible as the knob list
+   scrolls; bled to the sidebar edges via negative margins that cancel its
+   padding. */
+.tab-strip {
+  position: sticky;
+  top: calc(-1 * var(--space-7));
+  z-index: 3;
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-1);
+  margin: calc(-1 * var(--space-7)) calc(-1 * var(--space-7)) 0;
+  padding: var(--space-3) var(--space-5);
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  scrollbar-width: none; /* the +/tab row is self-evidently scrollable */
+}
+
+.tab-strip::-webkit-scrollbar {
+  display: none;
+}
+
+.tab {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+}
+
+.tab.active {
+  background: var(--inset);
+  border-color: var(--border-control);
+}
+
+.tab-btn {
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-size: var(--text-sm);
+  padding: var(--space-2) var(--space-3);
+  cursor: pointer;
+  white-space: nowrap;
+  border-radius: var(--r-sm);
+}
+
+.tab.active .tab-btn {
+  color: var(--fg);
+  font-weight: 600;
+}
+
+.tab-close {
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: var(--text-base);
+  line-height: 1;
+  padding: 0 var(--space-2) 0 0;
+  border-radius: var(--r-sm);
+}
+
+.tab-close:hover {
+  color: var(--accent);
+}
+
+.tab-add {
+  flex: 0 0 auto;
+  background: none;
+  border: 1px solid var(--border-control);
+  color: var(--muted);
+  border-radius: var(--r-sm);
+  width: 24px;
+  height: 24px;
+  align-self: center;
+  cursor: pointer;
+  font-size: var(--text-base);
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tab-add:hover {
+  color: var(--accent);
+  border-color: var(--border-hover);
+}
+
 .brand {
   display: flex;
   flex-direction: column;
@@ -254,7 +355,7 @@ button:focus-visible,
   min-width: 0;
 }
 
-.sidebar h1 {
+.brand h1 {
   font-size: var(--text-lg);
   font-weight: 700;
   margin: 0;


### PR DESCRIPTION
Run several antenna design sessions at once, as tabs across the top of the
sidebar (`Design 1 | Design 2 | +`). Each tab is a fully independent design —
geometry, knobs, freq, ground, results, view — not a partial/shared copy.

### Approach
Rather than duplicating a subset of state and re-deriving the layout (the
earlier A/B attempt, #200), this leans on React itself: the whole design UI is
extracted into a `DesignSession` component and the shell mounts **one instance
per tab**. Each instance carries its own copy of all ~90 hooks and its own
WebSocket, so component instances *are* the "array of sessions" — no
per-variable renaming, no shared-state plumbing, no layout rework.

Two commits:

1. **`gate App side-effects on an active flag`** — thread an `active` flag
   through every window listener, the WebSocket, and the auto-poll effects
   (solve/sweep/pattern/converge/optimiser/metrics). Behaviour-preserving on
   its own; it's what lets a hidden session go inert.
2. **`multiple design sessions as sidebar tabs`** — split App into
   `DesignSession` (the former body, takes `active`) + a shell `App` that owns
   the two truly-global things: the theme and the session list. `TabStrip`
   renders from `SessionsContext` atop each sidebar.

### Behaviour
- Inactive sessions stay **mounted but hidden** (`hidden` attr), so their
  inputs survive. Switching flips `active`: the outgoing session drops its
  socket/listeners/solves; the incoming one reconnects and re-solves — fast off
  the backend cache. Exactly one live socket at a time.
- Theme stays global (shell-owned, via `ThemeContext`); the per-session toggle
  writes back through `ThemeControlContext`. The gear stays per-session (it
  acts on that design).
- Tabs live in the 320px sidebar column, so the stage keeps full height (no
  full-width header bar).
- Closing the active tab activates its left neighbour; the last tab can't be
  closed.

### Verification
In-browser: adding a tab mounts a fresh solved session; enabling ground plane
on Design 2 left Design 1 untouched; switching back re-solved in <1 ms off the
cache; console clean. `tsc --noEmit` + production build pass.

Supersedes #200 (the parked A/B live-compare draft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
