### PR TITLE
Profile /ws phases 3+4: directivity-norm hotspot + electrical-size grid study

### DIFF
--- a/docs/status/2026-07-04-ws-postproc-serialization-profile.md
+++ b/docs/status/2026-07-04-ws-postproc-serialization-profile.md
@@ -1,0 +1,118 @@
+# Profile: /ws phases 3 + 4 decision (post-processing skip + serialization)
+
+Captured 2026-07-04 to decide whether phases 3 (skip stale post-processing) and
+4 (serialization) of the latest-wins refactor are worth building. Phases 1+2
+are merged (PR #226); 3+4 were left as "only if profiled" follow-ups.
+
+Both targets are server-side CPU costs, so this profiles on localhost — no
+fly.io deploy needed (the RTT-dependent tail-latency win is phases 1+2). Harness:
+`scripts/profile_ws_postproc_serialization.py`.
+
+## Test case + per-solver split
+
+Worst-case design: `arrays.bowtiearray2x4` + N=21. Both solvers feed the *same*
+1392-segment far-field integral (arrayblock and PyNEC both ship knot-only wire
+arrays, no segment-midpoint samples), so the norm cost is ~constant across them;
+only the core solve speed differs.
+
+| metric | momwire/arrayblock | pynec (dense) |
+|---|---|---|
+| core solve (impedance/currents) | ~260–390 ms | ~580 ms |
+| `_attach_derived_em_fields` | 0.01 ms | 0.01 ms |
+| `_compute_directivity_norm` | ~425–433 ms | ~426 ms |
+| total | ~700–800 ms | ~1007 ms |
+| **post / total** | **52–62 %** | **42 %** |
+| json.dumps → orjson.dumps | 3.4→0.27 ms (~13×) | 3.8→0.19 ms (~20×) |
+| deepcopy (per cache hit) | ~1.6 ms | ~1.8 ms |
+| payload | 128.6 KB | 138.2 KB |
+
+(PyNEC on this design is ~0.6 s, not dozens of seconds — dense NEC at ~336
+segments is sub-second; "dozens of seconds" needs higher N or Sommerfeld ground.)
+
+## Headline: the directivity-norm grid is ~10–16× oversampled
+
+`_compute_directivity_norm` (`server.py:156`) exists to produce **one scalar** —
+`directivity_norm = 4π / ∫|M_perp|² dΩ`, the total-radiated-power normalizer.
+Every per-direction value in its 45×90 = 4050-point grid is integrated away and
+discarded; the displayed pattern is computed separately in JS (`App.tsx:5022+`,
+along az/el cuts) and multiplied by this scalar.
+
+A scalar power integral converges fast on the bowtie (reference = 180×360):
+
+| grid | points | dB error vs ref | ms |
+|---|---|---|---|
+| 12×24 | 288 | −0.023 dB | 20 |
+| 18×36 | 648 | −0.009 dB | 51 |
+| 45×90 (current) | 4050 | −0.001 dB | 329 |
+
+BUT the required resolution scales with **electrical size** (Nyquist for the
+integral: ~2+ cells per pattern lobe, lobe count ∝ perimeter/λ). Stress test on
+`loops.triangular_skyloop` (80m loop) run at harmonics:
+
+| freq | loop size | 12×24 | 18×36 | 24×48 | 45×90 |
+|---|---|---|---|---|---|
+| 21 MHz (15m) | ~5.8λ | +0.001 | 0.000 | 0.000 | 0.000 |
+| 28.5 MHz | ~7.9λ | −0.016 | −0.005 | −0.003 | −0.001 |
+| 50 MHz | ~13.8λ | **−0.385** | −0.014 | −0.003 | −0.001 |
+| 100 MHz | ~27.6λ | +0.107 | **−0.134** | −0.084 | 0.000 |
+
+So a **fixed** coarse grid is NOT universally safe: at ~14λ, 12×24 is off
+0.385 dB; at ~28λ even 18×36 is off 0.13 dB. Gain is read to ~0.1 dB, so the
+grid must track the design's electrical extent. (The realistic 80m-on-15m case
+is ~5.8λ and fine at 12×24 — the problem only bites at VHF harmonics / long
+wires / big arrays.)
+
+## How the norm is computed (for the optimization questions)
+
+Fully numpy-vectorized, no Python loop over directions/segments. It materializes
+the whole `(nθ, nφ, Nseg) = (45, 90, 1392) ≈ 5.6M`-element complex tensor in one
+batch (doubled when ground is on — a second exp/einsum for the PEC image +
+Fresnel). Cost breakdown:
+- `phase = einsum("ijc,nc->ijn", rhat, mid)` — GEMM, inner dim 3.
+- `expp = np.exp(1j*phase)` — elementwise complex exp over 5.6M values. **The
+  bottleneck, and numpy runs it single-threaded** (no BLAS/OpenMP).
+- `M = einsum("ijn,nc->ijc", expp, weighted)` — real GEMM, BLAS-able if einsum
+  routes to it.
+
+Far-field is evaluated **twice per live solve**: Python (full sphere → scalar)
+and JS (cuts → plot). PyNEC has a **third** far-field path — `pynec_backend
+.pattern()` via NEC `rp_card`/`get_gain` — but that's a separate on-demand
+endpoint (pattern/heatmap view), not part of the live solve.
+
+## Recommendation (dwell + adaptive, NOT a fixed coarse grid)
+
+A fixed grid shrink is rejected — the electrical-size data above shows it aliases
+for large/harmonic designs. Instead, decouple the norm from the per-solve
+critical path and size the finalize grid to the design:
+
+1. **Skip the norm on superseded solves; finalize on the settled solve.** This
+   is Phase 3 specialized to the norm, and the latest-wins mailbox *already*
+   provides the dwell signal: a solve is superseded iff `mailbox` is non-empty
+   when it finishes. Doomed solves skip `_compute_directivity_norm` (fast churn,
+   they're skip-sent anyway); the settled solve (mailbox empty = the user
+   stopped = the dwell) computes it at full fidelity and renders correct. Never
+   cache a norm-skipped partial result.
+2. **JS carries forward the last-good norm during motion.** Pattern *shape* is
+   always live (JS computes cuts from currents every frame); only the absolute-dB
+   reference lags and snaps correct on settle. Small client change: reuse the
+   previous `directivity_norm` when a render lacks a fresh one.
+3. **Size the finalize grid to electrical extent** (`n_φ ≈ 3–4 × perimeter/λ`,
+   `n_θ ≈ half`): a dipole finalizes at ~12×24 (~20 ms), a 6λ loop at ~18×36, a
+   14λ structure at ~45×90+. Correct for every design, cheap for the common
+   (small) case. Paid once, on the settled solve.
+4. **Optionally move the norm to JS entirely.** It's display glue and JS already
+   has the currents + the same |M_perp| kernel; computing it there deletes the
+   server hotspot (cost → client idle CPU, no threadpool/OpenMP contention). The
+   adaptive-grid + dwell logic applies equally on the JS side.
+5. **C++ / OpenMP kernel: only if the norm stays server-side AND adaptive-grid +
+   dwell aren't enough.** Target is the single-threaded `np.exp`; a fused OpenMP
+   kernel over the direction grid would parallelize it. Try `numexpr` /
+   BLAS-routed einsums first. Caveat: an all-cores kernel contends with other
+   solves' threadpool + engine OpenMP under multi-user load.
+6. **Phase 4 (orjson): optional.** ~13–20× faster dump but only 3.4→0.2 ms
+   absolute; real argument is event-loop head-of-line blocking + 3×-cheaper
+   cache-hit responses. Low-risk drop-in; adopt if hosted multi-tab concurrency
+   is a priority, else defer. `deepcopy` (~1.7 ms/hit) is second-order.
+
+Note: `orjson` was pip-installed into `.venv` for this profiling run only; it is
+not in the app's runtime requirements.

--- a/scripts/profile_ws_postproc_serialization.py
+++ b/scripts/profile_ws_postproc_serialization.py
@@ -1,0 +1,207 @@
+"""Profile the /ws solve pipeline to decide whether phases 3 + 4 of the
+latest-wins refactor (docs/plan-ws-latest-wins.md) are worth building.
+
+Phase 3 — skip stale post-processing: when a solve is already superseded, skip
+`_attach_derived_em_fields` + `_compute_directivity_norm` between the core
+impedance/currents solve and the send. Worth it only if post-processing is a
+real fraction of a *slow* solve.
+
+Phase 4 — serialization: `json.dumps` runs on the event loop once per response
+and `solve()` pays a `deepcopy` per cache hit. Worth it only if either is a
+measurable cost on a large payload (swap to orjson / cache the string).
+
+Both are pure server-side CPU costs, so they profile on localhost — no fly.io
+deploy needed (the RTT-dependent tail-latency win is phases 1+2, already
+merged). Two cases on the worst-case design `arrays.bowtiearray2x4` + N=21:
+  - momwire / arrayblock (the interactive default; ~0.75 s warm/solve)
+  - pynec (dense NEC; dozens of seconds — post-proc uses coarser KNOT arrays
+    since PyNEC ships no segment-midpoint samples)
+
+Run: python scripts/profile_ws_postproc_serialization.py
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+import time
+from copy import deepcopy
+
+import orjson  # profiling-only dep; not in the app's runtime requirements
+
+from antennaknobs.web import pynec_backend, server
+from antennaknobs.web.examples import REGISTRY as EXAMPLES
+
+BASE_REQ = {
+    "geometry": "arrays.bowtiearray2x4",
+    "variant": "default",
+    "momwire_model": "arrayblock",
+    "n_per_wire": 21,
+    "measurement_freq_mhz": 28.47,
+    "design_freq_mhz": 28.47,
+    "wire_radius": 0.001,
+    "ground": False,
+    "ground_fast": False,
+}
+
+CHEAP_REPS = 50  # dumps/deepcopy are cheap → many reps
+
+
+def med_ms(fn, reps):
+    times = []
+    for _ in range(reps):
+        t0 = time.perf_counter()
+        fn()
+        times.append((time.perf_counter() - t0) * 1e3)
+    return statistics.median(times), min(times), max(times)
+
+
+def core_only(req):
+    """Core impedance/currents solve, mirroring server._solve_uncached but
+    stopping before the shared post-processing step."""
+    if req["solver"] == "pynec":
+        return pynec_backend.solve(dict(req))
+    ex = EXAMPLES[req["geometry"]]
+    out = ex.momwire_solve(dict(req))
+    out["solver"] = "momwire"
+    return out
+
+
+def profile_case(label, req, core_reps):
+    print(f"\n{'=' * 68}\nCASE: {label}\n{'=' * 68}")
+
+    # warm-up (JIT / caches / first-touch allocation)
+    warm = core_only(req)
+    server._attach_derived_em_fields(warm)
+    server._compute_directivity_norm(warm)
+
+    uses_samples = "sample_positions" in warm["wires"][0]
+    nseg = sum(
+        len(w.get("sample_positions", w["knot_positions"])) - 1 for w in warm["wires"]
+    )
+
+    core_med, core_lo, core_hi = med_ms(lambda: core_only(req), core_reps)
+
+    # Post-processing measured on a fresh core result each rep (the functions
+    # mutate in place, so re-running on the same dict would be a no-op/cheat).
+    emf_times, dir_times = [], []
+    for _ in range(core_reps):
+        base = core_only(req)
+        b1 = deepcopy(base)
+        t0 = time.perf_counter()
+        server._attach_derived_em_fields(b1)
+        emf_times.append((time.perf_counter() - t0) * 1e3)
+        t0 = time.perf_counter()
+        server._compute_directivity_norm(b1)
+        dir_times.append((time.perf_counter() - t0) * 1e3)
+    emf_med = statistics.median(emf_times)
+    dir_med = statistics.median(dir_times)
+    post_med = emf_med + dir_med
+    total_med = core_med + post_med
+
+    # --- Full result for serialization / copy measurements ---
+    full = core_only(req)
+    server._attach_derived_em_fields(full)
+    server._compute_directivity_norm(full)
+    full["cache_hit"] = False
+    full["_seq"] = 12345
+
+    payload = json.dumps(full)
+    payload_kb = len(payload.encode()) / 1024
+    jd_med, _, _ = med_ms(lambda: json.dumps(full), CHEAP_REPS)
+    oj_med, _, _ = med_ms(lambda: orjson.dumps(full), CHEAP_REPS)
+    dc_med, _, _ = med_ms(lambda: deepcopy(full), CHEAP_REPS)
+    assert json.loads(orjson.dumps(full)) == json.loads(payload)
+
+    arr_kind = "sample (knot+midpoint)" if uses_samples else "KNOT-only (coarse)"
+    print(
+        f"  wires={len(full['wires'])}  far-field segments={nseg} [{arr_kind}]  "
+        f"payload={payload_kb:.1f} KB  (core reps={core_reps}, median)"
+    )
+    print("\n  -- Phase 3: post-processing fraction --")
+    print(
+        f"    core (impedance/currents)   {core_med:9.1f} ms   [{core_lo:.1f}–{core_hi:.1f}]"
+    )
+    print(f"    _attach_derived_em_fields   {emf_med:9.2f} ms")
+    print(f"    _compute_directivity_norm   {dir_med:9.2f} ms")
+    print(f"    post-processing (sum)       {post_med:9.2f} ms")
+    print(f"    total                       {total_med:9.1f} ms")
+    print(f"    ==> post / total          = {100 * post_med / total_med:7.2f} %")
+    print("\n  -- Phase 4: serialization + copy --")
+    print(f"    json.dumps                  {jd_med:9.2f} ms")
+    print(
+        f"    orjson.dumps                {oj_med:9.2f} ms   ({jd_med / oj_med:.1f}x)"
+    )
+    print(f"    deepcopy (per cache hit)    {dc_med:9.2f} ms")
+
+
+def grid_convergence(label, req, grids, ref_grid=(240, 480)):
+    """Show how the directivity-norm scalar + its cost vary with grid
+    resolution, vs a fine reference. Demonstrates the norm is oversampled for
+    small designs but that the required resolution scales with electrical size
+    (so a *fixed* coarse grid is not universally safe)."""
+    import math
+
+    print(f"\n{'=' * 68}\nGRID CONVERGENCE: {label}\n{'=' * 68}")
+    base = core_only(req)
+    server._attach_derived_em_fields(base)
+
+    def norm(nt, nph):
+        o = deepcopy(base)
+        t0 = time.perf_counter()
+        server._compute_directivity_norm(o, n_theta=nt, n_phi=nph)
+        return o["directivity_norm"], (time.perf_counter() - t0) * 1e3
+
+    ref, _ = norm(*ref_grid)
+    print(f"  {'grid':>9} {'points':>7} {'dB err vs ref':>14} {'ms':>8}")
+    for nt, nph in grids:
+        dn, ms = norm(nt, nph)
+        db = 10 * math.log10(dn / ref) if dn > 0 and ref > 0 else float("nan")
+        print(f"  {f'{nt}x{nph}':>9} {nt * nph:>7} {db:>+11.3f} dB {ms:>8.1f}")
+
+
+def main():
+    profile_case(
+        "momwire / arrayblock — bowtiearray2x4 N=21",
+        {**BASE_REQ, "solver": "momwire"},
+        core_reps=5,
+    )
+    if pynec_backend.HAVE_PYNEC:
+        profile_case(
+            "pynec (dense NEC) — bowtiearray2x4 N=21",
+            {**BASE_REQ, "solver": "pynec"},
+            core_reps=2,  # dense solve is slow; keep rep count low
+        )
+    else:
+        print("\n[pynec case SKIPPED — HAVE_PYNEC is False]")
+
+    # Grid convergence: small design (bowtie) vs an electrically-large one
+    # (80m skyloop run at harmonics). Shows required grid scales with size.
+    grids = [(12, 24), (18, 36), (24, 48), (30, 60), (45, 90)]
+    grid_convergence(
+        "bowtiearray2x4 N=21 (moderate lobing)",
+        {**BASE_REQ, "solver": "momwire"},
+        grids,
+    )
+    sky = {
+        "geometry": "loops.triangular_skyloop",
+        "variant": "default",
+        "solver": "momwire",
+        "momwire_model": "triangular",
+        "n_per_wire": 80,
+        "design_freq_mhz": 3.8,  # sized for the 80m loop (~1λ)
+        "wire_radius": 0.001,
+        "ground": False,
+        "ground_fast": False,
+    }
+    for fmhz, band in [(21.0, "15m ~5.8λ"), (50.0, "6m ~13.8λ")]:
+        grid_convergence(
+            f"triangular_skyloop @ {fmhz} MHz ({band})",
+            {**sky, "measurement_freq_mhz": fmhz},
+            grids,
+        )
+    print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Profiling study (no production code touched) to decide the optional phases 3
(skip stale post-processing) and 4 (serialization) of the latest-wins /ws
refactor (#226). Adds a localhost harness + a captured `docs/status/` write-up.

- **`_compute_directivity_norm` is the hotspot** — a ~430 ms fixed tax on every
  heavy solve, independent of solver (momwire/arrayblock and dense PyNEC both
  feed the same 1392-segment far-field integral); 42–62 % of a heavy solve. It
  computes a 45×90 far-field only to extract **one scalar** (the radiated-power
  normalizer); the displayed pattern is computed separately in JS. So far-field
  is evaluated twice per live solve; PyNEC has a third path (NEC `rp_card`) but
  only in the on-demand pattern endpoint.
- **A fixed coarse grid is not universally safe.** Grid-convergence on an 80m
  `triangular_skyloop` run at harmonics shows required resolution scales with
  electrical size: 12×24 holds <0.001 dB at ~5.8λ but is off **0.385 dB at
  ~13.8λ**; ~28λ needs ~45×90.
- **Serialization (phase 4) is second-order** — orjson is ~13–20× faster but
  only 3.4→0.2 ms absolute; the only real argument is event-loop head-of-line
  blocking + cheaper cache-hit responses.

## Recommendation (captured in the doc)
Don't shrink to a fixed grid. **Skip the norm on superseded solves and finalize
on the settled solve** — the latest-wins mailbox already provides the dwell
signal — **size the finalize grid to electrical extent**, and have JS carry
forward the last-good norm during motion (shape stays live, absolute dB snaps
correct on settle). orjson/OpenMP are lower priority. Follow-up work is planned
in a separate doc for a subsequent session.

## Test plan
- [x] `ruff check` + `ruff format --check` clean (repo scope)
- [x] Harness runs; grid-convergence tables reproduce the doc's numbers
- [x] No runtime/production code changed — profiling script + status doc only

Note: `orjson` was pip-installed into `.venv` for the profiling run only; it is
not added to the app's runtime requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
