### PR TITLE
refactor(designs): trim variants to their overrides (Part 1b)

### DIFF
--- a/docs/plan-variant-overlay.md
+++ b/docs/plan-variant-overlay.md
@@ -169,6 +169,48 @@ Flat targets (top-level scalar overrides — all safe under the recursive merge)
 Do **not** attempt to trim inside `bands` tuples (see the shallow-overlay floor
 under Part 1) — those stay whole.
 
+**Landed (2026-07-03):** 254 stated keys → 130 across all 40 variants; every
+variant's fully-resolved params verified byte-identical (numeric equality)
+before/after via a snapshot of `resolve_variant_params` over all 113 (design,
+variant) pairs. See Part 1c for a latent-crash class this surfaced.
+
+### Part 1c — make `AntennaBuilder.__init__` overlay-aware (follow-up, not yet built)
+
+Trimming surfaced a latent crash on a path Part 1 did **not** cover. Part 1 made
+the *resolvers* (`resolve_variant_params`, `_variant_params`, CLI `get_builder`)
+overlay-aware, but **direct construction** — `cls(cls.<variant>_params)` — passes
+the raw dict straight to `AntennaBuilder.__init__`, which replaces rather than
+overlays. While variants were complete this worked by accident; once trimmed to
+partial dicts, `build_wires` crashes on the missing keys (`self.base`, etc.).
+
+Part 1b fixed the *consumers* (all in tests — `src/` already routes through the
+resolvers): `test_nec_export`, `test_momwire_engine`, `test_drone` constructed
+Builders directly from a variant dict as a convenient "complete preset", now
+resolve the variant first.
+
+The deeper fix is to make `__init__` itself overlay a partial `params` on
+`default_params` (reusing `merge_params`), so `cls(partial_dict)` is safe
+everywhere and this whole bug class disappears:
+
+```python
+def __init__(self, params=None):
+    merged = dict(self.FRAMEWORK_PARAMS)
+    if params is None:
+        merged.update(self.__class__.default_params)
+    else:
+        merged.update(merge_params(self.__class__.default_params, params))
+    ...
+```
+
+**Why it's a separate PR, not folded into Part 1b:** it's a Builder-semantics
+change with a real interaction to settle first — the web adapter's `_build_builder`
+calls `_strip_ui(...)` to drop `ui_params` before `cls(params=base)`; if
+`__init__` then overlays on `default_params` (which *has* `ui_params`), the
+Builder would silently re-inherit `ui_params`. Harmless in principle (build_wires
+ignores it) but it needs verifying against the web path before landing. Backward
+-compat otherwise holds: a complete dict overlaid on default equals itself, and a
+partial dict was already a latent crash, so nothing depends on the old behavior.
+
 ### Part 2 — per-variant `ui_params` (per-field override)
 
 **The merge half is done** (Option A above): a variant's `ui_params` already

--- a/src/antennaknobs/designs/arrays/delta_looparray.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray.py
@@ -21,40 +21,16 @@ class Builder(Array1x2Builder):
     # These were formerly suffixed `_dz2`; the del_z=2 they carried was an inert
     # rigid lift on this single-row 1x2 array (see Array1x2Builder) and has been
     # removed, so the variants are named by their distinguishing del_y.
+    # Element-spacing variants overlay default_params; each states only its
+    # top-leg tuning and del_y (design_freq / freq / base / phase_lr default).
     dy35_params = MappingProxyType(
-        {
-            "design_freq": 28.47,
-            "freq": 28.47,
-            "length_factor_top": 1.0843,
-            "angle_deg_top": 65.0422,
-            "base": 7.0,
-            "del_y": 3.5,
-            "phase_lr": 0.0,
-        }
+        {"length_factor_top": 1.0843, "angle_deg_top": 65.0422, "del_y": 3.5}
     )
-
     dy45_params = MappingProxyType(
-        {
-            "design_freq": 28.47,
-            "freq": 28.47,
-            "length_factor_top": 1.0801,
-            "angle_deg_top": 63.2603,
-            "base": 7.0,
-            "del_y": 4.5,
-            "phase_lr": 0.0,
-        }
+        {"length_factor_top": 1.0801, "angle_deg_top": 63.2603, "del_y": 4.5}
     )
-
     dy3_params = MappingProxyType(
-        {
-            "design_freq": 28.47,
-            "freq": 28.47,
-            "length_factor_top": 1.0801,
-            "angle_deg_top": 63.2603,
-            "base": 7.0,
-            "del_y": 3,
-            "phase_lr": 0.0,
-        }
+        {"length_factor_top": 1.0801, "angle_deg_top": 63.2603, "del_y": 3}
     )
 
     def __init__(self, params=None):

--- a/src/antennaknobs/designs/arrays/invveearray.py
+++ b/src/antennaknobs/designs/arrays/invveearray.py
@@ -11,19 +11,14 @@ class Builder(Array2x2Builder):
     #   length_factor = (length / 2) / (0.25 · λ_design)
     #                 = 2.542 / 2.6325 = 0.9656
     #   angle_deg = degrees(atan(slope)) = degrees(atan(0.604)) = 31.1345
+    # Overlays default_params; states only the leg tuning that differs (freq,
+    # base, spacing, and phases come from default).
     old_params = MappingProxyType(
         {
-            "design_freq": 28.47,
-            "freq": 28.47,
-            "base": 7.0,
             "length_factor_top": 0.9656,
             "length_factor_bot": 0.9656,
             "angle_deg_top": 31.1345,
             "angle_deg_bot": 31.1345,
-            "del_y": 4.0,
-            "del_z": 2,
-            "phase_lr": 0.0,
-            "phase_tb": 0.0,
         }
     )
 

--- a/src/antennaknobs/designs/beams/hexbeam.py
+++ b/src/antennaknobs/designs/beams/hexbeam.py
@@ -14,10 +14,10 @@ class Builder(AntennaBuilder):
         }
     )
 
+    # Overlays default_params; base comes from default.
     opt_params = MappingProxyType(
         {
             "freq": 28.57,
-            "base": 7.0,
             "halfdriver": 2.782539354535098,
             "tipspacer_factor": 0.20803460322922357,
             "t0_factor": 0.07058920808116927,

--- a/src/antennaknobs/designs/beams/moxon.py
+++ b/src/antennaknobs/designs/beams/moxon.py
@@ -3,12 +3,11 @@ from types import MappingProxyType
 
 
 class Builder(AntennaBuilder):
+    # Variants overlay default_params; each states only the driver geometry
+    # that differs (freq, base, aspect_ratio come from default).
     original_params = MappingProxyType(
         {
-            "freq": 28.57,
-            "base": 7.0,
             "halfdriver": (147.25 / 2 + 22 + 3 / 16) * 0.0254,
-            "aspect_ratio": (53 + 11 / 16) / 147.25,
             "tipspacer_factor": (4 + 1 / 16) / (53 + 11 / 16),
             "t0_factor": (22 + 3 / 16) / (53 + 11 / 16),
         }
@@ -27,10 +26,7 @@ class Builder(AntennaBuilder):
 
     opt_params = MappingProxyType(
         {
-            "freq": 28.57,
-            "base": 7.0,
             "halfdriver": 2.4454699666515394,
-            "aspect_ratio": 0.3646010186757216,
             "tipspacer_factor": 0.047061074343758946,
             "t0_factor": 0.42268888502818136,
         }

--- a/src/antennaknobs/designs/dipoles/invvee.py
+++ b/src/antennaknobs/designs/dipoles/invvee.py
@@ -32,15 +32,9 @@ class Builder(AntennaBuilder):
     # resonance (Z ≈ 66 + j1 Ω). Equivalent to the old top-level
     # dipole.py geometry, now reachable as the "dipole" variant on
     # dipoles.invvee.
-    dipole_params = MappingProxyType(
-        {
-            "design_freq": 28.47,
-            "freq": 28.47,
-            "base": 7.0,
-            "length_factor": 0.967,
-            "angle_deg": 0.0,
-        }
-    )
+    # Variants overlay default_params; each states only its length_factor /
+    # angle_deg tuning (design_freq / freq / base come from default).
+    dipole_params = MappingProxyType({"length_factor": 0.967, "angle_deg": 0.0})
 
     # Three-halves dipole: 1.484λ-long flat dipole, tuned to a near-
     # resonant length where Z_in collapses to ~95 Ω (real). Not the
@@ -52,15 +46,7 @@ class Builder(AntennaBuilder):
     # length_factor parameterises driver_y as 0.25·λ·length_factor, so
     # this 0.7422·λ driver_y lands at length_factor = 0.7422 / 0.25 =
     # 2.9688 (giving 2 × 0.7422 = 1.4844λ total length).
-    three_halves_params = MappingProxyType(
-        {
-            "design_freq": 28.47,
-            "freq": 28.47,
-            "base": 7.0,
-            "length_factor": 2.9688,
-            "angle_deg": 0.0,
-        }
-    )
+    three_halves_params = MappingProxyType({"length_factor": 2.9688, "angle_deg": 0.0})
 
     # Classic Extended Double Zepp: 1.28λ total length (driver_y =
     # 0.64λ per leg → length_factor = 0.64 / 0.25 = 2.56). Tuned for
@@ -68,15 +54,7 @@ class Builder(AntennaBuilder):
     # above ~1λ anti-resonance, so the input impedance is high and
     # very reactive (≈ 100 − j600 Ω at the design freq) and a matching
     # network is required.
-    classic_edz_params = MappingProxyType(
-        {
-            "design_freq": 28.47,
-            "freq": 28.47,
-            "base": 7.0,
-            "length_factor": 2.56,
-            "angle_deg": 0.0,
-        }
-    )
+    classic_edz_params = MappingProxyType({"length_factor": 2.56, "angle_deg": 0.0})
 
     def build_wires(self):
         eps = 0.05

--- a/src/antennaknobs/designs/loops/delta_loop.py
+++ b/src/antennaknobs/designs/loops/delta_loop.py
@@ -5,26 +5,6 @@ from ... import AntennaBuilder
 
 
 class Builder(AntennaBuilder):
-    z100_params = MappingProxyType(
-        {
-            "design_freq": 28.47,
-            "freq": 28.47,
-            "base": 7.0,
-            "length_factor": 1.0800,
-            "angle_deg": 62.3894,
-        }
-    )
-
-    z200_params = MappingProxyType(
-        {
-            "design_freq": 28.47,
-            "freq": 28.47,
-            "base": 7.0,
-            "length_factor": 1.0650,
-            "angle_deg": 43.9516,
-        }
-    )
-
     default_params = MappingProxyType(
         {
             "design_freq": 28.47,
@@ -34,6 +14,12 @@ class Builder(AntennaBuilder):
             "angle_deg": 62.3894,
         }
     )
+
+    # Feed-point variants overlay default_params (only the tuning that differs).
+    # z100 (100 Ω feed) is the design default; z200 (200 Ω feed) lowers the apex
+    # angle and shortens the loop.
+    z100_params = default_params
+    z200_params = MappingProxyType({"length_factor": 1.0650, "angle_deg": 43.9516})
 
     def build_wires(self):
         eps = 0.05

--- a/src/antennaknobs/designs/loops/delta_loop_slanted.py
+++ b/src/antennaknobs/designs/loops/delta_loop_slanted.py
@@ -18,26 +18,13 @@ class Builder(AntennaBuilder):
         }
     )
 
+    # Slant variants overlay default_params (only the tuning that differs);
+    # default is the 15° slant.
     slant30_params = MappingProxyType(
-        {
-            "design_freq": 28.47,
-            "freq": 28.47,
-            "base": 7.0,
-            "length_factor": 1.0850,
-            "angle_deg": 66.4918,
-            "slant_deg": 30,
-        }
+        {"length_factor": 1.0850, "angle_deg": 66.4918, "slant_deg": 30}
     )
-
     slant0_params = MappingProxyType(
-        {
-            "design_freq": 28.47,
-            "freq": 28.47,
-            "base": 7.0,
-            "length_factor": 1.0839,
-            "angle_deg": 61.4669,
-            "slant_deg": 0,
-        }
+        {"length_factor": 1.0839, "angle_deg": 61.4669, "slant_deg": 0}
     )
 
     def build_wires(self):

--- a/src/antennaknobs/designs/loops/diamond_loop.py
+++ b/src/antennaknobs/designs/loops/diamond_loop.py
@@ -5,26 +5,6 @@ from types import MappingProxyType
 
 
 class Builder(AntennaBuilder):
-    z100_params = MappingProxyType(
-        {
-            "design_freq": 28.47,
-            "freq": 28.47,
-            "base": 7.0,
-            "length_factor": 1.0724,
-            "angle_deg": 51.4573,
-        }
-    )
-
-    z200_params = MappingProxyType(
-        {
-            "design_freq": 28.47,
-            "freq": 28.47,
-            "base": 7.0,
-            "length_factor": 1.0703,
-            "angle_deg": 30.8767,
-        }
-    )
-
     default_params = MappingProxyType(
         {
             "design_freq": 28.47,
@@ -34,6 +14,12 @@ class Builder(AntennaBuilder):
             "angle_deg": 30.8767,
         }
     )
+
+    # Feed-point variants overlay default_params (only the tuning that differs).
+    # z200 (200 Ω feed) is the design default; z100 (100 Ω feed) raises the apex
+    # angle.
+    z100_params = MappingProxyType({"length_factor": 1.0724, "angle_deg": 51.4573})
+    z200_params = default_params
 
     def build_wires(self):
         eps = 0.05

--- a/src/antennaknobs/designs/loops/inv_delta_loop.py
+++ b/src/antennaknobs/designs/loops/inv_delta_loop.py
@@ -5,26 +5,6 @@ from types import MappingProxyType
 
 
 class Builder(AntennaBuilder):
-    z100_params = MappingProxyType(
-        {
-            "design_freq": 28.47,
-            "freq": 28.47,
-            "base": 7.0,
-            "length_factor": 1.0828,
-            "angle_deg": 64.6526,
-        }
-    )
-
-    z200_params = MappingProxyType(
-        {
-            "design_freq": 28.47,
-            "freq": 28.47,
-            "base": 7.0,
-            "length_factor": 1.0787,
-            "angle_deg": 47.2805,
-        }
-    )
-
     default_params = MappingProxyType(
         {
             "design_freq": 28.47,
@@ -34,6 +14,12 @@ class Builder(AntennaBuilder):
             "angle_deg": 64.6526,
         }
     )
+
+    # Feed-point variants overlay default_params (only the tuning that differs).
+    # z100 (100 Ω feed) is the design default; z200 (200 Ω feed) lowers the apex
+    # angle and shortens the loop.
+    z100_params = default_params
+    z200_params = MappingProxyType({"length_factor": 1.0787, "angle_deg": 47.2805})
 
     def build_wires(self):
         eps = 0.05

--- a/src/antennaknobs/designs/multiband/fandipole.py
+++ b/src/antennaknobs/designs/multiband/fandipole.py
@@ -88,11 +88,11 @@ class Builder(AntennaBuilder):
     # 17m/15m pair — the two active bands first, remaining slots padded
     # with the other bands so bumping n_bands back up reveals a sensible
     # 5-band fall-back instead of empty placeholders.
+    # Pair variants overlay default_params (base / angle_deg come from default);
+    # each drops n_bands to 2 and reorders the band tuple to lead with its pair.
     pair_17_15_params = MappingProxyType(
         {
             "freq": _BAND_15M["freq"],
-            "base": 7.0,
-            "angle_deg": 26.5651,
             "n_bands": 2,
             "bands": (_BAND_17M, _BAND_15M, _BAND_20M, _BAND_12M, _BAND_10M),
         }
@@ -102,8 +102,6 @@ class Builder(AntennaBuilder):
     pair_12_10_params = MappingProxyType(
         {
             "freq": _BAND_10M["freq"],
-            "base": 7.0,
-            "angle_deg": 26.5651,
             "n_bands": 2,
             "bands": (_BAND_12M, _BAND_10M, _BAND_20M, _BAND_17M, _BAND_15M),
         }

--- a/src/antennaknobs/designs/multiband/hexbeam_5band.py
+++ b/src/antennaknobs/designs/multiband/hexbeam_5band.py
@@ -256,14 +256,11 @@ class Builder(AntennaBuilder):
 
     # Sequential single-band tune against Z = 50 + 0j on PyNEC.
     # See _BAND_*_OPT comment and scripts/tune_hexbeam_5band_band.py.
+    # Tuned variants overlay default_params, differing only in the per-band
+    # shape factors (design_freq / freq / base / z_spacing / daisy_chain /
+    # n_bands all come from default).
     opt_params = MappingProxyType(
         {
-            "design_freq": 14.300,
-            "freq": 14.300,
-            "base": 7.0,
-            "z_spacing": 0.2,
-            "daisy_chain": False,
-            "n_bands": _MAX_BANDS,
             "bands": (
                 _BAND_20M_OPT,
                 _BAND_17M_OPT,
@@ -277,12 +274,6 @@ class Builder(AntennaBuilder):
     # Coupled multi-band tune; see _BAND_*_COUPLED comment.
     opt_coupled_params = MappingProxyType(
         {
-            "design_freq": 14.300,
-            "freq": 14.300,
-            "base": 7.0,
-            "z_spacing": 0.2,
-            "daisy_chain": False,
-            "n_bands": _MAX_BANDS,
             "bands": (
                 _BAND_20M_COUPLED,
                 _BAND_17M_COUPLED,

--- a/src/antennaknobs/designs/multiband/trap_fan_dipole.py
+++ b/src/antennaknobs/designs/multiband/trap_fan_dipole.py
@@ -221,18 +221,12 @@ class Builder(AntennaBuilder):
     # drives the right resonance into place. Used to refine defaults; once
     # the optimized length factors are folded back into the `bands` tuple
     # above these are just convenience entry points.
-    band0_inner_params = MappingProxyType(
-        {**default_params, "freq": _BAND_17_12["trap_freq"]}
-    )
-    band1_inner_params = MappingProxyType(
-        {**default_params, "freq": _BAND_15_10["trap_freq"]}
-    )
-    band0_full_params = MappingProxyType(
-        {**default_params, "freq": _BAND_17_12["full_freq"]}
-    )
-    band1_full_params = MappingProxyType(
-        {**default_params, "freq": _BAND_15_10["full_freq"]}
-    )
+    # Overlay default_params, anchoring only `freq` (band1_inner's target
+    # equals the default freq, so it resolves back to the default geometry).
+    band0_inner_params = MappingProxyType({"freq": _BAND_17_12["trap_freq"]})
+    band1_inner_params = MappingProxyType({"freq": _BAND_15_10["trap_freq"]})
+    band0_full_params = MappingProxyType({"freq": _BAND_17_12["full_freq"]})
+    band1_full_params = MappingProxyType({"freq": _BAND_15_10["full_freq"]})
 
     def build_wires(self):
         eps = 0.01

--- a/src/antennaknobs/designs/multiband/twoband_fan_dipole.py
+++ b/src/antennaknobs/designs/multiband/twoband_fan_dipole.py
@@ -25,8 +25,10 @@ from antennaknobs import AntennaBuilder
 logger = logging.getLogger(__name__)
 
 
-def _variant(freq, s, eps, *, len12, freq12, len10, freq10, base=7.0, angle=26.5651):
-    """A value-preset dict in the grouped (bands) shape.
+def _variant(freq, s, eps, *, len12, freq12, len10, freq10, angle=26.5651):
+    """A value-preset dict in the grouped (bands) shape, as an overlay on
+    default_params — it states only the swept knobs (freq / s / eps) and the
+    per-band lengths; base / gap_angle_deg / n_bands come from default.
 
     Band 0 is the 12m element (fans to +x), band 1 the 10m element (-x), matching
     the original A/B placement so geometry is unchanged by the regrouping.
@@ -34,11 +36,8 @@ def _variant(freq, s, eps, *, len12, freq12, len10, freq10, base=7.0, angle=26.5
     return MappingProxyType(
         {
             "freq": freq,
-            "base": base,
-            "gap_angle_deg": 0.0,
             "s": s,
             "eps": eps,
-            "n_bands": 2,
             # Plain dicts (NOT MappingProxyType): the adapter detects a band
             # group via isinstance(x, dict), which MappingProxyType fails.
             "bands": (

--- a/src/antennaknobs/designs/specialty/hentenna.py
+++ b/src/antennaknobs/designs/specialty/hentenna.py
@@ -5,11 +5,10 @@ from types import MappingProxyType
 
 
 class Builder(AntennaBuilder):
+    # z100 (100 Ω feed) overlays default_params (= z50, the 50 Ω tuning);
+    # it states only the shape factors that differ.
     z100_params = MappingProxyType(
         {
-            "design_freq": 28.47,
-            "freq": 28.47,
-            "base": 10.0,
             "top_height_factor": 0.4589,
             "mid_height_factor": 0.0962,
             "width_factor": 0.1841,

--- a/src/antennaknobs/designs/specialty/hentenna_slant.py
+++ b/src/antennaknobs/designs/specialty/hentenna_slant.py
@@ -92,15 +92,13 @@ class Builder(AntennaBuilder):
         }
     )
 
+    # z100 (100 Ω feed) overlays default_params (= z50, the 50 Ω tuning);
+    # it states only the shape factors that differ (slant_deg matches default).
     z100_params = MappingProxyType(
         {
-            "design_freq": 28.47,
-            "freq": 28.47,
-            "base": 10.0,
             "length_factor": 1.1114,
             "top_aspect": 1.672,
             "bot_aspect": 0.423,
-            "slant_deg": 30.0,
         }
     )
 

--- a/tests/test_drone.py
+++ b/tests/test_drone.py
@@ -5,7 +5,7 @@ import math
 import numpy as np
 import pytest
 
-from antennaknobs import Drone
+from antennaknobs import Drone, resolve_variant_params
 from antennaknobs.designs.loops.delta_loop import Builder as DeltaLoop
 from antennaknobs.designs.loops.delta_loop_flyby import Builder as DeltaLoopFlyby
 from antennaknobs.designs.loops.delta_loop_reflected import (
@@ -271,7 +271,7 @@ def test_delta_loop_topdown_matches_shipped():
 def test_four_delta_loops_identical_across_a_second_param_set():
     # The payoff: the same knob set produces identical geometry from every
     # construction, at a different operating point too (z200, not the default).
-    p = dict(DeltaLoop.z200_params)
+    p = resolve_variant_params(DeltaLoop, "z200")
     shipped = _undirected(DeltaLoop(p))
     assert _undirected(DeltaLoopFlyby(p)) == shipped
     assert _undirected(DeltaLoopReflected(p)) == shipped
@@ -360,8 +360,8 @@ def test_delta_loop_side_follows_total_wire_length_in_closed_form():
     # (length_factor*wavelength - 4*eps) / (2*(1 + cos θ)) in closed form, no
     # numerical solve needed. Keep that claim honest.
     eps = 0.05
-    for params in (DeltaLoop.default_params, DeltaLoop.z200_params):
-        p = dict(params)
+    for variant in ("default", "z200"):
+        p = resolve_variant_params(DeltaLoop, variant)
         wl = 299.792458 / p["design_freq"]
         theta = math.radians(p["angle_deg"])
         expected = (p["length_factor"] * wl - 4 * eps) / (2 * (1 + math.cos(theta)))

--- a/tests/test_momwire_engine.py
+++ b/tests/test_momwire_engine.py
@@ -4,6 +4,7 @@ geometry translator it sits on top of."""
 import numpy as np
 import pytest
 
+from antennaknobs import resolve_variant_params
 from antennaknobs.designs.dipoles.invvee import Builder
 from antennaknobs.engines import PyNECEngine, MomwireEngine
 from antennaknobs.geometry import flat_wires_to_polylines
@@ -12,7 +13,7 @@ from conftest import needs_pynec
 
 
 def test_translator_chains_dipole_into_single_polyline():
-    b = Builder(Builder.dipole_params)  # straight half-wave dipole
+    b = Builder(resolve_variant_params(Builder, "dipole"))  # straight half-wave dipole
     out = flat_wires_to_polylines(b.build_wires())
 
     assert len(out["polylines"]) == 1

--- a/tests/test_nec_export.py
+++ b/tests/test_nec_export.py
@@ -14,16 +14,21 @@ import pytest
 
 pytest.importorskip("PyNEC")
 
+from antennaknobs import resolve_variant_params  # noqa: E402
 from antennaknobs.designs.dipoles.invvee import Builder as InvVee  # noqa: E402
 from antennaknobs.designs.beams.yagi import Builder as Yagi  # noqa: E402
 from antennaknobs.engines import PyNECEngine  # noqa: E402
 from antennaknobs.nec_export import export_nec  # noqa: E402
 
+# InvVee's `dipole` variant is a partial overlay on default_params; resolve it
+# to a complete param set before constructing the Builder directly.
+_DIPOLE = resolve_variant_params(InvVee, "dipole")
+
 HAVE_NEC2C = shutil.which("nec2c") is not None
 
 
 def test_export_basic_structure():
-    deck = export_nec(InvVee(InvVee.dipole_params), ground="free", include_rp=False)
+    deck = export_nec(InvVee(_DIPOLE), ground="free", include_rp=False)
     lines = deck.splitlines()
     assert lines[0].startswith("CM ")
     assert "CE" in lines
@@ -38,7 +43,7 @@ def test_export_basic_structure():
 
 
 def test_export_rp_card_when_pattern_requested():
-    deck = export_nec(InvVee(InvVee.dipole_params), include_rp=True)
+    deck = export_nec(InvVee(_DIPOLE), include_rp=True)
     lines = deck.splitlines()
     assert any(ln.startswith("RP ") for ln in lines)
     assert "XQ 0" not in lines  # RP triggers the solve instead
@@ -52,12 +57,10 @@ def test_export_one_gw_per_wire():
 
 
 def test_export_ground_cards():
-    assert "GN 1" in export_nec(InvVee(InvVee.dipole_params), ground="pec")
-    assert "GN 0" in export_nec(
-        InvVee(InvVee.dipole_params), ground=("finite", 10.0, 0.002)
-    )
+    assert "GN 1" in export_nec(InvVee(_DIPOLE), ground="pec")
+    assert "GN 0" in export_nec(InvVee(_DIPOLE), ground=("finite", 10.0, 0.002))
     # free space emits no GN card
-    assert "GN " not in export_nec(InvVee(InvVee.dipole_params), ground="free")
+    assert "GN " not in export_nec(InvVee(_DIPOLE), ground="free")
 
 
 def test_export_reducer_network_raises():
@@ -108,9 +111,9 @@ def _nec2c_impedances(deck):
 @pytest.mark.parametrize(
     "builder,ground",
     [
-        (InvVee(InvVee.dipole_params), "free"),
-        (InvVee(InvVee.dipole_params), "pec"),
-        (InvVee(InvVee.dipole_params), ("finite", 10.0, 0.002)),
+        (InvVee(_DIPOLE), "free"),
+        (InvVee(_DIPOLE), "pec"),
+        (InvVee(_DIPOLE), ("finite", 10.0, 0.002)),
         (Yagi(), "free"),
     ],
 )

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -31,13 +31,16 @@ def test_explicit_default_variant():
 def test_named_variant_resolves():
     factory = get_builder("hexbeam:opt")
     inst = factory()
-    assert _design_params(inst) == dict(hexbeam.Builder.opt_params)
+    # Variants are partial overlays now, so compare against the resolved set
+    # (opt overrides the driver geometry; `base` is inherited from default).
+    assert _design_params(inst) == resolve_variant_params(hexbeam.Builder, "opt")
+    assert _design_params(inst)["base"] == hexbeam.Builder.default_params["base"]
 
 
 def test_variant_on_moxon_original():
     factory = get_builder("moxon:original")
     inst = factory()
-    assert _design_params(inst) == dict(moxon.Builder.original_params)
+    assert _design_params(inst) == resolve_variant_params(moxon.Builder, "original")
 
 
 def test_renamed_twoband_variant():
@@ -56,13 +59,13 @@ def test_renamed_twoband_variant():
 def test_renamed_specialty_variant():
     factory = get_builder("specialty.hentenna:z100")
     inst = factory()
-    assert _design_params(inst) == dict(hentenna.Builder.z100_params)
+    assert _design_params(inst) == resolve_variant_params(hentenna.Builder, "z100")
 
 
 def test_renamed_loop_variant():
     factory = get_builder("loops.delta_loop:z200")
     inst = factory()
-    assert _design_params(inst) == dict(delta_loop.Builder.z200_params)
+    assert _design_params(inst) == resolve_variant_params(delta_loop.Builder, "z200")
 
 
 def test_unknown_variant_raises_with_available():


### PR DESCRIPTION
## What

With variants now resolved as a recursive overlay on `default_params` (#220), a named variant only needs to state what it changes. This trims all **40 catalog variants** down to their genuine overrides across 15 design files: **254 stated param keys → 130** (the 124 removed were byte-identical to default).

## Safety: every resolved variant is provably unchanged

Before touching anything I snapshotted `resolve_variant_params` for **all 113 (design, variant) pairs**, then re-verified after each batch of edits. All 113 resolve identically — compared by *numeric* value, so the one incidental `del_z` int `2` → float `2.0` normalization counts as equal (same geometry).

- Full suite: **1331 passed**.
- Ruff format + check clean.

## Per-design decisions

- **Loops** (`delta_loop`, `diamond_loop`, `inv_delta_loop`): `default_params` moved to the top of the class; the coincident feed-point variant is now an explicit alias (`z100_params = default_params`) rather than a duplicated literal.
- **Multiband** `bands` tuples stay whole (the documented shallow-overlay floor) — only the redundant scalar keys around them are dropped.
- `twoband_fan_dipole`'s `_variant()` factory stops emitting `base`/`gap_angle_deg`/`n_bands` (always default); the swept knobs (`freq`/`s`/`eps`) + `bands` remain.
- The 3 pre-existing default aliases (`fandipole.five_band`, `hentenna.z50`, `hentenna_slant.z50`) are left as-is.

## Test changes (and a latent crash this surfaced)

Trimming activated a latent crash on a path #220 **didn't** cover: several tests used a variant dict as a convenient *complete* preset and constructed a Builder **directly** — `InvVee(InvVee.dipole_params)` — bypassing the overlay resolvers. With partial variants that crashes `build_wires` on the missing keys. All such sites were in tests (`src/` already routes through the resolvers); they now resolve the variant first via `resolve_variant_params`. The variant-resolution assertions in `test_variants.py` were updated to compare against the resolved set rather than the raw (now-partial) dict.

## Follow-up: Part 1c (separate PR)

The deeper fix for that crash class is to make `AntennaBuilder.__init__` itself overlay a partial `params` on `default_params`, so `cls(partial_dict)` is safe everywhere. Deferred to its own PR because it's a Builder-semantics change with a web-adapter `_strip_ui`/`ui_params` interaction to verify first. Written up in `docs/plan-variant-overlay.md` (Part 1c).

Depends on #220 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)