### PR TITLE
Pinned patterns shared across sessions, with per-pin show/hide

### DIFF
--- a/docs/plan-cross-session-pins.md
+++ b/docs/plan-cross-session-pins.md
@@ -126,8 +126,9 @@ type PinnedPattern = {
 
 ### Phase 3 — build, verify, ship
 
-- `npm run build` in `src/antennaknobs/web/frontend` and commit the rebuilt
-  static bundle (checked in under `web/static/assets/`), as usual.
+- `npm run build` in `src/antennaknobs/web/frontend` (runs `tsc --noEmit`
+  first). The output under `web/static/` is gitignored — built at
+  package/deploy time — so there is no bundle to commit.
 - Manual verify (browser must be a **visible** window — hidden Chrome
   suspends rAF and solves never send):
   1. Tab 1: pin a dipole; open tab 2, pick a yagi → ghost + table row appear

--- a/docs/plan-cross-session-pins.md
+++ b/docs/plan-cross-session-pins.md
@@ -1,0 +1,162 @@
+# Plan: cross-session pinned patterns, with per-pin enable/disable
+
+Status: **implemented & verified 2026-07-05** (Phases 1+2 on
+`cross-session-pinned-patterns`; Phase 3 loop run headless against the dev
+server — all five checks passed). Motivated by the tabbed-sessions
+work (PR #214): now that different antenna designs live in different session
+tabs, the pin mechanism — built for comparing tunings *within* one session —
+should span sessions so tab A's pattern can be overlaid on tab B's chart.
+
+## Motivation
+
+Pins exist to freeze a far-field snapshot and compare something else against
+it. With tabbed sessions the natural "something else" is *another session's
+design*, but today each session keeps its own private pin list, so the
+comparison the tabs were built for can't use the pins. Three asks:
+
+1. **Share pins across sessions** — one global pin list; a pin made in any tab
+   shows (ghost overlay + compare-table row) in every tab.
+2. **Individual delete** — already exists (✕ per row, `removePin`,
+   `App.tsx:2983`); must survive the refactor unchanged.
+3. **Individual enable/disable** — hide a pin's ghost overlay without losing
+   the snapshot, so a crowded chart can be decluttered pin-by-pin (today the
+   only options are delete-one or clear-all).
+
+## How it works today (baseline)
+
+All pin state is **per-session**, inside `DesignSession` (`App.tsx:1885`):
+
+- `pinnedPatterns: PinnedPattern[]` + `pinSeq` ref (`App.tsx:2379–2381`).
+  `PinnedPattern` (`App.tsx:5558`) = `{ id, label, result: SolveResponse,
+  metrics: PatternMetrics | null }`. The snapshot is frozen at pin time; pins
+  already survive design switches *within* a session.
+- `pinCurrentPattern()` (`App.tsx:2970`) snapshots the session's current
+  `result`, labels it `"{design label} @ {measFreq} MHz"`, and fetches
+  `/pattern_metrics` for the table row. `fetchMetrics` (`App.tsx:2953`) is a
+  plain async helper (no session state; can move to module level as-is).
+- `liveMetrics` (`App.tsx:2380`) is the *live* antenna's table row, refreshed
+  per solve while `comparing` (≥1 pin and a cut view) and gated on the
+  session being `active` (`App.tsx:2993`). Genuinely per-session — stays put.
+- Rendering: ghosts draw in the polar cut charts (`pinned={pinnedPatterns}` at
+  `App.tsx:5501/5515`, drawn dashed at `App.tsx:6010`); the compare table
+  (`PatternCompareTable`, `App.tsx:5565`) lists live + pins with per-row ✕ and
+  a clear-all; the table minimizes to a "{n} pinned" chip
+  (`compareCollapsed`, `App.tsx:2482`). Thumbnails intentionally pass
+  `pinnedPatterns={[]}` (`App.tsx:4855`) — keep that.
+- **Colors are positional**: both the table (`App.tsx:5589`) and the chart
+  (`App.tsx:6015`) use `GHOST_COLORS[i % len]` where `i` is the array index.
+  Consistent today only because both iterate the same array; deleting a pin
+  already recolors every later pin.
+
+Why sharing is safe: a `PinnedPattern` is a self-contained frozen snapshot —
+it holds the full `SolveResponse` and never touches the owning session's
+socket, knobs, or refs after creation. `computeCutDbi` (`App.tsx:5650`)
+recomputes its trace from the snapshot alone. Nothing about a pin needs its
+session to still exist.
+
+## Design
+
+### Phase 1 — lift pins to the shell (shared across sessions)
+
+Move `pinnedPatterns` + `pinSeq` from `DesignSession` up to `AppShell`
+(`App.tsx:4899`), exposed through a new dedicated context:
+
+```ts
+type PinsCtx = {
+  pins: PinnedPattern[];
+  addPin: (label: string, result: SolveResponse, req: SolveRequest) => void;
+  removePin: (id: string) => void;
+  togglePin: (id: string) => void;   // Phase 2
+  clearPins: () => void;
+};
+```
+
+- A **separate `PinsContext`**, not a field on `SessionsContext`: sessions
+  context is identity-memoized for tab-strip renders; pin churn (metrics
+  arriving async) shouldn't invalidate it.
+- `addPin` lives in the shell and owns the `/pattern_metrics` fetch +
+  patch-in (the `then` at `App.tsx:2976` moves with it). `fetchMetrics`
+  moves to module level. `pinCurrentPattern` stays in `DesignSession` — it
+  closes over `result` / `controlsRef` / `measFreq` / `currentExample` — and
+  shrinks to computing the label and calling `addPin(...)`.
+- **One shell-level `pinSeq`**, so ids stay unique across sessions (two
+  per-session counters would both mint `pin-0`).
+- Labels keep the current `"{design} @ {freq} MHz"` form — with cross-session
+  pins that's still the distinguishing information. No session id in the
+  label: sessions are anonymous tabs, and the pin outlives its tab anyway.
+- Pins deliberately **survive closing the session that made them** (frozen
+  snapshot, no live dependency). The tab-close confirm popover text
+  (`App.tsx:1724`) doesn't mention pins and needn't change.
+- `compareCollapsed` stays per-session UI state. `liveMetrics` and the
+  `comparing` gate stay per-session (each tab compares *its* live antenna
+  against the shared pins; the `active` gate already prevents hidden tabs
+  from fetching metrics).
+
+### Phase 2 — per-pin enable/disable + stable colors
+
+Extend the type:
+
+```ts
+type PinnedPattern = {
+  id: string;
+  label: string;
+  result: SolveResponse;
+  metrics: PatternMetrics | null;
+  enabled: boolean;    // ghost overlay drawn? default true
+  colorIdx: number;    // fixed at pin time — see below
+};
+```
+
+- **Color must become a stored property.** With enable/disable, the chart
+  draws a *filtered* list while the table draws the full list — positional
+  `GHOST_COLORS[i]` would desynchronize them (and index-based color already
+  shifts on delete). Assign `colorIdx` at pin time as the smallest palette
+  index unused by current pins (falling back to `seq % len` when all are
+  taken), and index `GHOST_COLORS[p.colorIdx % len]` at both render sites
+  (`App.tsx:5589`, `App.tsx:6015`).
+- `togglePin(id)` flips `enabled`.
+- **Charts** draw ghosts for `pins.filter(p => p.enabled)` only.
+- **Table** lists *all* pins (metrics stay visible while disabled — that's
+  the point of disable vs delete). Disabled rows render dimmed; the toggle is
+  the row's color swatch (click to toggle, `title` explains, swatch hollow
+  when disabled). ✕ delete and clear-all unchanged.
+- The `comparing` gate and the "{n} pinned" chip keep counting **all** pins:
+  the table (and its live-metrics fetch) is useful even with every ghost
+  hidden, and a chip that says "0 pinned" while pins exist would be worse.
+
+### Phase 3 — build, verify, ship
+
+- `npm run build` in `src/antennaknobs/web/frontend` and commit the rebuilt
+  static bundle (checked in under `web/static/assets/`), as usual.
+- Manual verify (browser must be a **visible** window — hidden Chrome
+  suspends rAF and solves never send):
+  1. Tab 1: pin a dipole; open tab 2, pick a yagi → ghost + table row appear
+     in tab 2.
+  2. Pin in tab 2 → both pins visible in both tabs, colors distinct and
+     matching between table and chart in each tab.
+  3. Toggle a pin off → ghost gone, row dimmed, metrics still shown; toggle
+     back on → same color returns.
+  4. Delete the *middle* pin → remaining pins keep their colors (regression
+     check on positional coloring).
+  5. Close the tab that created a pin → pin persists.
+- No backend changes; `tests/test_web_server.py` unaffected. There is no
+  frontend test harness — verification is the manual loop above.
+
+## Out of scope (noted for later)
+
+- **Persistence across page reloads** (localStorage/IndexedDB): a
+  `SolveResponse` snapshot carries every wire's sample positions + complex
+  currents, so serialized pins can run large; worth its own sizing look if
+  wanted. This plan keeps pins in-memory.
+- **Renaming pins**: labels are auto-generated; editable labels would help
+  once many similar pins accumulate, but it's cosmetic.
+- **Pin from an inactive session automatically** (e.g. "pin all tabs"): easy
+  to add on top of the shared list if it earns its keep.
+
+## Order of work
+
+Phases 1 and 2 touch the same few sites (type, `AppShell`, table, chart
+renderers) and Phase 2's color fix is needed the moment filtering exists — do
+them as one PR, commits split as `feat(web): lift pins to app shell` then
+`feat(web): per-pin enable/disable + stable ghost colors`, then the bundle
+rebuild.

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -136,8 +136,8 @@ tab, and close one with the **✕** (the last remaining tab can't be closed).
   model — e.g. `dipoles.invvee · Triangular N=40 · free space`.
 - Switching to a session **re-solves** it, which is near-instant because the
   server caches recent solves (see [How a knob turn works](#how-a-knob-turn-works)).
-- The light/dark theme is shared across all sessions; everything else is
-  per-session.
+- The light/dark theme and [pinned patterns](#comparing-patterns) are shared
+  across all sessions; everything else is per-session.
 
 Open the same design in two tabs to compare tunings, or load two different
 antennas — then pair it with [pattern pinning](#comparing-patterns) to overlay
@@ -148,18 +148,29 @@ one session's radiation pattern on another's.
 On the **azimuth** and **elevation** pattern views a **📌 Pin pattern** button
 (top-left of the plot) freezes the current radiation pattern as a dimmed,
 dashed **ghost** overlaid on the live one. Pin it, then change knobs — or switch
-to a completely different design — and the live lobe redraws over the pinned
-ghost so you can see the effect directly.
+to a completely different design, or another [session tab](#design-sessions-tabs)
+— and the live lobe redraws over the pinned ghost so you can see the effect
+directly.
 
-- **Pins survive a design switch**, so you can overlay one antenna's pattern on
-  another's — a Yagi's beam against a dipole's figure-8, say — not just two
-  tunings of the same design.
+- **Pins are shared across every design session**: pin in one tab and the
+  ghost (and its table row) is there in all the others, so you can overlay one
+  antenna's pattern on another's — a Yagi's beam against a dipole's figure-8,
+  say — not just two tunings of the same design. A pin is a frozen snapshot:
+  it survives switching designs and even closing the tab that made it.
 - Each pinned trace recomputes for whichever cut (azimuth or elevation) and
   cut-angle you're viewing, so it always shares the live plot's geometry.
 - A **compare table** appears alongside with a row per pattern — peak gain
   (dBi), takeoff angle, front-to-back, and −3 dB azimuth beamwidth — so the
-  overlaid shapes come with the numbers that matter. **clear** removes all
-  pins; the **✕** on a row removes one.
+  overlaid shapes come with the numbers that matter.
+- **Show or hide a pin without losing it**: click a pinned row's colored
+  swatch-and-name in the compare table. The ghost disappears from the plot and
+  the row dims, but its metrics stay readable for the side-by-side numbers;
+  click the name again to bring the ghost back in the same color. Handy when
+  several pins crowd the plot and you want to declutter one at a time.
+- **Removing pins**: the **✕** on a row deletes that pin (everywhere — pins
+  are shared); **clear** above the table removes them all. The **–** button
+  minimizes the table to a compact *n pinned* chip — ghosts stay on the plot —
+  and clicking the chip reopens it.
 
 ## Norm check — is the solve trustworthy?
 

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1726,12 +1726,15 @@ type PinsCtx = {
   // used to fetch the compare-table metrics.
   addPin: (label: string, result: SolveResponse, req: SolveRequest) => void;
   removePin: (id: string) => void;
+  // Flip a pin's ghost overlay on/off without losing the snapshot.
+  togglePin: (id: string) => void;
   clearPins: () => void;
 };
 const PinsContext = createContext<PinsCtx>({
   pins: [],
   addPin: () => {},
   removePin: () => {},
+  togglePin: () => {},
   clearPins: () => {},
 });
 
@@ -2402,6 +2405,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     pins: pinnedPatterns,
     addPin,
     removePin,
+    togglePin,
     clearPins,
   } = useContext(PinsContext);
   const [liveMetrics, setLiveMetrics] = useState<PatternMetrics | null>(null);
@@ -4726,6 +4730,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                       liveLabel={`${currentExample?.label ?? geometry} @ ${measFreq.toFixed(2)} MHz`}
                       pinned={pinnedPatterns}
                       onRemove={removePin}
+                      onToggle={togglePin}
                     />
                   </>
                 ))}
@@ -4981,11 +4986,19 @@ export function App() {
   const pinSeq = useRef(0);
 
   // Append the snapshot immediately (the ghost overlay needs no metrics),
-  // then patch the table metrics in when /pattern_metrics answers.
+  // then patch the table metrics in when /pattern_metrics answers. The color
+  // slot is the smallest one no current pin holds, so a freed color is reused
+  // before the palette wraps — and never shifts an existing pin's color.
   const addPin = useCallback(
     (label: string, result: SolveResponse, req: SolveRequest) => {
       const id = `pin-${pinSeq.current++}`;
-      setPins((ps) => [...ps, { id, label, result, metrics: null }]);
+      setPins((ps) => {
+        const used = new Set(ps.map((p) => p.colorIdx));
+        let colorIdx = 0;
+        while (used.has(colorIdx) && colorIdx < GHOST_COLORS.length) colorIdx++;
+        if (colorIdx >= GHOST_COLORS.length) colorIdx = ps.length % GHOST_COLORS.length;
+        return [...ps, { id, label, result, metrics: null, enabled: true, colorIdx }];
+      });
       fetchMetrics(req).then((m) =>
         setPins((ps) => ps.map((p) => (p.id === id ? { ...p, metrics: m } : p))),
       );
@@ -4997,11 +5010,17 @@ export function App() {
     setPins((ps) => ps.filter((p) => p.id !== id));
   }, []);
 
+  const togglePin = useCallback((id: string) => {
+    setPins((ps) =>
+      ps.map((p) => (p.id === id ? { ...p, enabled: !p.enabled } : p)),
+    );
+  }, []);
+
   const clearPins = useCallback(() => setPins([]), []);
 
   const pinsCtx = useMemo<PinsCtx>(
-    () => ({ pins, addPin, removePin, clearPins }),
-    [pins, addPin, removePin, clearPins],
+    () => ({ pins, addPin, removePin, togglePin, clearPins }),
+    [pins, addPin, removePin, togglePin, clearPins],
   );
 
   return (
@@ -5609,6 +5628,14 @@ type PinnedPattern = {
   label: string;
   result: SolveResponse;
   metrics: PatternMetrics | null;
+  // Whether the ghost overlay is drawn. A disabled pin keeps its table row
+  // (dimmed, metrics still readable) — that's the point of disable vs delete.
+  enabled: boolean;
+  // Fixed GHOST_COLORS slot, assigned at pin time. Stored — not the array
+  // index — because the chart draws a filtered (enabled-only) list while the
+  // table draws all pins; positional colors would desynchronize the two, and
+  // already shifted every later pin's color on delete.
+  colorIdx: number;
 };
 
 function PatternCompareTable({
@@ -5616,11 +5643,13 @@ function PatternCompareTable({
   liveLabel,
   pinned,
   onRemove,
+  onToggle,
 }: {
   live: PatternMetrics | null;
   liveLabel: string;
   pinned: PinnedPattern[];
   onRemove: (id: string) => void;
+  onToggle: (id: string) => void;
 }) {
   const fmt = (v: number | undefined, d: number) =>
     v === undefined || v === null ? "—" : v.toFixed(d);
@@ -5632,15 +5661,19 @@ function PatternCompareTable({
       bg: "rgba(var(--plot-lobe-rgb), 0.95)",
       label: liveLabel,
       m: live,
+      enabled: true,
+      onToggle: undefined as undefined | (() => void),
       onX: undefined as undefined | (() => void),
     },
-    ...pinned.map((p, i) => {
-      const [r, g, b] = GHOST_COLORS[i % GHOST_COLORS.length];
+    ...pinned.map((p) => {
+      const [r, g, b] = GHOST_COLORS[p.colorIdx % GHOST_COLORS.length];
       return {
         key: p.id,
         bg: `rgba(${r}, ${g}, ${b}, 0.95)`,
         label: p.label,
         m: p.metrics,
+        enabled: p.enabled,
+        onToggle: () => onToggle(p.id),
         onX: () => onRemove(p.id),
       };
     }),
@@ -5659,10 +5692,38 @@ function PatternCompareTable({
       </thead>
       <tbody>
         {rows.map((row) => (
-          <tr key={row.key}>
+          <tr key={row.key} className={row.enabled ? undefined : "compare-off"}>
             <td className="compare-name">
-              <span className="compare-swatch" style={{ background: row.bg }} />
-              {row.label}
+              {/* The whole swatch+name is the show/hide toggle — a big-enough
+                  touch target where the tiny swatch alone wouldn't be. The
+                  metrics stay readable while hidden; that's disable vs delete. */}
+              {row.onToggle ? (
+                <button
+                  type="button"
+                  className="compare-toggle"
+                  onClick={row.onToggle}
+                  aria-pressed={row.enabled}
+                  title={
+                    row.enabled
+                      ? "Hide this ghost overlay (keeps the pin)"
+                      : "Show this ghost overlay"
+                  }
+                >
+                  <span
+                    className="compare-swatch"
+                    style={{ background: row.bg }}
+                  />
+                  {row.label}
+                </button>
+              ) : (
+                <>
+                  <span
+                    className="compare-swatch"
+                    style={{ background: row.bg }}
+                  />
+                  {row.label}
+                </>
+              )}
             </td>
             <td>{fmt(row.m?.peak_gain_dbi, 1)}</td>
             <td>{row.m ? `${fmt(row.m.takeoff_deg, 0)}°` : "—"}</td>
@@ -5935,9 +5996,13 @@ function FarFieldChart({
     const liveTrace = result
       ? computeCutDbi(result, cut, azElevDeg, elevAzDeg)
       : null;
-    const pinnedTraces = pinned.map((p) =>
-      computeCutDbi(p.result, cut, azElevDeg, elevAzDeg),
-    );
+    // Disabled pins draw no ghost and don't stretch the radial scale.
+    const ghosts = pinned
+      .filter((p) => p.enabled)
+      .map((p) => ({
+        colorIdx: p.colorIdx,
+        trace: computeCutDbi(p.result, cut, azElevDeg, elevAzDeg),
+      }));
 
     // Radial axis: absolute directivity in dBi. Origin is a fixed −20 dBi
     // floor. The outer edge is +10 dBi by default, but expands to fit the peak
@@ -5948,7 +6013,7 @@ function FarFieldChart({
     const DBI_FLOOR = -20;
     const peaks: number[] = [];
     if (liveTrace) peaks.push(liveTrace.peakDbi);
-    for (const t of pinnedTraces) if (t) peaks.push(t.peakDbi);
+    for (const gh of ghosts) if (gh.trace) peaks.push(gh.trace.peakDbi);
     // Norm-check overlay: the norm scales the whole pattern, so switching to
     // the field-side norm shifts every dBi by this constant. null when the
     // check is off or the live result carries no norm to compare against.
@@ -6059,15 +6124,15 @@ function FarFieldChart({
     // Pinned ghosts first (dimmed, dashed), so the live lobe sits on top. Each
     // shares the adaptive radial scale computed above, so it tracks the cut and
     // angle sliders just like the live trace.
-    pinnedTraces.forEach((tr, i) => {
-      if (!tr) return;
-      const [r, g, b] = GHOST_COLORS[i % GHOST_COLORS.length];
-      strokeTrace(tr.dbi, {
+    for (const gh of ghosts) {
+      if (!gh.trace) continue;
+      const [r, g, b] = GHOST_COLORS[gh.colorIdx % GHOST_COLORS.length];
+      strokeTrace(gh.trace.dbi, {
         stroke: `rgba(${r}, ${g}, ${b}, 0.8)`,
         width: 1,
         dash: [5, 3],
       });
-    });
+    }
 
     // Live lobe (filled).
     if (!liveTrace) return;

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1714,6 +1714,27 @@ const SessionsContext = createContext<SessionsCtx>({
   reportSummary: () => {},
 });
 
+// Pinned far-field patterns, shared across all design sessions: pin in one
+// tab, compare against it in any other. Owned by the shell — a pin is a
+// frozen snapshot (full solve response + fetched metrics) with no live tie to
+// the session that made it, so it survives design switches and tab closes.
+// A separate context from SessionsContext: pin churn (async metrics arrivals)
+// shouldn't invalidate the memoized tab-strip context.
+type PinsCtx = {
+  pins: PinnedPattern[];
+  // Snapshot `result` under `label`; `req` is the request that produced it,
+  // used to fetch the compare-table metrics.
+  addPin: (label: string, result: SolveResponse, req: SolveRequest) => void;
+  removePin: (id: string) => void;
+  clearPins: () => void;
+};
+const PinsContext = createContext<PinsCtx>({
+  pins: [],
+  addPin: () => {},
+  removePin: () => {},
+  clearPins: () => {},
+});
+
 // The session tab strip, atop each session's sidebar. Global state comes from
 // SessionsContext, so every mounted session renders an identical strip. Tabs
 // are labelled "D1", "D2", … to stay compact for many designs; the full
@@ -2373,12 +2394,17 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   // NEC's rp_card pattern, fetched on a debounce so we don't fire one per
   // slider tick. Overlaid on the cuts as a comparison line.
   const [pattern, setPattern] = useState<PatternData | null>(null);
-  // Pinned far-field overlays for cross-antenna pattern comparison, plus the
-  // live antenna's metrics for the side-by-side table. A monotonic counter
-  // gives each pin a stable React key.
-  const [pinnedPatterns, setPinnedPatterns] = useState<PinnedPattern[]>([]);
+  // Pinned far-field overlays for cross-antenna pattern comparison — shared
+  // across all sessions through the shell (see PinsContext), so a pattern
+  // pinned in one tab can be compared against in any other. The live
+  // antenna's metrics for the side-by-side table stay per-session.
+  const {
+    pins: pinnedPatterns,
+    addPin,
+    removePin,
+    clearPins,
+  } = useContext(PinsContext);
   const [liveMetrics, setLiveMetrics] = useState<PatternMetrics | null>(null);
-  const pinSeq = useRef(0);
   const [view, setView] = useState<View>("antenna");
   const [cameraProjection, setCameraProjection] = useState<Projection>("xy");
   // When the user switches antennas, reset the camera to that example's
@@ -2948,40 +2974,13 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   const controlsRef = useRef<SolveRequest>(buildRequest());
 
   // --- Pattern compare (pin / ghost overlay) --------------------------------
-  // Fetch the scalar far-field metrics for a request (peak gain, takeoff, F/B,
-  // beamwidths). Returns null when the design can't be evaluated or on error.
-  async function fetchMetrics(req: SolveRequest): Promise<PatternMetrics | null> {
-    try {
-      const resp = await fetch("/pattern_metrics", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(req),
-      });
-      const data = await resp.json();
-      return data.available ? (data.metrics as PatternMetrics) : null;
-    } catch {
-      return null;
-    }
-  }
-
   // Pin the current pattern: snapshot the solve response (for the ghost trace)
-  // and fetch its metrics (for the table). The snapshot is frozen — it won't
+  // into the shared cross-session pin list. The snapshot is frozen — it won't
   // change as the live knobs move, which is the whole point of comparing.
   function pinCurrentPattern() {
     if (!result) return;
-    const id = `pin-${pinSeq.current++}`;
     const label = `${currentExample?.label ?? geometry} @ ${measFreq.toFixed(2)} MHz`;
-    setPinnedPatterns((ps) => [...ps, { id, label, result, metrics: null }]);
-    const req = controlsRef.current;
-    fetchMetrics(req).then((m) =>
-      setPinnedPatterns((ps) =>
-        ps.map((p) => (p.id === id ? { ...p, metrics: m } : p)),
-      ),
-    );
-  }
-
-  function removePin(id: string) {
-    setPinnedPatterns((ps) => ps.filter((p) => p.id !== id));
+    addPin(label, result, controlsRef.current);
   }
 
   // Keep the live antenna's metrics fresh for the table, but only while a
@@ -4708,7 +4707,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                       <button
                         type="button"
                         className="pin-clear"
-                        onClick={() => setPinnedPatterns([])}
+                        onClick={clearPins}
                         title="Remove all pinned patterns"
                       >
                         clear
@@ -4975,24 +4974,56 @@ export function App() {
     [sessions, activeId, add, close, setActive, summaries, reportSummary],
   );
 
+  // Pinned patterns, shared across sessions. The counter is shell-level so
+  // pin ids stay unique no matter which session mints them; a pin is a frozen
+  // snapshot, so it deliberately outlives the session that created it.
+  const [pins, setPins] = useState<PinnedPattern[]>([]);
+  const pinSeq = useRef(0);
+
+  // Append the snapshot immediately (the ghost overlay needs no metrics),
+  // then patch the table metrics in when /pattern_metrics answers.
+  const addPin = useCallback(
+    (label: string, result: SolveResponse, req: SolveRequest) => {
+      const id = `pin-${pinSeq.current++}`;
+      setPins((ps) => [...ps, { id, label, result, metrics: null }]);
+      fetchMetrics(req).then((m) =>
+        setPins((ps) => ps.map((p) => (p.id === id ? { ...p, metrics: m } : p))),
+      );
+    },
+    [],
+  );
+
+  const removePin = useCallback((id: string) => {
+    setPins((ps) => ps.filter((p) => p.id !== id));
+  }, []);
+
+  const clearPins = useCallback(() => setPins([]), []);
+
+  const pinsCtx = useMemo<PinsCtx>(
+    () => ({ pins, addPin, removePin, clearPins }),
+    [pins, addPin, removePin, clearPins],
+  );
+
   return (
     <ThemeContext.Provider value={theme}>
       <ThemeControlContext.Provider value={applyTheme}>
         <SessionsContext.Provider value={sessionsCtx}>
-          <div className="sessions">
-            {sessions.map((s) => (
-              <div
-                key={s.id}
-                className="session-mount"
-                // Hidden — not unmounted — so an inactive session keeps its
-                // inputs. `hidden` also removes it from the a11y tree and stops
-                // its canvases painting.
-                hidden={s.id !== activeId}
-              >
-                <DesignSession id={s.id} active={s.id === activeId} />
-              </div>
-            ))}
-          </div>
+          <PinsContext.Provider value={pinsCtx}>
+            <div className="sessions">
+              {sessions.map((s) => (
+                <div
+                  key={s.id}
+                  className="session-mount"
+                  // Hidden — not unmounted — so an inactive session keeps its
+                  // inputs. `hidden` also removes it from the a11y tree and stops
+                  // its canvases painting.
+                  hidden={s.id !== activeId}
+                >
+                  <DesignSession id={s.id} active={s.id === activeId} />
+                </div>
+              ))}
+            </div>
+          </PinsContext.Provider>
         </SessionsContext.Provider>
       </ThemeControlContext.Provider>
     </ThemeContext.Provider>
@@ -5551,10 +5582,28 @@ type PatternMetrics = {
   measurement_freq_mhz?: number;
 };
 
+// Fetch the scalar far-field metrics for a request (peak gain, takeoff, F/B,
+// beamwidths). Returns null when the design can't be evaluated or on error.
+async function fetchMetrics(req: SolveRequest): Promise<PatternMetrics | null> {
+  try {
+    const resp = await fetch("/pattern_metrics", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(req),
+    });
+    const data = await resp.json();
+    return data.available ? (data.metrics as PatternMetrics) : null;
+  } catch {
+    return null;
+  }
+}
+
 // A pinned far-field snapshot: the full solve response (so its cut traces
 // recompute through the same math as the live one, in whatever cut the user is
-// viewing) plus a label, and the metrics fetched for the table. Pins survive
-// design switches, so you can overlay one antenna's pattern on another's.
+// viewing) plus a label, and the metrics fetched for the table. Pins live in
+// the shell and are shared across sessions (see PinsContext), so they survive
+// design switches and tab closes — you can overlay one antenna's pattern on
+// another's, including a design open in a different tab.
 type PinnedPattern = {
   id: string;
   label: string;

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -4995,8 +4995,8 @@ export function App() {
       setPins((ps) => {
         const used = new Set(ps.map((p) => p.colorIdx));
         let colorIdx = 0;
-        while (used.has(colorIdx) && colorIdx < GHOST_COLORS.length) colorIdx++;
-        if (colorIdx >= GHOST_COLORS.length) colorIdx = ps.length % GHOST_COLORS.length;
+        while (used.has(colorIdx) && colorIdx < GHOST_COLOR_COUNT) colorIdx++;
+        if (colorIdx >= GHOST_COLOR_COUNT) colorIdx = ps.length % GHOST_COLOR_COUNT;
         return [...ps, { id, label, result, metrics: null, enabled: true, colorIdx }];
       });
       fetchMetrics(req).then((m) =>
@@ -5666,10 +5666,11 @@ function PatternCompareTable({
       onX: undefined as undefined | (() => void),
     },
     ...pinned.map((p) => {
-      const [r, g, b] = GHOST_COLORS[p.colorIdx % GHOST_COLORS.length];
+      const i = p.colorIdx % GHOST_COLOR_COUNT;
       return {
         key: p.id,
-        bg: `rgba(${r}, ${g}, ${b}, 0.95)`,
+        // CSS var (like the live row) so the swatch rethemes without a render.
+        bg: `rgba(var(--plot-ghost-${i}-rgb, ${GHOST_FALLBACK_RGB[i]}), 0.95)`,
         label: p.label,
         m: p.metrics,
         enabled: p.enabled,
@@ -6126,9 +6127,8 @@ function FarFieldChart({
     // angle sliders just like the live trace.
     for (const gh of ghosts) {
       if (!gh.trace) continue;
-      const [r, g, b] = GHOST_COLORS[gh.colorIdx % GHOST_COLORS.length];
       strokeTrace(gh.trace.dbi, {
-        stroke: `rgba(${r}, ${g}, ${b}, 0.8)`,
+        stroke: `rgba(${ghostRgb(gh.colorIdx)}, 0.8)`,
         width: 1,
         dash: [5, 3],
       });
@@ -6238,14 +6238,27 @@ const FEED_COLORS: [number, number, number][] = [
   [255, 130, 200],  // pink
 ];
 
-// Swatch colors for pinned far-field ghost overlays. Distinct from the live
-// lobe (orange) and the NEC overlay (cyan); they wrap past the 4th pin.
-const GHOST_COLORS: [number, number, number][] = [
-  [140, 230, 140],  // green
-  [255, 130, 200],  // pink
-  [180, 160, 255],  // violet
-  [120, 220, 220],  // teal
+// Swatch colors for pinned far-field ghost overlays, themed via CSS vars —
+// the dark theme's pastels are darker inks in light mode, where a 1px dashed
+// pastel stroke vanishes on the white canvas. Distinct from the live lobe
+// (orange) and the NEC overlay (cyan); they wrap past the 4th pin.
+const GHOST_COLOR_COUNT = 4;
+// Fallbacks match the dark-theme values in styles.css.
+const GHOST_FALLBACK_RGB = [
+  "140, 230, 140", // green
+  "255, 130, 200", // pink
+  "180, 160, 255", // violet
+  "120, 220, 220", // teal
 ];
+// "r, g, b" for a pin's color slot in the current theme, for canvas strokes.
+// (The compare table instead inlines the CSS var so it rethemes live.)
+function ghostRgb(colorIdx: number): string {
+  const i = colorIdx % GHOST_COLOR_COUNT;
+  const v = getComputedStyle(document.documentElement)
+    .getPropertyValue(`--plot-ghost-${i}-rgb`)
+    .trim();
+  return v || GHOST_FALLBACK_RGB[i];
+}
 
 function feedColor(i: number, alpha = 0.85): string {
   const [r, g, b] = FEED_COLORS[i % FEED_COLORS.length];

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -87,6 +87,12 @@
   --plot-nec-rgb: 47, 95, 176;        /* NEC overlay (blueprint blue) */
   --plot-ground-rgb: 150, 116, 70;    /* ground line (brown) */
   --plot-envelope-rgb: 47, 95, 176;   /* |I| envelope (blue) */
+  /* pinned-pattern ghosts: darker inks than the dark theme's pastels — a
+     1px dashed pastel stroke vanishes on the white canvas */
+  --plot-ghost-0-rgb: 52, 150, 66;    /* green */
+  --plot-ghost-1-rgb: 190, 55, 135;   /* pink */
+  --plot-ghost-2-rgb: 115, 85, 205;   /* violet */
+  --plot-ghost-3-rgb: 26, 145, 150;   /* teal */
 
   /* current heatmap ramp: faint where low, bold where high (reads on white) */
   --plot-current-0: 200, 212, 226;
@@ -155,6 +161,10 @@
   --plot-nec-rgb: 110, 220, 255;
   --plot-ground-rgb: 140, 110, 70;
   --plot-envelope-rgb: 118, 208, 255;
+  --plot-ghost-0-rgb: 140, 230, 140;
+  --plot-ghost-1-rgb: 255, 130, 200;
+  --plot-ghost-2-rgb: 180, 160, 255;
+  --plot-ghost-3-rgb: 120, 220, 220;
   --plot-current-0: 40, 64, 96;
   --plot-current-1: 60, 140, 200;
   --plot-current-2: 118, 208, 255;

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1769,6 +1769,32 @@ input[type=checkbox] {
   vertical-align: middle;
   border-radius: 1px;
 }
+/* Swatch+name of a pinned row is a button that shows/hides its ghost overlay.
+   Styled to sit flush in the cell — the swatch itself is far too small a
+   touch target, so the whole name is clickable. */
+.compare-toggle {
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  padding: 0;
+  display: block;
+  width: 100%;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* A disabled pin keeps its row (metrics still readable) but reads as off:
+   text dims, swatch fades. The ✕ stays full-strength — deleting a hidden
+   pin is a normal move. */
+.compare-table tr.compare-off td:not(:last-child) {
+  color: var(--muted-2);
+}
+.compare-table tr.compare-off .compare-swatch {
+  opacity: 0.3;
+}
 .compare-x {
   border: none;
   background: none;


### PR DESCRIPTION
## Summary
- Pins move from per-session state to the app shell (new `PinsContext`), so a pattern pinned in one session tab overlays and tabulates in every tab, and survives closing the tab that made it — pins are frozen snapshots with no live session ties
- Each pin gains an `enabled` flag: clicking a pinned row's swatch+name in the compare table hides/shows its ghost overlay; a hidden pin's row dims but keeps its metrics readable
- Ghost colors become a stored per-pin property (`colorIdx`, smallest free palette slot) instead of positional array indexing, which would desynchronize table vs filtered chart and already recolored later pins on delete
- Ghost colors are now themed via CSS vars (`--plot-ghost-N-rgb`): darker inks in light mode where the dashed pastels were nearly invisible; dark mode unchanged
- Site docs: web reference updated for cross-session pins, the show/hide toggle, per-row delete vs clear-all, and the minimize chip; plan doc at `docs/plan-cross-session-pins.md`

## Test plan
- [x] Headless-browser verification loop (Playwright against the dev server): pin in D1 → visible in new tab D2 with a different design (ghost + table row); pin in D2 → distinct colors in both tabs; toggle off/on → row dims, ghost disappears, same color returns; delete middle of three pins → survivors keep colors; close originating tab → pins persist
- [x] Light/dark theme screenshots: ghost dashes legible on white, dark mode pixel-identical to before
- [x] `npm run build` (tsc + vite) clean; `astro check` clean for the site docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)