### PR TITLE
feat(variants): resolve variants as a recursive overlay on default_params

### DIFF
--- a/docs/plan-variant-overlay.md
+++ b/docs/plan-variant-overlay.md
@@ -1,0 +1,265 @@
+# Plan: variants as an overlay on `default_params` (incl. per-variant `ui_params`)
+
+Status: **merge mechanism landed (Option A); per-variant ui derivation still
+open.** Scoped 2026-07-03 out of the triangular-skyloop work, where we wanted a
+"band-locked" *variant* of a design but found the sweep policy is pinned
+per-design, not per-variant.
+
+**Update (2026-07-03):** built as **Option A** — a single recursive merge over
+the whole param tree — rather than the two-tier "shallow for regular params,
+deep for `ui_params`" of the original Part 1/Part 2 split. `merge_params` /
+`resolve_variant_params` live in `builder.py`; `_variant_params`
+(`web/adapter.py`) and CLI `get_builder` both delegate to the resolver. Because
+`ui_params` (a `MappingProxyType`) is the only Mapping-valued param in the
+catalog, the recursion matches on `collections.abc.Mapping` and its only real
+effect today is to deep-merge `ui_params` — so Part 1 and Part 2's *merge* are
+now one mechanism. **What remains of Part 2 is derivation only:** making
+`_make_example` read the merged per-variant `ui_params` and emitting a
+`variant_ui` descriptor (see below). Coverage: `tests/test_variants.py`.
+
+## Motivation
+
+Two problems with the current variant model:
+
+1. **Redundancy.** A named variant must re-list *every* parameter, even ones it
+   doesn't change (see delta_loop's `z100_params`/`z200_params`, which repeat
+   `design_freq`/`freq`/`base` verbatim). A variant should only need to state
+   what it overrides.
+
+2. **`ui_params` can't vary per variant.** UI hints — `sweep_policy`,
+   `default_view`, `target_z0`, `meas_freq_range`, `bands`, `layout` — are
+   derived once from `default_params.ui_params`. So there is no way to have,
+   e.g., a band-locked *variant* (band-edge sweep) alongside a wide-window
+   default variant of the same antenna.
+
+## How it works today (baseline)
+
+Variants are **full replacements**, in two independent code paths:
+
+- **Web:** `adapter._variant_params(cls, variant)` (`adapter.py:719`) returns
+  `dict(<variant>_params)` outright, falling back to `default_params`.
+  `_build_builder` (`adapter.py:443`) then iterates **only the variant's keys**
+  and overlays the live request (slider) values.
+- **CLI:** `get_builder` (`cli.py`, `name:variant` spec) binds
+  `partial(cls, params=<variant>_params)` directly.
+- **Builder:** `AntennaBuilder.__init__` does `merged = dict(FRAMEWORK_PARAMS);
+  merged.update(params)` and asserts every key is in `default_params` or
+  `FRAMEWORK_PARAMS`. The passed dict is used as-is, so it must be complete for
+  `build_wires`.
+
+Consequence: a *partial* variant would drop the request values for its missing
+keys in `_build_builder` and crash `build_wires` on a missing attribute. Variants
+are complete today only by convention.
+
+**The frontend already merges — but only values.** `selectVariant`
+(`App.tsx:1985`) seeds `seedDefaults(schema)` then overlays
+`variant_values[variant]` for present keys. So the frontend does default+variant
+overlay; the backend does full replacement. They are inconsistent, and it only
+works because variants are complete and the request re-sends every param.
+
+**`ui_params` derivation is default-only:** `_make_example` (`adapter.py:874`)
+reads `dict(cls.default_params)["ui_params"]` and derives the schema,
+`sweep_policy` (`adapter.py:924`), `default_view`, `target_z0`,
+`meas_freq_range`, `bands`, and `layout` from it. Variant `ui_params` is ignored.
+
+## Proposed change
+
+### Part 1 — variants overlay `default_params` (built as Option A: one recursive merge)
+
+Implemented in `builder.py` and delegated to from both call sites
+(`_variant_params` in `web/adapter.py`, CLI `get_builder`):
+
+```python
+def merge_params(base, over):
+    out = dict(base)
+    for k, v in over.items():
+        # Match Mapping, not dict: ui_params is a MappingProxyType, which is
+        # a Mapping but not a dict subclass.
+        if isinstance(out.get(k), Mapping) and isinstance(v, Mapping):
+            out[k] = merge_params(out[k], v)   # recurse into dicts / proxies
+        else:
+            out[k] = v                          # scalars, tuples: replace
+    return out
+
+def resolve_variant_params(cls, variant):
+    base = dict(cls.default_params)
+    if variant and variant != "default":
+        v = getattr(cls, f"{variant}_params", None)
+        if v is not None and hasattr(v, "keys"):
+            return merge_params(base, v)
+    return base
+```
+
+A single recursive rule covers the whole param tree, so the original
+"shallow-for-regular, deep-for-`ui_params`" two-tier split collapses into one
+mechanism. Since `ui_params` is the only Mapping-valued key in the catalog, this
+is behaviorally identical to that split — it just isn't special-cased.
+
+- **Backward-compatible:** overlaying a *complete* variant dict == that dict, so
+  every existing variant keeps working unchanged. Verified: `test_variants.py`
+  (complete variants reproduce themselves).
+- **Fixes the latent crash:** `_build_builder`'s `base` is now always the full
+  key set, so a partial variant is safe.
+- **Invariant preserved:** the Builder's `assert all(k in default_params …)`
+  still forbids a variant introducing a *new* param.
+- **One CLI-side behavior change:** a variant that omits `ui_params` (e.g.
+  `twoband_fan_dipole.s07_params`) now inherits `default_params["ui_params"]`
+  when built via the CLI, matching how the default (`params=None`) path already
+  builds. `test_renamed_twoband_variant` was updated to expect `default ⊕ s07`;
+  geometry is unaffected (`build_wires` ignores `ui_params`).
+
+**The recursive-merge floor (tuples are replaced, not merged).**
+The merge recurses into Mappings only; every non-Mapping value — scalars and
+the multiband `bands` **tuple of dicts** — replaces wholesale. The limit is the
+tuple representation, *not* the merge algorithm (see Option C in "Removing the
+floor" below). The multiband designs store bands as a tuple:
+
+```python
+"bands": (_BAND_17_12, _BAND_15_10),   # multiband/trap_fan_dipole
+"bands": (_BAND_20M, _BAND_17M, ...),  # multiband/hexbeam_5band
+```
+
+- ✅ Overriding a **top-level scalar** (`freq`, `base`, `angle_deg`) is safe and
+  partial — that is all the multiband variants do today.
+- ❌ You **cannot** express "override just `bands[1].trap_freq`" as a partial. A
+  variant that touches one sub-band must restate the entire `bands` tuple.
+
+The recursive merge does **not** rescue this: it recurses into Mappings, and
+`bands` is a *tuple*, not a Mapping. Positional merge-by-index into a tuple is
+ill-defined (length/`n_bands` changes, reordering, no key identity), so the
+merge deliberately replaces tuples wholesale. The trim in Part 1b therefore
+applies to top-level scalar keys; nested `bands` tuples stay whole by design.
+Covered by `test_bands_tuple_replaced_wholesale`. Acceptable (no current variant
+needs a sub-band partial), but documented so nobody assumes "variants are
+overlays now" means they can partially override inside `bands` and get a
+silently whole-tuple-replaced result. See "Removing the floor" for the escape
+hatch (convert `bands` tuple → dict keyed by band).
+
+Consumers of `_variant_params` (all verified working under merge — full
+`tests/` suite green): `_build_builder`, `_design_freq_default`, params-source
+export, `variant_values` serialization (all in `web/adapter.py`).
+
+Keep serializing `variant_values` as the full merged values (frontend overlays
+them onto `seedDefaults`, so full or overrides both work; full is the smaller
+diff).
+
+### Part 1b — trim redundant variants to their overrides
+
+Once Part 1 lands, walk the catalog and trim each `<variant>_params` down to the
+keys it actually changes. This is the redundancy the Motivation calls out, and
+the trimmed variants become the real-world proof that partial overlay works —
+i.e. the regression the new `tests/test_variants.py` case is meant to guard.
+
+**Sequence it as its own commit, after Part 1 — not bundled in.** Part 1's whole
+safety argument is "overlaying a *complete* variant == that variant, so
+`test_variants.py` passes unchanged." That invariant is what makes the mechanism
+change auditable. Trimming in the same commit exercises a new merge path *and*
+newly-partial data at once, so a failure can't be localized. Land the mechanism
+first (variants still complete, tests prove overlay ≡ replacement), then trim.
+
+Flat targets (top-level scalar overrides — all safe under the recursive merge):
+
+- `loops/delta_loop.py` — `z100_params` is **byte-for-byte identical** to
+  `default_params` → trims to `{}`. `z200_params` → `{length_factor, angle_deg}`.
+- `multiband/trap_fan_dipole.py` — all four variants are `{**default_params,
+  "freq": X}` by construction → each trims to a single `{"freq": X}`.
+- `dipoles/invvee.py`, `specialty/hentenna_slant.py`, `arrays/delta_looparray.py`
+  — flat scalar variants; trim to their deltas.
+
+Do **not** attempt to trim inside `bands` tuples (see the shallow-overlay floor
+under Part 1) — those stay whole.
+
+### Part 2 — per-variant `ui_params` (per-field override)
+
+**The merge half is done** (Option A above): a variant's `ui_params` already
+deep-merges over the default's — `test_ui_params_deep_merge` proves a variant
+carrying only `{"ui_params": {"sweep_policy": {"band_locked": True}}}` inherits
+the default `anchor`/`lo_factor`/`hi_factor` and flips only `band_locked`. **What
+remains is derivation:** the ui-derived hints must be recomputed *per variant*
+and exposed to the frontend. Today `_make_example` still derives them from the
+default only.
+
+- **Merge depth (settled):** recursive Mapping-merge for the `ui_params`
+  subtree. Tradeoff: you can add/override nested fields but cannot *replace* a
+  whole nested dict wholesale — acceptable; documented. A `band_locked_params`
+  variant carries *only* `ui_params`, so all regular params come from default.
+
+- **Adapter:** `_make_example` computes `sweep_policy` (and optionally
+  `default_view`, etc.) **per variant** by merging each variant's `ui_params`
+  over the default's. Emit a new descriptor field:
+
+  ```
+  variant_ui: { <variant>: { sweep_policy: SweepPolicy, ... }, ... }
+  ```
+
+  Keep the existing top-level fields as the **default** variant's values for
+  backward compat. Design `variant_ui` as an extensible per-variant map so more
+  hints can move per-variant later without another `/examples` contract change.
+
+- **Server:** serialize `variant_ui` in the `/examples` payload.
+
+- **Frontend:** look up by active variant, falling back to the design-level value:
+
+  ```ts
+  const policy =
+    currentExample.variant_ui?.[currentVariant]?.sweep_policy
+    ?? currentExample.sweep_policy;
+  ```
+
+  Add the `variant_ui` type. (`App.tsx:3037` is the sweep-policy read site.)
+
+## Scope decision to settle before building Part 2
+
+Keep the per-variant override to `sweep_policy` (+ maybe `default_view`) only,
+or make *all* ui hints variant-aware? Recommendation: start narrow
+(`sweep_policy`) behind the extensible `variant_ui` map; generalize when a second
+real use case appears. The schema itself stays derived from `default_params`
+(one rendered form); variants override values + ui hints, not structure.
+
+## Removing the floor (only if a sub-band partial is ever needed)
+
+The floor is imposed by the `bands` *tuple* representation, not the merge. Three
+options were weighed:
+
+- **A (built):** one recursive Mapping-merge. Uniform semantics, but tuples still
+  replace wholesale — the floor stays.
+- **B (rejected):** teach the merge to descend into tuples positionally. Removes
+  the floor but fakes key-identity the data doesn't have — `n_bands`/length
+  changes become ambiguous, reordering silently corrupts, needs a no-op sentinel
+  per slot. Not worth it.
+- **C (deferred escape hatch):** change the data shape — `bands` tuple → dict
+  keyed by band (`{"17_12": {...}, "15_10": {...}}`). Then A's recursive merge
+  works at every depth with explicit identity. Cost is a data-model migration
+  through the machinery that assumes positional bands: multiband `build_wires`
+  iteration, the schema adapter's `ParamGroupSpec`/`repeat_count`/`max_repeats`,
+  the frontend's preallocated group instances, and serialization. Do this only
+  when a real sub-band-partial use case appears.
+
+## Effort / risk / sequencing
+
+| Part | Scope | Risk | Effort | Status |
+|------|-------|------|--------|--------|
+| 1 | `merge_params`/`resolve_variant_params` in `builder.py`; `_variant_params` + CLI delegate; `tests/test_variants.py` | Low — backward-compatible, and fixes the partial-variant crash | ~1–2h | **done** |
+| 1b | trim redundant variants to their overrides | Low | ~1h | not started |
+| 2 | per-variant ui *derivation* + `variant_ui` descriptor field + serialize + frontend lookup + types (merge already done) | Medium — changes the `/examples` contract | ~½ day | not started |
+
+**Sequence:** Part 1 landed. Part 1b (trim) and Part 2 (derivation) both build on
+it and are independent of each other. The **band-locked skyloop variant** lands
+as a 3-line `band_locked_params` on `loops.triangular_skyloop` once Part 2's
+derivation is in.
+
+## Test impact
+
+- `tests/test_variants.py` — primary coverage. Extended with overlay-semantics
+  tests: partial overlay, partial ≡ full equivalent, complete-reproduces-self,
+  `ui_params` deep-merge, and `bands`-tuple-replaced-wholesale (the floor).
+  `test_renamed_twoband_variant` updated for the `ui_params`-inheritance change.
+- Web: `tests/test_web_server.py` / `test_design_schemas.py` for the `/examples`
+  descriptor shape after Part 2 (`variant_ui`).
+
+## Interim option (if the band-locked skyloop is wanted before this lands)
+
+A separate sibling design `loops.triangular_skyloop_banded` that subclasses the
+base Builder and overrides only `default_params.ui_params` to add
+`sweep_policy: {band_locked: True}`. Works today with no architecture change, but
+shows as its own antenna in the catalog rather than a variant of the existing one.

--- a/src/antennaknobs/__init__.py
+++ b/src/antennaknobs/__init__.py
@@ -8,6 +8,8 @@ __all__ = [
     "Array2x4Builder",
     "Array1x4Builder",
     "Array1x4GroupedBuilder",
+    "merge_params",
+    "resolve_variant_params",
     "plot_patterns",
     "compare_patterns",
     "pattern_metrics",
@@ -31,6 +33,8 @@ from .builder import (
     Array2x4Builder,
     Array1x4Builder,
     Array1x4GroupedBuilder,
+    merge_params,
+    resolve_variant_params,
 )
 from .transform import Transform, TransformStack
 from .drone import Drone

--- a/src/antennaknobs/builder.py
+++ b/src/antennaknobs/builder.py
@@ -1,3 +1,5 @@
+from collections.abc import Mapping
+
 from .core import save_or_show
 import numpy as np
 
@@ -5,6 +7,46 @@ import numpy as np
 # draw() below — it costs ~0.1 s to import and only the drawing path needs it,
 # so keeping it off module import keeps `import antennaknobs` and web startup
 # (which never plots) lean.
+
+
+def merge_params(base, over):
+    """Recursively overlay ``over`` onto a copy of ``base``.
+
+    Dict values merge key-by-key at any depth; every other value replaces
+    wholesale. In practice ``ui_params`` (the only dict-valued param in the
+    catalog) deep-merges, so a variant can flip one nested ui hint without
+    restating the subtree, while scalars and the multiband ``bands`` *tuple*
+    replace as a unit. That tuple is the shallow-overlay "floor": a variant
+    that touches one sub-band must restate the whole ``bands`` tuple, because
+    a positional tuple has no key identity to merge on.
+    """
+    out = dict(base)
+    for k, v in over.items():
+        # Match Mapping, not dict: the catalog stores ui_params as
+        # MappingProxyType, which is a Mapping but not a dict subclass.
+        if isinstance(out.get(k), Mapping) and isinstance(v, Mapping):
+            out[k] = merge_params(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
+def resolve_variant_params(cls, variant):
+    """Seed params for the named variant, as an overlay on ``default_params``.
+
+    A variant lists only the keys it changes; the rest come from
+    ``default_params``. Overlaying a *complete* variant dict reproduces that
+    dict verbatim, so variants written before this became an overlay resolve
+    identically. Falls back to ``default_params`` when ``variant`` is falsy,
+    ``"default"``, or names no resolvable ``<variant>_params`` attribute
+    (stale frontend / unknown name).
+    """
+    base = dict(cls.default_params)
+    if variant and variant != "default":
+        v = getattr(cls, f"{variant}_params", None)
+        if v is not None and hasattr(v, "keys"):
+            return merge_params(base, v)
+    return base
 
 
 class AntennaBuilder:

--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -1,6 +1,6 @@
 from functools import partial
 
-from . import AntennaBuilder
+from . import AntennaBuilder, resolve_variant_params
 from . import (
     sweep,
     sweep_gain,
@@ -201,7 +201,11 @@ def get_builder(nm):
         raise ValueError(
             f"builder {name!r} has no variant {variant!r}; available: {available}"
         )
-    return partial(cls, params=params)
+    # Overlay the variant on default_params so a partial variant (only the
+    # keys it changes) resolves to a complete param set; a complete variant
+    # reproduces itself. Keep the getattr check above so an unknown variant
+    # name stays a hard error rather than silently falling back to default.
+    return partial(cls, params=resolve_variant_params(cls, variant))
 
 
 def get_builders(nms):

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -51,6 +51,7 @@ from antennaknobs.builder import (
     Array1x4GroupedBuilder,
     Array2x2Builder,
     Array2x4Builder,
+    resolve_variant_params,
 )
 
 try:
@@ -717,14 +718,13 @@ def _serialize_param_values(params: dict) -> dict:
 
 
 def _variant_params(cls, variant: str | None) -> dict:
-    """Return the seed params dict for the named variant. Falls back to
-    `default_params` when variant is None or doesn't resolve to an
-    attribute (stale frontend, unknown name)."""
-    if variant:
-        params = getattr(cls, f"{variant}_params", None)
-        if params is not None and hasattr(params, "keys"):
-            return dict(params)
-    return dict(cls.default_params)
+    """Return the seed params dict for the named variant, overlaid on
+    `default_params` (see `resolve_variant_params`). A variant need only
+    list the keys it overrides — including nested `ui_params` hints, which
+    deep-merge — and missing keys come from `default_params`. Falls back to
+    `default_params` when variant is None, "default", or doesn't resolve to
+    an attribute (stale frontend, unknown name)."""
+    return resolve_variant_params(cls, variant)
 
 
 def _ui_scalar(default_params: dict, key: str, default):

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -1,5 +1,8 @@
+from types import MappingProxyType
+
 import pytest
 
+from antennaknobs import AntennaBuilder, resolve_variant_params
 from antennaknobs.cli import get_builder, list_variants
 from antennaknobs.designs.beams import hexbeam, moxon
 from antennaknobs.designs.multiband import twoband_fan_dipole
@@ -38,9 +41,16 @@ def test_variant_on_moxon_original():
 
 
 def test_renamed_twoband_variant():
+    # s07_params is complete in regular params but omits `ui_params`; under
+    # the overlay it inherits `default_params["ui_params"]` (matching how the
+    # default path already builds), so the resolved set is default ⊕ s07.
     factory = get_builder("twoband_fan_dipole:s07")
     inst = factory()
-    assert _design_params(inst) == dict(twoband_fan_dipole.Builder.s07_params)
+    expected = {
+        **dict(twoband_fan_dipole.Builder.default_params),
+        **dict(twoband_fan_dipole.Builder.s07_params),
+    }
+    assert _design_params(inst) == expected
 
 
 def test_renamed_specialty_variant():
@@ -70,3 +80,95 @@ def test_list_variants_for_hexbeam():
 
 def test_list_variants_for_moxon():
     assert list_variants(moxon.Builder) == ["default", "opt", "original"]
+
+
+# --- overlay semantics (Option A: recursive merge over default_params) ---
+
+
+def test_partial_variant_overlays_default():
+    """A partial variant inherits every key it doesn't state from default."""
+
+    class B(AntennaBuilder):
+        default_params = MappingProxyType(
+            {"freq": 14.0, "length_factor": 1.00, "base": 7.0}
+        )
+        partial_params = MappingProxyType({"length_factor": 1.08})
+
+    merged = resolve_variant_params(B, "partial")
+    assert merged == {"freq": 14.0, "length_factor": 1.08, "base": 7.0}
+
+
+def test_partial_variant_solves_like_full_equivalent():
+    """The regression the overlay is meant to make safe: a partial variant
+    (only the changed key) resolves identically to the equivalent full one."""
+
+    class B(AntennaBuilder):
+        default_params = MappingProxyType(
+            {"freq": 14.0, "length_factor": 1.00, "base": 7.0}
+        )
+        partial_params = MappingProxyType({"length_factor": 1.08})
+        full_params = MappingProxyType(
+            {"freq": 14.0, "length_factor": 1.08, "base": 7.0}
+        )
+
+    assert resolve_variant_params(B, "partial") == resolve_variant_params(B, "full")
+
+
+def test_complete_variant_reproduces_itself():
+    """Overlaying a complete variant equals that variant — the backward-compat
+    guarantee for every pre-overlay variant in the catalog."""
+
+    class B(AntennaBuilder):
+        default_params = MappingProxyType({"freq": 14.0, "length_factor": 1.00})
+        v_params = MappingProxyType({"freq": 28.0, "length_factor": 1.08})
+
+    assert resolve_variant_params(B, "v") == dict(B.v_params)
+
+
+def test_ui_params_deep_merge():
+    """The one dict-valued param deep-merges: a variant flips a nested ui hint
+    without restating the subtree."""
+
+    class B(AntennaBuilder):
+        default_params = MappingProxyType(
+            {
+                "freq": 14.0,
+                "ui_params": MappingProxyType(
+                    {
+                        "sweep_policy": MappingProxyType(
+                            {"anchor": "center", "band_locked": False}
+                        )
+                    }
+                ),
+            }
+        )
+        banded_params = MappingProxyType(
+            {
+                "ui_params": MappingProxyType(
+                    {"sweep_policy": MappingProxyType({"band_locked": True})}
+                )
+            }
+        )
+
+    merged = resolve_variant_params(B, "banded")
+    # inherited anchor, flipped band_locked, regular params untouched
+    assert merged["freq"] == 14.0
+    assert merged["ui_params"]["sweep_policy"] == {
+        "anchor": "center",
+        "band_locked": True,
+    }
+
+
+def test_bands_tuple_replaced_wholesale():
+    """The shallow-overlay floor: `bands` is a positional tuple, so a variant
+    overriding it replaces the whole tuple rather than merging per-band."""
+
+    class B(AntennaBuilder):
+        default_params = MappingProxyType(
+            {"n_bands": 2, "bands": ({"freq": 14.0}, {"freq": 21.0})}
+        )
+        one_band_params = MappingProxyType({"bands": ({"freq": 18.0},)})
+
+    merged = resolve_variant_params(B, "one_band")
+    assert merged["bands"] == ({"freq": 18.0},)  # not merged with the default pair
+    assert merged["n_bands"] == 2  # untouched scalar still inherited


### PR DESCRIPTION
## Problem

Variants were **full replacements**: a named variant had to re-list every param, and a *partial* variant would drop the request values for its missing keys in `_build_builder` and crash `build_wires` on a missing attribute. Variants were complete only by convention. Separately, the web frontend already did default+variant *value* overlay while the backend did full replacement — an inconsistency that only worked because variants were complete and every param was re-sent.

## Change (Option A — one recursive merge)

Resolve a variant as a single **recursive merge over `default_params`** — a variant states only what it overrides; a *complete* variant reproduces itself, so every existing variant keeps working unchanged.

- `merge_params` / `resolve_variant_params` live in `builder.py` (exported from the package).
- Both call sites delegate: `_variant_params` (`web/adapter.py`) and CLI `get_builder` (`cli.py`, which keeps its explicit unknown-variant error).
- The merge matches `collections.abc.Mapping` — **not** `dict` — because the catalog stores `ui_params` as `MappingProxyType`, which is a Mapping but not a `dict` subclass. So `ui_params` deep-merges, while scalars and the multiband `bands` **tuple** replace wholesale (the documented "tuple floor" — the limit is the positional-tuple representation, not the merge).

This collapses the originally-planned two-tier split (shallow-for-regular + deep-for-`ui_params`) into one uniform rule; since `ui_params` is the only Mapping-valued param in the catalog, it's behaviorally equivalent.

## One intentional behavior change

A variant that omits `ui_params` (e.g. `twoband_fan_dipole.s07_params`) now inherits `default_params["ui_params"]` when built via the CLI — matching how the default (`params=None`) path already builds. This *removes* a pre-existing asymmetry. Geometry is unaffected (`build_wires` ignores `ui_params`). `test_renamed_twoband_variant` updated to expect `default ⊕ s07`.

## Tests

`tests/test_variants.py` gains overlay-semantics coverage:
- partial variant overlays default; partial ≡ full equivalent (the crash-regression this makes safe)
- complete variant reproduces itself (backward-compat guarantee)
- `ui_params` deep-merge (band-locked-style nested override)
- `bands` tuple replaced wholesale (the floor)

Full `tests/` suite green (1331 passed).

## Follow-ups (deliberately not in this PR)

- **Part 1b** — trim the now-redundant complete variants down to their overrides.
- **Part 2** — per-variant ui *derivation* (`variant_ui` descriptor + frontend lookup); the merge half is already done here. This is what unlocks the band-locked skyloop variant.

Design notes updated in `docs/plan-variant-overlay.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)