### PR TITLE
Station showcase designs: invvee + coax vs doublet + open-wire + tuner

### DIFF
--- a/docs/status/2026-07-11-station-loss-comparison.md
+++ b/docs/status/2026-07-11-station-loss-comparison.md
@@ -1,0 +1,70 @@
+# 2026-07-11 — station loss comparison: coax-fed inv-vee vs doublet + open-wire + tuner
+
+Closes the loop on the station-modelling arc (#297 lossy TL, #298 finite-Q
+components, #299 power budget, #300 this comparison). Two designs model the
+whole station from a virtual **rig** port, so impedance, SWR, gain, and the
+power budget are referenced to the transmitter:
+
+- `dipoles.invvee_coax_station` — the stock 28.47 MHz inv-vee + 100 ft of
+  50 Ω coax (cable preset dropdown).
+- `wire.doublet_ladder_tuner` — an 88 ft flat doublet + 100 ft of 600 Ω
+  open-wire line + T-network tuner (series C / shunt L with `coil_q` /
+  series C), stock-tuned for 40 m.
+
+All numbers below: momwire SinusoidalSolver, free space, `line_len_m` =
+30.48 m (100 ft), budget fractions of rig input power. Cross-engine check:
+PyNEC agrees on Z_rig within 0.2 % on both designs at defaults.
+
+## Coax station: the cable is the knob
+
+On its design band the V presents SWR ≈ 1.2 at the rig, so the line runs
+essentially matched — the budget is just the cable's matched loss. Worked
+one band down (24.94 MHz, where the antenna is far off resonance), the
+SWR-multiplied loss appears by itself out of the circuit solve:
+
+| Cable | 28.47 MHz (SWR≈1.2) | 24.94 MHz (off-band) |
+| --- | --- | --- |
+| RG-58 | 57.6 % radiated (−2.4 dB) | 14.3 % (−8.4 dB) |
+| RG-8X (default) | 68.8 % (−1.6 dB) | 20.3 % (−6.9 dB) |
+| RG-213 | 78.3 % (−1.1 dB) | 28.3 % (−5.5 dB) |
+| LMR-400 | 85.7 % (−0.7 dB) | 38.6 % (−4.1 dB) |
+
+Two folklore items land as numbers: coax at 10 m is not cheap even when
+matched (100 ft of RG-8X eats a third of the power), and an off-resonance
+antenna on coax is brutal — the same RG-8X run swallows ~80 %.
+
+## Doublet station: the tuner coil is where multiband is paid for
+
+Stock tune (7.1 MHz, C1 = 74.2 pF, L = 4.70 µH, C2 = 1618 pF, Q = 200)
+lands Z_rig = 50.0 + 0.0j:
+
+| Operating point | line | tuner coil | radiated |
+| --- | --- | --- | --- |
+| 40 m (7.1 MHz), Q=200 | 3.7 % | 4.5 % | **91.8 % (−0.4 dB)** |
+| 40 m, ideal coil (Q=0 knob) | ~3.9 % | 0 | 96.1 % |
+| 80 m retune (3.8 MHz)¹, Q=200 | 14.4 % | 13.7 % | **71.9 % (−1.4 dB)** |
+| 80 m retune, ideal coil | — | 0 | 83.3 % |
+
+¹ 80 m values: C1 = 44.6 pF, L = 27.05 µH, C2 = 6865 pF. At 3.8 MHz the
+88 ft doublet is electrically short (feed ≈ 23 − j504 Ω), so both the
+line's SWR loss and the coil's circulating-current loss climb — the honest
+cost of working a too-short wire. The T-network caps (ideal here) burn
+nothing; the coil is the entire tuner cost, scaling as expected with Q
+(`test_doublet_coil_loss_scales_with_q`).
+
+## The headline
+
+Same 100 ft of feedline, both stations matched at the rig:
+
+- **On a band each is built for**: doublet + open wire + Q-200 tuner
+  radiates 92 % (−0.4 dB); the resonant inv-vee on RG-8X radiates 69 %
+  (−1.6 dB) at 10 m. The "lossy tuner" station *wins* — open-wire line is
+  that much better than coax, and a decent coil costs less than the
+  difference.
+- **Flexibility**: retuned to 80 m the doublet still delivers 72 %; the
+  coax station worked equivalently off-band delivers ~20 %. Ladder line +
+  tuner degrades gracefully; coax + SWR does not.
+
+Every number above is read off the Info pane's power-budget table (or
+`antennaknobs pattern`); nothing is a formula overlay. Pinned by
+`tests/test_station_designs.py`.

--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -19,6 +19,7 @@ after L. B. Cebik (W4RNL)'s articles.
 | `dipoles.dipole_turnstile` | Crossed dipoles fed in phase quadrature |
 | `dipoles.koch_dipole` | Koch fractal dipole |
 | `dipoles.short_dipole_loaded` | Center-loaded shortened dipole (a Load-branch showcase) |
+| `dipoles.invvee_coax_station` | The inv-vee fed through 100 ft of real coax (cable preset dropdown), referenced to the rig — line loss and the SWR penalty in the power budget |
 
 ## Loops
 
@@ -78,6 +79,7 @@ L-network — series L, shunt C — matched to 50 Ω).
 | `wire.w8jk` | W8JK flat-top beam, a 2-element all-driven array |
 | `wire.zepp` | End-fed half-wave "Zepp" with a tuned-stub feeder |
 | `wire.sterba` | Sterba curtain (broadside, bidirectional) — plus the `sterba_tl` transmission-line-phased variant |
+| `wire.doublet_ladder_tuner` | 88 ft doublet + 100 ft of 600 Ω open-wire line + lossy T-network tuner, referenced to the rig — the classic multiband station, with the tuner-coil cost in the power budget |
 
 ## Broadband
 

--- a/src/antennaknobs/designs/dipoles/invvee_coax_station.py
+++ b/src/antennaknobs/designs/dipoles/invvee_coax_station.py
@@ -1,0 +1,68 @@
+"""Inverted-V fed through real coax — the classic "resonant antenna on
+50 Ω line" station, modelled from the rig (issue #300).
+
+Geometry is the stock `dipoles.invvee` (28.47 MHz half-wave V, ~32° droop).
+What changes is the reference plane: the source moves to a virtual **rig**
+port and reaches the feedpoint through `line_len_m` of a real cable from
+the `CABLES` catalog (`TL.from_cable`, issue #297) — so the impedance, SWR,
+gain, and power budget the workbench reports are what the *transmitter*
+sees, not the feedpoint.
+
+On the design frequency the V is near 50 Ω and the line runs close to
+matched: the budget shows roughly the cable's matched loss (~1.6 dB ≈ 31 %
+for 100 ft of RG-8X at 28 MHz — coax at 10 m is not cheap) and nothing
+else. Drag the measurement frequency off resonance and the SWR-multiplied
+line loss appears by itself — it emerges from the MNA circuit solve, not
+from a formula. Swap
+the `cable` preset (dropdown) to compare RG-58 against LMR-400, or pick
+the 450/600 Ω lines to see why open-wire feeders shrug off SWR that would
+cook coax.
+
+The natural comparison partner is `wire.doublet_ladder_tuner` — the same
+question answered the other way (non-resonant doublet + low-loss line +
+lossy tuner).
+"""
+
+from types import MappingProxyType
+
+from ...network import CABLES, TL, Driven, Network, PortAtEdge, PortVirtual
+from .invvee import Builder as InvVee
+
+
+class Builder(InvVee):
+    default_params = MappingProxyType(
+        {
+            **InvVee.default_params,
+            "cable": "RG-8X",
+            "line_len_m": 30.48,  # 100 ft
+            "ui_params": MappingProxyType(
+                {
+                    **InvVee.default_params["ui_params"],
+                    "target_z0": 50.0,
+                    "cable": {"enum_options": tuple(sorted(CABLES))},
+                    "line_len_m": {"min": 3.0, "max": 100.0, "unit": "m"},
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        # Stock inv-vee geometry; the driven gap becomes the named "feed"
+        # port and loses its inline excitation — the source lives at the
+        # virtual rig end of the line instead.
+        wires = []
+        for p0, p1, nseg, ev, *rest in super().build_wires():
+            if ev is not None:
+                wires.append((p0, p1, nseg, None, "feed"))
+            else:
+                wires.append((p0, p1, nseg, ev, *rest))
+        return wires
+
+    def build_network(self):
+        return Network(
+            ports={"feed": PortAtEdge("feed"), "rig": PortVirtual("rig")},
+            branches=[
+                TL.from_cable(self.cable, "rig", "feed", self.line_len_m),
+            ],
+            sources=[Driven(port="rig", voltage=1 + 0j)],
+        )

--- a/src/antennaknobs/designs/wire/doublet_ladder_tuner.py
+++ b/src/antennaknobs/designs/wire/doublet_ladder_tuner.py
@@ -1,0 +1,103 @@
+"""88 ft doublet + 100 ft of 600 Ω open-wire line + lossy T-network tuner —
+the "non-resonant wire and a matchbox" station, modelled from the rig
+(issue #300).
+
+The other half of the comparison with `dipoles.invvee_coax_station`: instead
+of a resonant antenna on 50 Ω coax, a deliberately non-resonant flat doublet
+(88 ft ≈ 26.8 m total, `design_freq` 5.593 MHz sizes it) feeds 100 ft of
+`openwire-600` ladder line (issue #297) into a T-network — series C, shunt L,
+series C, the `inverted_l_tmatch` topology — whose inductor has a finite
+`coil_q` (issue #298). The source sits at the virtual **rig** node, so
+impedance, SWR, gain, and the power budget (issue #299) are all referenced to
+the transmitter.
+
+Stock values match ~50 Ω at 7.1 MHz (40 m): the readout shows SWR ≈ 1 while
+the budget itemizes where the watts actually go — with Q = 200 about 4 % in
+the line and 4–5 % in the tuner coil, ~92 % radiated. Retune for 80 m
+(3.8 MHz: C1 ≈ 44.6 pF, L ≈ 27.05 µH, C2 ≈ 6865 pF) and the same doublet is
+electrically short: the line's SWR loss and the coil loss each climb to
+~14 %, the honest cost of working a too-short wire. The classic folklore —
+"open-wire line shrugs off SWR, the tuner coil is where multiband
+flexibility is paid for" — falls out of the circuit solve as numbers.
+
+T-network caveats inherited from `inverted_l_tmatch`: the degenerate slider
+endpoints are physics (a 0 pF series cap is an open — `series_c1_pF = 0`
+open-circuits the source, reported as Z = ∞), and T-match solutions are not
+unique — bigger capacitors with a smaller L generally mean less circulating
+current and lower coil loss.
+"""
+
+from types import MappingProxyType
+
+from ...network import TL, Driven, Network, PortAtEdge, PortVirtual, Shunt, TwoPort
+from ..dipoles.invvee import Builder as InvVee
+
+
+class Builder(InvVee):
+    default_params = MappingProxyType(
+        {
+            **InvVee.default_params,
+            # 88 ft flat doublet: 0.25·λ(5.593 MHz)·1.0 = 13.41 m per side.
+            "design_freq": 5.593,
+            "freq": 7.1,
+            "angle_deg": 0.0,
+            "length_factor": 1.0,
+            "base": 10.0,
+            # Feedline: 100 ft of 600 Ω open-wire line.
+            "line_len_m": 30.48,
+            # T-network, tuned for ~50 Ω at 7.1 MHz on the stock doublet
+            # (see the 80 m retune in the module docstring).
+            "series_c1_pF": 74.16,
+            "shunt_l_uH": 4.7007,
+            "series_c2_pF": 1617.7,
+            # Tuner coil Q (issue #298). Defaults LOSSY — the point of this
+            # design is seeing the tuner cost; set 0 for the ideal coil.
+            "coil_q": 200.0,
+            "ui_params": MappingProxyType(
+                {
+                    **InvVee.default_params["ui_params"],
+                    "target_z0": 50.0,
+                    "angle_deg": {"hidden": True},
+                    "line_len_m": {"min": 3.0, "max": 100.0, "unit": "m"},
+                    # Ranges span the 40 m stock tune AND the 80 m retune.
+                    "series_c1_pF": {"min": 5.0, "max": 500.0},
+                    "shunt_l_uH": {"min": 0.5, "max": 40.0},
+                    "series_c2_pF": {"min": 100.0, "max": 10000.0},
+                    "coil_q": {"min": 0.0, "max": 400.0},
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        # Flat-doublet geometry from the inv-vee builder (angle 0); the
+        # driven gap becomes the named "feed" port and loses its inline
+        # excitation — the source lives at the virtual rig node.
+        wires = []
+        for p0, p1, nseg, ev, *rest in super().build_wires():
+            if ev is not None:
+                wires.append((p0, p1, nseg, None, "feed"))
+            else:
+                wires.append((p0, p1, nseg, ev, *rest))
+        return wires
+
+    def build_network(self):
+        return Network(
+            ports={
+                "feed": PortAtEdge("feed"),
+                "li": PortVirtual("li"),  # line input (tuner output)
+                "m": PortVirtual("m"),  # tee midpoint
+                "rig": PortVirtual("rig"),
+            },
+            branches=[
+                TL.from_cable("openwire-600", "li", "feed", self.line_len_m),
+                TwoPort(a="rig", b="m", c=self.series_c1_pF * 1e-12),
+                Shunt(
+                    port="m",
+                    l=self.shunt_l_uH * 1e-6,
+                    ql=self.coil_q if self.coil_q > 0 else None,
+                ),
+                TwoPort(a="m", b="li", c=self.series_c2_pF * 1e-12),
+            ],
+            sources=[Driven(port="rig", voltage=1 + 0j)],
+        )

--- a/tests/test_station_designs.py
+++ b/tests/test_station_designs.py
@@ -1,0 +1,102 @@
+"""Station showcase designs (issue #300): invvee + real coax vs doublet +
+open-wire line + lossy T-network tuner, both referenced to a virtual rig
+port. Exercises the whole arc at once: lossy TL (#297), finite-Q coil
+(#298), and the power budget (#299), cross-checked on both engines.
+"""
+
+import numpy as np
+import pytest
+
+from antennaknobs.designs.dipoles.invvee_coax_station import Builder as CoaxStation
+from antennaknobs.designs.wire.doublet_ladder_tuner import Builder as DoubletStation
+from antennaknobs.network import CABLES
+
+
+def _momwire(builder):
+    from antennaknobs.engines import MomwireEngine
+    from momwire import SinusoidalSolver
+
+    return MomwireEngine(builder, ground=None, solver=SinusoidalSolver)
+
+
+def _with_params(cls, **overrides):
+    return cls(params={**cls.default_params, **overrides})
+
+
+def _budget_fractions(eng):
+    eng.current_distribution()
+    p_in = eng._excited_p_in
+    return {label: max(0.0, w) / p_in for label, w in eng._excited_power_budget}
+
+
+def test_designs_are_discoverable():
+    from antennaknobs.cli import list_builtin_designs
+
+    names = set(list_builtin_designs())
+    assert "dipoles.invvee_coax_station" in names
+    assert "wire.doublet_ladder_tuner" in names
+
+
+def test_coax_station_line_loss_brackets_matched_loss_on_resonance():
+    """Near-matched (SWR ≈ 1.2 at 28.47 MHz), the single TL entry sits just
+    above the cable's matched loss and well below 1 dB extra."""
+    eng = _momwire(CoaxStation())
+    fr = _budget_fractions(eng)
+    (tl_frac,) = fr.values()
+    c = CABLES["RG-8X"]
+    matched_db = c.k1 * np.sqrt(28.47) + c.k2 * 28.47  # per 100 ft = the run
+    matched_frac = 1.0 - 10.0 ** (-matched_db / 10.0)
+    assert matched_frac <= tl_frac < 1.0 - 10.0 ** (-(matched_db + 0.5) / 10.0)
+
+
+def test_coax_station_swr_penalty_off_resonance():
+    """Worked off-band (24.94 MHz) the same line burns far more than its
+    matched loss — the SWR penalty emerges from the circuit solve."""
+    eng = _momwire(_with_params(CoaxStation, freq=24.94))
+    fr = _budget_fractions(eng)
+    (tl_frac,) = fr.values()
+    c = CABLES["RG-8X"]
+    matched_db = c.k1 * np.sqrt(24.94) + c.k2 * 24.94
+    matched_frac = 1.0 - 10.0 ** (-matched_db / 10.0)
+    assert tl_frac > 2.0 * matched_frac
+    assert eng._excited_efficiency < 0.5
+
+
+def test_doublet_station_matches_fifty_ohms_with_coil_dominated_loss():
+    eng = _momwire(DoubletStation())
+    (z,) = eng.impedance()
+    assert abs(z - 50.0) < 1.0  # stock tune lands the rig at ~50 Ω
+    fr = _budget_fractions(eng)
+    coil = fr["Shunt m"]
+    line = fr["TL li→feed"]
+    caps = fr["TwoPort rig→m"] + fr["TwoPort m→li"]
+    # The coil is the tuner's loss; the (ideal) caps burn nothing.
+    assert coil > 0.02
+    assert caps < 1e-6
+    # Stock 40 m operating point: ~92% radiated, coil ≳ line.
+    assert 0.85 < eng._excited_efficiency < 0.95
+    assert coil > 0.8 * line
+
+
+def test_doublet_coil_loss_scales_with_q():
+    frac_q200 = _budget_fractions(_momwire(DoubletStation()))["Shunt m"]
+    frac_q100 = _budget_fractions(_momwire(_with_params(DoubletStation, coil_q=100.0)))[
+        "Shunt m"
+    ]
+    frac_ideal = _budget_fractions(_momwire(_with_params(DoubletStation, coil_q=0.0)))[
+        "Shunt m"
+    ]
+    assert frac_ideal < 1e-9
+    # Halving Q ~doubles the coil's share (the match shifts slightly, so
+    # allow a generous band around exactly 2×).
+    assert 1.5 * frac_q200 < frac_q100 < 3.0 * frac_q200
+
+
+def test_both_stations_cross_check_on_pynec():
+    pytest.importorskip("antennaknobs.engines.pynec")
+    from antennaknobs.engines import PyNECEngine
+
+    for cls in (CoaxStation, DoubletStation):
+        zm = _momwire(cls()).impedance()[0]
+        zn = PyNECEngine(cls(), ground=None).impedance()[0]
+        assert abs(zm - zn) / abs(zm) < 0.01, f"{cls.__module__}: {zm} vs {zn}"


### PR DESCRIPTION
## Summary
- The payoff piece of the station-modelling arc (#300, after #297/#298/#299): two designs modelled from a virtual **rig** port, so SWR/gain/budget are referenced to the transmitter.
- `dipoles.invvee_coax_station`: stock inv-vee + 100 ft of real coax with a **cable preset dropdown** (first use of the adapter's enum knob). On-band the budget shows the cable's matched loss (RG-8X @ 28 MHz: 31 %); one band off, the SWR-multiplied loss emerges from the circuit solve (80 % for the same run). RG-58 → LMR-400 spans −2.4 dB → −0.7 dB on-band.
- `wire.doublet_ladder_tuner`: 88 ft flat doublet + 100 ft of `openwire-600` + T-network tuner with a finite-Q coil (default Q = 200), numerically tuned to 50.00 + 0.00j at the rig on 40 m — line 3.7 %, coil 4.5 %, **91.8 % radiated**. The documented 80 m retune runs the electrically-short doublet at 72 %.
- Comparison writeup with full tables: `docs/status/2026-07-11-station-loss-comparison.md`. Headline: the "lossy tuner" station beats resonant-antenna-on-coax on their design bands (−0.4 dB vs −1.6 dB) and degrades gracefully off-band (72 % vs 20 %).
- Catalog rows added by hand (#292 hasn't landed).

## Test plan
- [x] 6 tests in `tests/test_station_designs.py`: design-tree discoverability, on-band line loss brackets the matched-loss value, off-band loss > 2× matched (the SWR-penalty gate), stock doublet tune lands within 1 Ω of 50 at the rig with coil-dominated and cap-free tuner loss, coil loss halves/doubles with Q, and momwire-vs-PyNEC rig impedance within 1 % on both designs
- [x] Full suite: 1532 passed (registry sweeps auto-cover the new designs on both engines)
- [x] Web knob schema verified: `cable` derives as an enum dropdown, sliders span both band tunes
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)