### PR TITLE
EFHW sloper + real 49:1 unun — the POTA antenna, complete

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -88,6 +88,7 @@ export default defineConfig({
           items: [
             { label: "Coax vs. ladder line", slug: "advanced/station-comparison" },
             { label: "Wire gauge for POTA", slug: "advanced/wire-gauge" },
+            { label: "The end-fed question", slug: "advanced/efhw" },
           ],
         },
         {

--- a/site/src/content/docs/advanced/efhw.md
+++ b/site/src/content/docs/advanced/efhw.md
@@ -1,0 +1,88 @@
+---
+title: "The end-fed question: where do the watts go in a 49:1?"
+description: An advanced worked example — a POTA end-fed half-wave sloper with a real transformer, real coax, and real wire, itemized watt by watt.
+---
+
+The end-fed half-wave is the most argued-about antenna in portable radio.
+Its fans point at the convenience — one wire over a branch, feed it at
+the bottom, no feedpoint dangling mid-air. Its critics point at the black
+box that makes it possible: the little 49:1 transformer, plus the
+counterpoise question, plus whatever the coax is quietly doing. The
+argument is usually conducted in folklore because the system is hard to
+reason about piecemeal — every piece interacts.
+
+[`wire.efhw_sloper`](/reference/catalog/) models the whole chain at once:
+~9.5 m of thin wire sloping from a 10 m mast apex down to a feed point at
+1.5 m, into a step-down unun with a real magnetizing branch and core
+loss, a compensation capacitor, a short counterpoise, and 5 m of RG-58 to
+the rig. Every stage is a knob, and the power budget itemizes each one.
+
+## Why a transformer at all
+
+The end of a half wave is a voltage antinode: the model's feedpoint
+impedance at resonance is **~2.2 kΩ** — no rig drives that directly.
+`unun_ratio` picks the classic step-downs (49:1, 64:1, or 225:4); at the
+stock 49:1 the rig sees 58 − 3j Ω, **SWR 1.17**, on 14.1 MHz. The
+transformer composition is exact in the network layer: idealize the unun
+(huge magnetizing L, no comp cap, zero-length line) and the rig impedance
+is the feedpoint divided by turns² to numerical precision — an oracle the
+test suite pins. Flip the ratio dropdown and the differences are honest
+too: 64:1 lands SWR 1.40 and 225:4 lands 1.26 on this particular wire,
+because the "right" ratio depends on a feed impedance the antenna's
+height and slope keep moving.
+
+Anti-resonance trivia worth knowing: an *ideal-wire* end-fed is a
+numerically nasty solve — the impedance peak at the half-wave point is a
+near-singularity. The real wire loss modelled since v0.23 damps it, which
+is both why this design solves cleanly and why physical EFHWs are more
+forgiving than lossless theory suggests.
+
+## Where the watts go
+
+At the stock operating point the budget reads (fractions of input power):
+
+| stage | share |
+|---|---|
+| unun core loss (magnetizing branch) | ~0.6 % |
+| 5 m RG-58 | ~6.0 % |
+| wire loss (I²R), 28 AWG PVC | ~6.1 % |
+| **radiated** | **~87 %** |
+
+Three readings worth taking home:
+
+1. **The wire is the transformer's equal.** The scary lossy-looking
+   ferrite box burns under a percent at mid-band with the stock
+   magnetizing Q; the innocent-looking 28 AWG wire burns six times that,
+   because the half-wave's current maximum lives in the middle of the
+   thin wire. Flip `wire_type` to 18 AWG PVC and the wire row drops to
+   ~1.9 % (efficiency 91 %) — the same gauge story as
+   [wire gauge for POTA](/advanced/wire-gauge/), amplified by the
+   end-fed's current distribution. The whole antenna still weighs 18 g
+   in 28 AWG.
+2. **The counterpoise is load-bearing.** The stock 1.05 m is the classic
+   0.05 λ. Shrink it to 0.3 m and the match collapses to SWR 4.3;
+   stretch it to 3 m and it detunes the system the other way (SWR 1.5).
+   "The coax shield is my counterpoise" works precisely because a short
+   deliberate one like this is all the return path the feed needs.
+3. **Loss buys bandwidth, again honestly.** The stepped-down 2.2 kΩ feed
+   plus the wire loss flatten the SWR curve: the model holds the *entire*
+   20 m band under 2:1. That's the EFHW's famously friendly SWR curve —
+   and the budget shows what it costs.
+
+The unun defaults (`lmag_uH` = 8, `qlmag` = 10) put the core in the
+85–90 % system-efficiency range measured for FT240-43-class 49:1 builds.
+The model is deliberately minimal — a magnetizing branch with finite Q,
+not a full transformer characterization — so treat the (mag) row as the
+shape of the loss, and tune `qlmag` against a measurement if you have
+one: Q = 5 doubles the core's share, Q = 20 halves it.
+
+## Try it
+
+Open [`wire.efhw_sloper`](https://app.antennaknobs.dev/) in the
+simulator with the sweep locked to 20 m. Flip `unun_ratio` and watch the
+match move; drag `cp_len_m` and watch it matter more; flip `wire_type`
+to bare wire and watch resonance jump up the band (retune with
+`length_factor` — insulated wire is a few percent electrically longer).
+Then drag the measurement frequency across the band and watch the power
+budget re-divide itself between the coax, the core, and the wire — the
+end-fed question, answered per watt.

--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -88,6 +88,7 @@ whole shape with a `Drone` — see
 | Design | Notes |
 | --- | --- |
 | `wire.doublet_ladder_tuner` | 88 ft doublet + 100 ft of 600 Ω open-wire line + lossy T-network tuner — the "non-resonant wire and a matchbox" station, modelled from the rig (issue #300) · variants: `classic_edz`, `dipole`, `three_halves` |
+| `wire.efhw_sloper` | End-fed half-wave sloper with a real 49:1 unun — "the POTA antenna, complete" (issue #329) |
 | `wire.lazy_h` | Lazy-H: two stacked collinear elements fed in phase (L. B. Cebik, W4RNL) |
 | `wire.longwire` | Resonant multi-wavelength long-wire (L. B. Cebik, W4RNL) |
 | `wire.rhombic` | Terminated rhombic: a traveling-wave directional long-wire (L. B. Cebik, W4RNL, "Long-Wire Antennas" / "The Terminated Vee-Beam and Rhombic") |

--- a/src/antennaknobs/designs/dipoles/pota_invvee.py
+++ b/src/antennaknobs/designs/dipoles/pota_invvee.py
@@ -25,9 +25,9 @@ switching to bare wire moves resonance UP — retune with the length knob
 and note how much shorter the insulated antenna is.
 
 Geometry is the stock `dipoles.invvee` V (same knobs) at 20 m scale.
-PyNEC models the conductor loss but not the jacket (no NEC-2 card), so
-engine-switching on a PVC variant shifts resonance — momwire is the
-fidelity engine there.
+Both engines model the full wire: momwire's distributed loading, and
+PyNEC via its native LD 5 (conductor loss) + LD 2 (jacket inductance,
+issue #328) cards — engine-switching holds the story steady.
 """
 
 from types import MappingProxyType

--- a/src/antennaknobs/designs/wire/efhw_sloper.py
+++ b/src/antennaknobs/designs/wire/efhw_sloper.py
@@ -1,0 +1,195 @@
+"""End-fed half-wave sloper with a real 49:1 unun — "the POTA antenna,
+complete" (issue #329).
+
+The classic park activation: ~10 m of thin wire hoisted to a mast apex,
+sloping down to a feed point near the ground, fed through a step-down
+transformer and a short run of coax. This design composes every station
+piece the modelling arcs built — `Transformer` with core loss (#301),
+lossy line (#297), lossy wire (#316–#318) — and the power budget (#299)
+answers the end-fed question honestly: *where do the watts go in a 49:1?*
+
+Physics worth knowing before turning the knobs:
+
+* **The end of a half wave is a voltage antinode.** The feed impedance
+  there is a few kΩ — which is why the unun exists. `unun_ratio` picks
+  the classic step-downs: 49:1 (7:1 turns, ~2450 Ω → 50 Ω), 64:1 (8:1,
+  ~3200 Ω), 225:4 (7.5:1, ~2812 Ω). The feed sits near the half-wave
+  ANTI-resonance, historically a numerically nasty spot — the wire loss
+  modelled since v0.23 damps that singularity, which is also physically
+  why a real EFHW is more forgiving than an ideal-wire model suggests.
+* **The unun is not free.** Its magnetizing branch (`lmag_uH` shunting
+  the 50 Ω side, with core-loss Q `qlmag`) burns a visible slice of the
+  power budget — the (mag) row. Real FT240-43-class 49:1s measure
+  85–90 % efficient; the defaults land in that range. The ~`comp_c_pF`
+  across the primary is the compensation capacitor every published
+  build hangs there — it tames the transformer's HF rolloff.
+* **The counterpoise is a knob, not a footnote.** `cp_len_m` defaults to
+  ~0.05 λ (the classic minimal counterpoise); the coax shield past the
+  unun plays this role in many field setups. Shrink it and watch the
+  feedpoint conditioning and SWR drift.
+* **The wire is a knob** (`wire_type`, the `WIRES` catalog): 28 AWG PVC
+  is the POTA classic here, and the high-current half-wave middle makes
+  gauge loss matter more than on a centre-fed dipole — the *wire loss
+  (I²R)* budget row and the weight readout quantify the tradeoff.
+
+The default `length_factor` is tuned so the stock 28 AWG PVC wire
+presents its best rig-side match near 14.1 MHz with the apex at 10 m
+over average ground; bare or thicker wire tunes higher — retune with the
+length knob (the insulated-wire velocity factor, same story as
+`dipoles.pota_invvee`).
+
+Geometry, in the framework's (x, y, z) convention:
+  - the radiator slopes in the x–z plane from the feed at
+    (0, 0, `h_feed`) up to the apex at height `h_apex`;
+  - a short named "ant" gap wire at the low end carries the port (ports
+    live in wire interiors — the feed needs its own short wire);
+  - the counterpoise runs horizontally from the feed point along −x.
+
+        apex (h_apex, mast)
+          \\
+           \\  radiator ≈ λ/2 · length_factor   (wire_type from WIRES)
+            \\
+    =========F                 z = h_feed
+    counterpoise  F = "ant" port → unun (49:1) → coax → rig
+"""
+
+from types import MappingProxyType
+
+import numpy as np
+
+from ... import AntennaBuilder
+from ...network import (
+    CABLES,
+    Driven,
+    Network,
+    PortOnWire,
+    PortVirtual,
+    Shunt,
+    TL,
+    Transformer,
+    WIRES,
+)
+
+# unun_ratio dropdown → transformer turns ratio (feed side : rig side).
+# Impedance steps down by turns²: 49:1, 64:1, 225:4 (= 56.25:1).
+UNUN_TURNS = {
+    "49:1": 7.0,
+    "64:1": 8.0,
+    "225:4": 7.5,
+}
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            # 20 m: the bread-and-butter POTA band (multiband harmonic
+            # operation — the EFHW's whole point — is a follow-up variant).
+            "design_freq": 14.1,
+            "freq": 14.1,
+            "h_apex": 10.0,
+            "h_feed": 1.5,
+            # Tuned for the DEFAULT wire below (28 AWG PVC) to put the
+            # rig-side SWR minimum near 14.1 MHz at the default heights
+            # over average ground.
+            "length_factor": 0.8965,
+            "wire_type": "28-awg-pvc",
+            # ~0.05 λ on 20 m — the classic minimal counterpoise.
+            "cp_len_m": 1.05,
+            "unun_ratio": "49:1",
+            # Magnetizing inductance shunting the unun's 50 Ω side and its
+            # core-loss Q: ~3 primary turns on an FT240-43-class core.
+            "lmag_uH": 8.0,
+            "qlmag": 10.0,
+            # Compensation capacitor across the primary.
+            "comp_c_pF": 100.0,
+            "cable": "RG-58",
+            "line_len_m": 5.0,
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 50.0,
+                    "default_view": "xz",
+                    "length_factor": {"min": 0.85, "max": 1.10},
+                    "h_apex": {"min": 4.0, "max": 20.0, "unit": "m"},
+                    "h_feed": {"min": 0.2, "max": 4.0, "unit": "m"},
+                    "cp_len_m": {"min": 0.3, "max": 6.0, "unit": "m"},
+                    "wire_type": {"enum_options": tuple(sorted(WIRES))},
+                    "unun_ratio": {"enum_options": tuple(UNUN_TURNS)},
+                    "lmag_uH": {"min": 1.0, "max": 50.0},
+                    "qlmag": {"min": 0.0, "max": 200.0},
+                    "comp_c_pF": {"min": 0.0, "max": 330.0, "unit": "pF"},
+                    "cable": {"enum_options": tuple(sorted(CABLES))},
+                    "line_len_m": {"min": 1.0, "max": 30.0, "unit": "m"},
+                    # The high-Z feed swings the rig-side trace around the
+                    # Smith chart fast off-resonance — lock the sweep to
+                    # the band being measured.
+                    "sweep_policy": {"anchor": "meas_freq", "band_locked": True},
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        eps = 0.05
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+
+        length = 0.5 * wavelength * self.length_factor
+        rise = self.h_apex - self.h_feed
+        if length <= rise:
+            raise ValueError(
+                f"radiator length {length:.2f} m must exceed the apex rise "
+                f"{rise:.2f} m (h_apex - h_feed) for a sloper to exist"
+            )
+        # Unit vector along the slope, feed → apex.
+        uz = rise / length
+        ux = float(np.sqrt(1.0 - uz * uz))
+        f = (0.0, 0.0, self.h_feed)
+
+        def along(d):
+            return (f[0] + ux * d, f[1], f[2] + uz * d)
+
+        return [
+            # Counterpoise: horizontal, away from the slope.
+            (
+                (-self.cp_len_m, 0.0, self.h_feed),
+                f,
+                self.segs_for(self.cp_len_m, quarter),
+                None,
+            ),
+            # Short named gap wire at the low end: the "ant" port. The
+            # port interrupts the current path between counterpoise and
+            # radiator — the end-fed's feed.
+            (f, along(eps), 1, None, "ant"),
+            # The half-wave radiator, sloping up to the apex.
+            (
+                along(eps),
+                along(length),
+                self.segs_for(length - eps, quarter),
+                None,
+            ),
+        ]
+
+    def build_network(self):
+        turns = UNUN_TURNS[self.unun_ratio]
+        branches = [
+            # Step-down unun: rig side "pri" sees Z_feed / turns².
+            Transformer(
+                a="pri",
+                b="ant",
+                n=1.0 / turns,
+                lmag=self.lmag_uH * 1e-6,
+                qlmag=self.qlmag if self.qlmag > 0 else None,
+            ),
+        ]
+        if self.comp_c_pF > 0:
+            branches.append(Shunt(port="pri", c=self.comp_c_pF * 1e-12))
+        branches.append(TL.from_cable(self.cable, "rig", "pri", self.line_len_m))
+        return Network(
+            ports={
+                "ant": PortOnWire("ant"),
+                "pri": PortVirtual("pri"),
+                "rig": PortVirtual("rig"),
+            },
+            branches=branches,
+            sources=[Driven(port="rig", voltage=1 + 0j)],
+        )

--- a/tests/test_efhw_sloper.py
+++ b/tests/test_efhw_sloper.py
@@ -1,0 +1,95 @@
+"""EFHW sloper + unun showcase (issue #329): the end-fed half wave fed
+through a real 49:1 transformer, composing Transformer (#301), lossy line
+(#297), lossy wire (#316–#318), and the power budget (#299).
+
+Stock tune targets the workbench default (finite-fast ground, B-spline
+solver), same convention as the station designs.
+"""
+
+import pytest
+
+from antennaknobs.designs.wire.efhw_sloper import UNUN_TURNS, Builder
+from antennaknobs.engines import MomwireEngine
+
+GROUND = dict(ground=("finite-fast", 10.0, 0.002), ground_z=0.0)
+
+
+def _with_params(**overrides):
+    return Builder(params={**Builder.default_params, **overrides})
+
+
+def _budget_fractions(eng):
+    eng.current_distribution()
+    p_in = eng._excited_p_in
+    return {label: max(0.0, w) / p_in for label, w in eng._excited_power_budget}
+
+
+def test_discoverable():
+    from antennaknobs.cli import list_builtin_designs
+
+    assert "wire.efhw_sloper" in set(list_builtin_designs())
+
+
+def test_stock_tune_matches_fifty_ohms():
+    """The tuned length_factor lands the rig near 50 Ω at 14.1 MHz: the
+    ~2.2 kΩ end-fed feed, stepped down 49:1, through comp cap and coax."""
+    (z,) = MomwireEngine(Builder(), **GROUND).impedance()
+    gamma = abs((z - 50.0) / (z + 50.0))
+    assert (1 + gamma) / (1 - gamma) < 1.3  # measured 1.17
+
+
+def test_unun_ratio_sanity():
+    """With the unun idealized (huge lmag, no comp cap, ~zero line) the rig
+    impedance is exactly the feedpoint stepped down by turns²: switching
+    ratios rescales Z by the turns-ratio quotient."""
+
+    def rig_z(ratio):
+        b = _with_params(
+            unun_ratio=ratio, lmag_uH=1e6, qlmag=0.0, comp_c_pF=0.0, line_len_m=1e-9
+        )
+        return complex(MomwireEngine(b, **GROUND).impedance()[0])
+
+    z49 = rig_z("49:1")
+    for ratio, turns in UNUN_TURNS.items():
+        expected = turns**2 / UNUN_TURNS["49:1"] ** 2
+        assert complex(z49 / rig_z(ratio)) == pytest.approx(expected, rel=1e-5)
+
+
+def test_budget_itemizes_unun_line_and_wire():
+    """The power budget answers "where do the watts go in a 49:1?" — unun
+    core loss, coax, and wire I²R each visible; winding row and ideal comp
+    cap burn nothing; efficiency in the measured-EFHW range."""
+    eng = MomwireEngine(Builder(), **GROUND)
+    fr = _budget_fractions(eng)
+    assert fr["Transformer pri→ant"] < 1e-9  # no winding R by default
+    assert fr["Shunt pri"] < 1e-9  # ideal comp cap
+    assert 0.002 < fr["Transformer pri→ant (mag)"] < 0.05  # core loss
+    assert 0.02 < fr["TL rig→pri"] < 0.15  # 5 m RG-58
+    assert 0.02 < fr["wire loss (I²R)"] < 0.15  # 28 AWG half wave
+    assert 0.80 < eng._excited_efficiency < 0.95  # measured 0.873
+
+
+def test_thicker_wire_recovers_watts():
+    """28 AWG → 18 AWG cuts the wire-loss fraction ~3× (measured 6.1 % →
+    1.9 %) — the high-current half-wave middle makes gauge matter."""
+    fr28 = _budget_fractions(MomwireEngine(Builder(), **GROUND))
+    fr18 = _budget_fractions(
+        MomwireEngine(_with_params(wire_type="18-awg-pvc"), **GROUND)
+    )
+    assert fr18["wire loss (I²R)"] < 0.5 * fr28["wire loss (I²R)"]
+
+
+def test_cross_engine_pynec():
+    """Matched-basis cross-check at the transformed rig port (ideal wire:
+    the sinusoidal basis drops the distributed loading). The counterpoise +
+    gap-wire feed keeps the high-Z end well-conditioned — measured 0.03 %
+    between engines, far from the zepp's bare-end-port spread."""
+    pytest.importorskip("antennaknobs.engines.pynec")
+    from antennaknobs.engines import PyNECEngine
+    from momwire import SinusoidalSolver
+
+    zm = MomwireEngine(
+        _with_params(wire_type=None), ground=None, solver=SinusoidalSolver
+    ).impedance()[0]
+    zn = PyNECEngine(_with_params(wire_type=None), ground=None).impedance()[0]
+    assert abs(zm - zn) / abs(zm) < 0.01


### PR DESCRIPTION
Closes #329.

## Summary
- New showcase `wire.efhw_sloper`: a 20 m end-fed half-wave sloper (mast apex → feed at 1.5 m) fed through a real step-down unun — `unun_ratio` enum (49:1 / 64:1 / 225:4), magnetizing branch with core-loss Q, ~100 pF comp cap, 0.05 λ counterpoise knob, coax to a virtual rig port, and `wire_type` from the WIRES catalog (28 AWG PVC default, 18 g of wire).
- Composes every station-arc piece — Transformer (#301), lossy TL (#297), lossy wire (#316–#318) — and the power budget (#299) itemizes the answer to "where do the watts go in a 49:1?": at stock, core ~0.6 %, 5 m RG-58 ~6.0 %, wire I²R ~6.1 %, 87.3 % radiated; the whole 20 m band sits under 2:1 SWR.
- `length_factor` 0.8965 tuned for rig SWR 1.17 at 14.1 MHz over finite-fast average ground (feedpoint ~2.2 kΩ — the wire loss damps the half-wave anti-resonance, exactly as the arc predicted).
- Tests: transformer turns² step-down exact to 1e-5 (idealized-unun oracle), stock-tune SWR, budget itemization, gauge recovery (28→18 AWG halves+ the wire row), cross-engine rig-Z check (momwire-sinusoidal vs PyNEC agree to 0.03 % — the counterpoise + gap-wire feed keeps the high-Z end well-conditioned).
- Docs: `advanced/efhw.md` ("The end-fed question") + sidebar entry + regenerated catalog page; also de-staled the pota_invvee docstring left behind by #328 (PyNEC does model the jacket now).

Front-page card / release notes deliberately untouched — that's the release ritual.

## Test plan
- [x] `tests/test_efhw_sloper.py` (6 passed)
- [x] Full suite: 1610 passed (catalog-wide sweeps picked up the new design)
- [x] `ruff check` / `format --check` clean; `node --check` on astro.config.mjs

🤖 Generated with [Claude Code](https://claude.com/claude-code)