### PR TITLE
Release 0.19.0: Sommerfeld ground on every solver; triangular retired

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.18.0"
+version = "0.19.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/concepts/first-builder.mdx
+++ b/site/src/content/docs/concepts/first-builder.mdx
@@ -153,11 +153,11 @@ parameter.
 <Aside type="note" title="You give a count; the solver picks the parity">
   You might expect the feed to need an **odd** count so a centre-fed wire has a
   true middle segment — and for some solvers it does. But which parity lands the
-  feed cleanly depends on the basis functions: sinusoidal and PyNEC want odd,
-  while the default dense (triangular) solver wants **even**. So `segs_for`
-  deliberately doesn't force a parity — it returns the natural count, and each
-  solver nudges it by at most one to suit its own basis at solve time. You size
-  the mesh; the solver gets the feed right.
+  feed cleanly depends on the basis functions: sinusoidal, PyNEC, and the
+  default B-spline (degree-2) solver want odd, while B-spline degree-1 wants
+  **even**. So `segs_for` deliberately doesn't force a parity — it returns the
+  natural count, and each solver nudges it by at most one to suit its own basis
+  at solve time. You size the mesh; the solver gets the feed right.
 </Aside>
 
 ## 5. Parameterize the length

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,14 +25,15 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.18.0" icon="star">
-  **Sommerfeld ground is now interactive.** The exact finite-ground
-  model introduced in v0.17.0 got a C++ engine and a grid cache in
-  momwire 0.7.0: repeat solves reuse cached interpolation grids, so
-  knob-turns respond in tens of milliseconds and impedance sweeps run
-  ~20× faster once warm — same physics, validated within ~2.4 Ω of an
-  independent NEC-2 implementation down to 0.02 λ. Superseded solves
-  now cancel mid-computation too.
+<Card title="New in v0.19.0" icon="star">
+  **Sommerfeld ground on every solver.** The exact finite-ground model
+  now runs on all momwire backends (momwire 0.8.0): the sinusoidal
+  basis lands within ~0.1 Ω of an independent NEC-2 implementation —
+  the sharpest validation of the model yet — and the H-matrix /
+  array-block accelerators solve it on their fast paths instead of
+  falling back to a dense solve. The ground selector is now uniform
+  across solvers, and the legacy triangular basis is retired (B-spline
+  is the default).
   [All release notes →](/reference/releases/)
 </Card>
 
@@ -52,8 +53,9 @@ formula calculator or a desktop app you have to install; this is neither.
     Most tools make you hand-place every coordinate.
   </Card>
   <Card title="Multi-basis MoM" icon="seti:python">
-    Triangular, sinusoidal, and B-spline bases in one engine — basis quality
-    that otherwise costs four figures in commercial tools.
+    Sinusoidal and B-spline bases in one engine, cross-validating each
+    other — basis quality that otherwise costs four figures in commercial
+    tools.
   </Card>
   <Card title="Fast on big arrays" icon="rocket">
     H-matrix / ACA acceleration with GMRES, where every free NEC tool is dense

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -31,8 +31,8 @@ python -m antennaknobs list            # arrays.bowtiearray, beams.yagi, loops.d
 ## Patterns
 
 ```bash
-# Far-field pattern of a Yagi, solved with momwire's triangular basis
-python -m antennaknobs pattern --builder beams.yagi --engine momwire:triangular
+# Far-field pattern of a Yagi, solved with momwire's default (B-spline) basis
+python -m antennaknobs pattern --builder beams.yagi --engine momwire
 ```
 
 Useful `pattern` flags: `--fn out.png` (write to a file instead of the screen),
@@ -44,8 +44,7 @@ Useful `pattern` flags: `--fn out.png` (write to a file instead of the screen),
 The `--engine` flag selects the solver:
 
 ```bash
---engine momwire                 # momwire (default), default (triangular) basis
---engine momwire:triangular      # piecewise-linear (tent) basis
+--engine momwire                 # momwire (default), default (B-spline) basis
 --engine momwire:sinusoidal      # NEC-2-style three-term basis
 --engine momwire:bspline         # B-spline Galerkin basis
 --engine momwire:hmatrix         # B-spline + hierarchical-matrix (ACA) acceleration

--- a/site/src/content/docs/reference/drone-transform.md
+++ b/site/src/content/docs/reference/drone-transform.md
@@ -97,8 +97,8 @@ trig:
 
 When `forward()` / `close()` / `line_to()` aren't given an explicit `nsegs`, the
 drone picks `max(3, round(nominal_nsegs · |length| / ref))`. It does **not**
-force a parity — each solver wants a different one (odd for sinusoidal / B-spline
-degree-2 / PyNEC, even for triangular / B-spline degree-1) so the feed lands
+force a parity — each solver wants a different one (odd for sinusoidal /
+B-spline degree-2 / PyNEC, even for B-spline degree-1) so the feed lands
 cleanly, and the engine coerces every count to its own parity at solve time.
 
 ### Example — a vertical delta loop

--- a/site/src/content/docs/reference/solver.md
+++ b/site/src/content/docs/reference/solver.md
@@ -9,12 +9,11 @@ cross-checking.
 
 ## Basis functions
 
-momwire offers three current-expansion bases in one engine — uncommon among free
-tools, where basis quality is usually a paid feature:
+momwire offers two current-expansion basis families in one engine — uncommon
+among free tools, where basis quality is usually a paid feature:
 
-- **triangular** (piecewise-linear "tent") — the default,
-- **sinusoidal** — a NEC-2-style three-term basis, useful as a cross-validator,
-- **B-spline** — a degree-1/2 Galerkin basis.
+- **B-spline** — a degree-1/2 Galerkin basis, the default (degree 2),
+- **sinusoidal** — a NEC-2-style three-term basis, useful as a cross-validator.
 
 Plus two **accelerated** solvers for large problems:
 
@@ -53,7 +52,7 @@ reach for them on small problems.
   single/few-element designs (often <100 ms), yet blows up on the log-periodic
   (13 s). "Use PyNEC as the reference" holds for small designs, not arrays.
 - **Among dense bases, `sinusoidal` stays fastest** on small/medium single
-  structures; `triangular` is the slowest dense basis.
+  structures.
 
 ## Segments & convergence
 
@@ -109,17 +108,18 @@ the limits are env-configurable (see `docs/deploy.md`).
 ### Honest limitations
 
 In the spirit of not overselling: momwire wires are currently PEC (no conductor
-loss — the NEC path with `ld_card` covers lossy elements), and finite-ground
-impedance on the triangular basis folds to the PEC image. The plain B-spline
-solver solves finite grounds with a true **Sommerfeld/Norton** model
-(momwire ≥ 0.6.0: NEC's exact-image-plus-remainder decomposition, validated
-within ~2.4 Ω of an independent NEC-2 implementation across 0.02–0.5λ
-heights — including the very-low region where reflection-coefficient models
-are tens of ohms off). The accelerated B-spline solvers (H-matrix /
-array-block) and the sinusoidal basis use the reflection-coefficient model
-(~2 Ω and ~0.1 Ω of NEC's gn 0 respectively over 0.1–0.5λ), and the NEC
-path offers its own Sommerfeld–Norton — so real-ground results cross-check
-across two independent engines at every height.
+loss — the NEC path with `ld_card` covers lossy elements). Finite grounds are
+solved with a true **Sommerfeld/Norton** model on every momwire solver
+(momwire ≥ 0.8.0: NEC's exact-image-plus-remainder decomposition; the
+accelerators carry the smooth remainder as one global low-rank term on their
+fast paths). Validation against an independent NEC-2 implementation across
+0.02–0.5λ heights — including the very-low region where
+reflection-coefficient models are tens of ohms off — lands within ~2.4 Ω on
+the B-spline basis and ~0.1 Ω on the sinusoidal basis (which shares NEC's
+basis, making it the sharpest check of the model). The faster
+reflection-coefficient model remains the default and the NEC path offers its
+own Sommerfeld–Norton — so real-ground results cross-check across two
+independent engines at every height.
 
 <!-- TODO: embed the benchmark plots once generated, and a parity/differentiator
      table vs PyNEC / 4nec2 / EZNEC / AN-SOF from the market-research doc. -->

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -95,7 +95,7 @@ variant just replaced. Re-mark the knobs and turn Optimize back on to resume.
 A **solver selector** offers a few preset slots so you can flip between engines
 without re-entering options — e.g. a fast dense basis, an accelerated array
 engine, and the PyNEC reference. The available engines are the momwire bases
-(**triangular**, **sinusoidal**, **bspline**), the accelerators (**hmatrix**,
+(**sinusoidal**, **bspline**), the accelerators (**hmatrix**,
 **arrayblock**), and the optional **PyNEC** backend — see
 [The solver & accuracy](/reference/solver/) for what each is good at.
 
@@ -128,23 +128,20 @@ The selector describes what the ground **is**, independent of solver:
 - **PEC** — a perfect reflector, mainly for apples-to-apples engine
   comparisons.
 
-Each solver then models that ground as well as it can, with a method
-sub-choice on both engines — full **Sommerfeld/Norton** (most accurate,
-the reference below ~0.1λ heights) vs. the **reflection-coefficient**
-approximation (the default: much faster per solve, and fine above
-~0.1λ; Sommerfeld is opt-in because its first solve at each frequency
-builds an interpolation grid — so the first sweep takes a few seconds —
-though repeat solves reuse cached grids and run in tens of milliseconds
-since momwire 0.7.0). On momwire the plain
-B-spline solver honours both (true Sommerfeld since momwire 0.6.0,
-validated within ~2.4 Ω of an independent NEC-2 implementation down to
-0.02λ); the accelerated B-spline solvers keep their fast
-reflection-coefficient paths, the sinusoidal basis is
-reflection-coefficient only (~0.1 Ω of NEC's gn 0 — it shares NEC's
-basis), and the triangular basis folds the impedance solve to the PEC
-image. The far-field pattern uses the real εr/σ on every basis. Whatever
-runs, the solve readout's **ground** row reports the model that was
-actually used, and over a finite ground the
+Every solver then offers the same method sub-choice — full
+**Sommerfeld/Norton** (most accurate, the reference below ~0.1λ heights)
+vs. the **reflection-coefficient** approximation (the default: much
+faster per solve, and fine above ~0.1λ; Sommerfeld is opt-in because its
+first solve at each frequency builds an interpolation grid — so the
+first sweep takes a few seconds — though repeat solves reuse cached
+grids and run in tens of milliseconds). Since momwire 0.8.0 the choice
+is uniform: every momwire solver honours both models (Sommerfeld
+validated against an independent NEC-2 implementation down to 0.02λ —
+within ~2.4 Ω on the B-spline bases, ~0.1 Ω on the sinusoidal basis, and
+the accelerators solve it on their fast paths), and PyNEC honours both
+natively. The far-field pattern uses the real εr/σ on every basis.
+Whatever runs, the solve readout's **ground** row reports the model that
+was actually used, and over a finite ground the
 [norm check](#norm-check--is-the-solve-trustworthy) Δ reads "incl. ground
 loss" — a steady dB or so there is absorbed power, not error.
 


### PR DESCRIPTION
## Summary
- Version bump to **0.19.0** + the release-ritual what's-new card refresh (Sommerfeld on all momwire solvers via momwire 0.8.0, uniform ground selector, triangular retired with B-spline as the default).
- De-stales the live docs-site pages that PR #267/#268 didn't touch: the solver-reference basis list and honest-limitations ground paragraph, the web-reference solver list and ground-selector section (now one uniform method choice), the CLI engine-spec examples, and the parity notes in first-builder / drone-transform.
- Site builds clean (astro, 15 pages).

Cutting the release after merge deploys this tagged commit to PyPI, the hosted app, and the docs site.

## Test plan
- [x] `npm run build` in site/ — 15 pages, no errors
- [x] No live-doc triangular references remain (only the retirement announcement and the unrelated triangular_skyloop design)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)