### PR TITLE
Release v0.27.1 (whip-deck memory + threading hardening)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.27.0"
+version = "0.27.1"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,22 +25,18 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.27.0" icon="star">
-  **Nine Cebik designs, and bring your own NEC decks.** The
-  [catalog](/reference/catalog/) grows by nine antennas modelled from
-  L. B. Cebik (W4RNL)'s articles — the Extended Double Zepp and expanded
-  lazy-H, the OWA Yagi and its 40 m counterpart (a phased-driver wire
-  Yagi holding the whole band under SWR 1.5 through one half-twisted
-  line), two more self-contained verticals (the "magnetic slot" rectangle
-  and right-angle delta), a satellite Moxon turnstile fed through a real
-  quadrature harness, the Tri-Moxon switched vertical array (three fixed
-  beams, a coax switch instead of a rotator), and a terminated end-fed
-  long-wire — the catalog's first design whose wires **connect to
-  ground**. And [`read_nec`](/reference/nec-import/) now imports a NEC2
-  card deck — the format xnec2c, 4nec2, EZNEC, and decades of handbooks
-  speak — as a viewable, solvable design, honouring the deck's geometry
-  transforms and feeds and matching an independent `nec2c` solve to
-  0.011 Ω. [All release notes →](/reference/releases/)
+<Card title="New in v0.27.1" icon="star">
+  **Big decks won't sink your machine.** A benchmark-grade NEC import — a
+  4,671-segment whip on a 96-inch ground-plane grid — used to exhaust the
+  memory of a 15 GB workstation on the dense solver and crash outright on
+  the compressed ones. The bundled momwire 0.12.0 hardens every engine in
+  the family: chunked dense assembly, fixed H-matrix compression on
+  junction-heavy meshes, and a graceful array-solver fallback bring the
+  whole [solver line-up](/reference/solver/) through that deck in at most
+  4.6 GB. The web backend also now sizes its solver thread pools
+  correctly at runtime — large-deck factorizations run up to 2.2× faster
+  on multi-core machines, with knob-drag latency untouched.
+  [All release notes →](/reference/releases/)
 </Card>
 
 ## The whole pitch, in one line


### PR DESCRIPTION
## Summary
- Version bump 0.27.0 → 0.27.1 and what's-new card refresh — the release PR ritual for a patch release.
- Carries two changes since v0.27.0: **momwire 0.12.0 adoption** (PR #379 — chunked dense assembly, H-matrix box fix, ArrayBlock fallback; the whole solver family now completes the 4,671-segment whip deck within 4.6 GB worst-case) and the **server thread-policy fix** (PR #378 — BLAS/OMP pools sized at runtime, 2.2× faster large-deck LU, the dead-env-pin class closed with a regression test).
- Docs de-stale sweep: `reference/web.md` was already updated in PR #378; solver.mdx's memory/cap statements remain accurate; catalog untouched (no design changes). Site builds clean (20 pages).

## Test plan
- [x] `npm run build` green
- [x] Both carried PRs individually CI-verified on main (fresh runs confirmed after each merge)
- [ ] After tag: watch publish + simulator deploy + docs deploy pipelines; verify PyPI serves 0.27.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUtqSdTwXJxBzms3jmV16u