### PR TITLE
Add wire.edz: Extended Double Zepp with series matching section (Cebik)

### DIFF
--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -91,6 +91,7 @@ whole shape with a `Drone` — see
 | Design | Notes |
 | --- | --- |
 | `wire.doublet_ladder_tuner` | 88 ft doublet + 100 ft of 600 Ω open-wire line + lossy T-network tuner — the "non-resonant wire and a matchbox" station, modelled from the rig (issue #300) · variants: `classic_edz`, `dipole`, `three_halves` |
+| `wire.edz` | Extended Double Zepp: 1.25 wl centre-fed doublet + series match (L. B. Cebik, W4RNL) |
 | `wire.efhw_sloper` | End-fed half-wave sloper with a real 49:1 unun — "the POTA antenna, complete" (issue #329) · variants: `band40` |
 | `wire.lazy_h` | Lazy-H: two stacked collinear elements fed in phase (L. B. Cebik, W4RNL) |
 | `wire.longwire` | Resonant multi-wavelength long-wire (L. B. Cebik, W4RNL) |

--- a/src/antennaknobs/designs/wire/edz.py
+++ b/src/antennaknobs/designs/wire/edz.py
@@ -1,0 +1,129 @@
+"""Extended Double Zepp: 1.25 wl centre-fed doublet + series match (L. B.
+Cebik, W4RNL).
+
+The EDZ is a centre-fed doublet stretched to ~1.25 wavelengths -- Cebik's
+"magic length": the LONGEST a centre-fed wire can get before the single
+broadside lobe splits apart. Each arm is ~5/8 wl, so the current
+distribution adds ~2-3 dB of broadside gain over a half-wave dipole
+(~4.5-5 dBi free space) while the first off-axis sidelobes are only just
+emerging. The same 1.25 wl number generates Cebik's 44'/88' doublets and,
+stacked, the expanded lazy-H; the catalog's `lazy_h` and `w8jk` elements are
+its shorter 1 wl cousins.
+
+The price of the stretch is the feedpoint: past resonance the centre sits
+well off 50 ohm with a large CAPACITIVE reactance -- Cebik quotes ~100-140
+ohm and -j500-600 for typical builds; this model's wire at exactly 1.25 wl
+reads ~150 -j800 ohm. Cebik's "Feeding the EDZ" catalogs the fixes -- ladder
+line + tuner, a reactance-cancelling stub, or the one modelled here (the
+scheme of WB4HFL's 10 m build): a short SERIES SECTION of parallel line
+whose length rotates the feedpoint around the line's SWR circle to its
+low-resistance crossing, for direct coax.
+
+That the series line CAN match here is the instructive contrast with `zepp`
+finding #2. An end-fed half wave reflects almost totally (|Gamma| ~ 1), so
+its low-R crossing is a few ohms and no series line reaches 50 ohm. The EDZ
+centre, mismatched as it looks, reflects at only |Gamma| ~ 0.84 against a
+600 ohm line -- and the crossing Z0 * (1-|Gamma|)/(1+|Gamma|) ~ 53 ohm lands
+almost exactly on coax (the catalog's `openwire-600`; WB4HFL's 450 ohm
+window line put his thicker-wire build's crossing in the same place). At
+~0.15 wl of line the model sees ~53 +0j ohm, and the match is narrow-band
+(~600 kHz at 2:1 on 10 m -- matching WB4HFL's measured bandwidth), which the
+SWR sweep shows off.
+
+Geometry, in the framework's (x, y, z) convention:
+  - y : the doublet axis (centre-fed, ~1.25 wl, along y)
+  - z : constant height `base`
+  - x : broadside; a slightly-split figure-8 with emerging ~50 deg sidelobes.
+The matching section is an electrical element (a `TL` branch), not geometry.
+
+    L=====================C===================R   z = base  (~1.25 wl doublet)
+                          |
+                          | series matching section (TL branch, z0_match)
+                          S                       S = shack feed (virtual port)
+"""
+
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.57,
+            "freq": 28.57,
+            "base": 10.0,
+            # Doublet length as a fraction of a wavelength. 1.25 wl is the
+            # EDZ proportion -- the longest centre-fed wire whose broadside
+            # lobe has not yet split.
+            "elem_frac": 1.25,
+            # Series matching section: characteristic impedance (ohm) and
+            # physical length as a fraction of a wavelength. ~600 ohm open
+            # wire; the length is tuned so the shack sees the SWR circle's
+            # low-resistance (~53 ohm) crossing.
+            "z0_match": 600.0,
+            "match_len_frac": 0.150,
+            # Overall scale knob.
+            "length_factor": 1.0,
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 50.0,
+                    "default_view": "yz",
+                    # Degenerate with elem_frac (length = elem_frac * wl *
+                    # length_factor); pin length_factor and keep elem_frac,
+                    # the curated ~1.25 wl knob.
+                    "length_factor": {"hidden": True},
+                    "elem_frac": {
+                        "min": 0.9,
+                        "max": 1.4,
+                    },
+                    "z0_match": {
+                        "min": 200.0,
+                        "max": 800.0,
+                        "step": 1.0,
+                        "precision": 1,
+                    },
+                    "match_len_frac": {
+                        "min": 0.05,
+                        "max": 0.45,
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        eps = 0.05
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+
+        length = self.elem_frac * wavelength * self.length_factor
+        half = length / 2.0
+        z = self.base
+
+        L = (0.0, -half, z)
+        C0 = (0.0, -eps, z)
+        C1 = (0.0, eps, z)
+        R = (0.0, half, z)
+        arm = self.segs_for(half - eps, quarter)
+        # Centre-fed doublet; the named centre gap "feed" is the antenna-side
+        # port the matching section connects to (no direct voltage source).
+        return [
+            (L, C0, arm, None, None),
+            (C0, C1, 1, None, "feed"),
+            (C1, R, arm, None, None),
+        ]
+
+    def build_network(self):
+        wavelength = 299.792458 / self.design_freq
+        match_len = self.match_len_frac * wavelength
+        return Network(
+            ports={
+                "feed": PortOnWire("feed"),  # doublet centre
+                "shack": PortVirtual("shack"),  # bottom of the series section
+            },
+            branches=[
+                TL(a="shack", b="feed", z0=self.z0_match, length=match_len),
+            ],
+            sources=[Driven(port="shack", voltage=1 + 0j)],
+        )

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -1171,6 +1171,119 @@ def test_zepp_series_feeder_cannot_match_to_coax():
 
 
 # ===========================================================================
+# Batch 4 -- second Cebik wave, cross-checked against the cebik.com mirror
+# (antenna2.github.io/cebik): EDZ, expanded lazy-H, OWA Yagi, right-angle
+# delta (issues #354-#357).
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# Extended Double Zepp (1.25 wl doublet + series matching section)
+# ---------------------------------------------------------------------------
+
+
+def _edz_bare():
+    """The EDZ with its centre gap driven directly (matching section removed),
+    to read the raw feedpoint the series section transforms."""
+    from antennaknobs.designs.wire.edz import Builder
+
+    class Bare(Builder):
+        def build_wires(self):
+            return [
+                (t[0], t[1], t[2], 1 + 0j) if len(t) == 5 and t[4] == "feed" else t[:4]
+                for t in super().build_wires()
+            ]
+
+        def build_network(self):
+            return None
+
+    return Bare()
+
+
+def test_edz_gain_over_dipole():
+    """~5.2 dBi free space -- the 2-3 dB broadside gain over a dipole that is
+    the whole point of the 1.25 wl stretch (Cebik)."""
+    from antennaknobs.designs.wire.edz import Builder
+
+    ff = _far_field(Builder())
+    assert 4.5 < ff.max_gain < 5.6
+
+
+def test_edz_broadside_with_end_nulls():
+    """Still a (slightly split) figure-8: broadside off +/- x dominates the
+    wire axis by a wide margin, with the ~50-deg sidelobes only emerging (the
+    sidelobes are also why the margin at this ring is a shade under the
+    half-square's)."""
+    from antennaknobs.designs.wire.edz import Builder
+
+    ff = _far_field(Builder())
+    rings = np.array(ff.rings)
+    row = rings[60]
+    broadside = max(row[0], row[180])
+    end_on = max(row[90], row[270])
+    assert broadside - end_on > 8.0
+
+
+def test_edz_bare_centre_high_r_strongly_capacitive():
+    """The raw 1.25 wl centre: high-R and strongly capacitive (Cebik quotes
+    ~100-140 -j500-600 for typical builds; this wire reads ~150 -j800)."""
+    z = _z(_edz_bare())
+    assert 100.0 < z.real < 220.0
+    assert z.imag < -500.0
+
+
+def test_edz_series_section_lands_on_coax():
+    """The contrast with the zepp: the EDZ centre reflects at |Gamma| ~ 0.84
+    (not ~1), so the 600 ohm series section's low-R crossing sits at ~53 ohm
+    and the shack sees a direct coax match (SWR ~ 1.07)."""
+    from antennaknobs.designs.wire.edz import Builder
+
+    z = _z(Builder())
+    assert 45.0 < z.real < 60.0
+    assert abs(z.imag) < 10.0
+    assert _swr(z, 50.0) < 1.25
+
+
+def test_edz_match_is_narrowband():
+    """The rotation match trades bandwidth: ~600 kHz at 2:1 on 10 m (WB4HFL's
+    measured build), so both band edges blow past 2:1."""
+    from antennaknobs.designs.wire.edz import Builder
+
+    for f in (28.0, 29.1):
+        z = _z(Builder(dict(Builder.default_params, freq=f)))
+        assert _swr(z, 50.0) > 2.0, (f, z)
+
+
+def test_edz_match_line_rotation_tunes_reactance():
+    """Along the series line the resistance stays pinned near the low-R
+    crossing while the reactance sweeps through zero -- rotation around the
+    SWR circle, not a transformer's R-scaling."""
+    from antennaknobs.designs.wire.edz import Builder
+
+    zs = [
+        _z(Builder(dict(Builder.default_params, match_len_frac=m)))
+        for m in (0.144, 0.150, 0.156)
+    ]
+    assert all(45.0 < z.real < 60.0 for z in zs)  # R barely moves
+    assert zs[0].imag < 0.0 < zs[2].imag  # X sweeps through resonance
+
+
+def test_edz_uses_a_series_tl_and_virtual_shack():
+    """One series TL branch from a virtual shack port to the real
+    doublet-centre port, driven at the shack (cf. g5rv/zepp)."""
+    from antennaknobs.designs.wire.edz import Builder
+    from antennaknobs.network import TL, Driven, PortVirtual
+
+    net = Builder().build_network()
+    tls = [br for br in net.branches if isinstance(br, TL)]
+    assert len(tls) == 1 and not tls[0].transposed
+    assert {tls[0].a, tls[0].b} == {"shack", "feed"}
+    assert isinstance(net.ports["shack"], PortVirtual)
+    (src,) = net.sources
+    assert isinstance(src, Driven) and src.port == "shack"
+
+
+# ===========================================================================
 # Methodology / cross-engine findings (momwire vs the PyNEC reference)
 #
 # These lock in WHERE the four momwire solver bases agree with PyNEC and where


### PR DESCRIPTION
## Summary
- New design `wire.edz` (closes #354): the 1.25 wl centre-fed doublet — Cebik's "magic length", the longest centre-fed wire before the broadside lobe splits, and the conceptual building block behind the catalog's `lazy_h` and `w8jk`.
- Feed models the WB4HFL scheme from Cebik's "Feeding the EDZ": a ~0.15 wl series section of 600-ohm open-wire line rotates the raw ~150 −j800 ohm centre impedance around its SWR circle to the ~53-ohm low-resistance crossing → direct coax match (SWR ~1.07 at 28.57 MHz), with the ~600 kHz 2:1 bandwidth matching WB4HFL's measured build.
- Docstring pins the instructive contrast with `wire.zepp` finding #2: the EDZ centre reflects at |Γ| ≈ 0.84 (not ~1), so a series line *can* land on coax — Z0·(1−|Γ|)/(1+|Γ|) ≈ 53 Ω.
- Seven physics tests in `test_cebik_designs.py` (new Batch 4 section for the second Cebik wave, issues #354–#357): gain, broadside pattern, raw capacitive centre, coax match, narrowband-ness, SWR-circle rotation (R pinned while X sweeps through zero), and TL/virtual-shack topology.
- Regenerated `site/.../reference/catalog.md` (drift gate).

## Test plan
- [x] `pytest tests/test_cebik_designs.py -k edz` — 7 passed
- [x] Fast lane `pytest -m "not antenna_computation_check"` — 1758 passed
- [x] `ruff check` / `ruff format --check` clean; catalog drift gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)