### PR TITLE
Web ground method: refl-coef default everywhere, Sommerfeld opt-in (and selectable on B-spline)

### DIFF
--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -131,7 +131,9 @@ The selector describes what the ground **is**, independent of solver:
 Each solver then models that ground as well as it can, with a method
 sub-choice on both engines — full **Sommerfeld/Norton** (most accurate,
 the reference below ~0.1λ heights) vs. the **reflection-coefficient**
-approximation (faster per solve; fine above ~0.1λ). On momwire the plain
+approximation (the default: much faster per solve, and fine above
+~0.1λ; Sommerfeld is opt-in because it costs seconds per solve on the
+B-spline backend). On momwire the plain
 B-spline solver honours both (true Sommerfeld since momwire 0.6.0,
 validated within ~2.4 Ω of an independent NEC-2 implementation down to
 0.02λ); the accelerated B-spline solvers keep their fast

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -463,13 +463,15 @@ def _build_builder(cls, req: dict):
 
 def _requested_ground_model(req: dict):
     """The frontend's three-way ground model when ground is on, else None.
-    The legacy boolean `ground_fast` is honoured when `ground_model` is
-    absent."""
+    Defaults to "fast" (reflection-coefficient) when `ground_model` is
+    absent — Sommerfeld is opt-in everywhere because it is the expensive
+    model (seconds per solve on the bspline backend, and PyNEC's own gn 2
+    is ~2x slower). The legacy boolean `ground_fast` remains accepted."""
     if not req.get("ground", False):
         return None
     model = req.get("ground_model")
     if model is None:
-        model = "fast" if req.get("ground_fast", False) else "sommerfeld"
+        model = "fast"
     return model
 
 

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1275,13 +1275,18 @@ function isBSplineFamily(b: Backend): boolean {
 // Sinusoidal keep the PEC image solve — either way the finite constants
 // reach the far-field Fresnel cut.
 type GroundType = "finite" | "pec";
-// PyNEC's finite-ground solve method (NEC ITYPE=2 vs ITYPE=0). Only shown
-// — and only meaningful — when backend === "pynec" && groundType === "finite".
-type PynecGroundMethod = "sommerfeld" | "fast";
-// The wire value (`ground_model` on SolveRequest), unchanged for server
-// compatibility: derived from groundType (+ the PyNEC method when it
-// applies); non-PyNEC finite grounds send the canonical "sommerfeld"
-// (momwire folds "sommerfeld" and "fast" to the same solve).
+// Finite-ground solve method. Meaningful — and shown — where both models
+// are real solves: PyNEC (NEC ITYPE=2 vs ITYPE=0) and the plain B-spline
+// backend (true Sommerfeld since momwire 0.6.0 vs refl-coef). "fast" is
+// the default everywhere; Sommerfeld is opt-in because it is much more
+// expensive per solve (and per sweep point).
+type FiniteGroundMethod = "sommerfeld" | "fast";
+function backendHasGroundMethod(b: Backend): boolean {
+  return b === "pynec" || b === "bspline";
+}
+// The wire value (`ground_model` on SolveRequest): derived from groundType
+// (+ the method where it applies); other finite-ground backends send
+// "fast" (their single finite model is the refl-coef one anyway).
 type GroundModel = "sommerfeld" | "fast" | "pec";
 
 function backendSupportsGround(b: Backend): boolean {
@@ -2367,30 +2372,33 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   // Shared ground choice — one selector describing the GROUND (finite vs
   // PEC); every backend solves it as best it can (see the GroundType note).
   const [groundType, setGroundType] = useState<GroundType>("finite");
-  // PyNEC-only finite-ground method; hidden (and inert) elsewhere, but kept
-  // in state so it survives backend flips during engine comparison.
-  const [pynecGroundMethod, setPynecGroundMethod] =
-    useState<PynecGroundMethod>("sommerfeld");
-  // Wire value derived for the unchanged server protocol (see GroundModel).
+  // Finite-ground method; hidden (and inert) on backends with a single
+  // finite model, but kept in state so it survives backend flips during
+  // engine comparison. Defaults to "fast" — Sommerfeld is opt-in (it costs
+  // seconds per solve on the B-spline backend).
+  const [finiteGroundMethod, setFiniteGroundMethod] =
+    useState<FiniteGroundMethod>("fast");
+  // Wire value derived for the server protocol (see GroundModel).
   const groundModel: GroundModel =
     groundType === "pec"
       ? "pec"
-      : backend === "pynec"
-        ? pynecGroundMethod
-        : "sommerfeld";
+      : backendHasGroundMethod(backend)
+        ? finiteGroundMethod
+        : "fast";
 
   // One-line tab-hover summary: design · solver N=segs · ground model. The
-  // wording reflects what the active solver actually runs: PyNEC honours
-  // the model directly; momwire B-spline-family solves refl-coef for both
-  // finite models; Triangular/Sinusoidal solve the PEC image and only the
-  // far-field pattern sees the finite constants. "free space" when ground
-  // is off or unsupported.
+  // wording reflects what the active solver actually runs: PyNEC and the
+  // plain B-spline backend honour the selected method; H-matrix/Array-block
+  // solve refl-coef for any finite model (their fast ground paths);
+  // Triangular/Sinusoidal solve the PEC image and only the far-field
+  // pattern sees the finite constants. "free space" when ground is off or
+  // unsupported.
   const groundActiveForSummary = groundEnabled && backendSupportsGround(backend);
   const groundSummary = !groundActiveForSummary
     ? "free space"
     : groundModel === "pec"
       ? "PEC ground"
-      : backend === "pynec"
+      : backendHasGroundMethod(backend)
         ? groundModel === "fast"
           ? "reflection-coef ground"
           : "Sommerfeld ground"
@@ -3410,7 +3418,9 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     // the active variant's entry in variant_ui, falling back to the
     // design-level sweep_policy.
     const slowGround =
-      backend === "pynec" && groundEnabled && groundModel === "sommerfeld";
+      backendHasGroundMethod(backend) &&
+      groundEnabled &&
+      groundModel === "sommerfeld";
     const N = slowGround ? 21 : 41;
     const policy =
       currentExample?.variant_ui?.[currentVariant]?.sweep_policy ??
@@ -4551,7 +4561,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                 ))}
               </div>
               {groundType === "finite" &&
-                (backend === "pynec" ? (
+                (backendHasGroundMethod(backend) ? (
                   <div
                     role="radiogroup"
                     aria-label="Finite-ground solve method"
@@ -4560,23 +4570,27 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                     {(
                       [
                         [
-                          "sommerfeld",
-                          "Sommerfeld",
-                          "Sommerfeld-Norton (NEC ITYPE=2) — most accurate, slowest; the impedance sweep drops to half resolution to compensate.",
-                        ],
-                        [
                           "fast",
                           "refl-coef (fast)",
-                          "Reflection-coefficient approximation (NEC ITYPE=0). ~2x faster per solve; impedance degrades below ~0.1λ height.",
+                          backend === "pynec"
+                            ? "Reflection-coefficient approximation (NEC ITYPE=0), the default. ~2x faster per solve; impedance degrades below ~0.1λ height."
+                            : "Reflection-coefficient model, the default. Fast; matches Sommerfeld above ~0.1λ heights.",
                         ],
-                      ] as [PynecGroundMethod, string, string][]
+                        [
+                          "sommerfeld",
+                          "Sommerfeld",
+                          backend === "pynec"
+                            ? "Sommerfeld-Norton (NEC ITYPE=2) — most accurate, slowest; the impedance sweep drops to half resolution to compensate."
+                            : "True Sommerfeld ground (momwire ≥ 0.6.0) — accurate at any height, but seconds per solve; the impedance sweep drops to half resolution to compensate.",
+                        ],
+                      ] as [FiniteGroundMethod, string, string][]
                     ).map(([value, label, title]) => (
                       <label key={value} className="link-toggle" title={title}>
                         <input
                           type="radio"
                           name="ground-method"
-                          checked={pynecGroundMethod === value}
-                          onChange={() => setPynecGroundMethod(value)}
+                          checked={finiteGroundMethod === value}
+                          onChange={() => setFiniteGroundMethod(value)}
                         />
                         {label}
                       </label>
@@ -4591,7 +4605,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                     }}
                   >
                     {isBSplineFamily(backend)
-                      ? "solved as refl-coef (momwire's finite model)"
+                      ? "solved as refl-coef (this solver's fast ground path)"
                       : "impedance solve uses the PEC image; pattern uses εr/σ"}
                   </em>
                 ))}

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -896,17 +896,22 @@ def test_solve_dispatches_to_pynec_when_requested():
 
 
 @pynec_required
-def test_pynec_ground_on_solves_over_sommerfeld_finite_ground():
+def test_pynec_ground_on_solves_over_finite_ground():
     base = {
         "geometry": "dipoles.invvee",
         "solver": "pynec",
         "measurement_freq_mhz": 28.47,
     }
     free = server.solve(base)
-    grounded = server.solve({**base, "ground": True})
-    # ground=True routes PyNEC to the Sommerfeld finite ground (εr=10,
-    # σ=0.002) rather than silently staying PEC/free, and the response
-    # carries the real constants so the frontend's Fresnel cut matches.
+    grounded = server.solve({**base, "ground": True, "ground_model": "sommerfeld"})
+    default = server.solve({**base, "ground": True})
+    # Sommerfeld is opt-in (expensive); a bare ground=True defaults to the
+    # reflection-coefficient model.
+    assert default["ground_model_applied"] == "refl-coef"
+    # ground=True + sommerfeld routes PyNEC to the Sommerfeld finite ground
+    # (εr=10, σ=0.002) rather than silently staying PEC/free, and the
+    # response carries the real constants so the frontend's Fresnel cut
+    # matches.
     assert grounded["ground"] is True
     assert grounded["ground_eps_r"] == 10.0
     assert grounded["ground_sigma"] == 0.002
@@ -932,7 +937,7 @@ def test_pynec_ground_model_selects_pec_fast_or_sommerfeld():
         "measurement_freq_mhz": 28.47,
         "ground": True,
     }
-    somm = server.solve(base)
+    somm = server.solve({**base, "ground_model": "sommerfeld"})
     fast = server.solve({**base, "ground_model": "fast"})
     fast_legacy = server.solve({**base, "ground_fast": True})
     pec = server.solve({**base, "ground_model": "pec"})
@@ -1815,12 +1820,16 @@ def test_momwire_bspline_ground_model_drives_sommerfeld_solve():
         "measurement_freq_mhz": 28.47,
         "ground": True,
     }
-    somm = server.solve(base)  # default ground_model = sommerfeld
+    somm = server.solve({**base, "ground_model": "sommerfeld"})
     fast = server.solve({**base, "ground_model": "fast"})
+    default = server.solve(base)
     pec = server.solve({**base, "ground_model": "pec"})
 
     assert somm["ground_model_applied"] == "sommerfeld"
     assert fast["ground_model_applied"] == "refl-coef"
+    # Sommerfeld costs seconds per solve, so it is opt-in: the default is
+    # the reflection-coefficient model.
+    assert default["ground_model_applied"] == "refl-coef"
     assert pec["ground_model_applied"] == "pec-image"
     assert somm["ground_eps_r"] == 10.0
     assert somm["ground_sigma"] == 0.002
@@ -1850,7 +1859,7 @@ def test_momwire_sinusoidal_ground_model_drives_refl_coef_solve():
         "measurement_freq_mhz": 28.47,
         "ground": True,
     }
-    fin = server.solve(base)  # default ground_model = sommerfeld
+    fin = server.solve(base)  # default ground_model = fast (refl-coef)
     pec = server.solve({**base, "ground_model": "pec"})
 
     assert fin["ground_model_applied"] == "refl-coef"


### PR DESCRIPTION
## Summary
- The finite-ground method selector (Sommerfeld vs refl-coef) now appears for the plain B-spline backend as well as PyNEC — both are real, different solves since momwire 0.6.0. Previously momwire requests hardcoded `"sommerfeld"`, which silently opted bspline into the expensive solve after PR #260 stopped folding the specs.
- The default flips to **fast (refl-coef)** everywhere — frontend state and the server-side `ground_model` fallback. Sommerfeld is opt-in: it costs seconds per solve on the bspline backend (per-frequency Sommerfeld grid fills) and slows sweeps. When opted in, bspline sweeps drop to half resolution like PyNEC's already did.
- Tooltips, tab summary, and web.md say which model actually runs per backend and that fast is the default.

## Test plan
- [x] `tsc --noEmit` + vite build clean
- [x] web ground tests updated for the new default (explicit sommerfeld requests + default-is-refl-coef assertions): 10 passed
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016thQg6NoZB9ETiWPcyTT25