### PR TITLE
Release v0.27.0 — nine Cebik designs + NEC deck import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.26.0"
+version = "0.27.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,21 +25,22 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.26.0" icon="star">
-  **Your designs, safely.** A design file is a full Python program on
-  purpose — so now it **doesn't run until you allow it**, like VS Code's
-  workspace-trust prompt. New files always ask first, edited files ask
-  again, and the web app gets a "designs need your OK to run" panel with
-  a built-in review: `antennaknobs screen` shows what a file does that's
-  unusual *without running it*. New
-  [`allow` / `disallow` / `screen` commands](/reference/cli/#allowing-user-designs-to-run),
-  and a confined `read_json` helper lets a design load wire lists from a
-  data file next to it — without raw file access, so it stays safe to
-  share. Built-in design files are now copy-portable: any catalog `.py`
-  works verbatim as a starting point in your designs folder. The
-  [hosted simulator](https://app.antennaknobs.dev/) also picked up a
-  security hardening pass (request limits and input validation on every
-  solve path). [All release notes →](/reference/releases/)
+<Card title="New in v0.27.0" icon="star">
+  **Nine Cebik designs, and bring your own NEC decks.** The
+  [catalog](/reference/catalog/) grows by nine antennas modelled from
+  L. B. Cebik (W4RNL)'s articles — the Extended Double Zepp and expanded
+  lazy-H, the OWA Yagi and its 40 m counterpart (a phased-driver wire
+  Yagi holding the whole band under SWR 1.5 through one half-twisted
+  line), two more self-contained verticals (the "magnetic slot" rectangle
+  and right-angle delta), a satellite Moxon turnstile fed through a real
+  quadrature harness, the Tri-Moxon switched vertical array (three fixed
+  beams, a coax switch instead of a rotator), and a terminated end-fed
+  long-wire — the catalog's first design whose wires **connect to
+  ground**. And [`read_nec`](/reference/nec-import/) now imports a NEC2
+  card deck — the format xnec2c, 4nec2, EZNEC, and decades of handbooks
+  speak — as a viewable, solvable design, honouring the deck's geometry
+  transforms and feeds and matching an independent `nec2c` solve to
+  0.011 Ω. [All release notes →](/reference/releases/)
 </Card>
 
 ## The whole pitch, in one line

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -153,6 +153,13 @@ was actually used, and over a finite ground the
 **radiated** percentage — the share of your input power that actually
 leaves as sky wave. The rest is absorbed power, not error.
 
+A wire that ends at exactly z = 0 **connects to the ground plane** — the
+return path a design like `wire.terminated_longwire` (fed and terminated
+against ground through its vertical legs) depends on. NEC-2 makes that
+connection physical over **PEC** ground only (finite-ground contact is a
+NEC-4 feature), so solve ground-connected designs with PEC selected;
+elevated designs are unaffected.
+
 ## Power budget
 
 Designs with a lossy feed network — a real coax or ladder-line run, a


### PR DESCRIPTION
Release PR per the ritual: version bump + what's-new card + docs de-stale sweep.

## In this release (since v0.26.0)

**Nine Cebik (W4RNL) designs** across two waves:
- `wire.edz` — Extended Double Zepp with series matching section (#358)
- `wire.expanded_lazy_h` — expanded lazy-H with a real TL phasing harness (#359)
- `beams.owa_yagi` — 4-el OWA with whole-band flat 50 Ω feed (#360)
- `verticals.right_angle_delta` — the coax-friendly SCV delta (#361)
- `verticals.rectangle` — "magnetic slot" SCV + quarter-wave transformer (#367)
- `wire.terminated_longwire` — terminated end-fed long-wire; first ground-connected design, with the new PyNEC GE-flag support (#368)
- `beams.moxon_turnstile` — satellite turnstile with a real quadrature harness (#370)
- `beams.phased_driver_yagi` — 40 m wide-band wire Yagi, transposed 250 Ω phaseline (#371)
- `verticals.tri_moxon` — switched vertical array with λ/4-shorted idle feedlines (#372)

**NEC deck import** (#369): `read_nec` / `parse_nec` load a `.nec` card deck as a viewable, solvable design — geometry transforms, feeds, `nec2c`-validated — documented at `reference/nec-import` (#374).

## Ritual checklist

- [x] `version = "0.27.0"` in pyproject.toml (no new momwire; pin unchanged at 0.11.0)
- [x] What's-new card refreshed on the front page
- [x] De-stale sweep: web.md ground section gains the z=0 ground-connection note (PEC-only in NEC-2); solver/cli pages had no stale claims; catalog is generated and already current
- [x] Site builds clean (20 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)