### PR TITLE
Rename PortAtEdge → PortOnWire (deprecated alias kept)

### DIFF
--- a/src/antennaknobs/designs/arrays/delta_looparray_network.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray_network.py
@@ -15,7 +15,7 @@ numerical precision; the showcase for the network-spec API in #65.
 """
 
 from ... import AntennaBuilder, Transform, TransformStack
-from ...network import Driven, Network, PortAtEdge, PortVirtual, TL
+from ...network import Driven, Network, PortOnWire, PortVirtual, TL
 
 import math
 from types import MappingProxyType
@@ -86,8 +86,8 @@ class Builder(AntennaBuilder):
         )
         return Network(
             ports={
-                "loop1": PortAtEdge("loop1"),
-                "loop2": PortAtEdge("loop2"),
+                "loop1": PortOnWire("loop1"),
+                "loop2": PortOnWire("loop2"),
                 "driver": PortVirtual("driver"),
             },
             branches=[

--- a/src/antennaknobs/designs/arrays/lumped_coupled_pair.py
+++ b/src/antennaknobs/designs/arrays/lumped_coupled_pair.py
@@ -22,7 +22,7 @@ cross-check pins first).
 """
 
 from ... import AntennaBuilder
-from ...network import Driven, Network, PortAtEdge, TwoPort
+from ...network import Driven, Network, PortOnWire, TwoPort
 
 from types import MappingProxyType
 
@@ -53,15 +53,15 @@ class Builder(AntennaBuilder):
         for x, name in ((0.0, "front"), (-spacing, "rear")):
             # One straight wire per dipole, feed edge at the centre. No `ev` —
             # the Network supplies the source (front) and the coupling terminal
-            # (rear); `name` marks each centre segment for PortAtEdge lookup.
+            # (rear); `name` marks each centre segment for PortOnWire lookup.
             tups.append(((x, -half_arm, z), (x, half_arm, z), 21, None, name))
         return tups
 
     def build_network(self):
         return Network(
             ports={
-                "front": PortAtEdge("front"),
-                "rear": PortAtEdge("rear"),
+                "front": PortOnWire("front"),
+                "rear": PortOnWire("rear"),
             },
             branches=[
                 TwoPort(

--- a/src/antennaknobs/designs/beams/hb9cv.py
+++ b/src/antennaknobs/designs/beams/hb9cv.py
@@ -34,7 +34,7 @@ in place of the ideal line). Treat F/B as "real but shallow" in this model.
 """
 
 from ... import AntennaBuilder
-from ...network import Driven, Network, PortAtEdge, TL
+from ...network import Driven, Network, PortOnWire, TL
 from types import MappingProxyType
 
 
@@ -112,7 +112,7 @@ class Builder(AntennaBuilder):
         wavelength = 299.792458 / self.design_freq
         length = self.phasing_frac * wavelength
         return Network(
-            ports={"rear": PortAtEdge("rear"), "front": PortAtEdge("front")},
+            ports={"rear": PortOnWire("rear"), "front": PortOnWire("front")},
             # Crossed ("half-twist") phasing line between the two driven elements.
             branches=[
                 TL(a="rear", b="front", z0=self.z0, length=length, transposed=True)

--- a/src/antennaknobs/designs/broadband/g5rv.py
+++ b/src/antennaknobs/designs/broadband/g5rv.py
@@ -16,7 +16,7 @@ part everyone argues about.
 
 This fills the "matched-line / impedance-transformer feed" gap and is a
 methodology stress case for the network layer: a single ideal transmission-line
-branch (a real PortAtEdge at the doublet centre, a virtual port at the shack)
+branch (a real PortOnWire at the doublet centre, a virtual port at the shack)
 feeding a NON-resonant, reactive antenna port. The driving-point impedance the
 engines report is the SHACK-side impedance after the line transforms the
 doublet -- a direct test of the network reducer's TL + virtual-port reduction
@@ -35,7 +35,7 @@ The matching line is an electrical element (a network branch), not geometry.
 """
 
 from ... import AntennaBuilder
-from ...network import Driven, Network, PortAtEdge, PortVirtual, TL
+from ...network import Driven, Network, PortOnWire, PortVirtual, TL
 from types import MappingProxyType
 
 
@@ -114,7 +114,7 @@ class Builder(AntennaBuilder):
         match_len = self.match_len_frac * wavelength
         return Network(
             ports={
-                "feed": PortAtEdge("feed"),  # doublet centre
+                "feed": PortOnWire("feed"),  # doublet centre
                 "shack": PortVirtual("shack"),  # bottom of the matched line
             },
             branches=[

--- a/src/antennaknobs/designs/broadband/lpda.py
+++ b/src/antennaknobs/designs/broadband/lpda.py
@@ -45,7 +45,7 @@ Horizontally polarised.
 """
 
 from ... import AntennaBuilder
-from ...network import Driven, Network, PortAtEdge, TL
+from ...network import Driven, Network, PortOnWire, TL
 from types import MappingProxyType
 
 
@@ -138,7 +138,7 @@ class Builder(AntennaBuilder):
         n = int(self.n_elements)
         z0 = self.z0
 
-        ports = {f"d{k}": PortAtEdge(f"d{k}") for k in range(n)}
+        ports = {f"d{k}": PortOnWire(f"d{k}") for k in range(n)}
         branches = []
         # Crossed feeder section between adjacent element centres. Length =
         # physical boom spacing; transposed=True gives the 180-degree

--- a/src/antennaknobs/designs/broadband/t2fd.py
+++ b/src/antennaknobs/designs/broadband/t2fd.py
@@ -30,7 +30,7 @@ far wire.
 """
 
 from ... import AntennaBuilder
-from ...network import Driven, Load, Network, PortAtEdge
+from ...network import Driven, Load, Network, PortOnWire
 import math
 from types import MappingProxyType
 
@@ -115,7 +115,7 @@ class Builder(AntennaBuilder):
 
     def build_network(self):
         return Network(
-            ports={"feed": PortAtEdge("feed"), "term": PortAtEdge("term")},
+            ports={"feed": PortOnWire("feed"), "term": PortOnWire("term")},
             branches=[Load(port="term", r=self.term_r)],
             sources=[Driven(port="feed", voltage=1 + 0j)],
         )

--- a/src/antennaknobs/designs/dipoles/invvee_coax_station.py
+++ b/src/antennaknobs/designs/dipoles/invvee_coax_station.py
@@ -25,7 +25,7 @@ lossy tuner).
 
 from types import MappingProxyType
 
-from ...network import CABLES, TL, Driven, Network, PortAtEdge, PortVirtual
+from ...network import CABLES, TL, Driven, Network, PortOnWire, PortVirtual
 from .invvee import Builder as InvVee
 
 
@@ -60,7 +60,7 @@ class Builder(InvVee):
 
     def build_network(self):
         return Network(
-            ports={"feed": PortAtEdge("feed"), "rig": PortVirtual("rig")},
+            ports={"feed": PortOnWire("feed"), "rig": PortVirtual("rig")},
             branches=[
                 TL.from_cable(self.cable, "rig", "feed", self.line_len_m),
             ],

--- a/src/antennaknobs/designs/dipoles/short_dipole_loaded.py
+++ b/src/antennaknobs/designs/dipoles/short_dipole_loaded.py
@@ -12,7 +12,7 @@ dipole at `design_freq` — recompute it if you change `length_factor`.
 """
 
 from ... import AntennaBuilder
-from ...network import Driven, Load, Network, PortAtEdge
+from ...network import Driven, Load, Network, PortOnWire
 
 from types import MappingProxyType
 
@@ -36,7 +36,7 @@ class Builder(AntennaBuilder):
         half_arm = 0.25 * wavelength * self.length_factor
         # Single straight wire spanning the dipole, feed at the centre.
         # No `ev` — the Network supplies the source; `name` marks the
-        # segment for PortAtEdge resolution.
+        # segment for PortOnWire resolution.
         return [
             (
                 (0, -half_arm, 5),
@@ -49,7 +49,7 @@ class Builder(AntennaBuilder):
 
     def build_network(self):
         return Network(
-            ports={"feed": PortAtEdge("feed")},
+            ports={"feed": PortOnWire("feed")},
             branches=[Load(port="feed", l=self.inductance_uH * 1e-6)],
             sources=[Driven(port="feed", voltage=1 + 0j)],
         )

--- a/src/antennaknobs/designs/loops/skyloop_lmatch.py
+++ b/src/antennaknobs/designs/loops/skyloop_lmatch.py
@@ -30,7 +30,7 @@ reducer computes exactly on top of the extracted antenna Y.
 from types import MappingProxyType
 
 from .triangular_skyloop import Builder as TriangularSkyloop
-from ...network import Driven, Network, PortAtEdge, PortVirtual, Shunt, TwoPort
+from ...network import Driven, Network, PortOnWire, PortVirtual, Shunt, TwoPort
 
 
 class Builder(TriangularSkyloop):
@@ -81,7 +81,7 @@ class Builder(TriangularSkyloop):
         tuner is; 0 keeps the ideal coil."""
         ql = self.coil_q if self.coil_q > 0 else None
         return Network(
-            ports={"feed": PortAtEdge("feed"), "in": PortVirtual("in")},
+            ports={"feed": PortOnWire("feed"), "in": PortVirtual("in")},
             branches=[
                 TwoPort(a="in", b="feed", l=self.series_L_uH * 1e-6, ql=ql),
                 Shunt(port="feed", c=self.shunt_C_pF * 1e-12),

--- a/src/antennaknobs/designs/multiband/trap_dipole.py
+++ b/src/antennaknobs/designs/multiband/trap_dipole.py
@@ -26,7 +26,7 @@ tuned independently; defaults are LC-resonant at design_freq.
 """
 
 from ... import AntennaBuilder
-from ...network import Driven, Load, Network, PortAtEdge
+from ...network import Driven, Load, Network, PortOnWire
 
 import math
 from types import MappingProxyType
@@ -124,9 +124,9 @@ class Builder(AntennaBuilder):
         C = self.trap_C_pF * 1e-12
         return Network(
             ports={
-                "feed": PortAtEdge("feed"),
-                "trap_l": PortAtEdge("trap_l"),
-                "trap_r": PortAtEdge("trap_r"),
+                "feed": PortOnWire("feed"),
+                "trap_l": PortOnWire("trap_l"),
+                "trap_r": PortOnWire("trap_r"),
             },
             branches=[
                 # Parallel-LC trap: Z = jωL / (1 − ω²LC); diverges at ω₀

--- a/src/antennaknobs/designs/multiband/trap_fan_dipole.py
+++ b/src/antennaknobs/designs/multiband/trap_fan_dipole.py
@@ -34,7 +34,7 @@ exactly as NEC2's ld_card type-1 would.
 """
 
 from ... import AntennaBuilder
-from ...network import Driven, Load, Network, PortAtEdge
+from ...network import Driven, Load, Network, PortOnWire
 
 import math
 from types import MappingProxyType
@@ -364,7 +364,7 @@ class Builder(AntennaBuilder):
 
     def build_network(self):
         bands = tuple(self.bands)
-        ports = {"feed": PortAtEdge("feed")}
+        ports = {"feed": PortOnWire("feed")}
         branches = []
         for i, b in enumerate(bands):
             L = float(b["trap_L_uH"]) * 1e-6
@@ -376,7 +376,7 @@ class Builder(AntennaBuilder):
             C = 1.0 / (omega0**2 * L)
             for sign in ("p", "n"):
                 name = f"trap_{sign}_b{i}"
-                ports[name] = PortAtEdge(name)
+                ports[name] = PortOnWire(name)
                 branches.append(Load(port=name, l=L, c=C, parallel=True))
         return Network(
             ports=ports,

--- a/src/antennaknobs/designs/verticals/inverted_l_tmatch.py
+++ b/src/antennaknobs/designs/verticals/inverted_l_tmatch.py
@@ -40,7 +40,7 @@ source itself.
 from types import MappingProxyType
 
 from .inverted_l import Builder as InvertedL
-from ...network import Driven, Network, PortAtEdge, PortVirtual, Shunt, TwoPort
+from ...network import Driven, Network, PortOnWire, PortVirtual, Shunt, TwoPort
 
 
 class Builder(InvertedL):
@@ -90,7 +90,7 @@ class Builder(InvertedL):
     def build_network(self):
         return Network(
             ports={
-                "feed": PortAtEdge("feed"),
+                "feed": PortOnWire("feed"),
                 "m": PortVirtual("m"),
                 "in": PortVirtual("in"),
             },

--- a/src/antennaknobs/designs/wire/doublet_ladder_tuner.py
+++ b/src/antennaknobs/designs/wire/doublet_ladder_tuner.py
@@ -29,7 +29,7 @@ current and lower coil loss.
 
 from types import MappingProxyType
 
-from ...network import TL, Driven, Network, PortAtEdge, PortVirtual, Shunt, TwoPort
+from ...network import TL, Driven, Network, PortOnWire, PortVirtual, Shunt, TwoPort
 from ..dipoles.invvee import Builder as InvVee
 
 
@@ -84,7 +84,7 @@ class Builder(InvVee):
     def build_network(self):
         return Network(
             ports={
-                "feed": PortAtEdge("feed"),
+                "feed": PortOnWire("feed"),
                 "li": PortVirtual("li"),  # line input (tuner output)
                 "m": PortVirtual("m"),  # tee midpoint
                 "rig": PortVirtual("rig"),

--- a/src/antennaknobs/designs/wire/rhombic.py
+++ b/src/antennaknobs/designs/wire/rhombic.py
@@ -32,7 +32,7 @@ polarised.
 """
 
 from ... import AntennaBuilder
-from ...network import Driven, Load, Network, PortAtEdge
+from ...network import Driven, Load, Network, PortOnWire
 import math
 from types import MappingProxyType
 
@@ -109,7 +109,7 @@ class Builder(AntennaBuilder):
 
     def build_network(self):
         return Network(
-            ports={"feed": PortAtEdge("feed"), "term": PortAtEdge("term")},
+            ports={"feed": PortOnWire("feed"), "term": PortOnWire("term")},
             branches=[Load(port="term", r=self.term_r)],
             sources=[Driven(port="feed", voltage=1 + 0j)],
         )

--- a/src/antennaknobs/designs/wire/sterba_tl.py
+++ b/src/antennaknobs/designs/wire/sterba_tl.py
@@ -32,7 +32,7 @@ exactly will raise in `network_reduce.tl_admittance_2x2`; keep lf away from 1.0.
 """
 
 from ... import AntennaBuilder
-from ...network import Driven, Network, PortAtEdge, TL
+from ...network import Driven, Network, PortOnWire, TL
 from types import MappingProxyType
 
 
@@ -138,15 +138,15 @@ class Builder(AntennaBuilder):
         z0 = self.z0
         length = self._tl_length
 
-        ports = {"feed": PortAtEdge("feed")}
+        ports = {"feed": PortOnWire("feed")}
         branches = []
         # One TL per junction j (1..n_sections-1): connects the right-end
         # port of section j-1 to the left-end port of section j — the
         # half-wave vertical phasing line, now ideal.
         for j in range(1, n_sections):
             a, b = f"p{j}_a", f"p{j}_b"
-            ports[a] = PortAtEdge(a)
-            ports[b] = PortAtEdge(b)
+            ports[a] = PortOnWire(a)
+            ports[b] = PortOnWire(b)
             branches.append(TL(a=a, b=b, z0=z0, length=length))
 
         return Network(

--- a/src/antennaknobs/designs/wire/zepp.py
+++ b/src/antennaknobs/designs/wire/zepp.py
@@ -43,7 +43,7 @@ The tuned feeder is an electrical element (a `TL` branch), not geometry.
 """
 
 from ... import AntennaBuilder
-from ...network import Driven, Network, PortAtEdge, PortVirtual, TL
+from ...network import Driven, Network, PortOnWire, PortVirtual, TL
 from types import MappingProxyType
 
 
@@ -114,7 +114,7 @@ class Builder(AntennaBuilder):
         stub_len = self.stub_len_frac * wavelength
         return Network(
             ports={
-                "ant": PortAtEdge("ant"),  # high-Z end of the radiator
+                "ant": PortOnWire("ant"),  # high-Z end of the radiator
                 "shack": PortVirtual("shack"),  # bottom of the tuned stub
             },
             branches=[

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -10,7 +10,7 @@ from momwire import BSplineSolver
 
 from ..engine import FarField, SimulationEngine, WireCurrents
 from ..geometry import flat_wires_to_polylines
-from ..network import PortAtEdge, PortVirtual
+from ..network import PortOnWire, PortVirtual
 from ..network_reduce import NetworkReducer, tl_admittance_2x2
 
 
@@ -214,18 +214,18 @@ class MomwireEngine(SimulationEngine):
     def _init_network(self):
         """Build the port-index map (real feeds first, virtual ports after)
         and the engine-agnostic NetworkReducer that stamps the branches and
-        reduces to driven-port impedance. Validates that every PortAtEdge
+        reduces to driven-port impedance. Validates that every PortOnWire
         resolves to a translated feed name."""
         net = self._network
         feed_name_to_idx = {n: i for i, n in enumerate(self._feed_names) if n}
 
         port_to_idx = {}
         for name, port in net.ports.items():
-            if isinstance(port, PortAtEdge):
+            if isinstance(port, PortOnWire):
                 if name not in feed_name_to_idx:
                     raise ValueError(
-                        f"network port {name!r} is a PortAtEdge but no edge in "
-                        f"build_wires() carries that name; named edges: "
+                        f"network port {name!r} is a PortOnWire but no wire in "
+                        f"build_wires() carries that name; named wires: "
                         f"{sorted(feed_name_to_idx)}"
                     )
                 port_to_idx[name] = feed_name_to_idx[name]

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -5,7 +5,7 @@ from ..engine import FarField, SimulationEngine, WireCurrents
 from ..network import (
     Driven,
     Load,
-    PortAtEdge,
+    PortOnWire,
     PortVirtual,
     Shunt,
     TL,
@@ -120,7 +120,7 @@ class PyNECEngine(SimulationEngine):
 
         # Walk build_wires(): emit `geo.wire` cards, collect ex_card pairs from
         # any tuple with a non-None `ev`, and remember (tag, mid_seg) for every
-        # named edge so the network path can resolve PortAtEdge later.
+        # named edge so the network path can resolve PortOnWire later.
         self.excitation_pairs = []
         self._feed_name_to_loc = {}
         for idx, t in enumerate(self.tups, start=1):
@@ -160,15 +160,15 @@ class PyNECEngine(SimulationEngine):
             self.c.ex_card(0, tag, sub_index, 0, voltage.real, voltage.imag, 0, 0, 0, 0)
 
     def _resolve_network_ports(self):
-        """Resolve every PortAtEdge to its (tag, sub_seg) for native ld_card /
+        """Resolve every PortOnWire to its (tag, sub_seg) for native ld_card /
         ex_card emission. Only reached for Load-only networks; TL and
         virtual-driver networks take the NetworkReducer path instead."""
         for name, port in self._network.ports.items():
-            if isinstance(port, PortAtEdge):
+            if isinstance(port, PortOnWire):
                 if name not in self._feed_name_to_loc:
                     raise ValueError(
-                        f"network port {name!r} is a PortAtEdge but no edge in "
-                        f"build_wires() carries that name; named edges: "
+                        f"network port {name!r} is a PortOnWire but no wire in "
+                        f"build_wires() carries that name; named wires: "
                         f"{sorted(self._feed_name_to_loc)}"
                     )
                 tag, mid_seg, _p0, _p1, _ns = self._feed_name_to_loc[name]
@@ -211,10 +211,10 @@ class PyNECEngine(SimulationEngine):
     def _emit_load_card(self, br):
         """Series/parallel RLC on a single segment -> ld_card (type 0/1)."""
         port = self._network.ports[br.port]
-        if not isinstance(port, PortAtEdge):
+        if not isinstance(port, PortOnWire):
             raise ValueError(
                 f"Load on virtual port {br.port!r}: a Load is a series "
-                "impedance on an antenna segment, which only PortAtEdge has"
+                "impedance on an antenna segment, which only PortOnWire has"
             )
         tag, seg = self._network_port_loc[br.port]
         r = float(br.r) if br.r is not None else 0.0
@@ -235,7 +235,7 @@ class PyNECEngine(SimulationEngine):
         per-frequency nt_cards should use the reducer path (this native oracle
         is a single-frequency reference)."""
         for name in (br.a, br.b):
-            if not isinstance(self._network.ports[name], PortAtEdge):
+            if not isinstance(self._network.ports[name], PortOnWire):
                 raise ValueError(
                     f"native nt_card TwoPort port {name!r} is virtual; nt_card "
                     "attaches to real segments only"
@@ -355,19 +355,19 @@ class PyNECEngine(SimulationEngine):
             )
 
     def _init_network(self):
-        """Build the port-index map (real PortAtEdge ports first, virtual
-        ports after) and the NetworkReducer. Validates that every PortAtEdge
+        """Build the port-index map (real PortOnWire ports first, virtual
+        ports after) and the NetworkReducer. Validates that every PortOnWire
         names an edge in build_wires()."""
         net = self._network
         named = {t[4] for t in self.tups if len(t) >= 5 and t[4] is not None}
         self._real_port_names = [
-            n for n, p in net.ports.items() if isinstance(p, PortAtEdge)
+            n for n, p in net.ports.items() if isinstance(p, PortOnWire)
         ]
         for name in self._real_port_names:
             if name not in named:
                 raise ValueError(
-                    f"network port {name!r} is a PortAtEdge but no edge in "
-                    f"build_wires() carries that name; named edges: {sorted(named)}"
+                    f"network port {name!r} is a PortOnWire but no wire in "
+                    f"build_wires() carries that name; named wires: {sorted(named)}"
                 )
         port_to_idx = {n: i for i, n in enumerate(self._real_port_names)}
         next_idx = len(self._real_port_names)

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -26,10 +26,22 @@ from typing import Union
 
 
 @dataclass(frozen=True)
-class PortAtEdge:
-    """Real port at a named edge from `build_wires()`. The named edge's
-    feed segment becomes the port location; momwire places a delta-gap at
-    the edge midpoint to read/inject current there."""
+class PortOnWire:
+    """Real port ON a named wire of the geometry: `name` matches the label
+    a `build_wires()` tuple carries as its 5th element, and the port is a
+    delta gap at that wire's MIDDLE segment (momwire: the arclength
+    midpoint; PyNEC: segment (n_seg+1)//2 — identical placement for odd
+    segment counts, which named port wires should therefore use). A port
+    must interrupt a current path, so it lives in a wire's interior, never
+    at an endpoint — to put a feed "at" some point of a structure, author
+    a short named wire there.
+
+    This is the only port type that touches geometry (contrast
+    `PortVirtual`, a pure circuit node): it becomes one row/column of the
+    antenna's multiport short-circuit Y that the network stamps onto.
+
+    Formerly `PortAtEdge` ("edge" in the wire-graph sense, which read as
+    "wire end"); that name remains as a deprecated alias."""
 
     name: str
 
@@ -43,7 +55,12 @@ class PortVirtual:
     name: str
 
 
-Port = Union[PortAtEdge, PortVirtual]
+# Deprecated alias — the pre-rename class name ("edge" meant a wire-graph
+# edge, i.e. one build_wires() tuple, but read as "wire end"). Kept so any
+# externally-authored design importing it keeps working.
+PortAtEdge = PortOnWire
+
+Port = Union[PortOnWire, PortVirtual]
 
 
 @dataclass(frozen=True)

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -2,7 +2,7 @@
 impedances, on top of a raw multiport antenna admittance matrix.
 
 Both MomwireEngine and PyNECEngine assemble the antenna's short-circuit Y at
-the real (`PortAtEdge`) ports, then hand it here with a port-name -> matrix-
+the real (`PortOnWire`) ports, then hand it here with a port-name -> matrix-
 index map. This module stamps the network branches and sources into one
 Modified Nodal Analysis (MNA) system — the SPICE formulation, issue #285 —
 and solves it once for everything: driven-port impedances, physical port
@@ -35,7 +35,7 @@ from .network import (
     TL,
     Driven,
     Load,
-    PortAtEdge,
+    PortOnWire,
     Shunt,
     TwoPort,
     _parallel_rlc_admittance,
@@ -319,10 +319,10 @@ class NetworkReducer:
                         )
                     )
             elif isinstance(br, Load):
-                if not isinstance(self.network.ports[br.port], PortAtEdge):
+                if not isinstance(self.network.ports[br.port], PortOnWire):
                     raise ValueError(
                         f"Load on virtual port {br.port!r}: a Load is a series "
-                        "impedance on an antenna segment, which only PortAtEdge has"
+                        "impedance on an antenna segment, which only PortOnWire has"
                     )
                 loads_by_node.setdefault(self.port_to_idx[br.port], []).append(br)
             else:

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -632,7 +632,7 @@ def _primary_feed(engine):
     network = getattr(engine, "_network", None)
     if network is not None and network.sources:
         # The first Driven source is the primary feed. If it resolves to a
-        # real (PortAtEdge) port, use its position; otherwise (virtual port,
+        # real (PortOnWire) port, use its position; otherwise (virtual port,
         # e.g. delta_looparray_network's "driver"), fall back to feeds[0].
         driven_name = network.sources[0].port
         if driven_name in feed_names:

--- a/tests/test_finite_q.py
+++ b/tests/test_finite_q.py
@@ -21,7 +21,7 @@ from antennaknobs.designs.verticals.inverted_l_tmatch import Builder as TMatchBu
 from antennaknobs.network import (
     Driven,
     Network,
-    PortAtEdge,
+    PortOnWire,
     PortVirtual,
     Shunt,
     TwoPort,
@@ -77,7 +77,7 @@ def test_series_matching_coil_loss_adds_directly_to_zin():
 
     def zin(ql):
         net = Network(
-            ports={"ant": PortAtEdge("ant"), "in": PortVirtual("in")},
+            ports={"ant": PortOnWire("ant"), "in": PortVirtual("in")},
             branches=[TwoPort(a="in", b="ant", l=l, ql=ql)],
             sources=[Driven("in", 1 + 0j)],
         )
@@ -94,7 +94,7 @@ def test_lossy_shunt_coil_dissipates_power():
 
     def p_in(ql):
         net = Network(
-            ports={"ant": PortAtEdge("ant")},
+            ports={"ant": PortOnWire("ant")},
             branches=[Shunt(port="ant", l=2.2e-6, ql=ql)],
             sources=[Driven("ant", 1 + 0j)],
         )

--- a/tests/test_lossy_tl.py
+++ b/tests/test_lossy_tl.py
@@ -16,7 +16,7 @@ they are pure circuit oracles:
 import numpy as np
 import pytest
 
-from antennaknobs.network import CABLES, TL, Driven, Network, PortAtEdge, PortVirtual
+from antennaknobs.network import CABLES, TL, Driven, Network, PortOnWire, PortVirtual
 from antennaknobs.network_reduce import C_LIGHT, NetworkReducer, tl_admittance_2x2
 
 F_MHZ = 10.0
@@ -27,7 +27,7 @@ FT100 = 30.48  # 100 ft in meters
 def _rig_fed_network(tl):
     """Virtual "rig" port driven through `tl` into the real "ant" port."""
     net = Network(
-        ports={"ant": PortAtEdge("ant"), "rig": PortVirtual("rig")},
+        ports={"ant": PortOnWire("ant"), "rig": PortVirtual("rig")},
         branches=[tl],
         sources=[Driven("rig", 1 + 0j)],
     )

--- a/tests/test_momwire_engine.py
+++ b/tests/test_momwire_engine.py
@@ -685,11 +685,11 @@ def test_network_spec_rejects_unknown_port_reference():
         )
 
 
-def test_network_spec_rejects_port_at_edge_with_no_named_edge():
-    """PortAtEdge("loop1") with no `loop1` edge in build_wires() should
+def test_network_spec_rejects_port_on_wire_with_no_named_wire():
+    """PortOnWire("loop1") with no `loop1` edge in build_wires() should
     raise a clear error at engine construction time."""
     from antennaknobs import AntennaBuilder
-    from antennaknobs.network import Driven, Network, PortAtEdge, PortVirtual, TL
+    from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL
     from types import MappingProxyType
 
     class BadBuilder(AntennaBuilder):
@@ -702,14 +702,14 @@ def test_network_spec_rejects_port_at_edge_with_no_named_edge():
         def build_network(self):
             return Network(
                 ports={
-                    "loop1": PortAtEdge("loop1"),  # no matching named edge!
+                    "loop1": PortOnWire("loop1"),  # no matching named edge!
                     "drv": PortVirtual("drv"),
                 },
                 branches=[TL(a="drv", b="loop1", z0=50, length=1.0)],
                 sources=[Driven(port="drv")],
             )
 
-    with pytest.raises(ValueError, match="no edge in build_wires"):
+    with pytest.raises(ValueError, match="no wire in build_wires"):
         MomwireEngine(BadBuilder())
 
 
@@ -745,7 +745,7 @@ def test_pynec_virtual_to_virtual_tl_supported():
     agreeing with MomwireEngine (was a hard ValueError under the old tl_card
     dispatch)."""
     from antennaknobs import AntennaBuilder
-    from antennaknobs.network import Driven, Network, PortAtEdge, PortVirtual, TL
+    from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL
     from types import MappingProxyType
 
     class Builder(AntennaBuilder):
@@ -757,7 +757,7 @@ def test_pynec_virtual_to_virtual_tl_supported():
         def build_network(self):
             return Network(
                 ports={
-                    "feed": PortAtEdge("feed"),
+                    "feed": PortOnWire("feed"),
                     "a": PortVirtual("a"),
                     "b": PortVirtual("b"),
                 },
@@ -780,7 +780,7 @@ def test_pynec_load_branch_resistor_adds_to_impedance():
     exactly R — ld_card type-0 inserts a series R+L+C at the segment. This
     is the cross-engine cross-check for piece (A) on the PyNEC side."""
     from antennaknobs import AntennaBuilder
-    from antennaknobs.network import Driven, Load, Network, PortAtEdge
+    from antennaknobs.network import Driven, Load, Network, PortOnWire
     from types import MappingProxyType
 
     class Builder(AntennaBuilder):
@@ -796,7 +796,7 @@ def test_pynec_load_branch_resistor_adds_to_impedance():
         def build_network(self):
             branches = [Load(port="feed", r=50.0)] if self._with_load else []
             return Network(
-                ports={"feed": PortAtEdge("feed")},
+                ports={"feed": PortOnWire("feed")},
                 branches=branches,
                 sources=[Driven(port="feed", voltage=1 + 0j)],
             )
@@ -878,7 +878,7 @@ def test_pynec_load_branch_rejects_virtual_port():
         Driven,
         Load,
         Network,
-        PortAtEdge,
+        PortOnWire,
         PortVirtual,
         TL,
     )
@@ -893,7 +893,7 @@ def test_pynec_load_branch_rejects_virtual_port():
         def build_network(self):
             return Network(
                 ports={
-                    "feed": PortAtEdge("feed"),
+                    "feed": PortOnWire("feed"),
                     "drv": PortVirtual("drv"),
                 },
                 branches=[
@@ -909,12 +909,12 @@ def test_pynec_load_branch_rejects_virtual_port():
 
 
 @needs_pynec
-def test_pynec_network_rejects_port_at_edge_with_no_named_edge():
-    """PortAtEdge("loop1") with no `loop1` edge in build_wires() should
+def test_pynec_network_rejects_port_on_wire_with_no_named_wire():
+    """PortOnWire("loop1") with no `loop1` edge in build_wires() should
     raise a clear error at engine construction time — mirror of the
     MomwireEngine check."""
     from antennaknobs import AntennaBuilder
-    from antennaknobs.network import Driven, Network, PortAtEdge, PortVirtual, TL
+    from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL
     from types import MappingProxyType
 
     class Builder(AntennaBuilder):
@@ -926,14 +926,14 @@ def test_pynec_network_rejects_port_at_edge_with_no_named_edge():
         def build_network(self):
             return Network(
                 ports={
-                    "loop1": PortAtEdge("loop1"),
+                    "loop1": PortOnWire("loop1"),
                     "drv": PortVirtual("drv"),
                 },
                 branches=[TL(a="drv", b="loop1", z0=50, length=1.0)],
                 sources=[Driven(port="drv")],
             )
 
-    with pytest.raises(ValueError, match="no edge in build_wires"):
+    with pytest.raises(ValueError, match="no wire in build_wires"):
         PyNECEngine(Builder(), ground=None)
 
 
@@ -1075,7 +1075,7 @@ def _load_dipole_builder(load_branch=None, name_feed=False):
     Load and a Driven on the same port. Otherwise build_network()=None and
     the engine falls through to the plain-feed path."""
     from antennaknobs import AntennaBuilder
-    from antennaknobs.network import Driven, Network, PortAtEdge
+    from antennaknobs.network import Driven, Network, PortOnWire
     from types import MappingProxyType
 
     class Builder(AntennaBuilder):
@@ -1092,7 +1092,7 @@ def _load_dipole_builder(load_branch=None, name_feed=False):
             if load_branch is None:
                 return None
             return Network(
-                ports={"feed": PortAtEdge("feed")},
+                ports={"feed": PortOnWire("feed")},
                 branches=[load_branch],
                 sources=[Driven(port="feed", voltage=1 + 0j)],
             )
@@ -1148,7 +1148,7 @@ def test_load_branch_rejects_virtual_port():
         Driven,
         Load,
         Network,
-        PortAtEdge,
+        PortOnWire,
         PortVirtual,
         TL,
     )
@@ -1163,7 +1163,7 @@ def test_load_branch_rejects_virtual_port():
         def build_network(self):
             return Network(
                 ports={
-                    "feed": PortAtEdge("feed"),
+                    "feed": PortOnWire("feed"),
                     "drv": PortVirtual("drv"),
                 },
                 branches=[
@@ -1384,7 +1384,7 @@ def test_native_nt_rejects_unemittable_networks():
     from antennaknobs.network import (
         Driven,
         Network,
-        PortAtEdge,
+        PortOnWire,
         PortVirtual,
         TwoPort,
     )
@@ -1400,7 +1400,7 @@ def test_native_nt_rejects_unemittable_networks():
             from antennaknobs.network import Load
 
             return Network(
-                ports={"feed": PortAtEdge("feed")},
+                ports={"feed": PortOnWire("feed")},
                 branches=[Load(port="feed", r=10.0)],
                 sources=[Driven(port="feed")],
             )
@@ -1413,7 +1413,7 @@ def test_native_nt_rejects_unemittable_networks():
 
         def build_network(self):
             return Network(
-                ports={"feed": PortAtEdge("feed"), "v": PortVirtual("v")},
+                ports={"feed": PortOnWire("feed"), "v": PortVirtual("v")},
                 branches=[TwoPort(a="feed", b="v", r=10.0)],
                 sources=[Driven(port="feed")],
             )
@@ -1443,7 +1443,7 @@ def test_shunt_lmatch_matches_circuit_theory():
     from antennaknobs.network import (
         Driven,
         Network,
-        PortAtEdge,
+        PortOnWire,
         PortVirtual,
         Shunt,
         TwoPort,
@@ -1464,7 +1464,7 @@ def test_shunt_lmatch_matches_circuit_theory():
 
         def build_network(self):
             return Network(
-                ports={"feed": PortAtEdge("feed")}, sources=[Driven(port="feed")]
+                ports={"feed": PortOnWire("feed")}, sources=[Driven(port="feed")]
             )
 
     class LMatch(AntennaBuilder):
@@ -1475,7 +1475,7 @@ def test_shunt_lmatch_matches_circuit_theory():
 
         def build_network(self):
             return Network(
-                ports={"feed": PortAtEdge("feed"), "in": PortVirtual("in")},
+                ports={"feed": PortOnWire("feed"), "in": PortVirtual("in")},
                 branches=[
                     TwoPort(a="in", b="feed", l=ls),
                     Shunt(port="in", c=cp),
@@ -1509,7 +1509,7 @@ def test_pynec_shunt_routes_through_reducer_not_native():
     """A Shunt has no native NEC card, so PyNECEngine must reduce it (never the
     baked-context native path), and native_nt must reject it up front."""
     from antennaknobs import AntennaBuilder
-    from antennaknobs.network import Driven, Network, PortAtEdge, Shunt, TwoPort
+    from antennaknobs.network import Driven, Network, PortOnWire, Shunt, TwoPort
     from types import MappingProxyType
 
     class ShuntDipole(AntennaBuilder):
@@ -1520,7 +1520,7 @@ def test_pynec_shunt_routes_through_reducer_not_native():
 
         def build_network(self):
             return Network(
-                ports={"feed": PortAtEdge("feed")},
+                ports={"feed": PortOnWire("feed")},
                 branches=[Shunt(port="feed", c=50e-12)],
                 sources=[Driven(port="feed")],
             )
@@ -1540,7 +1540,7 @@ def test_pynec_shunt_routes_through_reducer_not_native():
 
         def build_network(self):
             return Network(
-                ports={"feed": PortAtEdge("feed"), "feed2": PortAtEdge("feed2")},
+                ports={"feed": PortOnWire("feed"), "feed2": PortOnWire("feed2")},
                 branches=[
                     TwoPort(a="feed", b="feed2", r=20.0),
                     Shunt(port="feed", c=50e-12),
@@ -1559,7 +1559,7 @@ def test_series_short_twoport_is_a_hard_wire_on_the_engine():
     Y it must give a finite impedance equal to the vanishing-resistance
     limit."""
     from antennaknobs import AntennaBuilder
-    from antennaknobs.network import Driven, Network, PortAtEdge, TwoPort
+    from antennaknobs.network import Driven, Network, PortOnWire, TwoPort
     from types import MappingProxyType
 
     def make(r=None, l=None):
@@ -1574,7 +1574,7 @@ def test_series_short_twoport_is_a_hard_wire_on_the_engine():
 
             def build_network(self):
                 return Network(
-                    ports={"feed": PortAtEdge("feed"), "feed2": PortAtEdge("feed2")},
+                    ports={"feed": PortOnWire("feed"), "feed2": PortOnWire("feed2")},
                     branches=[TwoPort(a="feed", b="feed2", r=r, l=l)],
                     sources=[Driven(port="feed")],
                 )
@@ -1597,7 +1597,7 @@ def test_skyloop_matchbox_inert_is_passthrough():
     (issue #285) these degenerate values are stamped literally —
     build_network no longer special-cases the topology."""
     from antennaknobs.designs.loops.skyloop_lmatch import Builder as B
-    from antennaknobs.network import Driven, Network, PortAtEdge
+    from antennaknobs.network import Driven, Network, PortOnWire
     from types import MappingProxyType
 
     inert = {**B.default_params, "series_L_uH": 0.0, "shunt_C_pF": 0.0}
@@ -1609,7 +1609,7 @@ def test_skyloop_matchbox_inert_is_passthrough():
 
         def build_network(self):
             return Network(
-                ports={"feed": PortAtEdge("feed")}, sources=[Driven(port="feed")]
+                ports={"feed": PortOnWire("feed")}, sources=[Driven(port="feed")]
             )
 
     z_ant = _sinusoidal(Bare()).impedance()[0]
@@ -1629,7 +1629,7 @@ def _tmatch_bare(params=None):
     """The T-match design's antenna with the matchbox removed: same
     geometry, source directly on the feed."""
     from antennaknobs.designs.verticals.inverted_l_tmatch import Builder as B
-    from antennaknobs.network import Driven, Network, PortAtEdge
+    from antennaknobs.network import Driven, Network, PortOnWire
     from types import MappingProxyType
 
     class Bare(B):
@@ -1637,7 +1637,7 @@ def _tmatch_bare(params=None):
 
         def build_network(self):
             return Network(
-                ports={"feed": PortAtEdge("feed")}, sources=[Driven(port="feed")]
+                ports={"feed": PortOnWire("feed")}, sources=[Driven(port="feed")]
             )
 
     return Bare()

--- a/tests/test_network_mna.py
+++ b/tests/test_network_mna.py
@@ -29,7 +29,7 @@ from antennaknobs.network import (
     Driven,
     Load,
     Network,
-    PortAtEdge,
+    PortOnWire,
     PortVirtual,
     Shunt,
     TwoPort,
@@ -52,9 +52,9 @@ def synth_y(n, seed):
 
 
 def reducer(net, n_real):
-    """Build a reducer with the standard port indexing: real PortAtEdge
+    """Build a reducer with the standard port indexing: real PortOnWire
     ports first in declaration order, virtual ports after."""
-    real = [n for n, p in net.ports.items() if isinstance(p, PortAtEdge)]
+    real = [n for n, p in net.ports.items() if isinstance(p, PortOnWire)]
     virt = [n for n, p in net.ports.items() if isinstance(p, PortVirtual)]
     assert len(real) == n_real
     port_to_idx = {n: i for i, n in enumerate(real + virt)}
@@ -86,7 +86,7 @@ def nodal_reference(y_full, driven):
 
 def test_bare_driven_port():
     """One driven port, no branches: Z = 1/Y₀₀ and V = E exactly."""
-    net = Network(ports={"f": PortAtEdge("f")}, sources=[Driven(port="f")])
+    net = Network(ports={"f": PortOnWire("f")}, sources=[Driven(port="f")])
     y = synth_y(1, 0)
     red = reducer(net, 1)
     assert red.driven_impedance(y, WL)[0] == pytest.approx(1.0 / y[0, 0], rel=1e-12)
@@ -99,7 +99,7 @@ def test_bare_driven_port():
 def test_multi_driven_ports():
     """Two simultaneous sources: every port pinned, I = Y·V directly."""
     net = Network(
-        ports={"f1": PortAtEdge("f1"), "f2": PortAtEdge("f2")},
+        ports={"f1": PortOnWire("f1"), "f2": PortOnWire("f2")},
         sources=[Driven(port="f1", voltage=1 + 0j), Driven(port="f2", voltage=0.5j)],
     )
     y = synth_y(2, 1)
@@ -111,7 +111,7 @@ def test_multi_driven_ports():
 def test_zero_volt_source_pins_node():
     """The `Driven(port, 0)` datum trick: a 0 V source is a hard V = 0 pin."""
     net = Network(
-        ports={"f1": PortAtEdge("f1"), "f2": PortAtEdge("f2")},
+        ports={"f1": PortOnWire("f1"), "f2": PortOnWire("f2")},
         sources=[Driven(port="f1"), Driven(port="f2", voltage=0j)],
     )
     y = synth_y(2, 3)
@@ -129,7 +129,7 @@ def test_virtual_driver_with_tl_matches_line_transform():
     Z_in = Z₀ (Z_L + jZ₀ tanθ)/(Z₀ + jZ_L tanθ), efficiency 1 (lossless)."""
     z0, length = 300.0, 0.31 * WL
     net = Network(
-        ports={"f": PortAtEdge("f"), "in": PortVirtual("in")},
+        ports={"f": PortOnWire("f"), "in": PortVirtual("in")},
         branches=[TL(a="in", b="f", z0=z0, length=length)],
         sources=[Driven(port="in")],
     )
@@ -148,8 +148,8 @@ def test_transposed_tl_pair():
     voltage vector against the bare nodal reduction with the same stamps."""
     net = Network(
         ports={
-            "f1": PortAtEdge("f1"),
-            "f2": PortAtEdge("f2"),
+            "f1": PortOnWire("f1"),
+            "f2": PortOnWire("f2"),
             "in": PortVirtual("in"),
         },
         branches=[
@@ -178,7 +178,7 @@ def test_twoport_bridge():
     """Lumped series R+jωL bridging two ports = its 2×2 admittance stamp."""
     r, l = 20.0, 0.4e-6
     net = Network(
-        ports={"f1": PortAtEdge("f1"), "f2": PortAtEdge("f2")},
+        ports={"f1": PortOnWire("f1"), "f2": PortOnWire("f2")},
         branches=[TwoPort(a="f1", b="f2", r=r, l=l)],
         sources=[Driven(port="f1")],
     )
@@ -198,7 +198,7 @@ def test_twoport_open_zero_capacitor():
     """c = 0 F is an open series path: exactly as if the branch weren't
     there (the inert endpoint of a matching-network capacitor slider)."""
     net = Network(
-        ports={"f1": PortAtEdge("f1"), "f2": PortAtEdge("f2")},
+        ports={"f1": PortOnWire("f1"), "f2": PortOnWire("f2")},
         branches=[TwoPort(a="f1", b="f2", c=0.0)],
         sources=[Driven(port="f1")],
     )
@@ -215,7 +215,7 @@ def test_lmatch_matches_two_element_transform(seed):
     two-element transform Z_in = jωL + 1/(jωC + Y_ant)."""
     ls, cp = 0.873e-6, 59.57e-12
     net = Network(
-        ports={"feed": PortAtEdge("feed"), "in": PortVirtual("in")},
+        ports={"feed": PortOnWire("feed"), "in": PortVirtual("in")},
         branches=[
             TwoPort(a="in", b="feed", l=ls),
             Shunt(port="feed", c=cp),
@@ -231,7 +231,7 @@ def test_lmatch_matches_two_element_transform(seed):
 
 def test_parallel_shunt_is_tank_admittance_on_diagonal():
     net = Network(
-        ports={"f": PortAtEdge("f")},
+        ports={"f": PortOnWire("f")},
         branches=[Shunt(port="f", r=1000.0, l=1e-6, c=30e-12, parallel=True)],
         sources=[Driven(port="f")],
     )
@@ -248,7 +248,7 @@ def test_series_load_terminated_port():
     dissipation drives the efficiency readout."""
     r_l = 600.0
     net = Network(
-        ports={"f": PortAtEdge("f"), "term": PortAtEdge("term")},
+        ports={"f": PortOnWire("f"), "term": PortOnWire("term")},
         branches=[Load(port="term", r=r_l)],
         sources=[Driven(port="f")],
     )
@@ -273,7 +273,7 @@ def test_driven_and_loaded_same_port():
     divides accordingly, and only Re(Z_L) burns power."""
     z_l = 5.0 + 1j * OMEGA * 2e-6
     net = Network(
-        ports={"f": PortAtEdge("f")},
+        ports={"f": PortOnWire("f")},
         branches=[Load(port="f", r=5.0, l=2e-6)],
         sources=[Driven(port="f")],
     )
@@ -294,7 +294,7 @@ def test_parallel_trap_load_off_resonance():
     """Parallel-LC trap off resonance: a finite shunt impedance at the port."""
     l, c = 1.5e-6, 30e-12
     net = Network(
-        ports={"f": PortAtEdge("f"), "arm": PortAtEdge("arm")},
+        ports={"f": PortOnWire("f"), "arm": PortOnWire("arm")},
         branches=[Load(port="arm", l=l, c=c, parallel=True)],
         sources=[Driven(port="f")],
     )
@@ -317,10 +317,10 @@ def test_everything_at_once():
     lengths = {"tl1": 0.27 * WL, "tl2": 0.12 * WL}
     net = Network(
         ports={
-            "f1": PortAtEdge("f1"),
-            "f2": PortAtEdge("f2"),
-            "f3": PortAtEdge("f3"),
-            "f4": PortAtEdge("f4"),
+            "f1": PortOnWire("f1"),
+            "f2": PortOnWire("f2"),
+            "f3": PortOnWire("f3"),
+            "f4": PortOnWire("f4"),
             "in": PortVirtual("in"),
             "n1": PortVirtual("n1"),
         },
@@ -359,7 +359,7 @@ def test_everything_at_once():
 
 def test_load_on_virtual_port_rejected():
     net = Network(
-        ports={"f": PortAtEdge("f"), "v": PortVirtual("v")},
+        ports={"f": PortOnWire("f"), "v": PortVirtual("v")},
         branches=[TL(a="f", b="v", z0=50.0, length=0.1 * WL), Load(port="v", r=50.0)],
         sources=[Driven(port="f")],
     )
@@ -374,7 +374,7 @@ def test_load_on_virtual_port_rejected():
 
 def _series_twoport_z(r=None, l=None, c=None):
     net = Network(
-        ports={"f1": PortAtEdge("f1"), "f2": PortAtEdge("f2")},
+        ports={"f1": PortOnWire("f1"), "f2": PortOnWire("f2")},
         branches=[TwoPort(a="f1", b="f2", r=r, l=l, c=c)],
         sources=[Driven(port="f1")],
     )
@@ -401,7 +401,7 @@ def test_ideal_short_twoport_is_finite_and_identifies_nodes(kwargs):
     # Node identification: the shorted pair behaves as one merged node.
     y = synth_y(2, 0)
     merged = np.array([[y[0, 0] + y[0, 1] + y[1, 0] + y[1, 1]]])
-    net = Network(ports={"m": PortAtEdge("m")}, sources=[Driven(port="m")])
+    net = Network(ports={"m": PortOnWire("m")}, sources=[Driven(port="m")])
     z_merged = reducer(net, 1).driven_impedance(merged, WL)[0]
     assert z_short == pytest.approx(z_merged, rel=1e-9)
 
@@ -410,7 +410,7 @@ def test_shunt_ideal_short_pins_port_to_common():
     """A 0 H shunt hard-shorts the port to the common reference: V_k = 0,
     with the (finite) short-circuit current flowing through the branch."""
     net = Network(
-        ports={"f1": PortAtEdge("f1"), "f2": PortAtEdge("f2")},
+        ports={"f1": PortOnWire("f1"), "f2": PortOnWire("f2")},
         branches=[Shunt(port="f2", l=0.0)],
         sources=[Driven(port="f1")],
     )
@@ -430,7 +430,7 @@ def test_inert_lmatchbox_stamped_literally():
     Z_in = Z_ant, with no design-level topology special-casing (the interim
     dodge `skyloop_lmatch.build_network` needed on the admittance reducer)."""
     inert = Network(
-        ports={"feed": PortAtEdge("feed"), "in": PortVirtual("in")},
+        ports={"feed": PortOnWire("feed"), "in": PortVirtual("in")},
         branches=[TwoPort(a="in", b="feed", l=0.0), Shunt(port="feed", c=0.0)],
         sources=[Driven(port="in")],
     )
@@ -447,7 +447,7 @@ def test_open_circuited_source_reports_clean_infinity():
     import warnings
 
     net = Network(
-        ports={"f": PortAtEdge("f"), "in": PortVirtual("in")},
+        ports={"f": PortOnWire("f"), "in": PortVirtual("in")},
         branches=[TwoPort(a="in", b="f", c=0.0)],
         sources=[Driven(port="in")],
     )
@@ -465,7 +465,7 @@ def test_trap_load_at_exact_resonance_is_open():
     l = 1.0e-6
     c = 1.0 / (OMEGA**2 * l)  # resonate the tank exactly at FREQ_MHZ
     net = Network(
-        ports={"f": PortAtEdge("f"), "arm": PortAtEdge("arm")},
+        ports={"f": PortOnWire("f"), "arm": PortOnWire("arm")},
         branches=[Load(port="arm", l=l, c=c, parallel=True)],
         sources=[Driven(port="f")],
     )
@@ -478,3 +478,11 @@ def test_trap_load_at_exact_resonance_is_open():
     # network as having no Load branch at all.
     v_ref, _ = nodal_reference(y, {0: 1 + 0j})
     np.testing.assert_allclose(v, v_ref, rtol=1e-9)
+
+
+def test_port_at_edge_alias_survives():
+    """PortAtEdge is the deprecated pre-rename alias of PortOnWire; any
+    externally-authored design importing it must keep working."""
+    from antennaknobs.network import PortAtEdge, PortOnWire
+
+    assert PortAtEdge is PortOnWire

--- a/tests/test_power_budget.py
+++ b/tests/test_power_budget.py
@@ -15,7 +15,7 @@ from antennaknobs.network import (
     Driven,
     Load,
     Network,
-    PortAtEdge,
+    PortOnWire,
     PortVirtual,
     Shunt,
     TwoPort,
@@ -31,7 +31,7 @@ def _station_reducer():
     """Rig → lossy coax → lossy L-match → antenna: one of everything."""
     net = Network(
         ports={
-            "ant": PortAtEdge("ant"),
+            "ant": PortOnWire("ant"),
             "tuner": PortVirtual("tuner"),
             "rig": PortVirtual("rig"),
         },
@@ -65,7 +65,7 @@ def test_budget_sums_to_p_in():
 
 def test_lossless_network_reports_unity_and_zero_watts():
     net = Network(
-        ports={"ant": PortAtEdge("ant"), "rig": PortVirtual("rig")},
+        ports={"ant": PortOnWire("ant"), "rig": PortVirtual("rig")},
         branches=[
             TL("rig", "ant", z0=50.0, length=13.0),
             Shunt(port="ant", c=20e-12),
@@ -86,7 +86,7 @@ def test_load_only_efficiency_matches_the_pre_299_accounting():
     """For Load-only networks the termination probe IS the old p_diss sum,
     so the shipped efficiency numbers (T2FD, terminated designs) hold."""
     net = Network(
-        ports={"feed": PortAtEdge("feed"), "term": PortAtEdge("term")},
+        ports={"feed": PortOnWire("feed"), "term": PortOnWire("term")},
         branches=[Load(port="term", r=390.0)],
         sources=[Driven("feed", 1 + 0j)],
     )

--- a/tests/test_tl_composition.py
+++ b/tests/test_tl_composition.py
@@ -25,7 +25,7 @@ import pytest
 pytest.importorskip("PyNEC")
 
 from antennaknobs import AntennaBuilder  # noqa: E402
-from antennaknobs.network import Driven, Network, PortAtEdge, TL  # noqa: E402
+from antennaknobs.network import Driven, Network, PortOnWire, TL  # noqa: E402
 from antennaknobs.engines import MomwireEngine, PyNECEngine  # noqa: E402
 from momwire import BSplineSolver  # noqa: E402
 
@@ -58,7 +58,7 @@ class _NetBuilder(AntennaBuilder):
 
     def build_network(self):
         return Network(
-            ports={"rear": PortAtEdge("rear"), "front": PortAtEdge("front")},
+            ports={"rear": PortOnWire("rear"), "front": PortOnWire("front")},
             branches=[TL(a="front", b="rear", z0=Z0, length=LEN, transposed=False)],
             sources=[Driven(port="front", voltage=1 + 0j)],
         )


### PR DESCRIPTION
## Summary
- `PortAtEdge`'s "edge" meant a wire-graph edge (one `build_wires()` tuple) but reads as "wire end" — the port actually sits at the named wire's *middle* segment. `PortOnWire` says what it is.
- Mechanical rename across the core, both engines, all 16 network designs, and tests; engine error messages drop the graph jargon ("no **wire** in build_wires() carries that name"). The class docstring now documents the midpoint placement convention (and the odd-segment-count advice for cross-engine agreement), why ports live in wire interiors, and the `PortVirtual` contrast.
- `PortAtEdge = PortOnWire` stays as a deprecated alias so externally-authored designs importing it keep working, pinned by a regression test.

## Test plan
- [x] Full suite: 1533 passed (two error-message pins updated to the new wording; alias regression test added)
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)