### PR TITLE
Fix PyNEC native impedance readout: use NEC's network-corrected input parameters

### DIFF
--- a/docs/plan-network-impedance-readout.md
+++ b/docs/plan-network-impedance-readout.md
@@ -1,0 +1,107 @@
+# Plan: fix PyNEC native-path impedance readout (issue #283, re-scoped)
+
+Status: **Investigated 2026-07-11 — root cause found, and it is our bug, not
+a modeling-convention gap.** Issue #283's premise ("segment-level vs
+basis-level port convention", fix by segment-averaging the Y extraction) is
+refuted. NEC, EZNEC, and 4nec2 already report the same driving-point
+impedance as our reducer; the divergent number came from `PyNECEngine`'s own
+native-path readout. The fix is small and local.
+
+## TL;DR
+
+When a voltage source sits on a segment that also carries a network
+connection (NT or TL card), the driving-point current is the current the
+source delivers into the gap:
+
+    I_delivered = I_wire + I_network        (KCL at the feed gap)
+
+`PyNECEngine._impedances_at` computes native-path impedance as
+`V / I_wire`, reading the raw structure current at the EX segment — it
+misses the network share entirely. NEC itself does NOT make this mistake:
+`network.c` (nec2c 1.3.1, lines ~555–576) adds the network correction to the
+segment current before printing `IMPEDANCE` in ANTENNA INPUT PARAMETERS
+(`ntsc != 0` branch: `cux = einc[isc1] + <network terms>`). PyNEC exposes
+that corrected readout via `nec_context.get_input_parameters(idx)`.
+
+Measured on `lumped_coupled_pair` (native `nt_card`) and the
+`test_tl_composition` pair (native `tl_card`), free space:
+
+| | our `_impedances_at` | NEC input params | shared reducer |
+|---|---|---|---|
+| nt_card pair | 94.79−80.54j | **70.25−17.98j** | **70.25−17.98j** |
+| tl_card pair | 105.332+2.088j | **36.268−29.476j** | **36.268−29.476j** |
+
+NEC's corrected current (13.360+3.420j mA on the nt pair) equals the
+reducer's termination-branch current to every digit. The reducer was right
+all along; every path that reads NEC's ANTENNA INPUT PARAMETERS —
+**including EZNEC and 4nec2 — already agrees with the reducer**. There is no
+externally visible discrepancy for users comparing against those tools.
+
+## How the wrong hypothesis fell
+
+1. **Density sweep.** If the gap were a segment-vs-basis sampling artifact it
+   would shrink as O((kh)²). Measured on `lumped_coupled_pair`:
+   54.31% / 54.02% / 53.85% / 53.73% at 11/21/41/81 segments per wire —
+   density-independent. (Basis parity forcing also puts a segment center at
+   every named-edge midpoint, so the "distinction" never existed.)
+2. **KCL identity.** Predicting `V/I_wire` from the reducer's own solve —
+   `E / (Y_antenna·v)[driven]` — reproduced our native readout to all digits
+   on both branch types, proving the missing term was exactly the network
+   current.
+3. **Primary source.** nec2c's `network.c` shows NEC adds that term before
+   printing; `get_input_parameters` confirmed it numerically on both cases.
+
+This also retroactively explains the two old mysteries: the #63
+`delta_looparray_with_tls` "native" value of −77−18255j was 1 V divided by a
+nearly-decoupled stub's tiny wire current (all the real current leaves
+through the TL ports), and the "unphysical negative R" sightings were the
+same artifact — `V/I_wire` is not a driving-point quantity and isn't
+passivity-constrained. Both were artifacts of our readout, not of NEC.
+
+## Externally visible scope
+
+- **Users comparing with EZNEC / 4nec2 / raw NEC output: no discrepancy.**
+  Those tools print NEC's corrected input parameters, which match the
+  reducer (and the web UI / CLI / optimizer, which are all reducer-sourced).
+- The wrong number only ever surfaced in our own **native oracle paths**:
+  `PyNECEngine(native_nt=True).impedance()` and the legacy `build_tls()` →
+  native `tl_card` path, and only when a branch terminates on the driven
+  segment. Consequences today: `native_nt` is documented as a
+  "pattern reference, not an impedance one" (docstring, issue #283), and
+  strict tl_card impedance cross-validation was dropped back in #63 — the
+  oracle harness is weaker than it needs to be.
+
+## Plan
+
+1. **Fix the native readout.** In `PyNECEngine`, read native-path impedance
+   from `nec_context.get_input_parameters` instead of dividing EX voltage by
+   raw structure current. Covers both `nt_card` and `tl_card` paths in one
+   change. Care points: index ordering over (frequency × source) in
+   `impedance_sweep`, and preserving `sum_currents` semantics for multi-EX
+   designs. For source segments with no network attached NEC's `cux` is the
+   plain segment current, so plain designs are bit-identical — the change is
+   a strict correction.
+2. **Tighten the oracles.** `native_nt` becomes a genuine impedance oracle:
+   assert reducer ≈ native Z on `lumped_coupled_pair` (cross-solve rtol, now
+   that the 54% readout artifact is gone) and resurrect the strict
+   reducer-vs-native-`tl_card` impedance cross-check that #63 dropped
+   (`test_tl_composition` currently compares far field only).
+3. **Docstring sweep.** Remove the "segment-vs-basis port convention
+   (issue #63/#283)" language from `TwoPort`, the `PyNECEngine` constructor,
+   and `lumped_coupled_pair`; state that native and reducer agree on
+   impedance since the readout fix.
+4. **Re-scope and close #283** — comment with these findings (the proposed
+   segment-averaging fix is explicitly rejected; nothing changes in momwire
+   or the reducer).
+
+## Driving example (for the fix PR / tests)
+
+`lumped_coupled_pair`, stock params: two parallel dipoles, only `front` fed
+with 1 V; a series 20 Ω + 0.1 µH `TwoPort` bridges the two feed gaps. The
+source delivers 13.79 mA ∠14.4°, which splits (as phasors) into
+8.04 mA ∠40.4° flowing up the front wire and 7.45 mA ∠−13.9° leaving through
+the coupling element to excite the rear dipole. Driving-point impedance =
+1 V / 13.79 mA ∠14.4° = 70.25−17.98j Ω — reported identically by the
+reducer, by NEC's ANTENNA INPUT PARAMETERS, and therefore by EZNEC/4nec2.
+Our old native readout divided by the 8.04 mA wire share alone and got
+94.79−80.54j Ω.

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -57,12 +57,14 @@ class PyNECEngine(SimulationEngine):
           context and solved simultaneously with the MoM currents, instead of
           the default shared-NetworkReducer stamp. This is a correctness ORACLE
           for the reducer's TwoPort composition (analogous to build_tls() ->
-          native tl_card for TL) — it reproduces the far field the reducer
-          composes to within the cross-MoM tolerance. Only valid for all-real-
-          port, TL-free networks that contain a TwoPort (validated at
-          construction); the driving-point impedance it reports differs from the
-          reducer's by the segment-vs-basis port convention (issue #63), so
-          treat it as a pattern reference, not an impedance one.
+          native tl_card for TL): it reproduces both the far field and the
+          driving-point impedance the reducer composes. (Impedance is read
+          from NEC's network-corrected ANTENNA INPUT PARAMETERS; the historic
+          "reducer vs native impedance gap" was this engine dividing V by the
+          wire-only structure current — see
+          docs/plan-network-impedance-readout.md, issue #283.) Only valid for
+          all-real-port, TL-free networks that contain a TwoPort (validated
+          at construction).
         """
         super().__init__(builder)
         self.tups = self._coerce_wire_tuples(builder.build_wires())
@@ -418,11 +420,14 @@ class PyNECEngine(SimulationEngine):
             Y = self._compute_y_matrix(wavelength)
             _v, efficiency, p_in = self._reducer.excited_state(Y, wavelength)
             return efficiency, p_in
-        # Native path: read the solved feed (and load) currents.
+        # Native path: source input power from NEC's ANTENNA INPUT
+        # PARAMETERS (index 0 — `sc` always comes from the single-frequency
+        # solve here). NEC's per-source power uses the network-corrected
+        # gap current, so a native_nt / tl_card design normalises gain by
+        # the power the source actually delivers, not just the wire share.
         p_in = 0.0
-        for tag, seg, v in self.excitation_pairs or []:
-            cur = self._port_current(sc, tag, seg)
-            p_in += 0.5 * (complex(v) * np.conj(cur)).real
+        if self.excitation_pairs:
+            p_in = float(sum(self._input_parameters_at(0).get_power()))
         loads = (
             [b for b in self._network.branches if isinstance(b, Load)]
             if self._network is not None
@@ -478,19 +483,31 @@ class PyNECEngine(SimulationEngine):
         self.c.fr_card(0, 1, self.builder.freq, 0)
         self.c.xq_card(0)
 
+    def _input_parameters_at(self, freq_index):
+        """NEC's ANTENNA INPUT PARAMETERS block for one frequency: one row
+        per voltage source, in ex_card order (aligned with
+        `excitation_pairs`; verified by tag below).
+
+        NEC corrects the source-segment current for any network (nt_card /
+        tl_card) attached to the same segment — nec2c's network.c adds the
+        network-port current to the wire current before forming V/I — so
+        these rows are true driving-point quantities. The raw structure
+        current at the segment is only the wire share of the gap current;
+        dividing V by it misreported Z (and source power) whenever a branch
+        terminated on the driven segment. See
+        docs/plan-network-impedance-readout.md (issue #283)."""
+        ipt = self.c.get_input_parameters(freq_index)
+        tags = [int(t) for t in ipt.get_tag()]
+        expected = [tag for tag, _seg, _v in self.excitation_pairs]
+        if tags != expected:
+            raise RuntimeError(
+                f"ANTENNA INPUT PARAMETERS rows (tags {tags}) don't line up "
+                f"with the emitted ex_cards (tags {expected})"
+            )
+        return ipt
+
     def _impedances_at(self, freq_index, sum_currents=False):
-        sc = self.c.get_structure_currents(freq_index)
-
-        indices = []
-        for tag, tag_index, voltage in self.excitation_pairs:
-            matches = [
-                (i, t) for (i, t) in enumerate(sc.get_current_segment_tag()) if t == tag
-            ]
-            index = matches[tag_index - 1][0]
-            indices.append((index, voltage))
-
-        currents = sc.get_current()
-        zs = [voltage / currents[idx] for idx, voltage in indices]
+        zs = [complex(z) for z in self._input_parameters_at(freq_index).get_impedance()]
 
         if sum_currents:
             zs = [1 / sum(1 / z for z in zs)]

--- a/tests/test_momwire_engine.py
+++ b/tests/test_momwire_engine.py
@@ -1277,6 +1277,7 @@ def _sinusoidal(builder):
     return MomwireEngine(builder, solver=SinusoidalSolver, ground=None)
 
 
+@needs_pynec
 def test_twoport_cross_engine_impedance_matches():
     """Both engines reduce the TwoPort through the shared NetworkReducer, so on
     a matched basis (momwire's SinusoidalSolver = NEC2's basis family) they must
@@ -1311,11 +1312,32 @@ def test_twoport_open_branch_agrees_across_paths():
     z_mom = _sinusoidal(b()).impedance()[0]
     z_red = PyNECEngine(b(), ground=None).impedance()[0]
     z_nat = PyNECEngine(b(), ground=None, native_nt=True).impedance()[0]
-    # Same NEC basis on both PyNEC paths -> the #63 convention gap closes when
-    # the branch is open, so reducer == native to near machine level.
+    # Same NEC basis on both PyNEC paths -> reducer == native to near
+    # machine level.
     assert abs(z_red - z_nat) / abs(z_nat) < 1e-3, (z_red, z_nat)
     # Matched-basis momwire agrees to the solvers' quadrature difference.
     assert abs(z_mom - z_nat) / abs(z_nat) < 5e-3, (z_mom, z_nat)
+
+
+@needs_pynec
+def test_twoport_reducer_matches_native_nt_card_impedance():
+    """The native nt_card driving-point impedance must equal the reducer's,
+    including with a strongly-conducting branch on the DRIVEN segment — the
+    case that historically showed a 54% \"convention gap\". That gap was this
+    engine's readout dividing V by the wire-only structure current; NEC's
+    ANTENNA INPUT PARAMETERS include the current leaving through the network
+    port (nec2c network.c), which the readout now uses. See
+    docs/plan-network-impedance-readout.md (issue #283).
+
+    The stock lumped_coupled_pair splits the 1 V source's 13.8 mA into
+    ~8.0 mA up the front wire and ~7.5 mA through the coupling element, so a
+    wire-only readout is off by 35 Ω — this pins driving-point agreement, not
+    just far field."""
+    from antennaknobs.designs.arrays.lumped_coupled_pair import Builder as B
+
+    z_red = PyNECEngine(B(), ground=None).impedance()[0]
+    z_nat = PyNECEngine(B(), ground=None, native_nt=True).impedance()[0]
+    assert abs(z_red - z_nat) / abs(z_nat) < 1e-6, (z_red, z_nat)
 
 
 @needs_pynec
@@ -1323,17 +1345,16 @@ def test_twoport_reducer_matches_native_nt_card_far_field():
     """The native nt_card oracle bakes the 2x2 admittance into one NEC solve
     (like tl_card for TL); the reducer stamps the same admittance as a circuit
     post-process. They compose the RADIATING currents identically, so the far
-    field must match — even though the driving-point IMPEDANCE differs by the
-    known segment-vs-basis port convention gap (issue #63), the same gap native
-    tl_card has. This is the piece (B) analogue of test_tl_composition's
-    reducer-vs-native tl_card far-field check.
+    field must match. This is the piece (B) analogue of test_tl_composition's
+    reducer-vs-native tl_card far-field check (impedance agreement is pinned
+    separately by test_twoport_reducer_matches_native_nt_card_impedance).
 
     On a MATCHED basis (momwire SinusoidalSolver = NEC's family) the reducer's
     composed pattern lands right on the native nt_card oracle — the physical
     proof that the composition is correct. PyNEC's OWN reducer far field is
-    looser: its segment-level port carries the #63 convention offset into the
-    re-excitation voltages, nudging the pattern by a few tenths of a dB (well
-    inside the tolerance the TL check uses cross-engine)."""
+    looser: the re-excitation round-trip through per-port NEC solves nudges
+    the pattern by a few tenths of a dB (well inside the tolerance the TL
+    check uses cross-engine)."""
     from antennaknobs.designs.arrays.lumped_coupled_pair import Builder as B
 
     kw = dict(n_theta=90, n_phi=360, del_theta=1, del_phi=1)

--- a/tests/test_tl_composition.py
+++ b/tests/test_tl_composition.py
@@ -102,6 +102,20 @@ def test_reducer_matches_native_tl_card_same_engine():
     assert abs(b_red - b_nat) < 0.15
 
 
+def test_reducer_matches_native_tl_card_impedance():
+    """The native tl_card driving-point impedance must equal the reducer's —
+    the strict cross-validation dropped back in issue #63, restored by the
+    input-parameters readout fix (issue #283). The TL terminates on the
+    DRIVEN segment here, so a wire-only current readout would be off by ~3×
+    (105+2j vs the true 36−29j): most of the source current leaves through
+    the line, and NEC's ANTENNA INPUT PARAMETERS account for it."""
+    z_red = PyNECEngine(_NetBuilder(), ground=None).impedance()[0]
+    z_nat = PyNECEngine(_TlsBuilder(), ground=None).impedance()[0]
+    # Reducer Y comes from N separate NEC solves vs native's single baked
+    # context; they match to ~1e-5 relative, far below any physical scale.
+    assert abs(z_red - z_nat) / abs(z_nat) < 1e-4, (z_red, z_nat)
+
+
 def test_momwire_reducer_matches_native_tl_card_reference():
     """MomwireEngine's reducer TL far field must match NEC's native tl_card
     reference within a cross-engine MoM tolerance."""

--- a/tests/test_unit_sim.py
+++ b/tests/test_unit_sim.py
@@ -6,12 +6,16 @@ from unittest.mock import patch
 from conftest import needs_pynec
 
 
-class FakeSC:
-    def get_current_segment_tag(self):
-        return [1, 1, 2, 3, 3, 3, 4, 4, 4]
+class FakeInputParameters:
+    """Stands in for nec_antenna_input: one row per ex_card, in emission
+    order — V=1 into 0.02 A → 50 Ω at tag 2, V=0.5 into 0.02 A → 25 Ω at
+    tag 4 (the mock_geometry excitation_pairs below)."""
 
-    def get_current(self):
-        return [None, None, 0.02, None, None, None, None, 0.02, None]
+    def get_tag(self):
+        return [2, 4]
+
+    def get_impedance(self):
+        return [50 + 0j, 25 + 0j]
 
 
 class FakePyNEC:
@@ -21,8 +25,8 @@ class FakePyNEC:
     def xq_card(self, *args, **kargs):
         pass
 
-    def get_structure_currents(self, freq_index):
-        return FakeSC()
+    def get_input_parameters(self, freq_index):
+        return FakeInputParameters()
 
 
 def mock_geometry(self):


### PR DESCRIPTION
## Summary
- Root-causes the long-standing reducer-vs-native driving-point impedance gap (issues #63/#283): it was never a "segment-level vs basis-level port convention". `PyNECEngine._impedances_at` divided the EX voltage by the raw structure current at the source segment — the **wire share only** — so whenever an `nt_card`/`tl_card` terminated on the driven segment, the current leaving through the network port was dropped (54% error on `lumped_coupled_pair`, 3× on the TL pair, and the historical −77−18255j on `delta_looparray_with_tls` = 1 V over a decoupled stub's tiny wire current).
- NEC itself corrects the source-segment current for attached networks (nec2c `network.c`, `ntsc != 0` branch) before printing ANTENNA INPUT PARAMETERS — so EZNEC/4nec2/raw NEC output always agreed with our reducer; only our readout was off. The fix reads impedance (and native-path source power for the gain normaliser) from `get_input_parameters`. Plain designs are bit-identical: with no network, NEC's corrected current *is* the wire current.
- Native `nt_card`/`tl_card` thereby become strict **impedance** oracles, not just pattern references: new tests pin reducer == native to 1e-6 (`lumped_coupled_pair`) and 1e-4 (TL pair) on exactly the configurations that used to diverge, restoring the strict cross-validation dropped back in #63.
- Also fixes a pre-existing missing `@needs_pynec` on `test_twoport_cross_engine_impedance_matches` (failed on PyNEC-less platforms; found by running the suite with PyNEC removed), updates the `FakePyNEC` unit-test double, and sweeps the stale "segment-vs-basis convention" language from docstrings. Investigation write-up: `docs/plan-network-impedance-readout.md`.

Closes #283.

## Test plan
- [x] Full suite: 1465 passed
- [x] New oracle tests: `test_twoport_reducer_matches_native_nt_card_impedance` (rtol 1e-6), `test_reducer_matches_native_tl_card_impedance` (rtol 1e-4)
- [x] Verified skip behavior with PyNEC physically removed from site-packages: 42 passed, 35 skipped, 0 failures across the touched test files
- [x] Verified plain-design readout is bit-identical (multi-feed, multi-frequency sweep) and input-parameters rows follow ex_card order per frequency
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)