### PR TITLE
Generate the design-catalog listings from the design tree

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -39,7 +39,11 @@ direct push. In one commit, `chore: release vX.Y.Z (<theme>)`:
    last release, sweep `site/src/content/docs/` for pages describing the old
    behavior (`solver.md`, `web.md`, `cli.md`, the concepts pages). `site/` is
    NOT touched by feature PRs and is easy to forget — v0.19.0 found six stale
-   pages this way.
+   pages this way. The design catalog (`reference/catalog.md`) is EXCLUDED
+   from this sweep since issue #292: its listings are generated from the
+   design tree (`python scripts/generate_catalog.py`) and the test suite
+   fails if they drift, so design changes force the page in their own PR —
+   never hand-edit the tables.
 4. Build the site (`cd site && npm run build`) — it must pass before the PR.
 
 Merge with `/merge-pr` (rebase, CI green first).

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -1,0 +1,151 @@
+"""Generate the design-catalog listings from the design tree (issue #292).
+
+The catalog page (site/src/content/docs/reference/catalog.md) is curated
+prose (intro, family blurbs) wrapping GENERATED per-family tables. This
+script rewrites only what sits between the marker pairs
+
+    <!-- catalog:begin <family> -->
+    ...
+    <!-- catalog:end <family> -->
+
+so the listings can never drift from the code: every design enumerated by
+`python -m antennaknobs list` appears exactly once, its description is the
+first sentence of its module docstring (mandatory — this script fails on a
+design without one), and its variants come from the `*_params`
+class-attribute convention via the web adapter's `_discover_variants`.
+
+Usage:
+    python scripts/generate_catalog.py           # rewrite the page in place
+    python scripts/generate_catalog.py --check   # exit 1 if the committed
+                                                 # page is stale (CI mode —
+                                                 # also run by the test suite)
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+CATALOG = REPO / "site" / "src" / "content" / "docs" / "reference" / "catalog.md"
+
+# Page order; every family in the design tree must be listed here (the
+# script fails on a new family so it gets a curated section deliberately).
+FAMILIES = [
+    "dipoles",
+    "loops",
+    "beams",
+    "verticals",
+    "wire",
+    "broadband",
+    "multiband",
+    "arrays",
+    "specialty",
+]
+
+
+def _description(design: str) -> str:
+    """First sentence of the design module's docstring, collapsed to one
+    line, trailing period dropped (table-note style)."""
+    mod = importlib.import_module(f"antennaknobs.designs.{design}")
+    doc = (mod.__doc__ or "").strip()
+    if not doc:
+        raise SystemExit(
+            f"error: {design} has no module docstring — the catalog "
+            "description is its first sentence, so every design needs one"
+        )
+    first_para = doc.split("\n\n", 1)[0]
+    one_line = " ".join(first_para.split())
+    # First sentence: split at a period followed by whitespace, but not
+    # after an initial ("L. B. Cebik") — a single capital letter before
+    # the period is not a sentence end.
+    sentence = re.split(r"(?<![A-Z]\.)(?<=\.)\s", one_line, maxsplit=1)[0]
+    return sentence.rstrip(".")
+
+
+def _variants(design: str) -> tuple[str, ...]:
+    from antennaknobs.cli import resolve_class
+    from antennaknobs.web.adapter import _discover_variants
+
+    cls = resolve_class(design)
+    return tuple(v for v in _discover_variants(cls) if v != "default")
+
+
+def _family_table(designs: list[str]) -> str:
+    rows = ["| Design | Notes |", "| --- | --- |"]
+    for d in designs:
+        note = _description(d)
+        variants = _variants(d)
+        if variants:
+            note += " · variants: " + ", ".join(f"`{v}`" for v in variants)
+        rows.append(f"| `{d}` | {note} |")
+    return "\n".join(rows)
+
+
+def render(page: str) -> str:
+    """Return `page` with every marker block regenerated."""
+    # Import the server first: adapter has an import cycle with .examples
+    # when it is the entry module.
+    import antennaknobs.web.server  # noqa: F401
+
+    from antennaknobs.cli import list_builtin_designs
+
+    by_family: dict[str, list[str]] = {}
+    for name in list_builtin_designs():
+        by_family.setdefault(name.split(".", 1)[0], []).append(name)
+
+    unknown = set(by_family) - set(FAMILIES)
+    if unknown:
+        raise SystemExit(
+            f"error: design families {sorted(unknown)} are not in "
+            "generate_catalog.FAMILIES — add them (and a curated section "
+            "with markers to catalog.md)"
+        )
+
+    out = page
+    for family in FAMILIES:
+        designs = by_family.get(family)
+        if not designs:
+            raise SystemExit(f"error: no designs found for family {family!r}")
+        pattern = re.compile(
+            rf"<!-- catalog:begin {family} -->\n?.*?<!-- catalog:end {family} -->",
+            re.DOTALL,
+        )
+        if not pattern.search(out):
+            raise SystemExit(
+                f"error: catalog.md has no marker block for family {family!r}"
+            )
+        block = (
+            f"<!-- catalog:begin {family} -->\n"
+            + _family_table(designs)
+            + f"\n<!-- catalog:end {family} -->"
+        )
+        out = pattern.sub(lambda _m: block, out)
+    return out
+
+
+def main() -> int:
+    page = CATALOG.read_text()
+    fresh = render(page)
+    if "--check" in sys.argv[1:]:
+        if fresh != page:
+            sys.stderr.write(
+                "catalog.md is stale — regenerate with "
+                "`python scripts/generate_catalog.py` and commit the result\n"
+            )
+            return 1
+        print("catalog.md is up to date")
+        return 0
+    if fresh != page:
+        CATALOG.write_text(fresh)
+        print(f"rewrote {CATALOG.relative_to(REPO)}")
+    else:
+        print("catalog.md already up to date")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, str(REPO / "src"))
+    raise SystemExit(main())

--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -11,120 +11,158 @@ after L. B. Cebik (W4RNL)'s articles.
 
 ## Dipoles
 
+<!-- catalog:begin dipoles -->
 | Design | Notes |
 | --- | --- |
-| `dipoles.invvee` | Inverted-vee dipole (the default quickstart example) |
-| `dipoles.folded_invvee` | Folded inverted-vee |
-| `dipoles.ocf_dipole` | Off-center-fed dipole (Windom) — a half-wave fed away from the middle |
-| `dipoles.dipole_turnstile` | Crossed dipoles fed in phase quadrature |
-| `dipoles.koch_dipole` | Koch fractal dipole |
-| `dipoles.short_dipole_loaded` | Center-loaded shortened dipole (a Load-branch showcase) |
-| `dipoles.invvee_coax_station` | The inv-vee fed through 100 ft of real coax (cable preset dropdown), referenced to the rig — line loss and the SWR penalty in the power budget |
-| `dipoles.folded_invvee_balun` | Folded inv-vee (~218 Ω) through a lossy 4:1 balun onto 50 Ω coax — the Transformer-element showcase |
+| `dipoles.dipole_turnstile` | Crossed dipoles fed in phase quadrature (turnstile) |
+| `dipoles.folded_invvee` | Folded inverted-vee — the folded dipole's impedance step-up, with drooped arms |
+| `dipoles.folded_invvee_balun` | Folded inverted-V fed through a 4:1 balun and real coax — the `Transformer` showcase (issue #301) |
+| `dipoles.invvee` | Inverted-vee dipole — the default quickstart example · variants: `classic_edz`, `dipole`, `three_halves` |
+| `dipoles.invvee_coax_station` | Inverted-V fed through real coax — the classic "resonant antenna on 50 Ω line" station, modelled from the rig (issue #300) · variants: `classic_edz`, `dipole`, `three_halves` |
+| `dipoles.koch_dipole` | Koch fractal dipole (L. B. Cebik, W4RNL -- "fractal antennas") |
+| `dipoles.ocf_dipole` | Off-Center-Fed dipole (Windom): a half-wave fed away from the middle (L. B. Cebik, W4RNL) |
+| `dipoles.short_dipole_loaded` | Center-loaded shortened dipole — the Load-branch showcase for issue #65 |
+<!-- catalog:end dipoles -->
 
 ## Loops
 
 The delta loop is the catalog's teaching showpiece — one loop laid out **four
-ways**, all exposing the same knobs (`base`, `length_factor`, `angle_deg`) and
-producing byte-identical wires. They differ only in *how you specify the
-geometry*, from writing every corner as coordinates to flying the whole shape
-with a `Drone` (see [Many ways to express geometry](/concepts/authoring/)):
+ways** (`delta_loop`, `delta_loop_flyby`, `delta_loop_reflected`,
+`delta_loop_topdown`), all exposing the same knobs (`base`, `length_factor`,
+`angle_deg`) and producing byte-identical wires. They differ only in *how you
+specify the geometry*, from writing every corner as coordinates to flying the
+whole shape with a `Drone` — see
+[Many ways to express geometry](/concepts/authoring/).
 
-| Design | Built by |
+<!-- catalog:begin loops -->
+| Design | Notes |
 | --- | --- |
-| `loops.delta_loop` | the shipped version: corner coordinates from a closed-form expression for the top corner |
-| `loops.delta_loop_flyby` | full `Drone` (3D turtle) flyby; top laid by `forward_through_plane`, feed-anchored with a z-offset pass |
-| `loops.delta_loop_reflected` | `Drone` point-finder + `ry` reflection + `build_path` (side solved for the perimeter) |
-| `loops.delta_loop_topdown` | top-down flight: starts at the top, `forward_to_plane` lands the feed where the slant crosses `y = eps` |
-
-Other loops: `loops.delta_loop_slanted`, `loops.inv_delta_loop`,
-`loops.horizontal_loop` (full-wave "loop skywire") and its `Drone` twin
-`loops.horizontal_loop_drone`, `loops.diamond_loop` (+ `diamond_loop_turnstile`),
-`loops.quad` (2-element cubical quad beam), `loops.bisquare` (a two-wavelength
-broadside curtain), `loops.triangular_skyloop` (corner-fed full-wave triangle),
-and `loops.skyloop_lmatch` (the 80 m skyloop worked on 17 m through an
-L-network — series L, shunt C — matched to 50 Ω).
+| `loops.bisquare` | Bi-square: a two-wavelength loop worked as a vertical broadside curtain (L. B. Cebik, W4RNL) |
+| `loops.delta_loop` | Corner-fed full-wave delta loop; corner coordinates from a closed-form expression for the top corner · variants: `z100`, `z200` |
+| `loops.delta_loop_flyby` | The shipped delta loop, laid down as a full **drone flyby** — fly the whole perimeter and let the flight do the work, no coordinates written |
+| `loops.delta_loop_reflected` | The shipped delta loop, built as a **reflection hybrid**: the drone is a trig-free *point finder*, an ``ry`` mirror gives the left half for free, and ``build_path`` stitches the corners |
+| `loops.delta_loop_slanted` | Delta loop tilted out of the vertical plane by a slant_deg knob · variants: `slant0`, `slant30` |
+| `loops.delta_loop_topdown` | The shipped delta loop, built as a **top-down reflection flight**: the same reflection hybrid as ``delta_loop_reflected``, but the flight starts *at the top* — so the top height is right from move one and there is **no z-offset pass** |
+| `loops.diamond_loop` | Full-wave diamond (square) loop fed at the bottom corner · variants: `z100`, `z200` |
+| `loops.diamond_loop_turnstile` | Two diamond loops crossed and fed in phase quadrature (turnstile) |
+| `loops.horizontal_loop` | Horizontal full-wave loop / "loop skywire" (L. B. Cebik, W4RNL) |
+| `loops.horizontal_loop_drone` | A horizontal square loop, vertex-fed, authored with the 3D-turtle Drone |
+| `loops.inv_delta_loop` | Inverted delta loop — the triangle flipped so the feed edge sits at the top · variants: `z100`, `z200` |
+| `loops.quad` | Two-element cubical quad beam (L. B. Cebik, W4RNL) |
+| `loops.skyloop_lmatch` | 80 m triangular skyloop run on 17 m, matched to 50 Ω with an L-network — the `Shunt`-branch showcase for issue #65 (Q2, shunt-to-common) · variants: `band_locked` |
+| `loops.triangular_skyloop` | Triangular horizontal full-wave loop ("skyloop"), fed at a corner · variants: `band_locked` |
+<!-- catalog:end loops -->
 
 ## Beams
 
+<!-- catalog:begin beams -->
 | Design | Notes |
 | --- | --- |
-| `beams.yagi` | Yagi–Uda parasitic beam |
-| `beams.moxon` | Moxon rectangle |
-| `beams.hexbeam` | Hex beam |
-| `beams.hb9cv` | ZL-Special / HB9CV — a 2-element all-driven phased beam |
+| `beams.hb9cv` | ZL-Special / HB9CV: a 2-element all-driven phased beam (L. B. Cebik, W4RNL) |
+| `beams.hexbeam` | Hex beam — a W-folded 2-element beam on a hexagonal spreader footprint · variants: `opt` |
+| `beams.moxon` | Moxon rectangle — a 2-element beam with folded-back element tips · variants: `opt`, `original` |
+| `beams.yagi` | Yagi-Uda parasitic beam (driven element + reflector + directors) |
+<!-- catalog:end beams -->
 
 ## Verticals
 
+<!-- catalog:begin verticals -->
 | Design | Notes |
 | --- | --- |
-| `verticals.vertical` | Quarter-wave vertical |
-| `verticals.raised_vertical` | Elevated vertical |
-| `verticals.inverted_l` | Inverted-L, a bent top-loaded vertical |
-| `verticals.inverted_l_tmatch` | The 10 m inverted-L worked on 12 m through a T-network tuner (series C, shunt L, series C) |
-| `verticals.jpole` | J-pole, end-fed half-wave with a quarter-wave matching stub |
-| `verticals.half_square` | Half-square, a vertically-polarised wire antenna |
-| `verticals.bobtail` | Bobtail curtain, a 3-element vertical broadside array |
-| `verticals.bruce` | Bruce array, a series-fed vertical curtain |
-| `verticals.phased_verticals` | Two-element phased verticals (the 90° cardioid) |
-| `verticals.four_square` | Four-square phased array (diagonal-firing quadrature box) |
+| `verticals.bobtail` | Bobtail curtain: a 3-element vertically-polarised broadside array (L. B. Cebik, W4RNL) |
+| `verticals.bruce` | Bruce array: a series-fed vertically-polarised curtain (L. B. Cebik, W4RNL) |
+| `verticals.four_square` | Four-square phased vertical array -- the diagonal-firing quadrature box (L. B. Cebik, W4RNL) |
+| `verticals.half_square` | Half-square: a vertically-polarised wire antenna (L. B. Cebik, W4RNL) |
+| `verticals.inverted_l` | Inverted-L: a bent, top-loaded vertical (L. B. Cebik, W4RNL) |
+| `verticals.inverted_l_tmatch` | 10 m inverted-L worked on the 12 m band through a T-network tuner — the first design with a pure interior circuit node (series C, shunt L, series C), exercising the MNA network core on the classic "wire antenna + T-match" situation |
+| `verticals.jpole` | J-pole: an end-fed half-wave matched by a quarter-wave stub (L. B. Cebik, W4RNL) |
+| `verticals.phased_verticals` | Two-element phased vertical array -- the 90-degree cardioid (L. B. Cebik, W4RNL) |
+| `verticals.raised_vertical` | Elevated quarter-wave vertical, fed above ground |
+| `verticals.vertical` | Quarter-wave vertical over ground |
+<!-- catalog:end verticals -->
 
 ## Wire antennas & curtains
 
+<!-- catalog:begin wire -->
 | Design | Notes |
 | --- | --- |
-| `wire.longwire` | Resonant multi-wavelength long-wire |
-| `wire.rhombic` | Terminated rhombic, a traveling-wave directional long-wire |
-| `wire.vbeam` | Resonant V-beam, two long wires splayed into a V |
-| `wire.lazy_h` | Lazy-H, two stacked collinear elements fed in phase |
-| `wire.w8jk` | W8JK flat-top beam, a 2-element all-driven array |
-| `wire.zepp` | End-fed half-wave "Zepp" with a tuned-stub feeder |
-| `wire.sterba` | Sterba curtain (broadside, bidirectional) — plus the `sterba_tl` transmission-line-phased variant |
-| `wire.doublet_ladder_tuner` | 88 ft doublet + 100 ft of 600 Ω open-wire line + lossy T-network tuner, referenced to the rig — the classic multiband station, with the tuner-coil cost in the power budget |
+| `wire.doublet_ladder_tuner` | 88 ft doublet + 100 ft of 600 Ω open-wire line + lossy T-network tuner — the "non-resonant wire and a matchbox" station, modelled from the rig (issue #300) · variants: `classic_edz`, `dipole`, `three_halves` |
+| `wire.lazy_h` | Lazy-H: two stacked collinear elements fed in phase (L. B. Cebik, W4RNL) |
+| `wire.longwire` | Resonant multi-wavelength long-wire (L. B. Cebik, W4RNL) |
+| `wire.rhombic` | Terminated rhombic: a traveling-wave directional long-wire (L. B. Cebik, W4RNL, "Long-Wire Antennas" / "The Terminated Vee-Beam and Rhombic") |
+| `wire.sterba` | Sterba curtain: a broadside, bidirectional, horizontally-polarised curtain array (E. J. Sterba, Bell Labs, 1930s) |
+| `wire.sterba_tl` | Sterba curtain, transmission-line sister design of `sterba.py` |
+| `wire.vbeam` | Resonant V-beam: two long wires splayed into a V (L. B. Cebik, W4RNL) |
+| `wire.w8jk` | W8JK flat-top beam: a 2-element all-driven 180-degree array (L. B. Cebik, W4RNL, after John Kraus W8JK) |
+| `wire.zepp` | End-fed half-wave "Zepp" with a tuned-stub feeder (L. B. Cebik, W4RNL) |
+<!-- catalog:end wire -->
 
 ## Broadband
 
+<!-- catalog:begin broadband -->
 | Design | Notes |
 | --- | --- |
-| `broadband.discone` | Discone, a broadband vertical (disc + cone) as a wire cage |
-| `broadband.g5rv` | G5RV doublet with a matched-line section |
-| `broadband.t2fd` | T2FD — terminated tilted folded dipole |
-| `broadband.lpda` | Log-periodic dipole array (LPDA) |
+| `broadband.discone` | Discone: a broadband vertical (disc + cone), modelled as a wire cage (L. B. Cebik, W4RNL) |
+| `broadband.g5rv` | G5RV doublet with a matched-line section (analysed at length by L. B. Cebik, W4RNL, "The G5RV Antenna") |
+| `broadband.lpda` | Log-periodic dipole array (LPDA) (L. B. Cebik, W4RNL; ARRL Antenna Book LPDA chapter) |
+| `broadband.t2fd` | T2FD -- Terminated Tilted Folded Dipole (G2BCX; modeled per L. B. Cebik, W4RNL, "broadband wire antennas") |
+<!-- catalog:end broadband -->
 
 ## Multiband
 
+<!-- catalog:begin multiband -->
 | Design | Notes |
 | --- | --- |
-| `multiband.fandipole` | Fan dipole (parallel dipoles for several bands) |
-| `multiband.twoband_fan_dipole` | Two-band fan dipole |
-| `multiband.trap_dipole` | Dual-band trap dipole |
-| `multiband.trap_fan_dipole` | Four-band trapped fan dipole |
-| `multiband.hexbeam_5band` | Stacked hexbeam — up to 5 concentric shapes |
+| `multiband.fandipole` | Fan dipole — parallel dipoles off one feed for several bands · variants: `five_band`, `pair_12_10`, `pair_17_15` |
+| `multiband.hexbeam_5band` | Stacked hexbeam: up to 5 concentric hexbeam shapes stacked along z, each sized to its own band's wavelength and driven by its own feed · variants: `opt`, `opt_coupled` |
+| `multiband.trap_dipole` | Dual-band trap dipole — Load(parallel=True) showcase for issue #65 |
+| `multiband.trap_fan_dipole` | Four-band trapped fan dipole — combines `fandipole` geometry with the `trap_dipole` Load(parallel=True) idiom · variants: `band0_full`, `band0_inner`, `band1_full`, `band1_inner` |
+| `multiband.twoband_fan_dipole` | Two-band fan (parallel) dipole — two dipoles bonded at a common feed · variants: `current_physical`, `s01`, `s015`, `s01_eps001`, `s02`, `s025`, `s03`, `s05`, `s07` |
+<!-- catalog:end multiband -->
 
 ## Arrays
 
 Phased / stacked arrays of the elements above — the `arrayblock` solver's
 showcase (see [the solver guide](/reference/solver/)):
 
-`arrays.yagiarray`, `arrays.moxonarray`, `arrays.invveearray`,
-`arrays.folded_invveearray`, `arrays.bowtiearray` (+ `1x2`, `2x4`),
-`arrays.delta_looparray` (+ `1x4`, `1x4_grouped`, `2x2`, `network`, `with_tls`),
-`arrays.hentenna_array`, `arrays.hourglass_array`, and
-`arrays.lumped_coupled_pair` (a dipole pair steered through a lumped series
-R+jωL bridge between the two feeds — the `TwoPort` network element's
-showcase).
+<!-- catalog:begin arrays -->
+| Design | Notes |
+| --- | --- |
+| `arrays.bowtiearray` | 2x2 phased stack of bowtie dipoles |
+| `arrays.bowtiearray1x2` | Side-by-side bowtie pair (1x2) |
+| `arrays.bowtiearray2x4` | 2x4 phased bowtie curtain — the catalog's largest stack |
+| `arrays.delta_looparray` | Side-by-side delta-loop pair (1x2) · variants: `dy3`, `dy35`, `dy45` |
+| `arrays.delta_looparray_1x4` | Four delta loops in a broadside row (1x4) |
+| `arrays.delta_looparray_1x4_grouped` | 1x4 delta-loop row with per-group knobs (inner/outer pairs tuned separately) |
+| `arrays.delta_looparray_2x2` | 2x2 phased stack of delta loops |
+| `arrays.delta_looparray_network` | delta_looparray driven by two TLs from a central virtual driver |
+| `arrays.delta_looparray_with_tls` | Delta-loop pair phased through explicit transmission lines (legacy build_tls path) |
+| `arrays.folded_invveearray` | 2x2 phased stack of folded inverted-vees |
+| `arrays.hentenna_array` | Side-by-side hentenna pair (1x2) |
+| `arrays.hourglass_array` | Side-by-side hourglass pair (1x2) |
+| `arrays.invveearray` | 2x2 phased stack of inverted-vee dipoles · variants: `old` |
+| `arrays.lumped_coupled_pair` | Lumped-coupled dipole pair — the TwoPort-branch showcase for issue #65 |
+| `arrays.moxonarray` | 2x2 phased stack of Moxon rectangles |
+| `arrays.yagiarray` | 2x2 phased stack of Yagi beams |
+<!-- catalog:end arrays -->
 
 ## Specialty
 
+<!-- catalog:begin specialty -->
 | Design | Notes |
 | --- | --- |
-| `specialty.bowtie` | Bowtie dipole |
-| `specialty.helix` | Normal-mode helical vertical |
-| `specialty.hentenna` | Hentenna (+ `hentenna_slant`) |
-| `specialty.hourglass` | Hourglass (+ `hourglass_slant`) |
+| `specialty.bowtie` | Bowtie dipole — triangular fan arms for broadened bandwidth |
+| `specialty.helix` | Normal-mode helical vertical (L. B. Cebik, W4RNL) |
+| `specialty.hentenna` | Hentenna — the Japanese rectangular loop, fed off-center for vertical polarization · variants: `z100`, `z50` |
+| `specialty.hentenna_slant` | Slanted hentenna parameterised by top-rectangle perimeter + two aspect ratios · variants: `z100`, `z50` |
+| `specialty.hourglass` | Hourglass loop — a crossed (bowtie-folded) rectangular loop |
+| `specialty.hourglass_slant` | Hourglass loop tilted out of the vertical plane |
+<!-- catalog:end specialty -->
 
-:::note[Generated from source — coming soon]
-This page will be generated from the package's design tree so it can't drift
-from the code: each entry pulling its description, parameters, and rendered
-geometry straight from the `Builder`.
+:::note[Generated from source]
+The listings on this page are generated by `scripts/generate_catalog.py` from
+the package's design tree — each entry's description is the first sentence of
+the design module's docstring, and its variants come from the `*_params`
+convention. Do not edit the tables by hand; edit the docstrings and
+regenerate. The test suite fails if this page drifts from the code.
 :::

--- a/src/antennaknobs/designs/arrays/bowtiearray.py
+++ b/src/antennaknobs/designs/arrays/bowtiearray.py
@@ -1,3 +1,5 @@
+"""2x2 phased stack of bowtie dipoles."""
+
 from ... import Array2x2Builder
 from ..specialty import bowtie
 

--- a/src/antennaknobs/designs/arrays/bowtiearray1x2.py
+++ b/src/antennaknobs/designs/arrays/bowtiearray1x2.py
@@ -1,3 +1,5 @@
+"""Side-by-side bowtie pair (1x2)."""
+
 from ...builder import Array1x2Builder
 from ..specialty import bowtie
 

--- a/src/antennaknobs/designs/arrays/bowtiearray2x4.py
+++ b/src/antennaknobs/designs/arrays/bowtiearray2x4.py
@@ -1,3 +1,5 @@
+"""2x4 phased bowtie curtain — the catalog's largest stack."""
+
 from ... import Array2x4Builder
 from ..specialty import bowtie
 

--- a/src/antennaknobs/designs/arrays/delta_looparray.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray.py
@@ -1,3 +1,5 @@
+"""Side-by-side delta-loop pair (1x2)."""
+
 from ...builder import Array1x2Builder
 from ..loops import delta_loop
 

--- a/src/antennaknobs/designs/arrays/delta_looparray_1x4.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray_1x4.py
@@ -1,3 +1,5 @@
+"""Four delta loops in a broadside row (1x4)."""
+
 from ...builder import Array1x4Builder
 from ..loops import delta_loop
 

--- a/src/antennaknobs/designs/arrays/delta_looparray_1x4_grouped.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray_1x4_grouped.py
@@ -1,3 +1,5 @@
+"""1x4 delta-loop row with per-group knobs (inner/outer pairs tuned separately)."""
+
 from ...builder import Array1x4GroupedBuilder
 from ..loops import delta_loop
 

--- a/src/antennaknobs/designs/arrays/delta_looparray_2x2.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray_2x2.py
@@ -1,3 +1,5 @@
+"""2x2 phased stack of delta loops."""
+
 from ...builder import Array2x2Builder
 from ..loops import delta_loop
 

--- a/src/antennaknobs/designs/arrays/delta_looparray_with_tls.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray_with_tls.py
@@ -1,3 +1,5 @@
+"""Delta-loop pair phased through explicit transmission lines (legacy build_tls path)."""
+
 from ... import AntennaBuilder
 import math
 

--- a/src/antennaknobs/designs/arrays/folded_invveearray.py
+++ b/src/antennaknobs/designs/arrays/folded_invveearray.py
@@ -1,3 +1,5 @@
+"""2x2 phased stack of folded inverted-vees."""
+
 from ... import Array2x2Builder
 from ..dipoles import folded_invvee
 

--- a/src/antennaknobs/designs/arrays/hentenna_array.py
+++ b/src/antennaknobs/designs/arrays/hentenna_array.py
@@ -1,3 +1,5 @@
+"""Side-by-side hentenna pair (1x2)."""
+
 from ...builder import Array1x2Builder
 from ..specialty import hentenna
 

--- a/src/antennaknobs/designs/arrays/hourglass_array.py
+++ b/src/antennaknobs/designs/arrays/hourglass_array.py
@@ -1,3 +1,5 @@
+"""Side-by-side hourglass pair (1x2)."""
+
 from ...builder import Array1x2Builder
 from ..specialty import hourglass
 

--- a/src/antennaknobs/designs/arrays/invveearray.py
+++ b/src/antennaknobs/designs/arrays/invveearray.py
@@ -1,3 +1,5 @@
+"""2x2 phased stack of inverted-vee dipoles."""
+
 from ... import Array2x2Builder
 from ..dipoles import invvee
 

--- a/src/antennaknobs/designs/arrays/moxonarray.py
+++ b/src/antennaknobs/designs/arrays/moxonarray.py
@@ -1,3 +1,5 @@
+"""2x2 phased stack of Moxon rectangles."""
+
 from ... import Array2x2Builder
 from ..beams import moxon
 

--- a/src/antennaknobs/designs/arrays/yagiarray.py
+++ b/src/antennaknobs/designs/arrays/yagiarray.py
@@ -1,3 +1,5 @@
+"""2x2 phased stack of Yagi beams."""
+
 from ... import Array2x2Builder
 from ..beams import yagi
 

--- a/src/antennaknobs/designs/beams/hexbeam.py
+++ b/src/antennaknobs/designs/beams/hexbeam.py
@@ -1,3 +1,5 @@
+"""Hex beam — a W-folded 2-element beam on a hexagonal spreader footprint."""
+
 from ... import AntennaBuilder
 import math
 from types import MappingProxyType

--- a/src/antennaknobs/designs/beams/moxon.py
+++ b/src/antennaknobs/designs/beams/moxon.py
@@ -1,3 +1,5 @@
+"""Moxon rectangle — a 2-element beam with folded-back element tips."""
+
 from ... import AntennaBuilder
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/beams/yagi.py
+++ b/src/antennaknobs/designs/beams/yagi.py
@@ -1,3 +1,5 @@
+"""Yagi-Uda parasitic beam (driven element + reflector + directors)."""
+
 from ... import AntennaBuilder
 import math
 

--- a/src/antennaknobs/designs/dipoles/dipole_turnstile.py
+++ b/src/antennaknobs/designs/dipoles/dipole_turnstile.py
@@ -1,3 +1,5 @@
+"""Crossed dipoles fed in phase quadrature (turnstile)."""
+
 from ... import AntennaBuilder
 
 from types import MappingProxyType

--- a/src/antennaknobs/designs/dipoles/folded_invvee.py
+++ b/src/antennaknobs/designs/dipoles/folded_invvee.py
@@ -1,3 +1,5 @@
+"""Folded inverted-vee — the folded dipole's impedance step-up, with drooped arms."""
+
 from ... import AntennaBuilder
 import math
 

--- a/src/antennaknobs/designs/dipoles/invvee.py
+++ b/src/antennaknobs/designs/dipoles/invvee.py
@@ -1,3 +1,5 @@
+"""Inverted-vee dipole — the default quickstart example."""
+
 from ... import AntennaBuilder
 import math
 

--- a/src/antennaknobs/designs/loops/delta_loop.py
+++ b/src/antennaknobs/designs/loops/delta_loop.py
@@ -1,3 +1,5 @@
+"""Corner-fed full-wave delta loop; corner coordinates from a closed-form expression for the top corner."""
+
 import math
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/loops/delta_loop_slanted.py
+++ b/src/antennaknobs/designs/loops/delta_loop_slanted.py
@@ -1,3 +1,5 @@
+"""Delta loop tilted out of the vertical plane by a slant_deg knob."""
+
 from ... import AntennaBuilder
 import math
 

--- a/src/antennaknobs/designs/loops/diamond_loop.py
+++ b/src/antennaknobs/designs/loops/diamond_loop.py
@@ -1,3 +1,5 @@
+"""Full-wave diamond (square) loop fed at the bottom corner."""
+
 from ... import AntennaBuilder
 import math
 

--- a/src/antennaknobs/designs/loops/diamond_loop_turnstile.py
+++ b/src/antennaknobs/designs/loops/diamond_loop_turnstile.py
@@ -1,3 +1,5 @@
+"""Two diamond loops crossed and fed in phase quadrature (turnstile)."""
+
 from ... import AntennaBuilder
 import math
 

--- a/src/antennaknobs/designs/loops/inv_delta_loop.py
+++ b/src/antennaknobs/designs/loops/inv_delta_loop.py
@@ -1,3 +1,5 @@
+"""Inverted delta loop — the triangle flipped so the feed edge sits at the top."""
+
 from ... import AntennaBuilder
 import math
 

--- a/src/antennaknobs/designs/multiband/fandipole.py
+++ b/src/antennaknobs/designs/multiband/fandipole.py
@@ -1,3 +1,5 @@
+"""Fan dipole — parallel dipoles off one feed for several bands."""
+
 import logging
 import math
 from types import MappingProxyType

--- a/src/antennaknobs/designs/specialty/bowtie.py
+++ b/src/antennaknobs/designs/specialty/bowtie.py
@@ -1,3 +1,5 @@
+"""Bowtie dipole — triangular fan arms for broadened bandwidth."""
+
 from ... import AntennaBuilder
 import math
 from types import MappingProxyType

--- a/src/antennaknobs/designs/specialty/hentenna.py
+++ b/src/antennaknobs/designs/specialty/hentenna.py
@@ -1,3 +1,5 @@
+"""Hentenna — the Japanese rectangular loop, fed off-center for vertical polarization."""
+
 from ... import AntennaBuilder
 from ... import Transform, TransformStack
 

--- a/src/antennaknobs/designs/specialty/hourglass.py
+++ b/src/antennaknobs/designs/specialty/hourglass.py
@@ -1,3 +1,5 @@
+"""Hourglass loop — a crossed (bowtie-folded) rectangular loop."""
+
 from ... import AntennaBuilder
 from ... import Transform, TransformStack
 

--- a/src/antennaknobs/designs/specialty/hourglass_slant.py
+++ b/src/antennaknobs/designs/specialty/hourglass_slant.py
@@ -1,3 +1,5 @@
+"""Hourglass loop tilted out of the vertical plane."""
+
 import math
 
 from ... import AntennaBuilder

--- a/src/antennaknobs/designs/verticals/raised_vertical.py
+++ b/src/antennaknobs/designs/verticals/raised_vertical.py
@@ -1,3 +1,5 @@
+"""Elevated quarter-wave vertical, fed above ground."""
+
 from ... import AntennaBuilder
 
 import math

--- a/src/antennaknobs/designs/verticals/vertical.py
+++ b/src/antennaknobs/designs/verticals/vertical.py
@@ -1,3 +1,5 @@
+"""Quarter-wave vertical over ground."""
+
 from ... import AntennaBuilder
 
 import math

--- a/tests/test_catalog_generated.py
+++ b/tests/test_catalog_generated.py
@@ -1,0 +1,40 @@
+"""The design-catalog page is generated from the design tree (issue #292):
+this is the drift gate. If a design is added, renamed, retired, or its
+docstring/variants change without regenerating the page, the suite fails
+here with the regeneration command in the message.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+CATALOG = REPO / "site" / "src" / "content" / "docs" / "reference" / "catalog.md"
+
+
+def test_catalog_page_is_not_stale():
+    """Exactly what CI needs: the committed page equals a fresh render."""
+    proc = subprocess.run(
+        [sys.executable, str(REPO / "scripts" / "generate_catalog.py"), "--check"],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+    )
+    assert proc.returncode == 0, (
+        f"{proc.stderr or proc.stdout}\n"
+        "fix: python scripts/generate_catalog.py  (then commit catalog.md)"
+    )
+
+
+def test_every_design_listed_exactly_once():
+    from antennaknobs.cli import list_builtin_designs
+
+    page = CATALOG.read_text()
+    designs = list_builtin_designs()
+    for name in designs:
+        rows = re.findall(rf"^\| `{re.escape(name)}` \|", page, flags=re.M)
+        assert len(rows) == 1, f"{name}: {len(rows)} table rows (want exactly 1)"
+    # ...and nothing else: every table row is a real design.
+    listed = re.findall(r"^\| `([a-z0-9_]+\.[a-z0-9_]+)` \|", page, flags=re.M)
+    assert sorted(listed) == sorted(designs)


### PR DESCRIPTION
## Summary
- Closes #292. `scripts/generate_catalog.py` rewrites the catalog's per-family tables between `<!-- catalog:begin/end -->` markers straight from the code: enumeration via `cli.list_builtin_designs`, descriptions as the **first sentence of each design module's docstring** (the convention the issue left open; initials-aware splitting keeps "L. B. Cebik" intact), variants via the adapter's `_discover_variants` as a `variants:` suffix.
- Curated prose (intro, the delta-loop four-ways blurb, the arrays blurb) lives outside the markers and survives regeneration; the W4RNL attributions now come through the docstrings themselves. A design without a docstring, or a new family without a marker block, fails the generator loudly.
- The 32 design modules that had no docstring get one, porting the old hand-written catalog notes into the source where they drift-protect with the code.
- Drift gate in plain CI: `tests/test_catalog_generated.py` runs the generator in `--check` mode (failure message includes the regeneration command) and pins every design to exactly one table row with no extras. The "Generated from source — coming soon" footnote becomes the do-not-edit note, and the release skill's de-stale sweep now excludes the catalog.

## Test plan
- [x] Generator is idempotent (`--check` green immediately after a rewrite) and survives `ruff format` of the docstrings (suite ran after formatting: still green)
- [x] `tests/test_catalog_generated.py`: staleness gate + exactly-once/nothing-else pin over all 76 designs
- [x] Full suite: 1555 passed; `ruff check`/`format` clean
- [x] `cd site && npm run build` passes with the generated page

🤖 Generated with [Claude Code](https://claude.com/claude-code)