### PR TITLE
Add wire.expanded_lazy_h: Cebik's expanded lazy-H fed through a real TL phasing harness

### DIFF
--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -93,6 +93,7 @@ whole shape with a `Drone` — see
 | `wire.doublet_ladder_tuner` | 88 ft doublet + 100 ft of 600 Ω open-wire line + lossy T-network tuner — the "non-resonant wire and a matchbox" station, modelled from the rig (issue #300) · variants: `classic_edz`, `dipole`, `three_halves` |
 | `wire.edz` | Extended Double Zepp: 1.25 wl centre-fed doublet + series match (L. B. Cebik, W4RNL) |
 | `wire.efhw_sloper` | End-fed half-wave sloper with a real 49:1 unun — "the POTA antenna, complete" (issue #329) · variants: `band40` |
+| `wire.expanded_lazy_h` | Expanded Lazy-H: two stacked EDZs fed through a real phasing harness (L. B. Cebik, W4RNL) |
 | `wire.lazy_h` | Lazy-H: two stacked collinear elements fed in phase (L. B. Cebik, W4RNL) |
 | `wire.longwire` | Resonant multi-wavelength long-wire (L. B. Cebik, W4RNL) |
 | `wire.rhombic` | Terminated rhombic: a traveling-wave directional long-wire (L. B. Cebik, W4RNL, "Long-Wire Antennas" / "The Terminated Vee-Beam and Rhombic") |

--- a/src/antennaknobs/designs/wire/expanded_lazy_h.py
+++ b/src/antennaknobs/designs/wire/expanded_lazy_h.py
@@ -1,0 +1,130 @@
+"""Expanded Lazy-H: two stacked EDZs fed through a real phasing harness
+(L. B. Cebik, W4RNL).
+
+Cebik's favourite "big cheap wire gain" antenna, from "The Expanded Lazy-H":
+take the standard lazy-H and stretch BOTH knobs -- elements from 1 wl to
+1.25 wl (the EDZ length, see `wire.edz`) and the stack from 1/2 wl to 5/8 wl.
+On 10 m that is two 44' wires 22' apart. The wider in-phase stack pulls the
+EDZ pair's high-angle energy into one dominant low broadside lobe: this model
+reads ~10.1 dBi free space vs ~8.1 dBi for the catalog's standard `lazy_h`
+(Cebik's famous 15.1 dBi at 8 deg takeoff adds the height-over-ground gain).
+Fed through open-wire line and a wide-range tuner it stays useful far below
+the design band -- full performance 10-17 m, pressable to 40 -- with the
+stacking gain fading as the fixed 22' stack shrinks in wavelengths
+(~7.2 dBi at 21.1 MHz, ~4.1 dBi at 14.1 MHz free space here).
+
+Where the catalog's `lazy_h` IMPOSES equal in-phase drive as two ideal
+centre sources, this design models Cebik's actual feed: equal legs of
+open-wire line from both element centres to a junction at mid-stack height,
+as ideal `TL` branches, driven at the junction (the sister-design move of
+`sterba` vs `sterba_tl`). By symmetry the two legs still deliver identical
+in-phase drive, but the driving-point the tuner actually sees is the
+junction: the two transformed element impedances in parallel, low-R and
+strongly reactive -- honest ladder-line-plus-tuner territory, not a coax
+match (target_z0 300, like `lazy_h`).
+
+Geometry, in the framework's (x, y, z) convention:
+  - y : the long axis (both 1.25 wl wires run along y)
+  - z : height; lower wire at `base`, upper at `base + spacing`
+  - x : firing axis; radiation is broadside off +/- x
+The structure is planar in x = 0; the harness is electrical (TL branches).
+
+    ===================C===================   z = base + spacing  (1.25 wl)
+                       |
+                       J  <- junction feed (virtual port, mid-stack)
+                       |
+    ===================C===================   z = base            (1.25 wl)
+              (C = named centre ports; equal TL legs C-J)
+"""
+
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.57,
+            "freq": 28.57,
+            # Height of the lower element above ground.
+            "base": 10.0,
+            # Element length as a fraction of a wavelength: 1.25 wl is the
+            # EDZ stretch (the standard lazy-H uses 1.0).
+            "elem_frac": 1.25,
+            # Vertical stacking distance as a fraction of a wavelength:
+            # 5/8 wl is the expansion (the standard lazy-H uses 1/2).
+            "spacing_frac": 0.625,
+            # Characteristic impedance of the two harness legs (open-wire
+            # phasing line; Cebik discusses 300-600 ohm builds).
+            "z0_harness": 450.0,
+            "ui_params": MappingProxyType(
+                {
+                    # Reactive junction fed via open-wire line + tuner.
+                    "target_z0": 300.0,
+                    "default_view": "yz",
+                    "elem_frac": {
+                        "min": 0.8,
+                        "max": 1.4,
+                    },
+                    "spacing_frac": {
+                        "min": 0.3,
+                        "max": 0.75,
+                    },
+                    "z0_harness": {
+                        "min": 300.0,
+                        "max": 600.0,
+                        "step": 1.0,
+                        "precision": 1,
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        eps = 0.05
+
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+
+        elem = self.elem_frac * wavelength
+        spacing = self.spacing_frac * wavelength
+        half = elem / 2
+
+        def element(z, name):
+            """A 1.25 wl horizontal wire along y at height z with a named
+            one-segment centre port (the harness attaches here; no direct
+            voltage source)."""
+            L = (0.0, -half, z)
+            R = (0.0, half, z)
+            C0 = (0.0, -eps, z)
+            C1 = (0.0, eps, z)
+            return [
+                (L, C0, self.segs_for(half - eps, quarter), None, None),
+                (C0, C1, 1, None, name),
+                (C1, R, self.segs_for(half - eps, quarter), None, None),
+            ]
+
+        tups = []
+        tups.extend(element(self.base, "lo"))  # lower element
+        tups.extend(element(self.base + spacing, "hi"))  # upper element
+        return tups
+
+    def build_network(self):
+        wavelength = 299.792458 / self.design_freq
+        # Equal legs from each element centre to the mid-stack junction --
+        # equal length is what makes the drive in-phase.
+        leg = 0.5 * self.spacing_frac * wavelength
+        return Network(
+            ports={
+                "lo": PortOnWire("lo"),
+                "hi": PortOnWire("hi"),
+                "junction": PortVirtual("junction"),
+            },
+            branches=[
+                TL(a="junction", b="lo", z0=self.z0_harness, length=leg),
+                TL(a="junction", b="hi", z0=self.z0_harness, length=leg),
+            ],
+            sources=[Driven(port="junction", voltage=1 + 0j)],
+        )

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -1283,6 +1283,96 @@ def test_edz_uses_a_series_tl_and_virtual_shack():
     assert isinstance(src, Driven) and src.port == "shack"
 
 
+# ---------------------------------------------------------------------------
+# Expanded Lazy-H (two stacked EDZs + real phasing harness)
+# ---------------------------------------------------------------------------
+
+
+def test_expanded_lazy_h_gain():
+    """~10.1 dBi free space: the EDZ stretch + 5/8 wl stack (Cebik's 15.1 dBi
+    at 8 deg takeoff adds height-over-ground gain)."""
+    from antennaknobs.designs.wire.expanded_lazy_h import Builder
+
+    assert _far_field(Builder()).max_gain > 9.5
+
+
+def test_expanded_lazy_h_beats_standard_lazy_h():
+    """The expansion is worth ~2 dB over the standard 1 wl / 1/2 wl lazy-H --
+    the design's whole reason to exist."""
+    from antennaknobs.designs.wire.expanded_lazy_h import Builder
+    from antennaknobs.designs.wire.lazy_h import Builder as LazyH
+
+    g_x = _far_field(Builder()).max_gain
+    g_std = _far_field(LazyH()).max_gain
+    assert g_x - g_std > 1.5
+
+
+def test_expanded_lazy_h_broadside():
+    """One dominant broadside lobe off +/- x; the wire axis stays well down."""
+    from antennaknobs.designs.wire.expanded_lazy_h import Builder
+
+    ff = _far_field(Builder())
+    rings = np.array(ff.rings)
+    front = rings[:, 0].max()
+    side = rings[:, 90].max()
+    assert front - side > 7.0
+
+
+def test_expanded_lazy_h_wider_stack_adds_gain():
+    """Through the real harness (leg lengths track the spacing), expanding the
+    stack from the classic 1/2 wl to Cebik's 5/8 wl still pays ~0.7 dB."""
+    from antennaknobs.designs.wire.expanded_lazy_h import Builder
+
+    g_wide = _far_field(Builder()).max_gain  # 5/8 wl default
+    g_half = _far_field(
+        Builder(dict(Builder.default_params, spacing_frac=0.5))
+    ).max_gain
+    assert g_wide - g_half > 0.3
+
+
+def test_expanded_lazy_h_multiband_taper():
+    """Fed through a tuner it works far below the design band, with the
+    stacking gain fading as the fixed stack shrinks in wavelengths -- Cebik's
+    band taper (15.1/12.5/9.0 dBi at height -> ~10.1/7.2/4.1 free space)."""
+    from antennaknobs.designs.wire.expanded_lazy_h import Builder
+
+    gains = {
+        fr: _far_field(Builder(dict(Builder.default_params, freq=fr))).max_gain
+        for fr in (28.57, 21.1, 14.1)
+    }
+    assert gains[28.57] > gains[21.1] > gains[14.1]
+    assert gains[21.1] > 6.5
+
+
+def test_expanded_lazy_h_junction_is_tuner_territory():
+    """The junction the tuner sees -- two transformed EDZ centres in parallel
+    -- is low-R and strongly reactive, not a coax match (Cebik: open-wire
+    line to a wide-range balanced tuner)."""
+    from antennaknobs.designs.wire.expanded_lazy_h import Builder
+
+    z = _z(Builder())
+    assert z.real < 100.0
+    assert abs(z.imag) > 100.0
+
+
+def test_expanded_lazy_h_harness_topology():
+    """Two equal, untransposed TL legs from the element centres to a virtual
+    mid-stack junction, driven at the junction -- equal legs are what impose
+    the in-phase drive (cf. lazy_h's idealized dual sources)."""
+    from antennaknobs.designs.wire.expanded_lazy_h import Builder
+    from antennaknobs.network import TL, Driven, PortVirtual
+
+    net = Builder().build_network()
+    tls = [br for br in net.branches if isinstance(br, TL)]
+    assert len(tls) == 2
+    assert all(not tl.transposed for tl in tls)
+    assert abs(tls[0].length - tls[1].length) < 1e-12  # equal legs
+    assert {tls[0].b, tls[1].b} == {"lo", "hi"}
+    assert isinstance(net.ports["junction"], PortVirtual)
+    (src,) = net.sources
+    assert isinstance(src, Driven) and src.port == "junction"
+
+
 # ===========================================================================
 # Methodology / cross-engine findings (momwire vs the PyNEC reference)
 #


### PR DESCRIPTION
## Summary
- New design `wire.expanded_lazy_h` (closes #355): Cebik's "big cheap wire gain" antenna from "The Expanded Lazy-H" — the standard lazy-H with both knobs stretched: 1.25 wl EDZ-length elements and a 5/8 wl stack (two 44' wires 22' apart on 10 m).
- Models the **actual feed** rather than idealized sources: equal open-wire legs from both element centres to a mid-stack junction as `TL` branches, driven at a virtual junction port — the sister-design contrast with `wire.lazy_h`'s dual ideal centre feeds, same as `sterba` vs `sterba_tl`.
- Physics matches Cebik: ~10.1 dBi free space (~2 dB over standard `lazy_h`; his 15.1 dBi at 8° takeoff adds height-over-ground gain), multiband taper 10.1/7.2/4.1 dBi at 28.57/21.1/14.1 MHz, and a low-R strongly-reactive junction (28 +j268 Ω) — honest ladder-line + tuner territory.
- Seven physics tests in the Batch 4 Cebik section; catalog page regenerated.

## Test plan
- [x] `pytest tests/test_cebik_designs.py -k expanded_lazy_h` — 7 passed
- [x] Fast lane `pytest -m "not antenna_computation_check"` — 1771 passed
- [x] `ruff check` / `ruff format --check` clean; catalog drift gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)