### PR TITLE
Release v0.21.0 (MNA network core + matchbox designs)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.20.0"
+version = "0.21.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,17 +25,18 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.20.0" icon="star">
-  **Finite-ground solves got fast.** momwire 0.9.0 moves the Sommerfeld
-  remainder assembly into one fused compiled kernel — finite-ground
-  solves run **14–19× faster** on every solver, tying or beating the
-  NEC-2 reference on most benchmark designs — and a compiled
-  reflection-coefficient fill speeds the sinusoidal basis another
-  4–6×. Frequency sweeps on the default B-spline solver are now
-  k-batched under a tunable memory budget, and the
-  [solver guide](/reference/solver/) carries the full ground-model
-  benchmark (10 designs × 4 grounds × 6 engines).
-  [All release notes →](/reference/releases/)
+<Card title="New in v0.21.0" icon="star">
+  **Matching networks, solved like SPICE.** The lumped-network core is
+  rebuilt on Modified Nodal Analysis: series `TwoPort` bridges, `Shunt`
+  elements, and ideal shorts (a 0 Ω or 0 H slider endpoint) are all
+  legal stamps, so a matchbox tunes cleanly through its degenerate
+  endpoints — including a fully inert pass-through and an open, which
+  the SWR readout now reports as ∞ instead of breaking. Two new
+  showcase designs ride it: an 80 m skyloop **L-matched** to 50 Ω on
+  17 m, and a 10 m inverted-L **T-matched** onto the 12 m band. Under
+  the hood, the driving-point impedance now agrees with NEC's native
+  network cards to ~5 digits — a long-standing readout gap, run to
+  ground and fixed. [All release notes →](/reference/releases/)
 </Card>
 
 ## The whole pitch, in one line

--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -38,8 +38,10 @@ with a `Drone` (see [Many ways to express geometry](/concepts/authoring/)):
 Other loops: `loops.delta_loop_slanted`, `loops.inv_delta_loop`,
 `loops.horizontal_loop` (full-wave "loop skywire") and its `Drone` twin
 `loops.horizontal_loop_drone`, `loops.diamond_loop` (+ `diamond_loop_turnstile`),
-`loops.quad` (2-element cubical quad beam), and `loops.bisquare` (a two-wavelength
-broadside curtain).
+`loops.quad` (2-element cubical quad beam), `loops.bisquare` (a two-wavelength
+broadside curtain), `loops.triangular_skyloop` (corner-fed full-wave triangle),
+and `loops.skyloop_lmatch` (the 80 m skyloop worked on 17 m through an
+L-network — series L, shunt C — matched to 50 Ω).
 
 ## Beams
 
@@ -57,6 +59,7 @@ broadside curtain).
 | `verticals.vertical` | Quarter-wave vertical |
 | `verticals.raised_vertical` | Elevated vertical |
 | `verticals.inverted_l` | Inverted-L, a bent top-loaded vertical |
+| `verticals.inverted_l_tmatch` | The 10 m inverted-L worked on 12 m through a T-network tuner (series C, shunt L, series C) |
 | `verticals.jpole` | J-pole, end-fed half-wave with a quarter-wave matching stub |
 | `verticals.half_square` | Half-square, a vertically-polarised wire antenna |
 | `verticals.bobtail` | Bobtail curtain, a 3-element vertical broadside array |
@@ -103,7 +106,10 @@ showcase (see [the solver guide](/reference/solver/)):
 `arrays.yagiarray`, `arrays.moxonarray`, `arrays.invveearray`,
 `arrays.folded_invveearray`, `arrays.bowtiearray` (+ `1x2`, `2x4`),
 `arrays.delta_looparray` (+ `1x4`, `1x4_grouped`, `2x2`, `network`, `with_tls`),
-`arrays.hentenna_array`, `arrays.hourglass_array`.
+`arrays.hentenna_array`, `arrays.hourglass_array`, and
+`arrays.lumped_coupled_pair` (a dipole pair steered through a lumped series
+R+jωL bridge between the two feeds — the `TwoPort` network element's
+showcase).
 
 ## Specialty
 

--- a/site/src/content/docs/reference/releases.md
+++ b/site/src/content/docs/reference/releases.md
@@ -29,8 +29,9 @@ hosted simulator has it.
 
 ## How the two versions relate
 
-Each antennaknobs release declares a **minimum momwire version** — the oldest
-engine release carrying every solver API that antennaknobs version uses. A
-`pip install antennaknobs` resolves a compatible engine automatically; if you
-pin momwire yourself, keep it at or above the floor in that release's
-`pyproject.toml`.
+Each antennaknobs release pins an **exact momwire version** — the engine
+release it was tested and deployed against. A `pip install antennaknobs`
+installs that engine automatically, so the pair you run locally is the pair
+running on the hosted simulator. (Earlier releases declared a minimum
+version instead; the exact pin replaced it so a new engine release can't
+silently change solver behavior under an already-published antennaknobs.)


### PR DESCRIPTION
## Summary
- Version bump to **v0.21.0**. Release theme: the lumped-network arc — `TwoPort` (#281) and `Shunt` (#284) elements, the MNA reformulation of the network core (#285/#286), the PyNEC native impedance readout fix (#283/#287), the L-match and T-match showcase designs (#284/#288), and clean open-circuit handling end to end (#289/#290). Plus the finite-ground zenith polarization fix (#278) and the DiffTL/Sterba-research cleanup (#280).
- What's-new card refreshed (MNA / matchboxes / readout alignment / SWR ∞).
- Catalog page: adds `loops.skyloop_lmatch`, `verticals.inverted_l_tmatch`, `arrays.lumped_coupled_pair`, and `loops.triangular_skyloop` (never listed).
- Releases page de-staled: the momwire dependency is an **exact pin**, not a minimum-version floor (wording predated the pin policy).
- No momwire adoption this release: pin stays `momwire==0.9.0` in `pyproject.toml` and `Dockerfile`.

## Test plan
- [x] `cd site && npm run build` — 15 pages, clean
- [x] Full suite green on main (1482 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)