### PR TITLE
Confirm before closing a design session tab; stable per-session tab labels

### DIFF
--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1627,6 +1627,39 @@ const SessionsContext = createContext<SessionsCtx>({
 function TabStrip() {
   const { sessions, activeId, add, close, setActive, summaries } =
     useContext(SessionsContext);
+  // The session whose close (×) was clicked and is awaiting confirmation, plus
+  // the viewport coords of that × so the popover can anchor to it. Closing a
+  // session discards its unsaved knob state, so we guard it behind this popover
+  // rather than closing on the first click. The popover is position:fixed (not
+  // absolute) because .tab-strip is an overflow:auto scroll container that would
+  // otherwise clip it against the top/left edge.
+  const [confirm, setConfirm] = useState<
+    { id: number; x: number; y: number } | null
+  >(null);
+  const confirmId = confirm?.id ?? null;
+
+  // Dismiss the confirm popover on Escape or an outside click. Clicks on any
+  // tab-close × are excluded so switching the popover to another tab (or
+  // reopening it) doesn't fight this dismiss handler.
+  useEffect(() => {
+    if (confirmId === null) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setConfirm(null);
+    };
+    const onDoc = (e: MouseEvent) => {
+      const t = e.target as HTMLElement;
+      if (!t.closest(".tab-close-confirm") && !t.closest(".tab-close")) {
+        setConfirm(null);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    document.addEventListener("mousedown", onDoc);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.removeEventListener("mousedown", onDoc);
+    };
+  }, [confirmId]);
+
   return (
     <div className="tab-strip" role="tablist" aria-label="Design sessions">
       {sessions.map((s, i) => (
@@ -1648,9 +1681,14 @@ function TabStrip() {
             <button
               type="button"
               className="tab-close"
-              onClick={() => close(s.id)}
+              onClick={(e) => {
+                const r = e.currentTarget.getBoundingClientRect();
+                setConfirm({ id: s.id, x: r.left, y: r.bottom });
+              }}
               aria-label={`Close design ${i + 1}`}
               title={`Close design ${i + 1}`}
+              aria-haspopup="dialog"
+              aria-expanded={confirmId === s.id}
             >
               ×
             </button>
@@ -1666,6 +1704,43 @@ function TabStrip() {
       >
         +
       </button>
+      {confirm !== null &&
+        (() => {
+          const idx = sessions.findIndex((s) => s.id === confirm.id);
+          if (idx === -1) return null; // session vanished out from under us
+          return (
+            <div
+              className="tab-close-confirm"
+              role="dialog"
+              aria-label={`Close design ${idx + 1}?`}
+              style={{ left: confirm.x, top: confirm.y + 6 }}
+            >
+              <span className="tab-close-confirm-msg">
+                Close design {idx + 1}?
+              </span>
+              <div className="tab-close-confirm-actions">
+                <button
+                  type="button"
+                  className="tab-close-confirm-cancel"
+                  autoFocus
+                  onClick={() => setConfirm(null)}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="tab-close-confirm-ok"
+                  onClick={() => {
+                    close(confirm.id);
+                    setConfirm(null);
+                  }}
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+          );
+        })()}
     </div>
   );
 }

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1662,7 +1662,7 @@ function TabStrip() {
 
   return (
     <div className="tab-strip" role="tablist" aria-label="Design sessions">
-      {sessions.map((s, i) => (
+      {sessions.map((s) => (
         <div
           key={s.id}
           className={`tab ${s.id === activeId ? "active" : ""}`}
@@ -1673,9 +1673,9 @@ function TabStrip() {
             aria-selected={s.id === activeId}
             className="tab-btn"
             onClick={() => setActive(s.id)}
-            title={summaries[s.id] ?? `Design ${i + 1}`}
+            title={summaries[s.id] ?? `Design ${s.id}`}
           >
-            D{i + 1}
+            D{s.id}
           </button>
           {sessions.length > 1 && (
             <button
@@ -1685,8 +1685,8 @@ function TabStrip() {
                 const r = e.currentTarget.getBoundingClientRect();
                 setConfirm({ id: s.id, x: r.left, y: r.bottom });
               }}
-              aria-label={`Close design ${i + 1}`}
-              title={`Close design ${i + 1}`}
+              aria-label={`Close design ${s.id}`}
+              title={`Close design ${s.id}`}
               aria-haspopup="dialog"
               aria-expanded={confirmId === s.id}
             >
@@ -1705,42 +1705,38 @@ function TabStrip() {
         +
       </button>
       {confirm !== null &&
-        (() => {
-          const idx = sessions.findIndex((s) => s.id === confirm.id);
-          if (idx === -1) return null; // session vanished out from under us
-          return (
-            <div
-              className="tab-close-confirm"
-              role="dialog"
-              aria-label={`Close design ${idx + 1}?`}
-              style={{ left: confirm.x, top: confirm.y + 6 }}
-            >
-              <span className="tab-close-confirm-msg">
-                Close design {idx + 1}?
-              </span>
-              <div className="tab-close-confirm-actions">
-                <button
-                  type="button"
-                  className="tab-close-confirm-cancel"
-                  autoFocus
-                  onClick={() => setConfirm(null)}
-                >
-                  Cancel
-                </button>
-                <button
-                  type="button"
-                  className="tab-close-confirm-ok"
-                  onClick={() => {
-                    close(confirm.id);
-                    setConfirm(null);
-                  }}
-                >
-                  Close
-                </button>
-              </div>
+        sessions.some((s) => s.id === confirm.id) && (
+          <div
+            className="tab-close-confirm"
+            role="dialog"
+            aria-label={`Close design ${confirm.id}?`}
+            style={{ left: confirm.x, top: confirm.y + 6 }}
+          >
+            <span className="tab-close-confirm-msg">
+              Close design {confirm.id}?
+            </span>
+            <div className="tab-close-confirm-actions">
+              <button
+                type="button"
+                className="tab-close-confirm-cancel"
+                autoFocus
+                onClick={() => setConfirm(null)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="tab-close-confirm-ok"
+                onClick={() => {
+                  close(confirm.id);
+                  setConfirm(null);
+                }}
+              >
+                Close
+              </button>
             </div>
-          );
-        })()}
+          </div>
+        )}
     </div>
   );
 }

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -326,6 +326,58 @@ button:focus-visible,
   color: var(--accent);
 }
 
+/* Confirmation popover shown when a tab's × is clicked. Fixed-positioned (left/
+   top set inline from the ×'s rect) so it escapes .tab-strip's overflow clip. */
+.tab-close-confirm {
+  position: fixed;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  background: var(--panel);
+  border: 1px solid var(--border-control);
+  border-radius: var(--r-sm);
+  box-shadow: 0 6px 20px var(--shadow-strong);
+  white-space: nowrap;
+}
+
+.tab-close-confirm-msg {
+  font-size: var(--text-sm);
+  color: var(--fg);
+}
+
+.tab-close-confirm-actions {
+  display: flex;
+  gap: var(--space-2);
+  justify-content: flex-end;
+}
+
+.tab-close-confirm-actions button {
+  font-size: var(--text-sm);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--r-sm);
+  border: 1px solid var(--border-control);
+  background: var(--inset);
+  color: var(--fg);
+  cursor: pointer;
+}
+
+.tab-close-confirm-cancel:hover {
+  border-color: var(--border-hover);
+}
+
+.tab-close-confirm-ok {
+  border-color: var(--accent-border);
+  color: var(--accent);
+}
+
+.tab-close-confirm-ok:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--panel);
+}
+
 .tab-add {
   flex: 0 0 auto;
   background: none;


### PR DESCRIPTION
## Summary
- **Close confirmation**: clicking a session tab's × now opens a small confirmation popover ("Close design N?" with Cancel / Close) instead of closing on the first click — closing discarded unsaved knob state and was easy to hit by accident. Dismisses on Escape or outside click; Cancel takes initial focus so a stray Enter/Escape is non-destructive.
- **Popover positioning**: the popover is `position: fixed`, anchored to the ×'s viewport rect, so it escapes `.tab-strip`'s `overflow: auto` scroll container (which otherwise clipped it against the top/left edge).
- **Stable tab labels**: tabs now label by their stable, never-reused session id (`D{id}`) rather than array position. Previously `D{index+1}` renumbered every later tab when an earlier one closed — close D1 and your D3 silently became D2. Trade-off: heavy open/close churn leaves numbering gaps, which is far more legible than a silent renumber.

## Test plan
- [x] `tsc --noEmit` / `npm run build` clean
- [x] Verified in-browser: close-confirm popover renders fully (not clipped) below the tab
- [x] Verified in-browser: opened D1/D2/D3, closed D1 → remaining tabs stay D2/D3 (D3 not renumbered)
- [ ] While-hard-reloading sanity check that no bowtie flash regressed (separate, already-merged fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)