### PR TITLE
Pause the optimizer on design load; clear stale marks on variant

### DIFF
--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -83,6 +83,13 @@ fast **momwire** engine — never PyNEC, which is too slow for an interactive lo
 It's a tuning aid, not a global optimizer: give it sensible ranges and a couple
 of free knobs, not a dozen.
 
+**Loading a design pauses Optimize.** Switching antenna or picking a variant
+turns Optimize off — its objective and marks belong to the design you left —
+and briefly says so. Switching antenna *keeps* that design's marks (they're
+remembered per design, so coming back restores them); loading a **variant**
+instead *clears* its marks, because their ranges were scaled to the values the
+variant just replaced. Re-mark the knobs and turn Optimize back on to resume.
+
 ## Choosing a solver & segment count
 
 A **solver selector** offers a few preset slots so you can flip between engines

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1820,6 +1820,11 @@ type KnobOpt = {
   step: number;
 };
 
+// Why the optimizer auto-paused, for the transient cue. `knob` = the user grabbed
+// a marked knob by hand; `load` = a new design/variant was loaded (its marks and
+// ranges no longer apply).
+type OptPause = { kind: "knob"; name: string } | { kind: "load" };
+
 // One antenna design session: the entire left sidebar + right stage plus all
 // the state, effects, and the WebSocket that drive them. The shell (`App`,
 // below) mounts one instance per tab and passes `active` — true only for the
@@ -1890,19 +1895,35 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   const [optRunning, setOptRunning] = useState(false);
   const [optResult, setOptResult] = useState<OptimizeResult | null>(null);
   const [optError, setOptError] = useState<string | null>(null);
-  // When a user change to a knob marked for optimization auto-pauses the
-  // optimizer, this holds that knob's name for a brief "paused, you're
-  // changing X by hand" cue (cleared on re-enable / after a few seconds).
-  const [optPausedBy, setOptPausedBy] = useState<string | null>(null);
+  // When something auto-pauses the optimizer, this holds *why* for a brief cue
+  // (cleared on re-enable / after a few seconds): grabbing a knob marked for
+  // optimization by hand ("changing X by hand"), or loading a new design/variant
+  // ("loaded a new design").
+  const [optPausedBy, setOptPausedBy] = useState<OptPause | null>(null);
   const optAbortRef = useRef<AbortController | null>(null);
+  // Latest optEnabled mirrored into a ref so the design-load reset (effects keyed
+  // on geometry, and selectVariant) can tell whether the optimizer was actually
+  // running — to show the pause cue only then — without taking optEnabled as a
+  // dep (which would re-run the reset on every toggle).
+  const optEnabledRef = useRef(false);
+  optEnabledRef.current = optEnabled; // mirror latest for the design-load reset
   // Per-knob settings persist per geometry (knobOpt is keyed by geometry); just
   // close any open menu / clear the last result / abort any in-flight run when
-  // the antenna changes.
+  // the antenna changes. The optimizer also *pauses* on a design switch — its
+  // objective and marks belong to the design you left — but this design's marks
+  // are kept (they're keyed by geometry), so returning restores them; only the
+  // running toggle is switched off. Show the cue only if it was actually on.
   useEffect(() => {
     optAbortRef.current?.abort();
     setKnobMenu(null);
     setOptResult(null);
     setOptError(null);
+    if (optEnabledRef.current) {
+      setOptEnabled(false);
+      setOptPausedBy({ kind: "load" });
+    }
+    // optEnabledRef is read (not a dep) on purpose — see its declaration.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [geometry]);
 
   useEffect(() => {
@@ -1981,6 +2002,23 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   // via buildRequest on the next tick.
   function selectVariant(nextVariant: string) {
     if (!currentExample) return;
+    // Loading a variant bulk-replaces the knob values, so any optimize marks and
+    // their ranges (scaled to the values you're leaving) no longer apply. Drop
+    // this geometry's marks and pause the optimizer — the same "you took over"
+    // pause as grabbing a free knob by hand. (Unlike a design switch, the marks
+    // *are* wiped here: it's the same geometry, so keeping them would silently
+    // carry stale ranges into the new variant.)
+    optAbortRef.current?.abort();
+    setKnobOpt((prev) => {
+      if (!prev[geometry]) return prev;
+      const next = { ...prev };
+      delete next[geometry];
+      return next;
+    });
+    if (optEnabledRef.current) {
+      setOptEnabled(false);
+      setOptPausedBy({ kind: "load" });
+    }
     setVariantByGeom((prev) => ({ ...prev, [geometry]: nextVariant }));
     const vv = currentExample.variant_values?.[nextVariant];
     if (!vv) return;
@@ -2092,7 +2130,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
       if (ko?.vary) {
         optAbortRef.current?.abort();
         setOptEnabled(false);
-        setOptPausedBy(path[0]);
+        setOptPausedBy({ kind: "knob", name: path[0] });
       }
     }
     setParamAtPath(path, value);
@@ -4026,9 +4064,15 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
               {!optEnabled && optPausedBy && (
                 <span
                   className="opt-readout opt-paused"
-                  title="You changed a knob marked for optimization, so Optimize paused. Turn it back on to resume."
+                  title={
+                    optPausedBy.kind === "knob"
+                      ? "You changed a knob marked for optimization, so Optimize paused. Turn it back on to resume."
+                      : "Loading a design clears its optimize marks and pauses Optimize. Re-mark knobs and turn it back on to resume."
+                  }
                 >
-                  Paused — changing {optPausedBy} by hand
+                  {optPausedBy.kind === "knob"
+                    ? `Paused — changing ${optPausedBy.name} by hand`
+                    : "Paused — loaded a new design"}
                 </span>
               )}
             </div>


### PR DESCRIPTION
## Summary
Loading a new design or variant while the optimizer was running left it in a broken state: its reactive trigger keys off the *fixed* knobs (to avoid a write-back loop), so a variant that only moved a marked/free knob never re-fired it — the optimizer just sat still. And even when it did re-fire, the per-knob Optimize ranges were scaled to the values the load replaced, so it would clamp the fresh design into stale bounds.

This resets the optimizer on any design load, generalizing the existing "you grabbed a marked knob by hand" pause:

- **Switch antenna (geometry):** turn Optimize off + show a pause cue. Marks are **kept** — `knobOpt` is keyed by geometry, so returning to the design restores them.
- **Load a variant (same geometry):** also **wipe** that geometry's marks, since their ranges no longer apply to the values the variant replaced.

Details:
- An `optEnabledRef` mirrors `optEnabled` (the `ref.current = value` pattern the codebase already uses for `geometry`) so the geometry-keyed reset shows the cue only when the optimizer was actually running, without making `optEnabled` a dep.
- The pause cue (`optPausedBy`) becomes a discriminated union so it says either "changing X by hand" or "loaded a new design".
- Adds a note to the Optimizing docs section.

## Test plan
- [x] `npm run build` (tsc + vite) clean, incl. after rebase onto the `o`-shortcut merge
- [x] Verified live: knob marked + Optimize on → selecting a variant wipes the mark + pauses (cue shown); switching to `beams.yagi` pauses but preserves `dipoles.invvee`'s marks in `knobOpt`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)