### PR TITLE
Release v0.26.0 — user-design safety + hosted hardening

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.25.0"
+version = "0.26.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,24 +25,21 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.25.0" icon="star">
-  **Three ledgers of efficiency.** Three new showcase verticals
-  independently duplicate the published claims for KJ6ER's POTA
-  antennas — [`verticals.pota_performer`, `challenger`, and
-  `dominator`](/advanced/pota-performer/) — and the modeling arrives
-  with an honest accounting: "over 90% efficient" and "~30% radiated"
-  are **both true, in different ledgers**, and the difference is the
-  ground absorption nobody's efficiency figure counts. The new
-  `far_field.radiated_fraction` helper reads the third ledger off any
-  pattern, and the workbench now shows it **live**: a dwell-filled
-  **radiated (incl. ground)** row in the
-  [solve readout](/reference/web/#power-budget), derived from the
-  norm check at zero cost to knob dragging. Also new: the CLI draws
-  its **own Smith chart** (scikit-rf dependency dropped), every chart
-  gets a version brand and a style pass, `sweep --swr` plots SWR
-  against *any* knob, and the EFHW sloper gains a
-  [40 m NVIS variant](/advanced/efhw/).
-  [All release notes →](/reference/releases/)
+<Card title="New in v0.26.0" icon="star">
+  **Your designs, safely.** A design file is a full Python program on
+  purpose — so now it **doesn't run until you allow it**, like VS Code's
+  workspace-trust prompt. New files always ask first, edited files ask
+  again, and the web app gets a "designs need your OK to run" panel with
+  a built-in review: `antennaknobs screen` shows what a file does that's
+  unusual *without running it*. New
+  [`allow` / `disallow` / `screen` commands](/reference/cli/#allowing-user-designs-to-run),
+  and a confined `read_json` helper lets a design load wire lists from a
+  data file next to it — without raw file access, so it stays safe to
+  share. Built-in design files are now copy-portable: any catalog `.py`
+  works verbatim as a starting point in your designs folder. The
+  [hosted simulator](https://app.antennaknobs.dev/) also picked up a
+  security hardening pass (request limits and input validation on every
+  solve path). [All release notes →](/reference/releases/)
 </Card>
 
 ## The whole pitch, in one line

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -1,12 +1,12 @@
 ---
 title: Command line
-description: Driving antennaknobs from the terminal — list, draw, sweep, pattern, optimize, compare, params, and .nec export.
+description: Driving antennaknobs from the terminal — list, draw, sweep, pattern, optimize, compare, params, .nec export, and allowing user designs.
 ---
 
 antennaknobs has a command-line interface for batch work. The subcommands:
 
 ```text
-python -m antennaknobs {draw,sweep,optimize,pattern,compare_patterns,params,export,list}
+python -m antennaknobs {draw,sweep,optimize,pattern,compare_patterns,params,export,list,screen,allow,disallow}
 ```
 
 | Command | What it does |
@@ -19,6 +19,9 @@ python -m antennaknobs {draw,sweep,optimize,pattern,compare_patterns,params,expo
 | `optimize` | Optimize an antenna's parameters |
 | `params` | Print a design's knob values as paste-ready Python |
 | `export` | Export the design to a NEC-2 `.nec` card deck |
+| `screen` | Show what a design file does that's unusual, without running it |
+| `allow` | Allow a user design to run (it runs code on your machine) |
+| `disallow` | Stop allowing a user design to run |
 
 ## Naming a design
 
@@ -150,3 +153,29 @@ python -m antennaknobs export --builder beams.yagi --fn yagi.nec
 
 The deck is validated against `nec2c`, so designs round-trip into other NEC
 tools.
+
+## Allowing user designs to run
+
+A design file in `~/.antennaknobs/designs/` is a full Python program that runs
+with your user privileges, so it **does not run until you allow it** — like
+VS Code's workspace-trust prompt. The decision is remembered per file, by its
+contents: a new file always asks first, and an allowed file that later changes
+asks again.
+
+```bash
+# A design someone sent you: review it first, then allow that exact version
+python -m antennaknobs screen ~/Downloads/their_design.py
+python -m antennaknobs allow their_design
+
+# A design you author: allow your future edits too, so saves never re-prompt
+python -m antennaknobs allow my_dipole --edits
+
+# Stop allowing one
+python -m antennaknobs disallow their_design
+```
+
+`screen` prints what the file does that's unusual (imports outside the
+antenna-modelling stack, file access, network use) *without running it*. The
+report is advisory — it informs your decision, it isn't a verdict. See
+[Authoring designs with Claude](/concepts/authoring-with-claude/) for the full
+workflow, including the equivalent "needs your OK to run" panel in the web app.

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -115,8 +115,10 @@ A solve builds a matrix whose size grows with the total segment count, so the
 hosted instance **rejects** solves that would be too large for the shared box
 (you'll see a message in the error banner telling you to reduce N or pick a
 smaller design — or switch to the array-block / H-matrix engine for big arrays).
-This applies **only** to the shared hosted instance: a local install is
-**unlocked** (solve as big as your own machine allows). See `docs/deploy.md`.
+The same instance also caps sweep lengths and optimizer eval budgets, well
+above anything the UI sends. This applies **only** to the shared hosted
+instance: a local install is **unlocked** (solve as big as your own machine
+allows, sweep as long as you like). See `docs/deploy.md`.
 :::
 
 ## The ground plane


### PR DESCRIPTION
## Summary
- Bump version 0.25.0 → 0.26.0. Release theme: the user-design allow gate (screener + content-pinned trust, CLI `screen`/`allow`/`disallow`, the web app's "needs your OK to run" panel, confined `read_json`, copy-portable builtins — PRs #344/#349/#350) plus the hosted DoS-hardening pass (PR #351, closed #345–#348).
- Refresh the what's-new card on the site front page for v0.26.0.
- De-stale sweep: `reference/cli.md` now documents the `screen`/`allow`/`disallow` subcommands (the trust-arc PRs never touched this page); `reference/web.md`'s hosted-limits caution mentions the new sweep-length/optimizer-eval caps.
- Site builds clean (19 pages).

## Test plan
- [x] `cd site && npm run build` passes
- [x] CI on this PR
- [ ] After merge: tag v0.26.0, watch publish + both Fly deploys, verify PyPI serves 0.26.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)