### PR TITLE
chore: release v0.20.0 (momwire 0.9.0 — fast finite grounds, batched sweeps)

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -177,6 +177,20 @@ in `fly.toml`'s `[env]` if the VM grows:
 | Env var | Default | Applies to |
 |---|---|---|
 | `ANTENNAKNOBS_HOSTED` | *(unset → off)* | **master switch** — set to `1` to enforce the caps below |
-| `ANTENNAKNOBS_MAX_BASIS` | `7000` | dense momwire (triangular / sinusoidal / bspline) — full N×N |
+| `ANTENNAKNOBS_MAX_BASIS` | `7000` | dense momwire (bspline / sinusoidal) — full N×N |
 | `ANTENNAKNOBS_MAX_BASIS_COMPRESSED` | `9000` | `arrayblock` / `hmatrix` (block-low-rank, ~0.6× dense memory) |
 | `ANTENNAKNOBS_MAX_BASIS_PYNEC` | `7000` | PyNEC (full dense N×N, same as dense momwire) |
+
+## Sweep memory budget (`ANTENNAKNOBS_SWEPT_MEM_MB`)
+
+Separate from the size caps (and **not** gated on `ANTENNAKNOBS_HOSTED`):
+momwire ≥ 0.9 runs frequency sweeps on the bspline-family solvers through a
+k-batched fill whose transient memory is budgeted by the solver's
+`swept_mem_mb` kwarg (momwire default 256 MB — right for local use). When
+`ANTENNAKNOBS_SWEPT_MEM_MB` is set, the web adapter injects it into every
+bspline-family solve, **overriding** any client-sent `model_options` value —
+deployment owns the policy. This repo's `fly.toml` sets `64` so two concurrent
+worst-case sweeps stay well inside the 2 GB VM (~1.6× worst-case sweep latency;
+production-shaped sweeps are unaffected). Sinusoidal has no batched sweep path
+and is skipped; `arrayblock` / `hmatrix` inherit it as BSplineSolver
+subclasses.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.19.0"
+version = "0.20.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,15 +25,16 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.19.0" icon="star">
-  **Sommerfeld ground on every solver.** The exact finite-ground model
-  now runs on all momwire backends (momwire 0.8.0): the sinusoidal
-  basis lands within ~0.1 Ω of an independent NEC-2 implementation —
-  the sharpest validation of the model yet — and the H-matrix /
-  array-block accelerators solve it on their fast paths instead of
-  falling back to a dense solve. The ground selector is now uniform
-  across solvers, and the legacy triangular basis is retired (B-spline
-  is the default).
+<Card title="New in v0.20.0" icon="star">
+  **Finite-ground solves got fast.** momwire 0.9.0 moves the Sommerfeld
+  remainder assembly into one fused compiled kernel — finite-ground
+  solves run **14–19× faster** on every solver, tying or beating the
+  NEC-2 reference on most benchmark designs — and a compiled
+  reflection-coefficient fill speeds the sinusoidal basis another
+  4–6×. Frequency sweeps on the default B-spline solver are now
+  k-batched under a tunable memory budget, and the
+  [solver guide](/reference/solver/) carries the full ground-model
+  benchmark (10 designs × 4 grounds × 6 engines).
   [All release notes →](/reference/releases/)
 </Card>
 


### PR DESCRIPTION
## Summary
- Version 0.19.0 → 0.20.0, adopting momwire 0.9.0 (exact pins already on main via #272)
- What's-new card refreshed: fused Sommerfeld kernel (14–19× on every solver), compiled reflection-coefficient fill (sinusoidal 4–6×), k-batched B-spline sweeps under a deployment-tunable memory budget, ground-model benchmark on the solver guide (#273)
- De-stale pass: `docs/deploy.md` now documents `ANTENNAKNOBS_SWEPT_MEM_MB` (deployment-owned sweep memory policy, fly.toml=64) and drops the retired triangular solver from the size-cap table

## Test plan
- [x] `npm run build` in site/ — 15 pages, clean
- [x] ruff check + format clean
- [ ] After merge: tag v0.20.0, watch publish + both Fly deploys, verify PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xx4NrK5t4Xo98jf1MHs8rF