### PR TITLE
Sommerfeld ground on every momwire solver (momwire 0.8.0 wiring)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/sta
 # install below sees its requirement already satisfied, then the package with the
 # web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install "momwire==0.7.0" \
+ && pip install "momwire==0.8.0" \
  && pip install -e ".[web]"
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire==0.7.0",
+    "momwire==0.8.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -123,14 +123,11 @@ class MomwireEngine(SimulationEngine):
                                      coefficients on the reflected component.
                                      The impedance solve uses momwire's TRUE
                                      Sommerfeld ground (NEC gn 2 style,
-                                     ground_model="sommerfeld", momwire
-                                     >= 0.6.0) on plain BSplineSolver — the
-                                     accurate-at-any-height model. HMatrix/
-                                     ArrayBlock keep the reflection-
-                                     coefficient fast paths (momwire would
-                                     gate their sommerfeld to a dense solve),
-                                     SinusoidalSolver has only the refl-coef
-                                     model.
+                                     ground_model="sommerfeld") on every
+                                     momwire solver (momwire >= 0.8.0:
+                                     BSpline dense, Sinusoidal field-based,
+                                     HMatrix/ArrayBlock fast paths) — the
+                                     accurate-at-any-height model.
           ("finite-fast", eps_r, sigma) — the reflection-coefficient model
                                      (NEC gn 0 style, ground_eps) on every
                                      solver that supports it. Matches
@@ -190,19 +187,14 @@ class MomwireEngine(SimulationEngine):
             and _solver_supports_ground_eps(self._solver)
         ):
             self._ground_eps = (float(self._ground[1]), float(self._ground[2]))
-            # True Sommerfeld (momwire >= 0.6.0) only on plain BSplineSolver
-            # for the "finite" spec: HMatrix/ArrayBlock would be gated to a
-            # dense solve (a silent perf cliff on the large arrays they
-            # exist for) so they keep their refl-coef fast paths, and
-            # SinusoidalSolver has no sommerfeld model. "finite-fast" is
-            # refl-coef everywhere.
+            # "finite" means true Sommerfeld on EVERY momwire solver since
+            # momwire 0.8.0 (sinusoidal grew the model; HMatrix/ArrayBlock
+            # solve it on their fast paths — C2-scaled image blocks + one
+            # global low-rank remainder — so the old dense-solve cliff that
+            # kept them on refl-coef is gone). "finite-fast" is refl-coef
+            # everywhere.
             self._ground_model = (
-                "sommerfeld"
-                if (
-                    self._ground[0] == "finite"
-                    and getattr(self._solver, "__name__", None) == "BSplineSolver"
-                )
-                else "refl-coef"
+                "sommerfeld" if self._ground[0] == "finite" else "refl-coef"
             )
 
         # Map TL tags to feed indices for the legacy build_tls() path.
@@ -253,8 +245,9 @@ class MomwireEngine(SimulationEngine):
         if self._ground_eps is None:
             return {}
         kw = {"ground_eps": self._ground_eps}
-        # Only BSplineSolver takes ground_model (and refl-coef is its
-        # default); SinusoidalSolver would reject the kwarg.
+        # Every ground_eps solver accepts ground_model since momwire 0.8.0
+        # (refl-coef is the default, so it is only spliced in for
+        # sommerfeld to keep refl-coef solves bit-identical to older pins).
         if self._ground_model == "sommerfeld":
             kw["ground_model"] = "sommerfeld"
         return kw

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -479,14 +479,13 @@ def _ground_for_engine(req: dict, ground_z: float):
     same three-way model as `_pynec_ground_spec`, one shared selector
     describing the GROUND; each engine approximates it as best it can.
     "pec" → the PEC image; "sommerfeld" → ("finite", ...), which momwire
-    solves as the TRUE Sommerfeld ground on plain BSplineSolver (momwire
-    >= 0.6.0) and as the reflection-coefficient model on the other
-    ground_eps solvers (hmatrix/arrayblock keep their fast paths,
-    sinusoidal has no sommerfeld model); "fast" → ("finite-fast", ...),
-    the reflection-coefficient model everywhere it exists. The response ships the
-    engine's actual eps/sigma so the frontend far-field Fresnel uses the
-    real constants either way; `ground_model_applied` reports what the
-    impedance solve really used."""
+    solves as the TRUE Sommerfeld ground on every solver (momwire >=
+    0.8.0: bspline dense, sinusoidal field-based, hmatrix/arrayblock fast
+    paths); "fast" → ("finite-fast", ...), the reflection-coefficient
+    model everywhere. The response ships the engine's actual eps/sigma so
+    the frontend far-field Fresnel uses the real constants either way;
+    `ground_model_applied` reports what the impedance solve really
+    used."""
     model = _requested_ground_model(req)
     if model is None:
         return None
@@ -1139,9 +1138,9 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
                 else _PEC_GROUND_SIGMA
             ),
             # What the impedance solve actually used, for honest UI wording:
-            # "sommerfeld" (BSplineSolver + "finite", momwire >= 0.6.0),
-            # "refl-coef" (the other ground_eps solvers, or any solver with
-            # the "finite-fast" spec), "pec-image" (model="pec"), or "free".
+            # "sommerfeld" (any momwire solver + "finite", momwire >= 0.8.0),
+            # "refl-coef" (the "finite-fast" spec), "pec-image"
+            # (model="pec"), or "free".
             "ground_model_applied": (
                 "free" if eng._ground is None else (eng._ground_model or "pec-image")
             ),

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1288,25 +1288,21 @@ function isBSplineFamily(b: Backend): boolean {
 // a perfectly conducting one. It never promises more than the physics —
 // each backend solves it as best it can: PyNEC and the plain B-spline
 // backend offer a method sub-choice (Sommerfeld-Norton vs the
-// reflection-coefficient approximation); the fast B-spline variants use
-// refl-coef; Sinusoidal keeps the PEC image solve — either way
-// the finite constants reach the far-field Fresnel cut.
+// reflection-coefficient approximation) — since momwire 0.8.0 every
+// momwire backend honours both, so the choice is uniform across solvers;
+// either way the finite constants reach the far-field Fresnel cut.
 type GroundType = "finite" | "pec";
-// Finite-ground solve method. Meaningful — and shown — where both models
-// are real solves: PyNEC (NEC ITYPE=2 vs ITYPE=0) and the plain B-spline
-// backend (true Sommerfeld since momwire 0.6.0 vs refl-coef). "fast" is
-// the default everywhere; Sommerfeld is opt-in because it is more
-// expensive: since momwire 0.7.0 the first solve at a new frequency fills
-// an interpolation grid (~0.2-0.5 s on a small box; the first sweep pays
-// that per point), and repeat solves at seen frequencies reuse cached
-// grids (tens of ms).
+// Finite-ground solve method, shown for every finite-ground backend:
+// PyNEC (NEC ITYPE=2 vs ITYPE=0) and, since momwire 0.8.0, every momwire
+// solver (true Sommerfeld on bspline dense, sinusoidal field-based, and
+// the hmatrix/arrayblock fast paths). "fast" is the default everywhere;
+// Sommerfeld is opt-in because it is more expensive: the first solve at a
+// new frequency fills an interpolation grid (~0.2-0.5 s on a small box;
+// the first sweep pays that per point), and repeat solves at seen
+// frequencies reuse cached grids (tens of ms).
 type FiniteGroundMethod = "sommerfeld" | "fast";
-function backendHasGroundMethod(b: Backend): boolean {
-  return b === "pynec" || b === "bspline";
-}
 // The wire value (`ground_model` on SolveRequest): derived from groundType
-// (+ the method where it applies); other finite-ground backends send
-// "fast" (their single finite model is the refl-coef one anyway).
+// (+ the method wherever finite ground is supported).
 type GroundModel = "sommerfeld" | "fast" | "pec";
 
 function backendSupportsGround(b: Backend): boolean {
@@ -2425,29 +2421,21 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   const groundModel: GroundModel =
     groundType === "pec"
       ? "pec"
-      : backendHasGroundMethod(backend)
+      : backendSupportsGround(backend)
         ? finiteGroundMethod
         : "fast";
 
-  // One-line tab-hover summary: design · solver N=segs · ground model. The
-  // wording reflects what the active solver actually runs: PyNEC and the
-  // plain B-spline backend honour the selected method; H-matrix/Array-block
-  // solve refl-coef for any finite model (their fast ground paths);
-  // Sinusoidal solves the PEC image and only the far-field
-  // pattern sees the finite constants. "free space" when ground is off or
-  // unsupported.
+  // One-line tab-hover summary: design · solver N=segs · ground model.
+  // Every backend honours the selected method (momwire >= 0.8.0), so the
+  // wording is uniform; "free space" when ground is off or unsupported.
   const groundActiveForSummary = groundEnabled && backendSupportsGround(backend);
   const groundSummary = !groundActiveForSummary
     ? "free space"
     : groundModel === "pec"
       ? "PEC ground"
-      : backendHasGroundMethod(backend)
-        ? groundModel === "fast"
-          ? "reflection-coef ground"
-          : "Sommerfeld ground"
-        : isBSplineFamily(backend)
-          ? "reflection-coef ground"
-          : "PEC solve · Fresnel pattern";
+      : groundModel === "fast"
+        ? "reflection-coef ground"
+        : "Sommerfeld ground";
   const tabSummary = `${(currentExample?.label ?? geometry) || "new design"} · ${backendDisplayLabel(backend, currentOpts)} N=${nPerWire} · ${groundSummary}`;
   useEffect(() => {
     reportSummary(id, tabSummary);
@@ -3466,7 +3454,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     // the active variant's entry in variant_ui, falling back to the
     // design-level sweep_policy.
     const slowGround =
-      backendHasGroundMethod(backend) &&
+      backendSupportsGround(backend) &&
       groundEnabled &&
       groundModel === "sommerfeld";
     const N = slowGround ? 21 : 41;
@@ -4582,11 +4570,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                     [
                       "finite",
                       "finite (εr=10, σ=0.002 S/m)",
-                      backend === "pynec"
-                        ? "Finite ground — pick the solve method below (Sommerfeld-Norton or the reflection-coefficient approximation)."
-                        : isBSplineFamily(backend)
-                          ? "Finite ground, solved with momwire's reflection-coefficient model (its best finite model — within ~2 Ω of Sommerfeld-Norton above ~0.1λ heights); the pattern uses the real εr/σ."
-                          : "Finite ground: this solver only models the PEC image in the impedance solve; the far-field pattern still uses the real εr/σ (Fresnel).",
+                      "Finite ground — pick the solve method below (Sommerfeld-Norton or the reflection-coefficient approximation).",
                     ],
                     [
                       "pec",
@@ -4608,8 +4592,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                   </label>
                 ))}
               </div>
-              {groundType === "finite" &&
-                (backendHasGroundMethod(backend) ? (
+              {groundType === "finite" && (
                   <div
                     role="radiogroup"
                     aria-label="Finite-ground solve method"
@@ -4629,7 +4612,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                           "Sommerfeld",
                           backend === "pynec"
                             ? "Sommerfeld-Norton (NEC ITYPE=2) — most accurate, slowest; the impedance sweep drops to half resolution to compensate."
-                            : "True Sommerfeld ground (momwire ≥ 0.6.0) — accurate at any height. First solve at each frequency builds a grid (seconds); repeats are fast. The impedance sweep runs at half resolution.",
+                            : "True Sommerfeld ground — accurate at any height, on every momwire solver including the fast array paths (momwire ≥ 0.8.0). First solve at each frequency builds a grid (seconds); repeats are fast. The impedance sweep runs at half resolution.",
                         ],
                       ] as [FiniteGroundMethod, string, string][]
                     ).map(([value, label, title]) => (
@@ -4644,19 +4627,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                       </label>
                     ))}
                   </div>
-                ) : (
-                  <em
-                    style={{
-                      color: "var(--muted)",
-                      fontSize: "var(--text-sm)",
-                      marginLeft: "1.2em",
-                    }}
-                  >
-                    {isBSplineFamily(backend)
-                      ? "solved as refl-coef (this solver's fast ground path)"
-                      : "impedance solve uses the PEC image; pattern uses εr/σ"}
-                  </em>
-                ))}
+                )}
             </>
           )}
         </div>

--- a/tests/test_momwire_finite_ground.py
+++ b/tests/test_momwire_finite_ground.py
@@ -4,11 +4,10 @@ SinusoidalSolver support since 0.5.0; TRUE Sommerfeld since 0.6.0).
 Finite ground specs reach the impedance solve for solvers that support
 them, and since momwire 0.6.0 the two specs mean different physics:
 ("finite", eps_r, sigma) drives momwire's Sommerfeld ground
-(ground_model="sommerfeld", NEC gn 2 style) on plain BSplineSolver, while
-("finite-fast", eps_r, sigma) — and "finite" on the solvers without a
-sommerfeld model (HMatrix/ArrayBlock keep their refl-coef fast paths,
-SinusoidalSolver is refl-coef only) — maps to the reflection-coefficient
-ground_eps solve (NEC gn 0 style).
+(ground_model="sommerfeld", NEC gn 2 style) — since momwire 0.8.0 on
+EVERY momwire solver (bspline dense, sinusoidal field-based, the
+hmatrix/arrayblock fast paths) — while ("finite-fast", eps_r, sigma)
+maps to the reflection-coefficient ground_eps solve (NEC gn 0 style).
 
 The refl-coef numeric tests cross-check against PyNEC gn 0 (dipole
 0.1–0.5λ window: bspline max |ΔZ| ≈ 2.45 Ω, sinusoidal ≈ 0.11 Ω). The
@@ -51,9 +50,8 @@ def test_finite_specs_map_to_ground_eps_for_bspline():
 
 
 def test_ground_model_mapping_per_solver_and_spec():
-    """ "finite" → sommerfeld on plain BSplineSolver only; "finite-fast" →
-    refl-coef everywhere; solvers without a sommerfeld model keep
-    refl-coef for both specs."""
+    """ "finite" → sommerfeld on EVERY momwire solver (momwire >= 0.8.0);
+    "finite-fast" → refl-coef everywhere."""
     from momwire import ArrayBlockSolver, HMatrixSolver
 
     b = _flat_dipole(_height(0.2))
@@ -61,16 +59,16 @@ def test_ground_model_mapping_per_solver_and_spec():
     def model(solver, spec):
         return MomwireEngine(b, solver=solver, ground=spec)._ground_model
 
-    assert model(BSplineSolver, ("finite", 10.0, 0.002)) == "sommerfeld"
-    assert model(BSplineSolver, ("finite-fast", 10.0, 0.002)) == "refl-coef"
-    for solver in (HMatrixSolver, ArrayBlockSolver, SinusoidalSolver):
-        assert model(solver, ("finite", 10.0, 0.002)) == "refl-coef"
+    for solver in (BSplineSolver, HMatrixSolver, ArrayBlockSolver, SinusoidalSolver):
+        assert model(solver, ("finite", 10.0, 0.002)) == "sommerfeld"
         assert model(solver, ("finite-fast", 10.0, 0.002)) == "refl-coef"
-    # and the sommerfeld kwarg only reaches solvers that accept it
-    eng = MomwireEngine(b, solver=BSplineSolver, ground=("finite", 10.0, 0.002))
-    assert eng._ground_solver_kwargs().get("ground_model") == "sommerfeld"
-    eng = MomwireEngine(b, solver=SinusoidalSolver, ground=("finite", 10.0, 0.002))
-    assert "ground_model" not in eng._ground_solver_kwargs()
+    # the sommerfeld kwarg reaches every solver (refl-coef stays implicit,
+    # keeping "finite-fast" solves bit-identical to older pins)
+    for solver in (BSplineSolver, SinusoidalSolver):
+        eng = MomwireEngine(b, solver=solver, ground=("finite", 10.0, 0.002))
+        assert eng._ground_solver_kwargs().get("ground_model") == "sommerfeld"
+        eng = MomwireEngine(b, solver=solver, ground=("finite-fast", 10.0, 0.002))
+        assert "ground_model" not in eng._ground_solver_kwargs()
 
 
 def test_finite_specs_map_to_ground_eps_for_sinusoidal():

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1891,6 +1891,34 @@ def test_momwire_sinusoidal_ground_model_drives_refl_coef_solve():
     assert abs(z_fin - z_pec) > 2.0
 
 
+@pytest.mark.parametrize("model", ["sinusoidal", "hmatrix", "arrayblock"])
+def test_momwire_sommerfeld_applies_on_every_solver(model):
+    """Since momwire 0.8.0 the "sommerfeld" ground model drives the TRUE
+    Sommerfeld solve on every momwire backend (sinusoidal field-based,
+    hmatrix/arrayblock on their fast paths), not just plain bspline —
+    the wiring this release exists to deliver. The sommerfeld solve
+    agrees with bspline-sommerfeld at the cross-solver floor and stays
+    a genuinely different solve from refl-coef."""
+    base = {
+        "geometry": "dipoles.invvee",
+        "solver": "momwire",
+        "measurement_freq_mhz": 28.47,
+        "ground": True,
+    }
+    somm = server.solve({**base, "momwire_model": model, "ground_model": "sommerfeld"})
+    fast = server.solve({**base, "momwire_model": model, "ground_model": "fast"})
+    ref = server.solve(
+        {**base, "momwire_model": "bspline", "ground_model": "sommerfeld"}
+    )
+    assert somm["ground_model_applied"] == "sommerfeld"
+    assert fast["ground_model_applied"] == "refl-coef"
+    z_somm = complex(somm["z_in_re"], somm["z_in_im"])
+    z_fast = complex(fast["z_in_re"], fast["z_in_im"])
+    z_ref = complex(ref["z_in_re"], ref["z_in_im"])
+    assert z_somm != z_fast
+    assert abs(z_somm - z_ref) < 3.0  # cross-solver floor
+
+
 def test_retired_model_name_falls_back_to_bspline():
     """The triangular solver is retired: a stale client still naming it
     (or any unknown model) gets the default BSpline solve instead of a


### PR DESCRIPTION
## Summary
- `("finite", εr, σ)` now maps to `ground_model="sommerfeld"` on **all** momwire solvers — the `MomwireEngine` BSplineSolver-only gate is removed. momwire 0.8.0 solves Sommerfeld on sinusoidal (field-based, ~0.1 Ω from the nec2c gn 2 oracle) and on the hmatrix/arrayblock fast paths (C2-scaled image blocks + one global low-rank remainder), so the dense-solve cliff that motivated the gate no longer exists. `("finite-fast", …)` stays refl-coef everywhere, bit-identical to older pins.
- Exact pin bumped to `momwire==0.8.0` (pyproject + Dockerfile); PyPI already serves it (no wheel-smoke race).
- Frontend: `backendHasGroundMethod` collapses into `backendSupportsGround` — the fast/Sommerfeld method radio now shows for every finite-ground backend, and the per-backend "solved as refl-coef (this solver's fast ground path)" fallback strings are deleted. With Triangular retired (#267), the solver × ground matrix is fully uniform.
- Per the default-cost discipline: Sommerfeld stays **opt-in** (default "fast"). Latency smoke — unqualified path unchanged (3–24 ms per solver); opt-in Sommerfeld ≤265 ms cold (grid fill, shared module cache) / ≤62 ms warm on the smoke dipole.

## Test plan
- [x] `test_ground_model_mapping_per_solver_and_spec` updated: "finite" → sommerfeld on all four solvers, "finite-fast" → refl-coef, kwarg splice checked both ways
- [x] New `test_momwire_sommerfeld_applies_on_every_solver[sinusoidal|hmatrix|arrayblock]`: `ground_model_applied == "sommerfeld"`, distinct from refl-coef, agrees with bspline-sommerfeld within the cross-solver floor
- [x] Full suite: 1454 passed; `npm run build` green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)