### PR TITLE
chore: bump antennaknobs to 0.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.11.0"
+version = "0.12.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]


### PR DESCRIPTION
Minor release cutting **v0.12.0**.

Headline change since 0.11.0: **multiple antenna design sessions as sidebar tabs** (#214) — each tab is a fully independent design (geometry, knobs, freq, ground, solver slot, results), with compact `Dn` labels + a design/solver/segs/ground hover summary, and web-workbench docs.

Merging this tags `v0.12.0` on the bump commit, which triggers the publish workflow (PyPI Trusted Publishing + GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)