### PR TITLE
Web ground parity: momwire backends honor the shared ground model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire>=0.4.0",
+    "momwire>=0.4.1",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -461,14 +461,36 @@ def _build_builder(cls, req: dict):
     return builder
 
 
-def _ground_for_engine(req: dict, ground_z: float):
-    ground_on = bool(req.get("ground", False))
-    if not ground_on:
+def _requested_ground_model(req: dict):
+    """The frontend's three-way ground model when ground is on, else None.
+    The legacy boolean `ground_fast` is honoured when `ground_model` is
+    absent."""
+    if not req.get("ground", False):
         return None
-    # momwire only models a PEC ground in the impedance solve, so ground=True
-    # maps to the PEC image method here. (PyNEC's finite-ground mapping lives
-    # in _pynec_ground_spec.)
-    return "pec"
+    model = req.get("ground_model")
+    if model is None:
+        model = "fast" if req.get("ground_fast", False) else "sommerfeld"
+    return model
+
+
+def _ground_for_engine(req: dict, ground_z: float):
+    """Map the frontend's ground knobs to MomwireEngine's ground spec —
+    same three-way model as `_pynec_ground_spec`, one shared selector
+    describing the GROUND; each engine approximates it as best it can.
+    "pec" → the PEC image; "fast" and "sommerfeld" → the finite spec, which
+    MomwireEngine solves with momwire's reflection-coefficient model on the
+    bspline-family solvers (its best available finite model; Sommerfeld is
+    out of momwire's scope) and folds to the PEC image on triangular /
+    sinusoidal. The response ships the engine's actual eps/sigma so the
+    frontend far-field Fresnel uses the real constants either way."""
+    model = _requested_ground_model(req)
+    if model is None:
+        return None
+    if model == "pec":
+        return "pec"
+    if model == "fast":
+        return ("finite-fast",) + DEFAULT_GROUND[1:]
+    return DEFAULT_GROUND
 
 
 def _pynec_ground_spec(req: dict):
@@ -477,14 +499,10 @@ def _pynec_ground_spec(req: dict):
     "sommerfeld" (default) — Sommerfeld-Norton finite ground with
     DEFAULT_GROUND's eps_r=10, sigma=0.002; "fast" — the same finite ground
     via NEC's reflection-coefficient approximation; "pec" — perfectly
-    conducting ground (the image method momwire uses, for apples-to-apples
-    engine comparison). The legacy boolean `ground_fast` is honoured when
-    `ground_model` is absent. Ground off is free space."""
-    if not req.get("ground", False):
-        return "free"
-    model = req.get("ground_model")
+    conducting ground. Ground off is free space."""
+    model = _requested_ground_model(req)
     if model is None:
-        model = "fast" if req.get("ground_fast", False) else "sommerfeld"
+        return "free"
     if model == "pec":
         return "pec"
     if model == "fast":
@@ -1051,8 +1069,30 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             "solve_ms": solve_ms,
             "ground": bool(req.get("ground", False)),
             "height_m": 0.0,
-            "ground_eps_r": _PEC_GROUND_EPS_R,
-            "ground_sigma": _PEC_GROUND_SIGMA,
+            # Ship the eps_r/sigma of the ground the engine actually solved
+            # over, exactly like the PyNEC branch: the frontend's far-field
+            # cut applies PEC image + Fresnel with these, so finite grounds
+            # get their real constants while ground_model="pec" and free
+            # space keep the PEC placeholders (ρ→−1).
+            "ground_eps_r": (
+                eng._ground[1]
+                if isinstance(eng._ground, tuple) and len(eng._ground) == 3
+                else _PEC_GROUND_EPS_R
+            ),
+            "ground_sigma": (
+                eng._ground[2]
+                if isinstance(eng._ground, tuple) and len(eng._ground) == 3
+                else _PEC_GROUND_SIGMA
+            ),
+            # What the impedance solve actually used, for honest UI wording:
+            # "refl-coef" (bspline-family + finite ground), "pec-image"
+            # (model="pec", or a finite model on a solver without
+            # ground_eps — triangular/sinusoidal), or "free".
+            "ground_model_applied": (
+                "free"
+                if eng._ground is None
+                else ("refl-coef" if eng._ground_eps is not None else "pec-image")
+            ),
             "z0_ohms": hints()["target_z0"],
             # Geometry-derived UI hints, folded into the response so user
             # designs (which defer them) get correct values the moment they're

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -4727,7 +4727,11 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
               {normCheckEnabled && normCheck && (
                 <span
                   className="overlay-readout"
-                  title={`input-power norm vs pattern-integral norm (${normCheck.method}); 0 dB = perfect power balance`}
+                  title={
+                    normCheck.method.startsWith("grid_")
+                      ? `input-power norm vs pattern-integral norm (${normCheck.method}); over a finite ground Δ includes real ground absorption (NEC average-gain style), so a nonzero value is expected, not solver error`
+                      : `input-power norm vs pattern-integral norm (${normCheck.method}); 0 dB = perfect power balance`
+                  }
                 >
                   Δ {normCheck.delta_db >= 0 ? "+" : ""}
                   {normCheck.delta_db.toFixed(3)} dB

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1160,6 +1160,10 @@ type SolveResponse = {
   ground_eps_r?: number;
   ground_sigma?: number;
   ground_eps_im?: number;
+  /** What the impedance solve actually used (momwire responses):
+   *  "refl-coef" | "pec-image" | "free". Informational — the tab summary
+   *  derives the same fact from backend + groundModel state. */
+  ground_model_applied?: string;
   k_meas_m_inv?: number;
   // V-specific
   arm_len_m?: number;
@@ -1260,12 +1264,14 @@ function isBSplineFamily(b: Backend): boolean {
   return BSPLINE_FAMILY.includes(b);
 }
 
-// Every momwire model has the PEC image-method ground; PyNEC picks between
-// Sommerfeld-Norton, the reflection-coefficient approximation, and PEC (the
-// image method, for apples-to-apples comparison against momwire). Kept as an
-// explicit list so future backends without ground support can be excluded by
-// name.
-type PynecGroundModel = "sommerfeld" | "fast" | "pec";
+// One shared three-way ground model describing the GROUND; each backend
+// approximates it as best it can. PyNEC: Sommerfeld-Norton / the
+// reflection-coefficient approximation / PEC image. Momwire: "sommerfeld"
+// and "fast" both map to its reflection-coefficient solve on the B-spline
+// family (its best available finite model; momwire has no Sommerfeld),
+// while Triangular/Sinusoidal keep the PEC image solve — either way the
+// finite constants (εr=10, σ=0.002) reach the far-field Fresnel cut.
+type GroundModel = "sommerfeld" | "fast" | "pec";
 
 function backendSupportsGround(b: Backend): boolean {
   return (
@@ -1431,7 +1437,7 @@ type SolveRequest = {
   wire_radius: number;
   ground: boolean;
   ground_fast: boolean;
-  ground_model?: PynecGroundModel;
+  ground_model?: GroundModel;
   // V
   angle_deg?: number;
   halfdriver_factor?: number;
@@ -2329,23 +2335,28 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   const [linkMeas, setLinkMeas] = useState(true);
   // Ground plane at z = 0 (model per backend; see groundModel).
   const [groundEnabled, setGroundEnabled] = useState(false);
-  // PyNEC-only ground model choice; momwire always uses the PEC image method.
-  const [groundModel, setGroundModel] = useState<PynecGroundModel>("sommerfeld");
+  // Shared ground-model choice — one selector describing the ground, every
+  // backend approximates it (see the GroundModel type note).
+  const [groundModel, setGroundModel] = useState<GroundModel>("sommerfeld");
 
   // One-line tab-hover summary: design · solver N=segs · ground model. The
-  // ground wording follows the backend family (momwire = PEC image method,
-  // PyNEC = the selected groundModel), and reads "free space" when ground is
-  // off or unsupported by the active solver.
+  // wording reflects what the active solver actually runs: PyNEC honours
+  // the model directly; momwire B-spline-family solves refl-coef for both
+  // finite models; Triangular/Sinusoidal solve the PEC image and only the
+  // far-field pattern sees the finite constants. "free space" when ground
+  // is off or unsupported.
   const groundActiveForSummary = groundEnabled && backendSupportsGround(backend);
   const groundSummary = !groundActiveForSummary
     ? "free space"
-    : backend === "pynec"
-      ? groundModel === "fast"
-        ? "reflection-coef ground"
-        : groundModel === "pec"
-          ? "PEC ground"
+    : groundModel === "pec"
+      ? "PEC ground"
+      : backend === "pynec"
+        ? groundModel === "fast"
+          ? "reflection-coef ground"
           : "Sommerfeld ground"
-      : "PEC ground";
+        : isBSplineFamily(backend)
+          ? "reflection-coef ground"
+          : "PEC solve · Fresnel pattern";
   const tabSummary = `${(currentExample?.label ?? geometry) || "new design"} · ${BACKEND_LABEL[backend]} N=${nPerWire} · ${groundSummary}`;
   useEffect(() => {
     reportSummary(id, tabSummary);
@@ -2674,10 +2685,11 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   const solveRafRef = useRef<number | null>(null); // trailing-edge rAF throttle handle
 
   function buildRequest(): SolveRequest {
-    // Solver-family ground notes: PyNEC uses Sommerfeld-Norton (or the
-    // fast reflection-coefficient approximation) with εr=10, σ=0.002;
-    // momwire's Triangular and B-spline models use the PEC image method.
-    // Sinusoidal is free-space-only — the gear UI grays the toggle for it.
+    // ground_model is shared across backends (εr=10, σ=0.002 for the finite
+    // models): PyNEC honours it directly; momwire's B-spline family solves
+    // the finite models with its reflection-coefficient ground, while
+    // Triangular/Sinusoidal fold them to the PEC image solve (the server
+    // ships the real εr/σ for the pattern either way).
     const groundActive = groundEnabled && backendSupportsGround(backend);
     const base: SolveRequest = {
       geometry,
@@ -4454,11 +4466,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
         <div className="field">
           <label
             className="link-toggle"
-            title={
-              backend === "pynec"
-                ? "Ground plane at z=0; pick the NEC ground model below"
-                : "PEC image-method ground (perfect electric conductor)"
-            }
+            title="Ground plane at z=0; pick the ground model below"
           >
             <input
               type="checkbox"
@@ -4466,34 +4474,43 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
               disabled={!backendSupportsGround(backend)}
               onChange={(e) => setGroundEnabled(e.target.checked)}
             />
-            ground plane{" "}
-            {backend === "pynec" ? "" : "(PEC, perfect conductor)"}
+            ground plane
           </label>
-          {backend === "pynec" && groundEnabled && (
-            <div role="radiogroup" aria-label="NEC ground model">
+          {backendSupportsGround(backend) && groundEnabled && (
+            <div role="radiogroup" aria-label="Ground model">
               {(
                 [
                   [
                     "sommerfeld",
                     "Sommerfeld (εr=10, σ=0.002 S/m)",
-                    "Sommerfeld-Norton finite ground (NEC ITYPE=2) — most accurate, slowest; the impedance sweep drops to half resolution to compensate.",
+                    backend === "pynec"
+                      ? "Sommerfeld-Norton finite ground (NEC ITYPE=2) — most accurate, slowest; the impedance sweep drops to half resolution to compensate."
+                      : isBSplineFamily(backend)
+                        ? "Finite ground, approximated by momwire's reflection-coefficient solve (its best finite model — agrees with Sommerfeld to ~2 Ω above ~0.1λ heights); pattern uses the real εr/σ."
+                        : "Finite ground: this solver only models the PEC image in the impedance solve; the far-field pattern still uses the real εr/σ (Fresnel).",
                   ],
                   [
                     "fast",
                     "refl-coef (fast)",
-                    "Same finite ground via the reflection-coefficient approximation (NEC ITYPE=0). ~2x faster per solve; impedance degrades below ~0.1λ height.",
+                    backend === "pynec"
+                      ? "Same finite ground via the reflection-coefficient approximation (NEC ITYPE=0). ~2x faster per solve; impedance degrades below ~0.1λ height."
+                      : isBSplineFamily(backend)
+                        ? "Finite ground via momwire's reflection-coefficient solve (NEC gn 0 style; validated within ~2 Ω of NEC over 0.1–0.5λ heights); pattern uses the real εr/σ."
+                        : "Finite ground: this solver only models the PEC image in the impedance solve; the far-field pattern still uses the real εr/σ (Fresnel).",
                   ],
                   [
                     "pec",
                     "PEC",
-                    "Perfectly conducting ground (image method, NEC ITYPE=1) — matches the momwire backends' ground model for apples-to-apples engine comparison.",
+                    backend === "pynec"
+                      ? "Perfectly conducting ground (image method, NEC ITYPE=1) — matches every backend's model='PEC' for apples-to-apples engine comparison."
+                      : "Perfectly conducting ground (image method) — matches PyNEC's PEC model for apples-to-apples engine comparison.",
                   ],
-                ] as [PynecGroundModel, string, string][]
+                ] as [GroundModel, string, string][]
               ).map(([value, label, title]) => (
                 <label key={value} className="link-toggle" title={title}>
                   <input
                     type="radio"
-                    name="pynec-ground-model"
+                    name="ground-model"
                     checked={groundModel === value}
                     onChange={() => setGroundModel(value)}
                   />

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -267,12 +267,15 @@ def _pattern_integral_norm(out: dict) -> float:
     with spherical Bessels j₀, j₁ — real, smooth, exact. O(N²) pairs, no
     aliasing floor, no grid to size.
 
-    Ground (the web paths are PEC — eps_r is the 1e10 sentinel): image
-    segments (x,y,z) → (x,y,−z) with horizontal moment components flipped
-    reproduce the reflected wave exactly, and the imaged 2N system is
-    mirror-symmetric, so the upper-hemisphere power is half its full-sphere
-    power. The Fresnel coefficients at eps_r = 1e10 differ from the PEC
-    limit only within ~1e-5 of grazing — beyond any displayed precision.
+    Ground: evaluates the PEC-IMAGE functional regardless of the response's
+    ground constants — image segments (x,y,z) → (x,y,−z) with horizontal
+    moment components flipped reproduce the reflected wave exactly, and the
+    imaged 2N system is mirror-symmetric, so the upper-hemisphere power is
+    half its full-sphere power. Valid as a norm only when the response is
+    PEC (eps_r at the 1e10 sentinel, where Fresnel differs from the PEC
+    limit only within ~1e-5 of grazing); finite-ground responses (real
+    εr/σ shipped since the web ground-parity change) must use the grid
+    quadrature instead — `_norm_check` already routes them there.
 
     This is the same discrete functional the old grid integral sampled, so
     the delta against the P_in-based `directivity_norm` isolates the solver

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -962,7 +962,18 @@ def _norm_check(req: dict) -> dict:
         method = "closed_form"
     else:
         ref = dict(out)
-        n_theta, n_phi = _fine_norm_grid(45)
+        # Size the reference grid off THIS design's adaptive pick (2x margin,
+        # 45x90 floor — `_fine_norm_grid`'s contract), not the max-size grid:
+        # passing the literal floor here used to force 90x180 on every
+        # finite-ground check (~750 ms on a 6λ skyloop, ~8x the solve
+        # itself). Measured: the adaptive grid already matches 90x180 to
+        # <1e-4 dB on the calibration designs, so the doubled pick keeps a
+        # genuine safety margin at a fraction of the cost.
+        mid, _dr, _i = _moment_segments(out)
+        nt_adapt, _ = _adaptive_norm_grid(
+            float(out["k_meas_m_inv"]), mid.min(axis=0), mid.max(axis=0)
+        )
+        n_theta, n_phi = _fine_norm_grid(nt_adapt)
         _compute_directivity_norm(ref, n_theta=n_theta, n_phi=n_phi)
         pattern_norm = ref["directivity_norm"]
         method = f"grid_{n_theta}x{n_phi}"

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -371,6 +371,12 @@ def test_adaptive_norm_grid_scales_with_size_and_clamps():
 # Designs spanning the electrical-size range, incl. an 80m skyloop run up to
 # 50 MHz (~6λ bbox) — the case where a too-coarse grid falls off the aliasing
 # cliff (~1 dB). Ground on and off (the ground path is a separate integral).
+# The grounded entries pin ground_model="pec": these are solver
+# SELF-CONSISTENCY diagnostics (field-side pattern power vs circuit-side
+# P_in, and closed-form vs grid of the same PEC-image functional). Over a
+# finite ground the two sides legitimately differ by the absorbed power and
+# the closed form doesn't model Fresnel — that path is covered by
+# test_norm_check_finite_ground_uses_grid_method instead.
 _NORM_ACCURACY_REQS = [
     {
         "geometry": "dipoles.invvee",
@@ -385,6 +391,7 @@ _NORM_ACCURACY_REQS = [
         "design_freq_mhz": 28.47,
         "momwire_model": "triangular",
         "ground": True,
+        "ground_model": "pec",
     },
     {
         "geometry": "loops.triangular_skyloop",
@@ -401,6 +408,7 @@ _NORM_ACCURACY_REQS = [
         "momwire_model": "triangular",
         "n_per_wire": 80,
         "ground": True,
+        "ground_model": "pec",
     },
 ]
 
@@ -443,8 +451,10 @@ def test_pattern_integral_closed_form_matches_fine_grid(req):
 
 def test_norm_check_endpoint_reports_power_balance(client: TestClient):
     """/norm_check returns the live circuit-side norm plus the field-side
-    pattern norm (closed form on the PEC web paths); for a converged design
-    the two agree to within 0.05 dB (the overlay sits on the live trace)."""
+    pattern norm (closed form on PEC-ground responses); for a converged
+    design the two agree to within 0.05 dB (the overlay sits on the live
+    trace). Pinned to ground_model="pec": that is the closed-form path,
+    and the only ground where field-vs-circuit balance is physical."""
     server._SOLVE_CACHE.clear()
     req = {
         "geometry": "dipoles.invvee",
@@ -452,6 +462,7 @@ def test_norm_check_endpoint_reports_power_balance(client: TestClient):
         "design_freq_mhz": 28.47,
         "momwire_model": "triangular",
         "ground": True,
+        "ground_model": "pec",
     }
     resp = client.post("/norm_check", json=req).json()
     assert resp["available"] is True
@@ -459,6 +470,27 @@ def test_norm_check_endpoint_reports_power_balance(client: TestClient):
     assert resp["method"] == "closed_form"
     db = 10 * np.log10(resp["directivity_norm"] / resp["pattern_norm"])
     assert abs(db) < 0.05
+
+
+def test_norm_check_finite_ground_uses_grid_method(client: TestClient):
+    """Since the web momwire path ships real finite-ground constants, a
+    grounded solve with a finite model must route /norm_check to the
+    fine-grid Fresnel quadrature (the closed-form image identity is exact
+    only for a perfect reflector). No tight balance assertion: over a lossy
+    ground the field-side integral omits the absorbed power by design."""
+    server._SOLVE_CACHE.clear()
+    req = {
+        "geometry": "dipoles.invvee",
+        "measurement_freq_mhz": 28.47,
+        "design_freq_mhz": 28.47,
+        "momwire_model": "bspline",
+        "ground": True,
+        "ground_model": "fast",
+    }
+    resp = client.post("/norm_check", json=req).json()
+    assert resp["available"] is True
+    assert resp["method"].startswith("grid_")
+    assert resp["pattern_norm"] > 0
 
 
 def test_directivity_norm_gl_beats_uniform_at_coarse_grid():
@@ -1760,3 +1792,72 @@ def test_check_solve_size_unknown_geometry_does_not_falsely_reject(hosted):
     server._check_solve_size(
         {"geometry": "does.not.exist", "n_per_wire": 999999}, use_pynec=False
     )
+
+
+def test_momwire_bspline_ground_model_drives_refl_coef_solve():
+    """Web ground parity: with a B-spline-family solver, both finite ground
+    models map to momwire's reflection-coefficient solve (its single finite
+    model), the response ships the real εr/σ for the frontend Fresnel cut,
+    and ground_model_applied reports what actually ran."""
+    base = {
+        "geometry": "dipoles.invvee",
+        "solver": "momwire",
+        "momwire_model": "bspline",
+        "measurement_freq_mhz": 28.47,
+        "ground": True,
+    }
+    somm = server.solve(base)  # default ground_model = sommerfeld
+    fast = server.solve({**base, "ground_model": "fast"})
+    pec = server.solve({**base, "ground_model": "pec"})
+
+    assert somm["ground_model_applied"] == "refl-coef"
+    assert fast["ground_model_applied"] == "refl-coef"
+    assert pec["ground_model_applied"] == "pec-image"
+    assert somm["ground_eps_r"] == 10.0
+    assert somm["ground_sigma"] == 0.002
+    assert somm["ground_eps_im"] < 0.0  # derived -σ/(ωε₀)
+    assert pec["ground_eps_r"] == pytest.approx(1.0e10)
+    # "sommerfeld" and "fast" are the same momwire solve (one finite model).
+    assert somm["z_in_re"] == fast["z_in_re"]
+    assert somm["z_in_im"] == fast["z_in_im"]
+    # The finite solve differs measurably from the PEC image solve — the
+    # reactance correction the refl-coef ground exists to deliver.
+    z_fast = complex(fast["z_in_re"], fast["z_in_im"])
+    z_pec = complex(pec["z_in_re"], pec["z_in_im"])
+    assert abs(z_fast - z_pec) > 2.0
+
+
+def test_momwire_triangular_finite_folds_to_pec_solve_but_ships_real_eps():
+    """TriangularSolver has no ground_eps: a finite ground model keeps the
+    PEC image impedance solve (identical Z to model='pec') while the
+    response still ships the real constants so the far-field pattern gets
+    the finite-ground Fresnel treatment."""
+    base = {
+        "geometry": "dipoles.invvee",
+        "solver": "momwire",
+        "momwire_model": "triangular",
+        "measurement_freq_mhz": 28.47,
+        "ground": True,
+    }
+    fin = server.solve({**base, "ground_model": "fast"})
+    pec = server.solve({**base, "ground_model": "pec"})
+    assert fin["ground_model_applied"] == "pec-image"
+    assert pec["ground_model_applied"] == "pec-image"
+    assert fin["ground_eps_r"] == 10.0
+    assert fin["ground_sigma"] == 0.002
+    assert pec["ground_eps_r"] == pytest.approx(1.0e10)
+    assert fin["z_in_re"] == pec["z_in_re"]
+    assert fin["z_in_im"] == pec["z_in_im"]
+
+
+def test_momwire_ground_off_reports_free_model():
+    resp = server.solve(
+        {
+            "geometry": "dipoles.invvee",
+            "solver": "momwire",
+            "momwire_model": "bspline",
+            "measurement_freq_mhz": 28.47,
+        }
+    )
+    assert resp["ground_model_applied"] == "free"
+    assert resp["ground_eps_r"] == pytest.approx(1.0e10)


### PR DESCRIPTION
## Summary
- The web UI's three-way ground model (Sommerfeld / refl-coef / PEC) now applies to **every** backend — one selector describing the ground, each engine approximating it as best it can. Momwire bspline-family backends solve finite models with momwire's reflection-coefficient ground (v0.4.1); triangular/sinusoidal keep the PEC image solve while the far-field pattern gets the real εr/σ Fresnel treatment either way. Behavior change: grounded momwire tabs shift from PEC to finite results with the default model (`pec` remains available).
- Momwire responses ship real `ground_eps_r/sigma` (like the PyNEC branch) plus a new informational `ground_model_applied` field; frontend selector, per-backend tooltips, and tab-summary wording reflect what actually ran; bundle rebuilt.
- Norm machinery updated coherently: the closed-form pattern-integral norm is a PEC-image functional, so the grounded norm-accuracy diagnostics pin `ground_model="pec"` (field-vs-circuit power balance is only physical over a lossless reflector) and finite-ground responses route `/norm_check` to the fine-grid Fresnel quadrature (covered by a new test).
- momwire submodule pinned to **v0.4.1** + `momwire>=0.4.1` floor in the same PR — brings the Phase 5 fast-solver `ground_eps` support so grounded arrays don't drop to the dense path.

## Test plan
- [x] 5 new tests (3 web ground-parity solves incl. `ground_model_applied`, 1 triangular fold semantics, 1 /norm_check grid routing)
- [x] Full suite: 1372 passed
- [ ] CI green (momwire 0.4.1 confirmed on PyPI, so wheel-smoke resolves the floor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)