### PR TITLE
momwire 0.7.0: Sommerfeld ground solves reuse cached grids (~20x faster sweeps)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/sta
 # install below sees its requirement already satisfied, then the package with the
 # web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install "momwire==0.6.0" \
+ && pip install "momwire==0.7.0" \
  && pip install -e ".[web]"
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire==0.6.0",
+    "momwire==0.7.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -132,8 +132,10 @@ Each solver then models that ground as well as it can, with a method
 sub-choice on both engines — full **Sommerfeld/Norton** (most accurate,
 the reference below ~0.1λ heights) vs. the **reflection-coefficient**
 approximation (the default: much faster per solve, and fine above
-~0.1λ; Sommerfeld is opt-in because it costs seconds per solve on the
-B-spline backend). On momwire the plain
+~0.1λ; Sommerfeld is opt-in because its first solve at each frequency
+builds an interpolation grid — so the first sweep takes a few seconds —
+though repeat solves reuse cached grids and run in tens of milliseconds
+since momwire 0.7.0). On momwire the plain
 B-spline solver honours both (true Sommerfeld since momwire 0.6.0,
 validated within ~2.4 Ω of an independent NEC-2 implementation down to
 0.02λ); the accelerated B-spline solvers keep their fast

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1268,18 +1268,20 @@ function isBSplineFamily(b: Backend): boolean {
 // The UI separates WHAT the ground is from HOW it's solved. GroundType is
 // the shared, backend-agnostic choice: a finite ground (εr=10, σ=0.002) or
 // a perfectly conducting one. It never promises more than the physics —
-// each backend solves it as best it can: PyNEC picks Sommerfeld-Norton or
-// the reflection-coefficient approximation via a PyNEC-only method
-// sub-choice; momwire's B-spline family always solves finite grounds with
-// its reflection-coefficient model (momwire has no Sommerfeld); Triangular/
-// Sinusoidal keep the PEC image solve — either way the finite constants
-// reach the far-field Fresnel cut.
+// each backend solves it as best it can: PyNEC and the plain B-spline
+// backend offer a method sub-choice (Sommerfeld-Norton vs the
+// reflection-coefficient approximation); the fast B-spline variants use
+// refl-coef; Triangular/Sinusoidal keep the PEC image solve — either way
+// the finite constants reach the far-field Fresnel cut.
 type GroundType = "finite" | "pec";
 // Finite-ground solve method. Meaningful — and shown — where both models
 // are real solves: PyNEC (NEC ITYPE=2 vs ITYPE=0) and the plain B-spline
 // backend (true Sommerfeld since momwire 0.6.0 vs refl-coef). "fast" is
-// the default everywhere; Sommerfeld is opt-in because it is much more
-// expensive per solve (and per sweep point).
+// the default everywhere; Sommerfeld is opt-in because it is more
+// expensive: since momwire 0.7.0 the first solve at a new frequency fills
+// an interpolation grid (~0.2-0.5 s on a small box; the first sweep pays
+// that per point), and repeat solves at seen frequencies reuse cached
+// grids (tens of ms).
 type FiniteGroundMethod = "sommerfeld" | "fast";
 function backendHasGroundMethod(b: Backend): boolean {
   return b === "pynec" || b === "bspline";
@@ -3407,10 +3409,14 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     const controller = new AbortController();
     sweepAbortRef.current = controller;
 
-    // Sweep range, log-spaced. Sommerfeld-Norton ground is ~100x slower
-    // per point, so halve the resolution there to keep total sweep time
-    // near free-space cost. Fast (reflection-coefficient) ground and momwire
-    // PEC ground are cheap enough for full resolution.
+    // Sweep range, log-spaced. Sommerfeld ground stays at half resolution:
+    // momwire 0.7.0's C++ fill + grid cache made warm sweeps fast (~30 ms
+    // per point once the per-frequency grids are cached; measured 0.6 s for
+    // 21 points at 2 threads), but the FIRST sweep after enabling it still
+    // fills one grid per point (measured 4.3 s for 21 points at 2 threads;
+    // 41 would be ~9 s) — half resolution halves that cold hit. Fast
+    // (reflection-coefficient) ground and momwire PEC ground are cheap
+    // enough for full resolution.
     //
     // Anchor + span come from the active example's sweep_policy. See
     // SweepPolicy in web/examples/_base.py for the meaning of the fields.
@@ -4581,7 +4587,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                           "Sommerfeld",
                           backend === "pynec"
                             ? "Sommerfeld-Norton (NEC ITYPE=2) — most accurate, slowest; the impedance sweep drops to half resolution to compensate."
-                            : "True Sommerfeld ground (momwire ≥ 0.6.0) — accurate at any height, but seconds per solve; the impedance sweep drops to half resolution to compensate.",
+                            : "True Sommerfeld ground (momwire ≥ 0.6.0) — accurate at any height. First solve at each frequency builds a grid (seconds); repeats are fast. The impedance sweep runs at half resolution.",
                         ],
                       ] as [FiniteGroundMethod, string, string][]
                     ).map(([value, label, title]) => (


### PR DESCRIPTION
## Summary
- Submodule → momwire v0.7.0 + exact pins `momwire==0.7.0` in pyproject and Dockerfile together (first release under the exact-pin policy from #263).
- momwire 0.7.0 brings the Sommerfeld perf work: module-level grid cache + C++ fill kernel with OpenMP + cooperative cancellation reaching mid-fill. Measured through the web engine path at 2 threads: 21-pt Sommerfeld sweep **4.3 s cold / 0.61 s warm** (was ~24 s / 12 s), repeat single solves ~30 ms.
- Sweep stays at half resolution (N=21) for the Sommerfeld method: the cold first sweep still fills one grid per frequency; halving it halves the opt-in first hit.
- UI/docs copy updated to the new cost reality (and a stale 'momwire has no Sommerfeld' comment fixed).

## Test plan
- [x] Full suite against the v0.7.0 submodule: 1378 passed
- [x] Latency smoke cold/warm at 2 threads (numbers above)
- [x] momwire 0.7.0 verified on PyPI before this PR (wheel-smoke race)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016thQg6NoZB9ETiWPcyTT25