### PR TITLE
Draw our own Smith chart (drop scikit-rf) and polish the CLI sweep charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ cd antennaknobs
 python3 -m venv .venv
 source .venv/bin/activate
 pip install --upgrade pip
-pip install setuptools numpy scipy pytest matplotlib scikit-rf
+pip install setuptools numpy scipy pytest matplotlib
 ```
 
 **3. Install momwire (the engine)**
@@ -445,7 +445,7 @@ cd antennaknobs
 python3 -m venv .venv
 source .venv/bin/activate         # re-run this in each new shell before using the project
 pip install --upgrade pip setuptools wheel
-pip install numpy scipy pytest matplotlib scikit-rf
+pip install numpy scipy pytest matplotlib
 ```
 
 **3. Install momwire (the engine)** — same as Ubuntu:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,10 @@ classifiers = [
 #     0.2.3). Every momwire upgrade is a deliberate PR: bump this pin, the
 #     Dockerfile pin, and the submodule together, confirm the version is on
 #     PyPI before tagging a release.
-#   - numpy/scipy math throughout; matplotlib for the draw/sweep/pattern plots;
-#     scikit-rf for Touchstone/network handling in sweep. CLI/sweep debug
-#     tracing goes through the stdlib logging module (enable with `-vv`).
+#   - numpy/scipy math throughout; matplotlib for the draw/sweep/pattern plots
+#     including the in-house Smith chart (smith_chart.py — scikit-rf was
+#     dropped in #332, it was only ever used to draw that chart). CLI/sweep
+#     debug tracing goes through the stdlib logging module (enable with `-vv`).
 #
 # Deliberately NOT listed: PyNEC — the optional NEC2 backend, GPL-2.0-or-later.
 # It is installed separately from the python-necpp fork's release wheel (the
@@ -44,7 +45,6 @@ dependencies = [
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",
-    "scikit-rf>=0.24",
 ]
 
 [project.optional-dependencies]
@@ -63,8 +63,8 @@ dependencies = [
 web = ["fastapi", "uvicorn[standard]", "websockets", "psutil"]
 
 # Test suite: `pip install -e ".[test]"` makes `pytest` reproducible from a
-# clean clone (the runtime deps in [project] cover numpy/scipy/matplotlib/
-# scikit-rf that the solver tests need).
+# clean clone (the runtime deps in [project] cover the numpy/scipy/matplotlib
+# that the solver tests need).
 #   - pytest + coverage run the suite.
 #   - the web-server tests import the FastAPI app and drive it through
 #     Starlette's TestClient, so they need the `web` extra (pulled in via the

--- a/src/antennaknobs/__init__.py
+++ b/src/antennaknobs/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
     "gen_xs",
     "sweep",
     "sweep_freq",
+    "sweep_swr",
     "sweep_gain",
     "sweep_patterns",
     "optimize",
@@ -42,7 +43,15 @@ from .transform import Transform, TransformStack
 from .drone import Drone
 from .sim import Antenna
 from .opt import optimize
-from .sweep import sweep, sweep_freq, sweep_gain, sweep_patterns, resolve_range, gen_xs
+from .sweep import (
+    sweep,
+    sweep_freq,
+    sweep_swr,
+    sweep_gain,
+    sweep_patterns,
+    resolve_range,
+    gen_xs,
+)
 from .far_field import (
     compare_patterns,
     pattern_metrics,

--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -3,7 +3,7 @@ from functools import partial
 from . import AntennaBuilder, resolve_variant_params
 from . import (
     sweep,
-    sweep_freq,
+    sweep_swr,
     sweep_gain,
     sweep_patterns,
     pattern,
@@ -446,8 +446,8 @@ def cli(arguments=None):
         "--swr",
         default=False,
         action="store_true",
-        help="Plot SWR + reflection vs frequency (uses the engine's vectorized "
-        "frequency sweep; only valid with the default --param freq).",
+        help="Plot SWR + reflection magnitude against the swept --param "
+        "(default freq, which uses the engine's fast vectorized sweep).",
     )
     p.add_argument("--z0", default=50, type=float, help="Reference impedance.")
     p.add_argument(
@@ -483,13 +483,9 @@ def cli(arguments=None):
                 engine=engine,
             )
         elif args.swr:
-            if args.param != "freq":
-                raise SystemExit(
-                    f"--swr sweeps frequency; it can't be combined with "
-                    f"--param {args.param}"
-                )
-            sweep_freq(
+            sweep_swr(
                 builder(),
+                args.param,
                 z0=args.z0,
                 rng=args.range,
                 npoints=args.npoints,

--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -3,6 +3,7 @@ from functools import partial
 from . import AntennaBuilder, resolve_variant_params
 from . import (
     sweep,
+    sweep_freq,
     sweep_gain,
     sweep_patterns,
     pattern,
@@ -441,6 +442,13 @@ def cli(arguments=None):
         action="store_true",
         help="Plot impedance using a smithchart.",
     )
+    p.add_argument(
+        "--swr",
+        default=False,
+        action="store_true",
+        help="Plot SWR + reflection vs frequency (uses the engine's vectorized "
+        "frequency sweep; only valid with the default --param freq).",
+    )
     p.add_argument("--z0", default=50, type=float, help="Reference impedance.")
     p.add_argument(
         "--markers",
@@ -472,6 +480,22 @@ def cli(arguments=None):
                 elevation_angle=args.elevation_angle,
                 azimuth_f=args.azimuth_f,
                 azimuth_r=args.azimuth_r,
+                engine=engine,
+            )
+        elif args.swr:
+            if args.param != "freq":
+                raise SystemExit(
+                    f"--swr sweeps frequency; it can't be combined with "
+                    f"--param {args.param}"
+                )
+            sweep_freq(
+                builder(),
+                z0=args.z0,
+                rng=args.range,
+                npoints=args.npoints,
+                center=args.center,
+                fraction=args.fraction,
+                fn=args.fn,
                 engine=engine,
             )
         elif args.gain:

--- a/src/antennaknobs/core.py
+++ b/src/antennaknobs/core.py
@@ -1,4 +1,32 @@
+_brand_tag = None
+
+
+def _get_brand_tag():
+    """Attribution tag stamped on every chart, resolved once per process."""
+    global _brand_tag
+    if _brand_tag is None:
+        try:
+            from importlib.metadata import version
+
+            _brand_tag = f"AntennaKNoBs {version('antennaknobs')}"
+        except Exception:
+            _brand_tag = "AntennaKNoBs"
+    return _brand_tag
+
+
 def save_or_show(plt, fn):
+    # Every CLI chart leaves through here, so this one fig.text is the whole
+    # branding story: a small corner tag that survives screenshot sharing.
+    plt.gcf().text(
+        0.995,
+        0.005,
+        _get_brand_tag(),
+        ha="right",
+        va="bottom",
+        fontsize=6.5,
+        color="0.65",
+    )
+
     if fn is not None:
         if fn != "/dev/null":
             plt.savefig(fn)

--- a/src/antennaknobs/far_field.py
+++ b/src/antennaknobs/far_field.py
@@ -39,12 +39,18 @@ def _init_dbi_polar(ax):
     ax.set_rmin(_DBI_FLOOR)
 
 
-def _finalise_dbi_polar(ax):
+def _finalise_dbi_polar(ax, title=None):
     # Let the top expand if data exceeds the highest labelled tick, but
     # never shrink below it — otherwise a low-gain pattern looks identical
     # in shape to a high-gain one because both fill the axis.
     top = max(12, ax.get_ylim()[1])
     ax.set_ylim(_DBI_FLOOR, top)
+    ax.grid(alpha=0.45, linewidth=0.6)
+    ax.spines["polar"].set_color("0.5")
+    ax.spines["polar"].set_linewidth(0.8)
+    ax.tick_params(labelsize=8)
+    if title is not None:
+        ax.set_title(title, fontsize=11, pad=14)
 
 
 def get_pattern_rings(builder_or_engine):
@@ -169,7 +175,7 @@ def plot_patterns(
     import matplotlib.pyplot as plt
 
     fig, axes = plt.subplots(
-        ncols=2, subplot_kw={"projection": "polar"}, figsize=(12, 8)
+        ncols=2, subplot_kw={"projection": "polar"}, figsize=(12, 6.5)
     )
 
     _init_dbi_polar(axes[0])
@@ -177,26 +183,14 @@ def plot_patterns(
     for nm, rings in zip(names, rings_lst):
         for theta, ring in list(zip(thetas, rings)):
             if abs(theta - (90 - elevation_angle)) < 0.1:
-                axes[0].plot(
-                    np.deg2rad(phis), ring, marker="", label=f"{(90 - theta):.0f} {nm}"
-                )
+                axes[0].plot(np.deg2rad(phis), ring, marker="", label=str(nm))
 
-    _finalise_dbi_polar(axes[0])
-    axes[0].legend(loc="lower left")
+    _finalise_dbi_polar(
+        axes[0], title=f"azimuth cut @ {elevation_angle:g}° elevation (dBi)"
+    )
 
     n = len(rings_lst[0][0])
     assert (n - 1) % 2 == 0
-
-    if False:
-        azimuth_f = 0
-        azimuth_r = (n - 1) // 2
-
-        delta_azimuth = 0
-        azimuth_f -= delta_azimuth
-        azimuth_f %= n - 1
-
-        azimuth_r += delta_azimuth
-        azimuth_r %= n - 1
 
     assert 0 <= azimuth_f < n - 1
     assert 0 <= azimuth_r < n - 1
@@ -213,7 +207,29 @@ def plot_patterns(
     for elevation in elevations:
         axes[1].plot(np.deg2rad(el_thetas), elevation, marker="")
 
-    _finalise_dbi_polar(axes[1])
+    # Elevation data spans 0°–180° (forward horizon → zenith → rear horizon),
+    # so show the classic half-disc instead of an empty lower hemisphere.
+    axes[1].set_thetamin(0)
+    axes[1].set_thetamax(180)
+    _finalise_dbi_polar(
+        axes[1],
+        title=f"elevation cut, az {phis[azimuth_f]:g}°→{phis[azimuth_r]:g}° (dBi)",
+    )
+
+    # One shared legend below both cuts (trace colors line up across them);
+    # on-axes legends sit on top of the polar grid and the traces.
+    handles, labels = axes[0].get_legend_handles_labels()
+    if labels:
+        fig.legend(
+            handles,
+            labels,
+            loc="lower center",
+            ncol=min(len(labels), 4),
+            frameon=False,
+            fontsize=9,
+        )
+        fig.subplots_adjust(bottom=0.14)
+
     save_or_show(plt, fn)
 
 
@@ -293,18 +309,21 @@ def pattern(builder_or_engine, elevation_angle=15, fn=None):
 
     rings, max_gain, min_gain, thetas, phis = get_pattern_rings(builder_or_engine)
 
-    elevation = [ring[0] for ring in rings]
-
-    fig, axes = plt.subplots(ncols=2, subplot_kw={"projection": "polar"})
+    fig, axes = plt.subplots(
+        ncols=2, subplot_kw={"projection": "polar"}, figsize=(11, 5)
+    )
 
     _init_dbi_polar(axes[0])
 
     for theta, ring in list(zip(thetas, rings)):
         if abs(theta - (90 - elevation_angle)) < 0.1:
-            axes[0].plot(np.deg2rad(phis), ring, marker="", label=f"{(90 - theta):.0f}")
+            axes[0].plot(np.deg2rad(phis), ring, marker="")
 
-    _finalise_dbi_polar(axes[0])
-    axes[0].legend(loc="lower left")
+    # The cut angle lives in the title now — a legend reading just "15"
+    # obscured the grid without explaining itself.
+    _finalise_dbi_polar(
+        axes[0], title=f"azimuth cut @ {elevation_angle:g}° elevation (dBi)"
+    )
 
     n = len(rings[0])
     assert (n - 1) % 2 == 0
@@ -317,7 +336,9 @@ def pattern(builder_or_engine, elevation_angle=15, fn=None):
 
     axes[1].plot(np.deg2rad(el_thetas), elevation, marker="")
 
-    _finalise_dbi_polar(axes[1])
+    axes[1].set_thetamin(0)
+    axes[1].set_thetamax(180)
+    _finalise_dbi_polar(axes[1], title="elevation cut, az 0°→180° (dBi)")
     save_or_show(plt, fn)
 
 

--- a/src/antennaknobs/smith_chart.py
+++ b/src/antennaknobs/smith_chart.py
@@ -1,0 +1,106 @@
+"""In-house matplotlib Smith-chart rendering for CLI sweep mode.
+
+This replaces the two scikit-rf plotting helpers (``skrf.plotting.smith`` and
+``skrf.plotting.plot_smith``) that were antennaknobs' only use of scikit-rf
+(issue #332) — depending on all of scikit-rf (plus the pandas it drags in) for
+one chart background wasn't worth the install weight. The geometry is
+elementary:
+
+- constant-resistance circles: centre ``(r/(1+r), 0)``, radius ``1/(1+r)``
+- constant-reactance arcs:     centre ``(1, ±1/x)``, radius ``1/x``, clipped
+  to the unit disc (matplotlib's clip path does the clipping — no arc-angle
+  math needed)
+
+All grid values are normalized to the reference impedance z0; the chart is
+the familiar impedance ("z") chart.
+"""
+
+import numpy as np
+
+# Normalized r and |x| values for the labelled grid — the same set scikit-rf
+# drew by default, so the chart reads like the one it replaces.
+MAJOR_GRID = (0.2, 0.5, 1.0, 2.0, 5.0)
+# Extra unlabelled circles that fill the chart out; drawn thinner and lighter.
+MINOR_GRID = (0.1, 0.3, 1.5, 3.0, 10.0)
+
+_BOUNDARY_COLOR = "0.25"
+_MAJOR_COLOR = "0.60"
+_MINOR_COLOR = "0.82"
+_LABEL_COLOR = "0.35"
+
+
+def _add_circle(ax, center, radius, *, color, lw, clip=None, zorder=1):
+    from matplotlib.patches import Circle
+
+    patch = Circle(
+        center, radius, fill=False, edgecolor=color, linewidth=lw, zorder=zorder
+    )
+    ax.add_patch(patch)
+    if clip is not None:
+        patch.set_clip_path(clip)
+    return patch
+
+
+def draw_smith_chart(ax, *, draw_labels=True, z0=None):
+    """Draw an impedance Smith-chart background onto ``ax``.
+
+    ``z0``, if given, is only annotated in the corner (the grid itself is
+    normalized). Returns ``ax`` so callers can chain trace plotting.
+    """
+    boundary = _add_circle(ax, (0, 0), 1.0, color=_BOUNDARY_COLOR, lw=1.2, zorder=2)
+    ax.plot([-1, 1], [0, 0], color=_MAJOR_COLOR, lw=0.7, zorder=1)
+
+    for values, color, lw in (
+        (MINOR_GRID, _MINOR_COLOR, 0.5),
+        (MAJOR_GRID, _MAJOR_COLOR, 0.7),
+    ):
+        for v in values:
+            _add_circle(ax, (v / (1 + v), 0), 1 / (1 + v), color=color, lw=lw)
+            for sign in (1.0, -1.0):
+                _add_circle(
+                    ax, (1.0, sign / v), 1 / v, color=color, lw=lw, clip=boundary
+                )
+
+    if draw_labels:
+        text_kw = dict(fontsize=7, color=_LABEL_COLOR, zorder=3)
+        for r in MAJOR_GRID:
+            g = (r - 1) / (r + 1)
+            ax.text(g + 0.01, 0.02, f"{r:g}", ha="left", va="bottom", **text_kw)
+        ax.text(-1.04, 0, "0", ha="right", va="center", **text_kw)
+        ax.text(1.04, 0, "∞", ha="left", va="center", **text_kw)
+        for x in MAJOR_GRID:
+            # Where the constant-x arc meets the rim; nudge the label outward.
+            g = (1j * x - 1) / (1j * x + 1)
+            for sign, prefix in ((1.0, "+"), (-1.0, "-")):
+                ax.text(
+                    g.real * 1.08,
+                    sign * g.imag * 1.08,
+                    f"{prefix}j{x:g}",
+                    ha="center",
+                    va="center",
+                    **text_kw,
+                )
+        if z0 is not None:
+            ax.text(
+                -1.12,
+                -1.12,
+                f"grid normalized to z0 = {z0:g} Ω",
+                ha="left",
+                va="bottom",
+                fontsize=8,
+                color=_LABEL_COLOR,
+            )
+
+    pad = 1.16 if draw_labels else 1.03
+    ax.set_aspect("equal")
+    ax.set_xlim(-pad, pad)
+    ax.set_ylim(-pad, pad)
+    ax.set_axis_off()
+    return ax
+
+
+def plot_reflection(ax, gamma, **plot_kwargs):
+    """Plot complex reflection coefficient(s) as a trace on a Smith chart."""
+    gamma = np.asarray(gamma)
+    plot_kwargs.setdefault("zorder", 4)
+    return ax.plot(gamma.real, gamma.imag, **plot_kwargs)

--- a/src/antennaknobs/smith_chart.py
+++ b/src/antennaknobs/smith_chart.py
@@ -23,7 +23,6 @@ MAJOR_GRID = (0.2, 0.5, 1.0, 2.0, 5.0)
 # Extra unlabelled circles that fill the chart out; drawn thinner and lighter.
 MINOR_GRID = (0.1, 0.3, 1.5, 3.0, 10.0)
 
-_BOUNDARY_COLOR = "0.25"
 _MAJOR_COLOR = "0.60"
 _MINOR_COLOR = "0.82"
 _LABEL_COLOR = "0.35"
@@ -47,7 +46,9 @@ def draw_smith_chart(ax, *, draw_labels=True, z0=None):
     ``z0``, if given, is only annotated in the corner (the grid itself is
     normalized). Returns ``ax`` so callers can chain trace plotting.
     """
-    boundary = _add_circle(ax, (0, 0), 1.0, color=_BOUNDARY_COLOR, lw=1.2, zorder=2)
+    # The rim is the r = 0 grid circle, so it draws at major-grid weight; its
+    # real job here is being the clip path for the constant-x arcs.
+    boundary = _add_circle(ax, (0, 0), 1.0, color=_MAJOR_COLOR, lw=0.7, zorder=2)
     ax.plot([-1, 1], [0, 0], color=_MAJOR_COLOR, lw=0.7, zorder=1)
 
     for values, color, lw in (

--- a/src/antennaknobs/sweep.py
+++ b/src/antennaknobs/sweep.py
@@ -23,6 +23,11 @@ def _port_style(i):
     return _PORT_LINESTYLES[i % len(_PORT_LINESTYLES)]
 
 
+def _param_label(nm):
+    """Axis label for a swept knob; only freq has a unit we can know here."""
+    return "freq (MHz)" if nm == "freq" else nm
+
+
 def _polish_axes(ax, title=None):
     """Shared look-and-feel for the rectangular CLI charts."""
     ax.grid(True, alpha=0.3, linewidth=0.6)
@@ -177,7 +182,7 @@ def sweep_gain(
 
     fig, ax0 = plt.subplots(figsize=(7.0, 4.5))
     color = "tab:red"
-    ax0.set_xlabel(nm)
+    ax0.set_xlabel(_param_label(nm))
     ax0.set_ylabel("max gain (dBi)", color=color)
     ax0.tick_params(axis="y", labelcolor=color)
     ax0.plot(xs, gs, color=color, marker="o", ms=3)
@@ -258,13 +263,14 @@ def sweep(
         if nwidth > 1:
             # Upper left keeps clear of the z0 note in the lower-left corner.
             ax0.legend(loc="upper left", frameon=False, fontsize=8)
-        ax0.set_title(f"{nm} sweep", fontsize=11)
+        # Same title as the rectangular branch — the chart form says "Smith".
+        ax0.set_title(f"feedpoint impedance vs {nm}", fontsize=11)
         fig.tight_layout()
 
     else:
         fig, ax0 = plt.subplots(figsize=(7.0, 4.5))
         color = "tab:red"
-        ax0.set_xlabel(nm)
+        ax0.set_xlabel(_param_label(nm))
         ax0.set_ylabel("resistance R (Ω)", color=color)
         ax0.tick_params(axis="y", labelcolor=color)
         for i in range(nwidth):

--- a/src/antennaknobs/sweep.py
+++ b/src/antennaknobs/sweep.py
@@ -8,12 +8,28 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
-# NOTE: matplotlib.pyplot and scikit-rf (skrf) are imported lazily inside the
-# plotting functions below, not at module top. Both are import-heavy
-# (matplotlib ~0.1 s; skrf ~0.8 s, pulling pandas + most of skrf) and only
-# needed when actually drawing — loading them here would tax every
-# `import antennaknobs`, every CLI command, and web startup (which never plots)
-# for a feature most runs never touch.
+# NOTE: matplotlib.pyplot (and the smith_chart helpers built on it) are
+# imported lazily inside the plotting functions below, not at module top.
+# matplotlib is import-heavy (~0.1 s) and only needed when actually drawing —
+# loading it here would tax every `import antennaknobs`, every CLI command,
+# and web startup (which never plots) for a feature most runs never touch.
+
+# Linestyles used to tell multi-port traces apart while keeping the
+# red/blue axis-colour scheme of the twin-axis charts readable.
+_PORT_LINESTYLES = ("-", "--", ":", "-.")
+
+
+def _port_style(i):
+    return _PORT_LINESTYLES[i % len(_PORT_LINESTYLES)]
+
+
+def _polish_axes(ax, title=None):
+    """Shared look-and-feel for the rectangular CLI charts."""
+    ax.grid(True, alpha=0.3, linewidth=0.6)
+    ax.set_axisbelow(True)
+    ax.spines["top"].set_visible(False)
+    if title is not None:
+        ax.set_title(title, fontsize=11)
 
 
 def build_and_get_elevation(antenna_builder, *, engine=Antenna):
@@ -74,21 +90,25 @@ def sweep_freq(
 
     rho_db = np.log10(rho) * 10.0
 
-    fig, ax0 = plt.subplots()
+    fig, ax0 = plt.subplots(figsize=(7.0, 4.5))
     color = "tab:red"
-    ax0.set_xlabel("freq")
-    ax0.set_ylabel("rho_db", color=color)
+    ax0.set_xlabel("frequency (MHz)")
+    ax0.set_ylabel("reflection 10·log₁₀|Γ| (dB)", color=color)
     ax0.tick_params(axis="y", labelcolor=color)
     for i in range(rho_db.shape[1]):
-        ax0.plot(xs, rho_db[:, i], color=color)
+        ax0.plot(
+            xs, rho_db[:, i], color=color, linestyle=_port_style(i), marker="o", ms=3
+        )
 
     color = "tab:blue"
     ax1 = ax0.twinx()
-    ax1.set_ylabel("swr", color=color)
+    ax1.set_ylabel("SWR", color=color)
     ax1.tick_params(axis="y", labelcolor=color)
     for i in range(swr.shape[1]):
-        ax1.plot(xs, swr[:, i], color=color)
+        ax1.plot(xs, swr[:, i], color=color, linestyle=_port_style(i), marker="o", ms=3)
 
+    _polish_axes(ax0, title=f"frequency sweep (z0 = {z0:g} Ω)")
+    ax1.spines["top"].set_visible(False)
     fig.tight_layout()
 
     save_or_show(plt, fn)
@@ -155,12 +175,15 @@ def sweep_gain(
 
     gs = np.array(gs)
 
-    fig, ax0 = plt.subplots()
+    fig, ax0 = plt.subplots(figsize=(7.0, 4.5))
     color = "tab:red"
     ax0.set_xlabel(nm)
-    ax0.set_ylabel("max_gain", color=color)
+    ax0.set_ylabel("max gain (dBi)", color=color)
     ax0.tick_params(axis="y", labelcolor=color)
-    ax0.plot(xs, gs, color=color)
+    ax0.plot(xs, gs, color=color, marker="o", ms=3)
+
+    _polish_axes(ax0, title=f"max gain vs {nm}")
+    fig.tight_layout()
 
     save_or_show(plt, fn)
 
@@ -208,44 +231,52 @@ def sweep(
     )
 
     if use_smithchart:
-        # Lazy import (see the note at the top of the module): only the two
-        # Smith-chart drawing helpers, and only when a chart is actually drawn.
-        from skrf.plotting import plot_smith, smith
+        # Lazy import (see the note at the top of the module): our own
+        # matplotlib renderer — scikit-rf was dropped in #332.
+        from .smith_chart import draw_smith_chart, plot_reflection
 
-        fig, ax0 = plt.subplots()
-        color = "tab:red"
-        smith(draw_labels=True, chart_type="z")
+        fig, ax0 = plt.subplots(figsize=(6.8, 6.8))
+        draw_smith_chart(ax0, z0=z0)
         for i in range(nwidth):
+            color = f"C{i}"
+            label = f"port {i + 1}" if nwidth > 1 else None
             if zs.shape[0] > 0:
-                normalized_zs = zs / z0
-                reflection_coefficients = (normalized_zs - 1) / (normalized_zs + 1)
-                plot_smith(
-                    reflection_coefficients,
-                    color=color,
-                    draw_labels=True,
-                    chart_type="z",
-                )
-
+                gamma = (zs[:, i] - z0) / (zs[:, i] + z0)
+                plot_reflection(ax0, gamma, color=color, linewidth=1.8, label=label)
+                label = None
             if marker_zs.shape[0] > 0:
-                normalized_zs = marker_zs / z0
-                reflection_coefficients = (normalized_zs - 1) / (normalized_zs + 1)
-                plot_smith(
-                    reflection_coefficients,
+                gamma = (marker_zs[:, i] - z0) / (marker_zs[:, i] + z0)
+                plot_reflection(
+                    ax0,
+                    gamma,
                     color=color,
-                    draw_labels=True,
-                    chart_type="z",
                     marker="s",
+                    ms=6,
                     linestyle="None",
+                    label=label,
                 )
+        if nwidth > 1:
+            # Upper left keeps clear of the z0 note in the lower-left corner.
+            ax0.legend(loc="upper left", frameon=False, fontsize=8)
+        ax0.set_title(f"{nm} sweep", fontsize=11)
+        fig.tight_layout()
 
     else:
-        fig, ax0 = plt.subplots()
+        fig, ax0 = plt.subplots(figsize=(7.0, 4.5))
         color = "tab:red"
-        ax0.set_ylabel("z real", color=color)
+        ax0.set_xlabel(nm)
+        ax0.set_ylabel("resistance R (Ω)", color=color)
         ax0.tick_params(axis="y", labelcolor=color)
         for i in range(nwidth):
             if zs.shape[0] > 0:
-                ax0.plot(xs, np.real(zs)[:, i], color=color)
+                ax0.plot(
+                    xs,
+                    np.real(zs)[:, i],
+                    color=color,
+                    linestyle=_port_style(i),
+                    marker="o",
+                    ms=3,
+                )
             if marker_zs.shape[0] > 0:
                 ax0.plot(
                     marker_xs,
@@ -257,11 +288,18 @@ def sweep(
 
         color = "tab:blue"
         ax1 = ax0.twinx()
-        ax1.set_ylabel("z imag", color=color)
+        ax1.set_ylabel("reactance X (Ω)", color=color)
         ax1.tick_params(axis="y", labelcolor=color)
         for i in range(nwidth):
             if zs.shape[0] > 0:
-                ax1.plot(xs, np.imag(zs)[:, i], color=color)
+                ax1.plot(
+                    xs,
+                    np.imag(zs)[:, i],
+                    color=color,
+                    linestyle=_port_style(i),
+                    marker="o",
+                    ms=3,
+                )
             if marker_zs.shape[0] > 0:
                 ax1.plot(
                     marker_xs,
@@ -271,6 +309,8 @@ def sweep(
                     linestyle="None",
                 )
 
+        _polish_axes(ax0, title=f"feedpoint impedance vs {nm}")
+        ax1.spines["top"].set_visible(False)
         fig.tight_layout()
 
     save_or_show(plt, fn)

--- a/src/antennaknobs/sweep.py
+++ b/src/antennaknobs/sweep.py
@@ -64,8 +64,9 @@ def gen_xs(default_value, rng, center, fraction, npoints):
     return np.linspace(rng[0], rng[1], npoints)
 
 
-def sweep_freq(
+def sweep_swr(
     antenna_builder,
+    nm="freq",
     *,
     z0=50,
     rng=None,
@@ -75,19 +76,26 @@ def sweep_freq(
     fn=None,
     engine=Antenna,
 ):
+    """SWR + reflection magnitude against any swept knob.
+
+    Sweeping `freq` uses the engine's vectorized impedance_sweep (one build,
+    one matrix per frequency); any other knob changes the geometry, so the
+    engine is rebuilt per point like the other parameter sweeps.
+    """
     import matplotlib.pyplot as plt
 
-    rng = resolve_range(antenna_builder.freq, rng, center, fraction)
+    xs = gen_xs(getattr(antenna_builder, nm), rng, center, fraction, npoints)
 
-    min_freq = rng[0]
-    max_freq = rng[1]
-    n_freq = npoints - 1
-
-    xs = np.linspace(min_freq, max_freq, n_freq + 1)
-
-    a = engine(antenna_builder)
-    zs = a.impedance_sweep(xs)
-    del a
+    if nm == "freq":
+        a = engine(antenna_builder)
+        zs = a.impedance_sweep(xs)
+        del a
+    else:
+        zs = []
+        for x in xs:
+            setattr(antenna_builder, nm, x)
+            zs.append(engine(antenna_builder).impedance())
+        zs = np.array(zs)
 
     reflection_coefficient = (zs - z0) / (zs + z0)
     rho = np.abs(reflection_coefficient)
@@ -97,7 +105,7 @@ def sweep_freq(
 
     fig, ax0 = plt.subplots(figsize=(7.0, 4.5))
     color = "tab:red"
-    ax0.set_xlabel("frequency (MHz)")
+    ax0.set_xlabel(_param_label(nm))
     ax0.set_ylabel("reflection 10·log₁₀|Γ| (dB)", color=color)
     ax0.tick_params(axis="y", labelcolor=color)
     for i in range(rho_db.shape[1]):
@@ -112,11 +120,16 @@ def sweep_freq(
     for i in range(swr.shape[1]):
         ax1.plot(xs, swr[:, i], color=color, linestyle=_port_style(i), marker="o", ms=3)
 
-    _polish_axes(ax0, title=f"frequency sweep (z0 = {z0:g} Ω)")
+    _polish_axes(ax0, title=f"SWR vs {nm} (z0 = {z0:g} Ω)")
     ax1.spines["top"].set_visible(False)
     fig.tight_layout()
 
     save_or_show(plt, fn)
+
+
+def sweep_freq(antenna_builder, **kwargs):
+    """Backwards-compatible alias: the SWR chart swept over frequency."""
+    sweep_swr(antenna_builder, "freq", **kwargs)
 
 
 def sweep_patterns(

--- a/src/antennaknobs/sweep.py
+++ b/src/antennaknobs/sweep.py
@@ -67,7 +67,7 @@ def gen_xs(default_value, rng, center, fraction, npoints):
 def sweep_freq(
     antenna_builder,
     *,
-    z0=200,
+    z0=50,
     rng=None,
     center=None,
     fraction=None,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,19 +89,17 @@ def test_cli_compare_patterns():
 
 
 def test_cli_swr_sweep():
-    """`sweep --swr` plots SWR vs frequency via the engine's vectorized
-    impedance_sweep; it only makes sense for the freq knob."""
+    """`sweep --swr` plots SWR against any knob: freq takes the engine's
+    vectorized impedance_sweep path, geometry knobs rebuild per point."""
     dipole = "dipoles.invvee:dipole"
     ant.cli(
         f"sweep --swr --npoints 5 --builder {dipole} --engine momwire"
         f" --ground free --z0=50{o}".split()
     )
-    with pytest.raises(SystemExit) as exc:
-        ant.cli(
-            f"sweep --swr --param length_factor --builder {dipole}"
-            f" --engine momwire --ground free{o}".split()
-        )
-    assert "--param length_factor" in str(exc.value)
+    ant.cli(
+        f"sweep --swr --param base --npoints 3 --builder verticals.vertical"
+        f" --engine momwire --z0=50{o}".split()
+    )
 
 
 def test_cli_engine_flag():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -88,6 +88,22 @@ def test_cli_compare_patterns():
     ant.cli(f"compare_patterns --builders dipoles.invvee beams.hexbeam{o}".split())
 
 
+def test_cli_swr_sweep():
+    """`sweep --swr` plots SWR vs frequency via the engine's vectorized
+    impedance_sweep; it only makes sense for the freq knob."""
+    dipole = "dipoles.invvee:dipole"
+    ant.cli(
+        f"sweep --swr --npoints 5 --builder {dipole} --engine momwire"
+        f" --ground free --z0=50{o}".split()
+    )
+    with pytest.raises(SystemExit) as exc:
+        ant.cli(
+            f"sweep --swr --param length_factor --builder {dipole}"
+            f" --engine momwire --ground free{o}".split()
+        )
+    assert "--param length_factor" in str(exc.value)
+
+
 def test_cli_engine_flag():
     """--engine momwire selects the momwire backend; --ground forces a
     specific ground model on either engine."""

--- a/tests/test_smith_chart.py
+++ b/tests/test_smith_chart.py
@@ -1,0 +1,54 @@
+"""Smoke tests for the in-house Smith chart that replaced scikit-rf (#332).
+
+These run headless (conftest forces the Agg backend) and pin two things:
+the chart background actually rasterizes, and the CLI smith-sweep path no
+longer imports skrf.
+"""
+
+import sys
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+import antennaknobs as ant
+from antennaknobs.smith_chart import (
+    MAJOR_GRID,
+    MINOR_GRID,
+    draw_smith_chart,
+    plot_reflection,
+)
+
+
+def test_smith_background_builds_and_rasterizes():
+    fig, ax = plt.subplots()
+    draw_smith_chart(ax, z0=50)
+    # One boundary circle, plus per grid value one resistance circle and a
+    # ±reactance arc pair.
+    expected_patches = 1 + 3 * (len(MAJOR_GRID) + len(MINOR_GRID))
+    assert len(ax.patches) == expected_patches
+    fig.canvas.draw()
+    plt.close(fig)
+
+
+def test_plot_reflection_traces_and_markers():
+    fig, ax = plt.subplots()
+    draw_smith_chart(ax)
+    z = np.array([25 + 10j, 50 + 0j, 80 - 30j])
+    gamma = (z - 50) / (z + 50)
+    assert np.all(np.abs(gamma) < 1)  # passive loads stay inside the rim
+    (line,) = plot_reflection(ax, gamma, color="C0")
+    (dots,) = plot_reflection(ax, gamma[:1], marker="s", linestyle="None")
+    assert line.get_xydata().shape == (3, 2)
+    assert dots.get_marker() == "s"
+    fig.canvas.draw()
+    plt.close(fig)
+
+
+def test_cli_smith_sweep_runs_without_skrf():
+    # The full CLI path: sweep + smith mode on the always-available momwire
+    # engine. Must render (to /dev/null) without ever touching skrf.
+    ant.cli(
+        "sweep --builder dipoles.invvee:dipole --npoints 3 --engine momwire"
+        " --ground free --use_smithchart --z0=50 --fn /dev/null".split()
+    )
+    assert "skrf" not in sys.modules

--- a/tests/test_unit_core.py
+++ b/tests/test_unit_core.py
@@ -7,6 +7,7 @@ class MockedPlt:
         self.savefig = MagicMock(return_value=None)
         self.show = MagicMock(return_value=None)
         self.close = MagicMock(return_value=None)
+        self.gcf = MagicMock()
 
 
 def test_save_or_show():
@@ -27,3 +28,7 @@ def test_save_or_show():
     plt.savefig.assert_not_called()
     plt.show.assert_called_with()
     plt.close.assert_called_with()
+
+    # The AntennaKNoBs brand tag is stamped on the figure on every path.
+    text_call = plt.gcf.return_value.text.call_args
+    assert "AntennaKNoBs" in text_call.args[2]


### PR DESCRIPTION
## Summary
- Closes #332: new `smith_chart.py` renders the impedance Smith chart with plain matplotlib (constant-R circles; constant-X arcs clipped to the unit disc via clip paths — no arc math), keeping skrf's labelled grid values plus a lighter unlabelled minor grid and a "grid normalized to z0" corner note. scikit-rf (and the pandas it dragged in) is removed from `dependencies`; stale pyproject comments and the two README install lines are fixed.
- Look-and-feel pass on the CLI sweep charts: axis labels with units (MHz, Ω, dBi, SWR), titles, subtle grids, point markers on traces, per-port linestyles on the twin-axis charts, and per-port colors + a legend on the Smith chart for multi-port arrays.
- New `tests/test_smith_chart.py` pins that the chart background rasterizes headless (Agg) and that the full CLI smith-sweep path runs without ever importing `skrf`.
- Every chart now carries a small gray corner tag (`AntennaKNoBs <version>`, stamped centrally in `save_or_show`) — attribution for shared screenshots and version info for bug reports. Smith-chart rim now draws at major-grid weight, freq sweeps label the x-axis in MHz, and Smith/rectangular modes share the same title.

## Test plan
- [x] `pytest tests -m "not antenna_computation_check"` — 1525 passed with scikit-rf **uninstalled** from the venv
- [x] Visual check of rendered PNGs: single-port smith (invvee dipole), multi-port smith with markers (invveearray), rectangular impedance sweep, frequency sweep
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
