### PR TITLE
Release v0.23.0 — real wire: skin-effect loss, insulation vf, weight

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/sta
 # install below sees its requirement already satisfied, then the package with the
 # web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install "momwire==0.9.0" \
+ && pip install "momwire==0.10.0" \
  && pip install -e ".[web]"
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire==0.9.0",
+    "momwire==0.10.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.22.1"
+version = "0.23.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,19 +25,20 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.22.1" icon="star">
-  **The v0.22 station story, finished.** v0.22.0 made transmission
-  lines lossy the way real cable is, gave matching-network coils a
-  finite **Q**, added a `Transformer` element for baluns and ununs,
-  and put a **power budget** table in the solve readout showing where
-  every watt goes. v0.22.1 completes it: the two station rigs are
-  refit for a same-band **20 m head-to-head** — real matchbox
-  capacitor limits, band-locked sweeps — written up in a new Advanced
-  guide, [the coax-vs-ladder-line folklore, as
-  numbers](/advanced/station-comparison/). Plus a round of workbench
-  polish: knob-menu number fields now clear cleanly, panel enum
-  pulldowns are styled like real controls, and solve/rtt timing sits
-  together at the end of the readout.
+<Card title="New in v0.23.0" icon="star">
+  **The wire itself is now a knob.** Antenna wire stops being an ideal
+  conductor: pick a real gauge from the new **wire catalog** (28/22/18
+  AWG, bare or PVC) and the solve models its **skin-effect loss** —
+  entering the impedance matrix itself, validated against NEC's native
+  wire-loss card to half a percent — plus the **insulated-wire velocity
+  factor** (why a cut-to-formula PVC dipole tunes long), which NEC-2
+  can't model at all. The power budget grows a **wire loss (I²R)** row,
+  and the Info pane reports the antenna's **weight in grams**. A new
+  showcase design and Advanced guide put it to work on the classic
+  portable question: [how thin can you go? — wire gauge for
+  POTA](/advanced/wire-gauge/), where 17 g of #28 wire costs just
+  0.25 dB against #18 — but the jacket moves resonance further than
+  the gauge ever does.
   [All release notes →](/reference/releases/)
 </Card>
 

--- a/site/src/content/docs/reference/solver.mdx
+++ b/site/src/content/docs/reference/solver.mdx
@@ -138,8 +138,14 @@ the limits are env-configurable (see `docs/deploy.md`).
 
 ### Honest limitations
 
-In the spirit of not overselling: momwire wires are currently PEC (no conductor
-loss — the NEC path with `ld_card` covers lossy elements). Finite grounds are
+In the spirit of not overselling: momwire wires are PEC **by default**; designs
+that declare a wire material (the `WIRES` catalog — see the
+[wire-gauge example](/advanced/wire-gauge/)) get skin-effect conductor loss as
+a distributed series impedance in the solve itself (momwire ≥ 0.10.0, validated
+against NEC's native `LD 5` wire-loss card to ~0.5 %) plus the insulated-wire
+velocity factor, which NEC-2 cannot model at all. The B-spline solver family
+carries the loading; the sinusoidal solver still solves wires as bare PEC and
+says so loudly. Finite grounds are
 solved with a true **Sommerfeld/Norton** model on every momwire solver
 (momwire ≥ 0.8.0: NEC's exact-image-plus-remainder decomposition; the
 accelerators carry the smooth remainder as one global low-rank term on their

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -161,6 +161,14 @@ coupling and matching elements, not just explicit `Load`s. Gain is
 normalised by input power, so network loss already shows up in dBi;
 the budget tells you *where* it went. Lossless networks hide the table.
 
+Designs that declare a real wire material (a `wire_type` knob over the
+`WIRES` catalog, e.g. [`dipoles.pota_invvee`](/advanced/wire-gauge/))
+additionally get a **wire loss (I²R)** row: the skin-effect power burned
+in the antenna conductor itself, read from the solve's current
+distribution. It counts toward the reported efficiency the same way the
+network rows do, and the Info pane shows the matching **wire length**
+and **wire weight** rows.
+
 ## Convergence sweep
 
 To check that your chosen N is **converged** — i.e. adding more segments no


### PR DESCRIPTION
## Summary
- **Adopt momwire 0.10.0** (first commit): exact pin + Dockerfile + submodule pointer together, per the drift ritual. 0.10.0 ships the distributed series wire-impedance loading (momwire#131/#132).
- Bump version to **0.23.0** (minor: new capability — real wire materials).
- What's-new card: the wire-is-a-knob story (catalog, skin loss, insulation vf, weight readout, POTA showcase).
- De-stale sweep: `solver.mdx` honest-limitations paragraph updated (wires PEC *by default*, loading on the B-spline family, sinusoidal still PEC and loud about it); `web.md` power-budget section gains the wire-loss and weight rows.
- Site builds clean (17 pages).

## Ships (since v0.22.1)
- #312-#313 were in v0.22.1; this release: #316 (WIRES catalog + plumbing + LD-5 parity), #317 (wire-loss budget row + efficiency), #318 (POTA gauge showcase + docs), momwire 0.10.0 adoption.

## Test plan
- [ ] CI green (wheel-smoke now installs momwire 0.10.0 from PyPI — published and verified serving)
- [ ] After tag: PyPI serves 0.23.0, simulator + docs deploys green

🤖 Generated with [Claude Code](https://claude.com/claude-code)