### PR TITLE
CI: wheel-only solve smoke to catch submodule/PyPI dependency splits

### DIFF
--- a/.github/scripts/wheel_solve_smoke.py
+++ b/.github/scripts/wheel_solve_smoke.py
@@ -1,0 +1,38 @@
+"""Solve smoke test for a wheel-only install (PyPI deps, no git submodule).
+
+Run by the `wheel-smoke` job in test.yml after `pip install <wheel>[web]` in an
+environment with NO momwire submodule — momwire resolves from PyPI per the
+version floor in pyproject.toml. Dev and the other CI jobs install the
+submodule, so they can never notice code that uses a momwire API the floor
+does not guarantee. That exact split shipped v0.13.0 broken: server.solve()
+passed cancel=momwire.CancelToken() while the floor still admitted momwire
+0.2.3, which predates the cancel API — every solve on Fly raised
+AttributeError and the readout never populated.
+
+This script exercises precisely that seam: the web server's solve entry point,
+with a cancel token, against whatever momwire pip actually resolved.
+"""
+
+import momwire
+
+from antennaknobs.web import server
+
+req = {
+    "geometry": "loops.triangular_skyloop",
+    "measurement_freq_mhz": 3.8,
+    "design_freq_mhz": 3.8,
+    "momwire_model": "triangular",
+    "n_per_wire": 20,
+    "ground": False,
+}
+out = server.solve(req, cancel=momwire.CancelToken())
+
+assert "error" not in out, f"solve returned an error: {out.get('error')}"
+assert isinstance(out.get("z_in_re"), float), f"no impedance in response: {sorted(out)}"
+assert out.get("wires"), "no wire geometry in response"
+
+print(
+    f"wheel smoke OK: momwire {getattr(momwire, '__version__', '?')}, "
+    f"Z = {out['z_in_re']:.2f} {'+' if out['z_in_im'] >= 0 else '-'} "
+    f"j{abs(out['z_in_im']):.2f} ohm, solve {out['solve_ms']:.1f} ms"
+)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,3 +103,37 @@ jobs:
       uses: py-cov-action/python-coverage-comment-action@v3
       with:
         GITHUB_TOKEN: ${{ github.token }}
+
+  wheel-smoke:
+    # Install antennaknobs from the BUILT WHEEL with PyPI deps only — no git
+    # submodule — and run one real solve through the web server's entry point.
+    # This is the environment Fly and `pip install antennaknobs` actually get.
+    # The job above installs momwire editable from the submodule, so it can
+    # never catch code that uses a momwire API the pyproject version floor
+    # does not guarantee; that exact split shipped v0.13.0 broken (solves used
+    # momwire.CancelToken while the floor still admitted momwire 0.2.3).
+    #
+    # Deliberately cheap: no submodule checkout, no ccache, no PyNEC, no
+    # frontend build (the server's static mount is gated on the directory
+    # existing, and the smoke only calls the solve path).
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+      # No `submodules:` — momwire MUST come from PyPI here; that's the test.
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.12"
+    - name: Build the wheel
+      run: pipx run build --wheel
+    - name: Install from the wheel (PyPI deps only)
+      run: |
+        WHL=$(ls dist/*.whl)
+        pip install "${WHL}[web]"
+    - name: Solve smoke through the server entry point
+      # Run from a temp dir so a stray `momwire/` source dir on CWD can never
+      # shadow the installed package.
+      run: |
+        SMOKE=$(pwd)/.github/scripts/wheel_solve_smoke.py
+        cd "$(mktemp -d)"
+        python "$SMOKE"


### PR DESCRIPTION
## Summary
- Adds a cheap `wheel-smoke` job to test.yml (per PR + main push): build the wheel, install it with **PyPI deps only** (no momwire submodule), and run one real solve through `server.solve(..., cancel=momwire.CancelToken())` — the exact line that shipped v0.13.0 broken while every submodule-based job stayed green.
- Verified both directions locally in a fresh venv: passes against PyPI momwire 0.3.0 (Z = 113.64 + j0.69 Ω), and forcing momwire==0.2.3 reproduces the incident's `AttributeError` precisely.
- No frontend build, no ccache, no PyNEC — the server's static mount is directory-gated and PyNEC is optional, so the job stays ~1 minute.

## Test plan
- [ ] The new `wheel-smoke` check appears on this PR and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)