### PR TITLE
Sweep memory budget (ANTENNAKNOBS_SWEPT_MEM_MB) + momwire triangular-retirement prep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/sta
 # install below sees its requirement already satisfied, then the package with the
 # web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install "momwire==0.8.0" \
+ && pip install "momwire==0.9.0" \
  && pip install -e ".[web]"
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in

--- a/fly.toml
+++ b/fly.toml
@@ -15,6 +15,13 @@ primary_region = 'sjc'
   # unlocked by default; only this flag turns the caps on. Tune the limits with
   # ANTENNAKNOBS_MAX_BASIS[_COMPRESSED|_PYNEC] if the VM size changes.
   ANTENNAKNOBS_HOSTED = '1'
+  # Cap momwire's batched frequency-sweep transient memory per solve
+  # (BSplineSolver swept_mem_mb, momwire >= 0.9). 64 MB keeps two
+  # concurrent worst-case sweeps well inside this 2 GB VM (~160 MB peak
+  # RSS each) at ~1.6x worst-case sweep latency; interactive-size sweeps
+  # never hit the cap. Measured tradeoff in the momwire triangular
+  # retirement plan (docs/triangular-retirement-plan.md there).
+  ANTENNAKNOBS_SWEPT_MEM_MB = '64'
 
 [http_service]
   internal_port = 8000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire==0.8.0",
+    "momwire==0.9.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",

--- a/scripts/measure_solve_memory.py
+++ b/scripts/measure_solve_memory.py
@@ -13,7 +13,8 @@ reject the very runs we're trying to measure.
 Usage:
     python scripts/measure_solve_memory.py <geometry> <engine> <N> [<N> ...]
 
-    engine ∈ {triangular, sinusoidal, bspline, hmatrix, arrayblock, pynec}
+    engine ∈ {sinusoidal, bspline, hmatrix, arrayblock, pynec}
+    (retired names, e.g. "triangular", fall back to bspline)
 
 Example:
     python scripts/measure_solve_memory.py arrays.bowtiearray2x4 arrayblock 21 41 81

--- a/scripts/profile_compare_engines.py
+++ b/scripts/profile_compare_engines.py
@@ -3,8 +3,8 @@ range of antenna designs spanning the solver-selection space (single elements,
 beams, multiband dipoles, large single-wire structures, and arrays).
 
 Engines compared:
-  Tri   — momwire TriangularSolver
-  Bs1   — momwire BSplineSolver(degree=1)
+  Bs1   — momwire BSplineSolver(degree=1) (the tent basis; the retired
+          TriangularSolver was the same scheme to roundoff)
   Bs2   — momwire BSplineSolver(degree=2)
   Sin   — momwire SinusoidalSolver
   Arr   — momwire ArrayBlockSolver (element-aware block-low-rank)
@@ -100,7 +100,6 @@ from momwire import (  # noqa: E402
     BSplineSolver,
     HMatrixSolver,
     SinusoidalSolver,
-    TriangularSolver,
 )
 
 
@@ -138,7 +137,6 @@ def solve_pynec(builder_cls, n, f):
 
 
 ENGINES = [
-    ("Tri", make_momwire_solver(TriangularSolver, None)),
     ("Bs1", make_momwire_solver(BSplineSolver, {"degree": 1})),
     ("Bs2", make_momwire_solver(BSplineSolver, {"degree": 2})),
     ("Sin", make_momwire_solver(SinusoidalSolver, None)),

--- a/scripts/profile_ws_postproc_serialization.py
+++ b/scripts/profile_ws_postproc_serialization.py
@@ -234,7 +234,7 @@ def main():
         "geometry": "loops.triangular_skyloop",
         "variant": "default",
         "solver": "momwire",
-        "momwire_model": "triangular",
+        "momwire_model": "bspline",
         "n_per_wire": 80,
         "design_freq_mhz": 3.8,  # sized for the 80m loop (~1λ)
         "wire_radius": 0.001,

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import importlib
 import math
+import os
 import pathlib
 import time
 from collections.abc import Mapping
@@ -88,6 +89,18 @@ DESIGNS_PKG = "antennaknobs.designs"
 # once installed from a wheel they are separate top-level packages with no `src/`
 # in between. __path__ points at the real location in both layouts.
 DESIGNS_DIR = pathlib.Path(importlib.import_module(DESIGNS_PKG).__path__[0])
+
+# Memory budget (MB) for momwire's batched frequency sweeps, injected into
+# the bspline-family solvers' `swept_mem_mb` kwarg (momwire >= 0.9). None
+# (unset) leaves momwire's default (256 MB) — appropriate for local use;
+# the hosted fly.toml sets ANTENNAKNOBS_SWEPT_MEM_MB=64 so two concurrent
+# worst-case sweeps stay well inside the 2 GB VM. Read at import, like the
+# server's ANTENNAKNOBS_MAX_BASIS caps.
+_SWEPT_MEM_MB = (
+    int(os.environ["ANTENNAKNOBS_SWEPT_MEM_MB"])
+    if os.environ.get("ANTENNAKNOBS_SWEPT_MEM_MB")
+    else None
+)
 
 _MOMWIRE_MODELS = {
     "sinusoidal": SinusoidalSolver,
@@ -533,6 +546,16 @@ def _make_momwire_engine(req: dict, builder, cancel=None):
     wire_radius = float(req.get("wire_radius", 0.0005))
     ground = _ground_for_engine(req, 0.0)
     solver_kwargs = req.get("model_options") or None
+    if _SWEPT_MEM_MB is not None and issubclass(solver_cls, BSplineSolver):
+        # Deployment-owned memory policy (momwire >= 0.9): cap the batched
+        # frequency sweep's transient memory per solve. Server-side value
+        # OVERRIDES any client-sent model_options entry — on the shared
+        # hosted instance the budget bounds concurrent sweeps the same way
+        # the ANTENNAKNOBS_MAX_BASIS caps bound single solves. Sinusoidal
+        # has no batched sweep path and no such kwarg, so it is skipped
+        # (HMatrix/ArrayBlock are BSplineSolver subclasses and inherit it).
+        solver_kwargs = dict(solver_kwargs or {})
+        solver_kwargs["swept_mem_mb"] = _SWEPT_MEM_MB
     return MomwireEngine(
         builder,
         solver=solver_cls,

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1934,6 +1934,53 @@ def test_retired_model_name_falls_back_to_bspline():
     assert stale["z_in_im"] == bspline["z_in_im"]
 
 
+def test_swept_mem_budget_injected_for_bspline_family(monkeypatch):
+    """The deployment sweep-memory budget (ANTENNAKNOBS_SWEPT_MEM_MB, read
+    at adapter import into _SWEPT_MEM_MB) must be injected into the
+    bspline-family solvers' kwargs — overriding any client-sent value —
+    and must NOT be passed to sinusoidal (no batched sweep, no such
+    kwarg). Asserted at the engine-kwargs level so the test doesn't
+    require a momwire version that accepts the kwarg (momwire >= 0.9).
+    """
+    import importlib
+
+    from antennaknobs.web import adapter
+
+    design = importlib.import_module("antennaknobs.designs.dipoles.invvee")
+    req_base = {"measurement_freq_mhz": 28.47}
+    builder = adapter._build_builder(design.Builder, req_base)
+
+    monkeypatch.setattr(adapter, "_SWEPT_MEM_MB", 64)
+    for model in ("bspline", "hmatrix", "arrayblock"):
+        eng = adapter._make_momwire_engine(
+            {**req_base, "momwire_model": model}, builder
+        )
+        assert eng._solver_kwargs.get("swept_mem_mb") == 64, model
+    # Client-sent value loses to the server policy; other options survive.
+    eng = adapter._make_momwire_engine(
+        {
+            **req_base,
+            "momwire_model": "bspline",
+            "model_options": {"swept_mem_mb": 4096, "degree": 1},
+        },
+        builder,
+    )
+    assert eng._solver_kwargs["swept_mem_mb"] == 64
+    assert eng._solver_kwargs["degree"] == 1
+    # Sinusoidal is skipped (kwarg unsupported there).
+    eng = adapter._make_momwire_engine(
+        {**req_base, "momwire_model": "sinusoidal"}, builder
+    )
+    assert "swept_mem_mb" not in (eng._solver_kwargs or {})
+
+    # Unset (local default): nothing injected, momwire default applies.
+    monkeypatch.setattr(adapter, "_SWEPT_MEM_MB", None)
+    eng = adapter._make_momwire_engine(
+        {**req_base, "momwire_model": "bspline"}, builder
+    )
+    assert "swept_mem_mb" not in (eng._solver_kwargs or {})
+
+
 def test_momwire_ground_off_reports_free_model():
     resp = server.solve(
         {


### PR DESCRIPTION
## Summary
- **Deployment-owned sweep memory budget**: when `ANTENNAKNOBS_SWEPT_MEM_MB` is set, the adapter injects `swept_mem_mb` into the bspline-family momwire solver kwargs (momwire ≥ 0.9 constructor arg), overriding any client-sent value — same server-policy philosophy as the `ANTENNAKNOBS_MAX_BASIS` caps. Sinusoidal is skipped (no batched sweep path). Unset → momwire's 256 MB default for local use.
- **fly.toml sets 64 MB** for the 2 GB shared VM: two concurrent worst-case sweeps peak ~160 MB RSS each at ~1.6× worst-case sweep latency; interactive-size sweeps never hit the cap (measured tradeoff in momwire's `docs/triangular-retirement-plan.md`).
- **Triangular-retirement prep**: `profile_compare_engines.py` drops the Tri column (Bs1 *is* the tent basis — the retired TriangularSolver matched it to roundoff), `measure_solve_memory.py` / `profile_ws_postproc_serialization.py` updated for the retired model name.
- Full suite green against momwire `feat/retire-triangular` (1455 passed) via the dev-editable submodule.

## Sequencing (do not merge yet)
1. Full benchmarking run on the benchmark machine against momwire PR #126 (both single-solve and sweep paths) — gate for merging **either** PR.
2. Merge momwire #126, release momwire v0.9.0.
3. Then on this branch: bump the three pins together (pyproject `momwire==0.9.0`, Dockerfile, submodule pointer) per the /release skill, wait for PyPI, wheel-smoke green.
4. Merge.

## Test plan
- [x] `test_swept_mem_budget_injected_for_bspline_family` — injection for bspline/hmatrix/arrayblock, server-overrides-client, sinusoidal skipped, unset → untouched (kwargs-level, so it passes on momwire 0.8.0 CI too)
- [x] Full antennaknobs suite against the retirement-branch momwire (1455 passed)
- [ ] Benchmark run on the dedicated machine (pre-merge gate)
- [ ] Post-release: pins bump + wheel-smoke + sweep latency smoke on the hosted shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xx4NrK5t4Xo98jf1MHs8rF