### PR TITLE
Skip preview fetch for the unset initial geometry (kills bowtie-array flash on load)

### DIFF
--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -2764,6 +2764,13 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   // param/freq tweaks on the *same* antenna keep updating in place (no flicker),
   // matching the prior behaviour for the fast designs where this isn't a pain.
   useEffect(() => {
+    // Skip the "unset" initial state. On a fresh load `geometry` is "" until the
+    // /examples list resolves and the auto-select effect picks the default
+    // (dipoles.invvee). Fetching a preview for "" would POST an empty key, which
+    // the server resolves to the alphabetically-first design (arrays.bowtiearray)
+    // — building and rendering a geometry nobody asked for, only to be replaced a
+    // beat later. Bail here so the first preview is the real default.
+    if (!geometry) return;
     setResult(null);
     setPreview(null);
     setSolveError(null);


### PR DESCRIPTION
## Summary
- On a fresh load `geometry` is `""` until `/examples` resolves and the auto-select effect picks the default (`dipoles.invvee`). The preview-fetch effect was firing for that empty value.
- An empty geometry key POSTed to `/geometry` resolves server-side to the alphabetically-first design (`arrays.bowtiearray`) via the `or next(iter(EXAMPLES.values()))` fallback — so a bowtie array was built and rendered for a frame before the real default replaced it. Visible flash + a wasted geometry build on every hard reload.
- Added `if (!geometry) return;` at the top of the preview effect (`App.tsx`) so the first preview fetched is the real default. No behavior change once a design is selected.

## Test plan
- [x] `tsc --noEmit` passes clean
- [ ] Hard-reload the app (Ctrl+Shift+R) and confirm the inverted-vee dipole loads with no bowtie-array flash beforehand

🤖 Generated with [Claude Code](https://claude.com/claude-code)