### PR TITLE
Add 'o' keyboard shortcut to toggle a knob's optimize flag

### DIFF
--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -69,7 +69,9 @@ knobs you've marked to hit a target:
      by default).
 2. **Mark the knobs to vary** — right-click each knob you'll let the optimizer
    move, check **Optimize this knob**, and set its **Optimize range** (the search
-   bounds). A marked knob is visually flagged.
+   bounds). A marked knob is visually flagged. To flip the flag from the keyboard,
+   focus a knob (click or tab to it) and press **`o`** — the same toggle as the
+   menu checkbox, without leaving the home row.
 3. **Turn on Optimize.** While Live is also on, the optimizer runs reactively: any
    time you change a *fixed* knob, it re-tunes the *marked* knobs (a short
    debounce, then a few dozen solves) and writes the best values back, so the

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -852,10 +852,13 @@ function ParamForm({
   // PyNEC; momwire engines don't support transmission lines yet).
   disabledFields?: Set<string>;
   // Optimiser integration (top-level rail only). `settings` overrides a knob's
-  // effective min/max/step; `onContext` opens that knob's right-click menu.
+  // effective min/max/step; `onContext` opens that knob's right-click menu;
+  // `onToggleVary` flips a knob's "Optimize this knob" flag (the `o` shortcut,
+  // parallel to the menu checkbox).
   opt?: {
     settings: Record<string, KnobOpt>;
     onContext: (name: string, e: React.MouseEvent) => void;
+    onToggleVary: (name: string) => void;
   };
 }) {
   return (
@@ -1000,6 +1003,28 @@ function ParamForm({
             className={`field field-knob${ko?.vary ? " is-opt-var" : ""}`}
             style={layoutStyle(item.layout)}
             onContextMenu={opt ? (e) => opt.onContext(item.name, e) : undefined}
+            // `o` toggles this knob's "Optimize this knob" flag while it's
+            // focused — the keyboard parallel to the right-click menu. The event
+            // bubbles up from the focused role="slider" Knob; the edit <input>
+            // stops propagation, so typing a value never triggers it. Ignore it
+            // when a modifier is held (reserved for other shortcuts) or on
+            // auto-repeat (holding the key mustn't flip-flop the flag).
+            onKeyDown={
+              opt
+                ? (e) => {
+                    if (
+                      e.key.toLowerCase() === "o" &&
+                      !e.ctrlKey &&
+                      !e.metaKey &&
+                      !e.altKey &&
+                      !e.repeat
+                    ) {
+                      e.preventDefault();
+                      opt.onToggleVary(item.name);
+                    }
+                  }
+                : undefined
+            }
           >
             <span
               className="knob-label"
@@ -3747,6 +3772,8 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                   e.preventDefault();
                   setKnobMenu({ name, x: e.clientX, y: e.clientY });
                 },
+                onToggleVary: (name) =>
+                  updateKnobOpt(name, { vary: !knobOptFor(name).vary }),
               }}
             />
           </div>
@@ -3825,6 +3852,12 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                       onChange={(e) => set({ vary: e.target.checked })}
                     />
                     Optimize this knob
+                    <kbd
+                      className="knob-menu-kbd"
+                      title="Focus a knob and press O to toggle"
+                    >
+                      O
+                    </kbd>
                   </label>
                   <div className="knob-menu-row">
                     <span>Optimize range</span>

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -2101,6 +2101,16 @@ canvas {
   cursor: pointer;
   color: var(--fg);
 }
+/* Keyboard-shortcut hint chip: pushed to the right edge of the vary row. */
+.knob-menu-kbd {
+  margin-left: auto;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  font-size: 0.72em;
+  line-height: 1.5;
+  color: var(--muted);
+}
 .knob-menu-row {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Adds the workbench's first custom letter shortcut: focus a param knob (it's already `role="slider"`/`tabIndex=0`) and press **`o`** to toggle its **Optimize this knob** (`vary`) flag — the keyboard parallel to the existing right-click menu.
- Handler lives on the `field-knob` wrapper (next to its `onContextMenu`), catching the keydown as it bubbles from the focused `Knob`; the edit `<input>` already `stopPropagation()`s, so typing a value never triggers it.
- Guards: `Ctrl/Meta/Alt+O` and auto-repeat are ignored, so held keys can't flip-flop the flag and other shortcuts stay free.
- Discoverability: an `O` hint chip in the knob menu next to the checkbox, plus a sentence in the optimization section of the web docs.

## Test plan
- [x] `npm run build` (tsc + vite) clean
- [x] Verified live: focus a knob, `o` toggles `is-opt-var` on/off; `Ctrl+O` and auto-repeat are no-ops
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)