### PR TITLE
chore(ci): bump GitHub Actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,7 +20,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Stay green (not red) if the secret is missing: skip with a notice.
       - name: Check for Fly token

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -24,7 +24,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Stay green (not red) if the secret is missing: skip with a notice.
       - name: Check for Fly token

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,9 +21,9 @@ jobs:
     name: build sdist + wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         # No submodules: the dist is pure Python and does not build momwire.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: npm
@@ -36,14 +36,14 @@ jobs:
         run: |
           npm ci
           npm run build
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Build
         run: pipx run build
       - name: Check metadata
         run: pipx run twine check dist/*
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/*
@@ -61,7 +61,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist
@@ -79,11 +79,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist
       - name: Attach to the GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/*

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -4,7 +4,7 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: astral-sh/ruff-action@v1
         with:
           args: "check"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,9 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python 3.12
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
         cache: pip


### PR DESCRIPTION
The **v0.12.0** publish run warned that several actions target Node 20 (deprecated; runners already force them onto Node 24). This bumps each to the current major that natively runs on Node 24 — verified against each action's `action.yml` (`runs.using: node24`):

| action | before | after | note |
|---|---|---|---|
| actions/checkout | v4 | v5 | |
| actions/setup-node | v4 | v5 | |
| actions/setup-python | v4/v5 | v6 | |
| actions/upload-artifact | v4 | v7 | v5 is still node20 |
| actions/download-artifact | v4 | v8 | v5/v6 are still node20 |
| softprops/action-gh-release | v2 | v3 | |

Usage is basic (bare checkout, setup-* with version+cache, artifact name/path, release files), so no config changes are needed. `upload-artifact@v7` and `download-artifact@v8` share the v4+ artifact backend and interoperate.

Scope is the actions flagged in the deprecation notice. Others (ruff-action, gh-action-pypi-publish, ccache-action, coverage-comment, setup-flyctl) weren't flagged and are left as-is. The publish/Fly-deploy paths are tag-gated, so they'll get their first real exercise on the next `v*` tag; test + ruff run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)