### PR TITLE
Far-field gain norm from input power; closed-form pattern integral backs the norm check

### DIFF
--- a/docs/plan-directivity-norm-followup.md
+++ b/docs/plan-directivity-norm-followup.md
@@ -1,10 +1,16 @@
 # Plan: directivity-norm rework + remaining /ws follow-ups
 
-Status: **not started.** Scoped 2026-07-04 for a subsequent session, from the
-profiling in `docs/status/2026-07-04-ws-postproc-serialization-profile.md`
-(merged as PR #227). Builds on the merged latest-wins /ws pipeline (PR #226,
-phases 1+2). Goal: kill the `_compute_directivity_norm` hotspot without
-compromising the absolute-gain reference on any design.
+Status: **superseded (2026-07-04).** Moves 1–3 shipped (superseded-skip +
+adaptive grid + GL quadrature, PRs through #230), then the whole approach was
+replaced by a change of algorithm on the `gain-norm-input-power` branch: the
+live norm is now the O(1) input-power identity `η₀k²/(8π·P_in)` (the displayed
+gain algebraically equals the old `(4π/∮|M_perp|²dΩ)·efficiency`, so the
+integral cancelled out of the product), and the pattern integral survives only
+as the dwell-triggered `/norm_check` power-balance diagnostic, computed in
+closed form (spherical-Bessel pair sum — exact, no grid) on the PEC web paths.
+The superseded-skip and JS norm carry-forward from move 1 were removed again
+along with the hotspot they worked around. Kept below for the profiling
+background.
 
 ## Background — what the profiling established
 

--- a/scripts/profile_ws_postproc_serialization.py
+++ b/scripts/profile_ws_postproc_serialization.py
@@ -1,6 +1,13 @@
 """Profile the /ws solve pipeline to decide whether phases 3 + 4 of the
 latest-wins refactor (docs/plan-ws-latest-wins.md) are worth building.
 
+HISTORICAL NOTE: this harness motivated the input-power norm rework. The live
+solve path no longer runs `_compute_directivity_norm` at all — the gain norm
+is η₀k²/(8π·P_in), O(1) (`_attach_gain_norm`), and the pattern integral
+survives only in the dwell-triggered /norm_check (closed form on PEC paths,
+this grid quadrature as the finite-ground fallback) — so the norm timings
+below profile the *check* path, not the hot path.
+
 Phase 3 — skip stale post-processing: when a solve is already superseded, skip
 `_attach_derived_em_fields` + `_compute_directivity_norm` between the core
 impedance/currents solve and the send. Worth it only if post-processing is a

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -319,11 +319,11 @@ class MomwireEngine(SimulationEngine):
         if self._network is not None:
             # excited_state imposes the physical series-load BC (not the V=0
             # pin the impedance path uses), so resistive loads shape the
-            # current; it also returns the radiation efficiency the far field
-            # uses to turn directivity into gain.
+            # current; it also returns the radiation efficiency and the
+            # source input power the far field uses to normalise gain.
             Y = self._compute_y_matrix(wavelength)
-            V_full, self._excited_efficiency = self._reducer.excited_state(
-                Y, wavelength
+            V_full, self._excited_efficiency, self._excited_p_in = (
+                self._reducer.excited_state(Y, wavelength)
             )
             feeds_resolved = [
                 (w, arc, complex(V_full[i]))
@@ -333,12 +333,22 @@ class MomwireEngine(SimulationEngine):
             self._excited_efficiency = 1.0
             Y = self._compute_y_matrix(wavelength)
             Y_total = self._apply_tls(Y, wavelength)
-            V, _ = self._resolve_feed_voltages(Y_total)
+            V, driven = self._resolve_feed_voltages(Y_total)
+            # Source input power at the driven ports of the TL-stamped port
+            # model; the TLs are lossless so this equals the power entering
+            # the wires.
+            I_ports = Y_total @ V
+            self._excited_p_in = 0.5 * float(
+                sum((V[i] * np.conj(I_ports[i])).real for i in driven)
+            )
             feeds_resolved = [
                 (w, arc, complex(V[i])) for i, (w, arc, _v) in enumerate(self._feeds)
             ]
         else:
             self._excited_efficiency = 1.0
+            # Plain path: no port model here; input_power() derives P_in from
+            # the excited solve's driving-point impedance(s) on demand.
+            self._excited_p_in = None
             return self._make_solver(wavelength=wavelength)
         return self._solver(
             wires=self._polylines,
@@ -350,6 +360,30 @@ class MomwireEngine(SimulationEngine):
             junctions=self._junctions or None,
             **self._solver_kwargs,
         )
+
+    def input_power(self):
+        """Input power 1/2·Re(Σ V_f·I_f*) in watts over the SOURCE feeds of
+        the excited solve — the gain normaliser (gain = 4π·U/P_in). Power
+        burned in resistive loads and any ground absorption stay inside
+        P_in (that is what makes 4π·U/P_in GAIN rather than directivity).
+
+        Network / TL designs record it while resolving the excitation in
+        `_make_excited_solver` (a load port is excited too, but it is not a
+        source, so its absorbed power must not be summed — the port model
+        separates the two). The plain path derives it from the excited
+        driving-point impedance(s): I_f = V_f/Z_f, so each feed contributes
+        ½·|V_f|²·Re(Z_f)/|Z_f|².
+        """
+        wavelength = self._wavelength_for(self.builder.freq)
+        sim, _coeffs, z = self._solved_excited(wavelength)
+        p_in = getattr(self, "_excited_p_in", None)
+        if p_in is not None:
+            return float(p_in)
+        z_arr = np.atleast_1d(np.asarray(z, dtype=np.complex128))
+        volts = np.array([complex(v) for *_, v in sim.feeds], dtype=np.complex128)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            terms = 0.5 * np.abs(volts) ** 2 * z_arr.real / np.abs(z_arr) ** 2
+        return float(np.sum(terms[np.isfinite(terms)]))
 
     def current_distribution(self):
         sim, coeffs, _z = self._solved_excited(self._wavelength_for(self.builder.freq))

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -37,6 +37,7 @@ def _parity_for_solver(solver, solver_kwargs):
 
 
 C_LIGHT = 299_792_458.0
+ETA0 = 376.730313668  # free-space impedance, ohms
 EPS0 = 8.854_187_817e-12
 
 
@@ -519,30 +520,35 @@ class MomwireEngine(SimulationEngine):
         sim, coeffs, _z = self._solved_excited(wavelength)
         mid, dr, i_mid = self._segment_dipoles(sim, coeffs)
 
-        # Cell-centred integration grid for ∫|M_perp|² dΩ. With ground the
-        # antenna only radiates into the upper hemisphere, so integrate
-        # there only (otherwise we'd double-count the image contribution
-        # against zero-amplitude below the ground plane).
-        n_th_int, n_ph_int = 90, 180
-        if self._ground is not None:
-            theta_int = (np.arange(n_th_int) + 0.5) * (np.pi / 2 / n_th_int)
-            dtheta = np.pi / 2 / n_th_int
+        # Gain normaliser from the source input power (same convention as the
+        # web solve path): gain = 4π·U/P_in = η₀k²/(8π·P_in)·|M_perp|². Load
+        # loss lives inside P_in, so terminated antennas come out as GAIN with
+        # no efficiency multiply.
+        p_in = self.input_power()
+        if p_in > 0:
+            directivity_norm = ETA0 * k * k / (8.0 * np.pi * p_in)
         else:
-            theta_int = (np.arange(n_th_int) + 0.5) * (np.pi / n_th_int)
-            dtheta = np.pi / n_th_int
-        phi_int = np.arange(n_ph_int) * (2 * np.pi / n_ph_int)
-        dphi = 2 * np.pi / n_ph_int
-
-        mag2_int = self._evaluate_M_perp(mid, dr, i_mid, k, theta_int, phi_int, freq_hz)
-        p_rad = float(np.sum(mag2_int * np.sin(theta_int)[:, None]) * dtheta * dphi)
-        if p_rad <= 0:
-            raise RuntimeError("computed zero radiated power")
-        # For a network with resistive loads the excited solve reports the
-        # fraction of input power actually radiated; folding it in converts
-        # directivity into GAIN. Load-free / lossless designs report 1.0, so
-        # the field is unchanged for everything that isn't a terminated antenna.
-        efficiency = getattr(self, "_excited_efficiency", 1.0)
-        directivity_norm = 4 * np.pi / p_rad * efficiency
+            # Defensive fallback (a pathological R_in ≤ 0): normalise by the
+            # integrated pattern instead. Cell-centred grid over the sphere,
+            # upper hemisphere only with ground (the image contribution is
+            # already folded into |M_perp|² there).
+            n_th_int, n_ph_int = 90, 180
+            if self._ground is not None:
+                theta_int = (np.arange(n_th_int) + 0.5) * (np.pi / 2 / n_th_int)
+                dtheta = np.pi / 2 / n_th_int
+            else:
+                theta_int = (np.arange(n_th_int) + 0.5) * (np.pi / n_th_int)
+                dtheta = np.pi / n_th_int
+            phi_int = np.arange(n_ph_int) * (2 * np.pi / n_ph_int)
+            dphi = 2 * np.pi / n_ph_int
+            mag2_int = self._evaluate_M_perp(
+                mid, dr, i_mid, k, theta_int, phi_int, freq_hz
+            )
+            p_rad = float(np.sum(mag2_int * np.sin(theta_int)[:, None]) * dtheta * dphi)
+            if p_rad <= 0:
+                raise RuntimeError("computed zero radiated power")
+            efficiency = getattr(self, "_excited_efficiency", 1.0)
+            directivity_norm = 4 * np.pi / p_rad * efficiency
 
         # Evaluate on the user grid (NEC convention: θ from 0 to 90−Δθ).
         theta_deg = np.linspace(0, 90 - del_theta, n_theta)

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -59,6 +59,9 @@ class PyNECEngine(SimulationEngine):
         # NEC's own get_gain so engine-switching keeps the pattern meaning
         # the same thing. 1.0 = no resistive loss.
         self._excited_efficiency = 1.0
+        # Source input power 1/2·Re(Σ V·I*) in watts from the same solve; the
+        # web gain normaliser is η₀k²/(8π·P_in). None until a solve runs.
+        self._excited_p_in = None
         # Loads alone are handled natively (ld_card) and accurately by NEC, so
         # only divert to the multiport-Y + NetworkReducer path for what NEC
         # *can't* do natively: transmission lines (TL/DiffTL) and virtual
@@ -278,43 +281,45 @@ class PyNECEngine(SimulationEngine):
         return sc.get_current()[matches[seg - 1]]
 
     def _radiation_efficiency(self, sc, wavelength):
-        """P_radiated / P_input = 1 - P_dissipated / P_input over the explicit
-        resistive Load branches; 1.0 when there are none.
+        """Return ``(efficiency, p_in)``: the fraction of source input power
+        radiated rather than burned in explicit resistive Load branches
+        (1.0 when there are none), and the source input power
+        1/2·Re(Σ V·I*) itself in watts (the gain normaliser 4π·U/P_in).
 
-        This mirrors MomwireEngine's efficiency so the web UI can fold the same
-        directivity->gain correction on either engine (the JS far-field cut is
-        otherwise raw directivity). It matches NEC's own get_gain overlay to a
-        tenth of a dB -- NEC additionally counts the small global copper-loss
-        ld_card, which a PEC-wire analysis omits.
+        This mirrors MomwireEngine so the web UI normalises the far-field
+        cut identically on either engine. The efficiency matches NEC's own
+        get_gain overlay to a tenth of a dB -- NEC additionally counts the
+        small global copper-loss ld_card, which a PEC-wire analysis omits.
 
-        `sc` is the already-solved structure-currents object; `wavelength` sets
-        the load reactances. Reactive loads (a loading coil) burn nothing and
-        leave efficiency at 1.0.
+        `sc` is the already-solved structure-currents object; `wavelength`
+        sets the load reactances. Reactive loads (a loading coil) burn
+        nothing and leave efficiency at 1.0.
         """
-        if self._network is None:
-            return 1.0
-        loads = [b for b in self._network.branches if isinstance(b, Load)]
-        if not loads:
-            return 1.0
-        omega = 2.0 * np.pi * C_LIGHT / wavelength
-        # TL/DiffTL/virtual-driver networks carrying a load reduce through the
-        # shared reducer; reuse its port-level efficiency for them.
-        if self._use_reducer:
+        # TL/DiffTL/virtual-driver networks reduce through the shared
+        # reducer; reuse its port-level efficiency and input power.
+        if self._network is not None and self._use_reducer:
             Y = self._compute_y_matrix(wavelength)
-            return self._reducer.excited_state(Y, wavelength)[1]
-        # Native ld_card path: read the solved feed and load currents.
+            _v, efficiency, p_in = self._reducer.excited_state(Y, wavelength)
+            return efficiency, p_in
+        # Native path: read the solved feed (and load) currents.
         p_in = 0.0
-        for tag, seg, v in self.excitation_pairs:
+        for tag, seg, v in self.excitation_pairs or []:
             cur = self._port_current(sc, tag, seg)
             p_in += 0.5 * (complex(v) * np.conj(cur)).real
+        loads = (
+            [b for b in self._network.branches if isinstance(b, Load)]
+            if self._network is not None
+            else []
+        )
+        if not loads or p_in <= 0.0:
+            return 1.0, p_in
+        omega = 2.0 * np.pi * C_LIGHT / wavelength
         p_diss = 0.0
         for br in loads:
             tag, seg = self._network_port_loc[br.port]
             cur = self._port_current(sc, tag, seg)
             p_diss += 0.5 * load_impedance(br, omega).real * abs(cur) ** 2
-        if p_in <= 0.0:
-            return 1.0
-        return max(0.0, min(1.0, 1.0 - p_diss / p_in))
+        return max(0.0, min(1.0, 1.0 - p_diss / p_in)), p_in
 
     def _compute_y_matrix(self, wavelength):
         """Multiport short-circuit Y at the real ports, via one NEC solve per
@@ -422,7 +427,7 @@ class PyNECEngine(SimulationEngine):
             self.c = self._excited_real_context(C_LIGHT / (self.builder.freq * 1e6))
         self._set_freq_and_execute()
         sc = self.c.get_structure_currents(0)
-        self._excited_efficiency = self._radiation_efficiency(
+        self._excited_efficiency, self._excited_p_in = self._radiation_efficiency(
             sc, C_LIGHT / (self.builder.freq * 1e6)
         )
         all_tags = list(sc.get_current_segment_tag())

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -288,8 +288,11 @@ class PyNECEngine(SimulationEngine):
 
         This mirrors MomwireEngine so the web UI normalises the far-field
         cut identically on either engine. The efficiency matches NEC's own
-        get_gain overlay to a tenth of a dB -- NEC additionally counts the
-        small global copper-loss ld_card, which a PEC-wire analysis omits.
+        get_gain overlay to a tenth of a dB. (With WIRE_CONDUCTIVITY left at
+        None there is no global copper-loss ld_card — wires are PEC on both
+        engines — so over ground the remaining rp-vs-cut gap is purely NEC's
+        Sommerfeld ground versus the PEC-image approximation, measured within
+        ~0.5 dB.)
 
         `sc` is the already-solved structure-currents object; `wavelength`
         sets the load reactances. Reactive loads (a loading coil) burn

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -302,13 +302,15 @@ class NetworkReducer:
         ``V_k = -Z_L,k * I_k`` at each loaded port, so the load shapes the
         current the same way NEC2's ld_card does.
 
-        Returns ``(V_full, efficiency)``:
+        Returns ``(V_full, efficiency, p_in)``:
           V_full      -- (n_total,) port voltages to force in the excited solver
           efficiency  -- P_radiated / P_input = 1 - P_dissipated / P_input, the
                          fraction of input power radiated rather than burned in
-                         resistive loads. The far field multiplies directivity
-                         by it to get GAIN. A load-free / lossless network
-                         returns 1.0, leaving the field unchanged.
+                         resistive loads. A load-free / lossless network
+                         returns 1.0.
+          p_in        -- input power 1/2 Re(Σ V_src · I*) in watts, the gain
+                         normaliser (gain = 4π·U/P_in); it already includes the
+                         power burned in resistive loads.
         """
         omega = 2.0 * np.pi * C_LIGHT / wavelength
         # Lines stamped, loads left OUT -- they are imposed as BCs below, not
@@ -364,7 +366,7 @@ class NetworkReducer:
             sum(np.real(z_load[k]) * abs(current[k]) ** 2 for k in z_load)
         )
         efficiency = 1.0 if p_in <= 0.0 else max(0.0, min(1.0, 1.0 - p_diss / p_in))
-        return V, efficiency
+        return V, efficiency, p_in
 
     def impedance_from_y(self, Y_total):
         """Driven-port impedance: solve the network for V (loaded ports

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -1042,11 +1042,13 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             "multi_feed": hints()["multi_feed"],
             "default_view": hints()["default_view"],
             # Fraction of input power actually radiated (1.0 unless the design
-            # has resistive loads, e.g. a terminated rhombic / T2FD). The
-            # server's far-field normaliser multiplies directivity by this so
-            # the UI plots GAIN, not directivity; current_distribution() above
-            # populated it on the engine.
+            # has resistive loads, e.g. a terminated rhombic / T2FD);
+            # current_distribution() above populated it on the engine.
             "radiation_efficiency": float(getattr(eng, "_excited_efficiency", 1.0)),
+            # Source input power in watts: the server's gain normaliser is
+            # η₀k²/(8π·P_in), which is what makes the plot GAIN (load and
+            # ground losses live inside P_in, so no efficiency multiply).
+            "input_power_w": float(eng.input_power()),
         }
         if hints()["multi_feed"] and len(zs) > 1:
             # Pull per-feed drive voltages off the engine so the frontend
@@ -1194,10 +1196,11 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             "z0_ohms": hints()["target_z0"],
             "multi_feed": hints()["multi_feed"],
             "default_view": hints()["default_view"],
-            # Same directivity->gain factor as the momwire path, so switching
-            # engines in the UI keeps the far-field plot meaning GAIN.
-            # current_distribution() set it from the solved load currents.
+            # Same fields as the momwire path, so switching engines in the UI
+            # keeps the far-field plot meaning GAIN. current_distribution()
+            # set both from the solved feed/load currents.
             "radiation_efficiency": float(getattr(eng, "_excited_efficiency", 1.0)),
+            "input_power_w": float(getattr(eng, "_excited_p_in", None) or 0.0),
         }
         if hints()["multi_feed"] and len(zs) > 1:
             # PyNECEngine.excitation_pairs is [(tag, sub_seg, voltage)];

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1466,14 +1466,15 @@ type ConvergeData = {
   feeds_z_im_extrap?: (number | null)[];
 };
 
-// Result of the far-field grid-check: the adaptive norm the live plot uses vs
-// a fine-grid norm, with the grids that produced each. `delta_db` is the dBi
-// offset between them — the gap you see between the solid and dotted lobes.
-type GridCheckData = {
+// Result of the far-field norm consistency check: the live gain norm comes
+// from the circuit side (input power); `pattern_norm` recomputes it from the
+// field side (closed-form pattern integral). `delta_db` is the gap between
+// them — the solver's power-balance error (NEC's "average gain" diagnostic),
+// rendered as the offset between the solid and dotted lobes.
+type NormCheckData = {
   directivity_norm: number;
-  directivity_norm_grid: [number, number];
-  directivity_norm_fine: number;
-  grid_fine: [number, number];
+  pattern_norm: number;
+  method: string;
   delta_db: number;
 };
 
@@ -2249,12 +2250,13 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   const [convergeEnabled, setConvergeEnabled] = useState(false);
   const [converge, setConverge] = useState<ConvergeData | null>(null);
   const [convergeRunning, setConvergeRunning] = useState(false);
-  // Far-field grid-check: on dwell, recompute the directivity norm on a much
-  // finer grid and overlay the resulting pattern (dotted) so the user can see
-  // whether the adaptive grid was fine enough. `gridCheck` holds the fine norm
-  // + the two grids for the readout; null while off or pending.
-  const [gridCheckEnabled, setGridCheckEnabled] = useState(false);
-  const [gridCheck, setGridCheck] = useState<GridCheckData | null>(null);
+  // Far-field norm consistency check: on dwell, recompute the gain norm from
+  // the pattern integral (field side) and overlay the resulting pattern
+  // (dotted) against the live input-power norm (circuit side). The gap is the
+  // solver's power-balance error. Cheap (closed form), so on by default;
+  // the checkbox hides the overlay. `normCheck` is null while off or pending.
+  const [normCheckEnabled, setNormCheckEnabled] = useState(true);
+  const [normCheck, setNormCheck] = useState<NormCheckData | null>(null);
   // NEC's rp_card pattern, fetched on a debounce so we don't fire one per
   // slider tick. Overlaid on the cuts as a comparison line.
   const [pattern, setPattern] = useState<PatternData | null>(null);
@@ -2379,8 +2381,8 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   const patternAbortRef = useRef<AbortController | null>(null);
   const convergeTimerRef = useRef<number | null>(null);
   const convergeAbortRef = useRef<AbortController | null>(null);
-  const gridCheckTimerRef = useRef<number | null>(null);
-  const gridCheckAbortRef = useRef<AbortController | null>(null);
+  const normCheckTimerRef = useRef<number | null>(null);
+  const normCheckAbortRef = useRef<AbortController | null>(null);
   const previewAbortRef = useRef<AbortController | null>(null);
   // Timestamp (performance.now) when the busy chrome last became visible, so
   // the reveal effect can enforce a minimum-visible window. null = not shown.
@@ -2998,22 +3000,23 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     active,
   ]);
 
-  // Debounced far-field grid-check. Same shape as the converge sweep: re-runs
-  // on any antenna/param change (which invalidates the norm), gated by its own
-  // overlay checkbox, and defers until the live solve lands so it reuses that
-  // solve's server-cached currents rather than forcing a re-solve.
+  // Debounced far-field norm consistency check. Same shape as the converge
+  // sweep: re-runs on any antenna/param change (which invalidates the norm),
+  // gated by its own overlay checkbox, and defers until the live solve lands
+  // so it reuses that solve's server-cached currents rather than forcing a
+  // re-solve.
   useEffect(() => {
-    gridCheckAbortRef.current?.abort();
-    if (gridCheckTimerRef.current) {
-      window.clearTimeout(gridCheckTimerRef.current);
+    normCheckAbortRef.current?.abort();
+    if (normCheckTimerRef.current) {
+      window.clearTimeout(normCheckTimerRef.current);
     }
-    setGridCheck(null);
-    if (!gridCheckEnabled || !active) {
+    setNormCheck(null);
+    if (!normCheckEnabled || !active) {
       return;
     }
-    gridCheckTimerRef.current = window.setTimeout(runGridCheck, 500);
+    normCheckTimerRef.current = window.setTimeout(runNormCheck, 500);
     return () => {
-      if (gridCheckTimerRef.current) window.clearTimeout(gridCheckTimerRef.current);
+      if (normCheckTimerRef.current) window.clearTimeout(normCheckTimerRef.current);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
@@ -3021,7 +3024,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     currentValuesKey,
     designFreq, measFreq,
     groundEnabled, groundFast,
-    gridCheckEnabled,
+    normCheckEnabled,
     active,
   ]);
 
@@ -3300,46 +3303,45 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     }
   }
 
-  async function runGridCheck() {
-    // Defer until the live solve has returned, like the sweeps — the fine-grid
-    // norm reuses that settled solve (a server cache hit), so running before it
-    // lands would miss the cache and re-solve.
+  async function runNormCheck() {
+    // Defer until the live solve has returned, like the sweeps — the pattern
+    // norm reuses that settled solve (a server cache hit), so running before
+    // it lands would miss the cache and re-solve.
     if (solvePending()) {
-      gridCheckTimerRef.current = window.setTimeout(runGridCheck, 200);
+      normCheckTimerRef.current = window.setTimeout(runNormCheck, 200);
       return;
     }
-    gridCheckTimerRef.current = null;
-    gridCheckAbortRef.current?.abort();
+    normCheckTimerRef.current = null;
+    normCheckAbortRef.current?.abort();
     const controller = new AbortController();
-    gridCheckAbortRef.current = controller;
+    normCheckAbortRef.current = controller;
     try {
-      const resp = await fetch("/norm_grid_check", {
+      const resp = await fetch("/norm_check", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(buildRequest()),
         signal: controller.signal,
       });
-      if (!resp.ok) throw new Error(`grid check failed: ${resp.status}`);
+      if (!resp.ok) throw new Error(`norm check failed: ${resp.status}`);
       const data = await resp.json();
       if (controller.signal.aborted) return;
       if (!data.available) {
-        setGridCheck(null);
+        setNormCheck(null);
         return;
       }
-      const delta = 10 * Math.log10(data.directivity_norm_fine / data.directivity_norm);
-      setGridCheck({
+      const delta = 10 * Math.log10(data.pattern_norm / data.directivity_norm);
+      setNormCheck({
         directivity_norm: data.directivity_norm,
-        directivity_norm_grid: data.directivity_norm_grid,
-        directivity_norm_fine: data.directivity_norm_fine,
-        grid_fine: data.grid_fine,
+        pattern_norm: data.pattern_norm,
+        method: data.method,
         delta_db: delta,
       });
     } catch (e: unknown) {
       if (e instanceof DOMException && e.name === "AbortError") return;
-      console.error("grid check error", e);
+      console.error("norm check error", e);
     } finally {
-      if (gridCheckAbortRef.current === controller) {
-        gridCheckAbortRef.current = null;
+      if (normCheckAbortRef.current === controller) {
+        normCheckAbortRef.current = null;
       }
     }
   }
@@ -4278,22 +4280,22 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
             <div className="farfield-overlay">
               <label
                 className="overlay-checkbox"
-                title="On dwell, recompute the directivity norm on a far finer far-field grid and overlay it (dotted). Overlap ⇒ the adaptive grid is fine enough; a visible gap is the absolute-dBi error."
+                title="On dwell, renormalise the pattern by its own integrated radiated power (dotted) instead of the input power the solid line uses. Overlap ⇒ the solve conserves power; a visible gap is the solver's discretisation error (NEC's 'average gain' check)."
               >
                 <input
                   type="checkbox"
-                  checked={gridCheckEnabled}
-                  onChange={(e) => setGridCheckEnabled(e.target.checked)}
+                  checked={normCheckEnabled}
+                  onChange={(e) => setNormCheckEnabled(e.target.checked)}
                 />
-                grid check
+                norm check
               </label>
-              {gridCheckEnabled && gridCheck && (
+              {normCheckEnabled && normCheck && (
                 <span
                   className="overlay-readout"
-                  title={`adaptive ${gridCheck.directivity_norm_grid[0]}×${gridCheck.directivity_norm_grid[1]} vs fine ${gridCheck.grid_fine[0]}×${gridCheck.grid_fine[1]}`}
+                  title={`input-power norm vs pattern-integral norm (${normCheck.method}); 0 dB = perfect power balance`}
                 >
-                  Δ {gridCheck.delta_db >= 0 ? "+" : ""}
-                  {gridCheck.delta_db.toFixed(3)} dB
+                  Δ {normCheck.delta_db >= 0 ? "+" : ""}
+                  {normCheck.delta_db.toFixed(3)} dB
                 </span>
               )}
             </div>
@@ -4397,7 +4399,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
             showWireLabels={showWireLabels}
             showFeedNames={showFeedNames}
             multiFeed={effectiveMultiFeed}
-            fineNorm={gridCheck?.directivity_norm_fine ?? null}
+            fineNorm={normCheck?.pattern_norm ?? null}
           />
           {/* Solve readout, pinned to the lower-left of whichever view the
               carousel is centered on. Floats over the canvas as a HUD so the
@@ -5148,7 +5150,6 @@ function computeCutDbi(
   cut: FarFieldCut,
   azElevDeg: number,
   elevAzDeg: number,
-  fallbackNorm?: number,
 ): { dbi: number[]; peakDbi: number } | null {
   const azElevRad = (azElevDeg * Math.PI) / 180;
   const azSinT = Math.cos(azElevRad);
@@ -5302,19 +5303,13 @@ function computeCutDbi(
     if (mag2 > maxMag2) maxMag2 = mag2;
   }
   if (maxMag2 <= 0) return null;
-  // Absolute-dBi reference. Prefer this result's own norm. When it's absent
-  // (the server skipped the directivity-norm integral because this solve was
-  // superseded mid-drag), carry forward the last settled norm the caller
-  // tracked — the pattern *shape* is already live from the currents above, and
-  // the norm is a smooth scalar that only shifts the absolute labels by tenths
-  // until the drag settles and an exact norm arrives. Only if nothing is known
-  // (first solve of a session) fall back to peak-normalizing the trace.
+  // Absolute-dBi reference. Every solve carries its gain norm (an O(1)
+  // input-power scalar server-side), so the only fallback is peak-normalizing
+  // a response that somehow shipped without one (defensive).
   const norm =
     result.directivity_norm && result.directivity_norm > 0
       ? result.directivity_norm
-      : fallbackNorm && fallbackNorm > 0
-        ? fallbackNorm
-        : 1 / maxMag2;
+      : 1 / maxMag2;
   const dbi = mag2s.map((m) => (norm * m > 0 ? 10 * Math.log10(norm * m) : -Infinity));
   return { dbi, peakDbi: 10 * Math.log10(norm * maxMag2) };
 }
@@ -5336,20 +5331,16 @@ function FarFieldChart({
   cut: FarFieldCut;
   azElevDeg: number;
   elevAzDeg: number;
-  /** Directivity norm from a much finer far-field grid than the one that
-   *  produced `result.directivity_norm`, from the opt-in grid-check. When set,
-   *  the fine-grid pattern is overlaid dotted — the norm is a scalar multiplier,
-   *  so it is the live trace shifted radially by 10·log10(fineNorm/liveNorm).
-   *  Overlap ⇒ the adaptive grid was fine enough; a visible gap ⇒ its error. */
+  /** Field-side gain norm from the dwell-triggered norm check (the pattern
+   *  renormalised by its own integrated radiated power instead of the input
+   *  power the live norm uses). When set, that pattern is overlaid dotted —
+   *  the norm is a scalar multiplier, so it is the live trace shifted
+   *  radially by 10·log10(fineNorm/liveNorm). Overlap ⇒ the solve conserves
+   *  power; a visible gap ⇒ the solver's discretisation error. */
   fineNorm?: number | null;
 }) {
   const theme = useContext(ThemeContext); // repaint on theme toggle (dep below)
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  // Last absolute-dBi norm from a *settled* solve. Superseded solves ship no
-  // `directivity_norm` (the server skips that ~430 ms integral for a doomed
-  // result), so we carry the last good one forward: shape tracks live, the
-  // absolute reference lags a few tenths and snaps exact when the drag stops.
-  const lastGoodNormRef = useRef<number | null>(null);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -5390,22 +5381,9 @@ function FarFieldChart({
     // Compute every trace (live + any pinned ghosts) up front, so the radial
     // scale below can expand to fit the highest-gain lobe on screen. Cheap —
     // each is computed once here and reused when drawing.
-    // Record a fresh settled norm so it can be carried forward on the next
-    // superseded (norm-less) frame; pass the last good one as the fallback.
-    if (result?.directivity_norm && result.directivity_norm > 0) {
-      lastGoodNormRef.current = result.directivity_norm;
-    }
     const liveTrace = result
-      ? computeCutDbi(
-          result,
-          cut,
-          azElevDeg,
-          elevAzDeg,
-          lastGoodNormRef.current ?? undefined,
-        )
+      ? computeCutDbi(result, cut, azElevDeg, elevAzDeg)
       : null;
-    // Pinned ghosts are static captures of settled solves — they always carry
-    // their own norm, so no carry-forward applies.
     const pinnedTraces = pinned.map((p) =>
       computeCutDbi(p.result, cut, azElevDeg, elevAzDeg),
     );
@@ -5420,9 +5398,9 @@ function FarFieldChart({
     const peaks: number[] = [];
     if (liveTrace) peaks.push(liveTrace.peakDbi);
     for (const t of pinnedTraces) if (t) peaks.push(t.peakDbi);
-    // Fine-grid overlay: the norm scales the whole pattern, so switching to the
-    // fine norm shifts every dBi by this constant. null when the grid-check is
-    // off or the live result carries no (settled) norm to compare against.
+    // Norm-check overlay: the norm scales the whole pattern, so switching to
+    // the field-side norm shifts every dBi by this constant. null when the
+    // check is off or the live result carries no norm to compare against.
     const liveNorm = result?.directivity_norm;
     const gridDeltaDb =
       fineNorm && fineNorm > 0 && liveNorm && liveNorm > 0

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1601,7 +1601,7 @@ input[type=checkbox] {
   gap: var(--space-4);
 }
 
-/* Grid-check Δ readout beside the far-field grid-check checkbox. */
+/* Norm-check Δ readout beside the far-field norm-check checkbox. */
 .overlay-readout {
   font-size: var(--text-xs);
   color: var(--muted-2);

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -91,7 +91,6 @@ import hashlib
 import json
 import time
 from collections import OrderedDict
-from collections.abc import Callable
 from copy import deepcopy
 from pathlib import Path
 
@@ -152,6 +151,37 @@ def _attach_derived_em_fields(out: dict) -> None:
     out["k_meas_m_inv"] = omega / C_LIGHT
     sigma = float(out.get("ground_sigma", 0.0) or 0.0)
     out["ground_eps_im"] = -sigma / (omega * _EPS0) if omega > 0 else 0.0
+
+
+_ETA0 = 376.730313668  # free-space impedance, ohms
+
+
+def _attach_gain_norm(out: dict) -> None:
+    """Attach `directivity_norm` = η₀k²/(8π·P_in), the O(1) gain normaliser.
+
+    Multiplying this by the frontend's azimuth-cut |M_perp(π/2, φ)|² yields
+    absolute GAIN (linear); 10·log10 is dBi. Derivation: the far field of the
+    moment sum M = Σ I·dr·e^{jk·r̂·x} is E = (jkη₀/4πr)·e^{−jkr}·M_perp, so the
+    radiation intensity is U = r²|E|²/(2η₀) = (η₀k²/32π²)·|M_perp|² and
+    gain = 4π·U/P_in = (η₀k²/8π)·|M_perp|²/P_in.
+
+    Normalising by SOURCE input power is what makes this gain rather than
+    directivity: power burned in resistive loads (terminated rhombic / T2FD)
+    or absorbed by a lossy ground stays inside P_in, so no efficiency multiply
+    — this replaces the old pattern-integral norm (4π/∮|M_perp|²dΩ)×efficiency,
+    which equals it identically up to the solver's self-consistency gap (the
+    NEC "average gain" diagnostic; `_pattern_integral_norm` measures it).
+
+    Falls back to the pattern-integral norm when the response carries no
+    usable input power (defensive: a pathological R_in ≤ 0 from a nearly
+    lossless, strongly reactive discretisation).
+    """
+    p_in = float(out.get("input_power_w", 0.0) or 0.0)
+    if p_in <= 0.0:
+        _compute_directivity_norm(out)
+        return
+    k = float(out["k_meas_m_inv"])
+    out["directivity_norm"] = _ETA0 * k * k / (8.0 * np.pi * p_in)
 
 
 def _adaptive_norm_grid(k: float, lo: np.ndarray, hi: np.ndarray) -> tuple[int, int]:
@@ -567,7 +597,7 @@ def _canonical_solve_key(req: dict) -> str:
     return hashlib.blake2b(blob, digest_size=16).hexdigest()
 
 
-def _solve_uncached(req: dict, superseded: Callable[[], bool] | None = None) -> dict:
+def _solve_uncached(req: dict) -> dict:
     geometry = req.get("geometry", next(iter(EXAMPLES)))
     use_pynec = req.get("solver") == "pynec" and pynec_backend.HAVE_PYNEC
     _check_solve_size(req, use_pynec=use_pynec)
@@ -578,21 +608,11 @@ def _solve_uncached(req: dict, superseded: Callable[[], bool] | None = None) -> 
         out = ex.momwire_solve(req)
         out["solver"] = "momwire"
     _attach_derived_em_fields(out)
-    # The directivity norm is a ~430 ms far-field integral (the heaviest single
-    # step of a solve) whose only product is one scalar reference for absolute
-    # dBi. When a newer request already sits in the mailbox this result is
-    # doomed to be skip-sent, so computing its norm is pure waste — skip it and
-    # let the solver pull the fresher request sooner. The result then carries no
-    # `directivity_norm` key, which the caller uses to keep it out of the cache
-    # (only fully post-processed results may be cached) and which the frontend
-    # reads as "carry the last-good norm forward".
-    if superseded is not None and superseded():
-        return out
-    _compute_directivity_norm(out)
+    _attach_gain_norm(out)
     return out
 
 
-def solve(req: dict, superseded: Callable[[], bool] | None = None) -> dict:
+def solve(req: dict) -> dict:
     key = _canonical_solve_key(req)
     hit = _SOLVE_CACHE.get(key)
     if hit is not None:
@@ -606,16 +626,11 @@ def solve(req: dict, superseded: Callable[[], bool] | None = None) -> dict:
         out["solve_ms"] = (time.perf_counter() - t0) * 1e3
         out["cache_hit"] = True
         return out
-    out = _solve_uncached(req, superseded)
+    out = _solve_uncached(req)
     out["cache_hit"] = False
-    # Only cache a fully post-processed result. A norm-skipped (superseded)
-    # solve lacks `directivity_norm`; caching it would let a later exact-repeat
-    # request hit a partial entry and render with a stale/absent absolute
-    # reference forever.
-    if "directivity_norm" in out:
-        _SOLVE_CACHE[key] = deepcopy(out)
-        while len(_SOLVE_CACHE) > _SOLVE_CACHE_MAX:
-            _SOLVE_CACHE.popitem(last=False)
+    _SOLVE_CACHE[key] = deepcopy(out)
+    while len(_SOLVE_CACHE) > _SOLVE_CACHE_MAX:
+        _SOLVE_CACHE.popitem(last=False)
     return out
 
 
@@ -738,9 +753,8 @@ def _solve_z_only(req: dict) -> tuple[complex, list[complex] | None]:
 
     Returns (primary_z, feeds_z) where feeds_z is the per-feed Z list for
     multi-feed geometries (bowtie 1×2 array) and None for single-feed
-    geometries. Skips the directivity-norm integral that `solve()` would
-    otherwise tack on — for the /converge sweep we only need Z(N), and
-    at N ≳ 60 the directivity step adds non-negligible cost.
+    geometries. Skips solve()'s post-processing (derived EM fields, gain
+    norm) — for the /converge sweep we only need Z(N).
     """
     geometry = req.get("geometry", next(iter(EXAMPLES)))
     use_pynec = req.get("solver") == "pynec" and pynec_backend.HAVE_PYNEC
@@ -1175,14 +1189,8 @@ async def ws_endpoint(ws: WebSocket):
             if not mailbox:
                 continue
             req = mailbox.pop()
-            # `bool(mailbox)` flips to True the instant the reader queues a newer
-            # request, and the reader only ever *fills* the mailbox while we hold
-            # this popped request — so this closure is a monotonic "am I already
-            # stale?" signal that's safe to poll from the solve worker thread.
-            # solve() uses it to skip the doomed result's directivity norm.
-            superseded = lambda: bool(mailbox)  # noqa: E731
             try:
-                result = await run_in_threadpool(solve, req, superseded)
+                result = await run_in_threadpool(solve, req)
             except Exception as exc:  # noqa: BLE001 — a user design's build_wires can raise
                 # A solve that raises must not tear down the socket (that drops
                 # every subsequent slider-driven solve). Send the cause so the

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -221,6 +221,108 @@ def _fine_norm_grid(n_theta_adaptive: int) -> tuple[int, int]:
     return n_theta, 2 * n_theta
 
 
+def _moment_segments(out: dict) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Segment midpoints (Nseg,3), segment vectors dr (Nseg,3) and midpoint
+    currents (Nseg,) complex — the discrete moment set behind the far-field
+    sum M(r̂) = Σ I·dr·e^{jk·r̂·mid}, shared by every pattern normaliser.
+
+    Prefers the finer-grained sample arrays (knot + segment-midpoint) when
+    the model produced them, so non-tent bases get their intra-segment
+    curvature integrated. Falls back to knot arrays for any backend that
+    only ships knot data (PyNEC).
+    """
+    mids, drs, i_mids = [], [], []
+    for w in out["wires"]:
+        if "sample_positions" in w:
+            pts = np.asarray(w["sample_positions"], dtype=np.float64)
+            cur = np.asarray(
+                w["sample_currents_re"], dtype=np.float64
+            ) + 1j * np.asarray(w["sample_currents_im"], dtype=np.float64)
+        else:
+            pts = np.asarray(w["knot_positions"], dtype=np.float64)
+            cur = np.asarray(w["knot_currents_re"], dtype=np.float64) + 1j * np.asarray(
+                w["knot_currents_im"], dtype=np.float64
+            )
+        drs.append(pts[1:] - pts[:-1])
+        mids.append(0.5 * (pts[1:] + pts[:-1]))
+        i_mids.append(0.5 * (cur[1:] + cur[:-1]))
+    return (
+        np.concatenate(mids, axis=0),
+        np.concatenate(drs, axis=0),
+        np.concatenate(i_mids, axis=0),
+    )
+
+
+def _pattern_integral_norm(out: dict) -> float:
+    """The pattern-integral gain norm (4π/∮|M_perp|²dΩ)·efficiency evaluated
+    in CLOSED FORM — no angular grid. Because the radiated power is quadratic
+    in the currents, the sphere integral collapses to a pair sum over the
+    moment set with the classical mutual-radiation-resistance kernel:
+
+        ∮ (I₃ − r̂r̂)·e^{jk·r̂·d} dΩ = 4π[ a(x)·I₃ − b(x)·d̂d̂ ],  x = k|d|
+        a(x) = j₀(x) − j₁(x)/x        (→ 2/3 as x → 0)
+        b(x) = j₀(x) − 3·j₁(x)/x      (→ 0   as x → 0)
+
+    with spherical Bessels j₀, j₁ — real, smooth, exact. O(N²) pairs, no
+    aliasing floor, no grid to size.
+
+    Ground (the web paths are PEC — eps_r is the 1e10 sentinel): image
+    segments (x,y,z) → (x,y,−z) with horizontal moment components flipped
+    reproduce the reflected wave exactly, and the imaged 2N system is
+    mirror-symmetric, so the upper-hemisphere power is half its full-sphere
+    power. The Fresnel coefficients at eps_r = 1e10 differ from the PEC
+    limit only within ~1e-5 of grazing — beyond any displayed precision.
+
+    This is the same discrete functional the old grid integral sampled, so
+    the delta against the P_in-based `directivity_norm` isolates the solver
+    self-consistency gap (NEC's "average gain" diagnostic), not quadrature.
+    """
+    k = float(out["k_meas_m_inv"])
+    mid, dr, i_mid = _moment_segments(out)
+    w = i_mid[:, None] * dr  # complex moment per segment (Nseg, 3)
+    x_pts = mid
+    half = 1.0
+    if bool(out.get("ground", False)):
+        x_pts = np.concatenate([mid, mid * np.array([1.0, 1.0, -1.0])], axis=0)
+        w = np.concatenate([w, w * np.array([-1.0, -1.0, 1.0])], axis=0)
+        half = 0.5
+
+    # Pair sum in row blocks so peak memory stays O(block·N) instead of
+    # O(N²·3) — the terminated rhombic over ground is a ~2600-point set.
+    n_pts = x_pts.shape[0]
+    w_conj = np.conj(w)
+    block = max(1, int(2e6) // max(n_pts, 1))
+    p_sum = 0.0
+    for s in range(0, n_pts, block):
+        e = min(s + block, n_pts)
+        d = x_pts[s:e, None, :] - x_pts[None, :, :]  # (B, N, 3)
+        x = k * np.linalg.norm(d, axis=-1)  # (B, N)
+        small = x < 1e-3
+        xs = np.where(small, 1.0, x)  # avoid 0-division; small arm uses series
+        sin_x, cos_x = np.sin(xs), np.cos(xs)
+        j0 = sin_x / xs
+        j1_over_x = (sin_x / xs - cos_x) / (xs * xs)
+        x2 = x * x
+        # 2-term series at small x (the exact forms lose precision to
+        # cancellation): a = 2/3 − 2x²/15, b = −x²/15.
+        a = np.where(small, 2.0 / 3.0 - 2.0 * x2 / 15.0, j0 - j1_over_x)
+        b = np.where(small, -x2 / 15.0, j0 - 3.0 * j1_over_x)
+
+        # w_m*ᵀ [a·I − b·d̂d̂] w_n over the block's pairs. d̂ is undefined
+        # at d=0 but b→0 there, so guard the denominator instead of
+        # special-casing the diagonal.
+        dot_ww = w_conj[s:e] @ w.T  # (B, N)
+        d_norm = np.where(small, 1.0, x / k)  # |d| with the same guard
+        proj_m = np.einsum("bnc,bc->bn", d, w_conj[s:e]) / d_norm
+        proj_n = np.einsum("bnc,nc->bn", d, w) / d_norm
+        p_sum += float(np.sum(a * dot_ww.real - b * (proj_m * proj_n).real))
+    p_rad = 4.0 * np.pi * half * p_sum
+    if p_rad <= 0.0:
+        return 0.0
+    efficiency = float(out.get("radiation_efficiency", 1.0))
+    return 4.0 * np.pi / p_rad * efficiency
+
+
 def _compute_directivity_norm(
     out: dict,
     n_theta: int | None = None,
@@ -245,29 +347,7 @@ def _compute_directivity_norm(
     """
     k = float(out["k_meas_m_inv"])
     ground_on = bool(out.get("ground", False))
-
-    mids, drs, i_mids = [], [], []
-    for w in out["wires"]:
-        # Prefer the finer-grained sample arrays (knot + segment-midpoint)
-        # when the model produced them, so non-tent bases get their intra-
-        # segment curvature integrated. Falls back to knot arrays for any
-        # backend that only ships knot data (PyNEC).
-        if "sample_positions" in w:
-            pts = np.asarray(w["sample_positions"], dtype=np.float64)
-            cur = np.asarray(
-                w["sample_currents_re"], dtype=np.float64
-            ) + 1j * np.asarray(w["sample_currents_im"], dtype=np.float64)
-        else:
-            pts = np.asarray(w["knot_positions"], dtype=np.float64)
-            cur = np.asarray(w["knot_currents_re"], dtype=np.float64) + 1j * np.asarray(
-                w["knot_currents_im"], dtype=np.float64
-            )
-        drs.append(pts[1:] - pts[:-1])
-        mids.append(0.5 * (pts[1:] + pts[:-1]))
-        i_mids.append(0.5 * (cur[1:] + cur[:-1]))
-    mid = np.concatenate(mids, axis=0)  # (Nseg, 3)
-    dr = np.concatenate(drs, axis=0)  # (Nseg, 3)
-    i_mid = np.concatenate(i_mids, axis=0)  # (Nseg,)
+    mid, dr, i_mid = _moment_segments(out)
 
     if n_theta is None or n_phi is None:
         # Size the grid to the structure's electrical extent. Segment midpoints
@@ -843,36 +923,50 @@ async def pattern_endpoint(req: dict):
     return await run_in_threadpool(pynec_backend.pattern, req)
 
 
-def _norm_grid_check(req: dict) -> dict:
-    """Recompute the directivity norm on a grid much finer than the adaptive
-    one, on the *same* currents, so the frontend can overlay the fine-grid
-    pattern. The norm is a single scalar multiplying the whole pattern, so the
-    overlay is a pure radial dBi shift of the live trace — the gap between the
-    two lines is exactly the adaptive grid's error. Reuses the settled solve
-    (a cache hit on the dwell request, so no re-solve on the common path)."""
+def _norm_check(req: dict) -> dict:
+    """Consistency check for the far-field normalisation, dwell-triggered.
+
+    The live `directivity_norm` comes from the circuit side (η₀k²/8π·P_in);
+    here we recompute the same gain norm from the FIELD side — the closed-form
+    pattern integral (`_pattern_integral_norm`) × efficiency. The two agree
+    exactly for a self-consistent solve, so the dB gap between them is the
+    discretisation's power-balance error: NEC's "average gain" diagnostic.
+    The norm is a single scalar multiplying the whole pattern, so the frontend
+    overlays it as a pure radial dBi shift of the live trace.
+
+    Reuses the settled solve (a cache hit on the dwell request, so no re-solve
+    on the common path). Falls back to the fine-grid quadrature when the
+    response carries a finite (non-PEC-sentinel) ground — the image identity
+    behind the closed form is exact only for a perfect reflector."""
     out = solve(dict(req))
-    if "directivity_norm" not in out:
+    if "directivity_norm" not in out or out["directivity_norm"] <= 0:
         return {"available": False}
-    adaptive_grid = out.get("directivity_norm_grid") or [17, 34]
-    adaptive_norm = out["directivity_norm"]
-    n_theta, n_phi = _fine_norm_grid(int(adaptive_grid[0]))
-    # Recompute in place: `out` is already a copy solve() owns (cache-hit
-    # deepcopy or a fresh miss), and we only need its scalar norm now.
-    _compute_directivity_norm(out, n_theta=n_theta, n_phi=n_phi)
+    ground_on = bool(out.get("ground", False))
+    pec = float(out.get("ground_eps_r", _PEC_GROUND_EPS_R)) >= 1e6 and not float(
+        out.get("ground_sigma", 0.0) or 0.0
+    )
+    if not ground_on or pec:
+        pattern_norm = _pattern_integral_norm(out)
+        method = "closed_form"
+    else:
+        ref = dict(out)
+        n_theta, n_phi = _fine_norm_grid(45)
+        _compute_directivity_norm(ref, n_theta=n_theta, n_phi=n_phi)
+        pattern_norm = ref["directivity_norm"]
+        method = f"grid_{n_theta}x{n_phi}"
     return {
-        "available": True,
-        "directivity_norm": adaptive_norm,
-        "directivity_norm_grid": adaptive_grid,
-        "directivity_norm_fine": out["directivity_norm"],
-        "grid_fine": [n_theta, n_phi],
+        "available": pattern_norm > 0,
+        "directivity_norm": out["directivity_norm"],
+        "pattern_norm": pattern_norm,
+        "method": method,
     }
 
 
-@app.post("/norm_grid_check")
-async def norm_grid_check_endpoint(req: dict):
-    """Fine-grid directivity norm for the far-field grid-check overlay (opt-in,
-    dwell-triggered). See `_norm_grid_check`."""
-    return await run_in_threadpool(_norm_grid_check, req)
+@app.post("/norm_check")
+async def norm_check_endpoint(req: dict):
+    """Field-side vs circuit-side gain-norm consistency check for the
+    far-field overlay (dwell-triggered). See `_norm_check`."""
+    return await run_in_threadpool(_norm_check, req)
 
 
 @app.post("/export_nec")

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -318,17 +318,17 @@ def test_solve_dispatches_to_momwire_for_dipole():
     # _attach_derived_em_fields ran.
     assert "k_meas_m_inv" in out
     assert out["k_meas_m_inv"] > 0
-    # _compute_directivity_norm ran.
+    # _attach_gain_norm ran (η₀k²/8π·P_in — O(1), never skipped).
     assert "directivity_norm" in out
     assert out["directivity_norm"] > 0
+    assert out["input_power_w"] > 0
     # Real dipole has a real-part impedance roughly in the tens of ohms.
     assert out["z_in_re"] > 0
 
 
-def test_solve_skips_norm_and_cache_when_superseded():
-    """A solve whose result is already superseded (a newer request queued)
-    skips the ~430 ms directivity-norm integral and must NOT enter the cache —
-    a norm-less partial result would otherwise be served forever on repeats."""
+def test_solve_always_carries_norm_and_caches():
+    """Every solve carries directivity_norm (it's an O(1) input-power scalar
+    now, so there is no superseded-skip) and every solve result is cached."""
     req = {
         "geometry": "dipoles.invvee",
         "measurement_freq_mhz": 28.47,
@@ -336,34 +336,12 @@ def test_solve_skips_norm_and_cache_when_superseded():
         "momwire_model": "triangular",
     }
     server._SOLVE_CACHE.clear()
-    out = server.solve(req, superseded=lambda: True)
-    # Core solve ran and derived fields are attached...
-    assert out["solver"] == "momwire"
-    assert out["k_meas_m_inv"] > 0
-    # ...but the norm integral was skipped.
-    assert "directivity_norm" not in out
-    # And nothing was cached: the very next un-superseded solve must be a miss
-    # that produces a full (normed) result.
-    assert len(server._SOLVE_CACHE) == 0
-    full = server.solve(req, superseded=lambda: False)
-    assert full["cache_hit"] is False
-    assert full["directivity_norm"] > 0
-    assert len(server._SOLVE_CACHE) == 1
-
-
-def test_solve_computes_norm_when_not_superseded():
-    """The settled solve (mailbox empty → superseded() False) computes the norm
-    exactly as the default (superseded=None) path does, and caches it."""
-    req = {
-        "geometry": "dipoles.invvee",
-        "measurement_freq_mhz": 28.47,
-        "design_freq_mhz": 28.47,
-        "momwire_model": "triangular",
-    }
-    server._SOLVE_CACHE.clear()
-    out = server.solve(req, superseded=lambda: False)
+    out = server.solve(req)
     assert out["directivity_norm"] > 0
     assert len(server._SOLVE_CACHE) == 1
+    again = server.solve(req)
+    assert again["cache_hit"] is True
+    assert again["directivity_norm"] == out["directivity_norm"]
 
 
 def test_adaptive_norm_grid_scales_with_size_and_clamps():
@@ -426,28 +404,45 @@ _NORM_ACCURACY_REQS = [
 
 
 @pytest.mark.parametrize("req", _NORM_ACCURACY_REQS)
-def test_directivity_norm_adaptive_within_005_dB_of_fine_reference(req):
-    """The adaptively-sized norm must match a fine 120x240 reference to within
-    0.05 dB across the electrical-size range — the gain is read to ~0.1 dB."""
+def test_gain_norm_power_balance_within_005_dB(req):
+    """The circuit-side gain norm (η₀k²/8π·P_in) must match the field-side
+    pattern-integral norm to within 0.05 dB across the electrical-size range —
+    the momwire solve conserves power to well under the ~0.1 dB gain readout.
+    This is NEC's 'average gain' diagnostic run as a regression test."""
     server._SOLVE_CACHE.clear()
     out = server.solve(req)
-    adaptive = out["directivity_norm"]
-    assert adaptive > 0
-
-    ref = deepcopy(out)
-    server._compute_directivity_norm(ref, n_theta=120, n_phi=240)
-    db = 10 * np.log10(adaptive / ref["directivity_norm"])
+    circuit = out["directivity_norm"]
+    assert circuit > 0
+    field = server._pattern_integral_norm(out)
+    db = 10 * np.log10(circuit / field)
     assert abs(db) < 0.05, (
         f"{req['geometry']} @ {req['measurement_freq_mhz']} MHz "
-        f"ground={req['ground']}: adaptive off by {db:+.4f} dB"
+        f"ground={req['ground']}: power balance off by {db:+.4f} dB"
     )
 
 
-def test_norm_grid_check_endpoint_returns_finer_converged_norm(client: TestClient):
-    """The grid-check endpoint returns a fine-grid norm on a strictly finer grid
-    than the adaptive one, and — since the adaptive grid is already converged for
-    this design — the two agree to within 0.05 dB (the overlay would sit on top
-    of the live trace)."""
+@pytest.mark.parametrize("req", _NORM_ACCURACY_REQS)
+def test_pattern_integral_closed_form_matches_fine_grid(req):
+    """The closed-form pair-sum norm (spherical-Bessel kernel, PEC images)
+    equals the fine 120x240 GL quadrature of the same discrete functional to
+    within 0.01 dB — free space is exact; over ground the residual is the
+    eps=1e10-Fresnel-vs-PEC difference near grazing."""
+    server._SOLVE_CACHE.clear()
+    out = server.solve(req)
+    closed = server._pattern_integral_norm(out)
+    assert closed > 0
+    ref = deepcopy(out)
+    server._compute_directivity_norm(ref, n_theta=120, n_phi=240)
+    db = 10 * np.log10(closed / ref["directivity_norm"])
+    assert abs(db) < 0.01, (
+        f"{req['geometry']} ground={req['ground']}: closed form off by {db:+.4f} dB"
+    )
+
+
+def test_norm_check_endpoint_reports_power_balance(client: TestClient):
+    """/norm_check returns the live circuit-side norm plus the field-side
+    pattern norm (closed form on the PEC web paths); for a converged design
+    the two agree to within 0.05 dB (the overlay sits on the live trace)."""
     server._SOLVE_CACHE.clear()
     req = {
         "geometry": "dipoles.invvee",
@@ -456,13 +451,11 @@ def test_norm_grid_check_endpoint_returns_finer_converged_norm(client: TestClien
         "momwire_model": "triangular",
         "ground": True,
     }
-    resp = client.post("/norm_grid_check", json=req).json()
+    resp = client.post("/norm_check", json=req).json()
     assert resp["available"] is True
-    assert resp["directivity_norm"] > 0 and resp["directivity_norm_fine"] > 0
-    # Fine grid is strictly finer than the adaptive one.
-    assert resp["grid_fine"][0] > resp["directivity_norm_grid"][0]
-    assert resp["grid_fine"][1] == 2 * resp["grid_fine"][0]
-    db = 10 * np.log10(resp["directivity_norm"] / resp["directivity_norm_fine"])
+    assert resp["directivity_norm"] > 0 and resp["pattern_norm"] > 0
+    assert resp["method"] == "closed_form"
+    db = 10 * np.log10(resp["directivity_norm"] / resp["pattern_norm"])
     assert abs(db) < 0.05
 
 
@@ -494,9 +487,11 @@ def test_directivity_norm_gl_beats_uniform_at_coarse_grid():
 
 def test_solve_reports_radiation_efficiency_for_terminated_antenna():
     """A terminated antenna (the rhombic's load resistor) burns most of its
-    input power, so the server reports radiation_efficiency < 1 and folds it
-    into directivity_norm — the UI then plots GAIN, not directivity. A lossless
-    design reports 1.0 and its normaliser is unchanged."""
+    input power, so the server reports radiation_efficiency < 1 and the plot
+    means GAIN. With the input-power norm the load loss lives inside P_in (no
+    efficiency multiply), so the norm must still agree with the old
+    field-side construction (4π/∮|M_perp|²dΩ)·efficiency — the plotted gain
+    of the rhombic did not move in this rework."""
     term = server.solve({"geometry": "wire.rhombic", "momwire_model": "triangular"})
     assert 0.1 < term["radiation_efficiency"] < 0.6  # ~0.29: most power in the load
 
@@ -505,11 +500,12 @@ def test_solve_reports_radiation_efficiency_for_terminated_antenna():
     )
     assert lossless["radiation_efficiency"] == 1.0
 
-    # The efficiency actually scales the normaliser: dividing it back out
-    # recovers the bare directivity, which is strictly larger.
+    # Circuit-side norm ≡ (pattern-integral norm × efficiency), the old
+    # displayed quantity, up to the solver's power-balance gap.
     assert term["directivity_norm"] > 0
-    bare_directivity = term["directivity_norm"] / term["radiation_efficiency"]
-    assert bare_directivity > term["directivity_norm"]
+    field_side = server._pattern_integral_norm(term)  # already × efficiency
+    db = 10 * np.log10(term["directivity_norm"] / field_side)
+    assert abs(db) < 0.05
 
 
 def test_pynec_path_also_reports_radiation_efficiency():


### PR DESCRIPTION
## Summary
- Replace the per-solve far-field grid integral with the O(1) input-power gain norm `directivity_norm = η₀k²/(8π·P_in)` (the NEC gain convention). The displayed gain algebraically equals the old `(4π/∮|M_perp|²dΩ)·efficiency`, so plotted values move only by the solver's power-balance gap — measured <0.003 dB on invvee/g5rv/terminated-rhombic, ground on and off. Load loss lives inside P_in, so the efficiency multiply is deleted rather than moved.
- Both engines export source input power (`excited_state` returns `(V, efficiency, p_in)`; `MomwireEngine.input_power()`; PyNEC computes it on every solve); `input_power_w` rides the solve response. momwire `far_field()` (metrics endpoint) uses the same normaliser so metrics dBi and the plot share one definition.
- The pattern integral survives only in the dwell-triggered check, now computed in **closed form**: the sphere integral collapses to an O(N²) pair sum with the mutual-radiation-resistance kernel (spherical Bessels; PEC ground via image doubling + hemisphere halving). Matches a 120×240 GL reference to 1e-5 dB free-space / ~2e-3 dB over ground, no grid to size or alias. `/norm_grid_check` → `/norm_check`; the overlay delta now reads as the solver's power-balance error (NEC "average gain" diagnostic) and the check is default-on.
- Delete the machinery the hotspot required: superseded-solve norm-skip, norm-conditional cache gating, and the frontend's last-good-norm carry-forward (every solve carries its norm again).

## Test plan
- [x] `pytest tests/` — 1350 passed (includes new power-balance <0.05 dB and closed-form-vs-GL <0.01 dB parametrized tests, /norm_check contract, terminated-rhombic gain regression guard)
- [x] Frontend `tsc --noEmit` + vite build; bundle rebuilt
- [x] Live-server smoke test: `/norm_check` on the terminated rhombic over ground returns closed_form with +0.002 dB gap; new bundle served
- [x] Manual: drag a knob on a heavy design — norm always present (no absolute-dBi snap on settle); dotted overlay + Δ badge appear ~500 ms after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
