### PR TITLE
Full-screen toggle in the gear menu; stop Chrome's install-app banner

### DIFF
--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -208,6 +208,11 @@ dialed in — no more transcribing values off the screen by hand.
 The same gear menu also has **Download .nec deck**, which exports the design as
 a NEC-2 card deck for xnec2c / 4nec2 / EZNEC.
 
+It's also where **full screen** lives (under *display*): on a phone it hides
+the system status and navigation bars so the whole screen is workbench —
+uncheck it, press Esc, or use the back gesture to exit. (The control is hidden
+on browsers without full-screen support, e.g. iPhone Safari.)
+
 ## How a knob turn works
 
 A knob change sends one message over the `/ws` WebSocket; the server re-solves in

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -208,10 +208,11 @@ dialed in — no more transcribing values off the screen by hand.
 The same gear menu also has **Download .nec deck**, which exports the design as
 a NEC-2 card deck for xnec2c / 4nec2 / EZNEC.
 
-It's also where **full screen** lives (under *display*): on a phone it hides
-the system status and navigation bars so the whole screen is workbench —
-uncheck it, press Esc, or use the back gesture to exit. (The control is hidden
-on browsers without full-screen support, e.g. iPhone Safari.)
+On phones, the gear menu also has a **full screen** check (under *display*):
+it hides the system status and navigation bars so the whole screen is
+workbench — uncheck it or use the back gesture to exit. The control appears
+only in the mobile layout (desktop already has F11), and only on browsers
+with full-screen support (so not iPhone Safari).
 
 ## How a knob turn works
 

--- a/src/antennaknobs/web/frontend/index.html
+++ b/src/antennaknobs/web/frontend/index.html
@@ -4,10 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AntennaKNoBs</title>
-    <!-- PWA-lite: `display: standalone` in the manifest lets Android Chrome's
-         "Add to Home screen" launch the workbench full screen, with no URL
-         bar — the fixed-viewport layout never scrolls, so the bar would never
-         auto-hide in a normal tab. No service worker on purpose: the app is
+    <!-- Manifest is `display: browser` ON PURPOSE: standalone made the site
+         "installable", which fired Chrome's automatic install banner and
+         still left Android's status/nav bars up. Add-to-Home-screen now makes
+         a plain shortcut (the icons below keep it pretty), and true full
+         screen — both bars gone — is the gear menu's "full screen" toggle
+         (Fullscreen API) instead. No service worker on purpose: the app is
          useless offline (solves live on the server) and a stale-bundle cache
          is exactly what we don't want after the v0.13.0 incident. -->
     <link rel="manifest" href="/site.webmanifest" />

--- a/src/antennaknobs/web/frontend/public/site.webmanifest
+++ b/src/antennaknobs/web/frontend/public/site.webmanifest
@@ -3,7 +3,7 @@
   "short_name": "AntennaKNoBs",
   "description": "Scriptable antenna design with live, knob-driven tuning",
   "start_url": "/",
-  "display": "standalone",
+  "display": "browser",
   "background_color": "#f6f8fb",
   "theme_color": "#2563eb",
   "icons": [

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -3885,12 +3885,16 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                         to reach them there; on desktop it's a convenience
                         duplicate. */}
                     <div className="gear-menu-divider" />
-                    {fullscreen.supported && (
+                    {/* Mobile-layout only: it exists to reclaim the phone's
+                        status/nav bars; on desktop F11 already does this and
+                        the menu entry would be clutter. Also needs element
+                        fullscreen (missing on iPhone Safari). */}
+                    {isMobile && fullscreen.supported && (
                       <>
                         <div className="gear-menu-section">display</div>
                         <label
                           className="gear-menu-check"
-                          title="Take over the whole screen — on a phone this hides the system status and navigation bars. Uncheck (or Esc / back gesture) to exit."
+                          title="Take over the whole screen — hides the system status and navigation bars. Uncheck (or use the back gesture) to exit."
                         >
                           <input
                             type="checkbox"

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1653,6 +1653,39 @@ function useIsMobile() {
   };
 }
 
+// Document-fullscreen state + toggle for the gear menu's "full screen" check.
+// This is the phone answer to browser chrome: on Android it hides BOTH the
+// system status bar and the nav bar (the manifest's old standalone mode only
+// hid the URL bar, and made Chrome nag to "install the app" besides).
+// `supported` is false where element fullscreen doesn't exist (iPhone
+// Safari), which hides the control. The subscribe pattern mirrors
+// useMediaQuery: fullscreenchange fires on Esc / back-gesture exits too, so
+// the checkbox can never disagree with the actual state.
+function useFullscreen() {
+  const [subscribe, getSnapshot] = useMemo(() => {
+    const sub = (onChange: () => void) => {
+      document.addEventListener("fullscreenchange", onChange);
+      return () => document.removeEventListener("fullscreenchange", onChange);
+    };
+    return [sub, () => document.fullscreenElement != null] as const;
+  }, []);
+  const active = useSyncExternalStore(subscribe, getSnapshot);
+  const toggle = useCallback(() => {
+    if (document.fullscreenElement) {
+      document.exitFullscreen().catch(() => {});
+    } else {
+      document.documentElement
+        .requestFullscreen({ navigationUI: "hide" })
+        .catch(() => {});
+    }
+  }, []);
+  return {
+    active,
+    toggle,
+    supported: typeof document.documentElement.requestFullscreen === "function",
+  };
+}
+
 function useThumbColumnSize(
   stripRef: React.RefObject<HTMLDivElement>,
   maxThumb = 280,
@@ -1922,6 +1955,9 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   const [gearMenuOpen, setGearMenuOpen] = useState(false);
   // Transient "Copied ✓" confirmation on the Copy-params menu item.
   const [copiedParams, setCopiedParams] = useState(false);
+  // Document fullscreen (global, like theme) — the gear check is just the
+  // nearest settings surface to reach it from.
+  const fullscreen = useFullscreen();
 
   // Schema-driven parameter controls. Each registered example bundles
   // its parameter schema in web/examples/<name>.py; the backend serves
@@ -3849,6 +3885,22 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                         to reach them there; on desktop it's a convenience
                         duplicate. */}
                     <div className="gear-menu-divider" />
+                    {fullscreen.supported && (
+                      <>
+                        <div className="gear-menu-section">display</div>
+                        <label
+                          className="gear-menu-check"
+                          title="Take over the whole screen — on a phone this hides the system status and navigation bars. Uncheck (or Esc / back gesture) to exit."
+                        >
+                          <input
+                            type="checkbox"
+                            checked={fullscreen.active}
+                            onChange={fullscreen.toggle}
+                          />
+                          full screen
+                        </label>
+                      </>
+                    )}
                     <div className="gear-menu-section">antenna chart</div>
                     <label
                       className="gear-menu-check"


### PR DESCRIPTION
## Summary
- The manifest's `display: standalone` was a half-measure on phones: Android Chrome hid the URL bar but kept the status and navigation bars, and the installability it conferred made Chrome show its automatic "install app" banner (no app code was behind it)
- Manifest moves to `display: browser` — not installable, so no banner; Add-to-Home-screen still makes a plain shortcut with the knob icons
- New **display → full screen** checkbox in the gear (Tools) menu using the Fullscreen API, which hides *both* system bars on Android; the checkbox subscribes to `fullscreenchange` so Esc/back-gesture exits can't desync it, and it's hidden where element fullscreen is unsupported (iPhone Safari)
- Web reference docs note the new toggle

## Test plan
- [x] Headless verification: served manifest reports `display: browser`; gear menu shows the toggle; check → `document.fullscreenElement` set; uncheck → cleared; programmatic (Esc-style) exit unticks the checkbox
- [x] Phone test over LAN: full-screen toggle hides status + nav bars
- [ ] After deploy: confirm production no longer shows the install banner (installability requires HTTPS, so untestable on LAN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)