### PR TITLE
Add inverted-L + T-network matchbox design (first pure interior circuit node)

### DIFF
--- a/src/antennaknobs/designs/verticals/inverted_l_tmatch.py
+++ b/src/antennaknobs/designs/verticals/inverted_l_tmatch.py
@@ -1,0 +1,96 @@
+r"""10 m inverted-L worked on the 12 m band through a T-network tuner —
+the first design with a pure interior circuit node (series C, shunt L,
+series C), exercising the MNA network core on the classic "wire antenna +
+T-match" situation.
+
+Geometry is inherited wholesale from `inverted_l`: the same 10 m
+(28.57 MHz) bent, top-loaded vertical with four elevated radials. Operated
+on 24.9 MHz that riser is electrically short and the feed is the textbook
+tuner case — Z_ant ≈ 10.8 − 121.7j Ω (low R, big capacitive X), nowhere
+near 50 Ω.
+
+A **T-network** (the standard ham "T-tuner" topology, a high-pass tee)
+fixes it with two series capacitors flanking a shunt inductor:
+
+    source ──[ C1 series ]──┬──[ C2 series ]── feed
+                            │
+                     [ L shunt ]── common
+
+The port spec drives a virtual `in` node, chains `TwoPort` capacitors
+through a virtual midpoint `m`, and hangs a `Shunt` inductor off `m`. The
+midpoint is a pure interior circuit node — no antenna segment, no TL,
+nothing but lumped Group-2 branches meeting at a KCL row — which no other
+design exercises. Stock values land ~50 Ω / SWR ≈ 1.0005 at 24.9 MHz.
+
+Because the antenna is short (R ≈ 11 Ω) the match must ride a virtual
+resistance of ~2 kΩ, so there is no symmetric-capacitor solution and the
+loaded Q is high (~13) — the real-world "narrow retune on a short
+antenna" behavior, visible here as a sharp SWR notch in a frequency sweep.
+
+Degenerate slider endpoints (all legal since the MNA core, issue #285):
+a 0 H shunt inductor hard-shorts the midpoint to common (input becomes
+pure C1 reactance); a 0 F series capacitor is an OPEN — note this is the
+opposite convention from the L-match's arms, where zero meant "element
+absent": an absent series capacitor in a T-network is C → ∞ (a wire), not
+C → 0. Setting `series_c2_pF = 0` disconnects the antenna entirely (the
+source then sees only C1 + L), and `series_c1_pF = 0` open-circuits the
+source itself.
+"""
+
+from types import MappingProxyType
+
+from .inverted_l import Builder as InvertedL
+from ...network import Driven, Network, PortAtEdge, PortVirtual, Shunt, TwoPort
+
+
+class Builder(InvertedL):
+    default_params = MappingProxyType(
+        {
+            **InvertedL.default_params,
+            # Antenna is cut for 10 m (inherited design_freq 28.57) but
+            # operated on 12 m.
+            "freq": 24.9,
+            # T-network elements, tuned for ~50 Ω at 24.9 MHz on the stock
+            # inverted-L (virtual resistance ~2 kΩ; see module docstring).
+            "series_c1_pF": 20.47,  # source-side series capacitor
+            "shunt_l_uH": 0.6458,  # shunt inductor at the tee midpoint
+            "series_c2_pF": 254.5,  # antenna-side series capacitor
+            "ui_params": MappingProxyType(
+                {
+                    # Matched to 50 Ω, so the SWR readout shows ~1:1.
+                    "target_z0": 50.0,
+                    "default_view": "yz",
+                    "series_c1_pF": {"min": 5.0, "max": 60.0},
+                    "shunt_l_uH": {"min": 0.1, "max": 2.0},
+                    "series_c2_pF": {"min": 50.0, "max": 500.0},
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        # Reuse the inverted-L geometry verbatim; rename the driven base gap
+        # as the network's "feed" port and clear its inline excitation — the
+        # T-network supplies the source at the virtual `in` node instead.
+        wires = []
+        for p0, p1, nseg, ev, *rest in super().build_wires():
+            if ev is not None:
+                wires.append((p0, p1, nseg, None, "feed"))
+            else:
+                wires.append((p0, p1, nseg, ev, *rest))
+        return wires
+
+    def build_network(self):
+        return Network(
+            ports={
+                "feed": PortAtEdge("feed"),
+                "m": PortVirtual("m"),
+                "in": PortVirtual("in"),
+            },
+            branches=[
+                TwoPort(a="in", b="m", c=self.series_c1_pF * 1e-12),
+                Shunt(port="m", l=self.shunt_l_uH * 1e-6),
+                TwoPort(a="m", b="feed", c=self.series_c2_pF * 1e-12),
+            ],
+            sources=[Driven(port="in", voltage=1 + 0j)],
+        )

--- a/tests/test_momwire_engine.py
+++ b/tests/test_momwire_engine.py
@@ -1617,3 +1617,92 @@ def test_skyloop_matchbox_inert_is_passthrough():
     # And it agrees cross-engine (the pass-through is engine-agnostic).
     z_nec = PyNECEngine(B(params=inert), ground=None).impedance()[0]
     assert abs(z_inert - z_nec) / abs(z_inert) < 0.01, (z_inert, z_nec)
+
+
+# --------------------------------------------------------------------------
+# inverted_l_tmatch: T-network (series C, shunt L, series C) on a short
+# reactive vertical — the first design with a pure interior circuit node.
+# --------------------------------------------------------------------------
+
+
+def _tmatch_bare(params=None):
+    """The T-match design's antenna with the matchbox removed: same
+    geometry, source directly on the feed."""
+    from antennaknobs.designs.verticals.inverted_l_tmatch import Builder as B
+    from antennaknobs.network import Driven, Network, PortAtEdge
+    from types import MappingProxyType
+
+    class Bare(B):
+        default_params = MappingProxyType(params or dict(B.default_params))
+
+        def build_network(self):
+            return Network(
+                ports={"feed": PortAtEdge("feed")}, sources=[Driven(port="feed")]
+            )
+
+    return Bare()
+
+
+def test_tmatch_matches_circuit_theory():
+    """The T-network must reproduce the exact three-element transform
+    Z_in = X_C1 + (X_L ∥ (X_C2 + Z_ant)) of the bare antenna impedance —
+    lumped circuit theory composed on the extracted antenna Y, through a
+    tee midpoint that is a pure interior node (no antenna segment, no TL:
+    the only design whose KCL row has no Group-1 stamp at all)."""
+    from antennaknobs.designs.verticals.inverted_l_tmatch import Builder as B
+
+    p = B.default_params
+    omega = 2.0 * np.pi * p["freq"] * 1e6
+    xc1 = 1.0 / (1j * omega * p["series_c1_pF"] * 1e-12)
+    xl = 1j * omega * p["shunt_l_uH"] * 1e-6
+    xc2 = 1.0 / (1j * omega * p["series_c2_pF"] * 1e-12)
+
+    z_ant = _sinusoidal(_tmatch_bare()).impedance()[0]
+    z_hand = xc1 + 1.0 / (1.0 / xl + 1.0 / (xc2 + z_ant))
+    z_net = _sinusoidal(B()).impedance()[0]
+    assert np.allclose(z_net, z_hand, rtol=1e-9), (z_net, z_hand)
+
+
+@needs_pynec
+def test_inverted_l_tmatch_matches_50ohm_cross_engine():
+    """The showcase: a 10 m inverted-L worked on 12 m is a short vertical
+    (~10.8 − 121.7j) but the stock T-network brings it to ~50 Ω. Both
+    engines agree (the match is exact circuit theory on the antenna Y)."""
+    from antennaknobs.designs.verticals.inverted_l_tmatch import Builder as B
+
+    z_mom = _sinusoidal(B()).impedance()[0]
+    z_nec = PyNECEngine(B(), ground=None).impedance()[0]
+    for z in (z_mom, z_nec):
+        assert abs(z.real - 50.0) < 5.0 and abs(z.imag) < 5.0, z  # matched
+    assert abs(z_mom - z_nec) / abs(z_mom) < 0.01, (z_mom, z_nec)
+
+
+def test_tmatch_degenerate_endpoints():
+    """T-network slider endpoints under the MNA core (issue #285):
+
+    - shunt L = 0 hard-shorts the tee midpoint to common (a Group-2 ideal
+      short on a pure interior node — the old admittance reducer raised
+      here), so the input sees exactly C1's reactance;
+    - series C2 = 0 is an OPEN that disconnects the antenna (a series
+      capacitor's absent limit is C → ∞, not C → 0), so the input sees
+      exactly C1 in series with the shunt L;
+    - series C1 = 0 open-circuits the SOURCE itself: the delivered current
+      is exactly zero and Z = E/j is non-finite. Pinned here as the
+      documented behavior of driving an open circuit.
+    """
+    from antennaknobs.designs.verticals.inverted_l_tmatch import Builder as B
+
+    p = B.default_params
+    omega = 2.0 * np.pi * p["freq"] * 1e6
+    xc1 = 1.0 / (1j * omega * p["series_c1_pF"] * 1e-12)
+    xl = 1j * omega * p["shunt_l_uH"] * 1e-6
+
+    z = _sinusoidal(B(params={**p, "shunt_l_uH": 0.0})).impedance()[0]
+    assert np.allclose(z, xc1, rtol=1e-12), (z, xc1)
+
+    z = _sinusoidal(B(params={**p, "series_c2_pF": 0.0})).impedance()[0]
+    assert np.allclose(z, xc1 + xl, rtol=1e-12), (z, xc1 + xl)
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        z = _sinusoidal(B(params={**p, "series_c1_pF": 0.0})).impedance()[0]
+    assert not np.isfinite(z), z


### PR DESCRIPTION
## Summary
- New design `verticals/inverted_l_tmatch`: the stock 10 m inverted-L operated on the 12 m band (Z_ant ≈ 10.8 − 121.7j Ω — short vertical, textbook tuner case) matched to 50 Ω through a T-network (series C₁ 20.47 pF → shunt L 0.6458 µH → series C₂ 254.5 pF), the standard high-pass ham T-tuner topology. Stock SWR ≈ 1.0005.
- The tee midpoint is the first **pure interior circuit node** in any design — a virtual port whose KCL row carries only lumped Group-2 branches (no antenna stamp, no TL), exercising the MNA network core (#285) on a topology the old admittance reducer couldn't have handled at its degenerate endpoints.
- Design notes captured in the docstring: the match rides a ~2 kΩ virtual resistance (no symmetric-capacitor solution exists; loaded Q ≈ 13), and a series capacitor's "absent" limit is C → ∞ (a wire), not C → 0 (an open) — opposite polarity from the L-match arms.
- Tests pin: the exact three-element transform on the extracted antenna Y (rtol 1e-9), ~50 Ω cross-engine agreement (momwire vs PyNEC within 1%), and all three degenerate slider endpoints — 0 H shunt hard-shorts the midpoint to common (exact C₁ reactance), 0 F C₂ disconnects the antenna (exact C₁+L), 0 F C₁ open-circuits the source (non-finite Z, pinned as documented behavior).

## Test plan
- [x] Full suite: 1480 passed (registry auto-discovers the design)
- [x] `test_tmatch_matches_circuit_theory`, `test_inverted_l_tmatch_matches_50ohm_cross_engine`, `test_tmatch_degenerate_endpoints`
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)