### PR TITLE
Retire icecream in favor of stdlib logging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
       # `pip install -e ".[test]"`.
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools numpy scipy matplotlib icecream scikit-rf pybind11
+        pip install setuptools numpy scipy matplotlib scikit-rf pybind11
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
     - name: Install PyNEC from the python-necpp release wheel

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ cd antennaknobs
 python3 -m venv .venv
 source .venv/bin/activate
 pip install --upgrade pip
-pip install setuptools numpy scipy pytest matplotlib icecream scikit-rf
+pip install setuptools numpy scipy pytest matplotlib scikit-rf
 ```
 
 **3. Install momwire (the engine)**
@@ -446,7 +446,7 @@ cd antennaknobs
 python3 -m venv .venv
 source .venv/bin/activate         # re-run this in each new shell before using the project
 pip install --upgrade pip setuptools wheel
-pip install numpy scipy pytest matplotlib icecream scikit-rf
+pip install numpy scipy pytest matplotlib scikit-rf
 ```
 
 **3. Install momwire (the engine)** — same as Ubuntu:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ classifiers = [
 #     Dockerfile pin, and the submodule together, confirm the version is on
 #     PyPI before tagging a release.
 #   - numpy/scipy math throughout; matplotlib for the draw/sweep/pattern plots;
-#     icecream for the CLI/sweep debug tracing; scikit-rf for Touchstone/network
-#     handling in sweep.
+#     scikit-rf for Touchstone/network handling in sweep. CLI/sweep debug
+#     tracing goes through the stdlib logging module (enable with `-vv`).
 #
 # Deliberately NOT listed: PyNEC — the optional NEC2 backend, GPL-2.0-or-later.
 # It is installed separately from the python-necpp fork's release wheel (the
@@ -44,7 +44,6 @@ dependencies = [
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",
-    "icecream>=2.1",
     "scikit-rf>=0.24",
 ]
 

--- a/scripts/profile_ground_models.py
+++ b/scripts/profile_ground_models.py
@@ -35,7 +35,7 @@ momwire dense path), so the full 10×4×3×6 matrix takes a while. Use the
 --designs / --grounds / --engines / --nsegs filters to carve out a subset,
 or --once to time a single in-band point instead of averaging the band set.
 
-The tables print to stdout; momwire/CLI icecream tracing goes to stderr, so
+The tables print to stdout; any library warnings/log output go to stderr, so
 pipe 2>/dev/null (or 2>run.log) for a clean capture:
 
     .venv/bin/python scripts/profile_ground_models.py 2>/dev/null | tee run.txt

--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -21,11 +21,12 @@ from momwire import (
     ArrayBlockSolver,
 )
 
-from icecream import ic
-
 import argparse
+import logging
 from importlib import import_module
 from types import ModuleType
+
+logger = logging.getLogger(__name__)
 
 ENGINE_CLASSES = {
     "momwire": MomwireEngine,
@@ -52,15 +53,17 @@ def resolve_class(s):
     library with implicit Builder
     """
 
-    ic(s, lst)
+    logger.debug("resolve_class: spec=%r lst=%r", s, lst)
 
     def try_to_resolve(builder_name, module_name):
-        ic(builder_name, module_name)
+        logger.debug(
+            "try_to_resolve: builder_name=%r module_name=%r", builder_name, module_name
+        )
         try:
             module = import_module(module_name)
             try:
                 res = getattr(module, builder_name)
-                ic(res)
+                logger.debug("try_to_resolve: resolved %r", res)
                 return None if isinstance(res, ModuleType) else res
             except AttributeError:
                 return None
@@ -311,6 +314,14 @@ _GROUND_UNSET = object()
 def cli(arguments=None):
 
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase log verbosity: -v for INFO, -vv for DEBUG "
+        "(e.g. design-resolution and sweep tracing).",
+    )
 
     subparsers = parser.add_subparsers(dest="command")
 
@@ -752,4 +763,6 @@ def cli(arguments=None):
     p.set_defaults(func=f)
 
     args = parser.parse_args(args=arguments)
+    level = logging.WARNING - 10 * min(args.verbose, 2)
+    logging.basicConfig(level=level, format="%(name)s: %(message)s")
     args.func(args)

--- a/src/antennaknobs/sweep.py
+++ b/src/antennaknobs/sweep.py
@@ -1,9 +1,12 @@
+import logging
+
 from . import Antenna
 from .core import save_or_show
 from .far_field import get_elevation, get_pattern_rings, plot_patterns
-from icecream import ic
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 # NOTE: matplotlib.pyplot and scikit-rf (skrf) are imported lazily inside the
 # plotting functions below, not at module top. Both are import-heavy
@@ -195,7 +198,14 @@ def sweep(
     marker_zs = np.array(marker_zs)
 
     nwidth = zs.shape[1] if npoints > 0 else marker_zs.shape[1]
-    ic(nwidth, npoints, markers, zs.shape, marker_zs.shape)
+    logger.debug(
+        "smith sweep: nwidth=%s npoints=%s markers=%s zs.shape=%s marker_zs.shape=%s",
+        nwidth,
+        npoints,
+        markers,
+        zs.shape,
+        marker_zs.shape,
+    )
 
     if use_smithchart:
         # Lazy import (see the note at the top of the module): only the two

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,7 +1,6 @@
 import pytest
 
 from antennaknobs.designs.dipoles.invvee import Builder
-# from icecream import ic
 
 from types import MappingProxyType
 


### PR DESCRIPTION
## Summary
- Replaces the unconditional `icecream` `ic()` debug tracing in `cli.resolve_class` and `sweep` — which printed `ic|` lines to **stderr on every design resolution** — with a module-level `logging.getLogger(__name__)` + `logger.debug()`. Silent by default (fixes the leak), surfaced on demand via a new top-level **`-v/--verbose`** flag (`-v` INFO, `-vv` DEBUG).
- Drops the `icecream` dependency from `pyproject.toml`, both README install commands, and the CI workflow; removes a dead commented import in `test_unit.py` and a stale docstring mention in `profile_ground_models.py`.
- **momwire needs no change** — it already dropped icecream in its own PR #4 (the only remaining mentions are accurate historical notes in `momwire/NEXT_STEPS.md`).
- The stdlib messages are clearer than icecream's since they name variables explicitly, e.g. `resolve_class: spec='beams.moxon' lst=['beams', 'moxon']`.

## Test plan
- [x] Default run emits no debug on stderr; `-vv` surfaces the trace
- [x] `ruff check` / `ruff format --check` clean
- [x] Full suite (1423) passes **with icecream uninstalled from the venv** — proves nothing depends on it at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)