### PR TITLE
Per-variant UI hints (variant_ui) + band-locked skyloop sweep — Part 2

### DIFF
--- a/src/antennaknobs/designs/loops/triangular_skyloop.py
+++ b/src/antennaknobs/designs/loops/triangular_skyloop.py
@@ -74,6 +74,16 @@ class Builder(AntennaBuilder):
         }
     )
 
+    # Band-locked variant: identical geometry to default, but the frontend
+    # clamps the freq sweep to the amateur band containing the anchor (80 m,
+    # which holds the 3.8 MHz default) instead of the wide ±multiplier window.
+    # Only ui_params is stated — it deep-merges over default_params.ui_params
+    # (inheriting target_z0 / default_view / length_factor) and flips just
+    # sweep_policy.band_locked; every regular param overlays from default.
+    band_locked_params = MappingProxyType(
+        {"ui_params": MappingProxyType({"sweep_policy": {"band_locked": True}})}
+    )
+
     def build_wires(self):
         eps = 0.05
 

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -870,6 +870,33 @@ def _recommended_backend(cls) -> str | None:
     return "arrayblock" if len(sigs) * 2 <= n_elem else None
 
 
+def _derive_sweep_policy(ui: dict) -> SweepPolicy:
+    """Build a SweepPolicy from a `ui_params` dict's `sweep_policy` entry.
+
+    Accepts the positional 3-tuple `(anchor, lo_factor, hi_factor)` form or the
+    dict form (which can opt into named fields like `band_locked` without
+    supplying every positional; missing fields fall back to the dataclass
+    defaults). Anything else yields the default policy. Takes any ui dict, so
+    the same derivation runs for the default's ui_params and for each variant's
+    deep-merged ui_params (see `variant_ui` in `_make_example`)."""
+    raw = ui.get("sweep_policy")
+    if isinstance(raw, (tuple, list)) and len(raw) == 3:
+        return SweepPolicy(
+            anchor=str(raw[0]),
+            lo_factor=float(raw[1]),
+            hi_factor=float(raw[2]),
+        )
+    if isinstance(raw, dict):
+        d = DEFAULT_SWEEP_POLICY
+        return SweepPolicy(
+            anchor=str(raw.get("anchor", d.anchor)),
+            lo_factor=float(raw.get("lo_factor", d.lo_factor)),
+            hi_factor=float(raw.get("hi_factor", d.hi_factor)),
+            band_locked=bool(raw.get("band_locked", d.band_locked)),
+        )
+    return DEFAULT_SWEEP_POLICY
+
+
 def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExample:
     dp = dict(cls.default_params)
     ui = dict(dp.get("ui_params") or {})
@@ -921,26 +948,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         else None
     )
     bands_override = ui.get("bands") if not isinstance(ui.get("bands"), dict) else None
-    sweep_pol_raw = ui.get("sweep_policy")
-    if isinstance(sweep_pol_raw, (tuple, list)) and len(sweep_pol_raw) == 3:
-        sweep_policy = SweepPolicy(
-            anchor=str(sweep_pol_raw[0]),
-            lo_factor=float(sweep_pol_raw[1]),
-            hi_factor=float(sweep_pol_raw[2]),
-        )
-    elif isinstance(sweep_pol_raw, dict):
-        # Dict form lets ui_params opt into named fields (band_locked,
-        # ...) without having to supply every positional. Anchor +
-        # factors fall back to the dataclass defaults when absent.
-        defaults = DEFAULT_SWEEP_POLICY
-        sweep_policy = SweepPolicy(
-            anchor=str(sweep_pol_raw.get("anchor", defaults.anchor)),
-            lo_factor=float(sweep_pol_raw.get("lo_factor", defaults.lo_factor)),
-            hi_factor=float(sweep_pol_raw.get("hi_factor", defaults.hi_factor)),
-            band_locked=bool(sweep_pol_raw.get("band_locked", defaults.band_locked)),
-        )
-    else:
-        sweep_policy = DEFAULT_SWEEP_POLICY
+    sweep_policy = _derive_sweep_policy(ui)
 
     # Band tabs default to the HF amateur set in canonical order. The
     # frontend snaps to whichever band contains the design's native
@@ -955,6 +963,22 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
     param_schema = _derive_schema(dp)
     has_design_freq = "design_freq" in dp
     variants = _discover_variants(cls)
+
+    # Per-variant UI hints. A variant's `ui_params` deep-merges over the
+    # default's (resolve_variant_params), so a variant can flip a single nested
+    # hint (e.g. sweep_policy.band_locked) without restating the subtree. We
+    # emit only the variants whose derived hints differ from the design-level
+    # (default) value; the frontend falls back to the top-level field otherwise.
+    # Extensible per-variant map so more hints can move per-variant later
+    # without another /examples contract change.
+    variant_ui: dict[str, dict[str, Any]] = {}
+    for v in variants:
+        if v == "default":
+            continue
+        v_ui = dict(resolve_variant_params(cls, v).get("ui_params") or {})
+        v_sweep = _derive_sweep_policy(v_ui)
+        if v_sweep != sweep_policy:
+            variant_ui[v] = {"sweep_policy": v_sweep}
 
     def _design_freq_default(req: dict) -> float:
         # The active variant's `freq` is the right fallback when the
@@ -1328,6 +1352,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             v: _serialize_param_values(_strip_ui(_variant_params(cls, v)))
             for v in variants
         },
+        variant_ui=variant_ui,
         layout=grid_layout,
     )
 

--- a/src/antennaknobs/web/examples/_base.py
+++ b/src/antennaknobs/web/examples/_base.py
@@ -389,6 +389,13 @@ class AntennaExample:
     # stripped. Single-variant designs ship {} since there's nothing
     # to switch between.
     variant_values: dict = field(default_factory=dict)
+    # Per-variant UI-hint overrides, keyed by variant name → {hint_name:
+    # value}. Today the only hint is `sweep_policy` (a SweepPolicy), emitted
+    # only for variants whose derived policy differs from the design-level
+    # `sweep_policy` above; the frontend falls back to that top-level value
+    # for any variant absent here. Kept as an open map so more ui hints can
+    # move per-variant later without another /examples contract change.
+    variant_ui: dict = field(default_factory=dict)
     # Optional grid-level layout config for the top-level knob rail.
     # Recognised key today: {"columns": int} — pins the param grid to a
     # fixed column count so per-ParamSpec.layout col positions land

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -157,6 +157,11 @@ type ExampleDescriptor = {
    *  variants. Complex-valued params arrive as {re, im}. */
   variant_values: { [variant: string]: { [key: string]: unknown } };
   sweep_policy: SweepPolicy;
+  /** Per-variant UI-hint overrides, keyed by variant name. Only variants
+   *  whose derived hints differ from the design-level values appear; look up
+   *  the active variant and fall back to the top-level field (e.g.
+   *  `sweep_policy`) for any variant not listed. */
+  variant_ui?: { [variant: string]: { sweep_policy?: SweepPolicy } };
   /** Grid-level layout for the top-level knob rail. {columns: N} pins the
    *  grid to a fixed column count so per-knob `layout.col` positions are
    *  stable. null = responsive auto-flow packing. */
@@ -2955,6 +2960,10 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     // measFreq/linkMeas drive the anchor now (meas_freq policy, or any unlocked
     // design), so a meas-band change or dial turn re-runs the sweep.
     measFreq, linkMeas,
+    // A variant can override sweep_policy (variant_ui) without changing any
+    // param — e.g. a band-locked variant. currentValuesKey wouldn't move then,
+    // so depend on currentVariant directly to re-run the sweep on switch.
+    currentVariant,
   ]);
 
   // Debounced convergence sweep over segments-per-wire. Independent of the
@@ -3032,9 +3041,14 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     //
     // Anchor + span come from the active example's sweep_policy. See
     // SweepPolicy in web/examples/_base.py for the meaning of the fields.
+    // A variant can override the policy (e.g. a band-locked variant): prefer
+    // the active variant's entry in variant_ui, falling back to the
+    // design-level sweep_policy.
     const slowGround = backend === "pynec" && groundEnabled && !groundFast;
     const N = slowGround ? 21 : 41;
-    const policy = currentExample?.sweep_policy;
+    const policy =
+      currentExample?.variant_ui?.[currentVariant]?.sweep_policy ??
+      currentExample?.sweep_policy;
     // Anchor on the measurement frequency whenever the sweep should follow what
     // the user is *viewing*: multiband designs declare anchor="meas_freq", and
     // any design that's been unlocked from its design freq (to check the pattern

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -895,6 +895,14 @@ def examples_endpoint():
     """
     load_errors = user_designs.refresh()
 
+    def _sweep_policy_json(p) -> dict:
+        return {
+            "anchor": p.anchor,
+            "lo_factor": p.lo_factor,
+            "hi_factor": p.hi_factor,
+            "band_locked": p.band_locked,
+        }
+
     def _serialize_schema_item(item) -> dict:
         # Discriminate by attribute: ParamGroupSpec has `params`, ParamSpec
         # doesn't. Recurses so groups-in-groups serialize cleanly (the
@@ -987,11 +995,16 @@ def examples_endpoint():
                 "has_design_freq": ex.has_design_freq,
                 "variants": list(ex.variants),
                 "variant_values": dict(ex.variant_values),
-                "sweep_policy": {
-                    "anchor": ex.sweep_policy.anchor,
-                    "lo_factor": ex.sweep_policy.lo_factor,
-                    "hi_factor": ex.sweep_policy.hi_factor,
-                    "band_locked": ex.sweep_policy.band_locked,
+                "sweep_policy": _sweep_policy_json(ex.sweep_policy),
+                # Per-variant hint overrides; only variants that differ from the
+                # design-level sweep_policy appear here. Frontend falls back to
+                # the top-level `sweep_policy` for any variant not listed.
+                "variant_ui": {
+                    v: {
+                        "sweep_policy": _sweep_policy_json(h["sweep_policy"]),
+                    }
+                    for v, h in ex.variant_ui.items()
+                    if "sweep_policy" in h
                 },
                 "layout": ex.layout,
             }

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -223,6 +223,7 @@ def test_each_example_has_the_keys_the_frontend_reads(client: TestClient):
         "variants",
         "variant_values",
         "sweep_policy",
+        "variant_ui",
     }
     for ex in payload["examples"]:
         missing = required - set(ex.keys())
@@ -257,6 +258,39 @@ def test_examples_carry_sweep_policy_keys(client: TestClient):
         sp = ex["sweep_policy"]
         assert set(sp) == {"anchor", "lo_factor", "hi_factor", "band_locked"}
         assert sp["anchor"] in {"design_freq", "meas_freq"}
+
+
+def test_variant_ui_only_lists_variants_that_differ(client: TestClient):
+    # variant_ui is a per-variant override map; a variant appears only when its
+    # derived hints differ from the design-level value, and every listed
+    # sweep_policy is shaped exactly like the top-level one.
+    payload = client.get("/examples").json()
+    for ex in payload["examples"]:
+        vui = ex["variant_ui"]
+        assert isinstance(vui, dict)
+        for variant, hints in vui.items():
+            assert variant in ex["variants"]
+            assert variant != "default"
+            sp = hints["sweep_policy"]
+            assert set(sp) == {"anchor", "lo_factor", "hi_factor", "band_locked"}
+            assert sp != ex["sweep_policy"]  # only differing variants are listed
+
+
+def test_skyloop_band_locked_variant_flips_only_band_locked(client: TestClient):
+    # The Part 2 payoff: a variant carrying only ui_params.sweep_policy.
+    # band_locked deep-merges over the default's sweep_policy, inheriting anchor
+    # and the lo/hi factors and flipping just band_locked.
+    payload = client.get("/examples").json()
+    ex = next(e for e in payload["examples"] if e["name"] == "loops.triangular_skyloop")
+    assert "band_locked" in ex["variants"]
+    default_sp = ex["sweep_policy"]
+    assert default_sp["band_locked"] is False
+    locked_sp = ex["variant_ui"]["band_locked"]["sweep_policy"]
+    assert locked_sp["band_locked"] is True
+    # everything except band_locked is inherited from the design-level policy
+    assert {k: locked_sp[k] for k in ("anchor", "lo_factor", "hi_factor")} == {
+        k: default_sp[k] for k in ("anchor", "lo_factor", "hi_factor")
+    }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Completes the variant-overlay arc (Part 1 #220 → Part 1b #221 → **Part 2** here). Part 1 already deep-merges a variant's `ui_params` over the default's; Part 2 makes the ui-derived hints **variant-aware** and wires them through to the frontend.

- **Backend:** extracted `_derive_sweep_policy(ui)` so the same derivation runs for the default and each variant's merged `ui_params`. `_make_example` builds a `variant_ui` map (`{variant: {sweep_policy: …}}`), emitting **only** variants whose derived policy differs from the design-level value. New `AntennaExample.variant_ui` field, serialized in `GET /examples` via a shared `_sweep_policy_json` helper (which also DRYs the top-level field). Kept as an open per-variant map so more hints can move per-variant later without another `/examples` contract change.
- **Frontend:** added the `variant_ui` type; the sweep read site prefers `variant_ui[currentVariant].sweep_policy`, falling back to the top-level `sweep_policy`. Also added `currentVariant` to the sweep `useEffect` deps so a ui-only override (which leaves all params unchanged) re-runs the sweep on variant switch instead of keeping a stale range.
- **Payoff:** `loops.triangular_skyloop` gains a 3-line `band_locked_params` variant carrying **only** `ui_params` — it deep-merges over the default `sweep_policy` and flips just `band_locked`, so the frontend clamps the freq sweep to the 80m band. Geometry and sliders are identical to `default`.

Depends on #220 and #221 (both merged).

## Test plan
- [x] Full suite **1333 passed** (adds: `/examples` payload carries `variant_ui`; `variant_ui` lists only differing variants with well-formed `sweep_policy`; skyloop `band_locked` inherits anchor/lo/hi and flips only `band_locked`)
- [x] Frontend `tsc --noEmit` clean
- [x] Verified in-browser: selecting `triangular_skyloop` → `band_locked` (no other interaction) fires a fresh `/sweep` with `freqs_mhz` clamped to **3.5–4.0 MHz**, vs the `default` variant's **3.04–4.75 MHz** wide window

🤖 Generated with [Claude Code](https://claude.com/claude-code)