### PR TITLE
Retire the Triangular solver from antennaknobs (frontend + backend)

### DIFF
--- a/src/antennaknobs/builder.py
+++ b/src/antennaknobs/builder.py
@@ -139,12 +139,12 @@ class AntennaBuilder:
 
         Parity is intentionally NOT forced here. Each solver wants a particular
         segment parity so the feed lands on (or symmetrically across) the
-        center — sinusoidal, B-spline degree-2 and PyNEC want odd; triangular
-        and B-spline degree-1 want even — and every engine coerces each count
-        to its own parity at solve time (`SimulationEngine.coerce_n_seg`).
-        Returning the natural count and letting the solver round is why this is
-        `segs_for`, not the old `odd_nsegs`: baking in odd here would just make
-        a triangular solve bump the count up by one."""
+        center — sinusoidal, B-spline degree-2 and PyNEC want odd; B-spline
+        degree-1 wants even — and every engine coerces each count to its own
+        parity at solve time (`SimulationEngine.coerce_n_seg`). Returning the
+        natural count and letting the solver round is why this is `segs_for`,
+        not the old `odd_nsegs`: baking in odd here would just make an
+        even-parity solve bump the count up by one."""
         return max(3, round(self.nominal_nsegs * length / ref))
 
     def _phasor(self, name):

--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -15,7 +15,6 @@ from .serialize import builder_params_source
 from .user_designs import USER_NS, iter_design_files, resolve_user_design
 
 from momwire import (
-    TriangularSolver,
     SinusoidalSolver,
     BSplineSolver,
     HMatrixSolver,
@@ -35,7 +34,6 @@ if PyNECEngine is not None:
     ENGINE_CLASSES["pynec"] = PyNECEngine
 
 MOMWIRE_BASES = {
-    "triangular": TriangularSolver,
     "sinusoidal": SinusoidalSolver,
     "bspline": BSplineSolver,
     "hmatrix": HMatrixSolver,
@@ -274,7 +272,7 @@ def broadcast_pairs(builders, engines):
 def parse_engine_spec(spec):
     """Parse an engine spec into (engine_name, kwargs_to_bind).
 
-    Forms: "pynec", "momwire", "momwire:triangular|sinusoidal|bspline".
+    Forms: "pynec", "momwire", "momwire:sinusoidal|bspline|hmatrix|arrayblock".
     """
     name, _, basis = spec.partition(":")
     if name not in ENGINE_CLASSES:
@@ -347,7 +345,7 @@ def cli(arguments=None):
                 nargs="+",
                 default=["momwire"],
                 help="One or more simulation backends. Each spec is "
-                '"momwire[:triangular|sinusoidal|bspline]" or "pynec". '
+                '"momwire[:sinusoidal|bspline|hmatrix|arrayblock]" or "pynec". '
                 "Cross-products with --builders.",
             )
         else:
@@ -356,9 +354,10 @@ def cli(arguments=None):
                 type=str,
                 default="momwire",
                 help="Simulation backend: momwire | "
-                "momwire:triangular | momwire:sinusoidal | momwire:bspline | "
-                "pynec (default: momwire). pynec needs the optional pynec-accel "
-                "package; momwire is always available.",
+                "momwire:sinusoidal | momwire:bspline | momwire:hmatrix | "
+                "momwire:arrayblock | pynec (default: momwire). pynec needs "
+                "the optional pynec-accel package; momwire is always "
+                "available.",
             )
         p.add_argument(
             "--ground",

--- a/src/antennaknobs/designs/multiband/fandipole.py
+++ b/src/antennaknobs/designs/multiband/fandipole.py
@@ -181,11 +181,11 @@ class Builder(AntennaBuilder):
             )
 
         n_seg0 = self.nominal_nsegs
-        # The feed wire (T → S) needs at least one interior basis
-        # function for momwire's triangular solver; n_seg=1 leaves zero
-        # interior knots and triangular._feed_basis_indices crashes
-        # with "argmin of empty sequence". 3 matches the convention
-        # the rest of the design library uses for short feed wires.
+        # The feed wire (T → S) keeps n_seg=3: some bases need an
+        # interior knot at the feed (n_seg=1 left the retired triangular
+        # solver with zero interior knots and a crash), and 3 matches the
+        # convention the rest of the design library uses for short feed
+        # wires.
         n_seg1 = max(3, self.nominal_nsegs // 7)
 
         tups = []

--- a/src/antennaknobs/designs/multiband/trap_fan_dipole.py
+++ b/src/antennaknobs/designs/multiband/trap_fan_dipole.py
@@ -73,7 +73,7 @@ C_LIGHT_MHZ_M = 299.792458
 # Length factors tuned against MomwireEngine with BSplineSolver(degree=2)
 # at nominal_nsegs=41. After moving to adaptive per-wire segmentation
 # (target_seg_len = max_wire / nominal_nsegs, see build_wires), both Bs2
-# and Triangular stay essentially flat across N=21..81 — drift ≤ 0.22 Ω
+# and the (since retired) Triangular basis stay essentially flat across N=21..81 — drift ≤ 0.22 Ω
 # on every band — and agree with each other to ~1 Ω at the converged
 # limit. Sinusoidal still wanders 2–8 Ω over the same N range (basis-
 # family issue, not segmentation). PyNEC sits ~10 Ω above the momwire
@@ -318,9 +318,9 @@ class Builder(AntennaBuilder):
         # wire; everything else scales proportionally. Trap segments are
         # pinned to 1 (load-port convention — the named port lives on a
         # single basis function). Feed segment is also pinned to 1, which
-        # is fine for the BSpline d=2 basis this design is tuned against;
-        # the triangular basis can't drive a 1-segment feed gap, so this
-        # design is no longer drop-in compatible with TriangularSolver.
+        # is fine for the BSpline d=2 basis this design is tuned against
+        # (the retired triangular basis couldn't drive a 1-segment feed
+        # gap).
         adaptive_lengths = []
         for i, (trap_in, trap_out, tip) in enumerate(spokes):
             adaptive_lengths.append(dist(S, A[i]))
@@ -351,7 +351,7 @@ class Builder(AntennaBuilder):
 
         # Feed wire — named "feed", source supplied by build_network().
         # 1 segment matches the design's BSpline d=2 target; the basis
-        # handles a 1-segment feed cleanly (unlike triangular).
+        # handles a 1-segment feed cleanly.
         tups.append((T, S, 1, None, "feed"))
 
         # Lift to base height.

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -1,11 +1,12 @@
-"""momwire-backed SimulationEngine. Impedance via TriangularSolver;
-far-field/directivity ported from momwire/web/server.py:_compute_directivity_norm.
+"""momwire-backed SimulationEngine. Impedance via a momwire solver class
+(BSplineSolver by default); far-field/directivity ported from
+momwire/web/server.py:_compute_directivity_norm.
 """
 
 from __future__ import annotations
 
 import numpy as np
-from momwire import TriangularSolver
+from momwire import BSplineSolver
 
 from ..engine import FarField, SimulationEngine, WireCurrents
 from ..geometry import flat_wires_to_polylines
@@ -15,14 +16,11 @@ from ..network_reduce import NetworkReducer, tl_admittance_2x2
 
 def _parity_for_solver(solver, solver_kwargs):
     """The basis types have fixed parity expectations:
-      - TriangularSolver (tent / linear B-spline) → even (feed straddles 2 segs)
-      - BSplineSolver degree=1 → same as triangular → even
+      - BSplineSolver degree=1 → tent basis, even (feed straddles 2 segs)
       - BSplineSolver degree=2 → quadratic → odd
       - SinusoidalSolver → odd
     Anything else falls through as "any" (no coercion)."""
     name = getattr(solver, "__name__", "")
-    if name == "TriangularSolver":
-        return "even"
     if name == "SinusoidalSolver":
         return "odd"
     if name in ("BSplineSolver", "HMatrixSolver", "ArrayBlockSolver"):
@@ -80,9 +78,8 @@ def _normalise_ground(ground):
 # subclass it (dense fallback in momwire 0.4.0, fast-path blocks in 0.4.1);
 # SinusoidalSolver grew its own field-based ground_eps in momwire 0.5.0
 # (phase 6 — matches NEC gn 0 at the solver's own discretization floor,
-# ~0.1 ohm on the validation matrix). TriangularSolver only models the PEC
-# image (retirement-bound, intentionally skipped), so finite grounds keep
-# folding to PEC for it.
+# ~0.1 ohm on the validation matrix). Every shipping momwire solver is on
+# the list; the guard stays for exotic/user-supplied solver classes.
 _GROUND_EPS_SOLVERS = (
     "BSplineSolver",
     "HMatrixSolver",
@@ -102,7 +99,7 @@ class MomwireEngine(SimulationEngine):
         self,
         builder,
         *,
-        solver=TriangularSolver,
+        solver=BSplineSolver,
         wire_radius=0.0005,
         solver_kwargs=None,
         ground=None,
@@ -111,14 +108,14 @@ class MomwireEngine(SimulationEngine):
     ):
         """
         solver:
-          A momwire solver class — TriangularSolver (default), SinusoidalSolver,
-          or BSplineSolver. Different bases trade speed vs impedance fidelity;
-          on the hentenna sinusoidal is typically closer to PyNEC at modest
-          segmentation than triangular.
+          A momwire solver class — BSplineSolver (default), SinusoidalSolver,
+          or the fast BSpline subclasses (HMatrixSolver, ArrayBlockSolver).
+          Different bases trade speed vs impedance fidelity; on the hentenna
+          sinusoidal is typically closer to PyNEC at modest segmentation.
         solver_kwargs:
           Dict of solver-specific kwargs passed straight to the constructor
-          (e.g. `{"n_qp_reg": 8, "n_qp_off": 8}` for TriangularSolver, or
-          `{"n_qp_const": 16}` for SinusoidalSolver). None = solver defaults.
+          (e.g. `{"degree": 1}` for BSplineSolver, or `{"n_qp_const": 16}`
+          for SinusoidalSolver). None = solver defaults.
         ground:
           None or "free"           — no ground (default)
           "pec"                    — PEC plane at z=ground_z (image method)
@@ -133,8 +130,7 @@ class MomwireEngine(SimulationEngine):
                                      coefficient fast paths (momwire would
                                      gate their sommerfeld to a dense solve),
                                      SinusoidalSolver has only the refl-coef
-                                     model, and TriangularSolver folds to the
-                                     PEC image.
+                                     model.
           ("finite-fast", eps_r, sigma) — the reflection-coefficient model
                                      (NEC gn 0 style, ground_eps) on every
                                      solver that supports it. Matches
@@ -150,8 +146,8 @@ class MomwireEngine(SimulationEngine):
         self._cancel = cancel
         self._solver = solver
         self._solver_kwargs = dict(solver_kwargs) if solver_kwargs else {}
-        # Per-instance parity: triangular wants even, sinusoidal odd,
-        # bspline depends on degree. Set before _coerce_wire_tuples runs.
+        # Per-instance parity: sinusoidal wants odd, bspline depends on
+        # degree. Set before _coerce_wire_tuples runs.
         self.segment_parity = _parity_for_solver(self._solver, self._solver_kwargs)
 
         # build_wires() must run before build_tls() — some designs populate
@@ -185,7 +181,7 @@ class MomwireEngine(SimulationEngine):
         self._ground_z = ground_z if self._ground is not None else None
         # Finite ground constants forwarded to the impedance solve when the
         # solver supports the reflection-coefficient model; None otherwise
-        # (PEC image, today's behavior for triangular/sinusoidal).
+        # (PEC image).
         self._ground_eps = None
         self._ground_model = None
         if (
@@ -253,7 +249,7 @@ class MomwireEngine(SimulationEngine):
 
     def _ground_solver_kwargs(self):
         """Extra ground kwargs for solver construction. Only spliced in when
-        set — TriangularSolver / SinusoidalSolver don't accept ground_eps."""
+        set (free-space / PEC solves pass no ground_eps)."""
         if self._ground_eps is None:
             return {}
         kw = {"ground_eps": self._ground_eps}

--- a/src/antennaknobs/geometry.py
+++ b/src/antennaknobs/geometry.py
@@ -1,6 +1,6 @@
 """Translate the flat (p0, p1, n_seg, excitation) wire list used by
 AntennaBuilder.build_wires() into the polyline + feed-arclength shape
-that momwire's TriangularSolver consumes.
+that momwire's solver classes consume.
 
 The flat list expresses connectivity implicitly: two tuples are part of
 the same electrical wire when they share an endpoint (within `eps`).
@@ -43,8 +43,8 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
         edge_segments   : list of list[int] — n_seg per edge per polyline
         feeds           : list of (polyline_idx, arclength, voltage) —
                           one entry per excited tuple, in registration
-                          order. Suitable to pass directly to
-                          TriangularSolver(feeds=...).
+                          order. Suitable to pass directly to a
+                          momwire solver's feeds=... kwarg.
         feed_wire_index : int — polyline holding the first excited
                           segment (back-compat: feeds[0][0])
         feed_arclength  : float — arclength of the first feed
@@ -53,7 +53,7 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
                           (back-compat: feeds[0][2])
         junctions       : list of list[(wire_idx, "start"|"end")] —
                           shared-node groups, suitable to pass directly
-                          to TriangularSolver(junctions=...). Empty list
+                          to a momwire solver's junctions=... kwarg. Empty list
                           if every component is a simple path.
     """
     if not tups:

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -67,7 +67,6 @@ from momwire import (
     BSplineSolver,
     HMatrixSolver,
     SinusoidalSolver,
-    TriangularSolver,
 )
 
 from .examples import register
@@ -91,7 +90,6 @@ DESIGNS_PKG = "antennaknobs.designs"
 DESIGNS_DIR = pathlib.Path(importlib.import_module(DESIGNS_PKG).__path__[0])
 
 _MOMWIRE_MODELS = {
-    "triangular": TriangularSolver,
     "sinusoidal": SinusoidalSolver,
     "bspline": BSplineSolver,
     # Hierarchical (H-matrix / ACA) accelerator — same B-spline basis as
@@ -485,8 +483,7 @@ def _ground_for_engine(req: dict, ground_z: float):
     >= 0.6.0) and as the reflection-coefficient model on the other
     ground_eps solvers (hmatrix/arrayblock keep their fast paths,
     sinusoidal has no sommerfeld model); "fast" → ("finite-fast", ...),
-    the reflection-coefficient model everywhere it exists. Triangular
-    folds any finite spec to the PEC image. The response ships the
+    the reflection-coefficient model everywhere it exists. The response ships the
     engine's actual eps/sigma so the frontend far-field Fresnel uses the
     real constants either way; `ground_model_applied` reports what the
     impedance solve really used."""
@@ -530,8 +527,10 @@ def _pynec_ground_spec(req: dict):
 
 
 def _make_momwire_engine(req: dict, builder, cancel=None):
-    model = req.get("momwire_model", "triangular")
-    solver_cls = _MOMWIRE_MODELS.get(model, TriangularSolver)
+    # "bspline" is the default and the fallback for unknown/retired model
+    # names (a stale client may still send "triangular").
+    model = req.get("momwire_model", "bspline")
+    solver_cls = _MOMWIRE_MODELS.get(model, BSplineSolver)
     wire_radius = float(req.get("wire_radius", 0.0005))
     ground = _ground_for_engine(req, 0.0)
     solver_kwargs = req.get("model_options") or None
@@ -874,7 +873,7 @@ def _auto_default_view(cls) -> str:
 @lru_cache(maxsize=None)
 def _recommended_backend(cls) -> str | None:
     """Recommend a default solver for the design, or None to let the UI keep
-    its own default (the dense Triangular path).
+    its own default (the dense B-spline path).
 
     Returns "arrayblock" for true grid arrays — multiple electrically separate
     elements with at least one repeated shape — where the element-aware block
@@ -1142,8 +1141,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             # What the impedance solve actually used, for honest UI wording:
             # "sommerfeld" (BSplineSolver + "finite", momwire >= 0.6.0),
             # "refl-coef" (the other ground_eps solvers, or any solver with
-            # the "finite-fast" spec), "pec-image" (model="pec", or a finite
-            # model on a solver without ground_eps — triangular), or "free".
+            # the "finite-fast" spec), "pec-image" (model="pec"), or "free".
             "ground_model_applied": (
                 "free" if eng._ground is None else (eng._ground_model or "pec-image")
             ),

--- a/src/antennaknobs/web/examples/_feedline.py
+++ b/src/antennaknobs/web/examples/_feedline.py
@@ -7,7 +7,7 @@ jumpers, returning the single driving-point impedance the rig sees at
 the main-feed end. Port 0 is the main-feed connection; ports 1..N-1
 are subsequent stops along the chain; port N-1 is the open end.
 
-Usage from momwire: build Y_sc via `TriangularSolver.compute_y_matrix`,
+Usage from momwire: build Y_sc via `BSplineSolver.compute_y_matrix`,
 invert to get Z_oc, pass to `daisy_chain_z_in`. PyNEC's TL card path
 solves the same problem natively (no Python-side math) — this helper
 is just for the momwire half.

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -143,8 +143,10 @@ type ExampleDescriptor = {
   /** Recommended solver backend for this design (e.g. "arrayblock" for grid
    *  arrays). The active slot's backend is seeded from this on selection
    *  unless the user has manually picked a backend. null = keep the UI
-   *  default. */
-  default_backend: Backend | null;
+   *  default. Typed as a plain string because the server may name a backend
+   *  this UI has retired (e.g. "triangular"); run it through
+   *  normalizeBackend before use. */
+  default_backend: string | null;
   /** True when the Builder has a `design_freq` param that scales
    *  geometry (design_freq-sized designs). When false, the design-freq
    *  band-tab row is hidden because dragging it would be a no-op. */
@@ -1226,8 +1228,9 @@ type SolveResponse = {
   /** Recommended solver backend for this design (e.g. "arrayblock" for grid
    *  arrays). Carried on the geometry preview so the frontend can seed the
    *  backend from it and *then* fire the first solve, instead of the descriptor
-   *  racing the preview. Absent / null = no recommendation. */
-  default_backend?: Backend | null;
+   *  racing the preview. Absent / null = no recommendation. Plain string —
+   *  may name a retired backend; normalizeBackend before use. */
+  default_backend?: string | null;
   /** Set when the solve/geometry request failed — e.g. a user design's
    *  build_wires() raised. Carries a short, formatted message (type + file +
    *  line). Mutually exclusive with a normal result payload. */
@@ -1236,8 +1239,9 @@ type SolveResponse = {
 
 // Backend selector — Momwire model variants + PyNEC. Per-backend
 // `model_options` are forwarded to server.py's _make_momwire_sim.
+// "triangular" is retired from the UI (the server still accepts it);
+// see normalizeBackend for how a stale recommendation is mapped.
 type Backend =
-  | "triangular"
   | "sinusoidal"
   | "bspline"
   | "hmatrix"
@@ -1245,7 +1249,6 @@ type Backend =
   | "pynec";
 
 const BACKEND_LABEL: Record<Backend, string> = {
-  triangular: "Triangular",
   sinusoidal: "Sinusoidal",
   bspline: "B-spline",
   hmatrix: "H-matrix (ACA)",
@@ -1264,7 +1267,6 @@ function comboInappropriate(b: Backend, rec: Backend | null): boolean {
 }
 
 const BACKEND_ORDER: Backend[] = [
-  "triangular",
   "sinusoidal",
   "bspline",
   "hmatrix",
@@ -1287,7 +1289,7 @@ function isBSplineFamily(b: Backend): boolean {
 // each backend solves it as best it can: PyNEC and the plain B-spline
 // backend offer a method sub-choice (Sommerfeld-Norton vs the
 // reflection-coefficient approximation); the fast B-spline variants use
-// refl-coef; Triangular/Sinusoidal keep the PEC image solve — either way
+// refl-coef; Sinusoidal keeps the PEC image solve — either way
 // the finite constants reach the far-field Fresnel cut.
 type GroundType = "finite" | "pec";
 // Finite-ground solve method. Meaningful — and shown — where both models
@@ -1308,17 +1310,23 @@ function backendHasGroundMethod(b: Backend): boolean {
 type GroundModel = "sommerfeld" | "fast" | "pec";
 
 function backendSupportsGround(b: Backend): boolean {
-  return (
-    b === "triangular" ||
-    b === "sinusoidal" ||
-    isBSplineFamily(b) ||
-    b === "pynec"
-  );
+  return b === "sinusoidal" || isBSplineFamily(b) || b === "pynec";
+}
+
+// Coerce a server-supplied backend name into something this UI knows.
+// "triangular" was retired from the frontend (the server still accepts
+// it and may still recommend it, e.g. from an older adapter or a saved
+// design hint): map it to "bspline", the default working solver on the
+// same dense path. Anything else unrecognised falls back to null ("no
+// recommendation") so a stale value never reaches state or the wire.
+function normalizeBackend(b: string | null | undefined): Backend | null {
+  if (!b) return null;
+  if (b === "triangular") return "bspline";
+  return (BACKEND_ORDER as string[]).includes(b) ? (b as Backend) : null;
 }
 
 type CommonOpts = { nPerWire: number; wireRadius: number };
 
-type TriangularOpts = CommonOpts & { nQpReg: number; nQpOff: number };
 type SinusoidalOpts = CommonOpts & { nQpConst: number };
 type BSplineOpts = CommonOpts & {
   degree: 1 | 2;
@@ -1352,7 +1360,6 @@ type PyNECOpts = CommonOpts;
 // hmatrix and arrayblock share BSplineOpts (same basis + knobs); the ACA
 // tolerances use the solver defaults.
 type BackendOptsMap = {
-  triangular: TriangularOpts;
   sinusoidal: SinusoidalOpts;
   bspline: BSplineOpts;
   hmatrix: BSplineOpts;
@@ -1376,7 +1383,6 @@ const BSPLINE_DEFAULT_OPTS: BSplineOpts = {
 };
 
 const DEFAULT_BACKEND_OPTS: BackendOptsMap = {
-  triangular: { nPerWire: 30, wireRadius: 0.0005, nQpReg: 4, nQpOff: 4 },
   sinusoidal: { nPerWire: 30, wireRadius: 0.0005, nQpConst: 8 },
   bspline: { ...BSPLINE_DEFAULT_OPTS },
   hmatrix: { ...BSPLINE_DEFAULT_OPTS },
@@ -1412,8 +1418,8 @@ function backendDisplayLabel(b: Backend, opts: BackendOptsMap[Backend]): string 
 const DEFAULT_SLOTS: Record<Slot, SlotConfig> = {
   // A is the default working solver: B-spline d=2 — most accurate per
   // unknown, converged at a small odd N (interior knot at the feed), and
-  // its impedance solve honours finite grounds (Triangular, the old
-  // default, folds them to the PEC image).
+  // its impedance solve honours finite grounds (Triangular, the old,
+  // now-retired default, folded them to the PEC image).
   A: {
     backend: "bspline",
     opts: { ...DEFAULT_BACKEND_OPTS.bspline, nPerWire: 21 },
@@ -1437,10 +1443,6 @@ function modelOptionsForRequest(
   backend: Backend,
   opts: BackendOptsMap[Backend],
 ): Record<string, unknown> {
-  if (backend === "triangular") {
-    const o = opts as TriangularOpts;
-    return { n_qp_reg: o.nQpReg, n_qp_off: o.nQpOff };
-  }
   if (backend === "sinusoidal") {
     const o = opts as SinusoidalOpts;
     return { n_qp_const: o.nQpConst };
@@ -1472,7 +1474,6 @@ type SolveRequest = {
   variant?: string;
   solver: "momwire" | "pynec";
   momwire_model?:
-    | "triangular"
     | "sinusoidal"
     | "bspline"
     | "hmatrix"
@@ -1571,7 +1572,7 @@ const CONVERGE_N_VALUES: number[] = [8, 12, 17, 24, 34, 48, 68];
 
 // Richardson-style extrapolation Z(1/N) → Z(N→∞). Fits Z = a₀ + a₁·h + a₂·h²
 // (h = 1/N) on the last `nLast` points via least squares and returns a₀.
-// Quadratic gives a sane answer for O(1/N) limit (BSpline/Triangular without
+// Quadratic gives a sane answer for O(1/N) limit (BSpline without
 // enrichment) AND O(1/N^p) for p slightly above 1 — basis-cap, enrichment,
 // etc. With ≤2 points we can't fit; return null.
 function richardsonExtrap(
@@ -2432,7 +2433,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   // wording reflects what the active solver actually runs: PyNEC and the
   // plain B-spline backend honour the selected method; H-matrix/Array-block
   // solve refl-coef for any finite model (their fast ground paths);
-  // Triangular/Sinusoidal solve the PEC image and only the far-field
+  // Sinusoidal solves the PEC image and only the far-field
   // pattern sees the finite constants. "free space" when ground is off or
   // unsupported.
   const groundActiveForSummary = groundEnabled && backendSupportsGround(backend);
@@ -2778,7 +2779,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     // ground_model is shared across backends (εr=10, σ=0.002 for the finite
     // models): PyNEC honours it directly; momwire's B-spline family solves
     // the finite models with its reflection-coefficient ground, while
-    // Triangular/Sinusoidal fold them to the PEC image solve (the server
+    // Sinusoidal folds them to the PEC image solve (the server
     // ships the real εr/σ for the pattern either way).
     const groundActive = groundEnabled && backendSupportsGround(backend);
     const base: SolveRequest = {
@@ -3224,8 +3225,9 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     // user hasn't approved it — show a warning instead. The app never switches
     // the solver itself; the user does that in the gear menu, which changes
     // `backend` and re-runs this effect.
-    const rec =
-      preview?.default_backend ?? currentExample?.default_backend ?? null;
+    const rec = normalizeBackend(
+      preview?.default_backend ?? currentExample?.default_backend,
+    );
     if (comboInappropriate(backend, rec) && !approvedComboRef.current) {
       setSolverWarning(true);
       return;
@@ -4703,7 +4705,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
             </span>
             <span className="solver-suggest-sub">
               {backend === "arrayblock" || backend === "hmatrix"
-                ? "This accelerator is overkill on a single-element design — a dense solver (e.g. Triangular) is faster here. "
+                ? "This accelerator is overkill on a single-element design — a dense solver (e.g. B-spline) is faster here. "
                 : "This is a large array — a dense solver can be very slow. Array-block is far faster. "}
               Change the solver in the gear menu, solve anyway, or pause to keep
               editing.
@@ -5370,27 +5372,6 @@ function BackendConfigModal({
             step={0.0001}
             onChange={(v) => onPatch({ wireRadius: v })}
           />
-
-          {backend === "triangular" && (
-            <>
-              <NumberField
-                label="n_qp_reg (same-edge GL pts)"
-                value={(opts as TriangularOpts).nQpReg}
-                min={2}
-                max={16}
-                step={1}
-                onChange={(v) => onPatch({ nQpReg: v } as never)}
-              />
-              <NumberField
-                label="n_qp_off (cross-edge GL pts)"
-                value={(opts as TriangularOpts).nQpOff}
-                min={2}
-                max={16}
-                step={1}
-                onChange={(v) => onPatch({ nQpOff: v } as never)}
-              />
-            </>
-          )}
 
           {backend === "sinusoidal" && (
             <NumberField

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -131,7 +131,7 @@ app.add_middleware(
 )
 
 
-C_LIGHT = 299_792_458.0  # m/s, matches TriangularSolver's eps*mu derivation to ~1e-9
+C_LIGHT = 299_792_458.0  # m/s, matches the momwire solvers' eps*mu derivation to ~1e-9
 _EPS0 = 8.854187817e-12  # F/m
 
 

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -1182,17 +1182,16 @@ def test_parasitic_loop_quad_agrees_across_engines():
     """A parasitic (no-port) closed loop -- the cubical quad's reflector -- is
     now handled on every momwire basis (the geometry translator cuts the loop at
     an arbitrary edge and lets momwire's junction KCL carry the current around
-    it). All four bases agree with the PyNEC reference. This was the single
-    biggest momwire gap; the test that used to assert it RAISED now asserts it
-    SOLVES."""
+    it). Both basis families agree with the PyNEC reference. This was the
+    single biggest momwire gap; the test that used to assert it RAISED now
+    asserts it SOLVES."""
     from antennaknobs.designs.loops.quad import Builder
     from antennaknobs.engines import MomwireEngine
-    from momwire import BSplineSolver, SinusoidalSolver, TriangularSolver
+    from momwire import BSplineSolver, SinusoidalSolver
 
     z_ref = _z(Builder())  # PyNEC reference
     assert z_ref.real > 0.0
     for solver, kw in [
-        (TriangularSolver, {}),
         (SinusoidalSolver, {}),
         (BSplineSolver, {"degree": 2}),
     ]:
@@ -1214,10 +1213,9 @@ def test_terminated_rhombic_is_unidirectional_across_engines():
     the radiation efficiency folds the termination loss into GAIN."""
     from antennaknobs.designs.wire.rhombic import Builder
     from antennaknobs.engines import MomwireEngine
-    from momwire import TriangularSolver
 
     ref = _far_field(Builder())  # PyNEC reference
-    ff = MomwireEngine(Builder(), ground=None, solver=TriangularSolver).far_field(
+    ff = MomwireEngine(Builder(), ground=None).far_field(
         n_theta=90, n_phi=360, del_theta=1, del_phi=1
     )
 
@@ -1266,11 +1264,10 @@ def test_t2fd_broadband_gain_agrees_across_engines():
     several dB high."""
     from antennaknobs.designs.broadband.t2fd import Builder
     from antennaknobs.engines import MomwireEngine
-    from momwire import BSplineSolver, SinusoidalSolver, TriangularSolver
+    from momwire import BSplineSolver, SinusoidalSolver
 
     g_ref = _far_field(Builder()).max_gain  # PyNEC reference
     for solver, kw in [
-        (TriangularSolver, {}),
         (SinusoidalSolver, {}),
         (BSplineSolver, {"degree": 2}),
     ]:
@@ -1297,15 +1294,15 @@ def test_g5rv_ideal_halfwave_line_is_singular_on_every_engine():
 
 def test_bruce_high_z_feed_is_well_conditioned_across_bases():
     """The Bruce feed is high-Z and reactive, but because the tap sits a little
-    off the exact current null the four bases AGREE on it (within a few percent)
+    off the exact current null the bases AGREE on it (within a few percent)
     -- high-Z but NOT ill-conditioned."""
     from antennaknobs.designs.verticals.bruce import Builder
     from antennaknobs.engines import MomwireEngine
-    from momwire import SinusoidalSolver, TriangularSolver
+    from momwire import SinusoidalSolver
 
-    zt = MomwireEngine(Builder(), ground=None, solver=TriangularSolver).impedance()[0]
+    zb = MomwireEngine(Builder(), ground=None).impedance()[0]
     zs = MomwireEngine(Builder(), ground=None, solver=SinusoidalSolver).impedance()[0]
-    assert abs(zt - zs) / abs(zt) < 0.1
+    assert abs(zb - zs) / abs(zb) < 0.1
 
 
 def test_zepp_current_null_end_feed_is_basis_dependent():
@@ -1314,9 +1311,10 @@ def test_zepp_current_null_end_feed_is_basis_dependent():
     across bases but the REACTANCE inherits the basis spread."""
     from antennaknobs.designs.wire.zepp import Builder
     from antennaknobs.engines import MomwireEngine
-    from momwire import TriangularSolver
 
     zp = _z(Builder())  # PyNEC shack
-    zt = MomwireEngine(Builder(), ground=None, solver=TriangularSolver).impedance()[0]
-    assert abs(zp.real - zt.real) < 1.0  # R agrees
-    assert abs(zp.imag - zt.imag) > 4.0  # X inherits the end-null spread
+    zb = MomwireEngine(Builder(), ground=None).impedance()[0]
+    assert abs(zp.real - zb.real) < 1.0  # R agrees
+    # X inherits the end-null spread: ~2.7 ohm for BSpline d=2 vs PyNEC
+    # (the retired triangular basis sat >4), still ~170x the R agreement.
+    assert abs(zp.imag - zb.imag) > 2.0

--- a/tests/test_engine_spec.py
+++ b/tests/test_engine_spec.py
@@ -11,7 +11,7 @@ from antennaknobs.cli import (
     _GROUND_UNSET,
 )
 from antennaknobs.engines import PyNECEngine, MomwireEngine
-from momwire import TriangularSolver, SinusoidalSolver, BSplineSolver
+from momwire import SinusoidalSolver, BSplineSolver
 
 from conftest import needs_pynec
 
@@ -28,7 +28,6 @@ def test_parse_momwire_default():
 @pytest.mark.parametrize(
     "basis,cls",
     [
-        ("triangular", TriangularSolver),
         ("sinusoidal", SinusoidalSolver),
         ("bspline", BSplineSolver),
     ],
@@ -46,7 +45,7 @@ def test_parse_unknown_engine_raises():
 
 def test_parse_pynec_with_basis_raises():
     with pytest.raises(argparse.ArgumentTypeError):
-        parse_engine_spec("pynec:triangular")
+        parse_engine_spec("pynec:bspline")
 
 
 def test_parse_momwire_unknown_basis_raises():
@@ -74,7 +73,6 @@ def test_make_factory_binds_ground_and_solver():
 
 def test_momwire_bases_keys():
     assert set(MOMWIRE_BASES) == {
-        "triangular",
         "sinusoidal",
         "bspline",
         "hmatrix",
@@ -101,7 +99,7 @@ def test_cli_compare_patterns_single_engine_still_works():
 
 def test_cli_compare_patterns_momwire_basis():
     ant.cli(
-        f"compare_patterns --builders dipoles.invvee:dipole --engines momwire:triangular momwire:sinusoidal{O}".split()
+        f"compare_patterns --builders dipoles.invvee:dipole --engines momwire:bspline momwire:sinusoidal{O}".split()
     )
 
 
@@ -138,7 +136,7 @@ def test_broadcast_mismatch_raises():
 def test_cli_compare_patterns_three_by_three_paired():
     ant.cli(
         f"compare_patterns --builders dipoles.invvee:dipole dipoles.invvee specialty.bowtie "
-        f"--engines pynec momwire:triangular momwire:sinusoidal{O}".split()
+        f"--engines pynec momwire:bspline momwire:sinusoidal{O}".split()
     )
 
 
@@ -151,7 +149,7 @@ def test_cli_compare_patterns_three_builders_one_engine():
 def test_cli_compare_patterns_mismatch_rejected():
     with pytest.raises(argparse.ArgumentTypeError):
         ant.cli(
-            f"compare_patterns --builders dipoles.invvee:dipole dipoles.invvee --engines pynec momwire:triangular momwire:sinusoidal{O}".split()
+            f"compare_patterns --builders dipoles.invvee:dipole dipoles.invvee --engines pynec momwire:bspline momwire:sinusoidal{O}".split()
         )
 
 

--- a/tests/test_momwire_engine.py
+++ b/tests/test_momwire_engine.py
@@ -699,10 +699,10 @@ def test_translator_handles_fandipole_high_degree_junctions():
 def test_momwire_sinusoidal_hentenna_impedance_close_to_pynec():
     """Cross-validation on the hentenna (two tee junctions): momwire's
     Sinusoidal basis agrees with PyNEC's free-space gn_card-disabled
-    solve to within ~10% on R and ~10 Ω on X. Triangular at the same
-    segmentation lands at a different impedance — the two basis
+    solve to within ~10% on R and ~10 Ω on X. The polynomial bases at
+    the same segmentation land at a different impedance — the two basis
     families converge to two different limits (PyNEC and Sinusoidal
-    to one, Triangular and BSpline to another), not to a common point.
+    to one, BSpline to another), not to a common point.
     A cross-engine bound against PyNEC therefore only makes sense for
     Sinusoidal here. Picking a "more correct" pair is out of scope;
     this test is just verifying that the translator's junction/feed
@@ -718,8 +718,8 @@ def test_momwire_sinusoidal_hentenna_impedance_close_to_pynec():
 
 
 def test_momwire_sinusoidal_fandipole_runs():
-    """Fandipole has degree-6 junctions and a 1-segment feed gap. The
-    1-segment feed has zero interior knots so the Triangular tent basis
+    """Fandipole has degree-6 junctions and a 1-segment feed gap. A
+    1-segment feed has zero interior knots, so a knot-based tent basis
     has no feed to land on; Sinusoidal's const-source basis lives on
     segment centres and handles it. Just ensure it runs and produces
     a plausible value, the multi-wire geometry has too many freedoms
@@ -773,10 +773,10 @@ def test_momwire_sinusoidal_delta_loop_close_to_pynec():
     assert abs(z_ps.imag - z_nec.imag) < 5.0
 
 
-def test_momwire_triangular_bowtie_runs():
-    """Triangular handles the bowtie because its feed gap is n_seg=3
-    (interior tent basis available). Verifies the closed-loop path
-    doesn't trip Triangular's feed-basis lookup."""
+def test_momwire_default_bowtie_runs():
+    """The default engine (BSplineSolver d=2) handles the bowtie's
+    closed-loop cut with its n_seg=3 feed gap (interior knot available
+    for the feed)."""
     from antennaknobs.designs.specialty.bowtie import Builder as BT
 
     z = MomwireEngine(BT()).impedance()[0]

--- a/tests/test_momwire_finite_ground.py
+++ b/tests/test_momwire_finite_ground.py
@@ -8,8 +8,7 @@ them, and since momwire 0.6.0 the two specs mean different physics:
 ("finite-fast", eps_r, sigma) — and "finite" on the solvers without a
 sommerfeld model (HMatrix/ArrayBlock keep their refl-coef fast paths,
 SinusoidalSolver is refl-coef only) — maps to the reflection-coefficient
-ground_eps solve (NEC gn 0 style). TriangularSolver keeps folding to the
-PEC image.
+ground_eps solve (NEC gn 0 style).
 
 The refl-coef numeric tests cross-check against PyNEC gn 0 (dipole
 0.1–0.5λ window: bspline max |ΔZ| ≈ 2.45 Ω, sinusoidal ≈ 0.11 Ω). The
@@ -23,7 +22,7 @@ import pytest
 
 pytest.importorskip("PyNEC")
 
-from momwire import BSplineSolver, SinusoidalSolver, TriangularSolver  # noqa: E402
+from momwire import BSplineSolver, SinusoidalSolver  # noqa: E402
 
 from antennaknobs import resolve_variant_params  # noqa: E402
 from antennaknobs.designs.dipoles.invvee import Builder as InvVee  # noqa: E402
@@ -54,7 +53,7 @@ def test_finite_specs_map_to_ground_eps_for_bspline():
 def test_ground_model_mapping_per_solver_and_spec():
     """ "finite" → sommerfeld on plain BSplineSolver only; "finite-fast" →
     refl-coef everywhere; solvers without a sommerfeld model keep
-    refl-coef for both specs; triangular maps nothing."""
+    refl-coef for both specs."""
     from momwire import ArrayBlockSolver, HMatrixSolver
 
     b = _flat_dipole(_height(0.2))
@@ -67,19 +66,11 @@ def test_ground_model_mapping_per_solver_and_spec():
     for solver in (HMatrixSolver, ArrayBlockSolver, SinusoidalSolver):
         assert model(solver, ("finite", 10.0, 0.002)) == "refl-coef"
         assert model(solver, ("finite-fast", 10.0, 0.002)) == "refl-coef"
-    assert model(TriangularSolver, ("finite", 10.0, 0.002)) is None
     # and the sommerfeld kwarg only reaches solvers that accept it
     eng = MomwireEngine(b, solver=BSplineSolver, ground=("finite", 10.0, 0.002))
     assert eng._ground_solver_kwargs().get("ground_model") == "sommerfeld"
     eng = MomwireEngine(b, solver=SinusoidalSolver, ground=("finite", 10.0, 0.002))
     assert "ground_model" not in eng._ground_solver_kwargs()
-
-
-def test_finite_specs_fold_to_pec_for_triangular():
-    eng = MomwireEngine(
-        _flat_dipole(_height(0.2)), solver=TriangularSolver, ground=GROUND
-    )
-    assert eng._ground_eps is None
 
 
 def test_finite_specs_map_to_ground_eps_for_sinusoidal():

--- a/tests/test_segment_convergence.py
+++ b/tests/test_segment_convergence.py
@@ -57,17 +57,28 @@ def test_builder_nominal_nsegs_scales_per_edge_counts():
     assert min(seg_counts) >= 3  # floor on minor edges holds at small N
 
 
-def test_momwire_triangular_coerces_to_even_parity():
-    """Triangular momwire requires even-segment counts; the engine bumps any
-    odd build_wires() output up to even before the solver sees it."""
+def test_momwire_default_coerces_to_odd_parity():
+    """The default solver (BSplineSolver degree=2) wants odd-segment counts;
+    the engine bumps any even build_wires() output up to odd before the
+    solver sees it."""
     b = BowtieBuilder()
-    b.nominal_nsegs = 21  # odd
-    eng = MomwireEngine(b)  # default solver is TriangularSolver → parity="even"
+    b.nominal_nsegs = 20  # even
+    eng = MomwireEngine(b)  # default BSplineSolver d=2 → parity="odd"
     seg_lists = eng._edge_segments
     all_segs = [n for wire in seg_lists for n in wire]
-    assert all(n % 2 == 0 for n in all_segs), (
-        f"triangular engine left odd segs: {all_segs}"
+    assert all(n % 2 == 1 for n in all_segs), (
+        f"default engine left even segs: {all_segs}"
     )
+
+
+def test_momwire_bspline_d1_coerces_to_even_parity():
+    """BSplineSolver degree=1 (tent basis) wants even-segment counts."""
+    b = BowtieBuilder()
+    b.nominal_nsegs = 21  # odd
+    eng = MomwireEngine(b, solver_kwargs={"degree": 1})
+    seg_lists = eng._edge_segments
+    all_segs = [n for wire in seg_lists for n in wire]
+    assert all(n % 2 == 0 for n in all_segs), f"d=1 engine left odd segs: {all_segs}"
 
 
 def test_pynec_engine_segment_parity_is_odd():

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -327,7 +327,7 @@ def test_solve_dispatches_to_momwire_for_dipole():
             "geometry": "dipoles.invvee",
             "measurement_freq_mhz": 28.47,
             "design_freq_mhz": 28.47,
-            "momwire_model": "triangular",
+            "momwire_model": "bspline",
         }
     )
     assert out["solver"] == "momwire"
@@ -350,7 +350,7 @@ def test_solve_always_carries_norm_and_caches():
         "geometry": "dipoles.invvee",
         "measurement_freq_mhz": 28.47,
         "design_freq_mhz": 28.47,
-        "momwire_model": "triangular",
+        "momwire_model": "bspline",
     }
     server._SOLVE_CACHE.clear()
     out = server.solve(req)
@@ -397,31 +397,34 @@ _NORM_ACCURACY_REQS = [
         "geometry": "dipoles.invvee",
         "measurement_freq_mhz": 28.47,
         "design_freq_mhz": 28.47,
-        "momwire_model": "triangular",
+        "momwire_model": "bspline",
         "ground": False,
     },
     {
         "geometry": "dipoles.invvee",
         "measurement_freq_mhz": 28.47,
         "design_freq_mhz": 28.47,
-        "momwire_model": "triangular",
+        "momwire_model": "bspline",
         "ground": True,
         "ground_model": "pec",
     },
+    # n_per_wire=100: the 13-wavelength skyloop needs it for the BSpline
+    # d=2 basis to conserve power under the 0.05 dB gate (0.063 dB at 80,
+    # 0.041 at 100; the retired triangular basis sat under the gate at 80).
     {
         "geometry": "loops.triangular_skyloop",
         "measurement_freq_mhz": 50.0,
         "design_freq_mhz": 3.8,
-        "momwire_model": "triangular",
-        "n_per_wire": 80,
+        "momwire_model": "bspline",
+        "n_per_wire": 100,
         "ground": False,
     },
     {
         "geometry": "loops.triangular_skyloop",
         "measurement_freq_mhz": 50.0,
         "design_freq_mhz": 3.8,
-        "momwire_model": "triangular",
-        "n_per_wire": 80,
+        "momwire_model": "bspline",
+        "n_per_wire": 100,
         "ground": True,
         "ground_model": "pec",
     },
@@ -475,7 +478,7 @@ def test_norm_check_endpoint_reports_power_balance(client: TestClient):
         "geometry": "dipoles.invvee",
         "measurement_freq_mhz": 28.47,
         "design_freq_mhz": 28.47,
-        "momwire_model": "triangular",
+        "momwire_model": "bspline",
         "ground": True,
         "ground_model": "pec",
     }
@@ -516,7 +519,7 @@ def test_directivity_norm_gl_beats_uniform_at_coarse_grid():
         "geometry": "loops.triangular_skyloop",
         "measurement_freq_mhz": 50.0,
         "design_freq_mhz": 3.8,
-        "momwire_model": "triangular",
+        "momwire_model": "bspline",
         "n_per_wire": 80,
         "ground": False,
     }
@@ -541,12 +544,10 @@ def test_solve_reports_radiation_efficiency_for_terminated_antenna():
     efficiency multiply), so the norm must still agree with the old
     field-side construction (4π/∮|M_perp|²dΩ)·efficiency — the plotted gain
     of the rhombic did not move in this rework."""
-    term = server.solve({"geometry": "wire.rhombic", "momwire_model": "triangular"})
+    term = server.solve({"geometry": "wire.rhombic", "momwire_model": "bspline"})
     assert 0.1 < term["radiation_efficiency"] < 0.6  # ~0.29: most power in the load
 
-    lossless = server.solve(
-        {"geometry": "broadband.g5rv", "momwire_model": "triangular"}
-    )
+    lossless = server.solve({"geometry": "broadband.g5rv", "momwire_model": "bspline"})
     assert lossless["radiation_efficiency"] == 1.0
 
     # Circuit-side norm ≡ (pattern-integral norm × efficiency), the old
@@ -712,7 +713,7 @@ def test_sweep_endpoint_streams_one_record_per_freq_then_done(client: TestClient
             "geometry": "dipoles.invvee",
             "freqs_mhz": freqs,
             "measurement_freq_mhz": 28.47,
-            "momwire_model": "triangular",
+            "momwire_model": "bspline",
         },
     )
     assert r.status_code == 200
@@ -745,7 +746,7 @@ def test_converge_endpoint_streams_one_record_per_n_then_done(client: TestClient
             "geometry": "dipoles.invvee",
             "n_values": ns,
             "measurement_freq_mhz": 28.47,
-            "momwire_model": "triangular",
+            "momwire_model": "bspline",
         },
     )
     assert r.status_code == 200
@@ -973,11 +974,13 @@ def test_pynec_ground_model_selects_pec_fast_or_sommerfeld():
     z_pec = complex(pec["z_in_re"], pec["z_in_im"])
     z_somm = complex(somm["z_in_re"], somm["z_in_im"])
     assert abs(z_pec - z_somm) > 2.0
-    # ...and lands on momwire's PEC image solve (same physics, different
-    # solver: ~0.9 Ω of basis/segmentation difference measured).
+    # ...and lands near momwire's PEC image solve (same physics, different
+    # solver: ~6.1 Ω measured against the default BSpline d=2 mesh — the
+    # retired triangular basis' even mesh happened to sit ~0.9 Ω away.
+    # A sanity bound, not a convergence claim.
     momwire_pec = server.solve({**base, "solver": "momwire"})
     z_mom = complex(momwire_pec["z_in_re"], momwire_pec["z_in_im"])
-    assert abs(z_pec - z_mom) < 3.0
+    assert abs(z_pec - z_mom) < 8.0
 
 
 @pynec_required
@@ -1069,7 +1072,7 @@ def test_solve_for_multi_feed_geometry_includes_feeds_array():
         {
             "geometry": "arrays.bowtiearray1x2",
             "measurement_freq_mhz": 28.5,
-            "momwire_model": "triangular",
+            "momwire_model": "bspline",
         }
     )
     assert "feeds" in out
@@ -1089,7 +1092,7 @@ def test_solve_for_single_feed_geometry_omits_feeds_array():
         {
             "geometry": "dipoles.invvee",
             "measurement_freq_mhz": 28.47,
-            "momwire_model": "triangular",
+            "momwire_model": "bspline",
         }
     )
     assert "feeds" not in out
@@ -1133,7 +1136,7 @@ def test_solve_response_carries_z0_ohms_for_array_design():
         {
             "geometry": "arrays.bowtiearray1x2",
             "measurement_freq_mhz": 28.5,
-            "momwire_model": "triangular",
+            "momwire_model": "bspline",
         }
     )
     assert out["z0_ohms"] == 100.0
@@ -1176,7 +1179,7 @@ def test_phase_lr_drives_per_feed_voltage_phasor():
         {
             "geometry": "arrays.bowtiearray1x2",
             "measurement_freq_mhz": 28.5,
-            "momwire_model": "triangular",
+            "momwire_model": "bspline",
             "phase_lr": 0.0,
         }
     )
@@ -1184,7 +1187,7 @@ def test_phase_lr_drives_per_feed_voltage_phasor():
         {
             "geometry": "arrays.bowtiearray1x2",
             "measurement_freq_mhz": 28.5,
-            "momwire_model": "triangular",
+            "momwire_model": "bspline",
             "phase_lr": 90.0,
         }
     )
@@ -1208,7 +1211,7 @@ def test_sweep_endpoint_streams_feeds_z_for_multi_feed_geometry(client: TestClie
         json={
             "geometry": "arrays.bowtiearray1x2",
             "freqs_mhz": [28.4, 28.5],
-            "momwire_model": "triangular",
+            "momwire_model": "bspline",
         },
     )
     assert r.status_code == 200
@@ -1237,7 +1240,7 @@ def test_ws_endpoint_round_trips_a_solve(client: TestClient):
                 {
                     "geometry": "dipoles.invvee",
                     "measurement_freq_mhz": 28.47,
-                    "momwire_model": "triangular",
+                    "momwire_model": "bspline",
                 }
             )
         )
@@ -1256,7 +1259,7 @@ def test_ws_endpoint_handles_multiple_requests_on_one_socket(client: TestClient)
         {
             "geometry": "dipoles.invvee",
             "measurement_freq_mhz": 28.47,
-            "momwire_model": "triangular",
+            "momwire_model": "bspline",
         }
     )
     with client.websocket_connect("/ws") as ws:
@@ -1342,7 +1345,7 @@ def test_ws_endpoint_echoes_seq_on_success(client: TestClient):
                 {
                     "geometry": "dipoles.invvee",
                     "measurement_freq_mhz": 28.47,
-                    "momwire_model": "triangular",
+                    "momwire_model": "bspline",
                     "_seq": 7,
                 }
             )
@@ -1476,7 +1479,7 @@ def test_solve_aborted_propagates_uncached(monkeypatch):
     req = {
         "geometry": "dipoles.invvee",
         "solver": "momwire",
-        "momwire_model": "triangular",
+        "momwire_model": "bspline",
         "_seq": 7,
     }
     token = momwire.CancelToken()
@@ -1491,7 +1494,7 @@ def test_solve_z_only_returns_primary_z_and_no_feeds_for_dipole():
         {
             "geometry": "dipoles.invvee",
             "measurement_freq_mhz": 28.47,
-            "momwire_model": "triangular",
+            "momwire_model": "bspline",
         }
     )
     assert isinstance(z, complex)
@@ -1762,7 +1765,7 @@ def test_size_guard_disabled_by_default_local_is_unlocked():
         {
             "geometry": "dipoles.invvee",
             "n_per_wire": server._MAX_BASIS * 100,
-            "momwire_model": "triangular",
+            "momwire_model": "bspline",
         },
         use_pynec=False,
     )
@@ -1771,7 +1774,7 @@ def test_size_guard_disabled_by_default_local_is_unlocked():
 def test_check_solve_size_passes_for_normal_request(hosted):
     # A modest segment count is well under every cap → no rejection.
     server._check_solve_size(
-        {"geometry": "dipoles.invvee", "n_per_wire": 40, "momwire_model": "triangular"},
+        {"geometry": "dipoles.invvee", "n_per_wire": 40, "momwire_model": "bspline"},
         use_pynec=False,
     )
 
@@ -1784,7 +1787,7 @@ def test_check_solve_size_rejects_oversized_dense_but_allows_compressed(hosted):
     req = {
         "geometry": geom,
         "n_per_wire": _n_per_wire_for_basis(geom, target),
-        "momwire_model": "triangular",
+        "momwire_model": "bspline",
     }
     basis = REGISTRY[geom].count_basis(req)
     assert server._MAX_BASIS < basis <= server._MAX_BASIS_COMPRESSED, (
@@ -1809,7 +1812,7 @@ def test_solve_rejects_oversized_request_before_filling_matrix(hosted):
                 "geometry": "dipoles.invvee",
                 "n_per_wire": _n_per_wire_for_basis("dipoles.invvee", server._MAX_BASIS)
                 * 2,
-                "momwire_model": "triangular",
+                "momwire_model": "bspline",
             }
         )
 
@@ -1888,27 +1891,19 @@ def test_momwire_sinusoidal_ground_model_drives_refl_coef_solve():
     assert abs(z_fin - z_pec) > 2.0
 
 
-def test_momwire_triangular_finite_folds_to_pec_solve_but_ships_real_eps():
-    """TriangularSolver has no ground_eps: a finite ground model keeps the
-    PEC image impedance solve (identical Z to model='pec') while the
-    response still ships the real constants so the far-field pattern gets
-    the finite-ground Fresnel treatment."""
+def test_retired_model_name_falls_back_to_bspline():
+    """The triangular solver is retired: a stale client still naming it
+    (or any unknown model) gets the default BSpline solve instead of a
+    500 — same contract as the adapter's _MOMWIRE_MODELS fallback."""
     base = {
         "geometry": "dipoles.invvee",
         "solver": "momwire",
-        "momwire_model": "triangular",
         "measurement_freq_mhz": 28.47,
-        "ground": True,
     }
-    fin = server.solve({**base, "ground_model": "fast"})
-    pec = server.solve({**base, "ground_model": "pec"})
-    assert fin["ground_model_applied"] == "pec-image"
-    assert pec["ground_model_applied"] == "pec-image"
-    assert fin["ground_eps_r"] == 10.0
-    assert fin["ground_sigma"] == 0.002
-    assert pec["ground_eps_r"] == pytest.approx(1.0e10)
-    assert fin["z_in_re"] == pec["z_in_re"]
-    assert fin["z_in_im"] == pec["z_in_im"]
+    stale = server.solve({**base, "momwire_model": "triangular"})
+    bspline = server.solve({**base, "momwire_model": "bspline"})
+    assert stale["z_in_re"] == bspline["z_in_re"]
+    assert stale["z_in_im"] == bspline["z_in_im"]
 
 
 def test_momwire_ground_off_reports_free_model():


### PR DESCRIPTION
## Summary
- **Frontend** (first commit): removes "triangular" from the UI solver choices — `Backend` union, `BACKEND_ORDER`, labels, gear-menu options, capability helpers. A stale "triangular" server recommendation maps to "bspline" via `normalizeBackend()`.
- **Backend** (second commit): `MomwireEngine`'s default solver flips `TriangularSolver` → `BSplineSolver` (d=2; unqualified-path latency unchanged at ~3 ms), the adapter/CLI registries drop the "triangular" model, and unknown/retired model names fall back to bspline — a stale client naming "triangular" gets the bspline solve instead of a 500 (covered by `test_retired_model_name_falls_back_to_bspline`). Prose that referenced triangular as a live basis is reworded or marked retired; dated measurement records in docs/status are untouched.
- `TriangularSolver` itself still ships in momwire — its one remaining capability gets transferred to BSpline in a later momwire-only session, after which momwire drops it too.
- Test recalibrations from the default flip: the 13 λ skyloop power-balance cases need `n_per_wire=100` for the d=2 basis to hold the 0.05 dB gate (0.063 dB at 80, 0.041 at 100); the zepp end-null X-spread gate moves 4.0 → 2.0 Ω; the PyNEC-vs-momwire PEC sanity bound moves 3 → 8 Ω (bspline's odd mesh sits ~6.1 Ω from PyNEC's PEC where triangular's even mesh happened to sit ~0.9 Ω).

## Test plan
- [x] Full suite: 1451 passed
- [x] `npm run build` (tsc + vite) green
- [x] Latency smoke on the default request path: 3 ms before/after
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)