### PR TITLE
Add beams.owa_yagi: Cebik's 4-el OWA Yagi with whole-band flat 50-ohm feed

### DIFF
--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -62,6 +62,7 @@ whole shape with a `Drone` — see
 | `beams.hb9cv` | ZL-Special / HB9CV: a 2-element all-driven phased beam (L. B. Cebik, W4RNL) |
 | `beams.hexbeam` | Hex beam — a W-folded 2-element beam on a hexagonal spreader footprint · variants: `opt` |
 | `beams.moxon` | Moxon rectangle — a 2-element beam with folded-back element tips · variants: `opt`, `original` |
+| `beams.owa_yagi` | OWA Yagi: 4 elements, whole-band flat 50-ohm feed (NW3Z/WA3FET concept, systematized by L. B. Cebik, W4RNL) |
 | `beams.yagi` | Yagi-Uda parasitic beam (driven element + reflector + directors) |
 <!-- catalog:end beams -->
 

--- a/src/antennaknobs/designs/beams/owa_yagi.py
+++ b/src/antennaknobs/designs/beams/owa_yagi.py
@@ -1,0 +1,118 @@
+"""OWA Yagi: 4 elements, whole-band flat 50-ohm feed (NW3Z/WA3FET concept,
+systematized by L. B. Cebik, W4RNL).
+
+The Optimized Wideband Antenna is a Yagi with one deliberately "wasted"
+element: a FIRST DIRECTOR parked unusually close to the driver (~0.05 wl
+here, vs ~0.18 wl to the next director). That element barely adds gain --
+it is a COUPLED RESONATOR that flattens the driving-point impedance at
+50 ohm across an entire band: the matching network IS an element, so the
+feed is direct coax with no beta/gamma/stub hardware. Cebik published OWA
+families for 20/10/6/2 m; this is his 10 m 4-element on a 13.5' boom
+(reflector 17.68', driver 17.20' @ 5.12', D1 16.14' @ 6.87', D2 15.20'
+@ 13.0', 1" tubing), with lengths held as wavelength fractions so the
+design scales with `design_freq`.
+
+What the model reproduces (free space, length_factor 0.985 to centre the
+band for this segmentation): SWR(50) stays 1.10-1.32 over ALL of
+28.0-29.0 MHz while gain runs ~8.3-8.7 dBi and F/B ~12-14 dB. The two
+contrasts that make the point:
+  - the catalog's `beams.yagi` (a conventional driver-reflector-directors
+    design) swings past 5:1 SWR over the same span;
+  - delete D1 (or drag `d1_length_factor` off unity) and the OWA's own
+    match collapses to 2.7-5.9 -- the wideband feed lives in that one
+    close-coupled element, not in the driver.
+The trade Cebik documents: ~0.2 dB of peak gain given up for total-band
+consistency, and fat elements matter (thin-wire OWAs narrow; the 1" tubing
+is part of the published design, modelled via the wire-material spec).
+
+Geometry, in the framework's (x, y, z) convention:
+  - y : element axis (all four elements parallel to y)
+  - x : boom / firing axis; the beam fires +x (toward the directors)
+  - z : constant height `base`
+
+      refl      driver  D1              D2
+       |          |     |                |
+       |          F     |                |          (F = direct 50-ohm feed)
+       |          |     |                |
+    x= 0        .148  .198             .375  (wl)
+                     ^^ the OWA coupled resonator
+"""
+
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import WireSpec
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    # Cebik's 10 m 4-el OWA (ant36), feet -> fractions of the 28.4 MHz
+    # wavelength: (element half-length, boom position).
+    TABLE = (
+        (0.255250, 0.0),  # reflector
+        (0.248319, 0.147837),  # driver
+        (0.233017, 0.198367),  # D1 -- the coupled resonator
+        (0.219445, 0.375366),  # D2
+    )
+    DRIVER = 1
+    D1 = 2
+
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.4,
+            "freq": 28.4,
+            "base": 10.0,
+            # Overall element-length scale. 0.985 centres the published
+            # design's flat-SWR window on 28.0-29.0 MHz for this
+            # segmentation (Cebik's feet assume his NEC model's meshing).
+            "length_factor": 0.985,
+            # Scale on D1 alone -- the knob that shows the OWA mechanism:
+            # off unity, the whole-band match collapses while the pattern
+            # barely moves.
+            "d1_length_factor": 1.0,
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 50.0,
+                    # Single-band 10 m beam: snap the GUI sweep to the band.
+                    "sweep_policy": {"band_locked": True},
+                    "default_view": "xy",
+                    "length_factor": {
+                        "min": 0.95,
+                        "max": 1.02,
+                    },
+                    "d1_length_factor": {
+                        "min": 0.9,
+                        "max": 1.1,
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wire_material(self):
+        # 1" aluminum tubing idealized as PEC, held as a wavelength fraction
+        # (0.0127 m at 28.4 MHz) so the fat-element behaviour -- which the
+        # OWA's bandwidth depends on -- survives rescaling to other bands.
+        wavelength = 299.792458 / self.design_freq
+        return WireSpec(radius=0.001203 * wavelength)
+
+    def build_wires(self):
+        eps = 0.05
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+        b = self.base
+
+        tups = []
+        for i, (half_frac, pos_frac) in enumerate(self.TABLE):
+            half = half_frac * wavelength * self.length_factor
+            if i == self.D1:
+                half *= self.d1_length_factor
+            x = pos_frac * wavelength
+            if i == self.DRIVER:
+                # Driver: one-segment centre gap carries the direct feed.
+                arm = self.segs_for(half - eps, quarter)
+                tups.append(((x, -half, b), (x, -eps, b), arm, None))
+                tups.append(((x, -eps, b), (x, eps, b), 1, 1 + 0j))
+                tups.append(((x, eps, b), (x, half, b), arm, None))
+            else:
+                ns = self.segs_for(2 * half, quarter)
+                tups.append(((x, -half, b), (x, half, b), ns, None))
+        return tups

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -1373,6 +1373,89 @@ def test_expanded_lazy_h_harness_topology():
     assert isinstance(src, Driven) and src.port == "junction"
 
 
+# ---------------------------------------------------------------------------
+# OWA Yagi (4-el with the close-in coupled-resonator first director)
+# ---------------------------------------------------------------------------
+
+
+_OWA_BAND = (28.0, 28.5, 29.0)
+
+
+def test_owa_flat_swr_across_the_whole_band():
+    """The defining OWA behaviour: direct 50-ohm feed with SWR < 1.5 held
+    over all of 28.0-29.0 MHz (Cebik's design goal for the family; this
+    model reads 1.10-1.32)."""
+    from antennaknobs.designs.beams.owa_yagi import Builder
+
+    swrs = {
+        f: _swr(_z(Builder(dict(Builder.default_params, freq=f))), 50.0)
+        for f in _OWA_BAND
+    }
+    assert max(swrs.values()) < 1.5, swrs
+
+
+def test_owa_bandwidth_shames_the_generic_yagi():
+    """Same band, same 50-ohm reference: the conventional driver-reflector-
+    directors `beams.yagi` swings past 5:1 at a band edge while the OWA
+    never leaves ~1.3 -- the coupled resonator is worth a >2x band-max
+    margin."""
+    from antennaknobs.designs.beams.owa_yagi import Builder
+    from antennaknobs.designs.beams.yagi import Builder as Yagi
+
+    owa_max = max(
+        _swr(_z(Builder(dict(Builder.default_params, freq=f))), 50.0) for f in _OWA_BAND
+    )
+    yagi_max = max(
+        _swr(_z(Yagi(dict(Yagi.default_params, freq=f))), 50.0) for f in _OWA_BAND
+    )
+    assert owa_max * 2.0 < yagi_max
+
+
+def test_owa_gain_and_front_to_back_hold_across_band():
+    """~8.3-8.7 dBi forward with F/B > 10 dB at both edges and mid-band --
+    the smooth-across-the-band consistency the OWA trades ~0.2 dB of peak
+    gain for."""
+    from antennaknobs.designs.beams.owa_yagi import Builder
+
+    for f in _OWA_BAND:
+        ff = _far_field(Builder(dict(Builder.default_params, freq=f)))
+        rings = np.array(ff.rings)
+        fb = rings[:, 0].max() - rings[:, 180].max()
+        assert ff.max_gain > 8.0, (f, ff.max_gain)
+        assert fb > 10.0, (f, fb)
+
+
+def test_owa_d1_is_the_matching_network():
+    """Delete the close-in first director and the OWA's own match collapses
+    (mid-band SWR ~3.9): the wideband 50-ohm feed lives in that one
+    coupled-resonator element, not in the driver."""
+    from antennaknobs.designs.beams.owa_yagi import Builder
+
+    class NoD1(Builder):
+        TABLE = tuple(t for i, t in enumerate(Builder.TABLE) if i != Builder.D1)
+
+    z = _z(NoD1(dict(NoD1.default_params, freq=28.5)))
+    assert _swr(z, 50.0) > 2.5
+
+
+def test_owa_topology_close_in_first_director():
+    """Four y-parallel elements, one driven; the OWA signature is D1 parked
+    ~0.05 wl from the driver while D2 sits ~0.18 wl further on, with lengths
+    monotone reflector > driver > D1 > D2."""
+    from antennaknobs.designs.beams.owa_yagi import Builder
+
+    b = Builder()
+    feeds = [t for t in b.build_wires() if t[3] is not None]
+    assert len(feeds) == 1
+    halves = [h for h, _ in b.TABLE]
+    poss = [p for _, p in b.TABLE]
+    assert halves[0] > halves[1] > halves[2] > halves[3]
+    assert poss[2] - poss[1] < 0.06  # D1 hugs the driver...
+    assert poss[3] - poss[2] > 0.15  # ...D2 does not
+    # fat elements are part of the published design
+    assert b.build_wire_material().radius > 0.01
+
+
 # ===========================================================================
 # Methodology / cross-engine findings (momwire vs the PyNEC reference)
 #


### PR DESCRIPTION
## Summary
- New design `beams.owa_yagi` (closes #356): the NW3Z/WA3FET Optimized Wideband Antenna concept Cebik systematized — his published 10 m 4-el table (reflector 17.68', driver 17.20' @ 5.12', D1 16.14' @ 6.87', D2 15.20' @ 13.0', 1" tubing), held as wavelength fractions so it scales with `design_freq`.
- The OWA signature: D1 parked ~0.05 wl from the driver acts as a coupled resonator, holding SWR(50) at **1.10–1.32 across all of 28.0–29.0 MHz** with direct coax feed — vs the generic `beams.yagi` swinging past 5:1 over the same span. Gain 8.3–8.7 dBi, F/B 12–14 dB, smooth across the band.
- Fat elements are part of the published design: `build_wire_material()` returns a wavelength-scaled 1"-tubing PEC `WireSpec` (first design to use the spec for element diameter rather than wire gauge).
- A `d1_length_factor` knob exposes the mechanism in the UI: drag it off unity and the whole-band match collapses while the pattern barely moves; the test suite pins the same fact by deleting D1 (mid-band SWR → ~3.9).
- Five physics tests in the Batch 4 Cebik section; catalog page regenerated.

## Test plan
- [x] `pytest tests/test_cebik_designs.py -k owa` — passed
- [x] Fast lane `pytest -m "not antenna_computation_check"` — 1784 passed
- [x] `ruff check` / `ruff format` clean; catalog drift gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)