### PR TITLE
Require momwire >= 0.3.0 — the release that carries the cancel API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,12 @@ classifiers = [
 #     same index. The vendored git submodule remains for co-development (install
 #     it editable to override the wheel); a development checkout that does
 #     `pip install -e ./momwire` first satisfies this pin and pip won't refetch.
+#     IMPORTANT: the floor must name the momwire release that actually carries
+#     every momwire API this package uses — dev/CI run the submodule, so ONLY
+#     this pin protects PyPI installs and the Fly image. When code starts using
+#     a new momwire API, bump the floor in the same PR and confirm that version
+#     is on PyPI before tagging a release (v0.13.0 shipped broken because the
+#     cancel API existed only in the submodule while the floor allowed 0.2.3).
 #   - numpy/scipy math throughout; matplotlib for the draw/sweep/pattern plots;
 #     icecream for the CLI/sweep debug tracing; scikit-rf for Touchstone/network
 #     handling in sweep.
@@ -32,7 +38,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire>=0.1.0",
+    "momwire>=0.3.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",


### PR DESCRIPTION
## Summary
- **Fixes the v0.13.0 outage**: the /ws solve loop (PR #232) uses momwire's cooperative-cancel API, which existed only in the git submodule. PyPI momwire was still 0.2.3 without `CancelToken` (verified by inspecting the wheel), and the `momwire>=0.1.0` floor accepted it — so every solve on Fly and on fresh pip installs raised `AttributeError` and closed the websocket ("solves never happen"). Dev/CI install the submodule, so the suite couldn't catch it.
- Raises the floor to `momwire>=0.3.0`, advances the submodule pointer to the same v0.3.0 commit, and documents the pin-bump rule inline next to the dependency.
- Live was rolled back to v0.12.0 via workflow_dispatch and 0.13.0 was yanked on PyPI; after this merges, 0.13.1 re-releases the v0.13.0 features with the correct floor.

## Test plan
- [ ] momwire v0.3.0 on PyPI with the cancel API (tag build in progress; verify the published wheel contains CancelToken before merging)
- [ ] After 0.13.1 tags: Fly deploy solves (ws: open, readout populates) — the exact failure mode of v0.13.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
