### PR TITLE
Add verticals.rectangle: Cebik "magnetic slot" SCV with QW transformer

### DIFF
--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -83,6 +83,7 @@ whole shape with a `Drone` — see
 | `verticals.phased_verticals` | Two-element phased vertical array -- the 90-degree cardioid (L. B. Cebik, W4RNL) |
 | `verticals.pota_performer` | KJ6ER's "POTA PERformer" — elevated quarter-wave with tuned radials · variants: `band10`, `band12`, `band17`, `band20`, `band6`, `omni`, `single_radial` |
 | `verticals.raised_vertical` | Elevated quarter-wave vertical, fed above ground |
+| `verticals.rectangle` | Rectangle "magnetic slot" SCV: a flattened 1 wl loop (L. B. Cebik, W4RNL) |
 | `verticals.right_angle_delta` | Right-Angle Delta: the coax-friendly SCV delta (L. B. Cebik, W4RNL) |
 | `verticals.vertical` | Quarter-wave vertical over ground |
 <!-- catalog:end verticals -->

--- a/src/antennaknobs/designs/verticals/rectangle.py
+++ b/src/antennaknobs/designs/verticals/rectangle.py
@@ -1,0 +1,150 @@
+"""Rectangle "magnetic slot" SCV: a flattened 1 wl loop (L. B. Cebik, W4RNL).
+
+From Cebik's "SCVs: A Family Album" -- the same self-contained-vertical
+family as the catalog's `half_square`, `bobtail`, `bruce`, and
+`right_angle_delta`: 1 wl wire shapes that park their current maxima in
+vertical wire sections, so the verticals' fields add (vertically polarised,
+low takeoff, no radials) while the horizontal members largely cancel.
+
+This member is the 1 wl loop flattened into a wide, short rectangle --
+Cebik's 40 m numbers are 56' x 12.8' (~0.41 x 0.09 wl), fed at the CENTRE of
+one short vertical side. The squashed proportions put both short sides'
+current maxima to work and buy gain: 4.4 dBi free space, second only to the
+half-square's 4.6 in the family album. This model reads ~5.1 vs its own
+half-square's 4.9 -- it runs the whole family a few tenths hot and flips
+Cebik's 0.2 dB ordering, but the robust claim survives: the two are the
+family's top pair, over a dB clear of the delta. The "magnetic slot" name is
+the marketing physics Cebik was debunking -- it behaves as a plain loop SCV,
+no exotic mode.
+
+The price is the feedpoint: flattening the loop drops the mid-side feed to
+~15 ohm (Cebik's figure; this wire reads ~13 at length_factor 1.0325). Cebik
+suggests voltage feed via a tapped parallel-tuned circuit; the
+transmission-line fix modelled here is a QUARTER-WAVE TRANSFORMER of low-Z
+line -- two paralleled 50 ohm coaxes make z0 ~ 25 ohm, and 25^2/13.1 lands
+~48 ohm at the shack (this model: SWR 1.05, dead resonant). The
+instructive contrast with `wire.edz`: the EDZ's series line works by
+ROTATION around the SWR circle to its low-R crossing; here the feed is
+already near-resonant, so the quarter-wave section is the classic R-SCALING
+transformer (z_shack = z0^2 / z_feed) instead.
+
+Extensions Cebik also modelled, worth knowing: the Double Magnetic Slot
+(paralleled loops with a Mobius crossing; 4.7 dBi, a friendlier 80 ohm) and
+the end-fed Open Double Slot (110.8' x 11.1'; 5.7 dBi, 30 ohm).
+
+Geometry, in the framework's (x, y, z) convention:
+  - y : the long horizontal wires run along y
+  - z : height; bottom wire at `base`, top wire ~0.09 wl higher
+  - x : broadside; bidirectional off +/- x with end-on rejection
+The structure is planar in x = 0. The matching section is an electrical
+element (a `TL` branch), not geometry.
+
+    D===================================C   z = base + v  (top, ~0.41 wl)
+    F                                   |
+    |                                   |   F = feed, centre of the left
+    A===================================B   z = base       short side
+    :
+    : quarter-wave low-Z section (TL branch, z0_match)
+    S                                       S = shack feed (virtual port)
+"""
+
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.57,
+            "freq": 28.57,
+            # Height of the bottom wire above ground. Low, like the other
+            # SCVs: the short vertical sides do the work.
+            "base": 3.0,
+            # Long (horizontal) side as a fraction of a wavelength; Cebik's
+            # 56' on 40 m.
+            "horiz_frac": 0.407,
+            # Short (vertical) side as a fraction of a wavelength; Cebik's
+            # 12.8' -- the flattening that trades feed R for gain.
+            "vert_frac": 0.093,
+            # Quarter-wave transformer: characteristic impedance (ohm) and
+            # physical length as a fraction of a wavelength. ~25 ohm is two
+            # paralleled 50 ohm coaxes; sqrt(14 * 50) ~ 26 would be exact.
+            "z0_match": 25.0,
+            "match_len_frac": 0.25,
+            # Overall scale knob; 1.0325 is resonance (X ~ 0 at the bare
+            # feed) for this segmentation.
+            "length_factor": 1.0325,
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 50.0,
+                    "default_view": "yz",
+                    "length_factor": {
+                        "min": 0.9,
+                        "max": 1.1,
+                    },
+                    "z0_match": {
+                        "min": 10.0,
+                        "max": 75.0,
+                        "step": 0.5,
+                        "precision": 1,
+                    },
+                    "match_len_frac": {
+                        "min": 0.05,
+                        "max": 0.45,
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+        lf = self.length_factor
+
+        w = self.horiz_frac * wavelength * lf
+        v = self.vert_frac * wavelength * lf
+        half_w = w / 2
+        zb = self.base
+        zt = zb + v
+
+        A = (0.0, -half_w, zb)  # bottom-left
+        B = (0.0, half_w, zb)  # bottom-right
+        C = (0.0, half_w, zt)  # top-right
+        D = (0.0, -half_w, zt)  # top-left
+
+        # Feed gap centred on the LEFT short side -- the current maximum.
+        pe = 0.1  # feed-edge length, m
+        F0 = (0.0, -half_w, zb + (v - pe) / 2)
+        F1 = (0.0, -half_w, zb + (v + pe) / 2)
+
+        leg = self.segs_for((v - pe) / 2, quarter)
+        return [
+            # Left short side: bottom corner -> feed edge -> top corner.
+            (A, F0, leg, None, None),
+            (F0, F1, 1, None, "feed"),
+            (F1, D, leg, None, None),
+            # Top, right side, and bottom close the loop.
+            (D, C, self.segs_for(w, quarter), None, None),
+            (C, B, self.segs_for(v, quarter), None, None),
+            (B, A, self.segs_for(w, quarter), None, None),
+        ]
+
+    def build_network(self):
+        wavelength = 299.792458 / self.design_freq
+        return Network(
+            ports={
+                "feed": PortOnWire("feed"),  # centre of the left short side
+                "shack": PortVirtual("shack"),  # bottom of the transformer
+            },
+            branches=[
+                TL(
+                    a="shack",
+                    b="feed",
+                    z0=self.z0_match,
+                    length=self.match_len_frac * wavelength,
+                ),
+            ],
+            sources=[Driven(port="shack", voltage=1 + 0j)],
+        )

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -1551,6 +1551,148 @@ def test_rad_is_a_closed_right_angle_delta_one_feed():
 
 
 # ===========================================================================
+# Batch 5 -- tier-2 Cebik follow-ons (issues #362-#366), from the
+# cebik.com mirror (antenna2.github.io/cebik).
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# Rectangle "magnetic slot" SCV (1 wl loop flattened wide + QW transformer)
+# ---------------------------------------------------------------------------
+
+
+def _rectangle_bare():
+    """The rectangle with its side gap driven directly (matching section
+    removed), to read the raw very-low-R feedpoint the transformer steps up."""
+    from antennaknobs.designs.verticals.rectangle import Builder
+
+    class Bare(Builder):
+        def build_wires(self):
+            return [
+                (t[0], t[1], t[2], 1 + 0j) if len(t) == 5 and t[4] == "feed" else t[:4]
+                for t in super().build_wires()
+            ]
+
+        def build_network(self):
+            return None
+
+    return Bare()
+
+
+def test_rectangle_bare_feed_is_low_z_near_resonant():
+    """The flattened loop's mid-side feed on a short vertical side: very low
+    R, near-resonant (Cebik: ~15 ohm; the price of the squashed proportions)."""
+    z = _z(_rectangle_bare())
+    assert 8.0 < z.real < 25.0
+    assert abs(z.imag) < 15.0
+
+
+def test_rectangle_qw_section_steps_up_to_coax():
+    """The quarter-wave low-Z section (two paralleled 50-ohm coaxes ~ 25 ohm)
+    steps the ~15 ohm feed up to near-coax at the shack (cf. wire.edz's
+    series-line rotation -- this one is the R-scaling transformer instead)."""
+    from antennaknobs.designs.verticals.rectangle import Builder
+
+    z = _z(Builder())
+    assert _swr(z, 50.0) < 1.45
+    assert abs(z.imag) < 15.0
+
+
+def test_rectangle_gain_matches_cebik():
+    """Top of the SCV family album (Cebik: 4.4 dBi free space, second only
+    to the half-square's 4.6). This model reads ~5.1 -- it runs the whole
+    family a few tenths hot (its half-square reads 4.9 vs Cebik's 4.6, its
+    delta 3.6 vs 3.3)."""
+    from antennaknobs.designs.verticals.rectangle import Builder
+
+    ff = _far_field(Builder())
+    assert 4.4 < ff.max_gain < 5.6
+
+
+def test_rectangle_family_ranking():
+    """Cebik's family ranking, as robust as the model spread allows: the
+    rectangle and half-square are the family's top pair within a fraction of
+    a dB of each other (Cebik has the half-square 0.2 dB ahead; this model
+    reads the rectangle 0.2 ahead), and both clear the right-angle delta by
+    over a dB."""
+    from antennaknobs.designs.verticals.half_square import Builder as HalfSquare
+    from antennaknobs.designs.verticals.rectangle import Builder
+    from antennaknobs.designs.verticals.right_angle_delta import Builder as RAD
+
+    g_rect = _far_field(Builder()).max_gain
+    assert abs(g_rect - _far_field(HalfSquare()).max_gain) < 0.6
+    assert g_rect > _far_field(RAD()).max_gain + 1.0
+
+
+def test_rectangle_vertically_polarised_overhead_null():
+    """The SCV signature: pattern peaks at the horizon, deep null overhead --
+    the long horizontal wires cancel, the short vertical sides radiate."""
+    from antennaknobs.designs.verticals.rectangle import Builder
+
+    rings = np.array(_far_field(Builder()).rings)
+    horizon = rings[85:].max()
+    zenith = rings[:5].max()
+    assert horizon - zenith > 15.0
+
+
+def test_rectangle_broadside_with_end_nulls():
+    """Two in-phase verticals ~0.4 wl apart: bidirectional broadside off
+    +/- x with clear end-on rejection (like the half-square, unlike the
+    near-omni delta)."""
+    from antennaknobs.designs.verticals.rectangle import Builder
+
+    rings = np.array(_far_field(Builder()).rings)
+    row = rings[60]
+    broadside = max(row[0], row[180])
+    end_on = max(row[90], row[270])
+    assert broadside - end_on > 6.0
+
+
+def test_rectangle_is_a_wide_closed_loop_fed_mid_short_side():
+    """Topology: a closed 1 wl rectangle much wider than tall (Cebik's 56' x
+    12.8' proportions, aspect > 3.5), with the single port gap centred on one
+    short VERTICAL side -- the current maximum that makes it an SCV."""
+    from antennaknobs.designs.verticals.rectangle import Builder
+
+    b = Builder()
+    tups = b.build_wires()
+    ports = [t for t in tups if len(t) == 5 and t[4] == "feed"]
+    assert len(ports) == 1
+    (p,) = ports
+    # The port edge is vertical (spans z, constant y) and sits mid-side.
+    assert abs(p[0][1] - p[1][1]) < 1e-9
+    assert abs(p[0][2] - p[1][2]) > 0.0
+    wavelength = 299.792458 / b.design_freq
+    w = b.horiz_frac * wavelength * b.length_factor
+    v = b.vert_frac * wavelength * b.length_factor
+    assert w / v > 3.5
+    mid = b.base + v / 2
+    assert abs((p[0][2] + p[1][2]) / 2 - mid) < 0.05
+    # ~1 wl closed perimeter.
+    assert 0.9 < 2 * (w + v) / wavelength < 1.1
+
+
+def test_rectangle_uses_a_quarter_wave_tl_and_virtual_shack():
+    """One low-Z TL branch, a quarter wave long at the design frequency, from
+    a virtual shack port to the real mid-side port, driven at the shack
+    (the transformer counterpart of wire.edz's rotation line)."""
+    from antennaknobs.designs.verticals.rectangle import Builder
+    from antennaknobs.network import TL, Driven, PortVirtual
+
+    b = Builder()
+    net = b.build_network()
+    tls = [br for br in net.branches if isinstance(br, TL)]
+    assert len(tls) == 1 and not tls[0].transposed
+    assert {tls[0].a, tls[0].b} == {"shack", "feed"}
+    assert tls[0].z0 < 40.0  # a low-Z line: sqrt(15 * 50) ~ 27 ohm territory
+    wavelength = 299.792458 / b.design_freq
+    assert abs(tls[0].length - wavelength / 4) < 0.02 * wavelength
+    assert isinstance(net.ports["shack"], PortVirtual)
+    (src,) = net.sources
+    assert isinstance(src, Driven) and src.port == "shack"
+
+
+# ===========================================================================
 # Methodology / cross-engine findings (momwire vs the PyNEC reference)
 #
 # These lock in WHERE the four momwire solver bases agree with PyNEC and where


### PR DESCRIPTION
Closes #362.

Tier-2 follow-on to the Cebik second-wave arc, from "SCVs: A Family Album" (cebik.com mirror).

## What was built

- **`verticals.rectangle`** — the 1 λ loop flattened into a wide, short rectangle (Cebik's 56' × 12.8' on 40 m → ~0.407 × 0.093 λ fractions), fed at the centre of one short vertical side. Vertically polarised, deep overhead null, broadside figure-8 — a proper SCV alongside `half_square`, `bobtail`, `bruce`, `right_angle_delta`.
- **Quarter-wave transformer matching**: flattening the loop drops the feed to ~13 Ω (Cebik: 15 Ω), so the design models a 25 Ω quarter-wave section (two paralleled 50 Ω coaxes) that steps it up to ~48 Ω at a virtual shack port — SWR 1.05. It's the R-scaling counterpart of `wire.edz`'s series-line rotation match, per the issue's framing.
- **Knobs**: `horiz_frac`/`vert_frac` (Cebik proportions), `z0_match`, `match_len_frac`, `length_factor` (1.0325 = bare-feed resonance).

## Model vs Cebik

The model reads ~5.1 dBi free space vs Cebik's 4.4, and reads the rectangle ~0.2 dB **over** its own half-square where Cebik ranks the half-square 0.2 dB ahead — the model runs the whole SCV family a few tenths hot (half-square 4.9 vs 4.6, delta 3.6 vs 3.3). Docstring and tests state this honestly and pin the robust claim: rectangle + half-square are the family's top pair, over a dB clear of the delta.

## Tests

Eight physics tests extending `test_cebik_designs.py` (new Batch 5 section, `antenna_computation_check` lane): bare low-Z resonance, QW step-up to coax, gain, family ranking, VP overhead null, broadside end rejection, closed-loop mid-short-side topology, and the QW TL + virtual shack network shape. Catalog table regenerated via `scripts/generate_catalog.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)