### PR TITLE
Bump antennaknobs to 0.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.13.2"
+version = "0.14.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]


### PR DESCRIPTION
## Summary
- Minor release: cross-session pinned patterns with per-pin show/hide and themed ghost colors (#247), mobile full-screen toggle replacing the PWA install banner (#248), and the session-tab strikethrough fix (#249)

## Test plan
- [ ] CI green, then tag v0.14.0 → PyPI publish + Fly deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)