### PR TITLE
Reformulate NetworkReducer as Modified Nodal Analysis (MNA)

### DIFF
--- a/docs/plan-mna-network-core.md
+++ b/docs/plan-mna-network-core.md
@@ -1,8 +1,27 @@
 # Plan: reformulate `NetworkReducer` as Modified Nodal Analysis (MNA)
 
-Status: **Scoping / spike (2026-07-11).** Tracked by issue #285. Not started —
-this doc is the design scope so the stamp set can be reviewed and confirmed to
-reproduce the existing oracles before committing to the rewrite.
+Status: **Implemented (2026-07-11).** Tracked by issue #285. The MNA core
+landed via the staged migration below: built flag-gated next to the
+admittance reducer, cross-checked to 1e-9 on every branch/BC combination,
+default flipped with the full suite green, then the legacy Sherman-Morrison /
+three-BC code and the `abs(Z) < 1e-15` guards were deleted. Implementation
+notes that refined the plan during bring-up:
+
+- `Driven` + `Load` on a port collapse into ONE Group-2 "termination branch"
+  (EMF in series with Z_L, datum → node); its constitutive row
+  `v_k + Z_L·j = E` is exactly the old Thevenin BC, and `j` is the delivered
+  port current, so `Z = E/j`, the physical gap voltages, and the power
+  bookkeeping all read off a single solve.
+- Each Group-2 element picks the impedance- or admittance-form constitutive
+  row (exact at the short z = 0 and the open y = 0 respectively), so no
+  element value is ever inverted; a parallel-LC trap at exact resonance is
+  now finite in the excited path too (it used to form Z_L = ∞).
+- `resolve_voltages` now reports the PHYSICAL gap voltage at loaded ports
+  (formerly a V = 0 bookkeeping pin), so PyNEC's reducer-path excited
+  context gets the same load-shaped currents momwire's did.
+- `skyloop_lmatch.build_network` stamps its sliders literally; the
+  topology special-casing is gone. Degenerate coverage lives in
+  `tests/test_network_mna.py`.
 
 ## Why
 

--- a/src/antennaknobs/designs/loops/skyloop_lmatch.py
+++ b/src/antennaknobs/designs/loops/skyloop_lmatch.py
@@ -65,34 +65,18 @@ class Builder(TriangularSkyloop):
         return wires
 
     def build_network(self):
-        r"""L-match, built by TOPOLOGY so any arm can go inert:
-
-          * shunt C = 0  -> open shunt: the arm is simply omitted.
-          * series L = 0 -> the series arm is a bare wire, so the input node IS
-            the feed node: no `in` node, drive the feed directly. (A literal
-            0 H series element can't be stamped as a finite admittance — it's a
-            short — so we express "no series element" as topology rather than
-            asking the solver to invert a zero impedance; issue #285 (MNA) is
-            the general fix.)
-
-        With both arms zero the matchbox is fully inert — a pass-through — and
-        the input impedance is just the bare antenna's (Z_in = Z_ant).
-        """
-        series_l = self.series_L_uH * 1e-6
-        shunt_c = self.shunt_C_pF * 1e-12
-
-        ports = {"feed": PortAtEdge("feed")}
-        branches = []
-        if shunt_c:  # shunt arm across the feed (omitted when inert/open)
-            branches.append(Shunt(port="feed", c=shunt_c))
-        if series_l:  # series arm; a zero-L arm is a wire, so `in` == `feed`
-            ports["in"] = PortVirtual("in")
-            branches.append(TwoPort(a="in", b="feed", l=series_l))
-            driven = "in"
-        else:
-            driven = "feed"
+        r"""L-match, stamped LITERALLY at whatever the sliders say: the MNA
+        core (issue #285) handles the degenerate endpoints as physics, not
+        special cases — a 0 H series arm is an ideal wire (Group-2 short
+        identifying `in` with `feed`) and a 0 F shunt arm is an open (no
+        element). With both arms zero the matchbox is fully inert — a
+        pass-through — and the input impedance is just the bare antenna's
+        (Z_in = Z_ant)."""
         return Network(
-            ports=ports,
-            branches=branches,
-            sources=[Driven(port=driven, voltage=1 + 0j)],
+            ports={"feed": PortAtEdge("feed"), "in": PortVirtual("in")},
+            branches=[
+                TwoPort(a="in", b="feed", l=self.series_L_uH * 1e-6),
+                Shunt(port="feed", c=self.shunt_C_pF * 1e-12),
+            ],
+            sources=[Driven(port="in", voltage=1 + 0j)],
         )

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -409,10 +409,11 @@ class MomwireEngine(SimulationEngine):
         a placeholder V=0) would solve with no excitation — every basis
         coefficient is zero and `compute_impedance`'s V/I returns NaN."""
         if self._network is not None:
-            # excited_state imposes the physical series-load BC (not the V=0
-            # pin the impedance path uses), so resistive loads shape the
-            # current; it also returns the radiation efficiency and the
-            # source input power the far field uses to normalise gain.
+            # excited_state solves the same MNA system as the impedance
+            # path, so resistive loads shape the current through their
+            # physical series BC; it also returns the radiation efficiency
+            # and the source input power the far field uses to normalise
+            # gain.
             Y = self._compute_y_matrix(wavelength)
             V_full, self._excited_efficiency, self._excited_p_in = (
                 self._reducer.excited_state(Y, wavelength)

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -3,10 +3,9 @@
 A `Network` describes how the antenna's feed-edges (named real ports) and
 purely-logical nodes (virtual ports) hook together via two-port branches.
 Engines consume the network as a post-processing layer on top of the
-multi-port antenna Y matrix: each branch contributes a frequency-dependent
-2×2 admittance stamp into Y at the right port pair, then the system is
-reduced to the driven-port impedance via nodal analysis with passive ports
-floating (I_ext=0).
+multi-port antenna Y matrix: every branch and source stamps into one
+Modified Nodal Analysis system (see `network_reduce`), which is solved for
+the driven-port impedances and the physical port voltages in one shot.
 
 Compared with the legacy `build_tls()` API:
   - No dummy stub wire is required for the driver — virtual ports exist
@@ -88,9 +87,11 @@ class Load:
     NEC2 calls this `ld_card` type 1.
 
     Either way the effect is "lumped impedance in series with the segment":
-    Load modifies a single segment's self-Z (rank-1 update on the MoM
-    matrix). The classic dual-band trap dipole uses Load(parallel=True) at
-    a single segment in each arm — see designs/multiband/trap_dipole.py.
+    in the MNA reduction the load becomes the port's termination branch, a
+    series Z_load between the segment's gap and the common return — the same
+    physics as NEC2's ld_card modifying the segment's self-Z. The classic
+    dual-band trap dipole uses Load(parallel=True) at a single segment in
+    each arm — see designs/multiband/trap_dipole.py.
     """
 
     port: str
@@ -103,25 +104,25 @@ class Load:
 @dataclass(frozen=True)
 class TwoPort:
     """Lumped series R+jωL+1/(jωC) bridging two ports. Any of r/l/c may be
-    None (omitted term). Unlike `Load` — a self-impedance on ONE segment,
-    folded into that segment's MoM Z via Sherman-Morrison — a TwoPort is an
-    explicit 2×2 admittance connecting two DISTINCT ports:
-        Y = (1/Z) · [[1, -1], [-1, 1]],  Z = R + jωL + 1/(jωC).
+    None (omitted term). Unlike `Load` — a series termination on ONE port's
+    current path — a TwoPort is a series element connecting two DISTINCT
+    ports, Z = R + jωL + 1/(jωC).
 
-    Both engines stamp this into the port-Y through the shared
-    `NetworkReducer` (see `network_reduce.twoport_admittance_2x2`), exactly
-    like a TL branch — so it inherits the TL passive-port boundary condition
-    (I_ext=0) with no extra handling. PyNECEngine can instead emit a native
-    NEC2 `nt_card` (construct with ``native_nt=True``), which bakes the 2×2 Y
-    into one context and solves it simultaneously with the MoM currents — the
-    correctness oracle for this stamp, analogous to `tl_card` for TL. The
-    showcase and cross-engine cross-check is
-    `designs/arrays/lumped_coupled_pair.py` (issue #65 piece (B)).
+    Both engines stamp this through the shared `NetworkReducer` as an MNA
+    Group-2 element (the branch current is an explicit unknown, issue #285),
+    so the degenerate values are physics, not errors: Z = 0 — a 0 Ω / 0 H
+    element, an all-omitted branch, or exact series-LC resonance — is an
+    ideal short identifying the two nodes, and C = 0 is an open. PyNECEngine
+    can instead emit a native NEC2 `nt_card` (construct with
+    ``native_nt=True``), which bakes the 2×2 short-circuit admittance
+    Y = (1/Z)·[[1, -1], [-1, 1]] into one context and solves it
+    simultaneously with the MoM currents — the correctness oracle for this
+    stamp, analogous to `tl_card` for TL. The showcase and cross-engine
+    cross-check is `designs/arrays/lumped_coupled_pair.py` (issue #65 piece
+    (B)).
 
-    A series-LC short (Z → 0 at ω₀ = 1/√(LC)) makes the branch a hard wire
-    between the two segments and the stamp singular; both paths raise rather
-    than emit a degenerate short. For the trap-dipole idiom (a segment self-
-    interrupted at resonance) use `Load(parallel=True)`, not TwoPort."""
+    For the trap-dipole idiom (a segment self-interrupted at resonance) use
+    `Load(parallel=True)`, not TwoPort."""
 
     a: str
     b: str
@@ -134,9 +135,11 @@ class TwoPort:
 class Shunt:
     """Lumped R/L/C from a single port to the common reference — a shunt to
     "ground", where ground is the port's own return terminal (a circuit node,
-    not the antenna's earth plane). Stamps a 1-port admittance onto the port's
-    diagonal, ``Y[k,k] += y``: a current ``y·V_k`` drains from the node to the
-    common return, exactly a shunt element across the feed terminals.
+    not the antenna's earth plane): a current drains from the node to the
+    common return, exactly a shunt element across the feed terminals. Since
+    the MNA core (issue #285) a series-mode shunt is a Group-2 element, so
+    Z = 0 (a 0 Ω / 0 H arm or exact series-LC resonance) is a legal hard
+    short of the port to common, and C = 0 an open (no element).
 
     This is the element issue #65 Q2 deferred. With it, `Shunt` + a series
     `TwoPort` express an L-match (and pi / T networks) directly: drive a
@@ -200,9 +203,9 @@ def _parallel_rlc_admittance(r, l, c, omega):
 def load_series_admittance(br, omega):
     """Series-branch admittance y_load = 1/Z_load of a Load branch at ω.
 
-    This is the natural quantity for the Sherman-Morrison port-Y stamp
-    (see network_reduce.NetworkReducer.apply_loads): the stamp coefficient is
-    1/(y_load + Y_kk), which stays finite exactly where Z_load blows up.
+    This is the quantity the MNA termination stamp uses for a parallel-mode
+    Load (see network_reduce.NetworkReducer.apply_branches): it stays finite
+    exactly where Z_load blows up.
 
     Parallel mode: y_load IS the parallel-LC tank admittance,
         y = 1/R + 1/(jωL) + jωC,

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -15,6 +15,8 @@ post-process on top of the field solution, rather than via NEC2's native
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import numpy as np
 
 from .network import (
@@ -123,6 +125,105 @@ def shunt_admittance(r, l, c, omega, parallel=False):
     return 1.0 / z
 
 
+# ---------------------------------------------------------------------------
+# MNA (Modified Nodal Analysis) core — issue #285.
+#
+# The node space is the existing port space: one node per port (real feeds
+# first, virtual ports after), every node's voltage referenced to the common
+# return (the datum). The datum has no matrix row — every port's second
+# terminal is bonded to it, which is the same convention the antenna's
+# short-circuit multiport Y already assumes.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Group2Element:
+    """One Group-2 (auxiliary-current) element of the MNA system.
+
+    The element carries a branch current ``j`` flowing a → b *through* the
+    element (``None`` = the datum, which has no matrix row). KCL: ``+j``
+    leaves node a and enters node b. The constitutive row is
+
+        c_v · (v_b − v_a) + c_j · j = e
+
+    Two scalings describe the same physical series branch — an EMF ``emf``
+    (oriented to raise the potential from a to b) in series with impedance
+    ``z`` = 1/``y``:
+
+      impedance form:  (v_b − v_a) + z·j = emf      (c_v=1, c_j=z, e=emf)
+          exact for every finite z, including the ideal short z = 0;
+      admittance form: y·(v_b − v_a) + j = y·emf    (c_v=y, c_j=1, e=y·emf)
+          exact for every finite y, including the ideal open y = 0.
+
+    Each branch picks whichever form keeps its coefficients finite, so no
+    element value is ever inverted — the reason ideal shorts and trap-
+    resonance opens need no special-case guards here.
+    """
+
+    a: int | None
+    b: int | None
+    c_v: complex
+    c_j: complex
+    e: complex
+
+
+def _series_group2(a, b, r, l, c, omega, emf=0j):
+    """Group-2 stamp of a series R + jωL + 1/(jωC) (+ optional EMF) between
+    nodes a and b. A 0 F capacitor is an open in the series path (infinite
+    reactance) → admittance form with y = 0 (the branch carries no current).
+    Every other value combination has finite z — including the ideal short
+    z = 0 (0 Ω, 0 H, all-omitted, or exact series-LC resonance), which is
+    the degenerate case the old admittance-only stamps had to raise on."""
+    if c is not None and c == 0:
+        return _Group2Element(a, b, c_v=0j, c_j=1.0 + 0j, e=0j)
+    z = _series_rlc_impedance(r, l, c, omega)
+    return _Group2Element(a, b, c_v=1.0 + 0j, c_j=z, e=emf)
+
+
+class MNASystem:
+    """Assembled MNA system ``[[G, B], [Cᵀ, D]] · [v; j] = [i_ext; e]``.
+
+    ``v`` — node voltages vs. the datum (one per port, real feeds first);
+    ``j`` — Group-2 branch currents. ``i_ext`` is zero at every node (all
+    external injections enter through Group-2 source branches).
+
+    ``terminations`` maps a port node index → ``(column, emf)`` for the
+    per-port source/load termination branch (see
+    ``NetworkReducer._assemble_mna``); its current ``j[column]`` is the
+    current the termination delivers INTO the node, so a driven port's
+    impedance is ``emf / j[column]`` read straight off the solution.
+    """
+
+    def __init__(self, G, elements, terminations):
+        n = G.shape[0]
+        m = len(elements)
+        A = np.zeros((n + m, n + m), dtype=np.complex128)
+        A[:n, :n] = G
+        rhs = np.zeros(n + m, dtype=np.complex128)
+        for x, el in enumerate(elements):
+            col = n + x
+            if el.a is not None:
+                A[el.a, col] += 1.0  # j leaves node a
+                A[col, el.a] -= el.c_v
+            if el.b is not None:
+                A[el.b, col] -= 1.0  # j enters node b
+                A[col, el.b] += el.c_v
+            A[col, col] = el.c_j
+            rhs[col] = el.e
+        self.n_nodes = n
+        self.A = A
+        self.rhs = rhs
+        self.terminations = terminations
+        self._solution = None
+
+    def solve(self):
+        """Solve once (cached); returns ``(v, j)``."""
+        if self._solution is None:
+            x = np.linalg.solve(self.A, self.rhs)
+            self._solution = (x[: self.n_nodes], x[self.n_nodes :])
+        return self._solution
+
+
 class NetworkReducer:
     """Stamps a `Network`'s branches onto a raw real-port Y and reduces to
     the driven-port impedance(s).
@@ -134,7 +235,16 @@ class NetworkReducer:
     :meth:`apply_branches`; virtual ports come after.
     """
 
-    def __init__(self, network, port_to_idx, n_total_ports):
+    def __init__(self, network, port_to_idx, n_total_ports, formulation="admittance"):
+        # formulation: "admittance" (legacy: bare nodal Y + hand-rolled
+        # boundary conditions) or "mna" (Modified Nodal Analysis, issue #285).
+        # Both produce the same observable behavior on finite-element
+        # networks; only MNA can stamp ideal shorts / 0 Ω / 0 H elements.
+        # The flag exists for side-by-side bring-up and goes away once the
+        # default flips to MNA.
+        if formulation not in ("admittance", "mna"):
+            raise ValueError(f"unknown formulation {formulation!r}")
+        self.formulation = formulation
         self.network = network
         self.port_to_idx = port_to_idx
         self.n_total_ports = n_total_ports
@@ -166,6 +276,130 @@ class NetworkReducer:
     @property
     def n_driven(self):
         return len(self.driven_port_idx)
+
+    # ----- MNA formulation (issue #285) -----
+
+    def _assemble_mna(self, Y_real, wavelength):
+        """Stamp the antenna Y and every network branch into one MNA system.
+
+        Group 1 (node-admittance block G):
+          - the antenna's dense multiport short-circuit Y at the real-feed
+            nodes vs. datum;
+          - TL branches (their 2×2 has shunt legs, so it is a natural
+            admittance stamp; the half-wave singularity still raises);
+          - parallel-mode Shunt (the tank admittance is the natural finite
+            quantity, → 0 at trap resonance).
+
+        Group 2 (auxiliary branch currents):
+          - TwoPort and series-mode Shunt — series elements, exact for the
+            ideal short z = 0 and the 0 F open;
+          - one TERMINATION branch per port that is driven and/or loaded:
+            an EMF (0 if undriven) in series with the port's Load impedance
+            (0 if unloaded) from the datum into the node. Its constitutive
+            row v_k + Z_L·j = E is exactly the Thevenin boundary condition
+            the legacy `excited_state` hand-coded, and its current j is the
+            delivered port current — so the driven-point impedance E/j and
+            the load dissipation (E − v_k)·j* both read off the solution.
+            Driven-only ports (Z_L = 0) degenerate to the ideal voltage
+            source pin v_k = E; loaded-only ports (E = 0) to the series
+            load termination v_k = −Z_L·j.
+
+        Ports that are neither driven, loaded, nor touched by a branch keep
+        plain KCL with zero injection — the legacy floating (I_ext = 0) BC.
+        """
+        omega = 2.0 * np.pi * C_LIGHT / wavelength
+        n = self.n_total_ports
+        G = np.zeros((n, n), dtype=np.complex128)
+        n_real = Y_real.shape[0]
+        G[:n_real, :n_real] = Y_real
+
+        elements = []
+        loads_by_node = {}
+        for br in self.network.branches:
+            if isinstance(br, TL):
+                a, b = self.port_to_idx[br.a], self.port_to_idx[br.b]
+                G[np.ix_([a, b], [a, b])] += tl_admittance_2x2(
+                    br.z0, br.length, wavelength, transposed=br.transposed
+                )
+            elif isinstance(br, TwoPort):
+                a, b = self.port_to_idx[br.a], self.port_to_idx[br.b]
+                elements.append(_series_group2(a, b, br.r, br.l, br.c, omega))
+            elif isinstance(br, Shunt):
+                k = self.port_to_idx[br.port]
+                if br.parallel:
+                    G[k, k] += _parallel_rlc_admittance(br.r, br.l, br.c, omega)
+                else:
+                    elements.append(_series_group2(k, None, br.r, br.l, br.c, omega))
+            elif isinstance(br, Load):
+                if not isinstance(self.network.ports[br.port], PortAtEdge):
+                    raise ValueError(
+                        f"Load on virtual port {br.port!r}: a Load is a series "
+                        "impedance on an antenna segment, which only PortAtEdge has"
+                    )
+                loads_by_node.setdefault(self.port_to_idx[br.port], []).append(br)
+            else:
+                raise NotImplementedError(f"branch type {type(br).__name__}")
+
+        # Per-port termination branches. A port may carry BOTH a source and
+        # a series load (the centre-loaded driven short dipole); they chain
+        # into one branch: datum —EMF—Z_L→ node.
+        emf = dict(zip(self.driven_port_idx, self.driven_voltages))
+        terminations = {}
+        for k in sorted(set(emf) | set(loads_by_node)):
+            e = emf.get(k, 0j)
+            loads = loads_by_node.get(k, [])
+            zs = [load_impedance(br, omega) for br in loads]
+            if len(loads) == 1 and loads[0].parallel:
+                # Parallel-LC trap: the tank admittance is the finite
+                # quantity (→ 0 at resonance, the intended open circuit);
+                # the impedance form would blow up there.
+                y = load_series_admittance(loads[0], omega)
+                el = _Group2Element(None, k, c_v=y, c_j=1.0 + 0j, e=y * e)
+            elif all(np.isfinite(z) for z in zs):
+                # Series composition of every load (plus the EMF). Includes
+                # the no-load case z = 0: an ideal voltage-source pin.
+                el = _Group2Element(None, k, c_v=1.0 + 0j, c_j=sum(zs, 0j), e=e)
+            else:
+                # A chain containing an at-resonance trap is an open.
+                el = _Group2Element(None, k, c_v=0j, c_j=1.0 + 0j, e=0j)
+            terminations[k] = (len(elements), e)
+            elements.append(el)
+
+        return MNASystem(G, elements, terminations)
+
+    def _mna_impedances(self, system):
+        """Driven-point impedance per Driven source: Z = E / j_term, the
+        termination EMF over its delivered current — read straight off the
+        solution vector, no Y·V post-multiply."""
+        _v, j = system.solve()
+        out = []
+        for k in self.driven_port_idx:
+            col, e = system.terminations[k]
+            out.append(complex(e / j[col]))
+        return out
+
+    def _mna_excited_state(self, system):
+        """(V, efficiency, p_in) from one MNA solve — see `excited_state`
+        for the meaning of the readouts. The termination branches carry the
+        physical port currents, so source input power and load dissipation
+        are direct sums over them:
+
+            p_in   = ½ Σ Re(E_k · j_k*)          (E = 0 terms vanish)
+            p_diss = ½ Σ Re((E_k − v_k) · j_k*)  (drop across the load part
+                                                  is Z_L·j, so this is
+                                                  ½·Re(Z_L)·|j|² without
+                                                  ever forming a trap's ∞)
+        """
+        v, j = system.solve()
+        p_in = 0.0
+        p_diss = 0.0
+        for k, (col, e) in system.terminations.items():
+            p_in += 0.5 * float(np.real(e * np.conj(j[col])))
+            p_diss += 0.5 * float(np.real((e - v[k]) * np.conj(j[col])))
+        efficiency = 1.0 if p_in <= 0.0 else max(0.0, min(1.0, 1.0 - p_diss / p_in))
+        return v.copy(), efficiency, p_in
+
+    # ----- legacy admittance formulation -----
 
     def apply_loads(self, Y, omega):
         """Apply every Load branch as a Sherman-Morrison rank-1 update on
@@ -285,15 +519,31 @@ class NetworkReducer:
         (matching ld_card's effect inside the MoM), then TL branches stamp
         on the loaded Y. A TL connected to a loaded port sees the external
         side of the load.
+
+        Under the MNA formulation the return is an `MNASystem` instead of a
+        matrix; it composes with `impedance_from_y` / `resolve_voltages`
+        exactly as the matrix does.
         """
+        if self.formulation == "mna":
+            return self._assemble_mna(Y, wavelength)
         omega = 2.0 * np.pi * C_LIGHT / wavelength
         Y = self.apply_loads(Y, omega)
         return self._augment_with_lines(Y, wavelength)
 
     def resolve_voltages(self, Y_total):
         """Return the (n_total,) voltage vector after solving the network:
-        driven ports at their applied voltages, loaded ports pinned at V=0,
-        every other port floating with I_ext = 0."""
+        driven ports at their applied voltages, every other port floating
+        with I_ext = 0.
+
+        Loaded ports: the legacy admittance path pins V = 0 (the load is
+        folded into Y by `apply_loads`, so the pin is correct for the
+        impedance readout but shorts the load for anything else); the MNA
+        path returns the PHYSICAL gap voltage V_k = V_src − Z_L·I_k — the
+        same voltage `excited_state` reports, because both readouts come
+        from the one MNA solve."""
+        if self.formulation == "mna":
+            v, _j = Y_total.solve()
+            return v.copy()
         n = Y_total.shape[0]
         driven = list(self.driven_port_idx)
         floating = [
@@ -334,6 +584,8 @@ class NetworkReducer:
                          normaliser (gain = 4π·U/P_in); it already includes the
                          power burned in resistive loads.
         """
+        if self.formulation == "mna":
+            return self._mna_excited_state(self._assemble_mna(Y_real, wavelength))
         omega = 2.0 * np.pi * C_LIGHT / wavelength
         # Lines stamped, loads left OUT -- they are imposed as BCs below, not
         # folded into Y (that is the resolve_voltages/impedance path).
@@ -391,9 +643,14 @@ class NetworkReducer:
         return V, efficiency, p_in
 
     def impedance_from_y(self, Y_total):
-        """Driven-port impedance: solve the network for V (loaded ports
-        pinned at V=0, floating ports satisfying I_ext=0, driven ports at
-        their applied V), then read I_driven = (Y_total @ V)_driven."""
+        """Driven-port impedance from an `apply_branches` result.
+
+        MNA: Z = E / j_term straight off the solution vector. Legacy: solve
+        the network for V (loaded ports pinned at V=0, floating ports
+        satisfying I_ext=0, driven ports at their applied V), then read
+        I_driven = (Y_total @ V)_driven."""
+        if self.formulation == "mna":
+            return self._mna_impedances(Y_total)
         V = self.resolve_voltages(Y_total)
         I = Y_total @ V
         return [complex(V[i] / I[i]) for i in self.driven_port_idx]

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -3,14 +3,26 @@ impedances, on top of a raw multiport antenna admittance matrix.
 
 Both MomwireEngine and PyNECEngine assemble the antenna's short-circuit Y at
 the real (`PortAtEdge`) ports, then hand it here with a port-name -> matrix-
-index map. This module stamps the network branches (`TL` / `Load`)
-into the Y matrix and reduces it to the driven-port impedance(s). The only
-engine-specific work is producing that raw Y and the index map; the linear
-algebra here is identical regardless of which MoM solver produced Y.
+index map. This module stamps the network branches and sources into one
+Modified Nodal Analysis (MNA) system — the SPICE formulation, issue #285 —
+and solves it once for everything: driven-port impedances, physical port
+voltages for the excited far-field/current solve, and the source-power /
+load-dissipation bookkeeping. The only engine-specific work is producing the
+raw Y and the index map; the linear algebra here is identical regardless of
+which MoM solver produced Y.
 
-This is the EZNEC-style approach: model transmission lines as a circuit
-post-process on top of the field solution, rather than via NEC2's native
-`tl_card`.
+This is the EZNEC-style approach: model transmission lines and lumped
+elements as a circuit post-process on top of the field solution, rather than
+via NEC2's native `tl_card` / `nt_card` / `ld_card`.
+
+The node space is the port space: one node per port (real feeds first,
+virtual ports after), every node's voltage referenced to the common return
+(the datum). The datum has no matrix row — every port's second terminal is
+bonded to it, which is the same convention the antenna's short-circuit
+multiport Y already assumes. Elements that a bare admittance matrix cannot
+represent — ideal voltage sources, ideal shorts, 0 Ω / 0 H series elements —
+become Group-2 unknowns: the branch current joins the solution vector with a
+constitutive row, so no element value is ever inverted.
 """
 
 from __future__ import annotations
@@ -62,77 +74,8 @@ def tl_admittance_2x2(z0, length, wavelength, transposed=False):
     return scale * np.array([[c, off], [off, c]], dtype=np.complex128)
 
 
-def twoport_admittance_2x2(r, l, c, omega):
-    """Nodal admittance of a lumped series R+jωL+1/(jωC) bridging two ports.
-
-    A series impedance Z = R + jωL + 1/(jωC) between terminals a and b has the
-    2×2 short-circuit admittance
-        Y = (1/Z) · [[1, -1], [-1, 1]]
-    — current 1/Z flows a→b under a unit differential, and none into an
-    external short at either node beyond that branch. This is the same shape as
-    NEC2's `nt_card` takes directly (Y11=Y22=1/Z, Y12=Y21=−1/Z), which is why
-    the native-`nt_card` oracle path and this stamp agree by construction.
-
-    A series-LC short (Z → 0 at ω₀ = 1/√(LC)) makes Y singular; the two nodes
-    are then hard-shorted together. Raise rather than emit inf so the caller
-    can pick different element values — callers never depend on the short
-    limit (unlike the parallel-LC trap, which the Load path handles).
-    """
-    if c == 0:
-        # A 0 F capacitor is an open in the series path (infinite reactance):
-        # the branch carries no current, so it contributes no coupling. Return
-        # the zero stamp rather than forming 1/(jωC) and dividing by zero.
-        return np.zeros((2, 2), dtype=np.complex128)
-    z = _series_rlc_impedance(r, l, c, omega)
-    if abs(z) < 1e-15:
-        raise ValueError(
-            "TwoPort series impedance ≈ 0 (short circuit): a 0 Ω / 0 H element, "
-            "an all-omitted branch, or series-LC resonance shorts the two ports. "
-            "A lossless short is not a finite admittance stamp — express it as a "
-            "direct connection (drive the shared node) or use a small nonzero "
-            "value. General ideal-short handling is tracked in issue #285 (MNA)."
-        )
-    y = 1.0 / z
-    return y * np.array([[1.0, -1.0], [-1.0, 1.0]], dtype=np.complex128)
-
-
-def shunt_admittance(r, l, c, omega, parallel=False):
-    """Scalar admittance of a lumped R/L/C shunt from a port to the common
-    reference, stamped onto the port diagonal (``Y[k,k] += y``).
-
-    series (default): y = 1/(R + jωL + 1/(jωC)) — single C → jωC, single L →
-        1/(jωL), series LC → shunt trap.
-    parallel:         y = 1/R + 1/(jωL) + jωC — parallel-LC tank, → 0 at
-        resonance (open shunt).
-
-    A series-LC short (Z → 0) is a hard short of the port to common; raise
-    rather than emit inf so the caller can pick different element values."""
-    if parallel:
-        return _parallel_rlc_admittance(r, l, c, omega)
-    if c == 0:
-        # A 0 F shunt capacitor is an open shunt (infinite reactance): no
-        # element, y = 0. The natural "inert" limit of a matching-network
-        # slider — return it rather than dividing by zero forming 1/(jωC).
-        return 0.0 + 0.0j
-    z = _series_rlc_impedance(r, l, c, omega)
-    if abs(z) < 1e-15:
-        raise ValueError(
-            "Shunt series impedance ≈ 0 (short to common): a 0 Ω / 0 H element "
-            "or series-LC resonance shorts the port to the reference. A lossless "
-            "short is not a finite admittance stamp — remove the branch or use a "
-            "small nonzero value. General handling is tracked in issue #285 (MNA)."
-        )
-    return 1.0 / z
-
-
 # ---------------------------------------------------------------------------
 # MNA (Modified Nodal Analysis) core — issue #285.
-#
-# The node space is the existing port space: one node per port (real feeds
-# first, virtual ports after), every node's voltage referenced to the common
-# return (the datum). The datum has no matrix row — every port's second
-# terminal is bonded to it, which is the same convention the antenna's
-# short-circuit multiport Y already assumes.
 # ---------------------------------------------------------------------------
 
 
@@ -172,8 +115,8 @@ def _series_group2(a, b, r, l, c, omega, emf=0j):
     nodes a and b. A 0 F capacitor is an open in the series path (infinite
     reactance) → admittance form with y = 0 (the branch carries no current).
     Every other value combination has finite z — including the ideal short
-    z = 0 (0 Ω, 0 H, all-omitted, or exact series-LC resonance), which is
-    the degenerate case the old admittance-only stamps had to raise on."""
+    z = 0 (0 Ω, 0 H, all-omitted, or exact series-LC resonance), which the
+    old admittance-only stamps had to raise on."""
     if c is not None and c == 0:
         return _Group2Element(a, b, c_v=0j, c_j=1.0 + 0j, e=0j)
     z = _series_rlc_impedance(r, l, c, omega)
@@ -189,7 +132,7 @@ class MNASystem:
 
     ``terminations`` maps a port node index → ``(column, emf)`` for the
     per-port source/load termination branch (see
-    ``NetworkReducer._assemble_mna``); its current ``j[column]`` is the
+    ``NetworkReducer.apply_branches``); its current ``j[column]`` is the
     current the termination delivers INTO the node, so a driven port's
     impedance is ``emf / j[column]`` read straight off the solution.
     """
@@ -225,26 +168,18 @@ class MNASystem:
 
 
 class NetworkReducer:
-    """Stamps a `Network`'s branches onto a raw real-port Y and reduces to
-    the driven-port impedance(s).
+    """Stamps a `Network`'s branches and sources into an MNA system on top
+    of the raw real-port antenna Y and reads out driven-port impedances,
+    physical port voltages, and the power bookkeeping.
 
     Construct with the network spec, a ``port_to_idx`` mapping every port
-    name (real and virtual) to its row/column in the augmented Y matrix, and
+    name (real and virtual) to its row/column in the node space, and
     ``n_total_ports`` (real feeds + virtual ports). Real ports must occupy
     indices ``0..n_real-1`` in the same order as the raw Y handed to
     :meth:`apply_branches`; virtual ports come after.
     """
 
-    def __init__(self, network, port_to_idx, n_total_ports, formulation="mna"):
-        # formulation: "admittance" (legacy: bare nodal Y + hand-rolled
-        # boundary conditions) or "mna" (Modified Nodal Analysis, issue #285).
-        # Both produce the same observable behavior on finite-element
-        # networks; only MNA can stamp ideal shorts / 0 Ω / 0 H elements.
-        # The flag exists for side-by-side bring-up and goes away once the
-        # default flips to MNA.
-        if formulation not in ("admittance", "mna"):
-            raise ValueError(f"unknown formulation {formulation!r}")
-        self.formulation = formulation
+    def __init__(self, network, port_to_idx, n_total_ports):
         self.network = network
         self.port_to_idx = port_to_idx
         self.n_total_ports = n_total_ports
@@ -258,28 +193,11 @@ class NetworkReducer:
             self.driven_port_idx.append(port_to_idx[src.port])
             self.driven_voltages.append(complex(src.voltage))
 
-        # A Load on a port modifies the MoM Z-diagonal of that segment via
-        # Sherman-Morrison (equivalent to NEC2's ld_card on segment k). The
-        # right boundary condition at a loaded port is V_external = 0 (no
-        # source attached to the segment's external terminal) — NOT
-        # I_external = 0, which is the right BC for TL passive ports. With
-        # I_ext = 0 forced, the Sherman-Morrison update's effect on the
-        # driven-port impedance cancels out algebraically (you can derive
-        # it: V_passive picks up a factor (1 − α·Y_kk) that divides out).
-        # So track loaded ports separately and pin their V = 0 in the
-        # reduction. They take precedence over the floating-passive default.
-        self.loaded_port_idx = set()
-        for br in network.branches:
-            if isinstance(br, Load):
-                self.loaded_port_idx.add(port_to_idx[br.port])
-
     @property
     def n_driven(self):
         return len(self.driven_port_idx)
 
-    # ----- MNA formulation (issue #285) -----
-
-    def _assemble_mna(self, Y_real, wavelength):
+    def apply_branches(self, Y_real, wavelength):
         """Stamp the antenna Y and every network branch into one MNA system.
 
         Group 1 (node-admittance block G):
@@ -296,16 +214,17 @@ class NetworkReducer:
           - one TERMINATION branch per port that is driven and/or loaded:
             an EMF (0 if undriven) in series with the port's Load impedance
             (0 if unloaded) from the datum into the node. Its constitutive
-            row v_k + Z_L·j = E is exactly the Thevenin boundary condition
-            the legacy `excited_state` hand-coded, and its current j is the
-            delivered port current — so the driven-point impedance E/j and
-            the load dissipation (E − v_k)·j* both read off the solution.
-            Driven-only ports (Z_L = 0) degenerate to the ideal voltage
-            source pin v_k = E; loaded-only ports (E = 0) to the series
-            load termination v_k = −Z_L·j.
+            row v_k + Z_L·j = E is the Thevenin boundary condition, and its
+            current j is the delivered port current — so the driven-point
+            impedance E/j and the load dissipation (E − v_k)·j* both read
+            off the solution. Driven-only ports (Z_L = 0) degenerate to the
+            ideal voltage-source pin v_k = E; loaded-only ports (E = 0) to
+            the series load termination v_k = −Z_L·j. A `Load` is thus a
+            series impedance between the antenna gap and the common return,
+            matching NEC2's ld_card physics.
 
         Ports that are neither driven, loaded, nor touched by a branch keep
-        plain KCL with zero injection — the legacy floating (I_ext = 0) BC.
+        plain KCL with zero injection (the floating I_ext = 0 condition).
         """
         omega = 2.0 * np.pi * C_LIGHT / wavelength
         n = self.n_total_ports
@@ -367,212 +286,20 @@ class NetworkReducer:
 
         return MNASystem(G, elements, terminations)
 
-    def _mna_impedances(self, system):
-        """Driven-point impedance per Driven source: Z = E / j_term, the
-        termination EMF over its delivered current — read straight off the
-        solution vector, no Y·V post-multiply."""
-        _v, j = system.solve()
-        out = []
-        for k in self.driven_port_idx:
-            col, e = system.terminations[k]
-            out.append(complex(e / j[col]))
-        return out
-
-    def _mna_excited_state(self, system):
-        """(V, efficiency, p_in) from one MNA solve — see `excited_state`
-        for the meaning of the readouts. The termination branches carry the
-        physical port currents, so source input power and load dissipation
-        are direct sums over them:
-
-            p_in   = ½ Σ Re(E_k · j_k*)          (E = 0 terms vanish)
-            p_diss = ½ Σ Re((E_k − v_k) · j_k*)  (drop across the load part
-                                                  is Z_L·j, so this is
-                                                  ½·Re(Z_L)·|j|² without
-                                                  ever forming a trap's ∞)
-        """
-        v, j = system.solve()
-        p_in = 0.0
-        p_diss = 0.0
-        for k, (col, e) in system.terminations.items():
-            p_in += 0.5 * float(np.real(e * np.conj(j[col])))
-            p_diss += 0.5 * float(np.real((e - v[k]) * np.conj(j[col])))
-        efficiency = 1.0 if p_in <= 0.0 else max(0.0, min(1.0, 1.0 - p_diss / p_in))
-        return v.copy(), efficiency, p_in
-
-    # ----- legacy admittance formulation -----
-
-    def apply_loads(self, Y, omega):
-        """Apply every Load branch as a Sherman-Morrison rank-1 update on
-        the real-port Y — the network-level equivalent of NEC2's `ld_card`
-        modifying the segment's MoM Z[k,k].
-
-        The update has two algebraically-identical forms, dual under
-        Z_L ↔ y_L = 1/Z_L:
-
-            impedance:   Y − Z_L/(1 + Z_L·Y_kk) · outer(Y[:,k], Y[k,:])
-            admittance:  Y − 1/(y_L + Y_kk)     · outer(Y[:,k], Y[k,:])
-
-        Each Load mode has a resonance where one form divides by an
-        intermediate infinity while the other stays finite, so we pick the
-        form whose denominator is bounded at that mode's resonance:
-
-          - Parallel-LC trap: Z_L→∞ at ω₀ (open circuit). Use the
-            ADMITTANCE form — y_L is the tank admittance, →0 at ω₀, giving
-            coefficient 1/Y_kk (the open-circuit Schur complement).
-          - Series-LC: Z_L→0 at ω₀ (short circuit = unbroken wire). Use the
-            IMPEDANCE form — coefficient →0, i.e. no stamp.
-
-        This way neither path ever forms or tests for infinity.
-        """
-        Y = Y.copy()
-        for br in self.network.branches:
-            if not isinstance(br, Load):
-                continue
-            port = self.network.ports[br.port]
-            if not isinstance(port, PortAtEdge):
-                raise ValueError(
-                    f"Load on virtual port {br.port!r}: a Load is a series "
-                    "impedance on an antenna segment, which only PortAtEdge has"
-                )
-            k = self.port_to_idx[br.port]
-            y_col = Y[:, k].copy()
-
-            if br.parallel:
-                # Admittance form: y_L is the parallel-LC tank admittance,
-                # cleanly 0 at trap resonance (the open-circuit point).
-                y_l = load_series_admittance(br, omega)
-                denom = y_l + Y[k, k]
-                if abs(denom) < 1e-15:
-                    raise ValueError(
-                        f"Load on port {br.port!r}: y_L + Y[k,k] ≈ 0 (singular)"
-                    )
-                Y -= np.outer(y_col, y_col) / denom
-            else:
-                # Impedance form: Z_L is 0 at series-LC resonance (a short
-                # = unbroken wire), where the coefficient vanishes anyway.
-                z_l = load_impedance(br, omega)
-                if z_l == 0:
-                    continue
-                denom = 1.0 + z_l * Y[k, k]
-                if abs(denom) < 1e-15:
-                    raise ValueError(
-                        f"Load on port {br.port!r}: 1 + Z_L·Y[k,k] ≈ 0 (singular)"
-                    )
-                Y -= (z_l / denom) * np.outer(y_col, y_col)
-        return Y
-
-    def _augment_with_lines(self, Y, wavelength):
-        """Pad the real-port Y to all ports and stamp the TL branches.
-
-        Loads are NOT stamped here: for the impedance reduction they are folded
-        into the real-port Y by `apply_loads` (called first by `apply_branches`),
-        and for the current solve they are imposed as explicit series-impedance
-        boundary conditions by `excited_state`. Either way the line stamping is
-        identical, so it lives here and both paths share it."""
-        n_total = self.n_total_ports
-        Y_full = np.zeros((n_total, n_total), dtype=np.complex128)
-        n_real = Y.shape[0]
-        Y_full[:n_real, :n_real] = Y
-        for br in self.network.branches:
-            if isinstance(br, TL):
-                a, b = self.port_to_idx[br.a], self.port_to_idx[br.b]
-                y_tl = tl_admittance_2x2(
-                    br.z0, br.length, wavelength, transposed=br.transposed
-                )
-                Y_full[np.ix_([a, b], [a, b])] += y_tl
-            elif isinstance(br, Load):
-                continue  # not a line; see apply_loads / excited_state
-            elif isinstance(br, TwoPort):
-                # A lumped 2-port is an explicit admittance stamp exactly like
-                # a TL — same [[·,·],[·,·]] into Y_full at the (a,b) pair — so
-                # it inherits the TL passive-port BC (I_ext=0, handled in
-                # resolve_voltages / excited_state). No Sherman-Morrison fold
-                # (that is the Load path); the branch never redefines a port
-                # variable, so no V=0 pin is needed.
-                a, b = self.port_to_idx[br.a], self.port_to_idx[br.b]
-                omega = 2.0 * np.pi * C_LIGHT / wavelength
-                y_2p = twoport_admittance_2x2(br.r, br.l, br.c, omega)
-                Y_full[np.ix_([a, b], [a, b])] += y_2p
-            elif isinstance(br, Shunt):
-                # A shunt to common is a 1-port admittance on the node diagonal
-                # — the port's return terminal IS the reference, so no ground
-                # node is needed. Undriven shunt ports keep the floating
-                # (I_ext=0) BC; driven ones (the L-match input) stay pinned.
-                k = self.port_to_idx[br.port]
-                omega = 2.0 * np.pi * C_LIGHT / wavelength
-                Y_full[k, k] += shunt_admittance(
-                    br.r, br.l, br.c, omega, parallel=br.parallel
-                )
-            else:
-                raise NotImplementedError(f"branch type {type(br).__name__}")
-        return Y_full
-
-    def apply_branches(self, Y, wavelength):
-        """Pad Y to include virtual ports, then stamp every network branch.
-
-        Y is the raw real-port admittance, shape (n_real, n_real); the
-        return is a (n_total, n_total) augmented matrix with zeros in the
-        virtual-port rows/cols (no antenna admittance) plus the branch
-        contributions.
-
-        Order matters: Load branches modify the antenna's real-port Y first
-        (matching ld_card's effect inside the MoM), then TL branches stamp
-        on the loaded Y. A TL connected to a loaded port sees the external
-        side of the load.
-
-        Under the MNA formulation the return is an `MNASystem` instead of a
-        matrix; it composes with `impedance_from_y` / `resolve_voltages`
-        exactly as the matrix does.
-        """
-        if self.formulation == "mna":
-            return self._assemble_mna(Y, wavelength)
-        omega = 2.0 * np.pi * C_LIGHT / wavelength
-        Y = self.apply_loads(Y, omega)
-        return self._augment_with_lines(Y, wavelength)
-
-    def resolve_voltages(self, Y_total):
-        """Return the (n_total,) voltage vector after solving the network:
-        driven ports at their applied voltages, every other port floating
-        with I_ext = 0.
-
-        Loaded ports: the legacy admittance path pins V = 0 (the load is
-        folded into Y by `apply_loads`, so the pin is correct for the
-        impedance readout but shorts the load for anything else); the MNA
-        path returns the PHYSICAL gap voltage V_k = V_src − Z_L·I_k — the
-        same voltage `excited_state` reports, because both readouts come
-        from the one MNA solve."""
-        if self.formulation == "mna":
-            v, _j = Y_total.solve()
-            return v.copy()
-        n = Y_total.shape[0]
-        driven = list(self.driven_port_idx)
-        floating = [
-            i for i in range(n) if i not in driven and i not in self.loaded_port_idx
-        ]
-        v_driven = np.array(self.driven_voltages, dtype=np.complex128)
-        V = np.zeros(n, dtype=np.complex128)
-        V[driven] = v_driven
-        # V[loaded] = 0 by zeros init.
-        if floating:
-            # I_ext = 0 at floating ports: Y_ff V_f = -Y_fd V_d - Y_fl V_l.
-            # V_l = 0 so the last term drops.
-            Y_ff = Y_total[np.ix_(floating, floating)]
-            Y_fd = Y_total[np.ix_(floating, driven)]
-            V[floating] = np.linalg.solve(Y_ff, -Y_fd @ v_driven)
-        return V
+    def resolve_voltages(self, system):
+        """Return the (n_total,) physical port-voltage vector of the solved
+        network: driven ports at their applied voltages, loaded ports at the
+        gap voltage V_k = V_src − Z_L·I_k (the load shapes the current the
+        way NEC2's ld_card does), every other port floating with I_ext = 0.
+        These are the voltages the excited far-field/current solver forces
+        at the real feeds."""
+        v, _j = system.solve()
+        return v.copy()
 
     def excited_state(self, Y_real, wavelength):
         """Physical port voltages + radiation efficiency for the CURRENT-
-        DISTRIBUTION / far-field solve.
-
-        `resolve_voltages` pins loaded ports at V=0 and folds the load into the
-        Y matrix via Sherman-Morrison (`apply_loads`): correct for the driving-
-        point impedance, but WRONG for the radiated field. Forcing V=0 at a
-        loaded port makes the load a SHORT, so a terminated antenna (rhombic,
-        T2FD) never develops the traveling wave that makes it unidirectional.
-        Here we instead impose the physical series-load boundary condition
-        ``V_k = -Z_L,k * I_k`` at each loaded port, so the load shapes the
-        current the same way NEC2's ld_card does.
+        DISTRIBUTION / far-field solve — the same MNA solve as the
+        impedance path, read out for power bookkeeping.
 
         Returns ``(V_full, efficiency, p_in)``:
           V_full      -- (n_total,) port voltages to force in the excited solver
@@ -583,77 +310,42 @@ class NetworkReducer:
           p_in        -- input power 1/2 Re(Σ V_src · I*) in watts, the gain
                          normaliser (gain = 4π·U/P_in); it already includes the
                          power burned in resistive loads.
+
+        The termination branches carry the physical port currents, so both
+        power sums read directly off the solution vector:
+
+            p_in   = ½ Σ Re(E_k · j_k*)          (E = 0 terms vanish)
+            p_diss = ½ Σ Re((E_k − v_k) · j_k*)  (the drop across the load
+                                                  part is Z_L·j, so this is
+                                                  ½·Re(Z_L)·|j|² without ever
+                                                  forming a trap's ∞)
+
+        Reactive loads (a loading coil) burn nothing, so they leave
+        efficiency at 1.0. Dissipation in resistive TwoPort/Shunt branches
+        is deliberately NOT counted, matching the pre-MNA accounting; it
+        still lowers gain through p_in.
         """
-        if self.formulation == "mna":
-            return self._mna_excited_state(self._assemble_mna(Y_real, wavelength))
-        omega = 2.0 * np.pi * C_LIGHT / wavelength
-        # Lines stamped, loads left OUT -- they are imposed as BCs below, not
-        # folded into Y (that is the resolve_voltages/impedance path).
-        Y = self._augment_with_lines(Y_real, wavelength)
-        n = self.n_total_ports
-
-        # Per-port source EMF and series-load impedance. A port may carry
-        # BOTH (a driven segment with a series loading element, e.g. the
-        # centre-loaded short dipole) -- the Thevenin BC below covers it.
-        v_src = dict(zip(self.driven_port_idx, self.driven_voltages))
-        z_load = {
-            self.port_to_idx[br.port]: load_impedance(br, omega)
-            for br in self.network.branches
-            if isinstance(br, Load)
-        }
-
-        # A pure source (EMF, no series load) pins V_k = V_src,k and is known.
-        # Every other port is an unknown with a single linear BC:
-        #   load present:  V_k + Z_L,k * (Y V)_k = V_src,k   (Thevenin; V_src=0
-        #                                                      if undriven)
-        #   no load:                  (Y V)_k    = 0         (floating, I_ext=0)
-        pinned = [k for k in v_src if k not in z_load]
-        unknown = [k for k in range(n) if k not in pinned]
-        V = np.zeros(n, dtype=np.complex128)
-        for k in pinned:
-            V[k] = v_src[k]
-        if unknown:
-            pos = {p: j for j, p in enumerate(unknown)}
-            v_pin = np.array([V[k] for k in pinned], dtype=np.complex128)
-            A = np.zeros((len(unknown), len(unknown)), dtype=np.complex128)
-            rhs = np.zeros(len(unknown), dtype=np.complex128)
-            for row, k in enumerate(unknown):
-                # (Y V)_k = Y[k,unknown]·V_unknown + Y[k,pinned]·V_pin; the
-                # pinned part is known and moves to the right-hand side.
-                known = Y[k, pinned] @ v_pin if pinned else 0.0
-                if k in z_load:
-                    A[row, pos[k]] += 1.0
-                    A[row, :] += z_load[k] * Y[k, unknown]
-                    rhs[row] = v_src.get(k, 0.0 + 0.0j) - z_load[k] * known
-                else:
-                    A[row, :] += Y[k, unknown]
-                    rhs[row] = -known
-            V[unknown] = np.linalg.solve(A, rhs)
-
-        # Efficiency = P_radiated / P_input from the resulting port currents.
-        # Sources deliver P_in = 1/2 Re(V_src · I*); resistive loads burn
-        # P_diss = 1/2 Re(Z_L) |I|². Reactive loads (a loading coil) burn
-        # nothing, so they leave efficiency at 1.0.
-        current = Y @ V
-        p_in = 0.5 * float(np.real(sum(v_src[k] * np.conj(current[k]) for k in v_src)))
-        p_diss = 0.5 * float(
-            sum(np.real(z_load[k]) * abs(current[k]) ** 2 for k in z_load)
-        )
+        system = self.apply_branches(Y_real, wavelength)
+        v, j = system.solve()
+        p_in = 0.0
+        p_diss = 0.0
+        for k, (col, e) in system.terminations.items():
+            p_in += 0.5 * float(np.real(e * np.conj(j[col])))
+            p_diss += 0.5 * float(np.real((e - v[k]) * np.conj(j[col])))
         efficiency = 1.0 if p_in <= 0.0 else max(0.0, min(1.0, 1.0 - p_diss / p_in))
-        return V, efficiency, p_in
+        return v.copy(), efficiency, p_in
 
-    def impedance_from_y(self, Y_total):
-        """Driven-port impedance from an `apply_branches` result.
-
-        MNA: Z = E / j_term straight off the solution vector. Legacy: solve
-        the network for V (loaded ports pinned at V=0, floating ports
-        satisfying I_ext=0, driven ports at their applied V), then read
-        I_driven = (Y_total @ V)_driven."""
-        if self.formulation == "mna":
-            return self._mna_impedances(Y_total)
-        V = self.resolve_voltages(Y_total)
-        I = Y_total @ V
-        return [complex(V[i] / I[i]) for i in self.driven_port_idx]
+    def impedance_from_y(self, system):
+        """Driven-point impedance per Driven source from an `apply_branches`
+        result: Z = E / j_term, the termination EMF over its delivered
+        current — read straight off the solution vector, no Y·V
+        post-multiply."""
+        _v, j = system.solve()
+        out = []
+        for k in self.driven_port_idx:
+            col, e = system.terminations[k]
+            out.append(complex(e / j[col]))
+        return out
 
     def driven_impedance(self, Y_real, wavelength):
         """Convenience: stamp branches onto the raw real-port Y and reduce

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -235,7 +235,7 @@ class NetworkReducer:
     :meth:`apply_branches`; virtual ports come after.
     """
 
-    def __init__(self, network, port_to_idx, n_total_ports, formulation="admittance"):
+    def __init__(self, network, port_to_idx, n_total_ports, formulation="mna"):
         # formulation: "admittance" (legacy: bare nodal Y + hand-rolled
         # boundary conditions) or "mna" (Modified Nodal Analysis, issue #285).
         # Both produce the same observable behavior on finite-element

--- a/tests/test_momwire_engine.py
+++ b/tests/test_momwire_engine.py
@@ -1277,34 +1277,6 @@ def _sinusoidal(builder):
     return MomwireEngine(builder, solver=SinusoidalSolver, ground=None)
 
 
-def test_twoport_admittance_stamp_is_series_impedance_2port():
-    """twoport_admittance_2x2 is the short-circuit Y of a series impedance:
-    (1/Z)·[[1,-1],[-1,1]] with Z = R + jωL + 1/(jωC). Pure-math check, no
-    engine."""
-    from antennaknobs.network_reduce import twoport_admittance_2x2
-
-    omega = 2.0 * np.pi * 28e6
-    r, l, c = 30.0, 1e-7, 50e-12
-    z = r + 1j * omega * l + 1.0 / (1j * omega * c)
-    y = twoport_admittance_2x2(r, l, c, omega)
-    inv_z = 1.0 / z
-    assert np.allclose(y, inv_z * np.array([[1, -1], [-1, 1]]))
-    # Rows/cols sum to zero: a floating series element injects no net current.
-    assert np.allclose(y.sum(axis=0), 0) and np.allclose(y.sum(axis=1), 0)
-
-
-def test_twoport_series_lc_short_is_rejected():
-    """A series-LC at resonance is a 0 Ω short (the two segments become one
-    wire); the 2-port admittance is singular, so raise rather than emit inf."""
-    from antennaknobs.network_reduce import twoport_admittance_2x2
-
-    omega = 2.0 * np.pi * 28e6
-    l = 1e-6
-    c = 1.0 / (omega**2 * l)  # series resonance: jωL + 1/(jωC) = 0
-    with pytest.raises(ValueError, match="short"):
-        twoport_admittance_2x2(None, l, c, omega)
-
-
 def test_twoport_cross_engine_impedance_matches():
     """Both engines reduce the TwoPort through the shared NetworkReducer, so on
     a matched basis (momwire's SinusoidalSolver = NEC2's basis family) they must
@@ -1441,32 +1413,6 @@ def test_native_nt_rejects_unemittable_networks():
 # --------------------------------------------------------------------------
 
 
-def test_shunt_admittance_single_elements():
-    """A series-mode single element is the plain reactance admittance: C→jωC,
-    L→1/(jωL). Parallel mode is the tank admittance sum."""
-    from antennaknobs.network_reduce import shunt_admittance
-
-    omega = 2.0 * np.pi * 18.1e6
-    c, l = 57e-12, 1.52e-6
-    assert np.isclose(shunt_admittance(None, None, c, omega), 1j * omega * c)
-    assert np.isclose(shunt_admittance(None, l, None, omega), 1.0 / (1j * omega * l))
-    # Parallel R‖L‖C sums admittances directly.
-    y_par = shunt_admittance(100.0, l, c, omega, parallel=True)
-    assert np.isclose(y_par, 1 / 100.0 + 1 / (1j * omega * l) + 1j * omega * c)
-
-
-def test_shunt_series_lc_short_is_rejected():
-    """A series-LC shunt at resonance is a 0 Ω short to common (infinite
-    admittance); raise rather than emit inf."""
-    from antennaknobs.network_reduce import shunt_admittance
-
-    omega = 2.0 * np.pi * 18.1e6
-    l = 1e-6
-    c = 1.0 / (omega**2 * l)
-    with pytest.raises(ValueError, match="short"):
-        shunt_admittance(None, l, c, omega)
-
-
 def test_shunt_lmatch_matches_circuit_theory():
     """An L-match (series TwoPort in→feed, Shunt across in) must reproduce the
     exact two-element transform 1/(y_shunt + 1/(z_series + Z_ant)) of the bare
@@ -1585,38 +1531,50 @@ def test_pynec_shunt_routes_through_reducer_not_native():
         PyNECEngine(ShuntTwoPort(), ground=None, native_nt=True)
 
 
-def test_zero_capacitor_is_an_open_not_a_crash():
-    """A 0 F capacitor is an open in a series path (infinite reactance): a
-    Shunt with c=0 contributes y=0, a TwoPort with c=0 contributes no coupling.
-    Return the open limit rather than dividing by zero forming 1/(jωC) — this
-    is what lets a matching-network slider reach the inert endpoint."""
-    from antennaknobs.network_reduce import shunt_admittance, twoport_admittance_2x2
+def test_series_short_twoport_is_a_hard_wire_on_the_engine():
+    """A 0 Ω / 0 H series TwoPort is an ideal short between two real segments
+    — the degenerate stamp the old admittance reducer had to reject, now a
+    plain Group-2 element in the MNA core (issue #285). Through the real MoM
+    Y it must give a finite impedance equal to the vanishing-resistance
+    limit."""
+    from antennaknobs import AntennaBuilder
+    from antennaknobs.network import Driven, Network, PortAtEdge, TwoPort
+    from types import MappingProxyType
 
-    omega = 2.0 * np.pi * 18.1e6
-    assert shunt_admittance(None, None, 0.0, omega) == 0
-    assert np.allclose(twoport_admittance_2x2(None, None, 0.0, omega), 0)
+    def make(r=None, l=None):
+        class Pair(AntennaBuilder):
+            default_params = MappingProxyType({"design_freq": 28.0, "freq": 28.0})
 
+            def build_wires(self):
+                return [
+                    ((0, -2.5, 5), (0, 2.5, 5), 21, None, "feed"),
+                    ((1, -2.5, 5), (1, 2.5, 5), 21, None, "feed2"),
+                ]
 
-def test_series_short_raises_clear_message():
-    """A 0 Ω / 0 H series element (or all-omitted branch) is a lossless short,
-    which is not a finite admittance stamp; raise with an actionable message
-    (not the old 'series-LC resonance' wording, and not a bare ZeroDivision)."""
-    from antennaknobs.network_reduce import shunt_admittance, twoport_admittance_2x2
+            def build_network(self):
+                return Network(
+                    ports={"feed": PortAtEdge("feed"), "feed2": PortAtEdge("feed2")},
+                    branches=[TwoPort(a="feed", b="feed2", r=r, l=l)],
+                    sources=[Driven(port="feed")],
+                )
 
-    omega = 2.0 * np.pi * 18.1e6
-    with pytest.raises(ValueError, match="short"):
-        twoport_admittance_2x2(0.0, None, None, omega)  # 0 Ω series
-    with pytest.raises(ValueError, match="short"):
-        shunt_admittance(None, 0.0, None, omega)  # 0 H shunt short-to-common
+        return _sinusoidal(Pair()).impedance()[0]
+
+    z_zero_ohm = make(r=0.0)
+    z_zero_henry = make(l=0.0)
+    z_limit = make(r=1e-9)
+    assert np.isfinite(z_zero_ohm) and np.isfinite(z_zero_henry)
+    assert abs(z_zero_ohm - z_limit) / abs(z_limit) < 1e-6
+    assert abs(z_zero_henry - z_limit) / abs(z_limit) < 1e-6
 
 
 @needs_pynec
 def test_skyloop_matchbox_inert_is_passthrough():
     """Setting both L-match arms to zero makes the matchbox inert: the series
-    arm is a wire (input == feed, driven directly) and the shunt is omitted, so
-    the input impedance is just the bare antenna's. This is delivered by
-    topology (build_network drops/merges zero arms), so it works on today's
-    admittance reducer — a literal 0 H stamp awaits the MNA core (issue #285)."""
+    arm is an ideal wire (a literal 0 H TwoPort) and the shunt a 0 F open, so
+    the input impedance is just the bare antenna's. Since the MNA core
+    (issue #285) these degenerate values are stamped literally —
+    build_network no longer special-cases the topology."""
     from antennaknobs.designs.loops.skyloop_lmatch import Builder as B
     from antennaknobs.network import Driven, Network, PortAtEdge
     from types import MappingProxyType

--- a/tests/test_network_mna.py
+++ b/tests/test_network_mna.py
@@ -1,0 +1,372 @@
+"""Cross-checks for the MNA reformulation of `NetworkReducer` (issue #285).
+
+Two layers:
+
+1. **Formulation equivalence.** On finite-element networks the MNA system and
+   the legacy admittance reduction are algebraically the same circuit, so
+   `driven_impedance` / `excited_state` must agree to numerical precision.
+   These tests run both formulations over synthetic (reciprocal, well-
+   conditioned) antenna Y matrices covering every branch type and boundary-
+   condition combination the legacy code special-cased: TL, transposed TL,
+   TwoPort, series/parallel Shunt, series/parallel Load, driven+loaded ports,
+   multi-driven networks, virtual drivers, and 0 V sources.
+
+2. **Degenerate elements only MNA can stamp.** Ideal shorts (0 Ω, 0 H,
+   all-omitted branches), a literal inert L-matchbox, and an exactly-at-
+   resonance trap in the excited path. The legacy formulation raises (or
+   diverges) on these; MNA must return the physical limit.
+
+No MoM solves here — the antenna Y is synthetic, so the whole file is fast.
+The engine-level oracle suite (`test_tl_composition`, the `nt_card` oracle,
+the L-match and `delta_looparray` cross-engine checks) remains the harness
+for the real thing.
+"""
+
+import numpy as np
+import pytest
+
+from antennaknobs.network import (
+    TL,
+    Driven,
+    Load,
+    Network,
+    PortAtEdge,
+    PortVirtual,
+    Shunt,
+    TwoPort,
+)
+from antennaknobs.network_reduce import C_LIGHT, NetworkReducer
+
+FREQ_MHZ = 28.0
+WL = C_LIGHT / (FREQ_MHZ * 1e6)
+OMEGA = 2.0 * np.pi * FREQ_MHZ * 1e6
+
+
+def synth_y(n, seed):
+    """Reciprocal (symmetric), diagonally-dominant complex Y with antenna-ish
+    magnitudes (tens of mS on the diagonal) so both formulations are well
+    conditioned and disagreements are formulation bugs, not conditioning."""
+    rng = np.random.default_rng(seed)
+    a = rng.normal(size=(n, n)) + 1j * rng.normal(size=(n, n))
+    y = 0.004 * (a + a.T) / 2.0
+    return y + np.eye(n) * (0.02 + 0.008j)
+
+
+def reducers(net, n_real, extra_virtual=()):
+    """Build (legacy, mna) reducers with the standard port indexing: real
+    PortAtEdge ports first in declaration order, virtual ports after."""
+    real = [n for n, p in net.ports.items() if isinstance(p, PortAtEdge)]
+    virt = [n for n, p in net.ports.items() if isinstance(p, PortVirtual)]
+    assert len(real) == n_real
+    port_to_idx = {n: i for i, n in enumerate(real + virt)}
+    n_total = len(real) + len(virt)
+    return (
+        NetworkReducer(net, port_to_idx, n_total, formulation="admittance"),
+        NetworkReducer(net, port_to_idx, n_total, formulation="mna"),
+    )
+
+
+def assert_formulations_agree(net, n_real, seed=0, check_legacy_voltages=True):
+    """Impedances and excited-state outputs must match across formulations.
+
+    `check_legacy_voltages=False` for networks with loads: there the legacy
+    impedance path pins loaded-port V = 0 (a bookkeeping value) while MNA
+    reports the physical gap voltage, so only `excited_state`'s voltages —
+    physical in both — are comparable.
+    """
+    y = synth_y(n_real, seed)
+    legacy, mna = reducers(net, n_real)
+
+    z_legacy = legacy.driven_impedance(y, WL)
+    z_mna = mna.driven_impedance(y, WL)
+    np.testing.assert_allclose(z_mna, z_legacy, rtol=1e-9, atol=1e-12)
+
+    v_legacy, eff_legacy, pin_legacy = legacy.excited_state(y, WL)
+    v_mna, eff_mna, pin_mna = mna.excited_state(y, WL)
+    np.testing.assert_allclose(v_mna, v_legacy, rtol=1e-9, atol=1e-12)
+    assert eff_mna == pytest.approx(eff_legacy, rel=1e-9)
+    assert pin_mna == pytest.approx(pin_legacy, rel=1e-9)
+
+    if check_legacy_voltages:
+        v_legacy = legacy.resolve_voltages(legacy.apply_branches(y, WL))
+        v_mna = mna.resolve_voltages(mna.apply_branches(y, WL))
+        np.testing.assert_allclose(v_mna, v_legacy, rtol=1e-9, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# 1. Formulation equivalence
+# ---------------------------------------------------------------------------
+
+
+def test_bare_driven_port():
+    net = Network(ports={"f": PortAtEdge("f")}, sources=[Driven(port="f")])
+    assert_formulations_agree(net, 1)
+
+
+def test_multi_driven_ports():
+    net = Network(
+        ports={"f1": PortAtEdge("f1"), "f2": PortAtEdge("f2")},
+        sources=[Driven(port="f1", voltage=1 + 0j), Driven(port="f2", voltage=0.5j)],
+    )
+    assert_formulations_agree(net, 2)
+
+
+def test_zero_volt_source_pins_node():
+    """The `Driven(port, 0)` datum trick: a 0 V source is a hard V = 0 pin."""
+    net = Network(
+        ports={"f1": PortAtEdge("f1"), "f2": PortAtEdge("f2")},
+        sources=[Driven(port="f1"), Driven(port="f2", voltage=0j)],
+    )
+    assert_formulations_agree(net, 2)
+    y = synth_y(2, 3)
+    _, mna = reducers(net, 2)
+    v = mna.resolve_voltages(mna.apply_branches(y, WL))
+    assert v[1] == pytest.approx(0.0)
+
+
+def test_virtual_driver_with_tl():
+    net = Network(
+        ports={"f": PortAtEdge("f"), "in": PortVirtual("in")},
+        branches=[TL(a="in", b="f", z0=300.0, length=0.31 * WL)],
+        sources=[Driven(port="in")],
+    )
+    assert_formulations_agree(net, 1)
+
+
+def test_transposed_tl_pair():
+    net = Network(
+        ports={
+            "f1": PortAtEdge("f1"),
+            "f2": PortAtEdge("f2"),
+            "in": PortVirtual("in"),
+        },
+        branches=[
+            TL(a="in", b="f1", z0=300.0, length=0.18 * WL),
+            TL(a="in", b="f2", z0=300.0, length=0.18 * WL, transposed=True),
+        ],
+        sources=[Driven(port="in")],
+    )
+    assert_formulations_agree(net, 2)
+
+
+def test_twoport_bridge():
+    net = Network(
+        ports={"f1": PortAtEdge("f1"), "f2": PortAtEdge("f2")},
+        branches=[TwoPort(a="f1", b="f2", r=20.0, l=0.4e-6)],
+        sources=[Driven(port="f1")],
+    )
+    assert_formulations_agree(net, 2)
+
+
+def test_twoport_open_zero_capacitor():
+    """c = 0 F is an open series path: no coupling, on either formulation."""
+    net = Network(
+        ports={"f1": PortAtEdge("f1"), "f2": PortAtEdge("f2")},
+        branches=[TwoPort(a="f1", b="f2", c=0.0)],
+        sources=[Driven(port="f1")],
+    )
+    assert_formulations_agree(net, 2)
+
+
+def test_shunt_series_and_parallel():
+    net = Network(
+        ports={"f": PortAtEdge("f"), "in": PortVirtual("in")},
+        branches=[
+            TwoPort(a="in", b="f", l=0.2e-6),
+            Shunt(port="in", c=40e-12),
+            Shunt(port="f", r=1000.0, l=1e-6, c=30e-12, parallel=True),
+        ],
+        sources=[Driven(port="in")],
+    )
+    assert_formulations_agree(net, 1)
+
+
+def test_series_load_terminated_port():
+    """Series R load on an undriven second port (terminated-antenna idiom)."""
+    net = Network(
+        ports={"f": PortAtEdge("f"), "term": PortAtEdge("term")},
+        branches=[Load(port="term", r=600.0)],
+        sources=[Driven(port="f")],
+    )
+    assert_formulations_agree(net, 2, check_legacy_voltages=False)
+
+
+def test_driven_and_loaded_same_port():
+    """Centre-loaded driven short dipole: source and series load chain on
+    one port (the Thevenin BC the legacy excited path hand-coded)."""
+    net = Network(
+        ports={"f": PortAtEdge("f")},
+        branches=[Load(port="f", r=5.0, l=2e-6)],
+        sources=[Driven(port="f")],
+    )
+    assert_formulations_agree(net, 1, check_legacy_voltages=False)
+
+
+def test_parallel_trap_load_off_resonance():
+    net = Network(
+        ports={"f": PortAtEdge("f"), "arm": PortAtEdge("arm")},
+        branches=[Load(port="arm", l=1.5e-6, c=30e-12, parallel=True)],
+        sources=[Driven(port="f")],
+    )
+    assert_formulations_agree(net, 2, check_legacy_voltages=False)
+
+
+def test_everything_at_once():
+    """TL + transposed TL + TwoPort + both Shunt modes + both Load modes +
+    two sources, seven ports — the BC zoo in one network."""
+    net = Network(
+        ports={
+            "f1": PortAtEdge("f1"),
+            "f2": PortAtEdge("f2"),
+            "f3": PortAtEdge("f3"),
+            "f4": PortAtEdge("f4"),
+            "in": PortVirtual("in"),
+            "n1": PortVirtual("n1"),
+        },
+        branches=[
+            TL(a="in", b="f1", z0=450.0, length=0.27 * WL),
+            TL(a="in", b="n1", z0=300.0, length=0.12 * WL, transposed=True),
+            TwoPort(a="n1", b="f2", r=10.0, c=120e-12),
+            Shunt(port="in", c=25e-12),
+            Shunt(port="n1", r=800.0, l=0.9e-6, c=45e-12, parallel=True),
+            Load(port="f3", r=300.0, l=0.5e-6),
+            Load(port="f4", l=1.2e-6, c=40e-12, parallel=True),
+        ],
+        sources=[Driven(port="in"), Driven(port="f3", voltage=0.3 - 0.4j)],
+    )
+    assert_formulations_agree(net, 4, check_legacy_voltages=False)
+
+
+@pytest.mark.parametrize("seed", range(5))
+def test_lmatch_seeded(seed):
+    """The skyloop L-match shape over several synthetic antennas."""
+    net = Network(
+        ports={"feed": PortAtEdge("feed"), "in": PortVirtual("in")},
+        branches=[
+            TwoPort(a="in", b="feed", l=0.873e-6),
+            Shunt(port="feed", c=59.57e-12),
+        ],
+        sources=[Driven(port="in")],
+    )
+    assert_formulations_agree(net, 1, seed=seed)
+
+
+def test_load_on_virtual_port_rejected_by_mna():
+    net = Network(
+        ports={"f": PortAtEdge("f"), "v": PortVirtual("v")},
+        branches=[TL(a="f", b="v", z0=50.0, length=0.1 * WL), Load(port="v", r=50.0)],
+        sources=[Driven(port="f")],
+    )
+    _, mna = reducers(net, 1)
+    with pytest.raises(ValueError, match="virtual port"):
+        mna.driven_impedance(synth_y(1, 0), WL)
+
+
+# ---------------------------------------------------------------------------
+# 2. Degenerate elements only MNA can stamp
+# ---------------------------------------------------------------------------
+
+
+def _mna_z(net, n_real, seed=0):
+    _, mna = reducers(net, n_real)
+    return mna.driven_impedance(synth_y(n_real, seed), WL)[0]
+
+
+def _series_twoport_z(r=None, l=None, c=None):
+    net = Network(
+        ports={"f1": PortAtEdge("f1"), "f2": PortAtEdge("f2")},
+        branches=[TwoPort(a="f1", b="f2", r=r, l=l, c=c)],
+        sources=[Driven(port="f1")],
+    )
+    return _mna_z(net, 2)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"r": 0.0},  # 0 Ω resistor
+        {"l": 0.0},  # 0 H ideal wire
+        {},  # all-omitted branch
+    ],
+    ids=["zero-ohm", "zero-henry", "all-omitted"],
+)
+def test_ideal_short_twoport_is_finite_and_identifies_nodes(kwargs):
+    """A z = 0 series TwoPort is an ideal short: finite result, and exactly
+    the small-but-finite limit the legacy formulation could still stamp."""
+    z_short = _series_twoport_z(**kwargs)
+    assert np.isfinite(z_short)
+    z_almost = _series_twoport_z(r=1e-9)
+    assert z_short == pytest.approx(z_almost, rel=1e-6)
+    # Node identification: the shorted pair behaves as one merged node.
+    y = synth_y(2, 0)
+    merged = np.array([[y[0, 0] + y[0, 1] + y[1, 0] + y[1, 1]]])
+    net = Network(ports={"m": PortAtEdge("m")}, sources=[Driven(port="m")])
+    _, mna = reducers(net, 1)
+    z_merged = mna.driven_impedance(merged, WL)[0]
+    assert z_short == pytest.approx(z_merged, rel=1e-9)
+
+
+def test_shunt_ideal_short_pins_port_to_common():
+    """A 0 H shunt hard-shorts the port to the common reference: V_k = 0,
+    with the (finite) short-circuit current flowing through the branch."""
+    net = Network(
+        ports={"f1": PortAtEdge("f1"), "f2": PortAtEdge("f2")},
+        branches=[Shunt(port="f2", l=0.0)],
+        sources=[Driven(port="f1")],
+    )
+    y = synth_y(2, 1)
+    _, mna = reducers(net, 2)
+    system = mna.apply_branches(y, WL)
+    v = mna.resolve_voltages(system)
+    assert v[1] == pytest.approx(0.0, abs=1e-15)
+    z = mna.impedance_from_y(system)[0]
+    assert np.isfinite(z)
+    # With v₂ pinned at 0 the short-circuit Y applies directly: Z = 1/Y₁₁.
+    z_expect = 1.0 / y[0, 0]
+    assert z == pytest.approx(z_expect, rel=1e-9)
+
+
+def test_inert_lmatchbox_stamped_literally():
+    """TwoPort(l=0) + Shunt(c=0) stamped LITERALLY is a pass-through:
+    Z_in = Z_ant, with no design-level topology special-casing (the interim
+    dodge `skyloop_lmatch.build_network` used on the admittance reducer)."""
+    inert = Network(
+        ports={"feed": PortAtEdge("feed"), "in": PortVirtual("in")},
+        branches=[TwoPort(a="in", b="feed", l=0.0), Shunt(port="feed", c=0.0)],
+        sources=[Driven(port="in")],
+    )
+    bare = Network(ports={"feed": PortAtEdge("feed")}, sources=[Driven(port="feed")])
+    y = synth_y(1, 7)
+    _, mna_inert = reducers(inert, 1)
+    _, mna_bare = reducers(bare, 1)
+    z_inert = mna_inert.driven_impedance(y, WL)[0]
+    z_bare = mna_bare.driven_impedance(y, WL)[0]
+    assert z_inert == pytest.approx(z_bare, rel=1e-12)
+
+
+def test_trap_load_at_exact_resonance_is_open():
+    """A parallel-LC Load exactly at ω₀ = 1/√(LC) is the intended open
+    circuit. The legacy excited path formed Z_L = ∞ there; the MNA
+    termination uses the tank admittance (0 at resonance), so the excited
+    state is finite and the trap port carries no current."""
+    l = 1.0e-6
+    c = 1.0 / (OMEGA**2 * l)  # resonate the tank exactly at FREQ_MHZ
+    net = Network(
+        ports={"f": PortAtEdge("f"), "arm": PortAtEdge("arm")},
+        branches=[Load(port="arm", l=l, c=c, parallel=True)],
+        sources=[Driven(port="f")],
+    )
+    y = synth_y(2, 5)
+    _, mna = reducers(net, 2)
+    v, eff, p_in = mna.excited_state(y, WL)
+    assert np.all(np.isfinite(v)) and np.isfinite(p_in)
+    assert eff == pytest.approx(1.0)  # an open burns nothing
+    # Open termination at the arm: the arm port floats (I_ext = 0), which is
+    # the same network as having no Load branch at all.
+    bare = Network(
+        ports={"f": PortAtEdge("f"), "arm": PortAtEdge("arm")},
+        sources=[Driven(port="f")],
+    )
+    _, mna_bare = reducers(bare, 2)
+    v_bare, _, _ = mna_bare.excited_state(y, WL)
+    np.testing.assert_allclose(v, v_bare, rtol=1e-9)

--- a/tests/test_network_mna.py
+++ b/tests/test_network_mna.py
@@ -1,20 +1,19 @@
-"""Cross-checks for the MNA reformulation of `NetworkReducer` (issue #285).
+"""Tests for the MNA core of `NetworkReducer` (issue #285).
 
 Two layers:
 
-1. **Formulation equivalence.** On finite-element networks the MNA system and
-   the legacy admittance reduction are algebraically the same circuit, so
-   `driven_impedance` / `excited_state` must agree to numerical precision.
-   These tests run both formulations over synthetic (reciprocal, well-
-   conditioned) antenna Y matrices covering every branch type and boundary-
-   condition combination the legacy code special-cased: TL, transposed TL,
-   TwoPort, series/parallel Shunt, series/parallel Load, driven+loaded ports,
-   multi-driven networks, virtual drivers, and 0 V sources.
+1. **Circuit-theory oracles.** On finite-element networks the MNA solution
+   must match independent hand circuit theory: closed-form transforms (TL
+   input impedance, L-match, series load) and a ten-line bare nodal
+   reduction (`nodal_reference`) built directly from the boundary-condition
+   definitions. The MNA formulation was additionally brought up side by side
+   against the legacy admittance reducer and matched it to 1e-9 on every
+   branch/BC combination — see the flag-gated commits introducing this file.
 
 2. **Degenerate elements only MNA can stamp.** Ideal shorts (0 Ω, 0 H,
    all-omitted branches), a literal inert L-matchbox, and an exactly-at-
-   resonance trap in the excited path. The legacy formulation raises (or
-   diverges) on these; MNA must return the physical limit.
+   resonance trap in the excited path. The old admittance-only formulation
+   raised (or diverged) on these; MNA must return the physical limit.
 
 No MoM solves here — the antenna Y is synthetic, so the whole file is fast.
 The engine-level oracle suite (`test_tl_composition`, the `nt_card` oracle,
@@ -35,7 +34,7 @@ from antennaknobs.network import (
     Shunt,
     TwoPort,
 )
-from antennaknobs.network_reduce import C_LIGHT, NetworkReducer
+from antennaknobs.network_reduce import C_LIGHT, NetworkReducer, tl_admittance_2x2
 
 FREQ_MHZ = 28.0
 WL = C_LIGHT / (FREQ_MHZ * 1e6)
@@ -44,7 +43,7 @@ OMEGA = 2.0 * np.pi * FREQ_MHZ * 1e6
 
 def synth_y(n, seed):
     """Reciprocal (symmetric), diagonally-dominant complex Y with antenna-ish
-    magnitudes (tens of mS on the diagonal) so both formulations are well
+    magnitudes (tens of mS on the diagonal) so the systems are well
     conditioned and disagreements are formulation bugs, not conditioning."""
     rng = np.random.default_rng(seed)
     a = rng.normal(size=(n, n)) + 1j * rng.normal(size=(n, n))
@@ -52,63 +51,61 @@ def synth_y(n, seed):
     return y + np.eye(n) * (0.02 + 0.008j)
 
 
-def reducers(net, n_real, extra_virtual=()):
-    """Build (legacy, mna) reducers with the standard port indexing: real
-    PortAtEdge ports first in declaration order, virtual ports after."""
+def reducer(net, n_real):
+    """Build a reducer with the standard port indexing: real PortAtEdge
+    ports first in declaration order, virtual ports after."""
     real = [n for n, p in net.ports.items() if isinstance(p, PortAtEdge)]
     virt = [n for n, p in net.ports.items() if isinstance(p, PortVirtual)]
     assert len(real) == n_real
     port_to_idx = {n: i for i, n in enumerate(real + virt)}
-    n_total = len(real) + len(virt)
-    return (
-        NetworkReducer(net, port_to_idx, n_total, formulation="admittance"),
-        NetworkReducer(net, port_to_idx, n_total, formulation="mna"),
-    )
+    return NetworkReducer(net, port_to_idx, len(real) + len(virt))
 
 
-def assert_formulations_agree(net, n_real, seed=0, check_legacy_voltages=True):
-    """Impedances and excited-state outputs must match across formulations.
-
-    `check_legacy_voltages=False` for networks with loads: there the legacy
-    impedance path pins loaded-port V = 0 (a bookkeeping value) while MNA
-    reports the physical gap voltage, so only `excited_state`'s voltages —
-    physical in both — are comparable.
-    """
-    y = synth_y(n_real, seed)
-    legacy, mna = reducers(net, n_real)
-
-    z_legacy = legacy.driven_impedance(y, WL)
-    z_mna = mna.driven_impedance(y, WL)
-    np.testing.assert_allclose(z_mna, z_legacy, rtol=1e-9, atol=1e-12)
-
-    v_legacy, eff_legacy, pin_legacy = legacy.excited_state(y, WL)
-    v_mna, eff_mna, pin_mna = mna.excited_state(y, WL)
-    np.testing.assert_allclose(v_mna, v_legacy, rtol=1e-9, atol=1e-12)
-    assert eff_mna == pytest.approx(eff_legacy, rel=1e-9)
-    assert pin_mna == pytest.approx(pin_legacy, rel=1e-9)
-
-    if check_legacy_voltages:
-        v_legacy = legacy.resolve_voltages(legacy.apply_branches(y, WL))
-        v_mna = mna.resolve_voltages(mna.apply_branches(y, WL))
-        np.testing.assert_allclose(v_mna, v_legacy, rtol=1e-9, atol=1e-12)
+def nodal_reference(y_full, driven):
+    """Independent oracle: bare nodal reduction written straight from the
+    boundary-condition definitions — driven nodes pinned at their EMF, every
+    other node floating with I_ext = 0, currents read as Y·V. Only valid
+    when every element is a finite admittance stamp (fold loads as shunt
+    admittances first; no source may carry a series impedance)."""
+    n = y_full.shape[0]
+    idx = sorted(driven)
+    other = [i for i in range(n) if i not in driven]
+    v = np.zeros(n, dtype=np.complex128)
+    for k, e in driven.items():
+        v[k] = e
+    if other:
+        rhs = -y_full[np.ix_(other, idx)] @ np.array([driven[k] for k in idx])
+        v[other] = np.linalg.solve(y_full[np.ix_(other, other)], rhs)
+    return v, y_full @ v
 
 
 # ---------------------------------------------------------------------------
-# 1. Formulation equivalence
+# 1. Circuit-theory oracles
 # ---------------------------------------------------------------------------
 
 
 def test_bare_driven_port():
+    """One driven port, no branches: Z = 1/Y₀₀ and V = E exactly."""
     net = Network(ports={"f": PortAtEdge("f")}, sources=[Driven(port="f")])
-    assert_formulations_agree(net, 1)
+    y = synth_y(1, 0)
+    red = reducer(net, 1)
+    assert red.driven_impedance(y, WL)[0] == pytest.approx(1.0 / y[0, 0], rel=1e-12)
+    v, eff, p_in = red.excited_state(y, WL)
+    assert v[0] == pytest.approx(1.0)
+    assert eff == 1.0
+    assert p_in == pytest.approx(0.5 * float(np.real(np.conj(y[0, 0]))), rel=1e-12)
 
 
 def test_multi_driven_ports():
+    """Two simultaneous sources: every port pinned, I = Y·V directly."""
     net = Network(
         ports={"f1": PortAtEdge("f1"), "f2": PortAtEdge("f2")},
         sources=[Driven(port="f1", voltage=1 + 0j), Driven(port="f2", voltage=0.5j)],
     )
-    assert_formulations_agree(net, 2)
+    y = synth_y(2, 1)
+    v_ref, i_ref = nodal_reference(y, {0: 1 + 0j, 1: 0.5j})
+    z = reducer(net, 2).driven_impedance(y, WL)
+    np.testing.assert_allclose(z, v_ref[[0, 1]] / i_ref[[0, 1]], rtol=1e-9)
 
 
 def test_zero_volt_source_pins_node():
@@ -117,23 +114,38 @@ def test_zero_volt_source_pins_node():
         ports={"f1": PortAtEdge("f1"), "f2": PortAtEdge("f2")},
         sources=[Driven(port="f1"), Driven(port="f2", voltage=0j)],
     )
-    assert_formulations_agree(net, 2)
     y = synth_y(2, 3)
-    _, mna = reducers(net, 2)
-    v = mna.resolve_voltages(mna.apply_branches(y, WL))
-    assert v[1] == pytest.approx(0.0)
+    red = reducer(net, 2)
+    v = red.resolve_voltages(red.apply_branches(y, WL))
+    v_ref, i_ref = nodal_reference(y, {0: 1 + 0j, 1: 0j})
+    np.testing.assert_allclose(v, v_ref, rtol=1e-9, atol=1e-15)
+    z = red.driven_impedance(y, WL)
+    assert z[0] == pytest.approx(v_ref[0] / i_ref[0], rel=1e-9)
+    assert z[1] == 0.0  # 0 V across a finite current
 
 
-def test_virtual_driver_with_tl():
+def test_virtual_driver_with_tl_matches_line_transform():
+    """Virtual input → ideal line → antenna: the classic closed form
+    Z_in = Z₀ (Z_L + jZ₀ tanθ)/(Z₀ + jZ_L tanθ), efficiency 1 (lossless)."""
+    z0, length = 300.0, 0.31 * WL
     net = Network(
         ports={"f": PortAtEdge("f"), "in": PortVirtual("in")},
-        branches=[TL(a="in", b="f", z0=300.0, length=0.31 * WL)],
+        branches=[TL(a="in", b="f", z0=z0, length=length)],
         sources=[Driven(port="in")],
     )
-    assert_formulations_agree(net, 1)
+    y = synth_y(1, 2)
+    z_l = 1.0 / y[0, 0]
+    t = np.tan(2.0 * np.pi * length / WL)
+    z_expect = z0 * (z_l + 1j * z0 * t) / (z0 + 1j * z_l * t)
+    red = reducer(net, 1)
+    assert red.driven_impedance(y, WL)[0] == pytest.approx(z_expect, rel=1e-9)
+    _v, eff, _p = red.excited_state(y, WL)
+    assert eff == 1.0
 
 
 def test_transposed_tl_pair():
+    """Two lines off one virtual driver, one crossed — check the full
+    voltage vector against the bare nodal reduction with the same stamps."""
     net = Network(
         ports={
             "f1": PortAtEdge("f1"),
@@ -146,74 +158,163 @@ def test_transposed_tl_pair():
         ],
         sources=[Driven(port="in")],
     )
-    assert_formulations_agree(net, 2)
+    y = synth_y(2, 4)
+    y_full = np.zeros((3, 3), dtype=np.complex128)
+    y_full[:2, :2] = y
+    y_full[np.ix_([2, 0], [2, 0])] += tl_admittance_2x2(300.0, 0.18 * WL, WL)
+    y_full[np.ix_([2, 1], [2, 1])] += tl_admittance_2x2(
+        300.0, 0.18 * WL, WL, transposed=True
+    )
+    v_ref, i_ref = nodal_reference(y_full, {2: 1 + 0j})
+    red = reducer(net, 2)
+    v = red.resolve_voltages(red.apply_branches(y, WL))
+    np.testing.assert_allclose(v, v_ref, rtol=1e-9)
+    assert red.driven_impedance(y, WL)[0] == pytest.approx(
+        v_ref[2] / i_ref[2], rel=1e-9
+    )
 
 
 def test_twoport_bridge():
+    """Lumped series R+jωL bridging two ports = its 2×2 admittance stamp."""
+    r, l = 20.0, 0.4e-6
     net = Network(
         ports={"f1": PortAtEdge("f1"), "f2": PortAtEdge("f2")},
-        branches=[TwoPort(a="f1", b="f2", r=20.0, l=0.4e-6)],
+        branches=[TwoPort(a="f1", b="f2", r=r, l=l)],
         sources=[Driven(port="f1")],
     )
-    assert_formulations_agree(net, 2)
+    y = synth_y(2, 5)
+    y_br = 1.0 / (r + 1j * OMEGA * l)
+    y_full = y + y_br * np.array([[1, -1], [-1, 1]])
+    v_ref, i_ref = nodal_reference(y_full, {0: 1 + 0j})
+    red = reducer(net, 2)
+    assert red.driven_impedance(y, WL)[0] == pytest.approx(
+        v_ref[0] / i_ref[0], rel=1e-9
+    )
+    v, _eff, _p = red.excited_state(y, WL)
+    np.testing.assert_allclose(v, v_ref, rtol=1e-9)
 
 
 def test_twoport_open_zero_capacitor():
-    """c = 0 F is an open series path: no coupling, on either formulation."""
+    """c = 0 F is an open series path: exactly as if the branch weren't
+    there (the inert endpoint of a matching-network capacitor slider)."""
     net = Network(
         ports={"f1": PortAtEdge("f1"), "f2": PortAtEdge("f2")},
         branches=[TwoPort(a="f1", b="f2", c=0.0)],
         sources=[Driven(port="f1")],
     )
-    assert_formulations_agree(net, 2)
+    y = synth_y(2, 6)
+    v_ref, i_ref = nodal_reference(y, {0: 1 + 0j})
+    assert reducer(net, 2).driven_impedance(y, WL)[0] == pytest.approx(
+        v_ref[0] / i_ref[0], rel=1e-12
+    )
 
 
-def test_shunt_series_and_parallel():
+@pytest.mark.parametrize("seed", range(5))
+def test_lmatch_matches_two_element_transform(seed):
+    """Series-L TwoPort + shunt-C across the antenna feed: the exact
+    two-element transform Z_in = jωL + 1/(jωC + Y_ant)."""
+    ls, cp = 0.873e-6, 59.57e-12
     net = Network(
-        ports={"f": PortAtEdge("f"), "in": PortVirtual("in")},
+        ports={"feed": PortAtEdge("feed"), "in": PortVirtual("in")},
         branches=[
-            TwoPort(a="in", b="f", l=0.2e-6),
-            Shunt(port="in", c=40e-12),
-            Shunt(port="f", r=1000.0, l=1e-6, c=30e-12, parallel=True),
+            TwoPort(a="in", b="feed", l=ls),
+            Shunt(port="feed", c=cp),
         ],
         sources=[Driven(port="in")],
     )
-    assert_formulations_agree(net, 1)
+    y = synth_y(1, seed)
+    z_expect = 1j * OMEGA * ls + 1.0 / (1j * OMEGA * cp + y[0, 0])
+    assert reducer(net, 1).driven_impedance(y, WL)[0] == pytest.approx(
+        z_expect, rel=1e-9
+    )
+
+
+def test_parallel_shunt_is_tank_admittance_on_diagonal():
+    net = Network(
+        ports={"f": PortAtEdge("f")},
+        branches=[Shunt(port="f", r=1000.0, l=1e-6, c=30e-12, parallel=True)],
+        sources=[Driven(port="f")],
+    )
+    y = synth_y(1, 7)
+    y_tank = 1.0 / 1000.0 + 1.0 / (1j * OMEGA * 1e-6) + 1j * OMEGA * 30e-12
+    assert reducer(net, 1).driven_impedance(y, WL)[0] == pytest.approx(
+        1.0 / (y[0, 0] + y_tank), rel=1e-9
+    )
 
 
 def test_series_load_terminated_port():
-    """Series R load on an undriven second port (terminated-antenna idiom)."""
+    """Series R load on an undriven second port (terminated-antenna idiom):
+    a shunt impedance Z_L from the gap to the common return, and its
+    dissipation drives the efficiency readout."""
+    r_l = 600.0
     net = Network(
         ports={"f": PortAtEdge("f"), "term": PortAtEdge("term")},
-        branches=[Load(port="term", r=600.0)],
+        branches=[Load(port="term", r=r_l)],
         sources=[Driven(port="f")],
     )
-    assert_formulations_agree(net, 2, check_legacy_voltages=False)
+    y = synth_y(2, 8)
+    y_full = y + np.diag([0.0, 1.0 / r_l]).astype(np.complex128)
+    v_ref, i_ref = nodal_reference(y_full, {0: 1 + 0j})
+    red = reducer(net, 2)
+    assert red.driven_impedance(y, WL)[0] == pytest.approx(
+        v_ref[0] / i_ref[0], rel=1e-9
+    )
+    v, eff, p_in = red.excited_state(y, WL)
+    np.testing.assert_allclose(v, v_ref, rtol=1e-9)
+    p_in_ref = 0.5 * float(np.real(v_ref[0] * np.conj(i_ref[0])))
+    p_diss_ref = 0.5 * r_l * abs(v_ref[1] / r_l) ** 2
+    assert p_in == pytest.approx(p_in_ref, rel=1e-9)
+    assert eff == pytest.approx(1.0 - p_diss_ref / p_in_ref, rel=1e-9)
 
 
 def test_driven_and_loaded_same_port():
     """Centre-loaded driven short dipole: source and series load chain on
-    one port (the Thevenin BC the legacy excited path hand-coded)."""
+    one port. Exact one-port circuit: Z_seen = Z_L + 1/Y₀₀, the gap voltage
+    divides accordingly, and only Re(Z_L) burns power."""
+    z_l = 5.0 + 1j * OMEGA * 2e-6
     net = Network(
         ports={"f": PortAtEdge("f")},
         branches=[Load(port="f", r=5.0, l=2e-6)],
         sources=[Driven(port="f")],
     )
-    assert_formulations_agree(net, 1, check_legacy_voltages=False)
+    y = synth_y(1, 9)
+    z_ant = 1.0 / y[0, 0]
+    red = reducer(net, 1)
+    assert red.driven_impedance(y, WL)[0] == pytest.approx(z_l + z_ant, rel=1e-9)
+    v, eff, p_in = red.excited_state(y, WL)
+    i = 1.0 / (z_l + z_ant)
+    assert v[0] == pytest.approx(z_ant * i, rel=1e-9)  # physical gap voltage
+    assert p_in == pytest.approx(0.5 * float(np.real(np.conj(i))), rel=1e-9)
+    assert eff == pytest.approx(
+        1.0 - (0.5 * 5.0 * abs(i) ** 2) / (0.5 * float(np.real(np.conj(i)))), rel=1e-9
+    )
 
 
 def test_parallel_trap_load_off_resonance():
+    """Parallel-LC trap off resonance: a finite shunt impedance at the port."""
+    l, c = 1.5e-6, 30e-12
     net = Network(
         ports={"f": PortAtEdge("f"), "arm": PortAtEdge("arm")},
-        branches=[Load(port="arm", l=1.5e-6, c=30e-12, parallel=True)],
+        branches=[Load(port="arm", l=l, c=c, parallel=True)],
         sources=[Driven(port="f")],
     )
-    assert_formulations_agree(net, 2, check_legacy_voltages=False)
+    y = synth_y(2, 10)
+    y_tank = 1.0 / (1j * OMEGA * l) + 1j * OMEGA * c
+    y_full = y + np.diag([0.0, 1.0]).astype(np.complex128) * y_tank
+    v_ref, i_ref = nodal_reference(y_full, {0: 1 + 0j})
+    red = reducer(net, 2)
+    assert red.driven_impedance(y, WL)[0] == pytest.approx(
+        v_ref[0] / i_ref[0], rel=1e-9
+    )
+    v, _eff, _p = red.excited_state(y, WL)
+    np.testing.assert_allclose(v, v_ref, rtol=1e-9)
 
 
 def test_everything_at_once():
     """TL + transposed TL + TwoPort + both Shunt modes + both Load modes +
-    two sources, seven ports — the BC zoo in one network."""
+    two sources, six nodes — the whole stamp set in one network, against
+    the bare nodal reduction with loads folded as shunts."""
+    lengths = {"tl1": 0.27 * WL, "tl2": 0.12 * WL}
     net = Network(
         ports={
             "f1": PortAtEdge("f1"),
@@ -224,52 +325,51 @@ def test_everything_at_once():
             "n1": PortVirtual("n1"),
         },
         branches=[
-            TL(a="in", b="f1", z0=450.0, length=0.27 * WL),
-            TL(a="in", b="n1", z0=300.0, length=0.12 * WL, transposed=True),
+            TL(a="in", b="f1", z0=450.0, length=lengths["tl1"]),
+            TL(a="in", b="n1", z0=300.0, length=lengths["tl2"], transposed=True),
             TwoPort(a="n1", b="f2", r=10.0, c=120e-12),
             Shunt(port="in", c=25e-12),
             Shunt(port="n1", r=800.0, l=0.9e-6, c=45e-12, parallel=True),
             Load(port="f3", r=300.0, l=0.5e-6),
             Load(port="f4", l=1.2e-6, c=40e-12, parallel=True),
         ],
-        sources=[Driven(port="in"), Driven(port="f3", voltage=0.3 - 0.4j)],
+        sources=[Driven(port="in"), Driven(port="f2", voltage=0.3 - 0.4j)],
     )
-    assert_formulations_agree(net, 4, check_legacy_voltages=False)
-
-
-@pytest.mark.parametrize("seed", range(5))
-def test_lmatch_seeded(seed):
-    """The skyloop L-match shape over several synthetic antennas."""
-    net = Network(
-        ports={"feed": PortAtEdge("feed"), "in": PortVirtual("in")},
-        branches=[
-            TwoPort(a="in", b="feed", l=0.873e-6),
-            Shunt(port="feed", c=59.57e-12),
-        ],
-        sources=[Driven(port="in")],
+    y = synth_y(4, 11)
+    # in = node 4, n1 = node 5.
+    y_full = np.zeros((6, 6), dtype=np.complex128)
+    y_full[:4, :4] = y
+    y_full[np.ix_([4, 0], [4, 0])] += tl_admittance_2x2(450.0, lengths["tl1"], WL)
+    y_full[np.ix_([4, 5], [4, 5])] += tl_admittance_2x2(
+        300.0, lengths["tl2"], WL, transposed=True
     )
-    assert_formulations_agree(net, 1, seed=seed)
+    y_2p = 1.0 / (10.0 + 1.0 / (1j * OMEGA * 120e-12))
+    y_full[np.ix_([5, 1], [5, 1])] += y_2p * np.array([[1, -1], [-1, 1]])
+    y_full[4, 4] += 1j * OMEGA * 25e-12
+    y_full[5, 5] += 1.0 / 800.0 + 1.0 / (1j * OMEGA * 0.9e-6) + 1j * OMEGA * 45e-12
+    y_full[2, 2] += 1.0 / (300.0 + 1j * OMEGA * 0.5e-6)
+    y_full[3, 3] += 1.0 / (1j * OMEGA * 1.2e-6) + 1j * OMEGA * 40e-12
+    v_ref, i_ref = nodal_reference(y_full, {4: 1 + 0j, 1: 0.3 - 0.4j})
+    red = reducer(net, 4)
+    z = red.driven_impedance(y, WL)
+    np.testing.assert_allclose(z, v_ref[[4, 1]] / i_ref[[4, 1]], rtol=1e-9)
+    v, _eff, _p = red.excited_state(y, WL)
+    np.testing.assert_allclose(v, v_ref, rtol=1e-9)
 
 
-def test_load_on_virtual_port_rejected_by_mna():
+def test_load_on_virtual_port_rejected():
     net = Network(
         ports={"f": PortAtEdge("f"), "v": PortVirtual("v")},
         branches=[TL(a="f", b="v", z0=50.0, length=0.1 * WL), Load(port="v", r=50.0)],
         sources=[Driven(port="f")],
     )
-    _, mna = reducers(net, 1)
     with pytest.raises(ValueError, match="virtual port"):
-        mna.driven_impedance(synth_y(1, 0), WL)
+        reducer(net, 1).driven_impedance(synth_y(1, 0), WL)
 
 
 # ---------------------------------------------------------------------------
 # 2. Degenerate elements only MNA can stamp
 # ---------------------------------------------------------------------------
-
-
-def _mna_z(net, n_real, seed=0):
-    _, mna = reducers(net, n_real)
-    return mna.driven_impedance(synth_y(n_real, seed), WL)[0]
 
 
 def _series_twoport_z(r=None, l=None, c=None):
@@ -278,7 +378,7 @@ def _series_twoport_z(r=None, l=None, c=None):
         branches=[TwoPort(a="f1", b="f2", r=r, l=l, c=c)],
         sources=[Driven(port="f1")],
     )
-    return _mna_z(net, 2)
+    return reducer(net, 2).driven_impedance(synth_y(2, 0), WL)[0]
 
 
 @pytest.mark.parametrize(
@@ -287,12 +387,13 @@ def _series_twoport_z(r=None, l=None, c=None):
         {"r": 0.0},  # 0 Ω resistor
         {"l": 0.0},  # 0 H ideal wire
         {},  # all-omitted branch
+        {"l": 1e-6, "c": 1.0 / (OMEGA**2 * 1e-6)},  # exact series-LC resonance
     ],
-    ids=["zero-ohm", "zero-henry", "all-omitted"],
+    ids=["zero-ohm", "zero-henry", "all-omitted", "series-lc-resonance"],
 )
 def test_ideal_short_twoport_is_finite_and_identifies_nodes(kwargs):
-    """A z = 0 series TwoPort is an ideal short: finite result, and exactly
-    the small-but-finite limit the legacy formulation could still stamp."""
+    """A z = 0 series TwoPort is an ideal short: finite result, the limit of
+    a vanishing resistance, and exact node identification."""
     z_short = _series_twoport_z(**kwargs)
     assert np.isfinite(z_short)
     z_almost = _series_twoport_z(r=1e-9)
@@ -301,8 +402,7 @@ def test_ideal_short_twoport_is_finite_and_identifies_nodes(kwargs):
     y = synth_y(2, 0)
     merged = np.array([[y[0, 0] + y[0, 1] + y[1, 0] + y[1, 1]]])
     net = Network(ports={"m": PortAtEdge("m")}, sources=[Driven(port="m")])
-    _, mna = reducers(net, 1)
-    z_merged = mna.driven_impedance(merged, WL)[0]
+    z_merged = reducer(net, 1).driven_impedance(merged, WL)[0]
     assert z_short == pytest.approx(z_merged, rel=1e-9)
 
 
@@ -315,33 +415,28 @@ def test_shunt_ideal_short_pins_port_to_common():
         sources=[Driven(port="f1")],
     )
     y = synth_y(2, 1)
-    _, mna = reducers(net, 2)
-    system = mna.apply_branches(y, WL)
-    v = mna.resolve_voltages(system)
+    red = reducer(net, 2)
+    system = red.apply_branches(y, WL)
+    v = red.resolve_voltages(system)
     assert v[1] == pytest.approx(0.0, abs=1e-15)
-    z = mna.impedance_from_y(system)[0]
+    z = red.impedance_from_y(system)[0]
     assert np.isfinite(z)
     # With v₂ pinned at 0 the short-circuit Y applies directly: Z = 1/Y₁₁.
-    z_expect = 1.0 / y[0, 0]
-    assert z == pytest.approx(z_expect, rel=1e-9)
+    assert z == pytest.approx(1.0 / y[0, 0], rel=1e-9)
 
 
 def test_inert_lmatchbox_stamped_literally():
     """TwoPort(l=0) + Shunt(c=0) stamped LITERALLY is a pass-through:
     Z_in = Z_ant, with no design-level topology special-casing (the interim
-    dodge `skyloop_lmatch.build_network` used on the admittance reducer)."""
+    dodge `skyloop_lmatch.build_network` needed on the admittance reducer)."""
     inert = Network(
         ports={"feed": PortAtEdge("feed"), "in": PortVirtual("in")},
         branches=[TwoPort(a="in", b="feed", l=0.0), Shunt(port="feed", c=0.0)],
         sources=[Driven(port="in")],
     )
-    bare = Network(ports={"feed": PortAtEdge("feed")}, sources=[Driven(port="feed")])
     y = synth_y(1, 7)
-    _, mna_inert = reducers(inert, 1)
-    _, mna_bare = reducers(bare, 1)
-    z_inert = mna_inert.driven_impedance(y, WL)[0]
-    z_bare = mna_bare.driven_impedance(y, WL)[0]
-    assert z_inert == pytest.approx(z_bare, rel=1e-12)
+    z_inert = reducer(inert, 1).driven_impedance(y, WL)[0]
+    assert z_inert == pytest.approx(1.0 / y[0, 0], rel=1e-12)
 
 
 def test_trap_load_at_exact_resonance_is_open():
@@ -357,16 +452,11 @@ def test_trap_load_at_exact_resonance_is_open():
         sources=[Driven(port="f")],
     )
     y = synth_y(2, 5)
-    _, mna = reducers(net, 2)
-    v, eff, p_in = mna.excited_state(y, WL)
+    red = reducer(net, 2)
+    v, eff, p_in = red.excited_state(y, WL)
     assert np.all(np.isfinite(v)) and np.isfinite(p_in)
     assert eff == pytest.approx(1.0)  # an open burns nothing
-    # Open termination at the arm: the arm port floats (I_ext = 0), which is
-    # the same network as having no Load branch at all.
-    bare = Network(
-        ports={"f": PortAtEdge("f"), "arm": PortAtEdge("arm")},
-        sources=[Driven(port="f")],
-    )
-    _, mna_bare = reducers(bare, 2)
-    v_bare, _, _ = mna_bare.excited_state(y, WL)
-    np.testing.assert_allclose(v, v_bare, rtol=1e-9)
+    # Open termination at the arm: the arm port floats (I_ext = 0), the same
+    # network as having no Load branch at all.
+    v_ref, _ = nodal_reference(y, {0: 1 + 0j})
+    np.testing.assert_allclose(v, v_ref, rtol=1e-9)


### PR DESCRIPTION
## Summary
- Rebuilds `NetworkReducer` on the SPICE-style MNA formulation (closes #285): one system `[[G, B],[Cᵀ, D]]·[v; j] = [i_ext; e]` replaces the bare nodal-Y reduction and its three hand-rolled boundary-condition regimes.
- One uniform Group-2 stamp covers voltage sources, Loads, TwoPorts, and series Shunts: `Driven` + `Load` on a port collapse into a single termination branch whose constitutive row `v_k + Z_L·j = E` is exactly the old Thevenin BC, so driven-point impedance (`Z = E/j`), physical port voltages, and the power bookkeeping all read off a single solve — the separate `excited_state` formulation and the Sherman-Morrison `apply_loads` fold are deleted.
- Degenerate elements are now physics instead of errors: 0 Ω / 0 H / all-omitted / series-LC-resonant series elements are ideal shorts (node identification), C = 0 is an open, and a parallel-LC trap at exact resonance is finite in the excited path too. `skyloop_lmatch.build_network` stamps its sliders literally — the zero-arm topology special-casing is gone.
- Behavior note: `resolve_voltages` now reports the physical gap voltage at loaded ports (formerly a V = 0 bookkeeping pin), so PyNEC's reducer-path excited context gets the same load-shaped currents momwire's already did.
- Bring-up followed the staged plan in `docs/plan-mna-network-core.md`: flag-gated side-by-side with the legacy reducer (matched to 1e-9 across every branch/BC combination — see the first two commits), default flipped with the full suite green, then the legacy code deleted. `tests/test_network_mna.py` keeps permanent oracles against independent circuit theory (closed-form TL/L-match/load transforms + a bare nodal reference) plus the MNA-only degenerate cases.

## Test plan
- [x] Full suite (1463 tests) passes, including the oracle harness: `test_tl_composition` (reducer vs native `tl_card`), the `TwoPort` `nt_card` oracle, `Load` series/parallel, the Shunt L-match, and `delta_looparray` cross-engine
- [x] New `tests/test_network_mna.py`: circuit-theory oracles + degenerate stamps (0 Ω / 0 H / all-omitted / series-LC shorts, shunt short-to-common, literal inert L-matchbox, trap open at exact resonance)
- [x] New engine-level test: 0 Ω / 0 H series TwoPort through the real MoM Y equals the vanishing-resistance limit
- [x] `ruff check` and `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)