### PR TITLE
Emit copied variants as minimal deltas from default_params

### DIFF
--- a/site/src/content/docs/concepts/authoring-with-claude.md
+++ b/site/src/content/docs/concepts/authoring-with-claude.md
@@ -95,6 +95,14 @@ slider still reaches any band you select, but a fixed-metre wire only *resonates
 on the one band its dimensions happen to suit.
 :::
 
+:::note[Alternate knob-sets: variants are overlays]
+Ship alternate tunings as `<variant>_params` class attributes alongside
+`default_params` (`opt_params`, `z100_params`, …); a user selects one with
+`name:variant`. A variant lists **only the keys it changes** — the rest inherit
+from `default_params` — so keep them to the deltas. See
+[Variants are overlays](/reference/cli/#variants-are-overlays).
+:::
+
 For path-shaped geometry (loops, vees, rhombics), `build_wires` can fly a
 [`Drone`](/reference/drone-transform/) instead of computing corners by hand —
 return `drone.wires()`. Arrays of identical elements have dedicated builders

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -84,18 +84,45 @@ beams.yagi            8.89         1       8.2        60        42
 ## Copying params back to code
 
 After tuning — in the workbench or with `optimize` — turn the knob values back
-into source you can paste into a design file. `params` prints a design's (or a
-`name:variant`'s) current values as a `default_params = {...}` block:
+into source you can paste into a design file. `params` prints a design's current
+values as a `default_params = {...}` block:
 
 ```bash
 python -m antennaknobs params --builder beams.yagi
 python -m antennaknobs params --builder specialty.hentenna:z100 --wrap mappingproxy
 ```
 
+For a **`name:variant`** it prints a `<variant>_params` block instead — and that
+block carries **only the keys that differ from `default_params`**, because a
+variant is stored as an *overlay* on the defaults (just the deltas; the resolver
+fills the rest in — see [Variants are overlays](#variants-are-overlays)). So the
+second command above emits a minimal `z100_params = {...}` you can paste straight
+back as the variant. A bare design (or `:default`) prints the full
+`default_params`, since that is the baseline everything overlays.
+
 Useful flags: `--name <var>` (name the emitted block), `--no-ui` (knob values
 only, drop the `ui_params` block), and `--wrap mappingproxy` (match the
 catalog's frozen-params style). An `optimize` run ends by printing the same
 paste-ready block for its result, so the tuned values go straight into code.
+
+## Variants are overlays
+
+A design can ship named **variants** — alternate knob-sets selected with
+`name:variant` (`beams.moxon:original`, `specialty.hentenna:z100`). A variant is
+declared as a `<variant>_params` mapping on the `Builder` class, and it is an
+**overlay on `default_params`**: it lists *only the keys it changes*, and every
+other key is inherited from `default_params`.
+
+```python
+class Builder(AntennaBuilder):
+    default_params = {"freq": 28.5, "halfdriver": 2.46, "tipspacer_factor": 0.077}
+    original_params = {"halfdriver": 2.4336}   # just the delta — the rest inherit
+```
+
+That is exactly the form `params name:variant` emits, so the round-trip is
+lossless: copy a tuned variant, paste it back as its `<variant>_params`, and it
+means the same thing. (A variant written out in full still works — overlaying a
+complete dict reproduces that dict — but the minimal delta form is the idiom.)
 
 ## Exporting to NEC
 

--- a/src/antennaknobs/__init__.py
+++ b/src/antennaknobs/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     "Array1x4Builder",
     "Array1x4GroupedBuilder",
     "merge_params",
+    "diff_params",
     "resolve_variant_params",
     "plot_patterns",
     "compare_patterns",
@@ -34,6 +35,7 @@ from .builder import (
     Array1x4Builder,
     Array1x4GroupedBuilder,
     merge_params,
+    diff_params,
     resolve_variant_params,
 )
 from .transform import Transform, TransformStack

--- a/src/antennaknobs/builder.py
+++ b/src/antennaknobs/builder.py
@@ -49,6 +49,31 @@ def resolve_variant_params(cls, variant):
     return base
 
 
+def diff_params(base, target):
+    """Minimal overlay ``d`` such that ``merge_params(base, d) == target``.
+
+    The inverse of :func:`merge_params`: recurse into Mappings, keeping only the
+    leaves of ``target`` that ``base`` lacks or disagrees with. Used to trim a
+    fully-merged variant back down to just its deltas from ``default_params`` —
+    the same minimal form a hand-authored ``<variant>_params`` overlay takes.
+
+    Assumes ``target``'s keys are a superset of ``base``'s: a variant overlays
+    ``default_params`` and so only adds or changes keys, never drops one, which
+    is exactly the round-trip case this supports.
+    """
+    out = {}
+    for k, v in target.items():
+        if k not in base:
+            out[k] = v
+        elif isinstance(base[k], Mapping) and isinstance(v, Mapping):
+            sub = diff_params(base[k], v)
+            if sub:
+                out[k] = sub
+        elif base[k] != v:
+            out[k] = v
+    return out
+
+
 class AntennaBuilder:
     # Framework-level params live alongside per-design default_params but
     # don't surface in the UI param panel (adapter._auto_paramspec walks

--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -566,9 +566,24 @@ def cli(arguments=None):
     def f(args):
         builder = get_builder(args.builder)
         name = args.name or emit_params_name(args.builder)
+        # For a real variant, emit only its deltas from default_params — the
+        # minimal <variant>_params overlay (see resolve_variant_params). A bare
+        # design / :default emits the full block, since it *is* the baseline.
+        design, _, variant = args.builder.partition(":")
+        base = None
+        if variant and variant != "default":
+            cls = resolve_class(design)
+            if cls is not None and hasattr(
+                getattr(cls, f"{variant}_params", None), "keys"
+            ):
+                base = dict(cls.default_params)
         print(
             builder_params_source(
-                builder(), name=name, include_ui=not args.no_ui, wrap=args.wrap
+                builder(),
+                name=name,
+                include_ui=not args.no_ui,
+                wrap=args.wrap,
+                base=base,
             )
         )
 

--- a/src/antennaknobs/serialize.py
+++ b/src/antennaknobs/serialize.py
@@ -160,6 +160,7 @@ def builder_params_source(
     include_ui: bool = True,
     default_precision: int | None = None,
     wrap: str = "dict",
+    base: Mapping[str, Any] | None = None,
 ) -> str:
     """Serialise a live Builder instance's knobs to paste-ready source.
 
@@ -169,10 +170,20 @@ def builder_params_source(
     that *don't* declare a display precision: leave it ``None`` to dump existing
     literals losslessly, or set it (e.g. 6 after an optimise run) to trim the
     optimiser's sub-tolerance digits.
+
+    ``base``: if given (a params mapping, typically ``default_params``), emit
+    only the *deltas* of the builder's params from it — the minimal overlay a
+    ``<variant>_params`` block takes (the inverse of ``builder.merge_params``).
+    Display precision is still taken from the builder's full ``ui_params``.
+    ``None`` (default) emits the complete param set.
     """
     framework = type(builder).FRAMEWORK_PARAMS
     params = {k: v for k, v in builder._params.items() if k not in framework}
     precision = _precision_map(params.get("ui_params"))
+    if base is not None:
+        from .builder import diff_params
+
+        params = diff_params(dict(base), params)
     return params_source(
         params,
         name=name,

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -51,6 +51,7 @@ from antennaknobs.builder import (
     Array1x4GroupedBuilder,
     Array2x2Builder,
     Array2x4Builder,
+    diff_params,
     resolve_variant_params,
 )
 
@@ -1239,13 +1240,31 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
                 base[k] = _rehydrate_param(base[k], req[k])
             elif k in nested:
                 base[k] = _rehydrate_param(base[k], nested[k])
-        name = (
-            f"{variant}_params"
+        # A variant is stored as an *overlay* on default_params (only the keys it
+        # changes — see resolve_variant_params), so emit its block that way too:
+        # trim to just the deltas from default_params. This matches the minimal
+        # hand-authored form and keeps a copied variant paste-ready as a
+        # <variant>_params overlay. default_params itself is the baseline, so it
+        # is always emitted in full. A stale / unknown variant name (one with no
+        # <variant>_params attribute) resolves to default_params, where a delta
+        # would be an empty, misleading block — so fall back to the full block.
+        v_attr = (
+            getattr(cls, f"{variant}_params", None)
             if variant and variant != "default"
-            else "default_params"
+            else None
         )
+        if v_attr is not None and hasattr(v_attr, "keys"):
+            name = f"{variant}_params"
+            emit = diff_params(dict(_variant_params(cls, "default")), base)
+        else:
+            name = (
+                f"{variant}_params"
+                if variant and variant != "default"
+                else "default_params"
+            )
+            emit = base
         return _emit(
-            base,
+            emit,
             name=name,
             precision=_precision_map(ui),
             include_ui=bool(req.get("include_ui", False)),

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -175,3 +175,85 @@ def test_bands_tuple_replaced_wholesale():
     merged = resolve_variant_params(B, "one_band")
     assert merged["bands"] == ({"freq": 18.0},)  # not merged with the default pair
     assert merged["n_bands"] == 2  # untouched scalar still inherited
+
+
+# --- variants as deltas: diff_params is the inverse of merge_params ----------
+
+
+def test_diff_params_round_trips_merge():
+    from antennaknobs import diff_params, merge_params
+
+    base = {"a": 1, "b": 2, "ui_params": {"x": {"p": 1}, "y": {"p": 2}}}
+    target = {"a": 1, "b": 9, "ui_params": {"x": {"p": 1}, "y": {"p": 5}}}
+    d = diff_params(base, target)
+    # only the leaves that changed, recursively (a and x.p unchanged → dropped)
+    assert d == {"b": 9, "ui_params": {"y": {"p": 5}}}
+    assert merge_params(base, d) == target
+
+
+@pytest.mark.parametrize(
+    "cls, variant",
+    [(hexbeam.Builder, "opt"), (moxon.Builder, "original"), (moxon.Builder, "opt")],
+)
+def test_variant_delta_is_minimal_and_round_trips(cls, variant):
+    from antennaknobs import diff_params, merge_params
+
+    default = dict(cls.default_params)
+    full = resolve_variant_params(cls, variant)
+    delta = diff_params(default, full)
+    # a delta never restates a scalar it agrees with default on
+    for k, v in delta.items():
+        if not isinstance(v, dict):
+            assert default.get(k) != v, f"{k} equals default but is in the delta"
+    # and the overlay reconstructs the full variant
+    assert merge_params(default, delta) == full
+
+
+def test_cli_params_emits_variant_deltas_only():
+    """`params name:variant` emits the minimal <variant>_params overlay; a bare
+    design emits the full default_params block."""
+    from antennaknobs import diff_params
+    from antennaknobs.cli import get_builder
+    from antennaknobs.serialize import builder_params_source
+
+    cls = moxon.Builder
+    default = dict(cls.default_params)
+    variant_builder = get_builder("beams.moxon:original")
+    src = builder_params_source(
+        variant_builder(), name="original_params", include_ui=False, base=default
+    )
+    ns = {}
+    exec(src, {"MappingProxyType": dict}, ns)
+    emitted = ns["original_params"]
+    expected = {
+        k: v
+        for k, v in diff_params(default, dict(cls.original_params)).items()
+        if k != "ui_params"
+    }
+    assert emitted == expected
+    # it really is a subset — fewer keys than a full dump
+    assert set(emitted) < {k for k in default if k != "ui_params"}
+
+
+def test_web_params_source_emits_variant_deltas():
+    """The web 'Copy params' surface (adapter params_source) emits a variant as
+    its deltas from default_params, matching the CLI. Exercised by a built-in
+    catalog design that ships variants (dipoles.invvee)."""
+    from antennaknobs.web.examples import REGISTRY
+
+    ex = REGISTRY["dipoles.invvee"]
+    assert set(ex.variants) >= {"default", "dipole"}  # a real built-in with variants
+
+    src = ex.params_source({"geometry": "dipoles.invvee", "variant": "dipole"})
+    ns = {}
+    exec(src, {"MappingProxyType": dict}, ns)
+    # invvee's `dipole` variant overlays only length_factor + angle_deg
+    assert set(ns["dipole_params"]) == {"length_factor", "angle_deg"}
+
+    # the default is still emitted in full (it is the baseline)
+    src_default = ex.params_source({"geometry": "dipoles.invvee"})
+    ns2 = {}
+    exec(src_default, {"MappingProxyType": dict}, ns2)
+    assert {"design_freq", "base", "length_factor", "angle_deg"} <= set(
+        ns2["default_params"]
+    )


### PR DESCRIPTION
## Summary
- `params name:variant` (CLI) and the web **Copy params** surface now emit a `<variant>_params` block containing **only the keys that differ from `default_params`** — the same minimal-overlay form variants are authored in — instead of a full param dump. A bare design (or `:default`) still emits the complete `default_params` baseline.
- Adds `diff_params(base, target)` to `builder.py`: the inverse of `merge_params`, computing the minimal recursive overlay `d` such that `merge_params(base, d) == target`.
- Wires the delta path through `serialize.builder_params_source(..., base=...)`, `cli.py` (passes `base=default_params` for real variants), and `web/adapter.py` `params_source` (guarded against stale/unknown variants).
- Verified the built-in web catalog exercises the delta path: 16 of 73 designs ship variants (e.g. `dipoles.invvee`); `invvee:dipole` emits only `length_factor` + `angle_deg`, `moxon:original` collapses 6 keys → 3.

## Test plan
- [x] `test_variants.py` (21 passed) incl. `diff_params` round-trip, minimality, CLI-emits-deltas, web-emits-deltas
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)