### PR TITLE
docs(site): link the momwire MoM primer + bump momwire submodule

### DIFF
--- a/site/src/content/docs/reference/solver.mdx
+++ b/site/src/content/docs/reference/solver.mdx
@@ -3,9 +3,17 @@ title: The solver & accuracy
 description: The momwire MoM engine — its basis functions, accelerated solvers, which one to pick, and how results are cross-validated.
 ---
 
+import { LinkCard } from "@astrojs/starlight/components";
+
 antennaknobs solves antennas with **momwire**, an in-house method-of-moments
 (MoM) engine for wire structures, with an optional NEC-2 backend for
 cross-checking.
+
+<LinkCard
+  title="How the solver actually works →"
+  href="https://momwire.antennaknobs.dev/"
+  description="A method-of-moments primer keyed line-by-line to the momwire source — from a voltage in a gap to H-matrix acceleration, every idea first in 20 lines of Python, then in the production code."
+/>
 
 ## Basis functions
 
@@ -144,5 +152,5 @@ reflection-coefficient model remains the default and the NEC path offers its
 own Sommerfeld–Norton — so real-ground results cross-check across two
 independent engines at every height.
 
-<!-- TODO: embed the benchmark plots once generated, and a parity/differentiator
-     table vs PyNEC / 4nec2 / EZNEC / AN-SOF from the market-research doc. -->
+{/* TODO: embed the benchmark plots once generated, and a parity/differentiator
+     table vs PyNEC / 4nec2 / EZNEC / AN-SOF from the market-research doc. */}


### PR DESCRIPTION
The momwire "A voltage in a gap" MoM primer is live at [momwire.antennaknobs.dev](https://momwire.antennaknobs.dev/). This adds the cross-link from the antennaknobs docs and bumps the pinned solver.

## Changes
- **LinkCard** — add "How the solver actually works →" to the *Solver & accuracy* reference page, pointing to the primer. Converted `solver.md` → `solver.mdx` to host the component (slug `/reference/solver/` unchanged); the trailing HTML comment became an MDX comment.
- **Submodule bump** — `momwire` `43300d9 → 3d44c79` (origin/main; includes the merged primer site, PR #128).

## Verification
- `npm run build` green (15 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)