### PR TITLE
Finite-Q components: coil loss (ωL/Q) and capacitor ESR in network branches

### DIFF
--- a/src/antennaknobs/designs/loops/skyloop_lmatch.py
+++ b/src/antennaknobs/designs/loops/skyloop_lmatch.py
@@ -42,11 +42,16 @@ class Builder(TriangularSkyloop):
             # L-match elements, tuned for ~50 Ω at 18.1 MHz on the stock loop.
             "series_L_uH": 0.873,  # series arm, input → feed (TwoPort)
             "shunt_C_pF": 59.57,  # shunt arm, across the feed (Shunt)
+            # Coil quality factor (issue #298): adds R = ωL/Q in series with
+            # the matching inductor. 0 = ideal coil (the historical behavior);
+            # real air-wound coils run ~50–400.
+            "coil_q": 0.0,
             "ui_params": MappingProxyType(
                 {
                     # Matched to 50 Ω, so the SWR readout shows ~1:1.
                     "target_z0": 50.0,
                     "default_view": "xy",
+                    "coil_q": {"min": 0.0, "max": 400.0},
                 }
             ),
         }
@@ -71,11 +76,14 @@ class Builder(TriangularSkyloop):
         identifying `in` with `feed`) and a 0 F shunt arm is an open (no
         element). With both arms zero the matchbox is fully inert — a
         pass-through — and the input impedance is just the bare antenna's
-        (Z_in = Z_ant)."""
+        (Z_in = Z_ant). `coil_q > 0` gives the series inductor a finite Q
+        (R = ωL/Q, issue #298), turning the matchbox lossy the way a real
+        tuner is; 0 keeps the ideal coil."""
+        ql = self.coil_q if self.coil_q > 0 else None
         return Network(
             ports={"feed": PortAtEdge("feed"), "in": PortVirtual("in")},
             branches=[
-                TwoPort(a="in", b="feed", l=self.series_L_uH * 1e-6),
+                TwoPort(a="in", b="feed", l=self.series_L_uH * 1e-6, ql=ql),
                 Shunt(port="feed", c=self.shunt_C_pF * 1e-12),
             ],
             sources=[Driven(port="in", voltage=1 + 0j)],

--- a/src/antennaknobs/designs/verticals/inverted_l_tmatch.py
+++ b/src/antennaknobs/designs/verticals/inverted_l_tmatch.py
@@ -55,6 +55,12 @@ class Builder(InvertedL):
             "series_c1_pF": 20.47,  # source-side series capacitor
             "shunt_l_uH": 0.6458,  # shunt inductor at the tee midpoint
             "series_c2_pF": 254.5,  # antenna-side series capacitor
+            # Coil quality factor (issue #298): adds R = ωL/Q in series with
+            # the tee's shunt inductor. 0 = ideal coil (the historical
+            # behavior); real air-wound coils run ~50–400. A T-network runs
+            # high circulating current through this coil, so its loss is the
+            # classic hidden tuner cost.
+            "coil_q": 0.0,
             "ui_params": MappingProxyType(
                 {
                     # Matched to 50 Ω, so the SWR readout shows ~1:1.
@@ -63,6 +69,7 @@ class Builder(InvertedL):
                     "series_c1_pF": {"min": 5.0, "max": 60.0},
                     "shunt_l_uH": {"min": 0.1, "max": 2.0},
                     "series_c2_pF": {"min": 50.0, "max": 500.0},
+                    "coil_q": {"min": 0.0, "max": 400.0},
                 }
             ),
         }
@@ -89,7 +96,11 @@ class Builder(InvertedL):
             },
             branches=[
                 TwoPort(a="in", b="m", c=self.series_c1_pF * 1e-12),
-                Shunt(port="m", l=self.shunt_l_uH * 1e-6),
+                Shunt(
+                    port="m",
+                    l=self.shunt_l_uH * 1e-6,
+                    ql=self.coil_q if self.coil_q > 0 else None,
+                ),
                 TwoPort(a="m", b="feed", c=self.series_c2_pF * 1e-12),
             ],
             sources=[Driven(port="in", voltage=1 + 0j)],

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -302,6 +302,14 @@ class PyNECEngine(SimulationEngine):
         # shunt-to-common primitive); always reduce it.
         if any(isinstance(b, Shunt) for b in net.branches):
             return True
+        # A finite-Q Load (issue #298) needs R = ωL/Q re-derived at every
+        # frequency; ld_card takes fixed R/L/C baked into one context, which
+        # would freeze the loss resistance at the first frequency of a sweep.
+        if any(
+            isinstance(b, Load) and (b.ql is not None or b.qc is not None)
+            for b in net.branches
+        ):
+            return True
         # TwoPort goes native only when the oracle switch is on; otherwise it
         # is a shared-reducer stamp (the general path both engines agree on).
         if any(isinstance(b, TwoPort) for b in net.branches):
@@ -334,6 +342,15 @@ class PyNECEngine(SimulationEngine):
             raise ValueError(
                 "native_nt=True requires every port to be a real edge; "
                 "nt_card attaches to real segments, not virtual nodes"
+            )
+        if any(
+            (isinstance(b, (Load, TwoPort)) and (b.ql is not None or b.qc is not None))
+            for b in net.branches
+        ):
+            raise ValueError(
+                "native_nt=True cannot bake finite-Q components (issue #298): "
+                "R = ωL/Q changes with frequency but ld_card/nt_card values "
+                "are fixed in the context; run the default reducer path instead"
             )
 
     def _init_network(self):

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -242,7 +242,17 @@ def _series_rlc_impedance(r, l, c, omega, ql=None, qc=None):
     Finite component Q (issue #298): `ql` adds the coil's series loss
     R_coil = ωL/Q_L; `qc` adds the capacitor's ESR = 1/(ωC·Q_C). Both are
     frequency-dependent by construction — a fixed `r` cannot express them
-    across a sweep. None (default) = ideal component."""
+    across a sweep. None (default) = ideal component.
+
+    Q is treated as frequency-INDEPENDENT: R = ωL/Q is re-derived at each
+    solve frequency, so across a sweep R grows ∝ f. Physical truth for an
+    air-core HF coil sits between the two expressible models — skin effect
+    gives R ∝ √f (i.e. Q ∝ √f) — so constant Q overestimates loss above
+    the frequency where the quoted Q is true and underestimates below it,
+    while a fixed resistance (use plain `r` = ω_ref·L/Q for that) errs the
+    opposite way. At a single operating frequency, with Q quoted at that
+    frequency, all three agree. A √f reference-frequency model would slot
+    in here if sweep fidelity ever warrants it."""
     z = 0.0 + 0.0j
     if r is not None:
         z += r

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -155,6 +155,8 @@ class Load:
     l: float | None = None
     c: float | None = None
     parallel: bool = False
+    ql: float | None = None  # coil Q: adds series R = omega*L/Q (issue #298)
+    qc: float | None = None  # capacitor Q: adds ESR = 1/(omega*C*Q)
 
 
 @dataclass(frozen=True)
@@ -185,6 +187,8 @@ class TwoPort:
     r: float | None = None
     l: float | None = None
     c: float | None = None
+    ql: float | None = None  # coil Q: adds series R = omega*L/Q (issue #298)
+    qc: float | None = None  # capacitor Q: adds ESR = 1/(omega*C*Q)
 
 
 @dataclass(frozen=True)
@@ -218,6 +222,8 @@ class Shunt:
     l: float | None = None
     c: float | None = None
     parallel: bool = False
+    ql: float | None = None  # coil Q: adds series R = omega*L/Q (issue #298)
+    qc: float | None = None  # capacitor Q: adds ESR = 1/(omega*C*Q)
 
 
 Branch = Union[TL, Load, TwoPort, Shunt]
@@ -230,29 +236,49 @@ def _branch_port_refs(br):
     return (br.port,)  # Load
 
 
-def _series_rlc_impedance(r, l, c, omega):
-    """Series R + jωL + 1/(jωC). Any of r/l/c may be None (omitted term)."""
+def _series_rlc_impedance(r, l, c, omega, ql=None, qc=None):
+    """Series R + jωL + 1/(jωC). Any of r/l/c may be None (omitted term).
+
+    Finite component Q (issue #298): `ql` adds the coil's series loss
+    R_coil = ωL/Q_L; `qc` adds the capacitor's ESR = 1/(ωC·Q_C). Both are
+    frequency-dependent by construction — a fixed `r` cannot express them
+    across a sweep. None (default) = ideal component."""
     z = 0.0 + 0.0j
     if r is not None:
         z += r
     if l is not None:
         z += 1j * omega * l
+        if ql is not None:
+            z += omega * l / ql
     if c is not None:
         z += 1.0 / (1j * omega * c)
+        if qc is not None:
+            z += 1.0 / (omega * c * qc)
     return z
 
 
-def _parallel_rlc_admittance(r, l, c, omega):
+def _parallel_rlc_admittance(r, l, c, omega, ql=None, qc=None):
     """Parallel 1/R + 1/(jωL) + jωC. Any of r/l/c may be None (omitted term).
     Trap dipoles use this: parallel-LC has Y → 0 at ω₀ = 1/√(LC), so the
-    branch opens at the trap's resonant frequency."""
+    branch opens at the trap's resonant frequency.
+
+    Finite Q (issue #298) lossifies each leg: the L leg becomes
+    1/(ωL/Q_L + jωL), the C leg 1/(1/(jωC) + 1/(ωC·Q_C)). A lossy trap no
+    longer opens completely — its resonant impedance tops out at the
+    textbook ≈ Q·ω₀L instead of ∞."""
     y = 0.0 + 0.0j
     if r is not None:
         y += 1.0 / r
     if l is not None:
-        y += 1.0 / (1j * omega * l)
+        zl = 1j * omega * l
+        if ql is not None:
+            zl += omega * l / ql
+        y += 1.0 / zl
     if c is not None:
-        y += 1j * omega * c
+        if qc is not None:
+            y += 1.0 / (1.0 / (1j * omega * c) + 1.0 / (omega * c * qc))
+        else:
+            y += 1j * omega * c
     return y
 
 
@@ -273,8 +299,8 @@ def load_series_admittance(br, omega):
     the series impedance is exactly 0 (series-LC short circuit), which the
     caller treats as "no series element" (the wire is unbroken)."""
     if br.parallel:
-        return _parallel_rlc_admittance(br.r, br.l, br.c, omega)
-    z = _series_rlc_impedance(br.r, br.l, br.c, omega)
+        return _parallel_rlc_admittance(br.r, br.l, br.c, omega, br.ql, br.qc)
+    z = _series_rlc_impedance(br.r, br.l, br.c, omega, br.ql, br.qc)
     if z == 0:
         return complex(float("inf"), 0.0)
     return 1.0 / z
@@ -291,11 +317,11 @@ def load_impedance(br, omega):
     stamp the load into a port-Y matrix should prefer
     `load_series_admittance`, which avoids forming this infinity at all."""
     if br.parallel:
-        y = _parallel_rlc_admittance(br.r, br.l, br.c, omega)
+        y = _parallel_rlc_admittance(br.r, br.l, br.c, omega, br.ql, br.qc)
         if y == 0:
             return complex(float("inf"), 0.0)
         return 1.0 / y
-    return _series_rlc_impedance(br.r, br.l, br.c, omega)
+    return _series_rlc_impedance(br.r, br.l, br.c, omega, br.ql, br.qc)
 
 
 @dataclass(frozen=True)

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -125,16 +125,17 @@ class _Group2Element:
     e: complex
 
 
-def _series_group2(a, b, r, l, c, omega, emf=0j):
+def _series_group2(a, b, r, l, c, omega, emf=0j, ql=None, qc=None):
     """Group-2 stamp of a series R + jωL + 1/(jωC) (+ optional EMF) between
     nodes a and b. A 0 F capacitor is an open in the series path (infinite
     reactance) → admittance form with y = 0 (the branch carries no current).
     Every other value combination has finite z — including the ideal short
     z = 0 (0 Ω, 0 H, all-omitted, or exact series-LC resonance), which the
-    old admittance-only stamps had to raise on."""
+    old admittance-only stamps had to raise on. `ql`/`qc` add the finite-Q
+    component losses (issue #298, see `network._series_rlc_impedance`)."""
     if c is not None and c == 0:
         return _Group2Element(a, b, c_v=0j, c_j=1.0 + 0j, e=0j)
-    z = _series_rlc_impedance(r, l, c, omega)
+    z = _series_rlc_impedance(r, l, c, omega, ql, qc)
     return _Group2Element(a, b, c_v=1.0 + 0j, c_j=z, e=emf)
 
 
@@ -263,13 +264,21 @@ class NetworkReducer:
                 )
             elif isinstance(br, TwoPort):
                 a, b = self.port_to_idx[br.a], self.port_to_idx[br.b]
-                elements.append(_series_group2(a, b, br.r, br.l, br.c, omega))
+                elements.append(
+                    _series_group2(a, b, br.r, br.l, br.c, omega, ql=br.ql, qc=br.qc)
+                )
             elif isinstance(br, Shunt):
                 k = self.port_to_idx[br.port]
                 if br.parallel:
-                    G[k, k] += _parallel_rlc_admittance(br.r, br.l, br.c, omega)
+                    G[k, k] += _parallel_rlc_admittance(
+                        br.r, br.l, br.c, omega, br.ql, br.qc
+                    )
                 else:
-                    elements.append(_series_group2(k, None, br.r, br.l, br.c, omega))
+                    elements.append(
+                        _series_group2(
+                            k, None, br.r, br.l, br.c, omega, ql=br.ql, qc=br.qc
+                        )
+                    )
             elif isinstance(br, Load):
                 if not isinstance(self.network.ports[br.port], PortAtEdge):
                     raise ValueError(

--- a/tests/test_finite_q.py
+++ b/tests/test_finite_q.py
@@ -1,0 +1,151 @@
+"""Finite-Q components in lumped network branches (issue #298).
+
+Circuit-level oracles at the NetworkReducer/helper level (no MoM solve):
+
+  - a series inductor with Q has Z = ωL/Q + jωL exactly; a series capacitor
+    with Q has ESR = 1/(ωC·Q);
+  - a lossy parallel tank tops out at the textbook Z ≈ Q·ω₀L at resonance
+    instead of opening completely;
+  - ql/qc default to None and are bit-identical to the ideal expressions;
+  - a series matching element with finite Q shifts the input impedance by
+    exactly its loss resistance;
+  - PyNEC routing: a finite-Q Load takes the reducer path (ld_card values
+    are baked per context and cannot track R = ωL/Q across a sweep).
+"""
+
+import numpy as np
+import pytest
+
+from antennaknobs.designs.loops.skyloop_lmatch import Builder as LMatchBuilder
+from antennaknobs.designs.verticals.inverted_l_tmatch import Builder as TMatchBuilder
+from antennaknobs.network import (
+    Driven,
+    Network,
+    PortAtEdge,
+    PortVirtual,
+    Shunt,
+    TwoPort,
+    _parallel_rlc_admittance,
+    _series_rlc_impedance,
+)
+from antennaknobs.network_reduce import C_LIGHT, NetworkReducer
+
+F_MHZ = 10.0
+WL = C_LIGHT / (F_MHZ * 1e6)
+OMEGA = 2.0 * np.pi * F_MHZ * 1e6
+
+
+def test_series_coil_q_is_exactly_omega_l_over_q():
+    l, q = 2.2e-6, 150.0
+    z = _series_rlc_impedance(None, l, None, OMEGA, ql=q)
+    assert z == pytest.approx(OMEGA * l / q + 1j * OMEGA * l)
+
+
+def test_series_capacitor_q_is_exactly_the_esr():
+    c, q = 100e-12, 1000.0
+    z = _series_rlc_impedance(None, None, c, OMEGA, qc=q)
+    assert z == pytest.approx(1.0 / (OMEGA * c * q) + 1.0 / (1j * OMEGA * c))
+
+
+def test_default_q_is_bit_identical_to_ideal():
+    args = (10.0, 2.2e-6, 100e-12, OMEGA)
+    assert _series_rlc_impedance(*args) == _series_rlc_impedance(
+        *args, ql=None, qc=None
+    )
+    assert _parallel_rlc_admittance(*args) == _parallel_rlc_admittance(
+        *args, ql=None, qc=None
+    )
+
+
+def test_lossy_tank_resonates_at_q_omega_l():
+    l, c, q = 2.2e-6, 100e-12, 100.0
+    w0 = 1.0 / np.sqrt(l * c)
+    y = _parallel_rlc_admittance(None, l, c, w0, ql=q)
+    z_res = 1.0 / y
+    # Textbook parallel tank with lossy L: |Z| at resonance ≈ Q·ω₀L for
+    # high Q (exact value Q·ω₀L·(1 + 1/Q²) with a small phase angle).
+    assert abs(z_res) == pytest.approx(q * w0 * l, rel=2.0 / q)
+    # The ideal tank at resonance is an open to float rounding — negligible
+    # next to the lossy tank's finite conductance.
+    assert abs(_parallel_rlc_admittance(None, l, c, w0)) < 1e-6 * abs(y)
+
+
+def test_series_matching_coil_loss_adds_directly_to_zin():
+    """Series TwoPort L between the source and a resistive port: finite Q
+    must shift the input impedance by exactly ωL/Q + 0j."""
+    l, q = 2.2e-6, 100.0
+
+    def zin(ql):
+        net = Network(
+            ports={"ant": PortAtEdge("ant"), "in": PortVirtual("in")},
+            branches=[TwoPort(a="in", b="ant", l=l, ql=ql)],
+            sources=[Driven("in", 1 + 0j)],
+        )
+        reducer = NetworkReducer(net, {"ant": 0, "in": 1}, 2)
+        (z,) = reducer.driven_impedance(np.array([[1.0 / 50.0]]), WL)
+        return z
+
+    np.testing.assert_allclose(zin(q) - zin(None), OMEGA * l / q + 0j, rtol=1e-12)
+
+
+def test_lossy_shunt_coil_dissipates_power():
+    """Shunt L with finite Q across a driven port burns power: p_in rises
+    relative to the ideal-coil network for the same source voltage."""
+
+    def p_in(ql):
+        net = Network(
+            ports={"ant": PortAtEdge("ant")},
+            branches=[Shunt(port="ant", l=2.2e-6, ql=ql)],
+            sources=[Driven("ant", 1 + 0j)],
+        )
+        reducer = NetworkReducer(net, {"ant": 0}, 1)
+        _v, _eff, p = reducer.excited_state(np.array([[1.0 / 5000.0]]), WL)
+        return p
+
+    assert p_in(50.0) > p_in(None)
+
+
+def test_tuner_designs_expose_the_coil_q_knob():
+    # Default 0 = ideal coil: the branch carries ql=None (bit-identical).
+    for builder_cls, lossy_branch in [
+        (LMatchBuilder, TwoPort),
+        (TMatchBuilder, Shunt),
+    ]:
+        net = builder_cls().build_network()
+        coils = [
+            b
+            for b in net.branches
+            if isinstance(b, lossy_branch) and getattr(b, "l", None)
+        ]
+        assert coils and all(b.ql is None for b in coils)
+        net_q = builder_cls(
+            params={**builder_cls.default_params, "coil_q": 200.0}
+        ).build_network()
+        coils_q = [
+            b
+            for b in net_q.branches
+            if isinstance(b, lossy_branch) and getattr(b, "l", None)
+        ]
+        assert coils_q and all(b.ql == 200.0 for b in coils_q)
+
+
+def test_pynec_routes_finite_q_loads_down_the_reducer():
+    pynec_mod = pytest.importorskip("antennaknobs.engines.pynec")
+    from antennaknobs.designs.multiband.trap_dipole import Builder as TrapBuilder
+    from antennaknobs.network import Load
+
+    class LossyTrapBuilder(TrapBuilder):
+        def build_network(self):
+            net = super().build_network()
+            branches = [
+                Load(port=b.port, r=b.r, l=b.l, c=b.c, parallel=b.parallel, ql=100.0)
+                if isinstance(b, Load)
+                else b
+                for b in net.branches
+            ]
+            return Network(ports=net.ports, branches=branches, sources=net.sources)
+
+    ideal = pynec_mod.PyNECEngine(TrapBuilder())
+    lossy = pynec_mod.PyNECEngine(LossyTrapBuilder())
+    assert not ideal._use_reducer, "ideal trap Loads should stay native (ld_card)"
+    assert lossy._use_reducer, "finite-Q Loads must take the reducer path"


### PR DESCRIPTION
## Summary
- Second piece of the station-modelling arc (#298; follows #297 lossy TL, precedes #299 power budget). `Load`/`TwoPort`/`Shunt` gain optional `ql`/`qc` quality factors: the coil contributes R = ωL/Q in series, the capacitor ESR = 1/(ωC·Q). Implemented once in `_series_rlc_impedance`/`_parallel_rlc_admittance` so all branch types and both series/parallel modes inherit them. Frequency-dependent by construction — a fixed `r` can't express ωL/Q across a sweep.
- A lossy parallel tank now tops out at the textbook ≈ Q·ω₀L at resonance instead of opening completely; defaults (`None`) stay bit-identical to the ideal expressions.
- PyNEC routing: a finite-Q `Load` diverts to the shared reducer path (baked `ld_card` values would freeze the loss resistance at the first frequency of a sweep); `native_nt` rejects finite-Q branches with a clear error for the same reason.
- Both tuner designs grow a `coil_q` knob (0 = ideal, the historical default; slider to 400): `skyloop_lmatch`'s series arm and `inverted_l_tmatch`'s tee inductor — where a T-network's circulating current makes coil loss the classic hidden tuner cost.

## Test plan
- [x] 8 new oracles in `tests/test_finite_q.py`: exact ωL/Q and ESR values, lossy-tank resonance ceiling (rel 2/Q), bit-identical defaults, Zin shifted by exactly the coil's loss resistance through the MNA solve (1e-12), shunt-coil dissipation raising p_in, coil_q knob wiring in both tuner designs, and the native-vs-reducer routing split on a trap dipole
- [x] Full suite: 1498 passed
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)