### PR TITLE
fix(web): correct the feed-source-smoothing tooltip wording

### DIFF
--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -5417,7 +5417,7 @@ function BSplineFields({
         onChange={(v) => onPatch({ nQpPair: v })}
       />
       <div className="field">
-        <label className="link-toggle" title="Replace delta-gap source with cos² bump of width α·h_feed; helps where basis-limited convergence shows on straight-wire feeds.">
+        <label className="link-toggle" title="Replace the delta-gap with a cos² source of width α·h_feed; removes the delta-gap's O(1/N) convergence cap so a straight-wire feed converges at the basis rate.">
           <input
             type="checkbox"
             checked={opts.feedSmoothingFactor != null}


### PR DESCRIPTION
The "feed source smoothing" checkbox tooltip (B-spline slot options) had its cause and effect reversed.

## Change
- **Before:** *"Replace delta-gap source with cos² bump of width α·h_feed; helps where basis-limited convergence shows on straight-wire feeds."*
- **After:** *"Replace the delta-gap with a cos² source of width α·h_feed; removes the delta-gap's O(1/N) convergence cap so a straight-wire feed converges at the basis rate."*

The old "helps where basis-limited convergence shows" was backwards — smoothing is what *makes* convergence basis-limited; the symptom it cures is the delta-gap's O(1/N) cap (the log-singular feed-point current). Mechanism (cos² source, width α·h_feed) kept since the α slider sits right below.

Context: surfaced during the momwire primer feed-model discussion; a numerical experiment confirmed the delta-gap's convergence cap is a source-singularity effect distinct from basis error. Kept as its own small frontend PR rather than folded into the primer/docs work.

## Verification
- Single `title=` string literal; CI build job compiles the frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)