### PR TITLE
Add wire.terminated_longwire: Cebik's terminated end-fed long-wire

### DIFF
--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -102,6 +102,7 @@ whole shape with a `Drone` — see
 | `wire.rhombic` | Terminated rhombic: a traveling-wave directional long-wire (L. B. Cebik, W4RNL, "Long-Wire Antennas" / "The Terminated Vee-Beam and Rhombic") |
 | `wire.sterba` | Sterba curtain: a broadside, bidirectional, horizontally-polarised curtain array (E. J. Sterba, Bell Labs, 1930s) |
 | `wire.sterba_tl` | Sterba curtain, transmission-line sister design of `sterba.py` |
+| `wire.terminated_longwire` | Terminated end-fed long-wire: the directional single wire (L. B. Cebik, W4RNL, "Long-Wire Antennas", Part 2) |
 | `wire.vbeam` | Resonant V-beam: two long wires splayed into a V (L. B. Cebik, W4RNL) |
 | `wire.w8jk` | W8JK flat-top beam: a 2-element all-driven 180-degree array (L. B. Cebik, W4RNL, after John Kraus W8JK) |
 | `wire.zepp` | End-fed half-wave "Zepp" with a tuned-stub feeder (L. B. Cebik, W4RNL) |

--- a/src/antennaknobs/designs/wire/terminated_longwire.py
+++ b/src/antennaknobs/designs/wire/terminated_longwire.py
@@ -1,0 +1,120 @@
+"""Terminated end-fed long-wire: the directional single wire (L. B. Cebik,
+W4RNL, "Long-Wire Antennas", Part 2).
+
+Completes the catalog's traveling-wave set: `longwire` is the resonant
+single wire, `vbeam` the resonant V, `rhombic` the terminated diamond --
+this is the TERMINATED SINGLE WIRE the other three are built from. A
+horizontal wire several wavelengths long (Cebik models 3-11 wl; 10 wl here)
+at ~1 wl height, fed at the near end between a vertical leg and GROUND, with
+the far end brought down a matching leg and terminated to ground through a
+non-inductive resistor. The resistor absorbs the forward wave, so the
+current is progressive rather than standing and the pattern collapses to
+ONE main lobe, low and off the terminated end.
+
+Cebik's working termination is ~800 ohm (RL = 138*log10(4h/d) gives ~680 for
+his test wire; 600-1000 all work), and his headline numbers for the 10 wl
+model over average ground: 10.47 dBi at 11 deg takeoff, F/B 20.3 dB, feed
+544 +j87 -> SWR(600) 1.20 nearly flat across bands ("extreme
+frequency-changing agility"). Two corrections to the folklore he stresses,
+both pinned by the tests: the terminator burns ~25% of the power, NOT 50%
+(this model reads ~29%), and termination costs ~3.5 dB against the same wire
+unterminated -- the price of the clean unidirectional pattern.
+
+This is the catalog's first ground-CONNECTED design: both legs end at
+exactly z=0 and the PyNEC engine joins them to the ground image (the GE-flag
+support added alongside this design). Solve it OVER GROUND -- free space
+leaves the legs dangling and the circuit open. NEC-2 restriction worth
+knowing: ground contact is only physical over PEC ground ("pec"); the
+Sommerfeld/reflection-coefficient finite grounds do not support touching
+wires (a NEC-4 feature), so quantitative work stays on PEC and Cebik's
+average-ground figures are the field-expectation reference.
+
+Geometry, in the framework's (x, y, z) convention:
+  - x : the wire axis; feed leg at x=0, terminated leg at x=L; beam --> +x
+  - z : legs run from ground (z=0) to `height_frac` wl; wire horizontal
+  - y : 0 everywhere (the structure is planar in y=0)
+Horizontally polarised off the long run, with the legs' vertical
+contribution shaping the low-angle response.
+
+    F================================T   z = h (~1 wl, ~10 wl long)
+    |                                |
+    G  --> beam toward +x            R   R = term_r to ground
+   ---------------------------------------  z = 0 (ground plane)
+"""
+
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import Driven, Load, Network, PortOnWire
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.57,
+            "freq": 28.57,
+            # Horizontal run length in wavelengths. Cebik's tables run 3-11;
+            # 10 wl is his primary test case. Longer = more gain, narrower
+            # main lobe.
+            "length_frac": 10.0,
+            # Height of the horizontal run in wavelengths (Cebik: 1 wl).
+            "height_frac": 1.0,
+            # Terminating resistance (ohm) at the bottom of the far leg.
+            # Cebik's working value; RL = 138*log10(4h/d) ~ 680 for his
+            # wire, anything 600-1000 is usable.
+            "term_r": 800.0,
+            "ui_params": MappingProxyType(
+                {
+                    # The feed tracks the termination: ~600 ohm open-wire
+                    # territory (Cebik: 544 +j87, SWR(600) 1.20).
+                    "target_z0": 600.0,
+                    # Planar in y=0: the xz view shows the run and both legs.
+                    "default_view": "xz",
+                    "length_frac": {
+                        "min": 3.0,
+                        "max": 11.0,
+                        "step": 0.5,
+                        "precision": 2,
+                    },
+                    "height_frac": {
+                        "min": 0.5,
+                        "max": 1.5,
+                    },
+                    "term_r": {"min": 400.0, "max": 1000.0, "step": 10.0},
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+
+        L = self.length_frac * wavelength
+        h = self.height_frac * wavelength
+        pe = 0.3  # feed / termination edge length at the leg bottoms, m
+
+        G0 = (0.0, 0.0, 0.0)  # feed-leg ground end
+        F1 = (0.0, 0.0, pe)
+        A = (0.0, 0.0, h)  # near top corner
+        B = (L, 0.0, h)  # far top corner
+        T1 = (L, 0.0, pe)
+        GT = (L, 0.0, 0.0)  # terminated-leg ground end
+
+        leg = self.segs_for(h - pe, quarter)
+        return [
+            # Near leg: driven edge at the ground end, then up to the run.
+            (G0, F1, 1, None, "feed"),
+            (F1, A, leg, None, None),
+            # The long horizontal run.
+            (A, B, self.segs_for(L, quarter), None, None),
+            # Far leg down to the termination edge at the ground end.
+            (B, T1, leg, None, None),
+            (T1, GT, 1, None, "term"),
+        ]
+
+    def build_network(self):
+        return Network(
+            ports={"feed": PortOnWire("feed"), "term": PortOnWire("term")},
+            branches=[Load(port="term", r=self.term_r)],
+            sources=[Driven(port="feed", voltage=1 + 0j)],
+        )

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -138,6 +138,18 @@ class PyNECEngine(SimulationEngine):
         if c is not None:
             del self.c
 
+    def _ge_flag(self):
+        """NEC GE-card ground-plane flag: 1 when a ground card will be
+        emitted AND some wire endpoint touches z=0, so NEC interpolates the
+        touching segments' currents onto their images (a real ground
+        connection — e.g. a terminated long-wire's legs). 0 otherwise; with
+        flag 0 a z=0 wire end is a free end, silently insulated from the
+        ground plane."""
+        if self.ground in (None, "free"):
+            return 0
+        touches = any(t[0][2] == 0.0 or t[1][2] == 0.0 for t in self.tups)
+        return 1 if touches else 0
+
     def _build_geometry(self):
         self.c = nec.nec_context()
         geo = self.c.get_geometry()
@@ -170,7 +182,7 @@ class PyNECEngine(SimulationEngine):
 
         self._network_port_loc = {}
 
-        self.c.geometry_complete(0)
+        self.c.geometry_complete(self._ge_flag())
 
         if self._network is not None:
             # Only Load-only networks reach here; TL/virtual-driver
@@ -462,7 +474,7 @@ class PyNECEngine(SimulationEngine):
             )
             if name is not None:
                 loc[name] = (idx, (n_seg + 1) // 2)
-        c.geometry_complete(0)
+        c.geometry_complete(self._ge_flag())
         self._emit_wire_material_cards(c)
         self._apply_ground_card(c)
         return c, loc

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -1692,6 +1692,138 @@ def test_rectangle_uses_a_quarter_wave_tl_and_virtual_shack():
     assert isinstance(src, Driven) and src.port == "shack"
 
 
+# ---------------------------------------------------------------------------
+# Terminated end-fed long-wire (traveling wave against ground)
+# ---------------------------------------------------------------------------
+#
+# The catalog's first ground-CONNECTED design: both vertical legs end at
+# z=0 and NEC joins them to the ground image (the PyNECEngine GE-flag
+# support this design introduced; see test_pynec_ground.py). All numbers
+# run over PEC ground -- NEC-2's Sommerfeld ground does not support wire
+# contact (that is a NEC-4 feature), which the design docstring flags.
+
+
+def _tlw(**over):
+    from antennaknobs.designs.wire.terminated_longwire import Builder
+
+    return Builder(dict(Builder.default_params, **over) if over else None)
+
+
+def _tlw_unterminated():
+    """The terminating resistor deleted (far leg still grounded): the wave
+    reflects, the standing-wave pattern returns -- Cebik's comparison case."""
+    from antennaknobs.designs.wire.terminated_longwire import Builder
+    from antennaknobs.network import Driven, Network, PortOnWire
+
+    class Unterminated(Builder):
+        def build_network(self):
+            return Network(
+                ports={"feed": PortOnWire("feed")},
+                branches=[],
+                sources=[Driven(port="feed", voltage=1 + 0j)],
+            )
+
+    return Unterminated()
+
+
+def _fb(ff):
+    """Front-to-back at the strongest elevation ring, forward = +x."""
+    rings = np.array(ff.rings)
+    ti = int(np.argmax(rings[:, 0]))
+    return rings[ti, 0] - rings[ti, 180], ti
+
+
+def test_tlw_unidirectional_toward_the_termination():
+    """The traveling-wave signature: one main lobe off the TERMINATED end
+    (+x), F/B well into the teens (Cebik's 10 wl model: 20.3 dB over
+    average ground)."""
+    ff = _far_field(_tlw(), ground="pec")
+    fb, _ = _fb(ff)
+    assert fb > 12.0
+    rings = np.array(ff.rings)
+    ti, pi = np.unravel_index(int(np.argmax(rings)), rings.shape)
+    assert min(pi, 360 - pi) < 25  # global peak looks down +x
+
+
+def test_tlw_gain_and_low_takeoff():
+    """Cebik's 10 wl model: 10.47 dBi at 11 deg takeoff over average
+    ground; over PEC the image is lossless so this model reads a couple dB
+    hotter, still at a low DX angle."""
+    ff = _far_field(_tlw(), ground="pec")
+    assert 10.0 < ff.max_gain < 14.5
+    rings = np.array(ff.rings)
+    ti = int(np.unravel_index(int(np.argmax(rings)), rings.shape)[0])
+    assert ti > 70  # peak within ~20 deg of the horizon
+
+
+def test_tlw_terminator_burns_a_quarter_not_half():
+    """Cebik's headline correction to the folklore: the termination eats
+    ~25% of the power, not 50%. The engine's load-loss accounting (the
+    rhombic/momwire load-BC machinery) reads it directly."""
+    eng = PyNECEngine(_tlw(), ground="pec")
+    eng.current_distribution()
+    assert 0.60 < eng._excited_efficiency < 0.85
+
+
+def test_tlw_feed_impedance_tracks_the_line():
+    """The feedpoint sits near the termination value across a wide band
+    (Cebik: 544 +87j, SWR(600) = 1.20 at the design length; and 'extreme
+    frequency-changing agility' without rematching)."""
+    z = _z(_tlw(), ground="pec")
+    assert _swr(z, 600.0) < 1.6
+    for f in (28.57 * 0.8, 28.57 * 1.25):
+        zf = _z(_tlw(freq=f), ground="pec")
+        assert _swr(zf, 600.0) < 2.0, (f, zf)
+
+
+def test_tlw_termination_costs_gain_buys_direction():
+    """Delete the resistor and the reflected wave restores the standing-wave
+    bidirectional pattern: more gain (Cebik: +3.5 dB over average ground,
+    13.96 vs 10.47 at 10 wl; this PEC model with the far leg still grounded
+    reads +1.5) while the front-to-back collapses to nothing."""
+    g_term = _far_field(_tlw(), ground="pec").max_gain
+    ff_open = _far_field(_tlw_unterminated(), ground="pec")
+    fb_open, _ = _fb(ff_open)
+    assert 1.0 < ff_open.max_gain - g_term < 5.5
+    assert fb_open < 6.0
+
+
+def test_tlw_longer_is_stronger():
+    """Cebik's length ladder: gain climbs with wire length (7.1 dBi at 3 wl
+    -> 10.5 at 10 wl over ground) while the pattern stays unidirectional."""
+    gains = {}
+    for lw in (3.0, 7.0, 10.0):
+        ff = _far_field(_tlw(length_frac=lw), ground="pec")
+        gains[lw] = ff.max_gain
+        fb, _ = _fb(ff)
+        assert fb > 10.0, (lw, fb)
+    assert gains[3.0] < gains[7.0] < gains[10.0]
+
+
+def test_tlw_topology_grounded_legs():
+    """Both vertical legs touch z=0 (the ground connection the GE flag
+    makes real), the single driven edge sits at the bottom of the near leg,
+    and the far leg bottom carries the ~800 ohm Load (Cebik's working value
+    for RL = 138*log10(4h/d))."""
+    from antennaknobs.network import Load
+
+    b = _tlw()
+    tups = b.build_wires()
+    grounded = [t for t in tups if t[0][2] == 0.0 or t[1][2] == 0.0]
+    assert len(grounded) == 2
+    names = {t[4] for t in tups if len(t) == 5 and t[4]}
+    assert names == {"feed", "term"}
+    net = b.build_network()
+    (load,) = [br for br in net.branches if isinstance(br, Load)]
+    assert load.port == "term" and load.r == b.term_r
+    # ~10 wl of horizontal run at ~1 wl height.
+    wavelength = 299.792458 / b.design_freq
+    xs = [p[0] for t in tups for p in (t[0], t[1])]
+    assert abs((max(xs) - min(xs)) / wavelength - b.length_frac) < 0.2
+    zs = {p[2] for t in tups for p in (t[0], t[1])}
+    assert abs(max(zs) / wavelength - 1.0) < 0.15
+
+
 # ===========================================================================
 # Methodology / cross-engine findings (momwire vs the PyNEC reference)
 #

--- a/tests/test_pynec_ground.py
+++ b/tests/test_pynec_ground.py
@@ -64,3 +64,46 @@ def test_sommerfeld_and_reflection_coefficient_diverge_when_low():
     # and neither finite model is the PEC image in disguise
     assert abs(z_somm - z_pec) > 5.0
     assert abs(z_fast - z_pec) > 5.0
+
+
+class _GroundedMonopole:
+    """Minimal grounded quarter-wave monopole: bottom end at exactly z=0."""
+
+    def __new__(cls):
+        from types import MappingProxyType
+
+        from antennaknobs import AntennaBuilder
+
+        class Mono(AntennaBuilder):
+            default_params = MappingProxyType({"freq": 28.57, "design_freq": 28.57})
+
+            def build_wires(self):
+                h = 0.25 * 299.792458 / 28.57
+                return [
+                    ((0.0, 0.0, 0.0), (0.0, 0.0, 0.3), 1, 1 + 0j),
+                    ((0.0, 0.0, 0.3), (0.0, 0.0, h), 15, None),
+                ]
+
+        return Mono()
+
+
+def test_ge_flag_connects_z0_wire_ends_to_pec_ground():
+    """A wire ending at exactly z=0 over a ground plane must be CONNECTED to
+    it (NEC GE flag 1: touching segments' currents interpolate onto their
+    images). A bottom-fed grounded quarter-wave then reads the textbook
+    monopole ~36 +j21; with the old unconditional GE flag 0 the same feed
+    saw an insulated free end and thousands of ohms capacitive."""
+    z = PyNECEngine(_GroundedMonopole(), ground="pec").impedance()[0]
+    assert 25.0 < z.real < 55.0
+    assert -20.0 < z.imag < 60.0
+
+
+def test_ge_flag_stays_zero_when_nothing_touches_ground():
+    """Elevated geometry keeps GE flag 0 (no behaviour change for the whole
+    existing catalog), and free space never sets it even with a z=0 end."""
+    eng = PyNECEngine(_flat_dipole(10.0), ground="pec")
+    assert eng._ge_flag() == 0
+    eng_free = PyNECEngine(_GroundedMonopole(), ground=None)
+    assert eng_free._ge_flag() == 0
+    eng_gnd = PyNECEngine(_GroundedMonopole(), ground="pec")
+    assert eng_gnd._ge_flag() == 1


### PR DESCRIPTION
Closes #363.

Tier-2 follow-on to the Cebik second-wave arc, from "Long-Wire Antennas" Part 2 (cebik.com mirror).

## What was built

- **`wire.terminated_longwire`** — completes the traveling-wave set (`longwire` resonant, `vbeam` resonant, `rhombic` terminated): the terminated single wire. 10 λ horizontal run (knob 3–11 λ) at 1 λ height, fed at the near end between a vertical leg and ground, far end terminated to ground through 800 Ω (`term_r` knob; Cebik's RL = 138·log₁₀(4h/d) working value).
- **PyNEC ground-connection support (small engine change)**: this is the catalog's first design whose wires touch z=0. `PyNECEngine` now emits `geometry_complete(1)` when a ground card is present **and** some wire endpoint touches z=0, so NEC connects the touching segments to their ground images. Elevated designs and free space keep flag 0 — zero behaviour change for the existing catalog (fast lane green). Before the fix, a grounded quarter-wave monopole read thousands of ohms capacitive; it now reads the textbook ~36+j21 over PEC.

## Numbers vs Cebik (10 λ model)

| | Cebik (avg ground, NEC-4) | This model (PEC) |
|---|---|---|
| Max gain | 10.47 dBi @ 11° | 13.9 dBi @ 15° |
| F/B | 20.3 dB | 24 dB |
| Feed Z | 544 +j87, SWR(600) 1.20 | 450 −j19, SWR(600) 1.34 |
| Terminator loss | ~25 % (not the folkloric 50 %) | 27.6 % via the load-loss accounting |

NEC-2 restriction documented in the docstring: ground contact is only physical over PEC (Sommerfeld contact is NEC-4 territory), so quantitative tests run on `"pec"`.

## Tests

Seven physics tests in the Batch 5 section of `test_cebik_designs.py` (unidirectionality toward the termination, gain + low takeoff, the ~25 % terminator power budget, feed-tracks-the-line broadbandedness, the termination gain↔direction trade, the 3→10 λ length ladder, grounded-leg topology) and two engine tests in `test_pynec_ground.py` pinning the GE flag on and off. Catalog table regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)