### PR TITLE
Release 0.18.0: Sommerfeld ground goes interactive (momwire 0.7.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.17.0"
+version = "0.18.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,13 +25,14 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.17.0" icon="star">
-  **True Sommerfeld ground on the B-spline solver** — the exact
-  finite-ground model (NEC's gn 2), accurate at *any* antenna height:
-  validated within ~2.4 Ω of an independent NEC-2 implementation down to
-  0.02 λ, where reflection-coefficient models are tens of ohms off.
-  Opt in from the ground selector's method choice — the fast
-  reflection-coefficient model stays the default.
+<Card title="New in v0.18.0" icon="star">
+  **Sommerfeld ground is now interactive.** The exact finite-ground
+  model introduced in v0.17.0 got a C++ engine and a grid cache in
+  momwire 0.7.0: repeat solves reuse cached interpolation grids, so
+  knob-turns respond in tens of milliseconds and impedance sweeps run
+  ~20× faster once warm — same physics, validated within ~2.4 Ω of an
+  independent NEC-2 implementation down to 0.02 λ. Superseded solves
+  now cancel mid-computation too.
   [All release notes →](/reference/releases/)
 </Card>
 


### PR DESCRIPTION
## Summary
- Version bump to 0.18.0 and what's-new box refresh.
- Ships #264: momwire 0.7.0 (Sommerfeld grid cache + C++ fill kernel + mid-fill cancellation), exact pins, honest cost copy.

## Test plan
- [x] 1378 tests green on #264 against the v0.7.0 submodule
- [ ] After merge: tag v0.18.0 → verify PyPI + simulator + docs deploys and the what's-new box

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016thQg6NoZB9ETiWPcyTT25