### PR TITLE
Auto-generate release notes on tag publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,3 +87,9 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           files: dist/*
+          # Auto-populate the release body with the merged-PR list since the
+          # previous tag (GitHub's generated notes). Only fills an EMPTY body:
+          # hand-written notes on a pre-created release are preserved, and a
+          # grouped "Highlights" section can be added on top after the fact
+          # with `gh release edit`.
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- Release bodies have been empty — publish.yml's release job only attached the wheel/sdist. Setting `generate_release_notes: true` on the softprops step makes every tag-created release carry GitHub's generated notes (the merged-PR list since the previous tag) automatically.
- Hand-written notes are unaffected: the option only fills an empty body, and a grouped Highlights section can still be layered on afterwards with `gh release edit` (as was just backfilled for v0.13.0).

## Test plan
- [ ] Next `v*` tag: the created release has the What's-Changed PR list without manual steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)