### PR TITLE
Report open-circuited feeds as a clean Z = ∞ across engine, wire protocol, and UI

### DIFF
--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -344,7 +344,16 @@ class NetworkReducer:
         out = []
         for k in self.driven_port_idx:
             col, e = system.terminations[k]
-            out.append(complex(e / j[col]))
+            if j[col] == 0:
+                # Open-circuited source — no current path from the port
+                # (e.g. a matching-network series capacitor slider at 0 F,
+                # which is an open, not an absent element). The physical
+                # driving-point impedance is ∞; report it as a clean real
+                # infinity instead of dividing by zero (numpy would warn
+                # and produce inf+nanj). Issue #289.
+                out.append(complex(float("inf"), 0.0))
+            else:
+                out.append(complex(e / j[col]))
         return out
 
     def driven_impedance(self, Y_real, wavelength):

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -83,6 +83,25 @@ from .examples._base import (
 
 C_LIGHT = 299_792_458.0
 
+# Sentinel impedance for an open-circuited feed on the wire protocol. The
+# network core reports a true open (e.g. a series matchbox capacitor slider
+# at 0 F) as Z = inf (issue #289), but JSON has no Infinity/NaN — json.dumps
+# would emit literals the browser's JSON.parse rejects, killing the whole
+# solve/sweep response. Clamp to this huge-but-finite value instead: |Γ|
+# lands at ~1−1e−7 so the SWR readout shows ∞, the Smith chart pins at the
+# open point, and the R/X readout renders it as "∞ (open)" (the frontend
+# treats ≥1e8 Ω as open).
+Z_OPEN_OHMS = 1.0e9
+
+
+def _json_safe_z(z: complex) -> complex:
+    """Clamp a non-finite impedance to the open-circuit sentinel."""
+    z = complex(z)
+    if math.isfinite(z.real) and math.isfinite(z.imag):
+        return z
+    return complex(Z_OPEN_OHMS, 0.0)
+
+
 DESIGNS_PKG = "antennaknobs.designs"
 # Resolve the designs directory from the installed package, never a path relative
 # to this file: web/ and src/antennaknobs/ are siblings in a source checkout, but
@@ -1126,7 +1145,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             builder.design_freq = design_freq
         eng = _make_momwire_engine(req, builder, cancel=cancel)
         t0 = time.perf_counter()
-        zs = eng.impedance()
+        zs = [_json_safe_z(z) for z in eng.impedance()]
         currents = eng.current_distribution()
         solve_ms = (time.perf_counter() - t0) * 1e3
         feed_wire_idx, feed_knot_idx = _feed_indices(eng, currents)
@@ -1304,7 +1323,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             builder.design_freq = design_freq
         eng = _make_pynec_engine(req, builder)
         t0 = time.perf_counter()
-        zs = eng.impedance()
+        zs = [_json_safe_z(z) for z in eng.impedance()]
         currents = eng.current_distribution()
         solve_ms = (time.perf_counter() - t0) * 1e3
         feed_wire_idx, feed_knot_idx = _pynec_feed_indices(builder, currents)
@@ -1458,6 +1477,8 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             )
         eng = _make_momwire_engine(req, builder)
         zs = np.asarray(eng.impedance_sweep(list(freqs_mhz)))
+        # Open-circuited points sweep through as inf; clamp for JSON.
+        zs = np.where(np.isfinite(zs), zs, complex(Z_OPEN_OHMS, 0.0))
         # MomwireEngine.impedance_sweep returns (n_freqs, n_feeds).
         primary = zs[:, 0]
         re = primary.real.tolist()

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -5601,6 +5601,14 @@ const GROUND_APPLIED_LABEL: Record<string, string> = {
   free: "free space",
 };
 
+function formatOhms(v: number): string {
+  // The server clamps an open-circuited feed (e.g. a series matchbox
+  // capacitor slider at 0 pF) to a 1e9 Ω sentinel — JSON has no Infinity.
+  // Anything that large is physically an open, not a number worth printing.
+  if (Math.abs(v) >= 1e8) return "∞ (open)";
+  return `${v.toFixed(2)} Ω`;
+}
+
 function formatSwr(r: number, x: number, z0: number): string {
   const { gMag } = reflectionCoefficient(r, x, z0);
   if (gMag >= 0.9999) return "∞";
@@ -5630,12 +5638,22 @@ function SolveReadout({
     <div className={`readout${className ? " " + className : ""}`}>
       <div className="row">
         <span>R</span>
-        <span className="val">{result ? `${result.z_in_re.toFixed(2)} Ω` : "—"}</span>
+        <span className="val">{result ? formatOhms(result.z_in_re) : "—"}</span>
       </div>
       <div className="row">
         <span>X</span>
-        <span className={result && Math.abs(result.z_in_im) < 2 ? "val val-hot" : "val"}>
-          {result ? `${result.z_in_im.toFixed(2)} Ω` : "—"}
+        <span
+          className={
+            result && Math.abs(result.z_in_im) < 2 && Math.abs(result.z_in_re) < 1e8
+              ? "val val-hot"
+              : "val"
+          }
+        >
+          {result
+            ? Math.abs(result.z_in_re) >= 1e8
+              ? "∞ (open)"
+              : formatOhms(result.z_in_im)
+            : "—"}
         </span>
       </div>
       {currentExample && (

--- a/tests/test_momwire_engine.py
+++ b/tests/test_momwire_engine.py
@@ -1687,8 +1687,8 @@ def test_tmatch_degenerate_endpoints():
       capacitor's absent limit is C → ∞, not C → 0), so the input sees
       exactly C1 in series with the shunt L;
     - series C1 = 0 open-circuits the SOURCE itself: the delivered current
-      is exactly zero and Z = E/j is non-finite. Pinned here as the
-      documented behavior of driving an open circuit.
+      is exactly zero and the readout reports a clean Z = ∞ (real infinity,
+      no NaN, no numpy warnings — issue #289).
     """
     from antennaknobs.designs.verticals.inverted_l_tmatch import Builder as B
 
@@ -1703,6 +1703,9 @@ def test_tmatch_degenerate_endpoints():
     z = _sinusoidal(B(params={**p, "series_c2_pF": 0.0})).impedance()[0]
     assert np.allclose(z, xc1 + xl, rtol=1e-12), (z, xc1 + xl)
 
-    with np.errstate(divide="ignore", invalid="ignore"):
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         z = _sinusoidal(B(params={**p, "series_c1_pF": 0.0})).impedance()[0]
-    assert not np.isfinite(z), z
+    assert np.isinf(z.real) and z.imag == 0.0, z

--- a/tests/test_network_mna.py
+++ b/tests/test_network_mna.py
@@ -439,6 +439,24 @@ def test_inert_lmatchbox_stamped_literally():
     assert z_inert == pytest.approx(1.0 / y[0, 0], rel=1e-12)
 
 
+def test_open_circuited_source_reports_clean_infinity():
+    """A driven port with no current path (its only branch is a 0 F series
+    capacitor = an open) is a physical open circuit: Z = ∞. The readout must
+    return a clean real infinity — no ZeroDivision, no numpy divide-by-zero
+    warning, no NaN imaginary part (issue #289)."""
+    import warnings
+
+    net = Network(
+        ports={"f": PortAtEdge("f"), "in": PortVirtual("in")},
+        branches=[TwoPort(a="in", b="f", c=0.0)],
+        sources=[Driven(port="in")],
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        z = reducer(net, 1).driven_impedance(synth_y(1, 0), WL)[0]
+    assert np.isinf(z.real) and z.real > 0 and z.imag == 0.0, z
+
+
 def test_trap_load_at_exact_resonance_is_open():
     """A parallel-LC Load exactly at ω₀ = 1/√(LC) is the intended open
     circuit. The legacy excited path formed Z_L = ∞ there; the MNA

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -343,6 +343,31 @@ def test_solve_dispatches_to_momwire_for_dipole():
     assert out["z_in_re"] > 0
 
 
+def test_solve_open_circuited_feed_is_json_safe():
+    """A matching-network slider at a physical open (T-match series C1 = 0 pF
+    open-circuits the source; the network core reports Z = ∞, issue #289)
+    must stay on the wire protocol: the adapter clamps to the Z_OPEN_OHMS
+    sentinel so json.dumps never emits Infinity/NaN literals that the
+    browser's JSON.parse would reject, and the gain norm degrades to 0 (no
+    excitation, no pattern) instead of dividing by zero."""
+    import json
+
+    from antennaknobs.web.adapter import Z_OPEN_OHMS
+
+    out = server.solve(
+        {
+            "geometry": "verticals.inverted_l_tmatch",
+            "measurement_freq_mhz": 24.9,
+            "design_freq_mhz": 28.57,
+            "series_c1_pF": 0.0,
+        }
+    )
+    assert out["z_in_re"] == Z_OPEN_OHMS and out["z_in_im"] == 0.0
+    json.dumps(out, allow_nan=False)  # raises on any Infinity/NaN leftovers
+    assert out["directivity_norm"] == 0.0
+    assert out["input_power_w"] == 0.0
+
+
 def test_solve_always_carries_norm_and_caches():
     """Every solve carries directivity_norm (it's an O(1) input-power scalar
     now, so there is no superseded-skip) and every solve result is cached."""


### PR DESCRIPTION
## Summary
- Follow-up from the T-matchbox showcase (PR #288): a slider at a physical open (series matchbox capacitor at 0 pF open-circuits the source) used to yield `inf+nanj` plus numpy RuntimeWarnings, and would have broken the browser outright — `json.dumps` emits `Infinity`/`NaN` literals that `JSON.parse` rejects, killing the whole solve/sweep response.
- `NetworkReducer.impedance_from_y` now returns a clean `complex(inf, 0)` when the delivered current is exactly zero (an open is physics, not an error), with no division and no warnings.
- The web adapter clamps non-finite impedances to a `Z_OPEN_OHMS = 1e9` sentinel at every egress point (solve, multi-feed list, frequency sweep), keeping the wire protocol valid JSON; |Γ| ≈ 1−1e−7 so the existing SWR formatter shows "∞" unaided and the Smith chart pins at the open point.
- Frontend R/X readout renders the sentinel as "∞ (open)" instead of `1000000000.00 Ω`, and the sentinel's X=0 no longer lights the resonance highlight. Bundle is gitignored — publish CI rebuilds it (`tsc --noEmit` passed locally via `npm run build`).
- The gain-normalisation path already degraded cleanly (`p_in ≤ 0` → pattern-integral fallback → norm 0.0); now pinned by the web test.

Closes #289.

## Test plan
- [x] Full suite: 1482 passed
- [x] New tests at all three layers: `test_open_circuited_source_reports_clean_infinity` (reducer, warnings-as-errors), `test_tmatch_degenerate_endpoints` (engine, now asserts clean ∞), `test_solve_open_circuited_feed_is_json_safe` (web: sentinel + `json.dumps(allow_nan=False)` + norm/power degrade to 0)
- [x] Frontend builds (`npm run build` incl. type-check)
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)