### PR TITLE
POTA PERformer showcase: duplicate KJ6ER's claims, add the radiated-power ledger

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -89,6 +89,7 @@ export default defineConfig({
             { label: "Coax vs. ladder line", slug: "advanced/station-comparison" },
             { label: "Wire gauge for POTA", slug: "advanced/wire-gauge" },
             { label: "The end-fed question", slug: "advanced/efhw" },
+            { label: "Three ledgers of efficiency", slug: "advanced/pota-performer" },
           ],
         },
         {

--- a/site/src/content/docs/advanced/pota-performer.md
+++ b/site/src/content/docs/advanced/pota-performer.md
@@ -82,7 +82,7 @@ efficiency by definition stops at the antenna's terminals-and-metal.
 KJ6ER's own published +0.31 dBi peak is a ~25% radiated fraction,
 stated in dB.
 
-## Is that damning? No — it's the tax everyone pays
+## The tax everyone pays
 
 Ground absorption at these heights is nearly identical for every
 portable vertical. For calibration, the same integration on a 7 m-high

--- a/site/src/content/docs/advanced/pota-performer.md
+++ b/site/src/content/docs/advanced/pota-performer.md
@@ -1,0 +1,116 @@
+---
+title: "Three ledgers of efficiency: modeling the POTA PERformer"
+description: An advanced worked example — duplicating the published claims for KJ6ER's elevated vertical, and the difference between "90% efficient" and "30% radiated". Both are true.
+---
+
+Greg Mihran KJ6ER's **PERformer** is one of the most popular published
+portable antennas: an elevated quarter-wave vertical for 40M–6M — a 17'
+telescoping stainless whip with the feedpoint 52" up on a tripod or
+spike, and two elevated tuned radials sloping down to stakes. The
+[free plans](https://www.vhfclub.org/pdf/PERformer%20Antenna%20by%20KJ6ER%20%282025-02%29.pdf)
+include 4NEC2 model results and a headline claim: **over 90% efficient**,
+versus "only 37%" for a typical ground-mounted quarter-wave with four
+ground-coupled radials.
+
+[`verticals.pota_performer`](/reference/catalog/) models it faithfully —
+the plans' 15M reference geometry, per-band variants straight from the
+whip/radial tables, the 90° directional and 180° omni radial spans, and
+VA3KOT's single-radial simplification. This page is about what happens
+when you check the numbers: **almost every claim duplicates**, and the
+one that needs an asterisk teaches the most useful lesson in portable
+antenna modeling.
+
+## The claims duplicate
+
+Three independent engines (and two independent modelers) on the 15M
+configuration, two radials, average ground:
+
+| Model | Peak gain | Takeoff | F/B (90° span) | El. beamwidth |
+|---|---|---|---|---|
+| KJ6ER, 4NEC2 (published) | +0.31 dBi | 24° | 3.37 dB | 46° |
+| VA3KOT, EZNEC (independent) | +1.19 dBi | 25° | 3.34 dB | 47° |
+| antennaknobs, momwire | +1.06 dBi | 24° | 2.91 dB | 44° |
+| antennaknobs, PyNEC | +1.02 dBi | 23° | ~3 dB | 44° |
+
+The beam *shape* is unanimous: takeoff 23–25°, a mild ~3 dB
+front-to-back toward the radial span, mid-40s elevation beamwidth. The
+directional-vs-omni delta duplicates too (KJ6ER +0.98 dB, we measure
++0.76 dB), and so do VA3KOT's single-radial trends (more F/B, wider
+elevation, narrower azimuth). Absolute peak gain spreads about 0.9 dB
+across engines, with KJ6ER's own figure the lowest of the four —
+ordinary cross-model variation in ground constants and whip
+idealization.
+
+The SWR story holds up as well: at the plans' exact 15M lengths the
+directional feedpoint solves to 45 + 1j Ω — SWR 1.10, matching the
+"better than 1.1:1" field measurements (and the omni span solves lower,
+just as the plans say elevating radials should).
+
+## The efficiency claim: true, in its ledger
+
+"Over 90% efficient" is a **structural** efficiency: input power that
+isn't burned in conductors and components. We *confirm* it. Solving the
+same geometry with lossless wire and taking the ratio: the stainless
+whip plus radials cost only ~2–3%, structural efficiency ≈ 98% (KJ6ER's
+90.8% additionally carries his −0.12 dB choke and the whip's thin tip
+sections). And the physics behind his 90%-vs-37% comparison is real:
+elevated tuned radials remove the ground-coupled loss *resistance* that
+sits in series with a ground-mounted vertical's feed and eats half its
+power in-circuit.
+
+But there is a second ledger, and it's already visible in the table
+above. **Gain and efficiency are the same measurement.** Gain is power
+density per input watt; average linear gain over the sphere is exactly
+P<sub>radiated</sub>/P<sub>input</sub> (`radiated_fraction` in the
+library computes it from any pattern). Equivalently: this beam shape has
+a directivity of ~6.5 dBi — that's what the peak would read if every
+input watt were radiated. The peaks actually read about +1 dBi:
+
+| Model | Peak gain | Implied radiated fraction |
+|---|---|---|
+| KJ6ER, 4NEC2 | +0.31 dBi | ~24% |
+| VA3KOT, EZNEC | +1.19 dBi | ~30% |
+| momwire (integrated directly) | +1.06 dBi | 29% |
+| PyNEC (integrated directly) | +1.02 dBi | 34% |
+
+So for 100 W in: **~2 W warms the stainless, ~68 W warms the ground
+within a few wavelengths, ~30 W leaves as sky wave.** The missing
+4.5–6 dB between "+5.5 dBi if lossless" and "+1 dBi as modeled" *is*
+the Fresnel-zone ground absorption, and it appears in nobody's
+"efficiency" figure — including the 90.8% — because structural
+efficiency by definition stops at the antenna's terminals-and-metal.
+KJ6ER's own published +0.31 dBi peak is a ~25% radiated fraction,
+stated in dB.
+
+## Is that damning? No — it's the tax everyone pays
+
+Ground absorption at these heights is nearly identical for every
+portable vertical. For calibration, the same integration on a 7 m-high
+inverted vee gives 72% radiated on 20m, 72% on 15m, 69% on 10m — the
+classic reason horizontal wire beats a vertical over real ground when
+you have the supports, and the vertical's counter-argument is the low
+takeoff angle (23° here vs the vee's 51° on 20m), not efficiency. You
+cannot pack better dirt. That's precisely why the convention in
+antenna write-ups is to quote structural efficiency: it's the part the
+*builder* controls, and on that score the PERformer is genuinely
+excellent — the elevated-radial design earns its numbers, and the
+*relative* claims (beats ground-mounted, 3 dB of steerable F/B from a
+90° radial span, resonant with no tuner) all survive independent
+modeling.
+
+The lesson is about reading claims, not doubting this antenna: when a
+spec sheet says "90% efficient" and the same page's pattern plot peaks
+near 0 dBi, both numbers are correct — they are different ledgers. The
+gain plot is the one the ionosphere sees.
+
+## Try it
+
+Open [`verticals.pota_performer`](https://app.antennaknobs.dev/) in the
+simulator. Flip `radial_span_deg` between 90 and 180 and watch the
+front-to-back appear and vanish; drop `n_radials` to 1 for VA3KOT's
+fast-deploy config; walk the band variants (`band20` … `band6`) and
+watch the droop angle steepen as the radials shorten against the fixed
+stake height — exactly the table in the plans.
+
+*Sources: [KJ6ER's PERformer plans (rev 2025-02)](https://www.vhfclub.org/pdf/PERformer%20Antenna%20by%20KJ6ER%20%282025-02%29.pdf);
+[VA3KOT, "Testing and modifying the POTA PERformer antenna" (2025-05)](https://hamradiooutsidethebox.ca/2025/05/28/testing-and-modifying-the-pota-performer-antenna/).*

--- a/site/src/content/docs/advanced/pota-performer.md
+++ b/site/src/content/docs/advanced/pota-performer.md
@@ -103,6 +103,40 @@ spec sheet says "90% efficient" and the same page's pattern plot peaks
 near 0 dBi, both numbers are correct — they are different ledgers. The
 gain plot is the one the ionosphere sees.
 
+## The rest of the trio: Challenger and Dominator
+
+KJ6ER publishes two more antennas in the same family, and both are now
+in the tree: [`verticals.challenger`](/reference/catalog/) (off-center-fed
+halfwave vertical: 25' whip is ~77% of the halfwave, a short ~10% λ
+counterpoise completes it through a 4:1 unun) and
+[`verticals.dominator`](/reference/catalog/) (a true vertical EFHW: the
+whip is the whole halfwave, fed through a 49:1 with a long ~33% λ
+counterpoise). Same duplication exercise, same result — the claims hold:
+
+| Claim (4NEC2, 15M) | Published | antennaknobs |
+|---|---|---|
+| Challenger peak / takeoff / el BW | −0.32 dBi / 20° / 33° | +0.14 dBi / 21° / 34° |
+| Dominator peak / takeoff / el BW | +0.60 dBi / 18° / 27° | +0.34 dBi / 17° / 26° |
+| Takeoff ordering, trio | 18° < 21° < 24° | 17° < 21° < 23° |
+
+The transformers are where these two get interesting, because KJ6ER
+*measures* their insertion losses and itemizes them honestly — and our
+`Transformer` branch puts the same numbers in the power budget: the
+stock 49:1 burns **−0.96 dB (~20% of input power)**, the Challenger's
+4:1 only −0.34 dB, with the "plus" upgrades at −0.40/−0.24 dB
+(`plus` variants; the magnetizing branch is calibrated to the measured
+loss at 15M, not derived from core datasheets). His own comparison
+table shows the paradox: the Dominator has the trio's *highest*
+"structural efficiency" (99.5% — it's just one aluminum tube) and the
+trio's *lossiest* component. Both facts are itemized in our budget
+instead of living in separate ledgers.
+
+And the third ledger says: Challenger radiates 25%, Dominator 25%
+(transformer included), PERformer 29%. Nobody escapes the dirt. What
+actually separates these three antennas — exactly as KJ6ER's "primary
+reach" table frames it — is the takeoff angle, and that claim
+reproduces perfectly.
+
 ## Try it
 
 Open [`verticals.pota_performer`](https://app.antennaknobs.dev/) in the

--- a/site/src/content/docs/advanced/pota-performer.md
+++ b/site/src/content/docs/advanced/pota-performer.md
@@ -125,8 +125,9 @@ counterpoise). Same duplication exercise, same result — the claims hold:
 The transformers are where these two get interesting, because KJ6ER
 *measures* their insertion losses and itemizes them honestly — and our
 `Transformer` branch puts the same numbers in the power budget: the
-stock 49:1 burns **−0.96 dB (~20% of input power)**, the Challenger's
-4:1 only −0.34 dB, with the "plus" upgrades at −0.40/−0.24 dB
+stock 49:1 burns **−0.96 dB (~20% of input power)** — the same black
+box interrogated in [the end-fed question](/advanced/efhw/) — the
+Challenger's 4:1 only −0.34 dB, with the "plus" upgrades at −0.40/−0.24 dB
 (`plus` variants; the magnetizing branch is calibrated to the measured
 loss at 15M, not derived from core datasheets). His own comparison
 table shows the interesting tension — the Dominator has the trio's

--- a/site/src/content/docs/advanced/pota-performer.md
+++ b/site/src/content/docs/advanced/pota-performer.md
@@ -16,14 +16,15 @@ ground-coupled radials.
 the plans' 15M reference geometry, per-band variants straight from the
 whip/radial tables, the 90° directional and 180° omni radial spans, and
 VA3KOT's single-radial simplification. This page is about what happens
-when you check the numbers: **almost every claim duplicates**, and the
-one that needs an asterisk teaches the most useful lesson in portable
+when you check the numbers: **the claims duplicate**, and reading the
+efficiency number in full teaches the most useful lesson in portable
 antenna modeling.
 
 ## The claims duplicate
 
-Three independent engines (and two independent modelers) on the 15M
-configuration, two radials, average ground:
+Four models from three modelers — spanning two genuinely independent
+solver cores, the NEC-2 family and momwire — on the 15M configuration,
+two radials, average ground:
 
 | Model | Peak gain | Takeoff | F/B (90° span) | El. beamwidth |
 |---|---|---|---|---|
@@ -51,12 +52,14 @@ just as the plans say elevating radials should).
 "Over 90% efficient" is a **structural** efficiency: input power that
 isn't burned in conductors and components. We *confirm* it. Solving the
 same geometry with lossless wire and taking the ratio: the stainless
-whip plus radials cost only ~2–3%, structural efficiency ≈ 98% (KJ6ER's
-90.8% additionally carries his −0.12 dB choke and the whip's thin tip
-sections). And the physics behind his 90%-vs-37% comparison is real:
-elevated tuned radials remove the ground-coupled loss *resistance* that
-sits in series with a ground-mounted vertical's feed and eats half its
-power in-circuit.
+whip plus radials cost only ~2–3%, structural efficiency ≈ 98%. KJ6ER's
+90.8% is a few points lower — plausibly the real whip's thin stainless
+tip sections, which our uniform mid-taper radius flatters (his −0.12 dB
+choke is itemized separately in his table, not inside the 90.8%). And
+the physics behind his 90%-vs-37% comparison is real: elevated tuned
+radials remove the ground-coupled loss *resistance* that sits in series
+with a ground-mounted vertical's feed and eats over half its power
+in-circuit.
 
 But there is a second ledger, and it's already visible in the table
 above. **Gain and efficiency are the same measurement.** Gain is power
@@ -126,10 +129,11 @@ stock 49:1 burns **−0.96 dB (~20% of input power)**, the Challenger's
 4:1 only −0.34 dB, with the "plus" upgrades at −0.40/−0.24 dB
 (`plus` variants; the magnetizing branch is calibrated to the measured
 loss at 15M, not derived from core datasheets). His own comparison
-table shows the paradox: the Dominator has the trio's *highest*
-"structural efficiency" (99.5% — it's just one aluminum tube) and the
-trio's *lossiest* component. Both facts are itemized in our budget
-instead of living in separate ledgers.
+table shows the interesting tension — the Dominator has the trio's
+*highest* "structural efficiency" (99.5% — it's just one aluminum tube)
+and the trio's *lossiest* component — and to his credit both rows sit
+side by side on his page 14. Our power budget simply adds them, plus
+the dirt's share, into one delivered-watts number.
 
 And the third ledger says: Challenger radiates 25%, Dominator 25%
 (transformer included), PERformer 29%. Nobody escapes the dirt. What

--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -78,6 +78,7 @@ whole shape with a `Drone` — see
 | `verticals.inverted_l_tmatch` | 10 m inverted-L worked on the 12 m band through a T-network tuner — the first design with a pure interior circuit node (series C, shunt L, series C), exercising the MNA network core on the classic "wire antenna + T-match" situation |
 | `verticals.jpole` | J-pole: an end-fed half-wave matched by a quarter-wave stub (L. B. Cebik, W4RNL) |
 | `verticals.phased_verticals` | Two-element phased vertical array -- the 90-degree cardioid (L. B. Cebik, W4RNL) |
+| `verticals.pota_performer` | KJ6ER's "POTA PERformer" — elevated quarter-wave with tuned radials · variants: `band10`, `band12`, `band17`, `band20`, `band6`, `omni`, `single_radial` |
 | `verticals.raised_vertical` | Elevated quarter-wave vertical, fed above ground |
 | `verticals.vertical` | Quarter-wave vertical over ground |
 <!-- catalog:end verticals -->

--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -72,6 +72,8 @@ whole shape with a `Drone` — see
 | --- | --- |
 | `verticals.bobtail` | Bobtail curtain: a 3-element vertically-polarised broadside array (L. B. Cebik, W4RNL) |
 | `verticals.bruce` | Bruce array: a series-fed vertically-polarised curtain (L. B. Cebik, W4RNL) |
+| `verticals.challenger` | KJ6ER's "Challenger" — off-center-fed halfwave vertical with 4:1 unun · variants: `band10`, `band12`, `band17`, `band20`, `band6`, `plus` |
+| `verticals.dominator` | KJ6ER's "Dominator" — end-fed halfwave vertical with 49:1 transformer · variants: `band10`, `band12`, `band17`, `plus` |
 | `verticals.four_square` | Four-square phased vertical array -- the diagonal-firing quadrature box (L. B. Cebik, W4RNL) |
 | `verticals.half_square` | Half-square: a vertically-polarised wire antenna (L. B. Cebik, W4RNL) |
 | `verticals.inverted_l` | Inverted-L: a bent, top-loaded vertical (L. B. Cebik, W4RNL) |

--- a/src/antennaknobs/__init__.py
+++ b/src/antennaknobs/__init__.py
@@ -14,6 +14,7 @@ __all__ = [
     "plot_patterns",
     "compare_patterns",
     "pattern_metrics",
+    "radiated_fraction",
     "resolve_range",
     "gen_xs",
     "sweep",
@@ -58,6 +59,7 @@ from .far_field import (
     plot_patterns,
     pattern,
     pattern3d,
+    radiated_fraction,
 )
 from .serialize import params_source, builder_params_source
 from .cli import cli

--- a/src/antennaknobs/designs/verticals/challenger.py
+++ b/src/antennaknobs/designs/verticals/challenger.py
@@ -1,0 +1,145 @@
+"""KJ6ER's "Challenger" — off-center-fed halfwave vertical with 4:1 unun.
+
+Second of the KJ6ER trio (see verticals.pota_performer for the first and
+the advanced docs page for the claim-checking story). A 25' telescoping
+aluminum whip is the top ~77% of a halfwave; a short linked counterpoise
+(~10% λ) off the unun ground completes it. The 4:1 unun (200 Ω : 50 Ω)
+sits on a tripod with the feed ~3.5' up. Plans (rev 2025-02):
+https://www.vhfclub.org/pdf/Challenger%20Antenna%20by%20KJ6ER%20(2025-02).pdf
+
+Published claims this model duplicates (4NEC2, 15M = 21.350 MHz,
+"Computer Model" lengths 205" radiator / 65" counterpoise):
+peak −0.32 dBi @ 20° elevation, −3 dB beamwidth 33°, SWR 1.04 (at
+200 Ω); "structural efficiency" 94.3%; measured unun insertion loss
+−0.34 dB (LDG RU-4:1) or −0.24 dB (Palomar Bullet, the "Challenger+" —
+the `plus` variant). The same two efficiency ledgers apply as on the
+PERformer: the structural numbers check out, while the far-field
+radiated fraction over average ground is ~⅓ — see the docs page.
+
+The unun is a real `Transformer` branch: `lmag_uH`/`qlmag` are NOT
+derived from core datasheets — they are calibrated so the power
+budget's (mag) row reproduces the measured insertion loss at the 15M
+reference frequency (loss varies ~1/f across bands, a modeling
+simplification the measured broadband figures gloss over too). The
+feedline choke (−0.12 dB) is line hygiene, not modeled.
+
+Geometry: gap wire at the whip base carries the "ant" port; the
+counterpoise slopes from the feed down toward a near-ground end
+(`cp_end_h`), running along +x — "drops at 30–45° then along the
+ground" per the plans.
+"""
+
+import math
+from types import MappingProxyType
+
+from ... import AntennaBuilder
+from ...network import (
+    Driven,
+    Network,
+    PortOnWire,
+    PortVirtual,
+    Transformer,
+    WireSpec,
+)
+
+_IN = 0.0254
+
+# 25' telescoping aluminum whip (6063-class), mid-taper radius.
+_ALUMINUM = WireSpec(radius=0.006, conductivity=3.5e7)
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            # 15M — the band the plans publish detailed 4NEC2 claims for.
+            "freq": 21.35,
+            # "Computer Model" columns: 12" pigtail + whip = total radiator.
+            "whip_len_m": 205 * _IN,
+            "cp_len_m": 65 * _IN,
+            # Feed ~3.5' up on the tripod ("roughly 3-4 feet").
+            "h_feed": 42 * _IN,
+            # Counterpoise end lands just off the ground (droop ≈ 35°).
+            "cp_end_h": 0.12,
+            # Calibrated to the LDG RU-4:1's measured −0.34 dB at 21.35 MHz
+            # (see module docstring). The `plus` variant re-lands −0.24 dB.
+            "lmag_uH": 1.22,
+            "qlmag": 3.0,
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 50.0,
+                    "default_view": "xz",
+                    "whip_len_m": {"min": 1.0, "max": 8.0, "unit": "m"},
+                    "cp_len_m": {"min": 0.3, "max": 3.0, "unit": "m"},
+                    "h_feed": {"min": 0.3, "max": 1.5, "unit": "m"},
+                    "cp_end_h": {"min": 0.02, "max": 1.0, "unit": "m"},
+                    "lmag_uH": {"min": 0.2, "max": 50.0},
+                    "qlmag": {"min": 0.0, "max": 200.0},
+                    "sweep_policy": MappingProxyType(
+                        {"anchor": "meas_freq", "band_locked": True}
+                    ),
+                }
+            ),
+        }
+    )
+
+    # Challenger+: Palomar Bullet 4:1, measured −0.24 dB.
+    plus_params = MappingProxyType({"lmag_uH": 1.75, "qlmag": 3.0})
+
+    # Per-band "Computer Model" radiator/counterpoise lengths.
+    band20_params = MappingProxyType(
+        {"freq": 14.25, "whip_len_m": 304 * _IN, "cp_len_m": 99 * _IN}
+    )
+    band17_params = MappingProxyType(
+        {"freq": 18.14, "whip_len_m": 240 * _IN, "cp_len_m": 76 * _IN}
+    )
+    band12_params = MappingProxyType(
+        {"freq": 24.94, "whip_len_m": 175 * _IN, "cp_len_m": 56 * _IN}
+    )
+    band10_params = MappingProxyType(
+        {"freq": 28.40, "whip_len_m": 154 * _IN, "cp_len_m": 49 * _IN}
+    )
+    band6_params = MappingProxyType(
+        {"freq": 51.00, "whip_len_m": 87 * _IN, "cp_len_m": 26 * _IN}
+    )
+
+    # Transformer turns ratio: 4:1 impedance = 2:1 turns, rig side low.
+    turns = 2.0
+
+    def build_wire_material(self):
+        return _ALUMINUM
+
+    def build_wires(self):
+        eps = 0.05
+        h = self.h_feed
+
+        droop = math.asin(min(1.0, max(0.0, h - self.cp_end_h) / self.cp_len_m))
+
+        return [
+            ((0, 0, h), (0, 0, h + eps), 1, None, "ant"),
+            ((0, 0, h + eps), (0, 0, h + self.whip_len_m), self.nominal_nsegs, None),
+            (
+                (0, 0, h),
+                (
+                    self.cp_len_m * math.cos(droop),
+                    0.0,
+                    h - self.cp_len_m * math.sin(droop),
+                ),
+                max(5, self.nominal_nsegs // 3),
+                None,
+            ),
+        ]
+
+    def build_network(self):
+        return Network(
+            ports={"ant": PortOnWire("ant"), "rig": PortVirtual("rig")},
+            branches=[
+                Transformer(
+                    a="rig",
+                    b="ant",
+                    n=1.0 / self.turns,
+                    lmag=self.lmag_uH * 1e-6,
+                    qlmag=self.qlmag if self.qlmag > 0 else None,
+                )
+            ],
+            sources=[Driven(port="rig", voltage=1 + 0j)],
+        )

--- a/src/antennaknobs/designs/verticals/challenger.py
+++ b/src/antennaknobs/designs/verticals/challenger.py
@@ -14,7 +14,7 @@ peak −0.32 dBi @ 20° elevation, −3 dB beamwidth 33°, SWR 1.04 (at
 −0.34 dB (LDG RU-4:1) or −0.24 dB (Palomar Bullet, the "Challenger+" —
 the `plus` variant). The same two efficiency ledgers apply as on the
 PERformer: the structural numbers check out, while the far-field
-radiated fraction over average ground is ~⅓ — see the docs page.
+radiated fraction over average ground is ~¼ — see the docs page.
 
 The unun is a real `Transformer` branch: `lmag_uH`/`qlmag` are NOT
 derived from core datasheets — they are calibrated so the power

--- a/src/antennaknobs/designs/verticals/dominator.py
+++ b/src/antennaknobs/designs/verticals/dominator.py
@@ -1,0 +1,144 @@
+"""KJ6ER's "Dominator" — end-fed halfwave vertical with 49:1 transformer.
+
+Third of the KJ6ER trio (see verticals.pota_performer and
+verticals.challenger). The full halfwave stands on end: a 25' telescoping
+whip is the radiator, fed at its bottom end through a 49:1 (or 56:1)
+step-down transformer ~4' up a tripod, with a long ~33% λ linked
+counterpoise off the transformer ground sloping to the earth and along
+it. The vertical EFHW — lowest takeoff of the trio. Plans (rev 2025-02):
+https://www.vhfclub.org/pdf/Dominator%20Antenna%20by%20KJ6ER%20(2025-02).pdf
+
+Published claims this model duplicates (4NEC2, 15M = 21.350 MHz,
+"Computer Model" lengths 272" radiator / 175" counterpoise):
+peak +0.60 dBi @ 18° elevation, −3 dB beamwidth 27°, SWR 1.006 (at
+2450 Ω); "structural efficiency" 99.5%; measured transformer insertion
+loss −0.96 dB (TennTennas 49:1) or −0.40 dB (MyAntennas 56:1, the
+"Dominator+" — the `plus` variant). Note the honest asymmetry KJ6ER
+himself points out: the EFHW's transformer is the lossiest component in
+any of his three antennas — ~20% of input power for the stock 49:1 —
+which is the same story our wire.efhw_sloper budget tells.
+
+As with the Challenger, `lmag_uH`/`qlmag` are calibrated so the budget's
+(mag) row reproduces the measured insertion loss at 21.35 MHz, not
+derived from core data. The end-fed's high-Z feed uses the same
+gap-wire + counterpoise conditioning as wire.efhw_sloper.
+"""
+
+import math
+from types import MappingProxyType
+
+from ... import AntennaBuilder
+from ...network import (
+    Driven,
+    Network,
+    PortOnWire,
+    PortVirtual,
+    Transformer,
+    WireSpec,
+)
+
+_IN = 0.0254
+
+_ALUMINUM = WireSpec(radius=0.006, conductivity=3.5e7)
+
+# xfmr_ratio dropdown → turns (feed side : rig side). 56:1 is 56.25 (7.5t).
+XFMR_TURNS = {
+    "49:1": 7.0,
+    "56:1": 7.5,
+}
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            # 15M reference band ("Computer Model" columns).
+            "freq": 21.35,
+            "whip_len_m": 272 * _IN,
+            "cp_len_m": 175 * _IN,
+            # Feed 48–52" up ("I recommend the feedpoint be elevated
+            # around 48-52 inches").
+            "h_feed": 50 * _IN,
+            # The long counterpoise slopes gently to just above the earth
+            # (droop ≈ 15°) — "extended... to provide a reliable return
+            # path".
+            "cp_end_h": 0.08,
+            "xfmr_ratio": "49:1",
+            # Calibrated to the TennTennas 49:1's measured −0.96 dB at
+            # 21.35 MHz. The `plus` variant re-lands the MyAntennas 56:1's
+            # −0.40 dB.
+            "lmag_uH": 0.33,
+            "qlmag": 3.0,
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 50.0,
+                    "default_view": "xz",
+                    "whip_len_m": {"min": 2.0, "max": 8.5, "unit": "m"},
+                    "cp_len_m": {"min": 1.0, "max": 6.0, "unit": "m"},
+                    "h_feed": {"min": 0.3, "max": 1.6, "unit": "m"},
+                    "cp_end_h": {"min": 0.02, "max": 1.0, "unit": "m"},
+                    "xfmr_ratio": {"enum_options": tuple(XFMR_TURNS)},
+                    "lmag_uH": {"min": 0.1, "max": 50.0},
+                    "qlmag": {"min": 0.0, "max": 200.0},
+                    "sweep_policy": MappingProxyType(
+                        {"anchor": "meas_freq", "band_locked": True}
+                    ),
+                }
+            ),
+        }
+    )
+
+    # Dominator+: MyAntennas MEF-130-LP 56:1, measured −0.40 dB.
+    plus_params = MappingProxyType(
+        {"xfmr_ratio": "56:1", "lmag_uH": 0.74, "qlmag": 3.0}
+    )
+
+    # Per-band "Computer Model" radiator/counterpoise lengths.
+    band17_params = MappingProxyType(
+        {"freq": 18.14, "whip_len_m": 315 * _IN, "cp_len_m": 206 * _IN}
+    )
+    band12_params = MappingProxyType(
+        {"freq": 24.94, "whip_len_m": 233 * _IN, "cp_len_m": 150 * _IN}
+    )
+    band10_params = MappingProxyType(
+        {"freq": 28.40, "whip_len_m": 204 * _IN, "cp_len_m": 132 * _IN}
+    )
+
+    def build_wire_material(self):
+        return _ALUMINUM
+
+    def build_wires(self):
+        eps = 0.05
+        h = self.h_feed
+
+        droop = math.asin(min(1.0, max(0.0, h - self.cp_end_h) / self.cp_len_m))
+
+        return [
+            ((0, 0, h), (0, 0, h + eps), 1, None, "ant"),
+            ((0, 0, h + eps), (0, 0, h + self.whip_len_m), self.nominal_nsegs, None),
+            (
+                (0, 0, h),
+                (
+                    self.cp_len_m * math.cos(droop),
+                    0.0,
+                    h - self.cp_len_m * math.sin(droop),
+                ),
+                max(7, self.nominal_nsegs // 2),
+                None,
+            ),
+        ]
+
+    def build_network(self):
+        turns = XFMR_TURNS[self.xfmr_ratio]
+        return Network(
+            ports={"ant": PortOnWire("ant"), "rig": PortVirtual("rig")},
+            branches=[
+                Transformer(
+                    a="rig",
+                    b="ant",
+                    n=1.0 / turns,
+                    lmag=self.lmag_uH * 1e-6,
+                    qlmag=self.qlmag if self.qlmag > 0 else None,
+                )
+            ],
+            sources=[Driven(port="rig", voltage=1 + 0j)],
+        )

--- a/src/antennaknobs/designs/verticals/pota_performer.py
+++ b/src/antennaknobs/designs/verticals/pota_performer.py
@@ -1,0 +1,150 @@
+"""KJ6ER's "POTA PERformer" — elevated quarter-wave with tuned radials.
+
+A faithful model of a popular published portable design: Greg Mihran
+KJ6ER's PERformer (Portable, Elevated, Resonant), a one-band-at-a-time
+quarter-wave vertical for 40M–6M. A 17' telescoping stainless whip on a
+tripod/spike puts the feedpoint 52" up; two elevated tuned radials run
+from the feed down to stakes at 36", giving a small droop angle. With the
+radials 90° apart the antenna is mildly directional toward the radial
+span; 180° apart it is omnidirectional. Plans (free PDF, rev 2025-02):
+https://www.vhfclub.org/pdf/PERformer%20Antenna%20by%20KJ6ER%20(2025-02).pdf
+
+The reason this design is in the tree is the efficiency story. KJ6ER
+publishes ">90% efficient" (structural: conductor + component loss —
+which we CONFIRM: the stainless whip and copper radials burn only a few
+percent, and elevated radials really do remove the ground-coupled loss
+resistance that eats half a ground-mounted vertical's power in-circuit).
+But gain and efficiency are one measurement: integrate the published
+pattern and ~70% of the input power is absorbed by real earth in the
+near/far field — his own +0.31 dBi peak-gain plot *is* a ~25% radiated
+fraction, stated in dB (a lossless quarter-wave with this beam shape
+would show ~+5.5 dBi). Three independent engines agree on the absolute
+level (15M, average ground, two radials 90°):
+
+    KJ6ER 4NEC2:   +0.31 dBi @ 24°, F/B 3.37, el BW 46°  → ~24% radiated
+    VA3KOT EZNEC:  +1.19 dBi @ 25°, F/B 3.34, el BW 47°  → ~30%
+    momwire:       +1.06 dBi @ 24°, F/B 2.91, el BW 44°  →  29%
+    PyNEC:         +1.02 dBi @ 23°, F/B ~3,   same shape →  34%
+
+(VA3KOT = John, hamradiooutsidethebox.ca, independent EZNEC build of
+this antenna, 2025-05; he also modeled the single-radial config —
+`n_radials` reproduces it: slightly more gain and F/B, narrower el/wider
+az coverage.) None of this makes the PERformer a bad antenna — ground
+absorption at these heights is the same tax on every portable vertical,
+so KJ6ER's *relative* claims (elevated beats ground-mounted, the
+90°-span directionality) all hold up. See the advanced docs page for the
+full three-ledger power accounting.
+
+Modeling notes: the feed is a short gap wire at the whip base (ports
+live in wire interiors); the feedline choke KJ6ER itemizes (−0.12 dB) is
+line hygiene, not modeled. Wire material is stainless (17-7 class,
+1.35e6 S/m) at the whip's mid-taper radius everywhere — the real radials
+are 18 AWG copper, but wire material is per-design, and stainless
+everywhere is the conservative bound (conductor loss ~2–3% either way).
+Default configuration is the 15M directional (90° span) setup from the
+plans' reference tables, radial span bisector on +x so the main lobe
+lands on the workbench's forward direction.
+"""
+
+import math
+from types import MappingProxyType
+
+from ... import AntennaBuilder
+from ...network import WireSpec
+
+_IN = 0.0254
+
+# Telescoping 17' stainless whip: ~10 mm diameter at the taper midpoint,
+# 17-7 PH-class conductivity. Used for all wires (see modeling notes).
+_STAINLESS = WireSpec(radius=0.005, conductivity=1.35e6)
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            # 15M — the band KJ6ER publishes detailed model claims for.
+            # Whip/radial lengths straight from the plans' per-band table
+            # (144" / 120"); no retune, the point is duplicating HIS numbers.
+            "freq": 21.35,
+            "whip_len_m": 144 * _IN,
+            "radial_len_m": 120 * _IN,
+            "h_feed": 52 * _IN,
+            # Radial ends clip to fiberglass stakes at 36": droop ≈ 7.7°.
+            "radial_end_h": 36 * _IN,
+            # 90° span = directional (KJ6ER's field default); 180° = omni.
+            "radial_span_deg": 90.0,
+            "n_radials": 2,
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 50.0,
+                    "default_view": "xz",
+                    # Max covers band20's 207" = 5.26 m (17' whip + stud).
+                    "whip_len_m": {"min": 1.0, "max": 5.3, "unit": "m"},
+                    "radial_len_m": {"min": 0.5, "max": 5.1, "unit": "m"},
+                    "h_feed": {"min": 0.5, "max": 2.5, "unit": "m"},
+                    "radial_end_h": {"min": 0.2, "max": 2.0, "unit": "m"},
+                    "radial_span_deg": {"min": 30.0, "max": 180.0},
+                    "n_radials": {"min": 1, "max": 2},
+                }
+            ),
+        }
+    )
+
+    # Omnidirectional configuration: radials opposite each other.
+    omni_params = MappingProxyType({"radial_span_deg": 180.0})
+
+    # VA3KOT's single-radial field simplification (EZNEC: +1.34 dBi,
+    # F/B 4.6 vs 1.19/3.34 for the pair). The lone radial runs along +x.
+    single_radial_params = MappingProxyType({"n_radials": 1})
+
+    # Per-band whip/radial lengths from the plans (target freqs + inches).
+    band20_params = MappingProxyType(
+        {"freq": 14.25, "whip_len_m": 207 * _IN, "radial_len_m": 198 * _IN}
+    )
+    band17_params = MappingProxyType(
+        {"freq": 18.14, "whip_len_m": 165 * _IN, "radial_len_m": 149 * _IN}
+    )
+    band12_params = MappingProxyType(
+        {"freq": 24.94, "whip_len_m": 126 * _IN, "radial_len_m": 96 * _IN}
+    )
+    band10_params = MappingProxyType(
+        {"freq": 28.40, "whip_len_m": 113 * _IN, "radial_len_m": 80 * _IN}
+    )
+    band6_params = MappingProxyType(
+        {"freq": 51.00, "whip_len_m": 64 * _IN, "radial_len_m": 43 * _IN}
+    )
+
+    def build_wire_material(self):
+        return _STAINLESS
+
+    def build_wires(self):
+        eps = 0.05
+        h = self.h_feed
+
+        # Droop angle from the feed down to the staked radial ends.
+        drop = max(0.0, h - self.radial_end_h)
+        droop = math.asin(min(1.0, drop / self.radial_len_m))
+
+        tups = [
+            # Gap wire at the whip base carries the port (ev on its one
+            # segment); the whip proper stacks on top of it.
+            ((0, 0, h), (0, 0, h + eps), 1, 1 + 0j),
+            ((0, 0, h + eps), (0, 0, h + self.whip_len_m), self.nominal_nsegs, None),
+        ]
+
+        n = int(self.n_radials)
+        # Two radials straddle +x by ±span/2 so the lobe fires forward;
+        # a single radial runs along +x itself.
+        phis = (
+            [0.0] if n == 1 else [-self.radial_span_deg / 2, self.radial_span_deg / 2]
+        )
+        r_seg = max(5, self.nominal_nsegs // 3)
+        for phi_deg in phis:
+            p = math.radians(phi_deg)
+            end = (
+                self.radial_len_m * math.cos(droop) * math.cos(p),
+                self.radial_len_m * math.cos(droop) * math.sin(p),
+                h - self.radial_len_m * math.sin(droop),
+            )
+            tups.append(((0, 0, h), end, r_seg, None))
+        return tups

--- a/src/antennaknobs/far_field.py
+++ b/src/antennaknobs/far_field.py
@@ -162,6 +162,33 @@ def pattern_metrics(ff, *, beamwidth_db=3.0):
     }
 
 
+def radiated_fraction(ff):
+    """Fraction of input power that leaves as far-field radiation.
+
+    Gain is power density per *input* watt, so the average of linear gain
+    over the full sphere is exactly P_radiated / P_input. Over a ground
+    the lower hemisphere contributes nothing, so integrating the upper
+    hemisphere alone is the whole integral; what's missing from 1.0 is
+    conductor/component loss plus ground absorption. This is the honest
+    "where do the watts go" number — distinct from the *structural*
+    efficiency usually quoted for antennas (conductor + component loss
+    only), which ignores the ground's share entirely. A quarter-wave
+    vertical over average earth radiates ~30% by this measure while
+    being ">90% efficient" structurally; both are true, in different
+    ledgers.
+
+    Accuracy note: the integral is a trapezoid over the sampled grid, so
+    patterns with significant energy at the horizon (verticals over PEC
+    ground peak exactly there) lose a few percent to grid clipping;
+    over lossy ground the horizon gain is ~0 and the integral is clean.
+    """
+    g = 10.0 ** (np.asarray(ff.rings, float) / 10.0)
+    th = np.radians(np.asarray(ff.thetas, float))
+    ph = np.radians(np.asarray(ff.phis, float))
+    integ = np.trapezoid(np.trapezoid(g, ph, axis=1) * np.sin(th), th)
+    return float(integ / (4.0 * np.pi))
+
+
 def plot_patterns(
     rings_lst,
     names,

--- a/tests/test_challenger_dominator.py
+++ b/tests/test_challenger_dominator.py
@@ -1,0 +1,136 @@
+"""KJ6ER's Challenger (OCF halfwave + 4:1) and Dominator (EFHW vertical +
+49:1): duplicate the published claims, and pin the transformer insertion
+losses in the power budget (plans rev 2025-02, 4NEC2 at 21.350 MHz).
+
+Published reference points (15M, "Computer Model" lengths):
+  Challenger: peak −0.32 dBi @ 20°, el BW 33°, unun loss −0.34 dB (LDG)
+              / −0.24 dB (Palomar, "plus"); structural 94.3%
+  Dominator:  peak +0.60 dBi @ 18°, el BW 27°, xfmr loss −0.96 dB
+              (TennTennas 49:1) / −0.40 dB (MyAntennas 56:1, "plus");
+              structural 99.5%
+  Takeoff ordering (the trio's marquee claim): Dominator 18° <
+              Challenger 21° < PERformer 24°.
+We measure: Challenger +0.14 dBi @ 21° BW 34°, Dominator +0.34 dBi @ 17°
+BW 26°, ordering 17° < 21° < 23°.
+"""
+
+import numpy as np
+import pytest
+
+from antennaknobs import radiated_fraction, resolve_variant_params
+from antennaknobs.designs.verticals.challenger import Builder as Challenger
+from antennaknobs.designs.verticals.dominator import Builder as Dominator, XFMR_TURNS
+from antennaknobs.engines import MomwireEngine
+from antennaknobs.far_field import pattern_metrics
+
+# Pattern/efficiency claims solve over full Sommerfeld average ground;
+# the transformer-loss calibration used the workbench finite-fast ground.
+SOMMERFELD = dict(ground=("finite", 13.0, 0.005), ground_z=0.0)
+WORKBENCH = dict(ground=("finite-fast", 10.0, 0.002), ground_z=0.0)
+
+
+def _build(Builder, variant=None, **overrides):
+    params = (
+        resolve_variant_params(Builder, variant)
+        if variant
+        else dict(Builder.default_params)
+    )
+    params.update(overrides)
+    return Builder(params=params)
+
+
+def _pattern(builder):
+    eng = MomwireEngine(builder, **SOMMERFELD)
+    ff = eng.far_field(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
+    return ff, pattern_metrics(ff)
+
+
+def _mag_loss_db(builder):
+    eng = MomwireEngine(builder, **WORKBENCH)
+    eng.current_distribution()
+    budget = dict(eng._excited_power_budget)
+    frac = max(0.0, budget["Transformer rig→ant (mag)"]) / eng._excited_p_in
+    return -10.0 * np.log10(1.0 - frac)
+
+
+def test_discoverable():
+    from antennaknobs.cli import list_builtin_designs
+
+    designs = set(list_builtin_designs())
+    assert "verticals.challenger" in designs
+    assert "verticals.dominator" in designs
+
+
+def test_challenger_pattern_claims():
+    _, m = _pattern(_build(Challenger))
+    assert 18 <= m["takeoff_deg"] <= 24  # claim 20°
+    assert 28 <= m["el_beamwidth_deg"] <= 40  # claim 33°
+    assert -0.7 < m["peak_gain_dbi"] < 0.8  # claim −0.32, measured +0.14
+    assert m["front_to_back_db"] < 1.0  # omnidirectional
+
+
+def test_dominator_pattern_claims():
+    _, m = _pattern(_build(Dominator))
+    assert 14 <= m["takeoff_deg"] <= 21  # claim 18°
+    assert 21 <= m["el_beamwidth_deg"] <= 32  # claim 27°
+    assert -0.4 < m["peak_gain_dbi"] < 1.2  # claim +0.60, measured +0.34
+
+
+def test_takeoff_ordering_across_the_trio():
+    """The p.14 'primary reach' table's marquee physics: the EFHW halfwave
+    sits lowest, the OCF halfwave next, the quarterwave highest."""
+    from antennaknobs.designs.verticals.pota_performer import Builder as Performer
+
+    _, m_dom = _pattern(_build(Dominator))
+    _, m_cha = _pattern(_build(Challenger))
+    _, m_per = _pattern(_build(Performer, "omni"))
+    assert m_dom["takeoff_deg"] < m_cha["takeoff_deg"] <= m_per["takeoff_deg"]
+
+
+def test_transformer_losses_land_the_measured_values():
+    """lmag/qlmag are calibrated so the budget's (mag) row reproduces the
+    measured insertion losses at the 15M reference frequency."""
+    assert _mag_loss_db(_build(Challenger)) == pytest.approx(0.34, abs=0.08)
+    assert _mag_loss_db(_build(Challenger, "plus")) == pytest.approx(0.24, abs=0.06)
+    assert _mag_loss_db(_build(Dominator)) == pytest.approx(0.96, abs=0.15)
+    assert _mag_loss_db(_build(Dominator, "plus")) == pytest.approx(0.40, abs=0.10)
+
+
+def test_idealized_transformer_ratio_sanity():
+    """With the magnetizing branch idealized, switching the Dominator's
+    49:1 to 56:1 rescales the rig impedance by the turns² quotient."""
+
+    def rig_z(ratio):
+        b = _build(Dominator, xfmr_ratio=ratio, lmag_uH=1e6, qlmag=0.0)
+        return complex(MomwireEngine(b, **WORKBENCH).impedance()[0])
+
+    q = rig_z("49:1") / rig_z("56:1")
+    expected = XFMR_TURNS["56:1"] ** 2 / XFMR_TURNS["49:1"] ** 2
+    assert complex(q) == pytest.approx(expected, rel=1e-5)
+
+
+def test_radiated_fraction_same_ground_tax():
+    """Neither halfwave escapes the dirt: ~25% of input power radiates
+    (including their transformer's share), same regime as the PERformer.
+    The trio's real differentiator is takeoff angle, not efficiency."""
+    ff_c, _ = _pattern(_build(Challenger))
+    ff_d, _ = _pattern(_build(Dominator))
+    assert 0.17 < radiated_fraction(ff_c) < 0.35  # measured 0.247
+    assert 0.17 < radiated_fraction(ff_d) < 0.35  # measured 0.246
+
+
+def test_band_variants_build():
+    for Builder, bands in (
+        (Challenger, ("band20", "band17", "band12", "band10", "band6")),
+        (Dominator, ("band17", "band12", "band10")),
+    ):
+        for name in bands:
+            b = _build(Builder, name)
+            wires = b.build_wires()
+            top = max(max(p0[2], p1[2]) for p0, p1, *_ in wires)
+            bottom = min(min(p0[2], p1[2]) for p0, p1, *_ in wires)
+            assert top == pytest.approx(b.h_feed + b.whip_len_m)
+            # A counterpoise too short to reach the target end height
+            # (6M's 26") hangs straight down instead — the droop clamp.
+            expected_bottom = max(b.cp_end_h, b.h_feed - b.cp_len_m)
+            assert bottom == pytest.approx(expected_bottom, abs=0.02)

--- a/tests/test_pota_performer.py
+++ b/tests/test_pota_performer.py
@@ -1,0 +1,131 @@
+"""KJ6ER's POTA PERformer: duplicate the published claims (PDF rev
+2025-02, 4NEC2 at 21.350 MHz) and pin the three-ledger efficiency story.
+
+Cross-model reference points (15M, two radials, average ground):
+  KJ6ER 4NEC2:  directional peak +0.31 dBi @ 24°, F/B 3.37, el BW 46°;
+                omni peak −0.67 dBi @ 24°; "structural efficiency" 90.8%
+  VA3KOT EZNEC: two radials +1.19 dBi @ 25°, F/B 3.34, el BW 47°;
+                single radial +1.34 dBi, F/B 4.6
+  momwire:      +1.06 dBi @ 24°, F/B 2.91, radiated/input 29%
+  PyNEC:        +1.02 dBi @ 23°, radiated/input 34%
+"""
+
+import pytest
+
+from antennaknobs import radiated_fraction, resolve_variant_params
+from antennaknobs.designs.verticals.pota_performer import Builder
+from antennaknobs.engines import MomwireEngine
+from antennaknobs.far_field import pattern_metrics
+
+# Full Sommerfeld average ground: the claim tables are gain/efficiency
+# claims about real earth, not workbench-tune numbers.
+GROUND = dict(ground=("finite", 13.0, 0.005), ground_z=0.0)
+
+
+def _variant(name=None, **overrides):
+    params = (
+        resolve_variant_params(Builder, name) if name else dict(Builder.default_params)
+    )
+    params.update(overrides)
+    return Builder(params=params)
+
+
+def _solve(builder):
+    eng = MomwireEngine(builder, **GROUND)
+    ff = eng.far_field(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
+    return eng, ff, pattern_metrics(ff)
+
+
+def test_discoverable():
+    from antennaknobs.cli import list_builtin_designs
+
+    assert "verticals.pota_performer" in set(list_builtin_designs())
+
+
+def test_directional_claims_duplicate():
+    """The 90°-span pattern shape matches all three published models:
+    takeoff ~24°, F/B ~3 dB, lobe on +x, peak gain in the VA3KOT/momwire/
+    PyNEC cluster (+1.0–1.3 dBi) — about 0.8 dB above KJ6ER's own plot."""
+    _, ff, m = _solve(_variant())
+    assert 20 <= m["takeoff_deg"] <= 28  # claims say 23–25
+    assert m["azimuth_deg"] == pytest.approx(0.0, abs=15)
+    assert 2.0 < m["front_to_back_db"] < 4.5  # 2.91 here; 3.34–3.37 published
+    assert 0.5 < m["peak_gain_dbi"] < 1.7  # measured 1.06
+
+
+def test_omni_span_loses_the_directionality():
+    """180° span: the directionality claim inverts — F/B collapses and
+    the peak drops by roughly KJ6ER's published ~1 dB delta."""
+    _, _, m_dir = _solve(_variant())
+    _, _, m_omni = _solve(_variant("omni"))
+    assert m_omni["front_to_back_db"] < 0.5
+    delta = m_dir["peak_gain_dbi"] - m_omni["peak_gain_dbi"]
+    assert 0.4 < delta < 1.6  # KJ6ER +0.98 dB, we measure ~0.76
+
+
+def test_single_radial_matches_va3kot_trend():
+    """VA3KOT's EZNEC single-radial config: more front-to-back than the
+    orthogonal pair (4.6 vs 3.34 — we measure 4.01 vs 2.91), wider
+    elevation beamwidth, narrower azimuth coverage. Peak gain is the one
+    metric where the models split on ORDER (his +0.15 dB, ours −0.27 dB)
+    — sub-half-dB and sensitive to exact radial geometry, so we pin the
+    two gains to within a dB of each other rather than an ordering."""
+    _, _, m2 = _solve(_variant())
+    _, _, m1 = _solve(_variant("single_radial"))
+    assert m1["front_to_back_db"] > m2["front_to_back_db"]
+    assert m1["el_beamwidth_deg"] > m2["el_beamwidth_deg"]
+    assert m1["az_beamwidth_deg"] < m2["az_beamwidth_deg"]
+    assert abs(m1["peak_gain_dbi"] - m2["peak_gain_dbi"]) < 1.0
+
+
+def test_the_efficiency_ledgers():
+    """The headline: ~90% structural efficiency and ~30% radiated are
+    simultaneously true. Conductor loss (stainless everywhere) is a few
+    percent — the rest of the missing power is ground absorption, which
+    never appears in a structural-efficiency figure."""
+    eng, ff, m = _solve(_variant())
+    frac = radiated_fraction(ff)
+    assert 0.22 < frac < 0.40  # measured 0.29 (PyNEC 0.34, KJ6ER's own ~0.24)
+
+    # Same solve with lossless wire: the conductor's share is tiny, so
+    # structural efficiency (lossy/lossless radiated ratio) is >90% —
+    # KJ6ER's claim, confirmed in his own ledger.
+    class PECBuilder(Builder):
+        def build_wire_material(self):
+            from antennaknobs.network import WireSpec
+
+            return WireSpec(radius=0.005, conductivity=None)
+
+    _, ff_pec, _ = _solve(PECBuilder(params=dict(Builder.default_params)))
+    structural = frac / radiated_fraction(ff_pec)
+    assert 0.90 < structural <= 1.0  # measured ~0.98
+
+
+def test_radiated_fraction_normalization():
+    """Over PEC ground with lossless wire the integral must return ~all
+    the power (grid clipping at the horizon costs a few percent — the
+    vertical's PEC-ground pattern peaks exactly there)."""
+
+    class PECBuilder(Builder):
+        def build_wire_material(self):
+            from antennaknobs.network import WireSpec
+
+            return WireSpec(radius=0.005, conductivity=None)
+
+    eng = MomwireEngine(
+        PECBuilder(params=dict(Builder.default_params)), ground="pec", ground_z=0.0
+    )
+    ff = eng.far_field(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
+    assert 0.90 < radiated_fraction(ff) < 1.05  # measured 0.962
+
+
+def test_band_variants_build():
+    """Each per-band overlay from the plans' table builds valid geometry:
+    whip above the feed, radial ends at the stake height."""
+    for name in ("band20", "band17", "band12", "band10", "band6"):
+        b = _variant(name)
+        wires = b.build_wires()
+        top = max(max(p0[2], p1[2]) for p0, p1, *_ in wires)
+        bottom = min(min(p0[2], p1[2]) for p0, p1, *_ in wires)
+        assert top == pytest.approx(b.h_feed + b.whip_len_m)
+        assert bottom == pytest.approx(b.radial_end_h, abs=0.02)


### PR DESCRIPTION
## Summary
- **`verticals.pota_performer`** — faithful model of KJ6ER's published elevated quarter-wave ([plans PDF rev 2025-02](https://www.vhfclub.org/pdf/PERformer%20Antenna%20by%20KJ6ER%20%282025-02%29.pdf)): 15M reference geometry, stainless whip spec, variants for omni/single-radial/all six bands from the plans' table.
- **`far_field.radiated_fraction`** — average linear gain over the sphere = P_radiated/P_input. Validated over PEC ground (0.96) and cross-checked against PyNEC's independent Sommerfeld (0.34 vs momwire's 0.29).
- **`advanced/pota-performer.md`** — the three-ledger efficiency write-up: his pattern claims duplicate across four independent models (incl. [VA3KOT's EZNEC](https://hamradiooutsidethebox.ca/2025/05/28/testing-and-modifying-the-pota-performer-antenna/): +1.19 dBi vs our +1.06); his >90% structural efficiency **confirms** (~98% here); and simultaneously only ~30% of input power radiates — the other ~70% is ground absorption, visible in his own +0.31 dBi gain plot. Calibration: a 7 m inverted vee radiates ~70% on 20/15/10m.
- Tests pin the claim duplication, the two efficiency ledgers, the VA3KOT single-radial trends, and the integral's normalization.

## Test plan
- [x] `pytest tests -m "not antenna_computation_check"` — 1547 passed (catalog regenerated)
- [x] PEC-ground + PyNEC cross-validation of `radiated_fraction`
- [x] Stew done: tone pass + a read-through in KJ6ER's shoes (fixed a misattribution of his 90.8% figure); page added to the site sidebar; Challenger + Dominator landed as follow-on commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

