### PR TITLE
Add verticals.right_angle_delta: Cebik's coax-friendly SCV delta

### DIFF
--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -83,6 +83,7 @@ whole shape with a `Drone` — see
 | `verticals.phased_verticals` | Two-element phased vertical array -- the 90-degree cardioid (L. B. Cebik, W4RNL) |
 | `verticals.pota_performer` | KJ6ER's "POTA PERformer" — elevated quarter-wave with tuned radials · variants: `band10`, `band12`, `band17`, `band20`, `band6`, `omni`, `single_radial` |
 | `verticals.raised_vertical` | Elevated quarter-wave vertical, fed above ground |
+| `verticals.right_angle_delta` | Right-Angle Delta: the coax-friendly SCV delta (L. B. Cebik, W4RNL) |
 | `verticals.vertical` | Quarter-wave vertical over ground |
 <!-- catalog:end verticals -->
 

--- a/src/antennaknobs/designs/verticals/right_angle_delta.py
+++ b/src/antennaknobs/designs/verticals/right_angle_delta.py
@@ -1,0 +1,124 @@
+"""Right-Angle Delta: the coax-friendly SCV delta (L. B. Cebik, W4RNL).
+
+From Cebik's "SCVs: A Family Album" -- the same self-contained-vertical
+family as the catalog's `half_square`, `bobtail`, and `bruce`: closed or
+one-piece 1 wl wire shapes that put their current maxima into vertical wire
+sections, so the verticals' fields add (vertically polarised, low takeoff,
+no radial system) while the horizontal members' radiation largely cancels.
+
+This member is a 1 wl closed delta standing in a vertical plane, apex UP,
+with a ~0.44 wl horizontal base and two equal ~0.31 wl sides meeting at a
+RIGHT ANGLE, fed a quarter-wave down one side from the apex. That feed
+position parks the current maximum in the sloping side's most vertical run;
+the right-angle proportions are what Cebik singled out, because they bring
+the feed to ~51 ohm -- direct coax, where the equilateral delta's same feed
+sits at ~120 ohm (and gains ~0.4 dB less). This model reads ~48 ohm
+near-resonant at length_factor 1.004 and ~3.6 dBi free space (Cebik: 3.3
+dBi, 51 ohm at 7.15 MHz).
+
+Family rank per Cebik, worth knowing when picking an SCV: half-square 4.6 >
+rectangle 4.4 > RAD 3.3 > equilateral 2.9 dBi (the half-square wins on gain
+but the RAD is a CLOSED loop and takes coax without any trimming). The delta
+is the near-omni end of the family: front-to-side only ~3 dB (vs the
+bobtail's ~28 dB), so it trades the curtains' broadside discipline for
+whole-horizon DX coverage. The VP signature the tests pin: pattern peaks at
+the horizon with a deep (~25 dB) null overhead -- opposite of the catalog's
+`loops.delta_loop`, the corner-fed horizontally-dominant cousin.
+
+Geometry, in the framework's (x, y, z) convention:
+  - y : the horizontal base wire runs along y
+  - z : height; base wire at `base`, apex ~0.22 wl higher
+  - x : broadside; bidirectional off +/- x (front-to-side ~3 dB)
+The structure is planar in x = 0.
+
+           T          z = base + h   (apex, right angle)
+          / \
+         F   \        F = feed, 1/4 wl down the left side from T
+        /     \
+       A=======B      z = base       (~0.44 wl horizontal base)
+"""
+
+from antennaknobs import AntennaBuilder
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.57,
+            "freq": 28.57,
+            # Height of the horizontal base wire above ground. Low, like the
+            # other SCVs: the verticals do the work.
+            "base": 3.0,
+            # Horizontal base length as a fraction of a wavelength; Cebik's
+            # right-angle proportion (~0.44 wl base, apex angle 90 deg).
+            "base_frac": 0.442,
+            # Sloping side length as a fraction of a wavelength. With the
+            # base above, the two sides meet at a right angle and the
+            # perimeter comes out ~1.07 wl.
+            "side_frac": 0.3126,
+            # Feed position DOWN the left side from the apex, in wavelengths
+            # (~1/4 wl puts the current max in the side's vertical run).
+            "feed_frac": 0.25,
+            # Overall scale knob; 1.004 is resonance (X ~ 0) for this
+            # segmentation.
+            "length_factor": 1.004,
+            "ui_params": MappingProxyType(
+                {
+                    # The right-angle proportions' point: ~51 ohm direct coax.
+                    "target_z0": 50.0,
+                    "default_view": "yz",
+                    "length_factor": {
+                        "min": 0.9,
+                        "max": 1.1,
+                    },
+                    "feed_frac": {
+                        "min": 0.05,
+                        "max": 0.28,
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+        lf = self.length_factor
+
+        w = self.base_frac * wavelength * lf
+        s = self.side_frac * wavelength * lf
+        half_w = w / 2
+        h = (s**2 - half_w**2) ** 0.5  # apex height above the base wire
+
+        zb = self.base
+        A = (0.0, -half_w, zb)  # left base corner
+        B = (0.0, half_w, zb)  # right base corner
+        T = (0.0, 0.0, zb + h)  # apex
+
+        # Feed a quarter-wave down the LEFT side from the apex, measured
+        # along the wire; a short one-segment driven edge (cf. half_square).
+        d = min(self.feed_frac * wavelength, s - 0.1)
+        pe = 0.1  # feed-edge length, m
+        t0 = (d - pe / 2) / s
+        t1 = (d + pe / 2) / s
+
+        def lerp(p, q, t):
+            return (
+                p[0] + (q[0] - p[0]) * t,
+                p[1] + (q[1] - p[1]) * t,
+                p[2] + (q[2] - p[2]) * t,
+            )
+
+        F0 = lerp(T, A, t0)
+        F1 = lerp(T, A, t1)
+
+        return [
+            # Left side: apex -> feed edge -> base corner (driven mid-side).
+            (T, F0, self.segs_for(d, quarter), None),
+            (F0, F1, 1, 1 + 0j),
+            (F1, A, self.segs_for(s - d, quarter), None),
+            # Horizontal base and right side close the delta.
+            (A, B, self.segs_for(w, quarter), None),
+            (B, T, self.segs_for(s, quarter), None),
+        ]

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -1456,6 +1456,100 @@ def test_owa_topology_close_in_first_director():
     assert b.build_wire_material().radius > 0.01
 
 
+# ---------------------------------------------------------------------------
+# Right-angle delta (the coax-friendly SCV)
+# ---------------------------------------------------------------------------
+
+
+def test_rad_coax_friendly_near_resonant():
+    """The right-angle proportions' whole point: ~48-51 ohm near-resonant at
+    the quarter-wave-from-apex feed (Cebik: 51 ohm; the equilateral delta's
+    same feed sits at ~120 ohm)."""
+    from antennaknobs.designs.verticals.right_angle_delta import Builder
+
+    z = _z(Builder())
+    assert 40.0 < z.real < 60.0
+    assert abs(z.imag) < 15.0
+
+
+def test_rad_gain_matches_cebik():
+    """~3.3-3.6 dBi free space -- mid-pack SCV, above the equilateral's 2.9,
+    below the half-square's 4.6."""
+    from antennaknobs.designs.verticals.right_angle_delta import Builder
+
+    ff = _far_field(Builder())
+    assert 3.0 < ff.max_gain < 4.2
+
+
+def test_rad_ranks_below_the_half_square():
+    """Cebik's family ranking holds inside the catalog: the half-square
+    out-gains the RAD by ~1 dB."""
+    from antennaknobs.designs.verticals.half_square import Builder as HalfSquare
+    from antennaknobs.designs.verticals.right_angle_delta import Builder
+
+    assert _far_field(HalfSquare()).max_gain > _far_field(Builder()).max_gain + 0.5
+
+
+def test_rad_vertically_polarised_overhead_null():
+    """The SCV signature: the pattern peaks at the horizon and is deeply
+    nulled overhead -- the horizontal members cancel, the vertical runs
+    radiate. (The corner-fed `loops.delta_loop` is the horizontally-dominant
+    opposite.)"""
+    from antennaknobs.designs.verticals.right_angle_delta import Builder
+
+    rings = np.array(_far_field(Builder()).rings)
+    horizon = rings[85:].max()
+    zenith = rings[:5].max()
+    assert horizon - zenith > 15.0
+
+
+def test_rad_near_omni_front_to_side():
+    """The delta is the near-omni end of the SCV family: broadside is up on
+    the ends by only a few dB (Cebik: ~3 dB), nothing like the bobtail's
+    ~28 dB broadside discipline."""
+    from antennaknobs.designs.verticals.right_angle_delta import Builder
+
+    rings = np.array(_far_field(Builder()).rings)
+    row = rings[60]
+    margin = max(row[0], row[180]) - max(row[90], row[270])
+    assert 1.0 < margin < 8.0
+
+
+def test_rad_length_factor_tunes_reactance():
+    """Reactance climbs monotonically with length_factor through resonance
+    (cf. half_square)."""
+    from antennaknobs.designs.verticals.right_angle_delta import Builder
+
+    x_lo = _z(Builder(dict(Builder.default_params, length_factor=0.96))).imag
+    x_mid = _z(Builder(dict(Builder.default_params, length_factor=1.004))).imag
+    x_hi = _z(Builder(dict(Builder.default_params, length_factor=1.05))).imag
+    assert x_lo < x_mid < x_hi
+
+
+def test_rad_is_a_closed_right_angle_delta_one_feed():
+    """Topology: one driven gap on the left sloping side (not on the base),
+    the loop closes, and the side/base proportions make the apex a right
+    angle (side^2 + side^2 ~ diagonal relation: h = w/2)."""
+    from antennaknobs.designs.verticals.right_angle_delta import Builder
+
+    b = Builder()
+    tups = b.build_wires()
+    feeds = [t for t in tups if t[3] is not None]
+    assert len(feeds) == 1
+    zb = b.base
+    # The fed edge slopes: it is off the base wire and off y = 0.
+    assert feeds[0][0][2] > zb + 0.1
+    assert feeds[0][0][1] < 0.0  # on the left (-y) side
+    # Right angle at the apex: apex height equals half the base width.
+    wavelength = 299.792458 / b.design_freq
+    w = b.base_frac * wavelength * b.length_factor
+    apex_h = max(max(t[0][2], t[1][2]) for t in tups) - zb
+    assert abs(apex_h - w / 2) < 0.02 * wavelength
+    # ~1 wl closed perimeter (2 sides + base ~ 1.07 wl).
+    perim = w + 2 * b.side_frac * wavelength * b.length_factor
+    assert 0.95 < perim / wavelength < 1.15
+
+
 # ===========================================================================
 # Methodology / cross-engine findings (momwire vs the PyNEC reference)
 #


### PR DESCRIPTION
## Summary
- New design `verticals.right_angle_delta` (closes #357): the Right-Angle Delta from Cebik's "SCVs: A Family Album", completing our SCV family (`half_square`, `bobtail`, `bruce`) — a 1 wl closed vertical-plane delta, apex up at a right angle, fed 1/4 wl down one side so the current maximum sits in the sloping side's vertical run.
- The right-angle proportions are what Cebik singled out: **~48 Ω near-resonant direct-coax feed** (his model: 51 Ω) vs the equilateral delta's ~120 Ω. Model reads 3.6 dBi free space (Cebik: 3.3), horizon-peaked with a ~25 dB overhead null (vertically polarised, no radials), and the family's near-omni ~3 dB front-to-side.
- Docstring records Cebik's SCV family ranking (half-square 4.6 > rectangle 4.4 > RAD 3.3 > equilateral 2.9 dBi) and the contrast with the corner-fed, horizontally-dominant `loops.delta_loop`.
- Seven physics tests including a cross-design family-ranking check against `half_square`; catalog page regenerated.
- Full `test_cebik_designs.py` (114 tests, all four new Cebik designs included) passes locally.

## Test plan
- [x] `pytest tests/test_cebik_designs.py` — 114 passed
- [x] Fast lane `pytest -m "not antenna_computation_check"` — 1797 passed
- [x] `ruff check` / `ruff format` clean; catalog drift gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)