### PR TITLE
Bump momwire pin to 0.12.0 (whip-benchmark memory hardening)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/sta
 # install below sees its requirement already satisfied, then the package with the
 # web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install "momwire==0.11.0" \
+ && pip install "momwire==0.12.0" \
  && pip install -e ".[web]"
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire==0.11.0",
+    "momwire==0.12.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",


### PR DESCRIPTION
## Summary
- Adopt momwire **v0.12.0** ([release notes](https://github.com/stevenmburns/momwire/releases/tag/v0.12.0)) — the whip-benchmark hardening arc: chunked dense fill+assemble dropping the `(d+1,d+1,N,N)` J tensor (momwire#136), H-matrix padding-wing bounding-box fix (momwire#137), ArrayBlockSolver degenerate-partition fallback (momwire#143), and the sinusoidal adjoint-oracle LU stash.
- All three pin sites in one commit per the release ritual: `pyproject.toml` exact pin, `Dockerfile` install, and the **submodule pointer** (`ea10012`, the 0.12.0 bump commit).
- Net effect: every momwire engine completes the 4,671-segment whip deck within 4.6 GB worst-case (dense over ground) on a dev box; ArrayBlock previously died allocating a 21.6 GiB gather, and dense BSpline previously crashed a 15 GB machine.

## Default-cost audit
- Full antennaknobs suite against the submodule at 0.12.0: **2035 passed**.
- Interactive-path latency smoke (hentenna N=21, 40 reps): sinusoidal 6.0 ms / bspline 11.4 ms / pynec 13.0 ms medians — unchanged from 0.11.0. No new default-path costs; the ArrayBlock fallback only affects requests that previously OOMed.
- PyPI verified serving 0.12.0 before opening this PR (wheel-smoke race avoided).

## Test plan
- [x] Full suite green locally on the pinned code
- [x] Latency smoke of the live-solve path
- [x] `git -C momwire log --oneline -1` == the 0.12.0 bump commit (the drift check from PRs #268/#270)
- [ ] CI: wheel-smoke installs momwire 0.12.0 from PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUtqSdTwXJxBzms3jmV16u