### PR TITLE
Release v0.17.0: true Sommerfeld ground on the B-spline solver (opt-in), refl-coef default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.16.0"
+version = "0.17.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,11 +25,13 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.16.0" icon="star">
-  **Real-ground impedance on the sinusoidal solver** — finite grounds now
-  drive its impedance solve instead of folding to a perfect-conductor image,
-  matching NEC's finite-ground model to ~0.1 Ω. And **release notes are now
-  published for every version** of the app and the engine.
+<Card title="New in v0.17.0" icon="star">
+  **True Sommerfeld ground on the B-spline solver** — the exact
+  finite-ground model (NEC's gn 2), accurate at *any* antenna height:
+  validated within ~2.4 Ω of an independent NEC-2 implementation down to
+  0.02 λ, where reflection-coefficient models are tens of ohms off.
+  Opt in from the ground selector's method choice — the fast
+  reflection-coefficient model stays the default.
   [All release notes →](/reference/releases/)
 </Card>
 


### PR DESCRIPTION
## Summary
- Version 0.16.0 → 0.17.0. Headline: momwire 0.6.0's **true Sommerfeld finite ground** on the B-spline solver — validated within ~2.4 Ω of an independent NEC-2 implementation down to 0.02λ heights — opt-in via the web ground method selector, with the fast reflection-coefficient model as the default everywhere.
- Home-page what's-new box refreshed per the release ritual.
- Also brings PyPI back into a tested state: released 0.16.0 resolves momwire 0.6.0 today (floor was >=0.5.0), a pairing 0.16.0 was never validated with; 0.17.0 pins the floor at momwire>=0.6.0 and was tested against it end to end.
- Tagging the merge commit v0.17.0 triple-deploys: PyPI, the hosted simulator, and the docs site.

## Test plan
- [x] Full suite green on main pre-branch (post-merge run 28870182974)
- [x] Site build clean; box renders "New in v0.17.0"
- [ ] CI on this PR; post-tag: PyPI publish + fly deploy + docs deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016thQg6NoZB9ETiWPcyTT25