### PR TITLE
Lossy transmission lines: complex-γ TL stamp + cable catalog

### DIFF
--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -48,19 +48,33 @@ Port = Union[PortAtEdge, PortVirtual]
 
 @dataclass(frozen=True)
 class TL:
-    """Lossless transmission line between two ports.
+    """Transmission line between two ports — lossless by default, lossy when
+    matched-loss coefficients are given (issue #297).
 
     z0:     characteristic impedance in Ω
     length: physical length in meters
 
     The electrical length βl is computed at solve time from the antenna's
-    operating wavelength. Both endpoints can be either real or virtual.
+    operating wavelength and `vf`. Both endpoints can be either real or
+    virtual.
 
     transposed: crossed ("half-twist") line — inverts port B's polarity,
     flipping the sign of the off-diagonal transfer terms. This is the
     phase reversal a transposed-feeder array (LPDA, ZL-Special) needs.
     Prefer it over a negative z0, which would wrongly negate the diagonal
     self terms too.
+
+    vf: velocity factor — phase velocity as a fraction of c, so
+    β = 2π/(vf·λ₀). The default 1.0 preserves the historical behavior
+    (physical length read as free-space electrical length).
+
+    k1, k2: matched-loss coefficients in the cable-table convention,
+        matched loss [dB per 100 ft] = k1·√f_MHz + k2·f_MHz
+    (k1 = conductor/skin-effect term, k2 = dielectric term). α is derived
+    from these at each operating frequency, so sweeps get the loss slope
+    for free, and SWR-dependent additional loss emerges from the circuit
+    solution rather than a formula. Defaults 0.0 → lossless. Use
+    `TL.from_cable()` for real cables.
     """
 
     a: str  # port name
@@ -68,6 +82,48 @@ class TL:
     z0: float
     length: float
     transposed: bool = False
+    vf: float = 1.0
+    k1: float = 0.0
+    k2: float = 0.0
+
+    @classmethod
+    def from_cable(cls, cable, a, b, length, transposed=False):
+        """A `TL` with z0/vf/k1/k2 taken from the `CABLES` catalog entry
+        named `cable` (e.g. ``TL.from_cable("RG-8X", "rig", "feed", 30.48)``)."""
+        if cable not in CABLES:
+            raise KeyError(
+                f"unknown cable {cable!r}; available: {', '.join(sorted(CABLES))}"
+            )
+        c = CABLES[cable]
+        return cls(
+            a=a, b=b, z0=c.z0, length=length, transposed=transposed,
+            vf=c.vf, k1=c.k1, k2=c.k2,
+        )  # fmt: skip
+
+
+@dataclass(frozen=True)
+class Cable:
+    """Catalog entry for a feedline type: characteristic impedance, velocity
+    factor, and matched-loss coefficients (dB/100 ft = k1·√f_MHz + k2·f_MHz)."""
+
+    z0: float
+    vf: float
+    k1: float
+    k2: float
+
+
+# Nominal catalog values assembled from typical published matched-loss tables
+# (dB/100 ft at HF/VHF) — vendor datasheets vary by a few tens of percent
+# between constructions, so treat these as representative, not as any one
+# manufacturer's spec.
+CABLES = {
+    "RG-58": Cable(z0=50.0, vf=0.66, k1=0.40, k2=0.008),
+    "RG-8X": Cable(z0=50.0, vf=0.80, k1=0.27, k2=0.0055),
+    "RG-213": Cable(z0=50.0, vf=0.66, k1=0.18, k2=0.003),
+    "LMR-400": Cable(z0=50.0, vf=0.85, k1=0.122, k2=0.0003),
+    "window-450": Cable(z0=450.0, vf=0.91, k1=0.035, k2=0.0002),
+    "openwire-600": Cable(z0=600.0, vf=0.95, k1=0.02, k2=0.0001),
+}
 
 
 # Reserved for follow-up PR — sketched here so the discriminated-union

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -47,13 +47,24 @@ from .network import (
 C_LIGHT = 299_792_458.0
 
 
-def tl_admittance_2x2(z0, length, wavelength, transposed=False):
-    """Lossless ideal-TL nodal admittance between its two terminals.
+FEET_PER_M = 1.0 / 0.3048
+NEPER_PER_DB = 1.0 / (20.0 / np.log(10.0))  # 1/8.6859: dB → nepers
 
-    For electrical length θ = 2π·length/λ:
+
+def tl_admittance_2x2(z0, length, wavelength, transposed=False, vf=1.0, k1=0.0, k2=0.0):
+    """Ideal-TL nodal admittance between its two terminals — lossless or
+    lossy (issue #297).
+
+    For complex propagation γl = (α + jβ)·length with β = 2π/(vf·λ):
+        Y_TL = 1/(Z0 sinh γl) · [[cosh γl, -1], [-1, cosh γl]]
+    which reduces exactly to the classic lossless form
         Y_TL = 1/(j Z0 sin θ) · [[cos θ, -1], [-1, cos θ]]
-    Singular at sin θ = 0 (TL is a half-wavelength multiple); raise
-    rather than return garbage so callers can pick a different length.
+    at α = 0 (sinh jθ = j·sin θ). α comes from the cable-table matched-loss
+    model k1·√f_MHz + k2·f_MHz in dB per 100 ft (see `network.TL`).
+
+    Singular only for an exactly-lossless half-wavelength multiple
+    (sinh γl = 0 requires α = 0); raise rather than return garbage so
+    callers can pick a different length. Any nonzero loss regularizes it.
 
     `transposed=True` models a crossed ("half-twist") line: port B's
     polarity is inverted, which flips the sign of the off-diagonal
@@ -62,16 +73,20 @@ def tl_admittance_2x2(z0, length, wavelength, transposed=False):
     ZL-Special). Note it is NOT the same as a negative z0, which would
     (wrongly) negate the diagonal self terms too.
     """
-    theta = 2.0 * np.pi * length / wavelength
-    s, c = np.sin(theta), np.cos(theta)
-    if abs(s) < 1e-12:
+    beta = 2.0 * np.pi / (vf * wavelength)
+    f_mhz = C_LIGHT / wavelength / 1e6
+    loss_db_per_100ft = k1 * np.sqrt(f_mhz) + k2 * f_mhz
+    alpha = loss_db_per_100ft * NEPER_PER_DB * FEET_PER_M / 100.0  # nepers/m
+    gl = (alpha + 1j * beta) * length
+    sh, ch = np.sinh(gl), np.cosh(gl)
+    if abs(sh) < 1e-12:
         raise ValueError(
-            f"TL length {length} is ~kλ/2 at f={C_LIGHT / wavelength / 1e6:.4f} MHz "
-            "(sin βl ≈ 0); admittance is singular"
+            f"lossless TL length {length} is ~k·vf·λ/2 at "
+            f"f={f_mhz:.4f} MHz (sinh γl ≈ 0); admittance is singular"
         )
-    scale = 1.0 / (1j * z0 * s)
+    scale = 1.0 / (z0 * sh)
     off = 1.0 if transposed else -1.0
-    return scale * np.array([[c, off], [off, c]], dtype=np.complex128)
+    return scale * np.array([[ch, off], [off, ch]], dtype=np.complex128)
 
 
 # ---------------------------------------------------------------------------
@@ -238,7 +253,13 @@ class NetworkReducer:
             if isinstance(br, TL):
                 a, b = self.port_to_idx[br.a], self.port_to_idx[br.b]
                 G[np.ix_([a, b], [a, b])] += tl_admittance_2x2(
-                    br.z0, br.length, wavelength, transposed=br.transposed
+                    br.z0,
+                    br.length,
+                    wavelength,
+                    transposed=br.transposed,
+                    vf=br.vf,
+                    k1=br.k1,
+                    k2=br.k2,
                 )
             elif isinstance(br, TwoPort):
                 a, b = self.port_to_idx[br.a], self.port_to_idx[br.b]

--- a/tests/test_lossy_tl.py
+++ b/tests/test_lossy_tl.py
@@ -1,0 +1,128 @@
+"""Lossy transmission lines (issue #297).
+
+These tests exercise the complex-γ TL stamp and the cable catalog at the
+NetworkReducer level with a synthetic one-port antenna Y — no MoM solve, so
+they are pure circuit oracles:
+
+  - the lossless limit reproduces the historical stamp exactly;
+  - a matched lossy line dissipates exactly the k1·√f + k2·f matched loss;
+  - a mismatched lossy line's input impedance matches the analytic
+    Zin = Z0(Z_L + Z0 tanh γl)/(Z0 + Z_L tanh γl) wave solution, and its
+    total loss exceeds matched loss (the SWR penalty emerges from the
+    circuit, not a formula);
+  - loss regularizes the half-wave singularity.
+"""
+
+import numpy as np
+import pytest
+
+from antennaknobs.network import CABLES, TL, Driven, Network, PortAtEdge, PortVirtual
+from antennaknobs.network_reduce import C_LIGHT, NetworkReducer, tl_admittance_2x2
+
+F_MHZ = 10.0
+WL = C_LIGHT / (F_MHZ * 1e6)
+FT100 = 30.48  # 100 ft in meters
+
+
+def _rig_fed_network(tl):
+    """Virtual "rig" port driven through `tl` into the real "ant" port."""
+    net = Network(
+        ports={"ant": PortAtEdge("ant"), "rig": PortVirtual("rig")},
+        branches=[tl],
+        sources=[Driven("rig", 1 + 0j)],
+    )
+    return NetworkReducer(net, {"ant": 0, "rig": 1}, 2)
+
+
+def _gamma(tl, wavelength):
+    """The same α + jβ the stamp derives, for analytic cross-checks."""
+    f_mhz = C_LIGHT / wavelength / 1e6
+    db_per_m = (tl.k1 * np.sqrt(f_mhz) + tl.k2 * f_mhz) / (100.0 * 0.3048)
+    alpha = db_per_m * np.log(10.0) / 20.0
+    beta = 2.0 * np.pi / (tl.vf * wavelength)
+    return alpha + 1j * beta
+
+
+def _powers(reducer, z_ant):
+    """(p_in at the rig, power delivered into the antenna resistance)."""
+    y_real = np.array([[1.0 / z_ant]], dtype=np.complex128)
+    v, _eff, p_in = reducer.excited_state(y_real, WL)
+    p_ant = 0.5 * abs(v[0]) ** 2 * np.real(1.0 / z_ant)
+    return p_in, p_ant
+
+
+def test_lossless_limit_is_exact():
+    for z0, length in [(50.0, 3.7), (300.0, 0.18 * WL), (600.0, 21.0)]:
+        theta = 2.0 * np.pi * length / WL
+        s, c = np.sin(theta), np.cos(theta)
+        legacy = (1.0 / (1j * z0 * s)) * np.array([[c, -1.0], [-1.0, c]])
+        got = tl_admittance_2x2(z0, length, WL)
+        np.testing.assert_allclose(got, legacy, rtol=1e-12)
+
+
+def test_matched_line_dissipates_exactly_the_matched_loss():
+    tl = TL("rig", "ant", z0=50.0, length=FT100, vf=0.66, k1=0.40, k2=0.008)
+    reducer = _rig_fed_network(tl)
+    p_in, p_ant = _powers(reducer, 50.0)
+    loss_db = 10.0 * np.log10(p_in / p_ant)
+    expected_db = tl.k1 * np.sqrt(F_MHZ) + tl.k2 * F_MHZ  # per 100 ft, matched
+    np.testing.assert_allclose(loss_db, expected_db, rtol=1e-9)
+    # Matched termination: the rig sees Z0 regardless of line length.
+    (zin,) = reducer.driven_impedance(np.array([[1.0 / 50.0]]), WL)
+    np.testing.assert_allclose(zin, 50.0 + 0j, rtol=1e-9)
+
+
+def test_mismatched_zin_matches_the_wave_solution():
+    tl = TL("rig", "ant", z0=50.0, length=FT100, vf=0.80, k1=0.27, k2=0.0055)
+    z_l = 200.0 + 0j
+    reducer = _rig_fed_network(tl)
+    (zin,) = reducer.driven_impedance(np.array([[1.0 / z_l]]), WL)
+    t = np.tanh(_gamma(tl, WL) * tl.length)
+    zin_analytic = tl.z0 * (z_l + tl.z0 * t) / (tl.z0 + z_l * t)
+    np.testing.assert_allclose(zin, zin_analytic, rtol=1e-9)
+
+
+def test_swr_penalty_emerges_from_the_circuit():
+    tl = TL("rig", "ant", z0=50.0, length=FT100, vf=0.80, k1=0.27, k2=0.0055)
+    matched_db = tl.k1 * np.sqrt(F_MHZ) + tl.k2 * F_MHZ
+    p_in, p_ant = _powers(_rig_fed_network(tl), z_ant=200.0)  # SWR 4:1
+    total_db = 10.0 * np.log10(p_in / p_ant)
+    assert total_db > matched_db  # mismatch always adds loss
+    assert total_db < 4.0 * matched_db  # ...but stays in a sane range at SWR 4
+
+
+def test_loss_regularizes_the_halfwave_singularity():
+    vf = 0.66
+    halfwave = vf * WL / 2.0
+    with pytest.raises(ValueError, match="singular"):
+        tl_admittance_2x2(50.0, halfwave, WL, vf=vf)
+    y = tl_admittance_2x2(50.0, halfwave, WL, vf=vf, k1=0.40)
+    assert np.all(np.isfinite(y))
+    # A lossy half-wave line still ~repeats its load impedance.
+    tl = TL("rig", "ant", z0=50.0, length=halfwave, vf=vf, k1=0.40)
+    (zin,) = _rig_fed_network(tl).driven_impedance(np.array([[1.0 / 120.0]]), WL)
+    assert abs(zin - 120.0) < 15.0
+
+
+def test_velocity_factor_scales_electrical_length():
+    got = tl_admittance_2x2(50.0, 10.0, WL, vf=0.66)
+    equivalent = tl_admittance_2x2(50.0, 10.0 / 0.66, WL, vf=1.0)
+    np.testing.assert_allclose(got, equivalent, rtol=1e-12)
+
+
+def test_transposed_flips_only_the_off_diagonal():
+    kw = dict(vf=0.80, k1=0.27, k2=0.0055)
+    y = tl_admittance_2x2(50.0, FT100, WL, **kw)
+    y_t = tl_admittance_2x2(50.0, FT100, WL, transposed=True, **kw)
+    np.testing.assert_allclose(np.diag(y_t), np.diag(y), rtol=1e-15)
+    np.testing.assert_allclose(y_t[0, 1], -y[0, 1], rtol=1e-15)
+    np.testing.assert_allclose(y_t[1, 0], -y[1, 0], rtol=1e-15)
+
+
+def test_from_cable_catalog():
+    tl = TL.from_cable("RG-8X", "rig", "ant", FT100)
+    c = CABLES["RG-8X"]
+    assert (tl.z0, tl.vf, tl.k1, tl.k2) == (c.z0, c.vf, c.k1, c.k2)
+    assert (tl.a, tl.b, tl.length) == ("rig", "ant", FT100)
+    with pytest.raises(KeyError, match="RG-8X"):  # message lists availables
+        TL.from_cable("RG-9000", "rig", "ant", FT100)


### PR DESCRIPTION
## Summary
- First piece of the station-modelling arc (#297; then #298 finite-Q reactors, #299 power budget, #300 station showcase, #301 balun).
- `TL` gains `vf`, `k1`, `k2` — matched loss dB/100 ft = k1·√f_MHz + k2·f_MHz, the cable-table convention — and the nodal stamp generalizes to the lossy form `Y = 1/(Z0·sinh γl)·[[cosh γl, −1],[−1, cosh γl]]`, which reduces **exactly** to the historical lossless expression at α = 0 (`sinh jθ = j·sinθ` identically). Defaults (`vf=1, k1=k2=0`) are bit-compatible with every existing design.
- SWR-dependent additional loss emerges from the circuit solution, not a formula — that's the point of doing this in the MNA reduction. A lossy line also regularizes the half-wave singularity; the guard now only fires for exactly-lossless lines.
- New `Cable` dataclass + `CABLES` catalog (RG-58, RG-8X, RG-213, LMR-400, 450 Ω window, 600 Ω open wire; nominal published-table values, documented as such) and a `TL.from_cable()` factory.
- No engine-specific work: TL networks already take the shared reducer path on both engines (PyNEC native `tl_card` survives only on the legacy `build_tls()` path, which calls the stamp positionally and is untouched).

## Test plan
- [x] 8 new circuit-level oracles in `tests/test_lossy_tl.py`: lossless-limit exactness (1e-12), matched loss = k1√f+k2f to 1e-9, mismatched Zin vs the analytic `Z0(Z_L + Z0·tanh γl)/(Z0 + Z_L·tanh γl)` wave solution (1e-9), emergent SWR penalty bounds, lossy half-wave solves cleanly while lossless still raises, vf electrical-length scaling, transposed off-diagonal flip, catalog lookup + unknown-cable error
- [x] Full suite: 1490 passed
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)