### PR TITLE
Make builtin design files copy-portable to the user dir via absolute imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,9 +112,25 @@ extend-exclude = ["momwire"]
 
 [tool.ruff.lint]
 ignore = ["E741"]
+# TID252 bans relative imports, scoped (via the negated per-file-ignore
+# below) to the design files only. Designs are user-facing exemplars: any
+# builtin must keep working verbatim when copied to ~/.antennaknobs/designs/,
+# where it is loaded by file path with no package context, so relative
+# imports break on the first line. Core modules keep the usual
+# relative-intra-package style.
+extend-select = ["TID252"]
 # Keep "imported but unused" as a warning instead of auto-stripping.
 # Without this, multi-pass edits (add imports first, then add code that
 # uses them) can have the import deleted between edits — by the editor's
 # format-on-save, the project's auto-fix hook, or a pre-commit run —
 # producing a broken next edit. Manual cleanup of unused imports is fine.
 unfixable = ["F401"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+# "all" also bans single-dot imports: a copied design must not assume it has
+# sibling modules (the user dir has none).
+ban-relative-imports = "all"
+
+[tool.ruff.lint.per-file-ignores]
+# Relative imports are banned only under designs/ (see extend-select above).
+"!src/antennaknobs/designs/**" = ["TID252"]

--- a/src/antennaknobs/designs/arrays/bowtiearray.py
+++ b/src/antennaknobs/designs/arrays/bowtiearray.py
@@ -1,7 +1,7 @@
 """2x2 phased stack of bowtie dipoles."""
 
-from ... import Array2x2Builder
-from ..specialty import bowtie
+from antennaknobs import Array2x2Builder
+from antennaknobs.designs.specialty import bowtie
 
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/arrays/bowtiearray1x2.py
+++ b/src/antennaknobs/designs/arrays/bowtiearray1x2.py
@@ -1,7 +1,7 @@
 """Side-by-side bowtie pair (1x2)."""
 
-from ...builder import Array1x2Builder
-from ..specialty import bowtie
+from antennaknobs.builder import Array1x2Builder
+from antennaknobs.designs.specialty import bowtie
 
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/arrays/bowtiearray2x4.py
+++ b/src/antennaknobs/designs/arrays/bowtiearray2x4.py
@@ -1,7 +1,7 @@
 """2x4 phased bowtie curtain — the catalog's largest stack."""
 
-from ... import Array2x4Builder
-from ..specialty import bowtie
+from antennaknobs import Array2x4Builder
+from antennaknobs.designs.specialty import bowtie
 
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/arrays/delta_looparray.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray.py
@@ -1,7 +1,7 @@
 """Side-by-side delta-loop pair (1x2)."""
 
-from ...builder import Array1x2Builder
-from ..loops import delta_loop
+from antennaknobs.builder import Array1x2Builder
+from antennaknobs.designs.loops import delta_loop
 
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/arrays/delta_looparray_1x4.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray_1x4.py
@@ -1,7 +1,7 @@
 """Four delta loops in a broadside row (1x4)."""
 
-from ...builder import Array1x4Builder
-from ..loops import delta_loop
+from antennaknobs.builder import Array1x4Builder
+from antennaknobs.designs.loops import delta_loop
 
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/arrays/delta_looparray_1x4_grouped.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray_1x4_grouped.py
@@ -1,7 +1,7 @@
 """1x4 delta-loop row with per-group knobs (inner/outer pairs tuned separately)."""
 
-from ...builder import Array1x4GroupedBuilder
-from ..loops import delta_loop
+from antennaknobs.builder import Array1x4GroupedBuilder
+from antennaknobs.designs.loops import delta_loop
 
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/arrays/delta_looparray_2x2.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray_2x2.py
@@ -1,7 +1,7 @@
 """2x2 phased stack of delta loops."""
 
-from ...builder import Array2x2Builder
-from ..loops import delta_loop
+from antennaknobs.builder import Array2x2Builder
+from antennaknobs.designs.loops import delta_loop
 
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/arrays/delta_looparray_network.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray_network.py
@@ -14,8 +14,8 @@ MomwireEngine produces the same impedance as `delta_looparray_with_tls` to
 numerical precision; the showcase for the network-spec API in #65.
 """
 
-from ... import AntennaBuilder, Transform, TransformStack
-from ...network import Driven, Network, PortOnWire, PortVirtual, TL
+from antennaknobs import AntennaBuilder, Transform, TransformStack
+from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL
 
 import math
 from types import MappingProxyType

--- a/src/antennaknobs/designs/arrays/delta_looparray_with_tls.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray_with_tls.py
@@ -1,9 +1,9 @@
 """Delta-loop pair phased through explicit transmission lines (legacy build_tls path)."""
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 import math
 
-from ... import Transform, TransformStack
+from antennaknobs import Transform, TransformStack
 
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/arrays/folded_invveearray.py
+++ b/src/antennaknobs/designs/arrays/folded_invveearray.py
@@ -1,7 +1,7 @@
 """2x2 phased stack of folded inverted-vees."""
 
-from ... import Array2x2Builder
-from ..dipoles import folded_invvee
+from antennaknobs import Array2x2Builder
+from antennaknobs.designs.dipoles import folded_invvee
 
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/arrays/hentenna_array.py
+++ b/src/antennaknobs/designs/arrays/hentenna_array.py
@@ -1,7 +1,7 @@
 """Side-by-side hentenna pair (1x2)."""
 
-from ...builder import Array1x2Builder
-from ..specialty import hentenna
+from antennaknobs.builder import Array1x2Builder
+from antennaknobs.designs.specialty import hentenna
 
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/arrays/hourglass_array.py
+++ b/src/antennaknobs/designs/arrays/hourglass_array.py
@@ -1,7 +1,7 @@
 """Side-by-side hourglass pair (1x2)."""
 
-from ...builder import Array1x2Builder
-from ..specialty import hourglass
+from antennaknobs.builder import Array1x2Builder
+from antennaknobs.designs.specialty import hourglass
 
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/arrays/invveearray.py
+++ b/src/antennaknobs/designs/arrays/invveearray.py
@@ -1,7 +1,7 @@
 """2x2 phased stack of inverted-vee dipoles."""
 
-from ... import Array2x2Builder
-from ..dipoles import invvee
+from antennaknobs import Array2x2Builder
+from antennaknobs.designs.dipoles import invvee
 
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/arrays/lumped_coupled_pair.py
+++ b/src/antennaknobs/designs/arrays/lumped_coupled_pair.py
@@ -21,8 +21,8 @@ opens the branch and recovers the isolated driven dipole (the base case the
 cross-check pins first).
 """
 
-from ... import AntennaBuilder
-from ...network import Driven, Network, PortOnWire, TwoPort
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import Driven, Network, PortOnWire, TwoPort
 
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/arrays/moxonarray.py
+++ b/src/antennaknobs/designs/arrays/moxonarray.py
@@ -1,7 +1,7 @@
 """2x2 phased stack of Moxon rectangles."""
 
-from ... import Array2x2Builder
-from ..beams import moxon
+from antennaknobs import Array2x2Builder
+from antennaknobs.designs.beams import moxon
 
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/arrays/yagiarray.py
+++ b/src/antennaknobs/designs/arrays/yagiarray.py
@@ -1,7 +1,7 @@
 """2x2 phased stack of Yagi beams."""
 
-from ... import Array2x2Builder
-from ..beams import yagi
+from antennaknobs import Array2x2Builder
+from antennaknobs.designs.beams import yagi
 
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/beams/hb9cv.py
+++ b/src/antennaknobs/designs/beams/hb9cv.py
@@ -33,8 +33,8 @@ multi-variable optimisation (or real, near-field-coupled feedline conductors
 in place of the ideal line). Treat F/B as "real but shallow" in this model.
 """
 
-from ... import AntennaBuilder
-from ...network import Driven, Network, PortOnWire, TL
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import Driven, Network, PortOnWire, TL
 from types import MappingProxyType
 
 

--- a/src/antennaknobs/designs/beams/hexbeam.py
+++ b/src/antennaknobs/designs/beams/hexbeam.py
@@ -1,6 +1,6 @@
 """Hex beam — a W-folded 2-element beam on a hexagonal spreader footprint."""
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 import math
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/beams/moxon.py
+++ b/src/antennaknobs/designs/beams/moxon.py
@@ -1,6 +1,6 @@
 """Moxon rectangle — a 2-element beam with folded-back element tips."""
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 from types import MappingProxyType
 
 

--- a/src/antennaknobs/designs/beams/yagi.py
+++ b/src/antennaknobs/designs/beams/yagi.py
@@ -1,6 +1,6 @@
 """Yagi-Uda parasitic beam (driven element + reflector + directors)."""
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 import math
 
 from types import MappingProxyType

--- a/src/antennaknobs/designs/broadband/discone.py
+++ b/src/antennaknobs/designs/broadband/discone.py
@@ -30,7 +30,7 @@ Geometry, in the framework's (x, y, z) convention:
         cone:         o  o  o         (downward radial cage)     z < base
 """
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 import math
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/broadband/g5rv.py
+++ b/src/antennaknobs/designs/broadband/g5rv.py
@@ -34,8 +34,8 @@ The matching line is an electrical element (a network branch), not geometry.
                           S                       S = shack feed (virtual port)
 """
 
-from ... import AntennaBuilder
-from ...network import Driven, Network, PortOnWire, PortVirtual, TL
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL
 from types import MappingProxyType
 
 

--- a/src/antennaknobs/designs/broadband/lpda.py
+++ b/src/antennaknobs/designs/broadband/lpda.py
@@ -44,8 +44,8 @@ Horizontally polarised.
    back (low freq)                              front (high freq), beam --> +x
 """
 
-from ... import AntennaBuilder
-from ...network import Driven, Network, PortOnWire, TL
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import Driven, Network, PortOnWire, TL
 from types import MappingProxyType
 
 

--- a/src/antennaknobs/designs/broadband/t2fd.py
+++ b/src/antennaknobs/designs/broadband/t2fd.py
@@ -29,8 +29,8 @@ far wire.
     short |========= F =======|================| short    <- near wire (feed)
 """
 
-from ... import AntennaBuilder
-from ...network import Driven, Load, Network, PortOnWire
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import Driven, Load, Network, PortOnWire
 import math
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/dipoles/dipole_turnstile.py
+++ b/src/antennaknobs/designs/dipoles/dipole_turnstile.py
@@ -1,6 +1,6 @@
 """Crossed dipoles fed in phase quadrature (turnstile)."""
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/dipoles/folded_invvee.py
+++ b/src/antennaknobs/designs/dipoles/folded_invvee.py
@@ -1,6 +1,6 @@
 """Folded inverted-vee — the folded dipole's impedance step-up, with drooped arms."""
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 import math
 
 from types import MappingProxyType

--- a/src/antennaknobs/designs/dipoles/folded_invvee_balun.py
+++ b/src/antennaknobs/designs/dipoles/folded_invvee_balun.py
@@ -19,8 +19,16 @@ it; the geometry knobs are the stock folded-invvee ones.
 
 from types import MappingProxyType
 
-from ...network import CABLES, TL, Driven, Network, PortOnWire, PortVirtual, Transformer
-from .folded_invvee import Builder as FoldedInvVee
+from antennaknobs.network import (
+    CABLES,
+    TL,
+    Driven,
+    Network,
+    PortOnWire,
+    PortVirtual,
+    Transformer,
+)
+from antennaknobs.designs.dipoles.folded_invvee import Builder as FoldedInvVee
 
 
 class Builder(FoldedInvVee):

--- a/src/antennaknobs/designs/dipoles/invvee.py
+++ b/src/antennaknobs/designs/dipoles/invvee.py
@@ -1,6 +1,6 @@
 """Inverted-vee dipole — the default quickstart example."""
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 import math
 
 from types import MappingProxyType

--- a/src/antennaknobs/designs/dipoles/invvee_coax_station.py
+++ b/src/antennaknobs/designs/dipoles/invvee_coax_station.py
@@ -27,8 +27,8 @@ lossy tuner).
 
 from types import MappingProxyType
 
-from ...network import CABLES, TL, Driven, Network, PortOnWire, PortVirtual
-from .invvee import Builder as InvVee
+from antennaknobs.network import CABLES, TL, Driven, Network, PortOnWire, PortVirtual
+from antennaknobs.designs.dipoles.invvee import Builder as InvVee
 
 
 class Builder(InvVee):

--- a/src/antennaknobs/designs/dipoles/koch_dipole.py
+++ b/src/antennaknobs/designs/dipoles/koch_dipole.py
@@ -30,7 +30,7 @@ Geometry, in the framework's (x, y, z) convention:
     ___/  \\__F __/  \\___       F = centre feed at y = 0
 """
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 import math
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/dipoles/ocf_dipole.py
+++ b/src/antennaknobs/designs/dipoles/ocf_dipole.py
@@ -24,7 +24,7 @@ Geometry, in the framework's (x, y, z) convention:
     |<-- ~1/3 -->|<------------- ~2/3 ------------->|
 """
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 from types import MappingProxyType
 
 

--- a/src/antennaknobs/designs/dipoles/pota_invvee.py
+++ b/src/antennaknobs/designs/dipoles/pota_invvee.py
@@ -32,8 +32,8 @@ issue #328) cards — engine-switching holds the story steady.
 
 from types import MappingProxyType
 
-from ...network import WIRES
-from .invvee import Builder as InvVee
+from antennaknobs.network import WIRES
+from antennaknobs.designs.dipoles.invvee import Builder as InvVee
 
 
 class Builder(InvVee):

--- a/src/antennaknobs/designs/dipoles/short_dipole_loaded.py
+++ b/src/antennaknobs/designs/dipoles/short_dipole_loaded.py
@@ -11,8 +11,8 @@ natural cross-engine cross-check for the Load branch.
 dipole at `design_freq` — recompute it if you change `length_factor`.
 """
 
-from ... import AntennaBuilder
-from ...network import Driven, Load, Network, PortOnWire
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import Driven, Load, Network, PortOnWire
 
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/loops/bisquare.py
+++ b/src/antennaknobs/designs/loops/bisquare.py
@@ -28,7 +28,7 @@ Geometry, in the framework's (x, y, z) convention:
                     F  bottom corner (fed)     z = base
 """
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 from types import MappingProxyType
 import math
 

--- a/src/antennaknobs/designs/loops/delta_loop.py
+++ b/src/antennaknobs/designs/loops/delta_loop.py
@@ -3,7 +3,7 @@
 import math
 from types import MappingProxyType
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 
 
 class Builder(AntennaBuilder):

--- a/src/antennaknobs/designs/loops/delta_loop_flyby.py
+++ b/src/antennaknobs/designs/loops/delta_loop_flyby.py
@@ -29,7 +29,7 @@ top edge seats at ``base`` — the feed trailing below, its height emergent.
 import math
 from types import MappingProxyType
 
-from ... import AntennaBuilder, Drone
+from antennaknobs import AntennaBuilder, Drone
 
 
 class Builder(AntennaBuilder):

--- a/src/antennaknobs/designs/loops/delta_loop_reflected.py
+++ b/src/antennaknobs/designs/loops/delta_loop_reflected.py
@@ -33,7 +33,7 @@ every ``z`` so the top edge seats at ``base``, the feed trailing below.
 import math
 from types import MappingProxyType
 
-from ... import AntennaBuilder, Drone
+from antennaknobs import AntennaBuilder, Drone
 
 
 class Builder(AntennaBuilder):

--- a/src/antennaknobs/designs/loops/delta_loop_slanted.py
+++ b/src/antennaknobs/designs/loops/delta_loop_slanted.py
@@ -1,9 +1,9 @@
 """Delta loop tilted out of the vertical plane by a slant_deg knob."""
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 import math
 
-from ... import Transform, TransformStack
+from antennaknobs import Transform, TransformStack
 
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/loops/delta_loop_topdown.py
+++ b/src/antennaknobs/designs/loops/delta_loop_topdown.py
@@ -26,7 +26,7 @@ perimeter; ``ry`` mirrors the right half across ``y = 0`` for the left, and
 import math
 from types import MappingProxyType
 
-from ... import AntennaBuilder, Drone
+from antennaknobs import AntennaBuilder, Drone
 
 
 class Builder(AntennaBuilder):

--- a/src/antennaknobs/designs/loops/diamond_loop.py
+++ b/src/antennaknobs/designs/loops/diamond_loop.py
@@ -1,6 +1,6 @@
 """Full-wave diamond (square) loop fed at the bottom corner."""
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 import math
 
 from types import MappingProxyType

--- a/src/antennaknobs/designs/loops/diamond_loop_turnstile.py
+++ b/src/antennaknobs/designs/loops/diamond_loop_turnstile.py
@@ -1,6 +1,6 @@
 """Two diamond loops crossed and fed in phase quadrature (turnstile)."""
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 import math
 
 from types import MappingProxyType

--- a/src/antennaknobs/designs/loops/horizontal_loop.py
+++ b/src/antennaknobs/designs/loops/horizontal_loop.py
@@ -32,7 +32,7 @@ Geometry, in the framework's (x, y, z) convention:
         x=-h        x=+h
 """
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 from types import MappingProxyType
 
 

--- a/src/antennaknobs/designs/loops/horizontal_loop_drone.py
+++ b/src/antennaknobs/designs/loops/horizontal_loop_drone.py
@@ -28,7 +28,7 @@ bisected by the A-C diagonal, which is a mirror plane of the square, so the feed
 
 from types import MappingProxyType
 
-from ... import AntennaBuilder, Drone
+from antennaknobs import AntennaBuilder, Drone
 
 
 class Builder(AntennaBuilder):

--- a/src/antennaknobs/designs/loops/inv_delta_loop.py
+++ b/src/antennaknobs/designs/loops/inv_delta_loop.py
@@ -1,6 +1,6 @@
 """Inverted delta loop — the triangle flipped so the feed edge sits at the top."""
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 import math
 
 from types import MappingProxyType

--- a/src/antennaknobs/designs/loops/quad.py
+++ b/src/antennaknobs/designs/loops/quad.py
@@ -34,7 +34,7 @@ The loops lie in planes of constant x.
                           beam --> +x
 """
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 from types import MappingProxyType
 
 

--- a/src/antennaknobs/designs/loops/skyloop_lmatch.py
+++ b/src/antennaknobs/designs/loops/skyloop_lmatch.py
@@ -29,8 +29,15 @@ reducer computes exactly on top of the extracted antenna Y.
 
 from types import MappingProxyType
 
-from .triangular_skyloop import Builder as TriangularSkyloop
-from ...network import Driven, Network, PortOnWire, PortVirtual, Shunt, TwoPort
+from antennaknobs.designs.loops.triangular_skyloop import Builder as TriangularSkyloop
+from antennaknobs.network import (
+    Driven,
+    Network,
+    PortOnWire,
+    PortVirtual,
+    Shunt,
+    TwoPort,
+)
 
 
 class Builder(TriangularSkyloop):

--- a/src/antennaknobs/designs/loops/triangular_skyloop.py
+++ b/src/antennaknobs/designs/loops/triangular_skyloop.py
@@ -46,7 +46,7 @@ Geometry, in the framework's (x, y, z) convention:
 
 from types import MappingProxyType
 
-from ... import AntennaBuilder, Drone
+from antennaknobs import AntennaBuilder, Drone
 
 
 class Builder(AntennaBuilder):

--- a/src/antennaknobs/designs/multiband/fandipole.py
+++ b/src/antennaknobs/designs/multiband/fandipole.py
@@ -4,7 +4,7 @@ import logging
 import math
 from types import MappingProxyType
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 
 logger = logging.getLogger(__name__)
 

--- a/src/antennaknobs/designs/multiband/hexbeam_5band.py
+++ b/src/antennaknobs/designs/multiband/hexbeam_5band.py
@@ -22,7 +22,7 @@ Two feed modes are exposed via daisy_chain:
 import math
 from types import MappingProxyType
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 
 C_LIGHT_MHZ_M = 299.792458
 

--- a/src/antennaknobs/designs/multiband/trap_dipole.py
+++ b/src/antennaknobs/designs/multiband/trap_dipole.py
@@ -25,8 +25,8 @@ loaded full dipole comes near resonance at 14 MHz. Trap L and C can be
 tuned independently; defaults are LC-resonant at design_freq.
 """
 
-from ... import AntennaBuilder
-from ...network import Driven, Load, Network, PortOnWire
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import Driven, Load, Network, PortOnWire
 
 import math
 from types import MappingProxyType

--- a/src/antennaknobs/designs/multiband/trap_fan_dipole.py
+++ b/src/antennaknobs/designs/multiband/trap_fan_dipole.py
@@ -33,8 +33,8 @@ function carries the actual arm current and Load(parallel=True) acts
 exactly as NEC2's ld_card type-1 would.
 """
 
-from ... import AntennaBuilder
-from ...network import Driven, Load, Network, PortOnWire
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import Driven, Load, Network, PortOnWire
 
 import math
 from types import MappingProxyType

--- a/src/antennaknobs/designs/specialty/bowtie.py
+++ b/src/antennaknobs/designs/specialty/bowtie.py
@@ -1,6 +1,6 @@
 """Bowtie dipole — triangular fan arms for broadened bandwidth."""
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 import math
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/specialty/helix.py
+++ b/src/antennaknobs/designs/specialty/helix.py
@@ -37,7 +37,7 @@ Geometry, in the framework's (x, y, z) convention:
          F           base feed
 """
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 import math
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/specialty/hentenna.py
+++ b/src/antennaknobs/designs/specialty/hentenna.py
@@ -1,7 +1,7 @@
 """Hentenna — the Japanese rectangular loop, fed off-center for vertical polarization."""
 
-from ... import AntennaBuilder
-from ... import Transform, TransformStack
+from antennaknobs import AntennaBuilder
+from antennaknobs import Transform, TransformStack
 
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/specialty/hentenna_slant.py
+++ b/src/antennaknobs/designs/specialty/hentenna_slant.py
@@ -41,7 +41,7 @@ Wire layout (unchanged from the legacy implementation):
 import math
 from types import MappingProxyType
 
-from ... import AntennaBuilder, Transform, TransformStack
+from antennaknobs import AntennaBuilder, Transform, TransformStack
 
 
 class Builder(AntennaBuilder):

--- a/src/antennaknobs/designs/specialty/hourglass.py
+++ b/src/antennaknobs/designs/specialty/hourglass.py
@@ -1,7 +1,7 @@
 """Hourglass loop — a crossed (bowtie-folded) rectangular loop."""
 
-from ... import AntennaBuilder
-from ... import Transform, TransformStack
+from antennaknobs import AntennaBuilder
+from antennaknobs import Transform, TransformStack
 
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/specialty/hourglass_slant.py
+++ b/src/antennaknobs/designs/specialty/hourglass_slant.py
@@ -2,8 +2,8 @@
 
 import math
 
-from ... import AntennaBuilder
-from ... import Transform, TransformStack
+from antennaknobs import AntennaBuilder
+from antennaknobs import Transform, TransformStack
 
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/verticals/bobtail.py
+++ b/src/antennaknobs/designs/verticals/bobtail.py
@@ -43,7 +43,7 @@ The structure is planar in x = 0.
     A1         A2         A3     z = base   (outer ends open; A2 = open base)
 """
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 from types import MappingProxyType
 
 

--- a/src/antennaknobs/designs/verticals/bruce.py
+++ b/src/antennaknobs/designs/verticals/bruce.py
@@ -44,7 +44,7 @@ Geometry, in the framework's (x, y, z) convention:
    F  |__|      |__|      |       z = base        (bottom jogs); F = end feed
 """
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 import math
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/verticals/challenger.py
+++ b/src/antennaknobs/designs/verticals/challenger.py
@@ -32,8 +32,8 @@ ground" per the plans.
 import math
 from types import MappingProxyType
 
-from ... import AntennaBuilder
-from ...network import (
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import (
     Driven,
     Network,
     PortOnWire,

--- a/src/antennaknobs/designs/verticals/dominator.py
+++ b/src/antennaknobs/designs/verticals/dominator.py
@@ -27,8 +27,8 @@ gap-wire + counterpoise conditioning as wire.efhw_sloper.
 import math
 from types import MappingProxyType
 
-from ... import AntennaBuilder
-from ...network import (
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import (
     Driven,
     Network,
     PortOnWire,

--- a/src/antennaknobs/designs/verticals/four_square.py
+++ b/src/antennaknobs/designs/verticals/four_square.py
@@ -48,7 +48,7 @@ Geometry, in the framework's (x, y, z) convention:
            (back, reference)
 """
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 from types import MappingProxyType
 
 

--- a/src/antennaknobs/designs/verticals/half_square.py
+++ b/src/antennaknobs/designs/verticals/half_square.py
@@ -29,7 +29,7 @@ The structure is planar in x = 0.
     A               B     z = base          (open leg ends, voltage nulls)
 """
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 from types import MappingProxyType
 
 

--- a/src/antennaknobs/designs/verticals/inverted_l.py
+++ b/src/antennaknobs/designs/verticals/inverted_l.py
@@ -28,7 +28,7 @@ Geometry, in the framework's (x, y, z) convention:
                         \\    |    /     ____/
 """
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 import math
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/verticals/inverted_l_tmatch.py
+++ b/src/antennaknobs/designs/verticals/inverted_l_tmatch.py
@@ -39,8 +39,15 @@ source itself.
 
 from types import MappingProxyType
 
-from .inverted_l import Builder as InvertedL
-from ...network import Driven, Network, PortOnWire, PortVirtual, Shunt, TwoPort
+from antennaknobs.designs.verticals.inverted_l import Builder as InvertedL
+from antennaknobs.network import (
+    Driven,
+    Network,
+    PortOnWire,
+    PortVirtual,
+    Shunt,
+    TwoPort,
+)
 
 
 class Builder(InvertedL):

--- a/src/antennaknobs/designs/verticals/jpole.py
+++ b/src/antennaknobs/designs/verticals/jpole.py
@@ -27,7 +27,7 @@ Geometry, in the framework's (x, y, z) convention:
            |__|   <- bottom short                z = base
 """
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 from types import MappingProxyType
 
 

--- a/src/antennaknobs/designs/verticals/phased_verticals.py
+++ b/src/antennaknobs/designs/verticals/phased_verticals.py
@@ -34,7 +34,7 @@ Geometry, in the framework's (x, y, z) convention:
         |                   |       cardioid main lobe --> +x
 """
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 from types import MappingProxyType
 
 

--- a/src/antennaknobs/designs/verticals/pota_performer.py
+++ b/src/antennaknobs/designs/verticals/pota_performer.py
@@ -49,8 +49,8 @@ lands on the workbench's forward direction.
 import math
 from types import MappingProxyType
 
-from ... import AntennaBuilder
-from ...network import WireSpec
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import WireSpec
 
 _IN = 0.0254
 

--- a/src/antennaknobs/designs/verticals/raised_vertical.py
+++ b/src/antennaknobs/designs/verticals/raised_vertical.py
@@ -1,6 +1,6 @@
 """Elevated quarter-wave vertical, fed above ground."""
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 
 import math
 from types import MappingProxyType

--- a/src/antennaknobs/designs/verticals/vertical.py
+++ b/src/antennaknobs/designs/verticals/vertical.py
@@ -1,6 +1,6 @@
 """Quarter-wave vertical over ground."""
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 
 import math
 from types import MappingProxyType

--- a/src/antennaknobs/designs/wire/doublet_ladder_tuner.py
+++ b/src/antennaknobs/designs/wire/doublet_ladder_tuner.py
@@ -33,8 +33,16 @@ nearly flat, so the practical ceiling costs only tenths of a percent.
 
 from types import MappingProxyType
 
-from ...network import TL, Driven, Network, PortOnWire, PortVirtual, Shunt, TwoPort
-from ..dipoles.invvee import Builder as InvVee
+from antennaknobs.network import (
+    TL,
+    Driven,
+    Network,
+    PortOnWire,
+    PortVirtual,
+    Shunt,
+    TwoPort,
+)
+from antennaknobs.designs.dipoles.invvee import Builder as InvVee
 
 
 class Builder(InvVee):

--- a/src/antennaknobs/designs/wire/efhw_sloper.py
+++ b/src/antennaknobs/designs/wire/efhw_sloper.py
@@ -59,8 +59,8 @@ the radiator climbs toward −x precisely so the main lobe lands on **+x**
 
 from types import MappingProxyType
 
-from ... import AntennaBuilder, Drone
-from ...network import (
+from antennaknobs import AntennaBuilder, Drone
+from antennaknobs.network import (
     CABLES,
     Driven,
     Network,

--- a/src/antennaknobs/designs/wire/lazy_h.py
+++ b/src/antennaknobs/designs/wire/lazy_h.py
@@ -29,7 +29,7 @@ The structure is planar in x = 0.
                   (F = in-phase centre feed)
 """
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 from types import MappingProxyType
 
 

--- a/src/antennaknobs/designs/wire/longwire.py
+++ b/src/antennaknobs/designs/wire/longwire.py
@@ -31,7 +31,7 @@ The structure is a single straight conductor in x = 0, z = base.
   -L/2     centre     +L/2    F: one-segment driven gap at the current max
 """
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 from types import MappingProxyType
 
 

--- a/src/antennaknobs/designs/wire/rhombic.py
+++ b/src/antennaknobs/designs/wire/rhombic.py
@@ -31,8 +31,8 @@ polarised.
               (d, -w)
 """
 
-from ... import AntennaBuilder
-from ...network import Driven, Load, Network, PortOnWire
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import Driven, Load, Network, PortOnWire
 import math
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/wire/sterba.py
+++ b/src/antennaknobs/designs/wire/sterba.py
@@ -35,7 +35,7 @@ open-wire line to a tuner. With n_cells = 3 (~2 wl) this model gives, at
 gain falls off quickly below ~0.96 as the half-wave phasing breaks down.
 """
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 import math
 from types import MappingProxyType
 

--- a/src/antennaknobs/designs/wire/sterba_tl.py
+++ b/src/antennaknobs/designs/wire/sterba_tl.py
@@ -31,8 +31,8 @@ Note on the half-wave TL: this engine's nodal TL admittance
 exactly will raise in `network_reduce.tl_admittance_2x2`; keep lf away from 1.0.
 """
 
-from ... import AntennaBuilder
-from ...network import Driven, Network, PortOnWire, TL
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import Driven, Network, PortOnWire, TL
 from types import MappingProxyType
 
 

--- a/src/antennaknobs/designs/wire/vbeam.py
+++ b/src/antennaknobs/designs/wire/vbeam.py
@@ -30,7 +30,7 @@ Geometry, in the framework's (x, y, z) convention:
               o  (leg end, -y)        beam <--> +/- x (along the bisector)
 """
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 from types import MappingProxyType
 import math
 

--- a/src/antennaknobs/designs/wire/w8jk.py
+++ b/src/antennaknobs/designs/wire/w8jk.py
@@ -33,7 +33,7 @@ Geometry, in the framework's (x, y, z) convention:
                           beam <--> +/- x   (broadside null off +/- y)
 """
 
-from ... import AntennaBuilder
+from antennaknobs import AntennaBuilder
 from types import MappingProxyType
 
 

--- a/src/antennaknobs/designs/wire/zepp.py
+++ b/src/antennaknobs/designs/wire/zepp.py
@@ -42,8 +42,8 @@ The tuned feeder is an electrical element (a `TL` branch), not geometry.
     S                                              S = shack feed (virtual port)
 """
 
-from ... import AntennaBuilder
-from ...network import Driven, Network, PortOnWire, PortVirtual, TL
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL
 from types import MappingProxyType
 
 

--- a/src/antennaknobs/web/user_design_assets/CLAUDE.md
+++ b/src/antennaknobs/web/user_design_assets/CLAUDE.md
@@ -18,11 +18,16 @@ A design file must:
    no dots except the `.py` extension, one antenna per file.
 2. **Define a class named exactly `Builder`** that subclasses `AntennaBuilder`.
 3. **Import only** from `antennaknobs` and the Python standard library.
-   Do **not** import other design files — keep each one self-contained.
+   Do **not** import other files in this folder — keep each one
+   self-contained. (Importing an installed built-in as a base class is fine,
+   e.g. `from antennaknobs.designs.dipoles.invvee import Builder as InvVee`.)
 4. Provide a **`default_params`** mapping (use `MappingProxyType(...)`) and a
    **`build_wires(self)`** method.
 
 Start from `TEMPLATE.py` in this folder — copy it, rename it, edit it.
+Every built-in design follows this same contract, so copying a file out of
+the installed package's `antennaknobs/designs/` folders into this one also
+works verbatim as a starting point.
 
 The same file also works from the command line: once `my_dipole.py` is in
 this folder, run e.g. `antennaknobs draw --builder user.my_dipole` (or

--- a/src/antennaknobs/web/user_design_assets/TEMPLATE.py
+++ b/src/antennaknobs/web/user_design_assets/TEMPLATE.py
@@ -23,7 +23,10 @@ THE RULES (keep it this simple)
   (lowercase_with_underscores.py, no spaces, no dots except ``.py``).
 - Define a class named exactly ``Builder`` that subclasses ``AntennaBuilder``.
 - Stay self-contained: only import from ``antennaknobs`` and the Python
-  standard library. Don't import other antenna files.
+  standard library. Don't import other files in this folder.
+- Every built-in design follows these same rules, so any file from the
+  installed package's ``antennaknobs/designs/`` folders also works here
+  verbatim — copying one in is a great way to start a variation.
 """
 
 from types import MappingProxyType

--- a/tests/test_user_designs.py
+++ b/tests/test_user_designs.py
@@ -4,6 +4,8 @@ See web/user_designs.py — local users drop a Builder file in their user dir
 and it registers under `user.<filename>` with no restart.
 """
 
+from pathlib import Path
+
 import pytest
 
 import antennaknobs.web.examples  # noqa: F401 — bootstraps the adapter + REGISTRY
@@ -127,6 +129,39 @@ def test_template_file_is_skipped(userdir):
     (userdir / "TEMPLATE.py").write_text(VALID)
     user_designs.refresh()
     assert "user.TEMPLATE" not in REGISTRY
+
+
+# --- builtin designs are copy-portable (issue #341) -----------------------
+#
+# The advertised authoring workflow is `cp` a builtin design into the user
+# dir and start editing. That only works if design files use absolute
+# imports (relative imports break under the path-based loader, which has no
+# package context). Representative sample: one plain design, one carrying a
+# Network, one deriving from another design.
+
+PORTABLE_BUILTINS = [
+    "dipoles/invvee.py",  # plain AntennaBuilder
+    "dipoles/short_dipole_loaded.py",  # has a Network (Driven + Load)
+    "dipoles/pota_invvee.py",  # derives from another design's Builder
+]
+
+
+@pytest.mark.parametrize("relpath", PORTABLE_BUILTINS)
+def test_builtin_design_copies_verbatim_to_user_dir(relpath, tmp_path, monkeypatch):
+    import shutil
+
+    from antennaknobs import AntennaBuilder
+    from antennaknobs import designs as builtin_designs
+    from antennaknobs import user_designs as core_user_designs
+
+    monkeypatch.setenv("ANTENNAKNOBS_USER_DIR", str(tmp_path))
+    src = Path(builtin_designs.__file__).parent / relpath
+    stem = f"my_{src.stem}"
+    shutil.copy(src, tmp_path / f"{stem}.py")
+
+    cls = core_user_designs.resolve_user_design(stem)
+    assert cls is not None and issubclass(cls, AntennaBuilder)
+    assert cls().build_wires()  # defaults produce geometry
 
 
 def test_scaffold_creates_assets(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Sweep all 80 builtin design files under `src/antennaknobs/designs/` from relative to absolute imports (`from antennaknobs import AntennaBuilder`, cross-design bases via `antennaknobs.designs.<family>.<name>`), so `cp` of any builtin into `~/.antennaknobs/designs/` yields a working `user.<name>` design with zero edits — the path-based loader has no package context, so relative imports died on the first line. Import lines only; behavior identical.
- Enforce the style mechanically: ruff `flake8-tidy-imports` TID252 (`ban-relative-imports = "all"`) scoped to `src/antennaknobs/designs/**` via a negated per-file-ignore. Core modules keep the repo's relative-intra-package convention.
- Regression test copies representative builtins (plain `invvee`, Network-carrying `short_dipole_loaded`, derived `pota_invvee`) into a temp `ANTENNAKNOBS_USER_DIR` and asserts `resolve_user_design` loads each verbatim and builds geometry.
- Authoring docs (`TEMPLATE.py`, user-dir `CLAUDE.md`) now advertise the copy-a-builtin workflow and sharpen the self-contained rule to "no imports of other files in this folder".

Closes #341

## Test plan
- [x] `pytest -m "not antenna_computation_check"` — 1585 passed
- [x] Design discovery still finds all 81 builtins after the sweep
- [x] `ruff check` + `ruff format --check` clean; verified TID252 fires on a reintroduced relative import in a design and stays silent on core modules
- [x] New portability tests pass (would fail on main: copied builtin raises `ImportError: attempted relative import beyond top-level package`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)