### PR TITLE
Mobile layout groundwork: implementation plan + desktop-identical stage refactor (Phase A)

### DIFF
--- a/docs/plan-mobile-layout-mode.md
+++ b/docs/plan-mobile-layout-mode.md
@@ -1,0 +1,275 @@
+# Plan: mobile layout mode for the web workbench
+
+Status: **planned, not started.** This document is the implementation brief; a
+future session executes it. All work is in
+`src/antennaknobs/web/frontend/src/App.tsx` and `.../styles.css`.
+
+## Context
+
+On a phone today the workbench builds one desktop-sized canvas and lets you
+**pan around** it. The CSS block `@media (max-width:700px), (max-height:500px)
+and (pointer:coarse)` (styles.css ~2144–2178) turns `.app` into a fixed
+1920×1080 two-axis scroll surface. It works but is inconvenient: the knobs and
+the output charts are never on screen together, so you can't see the effect of a
+knob turn while you turn it.
+
+Goal: a purpose-built mobile layout that keeps knobs and one output view visible
+at once.
+
+- **Portrait**: top half = input knobs, bottom half = one output screen.
+- **Landscape**: knobs on the left, one output screen on the right.
+- Output = **5 swipeable screens** — Antenna (3D), Azimuth, Elevation, Smith,
+  and a new **Info** screen holding the R/X/SWR/rtt readout. Swipe left/right
+  with a **row of dots** showing position.
+- Each pane is independently scrollable.
+
+## Hard constraints
+
+1. **Desktop must not change at all** — the `>700px` fine-pointer render path
+   stays byte-for-byte today's DOM/CSS/behavior.
+2. **Refactor first, feature second** — the desktop-identical refactor (Phase A)
+   lands as its own commit before the mobile feature (Phase B), so the no-op
+   refactor is reviewable in isolation.
+
+## The invariant that guarantees desktop safety
+
+The new `useIsMobile()` hook's matchMedia string is **identical** to the existing
+CSS breakpoint: `(max-width:700px), (max-height:500px) and (pointer:coarse)`. So
+the set of viewports where `isMobile===true` equals the set that today already
+get the pan-around. No normal desktop viewport ever takes the mobile branch. All
+new hooks/effects are added **unconditionally** at stable positions (never behind
+an `if`), and the desktop JSX branch is left untouched.
+
+## UX decisions (already settled)
+
+- View switcher: **swipe + dot indicators** (a CSS scroll-snap carousel; no new
+  drag JS).
+- The info readout becomes a **dedicated 5th screen**; the floating HUD is
+  **suppressed on mobile only** (desktop HUD unchanged).
+- Split: portrait 50/50 stacked; landscape knobs-left / output-right.
+
+---
+
+## Phase A — desktop-identical refactor
+
+**A1. Extract `SolveReadout` (module scope).** Move the inline HUD JSX
+(App.tsx ~4534–4589) into a module-scope component placed near `formatSwr`
+(~5049), before `ViewPanel`. It reuses already-module-scope helpers `feedMag`
+(~5033), `formatSwr` (~5049), `ResultPanel` (~1073). Props:
+`{ result, rttMs, currentExample, effectiveMultiFeed, className = "" }`, rendering
+`` `readout${className ? " " + className : ""}` ``. Desktop call site:
+```
+<SolveReadout className={`stage-readout${stale ? " stale" : ""}`}
+  result={result} rttMs={rttMs} currentExample={currentExample}
+  effectiveMultiFeed={effectiveMultiFeed} />
+```
+This reproduces `readout stage-readout` / `readout stage-readout stale` exactly.
+*Riskiest line in Phase A — verify the className concatenation is byte-identical.*
+
+**A2. Add `useIsMobile()` (module scope, near `useSlideSize` ~1588).** Use
+`useSyncExternalStore` (StrictMode/SSR-safe) with the breakpoint string above,
+plus an `(orientation:portrait)` query; return `{ isMobile, orientation }`. Add
+`useSyncExternalStore` to the React import. Desktop never reads the result.
+**Snapshot gotcha:** `getSnapshot` must NOT return a fresh object each call
+(React warns "The result of getSnapshot should be cached" and re-renders
+forever). Implement as two internal `useSyncExternalStore` calls that each
+return a boolean primitive, then compose the result object.
+
+**A3. Extract a local `renderOutput` closure (NOT a component).** Inside
+`DesignSession`, before `return`, define
+`const renderOutput = (v: View, size: number, fill: boolean) => (<>…</>)` that
+moves the per-view overlays (~4320–4507, `view`→`v`) and the main
+`<ViewPanel view={v} size={size} fill={fill} …/>` (~4508–4530). A **closure**
+captures the ~30 locals for free — no prop surface, no drift; a Fragment adds no
+DOM node. Desktop `.carousel-slide` children become
+`{renderOutput(view, chartSize, view === "antenna")}` followed by the
+`<SolveReadout>` HUD. **Keep the HUD outside `renderOutput`** so mobile chart
+screens don't inherit it.
+
+**A4. Hoist the sidebar children to a `controls` const.** The `<aside>` closes
+over dozens of locals, so it can't be a prop-driven component; instead
+`const controls = (<>…children of the aside, ~3670–4216…</>)` and render
+`<aside className="sidebar">{controls}</aside>` on desktop (identical DOM). Lets
+Phase B reuse the exact knob JSX.
+
+**A5. Hoist the solve overlays to a `solveOverlays` const.** The stage children
+`.solve-bar` / `.solve-cancel` / `.solver-suggest` / `.solve-error`
+(~4220–4278) are NOT cosmetic and must exist on mobile too:
+`.solver-suggest` actively **withholds solves** (App.tsx ~2954–2956) until the
+user clicks "Solve anyway" / "Pause simulation" — without it a mismatched
+design never solves and gives no explanation; `.solve-error` is the only
+failure surface; `.solve-bar`/`.solve-cancel` are the only in-flight/stop
+affordances. Like `controls`: `const solveOverlays = (<>…~4220–4278…</>)`,
+rendered first inside `<main className="stage">` on desktop (identical DOM)
+and inside `.mobile-output` in Phase B (they're absolutely positioned relative
+to their container, so `.mobile-output { position:relative }` hosts them).
+
+**A6. Add an optional reattach key to `useSlideSize`.** Its effect runs once
+(deps `[maxSize]`) and early-returns when the ref is detached — so if the
+breakpoint flips at runtime (window resized across 700px, dev-tools device
+toolbar), the newly mounted branch's element attaches *after* the effect ran:
+no ResizeObserver, size stuck at the default. Add an optional
+`reattachKey?: unknown` param included in the effect deps. Desktop call sites
+pass nothing in Phase A (deps value `undefined` — behavior identical); Phase B
+passes `isMobile` at every call site (`slideRef`, `mobRef`) so both branches
+re-measure on a flip. Give `useThumbColumnSize` the same treatment.
+
+*No `<OutputCarousel>` component and no change to the `View` union — the closure +
+`SolveReadout` are the minimum reuse surface with the least desktop risk.*
+
+**Verify Phase A**: `npm run build`; run dev at desktop width and confirm the HUD,
+thumbstrip, and arrow-key view cycling are unchanged (optionally DOM-diff against
+`git stash`).
+
+---
+
+## Phase B — mobile feature (gated on `isMobile`)
+
+**B1. Branch the return.** At the top of `DesignSession`'s `return`:
+```
+if (isMobile) return (
+  <div className="app app-mobile">
+    <aside className="sidebar mobile-knobs">{controls}</aside>
+    <section className="mobile-output" ref={mobRef}>
+      {solveOverlays} …carousel + dots…
+    </section>
+  </div>
+);
+return ( /* existing desktop tree, unchanged */ );
+```
+Rendering a distinct mobile output tree (rather than CSS-hiding the desktop
+thumbstrip/status/HUD) is cleaner and lower-risk — but the solve overlays
+(A5) MUST be included; they carry solver-mismatch approval, solve errors, and
+cancel (see A5). The `.status` ws indicator may be dropped or folded into the
+Info screen.
+
+**B2. The 5-screen scroll-snap carousel (no new drag JS).** Add module-scope
+`const MOBILE_SCREENS = [...VIEWS, { id: "info", label: "Info" }]` (leave the
+`View` union at 4 so `"info"` never ripples into `ViewPanel`/effects). New state:
+`mobileIndex`, `carouselRef`, and a **second unconditional** `useSlideSize(720)`
+whose ref (`mobRef`) attaches to `.mobile-output` (unused/default on desktop).
+Each screen is `flex:0 0 100%` with `scroll-snap-align:start`; chart screens call
+`renderOutput(s.id as View, mobChartSize, s.id==="antenna")`, the info screen
+renders `<SolveReadout className="mobile-readout" …/>` (a normal block, not the
+positioned HUD). Dots = a button per screen; `.active` at `mobileIndex`.
+**Staleness**: desktop dims via `carousel-slide stale` (~4317) — carry the same
+cue over by rendering the carousel as
+`` className={`mobile-carousel${stale ? " stale" : ""}`} `` and reusing the
+existing dim rule for it. Do NOT also put `stale` on the mobile readout: on
+desktop the HUD sits inside the dimmed slide and its own `.readout.stale` rule
+compounds to ~0.25 opacity (double dim — possibly unintentional; candidate for
+a separate desktop PR). The mobile carousel dim already covers the Info screen,
+so mobile takes the single dim and doesn't inherit the quirk.
+All 5 mount at once (acceptable: canvases are pure, non-interactive render
+targets; data comes from existing effects). *Perf note: if the 3D canvas makes
+5-up sluggish on a real phone, a follow-up can render only active±1 screens.*
+
+**B3. Keep `view` as the source of truth for the 4 chart screens.**
+- `onCarouselScroll` (rAF-throttled): `i = round(scrollLeft/clientWidth)`; if
+  changed → `setMobileIndex(i)`, and if `i < VIEWS.length` → `setView(VIEWS[i].id)`.
+- `goToScreen(i)`: set state + `carouselRef.scrollTo({left:i*clientWidth,
+  behavior:"smooth"})`.
+- Reverse-sync effect keyed `[view]` (early-return `!isMobile`): if
+  `mobileIndex < VIEWS.length` and out of sync, scroll to the view's index.
+- Loop guard: only `scrollTo` when the rounded index differs (never fight a drag).
+- Leave the arrow-key cycler (~2416–2439) **unchanged** — it cycles the 4 chart
+  views; reverse-sync pages the carousel among them. Info is swipe/dot-only.
+
+**B4. Orientation flip.** Screen width changes on flip, so `scrollLeft` no longer
+lands on a snap point. Add an effect keyed `[orientation, mobChartSize]`
+(early-return `!isMobile`) that `requestAnimationFrame`s a
+`scrollTo({left: mobileIndex*clientWidth})` to re-center. `useSlideSize`'s
+ResizeObserver re-sizes the charts automatically.
+
+**B5. CSS (styles.css).** **Replace** the pan-around block (~2144–2178). Gate all
+mobile layout on the `.app-mobile` class (present only when `isMobile`, so JS and
+CSS can't disagree and plain `.app` is untouched):
+```css
+.app-mobile { grid-template-columns:1fr; grid-template-rows:1fr 1fr; overflow:hidden; }
+.app-mobile .mobile-knobs { grid-row:1; overflow-y:auto; overflow-x:hidden; min-height:0; }
+.app-mobile .mobile-output { grid-row:2; position:relative; overflow:hidden; min-height:0; min-width:0; }
+@media (orientation:landscape) {
+  .app-mobile { grid-template-columns:minmax(0,44%) 1fr; grid-template-rows:100%; }
+  .app-mobile .mobile-knobs  { grid-row:auto; grid-column:1; }
+  .app-mobile .mobile-output { grid-row:auto; grid-column:2; }
+}
+.mobile-carousel { display:flex; height:100%; overflow-x:auto; overflow-y:hidden;
+  scroll-snap-type:x mandatory; -webkit-overflow-scrolling:touch; }
+.mobile-screen { flex:0 0 100%; scroll-snap-align:start; scroll-snap-stop:always;
+  position:relative; display:flex; align-items:center; justify-content:center; overflow:hidden; }
+.mobile-screen.mobile-screen-info { overflow-y:auto; align-items:flex-start; }
+  /* Info can exceed a ~400px landscape pane (per-feed Z table) — it scrolls
+     vertically; y-scroll inside an x-snap carousel coexists fine. */
+.mobile-dots { position:absolute; bottom:var(--space-4); left:50%; transform:translateX(-50%);
+  display:flex; z-index:3; }
+.mobile-dots button { padding:16px 10px; border:none; background:none; }
+  /* ≥40px touch targets (cf. the coarse-pointer block ~2184); the visual dot
+     is the ::before pseudo-element. */
+.mobile-dots button::before { content:""; display:block; width:8px; height:8px;
+  border-radius:50%; background:var(--muted); opacity:.5; }
+.mobile-dots button.active::before { background:var(--accent); opacity:1; }
+.mobile-readout { max-width:min(90%,320px); }
+.app-mobile .stage-readout { display:none; } /* defensive; HUD isn't rendered on mobile anyway */
+```
+Because `.app-mobile` exists only on mobile, the `orientation:landscape` rule
+never touches a landscape desktop window (which has plain `.app`). Keep the touch
+hit-target block (~2184–2197) as-is.
+
+---
+
+## Edge cases
+
+- **Desktop byte-identity**: `SolveReadout` className concat + `renderOutput`
+  Fragment must reproduce ~4320–4589 exactly; all new hooks added unconditionally.
+- **Cut-angle `Knob`** on the az/elev screens keeps `touch-action:none`: a swipe
+  starting on the knob turns it (as on desktop); page-swipes use empty chart area.
+  No other canvas has pointer handlers, so no swipe conflict.
+- **View-gated data effects** (freq sweep / converge / norm-check / pin) key off
+  `view`; B3 keeps `view` synced to the snapped chart screen, so they behave as on
+  desktop. Info screen leaves `view` on the last chart.
+- **scroll ⇄ dots feedback loop**: guarded by the rounded-index tolerance + rAF.
+- **StrictMode double-mount**: `useSyncExternalStore` + idempotent ResizeObserver.
+- **Runtime breakpoint flip** (window resized across 700px / device toolbar):
+  handled by A6's reattach key — both branches re-measure when `isMobile`
+  changes. The solve overlays and solver-approval state live in `DesignSession`
+  state, so they survive the flip.
+
+## Verification
+
+1. `npm run build` (`tsc --noEmit && vite build`) in the frontend dir.
+2. Dev server at desktop width: confirm desktop unchanged (HUD, thumbstrip,
+   arrow cycling); optionally DOM-diff against `git stash`.
+3. Chrome device-toolbar / resize to a **portrait** phone viewport (≤700px):
+   50/50 stack, both panes scroll, swipe pages all 5 screens, dots track, Info
+   shows the full readout, no HUD over charts. Turning a knob dims the carousel
+   (stale) while the solve is in flight; a solver-mismatch design shows the
+   suggest dialog and a broken design shows the solve error.
+   Flip the device toolbar between mobile and desktop widths: charts re-measure
+   in both directions (A6).
+4. Rotate to **landscape**: knobs-left / output-right; active screen stays
+   centered across the flip.
+5. Tap dots to jump; arrow-cycle with a keyboard and confirm the carousel follows
+   for the 4 chart screens.
+
+## Reference: current architecture (verified)
+
+- `DesignSession({ id, active })` (App.tsx ~1835); its `return` (~3667–4596) is
+  `<div className="app">` = `<aside className="sidebar">` (knobs, ~3669–4217) +
+  `<main className="stage">` (~4219–4595). `App()` (~4606) mounts sessions.
+- `.app` grid `320px 1fr` (styles.css 234–240); `.sidebar` `overflow-y:auto`
+  single scroll container (242–253); `.stage` flex row (1819–1831).
+- Stage children: `.solve-bar`, `.solve-cancel?`, `.solver-suggest`,
+  `.solve-error`, `.thumbstrip` (~4279, sized by `useThumbColumnSize` from
+  column height), `.carousel-slide` (~4316, ref=`slideRef`, sized by
+  `useSlideSize`), `.status` (~4591).
+- `.carousel-slide` = per-view overlays (~4320–4507) + `<ViewPanel>` (~4508–4530)
+  + floating `.readout.stage-readout` HUD (~4534–4589).
+- `View`/`VIEWS` module scope (1571–1577): antenna, azimuth, elevation, smith.
+- `useSlideSize` (1588): measures ref via getBoundingClientRect + ResizeObserver,
+  clamps `min(w,h,max)` then `max(160, floor-16)`; returns default when detached.
+- Arrow-key view cycler (2416–2439): window keydown, `if(!active)return`, skips
+  INPUT/TEXTAREA/SELECT/contentEditable/`.knob`, cycles `VIEWS` mod-4.
+- Canvases (`CurrentCanvas` ~6221, `SmithChart` ~5777, `FarFieldChart` ~5444)
+  have **no** pointer/touch handlers; only `Knob` (~426, `touch-action:none`)
+  owns pointer drags (sidebar + az/elev cut-angle overlay).
+- No `matchMedia`/`innerWidth` anywhere today; React 18.3.1 (Vite + `tsc`).

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
 import type { CSSProperties } from "react";
 
@@ -1585,7 +1586,11 @@ const PROJECTIONS: { id: Projection; label: string; horizAxis: 0|1|2; vertAxis: 
   { id: "yz", label: "Side (yz)",  horizAxis: 1, vertAxis: 2 },
 ];
 
-function useSlideSize(maxSize = 720) {
+// `reattachKey`: the measuring effect early-returns while the ref is detached,
+// so a caller whose measured element mounts LATER (e.g. the layout branch flips
+// between mobile and desktop at runtime) must pass a value that changes with
+// the branch, re-running the effect once the element exists.
+function useSlideSize(maxSize = 720, reattachKey?: unknown) {
   const ref = useRef<HTMLDivElement>(null);
   const [size, setSize] = useState(maxSize);
   useEffect(() => {
@@ -1600,13 +1605,48 @@ function useSlideSize(maxSize = 720) {
     const ro = new ResizeObserver(update);
     ro.observe(el);
     return () => ro.disconnect();
-  }, [maxSize]);
+  }, [maxSize, reattachKey]);
   return { ref, size };
+}
+
+// Mirror of the stylesheet's phone breakpoint. The query string MUST stay
+// identical to the mobile `@media` prelude in styles.css so the JS layout
+// branch and the CSS rules can never disagree about which viewports are
+// "mobile": max-width 700px catches portrait phones, and the short+coarse
+// clause catches landscape phones that are wider than 700px.
+const MOBILE_MEDIA_QUERY =
+  "(max-width: 700px), (max-height: 500px) and (pointer: coarse)";
+const PORTRAIT_MEDIA_QUERY = "(orientation: portrait)";
+
+function useMediaQuery(query: string): boolean {
+  // useSyncExternalStore is StrictMode-safe and avoids the subscribe/setState
+  // races of a hand-rolled effect. The snapshot is a boolean primitive — an
+  // object snapshot would be re-created every call, which React rejects
+  // ("The result of getSnapshot should be cached").
+  const [subscribe, getSnapshot] = useMemo(() => {
+    const mql = window.matchMedia(query);
+    const sub = (onChange: () => void) => {
+      mql.addEventListener("change", onChange);
+      return () => mql.removeEventListener("change", onChange);
+    };
+    return [sub, () => mql.matches] as const;
+  }, [query]);
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+function useIsMobile() {
+  const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY);
+  const portrait = useMediaQuery(PORTRAIT_MEDIA_QUERY);
+  return {
+    isMobile,
+    orientation: portrait ? ("portrait" as const) : ("landscape" as const),
+  };
 }
 
 function useThumbColumnSize(
   stripRef: React.RefObject<HTMLDivElement>,
   maxThumb = 280,
+  reattachKey?: unknown, // see useSlideSize
 ) {
   // Vertical thumbstrip: 3 thumbs scaled so they ALWAYS fit (the strip never
   // scrolls — overflow:hidden in CSS). Fixed overhead:
@@ -1628,7 +1668,7 @@ function useThumbColumnSize(
     const ro = new ResizeObserver(update);
     ro.observe(el);
     return () => ro.disconnect();
-  }, [stripRef, maxThumb]);
+  }, [stripRef, maxThumb, reattachKey]);
   return size;
 }
 
@@ -2409,9 +2449,13 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   // labels default OFF — they're the noisiest, especially on PyNEC.
   const [showWireLabels, setShowWireLabels] = useState(false);
   const [showFeedNames, setShowFeedNames] = useState(true);
-  const { ref: slideRef, size: chartSize } = useSlideSize(720);
+  // Layout branch. Desktop never reads isMobile except as the sizing hooks'
+  // reattach key, so no desktop viewport is affected; the key makes both
+  // hooks re-measure if the window is resized across the breakpoint.
+  const { isMobile } = useIsMobile();
+  const { ref: slideRef, size: chartSize } = useSlideSize(720, isMobile);
   const thumbStripRef = useRef<HTMLDivElement>(null);
-  const thumbSize = useThumbColumnSize(thumbStripRef, 280);
+  const thumbSize = useThumbColumnSize(thumbStripRef, 280, isMobile);
 
   useEffect(() => {
     if (!active) return;
@@ -3664,9 +3708,13 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active]);
 
-  return (
-    <div className="app">
-      <aside className="sidebar">
+  // Hoisted JSX shared between the desktop tree below and the mobile tree
+  // (Phase B). These close over the session's locals, so they are consts /
+  // a closure rather than components — zero prop surface, identical DOM.
+  // The moved blocks keep their original indentation so the refactor diff
+  // shows them as pure moves.
+  const controls = (
+    <>
         <TabStrip />
         <div className="sidebar-header">
           <div className="brand">
@@ -4214,9 +4262,11 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
             onClose={() => setGearOpen(null)}
           />
         )}
-      </aside>
+    </>
+  );
 
-      <main className="stage" aria-label="Antenna output views">
+  const solveOverlays = (
+    <>
         {/* Indeterminate progress bar: appears once a solve outlasts the dwell
             and lingers out its min-visible window (showBusy), so it never
             flashes — the dim/label (stale) clear earlier, when the result lands. */}
@@ -4276,48 +4326,16 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
             </span>
           </div>
         )}
-        <div className="thumbstrip" ref={thumbStripRef}>
-          {VIEWS.filter((v) => v.id !== view).map((v) => (
-            <button
-              key={v.id}
-              className="thumb"
-              onClick={() => setView(v.id)}
-              title={`Switch to ${v.label}`}
-            >
-              <div
-                className="thumb-canvas"
-                style={{ width: thumbSize, height: thumbSize }}
-              >
-                <ViewPanel
-                  view={v.id}
-                  size={thumbSize}
-                  fill={false}
-                  result={result}
-                  preview={preview}
-                  sweep={sweep}
-                  converge={converge}
-                  pattern={pattern}
-                  pinnedPatterns={[]}
-                  measFreqMhz={measFreq}
-                  sweepRunning={sweepRunning}
-                  convergeRunning={convergeRunning}
-                  azElevDeg={azElevDeg}
-                  elevAzDeg={elevAzDeg}
-                  cameraProjection={cameraProjection}
-                  showHeatmap={showHeatmap}
-                  showEnvelope={showEnvelope}
-                  multiFeed={effectiveMultiFeed}
-                />
-              </div>
-              <div className="thumb-label">{v.label}</div>
-            </button>
-          ))}
-        </div>
-        <div
-          className={`carousel-slide${stale ? " stale" : ""}`}
-          ref={slideRef}
-        >
-          {view === "antenna" && (
+    </>
+  );
+
+  // One output view: the per-view overlays plus the main <ViewPanel>. A
+  // closure (not a component) so the ~30 captured locals need no props. The
+  // solve-readout HUD stays OUT of it — mobile chart screens must not
+  // inherit the floating readout.
+  const renderOutput = (v: View, size: number, fill: boolean) => (
+    <>
+          {v === "antenna" && (
             <div className="antenna-overlay">
               <div className="projection-toggle">
                 {PROJECTIONS.map((p) => (
@@ -4377,7 +4395,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
               </label>
             </div>
           )}
-          {view === "smith" && (
+          {v === "smith" && (
             <div className="smith-overlay">
               <label
                 className="overlay-checkbox"
@@ -4403,7 +4421,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
               </label>
             </div>
           )}
-          {(view === "azimuth" || view === "elevation") && (
+          {(v === "azimuth" || v === "elevation") && (
             <div className="farfield-overlay">
               <label
                 className="overlay-checkbox"
@@ -4430,7 +4448,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
           {/* The cut-angle knob lives on the plot it drives: the azimuth
               (xy) cut is taken at elevation azElevDeg; the elevation (yz) cut
               is taken at azimuth bearing elevAzDeg. CCW dials from 3 o'clock. */}
-          {view === "azimuth" && (
+          {v === "azimuth" && (
             <div
               className="cut-overlay"
               title="elevation at which this azimuth cut is taken"
@@ -4452,7 +4470,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
               <span className="cut-overlay-value">{azElevDeg}°</span>
             </div>
           )}
-          {view === "elevation" && (
+          {v === "elevation" && (
             <div
               className="cut-overlay"
               title="azimuth bearing at which this elevation cut is taken"
@@ -4474,7 +4492,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
               <span className="cut-overlay-value">{elevAzDeg}°</span>
             </div>
           )}
-          {(view === "azimuth" || view === "elevation") && (
+          {(v === "azimuth" || v === "elevation") && (
             <div className="compare-overlay">
               <button
                 type="button"
@@ -4506,9 +4524,9 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
             </div>
           )}
           <ViewPanel
-            view={view}
-            size={chartSize}
-            fill={view === "antenna"}
+            view={v}
+            size={size}
+            fill={fill}
             result={result}
             preview={preview}
             sweep={sweep}
@@ -4528,65 +4546,67 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
             multiFeed={effectiveMultiFeed}
             fineNorm={normCheck?.pattern_norm ?? null}
           />
+    </>
+  );
+
+  return (
+    <div className="app">
+      <aside className="sidebar">{controls}</aside>
+
+      <main className="stage" aria-label="Antenna output views">
+        {solveOverlays}
+        <div className="thumbstrip" ref={thumbStripRef}>
+          {VIEWS.filter((v) => v.id !== view).map((v) => (
+            <button
+              key={v.id}
+              className="thumb"
+              onClick={() => setView(v.id)}
+              title={`Switch to ${v.label}`}
+            >
+              <div
+                className="thumb-canvas"
+                style={{ width: thumbSize, height: thumbSize }}
+              >
+                <ViewPanel
+                  view={v.id}
+                  size={thumbSize}
+                  fill={false}
+                  result={result}
+                  preview={preview}
+                  sweep={sweep}
+                  converge={converge}
+                  pattern={pattern}
+                  pinnedPatterns={[]}
+                  measFreqMhz={measFreq}
+                  sweepRunning={sweepRunning}
+                  convergeRunning={convergeRunning}
+                  azElevDeg={azElevDeg}
+                  elevAzDeg={elevAzDeg}
+                  cameraProjection={cameraProjection}
+                  showHeatmap={showHeatmap}
+                  showEnvelope={showEnvelope}
+                  multiFeed={effectiveMultiFeed}
+                />
+              </div>
+              <div className="thumb-label">{v.label}</div>
+            </button>
+          ))}
+        </div>
+        <div
+          className={`carousel-slide${stale ? " stale" : ""}`}
+          ref={slideRef}
+        >
+          {renderOutput(view, chartSize, view === "antenna")}
           {/* Solve readout, pinned to the lower-left of whichever view the
               carousel is centered on. Floats over the canvas as a HUD so the
               left input rail stays inputs-only. */}
-          <div className={`readout stage-readout${stale ? " stale" : ""}`}>
-            <div className="row">
-              <span>R</span>
-              <span className="val">{result ? `${result.z_in_re.toFixed(2)} Ω` : "—"}</span>
-            </div>
-            <div className="row">
-              <span>X</span>
-              <span className={result && Math.abs(result.z_in_im) < 2 ? "val val-hot" : "val"}>
-                {result ? `${result.z_in_im.toFixed(2)} Ω` : "—"}
-              </span>
-            </div>
-            {currentExample && (
-              <ResultPanel
-                schema={currentExample.result_schema}
-                result={result as Record<string, unknown> | null}
-              />
-            )}
-            {effectiveMultiFeed && result?.feeds && result.feeds.length > 1 && (
-              <div className="feeds-table">
-                <div className="feeds-table-header">per-feed Z (V/I)</div>
-                {result.feeds.map((f, i) => (
-                  <div className="row" key={`feed-z-${i}`}>
-                    <span>
-                      feed {i} ∠{Math.round(Math.atan2(f.v_im, f.v_re) * 180 / Math.PI)}°
-                    </span>
-                    <span className="val">
-                      {f.z_re.toFixed(1)} {f.z_im >= 0 ? "+" : "−"} j
-                      {Math.abs(f.z_im).toFixed(1)} Ω
-                    </span>
-                  </div>
-                ))}
-              </div>
-            )}
-            <div className="row">
-              <span>|I_feed|</span>
-              <span className="val">
-                {result ? feedMag(result).toExponential(3) : "—"}
-              </span>
-            </div>
-            <div className="row">
-              <span>solve</span>
-              <span className="val">{result ? `${result.solve_ms.toFixed(1)} ms` : "—"}</span>
-            </div>
-            <div className="row">
-              <span>SWR ({(result?.z0_ohms ?? 50).toFixed(0)} Ω)</span>
-              <span className="val">
-                {result
-                  ? formatSwr(result.z_in_re, result.z_in_im, result.z0_ohms ?? 50)
-                  : "—"}
-              </span>
-            </div>
-            <div className="row">
-              <span>rtt</span>
-              <span className="val">{rttMs != null ? `${rttMs.toFixed(1)} ms` : "—"}</span>
-            </div>
-          </div>
+          <SolveReadout
+            className={`stage-readout${stale ? " stale" : ""}`}
+            result={result}
+            rttMs={rttMs}
+            currentExample={currentExample}
+            effectiveMultiFeed={effectiveMultiFeed}
+          />
         </div>
         <div className="status">
           ws: {status}
@@ -5052,6 +5072,83 @@ function formatSwr(r: number, x: number, z0: number): string {
   const swr = (1 + gMag) / (1 - gMag);
   if (swr > 99) return swr.toFixed(0);
   return swr.toFixed(2);
+}
+
+// The R/X/SWR/rtt solve readout. The desktop stage floats it over the canvas
+// as a HUD (className="stage-readout"); the mobile Info screen (Phase B)
+// renders it as a normal block. Module scope so both trees share one
+// implementation.
+function SolveReadout({
+  result,
+  rttMs,
+  currentExample,
+  effectiveMultiFeed,
+  className = "",
+}: {
+  result: SolveResponse | null;
+  rttMs: number | null;
+  currentExample: ExampleDescriptor | undefined;
+  effectiveMultiFeed: boolean;
+  className?: string;
+}) {
+  return (
+    <div className={`readout${className ? " " + className : ""}`}>
+      <div className="row">
+        <span>R</span>
+        <span className="val">{result ? `${result.z_in_re.toFixed(2)} Ω` : "—"}</span>
+      </div>
+      <div className="row">
+        <span>X</span>
+        <span className={result && Math.abs(result.z_in_im) < 2 ? "val val-hot" : "val"}>
+          {result ? `${result.z_in_im.toFixed(2)} Ω` : "—"}
+        </span>
+      </div>
+      {currentExample && (
+        <ResultPanel
+          schema={currentExample.result_schema}
+          result={result as Record<string, unknown> | null}
+        />
+      )}
+      {effectiveMultiFeed && result?.feeds && result.feeds.length > 1 && (
+        <div className="feeds-table">
+          <div className="feeds-table-header">per-feed Z (V/I)</div>
+          {result.feeds.map((f, i) => (
+            <div className="row" key={`feed-z-${i}`}>
+              <span>
+                feed {i} ∠{Math.round(Math.atan2(f.v_im, f.v_re) * 180 / Math.PI)}°
+              </span>
+              <span className="val">
+                {f.z_re.toFixed(1)} {f.z_im >= 0 ? "+" : "−"} j
+                {Math.abs(f.z_im).toFixed(1)} Ω
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="row">
+        <span>|I_feed|</span>
+        <span className="val">
+          {result ? feedMag(result).toExponential(3) : "—"}
+        </span>
+      </div>
+      <div className="row">
+        <span>solve</span>
+        <span className="val">{result ? `${result.solve_ms.toFixed(1)} ms` : "—"}</span>
+      </div>
+      <div className="row">
+        <span>SWR ({(result?.z0_ohms ?? 50).toFixed(0)} Ω)</span>
+        <span className="val">
+          {result
+            ? formatSwr(result.z_in_re, result.z_in_im, result.z0_ohms ?? 50)
+            : "—"}
+        </span>
+      </div>
+      <div className="row">
+        <span>rtt</span>
+        <span className="val">{rttMs != null ? `${rttMs.toFixed(1)} ms` : "—"}</span>
+      </div>
+    </div>
+  );
 }
 
 function ViewPanel({


### PR DESCRIPTION
## Summary
- **Plan** (docs/plan-mobile-layout-mode.md): purpose-built mobile layout replacing the pan-around — portrait stacks knobs over one output pane, landscape puts knobs left; output is a 5-screen scroll-snap carousel (Antenna / Azimuth / Elevation / Smith / Info readout) with dot indicators. Includes review amendments: solve overlays must survive on mobile (solver-suggest gates solves; solve-error is the only failure surface), reattach keys for runtime breakpoint flips, primitive useSyncExternalStore snapshots, single stale dim on mobile, Info screen scrolling, 40px dot targets.
- **Phase A refactor** (App.tsx): hoists the desktop stage JSX into reusable pieces — module-scope `SolveReadout`, `useIsMobile()`/`useMediaQuery` hooks, a `renderOutput(v, size, fill)` closure, and `controls`/`solveOverlays` consts — with the desktop DOM byte-identical. Moved blocks keep their original indentation, so `git diff --color-moved` shows them as pure moves.
- Phase B (the mobile feature itself, gated on `isMobile`) lands as a follow-up PR per the plan.

## Verification done
- Byte-identity script: hoisted blocks match the originals exactly, modulo the four planned `view`→`v`/`size`/`fill` substitutions inside `renderOutput`; the HUD className concat reproduces `readout stage-readout [stale]` byte-for-byte.
- `npm run build` (tsc + vite) clean; ruff check/format clean.
- Live desktop smoke test: HUD populated from a real solve, thumbstrip intact, ArrowUp/Down view cycling works, knobs consume arrows without cycling views.

## Test plan
- [ ] Desktop viewport: HUD, thumbstrip, and arrow-key view cycling unchanged
- [ ] Turn a knob during a long solve: view + HUD dim as before
- [ ] Resize across the 700px breakpoint: charts re-measure in both directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)