### PR TITLE
Release v0.25.0 (three ledgers of efficiency)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.24.0"
+version = "0.25.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,21 +25,23 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.24.0" icon="star">
-  **The POTA antenna, complete.** The new
-  [`wire.efhw_sloper`](/advanced/efhw/) showcase models the classic
-  end-fed half-wave with nothing idealized: a real **49:1 unun** (ratio
-  dropdown, magnetizing branch with core loss, compensation cap), a
-  **counterpoise that actually matters**, real coax, and real thin wire
-  — and the power budget answers the eternal question *where do the
-  watts go in a 49:1?* (Spoiler: the 28 AWG wire burns six times what
-  the ferrite does.) Under the hood, **every solver now carries the
-  real-wire model**: the sinusoidal (NEC-parity) basis models
-  skin-effect loss and insulation via NEC's own loading scheme
-  (momwire 0.11.0), and the NEC engine gains the insulated-wire
-  velocity factor as a distributed `LD 2` card — the two engines agree
-  on a PVC dipole's resonance shift to ~1 %, with nothing dropped on
-  either side.
+<Card title="New in v0.25.0" icon="star">
+  **Three ledgers of efficiency.** Three new showcase verticals
+  independently duplicate the published claims for KJ6ER's POTA
+  antennas — [`verticals.pota_performer`, `challenger`, and
+  `dominator`](/advanced/pota-performer/) — and the modeling arrives
+  with an honest accounting: "over 90% efficient" and "~30% radiated"
+  are **both true, in different ledgers**, and the difference is the
+  ground absorption nobody's efficiency figure counts. The new
+  `far_field.radiated_fraction` helper reads the third ledger off any
+  pattern, and the workbench now shows it **live**: a dwell-filled
+  **radiated (incl. ground)** row in the
+  [solve readout](/reference/web/#power-budget), derived from the
+  norm check at zero cost to knob dragging. Also new: the CLI draws
+  its **own Smith chart** (scikit-rf dependency dropped), every chart
+  gets a version brand and a style pass, `sweep --swr` plots SWR
+  against *any* knob, and the EFHW sloper gains a
+  [40 m NVIS variant](/advanced/efhw/).
   [All release notes →](/reference/releases/)
 </Card>
 

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -39,6 +39,25 @@ Useful `pattern` flags: `--fn out.png` (write to a file instead of the screen),
 `--ground free|pec|finite|finite:<eps_r>,<sigma>`, `--wireframe`, and
 `--elevation_angle`.
 
+## Sweeps
+
+`sweep` plots impedance against measurement frequency by default; `--param
+<knob>` sweeps any named knob instead. Add `--swr` to plot the curve as SWR
+(against a 50 Ω reference by default, `--z0` to change it):
+
+```bash
+# SWR across the band
+python -m antennaknobs sweep --builder dipoles.invvee --swr
+# how SWR responds to the droop angle, at a fixed frequency
+python -m antennaknobs sweep --builder dipoles.invvee --swr --param angle_deg
+```
+
+Frequency sweeps use the vectorized impedance sweep (one geometry, many
+frequencies), so they are much faster than scripting one solve per point.
+Note that knob sweeps in **free space** can be perfectly flat by design —
+translation-invariant knobs like a height `base` only matter over a ground
+(`--ground finite`).
+
 ## Choosing an engine
 
 The `--engine` flag selects the solver:


### PR DESCRIPTION
## Summary
- Bump version to **0.25.0**
- Refresh the front-page what's-new card: KJ6ER trio showcases + three-ledgers narrative, `far_field.radiated_fraction` + the dwell-filled **radiated (incl. ground)** HUD row (#340), in-house Smith chart with the scikit-rf dependency dropped, `sweep --swr` on any knob, EFHW 40 m NVIS variant
- De-stale sweep of `site/`: no stale pages found (the #340 docs commit already covered web.md); added the missing **Sweeps** section to `cli.md` for the new `--swr`/`--param`/`--z0` flags
- No momwire pin change (0.11.0 adopted in v0.24.0; pyproject/Dockerfile/submodule verified consistent)

Since v0.24.0: PRs #336, #337, #338, #340 + the three-ledgers sidebar commit.

## Test plan
- [x] `cd site && npm run build` passes (19 pages)
- [x] CI green on the PR before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)