### PR TITLE
Fix session-tab strikethrough: stop the tab strip collapsing under flex-shrink

### DIFF
--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -277,6 +277,14 @@ button:focus-visible,
   position: sticky;
   top: calc(-1 * var(--space-7));
   z-index: 3;
+  /* Never shrink as a .sidebar flex item. The strip is a scroll container
+     (overflow-x below), so its automatic minimum size is ZERO — when the knob
+     list overflows the pane, flex-shrink crushes the strip's content-box to
+     nothing while every other child stops at min-content. The 36px touch
+     buttons then overflow the collapsed .tab pills, whose border renders as a
+     strikethrough across the labels. The pane scrolls; nothing needs to
+     shrink. */
+  flex-shrink: 0;
   display: flex;
   align-items: stretch;
   gap: var(--space-1);

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -2399,15 +2399,14 @@ canvas {
   .opt-gear-btn {
     min-width: 36px;
   }
-  /* The session tab strip parks flush with the pane's top edge and its chips
-     are mouse-sized — give the row breathing room and the tabs a ~40px
-     touch target on phones. */
+  /* The session tab strip parks flush with the pane's top edge — give the
+     row breathing room on phones. (A min-height touch-size boost on .tab-btn
+     used to live here too, but it was compensating for the flex-shrink
+     collapse fixed on .tab-strip above — natural-size tabs read better now
+     that they actually render at natural size.) */
   .tab-strip {
     padding-top: var(--space-4);
     padding-bottom: var(--space-4);
-  }
-  .tab-btn {
-    min-height: 36px;
   }
 }
 


### PR DESCRIPTION
## Summary
- The "line through" the selected D1/D2 tab label was the active tab's 1px border on a pill collapsed to 2px tall: `.tab-strip` is a scroll container (`overflow-x: auto`), so its automatic minimum size as a `.sidebar` flex item is **zero** — whenever the knob list overflowed the pane, flex-shrink crushed the strip's content-box to nothing while every other child stopped at min-content. Mobile always overflows, so it always struck through; a short desktop window would too
- Fix is `flex-shrink: 0` on the strip — the pane scrolls, nothing needs to shrink
- Also drops the v0.13.2 coarse-pointer `min-height: 36px` on `.tab-btn`: it was compensating for the collapsed sliver, and at true natural size it read as oversized on the phone. The strip's breathing-room padding stays

## Test plan
- [x] Headless before/after: mobile strip was 17px with the active pill rendering as a line through "D2"; now 41px with a correct pill; desktop unchanged (37px)
- [x] Confirmed root cause by measurement (`.tab` height 0 with the 36px button overflowing) and a minimal repro isolating the flex-shrink/scroll-container interaction
- [ ] Phone check over LAN: selected tab pill looks right at natural size

🤖 Generated with [Claude Code](https://claude.com/claude-code)