### PR TITLE
PyNEC insulated wire: LD-2 distributed inductance parity (no more warn-and-drop)

### DIFF
--- a/site/src/content/docs/advanced/wire-gauge.md
+++ b/site/src/content/docs/advanced/wire-gauge.md
@@ -35,12 +35,14 @@ per-meter series impedance:
   bare wire cut to the same length. That's the velocity factor behind
   "my cut-to-formula insulated dipole came out long."
 
-Both engines model the conductor loss (the momwire loading and PyNEC's
-native `LD 5` agree on the added resistance to half a percent — a
-cross-engine oracle in the test suite). The insulation effect is
-momwire-only: NEC-2 has no insulated-wire card, so switching engines on
-a PVC wire visibly moves the resonance. That divergence is the lesson,
-not a bug.
+Both engines model both effects. Conductor loss: the momwire loading and
+PyNEC's native `LD 5` card agree on the added resistance to half a
+percent. Insulation: NEC-2 has no insulated-wire card, but the same
+jacket inductance enters as a distributed series load (`LD 2`, henries
+per metre), and the two engines agree on the resonance shift to a few
+percent. Each pairing is a cross-engine oracle in the test suite — two
+independent implementations of the same physics, kept honest against
+each other.
 
 ## The numbers
 

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -3,10 +3,10 @@ import logging
 import numpy as np
 import PyNEC as nec
 
-# Exact round-conductor internal impedance (momwire#131). Private-module
-# import, but antennaknobs pins momwire exactly, so the pair moves in
-# lockstep; promote to a public momwire export at the next API pass.
-from momwire._wire_loading import wire_internal_impedance
+# Exact round-conductor internal impedance + jacket inductance (momwire#131).
+# Private-module import, but antennaknobs pins momwire exactly, so the pair
+# moves in lockstep; promote to public momwire exports at the next API pass.
+from momwire._wire_loading import insulation_inductance, wire_internal_impedance
 
 from ..engine import FarField, SimulationEngine, WireCurrents
 from ..network import (
@@ -84,19 +84,16 @@ class PyNECEngine(SimulationEngine):
         # ld_card type 5 (NEC's native wire-loss model — the momwire#131
         # cross-engine oracle); the module-level WIRE_CONDUCTIVITY constant
         # below stays as the manual all-designs override for oracle runs.
-        # NEC-2 has no insulated-wire card, so a spec's insulation is NOT
-        # modeled here — momwire is the fidelity engine for that (same
-        # engine-divergence precedent as Sommerfeld ground).
+        # A spec's insulation is emitted as a global ld_card type 2
+        # (distributed series R/L/C per metre): the same quasi-static jacket
+        # inductance L' momwire loads, so both engines model the "insulated
+        # wire tunes long" velocity-factor effect. NEC stacks LD cards on a
+        # segment in series, so LD 2 composes with the LD 5 conductor loss
+        # (pinned by the cross-engine vf oracle in test_wire_material.py).
         self._wire_spec = builder.build_wire_material()
         self._wire_radius = (
             self._wire_spec.radius if self._wire_spec is not None else WIRE_RADIUS
         )
-        if self._wire_spec is not None and self._wire_spec.insulation_radius:
-            _logger.warning(
-                "NEC-2 has no insulated-wire card; PyNEC solves %s's wire "
-                "bare (no velocity-factor effect)",
-                type(builder).__name__,
-            )
         # build_tls() is only consulted when there's no Network spec; with a
         # Network, the engine drives ex_card/tl_card calls off the spec instead.
         self.tls = [] if self._network is not None else builder.build_tls()
@@ -186,19 +183,40 @@ class PyNECEngine(SimulationEngine):
             for idx1, seg1, idx2, seg2, impedance, length in self.tls:
                 self.c.tl_card(idx1, seg1, idx2, seg2, impedance, length, 0, 0, 0, 0)
 
-        # Spec conductivity from the design wins; the module constant stays
-        # as the manual all-designs oracle override (see its comment above).
+        self._emit_wire_material_cards(self.c)
+        self._apply_ground_card()
+
+        for tag, sub_index, voltage in self.excitation_pairs:
+            self.c.ex_card(0, tag, sub_index, 0, voltage.real, voltage.imag, 0, 0, 0, 0)
+
+    def _insulation_l_per_m(self):
+        """The spec jacket's distributed series inductance [H/m] (King's
+        quasi-static insulated-antenna limit — the same L' momwire loads),
+        or None for bare/ideal wire."""
+        spec = self._wire_spec
+        if spec is None or not spec.insulation_radius:
+            return None
+        return insulation_inductance(
+            self._wire_radius, spec.insulation_radius, spec.insulation_eps_r
+        )
+
+    def _emit_wire_material_cards(self, c):
+        """Global (all-segments) LD cards for the design's wire material:
+        conductor loss as type 5, insulation as type 2 (distributed series
+        R/L/C per metre — only the H/m slot is used). NEC connects multiple
+        loads on a segment in series, so the two stack. Spec conductivity
+        from the design wins; the module constant stays as the manual
+        all-designs oracle override (see its comment above)."""
         sigma = (
             self._wire_spec.conductivity
             if self._wire_spec is not None
             else WIRE_CONDUCTIVITY
         )
         if sigma is not None:
-            self.c.ld_card(5, 0, 0, 0, sigma, 0.0, 0.0)
-        self._apply_ground_card()
-
-        for tag, sub_index, voltage in self.excitation_pairs:
-            self.c.ex_card(0, tag, sub_index, 0, voltage.real, voltage.imag, 0, 0, 0, 0)
+            c.ld_card(5, 0, 0, 0, sigma, 0.0, 0.0)
+        l_ins = self._insulation_l_per_m()
+        if l_ins is not None:
+            c.ld_card(2, 0, 0, 0, 0.0, l_ins, 0.0)
 
     def _resolve_network_ports(self):
         """Resolve every PortOnWire to its (tag, sub_seg) for native ld_card /
@@ -446,13 +464,7 @@ class PyNECEngine(SimulationEngine):
             if name is not None:
                 loc[name] = (idx, (n_seg + 1) // 2)
         c.geometry_complete(0)
-        sigma = (
-            self._wire_spec.conductivity
-            if self._wire_spec is not None
-            else WIRE_CONDUCTIVITY
-        )
-        if sigma is not None:
-            c.ld_card(5, 0, 0, 0, sigma, 0.0, 0.0)
+        self._emit_wire_material_cards(c)
         self._apply_ground_card(c)
         return c, loc
 

--- a/src/antennaknobs/nec_export.py
+++ b/src/antennaknobs/nec_export.py
@@ -112,14 +112,18 @@ def export_nec(
             ldtyp = 1 if br.parallel else 0
             lines.append(f"LD {ldtyp} {tag} {seg} {seg} {_num(r)} {_num(l)} {_num(c)}")
 
-    # Wire conductor loss (issue #316): the same global LD 5 the engine
-    # emits — spec conductivity from the design, else the module-level
-    # oracle constant (normally None → card omitted, PEC).
+    # Wire material (issue #316): the same global LD cards the engine
+    # emits — conductor loss as LD 5 (spec conductivity from the design,
+    # else the module-level oracle constant; normally None → card omitted,
+    # PEC) and the insulation jacket's series inductance as LD 2 (H/m).
     sigma = (
         eng._wire_spec.conductivity if eng._wire_spec is not None else WIRE_CONDUCTIVITY
     )
     if sigma is not None:
         lines.append(f"LD 5 0 0 0 {_num(sigma)} 0. 0.")
+    l_ins = eng._insulation_l_per_m()
+    if l_ins is not None:
+        lines.append(f"LD 2 0 0 0 0. {_num(l_ins)} 0.")
 
     # Legacy build_tls() path -> native NEC TL cards. (The build_network() TL
     # path uses the multiport-Y reducer and is rejected above.)

--- a/tests/test_wire_material.py
+++ b/tests/test_wire_material.py
@@ -128,15 +128,17 @@ def test_momwire_sinusoidal_drops_loading_keeps_radius(caplog):
 
 
 @needs_pynec
-def test_pynec_ld5_and_radius_from_spec(caplog):
+def test_pynec_ld5_and_radius_from_spec():
     z0 = _z(PyNECEngine(_builder(), ground=None))
     z1 = _z(PyNECEngine(_builder("28-awg"), ground=None))
     assert z1.real > z0.real + 1.0
-    # Insulation: no NEC-2 card — warned, solved as the bare variant.
-    with caplog.at_level("WARNING"):
-        z2 = _z(PyNECEngine(_builder("28-awg-pvc"), ground=None))
-    assert "no insulated-wire card" in caplog.text
-    assert z2 == pytest.approx(z1, rel=1e-12)
+    # Insulation: LD 2 distributed series L' — electrically longer, X
+    # rises (mirrors test_momwire_insulation_shifts_reactance). NEC stacks
+    # LD cards in series, so the LD 5 copper loss must survive alongside:
+    # R stays elevated over the ideal wire.
+    z2 = _z(PyNECEngine(_builder("28-awg-pvc"), ground=None))
+    assert z2.imag > z1.imag + 10.0
+    assert z2.real > z0.real + 1.0
 
 
 @needs_pynec
@@ -149,9 +151,14 @@ def test_nec_export_carries_spec():
     deck = export_nec(_builder("28-awg"), ground=None)
     assert "LD 5 0 0 0  5.800000E+07" in deck
     assert " 1.600000E-04" in deck  # 28 AWG radius on the GW cards
+    assert "LD 2" not in deck  # bare wire: no insulation card
     deck0 = export_nec(_builder(), ground=None)
     assert "LD 5" not in deck0
     assert " 5.000000E-04" in deck0
+    # Insulated variant additionally carries the distributed-L' card.
+    deck2 = export_nec(_builder("28-awg-pvc"), ground=None)
+    assert "LD 5 0 0 0  5.800000E+07" in deck2
+    assert "LD 2 0 0 0 0. " in deck2
 
 
 @needs_pynec
@@ -168,3 +175,21 @@ def test_cross_engine_skin_loss_oracle():
         - _z(PyNECEngine(_builder(), ground=None)).real
     )
     assert dr_momwire == pytest.approx(dr_pynec, rel=0.05)
+
+
+@needs_pynec
+def test_cross_engine_insulation_vf_oracle():
+    """momwire's insulation loading vs NEC's LD 2 distributed inductance
+    on the same free-space invvee: the bare→PVC ΔX from two independent
+    implementations of the same quasi-static jacket L' must agree to a
+    few percent — and it also proves NEC stacks LD 2 with the LD 5
+    conductor loss rather than replacing it."""
+    dx_momwire = (
+        _z(MomwireEngine(_builder("28-awg-pvc"), ground=None)).imag
+        - _z(MomwireEngine(_builder("28-awg"), ground=None)).imag
+    )
+    dx_pynec = (
+        _z(PyNECEngine(_builder("28-awg-pvc"), ground=None)).imag
+        - _z(PyNECEngine(_builder("28-awg"), ground=None)).imag
+    )
+    assert dx_momwire == pytest.approx(dx_pynec, rel=0.05)


### PR DESCRIPTION
Closes #328.

## Summary
- PyNEC now models a WireSpec's insulation instead of logging a warning and solving the bare wire: the jacket's quasi-static series inductance (the same `insulation_inductance` momwire loads) is emitted as a global NEC `LD 2` card (distributed series L, H/m) on both context paths, via a shared `_emit_wire_material_cards` helper.
- NEC connects multiple loads on a segment in series, so `LD 2` stacks with the `LD 5` conductor loss — pinned by the updated `test_pynec_ld5_and_radius_from_spec` (R stays elevated while X shifts).
- New cross-engine oracle `test_cross_engine_insulation_vf_oracle`: bare→PVC ΔX from the two independent implementations agrees to 5 %. Measured on `pota_invvee` in free space: resonance shift 507 kHz (momwire) vs 513 kHz (PyNEC) — ~1 % apart, matching the arc's ~500 kHz story.
- `nec_export` mirrors the card (text-twin invariant) and the wire-gauge docs page no longer calls insulation momwire-only.

Since LD-2 panned out, the fallback UI `wire_model_applied` warning from the plan is unnecessary — the engines now agree.

## Test plan
- [x] `tests/test_wire_material.py` (12 passed) incl. the new vf oracle
- [x] Full suite: 1592 passed
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
