### PR TITLE
Sinusoidal-solver lossy wire: adopt momwire 0.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/sta
 # install below sees its requirement already satisfied, then the package with the
 # web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install "momwire==0.10.0" \
+ && pip install "momwire==0.11.0" \
  && pip install -e ".[web]"
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire==0.10.0",
+    "momwire==0.11.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",

--- a/site/src/content/docs/advanced/efhw.md
+++ b/site/src/content/docs/advanced/efhw.md
@@ -12,7 +12,8 @@ argument is usually conducted in folklore because the system is hard to
 reason about piecemeal — every piece interacts.
 
 [`wire.efhw_sloper`](/reference/catalog/) models the whole chain at once:
-~9.5 m of thin wire sloping from a 10 m mast apex down to a feed point at
+~9.5 m of thin wire sloping down at ~63° (the `slope_deg` knob — the
+apex, ≈10 m at the defaults, is derived from it) to a feed point at
 1.5 m, into a step-down unun with a real magnetizing branch and core
 loss, a compensation capacitor, a short counterpoise, and 5 m of RG-58 to
 the rig. Every stage is a knob, and the power budget itemizes each one.

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -96,10 +96,17 @@ def _solver_supports_ground_eps(solver):
     return getattr(solver, "__name__", None) in _GROUND_EPS_SOLVERS
 
 
-# Distributed wire loading (issue #316 / momwire#131) is a BSpline-family
-# feature; SinusoidalSolver rejects the kwargs (field-based assembly needs
-# its own overlap integrals — momwire defers it loudly).
-_WIRE_LOADING_SOLVERS = ("BSplineSolver", "HMatrixSolver", "ArrayBlockSolver")
+# Distributed wire loading (issue #316 / momwire#131): every momwire
+# solver models it since momwire 0.11.0 — the BSpline family as a Galerkin
+# overlap, SinusoidalSolver as NEC's impedance boundary condition at the
+# match points (momwire#134). The gate remains as the seam for any future
+# solver that lacks the feature (warn-and-drop, not crash).
+_WIRE_LOADING_SOLVERS = (
+    "BSplineSolver",
+    "HMatrixSolver",
+    "ArrayBlockSolver",
+    "SinusoidalSolver",
+)
 
 
 def _solver_supports_wire_loading(solver):

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -3,10 +3,9 @@ import logging
 import numpy as np
 import PyNEC as nec
 
-# Exact round-conductor internal impedance + jacket inductance (momwire#131).
-# Private-module import, but antennaknobs pins momwire exactly, so the pair
-# moves in lockstep; promote to public momwire exports at the next API pass.
-from momwire._wire_loading import insulation_inductance, wire_internal_impedance
+# Exact round-conductor internal impedance + jacket inductance — public
+# momwire exports since 0.11.0 (momwire#133).
+from momwire import insulation_inductance, wire_internal_impedance
 
 from ..engine import FarField, SimulationEngine, WireCurrents
 from ..network import (

--- a/tests/test_efhw_sloper.py
+++ b/tests/test_efhw_sloper.py
@@ -80,16 +80,15 @@ def test_thicker_wire_recovers_watts():
 
 
 def test_cross_engine_pynec():
-    """Matched-basis cross-check at the transformed rig port (ideal wire:
-    the sinusoidal basis drops the distributed loading). The counterpoise +
-    gap-wire feed keeps the high-Z end well-conditioned — measured 0.03 %
-    between engines, far from the zepp's bare-end-port spread."""
+    """Matched-basis cross-check at the transformed rig port, with the
+    FULL stock wire model on both engines (momwire#134 sinusoidal loading
+    vs NEC LD-5 + LD-2). The counterpoise + gap-wire feed keeps the
+    high-Z end well-conditioned — far from the zepp's bare-end-port
+    spread."""
     pytest.importorskip("antennaknobs.engines.pynec")
     from antennaknobs.engines import PyNECEngine
     from momwire import SinusoidalSolver
 
-    zm = MomwireEngine(
-        _with_params(wire_type=None), ground=None, solver=SinusoidalSolver
-    ).impedance()[0]
-    zn = PyNECEngine(_with_params(wire_type=None), ground=None).impedance()[0]
+    zm = MomwireEngine(Builder(), ground=None, solver=SinusoidalSolver).impedance()[0]
+    zn = PyNECEngine(Builder(), ground=None).impedance()[0]
     assert abs(zm - zn) / abs(zm) < 0.01

--- a/tests/test_wire_material.py
+++ b/tests/test_wire_material.py
@@ -110,16 +110,18 @@ def test_momwire_explicit_radius_overrides_spec():
     assert e_ideal._wire_radius == 0.0005
 
 
-def test_momwire_sinusoidal_drops_loading_keeps_radius(caplog):
-    """SinusoidalSolver can't model the loading: warn, solve with the real
-    radius but ideal metal — NOT a crash, NOT a silent identical solve."""
+def test_momwire_sinusoidal_carries_loading():
+    """SinusoidalSolver models the loading since momwire 0.11.0
+    (momwire#134): the kwargs thread through and the lossy solve shifts R
+    like the BSpline one — no warning, no silent ideal-metal solve."""
     from momwire import SinusoidalSolver
 
-    with caplog.at_level("WARNING"):
-        e = MomwireEngine(_builder("28-awg"), ground=None, solver=SinusoidalSolver)
-    assert "doesn't model distributed wire loading" in caplog.text
-    assert e._loading_kwargs == {}
+    e = MomwireEngine(_builder("28-awg"), ground=None, solver=SinusoidalSolver)
+    assert e._loading_kwargs["wire_conductivity"] == COPPER_CONDUCTIVITY
     assert e._wire_radius == WIRES["28-awg"].radius
+    z0 = _z(MomwireEngine(_builder(), ground=None, solver=SinusoidalSolver))
+    z1 = _z(e)
+    assert z1.real > z0.real + 1.0
 
 
 # ----------------------------------------------------------------------
@@ -193,3 +195,19 @@ def test_cross_engine_insulation_vf_oracle():
         - _z(PyNECEngine(_builder("28-awg"), ground=None)).imag
     )
     assert dx_momwire == pytest.approx(dx_pynec, rel=0.05)
+
+
+@needs_pynec
+def test_matched_basis_lossy_oracle():
+    """The strongest cross-engine pin (momwire#134): SAME basis family
+    (sinusoidal = NEC's) and SAME wire physics on both engines — the
+    absolute lossy-PVC impedance, not just deltas, must agree tightly.
+    Before momwire 0.11.0 this comparison required wire_type=None because
+    the sinusoidal solver dropped the loading."""
+    from momwire import SinusoidalSolver
+
+    z_m = _z(
+        MomwireEngine(_builder("28-awg-pvc"), ground=None, solver=SinusoidalSolver)
+    )
+    z_n = _z(PyNECEngine(_builder("28-awg-pvc"), ground=None))
+    assert abs(z_m - z_n) / abs(z_m) < 0.01


### PR DESCRIPTION
Closes #330.

## Summary
- Adopts momwire 0.11.0 (three-place ritual: exact pin, Dockerfile, submodule → `96ae77c`), which adds SinusoidalSolver distributed wire loading (momwire#134) and public wire-material exports (momwire#133).
- `SinusoidalSolver` joins `_WIRE_LOADING_SOLVERS`: lossy designs carry their wire model onto the NEC-parity basis instead of warn-and-drop. The gate stays as the seam for any future solver without the feature.
- New **matched-basis lossy oracle**: same basis family (sinusoidal = NEC's) and same wire physics on both engines — absolute lossy-PVC impedance agrees within 1 %, a comparison that was impossible before. The EFHW cross-engine test upgrades to the full stock wire model.
- `pynec.py` imports `wire_internal_impedance`/`insulation_inductance` from the public momwire namespace, retiring the private-module import.
- Latency smoke per the release discipline: sinusoidal pota_invvee solve 5.8 ms ideal vs 6.0 ms lossy (the point-matched loading is a sparse subtraction, no gram build); the default BSpline path is untouched.

## Test plan
- [x] Full suite: 1611 passed against the editable 0.11.0 submodule
- [x] `tests/test_wire_material.py` incl. the matched-basis oracle (13 passed)
- [x] ruff clean
- [ ] wheel-smoke green against PyPI 0.11.0 (published ~19:23Z; re-run rather than merge if it raced the publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)