### PR TITLE
Site: release-notes reference page

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -89,6 +89,7 @@ export default defineConfig({
             { label: "Web workbench", slug: "reference/web" },
             { label: "Drone & Transform API", slug: "reference/drone-transform" },
             { label: "Command line", slug: "reference/cli" },
+            { label: "Release notes", slug: "reference/releases" },
           ],
         },
         {

--- a/site/src/content/docs/reference/releases.md
+++ b/site/src/content/docs/reference/releases.md
@@ -1,0 +1,36 @@
+---
+title: Release notes
+description: Where to find what changed in each antennaknobs and momwire release, and what a release means for the hosted simulator.
+---
+
+antennaknobs ships as **two packages**, each with its own version and release
+notes:
+
+- **[antennaknobs releases](https://github.com/stevenmburns/antennaknobs/releases)** —
+  the designs, engines, CLI, and web workbench. This is the version shown by
+  the hosted simulator.
+- **[momwire releases](https://github.com/stevenmburns/momwire/releases)** —
+  the in-house MoM engine (basis functions, ground models, accelerated
+  solvers). Solver-level capabilities — a new ground model, a faster
+  assembly path — land here first.
+
+Notes are generated from the pull requests that went into each release, with a
+full-changelog diff link between tags, so every entry traces back to the code
+and discussion behind it.
+
+## What a release means for the hosted simulator
+
+The live simulator and this documentation site deploy **from release tags,
+not from every merge**: cutting an antennaknobs release publishes the package
+to PyPI and deploys the same tagged commit to the hosted app and docs. The
+version number therefore always names exactly what is running — if the
+release notes say a solver capability landed in the current version, the
+hosted simulator has it.
+
+## How the two versions relate
+
+Each antennaknobs release declares a **minimum momwire version** — the oldest
+engine release carrying every solver API that antennaknobs version uses. A
+`pip install antennaknobs` resolves a compatible engine automatically; if you
+pin momwire yourself, keep it at or above the floor in that release's
+`pyproject.toml`.


### PR DESCRIPTION
## Summary
- New site page `reference/releases` linking the antennaknobs and momwire GitHub release feeds (both now carry PR-derived notes; momwire's ten historical releases were backfilled via `gh release edit`).
- Explains the tag-to-deploy contract — the hosted simulator and docs deploy from release tags, so the version names what's live — and how the antennaknobs release's momwire floor relates the two version streams.
- Sidebar entry added under Reference.

## Test plan
- [x] `npm run build` in site/: 15 pages built clean (new page + sidebar render)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016thQg6NoZB9ETiWPcyTT25