### PR TITLE
Radiated-fraction ledger in the workbench HUD (dwell-filled, consolidated with the norm check)

### DIFF
--- a/site/src/content/docs/advanced/pota-performer.md
+++ b/site/src/content/docs/advanced/pota-performer.md
@@ -151,5 +151,12 @@ fast-deploy config; walk the band variants (`band20` … `band6`) and
 watch the droop angle steepen as the radials shorten against the fixed
 stake height — exactly the table in the plans.
 
+The third ledger is on screen while you do it: with a finite ground
+selected, the solve readout's **radiated (incl. ground)** row (and the
+**radiated %** readout on the pattern views) fills in whenever the knobs
+settle — ~29% for this antenna, the number this page is about. See
+[the workbench reference](/reference/web/#power-budget) for how it's
+computed.
+
 *Sources: [KJ6ER's PERformer plans (rev 2025-02)](https://www.vhfclub.org/pdf/PERformer%20Antenna%20by%20KJ6ER%20%282025-02%29.pdf);
 [VA3KOT, "Testing and modifying the POTA PERformer antenna" (2025-05)](https://hamradiooutsidethebox.ca/2025/05/28/testing-and-modifying-the-pota-performer-antenna/).*

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -142,8 +142,9 @@ the accelerators solve it on their fast paths), and PyNEC honours both
 natively. The far-field pattern uses the real εr/σ on every basis.
 Whatever runs, the solve readout's **ground** row reports the model that
 was actually used, and over a finite ground the
-[norm check](#norm-check--is-the-solve-trustworthy) Δ reads "incl. ground
-loss" — a steady dB or so there is absorbed power, not error.
+[norm check](#norm-check--is-the-solve-trustworthy) readout becomes a
+**radiated** percentage — the share of your input power that actually
+leaves as sky wave. The rest is absorbed power, not error.
 
 ## Power budget
 
@@ -152,14 +153,28 @@ matching network with a finite-Q coil, a lossy balun, a terminating
 resistor — get a
 **power budget** table in the solve readout: one row per network branch
 with the fraction of the source's input power it dissipates, plus an
-**antenna (radiated)** row for what actually reaches the wires. The rows
+**antenna (accepted)** row for what actually reaches the wires. The rows
 come straight from the MNA network solve (each branch current is an
 explicit unknown, so the watts are read off the solution, not modelled
 separately), and the same accounting drives the reported radiation
 efficiency: **every** dissipative branch counts, including resistive
 coupling and matching elements, not just explicit `Load`s. Gain is
 normalised by input power, so network loss already shows up in dBi;
-the budget tells you *where* it went. Lossless networks hide the table.
+the budget tells you *where* it went. Lossless networks hide the
+branch rows.
+
+Below the budget sits the honest bottom line: a **radiated (incl.
+ground)** row — the fraction of input power that leaves as far-field
+radiation *after* the ground has taken its share, the third of the
+[three efficiency ledgers](/advanced/pota-performer/#the-efficiency-claim-true-in-its-ledger).
+It comes from the dwell-triggered
+[norm check](#norm-check--is-the-solve-trustworthy) pattern integral, so
+it greys to **—** the moment any knob moves and fills in once you settle
+— never costing the live drag path anything. Expect a shock the first
+time: a "95% efficient" portable vertical over average ground radiates
+~30%; a 7 m-high inverted vee on 20 m about 70%. Over PEC ground or free
+space (nothing to absorb) it collapses back onto the structural
+efficiency.
 
 Designs that declare a real wire material (a `wire_type` knob over the
 `WIRES` catalog, e.g. [`dipoles.pota_invvee`](/advanced/wire-gauge/))
@@ -258,13 +273,17 @@ integral for free space and PEC ground, a small reference-grid quadrature over
 finite ground, either way evaluated once the knob settles), so it's **on by
 default** — uncheck it to hide the overlay and the readout.
 
-**Over a finite ground, Δ is not supposed to be zero.** The pattern integral
-only counts power that leaves upward — what the lossy ground absorbs never
-comes back — so a steady Δ of a dB or so *is the ground-loss reading* (the
-readout says "incl. ground loss" to remind you), exactly like NEC's average-gain
-value over real ground. It's still a mesh check: what should be small is how
-much Δ *moves* as you add segments, and switching the ground to PEC (or off)
-should send it back toward 0 dB.
+**Over a finite ground the gap is not supposed to be zero — it's physics**,
+so the readout switches to its honest form: **radiated NN%**, the fraction
+of input power that actually leaves as far-field radiation. The pattern
+integral only counts power that leaves upward — what the lossy ground
+absorbs never comes back — so the shortfall from 100% is structural loss
+plus real ground absorption, exactly like NEC's average-gain value over
+real ground (hover the readout for the raw Δ dB). The same number fills
+the [power budget](#power-budget)'s **radiated (incl. ground)** row, so
+it follows you to every view. It's still a mesh check: what should be
+small is how much the reading *moves* as you add segments, and switching
+the ground to PEC (or off) should send it back toward ~100% (Δ 0 dB).
 
 ## Copying params back to code
 

--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -660,7 +660,10 @@ def cli(arguments=None):
                 p_network += w
                 print(f"  {label}: {w * 1e3:.4g} mW ({w / p_in:.1%})")
             p_ant = p_in - p_network
-            print(f"  antenna (radiated): {p_ant * 1e3:.4g} mW ({p_ant / p_in:.1%})")
+            # "accepted", not "radiated": this is the structural remainder
+            # that reaches the wires — over a real ground the far field gets
+            # less (see far_field.radiated_fraction, the third ledger).
+            print(f"  antenna (accepted): {p_ant * 1e3:.4g} mW ({p_ant / p_in:.1%})")
 
     p.set_defaults(func=f)
 

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1557,12 +1557,18 @@ type ConvergeData = {
 // from the circuit side (input power); `pattern_norm` recomputes it from the
 // field side (closed-form pattern integral). `delta_db` is the gap between
 // them — the solver's power-balance error (NEC's "average gain" diagnostic),
-// rendered as the offset between the solid and dotted lobes.
+// rendered as the offset between the solid and dotted lobes. Over a finite
+// ground the same ratio, with the structural efficiency folded back out,
+// is the third efficiency ledger: `radiated_fraction` = P_radiated/P_input
+// including real ground absorption (issue #339) — the norm check restated
+// as a percentage.
 type NormCheckData = {
   directivity_norm: number;
   pattern_norm: number;
   method: string;
   delta_db: number;
+  radiated_fraction: number;
+  radiation_efficiency: number;
 };
 
 // Log-spaced segments-per-wire ladder for the convergence sweep. Hentenna's
@@ -3721,6 +3727,8 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
         pattern_norm: data.pattern_norm,
         method: data.method,
         delta_db: delta,
+        radiated_fraction: data.radiated_fraction ?? 0,
+        radiation_efficiency: data.radiation_efficiency ?? 1,
       });
     } catch (e: unknown) {
       if (e instanceof DOMException && e.name === "AbortError") return;
@@ -4831,18 +4839,28 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                   norm check
                 </label>
               )}
+              {/* Over a finite ground the norm gap IS physics (structural
+                  loss + real ground absorption), so show it in its honest
+                  form — the radiated fraction, same number as the Info-pane
+                  row. Free space / PEC keeps the raw Δ dB, where it is a
+                  pure solver power-balance diagnostic. */}
               {normCheckEnabled && normCheck && (
                 <span
                   className="overlay-readout"
                   title={
                     normCheck.method.startsWith("grid_")
-                      ? `input-power norm vs pattern-integral norm (${normCheck.method}); over a finite ground Δ includes real ground absorption (NEC average-gain style), so a nonzero value is expected, not solver error`
+                      ? `P_radiated/P_input from the pattern-integral norm (${normCheck.method}): the gap between the solid and dotted lobes as a fraction — structural loss plus real ground absorption (Δ ${normCheck.delta_db >= 0 ? "+" : ""}${normCheck.delta_db.toFixed(3)} dB, NEC average-gain style)`
                       : `input-power norm vs pattern-integral norm (${normCheck.method}); 0 dB = perfect power balance`
                   }
                 >
-                  Δ {normCheck.delta_db >= 0 ? "+" : ""}
-                  {normCheck.delta_db.toFixed(3)} dB
-                  {normCheck.method.startsWith("grid_") && " (incl. ground loss)"}
+                  {normCheck.method.startsWith("grid_") ? (
+                    <>radiated {(normCheck.radiated_fraction * 100).toFixed(0)}%</>
+                  ) : (
+                    <>
+                      Δ {normCheck.delta_db >= 0 ? "+" : ""}
+                      {normCheck.delta_db.toFixed(3)} dB
+                    </>
+                  )}
                 </span>
               )}
             </div>
@@ -5009,6 +5027,8 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                       rttMs={rttMs}
                       currentExample={currentExample}
                       effectiveMultiFeed={effectiveMultiFeed}
+                      normCheck={normCheck}
+                      normCheckEnabled={normCheckEnabled}
                     />
                     {/* The ws status lives HERE, not floating over the
                         carousel — on a phone the desktop-style absolute
@@ -5103,6 +5123,8 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
             rttMs={rttMs}
             currentExample={currentExample}
             effectiveMultiFeed={effectiveMultiFeed}
+            normCheck={normCheck}
+            normCheckEnabled={normCheckEnabled}
           />
         </div>
         <div className="status">
@@ -5655,12 +5677,16 @@ function SolveReadout({
   rttMs,
   currentExample,
   effectiveMultiFeed,
+  normCheck,
+  normCheckEnabled,
   className = "",
 }: {
   result: SolveResponse | null;
   rttMs: number | null;
   currentExample: ExampleDescriptor | undefined;
   effectiveMultiFeed: boolean;
+  normCheck: NormCheckData | null;
+  normCheckEnabled: boolean;
   className?: string;
 }) {
   return (
@@ -5735,33 +5761,54 @@ function SolveReadout({
       </div>
       {(() => {
         // Power budget (issue #299): where the input watts go, per network
-        // branch. Hidden unless the network actually dissipates something
-        // (lossless branches report float noise only).
+        // branch. Branch rows are hidden unless the network actually
+        // dissipates something (lossless branches report float noise only).
+        // The radiated row (issue #339) is the third efficiency ledger —
+        // P_radiated/P_input INCLUDING far-field ground absorption, derived
+        // from the dwell-triggered norm check — so it renders even for a
+        // lossless design over real ground, greyed to "—" while knobs move.
         const budget = result?.power_budget;
         const pin = result?.input_power_w;
-        if (!budget || budget.length === 0 || !pin || pin <= 0) return null;
-        const diss = budget.reduce((s, b) => s + b.watts, 0);
-        if (diss < 1e-6 * pin) return null;
+        const diss =
+          budget && pin ? budget.reduce((s, b) => s + b.watts, 0) : 0;
+        const showBudget =
+          !!budget && budget.length > 0 && !!pin && pin > 0 &&
+          diss >= 1e-6 * pin;
+        if (!showBudget && !normCheckEnabled) return null;
         return (
-          <div
-            className="feeds-table"
-            title="Fraction of the source input power dissipated in each network branch (from the MNA solve); the antenna row is the remainder that reaches the wires."
-          >
-            <div className="feeds-table-header">power budget</div>
-            {budget.map((b, i) => (
-              <div className="row" key={`pb-${i}`}>
-                <span>{b.label}</span>
-                <span className="val">
-                  {((b.watts / pin) * 100).toFixed(1)}%
+          <div className="feeds-table">
+            {showBudget && pin && (
+              <div title="Fraction of the source input power dissipated in each network branch (from the MNA solve); the antenna row is the remainder that reaches the wires.">
+                <div className="feeds-table-header">power budget</div>
+                {budget.map((b, i) => (
+                  <div className="row" key={`pb-${i}`}>
+                    <span>{b.label}</span>
+                    <span className="val">
+                      {((b.watts / pin) * 100).toFixed(1)}%
+                    </span>
+                  </div>
+                ))}
+                <div className="row" key="pb-ant">
+                  <span>antenna (accepted)</span>
+                  <span className="val">
+                    {(((pin - diss) / pin) * 100).toFixed(1)}%
+                  </span>
+                </div>
+              </div>
+            )}
+            {normCheckEnabled && (
+              <div
+                className="row"
+                title="P_radiated / P_input from the dwell-triggered pattern integral (the norm check as a percentage): what actually leaves as far-field radiation after network, wire AND real ground absorption. Fills in once the knobs settle; over PEC ground or free space it collapses onto the structural efficiency. See the 'three ledgers' section of the docs."
+              >
+                <span>radiated (incl. ground)</span>
+                <span className={normCheck ? "val" : "val val-pending"}>
+                  {normCheck
+                    ? `${(normCheck.radiated_fraction * 100).toFixed(0)}%`
+                    : "—"}
                 </span>
               </div>
-            ))}
-            <div className="row" key="pb-ant">
-              <span>antenna (radiated)</span>
-              <span className="val">
-                {(((pin - diss) / pin) * 100).toFixed(1)}%
-              </span>
-            </div>
+            )}
           </div>
         );
       })()}

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1579,6 +1579,9 @@ input[type=checkbox] {
 .readout .row {
   display: flex;
   justify-content: space-between;
+  /* Long label + value (e.g. "radiated (incl. ground)" at 100%) must
+     never fuse into one token when they fill the row. */
+  gap: var(--space-2);
 }
 
 .readout .row > span:first-child {

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1594,6 +1594,13 @@ input[type=checkbox] {
   font-weight: 600;
 }
 
+/* Dwell-derived values (the radiated-fraction ledger) while a knob is
+   moving: the number is stale the moment anything changes, so it greys
+   to an em-dash until the norm check lands. */
+.readout .val-pending {
+  color: var(--muted);
+}
+
 .feeds-table {
   margin-top: var(--space-3);
   padding-top: var(--space-3);

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -949,7 +949,17 @@ def _norm_check(req: dict) -> dict:
     Reuses the settled solve (a cache hit on the dwell request, so no re-solve
     on the common path). Falls back to the fine-grid quadrature when the
     response carries a finite (non-PEC-sentinel) ground — the image identity
-    behind the closed form is exact only for a perfect reflector."""
+    behind the closed form is exact only for a perfect reflector.
+
+    Also derives `radiated_fraction` = P_radiated/P_input, the honest third
+    efficiency ledger (`far_field.radiated_fraction`, issue #339). No extra
+    integral: gain-per-input-watt averaged over the sphere is exactly
+    efficiency · directivity_norm / pattern_norm — the norm-check ratio with
+    the structural efficiency folded back out of the field-side norm. Over a
+    finite ground the shortfall from 1.0 is structural loss plus real ground
+    absorption; over PEC/free space it collapses to ~structural efficiency
+    (times the solver's self-consistency gap, <0.05 dB on converged designs).
+    """
     out = solve(dict(req))
     if "directivity_norm" not in out or out["directivity_norm"] <= 0:
         return {"available": False}
@@ -977,11 +987,18 @@ def _norm_check(req: dict) -> dict:
         _compute_directivity_norm(ref, n_theta=n_theta, n_phi=n_phi)
         pattern_norm = ref["directivity_norm"]
         method = f"grid_{n_theta}x{n_phi}"
+    efficiency = float(out.get("radiation_efficiency", 1.0))
     return {
         "available": pattern_norm > 0,
         "directivity_norm": out["directivity_norm"],
         "pattern_norm": pattern_norm,
         "method": method,
+        "radiation_efficiency": efficiency,
+        "radiated_fraction": (
+            efficiency * out["directivity_norm"] / pattern_norm
+            if pattern_norm > 0
+            else 0.0
+        ),
     }
 
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -618,9 +618,7 @@ def test_norm_check_radiated_fraction_matches_far_field_ledger(
         mod.Builder(params=params), ground=("finite", 10.0, 0.002), ground_z=0.0
     )
     ff = eng.far_field(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
-    assert resp["radiated_fraction"] == pytest.approx(
-        radiated_fraction(ff), abs=0.01
-    )
+    assert resp["radiated_fraction"] == pytest.approx(radiated_fraction(ff), abs=0.01)
 
 
 def test_norm_check_radiated_fraction_pec_and_free_space(client: TestClient):

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -557,6 +557,92 @@ def test_norm_check_finite_ground_uses_grid_method(client: TestClient):
     assert resp["available"] is True
     assert resp["method"].startswith("grid_")
     assert resp["pattern_norm"] > 0
+    # The derived third-ledger number (issue #339) ships alongside, and is
+    # exactly the norm-check ratio with the structural efficiency folded
+    # back out of the field-side norm.
+    assert resp["radiated_fraction"] == pytest.approx(
+        resp["radiation_efficiency"] * resp["directivity_norm"] / resp["pattern_norm"]
+    )
+
+
+@pytest.mark.parametrize(
+    "geometry, req_extra, params_extra, lo, hi",
+    [
+        # KJ6ER's POTA PERformer on 15M: ground absorption dominates —
+        # ~30% radiated while >90% efficient structurally (the ledger
+        # split advanced/pota-performer.md narrates).
+        ("verticals.pota_performer", {}, {}, 0.22, 0.40),
+        # A 7 m invvee on 20 m: higher in wavelengths, ~70% radiated.
+        (
+            "dipoles.invvee",
+            {"measurement_freq_mhz": 14.1, "design_freq_mhz": 14.1},
+            {"design_freq": 14.1, "freq": 14.1},
+            0.60,
+            0.85,
+        ),
+    ],
+)
+def test_norm_check_radiated_fraction_matches_far_field_ledger(
+    client: TestClient, geometry, req_extra, params_extra, lo, hi
+):
+    """/norm_check's derived `radiated_fraction` (issue #339) agrees with the
+    independent `far_field.radiated_fraction` trapezoid integral — the same
+    solve run through MomwireEngine directly, over the web's Sommerfeld
+    average ground — within a point on the calibration pair from the
+    three-ledgers docs. The endpoint derives the number from the norm ratio
+    (no angular grid of its own), so this pins the whole identity chain:
+    gain-per-input-watt averaged over the sphere IS efficiency·dn/pn."""
+    import importlib
+
+    from antennaknobs import radiated_fraction
+    from antennaknobs.engines import MomwireEngine
+
+    server._SOLVE_CACHE.clear()
+    req = {
+        "geometry": geometry,
+        "measurement_freq_mhz": 21.35,
+        "design_freq_mhz": 21.35,
+        "momwire_model": "bspline",
+        "ground": True,
+        "ground_model": "sommerfeld",
+        **req_extra,
+    }
+    resp = client.post("/norm_check", json=req).json()
+    assert resp["available"] is True
+    assert lo < resp["radiated_fraction"] < hi
+
+    mod = importlib.import_module(f"antennaknobs.designs.{geometry}")
+    params = dict(mod.Builder.default_params)
+    params.update(params_extra)
+    eng = MomwireEngine(
+        mod.Builder(params=params), ground=("finite", 10.0, 0.002), ground_z=0.0
+    )
+    ff = eng.far_field(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
+    assert resp["radiated_fraction"] == pytest.approx(
+        radiated_fraction(ff), abs=0.01
+    )
+
+
+def test_norm_check_radiated_fraction_pec_and_free_space(client: TestClient):
+    """Where there is no ground absorption the third ledger collapses onto
+    the structural one: a lossless invvee reads ~100% radiated over PEC
+    (closed form — no integration clipping) and in free space, within the
+    solver's self-consistency gap."""
+    server._SOLVE_CACHE.clear()
+    base = {
+        "geometry": "dipoles.invvee",
+        "measurement_freq_mhz": 28.47,
+        "design_freq_mhz": 28.47,
+        "momwire_model": "bspline",
+    }
+    for ground in (
+        {"ground": True, "ground_model": "pec"},
+        {"ground": False},
+    ):
+        resp = client.post("/norm_check", json={**base, **ground}).json()
+        assert resp["available"] is True
+        assert resp["method"] == "closed_form"
+        assert resp["radiated_fraction"] == pytest.approx(1.0, abs=0.02)
 
 
 def test_directivity_norm_gl_beats_uniform_at_coarse_grid():


### PR DESCRIPTION
## Summary
- `/norm_check` now derives **`radiated_fraction`** — the honest third efficiency ledger (P_radiated/P_input including far-field ground absorption). No new integral and zero cost on the live drag path: over lossy ground the norm-check ratio with structural efficiency folded back out IS the radiated fraction (`efficiency × directivity_norm / pattern_norm`), so the dwell-triggered check ships it for free.
- The solve readout's power budget gains a dwell-filled **radiated (incl. ground)** row: greys to — the moment any knob moves, fills once settled. The old remainder row is renamed **antenna (accepted)** — it is the structural ledger, and calling it "radiated" was off by ~2× over real ground (the CLI's budget printout gets the same rename).
- The far-field overlay readout consolidates with it: over finite ground the norm gap is physics, so it now reads **radiated NN%** (raw Δ dB kept in the tooltip); free space/PEC keeps the **Δ dB** form, where it is a pure solver diagnostic.
- Docs: web.md power-budget + norm-check sections rewritten around the split; the POTA PERformer three-ledgers page points at the live readout.

Calibration (Sommerfeld average ground, pinned by tests against the independent `far_field.radiated_fraction` trapezoid integral within a point): `verticals.pota_performer` **28.4%** radiated at 98.5% structural; 7 m `dipoles.invvee` on 20 m **68.9%**. Over PEC/free space the number collapses onto the structural efficiency (~100% for lossless designs, closed form — no integration clipping).

Verified live in the workbench: row fills to 67% on the default invvee (10 m band, refl-coef ground), greys on ground-model change, reads 100% + Δ +0.005 dB over PEC.

Closes #339

## Test plan
- [x] `test_norm_check_radiated_fraction_matches_far_field_ledger` — endpoint vs independent integral on the calibration pair
- [x] `test_norm_check_radiated_fraction_pec_and_free_space` — collapses to ~100% where nothing absorbs
- [x] Full `tests/test_web_server.py` (132) + power-budget test files pass; `tsc --noEmit` + vite build clean
- [x] Live browser check: fill-after-dwell, clear-on-change, PEC/finite display forms

🤖 Generated with [Claude Code](https://claude.com/claude-code)