### PR TITLE
Finite grounds drive momwire's reflection-coefficient impedance solve

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire>=0.3.0",
+    "momwire>=0.4.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -66,10 +66,25 @@ def _normalise_ground(ground):
         )
     ):
         # "finite-fast" is a PyNECEngine distinction (Sommerfeld-Norton vs the
-        # reflection-coefficient approximation); momwire has a single finite
-        # model, so both fold to it.
+        # reflection-coefficient approximation); momwire's best finite model
+        # is the reflection-coefficient one (BSplineSolver ground_eps), so
+        # both fold to a single spec and, for solvers that support it, both
+        # get the refl-coef solve (Sommerfeld in momwire is out of scope —
+        # see momwire docs/refl-coef-ground-plan.md).
         return ("finite",) + tuple(ground[1:])
     raise ValueError(f"unrecognised ground spec: {ground!r}")
+
+
+# Solvers whose impedance solve honours the reflection-coefficient finite
+# ground. BSplineSolver implements it; HMatrixSolver / ArrayBlockSolver
+# subclass it and fall back to the dense path when ground_eps is set
+# (momwire >= 0.4.0). TriangularSolver / SinusoidalSolver only model the
+# PEC image, so finite grounds keep folding to PEC for them.
+_GROUND_EPS_SOLVERS = ("BSplineSolver", "HMatrixSolver", "ArrayBlockSolver")
+
+
+def _solver_supports_ground_eps(solver):
+    return getattr(solver, "__name__", None) in _GROUND_EPS_SOLVERS
 
 
 class MomwireEngine(SimulationEngine):
@@ -100,14 +115,17 @@ class MomwireEngine(SimulationEngine):
           None or "free"           — no ground (default)
           "pec"                    — PEC plane at z=ground_z (image method)
           ("finite", eps_r, sigma) — far-field uses PEC image + Fresnel
-                                     coefficients on the reflected component;
-                                     impedance solve still uses PEC because
-                                     momwire only models PEC ground. Cross-
-                                     validation against PyNEC's finite grounds
-                                     (Sommerfeld gn_card(2,...) or reflection-
-                                     coefficient gn_card(0,...)) is approximate.
-                                     ("finite-fast", eps_r, sigma) is accepted
-                                     as an alias.
+                                     coefficients on the reflected component.
+                                     The impedance solve uses momwire's
+                                     reflection-coefficient finite ground
+                                     (NEC gn 0 style, BSplineSolver
+                                     ground_eps) when the solver supports it
+                                     (bspline family); TriangularSolver /
+                                     SinusoidalSolver still fold to the PEC
+                                     image. ("finite-fast", eps_r, sigma) is
+                                     accepted as an alias; Sommerfeld gn 2 is
+                                     approximated by the same model (they
+                                     agree to ~2 ohm above ~0.1λ heights).
         """
         super().__init__(builder)
 
@@ -150,6 +168,16 @@ class MomwireEngine(SimulationEngine):
         self._wire_radius = wire_radius
         self._ground = _normalise_ground(ground)
         self._ground_z = ground_z if self._ground is not None else None
+        # Finite ground constants forwarded to the impedance solve when the
+        # solver supports the reflection-coefficient model; None otherwise
+        # (PEC image, today's behavior for triangular/sinusoidal).
+        self._ground_eps = None
+        if (
+            self._ground is not None
+            and self._ground[0] == "finite"
+            and _solver_supports_ground_eps(self._solver)
+        ):
+            self._ground_eps = (float(self._ground[1]), float(self._ground[2]))
 
         # Map TL tags to feed indices for the legacy build_tls() path.
         self._tag_to_feed = {}
@@ -193,6 +221,13 @@ class MomwireEngine(SimulationEngine):
 
         self._reducer = NetworkReducer(net, port_to_idx, next_idx)
 
+    def _ground_solver_kwargs(self):
+        """Extra ground kwargs for solver construction. Only spliced in when
+        set — TriangularSolver / SinusoidalSolver don't accept ground_eps."""
+        if self._ground_eps is None:
+            return {}
+        return {"ground_eps": self._ground_eps}
+
     def _make_solver(self, *, wavelength):
         return self._solver(
             wires=self._polylines,
@@ -203,6 +238,7 @@ class MomwireEngine(SimulationEngine):
             ground_z=self._ground_z,
             junctions=self._junctions or None,
             cancel=self._cancel,
+            **self._ground_solver_kwargs(),
             **self._solver_kwargs,
         )
 
@@ -391,6 +427,7 @@ class MomwireEngine(SimulationEngine):
             ground_z=self._ground_z,
             junctions=self._junctions or None,
             cancel=self._cancel,
+            **self._ground_solver_kwargs(),
             **self._solver_kwargs,
         )
 

--- a/tests/test_momwire_finite_ground.py
+++ b/tests/test_momwire_finite_ground.py
@@ -1,0 +1,77 @@
+"""MomwireEngine finite-ground mapping (momwire >= 0.4.0 ground_eps).
+
+Since the refl-coef ground landed in momwire (docs/refl-coef-ground-plan.md
+there), finite ground specs must reach the impedance solve for solvers that
+support it: ("finite", eps_r, sigma) and ("finite-fast", eps_r, sigma) both
+map to BSplineSolver's ground_eps (momwire's single finite model — NEC gn 0
+style reflection-coefficient weighting), while TriangularSolver /
+SinusoidalSolver keep folding to the PEC image.
+
+The numeric test cross-checks the momwire solve against PyNEC gn 0 — the
+oracle the momwire implementation was validated against (dipole 0.1–0.5λ
+window: max |ΔZ| ≈ 2.45 Ω with a ~1.4 Ω cross-solver floor).
+"""
+
+import pytest
+
+pytest.importorskip("PyNEC")
+
+from momwire import BSplineSolver, TriangularSolver  # noqa: E402
+
+from antennaknobs import resolve_variant_params  # noqa: E402
+from antennaknobs.designs.dipoles.invvee import Builder as InvVee  # noqa: E402
+from antennaknobs.engines import MomwireEngine, PyNECEngine  # noqa: E402
+
+GROUND = ("finite-fast", 10.0, 0.002)
+
+
+def _flat_dipole(height_m):
+    params = dict(resolve_variant_params(InvVee, "dipole"))
+    params["base"] = height_m
+    return InvVee(params)
+
+
+def _height(frac):
+    lam = 299.792458 / 28.47
+    return frac * lam
+
+
+def test_finite_specs_map_to_ground_eps_for_bspline():
+    for spec in (GROUND, ("finite", 13.0, 0.005)):
+        eng = MomwireEngine(
+            _flat_dipole(_height(0.2)), solver=BSplineSolver, ground=spec
+        )
+        assert eng._ground_eps == (spec[1], spec[2])
+
+
+def test_finite_specs_fold_to_pec_for_triangular():
+    eng = MomwireEngine(
+        _flat_dipole(_height(0.2)), solver=TriangularSolver, ground=GROUND
+    )
+    assert eng._ground_eps is None
+
+
+def test_pec_and_free_never_set_ground_eps():
+    assert (
+        MomwireEngine(
+            _flat_dipole(_height(0.2)), solver=BSplineSolver, ground="pec"
+        )._ground_eps
+        is None
+    )
+    assert (
+        MomwireEngine(_flat_dipole(_height(0.2)), solver=BSplineSolver)._ground_eps
+        is None
+    )
+
+
+def test_momwire_bspline_finite_ground_tracks_nec_gn0():
+    """The whole point of the upgrade: at 0.2λ the PEC-image solve is ~18 Ω
+    of reactance off NEC's finite ground; the ground_eps solve lands within
+    the validated ~2.5 Ω window and strictly beats PEC."""
+    builder = _flat_dipole(_height(0.2))
+    z_gn0 = PyNECEngine(builder, ground=GROUND).impedance()[0]
+    z_mom = MomwireEngine(builder, solver=BSplineSolver, ground=GROUND).impedance()[0]
+    z_pec = MomwireEngine(builder, solver=BSplineSolver, ground="pec").impedance()[0]
+    assert abs(z_mom - z_gn0) < 2.5
+    assert abs(z_mom - z_gn0) < abs(z_pec - z_gn0)
+    assert abs(z_pec - z_gn0) > 10.0  # the gap being fixed is real


### PR DESCRIPTION
## Summary
- momwire v0.4.0 added `BSplineSolver(ground_eps=...)` — a NEC gn 0 style reflection-coefficient finite ground in the impedance solve (validated there against PyNEC gn 0 goldens: dipole 0.1–0.5λ window max/mean |ΔZ| = 2.45/1.75 Ω vs 41/19 Ω for the PEC-image solve). `MomwireEngine` now maps both `("finite", εr, σ)` and `("finite-fast", εr, σ)` to it for solvers that support it (BSpline/HMatrix/ArrayBlock); TriangularSolver and SinusoidalSolver keep folding finite grounds to the PEC image.
- Submodule pin bumped to momwire v0.4.0 **and** the `momwire>=` floor to 0.4.0 in the same PR.
- New `tests/test_momwire_finite_ground.py`: ground-spec mapping unit tests plus a momwire-vs-PyNEC-gn0 numeric cross-check at 0.2λ (within 2.5 Ω and strictly better than PEC).
- Far-field Fresnel post-process unchanged (correct as-is); web adapter unchanged — its momwire path still maps ground toggles to PEC pending a decision on the client-side Fresnel interplay.

## Test plan
- [x] `tests/test_momwire_finite_ground.py` (4 tests, includes PyNEC cross-check)
- [x] Full local suite: 1368 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)