### PR TITLE
test(config): scope pytest discovery to tests/ (exclude momwire submodule)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,12 @@ Homepage = "https://github.com/stevenmburns/antennaknobs"
 Issues = "https://github.com/stevenmburns/antennaknobs/issues"
 
 [tool.pytest.ini_options]
+# Only discover this project's own suite. Without this, a bare `pytest`
+# recurses from the repo root into the momwire submodule's tests, which
+# fail to collect (they import momwire's `validation` package, only on-path
+# inside the submodule's own setup). CI already passes `tests/` explicitly;
+# this makes a bare local `pytest` match, mirroring ruff's momwire exclude.
+testpaths = ["tests"]
 markers = [
     # Tests that run an antenna solver across a *catalog* of named designs
     # (e.g. tests/test_cebik_designs.py) — the same solve code path repeated


### PR DESCRIPTION
## What

Add `testpaths = ["tests"]` to `[tool.pytest.ini_options]` so pytest only discovers this project's own suite.

## Why

`momwire` is a git submodule with its own test harness. With no `testpaths`, a bare `pytest` recursed from the repo root into `momwire/tests/*`, which fail to collect — they import momwire's `validation` package, only on-path inside the submodule's own setup:

```
ModuleNotFoundError: No module named 'validation'
!!! Interrupted: 2 errors during collection !!!
```

CI was never affected — it invokes `python -m pytest ... tests/` and `coverage ... -m pytest tests/` with the path explicit. This only bit a bare local `pytest`. The fix makes local runs match CI, and mirrors the existing ruff `extend-exclude = ["momwire"]`.

## Verify

`python -m pytest --collect-only` → 1331 collected, exit 0, **zero** nodes under `momwire/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)