### PR TITLE
docs: catch the docs up to Sommerfeld-everywhere (momwire 0.8/0.9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ What you get:
 - **A ground plane, on by default** — real antennas hang over real ground, so
   the workbench starts there (free space is one click away). The ground is
   described by what it *is* — finite (εr=10, σ=0.002) or PEC — independent of
-  solver; each backend solves it as best it can (PyNEC additionally offers
-  Sommerfeld-Norton vs. the faster reflection-coefficient method), and the
-  solve readout reports the model that actually ran.
+  solver; both backends offer the true Sommerfeld-Norton solve and the faster
+  reflection-coefficient method, and the solve readout reports the model that
+  actually ran.
 
 Live updates stay responsive because rapid knob drags are coalesced into one
 solve per round-trip, so the solver is never buried under stale requests.
@@ -105,17 +105,16 @@ point — agreement between independent engines is your confidence check.
 | | **PyNEC** | **momwire** |
 |---|---|---|
 | What | Python binding to the compiled C++ **NEC2** engine | In-house **method-of-moments** engines, pure-Python core with optional C++ accelerators |
-| Basis | NEC2 thin-wire (pulse/sinusoidal) | Three bases — triangular (tent), sinusoidal, B-spline — plus H-matrix and array-block accelerators built on them |
+| Basis | NEC2 thin-wire (pulse/sinusoidal) | Two bases — sinusoidal and B-spline (degree 1–2) — plus H-matrix and array-block accelerators built on them |
 | Speed | Very fast single-frequency solves | Fast; C++ accelerators (pybind11) for assembly/quadrature, pure-Python fallback |
-| Ground | Sommerfeld–Norton finite ground (default) or the faster reflection-coefficient approximation | Reflection-coefficient finite ground on the B-spline family; PEC image on the other bases; the engine API defaults to free space (the web workbench turns ground on) |
+| Ground | Sommerfeld–Norton finite ground (default) or the faster reflection-coefficient approximation | Same two models on every solver (momwire ≥ 0.8.0): true Sommerfeld–Norton or the faster reflection-coefficient approximation; the engine API defaults to free space (the web workbench turns ground on) |
 | Install | Prebuilt wheel from the `python-necpp` fork release (OpenBLAS vendored) | C++ accelerator built from the `momwire` submodule |
-| Use it for | The established reference; finite-ground patterns | Basis-flexible cross-validation; geometries where NEC2 reactance fails to converge |
+| Use it for | The established reference | Basis-flexible cross-validation; geometries where NEC2 reactance fails to converge |
 
 **Selecting an engine** (CLI):
 
 ```bash
---engine momwire                 # momwire (default), default triangular basis
---engine momwire:triangular      # piecewise-linear (tent) basis  — the momwire default
+--engine momwire                 # momwire (default), default B-spline basis
 --engine momwire:sinusoidal      # NEC2-style three-term basis (cross-validator)
 --engine momwire:bspline         # degree-1/2 B-spline Galerkin basis
 --engine momwire:hmatrix         # B-spline + hierarchical-matrix (ACA) acceleration
@@ -135,8 +134,8 @@ engine = MomwireEngine(builder, solver=BSplineSolver, solver_kwargs={"degree": 2
 
 **momwire** lives in its own repository and is vendored here as a git submodule;
 its `BSplineSolver` (the web workbench's default) is validated against the
-independent triangular (tent) basis, which converges to NEC accuracy in ~80
-segments. The H-matrix and array-block engines are newer and aimed at large
+independent sinusoidal basis and against PyNEC, converging to NEC accuracy in
+~80 segments. The H-matrix and array-block engines are newer and aimed at large
 arrays. **PyNEC** is an
 *optional* second backend — the `python-necpp` fork, distributed as a
 self-contained wheel (OpenBLAS vendored, so no SWIG/BLAS/autotools toolchain is

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -143,8 +143,10 @@ tag to roll back, or a fix branch) without cutting a new version.
 ## Latency note
 
 Perceived lag per knob turn ≈ one network round-trip + the server solve time.
-The **solve dominates** (free-space dipole-class solves are ~10–80 ms; real-ground
-Sommerfeld is ~100× slower). A regional Fly machine adds only ~5–40 ms RTT over a
+The **solve dominates** (free-space dipole-class solves are ~10–80 ms; the
+reflection-coefficient ground runs ~1.5–3× that, and full Sommerfeld — once
+~100× — is a few × since momwire 0.9.0's fused kernel; see
+`docs/status/2026-07-08-ground-model-benchmark.md`). A regional Fly machine adds only ~5–40 ms RTT over a
 persistent WebSocket, so typical tuning totals well under the ~100 ms "feels
 instant" threshold. If it ever feels sluggish, the levers are: debounce knob
 events client-side, lean on the existing solve cache, default to the fast ground

--- a/docs/market-research-antenna-simulators.md
+++ b/docs/market-research-antenna-simulators.md
@@ -34,13 +34,13 @@ The antenna-simulation market splits into three tiers:
 | **Solvers** | Two independent engines: **PyNEC** (NEC-2 via `necpp` wrapper) and **pysim** (pure-Python MoM). pysim offers 3 basis families: **TriangularPySim**, **SinusoidalPySim** (NEC2-style 3-term), **BSplinePySim** (degree 1–2, KCL junctions, ground via images). Large-N accelerator solvers, selectable and integrated into `PysimEngine` (impedance, sweep, current, and far-field all supported): **HMatrixPySim** (ACA + GMRES + near-field preconditioner), **ArrayBlockPySim** (block-low-rank for arrays; integrated via PR 103). C++ pybind11 accelerators (`_accelerators.cpp`, libmvec SIMD sincos) for Z-matrix fill. |
 | **Geometry** | 69+ wire designs: dipoles, inverted-V, Yagis, loops (delta/diamond/horizontal), fan/trap dipoles, Moxon, hexbeam, Sterba, LPDA, hentenna, + 25 Cebik reference designs (bobtail, bruce, G5RV, half-square, J-pole, quad, rhombic, W8JK, Zepp…). Arrays (1×4, 2×2, 2×4, grouped). Junctions (KCL), closed loops (driven / parasitic / terminated two-port), bent wires, multi-feed, port-based networks (TL + lumped R/L/C via `build_network`). |
 | **Outputs** | Impedance Z, Γ, SWR, current distribution (knot positions/currents), far-field directivity/gain (dBi), 2D pattern rings, elevation/azimuth cuts, radiation efficiency (loaded antennas), multi-port short-circuit Y. |
-| **Ground** | Free space; PEC (image method, all pysim bases); finite ground (PyNEC full Sommerfeld; pysim = PEC image + Fresnel on reflected wave — **impedance still PEC, an approximation**). |
+| **Ground** | Free space; PEC (image method, all bases); finite ground — **full Sommerfeld–Norton on both engines** (PyNEC natively; momwire ≥ 0.8.0 on every solver, validated against NEC gn 2), plus a faster reflection-coefficient approximation on both. |
 | **Sweeps / opt** | Frequency sweep (batched swept-k Y-matrix), parameter sweep, gain sweep, pattern sweep, `scipy.optimize` (SLSQP/L-BFGS-B) parameter optimization, cross-engine comparison. |
 | **UI / viz** | React 18 + Vite web frontend: 3D WebGL geometry, current distribution (mag/phase), Smith chart w/ SWR circle, polar patterns (az/el), frequency-sweep plots, live parameter sliders, solver/ground selection. FastAPI backend, WebSocket sweeps. matplotlib for CLI plots. |
 | **I/O** | Designs as Python builder classes; network spec (TL, DiffTL, Load, TwoPort, ports-at-edges). **`.nec` card export** via `nec_export` (CLI `export` subcommand + web gear-menu download; validated against `nec2c`); TL/DiffTL reducer designs excepted. NEC card *import* not yet (PyNEC consumes cards only for cross-validation). matplotlib PNG export. |
 | **Performance** | OpenMP/BLAS threading, libmvec AVX2 sincos, K-independent geometry cache for sweeps, on-demand block eval for H-matrix. H-matrix tested on 100-director Yagi (2142 segments), O(N log N) vs dense O(N²). |
 | **API / CLI** | Python API (`AntennaBuilder`, engines, `sweep*`, `optimize`, `pattern`, `compare_patterns`); CLI subcommands `draw / sweep / optimize / pattern / compare_patterns`; uniform `SimulationEngine` interface. |
-| **Validation / limits** | Cross-validated against PyNEC (≤0.1 dBi directivity on dipole; ~1–3% R on loops and multi-feed arrays). **Genuine open limits:** pysim wires are PEC (no copper loss); pysim finite-ground impedance is approximate (PEC image + Fresnel); `DiffTL` is pysim-only (PyNEC raises `NotImplementedError`); strict `tl_card` numerical agreement with PyNEC is unmet on low-coupling geometries (a segment-vs-basis port-convention difference, not a bug). |
+| **Validation / limits** | Cross-validated against PyNEC (≤0.1 dBi directivity on dipole; ~1–3% R on loops and multi-feed arrays). **Genuine open limits:** pysim wires are PEC (no copper loss); `DiffTL` is pysim-only (PyNEC raises `NotImplementedError`); strict `tl_card` numerical agreement with PyNEC is unmet on low-coupling geometries (a segment-vs-basis port-convention difference, not a bug). |
 | **License / platform** | Open-source Python; cross-platform (web UI = browser-based). |
 
 ---
@@ -176,7 +176,7 @@ The antenna-simulation market splits into three tiers:
 | Smith chart | via AutoEZ | ✓ | – | ✓ | – | – | ✓ |
 | Optimizer | via AutoEZ | ✓ (GA) | ✓ | ✓ (Platinum) | ✓ | – | ✓ (scipy) |
 | `.nec` import/export | ✓ / ✓ | ✓ / ✓ | limited | own | ✓ / ✓ | ✓ / ✓ | **export ✓ / import ✗** |
-| Real/Sommerfeld ground (impedance) | ✓ | ✓ | MININEC | ✓ | ✓ | ✓ | **PyNEC ✓; pysim approx** |
+| Real/Sommerfeld ground (impedance) | ✓ | ✓ | MININEC | ✓ | ✓ | ✓ | **✓ (both engines)** |
 
 ---
 
@@ -217,7 +217,7 @@ Impedance / SWR / Γ, gain / directivity, far-field 2D patterns, current distrib
 
 ### Gaps worth noting
 - **`.nec` import (round-trip) not yet** — export now exists (`nec_export`: CLI + web download, validated against `nec2c`, and round-tripped through xnec2c), closing the headline interoperability gap. What remains is *reading* external `.nec` decks back in; that's the lower-leverage half (most amateur-tier value is getting designs *out* to existing tools). PyNEC has no deck reader, so import would mean a small `.nec` parser driving the card API.
-- **Finite-ground impedance on the triangular basis folds to the PEC image** — the B-spline family solves it with momwire's reflection-coefficient model (validated within ~2 Ω of NEC over 0.1–0.5λ heights), the sinusoidal basis matches NEC's reflection-coefficient ground to ~0.1 Ω (momwire ≥ 0.5.0; shared basis), and PyNEC offers full Sommerfeld–Norton, so real-ground work cross-checks across two independent engines; below ~0.1λ heights the Sommerfeld path is the reference.
+- ~~Finite-ground impedance approximate on the momwire path~~ **closed**: since momwire 0.8.0 every momwire solver (sinusoidal, B-spline, H-matrix, array-block) solves the true Sommerfeld–Norton ground, validated against NEC gn 2; 0.9.0's fused C++ kernel made it competitive with (often faster than) PyNEC's native path (`docs/status/2026-07-08-ground-model-benchmark.md`). The reflection-coefficient model remains as the fast option, so real-ground work cross-checks across two independent engines at full fidelity.
 - **No copper/conductor loss in pysim** (PEC wires); efficiency on lossy elements requires PyNEC + `ld_card`.
 - **No FEM/FDTD/asymptotic, GPU/MPI, multiphysics, SAR/RCS/EMC, CAD import, auto-adaptive meshing** — Tier-1 features, out of scope for a focused wire-MoM tool, but worth stating explicitly so the positioning is honest.
 - **Remaining solver caveats** (per `NEXT_STEPS.md`): pysim wires are PEC (no conductor loss); strict `tl_card` PyNEC numerical agreement is unmet on near-decoupled geometries (segment-vs-basis port convention).

--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -374,7 +374,7 @@ def cli(arguments=None):
             "--ground",
             default=_GROUND_UNSET,
             help="Ground model: free | pec | finite[:<eps_r>,<sigma>] "
-            "(Sommerfeld-Norton on pynec) | finite-fast[:<eps_r>,<sigma>] "
+            "(Sommerfeld-Norton, both engines) | finite-fast[:<eps_r>,<sigma>] "
             "(reflection-coefficient approximation) "
             "(default: engine-specific — finite for pynec, free for momwire).",
         )


### PR DESCRIPTION
## Summary
- momwire 0.8.0 put the true Sommerfeld–Norton ground on every solver, and 0.9.0's fused kernel made it competitive with PyNEC's native gn 2 (14–19× faster; ties or beats PyNEC on 6/10 designs — see `docs/status/2026-07-08-ground-model-benchmark.md`), with the triangular basis retired into bspline d=1. Several docs still described the momwire finite ground as "refl-coef on B-spline only, PEC image elsewhere, an approximation."
- README: fixed the engine-comparison table (basis + ground rows), the `--engine` examples (dropped `momwire:triangular`; B-spline is the default), the workbench ground blurb, and the cross-validation paragraph.
- `docs/deploy.md`: the latency note claimed real-ground Sommerfeld is ~100× slower; now points at the benchmark numbers.
- `docs/market-research-antenna-simulators.md`: ground inventory row, open-limits row, comparison-table cell, and the finite-ground gaps bullet now reflect full Sommerfeld on both engines.
- `cli.py` `--ground` help: Sommerfeld–Norton is no longer described as pynec-only.

## Test plan
- [x] `ruff check` / `ruff format --check` on the touched Python file
- [x] Grepped README, docs/, and site/src/content/docs for remaining stale ground/triangular claims (site reference pages were already current)

🤖 Generated with [Claude Code](https://claude.com/claude-code)