### PR TITLE
Per-branch power budget: itemized network dissipation + consistent efficiency

### DIFF
--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -145,6 +145,21 @@ was actually used, and over a finite ground the
 [norm check](#norm-check--is-the-solve-trustworthy) Δ reads "incl. ground
 loss" — a steady dB or so there is absorbed power, not error.
 
+## Power budget
+
+Designs with a lossy feed network — a real coax or ladder-line run, a
+matching network with a finite-Q coil, a terminating resistor — get a
+**power budget** table in the solve readout: one row per network branch
+with the fraction of the source's input power it dissipates, plus an
+**antenna (radiated)** row for what actually reaches the wires. The rows
+come straight from the MNA network solve (each branch current is an
+explicit unknown, so the watts are read off the solution, not modelled
+separately), and the same accounting drives the reported radiation
+efficiency: **every** dissipative branch counts, including resistive
+coupling and matching elements, not just explicit `Load`s. Gain is
+normalised by input power, so network loss already shows up in dBi;
+the budget tells you *where* it went. Lossless networks hide the table.
+
 ## Convergence sweep
 
 To check that your chosen N is **converged** — i.e. adding more segments no

--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -622,10 +622,25 @@ def cli(arguments=None):
     def f(args):
         builder = get_builder(args.builder)
         engine = engine_factory_from_args(args)
+        eng = engine(builder())
         if args.wireframe:
-            pattern3d(engine(builder()), fn=args.fn)
+            pattern3d(eng, fn=args.fn)
         else:
-            pattern(engine(builder()), elevation_angle=args.elevation_angle, fn=args.fn)
+            pattern(eng, elevation_angle=args.elevation_angle, fn=args.fn)
+        # Power budget (issue #299): where the source watts went, from the
+        # excited solve the pattern just ran. Only printed when the design
+        # has a network with something to report.
+        budget = getattr(eng, "_excited_power_budget", None)
+        p_in = getattr(eng, "_excited_p_in", None)
+        if budget and p_in:
+            print(f"input power: {p_in * 1e3:.4g} mW")
+            p_network = 0.0
+            for label, w in budget:
+                w = max(0.0, w)
+                p_network += w
+                print(f"  {label}: {w * 1e3:.4g} mW ({w / p_in:.1%})")
+            p_ant = p_in - p_network
+            print(f"  antenna (radiated): {p_ant * 1e3:.4g} mW ({p_ant / p_in:.1%})")
 
     p.set_defaults(func=f)
 

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -415,15 +415,19 @@ class MomwireEngine(SimulationEngine):
             # and the source input power the far field uses to normalise
             # gain.
             Y = self._compute_y_matrix(wavelength)
-            V_full, self._excited_efficiency, self._excited_p_in = (
-                self._reducer.excited_state(Y, wavelength)
-            )
+            (
+                V_full,
+                self._excited_efficiency,
+                self._excited_p_in,
+                self._excited_power_budget,
+            ) = self._reducer.excited_state(Y, wavelength)
             feeds_resolved = [
                 (w, arc, complex(V_full[i]))
                 for i, (w, arc, _v) in enumerate(self._feeds)
             ]
         elif self._tls:
             self._excited_efficiency = 1.0
+            self._excited_power_budget = []
             Y = self._compute_y_matrix(wavelength)
             Y_total = self._apply_tls(Y, wavelength)
             V, driven = self._resolve_feed_voltages(Y_total)
@@ -439,6 +443,7 @@ class MomwireEngine(SimulationEngine):
             ]
         else:
             self._excited_efficiency = 1.0
+            self._excited_power_budget = []
             # Plain path: no port model here; input_power() derives P_in from
             # the excited solve's driving-point impedance(s) on demand.
             self._excited_p_in = None

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -80,6 +80,7 @@ class PyNECEngine(SimulationEngine):
         # NEC's own get_gain so engine-switching keeps the pattern meaning
         # the same thing. 1.0 = no resistive loss.
         self._excited_efficiency = 1.0
+        self._excited_power_budget = []
         # Source input power 1/2·Re(Σ V·I*) in watts from the same solve; the
         # web gain normaliser is η₀k²/(8π·P_in). None until a solve runs.
         self._excited_p_in = None
@@ -414,10 +415,11 @@ class PyNECEngine(SimulationEngine):
         return sc.get_current()[matches[seg - 1]]
 
     def _radiation_efficiency(self, sc, wavelength):
-        """Return ``(efficiency, p_in)``: the fraction of source input power
-        radiated rather than burned in explicit resistive Load branches
-        (1.0 when there are none), and the source input power
-        1/2·Re(Σ V·I*) itself in watts (the gain normaliser 4π·U/P_in).
+        """Return ``(efficiency, p_in, budget)``: the fraction of source
+        input power radiated rather than burned in the network (1.0 when it
+        is lossless), the source input power 1/2·Re(Σ V·I*) itself in watts
+        (the gain normaliser 4π·U/P_in), and the per-branch power budget
+        [(label, watts)] (issue #299).
 
         This mirrors MomwireEngine so the web UI normalises the far-field
         cut identically on either engine. The efficiency matches NEC's own
@@ -435,8 +437,8 @@ class PyNECEngine(SimulationEngine):
         # reducer; reuse its port-level efficiency and input power.
         if self._network is not None and self._use_reducer:
             Y = self._compute_y_matrix(wavelength)
-            _v, efficiency, p_in = self._reducer.excited_state(Y, wavelength)
-            return efficiency, p_in
+            _v, efficiency, p_in, budget = self._reducer.excited_state(Y, wavelength)
+            return efficiency, p_in, budget
         # Native path: source input power from NEC's ANTENNA INPUT
         # PARAMETERS (index 0 — `sc` always comes from the single-frequency
         # solve here). NEC's per-source power uses the network-corrected
@@ -451,14 +453,17 @@ class PyNECEngine(SimulationEngine):
             else []
         )
         if not loads or p_in <= 0.0:
-            return 1.0, p_in
+            return 1.0, p_in, []
         omega = 2.0 * np.pi * C_LIGHT / wavelength
         p_diss = 0.0
+        budget = []
         for br in loads:
             tag, seg = self._network_port_loc[br.port]
             cur = self._port_current(sc, tag, seg)
-            p_diss += 0.5 * load_impedance(br, omega).real * abs(cur) ** 2
-        return max(0.0, min(1.0, 1.0 - p_diss / p_in)), p_in
+            w = 0.5 * load_impedance(br, omega).real * abs(cur) ** 2
+            budget.append((f"Load {br.port}", w))
+            p_diss += w
+        return max(0.0, min(1.0, 1.0 - p_diss / p_in)), p_in, budget
 
     def _compute_y_matrix(self, wavelength):
         """Multiport short-circuit Y at the real ports, via one NEC solve per
@@ -578,9 +583,11 @@ class PyNECEngine(SimulationEngine):
             self.c = self._excited_real_context(C_LIGHT / (self.builder.freq * 1e6))
         self._set_freq_and_execute()
         sc = self.c.get_structure_currents(0)
-        self._excited_efficiency, self._excited_p_in = self._radiation_efficiency(
-            sc, C_LIGHT / (self.builder.freq * 1e6)
-        )
+        (
+            self._excited_efficiency,
+            self._excited_p_in,
+            self._excited_power_budget,
+        ) = self._radiation_efficiency(sc, C_LIGHT / (self.builder.freq * 1e6))
         all_tags = list(sc.get_current_segment_tag())
         all_cur = sc.get_current()
 

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -153,7 +153,7 @@ class MNASystem:
     impedance is ``emf / j[column]`` read straight off the solution.
     """
 
-    def __init__(self, G, elements, terminations):
+    def __init__(self, G, elements, terminations, probes=None):
         n = G.shape[0]
         m = len(elements)
         A = np.zeros((n + m, n + m), dtype=np.complex128)
@@ -173,7 +173,37 @@ class MNASystem:
         self.A = A
         self.rhs = rhs
         self.terminations = terminations
+        self.elements = elements
+        # (label, kind, payload) probes for the power budget (issue #299):
+        # kind "group1" → payload (node_idx_list, stamped Y block);
+        # kind "group2" → payload element index; kind "termination" →
+        # payload node index (dissipation = the Load part of the branch).
+        self.probes = probes or []
         self._solution = None
+
+    def branch_power(self, label_kind_payload):
+        """Time-average power in watts dissipated in one probed branch of
+        the SOLVED system (issue #299). Group-1 stamps: ½·Re(v†·Y_br·v)
+        over the branch's own stamped block (≈ 0 for a lossless TL, > 0
+        for a lossy one). Group-2 elements: ½·Re((v_a − v_b)·j*), the drop
+        across the element times its explicit branch current — exact in
+        both impedance and admittance form, including shorts and opens.
+        Terminations: ½·Re((E − v_k)·j*), the drop across the Load part
+        (the EMF term is the port's input power, not dissipation)."""
+        v, j = self.solve()
+        label, kind, payload = label_kind_payload
+        if kind == "group1":
+            nodes, y_block = payload
+            vb = v[nodes]
+            return 0.5 * float(np.real(np.conj(vb) @ (y_block @ vb)))
+        if kind == "group2":
+            el = self.elements[payload]
+            va = 0j if el.a is None else v[el.a]
+            vb = 0j if el.b is None else v[el.b]
+            return 0.5 * float(np.real((va - vb) * np.conj(j[payload])))
+        # termination: the Load part of the source/load branch at node k.
+        col, e = self.terminations[payload]
+        return 0.5 * float(np.real((e - v[payload]) * np.conj(j[col])))
 
     def solve(self):
         """Solve once (cached); returns ``(v, j)``."""
@@ -250,10 +280,11 @@ class NetworkReducer:
 
         elements = []
         loads_by_node = {}
+        probes = []
         for br in self.network.branches:
             if isinstance(br, TL):
                 a, b = self.port_to_idx[br.a], self.port_to_idx[br.b]
-                G[np.ix_([a, b], [a, b])] += tl_admittance_2x2(
+                y_tl = tl_admittance_2x2(
                     br.z0,
                     br.length,
                     wavelength,
@@ -262,18 +293,26 @@ class NetworkReducer:
                     k1=br.k1,
                     k2=br.k2,
                 )
+                G[np.ix_([a, b], [a, b])] += y_tl
+                probes.append((f"TL {br.a}→{br.b}", "group1", ([a, b], y_tl)))
             elif isinstance(br, TwoPort):
                 a, b = self.port_to_idx[br.a], self.port_to_idx[br.b]
+                probes.append((f"TwoPort {br.a}→{br.b}", "group2", len(elements)))
                 elements.append(
                     _series_group2(a, b, br.r, br.l, br.c, omega, ql=br.ql, qc=br.qc)
                 )
             elif isinstance(br, Shunt):
                 k = self.port_to_idx[br.port]
                 if br.parallel:
-                    G[k, k] += _parallel_rlc_admittance(
+                    y_sh = _parallel_rlc_admittance(
                         br.r, br.l, br.c, omega, br.ql, br.qc
                     )
+                    G[k, k] += y_sh
+                    probes.append(
+                        (f"Shunt {br.port}", "group1", ([k], np.array([[y_sh]])))
+                    )
                 else:
+                    probes.append((f"Shunt {br.port}", "group2", len(elements)))
                     elements.append(
                         _series_group2(
                             k, None, br.r, br.l, br.c, omega, ql=br.ql, qc=br.qc
@@ -313,8 +352,11 @@ class NetworkReducer:
                 el = _Group2Element(None, k, c_v=0j, c_j=1.0 + 0j, e=0j)
             terminations[k] = (len(elements), e)
             elements.append(el)
+            if loads:
+                names = [br.port for br in loads]
+                probes.append((f"Load {'+'.join(names)}", "termination", k))
 
-        return MNASystem(G, elements, terminations)
+        return MNASystem(G, elements, terminations, probes=probes)
 
     def resolve_voltages(self, system):
         """Return the (n_total,) physical port-voltage vector of the solved
@@ -327,43 +369,57 @@ class NetworkReducer:
         return v.copy()
 
     def excited_state(self, Y_real, wavelength):
-        """Physical port voltages + radiation efficiency for the CURRENT-
-        DISTRIBUTION / far-field solve — the same MNA solve as the
-        impedance path, read out for power bookkeeping.
+        """Physical port voltages + radiation efficiency + per-branch power
+        budget for the CURRENT-DISTRIBUTION / far-field solve — the same
+        MNA solve as the impedance path, read out for power bookkeeping.
 
-        Returns ``(V_full, efficiency, p_in)``:
+        Returns ``(V_full, efficiency, p_in, budget)``:
           V_full      -- (n_total,) port voltages to force in the excited solver
           efficiency  -- P_radiated / P_input = 1 - P_dissipated / P_input, the
                          fraction of input power radiated rather than burned in
-                         resistive loads. A load-free / lossless network
+                         the network. A load-free / lossless network
                          returns 1.0.
           p_in        -- input power 1/2 Re(Σ V_src · I*) in watts, the gain
                          normaliser (gain = 4π·U/P_in); it already includes the
-                         power burned in resistive loads.
+                         power burned in the network.
+          budget      -- list of ``(label, watts)`` per network branch, in
+                         branch order (issue #299): TL and parallel-Shunt
+                         stamps via ½·Re(v†·Y_br·v), TwoPort/series-Shunt
+                         via their explicit branch currents, Loads via the
+                         termination drop. Lossless branches report ~0.
+                         Power delivered to the antenna (radiated + any
+                         wire/ground loss inside the MoM solve) is
+                         p_in − Σ watts.
 
-        The termination branches carry the physical port currents, so both
-        power sums read directly off the solution vector:
+        The termination branches carry the physical port currents, so the
+        source power reads directly off the solution vector:
 
             p_in   = ½ Σ Re(E_k · j_k*)          (E = 0 terms vanish)
-            p_diss = ½ Σ Re((E_k − v_k) · j_k*)  (the drop across the load
-                                                  part is Z_L·j, so this is
-                                                  ½·Re(Z_L)·|j|² without ever
-                                                  forming a trap's ∞)
 
-        Reactive loads (a loading coil) burn nothing, so they leave
-        efficiency at 1.0. Dissipation in resistive TwoPort/Shunt branches
-        is deliberately NOT counted, matching the pre-MNA accounting; it
-        still lowers gain through p_in.
+        Reactive elements burn nothing and report ~0 in the budget.
+        Efficiency counts EVERY dissipative network branch — resistive
+        TwoPort/Shunt elements and lossy TLs included (issue #299; the
+        pre-#299 accounting counted Load terminations only, so designs
+        with resistive coupling/matching branches now report a lower,
+        physically consistent efficiency).
         """
         system = self.apply_branches(Y_real, wavelength)
         v, j = system.solve()
         p_in = 0.0
-        p_diss = 0.0
         for k, (col, e) in system.terminations.items():
             p_in += 0.5 * float(np.real(e * np.conj(j[col])))
-            p_diss += 0.5 * float(np.real((e - v[k]) * np.conj(j[col])))
+        budget = [
+            (label, system.branch_power((label, kind, payload)))
+            for label, kind, payload in system.probes
+        ]
+        p_diss = sum(w for _label, w in budget)
+        # A lossless network's probes read pure float noise (|w| ~ 1e-17·p_in
+        # from the reactive TL stamp); snap that to exactly 1.0 so lossless
+        # designs keep reporting unity efficiency.
+        if p_in > 0.0 and abs(p_diss) <= 1e-9 * p_in:
+            p_diss = 0.0
         efficiency = 1.0 if p_in <= 0.0 else max(0.0, min(1.0, 1.0 - p_diss / p_in))
-        return v.copy(), efficiency, p_in
+        return v.copy(), efficiency, p_in, budget
 
     def impedance_from_y(self, system):
         """Driven-point impedance per Driven source from an `apply_branches`

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -1196,6 +1196,13 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             # has resistive loads, e.g. a terminated rhombic / T2FD);
             # current_distribution() above populated it on the engine.
             "radiation_efficiency": float(getattr(eng, "_excited_efficiency", 1.0)),
+            # Per-branch network dissipation [(label, watts)] from the MNA
+            # solve (issue #299); empty for plain / lossless designs. Tiny
+            # negative float noise from reactive stamps is clamped to 0.
+            "power_budget": [
+                {"label": label, "watts": max(0.0, float(w))}
+                for label, w in (getattr(eng, "_excited_power_budget", None) or [])
+            ],
             # Source input power in watts: the server's gain normaliser is
             # η₀k²/(8π·P_in), which is what makes the plot GAIN (load and
             # ground losses live inside P_in, so no efficiency multiply).
@@ -1361,6 +1368,10 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             # keeps the far-field plot meaning GAIN. current_distribution()
             # set both from the solved feed/load currents.
             "radiation_efficiency": float(getattr(eng, "_excited_efficiency", 1.0)),
+            "power_budget": [
+                {"label": label, "watts": max(0.0, float(w))}
+                for label, w in (getattr(eng, "_excited_power_budget", None) or [])
+            ],
             "input_power_w": float(getattr(eng, "_excited_p_in", None) or 0.0),
         }
         if hints()["multi_feed"] and len(zs) > 1:

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1183,6 +1183,12 @@ type SolveResponse = {
    *  readout's ground row shows this rather than re-deriving it from
    *  backend + groundType state. */
   ground_model_applied?: string;
+  /** Per-branch network dissipation from the MNA solve (issue #299):
+   *  one entry per TL / TwoPort / Shunt / Load branch, in watts for the
+   *  canonical 1 V drive. Absent or all-~0 for plain and lossless
+   *  designs; input_power_w is the 100% reference. */
+  power_budget?: { label: string; watts: number }[];
+  input_power_w?: number;
   k_meas_m_inv?: number;
   // V-specific
   arm_len_m?: number;
@@ -5708,6 +5714,38 @@ function SolveReadout({
             : "—"}
         </span>
       </div>
+      {(() => {
+        // Power budget (issue #299): where the input watts go, per network
+        // branch. Hidden unless the network actually dissipates something
+        // (lossless branches report float noise only).
+        const budget = result?.power_budget;
+        const pin = result?.input_power_w;
+        if (!budget || budget.length === 0 || !pin || pin <= 0) return null;
+        const diss = budget.reduce((s, b) => s + b.watts, 0);
+        if (diss < 1e-6 * pin) return null;
+        return (
+          <div
+            className="feeds-table"
+            title="Fraction of the source input power dissipated in each network branch (from the MNA solve); the antenna row is the remainder that reaches the wires."
+          >
+            <div className="feeds-table-header">power budget</div>
+            {budget.map((b, i) => (
+              <div className="row" key={`pb-${i}`}>
+                <span>{b.label}</span>
+                <span className="val">
+                  {((b.watts / pin) * 100).toFixed(1)}%
+                </span>
+              </div>
+            ))}
+            <div className="row" key="pb-ant">
+              <span>antenna (radiated)</span>
+              <span className="val">
+                {(((pin - diss) / pin) * 100).toFixed(1)}%
+              </span>
+            </div>
+          </div>
+        );
+      })()}
       <div className="row">
         <span>rtt</span>
         <span className="val">{rttMs != null ? `${rttMs.toFixed(1)} ms` : "—"}</span>

--- a/tests/test_finite_q.py
+++ b/tests/test_finite_q.py
@@ -99,7 +99,7 @@ def test_lossy_shunt_coil_dissipates_power():
             sources=[Driven("ant", 1 + 0j)],
         )
         reducer = NetworkReducer(net, {"ant": 0}, 1)
-        _v, _eff, p = reducer.excited_state(np.array([[1.0 / 5000.0]]), WL)
+        _v, _eff, p, *_ = reducer.excited_state(np.array([[1.0 / 5000.0]]), WL)
         return p
 
     assert p_in(50.0) > p_in(None)

--- a/tests/test_lossy_tl.py
+++ b/tests/test_lossy_tl.py
@@ -46,7 +46,7 @@ def _gamma(tl, wavelength):
 def _powers(reducer, z_ant):
     """(p_in at the rig, power delivered into the antenna resistance)."""
     y_real = np.array([[1.0 / z_ant]], dtype=np.complex128)
-    v, _eff, p_in = reducer.excited_state(y_real, WL)
+    v, _eff, p_in, *_ = reducer.excited_state(y_real, WL)
     p_ant = 0.5 * abs(v[0]) ** 2 * np.real(1.0 / z_ant)
     return p_in, p_ant
 

--- a/tests/test_network_mna.py
+++ b/tests/test_network_mna.py
@@ -90,7 +90,7 @@ def test_bare_driven_port():
     y = synth_y(1, 0)
     red = reducer(net, 1)
     assert red.driven_impedance(y, WL)[0] == pytest.approx(1.0 / y[0, 0], rel=1e-12)
-    v, eff, p_in = red.excited_state(y, WL)
+    v, eff, p_in, *_ = red.excited_state(y, WL)
     assert v[0] == pytest.approx(1.0)
     assert eff == 1.0
     assert p_in == pytest.approx(0.5 * float(np.real(np.conj(y[0, 0]))), rel=1e-12)
@@ -139,7 +139,7 @@ def test_virtual_driver_with_tl_matches_line_transform():
     z_expect = z0 * (z_l + 1j * z0 * t) / (z0 + 1j * z_l * t)
     red = reducer(net, 1)
     assert red.driven_impedance(y, WL)[0] == pytest.approx(z_expect, rel=1e-9)
-    _v, eff, _p = red.excited_state(y, WL)
+    _v, eff, _p, *_ = red.excited_state(y, WL)
     assert eff == 1.0
 
 
@@ -190,7 +190,7 @@ def test_twoport_bridge():
     assert red.driven_impedance(y, WL)[0] == pytest.approx(
         v_ref[0] / i_ref[0], rel=1e-9
     )
-    v, _eff, _p = red.excited_state(y, WL)
+    v, _eff, _p, *_ = red.excited_state(y, WL)
     np.testing.assert_allclose(v, v_ref, rtol=1e-9)
 
 
@@ -259,7 +259,7 @@ def test_series_load_terminated_port():
     assert red.driven_impedance(y, WL)[0] == pytest.approx(
         v_ref[0] / i_ref[0], rel=1e-9
     )
-    v, eff, p_in = red.excited_state(y, WL)
+    v, eff, p_in, *_ = red.excited_state(y, WL)
     np.testing.assert_allclose(v, v_ref, rtol=1e-9)
     p_in_ref = 0.5 * float(np.real(v_ref[0] * np.conj(i_ref[0])))
     p_diss_ref = 0.5 * r_l * abs(v_ref[1] / r_l) ** 2
@@ -281,7 +281,7 @@ def test_driven_and_loaded_same_port():
     z_ant = 1.0 / y[0, 0]
     red = reducer(net, 1)
     assert red.driven_impedance(y, WL)[0] == pytest.approx(z_l + z_ant, rel=1e-9)
-    v, eff, p_in = red.excited_state(y, WL)
+    v, eff, p_in, *_ = red.excited_state(y, WL)
     i = 1.0 / (z_l + z_ant)
     assert v[0] == pytest.approx(z_ant * i, rel=1e-9)  # physical gap voltage
     assert p_in == pytest.approx(0.5 * float(np.real(np.conj(i))), rel=1e-9)
@@ -306,7 +306,7 @@ def test_parallel_trap_load_off_resonance():
     assert red.driven_impedance(y, WL)[0] == pytest.approx(
         v_ref[0] / i_ref[0], rel=1e-9
     )
-    v, _eff, _p = red.excited_state(y, WL)
+    v, _eff, _p, *_ = red.excited_state(y, WL)
     np.testing.assert_allclose(v, v_ref, rtol=1e-9)
 
 
@@ -353,7 +353,7 @@ def test_everything_at_once():
     red = reducer(net, 4)
     z = red.driven_impedance(y, WL)
     np.testing.assert_allclose(z, v_ref[[4, 1]] / i_ref[[4, 1]], rtol=1e-9)
-    v, _eff, _p = red.excited_state(y, WL)
+    v, _eff, _p, *_ = red.excited_state(y, WL)
     np.testing.assert_allclose(v, v_ref, rtol=1e-9)
 
 
@@ -471,7 +471,7 @@ def test_trap_load_at_exact_resonance_is_open():
     )
     y = synth_y(2, 5)
     red = reducer(net, 2)
-    v, eff, p_in = red.excited_state(y, WL)
+    v, eff, p_in, *_ = red.excited_state(y, WL)
     assert np.all(np.isfinite(v)) and np.isfinite(p_in)
     assert eff == pytest.approx(1.0)  # an open burns nothing
     # Open termination at the arm: the arm port floats (I_ext = 0), the same

--- a/tests/test_power_budget.py
+++ b/tests/test_power_budget.py
@@ -1,0 +1,125 @@
+"""Per-branch power budget (issue #299).
+
+The MNA solve carries every branch current explicitly, so "where did the
+watts go" is a readout: excited_state now returns a per-branch (label,
+watts) budget, and efficiency counts EVERY dissipative network branch —
+resistive TwoPort/Shunt elements and lossy TLs included, not just Load
+terminations (the pre-#299 parity gap).
+"""
+
+import numpy as np
+
+from antennaknobs.designs.arrays.lumped_coupled_pair import Builder as CoupledPair
+from antennaknobs.network import (
+    TL,
+    Driven,
+    Load,
+    Network,
+    PortAtEdge,
+    PortVirtual,
+    Shunt,
+    TwoPort,
+)
+from antennaknobs.network_reduce import C_LIGHT, NetworkReducer
+
+F_MHZ = 10.0
+WL = C_LIGHT / (F_MHZ * 1e6)
+OMEGA = 2.0 * np.pi * F_MHZ * 1e6
+
+
+def _station_reducer():
+    """Rig → lossy coax → lossy L-match → antenna: one of everything."""
+    net = Network(
+        ports={
+            "ant": PortAtEdge("ant"),
+            "tuner": PortVirtual("tuner"),
+            "rig": PortVirtual("rig"),
+        },
+        branches=[
+            TL("rig", "tuner", z0=50.0, length=30.48, vf=0.66, k1=0.40, k2=0.008),
+            TwoPort(a="tuner", b="ant", l=2.2e-6, ql=100.0),
+            Shunt(port="tuner", c=150e-12, qc=500.0),
+            Load(port="ant", r=10.0),
+        ],
+        sources=[Driven("rig", 1 + 0j)],
+    )
+    return NetworkReducer(net, {"ant": 0, "tuner": 1, "rig": 2}, 3)
+
+
+def test_budget_sums_to_p_in():
+    """radiated (= power into the antenna Y) + every branch's watts = p_in."""
+    reducer = _station_reducer()
+    z_ant = 60.0 + 25.0j
+    y_real = np.array([[1.0 / z_ant]], dtype=np.complex128)
+    v, eff, p_in, budget = reducer.excited_state(y_real, WL)
+    p_ant = 0.5 * abs(v[0]) ** 2 * np.real(1.0 / z_ant)
+    p_network = sum(w for _l, w in budget)
+    np.testing.assert_allclose(p_ant + p_network, p_in, rtol=1e-12)
+    # One entry per branch, labelled, every one dissipative here.
+    labels = [label for label, _w in budget]
+    assert labels == ["TL rig→tuner", "TwoPort tuner→ant", "Shunt tuner", "Load ant"]
+    assert all(w > 0 for _l, w in budget)
+    # Consistent efficiency: 1 - all network dissipation / p_in.
+    np.testing.assert_allclose(eff, 1.0 - p_network / p_in, rtol=1e-12)
+
+
+def test_lossless_network_reports_unity_and_zero_watts():
+    net = Network(
+        ports={"ant": PortAtEdge("ant"), "rig": PortVirtual("rig")},
+        branches=[
+            TL("rig", "ant", z0=50.0, length=13.0),
+            Shunt(port="ant", c=20e-12),
+        ],
+        sources=[Driven("rig", 1 + 0j)],
+    )
+    reducer = NetworkReducer(net, {"ant": 0, "rig": 1}, 2)
+    _v, eff, p_in, budget = reducer.excited_state(
+        np.array([[1.0 / 50.0]], dtype=np.complex128), WL
+    )
+    assert eff == 1.0
+    assert p_in > 0
+    for _label, w in budget:
+        assert abs(w) < 1e-12 * p_in  # float noise only
+
+
+def test_load_only_efficiency_matches_the_pre_299_accounting():
+    """For Load-only networks the termination probe IS the old p_diss sum,
+    so the shipped efficiency numbers (T2FD, terminated designs) hold."""
+    net = Network(
+        ports={"feed": PortAtEdge("feed"), "term": PortAtEdge("term")},
+        branches=[Load(port="term", r=390.0)],
+        sources=[Driven("feed", 1 + 0j)],
+    )
+    reducer = NetworkReducer(net, {"feed": 0, "term": 1}, 2)
+    y = np.array([[0.02, -0.015], [-0.015, 0.02]], dtype=np.complex128)
+    v, eff, p_in, budget = reducer.excited_state(y, WL)
+    (label, w) = budget[0]
+    assert label == "Load term"
+    # Recompute the old Load-only accounting directly: ½Re((E−v)·j*) over
+    # terminations with E=0 at the loaded port.
+    system = reducer.apply_branches(y, WL)
+    v2, j2 = system.solve()
+    col, e = system.terminations[1]
+    old = 0.5 * float(np.real((e - v2[1]) * np.conj(j2[col])))
+    np.testing.assert_allclose(w, old, rtol=1e-12)
+    np.testing.assert_allclose(eff, 1.0 - old / p_in, rtol=1e-12)
+
+
+def test_coupled_pair_coupling_resistor_now_counts():
+    """lumped_coupled_pair bridges its feeds with a series R+jωL TwoPort.
+    Pre-#299 the R burned power (visible in gain via p_in) while efficiency
+    read 1.0; now the budget itemizes it and efficiency drops below 1."""
+    from antennaknobs.engines import MomwireEngine
+    from momwire import SinusoidalSolver
+
+    eng = MomwireEngine(CoupledPair(), ground=None, solver=SinusoidalSolver)
+    eng.current_distribution()
+    budget = eng._excited_power_budget
+    assert len(budget) == 1 and budget[0][0].startswith("TwoPort")
+    assert budget[0][1] > 0
+    assert 0.0 < eng._excited_efficiency < 1.0
+    np.testing.assert_allclose(
+        eng._excited_efficiency,
+        1.0 - budget[0][1] / eng._excited_p_in,
+        rtol=1e-9,
+    )


### PR DESCRIPTION
## Summary
- Third piece of the station-modelling arc (#299; follows #297 lossy TL and #298 finite-Q). The MNA solve carries every branch current explicitly, so the budget is a readout, not a solver change: `apply_branches` attaches a labelled probe per branch, `MNASystem.branch_power` reads each branch's watts off the solved system (Group-2 elements via ½·Re((v_a−v_b)·j*); TL and parallel-Shunt stamps via ½·Re(v†·Y_br·v); Loads via the termination drop), and `excited_state` now returns a `(label, watts)` budget alongside V/efficiency/p_in.
- **Deliberate behavior change**: efficiency now counts *every* dissipative network branch — resistive TwoPort/Shunt elements and lossy TLs, not just Load terminations. `lumped_coupled_pair`'s coupling resistor burned power while efficiency read 1.0; it now itemizes the watts and reports efficiency < 1. Load-only designs are numerically unchanged (the termination probe is the old p_diss sum), and a noise snap keeps lossless networks at exactly 1.0. Gain normalisation (η₀k²/8π·P_in) is untouched — this is bookkeeping, not physics.
- Surfaced end to end: both engines stash `_excited_power_budget` (PyNEC's native `ld_card` path builds per-Load entries from its existing port-current loop); the web adapter ships `power_budget` in both solve payloads; the Info pane gets a power-budget table (percent of input power per branch + an "antenna (radiated)" remainder row, hidden for lossless networks); `antennaknobs pattern` prints the same breakdown; web.md documents the readout and the efficiency change.
- Supersedes the "efficiency is Load-only" follow-up noted after the MNA merge (PR #286).

## Test plan
- [x] 4 new oracles in `tests/test_power_budget.py`: a one-of-everything station network (lossy TL + finite-Q L-match + load) whose budget sums to p_in at 1e-12 with correct labels; lossless networks reporting exactly 1.0 and ~0 watts; Load-only accounting pinned equal to the pre-#299 formula; `lumped_coupled_pair` itemizing its coupling R with efficiency < 1 through a real momwire solve
- [x] Full suite: 1502 passed (no existing efficiency pins broke — the parity gap was untested, which is why it existed)
- [x] Frontend `tsc --noEmit && vite build` passes
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)