### PR TITLE
Per-variant slider ranges (variant_ui params) and a narrowed invvee length knob

### DIFF
--- a/docs/plan-catalog-scaling.md
+++ b/docs/plan-catalog-scaling.md
@@ -1,0 +1,102 @@
+# Plan: catalog architecture for 1k–10k designs
+
+Status: **future / not started.** Scoped 2026-07-08 during the per-variant
+ui_params work (PR #266), when "does /examples ship the whole catalog?"
+turned into "what would 10,000 designs need?". Nothing here is worth
+building at today's ~75 designs — see the trigger conditions at the end.
+
+## Where today's architecture is O(catalog)
+
+Three costs scale linearly with the number of registered designs:
+
+1. **Boot.** `register_all()` imports every design module and runs every
+   builder's `build_wires()` once to prime the derived hints
+   (`default_view`, `target_z0`, `multi_feed`, recommended backend). At
+   ~75 designs this is unnoticeable; at 10k it is minutes of imports and
+   geometry builds before the server can answer anything.
+2. **`GET /examples`.** One monolithic payload carrying every design's
+   full descriptor (param_schema, variants, variant_values, variant_ui,
+   bands, sweep_policy). Measured 2026-07-08: 240 kB uncompressed for 75
+   designs (~3.2 kB/design mean; group-heavy multiband designs 6–7 kB).
+   Linear extrapolation: ~3 MB at 1k, ~32 MB at 10k.
+3. **Discovery UX.** A flat family-grouped picker; unusable at 1k
+   regardless of payload size.
+
+What already does NOT scale with the catalog: solves, sweeps, geometry —
+all per-selected-design. And user designs already have the lazy pattern
+(`defer_hints=True`, rescan on request) that built-ins lack.
+
+## Target architecture
+
+### 1. Split the wire contract: index vs descriptor
+
+- `GET /catalog` — lightweight index entries only: name, label, family,
+  tags, one-line blurb, optional thumbnail URL. ~150–200 B/entry, so
+  even 10k ≈ 2 MB uncompressed — and with server-side search, facets,
+  and pagination the client never fetches it all anyway.
+- `GET /designs/{name}` — the full per-design descriptor, exactly the
+  shape one element of today's `/examples` array has. Fetched lazily on
+  selection, cached client-side keyed by (name, catalog version).
+
+The important property: **the existing descriptor shape becomes the
+lazy-loading unit unchanged.** ParamForm, variant_values overlay,
+variant_ui presentation hints — no downstream consumer changes.
+
+### 2. Build-time manifest for built-ins
+
+Derive every built-in design's descriptor at *package build time*: CI
+runs the same `_make_example` derivation and emits a static JSON
+manifest shipped in the wheel. At runtime the server serves index and
+descriptors straight from the manifest without importing a single
+design module. A design's module imports on its first *solve* — where
+the builder has to run anyway.
+
+This also kills the eager hint priming: hints are baked into the
+manifest for built-ins. `defer_hints=True` (today's user-design path)
+becomes the universal runtime rule rather than the exception.
+
+Skew guard: a manifest is derived output, so CI must assert
+manifest == live derivation for every design (one parametrized test),
+or the wheel build simply regenerates it unconditionally.
+
+### 3. Discovery as a server capability
+
+At 1k+ the picker is a search box, not a list: full-text over
+name/blurb/tags, facets (family, band coverage, polarization, feed
+impedance class), typeahead endpoint. Because descriptors are static
+per release, CI can also precompute *derived performance metrics* —
+gain, F/B, SWR bandwidth at design frequency — enabling sort/filter by
+performance. These must never be computed at request time; they are
+exactly the kind of thing the golden-capture scripts already know how
+to batch.
+
+### 4. Caching
+
+Built-in descriptors are immutable per release → ETag / long-lived
+immutable cache headers, CDN-friendly (the SPA is already static).
+User designs stay dynamic in their own namespace with the same
+descriptor contract — they are the only part that cannot be baked.
+
+## Migration path (each step independently valuable)
+
+1. Generalize `defer_hints` to all designs; stop running builders at
+   boot. (Smallest step, removes the boot-time O(catalog) term.)
+2. Split `/catalog` from `/designs/{name}`; frontend grows a small
+   descriptor cache. Comfortably carries ~1k designs.
+3. Build-time manifest for built-ins. Carries 10k.
+4. Search/facets/typeahead + precomputed performance metrics, when the
+   catalog is actually big enough that discovery is the bottleneck.
+
+## Trigger conditions (when to start)
+
+Do NOT build this at ~75 designs — the monolith is simpler to keep
+correct (one derivation path, no manifest/runtime skew class). Start
+step 1–2 when any of:
+
+- server boot time becomes noticeable in deploys or dev iteration,
+- `/examples` exceeds ~1 MB uncompressed (~300 designs at current
+  per-design size),
+- the design picker needs search to be usable.
+
+Step 3 only when import cost at boot is the residual problem after
+steps 1–2.

--- a/docs/plan-variant-overlay.md
+++ b/docs/plan-variant-overlay.md
@@ -1,7 +1,15 @@
 # Plan: variants as an overlay on `default_params` (incl. per-variant `ui_params`)
 
-Status: **merge mechanism landed (Option A); per-variant ui derivation still
-open.** Scoped 2026-07-03 out of the triangular-skyloop work, where we wanted a
+Status: **COMPLETE.** Merge mechanism landed 2026-07-03 (Option A); the
+remaining per-variant ui derivation landed 2026-07-08 (PR #266):
+`_make_example` diffs each variant's merged `ui_params` against the
+default's and emits `variant_ui` with per-variant `sweep_policy` and
+explicit per-param presentation hints (`params`: slider min/max/step,
+precision, unit, label, hidden), which the frontend overlays on
+`param_schema` for the active variant. First users: triangular_skyloop's
+band_locked sweep policy; dipoles.invvee's per-variant length_factor
+ranges and the dipole variant's hidden angle_deg knob. Originally scoped
+2026-07-03 out of the triangular-skyloop work, where we wanted a
 "band-locked" *variant* of a design but found the sweep policy is pinned
 per-design, not per-variant.
 

--- a/src/antennaknobs/designs/beams/hexbeam.py
+++ b/src/antennaknobs/designs/beams/hexbeam.py
@@ -11,6 +11,11 @@ class Builder(AntennaBuilder):
             "halfdriver": 2.82,
             "tipspacer_factor": 0.1312,
             "t0_factor": 0.1243,
+            # The opt variant's tip spacer (0.208) sits above the auto ±50%
+            # window around the default (≤0.197).
+            "ui_params": MappingProxyType(
+                {"tipspacer_factor": {"min": 0.065, "max": 0.25}}
+            ),
         }
     )
 

--- a/src/antennaknobs/designs/broadband/t2fd.py
+++ b/src/antennaknobs/designs/broadband/t2fd.py
@@ -69,7 +69,7 @@ class Builder(AntennaBuilder):
                         "max": 0.03,
                     },
                     "tilt_deg": {"min": 0.0, "max": 45.0, "step": 1.0, "precision": 1},
-                    "term_r": {"min": 200.0, "max": 800.0, "step": 10.0},
+                    "term_r": {"min": 200.0, "max": 1000.0, "step": 10.0},
                 }
             ),
         }

--- a/src/antennaknobs/designs/dipoles/invvee.py
+++ b/src/antennaknobs/designs/dipoles/invvee.py
@@ -12,14 +12,24 @@ class Builder(AntennaBuilder):
             "base": 7.0,
             "length_factor": 0.9719,
             "angle_deg": 31.6846,
-            # length_factor span has to cover both the half-wave default
-            # (~0.97) and the EDZ variant (~2.97, encoding a ~1.5λ
-            # element). Auto-derive's ±50% window would clip at ~1.46.
             "ui_params": MappingProxyType(
                 {
+                    # Half-wave tuning window for the default inv-vee and
+                    # the flat dipole variant. The long-wire variants carry
+                    # their own ranges (the same ×0.8–×1.25 window around
+                    # their lengths) in their variant ui_params, forwarded
+                    # per-variant via the /examples variant_ui["params"]
+                    # channel.
                     "length_factor": {
-                        "min": 0.4,
-                        "max": 3.2,
+                        "min": 0.8,
+                        "max": 1.25,
+                    },
+                    # Cover the default 31.7° droop AND the flat (0°)
+                    # variants: the auto ±50% window (15.8–47.5°) strands
+                    # the flat variants' angle below the slider minimum.
+                    "angle_deg": {
+                        "min": 0.0,
+                        "max": 60.0,
                     },
                 }
             ),
@@ -46,7 +56,15 @@ class Builder(AntennaBuilder):
     # length_factor parameterises driver_y as 0.25·λ·length_factor, so
     # this 0.7422·λ driver_y lands at length_factor = 0.7422 / 0.25 =
     # 2.9688 (giving 2 × 0.7422 = 1.4844λ total length).
-    three_halves_params = MappingProxyType({"length_factor": 2.9688, "angle_deg": 0.0})
+    three_halves_params = MappingProxyType(
+        {
+            "length_factor": 2.9688,
+            "angle_deg": 0.0,
+            "ui_params": MappingProxyType(
+                {"length_factor": {"min": 2.38, "max": 3.71}}
+            ),
+        }
+    )
 
     # Classic Extended Double Zepp: 1.28λ total length (driver_y =
     # 0.64λ per leg → length_factor = 0.64 / 0.25 = 2.56). Tuned for
@@ -54,7 +72,13 @@ class Builder(AntennaBuilder):
     # above ~1λ anti-resonance, so the input impedance is high and
     # very reactive (≈ 100 − j600 Ω at the design freq) and a matching
     # network is required.
-    classic_edz_params = MappingProxyType({"length_factor": 2.56, "angle_deg": 0.0})
+    classic_edz_params = MappingProxyType(
+        {
+            "length_factor": 2.56,
+            "angle_deg": 0.0,
+            "ui_params": MappingProxyType({"length_factor": {"min": 2.05, "max": 3.2}}),
+        }
+    )
 
     def build_wires(self):
         eps = 0.05

--- a/src/antennaknobs/designs/dipoles/invvee.py
+++ b/src/antennaknobs/designs/dipoles/invvee.py
@@ -44,7 +44,15 @@ class Builder(AntennaBuilder):
     # dipoles.invvee.
     # Variants overlay default_params; each states only its length_factor /
     # angle_deg tuning (design_freq / freq / base come from default).
-    dipole_params = MappingProxyType({"length_factor": 0.967, "angle_deg": 0.0})
+    dipole_params = MappingProxyType(
+        {
+            "length_factor": 0.967,
+            "angle_deg": 0.0,
+            # Flat by definition: pin the droop at 0 and hide its knob
+            # (droop exploration belongs to the default inv-vee variant).
+            "ui_params": MappingProxyType({"angle_deg": {"hidden": True}}),
+        }
+    )
 
     # Three-halves dipole: 1.484λ-long flat dipole, tuned to a near-
     # resonant length where Z_in collapses to ~95 Ω (real). Not the

--- a/src/antennaknobs/designs/loops/delta_loop_slanted.py
+++ b/src/antennaknobs/designs/loops/delta_loop_slanted.py
@@ -15,6 +15,10 @@ class Builder(AntennaBuilder):
             "length_factor": 1.0893,
             "angle_deg": 63.5181,
             "slant_deg": 15.0,
+            # Cover the full variant family (slant0 through slant30 with
+            # headroom): the auto ±50% window around the 15° default
+            # (7.5–22.5°) strands both non-default variants.
+            "ui_params": MappingProxyType({"slant_deg": {"min": 0.0, "max": 45.0}}),
         }
     )
 

--- a/src/antennaknobs/designs/loops/diamond_loop.py
+++ b/src/antennaknobs/designs/loops/diamond_loop.py
@@ -12,6 +12,9 @@ class Builder(AntennaBuilder):
             "base": 7.0,
             "length_factor": 1.0703,
             "angle_deg": 30.8767,
+            # Cover both feed variants: the z100 apex angle (51.5°) sits
+            # above the auto ±50% window around the z200 default (≤46.3°).
+            "ui_params": MappingProxyType({"angle_deg": {"min": 15.0, "max": 60.0}}),
         }
     )
 

--- a/src/antennaknobs/designs/specialty/helix.py
+++ b/src/antennaknobs/designs/specialty/helix.py
@@ -72,7 +72,7 @@ class Builder(AntennaBuilder):
                     # length_factor); pin it and keep length_factor as the knob.
                     "axial_frac": {"hidden": True},
                     "n_turns": {
-                        "min": 3.0,
+                        "min": 2.0,
                         "max": 9.0,
                         "step": 0.05,
                         "precision": 2,

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -955,7 +955,10 @@ def _derive_sweep_policy(ui: dict) -> SweepPolicy:
 # Presentation fields a variant's explicit ui_params may move per-variant
 # (forwarded through variant_ui["params"] and overlaid on the base schema by
 # the frontend). Values/defaults are variant_values' job, never listed here.
-_VARIANT_SPEC_KEYS = ("min", "max", "step", "precision", "unit", "label")
+# `hidden` only HIDES a base-visible knob for that variant (the value still
+# flows through solves via variant_values); it cannot unhide a knob hidden at
+# the design level — those never enter param_schema at all.
+_VARIANT_SPEC_KEYS = ("min", "max", "step", "precision", "unit", "label", "hidden")
 
 
 def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExample:

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -40,6 +40,7 @@ import importlib
 import math
 import pathlib
 import time
+from collections.abc import Mapping
 from functools import lru_cache
 from typing import Any
 
@@ -951,6 +952,12 @@ def _derive_sweep_policy(ui: dict) -> SweepPolicy:
     return DEFAULT_SWEEP_POLICY
 
 
+# Presentation fields a variant's explicit ui_params may move per-variant
+# (forwarded through variant_ui["params"] and overlaid on the base schema by
+# the frontend). Values/defaults are variant_values' job, never listed here.
+_VARIANT_SPEC_KEYS = ("min", "max", "step", "precision", "unit", "label")
+
+
 def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExample:
     dp = dict(cls.default_params)
     ui = dict(dp.get("ui_params") or {})
@@ -1025,14 +1032,41 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
     # (default) value; the frontend falls back to the top-level field otherwise.
     # Extensible per-variant map so more hints can move per-variant later
     # without another /examples contract change.
+    #
+    # Besides sweep_policy, per-param presentation hints (slider min/max/step,
+    # precision, unit, label) forward under "params" — EXPLICIT hints only,
+    # diffed against the default's ui_params. Deliberately NOT a diff of
+    # re-derived schemas: the auto-derivation windows track each variant's
+    # *values* (a flat variant's angle_deg=0 would auto-window to a useless
+    # -1..1), so only hints a variant actually authors move with it. First
+    # user: dipoles.invvee, whose long-wire variants carry their own
+    # length_factor slider ranges.
     variant_ui: dict[str, dict[str, Any]] = {}
     for v in variants:
         if v == "default":
             continue
         v_ui = dict(resolve_variant_params(cls, v).get("ui_params") or {})
+        hints_v: dict[str, Any] = {}
         v_sweep = _derive_sweep_policy(v_ui)
         if v_sweep != sweep_policy:
-            variant_ui[v] = {"sweep_policy": v_sweep}
+            hints_v["sweep_policy"] = v_sweep
+        p_over: dict[str, dict[str, Any]] = {}
+        for pname, hint in v_ui.items():
+            if not isinstance(hint, Mapping):
+                continue
+            base_hint = ui.get(pname)
+            base_hint = base_hint if isinstance(base_hint, Mapping) else {}
+            diff = {
+                k: hint[k]
+                for k in _VARIANT_SPEC_KEYS
+                if k in hint and hint[k] != base_hint.get(k)
+            }
+            if diff:
+                p_over[pname] = diff
+        if p_over:
+            hints_v["params"] = p_over
+        if hints_v:
+            variant_ui[v] = hints_v
 
     def _design_freq_default(req: dict) -> float:
         # The active variant's `freq` is the right fallback when the

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -175,7 +175,7 @@ type ExampleDescriptor = {
             SchemaParamSpec,
             "min" | "max" | "step" | "precision" | "unit" | "label"
           >
-        >;
+        > & { hidden?: boolean };
       };
     };
   };
@@ -2172,11 +2172,18 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     if (!currentExample) return [];
     const over = currentExample.variant_ui?.[currentVariant]?.params;
     if (!over) return currentExample.param_schema;
-    return currentExample.param_schema.map((item) =>
-      !isGroup(item) && over[item.name]
-        ? { ...item, ...over[item.name] }
-        : item,
-    );
+    return currentExample.param_schema
+      .map((item) =>
+        !isGroup(item) && over[item.name]
+          ? { ...item, ...over[item.name] }
+          : item,
+      )
+      .filter(
+        // A variant can hide a base-visible knob (e.g. invvee:dipole's
+        // angle_deg — flat by definition, value pinned at 0 by the
+        // variant). Display-only: the value still rides variant_values.
+        (item) => isGroup(item) || !(item as { hidden?: boolean }).hidden,
+      );
   }, [currentExample, currentVariant]);
 
   // Switch to a different variant: overlay the variant's per-param

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -162,7 +162,23 @@ type ExampleDescriptor = {
    *  whose derived hints differ from the design-level values appear; look up
    *  the active variant and fall back to the top-level field (e.g.
    *  `sweep_policy`) for any variant not listed. */
-  variant_ui?: { [variant: string]: { sweep_policy?: SweepPolicy } };
+  variant_ui?: {
+    [variant: string]: {
+      sweep_policy?: SweepPolicy;
+      /** Explicit per-param presentation overrides for this variant
+       *  (slider min/max/step, precision, unit, label), overlaid on
+       *  param_schema entries by name. Values come from variant_values,
+       *  never from here. */
+      params?: {
+        [name: string]: Partial<
+          Pick<
+            SchemaParamSpec,
+            "min" | "max" | "step" | "precision" | "unit" | "label"
+          >
+        >;
+      };
+    };
+  };
   /** Grid-level layout for the top-level knob rail. {columns: N} pins the
    *  grid to a fixed column count so per-knob `layout.col` positions are
    *  stable. null = responsive auto-flow packing. */
@@ -2146,6 +2162,23 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   const currentVariant =
     variantByGeom[geometry] ?? currentExample?.variants?.[0] ?? "default";
 
+  // param_schema with the active variant's explicit presentation
+  // overrides (variant_ui[variant].params) overlaid per param — e.g.
+  // invvee's long-wire variants carry their own length_factor slider
+  // range. Feeds the knob rail and the per-knob optimiser menu so both
+  // see variant-correct bounds; value seeding stays on the raw schema
+  // (defaults/values are variant_values' job).
+  const currentSchema = useMemo<SchemaItem[]>(() => {
+    if (!currentExample) return [];
+    const over = currentExample.variant_ui?.[currentVariant]?.params;
+    if (!over) return currentExample.param_schema;
+    return currentExample.param_schema.map((item) =>
+      !isGroup(item) && over[item.name]
+        ? { ...item, ...over[item.name] }
+        : item,
+    );
+  }, [currentExample, currentVariant]);
+
   // Switch to a different variant: overlay the variant's per-param
   // values onto the existing slider state for this geometry (keeping
   // schema-derived defaults for any key the variant doesn't supply),
@@ -2896,7 +2929,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   function knobOptFor(name: string): KnobOpt {
     const existing = knobOpt[geometry]?.[name];
     if (existing) return existing;
-    const s = currentExample?.param_schema.find(
+    const s = currentSchema.find(
       (x): x is SchemaParamSpec => !isGroup(x) && x.name === name,
     );
     const min = s?.min ?? 0;
@@ -4143,7 +4176,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
             }
           >
             <ParamForm
-              schema={currentExample.param_schema}
+              schema={currentSchema}
               values={currentValues}
               onChange={handleUserParamChange}
               // hexbeam_5band's daisy_chain mode emits NEC TL cards;
@@ -4216,7 +4249,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
           (() => {
             const name = knobMenu.name;
             const ko = knobOptFor(name);
-            const s = currentExample.param_schema.find(
+            const s = currentSchema.find(
               (x): x is SchemaParamSpec => !isGroup(x) && x.name === name,
             );
             const num = (v: number) => (Number.isFinite(v) ? v : 0);

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -1249,15 +1249,22 @@ def examples_endpoint():
                 "variants": list(ex.variants),
                 "variant_values": dict(ex.variant_values),
                 "sweep_policy": _sweep_policy_json(ex.sweep_policy),
-                # Per-variant hint overrides; only variants that differ from the
-                # design-level sweep_policy appear here. Frontend falls back to
-                # the top-level `sweep_policy` for any variant not listed.
+                # Per-variant hint overrides; only variants that differ from
+                # the design-level values appear here. `sweep_policy` falls
+                # back to the top-level field; `params` carries explicit
+                # per-param presentation hints (slider min/max/step, precision,
+                # unit, label) the frontend overlays on param_schema for the
+                # active variant.
                 "variant_ui": {
                     v: {
-                        "sweep_policy": _sweep_policy_json(h["sweep_policy"]),
+                        **(
+                            {"sweep_policy": _sweep_policy_json(h["sweep_policy"])}
+                            if "sweep_policy" in h
+                            else {}
+                        ),
+                        **({"params": h["params"]} if "params" in h else {}),
                     }
                     for v, h in ex.variant_ui.items()
-                    if "sweep_policy" in h
                 },
                 "layout": ex.layout,
             }

--- a/tests/test_design_schemas.py
+++ b/tests/test_design_schemas.py
@@ -547,7 +547,9 @@ def test_invvee_variant_length_factor_ranges():
         "min": 2.05,
         "max": 3.2,
     }
-    assert "dipole" not in ex.variant_ui
+    # dipole inherits the default length window but hides the droop knob
+    # (flat by definition; angle_deg=0 still flows via variant_values)
+    assert ex.variant_ui["dipole"]["params"] == {"angle_deg": {"hidden": True}}
     # the angle slider covers both the drooping default and the flat variants
     ang = next(s for s in ex.param_schema if s.name == "angle_deg")
     assert ang.min == 0.0 and ang.max >= 45.0

--- a/tests/test_design_schemas.py
+++ b/tests/test_design_schemas.py
@@ -503,3 +503,51 @@ def test_hidden_override_is_generic():
     ex = _make_example("hidden_demo", _HiddenBuilder, defer_hints=True)
     names = {s.name for s in ex.param_schema}
     assert names == {"shown"}  # `secret` suppressed, others untouched
+
+
+@pytest.mark.parametrize("name", DESIGN_NAMES)
+def test_variant_values_fit_their_effective_slider_ranges(name):
+    """Every variant's param values must sit inside the slider range the
+    frontend will actually show for that variant: the base schema min/max
+    overlaid with the variant's explicit variant_ui["params"] hints. A
+    variant whose value lands outside its slider strands the knob (the
+    invvee flat variants' angle_deg=0 sat below the auto-derived 15.8°
+    minimum until the design authored an explicit range)."""
+    ex = REGISTRY[name]
+    for v in ex.variants:
+        over = (ex.variant_ui.get(v) or {}).get("params", {})
+        vals = ex.variant_values.get(v, {})
+        for spec in ex.param_schema:
+            if getattr(spec, "kind", None) not in ("float", "int"):
+                continue
+            val = vals.get(spec.name, spec.default)
+            if not isinstance(val, (int, float)) or isinstance(val, bool):
+                continue
+            lo = over.get(spec.name, {}).get("min", spec.min)
+            hi = over.get(spec.name, {}).get("max", spec.max)
+            if lo is not None:
+                assert val >= lo, f"{name}/{v}: {spec.name}={val} below min {lo}"
+            if hi is not None:
+                assert val <= hi, f"{name}/{v}: {spec.name}={val} above max {hi}"
+
+
+def test_invvee_variant_length_factor_ranges():
+    """dipoles.invvee showcases per-variant slider ranges: half-wave
+    window (0.8–1.25) for default/dipole, the same ×0.8–×1.25 window
+    around each long-wire variant's own length. The dipole variant
+    inherits the default window, so it must NOT appear in variant_ui."""
+    ex = REGISTRY["dipoles.invvee"]
+    lf = next(s for s in ex.param_schema if s.name == "length_factor")
+    assert (lf.min, lf.max) == (0.8, 1.25)
+    assert ex.variant_ui["three_halves"]["params"]["length_factor"] == {
+        "min": 2.38,
+        "max": 3.71,
+    }
+    assert ex.variant_ui["classic_edz"]["params"]["length_factor"] == {
+        "min": 2.05,
+        "max": 3.2,
+    }
+    assert "dipole" not in ex.variant_ui
+    # the angle slider covers both the drooping default and the flat variants
+    ang = next(s for s in ex.param_schema if s.name == "angle_deg")
+    assert ang.min == 0.0 and ang.max >= 45.0

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -268,8 +268,9 @@ def test_examples_carry_sweep_policy_keys(client: TestClient):
 
 def test_variant_ui_only_lists_variants_that_differ(client: TestClient):
     # variant_ui is a per-variant override map; a variant appears only when its
-    # derived hints differ from the design-level value, and every listed
-    # sweep_policy is shaped exactly like the top-level one.
+    # derived hints differ from the design-level value. An entry carries a
+    # sweep_policy (shaped exactly like the top-level one), explicit per-param
+    # presentation overrides under "params", or both — never neither.
     payload = client.get("/examples").json()
     for ex in payload["examples"]:
         vui = ex["variant_ui"]
@@ -277,9 +278,22 @@ def test_variant_ui_only_lists_variants_that_differ(client: TestClient):
         for variant, hints in vui.items():
             assert variant in ex["variants"]
             assert variant != "default"
-            sp = hints["sweep_policy"]
-            assert set(sp) == {"anchor", "lo_factor", "hi_factor", "band_locked"}
-            assert sp != ex["sweep_policy"]  # only differing variants are listed
+            assert set(hints) <= {"sweep_policy", "params"} and hints
+            if "sweep_policy" in hints:
+                sp = hints["sweep_policy"]
+                assert set(sp) == {"anchor", "lo_factor", "hi_factor", "band_locked"}
+                assert sp != ex["sweep_policy"]  # only differing variants listed
+            if "params" in hints:
+                assert hints["params"]  # non-empty map of param -> hint fields
+                for pname, fields in hints["params"].items():
+                    assert fields and set(fields) <= {
+                        "min",
+                        "max",
+                        "step",
+                        "precision",
+                        "unit",
+                        "label",
+                    }, (ex["name"], variant, pname)
 
 
 def test_skyloop_band_locked_variant_flips_only_band_locked(client: TestClient):

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -293,6 +293,7 @@ def test_variant_ui_only_lists_variants_that_differ(client: TestClient):
                         "precision",
                         "unit",
                         "label",
+                        "hidden",
                     }, (ex["name"], variant, pname)
 
 


### PR DESCRIPTION
## Summary
- `variant_ui` grows an explicit-only `params` channel: presentation hints (slider min/max/step, precision, unit, label, hidden) that a variant's `ui_params` authors are diffed against the default's and forwarded per variant; the frontend overlays them on `param_schema` for the active variant (knob rail + per-knob optimiser menu both see variant-correct bounds).
- Deliberately **not** a re-derived-schema diff: auto ±50% windows track each variant's *values*, so a flat variant's `angle_deg=0` would forward a junk −1..1 range. Only hints a variant explicitly authors move with it.
- **invvee showcase**: the old 0.4–3.2 `length_factor` span was a deliberate one-slider-covers-all-variants compromise; with per-variant ranges available it narrows to 0.8–1.25 for default/`dipole` and the same ×0.8–×1.25 shape around each long-wire variant's length (`three_halves` 2.38–3.71, `classic_edz` 2.05–3.2). `angle_deg` gets an explicit 0–60° range, and the flat-by-definition `dipole` variant hides the droop knob entirely (per-variant `hidden`; the pinned 0° still flows through solves).
- New invariant test — every variant's values must fit its effective slider range — which surfaced stale/unnoticed ranges in five other designs, fixed with widened global ranges: hexbeam `opt` tip spacer, t2fd `term_r` (default 820 Ω vs stale max 800), delta_loop_slanted `slant0`/`slant30`, diamond_loop `z100` apex angle, helix `n_turns` (default 2.7 vs stale min 3.0).
- **Docs**: `docs/plan-catalog-scaling.md` — future architecture for a 1k–10k design catalog (index/descriptor split, build-time manifest, lazy imports, search facets) with explicit do-not-build-yet triggers; `docs/plan-variant-overlay.md` marked COMPLETE (this PR ships its remaining open item, the per-variant ui derivation).

## Reviewer notes
- The /examples contract change is additive; `variant_ui` entries may now carry `sweep_policy`, `params`, or both (contract test updated accordingly).
- Per-variant `hidden` only hides a base-visible knob; it cannot unhide a design-level hidden param (those never enter `param_schema`) — documented in the code.
- The five non-invvee fixes are presentation-only (`ui_params` hints) — no geometry or tuning values changed.

## Test plan
- [x] Full suite: 1452 passed
- [x] New tests: per-variant range invariant (all designs), targeted invvee range + hidden pins, /examples contract update
- [x] `tsc --noEmit` and Vite build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016thQg6NoZB9ETiWPcyTT25