### PR TITLE
Default solver slots: B-spline d=2 working + d=1 cross-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ What you get:
 - **A Smith chart** of input impedance, with optional frequency-sweep and
   convergence overlays.
 - **Three solver slots (A / B / C)** you can point at different backends and
-  compare side by side — e.g. momwire triangular vs. B-spline vs. PyNEC on the
-  same antenna, at once.
+  compare side by side on the same antenna, at once. The defaults are already
+  a cross-check: B-spline d=2 (the working solver) vs. B-spline d=1 (same
+  physics through an independent basis) vs. PyNEC.
 
 Live updates stay responsive because rapid knob drags are coalesced into one
 solve per round-trip, so the solver is never buried under stale requests.
@@ -127,9 +128,10 @@ engine = MomwireEngine(builder, solver=BSplineSolver, solver_kwargs={"degree": 2
 ```
 
 **momwire** lives in its own repository and is vendored here as a git submodule;
-its primary `TriangularSolver` engine converges to NEC accuracy in ~80 segments
-and is validated against the independent B-spline basis. The H-matrix and
-array-block engines are newer and aimed at large arrays. **PyNEC** is an
+its `BSplineSolver` (the web workbench's default) is validated against the
+independent triangular (tent) basis, which converges to NEC accuracy in ~80
+segments. The H-matrix and array-block engines are newer and aimed at large
+arrays. **PyNEC** is an
 *optional* second backend — the `python-necpp` fork, distributed as a
 self-contained wheel (OpenBLAS vendored, so no SWIG/BLAS/autotools toolchain is
 required at install time). It is licensed **GPL-2.0** and installed separately

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1356,8 +1356,8 @@ const DEFAULT_BACKEND_OPTS: BackendOptsMap = {
 // Three abstract solver slots. Each holds one backend choice and its
 // options; the user picks A/B/C with the row of buttons, configures the
 // inhabitants from the per-slot gear menu. Lets the same UI compare
-// e.g. "Triangular @ N=40" against "B-spline @ N=21 with enrichment"
-// without losing either setup.
+// e.g. "B-spline d=2 @ N=21" against "B-spline d=1 @ N=40" without
+// losing either setup.
 type Slot = "A" | "B" | "C";
 const SLOT_ORDER: Slot[] = ["A", "B", "C"];
 
@@ -1366,17 +1366,30 @@ type SlotConfig = {
   opts: BackendOptsMap[Backend];
 };
 
+// Display label for a configured backend: B-spline-family entries carry
+// their spline degree so two b-spline slots (the default A d=2 / B d=1
+// pair) stay distinguishable at a glance.
+function backendDisplayLabel(b: Backend, opts: BackendOptsMap[Backend]): string {
+  return isBSplineFamily(b)
+    ? `${BACKEND_LABEL[b]} d=${(opts as BSplineOpts).degree}`
+    : BACKEND_LABEL[b];
+}
+
 const DEFAULT_SLOTS: Record<Slot, SlotConfig> = {
+  // A is the default working solver: B-spline d=2 — most accurate per
+  // unknown, converged at a small odd N (interior knot at the feed), and
+  // its impedance solve honours finite grounds (Triangular, the old
+  // default, folds them to the PEC image).
   A: {
-    backend: "triangular",
-    opts: { ...DEFAULT_BACKEND_OPTS.triangular, nPerWire: 40 },
+    backend: "bspline",
+    opts: { ...DEFAULT_BACKEND_OPTS.bspline, nPerWire: 21 },
   },
+  // B is the cross-check basis: B-spline d=1 needs a larger N to reach
+  // the same answer (slower), which is what makes agreement with A a
+  // meaningful second opinion rather than the same solve twice.
   B: {
     backend: "bspline",
-    opts: {
-      ...DEFAULT_BACKEND_OPTS.bspline,
-      nPerWire: 21,
-    },
+    opts: { ...DEFAULT_BACKEND_OPTS.bspline, degree: 1, nPerWire: 40 },
   },
   C: {
     backend: "pynec",
@@ -4423,7 +4436,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
         <div className="field">
           <label>
             <span>solver slot</span>
-            <span>{BACKEND_LABEL[backend]} · N={nPerWire}</span>
+            <span>{backendDisplayLabel(backend, currentOpts)} · N={nPerWire}</span>
           </label>
           <div className="backend-tabs" role="tablist">
             {SLOT_ORDER.map((s) => {
@@ -4433,13 +4446,13 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                   <button
                     role="tab"
                     aria-selected={activeSlot === s}
-                    aria-label={`Solver slot ${s}: ${BACKEND_LABEL[cfg.backend]}, N=${cfg.opts.nPerWire}`}
+                    aria-label={`Solver slot ${s}: ${backendDisplayLabel(cfg.backend, cfg.opts)}, N=${cfg.opts.nPerWire}`}
                     className={`backend-tab-btn ${activeSlot === s ? "active" : ""}`}
-                    title={`${BACKEND_LABEL[cfg.backend]}, N=${cfg.opts.nPerWire}`}
+                    title={`${backendDisplayLabel(cfg.backend, cfg.opts)}, N=${cfg.opts.nPerWire}`}
                     onClick={() => setActiveSlot(s)}
                   >
                     <span className="slot-letter">{s}</span>
-                    <span className="slot-sub">{BACKEND_LABEL[cfg.backend]}</span>
+                    <span className="slot-sub">{backendDisplayLabel(cfg.backend, cfg.opts)}</span>
                   </button>
                   <button
                     className="backend-gear-btn"


### PR DESCRIPTION
## Summary
- Slot A default moves from Triangular N=40 to **B-spline d=2, N=21** — more accurate per unknown, converged at a small odd N, and its impedance solve honours finite grounds (Triangular folds them to the PEC image, which was the main motivation).
- Slot B default becomes **B-spline d=1, N=40** — a cross-check that reaches the same answer through an independent basis; verified live it agrees with slot A within ~0.1 Ω on dipoles.invvee and exactly reproduces the old Triangular N=40 result. Slot C stays PyNEC.
- With two b-spline slots, the slot buttons and the solver-slot header now carry the spline degree ("b-spline d=2" / "b-spline d=1") so the pair stays distinguishable without opening the gear.
- README updated: the slot example and the momwire cross-validation paragraph now reflect the B-spline defaults.

## Test plan
- [x] `tsc --noEmit` + vite build pass
- [x] Verified live in the browser: fresh load shows slot A "b-spline d=2" N=21 solving dipoles.invvee (R 55.09 / X −10.27 Ω, ~52 ms); slot B "b-spline d=1" N=40 gives 55.05 / −10.38 (~46 ms), matching the old Triangular N=40 numbers
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)