### PR TITLE
Add beams.phased_driver_yagi: Cebik's 40 m wide-band phased-driver wire Yagi

### DIFF
--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -64,6 +64,7 @@ whole shape with a `Drone` — see
 | `beams.moxon` | Moxon rectangle — a 2-element beam with folded-back element tips · variants: `opt`, `original` |
 | `beams.moxon_turnstile` | Moxon turnstile: two up-firing Moxons in real quadrature (L. B. Cebik, W4RNL, QST Aug 2001 pp |
 | `beams.owa_yagi` | OWA Yagi: 4 elements, whole-band flat 50-ohm feed (NW3Z/WA3FET concept, systematized by L. B. Cebik, W4RNL) |
+| `beams.phased_driver_yagi` | 40 m wide-band phased-driver wire Yagi (L. B. Cebik, W4RNL, "Wide-Band 40-Meter Yagis", Part 3) |
 | `beams.yagi` | Yagi-Uda parasitic beam (driven element + reflector + directors) |
 <!-- catalog:end beams -->
 

--- a/src/antennaknobs/designs/beams/phased_driver_yagi.py
+++ b/src/antennaknobs/designs/beams/phased_driver_yagi.py
@@ -1,0 +1,149 @@
+"""40 m wide-band phased-driver wire Yagi (L. B. Cebik, W4RNL, "Wide-Band
+40-Meter Yagis", Part 3).
+
+A fixed wire beam hung between supports that covers ALL of 7.0-7.3 MHz with
+50-ohm SWR under 1.5 -- where a conventional 2-element wire Yagi holds only
+~2/3 of the band -- using no traps and no loading. The trick is a
+PHASED-DRIVER CELL: two drivers close together (rear half 403", forward
+half 379", 93" apart in Cebik's AWG #12 build), joined by a 250-ohm ladder
+line with a SINGLE HALF TWIST. The transposition sets the rear driver's
+current phase so the pair steers like a driver+reflector cell but with the
+feedpoint R/X excursions of the two elements fighting each other instead of
+adding -- that cancellation is where the bandwidth comes from. A single
+director (half 377", 260" out) sharpens the forward lobe.
+
+This is the 40 m answer to the same question `beams.owa_yagi` answers on
+10 m -- hold a full band under SWR 1.5 without a matching network -- and the
+two make the instructive contrast: the OWA parks a coupled RESONATOR next
+to one driver, the wide-band Yagi PHASES two drivers against each other.
+Cebik's wire-version table: gain climbing 5.92 -> 6.97 dBi across the band
+with F/B 12.9-15.5 dB, SWR 1.42 / 1.11 / 1.48 at 7.0 / 7.15 / 7.3. This
+model's feed Z tracks that table to a few ohms at all three marks and the
+in-plane F/B lands 12.1 / 15.1 / 14.0 with the same mid-band peak; gain
+reads ~1 dB over his column (6.8 -> 8.0), rising the same way. The
+elements themselves are ladder line in the wire build -- two #12
+conductors at ~1" spacing -- modelled here as the equivalent single fat
+wire, sqrt(r*s) ~ 5.1 mm; thin single-wire elements shift the cell's
+reactance balance visibly. The half twist IS the design: untwist the line
+in the model and the feedpoint leaves the band (SWR ~20) while the
+front-to-back collapses.
+
+Geometry, in the framework's (x, y, z) convention:
+  - y : the three elements run parallel to y at height `base`
+  - x : the boom axis; beam fires +x (rear driver at x=0)
+  - the 250-ohm phase line is an electrical element (a transposed `TL`
+    branch), not geometry
+Horizontally polarised.
+
+    rear driver     =======x=======   x = 0       (port "rear")
+                           | 250-ohm line, ONE half twist
+    forward driver  ======[F]======   x ~ 0.056 wl (feed, 50-ohm line here)
+    director        ======================   x ~ 0.157 wl
+                                 beam --> +x
+"""
+
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import Driven, Network, PortOnWire, TL, WireSpec
+from types import MappingProxyType
+
+
+class Builder(AntennaBuilder):
+    # (half-length, boom position) per element, in wavelengths at the
+    # design frequency -- Cebik's Table 3 wire dimensions (403"/379"/377"
+    # halves, 93" and 260" spacings at 7.15 MHz).
+    REAR, FWD, DIR = 0, 1, 2
+    TABLE = (
+        (0.24414, 0.0),
+        (0.22960, 0.05633),
+        (0.22839, 0.15750),
+    )
+
+    default_params = MappingProxyType(
+        {
+            "design_freq": 7.15,
+            "freq": 7.15,
+            # Height of the wire beam above ground (hung between supports).
+            "base": 15.0,
+            # Phase line between the drivers: Cebik's 250-ohm #12 ladder
+            # line with a single half twist, run across the driver spacing
+            # ("just under 8 feet").
+            "z0_phase": 250.0,
+            # Overall scale knob.
+            "length_factor": 1.0,
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 50.0,
+                    "default_view": "xy",
+                    "length_factor": {
+                        "min": 0.95,
+                        "max": 1.05,
+                    },
+                    "z0_phase": {
+                        "min": 50.0,
+                        "max": 600.0,
+                        "step": 5.0,
+                        "precision": 1,
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wire_material(self):
+        # Cebik's wire elements are themselves LADDER LINE: two AWG #12
+        # conductors (0.0808" dia) at ~1" spacing, shorted at the tips.
+        # A two-conductor cage models as a single wire of equivalent
+        # radius sqrt(r * s) ~ 5.1 mm -- the element fatness the Table 3
+        # lengths (and the phased cell's reactance balance) assume.
+        r = 0.0808 * 0.0254 / 2
+        s = 1.0 * 0.0254
+        return WireSpec(radius=(r * s) ** 0.5)
+
+    def build_wires(self):
+        eps = 0.05
+        wavelength = 299.792458 / self.design_freq
+        quarter = 0.25 * wavelength
+        lf = self.length_factor
+
+        tups = []
+        for i, (half_frac, pos_frac) in enumerate(self.TABLE):
+            half = half_frac * wavelength * lf
+            x = pos_frac * wavelength
+            z = self.base
+            arm = self.segs_for(half - eps, quarter)
+            L = (x, -half, z)
+            C0 = (x, -eps, z)
+            C1 = (x, eps, z)
+            R = (x, half, z)
+            if i == self.DIR:
+                # Parasitic director: one unbroken wire.
+                tups.append((L, R, 2 * arm + 1, None, None))
+                continue
+            # Both drivers carry a centre gap: the forward one is the feed,
+            # the rear one takes the far end of the phase line.
+            name = "feed" if i == self.FWD else "rear"
+            tups.append((L, C0, arm, None, None))
+            tups.append((C0, C1, 1, None, name))
+            tups.append((C1, R, arm, None, None))
+        return tups
+
+    def build_network(self):
+        wavelength = 299.792458 / self.design_freq
+        drivers_apart = (self.TABLE[self.FWD][1] - self.TABLE[self.REAR][1]) * (
+            wavelength
+        )
+        return Network(
+            ports={"feed": PortOnWire("feed"), "rear": PortOnWire("rear")},
+            branches=[
+                # The single half twist: a TRANSPOSED 250-ohm line the
+                # length of the driver spacing.
+                TL(
+                    a="feed",
+                    b="rear",
+                    z0=self.z0_phase,
+                    length=drivers_apart,
+                    transposed=True,
+                ),
+            ],
+            sources=[Driven(port="feed", voltage=1 + 0j)],
+        )

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -1979,6 +1979,128 @@ def test_moxon_turnstile_network_topology():
     assert {g[4] for g in gaps} == {"feed_a", "feed_b"}
 
 
+# ---------------------------------------------------------------------------
+# 40 m wide-band phased-driver wire Yagi (the OWA's 40 m counterpart)
+# ---------------------------------------------------------------------------
+
+
+_PDY_BAND = (7.0, 7.15, 7.3)
+
+
+def test_pdy_flat_swr_across_the_whole_band():
+    """The design goal: all of 7.0-7.3 MHz under 50-ohm SWR 1.5 with no
+    traps or loading (Cebik's wire version: 1.42 / 1.11 / 1.48)."""
+    from antennaknobs.designs.beams.phased_driver_yagi import Builder
+
+    swrs = {
+        f: _swr(_z(Builder(dict(Builder.default_params, freq=f))), 50.0)
+        for f in _PDY_BAND
+    }
+    assert max(swrs.values()) < 1.6, swrs
+
+
+def test_pdy_bandwidth_shames_the_conventional_wire_yagi():
+    """Cebik's Part 1 premise: a conventional 2-el driver-reflector wire
+    Yagi covers only ~2/3 of 40 m -- same band, same 50-ohm reference, the
+    conventional cell blows far past the phased cell's band-max SWR."""
+    from antennaknobs.designs.beams.phased_driver_yagi import Builder
+    from antennaknobs.designs.beams.yagi import Builder as Yagi
+
+    pdy_max = max(
+        _swr(_z(Builder(dict(Builder.default_params, freq=f))), 50.0) for f in _PDY_BAND
+    )
+    yagi_max = max(
+        _swr(
+            _z(Yagi(dict(Yagi.default_params, design_freq=7.15, freq=f))),
+            50.0,
+        )
+        for f in _PDY_BAND
+    )
+    assert pdy_max * 2.0 < yagi_max
+
+
+def test_pdy_gain_and_front_to_back_across_band():
+    """Cebik's Table 3: gain CLIMBS across the band (5.92 -> 6.97 dBi; this
+    model reads ~1 dB over his numbers throughout, 6.8 -> 8.0) with the
+    in-plane front-to-back holding 12.9-15.5 dB (this model: 12.1-15.1,
+    peaking mid-band exactly as published). The F/B is measured in the
+    beam plane -- the free-space pattern also has a genuine overhead lobe
+    that a max-over-theta comparison would misread as a rear lobe."""
+    from antennaknobs.designs.beams.phased_driver_yagi import Builder
+
+    gains = {}
+    for f in _PDY_BAND:
+        ff = _far_field(Builder(dict(Builder.default_params, freq=f)))
+        rings = np.array(ff.rings)
+        fb = rings[89, 0] - rings[89, 180]
+        gains[f] = ff.max_gain
+        assert ff.max_gain > 6.3, (f, ff.max_gain)
+        assert fb > 11.0, (f, fb)
+    assert gains[7.0] < gains[7.3]
+
+
+def test_pdy_half_twist_is_the_point():
+    """Un-twist the 250-ohm phase line (transposed=False) and the phased
+    cell breaks outright: the feedpoint leaves the band (SWR ~20 mid-band)
+    and the front-to-back collapses -- the single half twist IS the
+    design. (The reducer's transposed TL matches NEC's native crossed-line
+    tl_card, z0 < 0, on this exact geometry -- verified while building.)"""
+    import dataclasses
+
+    from antennaknobs.designs.beams.phased_driver_yagi import Builder
+    from antennaknobs.network import TL
+
+    class Untwisted(Builder):
+        def build_network(self):
+            net = super().build_network()
+            net.branches[:] = [
+                dataclasses.replace(br, transposed=False) if isinstance(br, TL) else br
+                for br in net.branches
+            ]
+            return net
+
+    b = Untwisted(dict(Untwisted.default_params, freq=7.15))
+    assert _swr(_z(b), 50.0) > 5.0
+    rings = np.array(
+        _far_field(Untwisted(dict(Untwisted.default_params, freq=7.15))).rings
+    )
+    assert rings[89, 0] - rings[89, 180] < 5.0
+
+
+def test_pdy_topology_phased_driver_cell():
+    """Three y-parallel thin-wire elements: rear driver (longest) at x=0,
+    forward driver ~0.056 wl ahead carrying the single feed, director
+    ~0.16 wl out; one TRANSPOSED 250-ohm line joins the drivers (Cebik's
+    'single half twist' of ladder line)."""
+    from antennaknobs.designs.beams.phased_driver_yagi import Builder
+    from antennaknobs.network import TL, Driven
+
+    b = Builder()
+    tups = b.build_wires()
+    names = {t[4]: t for t in tups if len(t) == 5 and t[4]}
+    assert set(names) == {"feed", "rear"}
+    wavelength = 299.792458 / b.design_freq
+    halves = [h for h, _ in b.TABLE]
+    poss = [p for _, p in b.TABLE]
+    assert halves[0] > halves[1] > halves[2]  # rear > forward > director
+    assert poss[0] == 0.0
+    assert 0.04 < poss[1] < 0.07  # the drivers hug each other...
+    assert poss[2] - poss[1] > 0.08  # ...the director does not
+    # feed sits on the FORWARD driver, the phase line runs rear <- feed
+    assert abs(names["feed"][0][0] - poss[1] * wavelength) < 0.01
+    assert abs(names["rear"][0][0]) < 0.01
+    net = b.build_network()
+    (tl,) = [br for br in net.branches if isinstance(br, TL)]
+    assert tl.transposed and abs(tl.z0 - 250.0) < 1e-9
+    assert {tl.a, tl.b} == {"feed", "rear"}
+    (src,) = net.sources
+    assert isinstance(src, Driven) and src.port == "feed"
+    # The wire elements are #12 LADDER LINE (a two-conductor cage), so the
+    # model wire is its ~5 mm equivalent radius -- much fatter than a bare
+    # #12 (1 mm) yet nothing like the tubing version's taper schedule.
+    assert 0.003 < b.build_wire_material().radius < 0.008
+
+
 # ===========================================================================
 # Methodology / cross-engine findings (momwire vs the PyNEC reference)
 #


### PR DESCRIPTION
Closes #365.

Tier-2 follow-on to the Cebik second-wave arc, from "Wide-Band 40-Meter Yagis" Part 3 (cebik.com mirror, tables read raw from the page).

## What was built

- **`beams.phased_driver_yagi`** — Cebik's Table 3 wire version: rear driver half 403", forward driver half 379" spaced 93" (carrying the 50 Ω feed), director half 377" at 260", at 7.15 MHz design frequency. The drivers are joined by a **transposed 250 Ω `TL` branch** — Cebik's ladder line "with a single half twist". No traps, no loading.
- The wire elements are themselves **#12 ladder line** (two conductors at ~1" spacing); modelled as the equivalent cage conductor √(r·s) ≈ 5.1 mm via `WireSpec`. This matters: single thin wires shift the phased cell's reactance balance.
- The natural contrast pair to `beams.owa_yagi` (#356): the OWA holds a band with a coupled resonator; this one phases two drivers against each other.

## Model vs Cebik's Table 3

| f (MHz) | Feed Z (model) | Feed Z (Cebik) | F/B in-plane | F/B (Cebik) | SWR |
|---|---|---|---|---|---|
| 7.0 | 38.2+6.5j | 35.8+4.0j | 12.1 | 12.89 | 1.36 |
| 7.15 | 50.5+2.7j | 50.9+5.2j | 15.1 | 15.48 | 1.06 |
| 7.3 | 47.5−20.8j | 54.5−20.0j | 14.0 | 13.22 | 1.53 |

Gain rises across the band as published but reads ~1 dB over his column (6.8→8.0 vs 5.92→6.97) — stated honestly in docstring and tests.

## Findings from the build

- The reducer's `transposed` TL was cross-checked against NEC's **native crossed-line `tl_card`** (negative z0) on this exact geometry: identical Z, gain, and pattern.
- The free-space pattern has a genuine overhead lobe, so F/B must be read in the beam plane — a max-over-theta comparison at φ=180 picks up the zenith pole (where φ is degenerate) and misreads the overhead lobe as a rear lobe.
- Untwist the line and the design breaks outright: SWR ~20 mid-band, F/B collapses — pinned as a test.

## Tests

Five physics tests in the Batch 5 section of `test_cebik_designs.py`; catalog regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)