### PR TITLE
Fix finite-ground far-field zenith glitch (θ=0 read ~3 dB low)

### DIFF
--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -577,10 +577,22 @@ class MomwireEngine(SimulationEngine):
         # ("finite", eps_r, sigma): polarisation basis at each ray and
         # Fresnel reflection on the image wave.
         _, eps_r, sigma = self._ground
-        s = np.sqrt(rx * rx + ry * ry)
-        s_safe = np.where(s > 1e-12, s, 1.0)
-        h_hat = np.stack([-ry / s_safe, rx / s_safe, np.zeros_like(rx)], axis=-1)
-        v_hat = np.stack([-rx * rz / s_safe, -ry * rz / s_safe, s], axis=-1)
+        # Vertical (TM, in-plane) and horizontal (TE, out-of-plane)
+        # polarisation unit vectors for the reflected ray, written straight
+        # from the azimuth/zenith angles rather than from the horizontal
+        # projection s = sin(theta). Dividing by s degenerates at the zenith
+        # (s -> 0, the plane of incidence is undefined): the old s->1.0 guard
+        # collapsed BOTH vectors to zero there, dropping the reflected wave and
+        # reading ~3 dB low. The phi-limit h_hat=(-sin phi, cos phi, 0),
+        # v_hat=(-cos phi, -sin phi, 0) is exact, unit, orthonormal to rhat,
+        # and recovers the PEC limit (rho_h=-1, rho_v=+1) at theta=0.
+        s = np.sqrt(rx * rx + ry * ry)  # = sin(theta); feeds sin2_ti below
+        cos_p_g = np.broadcast_to(cos_p[None, :], rx.shape)
+        sin_p_g = np.broadcast_to(sin_p[None, :], rx.shape)
+        cos_t_g = np.broadcast_to(cos_t[:, None], rx.shape)
+        sin_t_g = np.broadcast_to(sin_t[:, None], rx.shape)
+        h_hat = np.stack([-sin_p_g, cos_p_g, np.zeros_like(rx)], axis=-1)
+        v_hat = np.stack([-cos_p_g * cos_t_g, -sin_p_g * cos_t_g, sin_t_g], axis=-1)
         M_img_h = np.sum(M_img_perp * h_hat, axis=-1)
         M_img_v = np.sum(M_img_perp * v_hat, axis=-1)
 

--- a/tests/test_finite_ground_zenith.py
+++ b/tests/test_finite_ground_zenith.py
@@ -1,0 +1,64 @@
+"""Regression: MomwireEngine far-field must not glitch at the zenith over a
+finite ground.
+
+The finite-ground far field (``_evaluate_M_perp``) decomposes each
+observation ray into vertical/horizontal polarisation to weight the
+ground-reflected wave by Fresnel coefficients. That basis is built from the
+ray's horizontal projection ``s = sin(theta)``, which vanishes at the zenith
+(theta = 0). The original guard replaced ``s`` with 1.0 there, collapsing
+BOTH polarisation unit vectors to zero and silently dropping the entire
+reflected wave — so the theta = 0 gain sample read ~3 dB low while every
+other angle tracked PyNEC within ~0.2 dB.
+
+An elevation pattern is smooth through the zenith: there is no physical
+mechanism for a multi-dB cliff between theta = 0 and theta = 1 deg (the 1 deg
+sample has s = sin(1 deg) ~ 0.017 > 0, so its basis is well conditioned and
+its value is trustworthy). This test pins that continuity for the finite-
+ground far field, and confirms the PEC/free paths (which never hit the
+decomposition) are unaffected.
+"""
+
+from momwire import BSplineSolver
+
+from antennaknobs import resolve_variant_params
+from antennaknobs.designs.dipoles.invvee import Builder as InvVee
+from antennaknobs.engines import MomwireEngine
+
+FINITE = ("finite", 10.0, 0.002)
+
+
+def _flat_dipole(height_m):
+    params = dict(resolve_variant_params(InvVee, "dipole"))
+    params["base"] = height_m
+    return InvVee(params)
+
+
+def _height(frac):
+    lam = 299.792458 / 28.47
+    return frac * lam
+
+
+def _zenith_and_1deg_gain(ground):
+    """Return (gain at theta=0, gain at theta=1 deg), each the max over the
+    azimuth ring so a horizontal dipole's phi variation can't hide the drop."""
+    eng = MomwireEngine(_flat_dipole(_height(0.2)), solver=BSplineSolver, ground=ground)
+    ff = eng.far_field(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
+    assert ff.thetas[0] == 0.0 and ff.thetas[1] == 1.0
+    return max(ff.rings[0]), max(ff.rings[1])
+
+
+def test_finite_ground_zenith_is_continuous():
+    """The theta=0 sample must sit within 0.5 dB of the theta=1 deg sample.
+    The bug produced a ~3 dB gap; a smooth elevation pattern allows none."""
+    g_zenith, g_1deg = _zenith_and_1deg_gain(FINITE)
+    assert abs(g_zenith - g_1deg) < 0.5, (
+        f"zenith glitch: gain(theta=0)={g_zenith:.2f} dBi vs "
+        f"gain(theta=1 deg)={g_1deg:.2f} dBi (gap {abs(g_zenith - g_1deg):.2f} dB)"
+    )
+
+
+def test_pec_ground_zenith_is_continuous():
+    """Control: the PEC path skips the Fresnel decomposition entirely, so it
+    was never affected. Guards against a fix that regresses the PEC limit."""
+    g_zenith, g_1deg = _zenith_and_1deg_gain("pec")
+    assert abs(g_zenith - g_1deg) < 0.5


### PR DESCRIPTION
## Summary
- Fixes the finite-ground far field reading **~3.3 dB low at exactly θ=0** (2.25 vs 5.56 dBi), while every other elevation angle tracked PyNEC within ~0.2 dB.
- Root cause in `_evaluate_M_perp` (`engines/momwire.py`): the vertical/horizontal Fresnel basis was built by dividing the observation ray by its horizontal projection `s = sin(θ)`; at the zenith `s = 0` and the `s → 1.0` guard collapsed both `h_hat` and `v_hat` to zero vectors, so the ground-reflected wave vanished. Only finite grounds hit this path (the PEC path skips the decomposition).
- Fix writes the basis straight from the azimuth/zenith angles (`h_hat = (−sin φ, cos φ, 0)`, `v_hat = (−cos φ cos θ, −sin φ cos θ, sin θ)`): exact, unit, orthonormal to the ray, **bit-identical for θ>0**, and finite at the zenith (recovers the PEC limit ρ_h=−1, ρ_v=+1).
- Fixed zenith gain **5.56 dBi vs PyNEC gn2 5.66** (0.10 dB — matching all other angles).

Closes #278.

## Test plan
- [x] `tests/test_finite_ground_zenith.py` — zenith-vs-1° continuity (red→green) plus a PEC control
- [x] Full ground + far-field suite (`test_momwire_finite_ground`, `test_pynec_ground`, `test_momwire_engine`) — 86 tests pass, no regressions
- [x] Cross-checked fixed zenith gain against PyNEC gn2 (0.10 dB)
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)