### PR TITLE
Bump the momwire submodule to v0.8.0 (match the pyproject pin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,14 @@ git submodule update --init momwire
 pip install --no-build-isolation -e ./momwire
 ```
 
+> The submodule pointer tracks the exact momwire release the pyproject pins.
+> If it ever drifts behind the pin, step 4 below silently replaces your
+> editable momwire with the PyPI wheel (pip resolving `momwire==X`) and edits
+> under `momwire/` stop taking effect — verify with
+> `python -c "import momwire; print(momwire.__file__)"`, which must point into
+> the checkout, and re-run this step after `git submodule update --remote
+> momwire` if it doesn't.
+
 **3b. (Optional) Install PyNEC for cross-validation**
 
 PyNEC is an optional second backend — **GPL-2.0**, installed separately from its


### PR DESCRIPTION
## Summary
- Verified a clean-room dev clone of both repos following the READMEs (momwire: fully clean — venv, C++ accelerator build, 344 tests, optional PyNEC wheel all work). antennaknobs surfaced one real issue:
- The momwire **submodule pointer was still at the v0.7.0 commit** while pyproject pins `momwire==0.8.0`. Following the README verbatim, step 3 builds editable momwire 0.7.0 from the submodule, then step 4 (`pip install -e ".[test]"`) silently uninstalls it in favour of the PyPI 0.8.0 wheel — the dev-checkout promise (editable momwire) breaks with no warning, and the C++ source build is wasted. CI never catches this because `test.yml` updates the submodule with `--remote`.
- Fix: pointer bumped to the v0.8.0 release commit (editable install then satisfies the pin and survives — verified in the clean room), plus a README note documenting the drift symptom and check.

## Test plan
- [x] Clean-room verification: with the pointer at 0.8.0, `pip install -e ".[test]"` keeps the editable submodule install (`momwire.__file__` inside the checkout)
- [x] Fresh-clone suite: 1279 passed, 49 skipped (optional-PyNEC skips)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)