### PR TITLE
Release v0.22.0 — full-station modelling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.21.0"
+version = "0.22.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,18 +25,18 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.21.0" icon="star">
-  **Matching networks, solved like SPICE.** The lumped-network core is
-  rebuilt on Modified Nodal Analysis: series `TwoPort` bridges, `Shunt`
-  elements, and ideal shorts (a 0 Ω or 0 H slider endpoint) are all
-  legal stamps, so a matchbox tunes cleanly through its degenerate
-  endpoints — including a fully inert pass-through and an open, which
-  the SWR readout now reports as ∞ instead of breaking. Two new
-  showcase designs ride it: an 80 m skyloop **L-matched** to 50 Ω on
-  17 m, and a 10 m inverted-L **T-matched** onto the 12 m band. Under
-  the hood, the driving-point impedance now agrees with NEC's native
-  network cards to ~5 digits — a long-standing readout gap, run to
-  ground and fixed. [All release notes →](/reference/releases/)
+<Card title="New in v0.22.0" icon="star">
+  **Model the whole station, not just the antenna.** Transmission lines
+  are now lossy the way real cable is (a preset catalog from RG-58 to
+  600 Ω open wire — SWR-multiplied loss emerges from the circuit solve),
+  matching-network coils take a finite **Q**, and a new
+  `Transformer` element models baluns and ununs, core loss included. A
+  **power budget** table in the solve readout shows where every watt
+  goes — line, tuner coil, balun, load, radiated. Three station designs
+  ride it, referenced to the rig: the inv-vee on 100 ft of real coax,
+  an 88 ft doublet on open-wire line into a lossy T-network tuner, and
+  a folded inv-vee through a 4:1 balun — the coax-vs-ladder-line
+  folklore, as numbers. [All release notes →](/reference/releases/)
 </Card>
 
 ## The whole pitch, in one line


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` to 0.22.0 and refresh the what's-new card for the station-modelling arc: lossy transmission lines + cable catalog (#302), finite-Q components (#303), the per-branch power budget (#304), station showcase designs (#305), the `Transformer`/balun element (#307), plus the `PortOnWire` rename (#306) and the generated design catalog (#308).
- De-stale sweep came back clean — the arc PRs updated `web.md`/`solver.mdx` as they landed, and the catalog is generated (excluded from the sweep per its note in the release skill).
- Site builds (15 pages).

## Test plan
- [x] `cd site && npm run build` passes
- [x] CI on this PR (full suite ran on every constituent PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)