### PR TITLE
Wire material plumbing: WIRES catalog, per-design radius, PyNEC LD-5 parity

### DIFF
--- a/src/antennaknobs/builder.py
+++ b/src/antennaknobs/builder.py
@@ -129,6 +129,21 @@ class AntennaBuilder:
         a dummy stub wire, branches refer to ports by name, etc."""
         return None
 
+    def build_wire_material(self):
+        """Return a `WireSpec` (see `antennaknobs.network.WIRES`) describing
+        the antenna wire's conductor and insulation, or None for the classic
+        idealization (PEC, 0.5 mm radius). Default behavior: a design with a
+        `wire_type` param (usually an enum knob over the WIRES catalog keys)
+        resolves it here; empty string / None / absent = ideal wire. Engines
+        consume the spec for the wire radius, skin-effect loss, and — on
+        solvers that model it — the insulated-wire velocity factor."""
+        wire_type = getattr(self, "wire_type", None)
+        if wire_type:
+            from .network import wire_from_catalog
+
+            return wire_from_catalog(wire_type)
+        return None
+
     def segs_for(self, length, ref):
         """Mesh segment count for a wire of the given `length`.
 

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -5,6 +5,8 @@ momwire/web/server.py:_compute_directivity_norm.
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 from momwire import BSplineSolver
 
@@ -12,6 +14,8 @@ from ..engine import FarField, SimulationEngine, WireCurrents
 from ..geometry import flat_wires_to_polylines
 from ..network import PortOnWire, PortVirtual
 from ..network_reduce import NetworkReducer, tl_admittance_2x2
+
+_logger = logging.getLogger(__name__)
 
 
 def _parity_for_solver(solver, solver_kwargs):
@@ -90,6 +94,16 @@ _GROUND_EPS_SOLVERS = (
 
 def _solver_supports_ground_eps(solver):
     return getattr(solver, "__name__", None) in _GROUND_EPS_SOLVERS
+
+
+# Distributed wire loading (issue #316 / momwire#131) is a BSpline-family
+# feature; SinusoidalSolver rejects the kwargs (field-based assembly needs
+# its own overlap integrals — momwire defers it loudly).
+_WIRE_LOADING_SOLVERS = ("BSplineSolver", "HMatrixSolver", "ArrayBlockSolver")
+
+
+def _solver_supports_wire_loading(solver):
+    return getattr(solver, "__name__", None) in _WIRE_LOADING_SOLVERS
 
 
 class MomwireEngine(SimulationEngine):
@@ -173,7 +187,39 @@ class MomwireEngine(SimulationEngine):
         self._feeds = translated["feeds"]
         self._feed_names = translated["feed_names"]
         self._junctions = translated["junctions"]
-        self._wire_radius = wire_radius
+        # Wire material (issue #316): a design-declared WireSpec supplies the
+        # conductor radius plus the distributed-loading kwargs. Precedence
+        # for the radius: an explicit non-default `wire_radius` (the web
+        # model-options control) wins; the stock 0.0005 acts as "auto" so a
+        # spec design's skin-effect loss is computed at its real radius.
+        self._wire_spec = builder.build_wire_material()
+        if wire_radius != 0.0005 and wire_radius is not None:
+            self._wire_radius = wire_radius
+        elif self._wire_spec is not None:
+            self._wire_radius = self._wire_spec.radius
+        else:
+            self._wire_radius = 0.0005
+        # Distributed loading rides only the solvers that model it; warn
+        # once (not raise) so a matched-basis sinusoidal comparison of a
+        # lossy design still solves — as the ideal wire, stated plainly.
+        self._loading_kwargs = {}
+        spec = self._wire_spec
+        if spec is not None and (
+            spec.conductivity is not None or spec.insulation_radius is not None
+        ):
+            if _solver_supports_wire_loading(self._solver):
+                if spec.conductivity is not None:
+                    self._loading_kwargs["wire_conductivity"] = spec.conductivity
+                if spec.insulation_radius is not None:
+                    self._loading_kwargs["insulation_radius"] = spec.insulation_radius
+                    self._loading_kwargs["insulation_eps_r"] = spec.insulation_eps_r
+            else:
+                _logger.warning(
+                    "%s doesn't model distributed wire loading; solving the "
+                    "design's %s wire as ideal (PEC, bare)",
+                    getattr(self._solver, "__name__", self._solver),
+                    type(builder).__name__,
+                )
         self._ground = _normalise_ground(ground)
         self._ground_z = ground_z if self._ground is not None else None
         # Finite ground constants forwarded to the impedance solve when the
@@ -262,6 +308,7 @@ class MomwireEngine(SimulationEngine):
             ground_z=self._ground_z,
             junctions=self._junctions or None,
             cancel=self._cancel,
+            **self._loading_kwargs,
             **self._ground_solver_kwargs(),
             **self._solver_kwargs,
         )
@@ -457,6 +504,7 @@ class MomwireEngine(SimulationEngine):
             ground_z=self._ground_z,
             junctions=self._junctions or None,
             cancel=self._cancel,
+            **self._loading_kwargs,
             **self._ground_solver_kwargs(),
             **self._solver_kwargs,
         )

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -1,3 +1,5 @@
+import logging
+
 import numpy as np
 import PyNEC as nec
 
@@ -15,6 +17,8 @@ from ..network import (
     load_impedance,
 )
 from ..network_reduce import C_LIGHT, NetworkReducer
+
+_logger = logging.getLogger(__name__)
 
 WIRE_RADIUS = 0.0005
 COPPER_CONDUCTIVITY = 5.8e7
@@ -70,6 +74,24 @@ class PyNECEngine(SimulationEngine):
         super().__init__(builder)
         self.tups = self._coerce_wire_tuples(builder.build_wires())
         self._network = builder.build_network()
+        # Wire material (issue #316): radius + conductor loss from the
+        # design's WireSpec. The spec's conductivity is emitted as a global
+        # ld_card type 5 (NEC's native wire-loss model — the momwire#131
+        # cross-engine oracle); the module-level WIRE_CONDUCTIVITY constant
+        # below stays as the manual all-designs override for oracle runs.
+        # NEC-2 has no insulated-wire card, so a spec's insulation is NOT
+        # modeled here — momwire is the fidelity engine for that (same
+        # engine-divergence precedent as Sommerfeld ground).
+        self._wire_spec = builder.build_wire_material()
+        self._wire_radius = (
+            self._wire_spec.radius if self._wire_spec is not None else WIRE_RADIUS
+        )
+        if self._wire_spec is not None and self._wire_spec.insulation_radius:
+            _logger.warning(
+                "NEC-2 has no insulated-wire card; PyNEC solves %s's wire "
+                "bare (no velocity-factor effect)",
+                type(builder).__name__,
+            )
         # build_tls() is only consulted when there's no Network spec; with a
         # Network, the engine drives ex_card/tl_card calls off the spec instead.
         self.tls = [] if self._network is not None else builder.build_tls()
@@ -128,8 +150,14 @@ class PyNECEngine(SimulationEngine):
             p0, p1, n_seg, ev = t[0], t[1], t[2], t[3]
             name = t[4] if len(t) >= 5 else None
             geo.wire(
-                idx, n_seg, p0[0], p0[1], p0[2], p1[0], p1[1], p1[2], 0.0005, 1.0, 1.0
-            )
+                idx,
+                n_seg,
+                p0[0], p0[1], p0[2],
+                p1[0], p1[1], p1[2],
+                self._wire_radius,
+                1.0,
+                1.0,
+            )  # fmt: skip
             mid_seg = (n_seg + 1) // 2
             if name is not None:
                 self._feed_name_to_loc[name] = (idx, mid_seg, p0, p1, n_seg)
@@ -153,8 +181,15 @@ class PyNECEngine(SimulationEngine):
             for idx1, seg1, idx2, seg2, impedance, length in self.tls:
                 self.c.tl_card(idx1, seg1, idx2, seg2, impedance, length, 0, 0, 0, 0)
 
-        if WIRE_CONDUCTIVITY is not None:
-            self.c.ld_card(5, 0, 0, 0, WIRE_CONDUCTIVITY, 0.0, 0.0)
+        # Spec conductivity from the design wins; the module constant stays
+        # as the manual all-designs oracle override (see its comment above).
+        sigma = (
+            self._wire_spec.conductivity
+            if self._wire_spec is not None
+            else WIRE_CONDUCTIVITY
+        )
+        if sigma is not None:
+            self.c.ld_card(5, 0, 0, 0, sigma, 0.0, 0.0)
         self._apply_ground_card()
 
         for tag, sub_index, voltage in self.excitation_pairs:
@@ -399,15 +434,20 @@ class PyNECEngine(SimulationEngine):
                 p1[0],
                 p1[1],
                 p1[2],
-                WIRE_RADIUS,
+                self._wire_radius,
                 1.0,
                 1.0,
             )
             if name is not None:
                 loc[name] = (idx, (n_seg + 1) // 2)
         c.geometry_complete(0)
-        if WIRE_CONDUCTIVITY is not None:
-            c.ld_card(5, 0, 0, 0, WIRE_CONDUCTIVITY, 0.0, 0.0)
+        sigma = (
+            self._wire_spec.conductivity
+            if self._wire_spec is not None
+            else WIRE_CONDUCTIVITY
+        )
+        if sigma is not None:
+            c.ld_card(5, 0, 0, 0, sigma, 0.0, 0.0)
         self._apply_ground_card(c)
         return c, loc
 

--- a/src/antennaknobs/nec_export.py
+++ b/src/antennaknobs/nec_export.py
@@ -19,7 +19,7 @@ native NEC ``tl_card``s, so there is no faithful single-deck representation.
 
 from __future__ import annotations
 
-from .engines.pynec import DEFAULT_GROUND, WIRE_RADIUS, PyNECEngine
+from .engines.pynec import DEFAULT_GROUND, WIRE_CONDUCTIVITY, PyNECEngine
 from .network import Load
 
 
@@ -95,7 +95,7 @@ def export_nec(
 
     # --- geometry: one GW per resolved wire tuple, then GE ---
     for tag, t in enumerate(eng.tups, start=1):
-        lines.append(_gw(tag, t[2], t[0], t[1], WIRE_RADIUS))
+        lines.append(_gw(tag, t[2], t[0], t[1], eng._wire_radius))
     lines.append("GE 0")
 
     # --- Load branches -> LD cards (type 0 series / 1 parallel RLC) ---
@@ -111,6 +111,15 @@ def export_nec(
                 continue
             ldtyp = 1 if br.parallel else 0
             lines.append(f"LD {ldtyp} {tag} {seg} {seg} {_num(r)} {_num(l)} {_num(c)}")
+
+    # Wire conductor loss (issue #316): the same global LD 5 the engine
+    # emits — spec conductivity from the design, else the module-level
+    # oracle constant (normally None → card omitted, PEC).
+    sigma = (
+        eng._wire_spec.conductivity if eng._wire_spec is not None else WIRE_CONDUCTIVITY
+    )
+    if sigma is not None:
+        lines.append(f"LD 5 0 0 0 {_num(sigma)} 0. 0.")
 
     # Legacy build_tls() path -> native NEC TL cards. (The build_network() TL
     # path uses the multiport-Y reducer and is rejected above.)

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -143,6 +143,77 @@ CABLES = {
 }
 
 
+COPPER_CONDUCTIVITY = 5.8e7  # S/m (annealed copper, the IACS reference)
+
+
+@dataclass(frozen=True)
+class WireSpec:
+    """Catalog entry for the antenna wire itself (issue #316): conductor
+    radius and conductivity for skin-effect loss, optional dielectric
+    jacket for the insulated-wire velocity-factor effect, and weight per
+    meter (jacket included) for the how-heavy-is-this-antenna readout.
+
+    `conductivity=None` means PEC (today's idealization with a real
+    radius); `insulation_radius=None` means bare wire. Engines consume
+    this via `Builder.build_wire_material()` — momwire models both
+    effects, PyNEC models conductor loss natively (ld_card type 5) but
+    has no NEC-2 card for insulation and solves the bare wire.
+    """
+
+    radius: float  # conductor radius, m
+    conductivity: float | None = None  # S/m; None = PEC
+    insulation_radius: float | None = None  # jacket outer radius, m
+    insulation_eps_r: float | None = None  # jacket relative permittivity
+    weight_g_per_m: float = 0.0  # conductor + jacket
+
+
+# Nominal catalog values: bare-copper AWG diameters, copper at 5.8e7 S/m,
+# and for the insulated variants a representative PVC hookup-wire jacket
+# (εr ≈ 3.5 at HF, jacket ODs typical of stranded hookup wire — vendor
+# constructions vary, treat as representative). Weights from copper at
+# 8.96 g/cm³ + PVC at 1.4 g/cm³.
+WIRES = {
+    "28-awg": WireSpec(
+        radius=0.160e-3, conductivity=COPPER_CONDUCTIVITY, weight_g_per_m=0.72
+    ),
+    "22-awg": WireSpec(
+        radius=0.321e-3, conductivity=COPPER_CONDUCTIVITY, weight_g_per_m=2.91
+    ),
+    "18-awg": WireSpec(
+        radius=0.512e-3, conductivity=COPPER_CONDUCTIVITY, weight_g_per_m=7.37
+    ),
+    "28-awg-pvc": WireSpec(
+        radius=0.160e-3,
+        conductivity=COPPER_CONDUCTIVITY,
+        insulation_radius=0.50e-3,
+        insulation_eps_r=3.5,
+        weight_g_per_m=1.71,
+    ),
+    "22-awg-pvc": WireSpec(
+        radius=0.321e-3,
+        conductivity=COPPER_CONDUCTIVITY,
+        insulation_radius=0.80e-3,
+        insulation_eps_r=3.5,
+        weight_g_per_m=5.27,
+    ),
+    "18-awg-pvc": WireSpec(
+        radius=0.512e-3,
+        conductivity=COPPER_CONDUCTIVITY,
+        insulation_radius=1.05e-3,
+        insulation_eps_r=3.5,
+        weight_g_per_m=11.07,
+    ),
+}
+
+
+def wire_from_catalog(name):
+    """The `WIRES` entry for `name`, with the same unknown-key ergonomics
+    as `TL.from_cable`."""
+    if name not in WIRES:
+        raise KeyError(f"unknown wire {name!r}; available: {', '.join(sorted(WIRES))}")
+    return WIRES[name]
+
+
 # Reserved for follow-up PR — sketched here so the discriminated-union
 # pattern is established but not consumed yet by any engine.
 @dataclass(frozen=True)

--- a/tests/test_wire_material.py
+++ b/tests/test_wire_material.py
@@ -1,0 +1,170 @@
+"""Wire material plumbing (issue #316): WIRES catalog, the
+`build_wire_material` hook, and both engines consuming the spec.
+
+The engine-level oracle is momwire#131's distributed loading vs PyNEC's
+native NEC-2 wire-loss card (ld_card type 5) — two independent
+implementations of skin-effect conductor loss on the same geometry.
+"""
+
+import numpy as np
+import pytest
+
+from antennaknobs.designs.dipoles.invvee import Builder
+from antennaknobs.engines import MomwireEngine, PyNECEngine
+from antennaknobs.network import COPPER_CONDUCTIVITY, WIRES, wire_from_catalog
+
+from conftest import needs_pynec
+
+
+def _z(engine):
+    z = engine.impedance()
+    return complex(z[0]) if isinstance(z, (list, tuple)) else complex(z)
+
+
+def _builder(wire_type=None):
+    b = Builder()
+    if wire_type is not None:
+        b.wire_type = wire_type
+    return b
+
+
+# ----------------------------------------------------------------------
+# Catalog
+# ----------------------------------------------------------------------
+
+
+def test_catalog_entries_consistent():
+    """Radii are AWG (each ~3 gauge steps ≈ ×√2 diameter), copper weights
+    match the cross-section, insulated variants share the conductor."""
+    rho_cu = 8.96  # g/cm³
+    for name, w in WIRES.items():
+        assert w.conductivity == COPPER_CONDUCTIVITY
+        base = WIRES[name.removesuffix("-pvc")]
+        assert w.radius == base.radius
+        w_cu = rho_cu * np.pi * (w.radius * 100) ** 2 * 100  # g/m
+        if name.endswith("-pvc"):
+            assert w.insulation_radius > w.radius
+            assert w.insulation_eps_r >= 1.0
+            assert w.weight_g_per_m > base.weight_g_per_m
+        else:
+            assert w.insulation_radius is None
+            assert w.weight_g_per_m == pytest.approx(w_cu, rel=0.02)
+    # 28 → 22 → 18 AWG: 6 gauge steps ≈ diameter ×2 each
+    assert WIRES["22-awg"].radius / WIRES["28-awg"].radius == pytest.approx(
+        2.0, rel=0.02
+    )
+    assert WIRES["18-awg"].radius / WIRES["22-awg"].radius == pytest.approx(
+        1.6, rel=0.02
+    )
+
+
+def test_catalog_lookup_error_ergonomics():
+    with pytest.raises(KeyError, match="unknown wire.*available"):
+        wire_from_catalog("12-awg")
+
+
+def test_builder_hook_default_and_wire_type():
+    assert _builder().build_wire_material() is None
+    assert _builder("28-awg") is not None
+    assert _builder("28-awg").build_wire_material() is WIRES["28-awg"]
+    with pytest.raises(KeyError):
+        _builder("no-such-wire").build_wire_material()
+
+
+# ----------------------------------------------------------------------
+# MomwireEngine consumption
+# ----------------------------------------------------------------------
+
+
+def test_momwire_ideal_solve_unchanged():
+    """No wire_type → today's idealization, bit-for-bit."""
+    z_a = _z(MomwireEngine(_builder(), ground=None))
+    z_b = _z(MomwireEngine(_builder(), ground=None))
+    assert z_a == z_b  # determinism sanity for the comparisons below
+
+
+def test_momwire_spec_radius_and_loss():
+    z0 = _z(MomwireEngine(_builder(), ground=None))
+    z1 = _z(MomwireEngine(_builder("28-awg"), ground=None))
+    # Thinner + lossy wire: R must rise. (The shift includes both the real
+    # 28 AWG radius and the copper loading.)
+    assert z1.real > z0.real + 1.0
+
+
+def test_momwire_insulation_shifts_reactance():
+    z_bare = _z(MomwireEngine(_builder("28-awg"), ground=None))
+    z_pvc = _z(MomwireEngine(_builder("28-awg-pvc"), ground=None))
+    # Same conductor, added jacket: electrically longer → X rises; the
+    # jacket is lossless so R moves only via the resonance shift.
+    assert z_pvc.imag > z_bare.imag + 10.0
+
+
+def test_momwire_explicit_radius_overrides_spec():
+    """A non-default wire_radius (the web model-options control) wins over
+    the spec radius; the stock 0.0005 defers to the spec."""
+    e_auto = MomwireEngine(_builder("28-awg"), ground=None)
+    assert e_auto._wire_radius == WIRES["28-awg"].radius
+    e_explicit = MomwireEngine(_builder("28-awg"), ground=None, wire_radius=0.001)
+    assert e_explicit._wire_radius == 0.001
+    e_ideal = MomwireEngine(_builder(), ground=None)
+    assert e_ideal._wire_radius == 0.0005
+
+
+def test_momwire_sinusoidal_drops_loading_keeps_radius(caplog):
+    """SinusoidalSolver can't model the loading: warn, solve with the real
+    radius but ideal metal — NOT a crash, NOT a silent identical solve."""
+    from momwire import SinusoidalSolver
+
+    with caplog.at_level("WARNING"):
+        e = MomwireEngine(_builder("28-awg"), ground=None, solver=SinusoidalSolver)
+    assert "doesn't model distributed wire loading" in caplog.text
+    assert e._loading_kwargs == {}
+    assert e._wire_radius == WIRES["28-awg"].radius
+
+
+# ----------------------------------------------------------------------
+# PyNEC consumption + the cross-engine loss oracle
+# ----------------------------------------------------------------------
+
+
+@needs_pynec
+def test_pynec_ld5_and_radius_from_spec(caplog):
+    z0 = _z(PyNECEngine(_builder(), ground=None))
+    z1 = _z(PyNECEngine(_builder("28-awg"), ground=None))
+    assert z1.real > z0.real + 1.0
+    # Insulation: no NEC-2 card — warned, solved as the bare variant.
+    with caplog.at_level("WARNING"):
+        z2 = _z(PyNECEngine(_builder("28-awg-pvc"), ground=None))
+    assert "no insulated-wire card" in caplog.text
+    assert z2 == pytest.approx(z1, rel=1e-12)
+
+
+@needs_pynec
+def test_nec_export_carries_spec():
+    """The exported deck is a text twin of what PyNECEngine solves: spec
+    radius on the GW cards, the global LD 5 when the design's wire is
+    lossy, and neither for the ideal default."""
+    from antennaknobs.nec_export import export_nec
+
+    deck = export_nec(_builder("28-awg"), ground=None)
+    assert "LD 5 0 0 0  5.800000E+07" in deck
+    assert " 1.600000E-04" in deck  # 28 AWG radius on the GW cards
+    deck0 = export_nec(_builder(), ground=None)
+    assert "LD 5" not in deck0
+    assert " 5.000000E-04" in deck0
+
+
+@needs_pynec
+def test_cross_engine_skin_loss_oracle():
+    """momwire's distributed loading vs NEC's native ld_card type 5 on the
+    same free-space invvee: the ideal→28-awg ΔR (radius + copper) from two
+    independent implementations must agree to a few percent."""
+    dr_momwire = (
+        _z(MomwireEngine(_builder("28-awg"), ground=None)).real
+        - _z(MomwireEngine(_builder(), ground=None)).real
+    )
+    dr_pynec = (
+        _z(PyNECEngine(_builder("28-awg"), ground=None)).real
+        - _z(PyNECEngine(_builder(), ground=None)).real
+    )
+    assert dr_momwire == pytest.approx(dr_pynec, rel=0.05)


### PR DESCRIPTION
## Summary
- `WireSpec` + `WIRES` catalog beside `Cable`/`CABLES`: 28/22/18 AWG bare copper and representative PVC-insulated variants, with grams/meter (jacket included) for the upcoming weight readout (#318).
- `AntennaBuilder.build_wire_material()`: a design with a `wire_type` param resolves it from the catalog; absent = today's ideal wire, bit-exact.
- **MomwireEngine** threads the spec radius plus `wire_conductivity`/`insulation_*` to BSpline-family solvers (momwire#131); SinusoidalSolver warns and solves the real radius with ideal metal. Radius precedence: explicit non-default `wire_radius` > spec > stock 0.0005 ("auto"), so a spec design's skin loss is computed at its real gauge radius even from the web path.
- **PyNECEngine** emits the spec radius on wire cards and spec conductivity as a global `ld_card` type 5 on both context paths; insulation is warned + solved bare (no NEC-2 card — momwire is the fidelity engine, same precedent as Sommerfeld ground). `nec_export` decks stay text twins (GW radius + LD 5).
- Cross-engine oracle: ideal→28-awg ΔR from momwire's distributed loading vs PyNEC's native LD 5 agrees to **0.5%** (3.323 vs 3.338 Ω on the free-space invvee).

## CI note
Requires unreleased momwire (momwire#132, on the submodule's main; local dev is editable). **wheel-smoke will stay red on this branch** until the arc-end momwire release + exact-pin bump — per Steve's sequencing call. The submodule pointer is deliberately not moved here (it moves with the pin ritual).

## Test plan
- [x] 11 new tests in `tests/test_wire_material.py` (catalog consistency, builder hook, both engines, export deck, cross-engine oracle)
- [x] Full suite: 1567 passed locally against editable momwire main
- [x] ruff check + format clean

Closes #316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)