### PR TITLE
Power budget: wire I²R row + efficiency fold-in

### DIFF
--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -375,10 +375,51 @@ class MomwireEngine(SimulationEngine):
         key = (float(wavelength), v_key)
         cached = getattr(self, "_solved_cache", None)
         if cached is not None and cached[0] == key:
-            return cached[1]
-        z, coeffs = sim.compute_impedance()
-        self._solved_cache = (key, (sim, coeffs, z))
+            sim, coeffs, z = cached[1]
+        else:
+            z, coeffs = sim.compute_impedance()
+            self._solved_cache = (key, (sim, coeffs, z))
+        # _make_excited_solver reset the power bookkeeping either way, so
+        # the wire-loss amendment below is applied exactly once per call.
+        self._amend_wire_loss(sim, coeffs, z)
         return sim, coeffs, z
+
+    def _amend_wire_loss(self, sim, coeffs, z):
+        """Fold ohmic wire loss (momwire#131 distributed loading) into the
+        power bookkeeping (issue #317): a "wire loss (I²R)" budget row and
+        the matching efficiency drop. The loss already lives inside P_in
+        (the loading raised the driving-point R), so gain = 4π·U/P_in needs
+        no change — this keeps the *reported* efficiency and budget rows
+        truthful about where those watts went. Insulation is reactive and
+        contributes nothing; lossless designs are untouched."""
+        self._excited_p_wire = 0.0
+        if not self._loading_kwargs:
+            return
+        p_wire, _per_wire = sim.wire_loss_power(coeffs)
+        if p_wire <= 0.0:
+            return
+        self._excited_p_wire = float(p_wire)
+        self._excited_power_budget = list(self._excited_power_budget) + [
+            ("wire loss (I²R)", float(p_wire))
+        ]
+        p_in = self._excited_p_in
+        if p_in is None:  # plain path records no port-model power
+            p_in = self._p_in_from_excited(sim, z)
+        if p_in > 0.0:
+            self._excited_efficiency = max(
+                0.0, min(1.0, self._excited_efficiency - p_wire / p_in)
+            )
+
+    @staticmethod
+    def _p_in_from_excited(sim, z):
+        """Source input power ½·Σ|V_f|²·Re(Z_f)/|Z_f|² from an excited
+        solve's driving-point impedances (the plain-path formula shared by
+        `input_power` and the wire-loss amendment)."""
+        z_arr = np.atleast_1d(np.asarray(z, dtype=np.complex128))
+        volts = np.array([complex(v) for *_, v in sim.feeds], dtype=np.complex128)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            terms = 0.5 * np.abs(volts) ** 2 * z_arr.real / np.abs(z_arr) ** 2
+        return float(np.sum(terms[np.isfinite(terms)]))
 
     def _raise_if_cancelled(self):
         """Poll the cancel token at an engine-phase boundary (no-op without one).
@@ -527,11 +568,7 @@ class MomwireEngine(SimulationEngine):
         p_in = getattr(self, "_excited_p_in", None)
         if p_in is not None:
             return float(p_in)
-        z_arr = np.atleast_1d(np.asarray(z, dtype=np.complex128))
-        volts = np.array([complex(v) for *_, v in sim.feeds], dtype=np.complex128)
-        with np.errstate(divide="ignore", invalid="ignore"):
-            terms = 0.5 * np.abs(volts) ** 2 * z_arr.real / np.abs(z_arr) ** 2
-        return float(np.sum(terms[np.isfinite(terms)]))
+        return self._p_in_from_excited(sim, z)
 
     def current_distribution(self):
         self._raise_if_cancelled()

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -3,6 +3,11 @@ import logging
 import numpy as np
 import PyNEC as nec
 
+# Exact round-conductor internal impedance (momwire#131). Private-module
+# import, but antennaknobs pins momwire exactly, so the pair moves in
+# lockstep; promote to a public momwire export at the next API pass.
+from momwire._wire_loading import wire_internal_impedance
+
 from ..engine import FarField, SimulationEngine, WireCurrents
 from ..network import (
     Driven,
@@ -477,10 +482,16 @@ class PyNECEngine(SimulationEngine):
         nothing and leave efficiency at 1.0.
         """
         # TL/virtual-driver networks reduce through the shared
-        # reducer; reuse its port-level efficiency and input power.
+        # reducer; reuse its port-level efficiency and input power, then
+        # fold in the wire loss (inside NEC's solve, invisible to the
+        # port-level reducer bookkeeping).
         if self._network is not None and self._use_reducer:
             Y = self._compute_y_matrix(wavelength)
             _v, efficiency, p_in, budget = self._reducer.excited_state(Y, wavelength)
+            p_wire = self._wire_loss_from_currents(sc, wavelength)
+            if p_wire > 0.0 and p_in > 0.0:
+                budget = list(budget) + [("wire loss (I²R)", p_wire)]
+                efficiency = max(0.0, min(1.0, efficiency - p_wire / p_in))
             return efficiency, p_in, budget
         # Native path: source input power from NEC's ANTENNA INPUT
         # PARAMETERS (index 0 — `sc` always comes from the single-frequency
@@ -495,8 +506,6 @@ class PyNECEngine(SimulationEngine):
             if self._network is not None
             else []
         )
-        if not loads or p_in <= 0.0:
-            return 1.0, p_in, []
         omega = 2.0 * np.pi * C_LIGHT / wavelength
         p_diss = 0.0
         budget = []
@@ -506,7 +515,42 @@ class PyNECEngine(SimulationEngine):
             w = 0.5 * load_impedance(br, omega).real * abs(cur) ** 2
             budget.append((f"Load {br.port}", w))
             p_diss += w
+        p_wire = self._wire_loss_from_currents(sc, wavelength)
+        if p_wire > 0.0:
+            budget.append(("wire loss (I²R)", p_wire))
+            p_diss += p_wire
+        if not budget or p_in <= 0.0:
+            return 1.0, p_in, []
         return max(0.0, min(1.0, 1.0 - p_diss / p_in)), p_in, budget
+
+    def _wire_loss_from_currents(self, sc, wavelength):
+        """Ohmic wire loss ½·Σ|I_seg|²·R'·l_seg in watts, integrated from
+        the excited structure currents (issue #317). NEC solves the global
+        LD 5 loading internally but exposes no structure-dissipation
+        readout, so re-integrate it from the same segment currents the
+        loss card shaped. R' is the exact solid-round-conductor internal
+        resistance — the same law NEC's zint (Kelvin ber/bei) implements —
+        so this tracks NEC's own accounting to well under a percent."""
+        sigma = (
+            self._wire_spec.conductivity
+            if self._wire_spec is not None
+            else WIRE_CONDUCTIVITY
+        )
+        if sigma is None:
+            return 0.0
+        omega = 2.0 * np.pi * C_LIGHT / wavelength
+        r_per_m = float(
+            np.real(wire_internal_impedance(omega, self._wire_radius, sigma))
+        )
+        all_tags = np.asarray(sc.get_current_segment_tag())
+        all_cur = np.asarray(sc.get_current())
+        p = 0.0
+        for tag_idx, t in enumerate(self.tups, start=1):
+            p0, p1, n_seg = np.asarray(t[0], float), np.asarray(t[1], float), t[2]
+            seg_len = float(np.linalg.norm(p1 - p0)) / n_seg
+            cur = all_cur[all_tags == tag_idx]
+            p += 0.5 * r_per_m * seg_len * float(np.sum(np.abs(cur) ** 2))
+        return p
 
     def _compute_y_matrix(self, wavelength):
         """Multiport short-circuit Y at the real ports, via one NEC solve per

--- a/tests/test_wire_loss_budget.py
+++ b/tests/test_wire_loss_budget.py
@@ -1,0 +1,116 @@
+"""Wire-loss power accounting (issue #317): the "wire loss (I²R)" budget
+row and the efficiency fold-in, on both engines and all excitation paths.
+
+Ohmic wire loss happens *inside* the MoM solve (momwire#131 loading /
+NEC's LD 5), so it already lives in P_in and the gain normalisation —
+these tests pin the *bookkeeping*: budget rows and reported efficiency.
+"""
+
+import numpy as np
+import pytest
+
+from antennaknobs import resolve_variant_params
+from antennaknobs.designs.dipoles.invvee import Builder
+from antennaknobs.engines import MomwireEngine, PyNECEngine
+
+from conftest import needs_pynec
+
+WIRE_ROW = "wire loss (I²R)"
+
+
+def _builder(wire_type=None, variant=None):
+    params = resolve_variant_params(Builder, variant) if variant else None
+    b = Builder(params)
+    if wire_type is not None:
+        b.wire_type = wire_type
+    return b
+
+
+def _excited(eng):
+    eng.current_distribution()
+    p_in = eng._excited_p_in
+    if p_in is None:  # momwire plain path derives it on demand
+        p_in = eng.input_power()
+    return eng._excited_efficiency, float(p_in), list(eng._excited_power_budget)
+
+
+def test_ideal_design_bookkeeping_unchanged():
+    eff, p_in, budget = _excited(MomwireEngine(_builder(), ground=None))
+    assert eff == 1.0
+    assert budget == []
+    assert p_in > 0.0
+
+
+def test_momwire_plain_path_row_and_efficiency():
+    eff, p_in, budget = _excited(MomwireEngine(_builder("28-awg"), ground=None))
+    rows = [w for label, w in budget if label == WIRE_ROW]
+    assert len(rows) == 1
+    p_wire = rows[0]
+    assert 0.0 < p_wire < p_in
+    assert eff == pytest.approx(1.0 - p_wire / p_in, abs=1e-12)
+    # 28 AWG on a 10 m-band invvee: mid-90s% efficiency window
+    assert 0.90 < eff < 0.97
+
+
+def test_momwire_repeated_excite_single_row():
+    eng = MomwireEngine(_builder("28-awg"), ground=None)
+    eng.current_distribution()
+    eng.far_field(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
+    eng.current_distribution()
+    labels = [label for label, _w in eng._excited_power_budget]
+    assert labels.count(WIRE_ROW) == 1
+
+
+def test_momwire_radiated_power_matches_far_field_integral():
+    """Free-space straight dipole (up/down symmetric): integrating the
+    gain pattern over the sphere must return 4π·efficiency — the wire
+    loss the budget claims is exactly the power missing from the sky."""
+    eng = MomwireEngine(_builder("28-awg", variant="dipole"), ground=None)
+    eff, _p_in, _budget = _excited(eng)
+    ff = eng.far_field(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
+    D = 10.0 ** (np.asarray(ff.rings) / 10.0)  # (n_theta, n_phi+1)
+    theta = np.deg2rad(np.linspace(0, 89, 90))
+    dth, dph = np.deg2rad(1.0), np.deg2rad(1.0)
+    hemi = float(np.sum(D[:, :-1] * np.sin(theta)[:, None]) * dth * dph)
+    eff_from_sky = 2.0 * hemi / (4.0 * np.pi)  # symmetric: sphere = 2×hemi
+    assert eff_from_sky == pytest.approx(eff, rel=0.05)
+
+
+@needs_pynec
+def test_cross_engine_efficiency_oracle():
+    """momwire's c†·Re(L)·c readout vs PyNEC's LD 5 + segment-current
+    integration: two independent implementations of the same physics."""
+    eff_m, _pm, bud_m = _excited(MomwireEngine(_builder("28-awg"), ground=None))
+    eff_p, _pp, bud_p = _excited(PyNECEngine(_builder("28-awg"), ground=None))
+    assert abs(eff_m - eff_p) < 0.01
+    assert [label for label, _ in bud_m] == [WIRE_ROW]
+    assert [label for label, _ in bud_p] == [WIRE_ROW]
+
+
+@needs_pynec
+def test_pynec_ideal_unchanged():
+    eff, _p_in, budget = _excited(PyNECEngine(_builder(), ground=None))
+    assert eff == 1.0
+    assert budget == []
+
+
+def test_momwire_network_path_appends_to_branch_rows():
+    """A lossy-wire station design (TL network): the wire row joins the
+    existing branch budget instead of replacing it, and efficiency drops
+    below the network-only value."""
+    from antennaknobs.designs.dipoles.invvee_coax_station import (
+        Builder as Station,
+    )
+
+    b_ideal = Station()
+    b_lossy = Station()
+    b_lossy.wire_type = "28-awg"
+    eng_i = MomwireEngine(b_ideal, ground=None)
+    eng_l = MomwireEngine(b_lossy, ground=None)
+    eff_i, _pi, bud_i = _excited(eng_i)
+    eff_l, _pl, bud_l = _excited(eng_l)
+    labels_i = [label for label, _ in bud_i]
+    labels_l = [label for label, _ in bud_l]
+    assert WIRE_ROW not in labels_i
+    assert labels_l == labels_i + [WIRE_ROW]
+    assert eff_l < eff_i


### PR DESCRIPTION
## Summary
- **MomwireEngine**: after the excited solve, `wire_loss_power(coeffs)` (momwire#131) is folded into the bookkeeping — a **"wire loss (I²R)"** budget row and the matching efficiency drop, on all three excitation paths (network/reducer, TL, plain). Gain normalisation needed no change: the loss already lives inside P_in; this makes the *reported* efficiency and budget truthful.
- **PyNECEngine**: NEC has no structure-dissipation readout, so the row is integrated from the excited segment currents (½·Σ|I|²·R'·l) using the exact round-conductor internal resistance — the same law NEC's `zint` implements — on both native and reducer paths.
- Cross-engine oracle: 28 AWG free-space invvee → efficiency **0.9360 vs 0.9352** from the two independent accountings.
- Energy conservation: integrating the momwire gain pattern over the sphere returns 4π·efficiency within 5% grid tolerance — the budget's watts are exactly the watts missing from the sky.
- Lossless designs bit-identical (efficiency 1.0, no row); the HUD's power-budget table renders the new row with no frontend change.

## Test plan
- [x] 7 new tests in `tests/test_wire_loss_budget.py` (both engines, all paths, idempotence, station-design branch-row composition, sky integral)
- [x] Full suite: 1574 passed locally against editable momwire main
- [x] ruff clean

Closes #317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)