### PR TITLE
Mobile layout mode: knobs and a swipeable 5-screen output on one screen (Phase B)

### DIFF
--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1577,6 +1577,16 @@ const VIEWS: { id: View; label: string }[] = [
   { id: "smith", label: "Smith" },
 ];
 
+// The mobile output carousel's screens: the 4 chart views plus a dedicated
+// Info screen for the solve readout (which floats as a HUD on desktop but
+// deserves its own page on a phone). "info" stays out of the `View` union on
+// purpose — `view` (and every data effect keyed on it) only ever holds a
+// chart view; the Info screen leaves `view` parked on the last chart.
+const MOBILE_SCREENS: { id: View | "info"; label: string }[] = [
+  ...VIEWS,
+  { id: "info", label: "Info" },
+];
+
 // Antenna-canvas camera projections. Pick two world axes to map to canvas
 // (horizontal, vertical) and project. The hidden axis is the camera ray.
 type Projection = "xy" | "xz" | "yz";
@@ -2452,10 +2462,74 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   // Layout branch. Desktop never reads isMobile except as the sizing hooks'
   // reattach key, so no desktop viewport is affected; the key makes both
   // hooks re-measure if the window is resized across the breakpoint.
-  const { isMobile } = useIsMobile();
+  const { isMobile, orientation } = useIsMobile();
   const { ref: slideRef, size: chartSize } = useSlideSize(720, isMobile);
   const thumbStripRef = useRef<HTMLDivElement>(null);
   const thumbSize = useThumbColumnSize(thumbStripRef, 280, isMobile);
+
+  // Mobile output carousel (all hooks unconditional — desktop leaves them
+  // inert). mobileIndex is which of the 5 screens the snap carousel rests on;
+  // `view` stays the source of truth for the 4 chart screens and their data
+  // effects, kept in sync by the scroll handler / reverse-sync effect below.
+  const [mobileIndex, setMobileIndex] = useState(0);
+  const mobileCarouselRef = useRef<HTMLDivElement>(null);
+  const mobileScrollRafRef = useRef<number | null>(null);
+  const { ref: mobRef, size: mobChartSize } = useSlideSize(720, isMobile);
+
+  // Track where a swipe/fling snaps and mirror it into state. rAF-throttled:
+  // scroll events arrive per frame during a fling, one rounding per frame is
+  // plenty. The rounded-index compare inside the setters keeps this from
+  // fighting the programmatic scrolls below.
+  const onMobileCarouselScroll = () => {
+    if (mobileScrollRafRef.current !== null) return;
+    mobileScrollRafRef.current = requestAnimationFrame(() => {
+      mobileScrollRafRef.current = null;
+      const el = mobileCarouselRef.current;
+      if (!el || el.clientWidth === 0) return;
+      const i = Math.round(el.scrollLeft / el.clientWidth);
+      setMobileIndex((prev) => (prev === i ? prev : i));
+      if (i < VIEWS.length) setView(VIEWS[i].id);
+    });
+  };
+
+  // Dot tap: jump to a screen. Info (the last index) is reachable only here
+  // and by swipe — it deliberately leaves `view` on the last chart screen.
+  const goToMobileScreen = (i: number) => {
+    setMobileIndex(i);
+    if (i < VIEWS.length) setView(VIEWS[i].id);
+    const el = mobileCarouselRef.current;
+    if (el) el.scrollTo({ left: i * el.clientWidth, behavior: "smooth" });
+  };
+
+  // Reverse sync: anything else that sets `view` (the arrow-key cycler) pages
+  // the carousel to match. The DOM scroll position is the ground truth for
+  // "where are we" — comparing rounded indices means we never fight an
+  // in-progress swipe, and parking on Info ignores view changes entirely.
+  useEffect(() => {
+    if (!isMobile) return;
+    const el = mobileCarouselRef.current;
+    if (!el || el.clientWidth === 0) return;
+    const target = VIEWS.findIndex((v) => v.id === view);
+    const current = Math.round(el.scrollLeft / el.clientWidth);
+    if (target < 0 || current >= VIEWS.length || current === target) return;
+    setMobileIndex(target);
+    el.scrollTo({ left: target * el.clientWidth, behavior: "smooth" });
+  }, [view, isMobile]);
+
+  // An orientation flip (or any pane resize) changes the screen width, so
+  // scrollLeft no longer sits on a snap point; re-center the active screen
+  // once the new layout lands (hence the rAF). Skipped when the rounded
+  // position already matches — never fights a drag.
+  useEffect(() => {
+    if (!isMobile) return;
+    const raf = requestAnimationFrame(() => {
+      const el = mobileCarouselRef.current;
+      if (!el || el.clientWidth === 0) return;
+      const i = Math.round(el.scrollLeft / el.clientWidth);
+      if (i !== mobileIndex) el.scrollTo({ left: mobileIndex * el.clientWidth });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [isMobile, orientation, mobChartSize, mobileIndex]);
 
   useEffect(() => {
     if (!active) return;
@@ -4548,6 +4622,65 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
           />
     </>
   );
+
+  // Mobile: knobs pane + a 5-screen scroll-snap output carousel, instead of
+  // the desktop thumbstrip/HUD stage. A distinct tree (not CSS-hiding the
+  // desktop one) keeps both layouts honest; the shared pieces are exactly the
+  // hoisted consts above. All hooks already ran, so branching here is safe.
+  if (isMobile) {
+    return (
+      <div className="app app-mobile">
+        <aside className="sidebar mobile-knobs">{controls}</aside>
+        <section
+          className="mobile-output"
+          ref={mobRef}
+          aria-label="Antenna output views"
+        >
+          {solveOverlays}
+          <div
+            className={`mobile-carousel${stale ? " stale" : ""}`}
+            ref={mobileCarouselRef}
+            onScroll={onMobileCarouselScroll}
+          >
+            {MOBILE_SCREENS.map((s) => (
+              <div
+                key={s.id}
+                className={`mobile-screen${s.id === "info" ? " mobile-screen-info" : ""}`}
+              >
+                {s.id === "info" ? (
+                  <SolveReadout
+                    className="mobile-readout"
+                    result={result}
+                    rttMs={rttMs}
+                    currentExample={currentExample}
+                    effectiveMultiFeed={effectiveMultiFeed}
+                  />
+                ) : (
+                  renderOutput(s.id as View, mobChartSize, s.id === "antenna")
+                )}
+              </div>
+            ))}
+          </div>
+          <div className="mobile-dots" aria-label="Output screens">
+            {MOBILE_SCREENS.map((s, i) => (
+              <button
+                key={s.id}
+                type="button"
+                className={i === mobileIndex ? "active" : ""}
+                aria-label={`Show ${s.label}`}
+                title={s.label}
+                onClick={() => goToMobileScreen(i)}
+              />
+            ))}
+          </div>
+          <div className="status">
+            ws: {status}
+            {stale && <span className="status-busy"> · solving…</span>}
+          </div>
+        </section>
+      </div>
+    );
+  }
 
   return (
     <div className="app">

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -2128,54 +2128,148 @@ canvas {
 }
 
 /* ---- Mobile (phones / small tablets) ----------------------------------------
-   The desktop layout is a fixed two-pane grid (320px control rail + a 1fr
-   output stage) with overflow hidden everywhere. On a narrow phone the 320px
-   rail eats the width, the 1fr stage collapses to a sliver, and the output
-   carousel is clipped with no way to reach it. Below this breakpoint we instead
-   lay the two panes out as near-full-width columns and let `.app` pan
-   horizontally: the controls fill the screen, and you swipe right to a
-   full-size output rectangle. Scroll-snap rests the pan on either pane.
-   Breakpoint ~700px: the two-pane needs ≈320px rail + ≈360px usable output to
-   be comfortable, so only below that do we switch to the pannable layout.
-   We ALSO switch on a short, touch viewport (max-height 500px + a coarse
-   pointer) so a phone in LANDSCAPE — wider than 700px but only ~400px tall,
-   where the two-pane's output stage gets squashed flat — gets the same wide
-   pannable rectangle you swipe across in portrait. Large landscape tablets
-   (height > 500px) keep the roomy two-pane. */
-@media (max-width: 700px),
-       (max-height: 500px) and (pointer: coarse) {
-  .app {
-    /* Controls nearly fill the viewport (capped so a sliver of the stage peeks
-       as a "swipe right" affordance); the stage is a fixed monitor-sized canvas
-       you pan across in BOTH axes. We floor it at 1920x1080 CSS px so the output
-       always renders at a full desktop-monitor size regardless of the phone's
-       own dimensions — in portrait the old 200vw width was < 1920, and in
-       landscape the viewport-height stage (~400px tall) starved the vertical
-       thumbstrip (3 thumbs scaled to the stage height) down to tiny thumbnails.
-       The canvas exceeds the viewport on both axes, so .app scrolls both ways;
-       --mobile-stage-w/-h keep the grid track and the stage min-size in sync. */
-    --mobile-stage-w: max(200vw, 1920px);
-    --mobile-stage-h: max(100%, 1080px);
-    grid-template-columns: min(340px, 86vw) var(--mobile-stage-w);
-    grid-template-rows: var(--mobile-stage-h);
-    overflow-x: auto;
-    overflow-y: auto;
-    scroll-snap-type: x proximity;
-    -webkit-overflow-scrolling: touch;
-  }
+   A purpose-built layout replacing the old pan-around-a-1920x1080-canvas: on a
+   phone the knobs and one output view are on screen TOGETHER (portrait stacks
+   them 50/50, landscape puts knobs left), so you can see the effect of a knob
+   while you turn it. The output pane is a 5-screen scroll-snap carousel (the 4
+   chart views + an Info readout screen) with dot indicators.
 
-  .sidebar {
-    scroll-snap-align: start;
-  }
+   Everything is gated on `.app-mobile`, which App.tsx adds exactly when its
+   useIsMobile() hook matches — the hook's media query string mirrors the old
+   breakpoint (max-width 700px for portrait phones; max-height 500px + coarse
+   pointer for landscape phones wider than 700px), so JS and CSS can never
+   disagree. Plain `.app` (desktop) is untouched by everything below. */
+.app-mobile {
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr 1fr;
+  overflow: hidden;
+}
 
-  .stage {
-    /* A fixed >=1920x1080 monitor canvas: wide enough for the output carousel's
-       landscape aspect, and tall enough that the vertical thumbstrip renders
-       its 3 thumbnails at full size. You pan across it in both directions. */
-    min-width: var(--mobile-stage-w);
-    min-height: var(--mobile-stage-h);
-    scroll-snap-align: start;
+.app-mobile .mobile-knobs {
+  grid-row: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-height: 0;
+  border-right: none;
+  border-bottom: 1px solid var(--border);
+}
+
+.app-mobile .mobile-output {
+  grid-row: 2;
+  position: relative; /* hosts the absolutely-positioned solve overlays */
+  overflow: hidden;
+  min-height: 0;
+  min-width: 0;
+}
+
+@media (orientation: landscape) {
+  /* Knobs-left / output-right. Only .app-mobile is targeted, so a landscape
+     DESKTOP window (plain .app) never takes these rules. */
+  .app-mobile {
+    grid-template-columns: minmax(0, 44%) 1fr;
+    grid-template-rows: 100%;
   }
+  .app-mobile .mobile-knobs {
+    grid-row: auto;
+    grid-column: 1;
+    border-bottom: none;
+    border-right: 1px solid var(--border);
+  }
+  .app-mobile .mobile-output {
+    grid-row: auto;
+    grid-column: 2;
+  }
+}
+
+.mobile-carousel {
+  display: flex;
+  height: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  transition: opacity 0.2s ease; /* same stale dim contract as .carousel-slide */
+}
+
+.mobile-carousel.stale {
+  opacity: 0.5;
+}
+
+.mobile-screen {
+  flex: 0 0 100%;
+  scroll-snap-align: start;
+  scroll-snap-stop: always; /* one screen per swipe — no fling-past */
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.mobile-screen-info {
+  /* The readout can exceed a ~400px landscape pane (per-feed Z table), so
+     this screen scrolls vertically; y-scroll inside an x-snap carousel
+     coexists fine. */
+  overflow-y: auto;
+  align-items: flex-start;
+  padding: var(--space-7) 0;
+}
+
+.mobile-readout {
+  max-width: min(90%, 320px);
+  margin: 0 auto;
+}
+
+.mobile-dots {
+  position: absolute;
+  bottom: var(--space-4);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  z-index: 3;
+}
+
+.mobile-dots button {
+  /* ~40px touch target (cf. the coarse-pointer block below); the visible
+     8px dot is the ::before. */
+  padding: 16px 10px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.mobile-dots button::before {
+  content: "";
+  display: block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--muted);
+  opacity: 0.5;
+}
+
+.mobile-dots button.active::before {
+  background: var(--accent);
+  opacity: 1;
+}
+
+/* The solve overlays are shared with the desktop stage. Most are absolutely
+   positioned and just work inside .mobile-output; .solve-error is a flow
+   child on desktop, so float it over the carousel here. */
+.app-mobile .solve-error {
+  position: absolute;
+  top: var(--space-5);
+  left: var(--space-5);
+  right: var(--space-5);
+  z-index: 5;
+  margin: 0;
+}
+
+/* Defensive: the floating HUD is never rendered in the mobile tree, but if a
+   future refactor moves it inside renderOutput it must not cover a phone
+   chart. */
+.app-mobile .stage-readout {
+  display: none;
 }
 
 /* Coarse pointers (touch): grow the small icon buttons and compact selects


### PR DESCRIPTION
## Summary
- Replaces the phone pan-around (fixed 1920×1080 canvas) with a purpose-built layout per `docs/plan-mobile-layout-mode.md`: **portrait** stacks knobs over the output pane 50/50; **landscape** puts knobs left (44%) / output right — knobs and one output view are always on screen together.
- The output pane is a CSS scroll-snap **carousel of 5 screens** — Antenna, Azimuth, Elevation, Smith, plus a new **Info** screen carrying the solve readout (the floating HUD is not rendered on mobile) — with dot indicators (~40px touch targets, 8px visual dots).
- `view` stays the source of truth for the 4 chart screens: a rAF-throttled scroll handler mirrors the snapped screen into `view`, dot taps and the ArrowUp/Down cycler page the carousel via a reverse-sync effect, rounded-index compares prevent fighting an in-progress swipe, and orientation flips re-center the active screen. Info stays out of the `View` union and leaves `view` parked on the last chart.
- The solve overlays (bar / cancel / solver-suggest / solve-error) render in the mobile output pane too — solver-suggest *gates* solves and solve-error is the only failure surface, so mobile must keep them. The whole carousel dims via the same stale contract as `.carousel-slide` (single dim, per #240).
- Desktop untouched: all mobile layout is gated on `.app-mobile`/`isMobile` (identical media queries in JS and CSS), the desktop JSX tree is unchanged, and all new hooks are unconditional.

## Verification done
Headless-Chrome test drive against the running app (23/23 checks): mobile branch renders at phone viewports with 5 screens + dots and no thumbstrip/HUD; portrait 50/50 stack and landscape side-by-side geometries confirmed by bounding boxes; initial solve populates the Info readout; dot taps, programmatic swipes, and arrow-key cycling all keep dots/`view`/scroll in sync; view changes while parked on Info are ignored; arrows on a focused knob turn the knob without paging; knob turns re-solve (R 55.05 → 50.94 Ω); orientation flip re-centers on a snap point; desktop viewport still renders plain `.app` with thumbstrip + HUD and solves normally.

## Test plan
- [ ] On a real phone (portrait): turn a knob and watch the chart react on the same screen; swipe through all 5 screens; dots track
- [ ] Rotate to landscape: knobs left, active screen stays centered
- [ ] Info screen shows the full readout incl. per-feed table on a multi-feed design, and scrolls in landscape
- [ ] A solver-mismatch design shows the suggest dialog on mobile; a broken design shows the solve error
- [ ] Desktop: everything unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)