### PR TITLE
Preempt in-flight solves on knob-drag: /ws cancellation + momwire Phase 0-2 bump

### DIFF
--- a/docs/plan-abortable-solves.md
+++ b/docs/plan-abortable-solves.md
@@ -1,0 +1,303 @@
+# Plan: fast cooperative abort of in-flight momwire solves
+
+Status: **not started.** Scoped 2026-07-04. Follow-up to
+`plan-ws-latest-wins.md`, whose item 3 deferred exactly this: "No preemption
+of a stale in-flight solve … the engine can't be interrupted without
+cooperative checks." With latest-wins squashing merged (PR #226), a stale
+solve no longer ships its payload — but it still runs to completion,
+occupying a threadpool worker and delaying the superseding solve by the full
+remainder of the doomed one. Goal: when a newer knob value arrives, the
+in-flight momwire solve dies within ~one LAPACK-call's worth of time
+(tens of ms), not seconds.
+
+Scope: momwire only (we own the code). PyNEC gets a start-gate check but no
+mid-solve abort — its solve is one opaque native call.
+
+## The mechanism in one paragraph
+
+A `CancelToken` — a single int32 in shared memory — is created per solve on
+the caller side and threaded down through `MomwireEngine` into the solver.
+The `/ws` reader task flips it the moment a superseding request lands in the
+mailbox (and on disconnect). The solver polls it at every cheap seam:
+Python-level phase boundaries and sweep/ACA/GMRES loops check
+`token.cancelled` and raise `momwire.SolveAborted`; the long C++ kernels
+receive the flag's raw address and poll it per outer-loop iteration without
+touching the GIL. The caller catches `SolveAborted`, stores nothing in the
+solve cache, sends nothing, and moves on to the queued request.
+
+Why a shared flag and not a Python callback: the C++ kernels run under
+OpenMP; calling back into Python per row would reacquire the GIL and
+serialize the parallel region. A relaxed load of an aligned int32 costs ~1 ns
+and is safe from any thread.
+
+## Critical prerequisite: the C++ kernels never release the GIL
+
+`momwire/src/momwire/_accelerators.cpp` contains no `gil_scoped_release`
+anywhere (verified by grep). Consequences:
+
+1. **Cancellation of C++ phases is impossible today even in principle**:
+   while `sinusoidal_field_tensor` or `assemble_Z_general` runs, the pybind11
+   call holds the GIL, so the asyncio event loop is frozen — the `/ws` reader
+   task cannot even *receive* the superseding knob message, let alone set a
+   flag.
+2. **The server event loop stalls for every connection during every C++
+   fill.** This is a live latency bug independent of this plan (masked so far
+   because typical fills are short and the hosted instance is single-user).
+
+So Phase 0 is: add `py::call_guard<py::gil_scoped_release>` (or explicit
+scoped release) to every long-running exported kernel. Rules for the audit:
+argument conversion happens before `call_guard` releases, and return-value
+conversion after it reacquires, so signatures are safe as-is; the audit must
+confirm each kernel body touches only raw buffers (no `py::` API, no numpy
+allocation) between release and reacquire — allocate output arrays before
+releasing. This phase is a standalone win and ships on its own.
+
+Note: `scipy.linalg.solve` already releases the GIL inside LAPACK, so the LU
+never freezes the loop — it is merely uninterruptible, which sets the floor
+on abort latency (~20 ms at N=160, per the PR #13 numbers in momwire's
+`NEXT_STEPS.md`).
+
+## Design
+
+### momwire: `CancelToken` + `SolveAborted` (new module `_cancel.py`)
+
+```python
+class SolveAborted(Exception):
+    """Solve was cancelled via CancelToken; no result was produced."""
+
+class CancelToken:
+    def __init__(self):
+        self._flag = np.zeros(1, dtype=np.int32)
+    def cancel(self):            # any thread; idempotent
+        self._flag[0] = 1
+    @property
+    def cancelled(self):
+        return bool(self._flag[0])
+    def raise_if_cancelled(self):
+        if self._flag[0]:
+            raise SolveAborted()
+    @property
+    def ptr(self):               # raw address for the C++ kernels
+        return self._flag.ctypes.data
+```
+
+Exported from `momwire/__init__.py`. The token owns the flag's memory; the
+solver holds the token, so pointer lifetime is covered for the duration of
+any kernel call. A relaxed racy read is fine — the only transition is 0→1
+and a missed read costs one extra poll interval. (If we want rigor, the C++
+side reads via `std::atomic_ref<int32_t>`; check the standard the extension
+builds with.)
+
+### momwire: solver API
+
+`cancel: CancelToken | None = None` keyword on the **solver constructors**
+(SinusoidalSolver, TriangularSolver, BSplineSolver → inherited by
+HMatrixSolver / ArrayBlockSolver), stored as `self._cancel`. Constructor
+injection rather than per-method kwargs keeps every `compute_*` signature
+unchanged and covers internal cross-calls for free. A private helper:
+
+```python
+def _checkpoint(self):
+    if self._cancel is not None:
+        self._cancel.raise_if_cancelled()
+```
+
+Default `None` → checkpoints are a single `is not None` test; zero cost for
+existing users. No behavior change unless a token is passed, so this is a
+backward-compatible minor version bump.
+
+### momwire: Python-level checkpoint placement (Phase 1)
+
+| Seam | Location | Granularity |
+|---|---|---|
+| Phase boundaries in `compute_impedance` | `triangular.py:660`, `sinusoidal.py:922`, `bspline.py:1368` — after geometry, after J-block build, after assemble, before LU | per phase |
+| Sweep k-loops in `compute_impedance_swept` | `triangular.py:991`, `sinusoidal.py:1013`, `bspline.py:1608` — top of each frequency iteration | per frequency |
+| ACA rank-building loop | `_aca.py:156` — top of each rank iteration | per rank (~4–8 per block) |
+| H-matrix matvec block loop | `hmatrix.py:230` — checked per near/far block; this also covers GMRES, since scipy's GMRES calls our matvec every iteration | per block per iteration |
+| Enrichment two-pass | `bspline.py` auto-enrichment — between passes | per pass |
+
+Phase 1 alone already makes the *slow* cases abortable — multi-frequency
+sweeps, and the H-matrix/array solvers (the "tens-of-seconds array solves"
+the latest-wins plan called painful) — because their time is spread across
+many loop iterations. What it does not cover is a single-frequency solve
+dominated by one bulk C++ fill call; that needs Phase 2.
+
+### momwire: C++ kernel polling (Phase 2)
+
+Add a trailing `uintptr_t cancel_flag = 0` parameter (0 = no cancellation,
+fully backward compatible) to the long kernels:
+
+`sinusoidal_field_tensor`, `seg_seg_quad_batch_3d`,
+`seg_seg_reg_quad_batch_1d`, `assemble_Z`, `assemble_Z_general`,
+`assemble_Z_bspline`, `bspline_assemble_offedge_block`.
+
+Inside each, poll once per **outer** iteration (per source row / per k
+slab — row cost dwarfs a flag load, so overhead is unmeasurable). OpenMP
+forbids `break` from a `omp for`, so use the standard drain pattern:
+
+```cpp
+const volatile int32_t* cancel =
+    reinterpret_cast<const volatile int32_t*>(cancel_flag);
+std::atomic<bool> aborted{false};
+#pragma omp parallel for
+for (int i = 0; i < n; ++i) {
+    if (aborted.load(std::memory_order_relaxed)) continue;   // drain
+    if (cancel && *cancel) { aborted.store(true); continue; }
+    // ... row work ...
+}
+if (aborted) throw AbortedError{};
+```
+
+Remaining iterations become no-ops and the loop drains in microseconds.
+Define `struct AbortedError {}` and register it once with
+`py::register_exception<AbortedError>(m, "AcceleratorAborted")`; the Python
+wrappers in `_accel.py` translate it to `momwire.SolveAborted` (or we map it
+directly to the shared exception type). `_accel.py` threads
+`self._cancel.ptr if self._cancel else 0` into each call.
+
+Abort-latency floor after Phase 2 ≈ max(one dense LU, one outer row of
+fill) ≈ the LU. The array solvers avoid the dense LU (GMRES + per-block
+checks), leaving their sparse-LU preconditioner factorization as the only
+uninterruptible stretch.
+
+### antennaknobs caller (Phase 3)
+
+Thread the token explicitly (no smuggling through the req dict — it must
+never reach the cache key or serialization):
+
+- `web/server.py:695 solve(req)` → `solve(req, cancel=None)`; same for
+  `_solve_uncached` (`server.py:680`). **Cache-hit path checks nothing** —
+  hits are O(1) and never worth aborting. On `SolveAborted`, the cache-store
+  line is skipped (the exception propagates before the store, but add a test
+  pinning it).
+- `web/adapter.py:1002 momwire_solve(req)` → accept `cancel`, pass to
+  `_make_momwire_engine`, which passes it to `MomwireEngine`.
+- `engines/momwire.py MomwireEngine.__init__` gains `cancel=None`, forwards
+  it into every solver construction (`_solved_excited` at line 237,
+  `impedance_sweep` at 271, the network-Y path), and calls
+  `cancel.raise_if_cancelled()` between its own phases — `impedance()` /
+  `current_distribution()` / `far_field()` — so a cancel landing between
+  engine phases doesn't wait for the next solver-internal checkpoint.
+  An aborted solve leaves no partial state behind because `_solved_excited`
+  assigns its instance cache only after `compute_impedance` returns —
+  exception propagation guarantees it; test pins it.
+
+`/ws` handler (`server.py:1246–1322`) — the two changes:
+
+```python
+current = {"token": None}          # shared cell, reader + solver loop
+
+async def reader():
+    while True:
+        req = json.loads(await ws.receive_text())
+        mailbox[:] = [req]
+        if current["token"] is not None:
+            current["token"].cancel()      # <-- preempt in-flight solve
+        newer.set()
+    # finally: closed.set(); also cancel() — disconnect kills the solve too
+
+# solver loop:
+req = mailbox.pop()
+token = momwire.CancelToken()
+current["token"] = token           # publish BEFORE dispatch (see race note)
+try:
+    result = await run_in_threadpool(solve, req, cancel=token)
+except momwire.SolveAborted:
+    continue                       # superseded: no send, no error banner
+except Exception as exc:
+    ...existing error-response path...
+finally:
+    current["token"] = None
+```
+
+Ordering note: the token is published to the shared cell before the
+threadpool dispatch, so a reader that fires in the gap cancels a
+not-yet-started solve — which then raises `SolveAborted` at its first
+checkpoint. No lost-wakeup window. The `SolveAborted` catch must precede the
+generic `except Exception` branch, which would otherwise ship it to the
+client as a solve-error banner.
+
+The skip-send guard (`if mailbox: continue`) stays — it covers a solve that
+completes in the sliver between mailbox refill and flag observation.
+
+PyNEC (`web/pynec_backend.py`, `engines/pynec.py`): start-gate only —
+`cancel.raise_if_cancelled()` before dispatching the native solve. A queued
+stale PyNEC request dies for free; an in-flight one runs to completion, as
+today.
+
+### `/sweep` and `/converge` (Phase 4, optional)
+
+Both already check `is_disconnected()` between chunks (`server.py:791, 876`).
+Adding in-chunk cancellation needs a watcher task per request that polls
+`is_disconnected()` and flips a token shared with the chunk's solve. Worth it
+only if the per-chunk `_CHUNK_TARGET_MS` (500 ms) granularity is actually
+hurting; defer until observed.
+
+## What was rejected
+
+- **Subprocess-per-solve + SIGKILL.** The only way to preempt LAPACK too,
+  but it forfeits the in-process solve cache and warm engine state, adds
+  serialization of the large current arrays on every solve, and complicates
+  fly.io memory headroom. The cooperative floor (~one LU) is far below human
+  slider-perception threshold; not worth it.
+- **`PyThreadState_SetAsyncExc` injection.** Cannot interrupt native code,
+  can vanish at interpreter discretion, and leaves the solver's internal
+  state undefined mid-phase. Cooperative checks are deterministic.
+- **Token via `req["_cancel"]`.** Would leak into the solve-cache key
+  machinery and JSON paths; explicit parameters keep it out by construction.
+
+## Phasing / PR plan
+
+Phases 0–2 land as PRs in the **momwire repo**; 3–4 in antennaknobs with a
+submodule-pointer bump. Each is independently shippable and useful:
+
+| Phase | Repo | Content | Standalone value |
+|---|---|---|---|
+| 0 | momwire | GIL release on long C++ kernels (+ audit no Python API in released regions) | server event loop stops stalling during fills |
+| 1 | momwire | `CancelToken`, `SolveAborted`, Python checkpoints (phases, k-loops, ACA, matvec) | sweeps & array solvers abortable |
+| 2 | momwire | `cancel_flag` polling in C++ kernels, `AcceleratorAborted` mapping | single-frequency fills abortable; floor ≈ one LU |
+| 3 | antennaknobs | token threading; `/ws` cancel-on-squash + cancel-on-disconnect; `SolveAborted` handling; cache-store guard; PyNEC start-gate; submodule bump | end-to-end preemption on knob drag |
+| 4 | antennaknobs | `/sweep`/`/converge` in-chunk cancel via disconnect watcher | finer than 500 ms chunk granularity |
+
+Phase 3 works end-to-end after Phase 1 alone (Phase 2 just tightens the
+latency), so the merge order 0 → 1 → 3 → 2 is also viable if we want the UX
+win sooner.
+
+## Testing
+
+momwire:
+
+- Pre-cancelled token → `compute_impedance` raises `SolveAborted` before any
+  J-block work (assert via elapsed time or a mocked kernel).
+- Timer thread cancels mid-`compute_impedance_swept` over ~40 frequencies →
+  raises, elapsed ≪ full-sweep time.
+- Phase 2: tripped flag passed straight to each C++ kernel → raises within
+  a small multiple of one row's cost.
+- No-token path: benchmark fill with `cancel=None` vs. before-series —
+  overhead indistinguishable (it's one `is not None` per checkpoint).
+- Aborted solve leaves no instance-cache residue: cancel mid-solve, clear
+  the token, re-run `compute_impedance` → result matches a fresh solver.
+- Phase 0: kernel releases GIL — spawn a thread that acquires the GIL
+  (increments a Python counter) while a large fill runs; assert it makes
+  progress.
+
+antennaknobs:
+
+- WS test: send request A (slow design), then B immediately; assert the A
+  solve raised `SolveAborted` (instrument via a counter monkeypatched into
+  the engine), only B's response is sent, `_seq` echoes B.
+- Disconnect mid-solve → solve aborts (threadpool worker freed promptly).
+- `SolveAborted` never reaches the solve cache and never produces an
+  error-banner response.
+- Existing power-balance / norm-check tests unchanged (no-token path).
+
+## Open questions
+
+- Which C++ standard does the extension build with? (`std::atomic_ref` needs
+  C++20; `volatile` read is the fallback and fine in practice.)
+- Does any kernel body currently allocate numpy outputs mid-computation?
+  The Phase 0 audit answers this; if so, hoist allocations before the GIL
+  release.
+- `impedance_sweep` multi-RHS path (`triangular.py:753`) does one big LU —
+  after Phase 2 that single call is the longest uninterruptible stretch for
+  sweeps; acceptable, but note it in profiling.

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -73,6 +73,7 @@ class MomwireEngine(SimulationEngine):
         solver_kwargs=None,
         ground=None,
         ground_z=0.0,
+        cancel=None,
     ):
         """
         solver:
@@ -96,6 +97,10 @@ class MomwireEngine(SimulationEngine):
         """
         super().__init__(builder)
 
+        # Cooperative-cancellation token (momwire.CancelToken or None). Forwarded
+        # into every solver construction so a mid-solve cancel aborts the C++
+        # fill / Python checkpoints, and polled between this engine's own phases.
+        self._cancel = cancel
         self._solver = solver
         self._solver_kwargs = dict(solver_kwargs) if solver_kwargs else {}
         # Per-instance parity: triangular wants even, sinusoidal odd,
@@ -183,6 +188,7 @@ class MomwireEngine(SimulationEngine):
             wire_radius=self._wire_radius,
             ground_z=self._ground_z,
             junctions=self._junctions or None,
+            cancel=self._cancel,
             **self._solver_kwargs,
         )
 
@@ -253,7 +259,18 @@ class MomwireEngine(SimulationEngine):
         self._solved_cache = (key, (sim, coeffs, z))
         return sim, coeffs, z
 
+    def _raise_if_cancelled(self):
+        """Poll the cancel token at an engine-phase boundary (no-op without one).
+
+        Complements the solver-internal checkpoints: catches a cancel that lands
+        between this engine's phases (e.g. after impedance() before far_field())
+        without waiting for the next solver-internal seam.
+        """
+        if self._cancel is not None:
+            self._cancel.raise_if_cancelled()
+
     def impedance(self):
+        self._raise_if_cancelled()
         wavelength = self._wavelength_for(self.builder.freq)
         if self._network is not None:
             Y = self._compute_y_matrix(wavelength)
@@ -359,6 +376,7 @@ class MomwireEngine(SimulationEngine):
             wire_radius=self._wire_radius,
             ground_z=self._ground_z,
             junctions=self._junctions or None,
+            cancel=self._cancel,
             **self._solver_kwargs,
         )
 
@@ -387,6 +405,7 @@ class MomwireEngine(SimulationEngine):
         return float(np.sum(terms[np.isfinite(terms)]))
 
     def current_distribution(self):
+        self._raise_if_cancelled()
         sim, coeffs, _z = self._solved_excited(self._wavelength_for(self.builder.freq))
         knot_currents = sim.currents_at_knots(coeffs)
         out = []
@@ -510,6 +529,7 @@ class MomwireEngine(SimulationEngine):
         return np.sum(M_perp.real**2 + M_perp.imag**2, axis=-1)
 
     def far_field(self, *, n_theta=90, n_phi=360, del_theta=1, del_phi=1):
+        self._raise_if_cancelled()
         assert 90 % n_theta == 0 and 90 == del_theta * n_theta
         assert 360 % n_phi == 0 and 360 == del_phi * n_phi
 

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -469,7 +469,7 @@ def _ground_for_engine(req: dict, ground_z: float):
     return "pec"
 
 
-def _make_momwire_engine(req: dict, builder):
+def _make_momwire_engine(req: dict, builder, cancel=None):
     model = req.get("momwire_model", "triangular")
     solver_cls = _MOMWIRE_MODELS.get(model, TriangularSolver)
     wire_radius = float(req.get("wire_radius", 0.0005))
@@ -481,6 +481,7 @@ def _make_momwire_engine(req: dict, builder):
         wire_radius=wire_radius,
         solver_kwargs=solver_kwargs,
         ground=ground,
+        cancel=cancel,
     )
 
 
@@ -999,7 +1000,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         except Exception:
             return None
 
-    def momwire_solve(req: dict) -> dict:
+    def momwire_solve(req: dict, cancel=None) -> dict:
         design_freq = float(req.get("design_freq_mhz", _design_freq_default(req)))
         meas_freq = float(req.get("measurement_freq_mhz", design_freq))
         builder = _build_builder(cls, req)
@@ -1012,7 +1013,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         # into _params and never read — guard on has_design_freq.
         if has_design_freq:
             builder.design_freq = design_freq
-        eng = _make_momwire_engine(req, builder)
+        eng = _make_momwire_engine(req, builder, cancel=cancel)
         t0 = time.perf_counter()
         zs = eng.impedance()
         currents = eng.current_distribution()

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -94,6 +94,7 @@ from collections import OrderedDict
 from copy import deepcopy
 from pathlib import Path
 
+import momwire
 import numpy as np
 from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.concurrency import run_in_threadpool
@@ -677,24 +678,32 @@ def _canonical_solve_key(req: dict) -> str:
     return hashlib.blake2b(blob, digest_size=16).hexdigest()
 
 
-def _solve_uncached(req: dict) -> dict:
+def _solve_uncached(req: dict, cancel=None) -> dict:
     geometry = req.get("geometry", next(iter(EXAMPLES)))
     use_pynec = req.get("solver") == "pynec" and pynec_backend.HAVE_PYNEC
     _check_solve_size(req, use_pynec=use_pynec)
     if use_pynec:
+        # PyNEC start-gate only: a request already superseded before its solve
+        # begins dies for free here; the native solve is one opaque call with no
+        # mid-solve abort, so an in-flight one runs to completion (as today).
+        if cancel is not None:
+            cancel.raise_if_cancelled()
         out = pynec_backend.solve(req)
     else:
         ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
-        out = ex.momwire_solve(req)
+        out = ex.momwire_solve(req, cancel=cancel)
         out["solver"] = "momwire"
     _attach_derived_em_fields(out)
     _attach_gain_norm(out)
     return out
 
 
-def solve(req: dict) -> dict:
+def solve(req: dict, cancel=None) -> dict:
     key = _canonical_solve_key(req)
     hit = _SOLVE_CACHE.get(key)
+    # Cache hits are O(1) and never worth aborting — the token is only consulted
+    # on the (expensive) miss path below. A SolveAborted from _solve_uncached
+    # propagates before the cache-store line, so an aborted solve is never cached.
     if hit is not None:
         _SOLVE_CACHE.move_to_end(key)
         t0 = time.perf_counter()
@@ -706,7 +715,7 @@ def solve(req: dict) -> dict:
         out["solve_ms"] = (time.perf_counter() - t0) * 1e3
         out["cache_hit"] = True
         return out
-    out = _solve_uncached(req)
+    out = _solve_uncached(req, cancel=cancel)
     out["cache_hit"] = False
     _SOLVE_CACHE[key] = deepcopy(out)
     while len(_SOLVE_CACHE) > _SOLVE_CACHE_MAX:
@@ -1258,6 +1267,11 @@ async def ws_endpoint(ws: WebSocket):
     mailbox: list[dict] = []  # size-1: newest unsolved request only
     newer = asyncio.Event()  # set when the mailbox is (re)filled
     closed = asyncio.Event()  # set when the socket disconnects
+    # In-flight solve's cancel token, shared between the reader and the solver
+    # loop (both coroutines on this event loop, so no lock needed — the token's
+    # flag is the only thing the threadpool worker touches). The reader trips it
+    # to preempt a solve the moment a newer request lands or the socket closes.
+    current: dict = {"token": None}
 
     async def reader() -> None:
         # Starlette requires a single reader on the socket, so *all*
@@ -1266,11 +1280,17 @@ async def ws_endpoint(ws: WebSocket):
             while True:
                 req = json.loads(await ws.receive_text())
                 mailbox[:] = [req]  # overwrite → squash anything unsolved
+                token = current["token"]
+                if token is not None:
+                    token.cancel()  # preempt the now-superseded in-flight solve
                 newer.set()
         except WebSocketDisconnect:
             pass
         finally:
             closed.set()
+            token = current["token"]
+            if token is not None:
+                token.cancel()  # disconnect: free the threadpool worker promptly
             newer.set()  # wake the solver so it can observe `closed` and exit
 
     reader_task = asyncio.create_task(reader())
@@ -1283,8 +1303,20 @@ async def ws_endpoint(ws: WebSocket):
             if not mailbox:
                 continue
             req = mailbox.pop()
+            # Publish the token BEFORE dispatch: a reader that fires in the gap
+            # cancels a not-yet-started solve, which then raises SolveAborted at
+            # its first checkpoint — no lost-wakeup window.
+            token = momwire.CancelToken()
+            current["token"] = token
             try:
-                result = await run_in_threadpool(solve, req)
+                result = await run_in_threadpool(solve, req, cancel=token)
+            except momwire.SolveAborted:
+                # Superseded (or disconnected) mid-solve: a newer request already
+                # tripped our token. Send nothing — the superseding response will
+                # carry a higher _seq and the client renders monotonically. This
+                # catch MUST precede the generic handler, which would otherwise
+                # ship the abort to the client as a solve-error banner.
+                continue
             except Exception as exc:  # noqa: BLE001 — a user design's build_wires can raise
                 # A solve that raises must not tear down the socket (that drops
                 # every subsequent slider-driven solve). Send the cause so the
@@ -1293,6 +1325,8 @@ async def ws_endpoint(ws: WebSocket):
                     "geometry": req.get("geometry"),
                     "error": user_designs.format_solve_error(exc),
                 }
+            finally:
+                current["token"] = None
             # Echo the sequence number on EVERY response, error path included —
             # the client keys ordering, RTT accounting, and solving-state off it,
             # and a stuck request would leave `solving` true forever if any path

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -14,8 +14,10 @@ from __future__ import annotations
 
 import json
 import threading
+import time
 from copy import deepcopy
 
+import momwire
 import numpy as np
 import pytest
 from fastapi.testclient import TestClient
@@ -1252,7 +1254,7 @@ def test_ws_endpoint_squashes_and_skips_superseded(client, monkeypatch):
     release = threading.Event()
     reader_saw_last = threading.Event()
 
-    def blocking_solve(req: dict, superseded=None) -> dict:
+    def blocking_solve(req: dict, cancel=None) -> dict:
         seq = req.get("_seq")
         seqs_solved.append(seq)
         if seq == 1:
@@ -1297,7 +1299,7 @@ def test_ws_endpoint_handles_disconnect_during_solve(client, monkeypatch):
     entered = threading.Event()
     release = threading.Event()
 
-    def blocking_solve(req: dict, superseded=None) -> dict:
+    def blocking_solve(req: dict, cancel=None) -> dict:
         entered.set()
         release.wait(5)
         return {"geometry": req.get("geometry")}
@@ -1312,6 +1314,59 @@ def test_ws_endpoint_handles_disconnect_during_solve(client, monkeypatch):
         # the close handshake.
         threading.Timer(0.2, release.set).start()
     release.set()  # belt-and-suspenders if the timer hasn't fired yet
+
+
+def test_ws_preempts_inflight_solve_on_supersede(client, monkeypatch):
+    # Phase 3: a newer request must PREEMPT the in-flight solve. The handler
+    # publishes a cancel token and the reader trips it the moment seq 2 lands;
+    # the in-flight solve observes it, raises SolveAborted, its doomed response
+    # is never sent, and only the superseding result ships.
+    entered = threading.Event()
+    aborted_seqs: list[int] = []
+    completed_seqs: list[int] = []
+
+    def cancellable_solve(req: dict, cancel=None) -> dict:
+        seq = req.get("_seq")
+        if seq == 1:
+            entered.set()
+            # Block until the reader trips our token (when seq 2 arrives), then
+            # abort cooperatively — exactly what a real solve's checkpoint does.
+            for _ in range(500):
+                if cancel is not None and cancel.cancelled:
+                    aborted_seqs.append(seq)
+                    raise momwire.SolveAborted()
+                time.sleep(0.01)
+        completed_seqs.append(seq)
+        return {"geometry": req.get("geometry"), "z_in_re": 1.0}
+
+    monkeypatch.setattr(server, "solve", cancellable_solve)
+
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(json.dumps({"geometry": "dipoles.invvee", "_seq": 1}))
+        assert entered.wait(5), "first solve never started"
+        ws.send_text(json.dumps({"geometry": "dipoles.invvee", "_seq": 2}))
+        resp = json.loads(ws.receive_text())
+
+    assert aborted_seqs == [1], "the in-flight solve was not preempted"
+    assert 1 not in completed_seqs, "an aborted solve must not complete"
+    assert resp["_seq"] == 2, "only the superseding result should ship"
+
+
+def test_solve_aborted_propagates_uncached(monkeypatch):
+    # A SolveAborted from the miss path must propagate to the caller (so the /ws
+    # handler can `continue`) and never be stored in the solve cache.
+    server._SOLVE_CACHE.clear()
+    req = {
+        "geometry": "dipoles.invvee",
+        "solver": "momwire",
+        "momwire_model": "triangular",
+        "_seq": 7,
+    }
+    token = momwire.CancelToken()
+    token.cancel()
+    with pytest.raises(momwire.SolveAborted):
+        server.solve(req, cancel=token)
+    assert len(server._SOLVE_CACHE) == 0, "an aborted solve must not be cached"
 
 
 def test_solve_z_only_returns_primary_z_and_no_feeds_for_dipole():


### PR DESCRIPTION
## Summary
- **End-to-end preemption on `/ws`.** Dragging a knob now *aborts* the in-flight solve within ~one checkpoint / kernel row instead of running it to completion and hogging a threadpool worker. This completes the abortable-solves plan (`docs/plan-abortable-solves.md`), whose plan doc is the first commit on this branch.
- **Bumps the momwire submodule `b23d4bd → 24c4f78`** (Phases 0–2, already merged in momwire: GIL release on all C++ kernels, `CancelToken`/`SolveAborted` + Python checkpoints, and C++ `cancel_flag` polling). The code changes depend on that API, so the pointer bump lands here with them.
- **Token threading (explicit — never through the req dict, so it can't reach the cache key or JSON):** `solve`/`_solve_uncached` gain `cancel=None` (cache hits check nothing; on a miss a `SolveAborted` propagates *before* the cache-store line, so aborted solves are never cached); `adapter.momwire_solve`/`_make_momwire_engine` forward it; `MomwireEngine` forwards `cancel` into every solver construction and polls it between its own phases via `_raise_if_cancelled()`. PyNEC gets a **start-gate only** (a queued-stale request dies free; an in-flight native solve runs to completion, as designed).
- **`/ws` handler:** a shared `current["token"]` cell (reader + solver loop, both on the event loop). The reader trips the token the moment a superseding request lands and on disconnect. The solver loop publishes a fresh token **before** the threadpool dispatch (no lost-wakeup window) and catches `SolveAborted` to skip the send — placed **before** the generic handler, which would otherwise ship the abort as a solve-error banner. The existing `if mailbox: continue` skip-send guard is retained.

## Test plan
- [x] `ruff check` + `ruff format --check` clean; per-PR suite **1263 passed, 89 deselected**
- [x] New: a superseding request preempts the in-flight solve (it raises `SolveAborted`, never completes, only the newer `_seq` ships); a pre-cancelled solve propagates `SolveAborted` uncached and un-bannered
- [x] Existing squash/disconnect `/ws` tests still pass (stubs updated for the `cancel=` kwarg)
- [ ] CI green (Ruff + tests)
- [ ] (optional) manual: drag a slider rapidly and confirm stale solves are dropped promptly

Phase 4 (`/sweep` + `/converge` in-chunk cancel) remains optional and is intentionally deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)