### PR TITLE
POTA wire-gauge showcase: pota_invvee design, weight readout, Advanced docs

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -87,6 +87,7 @@ export default defineConfig({
           label: "Advanced",
           items: [
             { label: "Coax vs. ladder line", slug: "advanced/station-comparison" },
+            { label: "Wire gauge for POTA", slug: "advanced/wire-gauge" },
           ],
         },
         {

--- a/site/src/content/docs/advanced/wire-gauge.md
+++ b/site/src/content/docs/advanced/wire-gauge.md
@@ -1,0 +1,89 @@
+---
+title: "How thin can you go? Wire gauge for POTA"
+description: An advanced worked example — weigh 28 vs 22 vs 18 AWG antenna wire against SWR bandwidth and radiated power, with skin-effect loss and insulation modelled for real.
+---
+
+Every portable operator has packed this decision. The 28 AWG magnet-wire
+dipole weighs nothing and disappears into a tree; the 18 AWG version
+survives being yanked out of one. Between them sits a real three-way
+tradeoff — **weight vs. SWR bandwidth vs. radiated power** — that mostly
+gets settled by folklore ("thin wire is lossy", "thick wire is broader").
+This example settles it with a solver instead.
+
+One catalog design carries the whole comparison:
+[`dipoles.pota_invvee`](/reference/catalog/) — a half-wave 20 m inverted-V
+on a 7 m telescoping pole over average ground, where **the wire itself is
+a knob**. The `wire_type` dropdown selects from a wire catalog the same
+way the station designs pick a feedline from the cable catalog: 28, 22,
+or 18 AWG copper, bare or PVC-insulated, each entry carrying its real
+radius, conductivity, jacket, and grams per meter.
+
+## What the wire actually does in the model
+
+This isn't a lookup-table correction. Since momwire's distributed-loading
+release, the wire's material enters the impedance matrix itself as a
+per-meter series impedance:
+
+- **Skin-effect resistance.** At 14 MHz current flows in the outer
+  ~17 µm of the copper, so RF resistance runs 5–15× the DC value —
+  about 1 Ω/m for 28 AWG, 0.3 Ω/m for 18 AWG. The solver uses the exact
+  solid-round-conductor law (the same one NEC's `LD 5` card implements),
+  valid from DC through full skin effect.
+- **Insulation loading.** A dielectric jacket stores E-field energy next
+  to the wire, which acts as distributed series inductance — the wave on
+  the wire slows down, and the antenna tunes a few percent *lower* than
+  bare wire cut to the same length. That's the velocity factor behind
+  "my cut-to-formula insulated dipole came out long."
+
+Both engines model the conductor loss (the momwire loading and PyNEC's
+native `LD 5` agree on the added resistance to half a percent — a
+cross-engine oracle in the test suite). The insulation effect is
+momwire-only: NEC-2 has no insulated-wire card, so switching engines on
+a PVC wire visibly moves the resonance. That divergence is the lesson,
+not a bug.
+
+## The numbers
+
+Stock design, PVC-insulated wire, retuned length per gauge not required —
+the numbers below are the dropdown flipped with everything else constant
+(2:1 SWR window from the band-locked sweep; weight for the full ~10 m of
+wire; loss relative to a perfect conductor):
+
+| wire | weight | 2:1 SWR window | radiated power |
+|---|---|---|---|
+| 28 AWG PVC | **17 g** | 550 kHz | −0.36 dB (92 %) |
+| 22 AWG PVC | 53 g | 605 kHz | −0.18 dB (96 %) |
+| 18 AWG PVC | 111 g | **645 kHz** | **−0.11 dB (97.5 %)** |
+
+Three readings worth taking home:
+
+1. **The loss argument is real but small.** Going from 18 AWG all the way
+   down to 28 AWG costs a quarter of a decibel — nobody on the other end
+   will hear it. The power budget in the workbench shows exactly where it
+   went: a **wire loss (I²R)** row that grows from ~2.5 % to ~8 % of the
+   input power as the wire thins.
+2. **Bandwidth favors thick wire, for the geometric reason.** Two effects
+   stack here and pull the same way with different price tags: a fatter
+   conductor is intrinsically broader (lower ln(L/a) Q — free), and a
+   lossier conductor is *also* broader (resistance flattens the SWR
+   curve — paid for in watts). The table shows the honest sum: 18 AWG is
+   ~100 kHz broader than 28 AWG *and* radiates more. Thin wire's loss
+   does not buy its bandwidth back.
+3. **The insulation is a bigger tuning effect than the gauge.** Flip any
+   PVC entry to its bare twin and the resonance jumps ~500 kHz — several
+   times the entire gauge-to-gauge bandwidth difference. Cut your antenna
+   for the wire you'll actually hang.
+
+And the weight column is the one the solver can't argue with: the 28 AWG
+antenna is **17 grams**. For a summit activation where every antenna is a
+compromise, −0.36 dB for a 6× lighter pack is a fine trade — now it's a
+number instead of a guess.
+
+## Try it
+
+Open [`dipoles.pota_invvee`](https://app.antennaknobs.dev/) in the
+simulator, put the sweep on 20 m, and flip `wire_type` through the
+catalog. Watch the **wire weight** row in the Info pane, the **wire loss
+(I²R)** row in the power budget, and the SWR trace breathe as the gauge
+changes. Then flip 22 AWG PVC to bare 22 AWG and watch the whole
+resonance walk up the band — the velocity factor, live.

--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -21,6 +21,7 @@ after L. B. Cebik (W4RNL)'s articles.
 | `dipoles.invvee_coax_station` | Inverted-V fed through real coax — the classic "resonant antenna on 50 Ω line" station, modelled from the rig (issue #300) · variants: `classic_edz`, `dipole`, `three_halves` |
 | `dipoles.koch_dipole` | Koch fractal dipole (L. B. Cebik, W4RNL -- "fractal antennas") |
 | `dipoles.ocf_dipole` | Off-Center-Fed dipole (Windom): a half-wave fed away from the middle (L. B. Cebik, W4RNL) |
+| `dipoles.pota_invvee` | POTA wire-gauge tradeoff: a 20 m inverted-V where the wire is a knob · variants: `classic_edz`, `dipole`, `three_halves` |
 | `dipoles.short_dipole_loaded` | Center-loaded shortened dipole — the Load-branch showcase for issue #65 |
 <!-- catalog:end dipoles -->
 

--- a/src/antennaknobs/designs/dipoles/pota_invvee.py
+++ b/src/antennaknobs/designs/dipoles/pota_invvee.py
@@ -1,0 +1,65 @@
+"""POTA wire-gauge tradeoff: a 20 m inverted-V where the wire is a knob.
+
+The park-activation question, as numbers (issue #318): a half-wave
+inverted-V on a 7 m telescoping pole, with the **wire itself** selectable
+from the `WIRES` catalog — 28/22/18 AWG, bare or PVC-insulated. Flip the
+`wire_type` dropdown and watch three things move at once:
+
+* **weight** — the Info pane reports the total wire run and its grams
+  (jacket included). 28 AWG is a tenth the copper of 18 AWG.
+* **radiated power** — skin-effect loss (momwire#131 distributed loading;
+  PyNEC's native LD 5) shows up as a *wire loss (I²R)* row in the power
+  budget and as lost tenths of a dB. Thin wire pays roughly −0.3 dB on
+  this antenna; thick wire nearly nothing.
+* **SWR bandwidth** — two stacked effects the sweep untangles honestly:
+  thicker wire widens the resonance *geometrically* (lower ln(L/a) Q),
+  while thinner wire widens it *dissipatively* — bandwidth you pay for
+  in watts. The band-locked sweep shows 20 m edge-to-edge.
+
+The PVC variants also land visibly lower in frequency than bare copper
+cut to the same length — the insulated-wire velocity factor (a few
+percent, King's jacket inductance), i.e. why a cut-to-formula insulated
+dipole tunes long. The default `length_factor` is tuned so the stock
+22 AWG PVC wire resonates near 14.1 MHz at 7 m over average ground;
+switching to bare wire moves resonance UP — retune with the length knob
+and note how much shorter the insulated antenna is.
+
+Geometry is the stock `dipoles.invvee` V (same knobs) at 20 m scale.
+PyNEC models the conductor loss but not the jacket (no NEC-2 card), so
+engine-switching on a PVC variant shifts resonance — momwire is the
+fidelity engine there.
+"""
+
+from types import MappingProxyType
+
+from ...network import WIRES
+from .invvee import Builder as InvVee
+
+
+class Builder(InvVee):
+    default_params = MappingProxyType(
+        {
+            **InvVee.default_params,
+            # 20 m: the bread-and-butter POTA band.
+            "design_freq": 14.1,
+            "freq": 14.1,
+            # Apex on a 7 m telescoping pole (≈0.33λ up on 20 m).
+            "base": 7.0,
+            # Tuned for the DEFAULT wire below (22 AWG PVC) to resonate
+            # near 14.1 MHz at this height over average ground — insulated
+            # wire is a few percent electrically longer than bare, so this
+            # sits below the bare-wire invvee factor.
+            "length_factor": 0.9440,
+            "wire_type": "22-awg-pvc",
+            "ui_params": MappingProxyType(
+                {
+                    **InvVee.default_params["ui_params"],
+                    "wire_type": {"enum_options": tuple(sorted(WIRES))},
+                    # The story lives inside the band: lock the sweep to the
+                    # band being measured so the SWR-bandwidth comparison
+                    # reads edge-to-edge on 20 m.
+                    "sweep_policy": {"anchor": "meas_freq", "band_locked": True},
+                }
+            ),
+        }
+    )

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -78,6 +78,7 @@ from .examples._base import (
     BandSpec,
     ParamGroupSpec,
     ParamSpec,
+    ResultFieldSpec,
     SweepPolicy,
 )
 
@@ -562,6 +563,26 @@ def _pynec_ground_spec(req: dict):
     if model == "fast":
         return ("finite-fast",) + DEFAULT_GROUND[1:]
     return DEFAULT_GROUND
+
+
+def _wire_material_results(builder) -> dict:
+    """Wire length + weight response fields (issue #318) for designs that
+    declare a wire material: total conductor run from build_wires(), weight
+    from the catalog's grams/meter (jacket included). {} when the design
+    has no material — the fields (and their Info-pane rows) only exist for
+    wire_type designs."""
+    spec = builder.build_wire_material()
+    if spec is None:
+        return {}
+    length = 0.0
+    for t in builder.build_wires():
+        p0 = np.asarray(t[0], dtype=float)
+        p1 = np.asarray(t[1], dtype=float)
+        length += float(np.linalg.norm(p1 - p0))
+    return {
+        "wire_length_m": length,
+        "wire_weight_g": length * spec.weight_g_per_m,
+    }
 
 
 def _make_momwire_engine(req: dict, builder, cancel=None):
@@ -1075,6 +1096,22 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
     has_design_freq = "design_freq" in dp
     variants = _discover_variants(cls)
 
+    # Wire-material designs (issue #318): a `wire_type` param means the
+    # solve responses carry wire_length_m / wire_weight_g (see
+    # _wire_material_results) — surface them as Info-pane result rows.
+    # The weight row is the POTA question in one number: how many grams
+    # of wire buy how much bandwidth and how many tenths of a dB.
+    result_schema: tuple = ()
+    if "wire_type" in dp:
+        result_schema = (
+            ResultFieldSpec(
+                field="wire_length_m", label="wire length", precision=1, unit=" m"
+            ),
+            ResultFieldSpec(
+                field="wire_weight_g", label="wire weight", precision=1, unit=" g"
+            ),
+        )
+
     # Per-variant UI hints. A variant's `ui_params` deep-merges over the
     # default's (resolve_variant_params), so a variant can flip a single nested
     # hint (e.g. sweep_policy.band_locked) without restating the subtree. We
@@ -1214,6 +1251,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             # η₀k²/(8π·P_in), which is what makes the plot GAIN (load and
             # ground losses live inside P_in, so no efficiency multiply).
             "input_power_w": float(eng.input_power()),
+            **_wire_material_results(builder),
         }
         if hints()["multi_feed"] and len(zs) > 1:
             # Pull per-feed drive voltages off the engine so the frontend
@@ -1380,6 +1418,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
                 for label, w in (getattr(eng, "_excited_power_budget", None) or [])
             ],
             "input_power_w": float(getattr(eng, "_excited_p_in", None) or 0.0),
+            **_wire_material_results(builder),
         }
         if hints()["multi_feed"] and len(zs) > 1:
             # PyNECEngine.excitation_pairs is [(tag, sub_seg, voltage)];
@@ -1543,6 +1582,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         far_field_metrics=far_field_metrics,
         multi_feed=field_multi_feed,
         param_schema=param_schema,
+        result_schema=result_schema,
         bands=bands,
         meas_freq_range_mhz=tuple(meas_range) if meas_range else None,
         sweep_policy=sweep_policy,

--- a/tests/test_pota_invvee.py
+++ b/tests/test_pota_invvee.py
@@ -1,0 +1,86 @@
+"""The POTA wire-gauge showcase design (issue #318): dipoles.pota_invvee.
+
+Pins the three-way tradeoff story the design exists to tell — weight vs
+radiated power vs resonance placement — plus the web plumbing (wire_type
+enum knob, weight result rows, wire-loss budget row).
+"""
+
+import pytest
+
+from antennaknobs.designs.dipoles.pota_invvee import Builder
+from antennaknobs.engines.momwire import MomwireEngine
+from antennaknobs.engines.pynec import DEFAULT_GROUND
+from antennaknobs.network import WIRES
+
+
+def _engine(wire_type=None, **params):
+    b = Builder()
+    for k, v in params.items():
+        setattr(b, k, v)
+    if wire_type is not None:
+        b.wire_type = wire_type
+    return MomwireEngine(b, ground=DEFAULT_GROUND)
+
+
+def _eff(eng):
+    eng.current_distribution()
+    return eng._excited_efficiency
+
+
+def test_default_resonant_on_20m():
+    """Stock 22 AWG PVC at length_factor 0.9440 sits near resonance at
+    14.1 MHz over average ground, in the ~65 Ω inverted-V window."""
+    z = _engine().impedance()[0]
+    assert abs(z.imag) < 3.0
+    assert 55.0 < z.real < 75.0
+
+
+def test_gauge_efficiency_ordering():
+    """Thicker wire radiates more of the input power: 18 > 22 > 28 AWG,
+    each in its physics window (−0.11 / −0.18 / −0.36 dB measured)."""
+    eff = {g: _eff(_engine(f"{g}-awg-pvc")) for g in (28, 22, 18)}
+    assert eff[18] > eff[22] > eff[28]
+    assert 0.90 < eff[28] < 0.94
+    assert 0.95 < eff[22] < 0.97
+    assert 0.97 < eff[18] < 0.99
+
+
+def test_insulation_velocity_factor_direction():
+    """Bare wire cut to the insulated length resonates HIGH: at the stock
+    length the bare 22 AWG shows a large capacitive X (resonance moved up
+    by the missing jacket loading)."""
+    z_pvc = _engine("22-awg-pvc").impedance()[0]
+    z_bare = _engine("22-awg").impedance()[0]
+    assert abs(z_pvc.imag) < 3.0
+    assert z_bare.imag < -40.0
+
+
+def test_weight_ordering_matches_catalog():
+    w = {g: WIRES[f"{g}-awg-pvc"].weight_g_per_m for g in (28, 22, 18)}
+    assert w[28] < w[22] < w[18]
+
+
+def test_web_example_carries_the_story():
+    """The registered example has the wire_type enum, the weight result
+    rows, and a solve response with weight fields + wire-loss budget row."""
+    from antennaknobs.web.examples import REGISTRY
+
+    ex = REGISTRY["dipoles.pota_invvee"]
+    fields = [r.field for r in ex.result_schema]
+    assert fields == ["wire_length_m", "wire_weight_g"]
+    specs = {p.name: p for p in ex.param_schema if hasattr(p, "name")}
+    assert specs["wire_type"].kind == "enum"
+    assert len(specs["wire_type"].enum_options) == len(WIRES)
+    assert ex.sweep_policy.band_locked
+
+    out = ex.momwire_solve(
+        {"measurement_freq_mhz": 14.1, "design_freq_mhz": 14.1, "ground": True}
+    )
+    spec = WIRES["22-awg-pvc"]
+    assert out["wire_weight_g"] == pytest.approx(
+        out["wire_length_m"] * spec.weight_g_per_m
+    )
+    assert 9.0 < out["wire_length_m"] < 11.0
+    labels = [b["label"] for b in out["power_budget"]]
+    assert labels == ["wire loss (I²R)"]
+    assert 0.9 < out["radiation_efficiency"] < 1.0


### PR DESCRIPTION
Supersedes #321 (auto-closed when its stacked base branch was deleted on #320's merge — the classic stacked-PR bite; branch since rebased onto main).

## Summary
- **`dipoles.pota_invvee`**: 20 m inverted-V on a 7 m pole, `wire_type` enum knob over the WIRES catalog (28/22/18 AWG, bare + PVC), band-locked sweep, tuned so stock 22 AWG PVC resonates at 14.1 MHz over average ground.
- **Weight readout, generic**: any design with a `wire_type` param automatically gets `wire_length_m`/`wire_weight_g` response fields and Info-pane rows (computed from `build_wires()` × catalog g/m) — no per-design code, no frontend change.
- **Advanced docs page** with the measured tradeoff: 17/53/111 g, 550/605/645 kHz 2:1 SWR windows, −0.36/−0.18/−0.11 dB for 28/22/18 AWG PVC. Two honest findings: thin wire's extra loss does **not** buy its bandwidth back (geometric broadening beats dissipative), and the insulation velocity factor (~500 kHz) dwarfs every gauge-to-gauge difference.

## Test plan
- [x] 5 new tests (resonance pin, efficiency ordering, vf direction, weight ordering, web example end-to-end)
- [x] Full suite: 1591 passed locally; site builds (17 pages); catalog regenerated

Closes #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)