### PR TITLE
True Sommerfeld ground on the B-spline solver (momwire 0.6.0): "finite" now means NEC gn 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/sta
 # install below sees its requirement already satisfied, then the package with the
 # web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install "momwire>=0.5.0" \
+ && pip install "momwire>=0.6.0" \
  && pip install -e ".[web]"
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire>=0.5.0",
+    "momwire>=0.6.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",

--- a/site/src/content/docs/reference/solver.md
+++ b/site/src/content/docs/reference/solver.md
@@ -110,14 +110,16 @@ the limits are env-configurable (see `docs/deploy.md`).
 
 In the spirit of not overselling: momwire wires are currently PEC (no conductor
 loss — the NEC path with `ld_card` covers lossy elements), and finite-ground
-impedance on the triangular basis folds to the PEC image. The B-spline family
-solves finite grounds with the reflection-coefficient model (validated within
-~2 Ω of NEC over 0.1–0.5λ heights), the sinusoidal basis solves them with the
-same model applied to total fields (NEC's own formulation — it matches NEC's
-reflection-coefficient ground to ~0.1 Ω, the solvers' mutual discretization
-floor), and the NEC path offers full Sommerfeld–Norton — the reference for
-very low antennas (below ~0.1λ) — so real-ground results cross-check across
-two independent engines.
+impedance on the triangular basis folds to the PEC image. The plain B-spline
+solver solves finite grounds with a true **Sommerfeld/Norton** model
+(momwire ≥ 0.6.0: NEC's exact-image-plus-remainder decomposition, validated
+within ~2.4 Ω of an independent NEC-2 implementation across 0.02–0.5λ
+heights — including the very-low region where reflection-coefficient models
+are tens of ohms off). The accelerated B-spline solvers (H-matrix /
+array-block) and the sinusoidal basis use the reflection-coefficient model
+(~2 Ω and ~0.1 Ω of NEC's gn 0 respectively over 0.1–0.5λ), and the NEC
+path offers its own Sommerfeld–Norton — so real-ground results cross-check
+across two independent engines at every height.
 
 <!-- TODO: embed the benchmark plots once generated, and a parity/differentiator
      table vs PyNEC / 4nec2 / EZNEC / AN-SOF from the market-research doc. -->

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -128,18 +128,21 @@ The selector describes what the ground **is**, independent of solver:
 - **PEC** — a perfect reflector, mainly for apples-to-apples engine
   comparisons.
 
-Each solver then models that ground as well as it can. The momwire B-spline
-family solves finite grounds with its reflection-coefficient model (validated
-within ~2 Ω of NEC over 0.1–0.5λ heights), and the sinusoidal basis does too
-(within ~0.1 Ω of NEC's reflection-coefficient ground — it shares NEC's
-basis); PyNEC adds a method sub-choice —
-full **Sommerfeld–Norton** (most accurate, slowest; the reference below ~0.1λ)
-vs. the **reflection-coefficient** approximation (~2× faster per solve). The
-triangular basis folds the impedance solve to the PEC image; the
-far-field pattern uses the real εr/σ on every basis. Whatever runs, the solve
-readout's **ground** row reports the model that was actually used, and over a
-finite ground the [norm check](#norm-check--is-the-solve-trustworthy) Δ reads
-"incl. ground loss" — a steady dB or so there is absorbed power, not error.
+Each solver then models that ground as well as it can, with a method
+sub-choice on both engines — full **Sommerfeld/Norton** (most accurate,
+the reference below ~0.1λ heights) vs. the **reflection-coefficient**
+approximation (faster per solve; fine above ~0.1λ). On momwire the plain
+B-spline solver honours both (true Sommerfeld since momwire 0.6.0,
+validated within ~2.4 Ω of an independent NEC-2 implementation down to
+0.02λ); the accelerated B-spline solvers keep their fast
+reflection-coefficient paths, the sinusoidal basis is
+reflection-coefficient only (~0.1 Ω of NEC's gn 0 — it shares NEC's
+basis), and the triangular basis folds the impedance solve to the PEC
+image. The far-field pattern uses the real εr/σ on every basis. Whatever
+runs, the solve readout's **ground** row reports the model that was
+actually used, and over a finite ground the
+[norm check](#norm-check--is-the-solve-trustworthy) Δ reads "incl. ground
+loss" — a steady dB or so there is absorbed power, not error.
 
 ## Convergence sweep
 

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -65,13 +65,13 @@ def _normalise_ground(ground):
             "finite-fast",
         )
     ):
-        # "finite-fast" is a PyNECEngine distinction (Sommerfeld-Norton vs the
-        # reflection-coefficient approximation); momwire's best finite model
-        # is the reflection-coefficient one (BSplineSolver ground_eps), so
-        # both fold to a single spec and, for solvers that support it, both
-        # get the refl-coef solve (Sommerfeld in momwire is out of scope —
-        # see momwire docs/refl-coef-ground-plan.md).
-        return ("finite",) + tuple(ground[1:])
+        # The variant is preserved: "finite" means the true Sommerfeld/
+        # Norton ground (NEC gn 2 — momwire BSplineSolver implements it
+        # since 0.6.0), "finite-fast" the reflection-coefficient
+        # approximation (NEC gn 0). Solvers without the requested model
+        # fall back to their best available one — see the ground-model
+        # mapping in __init__.
+        return (ground[0],) + tuple(ground[1:])
     raise ValueError(f"unrecognised ground spec: {ground!r}")
 
 
@@ -124,16 +124,23 @@ class MomwireEngine(SimulationEngine):
           "pec"                    — PEC plane at z=ground_z (image method)
           ("finite", eps_r, sigma) — far-field uses PEC image + Fresnel
                                      coefficients on the reflected component.
-                                     The impedance solve uses momwire's
-                                     reflection-coefficient finite ground
-                                     (NEC gn 0 style, ground_eps) when the
-                                     solver supports it (bspline family +
-                                     SinusoidalSolver); TriangularSolver
-                                     still folds to the PEC
-                                     image. ("finite-fast", eps_r, sigma) is
-                                     accepted as an alias; Sommerfeld gn 2 is
-                                     approximated by the same model (they
-                                     agree to ~2 ohm above ~0.1λ heights).
+                                     The impedance solve uses momwire's TRUE
+                                     Sommerfeld ground (NEC gn 2 style,
+                                     ground_model="sommerfeld", momwire
+                                     >= 0.6.0) on plain BSplineSolver — the
+                                     accurate-at-any-height model. HMatrix/
+                                     ArrayBlock keep the reflection-
+                                     coefficient fast paths (momwire would
+                                     gate their sommerfeld to a dense solve),
+                                     SinusoidalSolver has only the refl-coef
+                                     model, and TriangularSolver folds to the
+                                     PEC image.
+          ("finite-fast", eps_r, sigma) — the reflection-coefficient model
+                                     (NEC gn 0 style, ground_eps) on every
+                                     solver that supports it. Matches
+                                     "finite" to ~2 ohm above ~0.1λ heights
+                                     but diverges hard below (~22 ohm at
+                                     0.05λ, >100 ohm at 0.02λ).
         """
         super().__init__(builder)
 
@@ -180,12 +187,27 @@ class MomwireEngine(SimulationEngine):
         # solver supports the reflection-coefficient model; None otherwise
         # (PEC image, today's behavior for triangular/sinusoidal).
         self._ground_eps = None
+        self._ground_model = None
         if (
             self._ground is not None
-            and self._ground[0] == "finite"
+            and self._ground[0] in ("finite", "finite-fast")
             and _solver_supports_ground_eps(self._solver)
         ):
             self._ground_eps = (float(self._ground[1]), float(self._ground[2]))
+            # True Sommerfeld (momwire >= 0.6.0) only on plain BSplineSolver
+            # for the "finite" spec: HMatrix/ArrayBlock would be gated to a
+            # dense solve (a silent perf cliff on the large arrays they
+            # exist for) so they keep their refl-coef fast paths, and
+            # SinusoidalSolver has no sommerfeld model. "finite-fast" is
+            # refl-coef everywhere.
+            self._ground_model = (
+                "sommerfeld"
+                if (
+                    self._ground[0] == "finite"
+                    and getattr(self._solver, "__name__", None) == "BSplineSolver"
+                )
+                else "refl-coef"
+            )
 
         # Map TL tags to feed indices for the legacy build_tls() path.
         self._tag_to_feed = {}
@@ -234,7 +256,12 @@ class MomwireEngine(SimulationEngine):
         set — TriangularSolver / SinusoidalSolver don't accept ground_eps."""
         if self._ground_eps is None:
             return {}
-        return {"ground_eps": self._ground_eps}
+        kw = {"ground_eps": self._ground_eps}
+        # Only BSplineSolver takes ground_model (and refl-coef is its
+        # default); SinusoidalSolver would reject the kwarg.
+        if self._ground_model == "sommerfeld":
+            kw["ground_model"] = "sommerfeld"
+        return kw
 
     def _make_solver(self, *, wavelength):
         return self._solver(

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -477,12 +477,16 @@ def _ground_for_engine(req: dict, ground_z: float):
     """Map the frontend's ground knobs to MomwireEngine's ground spec —
     same three-way model as `_pynec_ground_spec`, one shared selector
     describing the GROUND; each engine approximates it as best it can.
-    "pec" → the PEC image; "fast" and "sommerfeld" → the finite spec, which
-    MomwireEngine solves with momwire's reflection-coefficient model on the
-    bspline-family and sinusoidal solvers (its best available finite model;
-    Sommerfeld is out of momwire's scope) and folds to the PEC image on
-    triangular. The response ships the engine's actual eps/sigma so the
-    frontend far-field Fresnel uses the real constants either way."""
+    "pec" → the PEC image; "sommerfeld" → ("finite", ...), which momwire
+    solves as the TRUE Sommerfeld ground on plain BSplineSolver (momwire
+    >= 0.6.0) and as the reflection-coefficient model on the other
+    ground_eps solvers (hmatrix/arrayblock keep their fast paths,
+    sinusoidal has no sommerfeld model); "fast" → ("finite-fast", ...),
+    the reflection-coefficient model everywhere it exists. Triangular
+    folds any finite spec to the PEC image. The response ships the
+    engine's actual eps/sigma so the frontend far-field Fresnel uses the
+    real constants either way; `ground_model_applied` reports what the
+    impedance solve really used."""
     model = _requested_ground_model(req)
     if model is None:
         return None
@@ -1097,13 +1101,12 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
                 else _PEC_GROUND_SIGMA
             ),
             # What the impedance solve actually used, for honest UI wording:
-            # "refl-coef" (bspline-family/sinusoidal + finite ground),
-            # "pec-image" (model="pec", or a finite model on a solver
-            # without ground_eps — triangular), or "free".
+            # "sommerfeld" (BSplineSolver + "finite", momwire >= 0.6.0),
+            # "refl-coef" (the other ground_eps solvers, or any solver with
+            # the "finite-fast" spec), "pec-image" (model="pec", or a finite
+            # model on a solver without ground_eps — triangular), or "free".
             "ground_model_applied": (
-                "free"
-                if eng._ground is None
-                else ("refl-coef" if eng._ground_eps is not None else "pec-image")
+                "free" if eng._ground is None else (eng._ground_model or "pec-image")
             ),
             "z0_ohms": hints()["target_z0"],
             # Geometry-derived UI hints, folded into the response so user

--- a/tests/test_momwire_finite_ground.py
+++ b/tests/test_momwire_finite_ground.py
@@ -1,18 +1,22 @@
 """MomwireEngine finite-ground mapping (momwire >= 0.4.0 ground_eps;
-SinusoidalSolver support since momwire 0.5.0).
+SinusoidalSolver support since 0.5.0; TRUE Sommerfeld since 0.6.0).
 
-Since the refl-coef ground landed in momwire (docs/refl-coef-ground-plan.md
-there), finite ground specs must reach the impedance solve for solvers that
-support it: ("finite", eps_r, sigma) and ("finite-fast", eps_r, sigma) both
-map to the solver's ground_eps (momwire's single finite model — NEC gn 0
-style reflection-coefficient weighting) on the bspline family and, since
-momwire 0.5.0, SinusoidalSolver; TriangularSolver keeps folding to the PEC
-image.
+Finite ground specs reach the impedance solve for solvers that support
+them, and since momwire 0.6.0 the two specs mean different physics:
+("finite", eps_r, sigma) drives momwire's Sommerfeld ground
+(ground_model="sommerfeld", NEC gn 2 style) on plain BSplineSolver, while
+("finite-fast", eps_r, sigma) — and "finite" on the solvers without a
+sommerfeld model (HMatrix/ArrayBlock keep their refl-coef fast paths,
+SinusoidalSolver is refl-coef only) — maps to the reflection-coefficient
+ground_eps solve (NEC gn 0 style). TriangularSolver keeps folding to the
+PEC image.
 
-The numeric tests cross-check the momwire solves against PyNEC gn 0 — the
-oracle the momwire implementations were validated against (dipole 0.1–0.5λ
-window: bspline max |ΔZ| ≈ 2.45 Ω with a ~1.4 Ω cross-solver floor;
-sinusoidal ≈ 0.11 Ω, at its own ~0.11 Ω floor — same basis as NEC).
+The refl-coef numeric tests cross-check against PyNEC gn 0 (dipole
+0.1–0.5λ window: bspline max |ΔZ| ≈ 2.45 Ω, sinusoidal ≈ 0.11 Ω). The
+Sommerfeld numeric tests gate against nec2c-captured gn 2 literals —
+PyNEC's own gn 2 solve is order-dependent in-process and numerically
+broken below 0.1λ (see momwire scripts/capture_refl_coef_ground_golden.py
+for the controls), so it must never be a live oracle at low heights.
 """
 
 import pytest
@@ -45,6 +49,30 @@ def test_finite_specs_map_to_ground_eps_for_bspline():
             _flat_dipole(_height(0.2)), solver=BSplineSolver, ground=spec
         )
         assert eng._ground_eps == (spec[1], spec[2])
+
+
+def test_ground_model_mapping_per_solver_and_spec():
+    """ "finite" → sommerfeld on plain BSplineSolver only; "finite-fast" →
+    refl-coef everywhere; solvers without a sommerfeld model keep
+    refl-coef for both specs; triangular maps nothing."""
+    from momwire import ArrayBlockSolver, HMatrixSolver
+
+    b = _flat_dipole(_height(0.2))
+
+    def model(solver, spec):
+        return MomwireEngine(b, solver=solver, ground=spec)._ground_model
+
+    assert model(BSplineSolver, ("finite", 10.0, 0.002)) == "sommerfeld"
+    assert model(BSplineSolver, ("finite-fast", 10.0, 0.002)) == "refl-coef"
+    for solver in (HMatrixSolver, ArrayBlockSolver, SinusoidalSolver):
+        assert model(solver, ("finite", 10.0, 0.002)) == "refl-coef"
+        assert model(solver, ("finite-fast", 10.0, 0.002)) == "refl-coef"
+    assert model(TriangularSolver, ("finite", 10.0, 0.002)) is None
+    # and the sommerfeld kwarg only reaches solvers that accept it
+    eng = MomwireEngine(b, solver=BSplineSolver, ground=("finite", 10.0, 0.002))
+    assert eng._ground_solver_kwargs().get("ground_model") == "sommerfeld"
+    eng = MomwireEngine(b, solver=SinusoidalSolver, ground=("finite", 10.0, 0.002))
+    assert "ground_model" not in eng._ground_solver_kwargs()
 
 
 def test_finite_specs_fold_to_pec_for_triangular():
@@ -102,3 +130,31 @@ def test_momwire_sinusoidal_finite_ground_tracks_nec_gn0():
     assert abs(z_mom - z_gn0) < 0.6
     assert abs(z_mom - z_gn0) < abs(z_pec - z_gn0)
     assert abs(z_pec - z_gn0) > 10.0  # the gap being fixed is real
+
+
+# nec2c-captured gn 2 oracles (momwire tests/golden_refl_coef_ground.py,
+# regenerated 2026-07-06 via the nec2c CLI): flat dipole, (10.0, 0.002).
+_GN2_NEC2C = {
+    0.05: 68.002 + 1.551j,
+    0.02: 95.080 + 32.413j,
+}
+
+
+@pytest.mark.parametrize(
+    "frac,gate",
+    [(0.05, 2.5), (0.02, 3.0)],  # measured 1.43 / 2.17 through this engine
+)
+def test_momwire_bspline_sommerfeld_tracks_gn2_at_low_heights(frac, gate):
+    """The point of the 0.6.0 upgrade: below 0.1λ the refl-coef model is
+    tens of ohms from the true (gn 2) ground; the ("finite", ...) spec on
+    BSplineSolver now lands at the cross-solver floor there."""
+    builder = _flat_dipole(_height(frac))
+    gn2 = _GN2_NEC2C[frac]
+    z_somm = MomwireEngine(
+        builder, solver=BSplineSolver, ground=("finite", 10.0, 0.002)
+    ).impedance()[0]
+    z_refl = MomwireEngine(
+        builder, solver=BSplineSolver, ground=("finite-fast", 10.0, 0.002)
+    ).impedance()[0]
+    assert abs(z_somm - gn2) < gate
+    assert abs(z_refl - gn2) > 10.0  # the gap sommerfeld closes is real

--- a/tests/test_pynec_ground.py
+++ b/tests/test_pynec_ground.py
@@ -35,8 +35,16 @@ def test_parse_ground_finite_variants():
         parse_ground("finite-slow")
 
 
-def test_momwire_folds_finite_fast_to_its_single_finite_model():
-    assert _normalise_ground(("finite-fast", 10.0, 0.002)) == ("finite", 10.0, 0.002)
+def test_momwire_preserves_the_finite_variant():
+    """Since momwire 0.6.0 the two finite specs mean different physics
+    (true Sommerfeld vs reflection-coefficient), so normalisation must
+    keep the variant instead of folding to a single model."""
+    assert _normalise_ground(("finite-fast", 10.0, 0.002)) == (
+        "finite-fast",
+        10.0,
+        0.002,
+    )
+    assert _normalise_ground(("finite", 10.0, 0.002)) == ("finite", 10.0, 0.002)
 
 
 def test_sommerfeld_and_reflection_coefficient_diverge_when_low():

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1802,11 +1802,12 @@ def test_check_solve_size_unknown_geometry_does_not_falsely_reject(hosted):
     )
 
 
-def test_momwire_bspline_ground_model_drives_refl_coef_solve():
-    """Web ground parity: with a B-spline-family solver, both finite ground
-    models map to momwire's reflection-coefficient solve (its single finite
-    model), the response ships the real εr/σ for the frontend Fresnel cut,
-    and ground_model_applied reports what actually ran."""
+def test_momwire_bspline_ground_model_drives_sommerfeld_solve():
+    """Web ground parity: with the plain B-spline solver the default
+    "sommerfeld" ground model drives momwire's TRUE Sommerfeld solve
+    (momwire >= 0.6.0), "fast" drives the reflection-coefficient one, the
+    response ships the real εr/σ for the frontend Fresnel cut, and
+    ground_model_applied reports what actually ran."""
     base = {
         "geometry": "dipoles.invvee",
         "solver": "momwire",
@@ -1818,19 +1819,22 @@ def test_momwire_bspline_ground_model_drives_refl_coef_solve():
     fast = server.solve({**base, "ground_model": "fast"})
     pec = server.solve({**base, "ground_model": "pec"})
 
-    assert somm["ground_model_applied"] == "refl-coef"
+    assert somm["ground_model_applied"] == "sommerfeld"
     assert fast["ground_model_applied"] == "refl-coef"
     assert pec["ground_model_applied"] == "pec-image"
     assert somm["ground_eps_r"] == 10.0
     assert somm["ground_sigma"] == 0.002
     assert somm["ground_eps_im"] < 0.0  # derived -σ/(ωε₀)
     assert pec["ground_eps_r"] == pytest.approx(1.0e10)
-    # "sommerfeld" and "fast" are the same momwire solve (one finite model).
-    assert somm["z_in_re"] == fast["z_in_re"]
-    assert somm["z_in_im"] == fast["z_in_im"]
-    # The finite solve differs measurably from the PEC image solve — the
-    # reactance correction the refl-coef ground exists to deliver.
+    # "sommerfeld" and "fast" are now genuinely different solves of the
+    # same physical ground: distinct values, but in agreement at this
+    # comfortable height (they only diverge hard below ~0.1λ).
+    z_somm = complex(somm["z_in_re"], somm["z_in_im"])
     z_fast = complex(fast["z_in_re"], fast["z_in_im"])
+    assert z_somm != z_fast
+    assert abs(z_somm - z_fast) < 5.0
+    # The finite solves differ measurably from the PEC image solve — the
+    # reactance correction the finite grounds exist to deliver.
     z_pec = complex(pec["z_in_re"], pec["z_in_im"])
     assert abs(z_fast - z_pec) > 2.0
 


### PR DESCRIPTION
## Summary
- momwire 0.6.0 implements NEC's Sommerfeld/Norton finite ground on `BSplineSolver` (`ground_model="sommerfeld"`, validated within ~2.4 Ω of an independent NEC-2 implementation across 0.02–0.5λ heights). `MomwireEngine` now preserves the finite-ground variant instead of folding both specs to one model: `("finite", εr, σ)` drives the true Sommerfeld solve on plain `BSplineSolver`; `("finite-fast", …)` — and `"finite"` on solvers without a sommerfeld model — keeps the reflection-coefficient solve. HMatrix/ArrayBlock deliberately retain their fast refl-coef ground paths (momwire gates their sommerfeld to a dense solve); sinusoidal is refl-coef only; triangular still folds to the PEC image.
- Web: the ground selector's **sommerfeld** choice is now the real thing on the bspline backend, and `ground_model_applied` reports `"sommerfeld"`/`"refl-coef"` per what actually ran. Site docs updated accordingly (solver honest-limitations + web ground-model story).
- Low-height numeric gates use nec2c-captured gn 2 literals: PyNEC's own Sommerfeld solve is order-dependent in-process and numerically broken below 0.1λ (controls in momwire's capture-script docstring), so it is never a live oracle down low.
- Submodule pinned to momwire v0.6.0 + version floor `momwire>=0.6.0` (pyproject + Dockerfile) in the same PR; momwire 0.6.0 is already on PyPI (wheel-smoke safe).

## Test plan
- [x] Full antennaknobs suite green locally against the pinned v0.6.0 submodule (1378 tests, including the new mapping matrix, gn 2 gates at 0.02/0.05λ, and web sommerfeld-vs-fast distinction)
- [x] Site `npm run build` clean (15 pages)
- [ ] CI (including wheel-smoke against PyPI momwire 0.6.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016thQg6NoZB9ETiWPcyTT25