### PR TITLE
Fix knob-menu number fields snapping to 0 when cleared

### DIFF
--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -4289,41 +4289,31 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                   </label>
                   <div className="knob-menu-row">
                     <span>Optimize range</span>
-                    <input
-                      type="number"
-                      step="any"
+                    <KnobMenuNumber
                       value={num(ko.optMin)}
-                      onChange={(e) => set({ optMin: Number(e.target.value) })}
+                      onChange={(v) => set({ optMin: v })}
                     />
-                    <input
-                      type="number"
-                      step="any"
+                    <KnobMenuNumber
                       value={num(ko.optMax)}
-                      onChange={(e) => set({ optMax: Number(e.target.value) })}
+                      onChange={(v) => set({ optMax: v })}
                     />
                   </div>
                   <div className="knob-menu-row">
                     <span>Display range</span>
-                    <input
-                      type="number"
-                      step="any"
+                    <KnobMenuNumber
                       value={num(ko.dispMin)}
-                      onChange={(e) => set({ dispMin: Number(e.target.value) })}
+                      onChange={(v) => set({ dispMin: v })}
                     />
-                    <input
-                      type="number"
-                      step="any"
+                    <KnobMenuNumber
                       value={num(ko.dispMax)}
-                      onChange={(e) => set({ dispMax: Number(e.target.value) })}
+                      onChange={(v) => set({ dispMax: v })}
                     />
                   </div>
                   <div className="knob-menu-row">
                     <span>Turn step</span>
-                    <input
-                      type="number"
-                      step="any"
+                    <KnobMenuNumber
                       value={num(ko.step)}
-                      onChange={(e) => set({ step: Number(e.target.value) })}
+                      onChange={(v) => set({ step: v })}
                     />
                   </div>
                 </div>
@@ -5528,6 +5518,39 @@ function BSplineFields({
         )}
       </div>
     </>
+  );
+}
+
+// Bare numeric input with the same clear-without-snapping-to-0 draft treatment
+// as NumberField (which carries its own label/value chrome and doesn't fit the
+// knob menu's grid rows).
+function KnobMenuNumber({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+}) {
+  const [draft, setDraft] = useState(String(value));
+  useEffect(() => {
+    setDraft(String(value));
+  }, [value]);
+  return (
+    <input
+      type="number"
+      step="any"
+      value={draft}
+      onChange={(e) => {
+        const text = e.target.value;
+        setDraft(text); // allow "", partial, or leading-zero input while typing
+        if (text.trim() === "") return; // empty: don't commit (no snap to 0)
+        const v = Number(text);
+        if (!Number.isNaN(v)) onChange(v);
+      }}
+      // Normalize on blur: drop any leading zeros / revert an empty field to
+      // the last committed value.
+      onBlur={() => setDraft(String(value))}
+    />
   );
 }
 


### PR DESCRIPTION
## Summary
- The per-knob optimiser menu (right-click / long-press a knob) bound its five numeric inputs (optimize range, display range, turn step) directly to the number via `Number(e.target.value)`; since `Number("") === 0`, backspacing to empty committed 0, the field couldn't be cleared, and the forced 0 left a leading zero when typing resumed (entering 1 required typing "01").
- Same bug was fixed earlier in the engine option fields (9987f01d) with `NumberField`'s local text-draft pattern; that component carries its own label/value chrome, so this adds a bare `KnobMenuNumber` with the identical draft logic and swaps the five menu inputs onto it.
- Empty/partial/leading-zero input is now held in a local draft while typing; a value is only committed when it parses, and the field normalizes back to the last committed value on blur.

## Test plan
- [ ] Long-press (or right-click) a knob to open the optimiser menu
- [ ] Backspace an optimize-range field to empty — it stays empty instead of showing a stuck 0
- [ ] Type "1" into the cleared field — shows "1", not "01", and commits 1
- [ ] Blur an empty field — it reverts to the last committed value
- [ ] `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)