### PR TITLE
Station comparison deep-dive: new Advanced docs section, workbench-faithful station designs

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -82,6 +82,14 @@ export default defineConfig({
           ],
         },
         {
+          // Advanced worked examples — full-station modelling, multi-design
+          // studies. Grows as more "advanced ideas" pages land.
+          label: "Advanced",
+          items: [
+            { label: "Coax vs. ladder line", slug: "advanced/station-comparison" },
+          ],
+        },
+        {
           label: "Reference",
           items: [
             { label: "Design catalog", slug: "reference/catalog" },

--- a/site/src/content/docs/advanced/station-comparison.md
+++ b/site/src/content/docs/advanced/station-comparison.md
@@ -7,8 +7,9 @@ Every club meeting has the argument. One camp: *a resonant antenna on 50 Ω coax
 is simple and it works*. The other: *put up one non-resonant wire, feed it with
 open-wire line, and let the tuner sort it out — ladder line shrugs off SWR*.
 Both camps are right, and both are paying for something. This example models
-both stations **end to end — rig, feedline, matching, wire** — and reads the
-folklore off the [power budget](/reference/web/#power-budget) as numbers.
+both stations **end to end — rig, feedline, matching, wire** — reads the
+folklore off the [power budget](/reference/web/#power-budget) as numbers, and
+finishes with the two stations head to head on the same band, 20 m.
 
 Two catalog designs (new in v0.22) carry the comparison:
 
@@ -60,10 +61,11 @@ in the [workbench](https://app.antennaknobs.dev/) and look at three things:
 
 ## Station B — the doublet and the matchbox
 
-The other philosophy: don't chase resonance at all. An 88 ft doublet
-(`design_freq = 5.593 MHz` sizes it; it's resonant nowhere you'd operate it)
-feeds 100 ft of 600 Ω open-wire line into a T-network — series C, shunt L,
-series C — whose inductor has a finite `coil_q`:
+The other philosophy: don't chase resonance at all. An 88 ft doublet — a
+40 m quarter-wave per side stretched by `length_factor = 1.269`, resonant
+nowhere you'd operate it — feeds 100 ft of 600 Ω open-wire line into a
+T-network — series C, shunt L, series C — whose inductor has a finite
+`coil_q`:
 
 ```python
 def build_network(self):
@@ -86,42 +88,87 @@ def build_network(self):
 ```
 
 The stock capacitor and inductor values match ~50 Ω at **7.1 MHz (40 m)**, and
-the budget itemizes the price of the matchbox: with Q = 200, about **4 % in
-the line and 4–5 % in the tuner coil — ~92 % radiated**. That's the ladder-line
+the budget itemizes the price of the matchbox: with Q = 200, about **3.5 % in
+the line and 4 % in the tuner coil — ~92 % radiated**. That's the ladder-line
 promise kept.
 
-Now make the wire *too short* — retune for **80 m** (`freq = 3.8`,
-`series_c1_pF ≈ 44.6`, `shunt_l_uH ≈ 27.05`, `series_c2_pF ≈ 6865`). SWR at
-the rig is still ≈ 1 — the tuner did its job — but the line's SWR loss and
-the coil loss each climb to **~14 %**. A perfect match at the rig, and more
-than a quarter of the power never leaves the shack wiring. That is the honest
-cost of working an electrically short wire, and no SWR meter will ever show
-it to you.
+Now make the wire *too short* — retune for **80 m** (pick 80m in the
+measurement-band selector, dial the frequency to 3.8, then
+`series_c1_pF ≈ 38.8`, `shunt_l_uH ≈ 32.6`; `series_c2_pF` stays at 500).
+SWR at the rig is still ≈ 1 — the tuner did its job — but the line's SWR
+loss climbs to **~17 %** and the coil's to **~15 %**. A perfect match at the
+rig, and a third of the power never leaves the shack wiring. That is the
+honest cost of working an electrically short wire, and no SWR meter will
+ever show it to you.
 
 Two things worth knowing while you drag:
 
 - **T-match solutions aren't unique.** Bigger capacitors with a smaller L
   generally mean less circulating current and lower coil loss — try finding a
-  second match for the same band and compare budgets. Sweep `coil_q` too
+  second match for the same band and compare budgets. The capacitor knobs
+  stop at 600 pF, about the largest variable cap a real matchbox offers, so
+  every tune you can dial here is one you could dial on hardware (past
+  ~300 pF the coil-loss curve is nearly flat anyway). Sweep `coil_q` too
   (0 = ideal coil) to see how much of the loss is the coil's fault.
 - **The slider endpoints are physics, not bugs.** `series_c1_pF = 0` is a
   0 pF series capacitor — an open circuit — so the readout reports Z = ∞.
 
-## Put them side by side
+## The head-to-head: both stations on 20 m
 
-The sidebar tabs are independent
-[design sessions](/reference/web/#design-sessions-tabs): load Station A in
-**D1**, Station B in **D2**, and flip between them — each keeps its own knobs,
-frequency, and results, and the two power-budget tables make the comparison
-directly. [Pin a pattern](/reference/web/#comparing-patterns) from one session
-to overlay it on the other.
+Stock, the two designs sit on different bands — the V on 10 m, the doublet
+tuned for 40 m — so their budgets above aren't yet comparable. Put both on
+**20 m** and let them fight fair. Load Station A and Station B in two
+[design sessions](/reference/web/#design-sessions-tabs) (**D1** / **D2**).
+The workbench's frequency controls are band-first, and the two stations use
+them in tellingly different ways:
 
-Note what the comparison *is*: the two stations live on different bands by
-design, so this isn't a same-band shoot-out — it's two feed philosophies, each
-shown at its best and at its breaking point. Station A is unbeatable in
-simplicity and fine on its one band, and quietly donates a third of your
-power to warm coax even there. Station B covers every band with one wire, and
-the budget shows exactly what each extra band costs in line SWR and coil heat.
+- **Station A** — click **20m** in the *design-frequency band row*. The
+  design frequency snaps to 14.300 MHz, the measurement frequency follows,
+  and the V rebuilds itself resonant on the new band. That's the resonant
+  station's whole deal: changing bands means changing the antenna, because
+  the antenna *is* the match.
+- **Station B** — click **20m** in the *measurement-band selector* instead.
+  That moves only the operating frequency (unlinking it from the design
+  frequency automatically); the wire and the line are untouched. Then retune
+  the box: `series_c1_pF = 29.1`, `shunt_l_uH = 2.56` (`series_c2_pF` stays
+  at its 500 pF default). Band-hopping is two tuner knobs.
+
+Same frequency (14.300 MHz), same 100 ft feed run, rig-referenced budgets
+side by side:
+
+| at 14.3 MHz | A — inv-vee + RG-8X | B — doublet + ladder line + tuner |
+|---|---|---|
+| SWR at the rig | 1.4 | 1.0 |
+| SWR on the feedline | ≈ 1.4 | ≈ 11 |
+| feedline loss | 24 % | 9 % |
+| tuner coil loss | — | 6 % |
+| **radiated** | **76 %** | **84 %** |
+
+(Every number on this page is solved the way the workbench solves it by
+default: finite ground — εr = 10, σ = 0.002, reflection-coefficient model —
+with the B-spline d = 2 solver.)
+
+What the table says:
+
+- **Matched loss is a floor.** Station A's coax runs essentially flat —
+  SWR 1.4 — and still eats 24 %, because 100 ft of RG-8X is 1.10 dB at
+  14.3 MHz *matched*. No antenna trimming gets under that line.
+- **The ladder line runs SWR ≈ 11 and shrugs.** The mismatch that multiplies
+  coax loss into disaster (Station A's off-resonance beat, above) costs the
+  open-wire line 9 % — total, matched loss included.
+- **The coil takes its cut — and B still wins.** 6 % in the tuner inductor is
+  the price of the matchbox, and the doublet station radiates eight points
+  more anyway.
+- **The tuner protects the rig, not the watts.** Wreck the match on purpose:
+  drag `shunt_l_uH` from 2.56 to 3.0 and the rig sees SWR 5 — yet radiated
+  power doesn't drop at all (84.3 % → 85.2 %). The watts were already decided
+  out on the line and in the coil; the match just decides whether your
+  transmitter is happy delivering them.
+
+[Pin a pattern](/reference/web/#comparing-patterns) from one session onto the
+other before you leave: both antennas hang at 10 m, but at 14.3 MHz the 88 ft
+doublet is about 1.28 λ long, so its azimuth pattern is starting to break
+into lobes — the budget is only half of what distinguishes two stations.
 
 ## What's actually being solved
 

--- a/site/src/content/docs/advanced/station-comparison.md
+++ b/site/src/content/docs/advanced/station-comparison.md
@@ -1,0 +1,146 @@
+---
+title: "Coax vs. ladder line: a tale of two stations"
+description: An advanced worked example — model two complete HF stations from the rig to the wire, and read where every watt goes off the power budget.
+---
+
+Every club meeting has the argument. One camp: *a resonant antenna on 50 Ω coax
+is simple and it works*. The other: *put up one non-resonant wire, feed it with
+open-wire line, and let the tuner sort it out — ladder line shrugs off SWR*.
+Both camps are right, and both are paying for something. This example models
+both stations **end to end — rig, feedline, matching, wire** — and reads the
+folklore off the [power budget](/reference/web/#power-budget) as numbers.
+
+Two catalog designs (new in v0.22) carry the comparison:
+
+| | Station A | Station B |
+|---|---|---|
+| Design | `dipoles.invvee_coax_station` | `wire.doublet_ladder_tuner` |
+| Antenna | resonant inverted-V (half-wave at 28.47 MHz) | 88 ft flat doublet — deliberately *non*-resonant |
+| Feedline | 100 ft of RG-8X coax | 100 ft of 600 Ω open-wire line |
+| Matching | none — the antenna itself is the match | T-network tuner with a finite-Q coil |
+
+Both are **modelled from the rig**: the source sits at a virtual *rig* port and
+reaches the wire through the real feed network, so every number the workbench
+reports — impedance, SWR, gain, the power budget — is referenced to the
+transmitter, not the feedpoint. That reference-plane move is the whole trick;
+everything below falls out of it.
+
+## Station A — the resonant antenna on coax
+
+The geometry is the stock `dipoles.invvee`. What changes is the feed: the
+driven gap becomes a named **feed** port, and the excitation moves to the far
+end of a real cable:
+
+```python
+def build_network(self):
+    return Network(
+        ports={"feed": PortOnWire("feed"), "rig": PortVirtual("rig")},
+        branches=[
+            TL.from_cable(self.cable, "rig", "feed", self.line_len_m),
+        ],
+        sources=[Driven(port="rig", voltage=1 + 0j)],
+    )
+```
+
+`TL.from_cable` pulls attenuation and velocity factor from the built-in
+`CABLES` catalog, so the line is lossy the way real cable is. Open the design
+in the [workbench](https://app.antennaknobs.dev/) and look at three things:
+
+1. **On resonance, coax at 10 m still isn't cheap.** The V is near 50 Ω, the
+   line runs essentially matched — and the budget still shows roughly the
+   cable's matched loss: **~1.6 dB ≈ 31 % of your power** for 100 ft of RG-8X
+   at 28 MHz, before any mismatch enters the story.
+2. **Drag `freq` off resonance.** The SWR climbs, and the line row of the
+   budget grows past the matched loss — the classic *SWR-multiplied line loss*.
+   Nobody typed that formula in: it emerges from the circuit solve.
+3. **Swap the `cable` preset.** RG-58 vs. LMR-400 is the "should I buy better
+   coax?" question answered in one dropdown. Then pick one of the 450/600 Ω
+   window-line presets and watch the loss nearly vanish even at high SWR —
+   that's the effect Station B is built around.
+
+## Station B — the doublet and the matchbox
+
+The other philosophy: don't chase resonance at all. An 88 ft doublet
+(`design_freq = 5.593 MHz` sizes it; it's resonant nowhere you'd operate it)
+feeds 100 ft of 600 Ω open-wire line into a T-network — series C, shunt L,
+series C — whose inductor has a finite `coil_q`:
+
+```python
+def build_network(self):
+    return Network(
+        ports={
+            "feed": PortOnWire("feed"),
+            "li": PortVirtual("li"),   # line input (tuner output)
+            "m": PortVirtual("m"),     # tee midpoint
+            "rig": PortVirtual("rig"),
+        },
+        branches=[
+            TL.from_cable("openwire-600", "li", "feed", self.line_len_m),
+            TwoPort(a="rig", b="m", c=self.series_c1_pF * 1e-12),
+            Shunt(port="m", l=self.shunt_l_uH * 1e-6,
+                  ql=self.coil_q if self.coil_q > 0 else None),
+            TwoPort(a="m", b="li", c=self.series_c2_pF * 1e-12),
+        ],
+        sources=[Driven(port="rig", voltage=1 + 0j)],
+    )
+```
+
+The stock capacitor and inductor values match ~50 Ω at **7.1 MHz (40 m)**, and
+the budget itemizes the price of the matchbox: with Q = 200, about **4 % in
+the line and 4–5 % in the tuner coil — ~92 % radiated**. That's the ladder-line
+promise kept.
+
+Now make the wire *too short* — retune for **80 m** (`freq = 3.8`,
+`series_c1_pF ≈ 44.6`, `shunt_l_uH ≈ 27.05`, `series_c2_pF ≈ 6865`). SWR at
+the rig is still ≈ 1 — the tuner did its job — but the line's SWR loss and
+the coil loss each climb to **~14 %**. A perfect match at the rig, and more
+than a quarter of the power never leaves the shack wiring. That is the honest
+cost of working an electrically short wire, and no SWR meter will ever show
+it to you.
+
+Two things worth knowing while you drag:
+
+- **T-match solutions aren't unique.** Bigger capacitors with a smaller L
+  generally mean less circulating current and lower coil loss — try finding a
+  second match for the same band and compare budgets. Sweep `coil_q` too
+  (0 = ideal coil) to see how much of the loss is the coil's fault.
+- **The slider endpoints are physics, not bugs.** `series_c1_pF = 0` is a
+  0 pF series capacitor — an open circuit — so the readout reports Z = ∞.
+
+## Put them side by side
+
+The sidebar tabs are independent
+[design sessions](/reference/web/#design-sessions-tabs): load Station A in
+**D1**, Station B in **D2**, and flip between them — each keeps its own knobs,
+frequency, and results, and the two power-budget tables make the comparison
+directly. [Pin a pattern](/reference/web/#comparing-patterns) from one session
+to overlay it on the other.
+
+Note what the comparison *is*: the two stations live on different bands by
+design, so this isn't a same-band shoot-out — it's two feed philosophies, each
+shown at its best and at its breaking point. Station A is unbeatable in
+simplicity and fine on its one band, and quietly donates a third of your
+power to warm coax even there. Station B covers every band with one wire, and
+the budget shows exactly what each extra band costs in line SWR and coil heat.
+
+## What's actually being solved
+
+There is no special-case feedline math anywhere in this page. A design's
+`build_network()` declares **ports** (`PortOnWire` on a wire gap,
+`PortVirtual` for pure circuit nodes), **branches** (`TL`, `TwoPort`, `Shunt`,
+`Transformer`), and **sources** (`Driven`), and the whole thing is solved as
+one MNA circuit coupled to the method-of-moments wire solution. Every branch
+current is an explicit unknown, so the watts in the
+[power budget](/reference/web/#power-budget) are *read off the solution*, and
+gain is normalised by input power — network loss is already in the dBi you see.
+
+## Where to go next
+
+- **`dipoles.folded_invvee_balun`** — the third v0.22 station design: a folded
+  inverted-V through a 4:1 balun (`Transformer`, core loss included).
+- **Roll your own station.** Any builder can add a `build_network()` — take a
+  design you care about from the [catalog](/reference/catalog/), and put *your*
+  actual feedline length and tuner on it.
+- **[The model](/concepts/model/)** and
+  **[write your first design](/concepts/first-builder/)** — if you want to
+  build the antenna itself from scratch first.

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -35,8 +35,9 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
   goes — line, tuner coil, balun, load, radiated. Three station designs
   ride it, referenced to the rig: the inv-vee on 100 ft of real coax,
   an 88 ft doublet on open-wire line into a lossy T-network tuner, and
-  a folded inv-vee through a 4:1 balun — the coax-vs-ladder-line
-  folklore, as numbers. [All release notes →](/reference/releases/)
+  a folded inv-vee through a 4:1 balun — [the coax-vs-ladder-line
+  folklore, as numbers](/advanced/station-comparison/).
+  [All release notes →](/reference/releases/)
 </Card>
 
 ## The whole pitch, in one line

--- a/src/antennaknobs/designs/dipoles/folded_invvee_balun.py
+++ b/src/antennaknobs/designs/dipoles/folded_invvee_balun.py
@@ -38,6 +38,10 @@ class Builder(FoldedInvVee):
                     "target_z0": 50.0,
                     "cable": {"enum_options": tuple(sorted(CABLES))},
                     "line_len_m": {"min": 3.0, "max": 100.0, "unit": "m"},
+                    # 100 ft of coax rotates the sweep trace around the
+                    # Smith chart several times over the default ±20/25 %
+                    # window — lock the sweep to the band being measured.
+                    "sweep_policy": {"anchor": "meas_freq", "band_locked": True},
                     "balun_n": {"min": 0.25, "max": 1.0},
                     "lmag_uH": {"min": 1.0, "max": 50.0},
                     "qlmag": {"min": 0.0, "max": 400.0},

--- a/src/antennaknobs/designs/dipoles/invvee_coax_station.py
+++ b/src/antennaknobs/designs/dipoles/invvee_coax_station.py
@@ -1,7 +1,9 @@
 """Inverted-V fed through real coax — the classic "resonant antenna on
 50 Ω line" station, modelled from the rig (issue #300).
 
-Geometry is the stock `dipoles.invvee` (28.47 MHz half-wave V, ~32° droop).
+Geometry is the stock `dipoles.invvee` (28.47 MHz half-wave V, ~32° droop)
+with the apex raised to 10 m so the station pair (see below) compares at the
+same height.
 What changes is the reference plane: the source moves to a virtual **rig**
 port and reaches the feedpoint through `line_len_m` of a real cable from
 the `CABLES` catalog (`TL.from_cable`, issue #297) — so the impedance, SWR,
@@ -35,12 +37,19 @@ class Builder(InvVee):
             **InvVee.default_params,
             "cable": "RG-8X",
             "line_len_m": 30.48,  # 100 ft
+            # Apex at 10 m, matching wire.doublet_ladder_tuner, so the
+            # station pair compares at the same height.
+            "base": 10.0,
             "ui_params": MappingProxyType(
                 {
                     **InvVee.default_params["ui_params"],
                     "target_z0": 50.0,
                     "cable": {"enum_options": tuple(sorted(CABLES))},
                     "line_len_m": {"min": 3.0, "max": 100.0, "unit": "m"},
+                    # 100 ft of coax rotates the sweep trace around the
+                    # Smith chart several times over the default ±20/25 %
+                    # window — lock the sweep to the band being measured.
+                    "sweep_policy": {"anchor": "meas_freq", "band_locked": True},
                 }
             ),
         }

--- a/src/antennaknobs/designs/wire/doublet_ladder_tuner.py
+++ b/src/antennaknobs/designs/wire/doublet_ladder_tuner.py
@@ -4,27 +4,31 @@ the "non-resonant wire and a matchbox" station, modelled from the rig
 
 The other half of the comparison with `dipoles.invvee_coax_station`: instead
 of a resonant antenna on 50 Ω coax, a deliberately non-resonant flat doublet
-(88 ft ≈ 26.8 m total, `design_freq` 5.593 MHz sizes it) feeds 100 ft of
+(88 ft ≈ 26.8 m total — 0.25·λ(7.1 MHz)·length_factor 1.26944) feeds 100 ft of
 `openwire-600` ladder line (issue #297) into a T-network — series C, shunt L,
 series C, the `inverted_l_tmatch` topology — whose inductor has a finite
 `coil_q` (issue #298). The source sits at the virtual **rig** node, so
 impedance, SWR, gain, and the power budget (issue #299) are all referenced to
 the transmitter.
 
-Stock values match ~50 Ω at 7.1 MHz (40 m): the readout shows SWR ≈ 1 while
-the budget itemizes where the watts actually go — with Q = 200 about 4 % in
-the line and 4–5 % in the tuner coil, ~92 % radiated. Retune for 80 m
-(3.8 MHz: C1 ≈ 44.6 pF, L ≈ 27.05 µH, C2 ≈ 6865 pF) and the same doublet is
-electrically short: the line's SWR loss and the coil loss each climb to
-~14 %, the honest cost of working a too-short wire. The classic folklore —
+Stock values match ~50 Ω at 7.1 MHz (40 m) over the workbench-default
+finite-fast ground (εr=10, σ=0.002): the readout shows SWR ≈ 1 while the
+budget itemizes where the watts actually go — with Q = 200 about 3.5 % in
+the line and 4 % in the tuner coil, ~92 % radiated. Retune for 80 m
+(3.8 MHz: C1 ≈ 38.8 pF, L ≈ 32.6 µH, C2 stays at 500 pF) and the same
+doublet is electrically short: the line's SWR loss climbs to ~17 % and the
+coil to ~15 % — a third of the power never leaves the shack — the honest
+cost of working a too-short wire. The classic folklore —
 "open-wire line shrugs off SWR, the tuner coil is where multiband
 flexibility is paid for" — falls out of the circuit solve as numbers.
 
-T-network caveats inherited from `inverted_l_tmatch`: the degenerate slider
-endpoints are physics (a 0 pF series cap is an open — `series_c1_pF = 0`
-open-circuits the source, reported as Z = ∞), and T-match solutions are not
-unique — bigger capacitors with a smaller L generally mean less circulating
-current and lower coil loss.
+T-network caveats inherited from `inverted_l_tmatch`: T-match solutions are
+not unique — bigger capacitors with a smaller L generally mean less
+circulating current and lower coil loss. Both capacitor knobs run
+25–600 pF, the span a real matchbox's variable caps cover, so every tune
+here is one you could actually dial: the degenerate 0 pF endpoint (a series
+open — Z = ∞) is out of reach, and past ~300 pF the coil-loss curve is
+nearly flat, so the practical ceiling costs only tenths of a percent.
 """
 
 from types import MappingProxyType
@@ -37,19 +41,29 @@ class Builder(InvVee):
     default_params = MappingProxyType(
         {
             **InvVee.default_params,
-            # 88 ft flat doublet: 0.25·λ(5.593 MHz)·1.0 = 13.41 m per side.
-            "design_freq": 5.593,
+            # 88 ft flat doublet: 0.25·λ(7.1 MHz)·1.26944 = 13.40 m per
+            # side. design_freq matches the stock operating band (40 m) so
+            # the workbench band row loads — and band-hops — this station
+            # without silently resizing the wire; the 88 ft length lives in
+            # length_factor. (An earlier expression put design_freq at
+            # 5.593 MHz with length_factor 1.0 — same geometry, but the
+            # band snap on load clobbered it to the 40 m default.)
+            "design_freq": 7.1,
             "freq": 7.1,
             "angle_deg": 0.0,
-            "length_factor": 1.0,
+            "length_factor": 1.26944,
             "base": 10.0,
             # Feedline: 100 ft of 600 Ω open-wire line.
             "line_len_m": 30.48,
             # T-network, tuned for ~50 Ω at 7.1 MHz on the stock doublet
-            # (see the 80 m retune in the module docstring).
-            "series_c1_pF": 74.16,
-            "shunt_l_uH": 4.7007,
-            "series_c2_pF": 1617.7,
+            # over the workbench-default finite-fast ground (εr=10,
+            # σ=0.002) — the reference the workbench actually shows —
+            # with both capacitors inside a real matchbox's range
+            # (≤ 600 pF; see the ui ranges below).
+            # (See the 80 m retune in the module docstring.)
+            "series_c1_pF": 81.2,
+            "shunt_l_uH": 4.218,
+            "series_c2_pF": 500.0,
             # Tuner coil Q (issue #298). Defaults LOSSY — the point of this
             # design is seeing the tuner cost; set 0 for the ideal coil.
             "coil_q": 200.0,
@@ -58,11 +72,23 @@ class Builder(InvVee):
                     **InvVee.default_params["ui_params"],
                     "target_z0": 50.0,
                     "angle_deg": {"hidden": True},
+                    # 100 ft of line rotates the sweep trace around the
+                    # Smith chart several times over the default ±20/25 %
+                    # window — lock the sweep to the band being measured.
+                    "sweep_policy": {"anchor": "meas_freq", "band_locked": True},
+                    # The 88 ft default (1.26944) sits above the inherited
+                    # half-wave window (0.8–1.25).
+                    "length_factor": {"min": 0.9, "max": 1.6},
                     "line_len_m": {"min": 3.0, "max": 100.0, "unit": "m"},
                     # Ranges span the 40 m stock tune AND the 80 m retune.
-                    "series_c1_pF": {"min": 5.0, "max": 500.0},
+                    # Both capacitor knobs stop at 600 pF — about the
+                    # largest variable cap any real matchbox offers — so
+                    # every tune reachable here is one you could dial on
+                    # actual hardware. (The loss penalty vs arbitrarily
+                    # big caps is a few tenths of a percent.)
+                    "series_c1_pF": {"min": 25.0, "max": 600.0},
                     "shunt_l_uH": {"min": 0.5, "max": 40.0},
-                    "series_c2_pF": {"min": 100.0, "max": 10000.0},
+                    "series_c2_pF": {"min": 25.0, "max": 600.0},
                     "coil_q": {"min": 0.0, "max": 400.0},
                 }
             ),

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -311,12 +311,19 @@ def _auto_paramspec(name: str, default: Any, override: dict | None) -> ParamSpec
         opts = override.pop("enum_options", None)
         if opts is None:
             return None
+        # The frontend renders SchemaEnumOption dicts ({value, label}, plus
+        # free-form extras). Designs with no per-option metadata may pass
+        # bare strings (e.g. the CABLES keys) — normalise those here;
+        # un-normalised strings render as empty <option>s.
         return ParamSpec(
             name=name,
             label=label,
             default=default,
             kind="enum",
-            enum_options=tuple(opts),
+            enum_options=tuple(
+                o if isinstance(o, dict) else {"value": str(o), "label": str(o)}
+                for o in opts
+            ),
             precision=precision,
             unit=unit,
             layout=layout,

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1045,6 +1045,30 @@ button:focus-visible,
   box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
+/* enum params (e.g. the station designs' cable pick) render as a native
+   <select> in the panel; match the number-input treatment so any custom
+   pulldown reads as part of the control rail, not a browser default. */
+.field select {
+  background: var(--inset);
+  color: var(--fg);
+  border: 1px solid var(--border-control);
+  border-radius: var(--r-sm);
+  padding: var(--space-3) var(--space-4);
+  width: 100%;
+  font: inherit;
+  cursor: pointer;
+}
+
+.field select:hover {
+  border-color: var(--border-hover);
+}
+
+.field select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
 /* rotary knob — opt-in alternative to the range slider (see Knob in App.tsx) */
 .knob {
   width: 54px;
@@ -1306,13 +1330,18 @@ button:focus-visible,
   gap: var(--space-5) var(--space-4);
   justify-items: center;
 }
-.param-grid .field-enum,
 .param-grid .field-bool,
 .param-grid .param-group {
   grid-column: 1 / -1;
   /* The is-knobs grid sets justify-items:center, which would otherwise shrink
      these full-width spanners to their content width (collapsing a band group's
      nested grid to one column). Force them to fill the row. */
+  justify-self: stretch;
+}
+/* Enum selects don't need a whole row — two knob cells is plenty for a
+   cable name, and the neighbouring cell stays free for the next knob. */
+.param-grid .field-enum {
+  grid-column: span 2;
   justify-self: stretch;
 }
 .param-grid.is-knobs .field {

--- a/tests/test_station_designs.py
+++ b/tests/test_station_designs.py
@@ -63,7 +63,13 @@ def test_coax_station_swr_penalty_off_resonance():
 
 
 def test_doublet_station_matches_fifty_ohms_with_coil_dominated_loss():
-    eng = _momwire(DoubletStation())
+    """Stock tune targets the workbench default — finite-fast ground AND the
+    B-spline solver — so solve with both. (The 100 ft high-SWR line amplifies
+    basis-level feedpoint differences: the sinusoidal basis lands the rig tens
+    of ohms away, and free space is ~SWR 2.)"""
+    from antennaknobs.engines import MomwireEngine
+
+    eng = MomwireEngine(DoubletStation(), ground=("finite-fast", 10.0, 0.002))
     (z,) = eng.impedance()
     assert abs(z - 50.0) < 1.0  # stock tune lands the rig at ~50 Ω
     fr = _budget_fractions(eng)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -252,6 +252,29 @@ def test_examples_serialize_param_groups_with_kind_group(client: TestClient):
     assert {p["name"] for p in g["params"]} == {"freq", "length_factor"}
 
 
+def test_enum_options_always_serialize_as_value_label_dicts(client: TestClient):
+    """The frontend renders enum_options as SchemaEnumOption dicts; designs
+    may declare them as bare strings (the CABLES keys), which the adapter
+    must normalise — un-normalised strings render as empty <option>s (the
+    22px-wide cable dropdown bug)."""
+    payload = client.get("/examples").json()
+    seen_enum = False
+    for ex in payload["examples"]:
+        for p in ex["param_schema"]:
+            if p.get("kind") != "enum":
+                continue
+            seen_enum = True
+            for o in p["enum_options"]:
+                assert isinstance(o, dict) and o.get("value") and o.get("label"), (
+                    f"{ex['name']}.{p['name']}: bad enum option {o!r}"
+                )
+            values = [o["value"] for o in p["enum_options"]]
+            assert p["default"] in values, (
+                f"{ex['name']}.{p['name']}: default {p['default']!r} not in {values}"
+            )
+    assert seen_enum, "no enum params found — did the cable dropdowns vanish?"
+
+
 def test_examples_carry_default_view_in_valid_set(client: TestClient):
     payload = client.get("/examples").json()
     for ex in payload["examples"]:


### PR DESCRIPTION
## Summary
- **New docs section**: an "Advanced" sidebar group on antennaknobs.dev opens with *Coax vs. ladder line: a tale of two stations* — the v0.22 station showcase written up as a worked example. Both stations are modelled from the rig, the folklore is read off the power budget, and the page ends with a same-band 20 m head-to-head reached purely by band selection (A: 76% radiated at SWR 1.4 on nearly-matched coax; B: 84% radiated through an SWR-11 ladder line plus tuner). Every number is solved the way the workbench solves it by default (finite-fast ground, B-spline d=2) and was verified live in the app.
- **Station designs made workbench-faithful**: the doublet's 88 ft wire is re-expressed as `design_freq=7.1 × length_factor=1.26944` (identical geometry) so the on-load band snap no longer silently resizes it (it loaded at rig SWR 13 instead of the documented ~1); T-network tunes retuned for the workbench-default ground with both capacitor knobs constrained to a real matchbox's 25–600 pF (C2 pinned at 500 pF on every band); inv-vee apex raised to 10 m so the pair compares at one height; all three station designs get band-locked frequency sweeps so 100 ft of line no longer spirals the Smith chart trace.
- **Web fixes**: enum options passed as bare strings (the `CABLES` keys) rendered as six empty `<option>`s — the cable dropdown collapsed to a 22 px chevron; the adapter now normalises them to `{value, label}` (regression-tested). Enum pulldowns also get the app's control styling and span two knob cells instead of a full row.
- The homepage "New in v0.22" card now links its coax-vs-ladder-line line to the new page.

## Test plan
- [x] Full suite passes (1556 tests), including new regression tests: enum options always serialize as value/label dicts; doublet stock tune lands the rig at ~50 Ω solved workbench-style
- [x] Astro site builds clean (16 pages); new page's cross-links point at anchors verified in the built output
- [x] Verified live in Chrome: cable dropdown readable/styled/two-cells, doublet loads at SWR 1.00 with 92.5% radiated, coax station sweep locked to 28.00→29.70 MHz, head-to-head numbers match the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)