### PR TITLE
Transformer/balun element: ideal ratio + core-loss model

### DIFF
--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -20,6 +20,7 @@ after L. B. Cebik (W4RNL)'s articles.
 | `dipoles.koch_dipole` | Koch fractal dipole |
 | `dipoles.short_dipole_loaded` | Center-loaded shortened dipole (a Load-branch showcase) |
 | `dipoles.invvee_coax_station` | The inv-vee fed through 100 ft of real coax (cable preset dropdown), referenced to the rig — line loss and the SWR penalty in the power budget |
+| `dipoles.folded_invvee_balun` | Folded inv-vee (~218 Ω) through a lossy 4:1 balun onto 50 Ω coax — the Transformer-element showcase |
 
 ## Loops
 

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -148,7 +148,8 @@ loss" — a steady dB or so there is absorbed power, not error.
 ## Power budget
 
 Designs with a lossy feed network — a real coax or ladder-line run, a
-matching network with a finite-Q coil, a terminating resistor — get a
+matching network with a finite-Q coil, a lossy balun, a terminating
+resistor — get a
 **power budget** table in the solve readout: one row per network branch
 with the fraction of the source's input power it dissipates, plus an
 **antenna (radiated)** row for what actually reaches the wires. The rows

--- a/src/antennaknobs/designs/dipoles/folded_invvee_balun.py
+++ b/src/antennaknobs/designs/dipoles/folded_invvee_balun.py
@@ -1,0 +1,78 @@
+"""Folded inverted-V fed through a 4:1 balun and real coax — the
+`Transformer` showcase (issue #301).
+
+The stock folded inv-vee presents ~218 Ω at its feed (the folded geometry's
+step-up, pulled below the ideal 4×73 by droop and tuning). A 4:1 balun
+(`Transformer` with `balun_n` = 0.5, so Z_line = n²·Z_feed ≈ 55 Ω) steps
+that down onto `line_len_m` of 50 Ω cable, and the source sits at the
+virtual **rig** node — the full chain the back of a real folded dipole
+carries.
+
+The balun is lossy the way a real ferrite one is: `lmag_uH` is the
+magnetizing inductance shunting its line side and `qlmag` its Q (core
+loss). At 28 MHz the magnetizing reactance dwarfs 50 Ω and the balun is
+nearly free; drag the measurement frequency down and the classic low-band
+insertion-loss rolloff appears as the balun's `(mag)` row in the power
+budget. Winding resistance is available via the network's `r` if you want
+it; the geometry knobs are the stock folded-invvee ones.
+"""
+
+from types import MappingProxyType
+
+from ...network import CABLES, TL, Driven, Network, PortOnWire, PortVirtual, Transformer
+from .folded_invvee import Builder as FoldedInvVee
+
+
+class Builder(FoldedInvVee):
+    default_params = MappingProxyType(
+        {
+            **FoldedInvVee.default_params,
+            "cable": "RG-8X",
+            "line_len_m": 30.48,  # 100 ft
+            # 4:1 balun: line-side voltage is half the feed-side voltage.
+            "balun_n": 0.5,
+            "lmag_uH": 10.0,
+            "qlmag": 100.0,
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 50.0,
+                    "cable": {"enum_options": tuple(sorted(CABLES))},
+                    "line_len_m": {"min": 3.0, "max": 100.0, "unit": "m"},
+                    "balun_n": {"min": 0.25, "max": 1.0},
+                    "lmag_uH": {"min": 1.0, "max": 50.0},
+                    "qlmag": {"min": 0.0, "max": 400.0},
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        # Stock folded inv-vee geometry; the driven gap becomes the named
+        # "feed" port (the source lives at the virtual rig node).
+        wires = []
+        for p0, p1, nseg, ev, *rest in super().build_wires():
+            if ev is not None:
+                wires.append((p0, p1, nseg, None, "feed"))
+            else:
+                wires.append((p0, p1, nseg, ev, *rest))
+        return wires
+
+    def build_network(self):
+        return Network(
+            ports={
+                "feed": PortOnWire("feed"),
+                "bal": PortVirtual("bal"),  # balun line-side terminals
+                "rig": PortVirtual("rig"),
+            },
+            branches=[
+                TL.from_cable(self.cable, "rig", "bal", self.line_len_m),
+                Transformer(
+                    a="bal",
+                    b="feed",
+                    n=self.balun_n,
+                    lmag=self.lmag_uH * 1e-6,
+                    qlmag=self.qlmag if self.qlmag > 0 else None,
+                ),
+            ],
+            sources=[Driven(port="rig", voltage=1 + 0j)],
+        )

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -9,6 +9,7 @@ from ..network import (
     PortVirtual,
     Shunt,
     TL,
+    Transformer,
     TwoPort,
     _series_rlc_impedance,
     load_impedance,
@@ -300,8 +301,9 @@ class PyNECEngine(SimulationEngine):
         if any(isinstance(p, PortVirtual) for p in net.ports.values()):
             return True
         # A Shunt to common has no native NEC card (there's no 1-port
-        # shunt-to-common primitive); always reduce it.
-        if any(isinstance(b, Shunt) for b in net.branches):
+        # shunt-to-common primitive); always reduce it. Same for the ideal
+        # Transformer (issue #301): no NEC card expresses the ideal ratio.
+        if any(isinstance(b, (Shunt, Transformer)) for b in net.branches):
             return True
         # A finite-Q Load (issue #298) needs R = ωL/Q re-derived at every
         # frequency; ld_card takes fixed R/L/C baked into one context, which
@@ -328,10 +330,11 @@ class PyNECEngine(SimulationEngine):
             raise ValueError("native_nt=True requires a build_network() design")
         if not any(isinstance(b, TwoPort) for b in net.branches):
             raise ValueError("native_nt=True but the network has no TwoPort branch")
-        if any(isinstance(b, Shunt) for b in net.branches):
+        if any(isinstance(b, (Shunt, Transformer)) for b in net.branches):
             raise ValueError(
-                "native_nt=True cannot emit a Shunt natively (no 1-port "
-                "shunt-to-common NEC card); run the default reducer path instead"
+                "native_nt=True cannot emit a Shunt or Transformer natively "
+                "(no 1-port shunt-to-common NEC card; no card for an ideal "
+                "transformer ratio); run the default reducer path instead"
             )
         if any(isinstance(b, TL) for b in net.branches):
             raise ValueError(

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -243,14 +243,51 @@ class Shunt:
     qc: float | None = None  # capacitor Q: adds ESR = 1/(omega*C*Q)
 
 
-Branch = Union[TL, Load, TwoPort, Shunt]
+@dataclass(frozen=True)
+class Transformer:
+    """Ideal transformer between two ports, with optional loss — the
+    balun/unun element (issue #301). Each winding spans its port's node to
+    the common datum (the same two-terminal convention every branch uses).
+
+    n is the a:b turns ratio: v_a = n·v_b and i_b = −n·i_a, so the
+    impedance seen at port a is n²·Z_b — a 4:1 balun stepping a ~300 Ω
+    folded-dipole feed down to ~75 Ω line is `Transformer(a=line_side,
+    b=feed, n=0.5)`. n = 1 (with no loss) is an ideal through-connection;
+    n = 0 is rejected at stamp time (it would pin v_a = 0 while
+    open-circuiting b — no physical transformer does that).
+
+    Loss model, deliberately minimal (enough to reproduce a published
+    insertion-loss curve's shape, not a full transformer model):
+      r     — series winding resistance in Ω, referred to side a
+              (constitutive row v_a − n·v_b = r·i_a);
+      lmag  — magnetizing inductance in H, shunted across side a: at low
+              frequency ωL_mag stops dwarfing the source impedance and
+              insertion loss rises, the classic balun low-end rolloff;
+      qlmag — finite Q of the magnetizing branch (core loss), same
+              convention as `ql` elsewhere (issue #298).
+
+    Reducer-only on both engines: there is no native NEC card for an
+    ideal transformer (nt_card could bake a lossy 2×2 but not the ideal
+    ratio), so a Transformer always takes the shared MNA path. Its
+    dissipation (winding + magnetizing) itemizes in the power budget
+    (issue #299)."""
+
+    a: str
+    b: str
+    n: float
+    r: float | None = None
+    lmag: float | None = None
+    qlmag: float | None = None
+
+
+Branch = Union[TL, Load, TwoPort, Shunt, Transformer]
 
 
 def _branch_port_refs(br):
     """Port names a branch references, regardless of branch type."""
-    if hasattr(br, "a"):  # TL, TwoPort
+    if hasattr(br, "a"):  # TL, TwoPort, Transformer
         return (br.a, br.b)
-    return (br.port,)  # Load
+    return (br.port,)  # Load, Shunt
 
 
 def _series_rlc_impedance(r, l, c, omega, ql=None, qc=None):

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -37,6 +37,7 @@ from .network import (
     Load,
     PortOnWire,
     Shunt,
+    Transformer,
     TwoPort,
     _parallel_rlc_admittance,
     _series_rlc_impedance,
@@ -116,6 +117,18 @@ class _Group2Element:
     Each branch picks whichever form keeps its coefficients finite, so no
     element value is ever inverted — the reason ideal shorts and trap-
     resonance opens need no special-case guards here.
+
+    Generalization for coupled elements (issue #301, the Transformer):
+    ``ka``/``kb`` scale the KCL currents (``ka·j`` leaves node a,
+    ``kb·j`` enters node b — an ideal transformer's windings carry
+    ratio-linked currents, so kb = n), and ``c_va``/``c_vb``, when set,
+    replace the symmetric ``∓c_v`` voltage coefficients of the
+    constitutive row with
+
+        c_va · v_a + c_vb · v_b + c_j · j = e
+
+    (the transformer's row is v_a − n·v_b − r_w·j = 0). Defaults keep
+    every pre-existing series element bit-identical.
     """
 
     a: int | None
@@ -123,6 +136,10 @@ class _Group2Element:
     c_v: complex
     c_j: complex
     e: complex
+    ka: complex = 1.0 + 0j
+    kb: complex = 1.0 + 0j
+    c_va: complex | None = None
+    c_vb: complex | None = None
 
 
 def _series_group2(a, b, r, l, c, omega, emf=0j, ql=None, qc=None):
@@ -162,11 +179,11 @@ class MNASystem:
         for x, el in enumerate(elements):
             col = n + x
             if el.a is not None:
-                A[el.a, col] += 1.0  # j leaves node a
-                A[col, el.a] -= el.c_v
+                A[el.a, col] += el.ka  # ka·j leaves node a
+                A[col, el.a] += -el.c_v if el.c_va is None else el.c_va
             if el.b is not None:
-                A[el.b, col] -= 1.0  # j enters node b
-                A[col, el.b] += el.c_v
+                A[el.b, col] -= el.kb  # kb·j enters node b
+                A[col, el.b] += el.c_v if el.c_vb is None else el.c_vb
             A[col, col] = el.c_j
             rhs[col] = el.e
         self.n_nodes = n
@@ -200,7 +217,13 @@ class MNASystem:
             el = self.elements[payload]
             va = 0j if el.a is None else v[el.a]
             vb = 0j if el.b is None else v[el.b]
-            return 0.5 * float(np.real((va - vb) * np.conj(j[payload])))
+            # Power absorbed = ½Re(v_a·(ka·j)* − v_b·(kb·j)*): the element
+            # draws ka·j from node a and delivers kb·j into node b. Plain
+            # series elements have ka = kb = 1 (the familiar (v_a − v_b)·j*);
+            # a transformer's ratio-linked windings make it (v_a − n·v_b)·j*,
+            # i.e. only the winding-resistance drop dissipates.
+            i_a, i_b = el.ka * j[payload], el.kb * j[payload]
+            return 0.5 * float(np.real(va * np.conj(i_a) - vb * np.conj(i_b)))
         # termination: the Load part of the source/load branch at node k.
         col, e = self.terminations[payload]
         return 0.5 * float(np.real((e - v[payload]) * np.conj(j[col])))
@@ -316,6 +339,46 @@ class NetworkReducer:
                     elements.append(
                         _series_group2(
                             k, None, br.r, br.l, br.c, omega, ql=br.ql, qc=br.qc
+                        )
+                    )
+            elif isinstance(br, Transformer):
+                if br.n == 0:
+                    raise ValueError(
+                        f"Transformer {br.a!r}→{br.b!r} has turns ratio n = 0; "
+                        "no physical transformer pins one winding at 0 V while "
+                        "open-circuiting the other"
+                    )
+                a, b = self.port_to_idx[br.a], self.port_to_idx[br.b]
+                nr = complex(br.n)
+                z_w = complex(br.r) if br.r is not None else 0j
+                # Ideal ratio + winding R referred to side a: the auxiliary
+                # current j is i_a (into winding A); KCL carries j out of a
+                # and n·j into b; constitutive row v_a − n·v_b − r_w·j = 0.
+                probes.append((f"Transformer {br.a}→{br.b}", "group2", len(elements)))
+                elements.append(
+                    _Group2Element(
+                        a,
+                        b,
+                        c_v=0j,
+                        c_j=-z_w,
+                        e=0j,
+                        ka=1.0 + 0j,
+                        kb=nr,
+                        c_va=1.0 + 0j,
+                        c_vb=-nr,
+                    )
+                )
+                if br.lmag is not None:
+                    zl = 1j * omega * br.lmag
+                    if br.qlmag is not None:
+                        zl += omega * br.lmag / br.qlmag
+                    y_mag = 1.0 / zl
+                    G[a, a] += y_mag
+                    probes.append(
+                        (
+                            f"Transformer {br.a}→{br.b} (mag)",
+                            "group1",
+                            ([a], np.array([[y_mag]])),
                         )
                     )
             elif isinstance(br, Load):

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1,0 +1,128 @@
+"""Transformer/balun network element (issue #301).
+
+Circuit-level oracles through the NetworkReducer with a synthetic one-port
+antenna Y: the ideal ratio (Z_in = n²·Z_L exactly), the degenerate
+through-connection at n = 1, winding-resistance and magnetizing-branch loss
+landing in the power budget (#299), and the low-frequency insertion-loss
+rolloff a real balun shows.
+"""
+
+import numpy as np
+import pytest
+
+from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, Transformer
+from antennaknobs.network_reduce import C_LIGHT, NetworkReducer
+
+F_MHZ = 10.0
+WL = C_LIGHT / (F_MHZ * 1e6)
+OMEGA = 2.0 * np.pi * F_MHZ * 1e6
+
+
+def _reducer(xfmr):
+    net = Network(
+        ports={"ant": PortOnWire("ant"), "rig": PortVirtual("rig")},
+        branches=[xfmr],
+        sources=[Driven("rig", 1 + 0j)],
+    )
+    return NetworkReducer(net, {"ant": 0, "rig": 1}, 2)
+
+
+def _zin(xfmr, z_l, wl=WL):
+    red = _reducer(xfmr)
+    (z,) = red.driven_impedance(np.array([[1.0 / z_l]], dtype=np.complex128), wl)
+    return z
+
+
+def _excited(xfmr, z_l, wl=WL):
+    red = _reducer(xfmr)
+    return red.excited_state(np.array([[1.0 / z_l]], dtype=np.complex128), wl)
+
+
+def test_ideal_ratio_is_exactly_n_squared():
+    z_l = 300.0 - 40.0j
+    for n in (2.0, 0.5, 3.5):
+        z = _zin(Transformer(a="rig", b="ant", n=n), z_l)
+        np.testing.assert_allclose(z, n * n * z_l, rtol=1e-12)
+
+
+def test_unity_ratio_is_a_through_connection():
+    z_l = 73.0 + 42.5j
+    np.testing.assert_allclose(
+        _zin(Transformer(a="rig", b="ant", n=1.0), z_l), z_l, rtol=1e-12
+    )
+
+
+def test_lossless_transformer_dissipates_nothing():
+    _v, eff, p_in, budget = _excited(Transformer(a="rig", b="ant", n=0.5), 300.0)
+    assert eff == 1.0
+    assert p_in > 0
+    (label, w) = budget[0]
+    assert label == "Transformer rig→ant"
+    assert abs(w) < 1e-12 * p_in
+
+
+def test_winding_resistance_adds_referred_to_side_a():
+    z_l, n, r = 300.0 + 0j, 0.5, 1.2
+    z = _zin(Transformer(a="rig", b="ant", n=n, r=r), z_l)
+    np.testing.assert_allclose(z, n * n * z_l + r, rtol=1e-12)
+    v, eff, p_in, budget = _excited(Transformer(a="rig", b="ant", n=n, r=r), z_l)
+    p_ant = 0.5 * abs(v[0]) ** 2 * np.real(1.0 / z_l)
+    p_network = sum(w for _l, w in budget)
+    np.testing.assert_allclose(p_ant + p_network, p_in, rtol=1e-12)
+    assert eff < 1.0
+    np.testing.assert_allclose(eff, 1.0 - p_network / p_in, rtol=1e-12)
+
+
+def test_magnetizing_branch_matches_the_parallel_formula():
+    z_l, n, lmag = 300.0 + 0j, 0.5, 10e-6
+    z = _zin(Transformer(a="rig", b="ant", n=n, lmag=lmag), z_l)
+    z_ideal = n * n * z_l
+    z_mag = 1j * OMEGA * lmag
+    np.testing.assert_allclose(z, z_ideal * z_mag / (z_ideal + z_mag), rtol=1e-12)
+
+
+def test_core_loss_rises_toward_low_frequency():
+    """Finite-Q magnetizing branch: the classic balun low-end rolloff —
+    the (mag) budget entry grows as the frequency drops."""
+    xf = Transformer(a="rig", b="ant", n=0.5, lmag=10e-6, qlmag=50.0)
+
+    def mag_fraction(f_mhz):
+        wl = C_LIGHT / (f_mhz * 1e6)
+        _v, _eff, p_in, budget = _excited(xf, 300.0, wl=wl)
+        return dict(budget)["Transformer rig→ant (mag)"] / p_in
+
+    assert mag_fraction(1.8) > 3.0 * mag_fraction(28.0)
+    assert mag_fraction(1.8) > 0.0
+
+
+def test_zero_turns_ratio_is_rejected():
+    red = _reducer(Transformer(a="rig", b="ant", n=0.0))
+    with pytest.raises(ValueError, match="turns ratio n = 0"):
+        red.driven_impedance(np.array([[1.0 / 50.0]], dtype=np.complex128), WL)
+
+
+def test_folded_invvee_balun_showcase():
+    """The showcase design: ~218 Ω folded inv-vee feed stepped to ~55 Ω by
+    the 4:1 balun, onto 50 Ω coax — SWR at the rig near 1, the transformer's
+    ideal-ratio row lossless, and both engines agreeing."""
+    from antennaknobs.cli import list_builtin_designs
+    from antennaknobs.designs.dipoles.folded_invvee_balun import Builder
+    from antennaknobs.engines import MomwireEngine
+    from momwire import SinusoidalSolver
+
+    assert "dipoles.folded_invvee_balun" in set(list_builtin_designs())
+    eng = MomwireEngine(Builder(), ground=None, solver=SinusoidalSolver)
+    (z,) = eng.impedance()
+    gamma = abs((z - 50.0) / (z + 50.0))
+    assert (1 + gamma) / (1 - gamma) < 1.3  # matched at the rig
+    eng.current_distribution()
+    fr = {
+        label: max(0.0, w) / eng._excited_p_in for label, w in eng._excited_power_budget
+    }
+    assert fr["Transformer bal→feed"] < 1e-9  # ideal ratio burns nothing
+    assert 0.0 < fr["Transformer bal→feed (mag)"] < 0.01  # tiny at 28 MHz
+    assert fr["TL rig→bal"] > 0.25  # RG-8X at 10 m, the familiar ~31%
+
+    pynec = pytest.importorskip("antennaknobs.engines.pynec")
+    zn = pynec.PyNECEngine(Builder(), ground=None).impedance()[0]
+    assert abs(z - zn) / abs(z) < 0.01


### PR DESCRIPTION
## Summary
- Final piece of the station-modelling arc (#301): `Transformer(a, b, n, r, lmag, qlmag)` — ideal turns ratio (Z_a = n²·Z_b exactly) with a minimal loss model: series winding R referred to side a, and a finite-Q magnetizing inductance shunting side a that reproduces the classic balun low-band insertion-loss rolloff.
- The MNA core needed one generalization rather than a paired row: `_Group2Element` grows `ka`/`kb` KCL current coefficients (ratio-linked winding currents, kb = n) and optional asymmetric row coefficients, defaults bit-identical for every existing element. The #299 budget probe generalizes to ½·Re(v_a·(ka·j)* − v_b·(kb·j)*), so the ideal ratio dissipates exactly zero.
- Degenerates per the house Group-2 conventions: n = 1 lossless is an exact through-connection; n = 0 raises a clear error. Reducer-only on both engines; `native_nt` rejects it; `nec_export` refuses via the `_use_reducer` gate.
- Showcase: `dipoles.folded_invvee_balun` — ~218 Ω folded inv-vee → 4:1 balun → 100 ft RG-8X: SWR 1.10 at the rig, the budget itemizing line (31 %) / ideal ratio (0) / magnetizing (0.02 % at 28 MHz, >3× larger at 1.8 MHz), PyNEC agreeing to 0.01 %. Catalog row added.

## Test plan
- [x] 8 oracles in `tests/test_transformer.py`: exact n² ratio and unity pass-through (1e-12), lossless-dissipates-nothing, winding-R conservation (radiated + branches = p_in at 1e-12), analytic jωL_mag ∥ n²Z_L check, low-frequency core-loss rolloff, n = 0 rejection, showcase design end-to-end on both engines
- [x] Full suite: 1553 passed (registry sweeps auto-cover the new design)
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)