### PR TITLE
Fix solve HUD dimming to ~25% opacity during long solves

### DIFF
--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -4599,9 +4599,11 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
           {renderOutput(view, chartSize, view === "antenna")}
           {/* Solve readout, pinned to the lower-left of whichever view the
               carousel is centered on. Floats over the canvas as a HUD so the
-              left input rail stays inputs-only. */}
+              left input rail stays inputs-only. It sits INSIDE the slide, so
+              the slide's stale dim already covers it — no own stale class, or
+              the two opacities would compound. */}
           <SolveReadout
-            className={`stage-readout${stale ? " stale" : ""}`}
+            className="stage-readout"
             result={result}
             rttMs={rttMs}
             currentExample={currentExample}

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1889,15 +1889,16 @@ canvas {
   }
 }
 
-/* Dim panels whose data is being recomputed (gated on the same dwell as the
-   bar). Transition lives on the base elements so it eases both in and out. */
-.carousel-slide,
-.readout {
+/* Dim the panel whose data is being recomputed (gated on the same dwell as
+   the bar). Transition lives on the base element so it eases both in and out.
+   The readout HUD lives inside the slide and inherits this dim visually; it
+   used to carry its own .readout.stale rule from when it lived in the sidebar,
+   which compounded to ~0.25 opacity once it moved into the slide. */
+.carousel-slide {
   transition: opacity 0.2s ease;
 }
 
-.carousel-slide.stale,
-.readout.stale {
+.carousel-slide.stale {
   opacity: 0.5;
 }
 


### PR DESCRIPTION
## Summary
- On a long solve the R/X/SWR readout HUD dimmed twice: the stale slide dims to opacity 0.5, and the HUD inside it carried its own `.readout.stale` 0.5 — compounding to ~0.25, noticeably darker than the charts around it.
- Root cause is a relocation leftover: when the dim rule was written (7e580037) the readout lived in the sidebar, outside the stage, and needed its own stale rule; once it moved into the slide as a floating HUD, the parent dim already covered it.
- Fix: the HUD call site no longer applies the stale class, and the now-dead `.readout` halves of the dim/transition selectors are removed. The HUD now dims exactly once, with the slide.
- Follow-up agreed during the mobile-layout planning (PR #239); landing it before Phase B because Phase B extends the same CSS selector.

## Test plan
- [ ] Load a slow design and turn a knob: after the dwell, charts and HUD dim together to the same 50% level (previously the HUD went darker)
- [ ] Result lands: both un-dim together with the 0.2s ease

🤖 Generated with [Claude Code](https://claude.com/claude-code)