### PR TITLE
Opt-in far-field grid-check overlay

### DIFF
--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1466,6 +1466,17 @@ type ConvergeData = {
   feeds_z_im_extrap?: (number | null)[];
 };
 
+// Result of the far-field grid-check: the adaptive norm the live plot uses vs
+// a fine-grid norm, with the grids that produced each. `delta_db` is the dBi
+// offset between them — the gap you see between the solid and dotted lobes.
+type GridCheckData = {
+  directivity_norm: number;
+  directivity_norm_grid: [number, number];
+  directivity_norm_fine: number;
+  grid_fine: [number, number];
+  delta_db: number;
+};
+
 // Log-spaced segments-per-wire ladder for the convergence sweep. Hentenna's
 // 8N+2 total segments at N=68 puts the dense LU at a ~550-cell matrix —
 // still snappy at this N range on all backends, but enough span to see
@@ -2238,6 +2249,12 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   const [convergeEnabled, setConvergeEnabled] = useState(false);
   const [converge, setConverge] = useState<ConvergeData | null>(null);
   const [convergeRunning, setConvergeRunning] = useState(false);
+  // Far-field grid-check: on dwell, recompute the directivity norm on a much
+  // finer grid and overlay the resulting pattern (dotted) so the user can see
+  // whether the adaptive grid was fine enough. `gridCheck` holds the fine norm
+  // + the two grids for the readout; null while off or pending.
+  const [gridCheckEnabled, setGridCheckEnabled] = useState(false);
+  const [gridCheck, setGridCheck] = useState<GridCheckData | null>(null);
   // NEC's rp_card pattern, fetched on a debounce so we don't fire one per
   // slider tick. Overlaid on the cuts as a comparison line.
   const [pattern, setPattern] = useState<PatternData | null>(null);
@@ -2362,6 +2379,8 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   const patternAbortRef = useRef<AbortController | null>(null);
   const convergeTimerRef = useRef<number | null>(null);
   const convergeAbortRef = useRef<AbortController | null>(null);
+  const gridCheckTimerRef = useRef<number | null>(null);
+  const gridCheckAbortRef = useRef<AbortController | null>(null);
   const previewAbortRef = useRef<AbortController | null>(null);
   // Timestamp (performance.now) when the busy chrome last became visible, so
   // the reveal effect can enforce a minimum-visible window. null = not shown.
@@ -2979,6 +2998,33 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     active,
   ]);
 
+  // Debounced far-field grid-check. Same shape as the converge sweep: re-runs
+  // on any antenna/param change (which invalidates the norm), gated by its own
+  // overlay checkbox, and defers until the live solve lands so it reuses that
+  // solve's server-cached currents rather than forcing a re-solve.
+  useEffect(() => {
+    gridCheckAbortRef.current?.abort();
+    if (gridCheckTimerRef.current) {
+      window.clearTimeout(gridCheckTimerRef.current);
+    }
+    setGridCheck(null);
+    if (!gridCheckEnabled || !active) {
+      return;
+    }
+    gridCheckTimerRef.current = window.setTimeout(runGridCheck, 500);
+    return () => {
+      if (gridCheckTimerRef.current) window.clearTimeout(gridCheckTimerRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    geometry, backend, backendOptsKey,
+    currentValuesKey,
+    designFreq, measFreq,
+    groundEnabled, groundFast,
+    gridCheckEnabled,
+    active,
+  ]);
+
   // Debounced NEC pattern fetch. PyNEC only — for momwire there's no rp_card
   // equivalent. Tracks measurement freq too (unlike the impedance sweep).
   useEffect(() => {
@@ -3250,6 +3296,50 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
       if (convergeAbortRef.current === controller) {
         convergeAbortRef.current = null;
         setConvergeRunning(false);
+      }
+    }
+  }
+
+  async function runGridCheck() {
+    // Defer until the live solve has returned, like the sweeps — the fine-grid
+    // norm reuses that settled solve (a server cache hit), so running before it
+    // lands would miss the cache and re-solve.
+    if (solvePending()) {
+      gridCheckTimerRef.current = window.setTimeout(runGridCheck, 200);
+      return;
+    }
+    gridCheckTimerRef.current = null;
+    gridCheckAbortRef.current?.abort();
+    const controller = new AbortController();
+    gridCheckAbortRef.current = controller;
+    try {
+      const resp = await fetch("/norm_grid_check", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildRequest()),
+        signal: controller.signal,
+      });
+      if (!resp.ok) throw new Error(`grid check failed: ${resp.status}`);
+      const data = await resp.json();
+      if (controller.signal.aborted) return;
+      if (!data.available) {
+        setGridCheck(null);
+        return;
+      }
+      const delta = 10 * Math.log10(data.directivity_norm_fine / data.directivity_norm);
+      setGridCheck({
+        directivity_norm: data.directivity_norm,
+        directivity_norm_grid: data.directivity_norm_grid,
+        directivity_norm_fine: data.directivity_norm_fine,
+        grid_fine: data.grid_fine,
+        delta_db: delta,
+      });
+    } catch (e: unknown) {
+      if (e instanceof DOMException && e.name === "AbortError") return;
+      console.error("grid check error", e);
+    } finally {
+      if (gridCheckAbortRef.current === controller) {
+        gridCheckAbortRef.current = null;
       }
     }
   }
@@ -4184,6 +4274,30 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
               </label>
             </div>
           )}
+          {(view === "azimuth" || view === "elevation") && (
+            <div className="farfield-overlay">
+              <label
+                className="overlay-checkbox"
+                title="On dwell, recompute the directivity norm on a far finer far-field grid and overlay it (dotted). Overlap ⇒ the adaptive grid is fine enough; a visible gap is the absolute-dBi error."
+              >
+                <input
+                  type="checkbox"
+                  checked={gridCheckEnabled}
+                  onChange={(e) => setGridCheckEnabled(e.target.checked)}
+                />
+                grid check
+              </label>
+              {gridCheckEnabled && gridCheck && (
+                <span
+                  className="overlay-readout"
+                  title={`adaptive ${gridCheck.directivity_norm_grid[0]}×${gridCheck.directivity_norm_grid[1]} vs fine ${gridCheck.grid_fine[0]}×${gridCheck.grid_fine[1]}`}
+                >
+                  Δ {gridCheck.delta_db >= 0 ? "+" : ""}
+                  {gridCheck.delta_db.toFixed(3)} dB
+                </span>
+              )}
+            </div>
+          )}
           {/* The cut-angle knob lives on the plot it drives: the azimuth
               (xy) cut is taken at elevation azElevDeg; the elevation (yz) cut
               is taken at azimuth bearing elevAzDeg. CCW dials from 3 o'clock. */}
@@ -4283,6 +4397,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
             showWireLabels={showWireLabels}
             showFeedNames={showFeedNames}
             multiFeed={effectiveMultiFeed}
+            fineNorm={gridCheck?.directivity_norm_fine ?? null}
           />
           {/* Solve readout, pinned to the lower-left of whichever view the
               carousel is centered on. Floats over the canvas as a HUD so the
@@ -4831,6 +4946,7 @@ function ViewPanel({
   showWireLabels = false,
   showFeedNames = true,
   multiFeed,
+  fineNorm,
 }: {
   view: View;
   size: number;
@@ -4852,6 +4968,7 @@ function ViewPanel({
   showWireLabels?: boolean;
   showFeedNames?: boolean;
   multiFeed: boolean;
+  fineNorm?: number | null;
 }) {
   if (view === "antenna") {
     // Fall back to the geometry-only preview while the real solve is in
@@ -4882,6 +4999,7 @@ function ViewPanel({
         cut="xy"
         azElevDeg={azElevDeg}
         elevAzDeg={elevAzDeg}
+        fineNorm={fineNorm}
       />
     );
   }
@@ -4895,6 +5013,7 @@ function ViewPanel({
         cut="yz"
         azElevDeg={azElevDeg}
         elevAzDeg={elevAzDeg}
+        fineNorm={fineNorm}
       />
     );
   }
@@ -5208,6 +5327,7 @@ function FarFieldChart({
   cut,
   azElevDeg,
   elevAzDeg,
+  fineNorm,
 }: {
   result: SolveResponse | null;
   pattern: PatternData | null;
@@ -5216,6 +5336,12 @@ function FarFieldChart({
   cut: FarFieldCut;
   azElevDeg: number;
   elevAzDeg: number;
+  /** Directivity norm from a much finer far-field grid than the one that
+   *  produced `result.directivity_norm`, from the opt-in grid-check. When set,
+   *  the fine-grid pattern is overlaid dotted — the norm is a scalar multiplier,
+   *  so it is the live trace shifted radially by 10·log10(fineNorm/liveNorm).
+   *  Overlap ⇒ the adaptive grid was fine enough; a visible gap ⇒ its error. */
+  fineNorm?: number | null;
 }) {
   const theme = useContext(ThemeContext); // repaint on theme toggle (dep below)
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -5294,6 +5420,16 @@ function FarFieldChart({
     const peaks: number[] = [];
     if (liveTrace) peaks.push(liveTrace.peakDbi);
     for (const t of pinnedTraces) if (t) peaks.push(t.peakDbi);
+    // Fine-grid overlay: the norm scales the whole pattern, so switching to the
+    // fine norm shifts every dBi by this constant. null when the grid-check is
+    // off or the live result carries no (settled) norm to compare against.
+    const liveNorm = result?.directivity_norm;
+    const gridDeltaDb =
+      fineNorm && fineNorm > 0 && liveNorm && liveNorm > 0
+        ? 10 * Math.log10(fineNorm / liveNorm)
+        : null;
+    // Let the radial scale grow to fit the shifted overlay when it lands higher.
+    if (liveTrace && gridDeltaDb != null) peaks.push(liveTrace.peakDbi + gridDeltaDb);
     const maxPeak = peaks.filter(Number.isFinite).reduce((a, b) => Math.max(a, b), 10);
     const DBI_TOP = Math.max(10, Math.ceil(maxPeak + 1));
     const DB_SPAN = DBI_TOP - DBI_FLOOR;
@@ -5412,6 +5548,17 @@ function FarFieldChart({
       width: 1.5,
     });
 
+    // Fine-grid norm overlay (dotted, same lobe hue): the live trace shifted
+    // radially by the constant dB offset. Sits exactly on the solid lobe when
+    // the adaptive grid was fine enough; a visible gap is the grid error. Drawn
+    // open (no fill) so the solid lobe still reads underneath.
+    if (gridDeltaDb != null) {
+      strokeTrace(
+        liveTrace.dbi.map((d) => d + gridDeltaDb),
+        { stroke: `rgba(${PC.lobeRgb}, 0.85)`, width: 1, dash: [2, 2] },
+      );
+    }
+
     // NEC exact-pattern overlay (dashed cyan line) when available. Bilinear
     // interpolation off the (θ, φ) grid; rays below horizon are skipped so
     // the line breaks at the ground rather than wrapping to the origin.
@@ -5480,7 +5627,7 @@ function FarFieldChart({
     const peakText = `peak ${peakDbi >= 0 ? "+" : ""}${peakDbi.toFixed(1)} dBi`;
     const tw = ctx.measureText(peakText).width;
     ctx.fillText(peakText, size - tw - 6, 14);
-  }, [result, pattern, pinned, size, cut, azElevDeg, elevAzDeg, theme]);
+  }, [result, pattern, pinned, size, cut, azElevDeg, elevAzDeg, fineNorm, theme]);
 
   return <canvas ref={canvasRef} className="farfield" />;
 }

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1589,7 +1589,8 @@ input[type=checkbox] {
 }
 
 .antenna-overlay,
-.smith-overlay {
+.smith-overlay,
+.farfield-overlay {
   position: absolute;
   top: var(--space-6);
   right: var(--space-6);
@@ -1598,6 +1599,18 @@ input[type=checkbox] {
   flex-direction: column;
   align-items: flex-end;
   gap: var(--space-4);
+}
+
+/* Grid-check Δ readout beside the far-field grid-check checkbox. */
+.overlay-readout {
+  font-size: var(--text-xs);
+  color: var(--muted-2);
+  font-variant-numeric: tabular-nums;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: var(--space-1) var(--space-3);
+  box-shadow: 0 2px 10px var(--shadow);
 }
 
 /* far-field cut-angle knob, overlaid bottom-right on the plot it drives */

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -180,6 +180,17 @@ def _adaptive_norm_grid(k: float, lo: np.ndarray, hi: np.ndarray) -> tuple[int, 
     return n_theta, 2 * n_theta
 
 
+def _fine_norm_grid(n_theta_adaptive: int) -> tuple[int, int]:
+    """A reference grid comfortably finer than the adaptive pick, for the
+    opt-in far-field grid-check overlay. At least 45×90 (the pre-adaptive
+    "gold" grid, measured converged to ~0.000 dB on the calibration designs)
+    and at least 2× the adaptive n_theta, capped to bound the one-shot cost on
+    electrically-huge designs. If the adaptive pick were badly low, doubling it
+    crosses the aliasing floor, so the overlay still exposes the shortfall."""
+    n_theta = int(np.clip(max(45, 2 * n_theta_adaptive), 45, 120))
+    return n_theta, 2 * n_theta
+
+
 def _compute_directivity_norm(
     out: dict,
     n_theta: int | None = None,
@@ -321,6 +332,9 @@ def _compute_directivity_norm(
     # unchanged.
     efficiency = float(out.get("radiation_efficiency", 1.0))
     out["directivity_norm"] = (4 * np.pi / p_rad * efficiency) if p_rad > 0 else 0.0
+    # Record the grid that produced this norm — the far-field grid-check overlay
+    # reads it to derive a finer reference grid and to label the comparison.
+    out["directivity_norm_grid"] = [int(n_theta), int(n_phi)]
 
 
 def _wire_record(
@@ -813,6 +827,38 @@ async def pattern_endpoint(req: dict):
     if req.get("solver") != "pynec" or not pynec_backend.HAVE_PYNEC:
         return {"available": False}
     return await run_in_threadpool(pynec_backend.pattern, req)
+
+
+def _norm_grid_check(req: dict) -> dict:
+    """Recompute the directivity norm on a grid much finer than the adaptive
+    one, on the *same* currents, so the frontend can overlay the fine-grid
+    pattern. The norm is a single scalar multiplying the whole pattern, so the
+    overlay is a pure radial dBi shift of the live trace — the gap between the
+    two lines is exactly the adaptive grid's error. Reuses the settled solve
+    (a cache hit on the dwell request, so no re-solve on the common path)."""
+    out = solve(dict(req))
+    if "directivity_norm" not in out:
+        return {"available": False}
+    adaptive_grid = out.get("directivity_norm_grid") or [17, 34]
+    adaptive_norm = out["directivity_norm"]
+    n_theta, n_phi = _fine_norm_grid(int(adaptive_grid[0]))
+    # Recompute in place: `out` is already a copy solve() owns (cache-hit
+    # deepcopy or a fresh miss), and we only need its scalar norm now.
+    _compute_directivity_norm(out, n_theta=n_theta, n_phi=n_phi)
+    return {
+        "available": True,
+        "directivity_norm": adaptive_norm,
+        "directivity_norm_grid": adaptive_grid,
+        "directivity_norm_fine": out["directivity_norm"],
+        "grid_fine": [n_theta, n_phi],
+    }
+
+
+@app.post("/norm_grid_check")
+async def norm_grid_check_endpoint(req: dict):
+    """Fine-grid directivity norm for the far-field grid-check overlay (opt-in,
+    dwell-triggered). See `_norm_grid_check`."""
+    return await run_in_threadpool(_norm_grid_check, req)
 
 
 @app.post("/export_nec")

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -443,6 +443,29 @@ def test_directivity_norm_adaptive_within_005_dB_of_fine_reference(req):
     )
 
 
+def test_norm_grid_check_endpoint_returns_finer_converged_norm(client: TestClient):
+    """The grid-check endpoint returns a fine-grid norm on a strictly finer grid
+    than the adaptive one, and — since the adaptive grid is already converged for
+    this design — the two agree to within 0.05 dB (the overlay would sit on top
+    of the live trace)."""
+    server._SOLVE_CACHE.clear()
+    req = {
+        "geometry": "dipoles.invvee",
+        "measurement_freq_mhz": 28.47,
+        "design_freq_mhz": 28.47,
+        "momwire_model": "triangular",
+        "ground": True,
+    }
+    resp = client.post("/norm_grid_check", json=req).json()
+    assert resp["available"] is True
+    assert resp["directivity_norm"] > 0 and resp["directivity_norm_fine"] > 0
+    # Fine grid is strictly finer than the adaptive one.
+    assert resp["grid_fine"][0] > resp["directivity_norm_grid"][0]
+    assert resp["grid_fine"][1] == 2 * resp["grid_fine"][0]
+    db = 10 * np.log10(resp["directivity_norm"] / resp["directivity_norm_fine"])
+    assert abs(db) < 0.05
+
+
 def test_directivity_norm_gl_beats_uniform_at_coarse_grid():
     """At a coarse theta grid on an electrically-large design, Gauss-Legendre is
     strictly closer to the fine reference than the legacy uniform-midpoint rule


### PR DESCRIPTION
## Summary
Adds a "grid check" checkbox on the azimuth/elevation views, mirroring the Smith chart's converge-sweep idiom, to answer "we can't know a priori whether the far-field norm grid is fine enough" by *measuring* it for the actual design.

- On dwell it recomputes the directivity norm on a grid much finer than the adaptive one and overlays the resulting pattern **dotted**. Because the norm is a single scalar multiplying the whole pattern, the overlay is the live trace shifted radially by `10·log10(fine/adaptive)` — overlap ⇒ the adaptive grid was fine enough; a visible gap is its absolute-dBi error. A Δ readout shows the offset and the two grids.
- **Server:** `/norm_grid_check` endpoint + `_norm_grid_check`/`_fine_norm_grid`. Reuses the settled solve's currents (a cache hit on the dwell request → no re-solve on the common path) and re-integrates once on a ≥45×90, ≥2×-adaptive grid. `_compute_directivity_norm` now records `directivity_norm_grid`.
- **Client:** `gridCheckEnabled`/`gridCheck` state + a dwell-debounced effect (deferring until the live solve lands, like the converge sweep); `FarFieldChart` draws the dotted shifted overlay and grows the radial scale to fit it.

Follow-on to the directivity-norm rework (moves 1–3, merged). This is the robustness net for the adaptive grid on designs we never calibrated.

## Test plan
- [x] `pytest tests/test_web_server.py` — 111 pass (incl. new `/norm_grid_check` test: strictly-finer grid, agrees <0.05 dB on a converged design)
- [x] `tsc --noEmit` clean; `ruff check` + `ruff format --check` clean
- [x] Browser run: checkbox on azimuth view → dwell fetch → "Δ +0.000 dB" readout (dipole adaptive 14×28 vs fine 45×90, converged so the dotted overlay coincides with the live lobe). `curl` confirmed the bowtie ground-on case (adaptive 17×34 vs fine 45×90, Δ ≈ 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)