### PR TITLE
Security: close the hosted unauthenticated DoS cluster (#345–#348)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,5 +65,7 @@ EXPOSE 8000
 
 # One worker: solves are CPU-bound and run in a threadpool, so extra uvicorn
 # workers would only contend for the same cores. --host 0.0.0.0 to accept the
-# proxy's traffic inside the container.
-CMD ["sh", "-c", "uvicorn antennaknobs.web.server:app --host 0.0.0.0 --port ${PORT:-8000}"]
+# proxy's traffic inside the container. --ws-max-size caps a WebSocket frame
+# at 1 MiB (uvicorn's default is 16 MiB): /ws solve requests are a few KB, so
+# this bounds what an abusive client can make the reader json.loads per frame.
+CMD ["sh", "-c", "uvicorn antennaknobs.web.server:app --host 0.0.0.0 --port ${PORT:-8000} --ws-max-size 1048576"]

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -17,6 +17,11 @@ The `[web]` extra pulls in `uvicorn[standard]`, which provides the WebSocket
 support the live-solve channel (`/ws`) needs — plain `uvicorn` fails that
 handshake.
 
+A local instance has no login and none of the hosted instance's solve-size
+limits, and it runs any design files you've allowed with your user privileges —
+keep it on the default `127.0.0.1` bind rather than exposing it to a network
+you don't fully control.
+
 ## The hosted instance
 
 A hosted simulator is running at

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -245,6 +245,24 @@ def sanitize_model_options(req: dict) -> dict | None:
     return out or None
 
 
+def _positive_finite(name: str, value) -> float:
+    """Validate a client-supplied physics scalar: a number, finite, > 0.
+
+    Client JSON reaches the solvers unvalidated and stdlib json.loads accepts
+    NaN/Infinity literals, so this is the physics boundary's input check
+    (issue #347): a zero frequency divides C_LIGHT by zero, a zero wire
+    radius makes the MoM log-kernel singular, and non-finite values poison
+    the matrices with an opaque solver error.
+    """
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{name} must be a number (got {value!r})") from None
+    if not math.isfinite(v) or v <= 0.0:
+        raise ValueError(f"{name} must be a positive, finite number (got {value!r})")
+    return v
+
+
 # ---------------------------------------------------------------------------
 # Schema derivation
 # ---------------------------------------------------------------------------
@@ -595,6 +613,16 @@ def _build_builder(cls, req: dict):
             base[k] = _rehydrate_param(base[k], req[k])
         elif k in nested:
             base[k] = _rehydrate_param(base[k], nested[k])
+    # The defaults are all finite, so this only fires on a client-sent value —
+    # stdlib json accepts NaN/Infinity literals and a non-finite knob would
+    # otherwise surface as an opaque solver error (issue #347).
+    for k, v in base.items():
+        if isinstance(v, float) and not math.isfinite(v):
+            raise ValueError(f"parameter {k!r} must be finite (got {v!r})")
+        if isinstance(v, complex) and not (
+            math.isfinite(v.real) and math.isfinite(v.imag)
+        ):
+            raise ValueError(f"parameter {k!r} must be finite (got {v!r})")
     builder = cls(params=base)
     # n_per_wire drives the per-Builder nominal_nsegs (the convergence
     # sweep at /converge overrides this value per N). Each generator
@@ -602,7 +630,15 @@ def _build_builder(cls, req: dict):
     # fixed (feed gaps). See AntennaBuilder.FRAMEWORK_PARAMS.
     n_per_wire = req.get("n_per_wire")
     if n_per_wire is not None:
-        builder.nominal_nsegs = int(n_per_wire)
+        try:
+            n = int(n_per_wire)
+        except (TypeError, ValueError, OverflowError):
+            raise ValueError(
+                f"n_per_wire must be an integer (got {n_per_wire!r})"
+            ) from None
+        if n < 1:
+            raise ValueError(f"n_per_wire must be >= 1 (got {n})")
+        builder.nominal_nsegs = n
     return builder
 
 
@@ -696,7 +732,7 @@ def _make_momwire_engine(req: dict, builder, cancel=None):
     # names (a stale client may still send "triangular").
     model = req.get("momwire_model", "bspline")
     solver_cls = _MOMWIRE_MODELS.get(model, BSplineSolver)
-    wire_radius = float(req.get("wire_radius", 0.0005))
+    wire_radius = _positive_finite("wire_radius", req.get("wire_radius", 0.0005))
     ground = _ground_for_engine(req, 0.0)
     solver_kwargs = sanitize_model_options(req)
     if _SWEPT_MEM_MB is not None and issubclass(solver_cls, BSplineSolver):
@@ -1269,6 +1305,19 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         vp = _variant_params(cls, req.get("variant"))
         return float(vp.get("freq", 14.0))
 
+    def _req_freqs(req: dict) -> tuple[float, float]:
+        # One validated (design_freq, meas_freq) pair for every solve-forming
+        # closure below — the request values are client JSON and must be
+        # positive and finite before they reach a wavelength division or the
+        # MoM kernel (issue #347).
+        design_freq = _positive_finite(
+            "design_freq_mhz", req.get("design_freq_mhz", _design_freq_default(req))
+        )
+        meas_freq = _positive_finite(
+            "measurement_freq_mhz", req.get("measurement_freq_mhz", design_freq)
+        )
+        return design_freq, meas_freq
+
     def count_basis(req: dict):
         """Total wire segments (≈ MoM basis functions, the N×N matrix dim) the
         request would build. Geometry-only (cheap) — runs build_wires but no
@@ -1281,8 +1330,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             return None
 
     def momwire_solve(req: dict, cancel=None) -> dict:
-        design_freq = float(req.get("design_freq_mhz", _design_freq_default(req)))
-        meas_freq = float(req.get("measurement_freq_mhz", design_freq))
+        design_freq, meas_freq = _req_freqs(req)
         builder = _build_builder(cls, req)
         builder.freq = meas_freq
         # For design_freq-sized designs the geometry computes from
@@ -1385,8 +1433,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         # waiting tens of seconds for the MoM solve. Mirrors momwire_solve's
         # builder setup but returns zero currents and omits impedance / far
         # field (the live solve fills those in).
-        design_freq = float(req.get("design_freq_mhz", _design_freq_default(req)))
-        meas_freq = float(req.get("measurement_freq_mhz", design_freq))
+        design_freq, meas_freq = _req_freqs(req)
         builder = _build_builder(cls, req)
         builder.freq = meas_freq
         if has_design_freq:
@@ -1437,8 +1484,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         #   _engine      — keep the PyNECEngine alive so the
         #                  underlying nec_context isn't released
         #                  before rp_card runs
-        design_freq = float(req.get("design_freq_mhz", _design_freq_default(req)))
-        meas_freq = float(req.get("measurement_freq_mhz", design_freq))
+        design_freq, meas_freq = _req_freqs(req)
         builder = _build_builder(cls, req)
         builder.freq = meas_freq
         if has_design_freq:
@@ -1473,8 +1519,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         # shape is identical so the frontend renders the result the
         # same way; the `solver` field gets stamped to "pynec" by
         # server.solve()'s outer wrapper.
-        design_freq = float(req.get("design_freq_mhz", _design_freq_default(req)))
-        meas_freq = float(req.get("measurement_freq_mhz", design_freq))
+        design_freq, meas_freq = _req_freqs(req)
         builder = _build_builder(cls, req)
         builder.freq = meas_freq
         if has_design_freq:
@@ -1599,8 +1644,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         # the client-derived lobe on screen), then summarises the full grid.
         from antennaknobs.far_field import pattern_metrics
 
-        design_freq = float(req.get("design_freq_mhz", _design_freq_default(req)))
-        meas_freq = float(req.get("measurement_freq_mhz", design_freq))
+        design_freq, meas_freq = _req_freqs(req)
         builder = _build_builder(cls, req)
         builder.freq = meas_freq
         if has_design_freq:
@@ -1617,8 +1661,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         # downloaded deck matches the antenna the user is viewing.
         from antennaknobs.nec_export import export_nec as _export_nec
 
-        design_freq = float(req.get("design_freq_mhz", _design_freq_default(req)))
-        meas_freq = float(req.get("measurement_freq_mhz", design_freq))
+        design_freq, meas_freq = _req_freqs(req)
         builder = _build_builder(cls, req)
         builder.freq = meas_freq
         if has_design_freq:
@@ -1635,9 +1678,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         # design_freq so the sweep sees the same antenna the live
         # solve sees. See momwire_solve for the rationale.
         if has_design_freq:
-            builder.design_freq = float(
-                req.get("design_freq_mhz", _design_freq_default(req))
-            )
+            builder.design_freq = _req_freqs(req)[0]
         eng = _make_momwire_engine(req, builder)
         zs = np.asarray(eng.impedance_sweep(list(freqs_mhz)))
         # Open-circuited points sweep through as inf; clamp for JSON.

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -228,9 +228,7 @@ def sanitize_model_options(req: dict) -> dict | None:
     if raw is None:
         return None
     if not isinstance(raw, dict):
-        raise ValueError(
-            "model_options must be an object of solver keyword arguments"
-        )
+        raise ValueError("model_options must be an object of solver keyword arguments")
     if not _HOSTED:
         return dict(raw) or None
     out = {}

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -140,6 +140,112 @@ _MOMWIRE_MODELS = {
 
 
 # ---------------------------------------------------------------------------
+# model_options sanitisation (issue #346)
+# ---------------------------------------------------------------------------
+
+# Mirrors server.py's _HOSTED master switch: the whitelist below only applies
+# on the shared instance; a local install forwards model_options verbatim.
+_HOSTED = os.environ.get("ANTENNAKNOBS_HOSTED", "").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
+
+
+def _int_in(lo: int, hi: int):
+    def check(v):
+        if isinstance(v, bool) or not isinstance(v, (int, float)) or int(v) != v:
+            raise ValueError("must be an integer")
+        n = int(v)
+        if not lo <= n <= hi:
+            raise ValueError(f"must be in [{lo}, {hi}]")
+        return n
+
+    return check
+
+
+def _float_in(lo: float, hi: float, *, allow_none: bool = False):
+    def check(v):
+        if v is None and allow_none:
+            return None
+        if isinstance(v, bool) or not isinstance(v, (int, float)):
+            raise ValueError("must be a number")
+        f = float(v)
+        if not (math.isfinite(f) and lo <= f <= hi):
+            raise ValueError(f"must be a finite number in [{lo}, {hi}]")
+        return f
+
+    return check
+
+
+def _bool_opt(v):
+    if not isinstance(v, bool):
+        raise ValueError("must be a boolean")
+    return v
+
+
+def _enum_opt(*allowed: str):
+    def check(v):
+        if v not in allowed:
+            raise ValueError(f"must be one of {sorted(allowed)}")
+        return v
+
+    return check
+
+
+# The solver kwargs the frontend's gear menus actually send (App.tsx
+# modelOptionsForRequest), each with a sane range. When hosted, model_options
+# is filtered to THESE keys — anything else (ACA leaf sizes, GMRES/solve
+# tolerances, the server-owned swept_mem_mb, arbitrary constructor kwargs) is
+# dropped, so a hand-crafted request can't amplify per-solve CPU beyond what
+# the segment-count cap models.
+_HOSTED_MODEL_OPTIONS = {
+    "degree": _int_in(1, 2),
+    "n_qp_const": _int_in(1, 64),
+    "n_qp_pair": _int_in(1, 64),
+    "n_qp_source": _int_in(1, 64),
+    "n_qp_sing": _int_in(1, 128),
+    "feed_smoothing_factor": _float_in(0.0, 100.0, allow_none=True),
+    "use_singular_enrichment": _bool_opt,
+    "enrichment_variant": _enum_opt("raw", "stable", "tikhonov", "auto"),
+    "tikhonov_lambda": _float_in(0.0, 1e3),
+    "auto_tap_ratio_threshold": _float_in(0.0, 1.0),
+    "enrichment_min_k": _int_in(2, 64),
+}
+
+
+def sanitize_model_options(req: dict) -> dict | None:
+    """Validated solver kwargs from the request's ``model_options``.
+
+    Everywhere: a non-dict value raises a clean ValueError instead of a
+    TypeError deep inside a solver constructor. When hosted, additionally
+    filters to the whitelisted keys above (unknown keys are dropped, not
+    forwarded) and validates each value's type/range. Local instances keep
+    verbatim forwarding — solver experiments stay unlocked.
+    """
+    raw = req.get("model_options")
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError(
+            "model_options must be an object of solver keyword arguments"
+        )
+    if not _HOSTED:
+        return dict(raw) or None
+    out = {}
+    for k, v in raw.items():
+        check = _HOSTED_MODEL_OPTIONS.get(k)
+        if check is None:
+            continue
+        try:
+            out[k] = check(v)
+        except ValueError as e:
+            raise ValueError(f"model_options.{k} {e}") from None
+    return out or None
+
+
+# ---------------------------------------------------------------------------
 # Schema derivation
 # ---------------------------------------------------------------------------
 
@@ -592,7 +698,7 @@ def _make_momwire_engine(req: dict, builder, cancel=None):
     solver_cls = _MOMWIRE_MODELS.get(model, BSplineSolver)
     wire_radius = float(req.get("wire_radius", 0.0005))
     ground = _ground_for_engine(req, 0.0)
-    solver_kwargs = req.get("model_options") or None
+    solver_kwargs = sanitize_model_options(req)
     if _SWEPT_MEM_MB is not None and issubclass(solver_cls, BSplineSolver):
         # Deployment-owned memory policy (momwire >= 0.9): cap the batched
         # frequency sweep's transient memory per solve. Server-side value

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -597,6 +597,14 @@ _MAX_BASIS_COMPRESSED = _env_int("ANTENNAKNOBS_MAX_BASIS_COMPRESSED", 9000)
 _MAX_BASIS_PYNEC = _env_int("ANTENNAKNOBS_MAX_BASIS_PYNEC", 7000)
 _COMPRESSED_MODELS = frozenset({"arrayblock", "hmatrix"})
 
+# Hosted compute levers beyond the matrix cap (issue #346): a client-chosen
+# list length or eval budget multiplies whole solves, so even under-cap
+# requests can pin the single vCPU indefinitely. Both limits sit far above
+# what the UI ever sends (41-point sweeps, ≤200 optimizer evals) and are only
+# enforced when hosted; local instances stay unlocked.
+_MAX_SWEEP_POINTS = _env_int("ANTENNAKNOBS_MAX_SWEEP_POINTS", 500)
+_MAX_OPT_EVALS = _env_int("ANTENNAKNOBS_MAX_OPT_EVALS", 500)
+
 
 class SolveTooLargeError(ValueError):
     """A solve request exceeds the hosted live-engine segment-count cap."""
@@ -748,6 +756,23 @@ async def sweep_endpoint(req: dict, request: Request):
         _check_solve_size(req, use_pynec=use_pynec)
     except SolveTooLargeError as e:
         raise HTTPException(status_code=413, detail=str(e)) from e
+    if _HOSTED and len(freqs) > _MAX_SWEEP_POINTS:
+        raise HTTPException(
+            status_code=413,
+            detail=f"A sweep of {len(freqs)} points is over the live limit "
+            f"of {_MAX_SWEEP_POINTS}. Reduce the frequency count.",
+        )
+    # Validate the client's solver kwargs up front: this endpoint streams, so
+    # an error surfacing mid-generator can't become a clean status code.
+    # Imported here (like /optimize's optimizer import): adapter ↔ examples
+    # resolve their import cycle examples-first, so a module-level import
+    # of adapter from server would re-trip it.
+    from .adapter import sanitize_model_options
+
+    try:
+        sanitize_model_options(req)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
 
     async def gen():
         if not freqs:
@@ -889,6 +914,12 @@ async def converge_endpoint(req: dict, request: Request):
     n_values = [int(n) for n in req.get("n_values", [])]
     use_pynec = req.get("solver") == "pynec" and pynec_backend.HAVE_PYNEC
     solver_name = "pynec" if use_pynec else "momwire"
+    if _HOSTED and len(n_values) > _MAX_SWEEP_POINTS:
+        raise HTTPException(
+            status_code=413,
+            detail=f"A convergence sweep of {len(n_values)} points is over "
+            f"the live limit of {_MAX_SWEEP_POINTS}. Reduce the N count.",
+        )
 
     async def gen():
         for n in n_values:
@@ -1145,6 +1176,19 @@ async def optimize_endpoint(req: dict):
     objective = opt.get("objective", "swr")
     if objective not in OBJECTIVES:
         return {"error": f"unknown objective {objective!r}"}
+    max_evals = opt.get("max_evals")
+    if max_evals is not None:
+        try:
+            max_evals = int(max_evals)
+        except (TypeError, ValueError):
+            return {"error": f"max_evals must be an integer (got {max_evals!r})"}
+        if max_evals <= 0:
+            max_evals = None
+        elif _HOSTED:
+            # Hard ceiling regardless of the client value: every eval is a
+            # full MoM solve that skips the solve cache, so an unbounded
+            # budget is a sustained-CPU lever (issue #346).
+            max_evals = min(max_evals, _MAX_OPT_EVALS)
 
     geometry = req.get("geometry", next(iter(EXAMPLES)))
     ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
@@ -1163,7 +1207,7 @@ async def optimize_endpoint(req: dict):
             free,
             objective,
             solve_fn=ex.momwire_solve,
-            max_evals=opt.get("max_evals"),
+            max_evals=max_evals,
         )
     except Exception as exc:  # noqa: BLE001 — a user design's build_wires can raise
         return {"geometry": geometry, "error": user_designs.format_solve_error(exc)}

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -89,6 +89,7 @@ os.environ.setdefault("GOMP_SPINCOUNT", "0")
 import asyncio
 import hashlib
 import json
+import math
 import time
 from collections import OrderedDict
 from copy import deepcopy
@@ -744,7 +745,17 @@ async def sweep_endpoint(req: dict, request: Request):
     keeps grinding through all 41 expensive PyNEC ground solves, starving
     the live /ws solves of CPU.
     """
-    freqs = [float(f) for f in req.get("freqs_mhz", [])]
+    try:
+        freqs = [float(f) for f in req.get("freqs_mhz", [])]
+    except (TypeError, ValueError):
+        raise HTTPException(
+            status_code=422, detail="freqs_mhz must be a list of numbers"
+        ) from None
+    if any(not math.isfinite(f) or f <= 0.0 for f in freqs):
+        raise HTTPException(
+            status_code=422,
+            detail="freqs_mhz entries must be positive, finite numbers",
+        )
     geometry = req.get("geometry", next(iter(EXAMPLES)))
     sweep_ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
     use_pynec = req.get("solver") == "pynec" and pynec_backend.HAVE_PYNEC
@@ -911,7 +922,12 @@ async def converge_endpoint(req: dict, request: Request):
     Cancels on client disconnect (slider drag interrupts a stale sweep)
     using the same pattern as /sweep.
     """
-    n_values = [int(n) for n in req.get("n_values", [])]
+    try:
+        n_values = [int(n) for n in req.get("n_values", [])]
+    except (TypeError, ValueError, OverflowError):
+        raise HTTPException(
+            status_code=422, detail="n_values must be a list of integers"
+        ) from None
     use_pynec = req.get("solver") == "pynec" and pynec_backend.HAVE_PYNEC
     solver_name = "pynec" if use_pynec else "momwire"
     if _HOSTED and len(n_values) > _MAX_SWEEP_POINTS:
@@ -1070,7 +1086,9 @@ async def export_nec_endpoint(req: dict):
         )
     try:
         deck = await run_in_threadpool(ex.nec_export, req)
-    except NotImplementedError as e:
+    except (NotImplementedError, ValueError) as e:
+        # ValueError: request validation (bad freq / radius / n_per_wire) —
+        # a clean 422 rather than a 500 (issue #347).
         raise HTTPException(status_code=422, detail=str(e)) from e
     filename = f"{ex.name.replace('.', '_')}.nec"
     return Response(

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -741,6 +741,13 @@ async def sweep_endpoint(req: dict, request: Request):
     sweep_ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
     use_pynec = req.get("solver") == "pynec" and pynec_backend.HAVE_PYNEC
     solver_name = "pynec" if use_pynec else "momwire"
+    # Hosted size guard, same as the /ws and /converge paths: reject an
+    # over-cap matrix dimension BEFORE the stream starts, as a clean 413,
+    # instead of attempting the N×N allocation per sweep point.
+    try:
+        _check_solve_size(req, use_pynec=use_pynec)
+    except SolveTooLargeError as e:
+        raise HTTPException(status_code=413, detail=str(e)) from e
 
     async def gen():
         if not freqs:
@@ -932,6 +939,12 @@ async def pattern_endpoint(req: dict):
     """NEC's rp_card-computed gain pattern. PyNEC-only."""
     if req.get("solver") != "pynec" or not pynec_backend.HAVE_PYNEC:
         return {"available": False}
+    # rp_card needs a full NEC solve first, so the hosted matrix-size cap
+    # applies here exactly like the /ws solve path.
+    try:
+        _check_solve_size(req, use_pynec=True)
+    except SolveTooLargeError as e:
+        return {"available": False, "error": str(e)}
     return await run_in_threadpool(pynec_backend.pattern, req)
 
 
@@ -1070,6 +1083,12 @@ async def pattern_metrics_endpoint(req: dict):
     ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
     if ex.far_field_metrics is None:
         return {"available": False}
+    # far_field_metrics runs a full momwire solve; apply the hosted matrix-
+    # size cap here like every other solve-forming route.
+    try:
+        _check_solve_size(req, use_pynec=False)
+    except SolveTooLargeError as e:
+        return {"geometry": geometry, "error": str(e)}
     try:
         metrics = await run_in_threadpool(ex.far_field_metrics, req)
     except Exception as exc:  # noqa: BLE001 — a user design's build_wires can raise
@@ -1130,6 +1149,13 @@ async def optimize_endpoint(req: dict):
     geometry = req.get("geometry", next(iter(EXAMPLES)))
     ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
     base = {k: v for k, v in req.items() if k != "optimize"}
+    # Every optimizer eval is a full momwire solve of the base geometry (the
+    # free knobs never change n_per_wire), so one hosted size check on the
+    # base request covers the whole run.
+    try:
+        _check_solve_size(base, use_pynec=False)
+    except SolveTooLargeError as e:
+        return {"geometry": geometry, "error": str(e)}
     try:
         result = await run_in_threadpool(
             _optimize,

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -122,7 +122,33 @@ user_designs.refresh()
 _CHUNK_TARGET_MS = 500
 
 
-app = FastAPI(title="momwire interactive")
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        v = int(os.environ.get(name, ""))
+    except ValueError:
+        return default
+    return v if v > 0 else default
+
+
+# The master switch for every hosted-only limit in this file (the solve-size
+# caps and request clamps below): enforced only on the shared/hosted instance,
+# which sets ANTENNAKNOBS_HOSTED via fly.toml. Local installs are unlocked.
+_HOSTED = _env_flag("ANTENNAKNOBS_HOSTED")
+
+app = FastAPI(
+    title="momwire interactive",
+    # The hosted instance is public with no auth: don't serve the interactive
+    # API docs / OpenAPI schema there — they enumerate the exact endpoint and
+    # parameter surface an attacker would probe (issue #348). Local installs
+    # keep /docs for development.
+    docs_url=None if _HOSTED else "/docs",
+    redoc_url=None if _HOSTED else "/redoc",
+    openapi_url=None if _HOSTED else "/openapi.json",
+)
 
 app.add_middleware(
     CORSMiddleware,
@@ -577,22 +603,8 @@ _SOLVE_CACHE_MAX = 100
 # low-rank uses ~0.6× of that — so it's allowed a proportionally higher cap.
 # Caps are about MEMORY, not solve time (PyNEC's ~N³ LU is slow long before it
 # is large; that's a responsiveness concern, deliberately not guarded here).
-# All env-overridable for self-hosting on bigger boxes.
-def _env_flag(name: str) -> bool:
-    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
-
-
-def _env_int(name: str, default: int) -> int:
-    try:
-        v = int(os.environ.get(name, ""))
-    except ValueError:
-        return default
-    return v if v > 0 else default
-
-
-# The master switch: enforce the caps only on the shared/hosted instance.
-_HOSTED = _env_flag("ANTENNAKNOBS_HOSTED")
-
+# All env-overridable for self-hosting on bigger boxes. (_HOSTED and the
+# _env_* helpers live above the FastAPI construction, which also needs them.)
 _MAX_BASIS = _env_int("ANTENNAKNOBS_MAX_BASIS", 7000)  # dense momwire (~800 MB)
 _MAX_BASIS_COMPRESSED = _env_int("ANTENNAKNOBS_MAX_BASIS_COMPRESSED", 9000)
 _MAX_BASIS_PYNEC = _env_int("ANTENNAKNOBS_MAX_BASIS_PYNEC", 7000)
@@ -956,7 +968,10 @@ async def converge_endpoint(req: dict, request: Request):
                     json.dumps(
                         {
                             "n_per_wire": n,
-                            "error": str(e),
+                            # Same formatter as every other endpoint: type +
+                            # message + user-design basename only, never a
+                            # raw path or traceback (issue #348).
+                            "error": user_designs.format_solve_error(e),
                             "solver": solver_name,
                         }
                     )
@@ -1537,9 +1552,10 @@ async def ws_endpoint(ws: WebSocket):
 
 # Serve the built React frontend (web/static, produced by `npm run build` in
 # web/frontend) at "/". Mounted LAST so every API route and FastAPI's own
-# /docs + /openapi.json — all registered above — take precedence; the mount
-# only catches "/", the SPA's assets, and other unclaimed GETs. html=True
-# serves index.html for the root.
+# /docs + /openapi.json (local only — disabled when hosted, see the FastAPI
+# construction) — all registered above — take precedence; the mount only
+# catches "/", the SPA's assets, and other unclaimed GETs. html=True serves
+# index.html for the root.
 #
 # Gated on the directory existing: a source checkout / editable install without
 # a frontend build (the dev workflow, where Vite serves the SPA on :5173 and

--- a/src/antennaknobs/web/user_design_assets/CLAUDE.md
+++ b/src/antennaknobs/web/user_design_assets/CLAUDE.md
@@ -63,6 +63,9 @@ earlier), and a previously-allowed file that later changes asks again.
   there to make your decision informed. **Only allow designs from sources you
   trust.** For a single-user machine you can allow everything up front with
   `ANTENNAKNOBS_TRUST_USER_DESIGNS=1`.
+- The local web app has no login and no solve-size limits (those exist only on
+  the shared public instance), so keep it on `localhost` — don't bind it to
+  `0.0.0.0` or expose it to a network you don't fully control.
 
 ### Loading geometry from a data file
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2089,6 +2089,113 @@ def test_pattern_rejects_oversized_request_when_hosted(hosted, client):
     assert "segments / wire" in body["error"]
 
 
+# ---------------------------------------------------------------------------
+# Hosted compute levers (issue #346): list lengths, optimizer eval budget, and
+# solver kwargs are clamped/whitelisted when hosted so an under-cap request
+# can't multiply whole solves without bound.
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_rejects_over_length_freq_list_when_hosted(hosted, client):
+    freqs = [14.0 + i * 1e-4 for i in range(server._MAX_SWEEP_POINTS + 1)]
+    resp = client.post(
+        "/sweep",
+        json={"geometry": "dipoles.invvee", "n_per_wire": 5, "freqs_mhz": freqs},
+    )
+    assert resp.status_code == 413
+    assert "limit" in resp.json()["detail"]
+
+
+def test_converge_rejects_over_length_n_values_when_hosted(hosted, client):
+    n_values = list(range(5, 5 + server._MAX_SWEEP_POINTS + 1))
+    resp = client.post(
+        "/converge",
+        json={"geometry": "dipoles.invvee", "n_values": n_values},
+    )
+    assert resp.status_code == 413
+
+
+def test_optimize_max_evals_clamped_when_hosted(hosted, client, monkeypatch):
+    # A tiny ceiling keeps the test fast while proving the client value can't
+    # override it: the optimizer's own evals stop at the clamp, plus the two
+    # bookend solves (x0 before, best-point after) optimize() always runs.
+    monkeypatch.setattr(server, "_MAX_OPT_EVALS", 3)
+    req = {
+        "geometry": "dipoles.invvee",
+        "n_per_wire": 7,
+        "momwire_model": "bspline",
+        "optimize": {
+            "free": [{"name": "length_factor", "min": 0.95, "max": 1.05}],
+            "objective": "swr",
+            "max_evals": 10**9,
+        },
+    }
+    body = client.post("/optimize", json=req).json()
+    assert "error" not in body
+    assert body["n_evals"] <= 3 + 2
+
+
+def test_optimize_non_numeric_max_evals_is_clean_error(client):
+    req = {
+        "geometry": "dipoles.invvee",
+        "optimize": {
+            "free": [{"name": "length_factor", "min": 0.95, "max": 1.05}],
+            "max_evals": "lots",
+        },
+    }
+    body = client.post("/optimize", json=req).json()
+    assert "max_evals" in body["error"]
+
+
+def test_sweep_non_dict_model_options_is_422(client):
+    resp = client.post(
+        "/sweep",
+        json={
+            "geometry": "dipoles.invvee",
+            "freqs_mhz": [14.0],
+            "model_options": "junk",
+        },
+    )
+    assert resp.status_code == 422
+    assert "model_options" in resp.json()["detail"]
+
+
+def test_hosted_model_options_filtered_to_whitelist(monkeypatch):
+    from antennaknobs.web import adapter
+
+    monkeypatch.setattr(adapter, "_HOSTED", True)
+    out = adapter.sanitize_model_options(
+        {
+            "model_options": {
+                "degree": 1,
+                "use_singular_enrichment": False,
+                # Internal compute-amplification levers: dropped, not forwarded.
+                "aca_leaf_size": 2,
+                "solve_tol": 1e-15,
+                "swept_mem_mb": 10**6,
+            }
+        }
+    )
+    assert out == {"degree": 1, "use_singular_enrichment": False}
+
+    with pytest.raises(ValueError, match="degree"):
+        adapter.sanitize_model_options({"model_options": {"degree": 7}})
+    with pytest.raises(ValueError, match="tikhonov_lambda"):
+        adapter.sanitize_model_options(
+            {"model_options": {"tikhonov_lambda": float("inf")}}
+        )
+
+
+def test_local_model_options_forward_verbatim():
+    from antennaknobs.web import adapter
+
+    assert adapter.sanitize_model_options(
+        {"model_options": {"anything_goes": 1}}
+    ) == {"anything_goes": 1}
+    with pytest.raises(ValueError):  # non-dict is a clean error even locally
+        adapter.sanitize_model_options({"model_options": "junk"})
+
+
 def test_momwire_bspline_ground_model_drives_sommerfeld_solve():
     """Web ground parity: with the plain B-spline solver the default
     "sommerfeld" ground model drives momwire's TRUE Sommerfeld solve

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2037,6 +2037,58 @@ def test_check_solve_size_unknown_geometry_does_not_falsely_reject(hosted):
     )
 
 
+# ---------------------------------------------------------------------------
+# Size guard on every solve-forming endpoint (issue #345). /ws and /converge
+# always had it; /sweep, /optimize, /pattern_metrics, and /pattern each form
+# the same N×N matrix and must reject an over-cap request instead of
+# attempting the allocation.
+# ---------------------------------------------------------------------------
+
+
+def _oversized_req(**extra) -> dict:
+    n = _n_per_wire_for_basis("dipoles.invvee", server._MAX_BASIS) * 2
+    return {
+        "geometry": "dipoles.invvee",
+        "n_per_wire": n,
+        "momwire_model": "bspline",
+        **extra,
+    }
+
+
+def test_sweep_rejects_oversized_request_when_hosted(hosted, client):
+    resp = client.post("/sweep", json=_oversized_req(freqs_mhz=[14.1]))
+    assert resp.status_code == 413
+    assert "segments / wire" in resp.json()["detail"]
+
+
+def test_optimize_rejects_oversized_request_when_hosted(hosted, client):
+    req = _oversized_req(
+        optimize={
+            "free": [{"name": "length_factor", "min": 0.9, "max": 1.1}],
+            "objective": "swr",
+        }
+    )
+    resp = client.post("/optimize", json=req)
+    assert resp.status_code == 200  # error payload, not an exception
+    assert "segments / wire" in resp.json()["error"]
+
+
+def test_pattern_metrics_rejects_oversized_request_when_hosted(hosted, client):
+    resp = client.post("/pattern_metrics", json=_oversized_req())
+    assert resp.status_code == 200
+    assert "segments / wire" in resp.json()["error"]
+
+
+@pytest.mark.skipif(
+    not server.pynec_backend.HAVE_PYNEC, reason="PyNEC not installed"
+)
+def test_pattern_rejects_oversized_request_when_hosted(hosted, client):
+    resp = client.post("/pattern", json=_oversized_req(solver="pynec"))
+    body = resp.json()
+    assert body["available"] is False
+    assert "segments / wire" in body["error"]
+
+
 def test_momwire_bspline_ground_model_drives_sommerfeld_solve():
     """Web ground parity: with the plain B-spline solver the default
     "sommerfeld" ground model drives momwire's TRUE Sommerfeld solve

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2079,9 +2079,7 @@ def test_pattern_metrics_rejects_oversized_request_when_hosted(hosted, client):
     assert "segments / wire" in resp.json()["error"]
 
 
-@pytest.mark.skipif(
-    not server.pynec_backend.HAVE_PYNEC, reason="PyNEC not installed"
-)
+@pytest.mark.skipif(not server.pynec_backend.HAVE_PYNEC, reason="PyNEC not installed")
 def test_pattern_rejects_oversized_request_when_hosted(hosted, client):
     resp = client.post("/pattern", json=_oversized_req(solver="pynec"))
     body = resp.json()
@@ -2189,9 +2187,9 @@ def test_hosted_model_options_filtered_to_whitelist(monkeypatch):
 def test_local_model_options_forward_verbatim():
     from antennaknobs.web import adapter
 
-    assert adapter.sanitize_model_options(
-        {"model_options": {"anything_goes": 1}}
-    ) == {"anything_goes": 1}
+    assert adapter.sanitize_model_options({"model_options": {"anything_goes": 1}}) == {
+        "anything_goes": 1
+    }
     with pytest.raises(ValueError):  # non-dict is a clean error even locally
         adapter.sanitize_model_options({"model_options": "junk"})
 
@@ -2244,7 +2242,9 @@ def test_geometry_rejects_non_finite_knob_value(client):
 
 
 def test_geometry_rejects_non_positive_n_per_wire(client):
-    resp = client.post("/geometry", json={"geometry": "dipoles.invvee", "n_per_wire": 0})
+    resp = client.post(
+        "/geometry", json={"geometry": "dipoles.invvee", "n_per_wire": 0}
+    )
     assert "n_per_wire" in resp.json()["error"]
 
 
@@ -2276,6 +2276,52 @@ def test_positive_finite_helper():
     for bad in (0, -1, float("nan"), float("inf"), None, "abc", [1]):
         with pytest.raises(ValueError, match="x must be"):
             _positive_finite("x", bad)
+
+
+# ---------------------------------------------------------------------------
+# Hosted hardening (issue #348): API docs off when hosted, /converge errors
+# through the shared formatter.
+# ---------------------------------------------------------------------------
+
+
+def test_docs_available_locally(client):
+    # The default (unhosted) app keeps the interactive docs for development.
+    assert server.app.docs_url == "/docs"
+    assert client.get("/openapi.json").status_code == 200
+
+
+def test_docs_disabled_when_hosted_at_import():
+    # docs_url is baked in at FastAPI construction (import time), so the
+    # hosted flag can't be monkeypatched after the fact — check in a fresh
+    # interpreter with the env var set, exactly like the Fly container.
+    import os
+    import subprocess
+    import sys
+
+    code = (
+        "from antennaknobs.web import server; "
+        "assert server.app.docs_url is None; "
+        "assert server.app.redoc_url is None; "
+        "assert server.app.openapi_url is None"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        env={**os.environ, "ANTENNAKNOBS_HOSTED": "1"},
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_converge_error_goes_through_solve_error_formatter(hosted, client):
+    # A per-N failure (here the size rejection) streams through
+    # format_solve_error — "TypeName: message", never a raw str(e)/traceback.
+    n = _n_per_wire_for_basis("dipoles.invvee", server._MAX_BASIS) * 2
+    resp = client.post(
+        "/converge", json={"geometry": "dipoles.invvee", "n_values": [n]}
+    )
+    first = json.loads(resp.text.strip().splitlines()[0])
+    assert first["error"].startswith("SolveTooLargeError: ")
 
 
 def test_momwire_bspline_ground_model_drives_sommerfeld_solve():

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2196,6 +2196,88 @@ def test_local_model_options_forward_verbatim():
         adapter.sanitize_model_options({"model_options": "junk"})
 
 
+# ---------------------------------------------------------------------------
+# Numeric input validation at the physics boundary (issue #347). stdlib json
+# accepts NaN/Infinity literals and nothing floored the physics inputs, so a
+# zero/non-finite freq or radius reached the solver as a ZeroDivisionError /
+# NaN matrix. /geometry exercises the same _build_builder + engine path as the
+# solves, without the cost of one.
+# ---------------------------------------------------------------------------
+
+
+def _post_raw(client, path: str, payload: dict):
+    # stdlib json.dumps emits bare NaN/Infinity literals (allow_nan=True is
+    # the default) — the exact wire form the attack uses; httpx's json= kwarg
+    # refuses to serialize them.
+    return client.post(
+        path,
+        content=json.dumps(payload),
+        headers={"content-type": "application/json"},
+    )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("design_freq_mhz", 0),
+        ("design_freq_mhz", float("nan")),
+        ("measurement_freq_mhz", float("inf")),
+        ("wire_radius", 0),
+        ("wire_radius", -0.001),
+    ],
+)
+def test_geometry_rejects_bad_physics_scalar(client, field, value):
+    resp = _post_raw(client, "/geometry", {"geometry": "dipoles.invvee", field: value})
+    assert resp.status_code == 200  # error payload for the UI banner, not a 500
+    body = resp.json()
+    assert field in body["error"]
+    assert "positive, finite" in body["error"]
+
+
+def test_geometry_rejects_non_finite_knob_value(client):
+    resp = _post_raw(
+        client,
+        "/geometry",
+        {"geometry": "dipoles.invvee", "length_factor": float("nan")},
+    )
+    assert "length_factor" in resp.json()["error"]
+
+
+def test_geometry_rejects_non_positive_n_per_wire(client):
+    resp = client.post("/geometry", json={"geometry": "dipoles.invvee", "n_per_wire": 0})
+    assert "n_per_wire" in resp.json()["error"]
+
+
+def test_sweep_rejects_non_finite_freqs(client):
+    resp = _post_raw(
+        client,
+        "/sweep",
+        {"geometry": "dipoles.invvee", "freqs_mhz": [14.0, float("nan")]},
+    )
+    assert resp.status_code == 422
+    resp = client.post(
+        "/sweep", json={"geometry": "dipoles.invvee", "freqs_mhz": ["abc"]}
+    )
+    assert resp.status_code == 422
+
+
+def test_converge_rejects_non_numeric_n_values(client):
+    resp = client.post(
+        "/converge", json={"geometry": "dipoles.invvee", "n_values": ["abc"]}
+    )
+    assert resp.status_code == 422
+
+
+def test_positive_finite_helper():
+    from antennaknobs.web.adapter import _positive_finite
+
+    assert _positive_finite("x", 14.1) == 14.1
+    assert _positive_finite("x", "14.1") == 14.1  # numeric strings are fine
+    for bad in (0, -1, float("nan"), float("inf"), None, "abc", [1]):
+        with pytest.raises(ValueError, match="x must be"):
+            _positive_finite("x", bad)
+
+
 def test_momwire_bspline_ground_model_drives_sommerfeld_solve():
     """Web ground parity: with the plain B-spline solver the default
     "sommerfeld" ground model drives momwire's TRUE Sommerfeld solve


### PR DESCRIPTION
## Summary
Fixes the four DoS/hardening issues from the 2026-07-13 security scan of the hosted instance, in priority order. Every new limit is gated on `ANTENNAKNOBS_HOSTED` — local installs stay fully unlocked.

- **#345 (HIGH, single-request OOM):** `/sweep`, `/optimize`, and `/pattern_metrics` now run `_check_solve_size` like `/ws` and `/converge` always did, so an over-cap `n_per_wire` is rejected (413 / error payload) before the N×N allocation. Also guarded `/pattern`, which the scan missed — it runs a full NEC solve before `rp_card`. The checks are per-endpoint rather than centralized in `_build_builder` because `count_basis` itself calls `_build_builder` (the centralized form would recurse).
- **#346 (HIGH, sustained CPU):** hosted clamps for the compute levers — `max_evals` capped at `ANTENNAKNOBS_MAX_OPT_EVALS` (500) regardless of the client value, `freqs_mhz`/`n_values` list lengths capped at `ANTENNAKNOBS_MAX_SWEEP_POINTS` (500) with a 413, and `model_options` filtered at the engine choke point to the whitelisted frontend gear-menu kwargs with type/range validation (internal levers like ACA leaf sizes, GMRES/solve tolerances, and `swept_mem_mb` are dropped). Non-dict `model_options` is a clean error everywhere instead of a 500.
- **#347 (MED, input validation):** `design_freq_mhz`/`measurement_freq_mhz`/`wire_radius` must be positive and finite (stdlib `json.loads` accepts `NaN`/`Infinity` literals), rehydrated params are finiteness-checked, and `n_per_wire` must be a positive int — all raising clean `ValueError`s at the adapter boundary that surface as the UI error banner or a 422, never a `ZeroDivisionError`/NaN-matrix 500. The six copy-pasted freq-parse sites in `_make_example` collapsed into one `_req_freqs` helper.
- **#348 (LOW, hardening):** `/docs`, `/redoc`, `/openapi.json` disabled when hosted; `/converge` errors go through `format_solve_error`; uvicorn `--ws-max-size 1048576` in the Dockerfile; docs note that a local instance (no auth, no caps) should stay on localhost. The "don't run untrusted design files" docs item was already covered by the design-trust arc (#349/#350).

## Test plan
- [x] New regression tests: over-cap requests to each newly guarded endpoint, hosted list-length caps, `max_evals` clamp (end-to-end with a tiny monkeypatched ceiling), `model_options` whitelist/verbatim-local behavior, NaN/Inf/zero freq + radius + `n_per_wire` rejection (raw-JSON posts so the `NaN` literal actually travels), hosted-import `/docs` 404 (fresh interpreter), `/converge` error formatting
- [x] Full suite: 1834 passed
- [x] `ruff check` + `ruff format --check` clean
- [ ] Post-merge: verify on the deployed instance that `/docs` 404s and an over-cap `/sweep` returns 413

🤖 Generated with [Claude Code](https://claude.com/claude-code)