### PR TITLE
Skip directivity norm on superseded /ws solves + ground-on profiling

### DIFF
--- a/docs/plan-directivity-norm-followup.md
+++ b/docs/plan-directivity-norm-followup.md
@@ -1,0 +1,140 @@
+# Plan: directivity-norm rework + remaining /ws follow-ups
+
+Status: **not started.** Scoped 2026-07-04 for a subsequent session, from the
+profiling in `docs/status/2026-07-04-ws-postproc-serialization-profile.md`
+(merged as PR #227). Builds on the merged latest-wins /ws pipeline (PR #226,
+phases 1+2). Goal: kill the `_compute_directivity_norm` hotspot without
+compromising the absolute-gain reference on any design.
+
+## Background — what the profiling established
+
+- `_compute_directivity_norm` (`web/server.py:156`) is a **~430 ms fixed tax on
+  every heavy solve**, solver-independent (momwire/arrayblock and dense PyNEC
+  both feed the same 1392-segment far-field integral), 42–62 % of a heavy solve.
+- It computes a 45×90 far-field **only to extract one scalar** — the
+  radiated-power normalizer `directivity_norm = 4π/∫|M_perp|² dΩ`. The displayed
+  pattern is computed separately in JS (`App.tsx:5022+`, az/el cuts) and scaled
+  by this scalar. So far-field is evaluated twice per live solve; PyNEC has a
+  third path (NEC `rp_card` in the on-demand pattern endpoint) but not per-solve.
+- **A fixed coarse grid is NOT universally safe.** Required resolution scales
+  with electrical size (Nyquist-for-integral: ~2+ cells per pattern lobe, lobe
+  count ∝ perimeter/λ). On an 80m `triangular_skyloop` at harmonics, 12×24 holds
+  <0.001 dB at ~5.8λ but is off **0.385 dB at ~13.8λ**; ~28λ needs ~45×90. Gain
+  is read to ~0.1 dB, so the grid must track the design's electrical extent.
+
+## Design — decouple the norm from the per-solve critical path
+
+Three independent, composable moves. Do them in order; each stands alone.
+
+### 1. Skip the norm on superseded solves; finalize on the settled solve
+
+This is the plan's "phase 3" specialized to the norm — and the latest-wins
+mailbox already provides the dwell signal for free. In the `/ws` solver loop
+(`web/server.py`, the mailbox handler from PR #226), a solve is superseded iff
+`mailbox` is non-empty when it finishes.
+
+- Thread a `superseded: Callable[[], bool]` (closure over `bool(mailbox)`, safe
+  to read from the worker thread) into the solve path. Between the core solve
+  and `_compute_directivity_norm`, if `superseded()` → skip the norm entirely and
+  return (the result is skip-sent anyway, so its norm would be wasted).
+- The settled solve (mailbox empty = user stopped = the dwell) computes the norm
+  at full/adaptive fidelity and renders correct.
+- **Do NOT cache a norm-skipped partial result** — only fully post-processed
+  results may enter `_SOLVE_CACHE`. Gate the cache insert on "norm present".
+
+### 2. JS carries forward the last-good norm during motion
+
+Pattern *shape* is always live (JS computes cuts from the currents every frame);
+only the absolute-dB reference should lag and snap correct on settle.
+
+- In `App.tsx`, when a rendered result lacks a fresh `directivity_norm` (norm
+  skipped upstream), reuse the previous good value instead of the current
+  fallback branch (`App.tsx:5186`). Track `lastGoodNorm` in a ref.
+- Net UX: during a drag the shape updates live, absolute dBi labels are slightly
+  stale (a few tenths at most — the norm is a smooth scalar), and snap exact when
+  the user stops. Matches the "we see the shape change, absolute value settles"
+  intent.
+
+### 3. Size the finalize grid to electrical extent (+ Gauss–Legendre in θ)
+
+Replace the fixed 45×90 with a grid sized to the design, so the settled value is
+correct for every design and cheap for the common (small) case.
+
+- **Adaptive sizing:** compute the structure's max extent in wavelengths
+  `D_λ` (bounding-box diagonal / λ_meas) and set the band limit `L ≈ ceil(2π·D_λ)`.
+  Then `n_θ ≈ L + a_pad`, `n_φ ≈ 2L + b_pad` (small pads for safety). Clamp to a
+  sane floor (e.g. 12×24) and ceiling. A dipole finalizes at ~12×24 (~20 ms), a
+  6λ loop at ~18×36, a 14λ structure at ~45×90+.
+- **Quadrature:** switch the θ rule from midpoint-rectangle to **Gauss–Legendre
+  in u = cos θ** (nodes/weights from `np.polynomial.legendre.leggauss`; the
+  weight absorbs the sin θ Jacobian). Keep φ uniform — it is periodic, so the
+  rectangle rule is already spectrally accurate. Measured on the 13.8λ skyloop:
+  above the resolution floor GL is ~10–70× more accurate per θ-point (e.g. at
+  n_θ=20, uniform 0.0069 dB vs GL 0.0001 dB), saving ~30–50 % of θ points at a
+  tight tolerance. It does NOT lower the floor (~L θ points) — that is set by the
+  band-limit, not the quadrature. Low-risk, isolated change to the two node/weight
+  lines.
+- **Optional further step — Lebedev quadrature:** a true 2-D spherical rule that
+  integrates spherical harmonics to a given degree with ~30–50 % fewer points
+  than the product Gauss×uniform rule. Needs tabulated node sets (hardcode a few
+  degrees or a small dep). Only if the norm is still a bottleneck after GL +
+  adaptive + dwell. Investigate; likely not worth the complexity.
+- **Re-check the ground-on path:** it runs a *second* exp/einsum for the PEC
+  image + Fresnel (`server.py:216-253`), so it is ~2× the free-space cost and its
+  convergence should be re-measured (the reflected term is smooth, so quadrature
+  applies equally — expect similar behavior).
+
+### Alternative to 1+3: move the norm to JS entirely
+
+The norm is display glue, the display is JS, and JS already receives the currents
+*and* computes the same |M_perp| kernel. Computing the scalar in JS deletes
+`_compute_directivity_norm` from the server outright — cost moves to the client's
+idle, per-user CPU (no threadpool/OpenMP contention, scales per-user for free).
+The adaptive-grid + GL-quadrature + dwell logic all port to the JS side. Bigger
+change (reimplement the sphere integral + ground image in TS, keep it consistent
+with the existing cut renderer) but architecturally cleanest. Weigh against 1–3
+once those are in.
+
+## Lower-priority / optional
+
+- **Phase 4 (orjson serialization):** ~13–20× faster dump but only 3.4→0.2 ms
+  absolute; real argument is event-loop head-of-line blocking + 3×-cheaper
+  cache-hit responses (5.3→1.8 ms). Low-risk drop-in for the `/ws` send path
+  (add `orjson` to the `web` extra). Adopt only if hosted multi-tab concurrency
+  is a priority. `deepcopy` (~1.7 ms/hit) is second-order.
+- **Generic Phase 3 (skip ALL post-processing when superseded):** mostly
+  subsumed — `_attach_derived_em_fields` is free (0.01 ms), so the norm skip
+  (move 1) captures ~all of it. No separate work needed.
+- **C++/OpenMP kernel for the norm:** only if it stays server-side AND
+  adaptive-grid + GL + dwell are not enough. Target is the single-threaded
+  `np.exp` over the direction×segment tensor. Try `numexpr` / BLAS-routed
+  einsums first. Caveat: an all-cores kernel contends with other solves'
+  threadpool + engine OpenMP under multi-user load.
+- **rAF-hidden-tab deferral (carried over from PR #226):** the rAF send-throttle
+  pauses while a tab is backgrounded, so a background-opened tab defers its
+  solves until focused (self-heals on refocus). Left as-is deliberately. Fix only
+  if background-tab load proves a common entry path: `document.hidden` →
+  `setTimeout` fallback, or a `visibilitychange` flush.
+
+## Verification
+
+- The harness `scripts/profile_ws_postproc_serialization.py` already measures
+  per-solver cost + grid convergence (bowtie + skyloop harmonics). Extend it to
+  compare uniform vs Gauss–Legendre θ and to exercise the adaptive sizing.
+- Add a unit test for the adaptive grid sizer (extent → L → n_θ/n_φ) and an
+  accuracy regression: for a spread of designs incl. the 13.8λ skyloop, assert
+  the adaptive norm is within ~0.05 dB of a fine reference.
+- Re-measure the ground-on path convergence before shipping the adaptive grid.
+- End-to-end: scrub a heavy design (bowtiearray2x4) and confirm shape stays live
+  while absolute dBi snaps correct on settle; confirm no norm-skipped result
+  enters the cache.
+
+## Suggested sequencing
+
+1. Moves 1 + 2 together (server norm-skip on superseded + JS carry-forward) —
+   smallest change, reuses the merged mailbox, gives the fast-churn/settle
+   behavior immediately. One PR.
+2. Move 3 (adaptive grid + Gauss–Legendre θ, ground-on re-check, tests) — the
+   correctness-preserving speedup for the settled solve. One PR.
+3. Re-profile; decide whether the JS-side move, orjson, or an OpenMP kernel is
+   still warranted. Likely none are, after 1–3.

--- a/scripts/profile_ws_postproc_serialization.py
+++ b/scripts/profile_ws_postproc_serialization.py
@@ -12,10 +12,17 @@ measurable cost on a large payload (swap to orjson / cache the string).
 
 Both are pure server-side CPU costs, so they profile on localhost — no fly.io
 deploy needed (the RTT-dependent tail-latency win is phases 1+2, already
-merged). Two cases on the worst-case design `arrays.bowtiearray2x4` + N=21:
+merged). Cases on the worst-case design `arrays.bowtiearray2x4` + N=21:
   - momwire / arrayblock (the interactive default; ~0.75 s warm/solve)
   - pynec (dense NEC; dozens of seconds — post-proc uses coarser KNOT arrays
     since PyNEC ships no segment-midpoint samples)
+
+Ground is the usual interactive case, and the ground-on norm runs a *second*
+exp/einsum (PEC image + Fresnel over the upper hemisphere), so it is ~2× the
+free-space norm cost. We profile arrayblock both ground OFF and ON so the delta
+is visible, and run the grid-convergence study under ground too — the adaptive
+grid (move 3 of the directivity-norm rework) must be sized for the ground-on
+integral, not the cheaper free-space one.
 
 Run: python scripts/profile_ws_postproc_serialization.py
 """
@@ -40,7 +47,9 @@ BASE_REQ = {
     "measurement_freq_mhz": 28.47,
     "design_freq_mhz": 28.47,
     "wire_radius": 0.001,
-    "ground": False,
+    # Ground on is the usual interactive case; per-case overrides below still
+    # exercise ground OFF for the delta.
+    "ground": True,
     "ground_fast": False,
 }
 
@@ -161,14 +170,18 @@ def grid_convergence(label, req, grids, ref_grid=(240, 480)):
 
 
 def main():
-    profile_case(
-        "momwire / arrayblock — bowtiearray2x4 N=21",
-        {**BASE_REQ, "solver": "momwire"},
-        core_reps=5,
-    )
+    # arrayblock both ground OFF and ON — the ground-on norm is ~2× (image +
+    # Fresnel), and ground on is the usual interactive case.
+    for ground in (False, True):
+        tag = "ground ON" if ground else "ground OFF"
+        profile_case(
+            f"momwire / arrayblock — bowtiearray2x4 N=21 [{tag}]",
+            {**BASE_REQ, "solver": "momwire", "ground": ground},
+            core_reps=5,
+        )
     if pynec_backend.HAVE_PYNEC:
         profile_case(
-            "pynec (dense NEC) — bowtiearray2x4 N=21",
+            "pynec (dense NEC) — bowtiearray2x4 N=21 [ground ON]",
             {**BASE_REQ, "solver": "pynec"},
             core_reps=2,  # dense solve is slow; keep rep count low
         )
@@ -177,12 +190,16 @@ def main():
 
     # Grid convergence: small design (bowtie) vs an electrically-large one
     # (80m skyloop run at harmonics). Shows required grid scales with size.
+    # Run the bowtie both ground OFF and ON — the adaptive grid must be sized
+    # for the ground-on integral (upper hemisphere + reflected term).
     grids = [(12, 24), (18, 36), (24, 48), (30, 60), (45, 90)]
-    grid_convergence(
-        "bowtiearray2x4 N=21 (moderate lobing)",
-        {**BASE_REQ, "solver": "momwire"},
-        grids,
-    )
+    for ground in (False, True):
+        tag = "ground ON" if ground else "ground OFF"
+        grid_convergence(
+            f"bowtiearray2x4 N=21 (moderate lobing) [{tag}]",
+            {**BASE_REQ, "solver": "momwire", "ground": ground},
+            grids,
+        )
     sky = {
         "geometry": "loops.triangular_skyloop",
         "variant": "default",

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -5029,6 +5029,7 @@ function computeCutDbi(
   cut: FarFieldCut,
   azElevDeg: number,
   elevAzDeg: number,
+  fallbackNorm?: number,
 ): { dbi: number[]; peakDbi: number } | null {
   const azElevRad = (azElevDeg * Math.PI) / 180;
   const azSinT = Math.cos(azElevRad);
@@ -5182,10 +5183,19 @@ function computeCutDbi(
     if (mag2 > maxMag2) maxMag2 = mag2;
   }
   if (maxMag2 <= 0) return null;
+  // Absolute-dBi reference. Prefer this result's own norm. When it's absent
+  // (the server skipped the directivity-norm integral because this solve was
+  // superseded mid-drag), carry forward the last settled norm the caller
+  // tracked — the pattern *shape* is already live from the currents above, and
+  // the norm is a smooth scalar that only shifts the absolute labels by tenths
+  // until the drag settles and an exact norm arrives. Only if nothing is known
+  // (first solve of a session) fall back to peak-normalizing the trace.
   const norm =
     result.directivity_norm && result.directivity_norm > 0
       ? result.directivity_norm
-      : 1 / maxMag2;
+      : fallbackNorm && fallbackNorm > 0
+        ? fallbackNorm
+        : 1 / maxMag2;
   const dbi = mag2s.map((m) => (norm * m > 0 ? 10 * Math.log10(norm * m) : -Infinity));
   return { dbi, peakDbi: 10 * Math.log10(norm * maxMag2) };
 }
@@ -5209,6 +5219,11 @@ function FarFieldChart({
 }) {
   const theme = useContext(ThemeContext); // repaint on theme toggle (dep below)
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  // Last absolute-dBi norm from a *settled* solve. Superseded solves ship no
+  // `directivity_norm` (the server skips that ~430 ms integral for a doomed
+  // result), so we carry the last good one forward: shape tracks live, the
+  // absolute reference lags a few tenths and snaps exact when the drag stops.
+  const lastGoodNormRef = useRef<number | null>(null);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -5249,9 +5264,22 @@ function FarFieldChart({
     // Compute every trace (live + any pinned ghosts) up front, so the radial
     // scale below can expand to fit the highest-gain lobe on screen. Cheap —
     // each is computed once here and reused when drawing.
+    // Record a fresh settled norm so it can be carried forward on the next
+    // superseded (norm-less) frame; pass the last good one as the fallback.
+    if (result?.directivity_norm && result.directivity_norm > 0) {
+      lastGoodNormRef.current = result.directivity_norm;
+    }
     const liveTrace = result
-      ? computeCutDbi(result, cut, azElevDeg, elevAzDeg)
+      ? computeCutDbi(
+          result,
+          cut,
+          azElevDeg,
+          elevAzDeg,
+          lastGoodNormRef.current ?? undefined,
+        )
       : null;
+    // Pinned ghosts are static captures of settled solves — they always carry
+    // their own norm, so no carry-forward applies.
     const pinnedTraces = pinned.map((p) =>
       computeCutDbi(p.result, cut, azElevDeg, elevAzDeg),
     );

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -91,6 +91,7 @@ import hashlib
 import json
 import time
 from collections import OrderedDict
+from collections.abc import Callable
 from copy import deepcopy
 from pathlib import Path
 
@@ -496,24 +497,32 @@ def _canonical_solve_key(req: dict) -> str:
     return hashlib.blake2b(blob, digest_size=16).hexdigest()
 
 
-def _solve_uncached(req: dict) -> dict:
+def _solve_uncached(req: dict, superseded: Callable[[], bool] | None = None) -> dict:
     geometry = req.get("geometry", next(iter(EXAMPLES)))
     use_pynec = req.get("solver") == "pynec" and pynec_backend.HAVE_PYNEC
     _check_solve_size(req, use_pynec=use_pynec)
     if use_pynec:
         out = pynec_backend.solve(req)
-        _attach_derived_em_fields(out)
-        _compute_directivity_norm(out)
-        return out
-    ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
-    out = ex.momwire_solve(req)
-    out["solver"] = "momwire"
+    else:
+        ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
+        out = ex.momwire_solve(req)
+        out["solver"] = "momwire"
     _attach_derived_em_fields(out)
+    # The directivity norm is a ~430 ms far-field integral (the heaviest single
+    # step of a solve) whose only product is one scalar reference for absolute
+    # dBi. When a newer request already sits in the mailbox this result is
+    # doomed to be skip-sent, so computing its norm is pure waste — skip it and
+    # let the solver pull the fresher request sooner. The result then carries no
+    # `directivity_norm` key, which the caller uses to keep it out of the cache
+    # (only fully post-processed results may be cached) and which the frontend
+    # reads as "carry the last-good norm forward".
+    if superseded is not None and superseded():
+        return out
     _compute_directivity_norm(out)
     return out
 
 
-def solve(req: dict) -> dict:
+def solve(req: dict, superseded: Callable[[], bool] | None = None) -> dict:
     key = _canonical_solve_key(req)
     hit = _SOLVE_CACHE.get(key)
     if hit is not None:
@@ -527,11 +536,16 @@ def solve(req: dict) -> dict:
         out["solve_ms"] = (time.perf_counter() - t0) * 1e3
         out["cache_hit"] = True
         return out
-    out = _solve_uncached(req)
+    out = _solve_uncached(req, superseded)
     out["cache_hit"] = False
-    _SOLVE_CACHE[key] = deepcopy(out)
-    while len(_SOLVE_CACHE) > _SOLVE_CACHE_MAX:
-        _SOLVE_CACHE.popitem(last=False)
+    # Only cache a fully post-processed result. A norm-skipped (superseded)
+    # solve lacks `directivity_norm`; caching it would let a later exact-repeat
+    # request hit a partial entry and render with a stale/absent absolute
+    # reference forever.
+    if "directivity_norm" in out:
+        _SOLVE_CACHE[key] = deepcopy(out)
+        while len(_SOLVE_CACHE) > _SOLVE_CACHE_MAX:
+            _SOLVE_CACHE.popitem(last=False)
     return out
 
 
@@ -1059,8 +1073,14 @@ async def ws_endpoint(ws: WebSocket):
             if not mailbox:
                 continue
             req = mailbox.pop()
+            # `bool(mailbox)` flips to True the instant the reader queues a newer
+            # request, and the reader only ever *fills* the mailbox while we hold
+            # this popped request — so this closure is a monotonic "am I already
+            # stale?" signal that's safe to poll from the solve worker thread.
+            # solve() uses it to skip the doomed result's directivity norm.
+            superseded = lambda: bool(mailbox)  # noqa: E731
             try:
-                result = await run_in_threadpool(solve, req)
+                result = await run_in_threadpool(solve, req, superseded)
             except Exception as exc:  # noqa: BLE001 — a user design's build_wires can raise
                 # A solve that raises must not tear down the socket (that drops
                 # every subsequent slider-driven solve). Send the cause so the

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -324,6 +324,47 @@ def test_solve_dispatches_to_momwire_for_dipole():
     assert out["z_in_re"] > 0
 
 
+def test_solve_skips_norm_and_cache_when_superseded():
+    """A solve whose result is already superseded (a newer request queued)
+    skips the ~430 ms directivity-norm integral and must NOT enter the cache —
+    a norm-less partial result would otherwise be served forever on repeats."""
+    req = {
+        "geometry": "dipoles.invvee",
+        "measurement_freq_mhz": 28.47,
+        "design_freq_mhz": 28.47,
+        "momwire_model": "triangular",
+    }
+    server._SOLVE_CACHE.clear()
+    out = server.solve(req, superseded=lambda: True)
+    # Core solve ran and derived fields are attached...
+    assert out["solver"] == "momwire"
+    assert out["k_meas_m_inv"] > 0
+    # ...but the norm integral was skipped.
+    assert "directivity_norm" not in out
+    # And nothing was cached: the very next un-superseded solve must be a miss
+    # that produces a full (normed) result.
+    assert len(server._SOLVE_CACHE) == 0
+    full = server.solve(req, superseded=lambda: False)
+    assert full["cache_hit"] is False
+    assert full["directivity_norm"] > 0
+    assert len(server._SOLVE_CACHE) == 1
+
+
+def test_solve_computes_norm_when_not_superseded():
+    """The settled solve (mailbox empty → superseded() False) computes the norm
+    exactly as the default (superseded=None) path does, and caches it."""
+    req = {
+        "geometry": "dipoles.invvee",
+        "measurement_freq_mhz": 28.47,
+        "design_freq_mhz": 28.47,
+        "momwire_model": "triangular",
+    }
+    server._SOLVE_CACHE.clear()
+    out = server.solve(req, superseded=lambda: False)
+    assert out["directivity_norm"] > 0
+    assert len(server._SOLVE_CACHE) == 1
+
+
 def test_solve_reports_radiation_efficiency_for_terminated_antenna():
     """A terminated antenna (the rhombic's load resistor) burns most of its
     input power, so the server reports radiation_efficiency < 1 and folds it
@@ -1088,7 +1129,7 @@ def test_ws_endpoint_squashes_and_skips_superseded(client, monkeypatch):
     release = threading.Event()
     reader_saw_last = threading.Event()
 
-    def blocking_solve(req: dict) -> dict:
+    def blocking_solve(req: dict, superseded=None) -> dict:
         seq = req.get("_seq")
         seqs_solved.append(seq)
         if seq == 1:
@@ -1133,7 +1174,7 @@ def test_ws_endpoint_handles_disconnect_during_solve(client, monkeypatch):
     entered = threading.Event()
     release = threading.Event()
 
-    def blocking_solve(req: dict) -> dict:
+    def blocking_solve(req: dict, superseded=None) -> dict:
         entered.set()
         release.wait(5)
         return {"geometry": req.get("geometry")}


### PR DESCRIPTION
## Summary
Moves 1+2 of the directivity-norm rework (`docs/plan-directivity-norm-followup.md`), which targets the `_compute_directivity_norm` hotspot — measured at **~840 ms (75% of a solve) with ground on**, the usual interactive case.

- **Server (move 1):** thread a `superseded: Callable[[], bool]` closure over the `/ws` mailbox into `solve()`/`_solve_uncached()`. A solve that finds a newer request already queued skips the far-field norm integral (its result is skip-sent anyway) and returns without `directivity_norm`, freeing the solver to pull the fresher request sooner. The cache insert is gated on norm-present so a partial result never enters `_SOLVE_CACHE`.
- **Client (move 2):** `FarFieldChart` tracks the last settled norm in a ref and passes it to `computeCutDbi` as a fallback — when a rendered result lacks a fresh `directivity_norm` the absolute-dBi reference carries forward (shape stays live from the currents) and snaps exact on settle.
- **Profiling:** extend `scripts/profile_ws_postproc_serialization.py` to measure the norm with **ground on** (2× the free-space cost: PEC image + Fresnel over the upper hemisphere) and run the grid-convergence study under ground, so the move-3 adaptive grid can be sized for the integral users actually pay. Ground-on 12×24 is within 0.006 dB vs ~840 ms at 45×90.
- **Plan doc** for the whole rework (moves 1–3) added.

Note: move 1 is a latency win (doomed solves stop wasting the norm); the norm on the *settled* solve is still paid — that's what move 3 (adaptive grid + Gauss–Legendre) will cut, in a follow-up PR.

## Test plan
- [x] `pytest tests/test_web_server.py` — 104 pass (incl. new norm-skip + cache-gating tests)
- [x] `tsc --noEmit` clean; `ruff check` + `ruff format --check` clean
- [ ] Manual: scrub a heavy ground-on design (bowtiearray2x4) — shape stays live, absolute dBi snaps correct on settle, no norm-skipped result cached

🤖 Generated with [Claude Code](https://claude.com/claude-code)