### PR TITLE
Fix #377: size BLAS/OMP thread pools at runtime — the server's env pins never applied

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,4 +68,11 @@ EXPOSE 8000
 # proxy's traffic inside the container. --ws-max-size caps a WebSocket frame
 # at 1 MiB (uvicorn's default is 16 MiB): /ws solve requests are a few KB, so
 # this bounds what an abusive client can make the reader json.loads per frame.
-CMD ["sh", "-c", "uvicorn antennaknobs.web.server:app --host 0.0.0.0 --port ${PORT:-8000} --ws-max-size 1048576"]
+#
+# OMP_WAIT_POLICY/GOMP_SPINCOUNT park idle OMP workers between solves instead
+# of busy-spinning through each solve's Python phases. libgomp reads these
+# once at load — before any Python code runs — so they must live here in the
+# launch env, not in server.py (see its thread-policy block / issue #377).
+# Thread COUNTS by contrast are set at runtime by server.py via threadpoolctl.
+# Moot on a 1-vCPU machine (no OMP team to park) but correct if the VM grows.
+CMD ["sh", "-c", "OMP_WAIT_POLICY=PASSIVE GOMP_SPINCOUNT=0 uvicorn antennaknobs.web.server:app --host 0.0.0.0 --port ${PORT:-8000} --ws-max-size 1048576"]

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ uvicorn antennaknobs.web.server:app      # open http://127.0.0.1:8000
 The backend serves the UI at `/` and the JSON/`/ws` API on the same origin;
 `/docs` is the interactive API explorer.
 
+Optional, multi-core boxes: prefix the command with
+`OMP_WAIT_POLICY=PASSIVE GOMP_SPINCOUNT=0` to park idle solver threads between
+solves (~15% lower knob-drag latency). These are read once at process start,
+so they only work as launch env — everything else about threading the server
+configures itself.
+
 **Development (two terminals, hot-reload).** When editing the frontend, run the
 Vite dev server alongside the backend so you get HMR:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,11 @@ dependencies = [
 #   - psutil powers _physical_cpu_count() in antennaknobs.web.server — portable across
 #     Windows/macOS/Linux. Falls back to os.cpu_count() if missing, which
 #     misfires on chips without HT (pins to half the actual cores).
-web = ["fastapi", "uvicorn[standard]", "websockets", "psutil"]
+#   - threadpoolctl sizes the BLAS/OpenMP pools at runtime in
+#     antennaknobs.web.server — env vars are snapshotted by each library at
+#     import time, which happens (via antennaknobs/__init__) before server.py
+#     can set them (issue #377).
+web = ["fastapi", "uvicorn[standard]", "websockets", "psutil", "threadpoolctl"]
 
 # Test suite: `pip install -e ".[test]"` makes `pytest` reproducible from a
 # clean clone (the runtime deps in [project] cover the numpy/scipy/matplotlib

--- a/scripts/bench_wire_loading.py
+++ b/scripts/bench_wire_loading.py
@@ -56,9 +56,8 @@ def _physical_cpu_count() -> int:
 
 
 _NPROC = str(_physical_cpu_count())
-os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+os.environ.setdefault("OPENBLAS_NUM_THREADS", _NPROC)
 os.environ.setdefault("OMP_NUM_THREADS", _NPROC)
-os.environ.setdefault("MKL_NUM_THREADS", _NPROC)
 os.environ.setdefault("OMP_WAIT_POLICY", "PASSIVE")
 os.environ.setdefault("GOMP_SPINCOUNT", "0")
 

--- a/scripts/profile_compare_engines.py
+++ b/scripts/profile_compare_engines.py
@@ -25,8 +25,11 @@ from __future__ import annotations
 
 # Mirror the UI backend's threading setup (web/server.py) BEFORE numpy/scipy/
 # PyNEC import — each library snapshots the env at its own import time. Keep
-# this in sync with web/server.py: physical-core count for OMP/MKL, OpenBLAS
-# pinned to 1, OMP workers parked between regions.
+# this in sync with web/server.py's thread policy: physical-core count for
+# both OMP and OpenBLAS (fill and LU are sequential phases), OMP workers
+# parked between regions. Env vars work here because they are set before the
+# first numpy/scipy/PyNEC import — the server itself must use threadpoolctl
+# at runtime instead (see issue #377).
 import os
 
 
@@ -55,9 +58,8 @@ def _physical_cpu_count() -> int:
 
 
 _NPROC = str(_physical_cpu_count())
-os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+os.environ.setdefault("OPENBLAS_NUM_THREADS", _NPROC)
 os.environ.setdefault("OMP_NUM_THREADS", _NPROC)
-os.environ.setdefault("MKL_NUM_THREADS", _NPROC)
 os.environ.setdefault("OMP_WAIT_POLICY", "PASSIVE")
 os.environ.setdefault("GOMP_SPINCOUNT", "0")
 
@@ -178,7 +180,6 @@ def run_design(label, builder_cls, bands, warmup_freq):
 def main():
     print(
         f"OMP_NUM_THREADS={os.environ['OMP_NUM_THREADS']} "
-        f"MKL_NUM_THREADS={os.environ['MKL_NUM_THREADS']} "
         f"OPENBLAS_NUM_THREADS={os.environ['OPENBLAS_NUM_THREADS']} "
         f"OMP_WAIT_POLICY={os.environ['OMP_WAIT_POLICY']} "
         f"GOMP_SPINCOUNT={os.environ['GOMP_SPINCOUNT']}"

--- a/scripts/profile_ground_models.py
+++ b/scripts/profile_ground_models.py
@@ -45,8 +45,11 @@ from __future__ import annotations
 
 # Mirror the UI backend's threading setup (web/server.py) BEFORE numpy/scipy/
 # PyNEC import — each library snapshots the env at its own import time. Keep
-# this in sync with web/server.py: physical-core count for OMP/MKL, OpenBLAS
-# pinned to 1, OMP workers parked between regions.
+# this in sync with web/server.py's thread policy: physical-core count for
+# both OMP and OpenBLAS (fill and LU are sequential phases), OMP workers
+# parked between regions. Env vars work here because they are set before the
+# first numpy/scipy/PyNEC import — the server itself must use threadpoolctl
+# at runtime instead (see issue #377).
 import os
 
 
@@ -75,9 +78,8 @@ def _physical_cpu_count() -> int:
 
 
 _NPROC = str(_physical_cpu_count())
-os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+os.environ.setdefault("OPENBLAS_NUM_THREADS", _NPROC)
 os.environ.setdefault("OMP_NUM_THREADS", _NPROC)
-os.environ.setdefault("MKL_NUM_THREADS", _NPROC)
 os.environ.setdefault("OMP_WAIT_POLICY", "PASSIVE")
 os.environ.setdefault("GOMP_SPINCOUNT", "0")
 
@@ -288,7 +290,6 @@ def main():
 
     print(
         f"OMP_NUM_THREADS={os.environ['OMP_NUM_THREADS']} "
-        f"MKL_NUM_THREADS={os.environ['MKL_NUM_THREADS']} "
         f"OPENBLAS_NUM_THREADS={os.environ['OPENBLAS_NUM_THREADS']} "
         f"OMP_WAIT_POLICY={os.environ['OMP_WAIT_POLICY']} "
         f"GOMP_SPINCOUNT={os.environ['GOMP_SPINCOUNT']}"

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -17,6 +17,12 @@ The `[web]` extra pulls in `uvicorn[standard]`, which provides the WebSocket
 support the live-solve channel (`/ws`) needs — plain `uvicorn` fails that
 handshake.
 
+The server sizes its BLAS/OpenMP thread pools itself (physical-core count).
+On multi-core boxes you can optionally prefix the command with
+`OMP_WAIT_POLICY=PASSIVE GOMP_SPINCOUNT=0` to park idle solver threads
+between solves — worth ~15% on live knob-drag latency. These two are read
+once at process start, so they only take effect as launch environment.
+
 A local instance has no login and none of the hosted instance's solve-size
 limits, and it runs any design files you've allowed with your user privileges —
 keep it on the default `127.0.0.1` bind rather than exposing it to a network

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -9,38 +9,36 @@ The response shape is uniform across geometries — each wire is a sequence of
 knots with per-knot complex currents and the feed lives on one of the wires —
 so the frontend draws every geometry the same way.
 
-Run: uvicorn antennaknobs.web.server:app --reload
-(needs uvicorn[standard] — /ws is a WebSocket upgrade.)
+Run: OMP_WAIT_POLICY=PASSIVE GOMP_SPINCOUNT=0 uvicorn antennaknobs.web.server:app --reload
+(needs uvicorn[standard] — /ws is a WebSocket upgrade. The env prefix parks
+idle OMP workers between solves — see the thread-policy block below; the
+server works without it at ~15% higher interactive-solve latency.)
 """
 
 from __future__ import annotations
 
-# Configure BLAS/OpenMP thread counts BEFORE numpy/scipy/PyNEC import — each
-# library snapshots the env at its own import time and ignores later changes.
-#
-# OPENBLAS_NUM_THREADS=1: numpy/scipy bring their own OpenBLAS thread pool
-#   that sits idle most of the request lifetime but contends with PyNEC's
-#   MKL/OpenBLAS-LAPACKE pool for cores. vtune confirmed this was costing
-#   ~8% wall time at NP=4 on the gather-scatter fill.
-#
-# OMP_NUM_THREADS / MKL_NUM_THREADS: with the gather-scatter matrix fill
-#   (see PR #21) the per-source parallel-for inside cmset() and MKL/OpenBLAS'
-#   zgetrf both want available cores. Default to the physical-core count
-#   (not logical / HT count) — see _physical_cpu_count(); the FP-vector-
-#   saturated quadrature inner loops gain nothing from HT siblings and
-#   actually slow down ~15% from execution-unit contention on KBL-class
-#   chips. An operator can override via the env to share with other
-#   workloads on the same host.
-#
-# Older comment explaining why we used to pin everything to 1: the interactive
-# workload is many small solves (≤ 250×250 dense complex matrices), and on
-# the pre-gather-scatter code path thread orchestration costs dwarfed the
-# per-call work — a 2-director live solve went from 220 ms (8 threads) to
-# 67 ms (1 thread) on an 8-core box. That regression is no longer reproducible
-# with the current build: matrix fill itself parallelizes, the OMP team is
-# spawned once per cmset(), and OpenBLAS contention is removed by the
-# OPENBLAS_NUM_THREADS=1 pin above.
+import asyncio
+import hashlib
+import json
+import math
 import os
+import time
+from collections import OrderedDict
+from copy import deepcopy
+from pathlib import Path
+
+import momwire
+import numpy as np
+from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
+from fastapi.concurrency import run_in_threadpool
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import Response, StreamingResponse
+from fastapi.staticfiles import StaticFiles
+from starlette.websockets import WebSocketState
+from threadpoolctl import threadpool_limits
+
+from . import pynec_backend, user_designs
+from .examples import REGISTRY as EXAMPLES
 
 
 def _physical_cpu_count() -> int:
@@ -68,44 +66,50 @@ def _physical_cpu_count() -> int:
     return max(1, os.cpu_count() or 1)
 
 
-_NPROC = str(_physical_cpu_count())
-os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
-os.environ.setdefault("OMP_NUM_THREADS", _NPROC)
-os.environ.setdefault("MKL_NUM_THREADS", _NPROC)
-# Between OMP parallel regions the workers default to busy-spinning on the
-# team barrier (GOMP_SPINCOUNT ~300k, ~80 ms on KBL). Each momwire solve runs
-# only ~1 ms of C++ kernel then ~10–20 ms of Python serial work (basis-coef
-# build, sparse matmul, LU solve); the workers spin through all of that
-# Python time on every solve. On the N=21 hentenna width-sweep harness
-# (`scripts/vtune_hentenna_width_sweep.py`) VTune attributed ~63% of sin's
-# CPU and ~32% of pynec's CPU to `libgomp` barrier-wait under this default.
-# Make workers park immediately so the spin time goes away — wall-clock
-# drops ~4× on both solvers at N=21 (sin 78 → 19 ms/step, pynec 67 → 9 ms).
-os.environ.setdefault("OMP_WAIT_POLICY", "PASSIVE")
-os.environ.setdefault("GOMP_SPINCOUNT", "0")
-
-# ruff: noqa: E402 — imports below must follow the env-var setup above so
-# OpenBLAS picks up the thread count at its own import time.
-import asyncio
-import hashlib
-import json
-import math
-import time
-from collections import OrderedDict
-from copy import deepcopy
-from pathlib import Path
-
-import momwire
-import numpy as np
-from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
-from fastapi.concurrency import run_in_threadpool
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import Response, StreamingResponse
-from fastapi.staticfiles import StaticFiles
-from starlette.websockets import WebSocketState
-
-from . import pynec_backend, user_designs
-from .examples import REGISTRY as EXAMPLES
+# BLAS/OpenMP thread policy — applied at RUNTIME via threadpoolctl, not env.
+#
+# This block used to set OPENBLAS_NUM_THREADS / OMP_NUM_THREADS etc. before
+# the heavy imports, but that never worked in a served process: importing
+# `antennaknobs.web.server` executes `antennaknobs/__init__` first, which
+# already pulls in numpy/scipy/PyNEC/libgomp — every pool snapshots the env
+# before this module's body runs (issue #377 post-mortem; small solves were
+# 5–7× slower than the config intended). threadpoolctl talks to the already-
+# loaded pools directly, so it is immune to import order.
+#
+# The whole stack is OpenBLAS: numpy, scipy, and PyNEC each bundle their own
+# copy (numpy.libs / scipy.libs / pynec_accel.libs — inspect with
+# threadpoolctl.threadpool_info()); nothing links MKL. A solve has two
+# core-hungry phases that run sequentially, so both get the physical-core
+# count without oversubscribing:
+#   - matrix fill: the per-source OMP parallel-for inside cmset() (libgomp,
+#     see PR #21), and
+#   - LU factorization: scipy zgesv (momwire) / LAPACKE zgetrf (pynec_accel),
+#     both OpenBLAS-backed — the dominant O(N³) phase of large solves.
+#
+# Physical cores, not 1 and not the logical count:
+#   - An older OPENBLAS_NUM_THREADS=1 pin predates PyNEC bundling OpenBLAS
+#     (its factorization stayed parallel via MKL back then); with the current
+#     stack it would serialize the LU phase of every big solve — the pin vs
+#     NPROC is 2.3× on pynec (12.8 → 5.5 s) and 1.6× on bspline (7.3 →
+#     4.6 s) at ~4000 basis on a 4C/8T box (issue #377).
+#   - The FP-vector-saturated quadrature inner loops gain nothing from HT
+#     siblings and lose ~15% to execution-unit contention on KBL-class
+#     chips — see _physical_cpu_count().
+#
+# Operators can still override per-pool via the usual env vars (honored by
+# the libraries at load AND respected here). Two knobs remain env-only —
+# libgomp reads them once at load, before any Python code can run, so they
+# must be set in the launch environment (the Dockerfile CMD does; for local
+# runs see the docstring): OMP_WAIT_POLICY=PASSIVE + GOMP_SPINCOUNT=0 park
+# idle OMP workers instead of busy-spinning through each solve's Python
+# phases (~13–20% off small-solve latency, hentenna N=21).
+_NPROC = _physical_cpu_count()
+threadpool_limits(
+    limits={
+        "blas": int(os.environ.get("OPENBLAS_NUM_THREADS", _NPROC)),
+        "openmp": int(os.environ.get("OMP_NUM_THREADS", _NPROC)),
+    }
+)
 
 # Scaffold the user-design folder (TEMPLATE.py + CLAUDE.md on first run) and
 # load any existing user designs into the registry at startup. They are also

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -45,6 +45,32 @@ def test_physical_cpu_count_is_positive():
     assert server._physical_cpu_count() >= 1
 
 
+def test_thread_pools_sized_to_physical_cores():
+    """Importing the server must actually resize the BLAS/OpenMP pools.
+
+    Regression test for issue #377: env vars set in server.py never took
+    effect because antennaknobs/__init__ imports numpy (and friends) before
+    server.py's module body runs, so every pool had already snapshotted the
+    env. The runtime threadpoolctl call is immune to import order — assert
+    the pools really report the configured size, whatever machine this runs
+    on (env overrides included, mirroring server.py's own logic).
+    """
+    import os
+
+    from threadpoolctl import threadpool_info
+
+    expected = {
+        "blas": int(os.environ.get("OPENBLAS_NUM_THREADS", server._NPROC)),
+        "openmp": int(os.environ.get("OMP_NUM_THREADS", server._NPROC)),
+    }
+    pools = threadpool_info()
+    assert pools, "no BLAS/OpenMP pools found — did the solver stack change?"
+    for pool in pools:
+        want = expected.get(pool["user_api"])
+        if want is not None:
+            assert pool["num_threads"] == want, pool["filepath"]
+
+
 def test_polyline_knots_dedup_shared_corners():
     poly = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0]])
     knots = server._polyline_knots(poly, [2, 3])


### PR DESCRIPTION
## Summary
- **Issue #377 as filed**: `OPENBLAS_NUM_THREADS=1` serialized the O(N³) LU phase of large solves (the whole stack is bundled OpenBLAS now — numpy, scipy, *and* pynec_accel), and `MKL_NUM_THREADS` was dead config since nothing links MKL.
- **Worse bug found while fixing it**: *none* of `server.py`'s env setdefaults ever took effect in a served process. `uvicorn antennaknobs.web.server:app` imports `antennaknobs/__init__` first, which pulls in numpy/scipy/PyNEC/libgomp — every pool snapshots the env before `server.py`'s module body runs. Measured on a 4C/8T box, a bare launch ran small interactive solves **5–7× slower** than the config intended (hentenna N=21: pynec 85 ms vs 12 ms, sinusoidal 43 ms vs 8.6 ms median) — 8-thread pools + default busy-spin, exactly the regressions the env block existed to prevent.
- **Fix**: thread counts are now applied at **runtime via threadpoolctl** (immune to import order), physical-core count for both the OMP matrix fill and the OpenBLAS LU — sequential phases, so no oversubscription. Operator env overrides still win. `threadpoolctl` added to the `[web]` extra.
- **Env-only knobs relocated**: `OMP_WAIT_POLICY=PASSIVE` + `GOMP_SPINCOUNT=0` are read once by libgomp at load and cannot be set from Python, so the Dockerfile CMD now sets them and README/site docs recommend the prefix for local multi-core runs (~13–20% off small-solve latency; the server works fine without them).
- Profile scripts realigned with the new policy; regression test asserts importing the server actually resizes the live pools (`threadpool_info`).

## Measured (4C/8T KBL-R, ~4000-basis bowtie array / N=21 hentenna)
| | old pin (env effective) | old code, bare launch | new code, bare launch |
|---|---|---|---|
| pynec large | 12.5–13.0 s | — | **5.7 s (2.2×)** |
| bspline large | 7.2–7.4 s | — | **4.7 s (1.6×)** |
| pynec small (median) | 11.9 ms | 85 ms | **15 ms** (11.7 with env prefix) |
| sinusoidal small (median) | 7.6 ms | 43 ms | **8.3 ms** (8.0 with env prefix) |

## Test plan
- [x] Full suite: 2035 passed
- [x] New regression test: importing `web.server` resizes all OpenBLAS pools + libgomp to physical-core count (env overrides respected)
- [x] Real uvicorn boot + live `/ws` solve round-trip (28.8 ms, matches known-good RTT)
- [x] `threadpool_info()` shows all three bundled OpenBLAS pools + libgomp at 4 after bare import (was 8)
- [x] ruff check + format clean

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUtqSdTwXJxBzms3jmV16u