### PR TITLE
Add a 40 m variant of the EFHW sloper (wire.efhw_sloper:band40)

### DIFF
--- a/site/src/content/docs/advanced/efhw.md
+++ b/site/src/content/docs/advanced/efhw.md
@@ -77,6 +77,24 @@ not a full transformer characterization — so treat the (mag) row as the
 shape of the loss, and tune `qlmag` against a measurement if you have
 one: Q = 5 doubles the core's share, Q = 20 halves it.
 
+## The 40 m variant
+
+`wire.efhw_sloper:band40` is the same POTA box — unun, comp cap, and
+coax untouched — with twice the wire: ~19 m of 28 AWG PVC retuned to
+put the rig-side SWR minimum at 7.1 MHz (SWR 1.36, and the whole band
+under about 2:1). Two things change with the band, and both are honest
+physics rather than knob-turning:
+
+- **The slope comes down.** A 63° rise would put the apex at ~18 m; the
+  variant's 30° lands it near 11 m — a tall mast or a friendly tree
+  limb. At ~0.26 λ up the pattern is near-NVIS (takeoff ≈ 78°,
+  essentially omnidirectional), which is exactly how 40 m POTA operates:
+  regional skywave, not DX.
+- **The wire loss doubles.** The longer high-current half wave burns
+  ~10 % in I²R (vs ~6 % on 20 m), for 84 % system efficiency. The 100 pF
+  comp cap is a 20 m-flavored compromise, too — ~200 pF would buy
+  SWR 1.19 here, if you'd rather rebuild the unun than accept 1.36.
+
 ## Try it
 
 Open [`wire.efhw_sloper`](https://app.antennaknobs.dev/) in the

--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -88,7 +88,7 @@ whole shape with a `Drone` — see
 | Design | Notes |
 | --- | --- |
 | `wire.doublet_ladder_tuner` | 88 ft doublet + 100 ft of 600 Ω open-wire line + lossy T-network tuner — the "non-resonant wire and a matchbox" station, modelled from the rig (issue #300) · variants: `classic_edz`, `dipole`, `three_halves` |
-| `wire.efhw_sloper` | End-fed half-wave sloper with a real 49:1 unun — "the POTA antenna, complete" (issue #329) |
+| `wire.efhw_sloper` | End-fed half-wave sloper with a real 49:1 unun — "the POTA antenna, complete" (issue #329) · variants: `band40` |
 | `wire.lazy_h` | Lazy-H: two stacked collinear elements fed in phase (L. B. Cebik, W4RNL) |
 | `wire.longwire` | Resonant multi-wavelength long-wire (L. B. Cebik, W4RNL) |
 | `wire.rhombic` | Terminated rhombic: a traveling-wave directional long-wire (L. B. Cebik, W4RNL, "Long-Wire Antennas" / "The Terminated Vee-Beam and Rhombic") |

--- a/src/antennaknobs/designs/wire/efhw_sloper.py
+++ b/src/antennaknobs/designs/wire/efhw_sloper.py
@@ -135,6 +135,26 @@ class Builder(AntennaBuilder):
         }
     )
 
+    # 40 m: the same POTA box — unun, comp cap, coax untouched — with twice
+    # the wire. The ~19 m radiator needs a gentler rise: 30° lands the apex
+    # near 11 m (a tall mast or a friendly tree limb), and the counterpoise
+    # scales to ~0.05 λ. length_factor retuned for the stock 28 AWG PVC wire:
+    # rig-side SWR 1.36 at 7.1 MHz. The 100 pF comp cap is a 20 m-flavored
+    # compromise that caps the match here (~200 pF would buy 1.19 — turn the
+    # knob if you'd rebuild the unun), and the longer thin wire burns ~10 %
+    # in I²R (efficiency 84 %) — the gauge tradeoff, amplified. At ~0.26 λ
+    # up the pattern is near-NVIS (takeoff ≈ 78°, essentially omni) — which
+    # is exactly how 40 m POTA actually works: regional skywave, not DX.
+    band40_params = MappingProxyType(
+        {
+            "design_freq": 7.1,
+            "freq": 7.1,
+            "slope_deg": 30.0,
+            "length_factor": 0.8935,
+            "cp_len_m": 2.1,
+        }
+    )
+
     def build_wires(self):
         eps = 0.05
         wavelength = 299.792458 / self.design_freq

--- a/tests/test_efhw_sloper.py
+++ b/tests/test_efhw_sloper.py
@@ -79,6 +79,35 @@ def test_thicker_wire_recovers_watts():
     assert fr18["wire loss (I²R)"] < 0.5 * fr28["wire loss (I²R)"]
 
 
+def test_band40_variant_tune():
+    """wire.efhw_sloper:band40 — same unun box, twice the wire, gentler
+    slope. The retuned length_factor lands the rig under SWR 1.5 at
+    7.1 MHz (measured 1.36; the 100 pF comp cap is the 20 m-flavored
+    compromise that caps the match on this band)."""
+    from antennaknobs import resolve_variant_params
+
+    b = Builder(params=resolve_variant_params(Builder, "band40"))
+    (z,) = MomwireEngine(b, **GROUND).impedance()
+    gamma = abs((z - 50.0) / (z + 50.0))
+    assert (1 + gamma) / (1 - gamma) < 1.5
+
+
+def test_band40_geometry_and_budget():
+    """The 30° rise keeps the ~19 m radiator's apex at a realistic mast
+    height, and the longer thin wire roughly doubles the I²R fraction
+    relative to 20 m (measured 10.0 % vs 6.1 %, efficiency 0.841)."""
+    from antennaknobs import resolve_variant_params
+
+    b = Builder(params=resolve_variant_params(Builder, "band40"))
+    apex = max(max(p0[2], p1[2]) for p0, p1, *_ in b.build_wires())
+    assert 9.0 < apex < 12.0
+
+    eng = MomwireEngine(b, **GROUND)
+    fr = _budget_fractions(eng)
+    assert 0.05 < fr["wire loss (I²R)"] < 0.20
+    assert 0.75 < eng._excited_efficiency < 0.92
+
+
 def test_cross_engine_pynec():
     """Matched-basis cross-check at the transformed rig port, with the
     FULL stock wire model on both engines (momwire#134 sinusoidal loading


### PR DESCRIPTION
## Summary
- New `band40` variant overlay on `wire.efhw_sloper`: same POTA hardware (unun, comp cap, coax), twice the wire — design_freq/freq 7.1 MHz, counterpoise scaled to ~0.05 λ (2.1 m), rise dropped to 30° so the ~19 m radiator's apex lands near 11 m (a 63° slope would demand an 18 m mast).
- `length_factor` retuned to 0.8935 for the stock 28 AWG PVC wire over the workbench finite-fast ground: rig-side SWR 1.36 at 7.1 MHz, whole band under ~2:1, efficiency 84 % (the longer thin wire doubles the I²R fraction to ~10 % — the gauge story amplified). Main lobe still on +x; at ~0.26 λ up the pattern is honestly near-NVIS (takeoff ≈ 78°), which is how 40 m POTA operates.
- Deliberately NOT retuned: the 100 pF comp cap (a 20 m-flavored compromise that caps the match at 1.36 — ~200 pF would buy 1.19, documented for anyone rebuilding their unun).
- Tests pin the tune (< 1.5), apex height (9–12 m), and budget fractions; `advanced/efhw.md` grows a 40 m section; `catalog.md` regenerated.

## Test plan
- [x] `pytest tests -m "not antenna_computation_check"` — full fast suite green after regenerating catalog.md
- [x] Visual: `draw` + `sweep --swr` on the variant (SWR minimum sits at 7.1, band edges ~2:1)
- [x] Pattern check: peak azimuth 0° (+x), takeoff 78°

🤖 Generated with [Claude Code](https://claude.com/claude-code)