### PR TITLE
Move solve/rtt timing rows to the end of the HUD readout

### DIFF
--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -5713,10 +5713,6 @@ function SolveReadout({
           {result ? feedMag(result).toExponential(3) : "—"}
         </span>
       </div>
-      <div className="row">
-        <span>solve</span>
-        <span className="val">{result ? `${result.solve_ms.toFixed(1)} ms` : "—"}</span>
-      </div>
       {result?.ground && result.ground_model_applied && (
         <div
           className="row"
@@ -5769,9 +5765,24 @@ function SolveReadout({
           </div>
         );
       })()}
-      <div className="row">
-        <span>rtt</span>
-        <span className="val">{rttMs != null ? `${rttMs.toFixed(1)} ms` : "—"}</span>
+      {/* Engine timing grouped last: solve/rtt describe how fast the answer
+          arrived, not what the antenna is doing, so they sit below the RF
+          readout (and below the power budget when one is shown). The
+          feeds-table wrapper is used only for its dashed separator rule —
+          no header. */}
+      <div className="feeds-table">
+        <div className="row">
+          <span>solve</span>
+          <span className="val">
+            {result ? `${result.solve_ms.toFixed(1)} ms` : "—"}
+          </span>
+        </div>
+        <div className="row">
+          <span>rtt</span>
+          <span className="val">
+            {rttMs != null ? `${rttMs.toFixed(1)} ms` : "—"}
+          </span>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- The solve readout interleaved engine diagnostics with RF results: R, X, |I_feed|, solve, ground, SWR, (power budget), rtt.
- solve and rtt describe how fast the answer arrived, not what the antenna is doing, so they now sit together at the bottom — below SWR and below the power budget when one is shown.
- The pair is set apart by the `feeds-table` dashed separator rule (no header text; the rule is enough for two rows).

## Test plan
- [ ] Desktop HUD: rows read R, X, |I_feed|, ground, SWR, then solve/rtt after a dashed rule
- [ ] With a design that has a power budget (e.g. lossy-line station), the budget section renders above the solve/rtt pair
- [ ] Mobile Info screen shows the same order
- [ ] `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)