### PR TITLE
Release v0.24.0 — EFHW sloper + full-solver lossy wire

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.23.0"
+version = "0.24.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,20 +25,21 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.23.0" icon="star">
-  **The wire itself is now a knob.** Antenna wire stops being an ideal
-  conductor: pick a real gauge from the new **wire catalog** (28/22/18
-  AWG, bare or PVC) and the solve models its **skin-effect loss** —
-  entering the impedance matrix itself, validated against NEC's native
-  wire-loss card to half a percent — plus the **insulated-wire velocity
-  factor** (why a cut-to-formula PVC dipole tunes long), which NEC-2
-  can't model at all. The power budget grows a **wire loss (I²R)** row,
-  and the Info pane reports the antenna's **weight in grams**. A new
-  showcase design and Advanced guide put it to work on the classic
-  portable question: [how thin can you go? — wire gauge for
-  POTA](/advanced/wire-gauge/), where 17 g of #28 wire costs just
-  0.25 dB against #18 — but the jacket moves resonance further than
-  the gauge ever does.
+<Card title="New in v0.24.0" icon="star">
+  **The POTA antenna, complete.** The new
+  [`wire.efhw_sloper`](/advanced/efhw/) showcase models the classic
+  end-fed half-wave with nothing idealized: a real **49:1 unun** (ratio
+  dropdown, magnetizing branch with core loss, compensation cap), a
+  **counterpoise that actually matters**, real coax, and real thin wire
+  — and the power budget answers the eternal question *where do the
+  watts go in a 49:1?* (Spoiler: the 28 AWG wire burns six times what
+  the ferrite does.) Under the hood, **every solver now carries the
+  real-wire model**: the sinusoidal (NEC-parity) basis models
+  skin-effect loss and insulation via NEC's own loading scheme
+  (momwire 0.11.0), and the NEC engine gains the insulated-wire
+  velocity factor as a distributed `LD 2` card — the two engines agree
+  on a PVC dipole's resonance shift to ~1 %, with nothing dropped on
+  either side.
   [All release notes →](/reference/releases/)
 </Card>
 

--- a/site/src/content/docs/reference/solver.mdx
+++ b/site/src/content/docs/reference/solver.mdx
@@ -143,9 +143,12 @@ that declare a wire material (the `WIRES` catalog — see the
 [wire-gauge example](/advanced/wire-gauge/)) get skin-effect conductor loss as
 a distributed series impedance in the solve itself (momwire ≥ 0.10.0, validated
 against NEC's native `LD 5` wire-loss card to ~0.5 %) plus the insulated-wire
-velocity factor, which NEC-2 cannot model at all. The B-spline solver family
-carries the loading; the sinusoidal solver still solves wires as bare PEC and
-says so loudly. Finite grounds are
+velocity factor (mirrored on the NEC engine as an `LD 2` distributed-inductance
+card, agreeing on the resonance shift to ~1 %). Every momwire solver carries
+the loading (momwire ≥ 0.11.0): the B-spline family as a Galerkin overlap, the
+sinusoidal solver through NEC's impedance boundary condition at its match
+points — so matched-basis cross-engine comparisons keep the full wire physics
+on both sides. Finite grounds are
 solved with a true **Sommerfeld/Norton** model on every momwire solver
 (momwire ≥ 0.8.0: NEC's exact-image-plus-remainder decomposition; the
 accelerators carry the smooth remainder as one global low-rank term on their


### PR DESCRIPTION
## Summary
- Version bump to 0.24.0. Since v0.23.0: the EFHW sloper + 49:1 unun showcase with slope-angle knob and +x lobe (#329, PRs #331/#333), sinusoidal-solver lossy wire via momwire 0.11.0 (#330, PR #334), PyNEC insulated-wire LD-2 parity (#328, PR #326), and the wire-loading runtime study + decision memo (#327, PR #325).
- What's-new card refreshed (EFHW + every-solver wire model).
- `solver.mdx` de-staled: the "sinusoidal solves bare PEC" and "NEC-2 cannot model insulation" caveats no longer exist.
- Site builds clean (18 pages).

## Test plan
- [x] Full suite green on the momwire 0.11.0 pin (1611, PR #334)
- [x] `npm run build` passes
- [ ] Tag fires publish + both Fly deploys; verify PyPI + release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)