### PR TITLE
Use NEC's actual Sommerfeld ground for "finite", and wire it through the web UI

### DIFF
--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -227,23 +227,28 @@ def emit_params_name(builder_spec):
 
 def parse_ground(s):
     """--ground argument:
-    free                      -> None
-    pec                       -> 'pec'
-    finite                    -> default ('finite', 10.0, 0.002)
-    finite:<eps_r>,<sigma>    -> ('finite', eps_r, sigma)
+    free                          -> None
+    pec                           -> 'pec'
+    finite                        -> default ('finite', 10.0, 0.002)
+                                     (Sommerfeld-Norton on PyNEC)
+    finite:<eps_r>,<sigma>        -> ('finite', eps_r, sigma)
+    finite-fast                   -> default ('finite-fast', 10.0, 0.002)
+                                     (reflection-coefficient approximation)
+    finite-fast:<eps_r>,<sigma>   -> ('finite-fast', eps_r, sigma)
     """
     if s is None or s == "free":
         return None
     if s == "pec":
         return "pec"
-    if s == "finite":
-        return ("finite", 10.0, 0.002)
-    if s.startswith("finite:"):
-        try:
-            eps_r, sigma = (float(x) for x in s[len("finite:") :].split(","))
-        except ValueError as e:
-            raise argparse.ArgumentTypeError(f"bad --ground spec {s!r}: {e}") from e
-        return ("finite", eps_r, sigma)
+    for kind in ("finite-fast", "finite"):
+        if s == kind:
+            return (kind, 10.0, 0.002)
+        if s.startswith(kind + ":"):
+            try:
+                eps_r, sigma = (float(x) for x in s[len(kind) + 1 :].split(","))
+            except ValueError as e:
+                raise argparse.ArgumentTypeError(f"bad --ground spec {s!r}: {e}") from e
+            return (kind, eps_r, sigma)
     raise argparse.ArgumentTypeError(f"unrecognised --ground: {s!r}")
 
 
@@ -358,7 +363,9 @@ def cli(arguments=None):
         p.add_argument(
             "--ground",
             default=_GROUND_UNSET,
-            help="Ground model: free | pec | finite | finite:<eps_r>,<sigma> "
+            help="Ground model: free | pec | finite[:<eps_r>,<sigma>] "
+            "(Sommerfeld-Norton on pynec) | finite-fast[:<eps_r>,<sigma>] "
+            "(reflection-coefficient approximation) "
             "(default: engine-specific — finite for pynec, free for momwire).",
         )
 

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -56,8 +56,19 @@ def _normalise_ground(ground):
         return None
     if ground == "pec":
         return ("pec",)
-    if isinstance(ground, tuple) and len(ground) == 3 and ground[0] == "finite":
-        return ground
+    if (
+        isinstance(ground, tuple)
+        and len(ground) == 3
+        and ground[0]
+        in (
+            "finite",
+            "finite-fast",
+        )
+    ):
+        # "finite-fast" is a PyNECEngine distinction (Sommerfeld-Norton vs the
+        # reflection-coefficient approximation); momwire has a single finite
+        # model, so both fold to it.
+        return ("finite",) + tuple(ground[1:])
     raise ValueError(f"unrecognised ground spec: {ground!r}")
 
 
@@ -92,8 +103,11 @@ class MomwireEngine(SimulationEngine):
                                      coefficients on the reflected component;
                                      impedance solve still uses PEC because
                                      momwire only models PEC ground. Cross-
-                                     validation against PyNEC's gn_card(0,...)
-                                     is approximate.
+                                     validation against PyNEC's finite grounds
+                                     (Sommerfeld gn_card(2,...) or reflection-
+                                     coefficient gn_card(0,...)) is approximate.
+                                     ("finite-fast", eps_r, sigma) is accepted
+                                     as an alias.
         """
         super().__init__(builder)
 

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -39,11 +39,17 @@ class PyNECEngine(SimulationEngine):
     def __init__(self, builder, *, ground=DEFAULT_GROUND):
         """
         ground:
-          None or "free"               — no gn_card (free space)
-          "pec"                        — perfectly conducting ground
-          ("finite", eps_r, sigma)     — Sommerfeld finite ground (default,
-                                         matches the historical hard-coded
-                                         eps_r=10, sigma=0.002)
+          None or "free"                 — no gn_card (free space)
+          "pec"                          — perfectly conducting ground
+          ("finite", eps_r, sigma)       — Sommerfeld-Norton finite ground
+                                           (default, matches the historical
+                                           hard-coded eps_r=10, sigma=0.002)
+          ("finite-fast", eps_r, sigma)  — finite ground via NEC's reflection-
+                                           coefficient approximation. Much
+                                           cheaper than Sommerfeld and within
+                                           ~0.1 dB / a few Ω of it for wires
+                                           ≳0.2λ above ground, but impedance
+                                           drifts by 10+ Ω below ~0.1λ.
         """
         super().__init__(builder)
         self.tups = self._coerce_wire_tuples(builder.build_wires())
@@ -186,9 +192,11 @@ class PyNECEngine(SimulationEngine):
         if g == "pec":
             c.gn_card(1, 0, 0, 0, 0, 0, 0, 0)
             return
-        if isinstance(g, tuple) and len(g) == 3 and g[0] == "finite":
+        if isinstance(g, tuple) and len(g) == 3 and g[0] in ("finite", "finite-fast"):
             _, eps_r, sigma = g
-            c.gn_card(0, 0, eps_r, sigma, 0, 0, 0, 0)
+            # gn_card's first parameter (IPERF): 2 = Sommerfeld-Norton,
+            # 0 = reflection-coefficient approximation.
+            c.gn_card(2 if g[0] == "finite" else 0, 0, eps_r, sigma, 0, 0, 0, 0)
             return
         raise ValueError(f"unrecognised ground spec: {g!r}")
 

--- a/src/antennaknobs/nec_export.py
+++ b/src/antennaknobs/nec_export.py
@@ -44,9 +44,19 @@ def _gn(ground):
         return None
     if ground == "pec":
         return "GN 1 0 0 0 0 0"
-    if isinstance(ground, tuple) and len(ground) == 3 and ground[0] == "finite":
+    if (
+        isinstance(ground, tuple)
+        and len(ground) == 3
+        and ground[0]
+        in (
+            "finite",
+            "finite-fast",
+        )
+    ):
         _, eps_r, sigma = ground
-        return f"GN 0 0 0 0 {_num(eps_r)} {_num(sigma)}"
+        # IPERF 2 = Sommerfeld-Norton, 0 = reflection-coefficient approximation.
+        iperf = 2 if ground[0] == "finite" else 0
+        return f"GN {iperf} 0 0 0 {_num(eps_r)} {_num(sigma)}"
     raise ValueError(f"unrecognised ground spec: {ground!r}")
 
 
@@ -62,8 +72,9 @@ def export_nec(
 ):
     """Return a NEC2 card deck (str) for ``builder``.
 
-    ground   : same spec as PyNECEngine — None/"free", "pec", or
-               ("finite", eps_r, sigma).
+    ground   : same spec as PyNECEngine — None/"free", "pec",
+               ("finite", eps_r, sigma) (Sommerfeld-Norton), or
+               ("finite-fast", eps_r, sigma) (reflection-coefficient).
     freq     : design frequency in MHz; defaults to ``builder.freq``.
     df       : FR-card frequency step in MHz (for a sweep).
     npoints  : FR-card frequency count.

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -56,9 +56,10 @@ from antennaknobs.builder import (
 )
 
 try:
-    from antennaknobs.engines.pynec import PyNECEngine
+    from antennaknobs.engines.pynec import DEFAULT_GROUND, PyNECEngine
 except ImportError:
     PyNECEngine = None
+    DEFAULT_GROUND = ("finite", 10.0, 0.002)
 from antennaknobs.engines.momwire import MomwireEngine
 from momwire import (
     ArrayBlockSolver,
@@ -464,10 +465,22 @@ def _ground_for_engine(req: dict, ground_z: float):
     ground_on = bool(req.get("ground", False))
     if not ground_on:
         return None
-    # Map the frontend's ground knobs to the engine's ground spec. The
-    # momwire frontend currently sends ground=True with an implicit PEC;
-    # finite ground specs can be wired through later via dedicated UI.
+    # momwire only models a PEC ground in the impedance solve, so ground=True
+    # maps to the PEC image method here. (PyNEC's finite-ground mapping lives
+    # in _pynec_ground_spec.)
     return "pec"
+
+
+def _pynec_ground_spec(req: dict):
+    """Map the frontend's ground knobs to PyNECEngine's ground spec, matching
+    the UI labels: ground=True gives the Sommerfeld-Norton finite ground with
+    DEFAULT_GROUND's eps_r=10, sigma=0.002; ground_fast=True downgrades to
+    NEC's reflection-coefficient approximation; ground off is free space."""
+    if not req.get("ground", False):
+        return "free"
+    if req.get("ground_fast", False):
+        return ("finite-fast",) + DEFAULT_GROUND[1:]
+    return DEFAULT_GROUND
 
 
 def _make_momwire_engine(req: dict, builder, cancel=None):
@@ -487,13 +500,7 @@ def _make_momwire_engine(req: dict, builder, cancel=None):
 
 
 def _make_pynec_engine(req: dict, builder):
-    # PyNECEngine accepts the same ground-spec vocabulary as MomwireEngine
-    # — None / "pec" / ("finite", eps_r, sigma) — but defaults to a
-    # finite ground rather than free space if you pass nothing. Match
-    # MomwireEngine's behaviour: ground off => free space, ground on =>
-    # PEC plane at z=0.
-    ground = _ground_for_engine(req, 0.0) or "free"
-    return PyNECEngine(builder, ground=ground)
+    return PyNECEngine(builder, ground=_pynec_ground_spec(req))
 
 
 # ---------------------------------------------------------------------------
@@ -1147,7 +1154,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             "feed_tag": int(feed_tag),
             "n_per_wire": 1,
             "ground": bool(req.get("ground", False)),
-            "ground_fast": False,
+            "ground_fast": bool(req.get("ground_fast", False)),
             "z_offset": 0.0,
             "_engine": eng,
         }
@@ -1193,8 +1200,17 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             "solve_ms": solve_ms,
             "ground": bool(req.get("ground", False)),
             "height_m": 0.0,
-            "ground_eps_r": _PEC_GROUND_EPS_R,
-            "ground_sigma": _PEC_GROUND_SIGMA,
+            # The engine solved over the Sommerfeld finite ground, so ship its
+            # real eps_r/sigma: the frontend's far-field cut applies PEC image
+            # + Fresnel with these, which tracks NEC's finite-ground rp_card
+            # pattern to ~0.2 dB. (momwire keeps the PEC constants — its
+            # impedance solve genuinely is PEC-image.)
+            "ground_eps_r": (
+                DEFAULT_GROUND[1] if req.get("ground", False) else _PEC_GROUND_EPS_R
+            ),
+            "ground_sigma": (
+                DEFAULT_GROUND[2] if req.get("ground", False) else _PEC_GROUND_SIGMA
+            ),
             "z0_ohms": hints()["target_z0"],
             "multi_feed": hints()["multi_feed"],
             "default_view": hints()["default_view"],

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -473,12 +473,21 @@ def _ground_for_engine(req: dict, ground_z: float):
 
 def _pynec_ground_spec(req: dict):
     """Map the frontend's ground knobs to PyNECEngine's ground spec, matching
-    the UI labels: ground=True gives the Sommerfeld-Norton finite ground with
-    DEFAULT_GROUND's eps_r=10, sigma=0.002; ground_fast=True downgrades to
-    NEC's reflection-coefficient approximation; ground off is free space."""
+    the UI labels. `ground_model` picks the model when ground is on:
+    "sommerfeld" (default) — Sommerfeld-Norton finite ground with
+    DEFAULT_GROUND's eps_r=10, sigma=0.002; "fast" — the same finite ground
+    via NEC's reflection-coefficient approximation; "pec" — perfectly
+    conducting ground (the image method momwire uses, for apples-to-apples
+    engine comparison). The legacy boolean `ground_fast` is honoured when
+    `ground_model` is absent. Ground off is free space."""
     if not req.get("ground", False):
         return "free"
-    if req.get("ground_fast", False):
+    model = req.get("ground_model")
+    if model is None:
+        model = "fast" if req.get("ground_fast", False) else "sommerfeld"
+    if model == "pec":
+        return "pec"
+    if model == "fast":
         return ("finite-fast",) + DEFAULT_GROUND[1:]
     return DEFAULT_GROUND
 
@@ -1200,16 +1209,16 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             "solve_ms": solve_ms,
             "ground": bool(req.get("ground", False)),
             "height_m": 0.0,
-            # The engine solved over the Sommerfeld finite ground, so ship its
-            # real eps_r/sigma: the frontend's far-field cut applies PEC image
-            # + Fresnel with these, which tracks NEC's finite-ground rp_card
-            # pattern to ~0.2 dB. (momwire keeps the PEC constants — its
-            # impedance solve genuinely is PEC-image.)
+            # Ship the eps_r/sigma of the ground the engine actually solved
+            # over: the frontend's far-field cut applies PEC image + Fresnel
+            # with these, so finite grounds get their real constants (tracks
+            # NEC's rp_card pattern to ~0.2 dB) while ground_model="pec" and
+            # free space keep the PEC placeholders (ρ→−1).
             "ground_eps_r": (
-                DEFAULT_GROUND[1] if req.get("ground", False) else _PEC_GROUND_EPS_R
+                eng.ground[1] if isinstance(eng.ground, tuple) else _PEC_GROUND_EPS_R
             ),
             "ground_sigma": (
-                DEFAULT_GROUND[2] if req.get("ground", False) else _PEC_GROUND_SIGMA
+                eng.ground[2] if isinstance(eng.ground, tuple) else _PEC_GROUND_SIGMA
             ),
             "z0_ohms": hints()["target_z0"],
             "multi_feed": hints()["multi_feed"],

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1260,9 +1260,13 @@ function isBSplineFamily(b: Backend): boolean {
   return BSPLINE_FAMILY.includes(b);
 }
 
-// Every momwire model has the PEC image-method ground; PyNEC uses its own
-// Sommerfeld / reflection-coefficient ground. Kept as an explicit list so
-// future backends without ground support can be excluded by name.
+// Every momwire model has the PEC image-method ground; PyNEC picks between
+// Sommerfeld-Norton, the reflection-coefficient approximation, and PEC (the
+// image method, for apples-to-apples comparison against momwire). Kept as an
+// explicit list so future backends without ground support can be excluded by
+// name.
+type PynecGroundModel = "sommerfeld" | "fast" | "pec";
+
 function backendSupportsGround(b: Backend): boolean {
   return (
     b === "triangular" ||
@@ -1427,6 +1431,7 @@ type SolveRequest = {
   wire_radius: number;
   ground: boolean;
   ground_fast: boolean;
+  ground_model?: PynecGroundModel;
   // V
   angle_deg?: number;
   halfdriver_factor?: number;
@@ -2322,21 +2327,24 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   const [designFreq, setDesignFreq] = useState(14.3);
   const [measFreq, setMeasFreq] = useState(14.3);
   const [linkMeas, setLinkMeas] = useState(true);
-  // PEC ground plane (image method at z = 0).
+  // Ground plane at z = 0 (model per backend; see groundModel).
   const [groundEnabled, setGroundEnabled] = useState(false);
-  const [groundFast, setGroundFast] = useState(false);
+  // PyNEC-only ground model choice; momwire always uses the PEC image method.
+  const [groundModel, setGroundModel] = useState<PynecGroundModel>("sommerfeld");
 
   // One-line tab-hover summary: design · solver N=segs · ground model. The
   // ground wording follows the backend family (momwire = PEC image method,
-  // PyNEC = Sommerfeld, or its fast reflection-coefficient approximation), and
-  // reads "free space" when ground is off or unsupported by the active solver.
+  // PyNEC = the selected groundModel), and reads "free space" when ground is
+  // off or unsupported by the active solver.
   const groundActiveForSummary = groundEnabled && backendSupportsGround(backend);
   const groundSummary = !groundActiveForSummary
     ? "free space"
     : backend === "pynec"
-      ? groundFast
+      ? groundModel === "fast"
         ? "reflection-coef ground"
-        : "Sommerfeld ground"
+        : groundModel === "pec"
+          ? "PEC ground"
+          : "Sommerfeld ground"
       : "PEC ground";
   const tabSummary = `${(currentExample?.label ?? geometry) || "new design"} · ${BACKEND_LABEL[backend]} N=${nPerWire} · ${groundSummary}`;
   useEffect(() => {
@@ -2680,7 +2688,10 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
       measurement_freq_mhz: measFreq,
       wire_radius: wireRadius,
       ground: groundActive,
-      ground_fast: groundActive && groundFast,
+      // ground_fast is the legacy boolean; ground_model is authoritative
+      // server-side when present. Send both so either server version agrees.
+      ground_fast: groundActive && groundModel === "fast",
+      ground_model: groundModel,
     };
     if (backend !== "pynec") {
       base.momwire_model = backend;
@@ -3126,7 +3137,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     geometry, previewReady, backend, backendOptsKey,
     currentValuesKey,
     designFreq, measFreq,
-    groundEnabled, groundFast,
+    groundEnabled, groundModel,
   ]);
 
   // Antenna switch: drop the previous antenna's results immediately so nothing
@@ -3228,7 +3239,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     geometry, backend, backendOptsKey,
     currentValuesKey,
     designFreq,
-    groundEnabled, groundFast,
+    groundEnabled, groundModel,
     sweepEnabled,
     active,
     // measFreq/linkMeas drive the anchor now (meas_freq policy, or any unlocked
@@ -3265,7 +3276,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     geometry, backend, backendOptsKey,
     currentValuesKey,
     designFreq, measFreq,
-    groundEnabled, groundFast,
+    groundEnabled, groundModel,
     convergeEnabled,
     active,
   ]);
@@ -3293,7 +3304,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     geometry, backend, backendOptsKey,
     currentValuesKey,
     designFreq, measFreq,
-    groundEnabled, groundFast,
+    groundEnabled, groundModel,
     normCheckEnabled,
     active,
   ]);
@@ -3316,7 +3327,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     geometry, backend, backendOptsKey,
     currentValuesKey,
     designFreq, measFreq,
-    groundEnabled, groundFast,
+    groundEnabled, groundModel,
     active,
   ]);
 
@@ -3346,7 +3357,8 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     // A variant can override the policy (e.g. a band-locked variant): prefer
     // the active variant's entry in variant_ui, falling back to the
     // design-level sweep_policy.
-    const slowGround = backend === "pynec" && groundEnabled && !groundFast;
+    const slowGround =
+      backend === "pynec" && groundEnabled && groundModel === "sommerfeld";
     const N = slowGround ? 21 : 41;
     const policy =
       currentExample?.variant_ui?.[currentVariant]?.sweep_policy ??
@@ -4444,7 +4456,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
             className="link-toggle"
             title={
               backend === "pynec"
-                ? "Sommerfeld-Norton ground (εr=10, σ=0.002 S/m)"
+                ? "Ground plane at z=0; pick the NEC ground model below"
                 : "PEC image-method ground (perfect electric conductor)"
             }
           >
@@ -4455,22 +4467,40 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
               onChange={(e) => setGroundEnabled(e.target.checked)}
             />
             ground plane{" "}
-            {backend === "pynec"
-              ? "(εr=10, σ=0.002 S/m)"
-              : "(PEC, perfect conductor)"}
+            {backend === "pynec" ? "" : "(PEC, perfect conductor)"}
           </label>
           {backend === "pynec" && groundEnabled && (
-            <label
-              className="link-toggle"
-              title="Reflection-coefficient approximation (NEC ITYPE=0). ~10x faster per solve than Sommerfeld-Norton; degrades for very-low antennas near the horizon."
-            >
-              <input
-                type="checkbox"
-                checked={groundFast}
-                onChange={(e) => setGroundFast(e.target.checked)}
-              />
-              fast ground (reflection coefficient)
-            </label>
+            <div role="radiogroup" aria-label="NEC ground model">
+              {(
+                [
+                  [
+                    "sommerfeld",
+                    "Sommerfeld (εr=10, σ=0.002 S/m)",
+                    "Sommerfeld-Norton finite ground (NEC ITYPE=2) — most accurate, slowest; the impedance sweep drops to half resolution to compensate.",
+                  ],
+                  [
+                    "fast",
+                    "refl-coef (fast)",
+                    "Same finite ground via the reflection-coefficient approximation (NEC ITYPE=0). ~2x faster per solve; impedance degrades below ~0.1λ height.",
+                  ],
+                  [
+                    "pec",
+                    "PEC",
+                    "Perfectly conducting ground (image method, NEC ITYPE=1) — matches the momwire backends' ground model for apples-to-apples engine comparison.",
+                  ],
+                ] as [PynecGroundModel, string, string][]
+              ).map(([value, label, title]) => (
+                <label key={value} className="link-toggle" title={title}>
+                  <input
+                    type="radio"
+                    name="pynec-ground-model"
+                    checked={groundModel === value}
+                    onChange={() => setGroundModel(value)}
+                  />
+                  {label}
+                </label>
+              ))}
+            </div>
           )}
         </div>
 

--- a/tests/test_momwire_engine.py
+++ b/tests/test_momwire_engine.py
@@ -541,10 +541,10 @@ def test_momwire_pec_ground_directivity_matches_pynec():
 
 def test_momwire_finite_ground_returns_sane_values():
     """Finite ground in MomwireEngine is PEC-image-plus-Fresnel post-
-    processing; PyNEC's gn_card(0,...) uses a more sophisticated
-    Sommerfeld/Norton model. The two diverge by ~1.5 dBi on a 10m
-    dipole over (eps_r=10, sigma=0.002) ground. Don't claim equality;
-    just sanity-check the output."""
+    processing; PyNEC's ("finite",...) ground uses the more sophisticated
+    Sommerfeld/Norton model (gn_card(2,...)). The two diverge by ~1.5 dBi
+    on a 10m dipole over (eps_r=10, sigma=0.002) ground. Don't claim
+    equality; just sanity-check the output."""
     b = Builder()
     ff = MomwireEngine(b, ground=("finite", 10.0, 0.002)).far_field(
         n_theta=90, n_phi=360, del_theta=1, del_phi=1

--- a/tests/test_nec_export.py
+++ b/tests/test_nec_export.py
@@ -58,7 +58,10 @@ def test_export_one_gw_per_wire():
 
 def test_export_ground_cards():
     assert "GN 1" in export_nec(InvVee(_DIPOLE), ground="pec")
-    assert "GN 0" in export_nec(InvVee(_DIPOLE), ground=("finite", 10.0, 0.002))
+    # finite = Sommerfeld-Norton (IPERF 2); finite-fast = reflection-
+    # coefficient approximation (IPERF 0)
+    assert "GN 2" in export_nec(InvVee(_DIPOLE), ground=("finite", 10.0, 0.002))
+    assert "GN 0" in export_nec(InvVee(_DIPOLE), ground=("finite-fast", 10.0, 0.002))
     # free space emits no GN card
     assert "GN " not in export_nec(InvVee(_DIPOLE), ground="free")
 
@@ -114,6 +117,7 @@ def _nec2c_impedances(deck):
         (InvVee(_DIPOLE), "free"),
         (InvVee(_DIPOLE), "pec"),
         (InvVee(_DIPOLE), ("finite", 10.0, 0.002)),
+        (InvVee(_DIPOLE), ("finite-fast", 10.0, 0.002)),
         (Yagi(), "free"),
     ],
 )

--- a/tests/test_pynec_ground.py
+++ b/tests/test_pynec_ground.py
@@ -1,0 +1,58 @@
+"""PyNEC finite-ground handling.
+
+("finite", eps_r, sigma) must select NEC's Sommerfeld-Norton ground (IPERF 2)
+and ("finite-fast", eps_r, sigma) the reflection-coefficient approximation
+(IPERF 0). The numerical test pins the two apart at a height where they
+genuinely diverge, guarding against both specs silently mapping to the same
+gn_card again (the pre-fix behaviour: "finite" emitted IPERF 0).
+"""
+
+import argparse
+
+import pytest
+
+pytest.importorskip("PyNEC")
+
+from antennaknobs import resolve_variant_params  # noqa: E402
+from antennaknobs.cli import parse_ground  # noqa: E402
+from antennaknobs.designs.dipoles.invvee import Builder as InvVee  # noqa: E402
+from antennaknobs.engines import PyNECEngine  # noqa: E402
+from antennaknobs.engines.momwire import _normalise_ground  # noqa: E402
+
+
+def _flat_dipole(height_m):
+    params = dict(resolve_variant_params(InvVee, "dipole"))
+    params["base"] = height_m
+    return InvVee(params)
+
+
+def test_parse_ground_finite_variants():
+    assert parse_ground("finite") == ("finite", 10.0, 0.002)
+    assert parse_ground("finite:13,0.005") == ("finite", 13.0, 0.005)
+    assert parse_ground("finite-fast") == ("finite-fast", 10.0, 0.002)
+    assert parse_ground("finite-fast:13,0.005") == ("finite-fast", 13.0, 0.005)
+    with pytest.raises(argparse.ArgumentTypeError):
+        parse_ground("finite-slow")
+
+
+def test_momwire_folds_finite_fast_to_its_single_finite_model():
+    assert _normalise_ground(("finite-fast", 10.0, 0.002)) == ("finite", 10.0, 0.002)
+
+
+def test_sommerfeld_and_reflection_coefficient_diverge_when_low():
+    # At 0.05λ height the Sommerfeld and reflection-coefficient grounds
+    # disagree on R by ~15 Ω (they agree within ~1 Ω above ~0.2λ, so a low
+    # antenna is what tells them apart).
+    lam = 299.792458 / 28.47
+    height = 0.05 * lam
+    z_somm = PyNECEngine(
+        _flat_dipole(height), ground=("finite", 10.0, 0.002)
+    ).impedance()[0]
+    z_fast = PyNECEngine(
+        _flat_dipole(height), ground=("finite-fast", 10.0, 0.002)
+    ).impedance()[0]
+    z_pec = PyNECEngine(_flat_dipole(height), ground="pec").impedance()[0]
+    assert abs(z_somm - z_fast) > 5.0
+    # and neither finite model is the PEC image in disguise
+    assert abs(z_somm - z_pec) > 5.0
+    assert abs(z_fast - z_pec) > 5.0

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -864,6 +864,32 @@ def test_solve_dispatches_to_pynec_when_requested():
 
 
 @pynec_required
+def test_pynec_ground_on_solves_over_sommerfeld_finite_ground():
+    base = {
+        "geometry": "dipoles.invvee",
+        "solver": "pynec",
+        "measurement_freq_mhz": 28.47,
+    }
+    free = server.solve(base)
+    grounded = server.solve({**base, "ground": True})
+    # ground=True routes PyNEC to the Sommerfeld finite ground (εr=10,
+    # σ=0.002) rather than silently staying PEC/free, and the response
+    # carries the real constants so the frontend's Fresnel cut matches.
+    assert grounded["ground"] is True
+    assert grounded["ground_eps_r"] == 10.0
+    assert grounded["ground_sigma"] == 0.002
+    assert grounded["ground_eps_im"] < 0.0  # derived -σ/(ωε₀)
+    # the solve actually felt the ground
+    dz = abs(
+        complex(grounded["z_in_re"], grounded["z_in_im"])
+        - complex(free["z_in_re"], free["z_in_im"])
+    )
+    assert dz > 1.0
+    # ground off keeps the PEC placeholder constants (unused by the frontend)
+    assert free["ground_eps_r"] == pytest.approx(1.0e10)
+
+
+@pynec_required
 def test_sweep_endpoint_with_pynec_streams_per_point(client: TestClient):
     freqs = [28.0, 28.47, 29.0]
     r = client.post(

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -890,6 +890,37 @@ def test_pynec_ground_on_solves_over_sommerfeld_finite_ground():
 
 
 @pynec_required
+def test_pynec_ground_model_selects_pec_fast_or_sommerfeld():
+    base = {
+        "geometry": "dipoles.invvee",
+        "solver": "pynec",
+        "measurement_freq_mhz": 28.47,
+        "ground": True,
+    }
+    somm = server.solve(base)
+    fast = server.solve({**base, "ground_model": "fast"})
+    fast_legacy = server.solve({**base, "ground_fast": True})
+    pec = server.solve({**base, "ground_model": "pec"})
+    # PEC keeps the placeholder constants (client-side Fresnel ρ→−1); finite
+    # models ship the real ones.
+    assert pec["ground_eps_r"] == pytest.approx(1.0e10)
+    assert pec["ground_sigma"] == 0.0
+    assert fast["ground_eps_r"] == 10.0
+    # The legacy ground_fast boolean and ground_model="fast" are the same solve.
+    assert fast_legacy["z_in_re"] == fast["z_in_re"]
+    assert fast_legacy["z_in_im"] == fast["z_in_im"]
+    # PEC differs measurably from Sommerfeld (~5 Ω on this dipole)...
+    z_pec = complex(pec["z_in_re"], pec["z_in_im"])
+    z_somm = complex(somm["z_in_re"], somm["z_in_im"])
+    assert abs(z_pec - z_somm) > 2.0
+    # ...and lands on momwire's PEC image solve (same physics, different
+    # solver: ~0.9 Ω of basis/segmentation difference measured).
+    momwire_pec = server.solve({**base, "solver": "momwire"})
+    z_mom = complex(momwire_pec["z_in_re"], momwire_pec["z_in_im"])
+    assert abs(z_pec - z_mom) < 3.0
+
+
+@pynec_required
 def test_sweep_endpoint_with_pynec_streams_per_point(client: TestClient):
     freqs = [28.0, 28.47, 29.0]
     r = client.post(


### PR DESCRIPTION
## Summary
- PyNECEngine's `("finite", eps_r, sigma)` ground claimed to be Sommerfeld but emitted `gn_card(0, ...)` — NEC-2's reflection-coefficient approximation. It now emits IPERF 2 (true Sommerfeld-Norton), in both the engine and `nec_export`'s GN card. The two models agree within ~0.1 dB above ~0.2λ height but diverge hard for low antennas (0.05λ dipole: 47+9j vs 62−2j Ω, 1.3 dB of gain).
- The cheap approximation stays available as a new `("finite-fast", eps_r, sigma)` spec / `--ground finite-fast[:<eps_r>,<sigma>]` CLI option; MomwireEngine folds it to its single finite model.
- The web adapter mapped ground-on to PEC for **both** engines, so the UI's "Sommerfeld ground" label on the PyNEC backend was fiction and engine comparisons with ground on were PEC vs PEC. The adapter now honours the frontend contract, and the UI's old "fast ground" checkbox is replaced by a three-way ground-model picker for PyNEC: **Sommerfeld-Norton** (default), **reflection-coefficient** (fast), or **PEC** — the last giving an apples-to-apples comparison against momwire's PEC image method (within ~0.9 Ω on the dipole, vs ~5 Ω between PEC and Sommerfeld). momwire keeps the PEC image method, matching its label.
- The PyNEC solve response now ships the ground constants the engine actually solved over (real εr/σ for finite models, ρ→−1 placeholders for PEC/free), so the frontend's client-side PEC-image+Fresnel far-field cut tracks the engine's ground (~0.2 dB) instead of always assuming PEC. The request gains an authoritative `ground_model` field; the legacy `ground_fast` boolean still works.

## Test plan
- [x] New `tests/test_pynec_ground.py`: pins Sommerfeld and reflection-coefficient apart at 0.05λ height (guards against both specs mapping to the same gn_card again), covers `parse_ground` finite-fast variants and momwire's alias folding
- [x] `test_nec_export.py`: GN card assertions updated (finite → `GN 2`, finite-fast → `GN 0`); both finite decks cross-checked against `nec2c` impedance
- [x] New web tests: `solver=pynec, ground=true` returns εr=10/σ=0.002 with a measurably different Z than free space; `ground_model` selects pec/fast/sommerfeld, legacy `ground_fast` matches `ground_model="fast"` exactly, and PyNEC-PEC lands within 3 Ω of momwire's PEC image solve
- [x] Frontend rebuilt (`npm run build`, tsc clean); `/pattern` rp-card overlay verified over all ground models (PEC 8.97 dBi vs Sommerfeld 7.41 dBi max on the grounded dipole)
- [x] Full suite passes locally (1364 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
