### PR TITLE
Latest-wins /ws solve pipeline: eager-send + server-side squash

### DIFF
--- a/docs/plan-ws-latest-wins.md
+++ b/docs/plan-ws-latest-wins.md
@@ -1,0 +1,237 @@
+# Plan: eager-send + server-side latest-wins squash for the /ws solve pipeline
+
+Status: **not started.** Scoped 2026-07-04 from an audit of the stale-knob
+squashing mechanisms. Goal: cut the tail latency of a knob change → rendered
+charts on the hosted (fly.io) instance, where client↔server RTT is real
+(~tens of ms), without regressing the localhost path (RTT ≈ 0).
+
+## Motivation — what the audit found
+
+Today the client enforces **one in-flight request + a latest-wins pending
+slot** (`web/frontend/src/App.tsx:3326-3340`, refs at `App.tsx:2371-2372`).
+The server `/ws` loop is strictly serial: receive → `run_in_threadpool(solve)`
+→ send (`web/server.py:1016-1049`). This already squashes intermediate knob
+values client-side — the server never sees a backlog. Three costs remain:
+
+1. **One full round-trip of hold-back per superseded change.** The pending
+   request isn't sent until the previous response has fully downloaded and
+   been `JSON.parse`d. Tail latency for the final knob value =
+   remainder of in-flight solve + response download + parse + request upload
+   + solve(final) + response download. The upload leg and the
+   response-processing dependency are pure waste on the fly path.
+2. **Superseded results are fully shipped and rendered.** When controls
+   changed mid-solve, the doomed payload (wires + interleaved sample-current
+   arrays — the big part) still travels back and gets parsed before the
+   pending request fires (`App.tsx:3368-3406`).
+3. **No preemption of a stale in-flight solve** — acknowledged at
+   `App.tsx:2080-2082` ("cancels the WAIT, not the computation"). Fine at
+   10–100 ms; painful on tens-of-seconds array solves. (Optional phase; the
+   engine can't be interrupted without cooperative checks.)
+
+The fix inverts the squash point: **client sends every change eagerly with a
+sequence number; the server keeps only the newest queued request (a size-1
+latest-wins mailbox), solves that when free, and skips sending results it
+already knows are superseded.** The final knob value is then already waiting
+at the server when the current solve finishes, and doomed payloads never
+travel.
+
+Groundwork that already exists:
+
+- `_CACHE_KEY_BLOCKLIST` (`web/server.py:463-468`) already excludes
+  `_request_id` / `_client_ts` from the solve-cache key — the seq field slots
+  in with one line.
+- The send-guard structure (`web/server.py:1042-1047`, connected-state check
+  before `send_text`) is where the "superseded → skip send" check goes.
+
+## Design
+
+### Wire protocol
+
+- Client adds `_seq` (monotonic int, per App instance, never reset — survives
+  reconnects) and keeps/adds `_client_ts` to every /ws solve request.
+- Server echoes `_seq` verbatim in every response, **including error
+  responses** (the `except` branch at `web/server.py:1025-1032`).
+- Add `_seq` to `_CACHE_KEY_BLOCKLIST` so it can't shred the cache hit rate.
+
+Compatibility note: new-client + old-server would pile up (client no longer
+gates in-flight, old server solves every message serially). Not a real
+deployment state — the fly image bundles frontend + server, and dev runs both
+from the checkout — but don't split the two halves across separate deploys.
+
+### Server: `/ws` handler rewrite (`web/server.py:1016-1049`)
+
+Replace the serial receive→solve→send loop with a reader task + solver loop
+sharing a latest-wins mailbox:
+
+```python
+@app.websocket("/ws")
+async def ws_endpoint(ws: WebSocket):
+    await ws.accept()
+    mailbox: list[dict] = []          # size-1, newest only
+    newer = asyncio.Event()           # "mailbox refilled"
+    closed = asyncio.Event()
+
+    async def reader():
+        try:
+            while True:
+                req = json.loads(await ws.receive_text())
+                mailbox[:] = [req]    # overwrite: squash anything unsolved
+                newer.set()
+        except WebSocketDisconnect:
+            closed.set()
+            newer.set()               # wake the solver so it can exit
+
+    reader_task = asyncio.create_task(reader())
+    try:
+        while True:
+            await newer.wait()
+            if closed.is_set():
+                return
+            newer.clear()
+            req = mailbox.pop()
+            try:
+                result = await run_in_threadpool(solve, req)
+            except Exception as exc:
+                result = {"geometry": req.get("geometry"),
+                          "error": user_designs.format_solve_error(exc)}
+            result["_seq"] = req.get("_seq")
+            # Superseded while solving? Skip the send — the newer request's
+            # response will carry a higher _seq and the client renders
+            # monotonically. Saves the full doomed payload on the wire.
+            if mailbox:
+                continue
+            if ws.client_state != WebSocketState.CONNECTED or closed.is_set():
+                return
+            try:
+                await ws.send_text(json.dumps(result))
+            except (WebSocketDisconnect, RuntimeError):
+                return
+    finally:
+        reader_task.cancel()
+```
+
+Details to get right:
+
+- The reader task must be the **only** receiver on the socket (starlette
+  requires single-reader).
+- Keep the existing behaviors: error responses don't tear down the socket;
+  send is skipped when the client already disconnected.
+- Cache-hit responses mutate `solve_ms` (`web/server.py:514-523`) — the
+  `_seq` stamp goes on the (deep)copied result, never the cached entry.
+
+### Client: `App.tsx` solve path
+
+- `requestSolve()` (`App.tsx:3326-3340`): drop the `inFlightRef` gate for
+  sends. When the socket is OPEN, always send immediately with
+  `_seq: ++seqRef.current`; record `sentAt.set(seq, performance.now())` for
+  RTT. When not OPEN, keep the current "stash in pendingRef, flush onopen"
+  behavior.
+- **Send throttle (localhost-neutrality guard):** coalesce sends to one per
+  animation frame (a trailing-edge rAF throttle inside `requestSolve`).
+  During a drag this bounds upload to ≤60 msg/s of ~1 KB requests, and on
+  localhost keeps message churn near what the old gate produced. Latest value
+  always wins within the frame.
+- Replace `inFlightRef`/`pendingRef` bookkeeping with two counters:
+  `lastSentSeq`, `lastRenderedSeq` (or `lastReceivedSeq`).
+  - `solving` ⇔ `lastSentSeq > lastReceivedSeq` (replaces `syncSolving()`,
+    `App.tsx:3272-3277`).
+  - `onmessage`: drop any response with `_seq <= lastReceivedSeq` (belt and
+    suspenders — one socket delivers in order anyway); keep the existing
+    geometry-mismatch drop (`App.tsx:3387`) for antenna switches; then
+    `setResult`, update RTT from `sentAt`, and prune `sentAt` entries ≤ seq.
+    Note responses may be *skipped* server-side — a higher `_seq` response
+    implicitly acknowledges all lower seqs; treat it as such everywhere
+    (RTT map pruning, solving state).
+  - `cancelSolve()` (`App.tsx:2287-2292`): set `canceledThroughSeq =
+    lastSentSeq`; onmessage drops rendering for `_seq <=
+    canceledThroughSeq` but still updates `lastReceivedSeq`.
+  - `onopen` (`App.tsx:3346-3355`): set `lastReceivedSeq = lastSentSeq`
+    (nothing from a dead socket can arrive), then send a fresh request —
+    same recovery the current code does with `inFlightRef = false`.
+  - `onclose`/`onerror`: same as today, plus `lastReceivedSeq = lastSentSeq`
+    so `solving` can't stick true.
+- Sweep/converge hold-off polls (`App.tsx:2998`, `App.tsx:3127`) test
+  `inFlightRef.current || pendingRef.current` — replace with the same
+  `lastSentSeq > lastReceivedSeq` predicate (extract a helper).
+
+### Optional phase: skip stale post-processing / cooperative preempt
+
+Cheap variant: thread a `superseded: Callable[[], bool]` (closure over
+`bool(mailbox)`; safe to read from the worker thread) into the ws-path solve
+and check it between the impedance/currents solve and
+`_attach_derived_em_fields` + `_compute_directivity_norm`
+(`web/server.py:493-507`). If superseded, return a sentinel; the ws loop just
+continues. **Do not cache partial results** — only fully post-processed
+results may enter `_SOLVE_CACHE`. Full mid-solve preemption (checks between
+matrix fill / LU inside the engines) is out of scope here.
+
+### Optional phase: serialization
+
+`json.dumps` of a large result runs on the event loop once per response and
+`solve()` pays a `deepcopy` per cache hit. If profiling shows it matters
+(multi-tab hosted use): swap to `orjson` for dumps, or cache the serialized
+string. Second-order; skip unless measured.
+
+## Phases
+
+1. **Server mailbox + `_seq` echo + skip-send** (server.py only, protocol is
+   additive — old client still works against it since `_seq` is optional).
+   Tests below land here.
+2. **Client eager-send + seq counters + rAF throttle** (App.tsx). Remove
+   `inFlightRef`/`pendingRef`/`solveCanceledRef` in favor of seq counters.
+3. *(Optional)* post-processing skip for superseded requests.
+4. *(Optional)* serialization work, only if profiled.
+
+Phases 1+2 are one PR (they're only correct together — see compatibility
+note); 3 and 4 separate follow-ups.
+
+## Tests (`tests/test_web_server.py`)
+
+Existing ws tests to keep green: round-trip (`:947`), two-sequential-requests
+(`:965`), disconnect-during-solve (`:988`), error-keeps-socket-alive
+(`:1036`).
+
+New, with `solve` monkeypatched to count calls and optionally block on an
+event so requests genuinely queue:
+
+- **Squash:** hold the first solve, send requests seq 1..5, release. Assert
+  solve ran exactly twice (seq 1 and seq 5) and the only responses carry
+  `_seq` 1 and 5 — no responses for 2–4 (skip-send) unless 1's send already
+  left before 5 arrived, in which case exactly {1, 5}.
+- **Seq echo:** response `_seq` equals request `_seq`, including on the error
+  path (a request whose solve raises).
+- **Skip-send:** with a newer request queued before send, the older result
+  never appears on the socket.
+- **Cache key:** `_seq`/`_client_ts` variations hit the same cache entry
+  (extend the blocklist tests at `:1159-1249`).
+- **Disconnect:** client drops mid-solve → handler returns cleanly, reader
+  task cancelled, no stray exceptions.
+
+Frontend has no unit-test rig for App.tsx; verify by hand (below).
+
+## Verification (the fly-vs-localhost tradeoff, measured)
+
+- **Localhost:** run the app, scrub a knob on a mid-weight design; compare
+  solve cadence and the RTT/solve-time HUD before vs after. Expect: identical
+  solve counts (squash point moved, not tightened), no added jank.
+- **Simulated fly:** Chrome DevTools network throttling (add ~80 ms RTT),
+  scrub, measure time from last knob tick to final chart paint. Expect:
+  roughly one RTT + one response-parse less per superseded change; doomed
+  payloads absent from the WS frame log.
+- **Hosted smoke test** after deploy: scrub on the fly instance, confirm
+  final value renders and `solving` clears.
+
+## Risks / edge cases
+
+- `solving` stuck true if a response is skipped and no newer one ever sends
+  (e.g. newest request errors → error response still carries `_seq`, so this
+  resolves; make sure *every* path echoes `_seq`).
+- StrictMode/HMR socket teardown: the seq counters live in refs that survive
+  remounts of the effect but the counter must never reset below
+  `lastReceivedSeq` — keep `seqRef` at module/App scope, not inside the
+  effect.
+- Multiple design-session tabs: each session has its own socket/handler; the
+  mailbox is per-connection, so no cross-tab interaction. Inactive sessions
+  already close their socket (`active` gate).
+- The `/ws` handler change must not alter response *shape* other than adding
+  `_seq` — the pinned-pattern snapshots and result schema readers consume it.

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1124,6 +1124,10 @@ type SolveResponse = {
   measurement_freq_mhz: number;
   lambda_design_m: number;
   solve_ms: number;
+  /** Echoed from the request. The latest-wins /ws protocol orders and prunes
+   *  responses by this; a higher `_seq` implicitly acks every lower one.
+   *  Absent from geometry-preview payloads (they never carry a request seq). */
+  _seq?: number;
   directivity_norm?: number;
   ground?: boolean;
   height_m?: number;
@@ -1426,6 +1430,9 @@ type SolveRequest = {
   length_factor?: number;
   del_y_m?: number;
   phase_lr_deg?: number;
+  /** Monotonic per-tab sequence number for the latest-wins /ws protocol. The
+   *  server echoes it back and keeps only the freshest queued request. */
+  _seq?: number;
 };
 
 type SweepData = {
@@ -2076,10 +2083,6 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   // solve is withheld until the user clicks "Solve anyway" or changes the solver
   // themselves; the app never switches solvers on its own.
   const [solverWarning, setSolverWarning] = useState(false);
-  // Set by Cancel: discard the in-flight solve's result and drop the busy UI.
-  // The server's /ws loop is sequential and a running MoM solve can't be
-  // interrupted, so this cancels the WAIT, not the computation.
-  const solveCanceledRef = useRef(false);
   const [gearOpen, setGearOpen] = useState<Slot | null>(null);
   const activeConfig = slots[activeSlot];
   const backend = activeConfig.backend;
@@ -2285,9 +2288,11 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   // keeps computing (its /ws loop is sequential and a running MoM solve can't be
   // interrupted), so this cancels the wait, not the computation.
   function cancelSolve() {
-    if (!inFlightRef.current) return;
-    solveCanceledRef.current = true;
-    pendingRef.current = null;
+    if (lastSentSeqRef.current <= lastReceivedSeqRef.current) return; // nothing in flight
+    // Mark every seq sent so far as cancelled: onmessage will advance the
+    // received watermark for these but drop their results. A newer knob change
+    // bumps lastSentSeq past this and solves again.
+    canceledThroughSeqRef.current = lastSentSeqRef.current;
     syncSolving();
   }
 
@@ -2368,9 +2373,18 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   geometryRef.current = geometry;
 
   const wsRef = useRef<WebSocket | null>(null);
-  const inFlightRef = useRef(false);
-  const pendingRef = useRef<SolveRequest | null>(null);
-  const sendStartRef = useRef(0);
+  // Latest-wins /ws protocol counters. Every knob change is sent eagerly with a
+  // monotonic `_seq`; the server keeps only the freshest queued request and may
+  // skip-send superseded results, so the client orders and prunes by `_seq`. A
+  // solve is outstanding iff more has been sent than received. These live in
+  // refs so they survive StrictMode/HMR socket teardown — the counter must
+  // never rewind below what's already been received.
+  const seqRef = useRef(0); // last _seq assigned (monotonic, never reset)
+  const lastSentSeqRef = useRef(0); // highest _seq put on the wire
+  const lastReceivedSeqRef = useRef(0); // highest _seq received or implicitly acked
+  const canceledThroughSeqRef = useRef(0); // drop rendering for _seq <= this
+  const sentAtRef = useRef<Map<number, number>>(new Map()); // _seq → send time (RTT)
+  const solveRafRef = useRef<number | null>(null); // trailing-edge rAF throttle handle
 
   function buildRequest(): SolveRequest {
     // Solver-family ground notes: PyNEC uses Sommerfeld-Norton (or the
@@ -2847,7 +2861,6 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     setSolveError(null);
     setPreviewReady(null); // close the solve gate until this antenna's preview lands
     setSolverWarning(false); // drop any combo warning from the prior design
-    solveCanceledRef.current = false;
     previewAbortRef.current?.abort();
     const controller = new AbortController();
     previewAbortRef.current = controller;
@@ -2995,7 +3008,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     // pain that motivated this on large arrays. Re-poll until the main solve is
     // idle, then proceed; the input-change effect cancels this timer on the
     // next change, so rapid edits still debounce.
-    if (inFlightRef.current || pendingRef.current) {
+    if (solvePending()) {
       sweepTimerRef.current = window.setTimeout(runSweep, 200);
       return;
     }
@@ -3124,7 +3137,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     // Same as runSweep: defer the converge ladder (another batch of solves)
     // until the live solve has returned, so it never competes with the solve
     // that draws the heatmap.
-    if (inFlightRef.current || pendingRef.current) {
+    if (solvePending()) {
       convergeTimerRef.current = window.setTimeout(runConverge, 200);
       return;
     }
@@ -3267,12 +3280,27 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     }
   }
 
-  // Mirror the solve refs into `solving` state so the UI can react. Called
-  // wherever inFlightRef/pendingRef change.
+  // True while a live /ws solve is outstanding — a request scheduled by the rAF
+  // throttle but not yet sent, or sent and not yet acked by an equal/higher
+  // `_seq`. Sweep/converge hold off on this so their batches of background
+  // solves don't compete with the live solve that draws the heatmap.
+  function solvePending(): boolean {
+    return (
+      solveRafRef.current !== null ||
+      lastSentSeqRef.current > lastReceivedSeqRef.current
+    );
+  }
+
+  // Mirror the seq counters into `solving` state so the UI can react. Called
+  // wherever the sent / received / cancel watermarks move. A solve reads as
+  // running when more has been sent than received — unless everything
+  // outstanding was cancelled (lastSentSeq hasn't advanced past the cancel
+  // watermark), in which case the wait is over even though a doomed response
+  // is still coming.
   function syncSolving() {
     setSolving(
-      (inFlightRef.current || pendingRef.current !== null) &&
-        !solveCanceledRef.current,
+      lastSentSeqRef.current > lastReceivedSeqRef.current &&
+        lastSentSeqRef.current > canceledThroughSeqRef.current,
     );
   }
 
@@ -3326,17 +3354,26 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   function requestSolve() {
     const ws = wsRef.current;
     if (!ws || ws.readyState !== WebSocket.OPEN) {
-      pendingRef.current = controlsRef.current;
-    } else if (inFlightRef.current) {
-      // Coalesce: latest controls will be picked up when the response arrives.
-      pendingRef.current = controlsRef.current;
-    } else {
-      inFlightRef.current = true;
-      solveCanceledRef.current = false; // a fresh send is never pre-cancelled
-      sendStartRef.current = performance.now();
-      ws.send(JSON.stringify(controlsRef.current));
+      // Can't send now. onopen resends controlsRef.current on (re)connect, so
+      // the latest state is solved as soon as the socket comes up.
+      return;
     }
-    syncSolving();
+    // Trailing-edge rAF throttle: coalesce a burst of knob changes within one
+    // animation frame to a single send of the latest controls. Bounds upload to
+    // ≤~60 msg/s during a drag and keeps localhost message churn near what the
+    // old one-in-flight gate produced; the server's latest-wins mailbox squashes
+    // whatever still piles up. The freshest value always wins within the frame.
+    if (solveRafRef.current !== null) return;
+    solveRafRef.current = requestAnimationFrame(() => {
+      solveRafRef.current = null;
+      const sock = wsRef.current;
+      if (!sock || sock.readyState !== WebSocket.OPEN) return;
+      const seq = ++seqRef.current;
+      lastSentSeqRef.current = seq;
+      sentAtRef.current.set(seq, performance.now());
+      sock.send(JSON.stringify({ ...controlsRef.current, _seq: seq }));
+      syncSolving();
+    });
   }
 
   useEffect(() => {
@@ -3345,47 +3382,60 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     wsRef.current = ws;
     ws.onopen = () => {
       setStatus("open");
-      // A prior socket's pending response can never arrive here; clear the
-      // in-flight flag so this socket can start sending. StrictMode and HMR
-      // both tear down + recreate this socket and would otherwise leave the
-      // flag stuck true, blocking all subsequent slider-driven solves.
-      inFlightRef.current = false;
-      pendingRef.current = controlsRef.current;
+      // A prior socket's in-flight responses can never arrive on this new one.
+      // Treat everything sent so far as received so `solving` can't stick true,
+      // drop stale RTT timers, then send fresh current state. StrictMode and HMR
+      // both tear the socket down + recreate it; the seq counters survive in
+      // refs, so they must never rewind below what's already been received.
+      lastReceivedSeqRef.current = lastSentSeqRef.current;
+      sentAtRef.current.clear();
       requestSolve();
     };
     ws.onclose = () => {
       setStatus("closed");
-      inFlightRef.current = false;
-      // No solve can progress while disconnected — drop the busy state so the
-      // bar doesn't spin under a "closed" status (reconnect re-arms it).
+      // No solve can progress while disconnected — collapse the outstanding
+      // count so the busy bar can't spin under a "closed" status (reconnect
+      // re-arms it via onopen).
+      lastReceivedSeqRef.current = lastSentSeqRef.current;
       setSolving(false);
     };
     ws.onerror = () => {
       setStatus("closed");
-      inFlightRef.current = false;
+      lastReceivedSeqRef.current = lastSentSeqRef.current;
       setSolving(false);
     };
     ws.onmessage = (ev) => {
-      setRttMs(performance.now() - sendStartRef.current);
       const data: SolveResponse = JSON.parse(ev.data);
-      inFlightRef.current = false;
-      // Cancelled solve: drop its result (the user bailed). Still honor any
-      // solve queued after the cancel so the next request isn't lost.
-      if (solveCanceledRef.current) {
-        solveCanceledRef.current = false;
-        if (pendingRef.current) {
-          pendingRef.current = null;
-          requestSolve();
-        }
+      const seq = data._seq ?? 0;
+      // One socket delivers in order, and the server may skip-send superseded
+      // results — so a higher `_seq` implicitly acknowledges every lower one.
+      // Ignore a straggler/duplicate at or below the received watermark.
+      if (seq <= lastReceivedSeqRef.current) {
+        syncSolving();
+        return;
+      }
+      lastReceivedSeqRef.current = seq;
+      // RTT from this seq's send; prune every acked entry (≤ seq) from the map —
+      // seqs skipped server-side never get their own response, so a single
+      // higher-seq arrival clears the whole run of them.
+      const sentAt = sentAtRef.current;
+      const t0 = sentAt.get(seq);
+      if (t0 !== undefined) setRttMs(performance.now() - t0);
+      for (const k of sentAt.keys()) {
+        if (k <= seq) sentAt.delete(k);
+      }
+      // Cancelled through this seq: the user bailed on it (and everything
+      // before). The watermark advanced above so `solving` can clear; just drop
+      // the result rather than rendering it.
+      if (seq <= canceledThroughSeqRef.current) {
         syncSolving();
         return;
       }
       // Drop a response for an antenna the user already switched away from: a
       // slow in-flight solve for the previous selection must not stomp the new
-      // antenna's geometry preview (and briefly show the wrong antenna). The
-      // pending solve below still fires so the current selection gets solved.
-      const stale = !!data.geometry && data.geometry !== geometryRef.current;
-      if (!stale) {
+      // antenna's geometry preview (and briefly show the wrong antenna).
+      const staleGeom = !!data.geometry && data.geometry !== geometryRef.current;
+      if (!staleGeom) {
         if (data.error) {
           // A solve that raised (e.g. a user design's build_wires) — show the
           // message and clear stale plot data rather than rendering an empty
@@ -3397,14 +3447,15 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
           setResult(data);
         }
       }
-      // If controls changed while waiting, fire the next solve immediately.
-      if (pendingRef.current) {
-        pendingRef.current = null;
-        requestSolve();
-      }
       syncSolving();
     };
-    return () => ws.close();
+    return () => {
+      if (solveRafRef.current !== null) {
+        cancelAnimationFrame(solveRafRef.current);
+        solveRafRef.current = null;
+      }
+      ws.close();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active]);
 

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -86,6 +86,7 @@ os.environ.setdefault("GOMP_SPINCOUNT", "0")
 
 # ruff: noqa: E402 — imports below must follow the env-var setup above so
 # OpenBLAS picks up the thread count at its own import time.
+import asyncio
 import hashlib
 import json
 import time
@@ -464,6 +465,11 @@ _CACHE_KEY_BLOCKLIST = frozenset(
     {
         "_request_id",
         "_client_ts",
+        # Per-request sequence number for the /ws latest-wins protocol. Pure
+        # metadata — echoed back so the client can order/prune responses; must
+        # not shred the cache hit rate (a scrub back to an earlier value should
+        # still hit even though its _seq is higher).
+        "_seq",
     }
 )
 
@@ -1015,11 +1021,44 @@ def examples_endpoint():
 
 @app.websocket("/ws")
 async def ws_endpoint(ws: WebSocket):
+    # Latest-wins mailbox. A dedicated reader task drains the socket into a
+    # size-1 mailbox (overwriting any unsolved request), while the solver loop
+    # below pulls the newest request whenever it's free. This squashes
+    # superseded knob changes *server-side*: the client sends every change
+    # eagerly with a monotonic `_seq`, and only the freshest queued request is
+    # ever solved. Results known to be superseded (a newer request already sat
+    # in the mailbox before we could send) are skipped — the doomed payload
+    # never travels. The client renders monotonically by `_seq`, so a higher
+    # `_seq` response implicitly acknowledges every lower one.
     await ws.accept()
+    mailbox: list[dict] = []  # size-1: newest unsolved request only
+    newer = asyncio.Event()  # set when the mailbox is (re)filled
+    closed = asyncio.Event()  # set when the socket disconnects
+
+    async def reader() -> None:
+        # Starlette requires a single reader on the socket, so *all*
+        # receive_text calls happen here; the solver loop never reads.
+        try:
+            while True:
+                req = json.loads(await ws.receive_text())
+                mailbox[:] = [req]  # overwrite → squash anything unsolved
+                newer.set()
+        except WebSocketDisconnect:
+            pass
+        finally:
+            closed.set()
+            newer.set()  # wake the solver so it can observe `closed` and exit
+
+    reader_task = asyncio.create_task(reader())
     try:
         while True:
-            raw = await ws.receive_text()
-            req = json.loads(raw)
+            await newer.wait()
+            newer.clear()
+            if closed.is_set() and not mailbox:
+                return
+            if not mailbox:
+                continue
+            req = mailbox.pop()
             try:
                 result = await run_in_threadpool(solve, req)
             except Exception as exc:  # noqa: BLE001 — a user design's build_wires can raise
@@ -1030,23 +1069,32 @@ async def ws_endpoint(ws: WebSocket):
                     "geometry": req.get("geometry"),
                     "error": user_designs.format_solve_error(exc),
                 }
-            # The client can disconnect *during* the solve (rapid
-            # slider drag tears down the React effect's WS and opens
-            # a fresh one before our threadpool finishes). When that
-            # happens send_text races with the closed socket and
-            # uvicorn logs a noisy "socket.send() raised exception"
-            # per dropped response. Skip the send when we've already
-            # been disconnected, and treat any error during send as a
-            # disconnect (the next receive_text will raise
-            # WebSocketDisconnect anyway).
-            if ws.client_state != WebSocketState.CONNECTED:
+            # Echo the sequence number on EVERY response, error path included —
+            # the client keys ordering, RTT accounting, and solving-state off it,
+            # and a stuck request would leave `solving` true forever if any path
+            # dropped the echo. The stamp lands on the (deep)copied result solve()
+            # returns, never on a cached entry.
+            result["_seq"] = req.get("_seq")
+            # Superseded while we solved? A newer request is already queued, so
+            # skip this send entirely — its response will carry a higher `_seq`
+            # and the client renders monotonically. Saves the full doomed payload
+            # (wires + interleaved sample-current arrays) on the wire.
+            if mailbox:
+                continue
+            # The client can disconnect *during* the solve (rapid slider drag
+            # tears down the React effect's WS and opens a fresh one before our
+            # threadpool finishes). When that happens send_text races with the
+            # closed socket and uvicorn logs a noisy "socket.send() raised
+            # exception". Skip the send when we've already been disconnected, and
+            # treat any error during send as a disconnect.
+            if closed.is_set() or ws.client_state != WebSocketState.CONNECTED:
                 return
             try:
                 await ws.send_text(json.dumps(result))
             except (WebSocketDisconnect, RuntimeError):
                 return
-    except WebSocketDisconnect:
-        return
+    finally:
+        reader_task.cancel()
 
 
 # Serve the built React frontend (web/static, produced by `npm run build` in

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -12,6 +12,9 @@ integration territory and want their own targeted tests.
 
 from __future__ import annotations
 
+import json
+import threading
+
 import numpy as np
 import pytest
 from fastapi.testclient import TestClient
@@ -1047,6 +1050,106 @@ def test_ws_solve_error_keeps_socket_alive(client, broken_user_design):
     assert "wires" in good
 
 
+def test_ws_endpoint_echoes_seq_on_success(client: TestClient):
+    # The latest-wins protocol keys ordering, RTT accounting, and solving-state
+    # off the echoed `_seq`; every successful response must carry the request's.
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(
+            json.dumps(
+                {
+                    "geometry": "dipoles.invvee",
+                    "measurement_freq_mhz": 28.47,
+                    "momwire_model": "triangular",
+                    "_seq": 7,
+                }
+            )
+        )
+        result = json.loads(ws.receive_text())
+    assert result["_seq"] == 7
+    assert result["geometry"] == "dipoles.invvee"
+
+
+def test_ws_endpoint_echoes_seq_on_error(client, broken_user_design):
+    # The error path must echo `_seq` too — a dropped echo here would leave the
+    # client's `solving` state stuck true forever when the newest request fails.
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(json.dumps({"geometry": broken_user_design, "_seq": 42}))
+        bad = json.loads(ws.receive_text())
+    assert "error" in bad
+    assert bad["_seq"] == 42
+
+
+def test_ws_endpoint_squashes_and_skips_superseded(client, monkeypatch):
+    # Latest-wins: while the first solve is held, a burst of newer requests
+    # collapses in the size-1 mailbox to only the freshest. The held solve is
+    # then superseded, so its send is skipped and only the newest result ships.
+    seqs_solved: list[int] = []
+    entered = threading.Event()
+    release = threading.Event()
+    reader_saw_last = threading.Event()
+
+    def blocking_solve(req: dict) -> dict:
+        seq = req.get("_seq")
+        seqs_solved.append(seq)
+        if seq == 1:
+            entered.set()
+            # Hold until the reader has drained the whole burst into the mailbox,
+            # so this solve returns to find itself superseded (deterministic).
+            release.wait(5)
+        return {"geometry": req.get("geometry"), "z_in_re": 1.0}
+
+    real_loads = json.loads
+
+    def recording_loads(s):
+        d = real_loads(s)
+        if isinstance(d, dict) and d.get("_seq") == 5:
+            reader_saw_last.set()
+        return d
+
+    monkeypatch.setattr(server, "solve", blocking_solve)
+    monkeypatch.setattr(server.json, "loads", recording_loads)
+
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(json.dumps({"geometry": "dipoles.invvee", "_seq": 1}))
+        assert entered.wait(5), "first solve never started"
+        for s in (2, 3, 4, 5):
+            ws.send_text(json.dumps({"geometry": "dipoles.invvee", "_seq": s}))
+        # Wait until the reader has consumed seq 5 (mailbox == [seq 5]) before
+        # releasing, so seq 2..4 are provably squashed, never solved.
+        assert reader_saw_last.wait(5), "reader never drained the burst"
+        release.set()
+        first = json.loads(ws.receive_text())
+
+    # Only seq 1 and seq 5 ever reach solve(); 2..4 die in the mailbox.
+    assert seqs_solved == [1, 5]
+    # seq 1's result is superseded → skipped; seq 5 is the only thing sent.
+    assert first["_seq"] == 5
+
+
+def test_ws_endpoint_handles_disconnect_during_solve(client, monkeypatch):
+    # Client drops mid-solve: the reader sees WebSocketDisconnect, the held
+    # solve later returns to a closed socket, and the handler exits cleanly with
+    # the reader task cancelled — no stray exception out of the context manager.
+    entered = threading.Event()
+    release = threading.Event()
+
+    def blocking_solve(req: dict) -> dict:
+        entered.set()
+        release.wait(5)
+        return {"geometry": req.get("geometry")}
+
+    monkeypatch.setattr(server, "solve", blocking_solve)
+
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(json.dumps({"geometry": "dipoles.invvee", "_seq": 1}))
+        assert entered.wait(5), "solve never started"
+        # Release shortly after the context exit disconnects the socket, so the
+        # handler can finish its in-flight solve and return without deadlocking
+        # the close handshake.
+        threading.Timer(0.2, release.set).start()
+    release.set()  # belt-and-suspenders if the timer hasn't fired yet
+
+
 def test_solve_z_only_returns_primary_z_and_no_feeds_for_dipole():
     z, feeds_z = server._solve_z_only(
         {
@@ -1152,6 +1255,7 @@ _IGNORED_FIELDS = frozenset(
     {
         "_request_id",
         "_client_ts",
+        "_seq",
     }
 )
 


### PR DESCRIPTION
## Summary
- **Inverts where stale knob changes get squashed** — from client hold-back to a server-side latest-wins mailbox — to cut tail latency on the hosted (fly.io) path, where client↔server RTT is real. Localhost behavior is preserved via a send throttle.
- **Server (phase 1, `web/server.py`):** rewrites the `/ws` handler as a single-reader task draining the socket into a size-1 latest-wins mailbox + a solver loop that only ever solves the freshest queued request. Echoes `_seq` on every response (success and error), skips sending results superseded mid-solve (doomed payloads never travel), and adds `_seq` to the cache-key blocklist.
- **Client (phase 2, `web/frontend/src/App.tsx`):** sends every knob change eagerly with a monotonic `_seq` (trailing-edge rAF throttle coalescing a drag to ≤~60 msg/s), replacing the `inFlightRef`/`pendingRef`/`solveCanceledRef` bookkeeping with seq watermarks. A solve is outstanding iff `lastSentSeq > lastReceivedSeq`; a higher `_seq` implicitly acks (and prunes) every lower one, including results the server skip-sent.
- Protocol is additive (`_seq` optional), but phases 1+2 must ship together — a new client against an old server would pile up since the client drops its in-flight gate.

## Known behavior (deliberate, not fixed here)
The rAF send-throttle is paused by the browser while a tab is backgrounded (`document.visibilityState === "hidden"`), so a **background-opened tab** (e.g. ctrl/cmd-click) defers its solves — including the initial `onopen` solve — until first focused. It fully self-heals: `controlsRef` holds the latest value and the queued rAF fires automatically on refocus, so nothing is lost or stuck; the only effect is a one-solve delay starting the moment the user actually looks at the tab.

Decided to **leave as-is**, because:
- It's aligned with this PR's thesis — not computing solves for a tab nobody is watching is a feature, not a bug, and saves shared threadpool CPU on the hosted instance.
- Zero correctness cost; the interactive scrub path (this PR's actual target) always runs in a visible tab and is never affected.
- A `document.hidden` fallback (`setTimeout`) is itself throttled to ≥1s in hidden tabs, so it'd be half-effective while adding a second send path to the freshly-rewritten protocol.

Cheap, self-contained follow-up if background-tab load ever proves to be a common entry path worth polishing.

## Test plan
- [x] `pytest tests/test_web_server.py` — 102 passing incl. new seq-echo (success/error), deterministic burst squash + skip-send, and disconnect-during-solve tests
- [x] Frontend `tsc --noEmit` + `vite build` clean
- [x] Manual verify in running app: knob scrub renders final value, impedance/Smith/patterns update, `solving` clears; raw-socket burst of 25 eager sends → 1 response (24 superseded results skipped server-side), `_seq` echoed exactly
- [ ] Post-deploy smoke test on fly.io: scrub a knob, confirm final value renders and `solving` clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
