### PR TITLE
ELT whip NEC benchmark: catalog design with matching network, workbench-usable

### DIFF
--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -77,6 +77,7 @@ whole shape with a `Drone` — see
 | `verticals.bruce` | Bruce array: a series-fed vertically-polarised curtain (L. B. Cebik, W4RNL) |
 | `verticals.challenger` | KJ6ER's "Challenger" — off-center-fed halfwave vertical with 4:1 unun · variants: `band10`, `band12`, `band17`, `band20`, `band6`, `plus` |
 | `verticals.dominator` | KJ6ER's "Dominator" — end-fed halfwave vertical with 49:1 transformer · variants: `band10`, `band12`, `band17`, `plus` |
+| `verticals.elt_whip` | Parametric rebuild of the ELT whip on a 96-inch rounded ground-plane grid — the heavier of the two classic NEC performance benchmarks (``whip_antenna_8ft_groundplane.nec`` from the W8IO NEC benchmarks page, http://www.w8io.com/nec-benchmarks.htm): 434 deck wires, ~4,400 segments |
 | `verticals.four_square` | Four-square phased vertical array -- the diagonal-firing quadrature box (L. B. Cebik, W4RNL) |
 | `verticals.half_square` | Half-square: a vertically-polarised wire antenna (L. B. Cebik, W4RNL) |
 | `verticals.inverted_l` | Inverted-L: a bent, top-loaded vertical (L. B. Cebik, W4RNL) |

--- a/src/antennaknobs/designs/verticals/elt_whip.py
+++ b/src/antennaknobs/designs/verticals/elt_whip.py
@@ -1,0 +1,316 @@
+"""Parametric rebuild of the ELT whip on a 96-inch rounded ground-plane grid
+— the heavier of the two classic NEC performance benchmarks
+(``whip_antenna_8ft_groundplane.nec`` from the W8IO NEC benchmarks page,
+http://www.w8io.com/nec-benchmarks.htm): 434 deck wires, ~4,400 segments.
+It is in the catalog to stress the solvers, not to be a usable antenna —
+expect seconds-per-solve knob response.
+
+Where the source deck hand-authors 434 GW cards, this design *generates*
+the same geometry from knobs. At the default parameter values the wire
+paths and segment boundaries reproduce the deck to well under 0.1 mm
+(the only differences are ~1e-8 m, from the deck writing cos(30 deg) as the
+truncated literal .216506). The structure:
+
+  * **Whip** — a thin lower section (fed on its bottom segment, exactly where
+    the deck's EX card drives it) and a thicker upper section.
+  * **Cage/sleeve** — a ring of ``num_cage_wires`` verticals at
+    ``cage_radius`` around the lower whip, tied by a polygon ring every
+    ``cage_ring_spacing``, bonded to the whip by ``num_spokes`` spokes at
+    ``cage_base`` and to the ground mesh by ``num_posts`` grounded posts.
+  * **Ground plane** — a wire grid at ``grid_pitch``, trimmed to a rounded
+    outline of radius ``plane_radius``, with the central row/column and the
+    centre 2x2 cells re-meshed at ``fine_pitch``, and the feed row split
+    at the post feet (at ``cage_radius``-length segments, as in the deck).
+
+Every mesh crossing is emitted as a wire *endpoint* junction (unit cell
+edges), so the geometry survives the engines' odd-parity re-segmentation —
+the same form a NEC deck import's junction-splitting pass would produce
+(mid-wire junctions don't survive resegmentation; see the NEC-import docs).
+
+**The outline is data, not a formula.** The deck's "rounded" boundary is
+hand-drawn: no circle radius reproduces its column extents (it isn't even
+x/y symmetric — the node at (28", 40") is inside, (40", 28") is not). The
+profile is therefore kept as a table of the deck's 25 column half-extents,
+normalized, and resampled linearly when the knobs change the column count;
+rows are derived as its exact transpose, as in the deck. At the default 24
+cells it is used verbatim.
+
+Constraints worth knowing:
+  * Keep ``num_cage_wires`` a multiple of 4 if you use posts/spokes on all
+    four axes: posts bond to the ground mesh only where their feet land on
+    the centre mesh lines (the +/-x and +/-y axes). An off-axis post is still
+    drawn but its foot floats above the mesh.
+  * ``num_posts``/``num_spokes`` pick evenly spaced cage wires starting at
+    +x, so 2 posts land on +/-x (the deck) and 4 spokes on +/-x/+/-y (the
+    deck's two crossed diameter bars).
+  * The deck's LD matching network IS modelled (unlike a raw deck import,
+    which records the LD cards in ``deck.ignored``): ``build_network``
+    puts ``post_l_nh`` (deck: 90 nH) in series with the first grounded
+    post and ``post_c_pf`` (deck: 3 pF) in series with the second — the
+    cage's two grounded legs are the matching network. Set a knob to 0 to
+    omit that element.
+  * Remaining deviation: engines take a single wire radius (default: the
+    deck's length-dominant 0.254 mm; the upper whip's 0.889 mm is
+    approximated).
+"""
+
+import math
+from types import MappingProxyType
+
+from antennaknobs import AntennaBuilder, WireSpec
+from antennaknobs.network import Driven, Load, Network, PortOnWire
+
+# Half-extent of each ground-grid column, in cells: column i (x = i * pitch)
+# runs to y = +/-extent * pitch. Sampled from the source deck's hand-drawn
+# outline; index 0 is the centre column, index 24 the rim.
+_GRID_PROFILE = (
+    24,
+    24,
+    24,
+    24,
+    24,
+    24,
+    23,
+    23,
+    23,
+    23,
+    22,
+    22,
+    21,
+    21,
+    20,
+    19,
+    18,
+    17,
+    16,
+    15,
+    13,
+    12,
+    10,
+    8,
+    5,
+)
+
+
+def _column_extent(i, n):
+    """Half-extent, in cells, of column ``|i|`` on a plane ``n`` cells in
+    radius: the deck profile resampled to ``n``. Exact for n == 24."""
+    m = len(_GRID_PROFILE) - 1
+    x = abs(i) * m / n
+    k = min(int(x), m - 1)
+    e = _GRID_PROFILE[k] + (x - k) * (_GRID_PROFILE[k + 1] - _GRID_PROFILE[k])
+    return max(0, round(e * n / m))
+
+
+class Builder(AntennaBuilder):
+    label = "ELT whip on 8 ft ground grid (NEC benchmark)"
+
+    default_params = MappingProxyType(
+        {
+            "freq": 406.0,  # MHz — deck FR sweep centre (400-412)
+            "height": 1.0,  # metres above the app's ground plane
+            # Whip (deck: 7" thin fed section + 15.75" thick top section)
+            "whip_lower_len": 0.1778,
+            "whip_upper_len": 0.40005,
+            "whip_upper_segs": 28,
+            # Cage/sleeve around the lower whip (deck: 12 wires at 0.25",
+            # rings every 0.5", 2 grounded posts, 4 spokes at z = 0.5")
+            "cage_radius": 0.00635,
+            "cage_base": 0.0127,
+            "cage_ring_spacing": 0.0127,
+            "num_cage_wires": 12,
+            "num_posts": 2,
+            "num_spokes": 4,
+            # Matching network (deck: LD cards put 90 nH in series with the
+            # +x post and 3 pF in series with the -x post — the cage's two
+            # grounded legs ARE the matching network). 0 = element omitted,
+            # leaving that post a plain wire.
+            "post_l_nh": 90.0,
+            "post_c_pf": 3.0,
+            # Ground-plane grid (deck: 48" radius, 2" mesh, 1" fine mesh)
+            "plane_radius": 1.2192,
+            "grid_pitch": 0.0508,
+            "fine_pitch": 0.0254,
+            "wire_radius": 0.000254,
+            "ui_params": MappingProxyType(
+                {
+                    "default_view": "xz",
+                    "meas_freq_range": (400.0, 412.0),
+                    # integer knobs, not continuous lengths
+                    "whip_upper_segs": {"min": 4, "max": 56, "step": 1},
+                    "num_cage_wires": {"min": 4, "max": 24, "step": 1},
+                    "num_posts": {"min": 0, "max": 4, "step": 1},
+                    "num_spokes": {"min": 0, "max": 12, "step": 1},
+                    "post_l_nh": {"min": 0.0, "max": 200.0, "step": 1.0},
+                    "post_c_pf": {"min": 0.0, "max": 20.0, "step": 0.1},
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        h = self.height
+        pitch = self.grid_pitch
+        n = max(2, round(self.plane_radius / pitch))  # plane radius, in cells
+        s = max(1, round(pitch / self.fine_pitch))  # fine cells per cell
+        r = max(1e-6, self.cage_radius)
+        base = self.cage_base
+        spacing = self.cage_ring_spacing
+        l1 = self.whip_lower_len
+        m_cage = max(3, round(self.num_cage_wires))
+        n_posts = max(0, round(self.num_posts))
+        n_spokes = max(0, round(self.num_spokes))
+
+        wires = []
+
+        def add(p0, p1, nseg, ex=None, name=None):
+            wires.append((p0, p1, nseg, ex, name) if name else (p0, p1, nseg, ex))
+
+        # Unit direction of each cage wire. Snap the on-axis components to
+        # exact zeros: wires are recognised as connected only where endpoint
+        # coordinates match bitwise, and the post feet must land exactly on
+        # the split points of the centre mesh lines below.
+        dirs = []
+        for m in range(m_cage):
+            th = 2.0 * math.pi * m / m_cage
+            c, si = math.cos(th), math.sin(th)
+            dirs.append((0.0 if abs(c) < 1e-15 else c, 0.0 if abs(si) < 1e-15 else si))
+
+        def cage_pt(m, z):
+            c, si = dirs[m % m_cage]
+            return (r * c, r * si, z + h)
+
+        # --- whip: driven on its bottom segment, as the deck's EX card
+        # (via the network's Driven port — see build_network) ---
+        add((0.0, 0.0, h), (0.0, 0.0, base + h), 1, name="feed")
+        add(
+            (0.0, 0.0, base + h),
+            (0.0, 0.0, l1 + h),
+            max(1, round((l1 - base) / spacing)),
+        )
+        add(
+            (0.0, 0.0, l1 + h),
+            (0.0, 0.0, l1 + self.whip_upper_len + h),
+            max(1, round(self.whip_upper_segs)),
+        )
+
+        # --- cage: verticals in ring-to-ring pieces, a polygon per ring ---
+        n_levels = max(1, int((l1 - base) / spacing + 1e-9) + 1)
+        levels = [base + l * spacing for l in range(n_levels)]
+        for m in range(m_cage):
+            for za, zb in zip(levels, levels[1:]):
+                add(cage_pt(m, za), cage_pt(m, zb), 1)
+        for z in levels:
+            for m in range(m_cage):
+                add(cage_pt(m, z), cage_pt(m + 1, z), 1)
+
+        post_idx = sorted(
+            {round(k * m_cage / n_posts) % m_cage for k in range(n_posts)}
+        )
+        spoke_idx = sorted(
+            {round(k * m_cage / n_spokes) % m_cage for k in range(n_spokes)}
+        )
+        # grounded posts: mesh up to the first ring. Named so build_network
+        # can insert the deck's LD elements in series (post0 gets the coil,
+        # post1 the capacitor — with the deck's 2 posts that is +x and −x).
+        for k, m in enumerate(post_idx):
+            c, si = dirs[m]
+            add((r * c, r * si, h), cage_pt(m, base), 1, name=f"post{k}")
+        for m in spoke_idx:  # spokes: whip out to the first ring
+            add((0.0, 0.0, base + h), cage_pt(m, base), 1)
+
+        # --- coarse ground grid, as unit cell edges so every crossing is a
+        # wire-endpoint junction; the centre row/column and their +/-1
+        # neighbours carry the deck's finer segmentation ---
+        ecol = [_column_extent(i, n) for i in range(n + 1)]
+
+        def row_extent(j):
+            # transpose of the column profile: the row at |j| reaches the
+            # outermost column that reaches |j|
+            return max((i for i in range(n + 1) if ecol[i] >= j), default=0)
+
+        for i in range(-n, n + 1):
+            x = i * pitch
+            dense = abs(i) <= 1
+            e = ecol[abs(i)]
+            for j in range(-e, e):
+                if dense and j in (-1, 0):
+                    continue  # covered by the fine centre mesh below
+                add((x, j * pitch, h), (x, (j + 1) * pitch, h), s if dense else 1)
+        for j in range(-n, n + 1):
+            y = j * pitch
+            dense = abs(j) <= 1
+            e = row_extent(abs(j))
+            for i in range(-e, e):
+                if dense and i in (-1, 0):
+                    continue
+                add((i * pitch, y, h), ((i + 1) * pitch, y, h), s if dense else 1)
+
+        # --- fine centre mesh: the central +/-1-cell square at fine pitch ---
+        def fine(k):
+            # k-th fine node; the +/-s rim is written as +/-pitch itself so
+            # the fine mesh and the coarse grid share exact coordinates
+            return math.copysign(pitch, k) if abs(k) == s else k * pitch / s
+
+        x_feet = sorted({r * dirs[m][0] for m in post_idx if dirs[m][1] == 0.0})
+        y_feet = sorted({r * dirs[m][1] for m in post_idx if dirs[m][0] == 0.0})
+
+        def line_pieces(feet):
+            """Split points and per-piece segment counts for a centre mesh
+            line that hosts post feet: break at each foot, and keep the whole
+            line at ~foot-offset-length segments, as the deck's feed row."""
+            pts = [fine(k) for k in range(-s, s + 1)]
+            pts += [
+                ft
+                for ft in feet
+                if -pitch < ft < pitch and not any(abs(ft - p) < 1e-12 for p in pts)
+            ]
+            pts.sort()
+            seg = min(r, pitch / s)
+            return [(a, b, max(1, round((b - a) / seg))) for a, b in zip(pts, pts[1:])]
+
+        for u in range(-s, s + 1):
+            x = fine(u)
+            if u == 0 and y_feet:
+                for a, b, nseg in line_pieces(y_feet):
+                    add((x, a, h), (x, b, h), nseg)
+            else:
+                for v in range(-s, s):
+                    add((x, fine(v), h), (x, fine(v + 1), h), 1)
+        for v in range(-s, s + 1):
+            y = fine(v)
+            if v == 0 and x_feet:
+                for a, b, nseg in line_pieces(x_feet):
+                    add((a, y, h), (b, y, h), nseg)
+            else:
+                for u in range(-s, s):
+                    add((fine(u), y, h), (fine(u + 1), y, h), 1)
+
+        return wires
+
+    def build_network(self):
+        """The deck's matching network: LD cards put 90 nH in series with
+        the +x grounded post and 3 pF in series with the −x one (ld_card
+        type 0 → `Load`, a series element in the named 1-segment post wire).
+        A zero knob omits that element, leaving the post a plain wire; the
+        feed is the whip's bottom segment, as the deck's EX card."""
+        ports = {"feed": PortOnWire("feed")}
+        branches = []
+        n_posts = max(0, round(self.num_posts))
+        elems = [
+            ("post0", self.post_l_nh * 1e-9, None),
+            ("post1", None, self.post_c_pf * 1e-12),
+        ]
+        for k, (pname, l, c) in enumerate(elems):
+            if k >= n_posts or not (l or c):
+                continue
+            ports[pname] = PortOnWire(pname)
+            branches.append(Load(port=pname, l=l or None, c=c or None))
+        return Network(
+            ports=ports,
+            branches=branches,
+            sources=[Driven(port="feed", voltage=1 + 0j)],
+        )
+
+    def build_wire_material(self):
+        return WireSpec(radius=self.wire_radius)

--- a/src/antennaknobs/designs/verticals/elt_whip.py
+++ b/src/antennaknobs/designs/verticals/elt_whip.py
@@ -136,6 +136,12 @@ class Builder(AntennaBuilder):
                 {
                     "default_view": "xz",
                     "meas_freq_range": (400.0, 412.0),
+                    # 406 MHz sits outside every HF amateur band; without a
+                    # containing band the UI's design-switch snap would drag
+                    # design_freq down to the first HF band (160 m!). One
+                    # custom band covering the deck's FR sweep keeps the
+                    # tabs honest: (key, label, freq, min, max).
+                    "bands": (("406", "406 MHz", 406.0, 400.0, 412.0),),
                     # integer knobs, not continuous lengths
                     "whip_upper_segs": {"min": 4, "max": 56, "step": 1},
                     "num_cage_wires": {"min": 4, "max": 24, "step": 1},

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -1079,6 +1079,13 @@ def _auto_default_view(cls) -> str:
     return "".join(sorted(s[0] for s in spans[:2]))
 
 
+# Above this estimated b-spline basis count, a dense (or compressed) b-spline
+# solve is minutes-per-knob-drag and the UI recommends the sinusoidal solver
+# instead. Dense at 3,000 bases is a ~140 MB Z and ~10 s on a 4-core dev box —
+# already past interactive; the whip benchmark sits at ~12,700.
+_SINUSOIDAL_RECOMMEND_MIN_BASIS = 3000
+
+
 @lru_cache(maxsize=None)
 def _recommended_backend(cls) -> str | None:
     """Recommend a default solver for the design, or None to let the UI keep
@@ -1089,8 +1096,18 @@ def _recommended_backend(cls) -> str | None:
     solver is dramatically faster than the dense default (e.g. bowtiearray2x4:
     ~1 s vs ~8 s). Single-element designs, and multi-element designs whose
     elements are all distinct (Yagi-style), keep the dense default so their
-    basis/results are unchanged. Detection is geometry-only (no solve) and any
-    failure falls back to None.
+    basis/results are unchanged.
+
+    Returns "sinusoidal" for benchmark-class meshes — thousands of explicit
+    segments in one connected structure (e.g. verticals.elt_whip: 4,392
+    segments in 4,067 junction-split pieces ⇒ ~12,700 b-spline bases) —
+    where every b-spline-family solver takes minutes per solve and a few
+    concurrent requests (live solve + sweep + norm-check) can exhaust a
+    development machine's memory, while the sinusoidal solver answers in
+    seconds. The frontend withholds the solve and warns when the selected
+    solver conflicts with this recommendation (`comboInappropriate`).
+
+    Detection is geometry-only (no solve) and any failure falls back to None.
 
     Memoised per design class: it already runs only once per design at registry
     build (the result is baked into the immutable `AntennaExample`, which the
@@ -1102,6 +1119,19 @@ def _recommended_backend(cls) -> str | None:
         from momwire.array_block import _wire_to_element
 
         builder = _build_builder(cls, {})
+        # B-spline basis estimate without meshing: explicit segments plus
+        # degree (2) boundary bases per wire piece — the junction-split
+        # inflation exactly (issue momwire#138: those extra bases are the
+        # physics of junction current discontinuities, not overhead).
+        # Designs that defer segmentation to the app (nseg None) raise on
+        # int() and fall through to the array detection below.
+        try:
+            wires = builder.build_wires()
+            est_basis = sum(int(w[2]) for w in wires) + 2 * len(wires)
+            if est_basis > _SINUSOIDAL_RECOMMEND_MIN_BASIS:
+                return "sinusoidal"
+        except Exception:
+            pass
         eng = _make_momwire_engine({}, builder)
         polylines = [np.asarray(p, dtype=float) for p in eng._polylines]
     except Exception:

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1378,12 +1378,16 @@ const BACKEND_LABEL: Record<Backend, string> = {
 };
 
 // A design/solver combo is "inappropriate" when the solver is a poor fit: a
-// dense solver (or PyNEC) on a large array is very slow, and an accelerator
-// (array-block / H-matrix) on a single-element design is pure overhead. `rec` is
-// the server's recommended backend ("arrayblock" for grid arrays, else null).
+// dense solver (or PyNEC) on a large array is very slow, an accelerator
+// (array-block / H-matrix) on a single-element design is pure overhead, and
+// on a benchmark-class mesh (thousands of segments) every b-spline-family
+// solver is minutes per solve where sinusoidal (or PyNEC) is seconds. `rec`
+// is the server's recommended backend ("arrayblock" for grid arrays,
+// "sinusoidal" for huge meshes, else null).
 function comboInappropriate(b: Backend, rec: Backend | null): boolean {
   const accel = b === "arrayblock" || b === "hmatrix";
   if (rec === "arrayblock") return !accel; // an array wants an accelerator
+  if (rec === "sinusoidal") return b !== "sinusoidal" && b !== "pynec";
   return accel; // everything else doesn't need one
 }
 
@@ -2636,6 +2640,24 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   // `result` the moment the real solve lands; only consulted while result is
   // null (i.e. right after an antenna switch).
   const [preview, setPreview] = useState<SolveResponse | null>(null);
+  // The server's per-design solver recommendation ("arrayblock" for grid
+  // arrays, "sinusoidal" for benchmark-sized meshes, null otherwise) — used
+  // by the withhold gate and to pick the right warning copy.
+  const recommendedBackend = normalizeBackend(
+    preview?.default_backend ?? currentExample?.default_backend,
+  );
+  // True while the live solve is being withheld by the solver-mismatch gate.
+  // The batch endpoints (sweep / converge / norm-check) defer on this exactly
+  // like they defer on solvePending(): they are batches of the same solves
+  // the gate is protecting the machine from (a dense sweep on a benchmark
+  // mesh is 41 multi-GiB solves). Reads the approval ref, so "Solve anyway"
+  // unblocks their 200 ms re-poll without any effect re-run.
+  function solveWithheld(): boolean {
+    return (
+      comboInappropriate(backend, recommendedBackend) &&
+      !approvedComboRef.current
+    );
+  }
   // Set when the selected design fails to solve/build — most often a user
   // design whose build_wires() raises. Geometry errors are deferred to
   // selection now (the builder isn't run at registration), so this banner is
@@ -3367,10 +3389,10 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     // user hasn't approved it — show a warning instead. The app never switches
     // the solver itself; the user does that in the gear menu, which changes
     // `backend` and re-runs this effect.
-    const rec = normalizeBackend(
-      preview?.default_backend ?? currentExample?.default_backend,
-    );
-    if (comboInappropriate(backend, rec) && !approvedComboRef.current) {
+    if (
+      comboInappropriate(backend, recommendedBackend) &&
+      !approvedComboRef.current
+    ) {
       setSolverWarning(true);
       return;
     }
@@ -3584,7 +3606,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     // pain that motivated this on large arrays. Re-poll until the main solve is
     // idle, then proceed; the input-change effect cancels this timer on the
     // next change, so rapid edits still debounce.
-    if (solvePending()) {
+    if (solvePending() || solveWithheld()) {
       sweepTimerRef.current = window.setTimeout(runSweep, 200);
       return;
     }
@@ -3720,7 +3742,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     // Same as runSweep: defer the converge ladder (another batch of solves)
     // until the live solve has returned, so it never competes with the solve
     // that draws the heatmap.
-    if (solvePending()) {
+    if (solvePending() || solveWithheld()) {
       convergeTimerRef.current = window.setTimeout(runConverge, 200);
       return;
     }
@@ -3841,7 +3863,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     // Defer until the live solve has returned, like the sweeps — the pattern
     // norm reuses that settled solve (a server cache hit), so running before
     // it lands would miss the cache and re-solve.
-    if (solvePending()) {
+    if (solvePending() || solveWithheld()) {
       normCheckTimerRef.current = window.setTimeout(runNormCheck, 200);
       return;
     }
@@ -4838,9 +4860,11 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
               {BACKEND_LABEL[backend]} is a poor match for this design
             </span>
             <span className="solver-suggest-sub">
-              {backend === "arrayblock" || backend === "hmatrix"
-                ? "This accelerator is overkill on a single-element design — a dense solver (e.g. B-spline) is faster here. "
-                : "This is a large array — a dense solver can be very slow. Array-block is far faster. "}
+              {recommendedBackend === "sinusoidal"
+                ? "This mesh is benchmark-sized — B-spline-family solvers take minutes per solve here (and concurrent solves can exhaust memory). The sinusoidal solver or PyNEC answers in seconds. "
+                : backend === "arrayblock" || backend === "hmatrix"
+                  ? "This accelerator is overkill on a single-element design — a dense solver (e.g. B-spline) is faster here. "
+                  : "This is a large array — a dense solver can be very slow. Array-block is far faster. "}
               Change the solver in the gear menu, solve anyway, or pause to keep
               editing.
             </span>

--- a/tests/test_elt_whip.py
+++ b/tests/test_elt_whip.py
@@ -110,3 +110,20 @@ def test_free_space_impedance_matches_benchmark():
     z = PyNECEngine(Builder(), ground=None).impedance()[0]
     assert 50.0 < z.real < 75.0
     assert abs(z.imag) < 20.0
+
+
+def test_example_recommends_sinusoidal_and_declares_406_band():
+    """The /examples payload must steer the UI: benchmark-sized mesh ⇒
+    default_backend "sinusoidal" (the withhold-warning gate keys on it), and
+    a custom 406 MHz band so the design-switch snap can't drag design_freq
+    down to 160 m (406 sits outside every HF band)."""
+    import antennaknobs.web.examples  # noqa: F401 — primes the adapter
+
+    from antennaknobs.web.examples import REGISTRY
+
+    ex = REGISTRY["verticals.elt_whip"]
+    assert ex.default_backend == "sinusoidal"
+    assert [(b.key, b.freq_mhz, b.min_mhz, b.max_mhz) for b in ex.bands] == [
+        ("406", 406.0, 400.0, 412.0)
+    ]
+    assert ex.meas_freq_range_mhz == (400.0, 412.0)

--- a/tests/test_elt_whip.py
+++ b/tests/test_elt_whip.py
@@ -1,0 +1,112 @@
+"""Tests for the ELT whip NEC-benchmark design (verticals.elt_whip).
+
+The design's value is *fidelity to the source deck* — a parametric rebuild
+of the W8IO ``whip_antenna_8ft_groundplane.nec`` benchmark, including its LD
+matching network (90 nH / 3 pF in the two grounded posts) via
+``build_network``. The structural pins below are cheap (build only) and run
+per-PR; the full-size PyNEC solves are quarantined to the main-only catalog
+lane like every per-design solve.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from antennaknobs import merge_params
+from antennaknobs.designs.verticals.elt_whip import Builder
+
+
+def _wire(w):
+    """Normalize a build_wires tuple: (p0, p1, nseg, ex, name-or-None)."""
+    return (*w, None) if len(w) == 4 else w
+
+
+def test_default_build_reproduces_deck_counts():
+    """At the default knobs the generator must emit exactly the source
+    deck's segmentation: 4,392 segments (the number the W8IO benchmark is
+    known by). The wire count is pinned too — it changes only if the
+    unit-cell emission or the outline profile logic changes."""
+    wires = Builder().build_wires()
+    assert len(wires) == 4067
+    assert sum(w[2] for w in wires) == 4392
+
+
+def test_default_build_is_well_formed():
+    """Finite endpoints, positive lengths, and the network's named wires:
+    one "feed" (whip bottom segment) and two posts. No legacy ex markers —
+    the drive comes from build_network's Driven port."""
+    wires = [_wire(w) for w in Builder().build_wires()]
+    names = {name for *_rest, name in wires if name is not None}
+    assert names == {"feed", "post0", "post1"}
+    assert all(ex is None for _p0, _p1, _n, ex, _name in wires)
+    feed = next(w for w in wires if w[4] == "feed")
+    assert feed[0] == (0.0, 0.0, 1.0) and feed[2] == 1  # bottom, height=1
+    for p0, p1, nseg, _ex, _name in wires:
+        assert nseg >= 1
+        assert all(math.isfinite(c) for c in (*p0, *p1))
+        assert math.dist(p0, p1) > 1e-9
+
+
+def test_network_matches_deck_ld_cards():
+    """build_network carries the deck's LD elements: 90 nH in series with
+    post0 (+x), 3 pF in series with post1 (−x); zero knobs omit elements."""
+    net = Builder().build_network()
+    by_port = {br.port: br for br in net.branches}
+    assert by_port["post0"].l == pytest.approx(90e-9) and by_port["post0"].c is None
+    assert by_port["post1"].c == pytest.approx(3e-12) and by_port["post1"].l is None
+    assert [s.port for s in net.sources] == ["feed"]
+
+    bare = Builder(
+        merge_params(Builder.default_params, {"post_l_nh": 0.0, "post_c_pf": 0.0})
+    ).build_network()
+    assert bare.branches == []
+
+
+def test_shrunken_knobs_build():
+    """Off-default knobs (smaller plane, coarser mesh, fewer cage wires)
+    still produce a sane mesh — the resampled outline profile and the
+    post/spoke index selection must not crash or emit zero-length wires."""
+    b = Builder(
+        merge_params(
+            Builder.default_params,
+            {
+                "plane_radius": 0.6,
+                "grid_pitch": 0.1016,
+                "fine_pitch": 0.0508,
+                "num_cage_wires": 8,
+                "num_posts": 2,
+                "num_spokes": 4,
+            },
+        )
+    )
+    wires = [_wire(w) for w in b.build_wires()]
+    assert len(wires) > 100
+    for p0, p1, _nseg, _ex, _name in wires:
+        assert math.dist(p0, p1) > 1e-9
+
+
+@pytest.mark.antenna_computation_check
+def test_free_space_impedance_matches_benchmark():
+    """Full-size PyNEC solves at the deck's 406 MHz centre.
+
+    With the posts' elements zeroed the feed must reproduce the raw
+    benchmark impedance every engine agreed on in the 2026-07-14 run
+    (Z ≈ 1.38 + 33.5j free space); with the deck's LD values the network
+    transforms that to a ~50 Ω-class match (measured 63.0 + 8.1j). A
+    geometry or network-stamping regression moves either far outside its
+    window."""
+    pytest.importorskip("PyNEC")
+    from antennaknobs.engines import PyNECEngine
+
+    bare = Builder(
+        merge_params(Builder.default_params, {"post_l_nh": 0.0, "post_c_pf": 0.0})
+    )
+    z0 = PyNECEngine(bare, ground=None).impedance()[0]
+    assert 1.0 < z0.real < 1.8
+    assert 30.0 < z0.imag < 37.0
+
+    z = PyNECEngine(Builder(), ground=None).impedance()[0]
+    assert 50.0 < z.real < 75.0
+    assert abs(z.imag) < 20.0

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1053,14 +1053,16 @@ def test_geometry_endpoint_returns_wires_without_solving(client: TestClient):
 
 def test_examples_carry_default_backend(client: TestClient):
     # Every example exposes default_backend (str | null). Grid arrays recommend
-    # the array-block accelerator; single-element designs keep the UI default
-    # (null) so their basis/results are unchanged.
+    # the array-block accelerator; benchmark-sized meshes recommend the
+    # sinusoidal solver (see _SINUSOIDAL_RECOMMEND_MIN_BASIS); other designs
+    # keep the UI default (null) so their basis/results are unchanged.
     payload = client.get("/examples").json()
     by_name = {e["name"]: e for e in payload["examples"]}
     for e in payload["examples"]:
         assert "default_backend" in e
-        assert e["default_backend"] in (None, "arrayblock")
+        assert e["default_backend"] in (None, "arrayblock", "sinusoidal")
     assert by_name["arrays.bowtiearray2x4"]["default_backend"] == "arrayblock"
+    assert by_name["verticals.elt_whip"]["default_backend"] == "sinusoidal"
     # A plain single-element design keeps the default.
     assert by_name["specialty.bowtie"]["default_backend"] is None
     # Regression: a Yagi is NOT a grid array — its equal-length directors used


### PR DESCRIPTION
## Summary
- **New design `verticals.elt_whip`**: parametric rebuild of the W8IO `whip_antenna_8ft_groundplane.nec` benchmark (434 deck wires / 4,392 segments), promoted from the user-design folder. Reproduces the deck's wire paths and segment boundaries to <0.1 mm at default knobs; the hand-drawn ground outline rides along as a resampled data table.
- **The deck's LD matching network is modelled explicitly** (a raw deck import only records it in `deck.ignored`): `build_network` puts 90 nH in series with the +x grounded post and 3 pF with the −x one (ld_card type 0 → `Load` on named 1-segment post wires), driven via a `PortOnWire` feed. Knobs `post_l_nh`/`post_c_pf`; 0 omits an element. Measured at 406 MHz free space: raw feed 1.379+33.5j (three-digit match to the all-engines benchmark value), matched 63.0+8.1j PyNEC vs 63.1+8.1j momwire sinusoidal — 0.1% cross-engine parity through both network-stamping paths.
- **Workbench fixes so a benchmark-sized design is actually usable** (each at the layer that owns it): the design declares its own "406 MHz" band (406 sits outside every HF band, so the design-switch snap used to retune it to 1.9 MHz); `_recommended_backend` now returns `"sinusoidal"` above an estimated 3,000 bases, feeding the existing withhold-warning gate instead of silently starting a minutes-long dense solve; and the sweep/converge/norm-check batch fetches defer while the solve is withheld — with nothing cached they'd otherwise fire the very dense solves the gate exists to prevent.
- Interim by design: the deeper scheduling model (batches concurrent with each other, `solvePending()` clearing on error acks, chunk-granular disconnect checks) is #382's single-lane redesign; this PR's gating is the minimal correct stopgap.

## Test plan
- [x] 6 per-PR structural pins in `tests/test_elt_whip.py`: exact deck counts (4,067 wires / 4,392 segments), named feed/post wires with no legacy ex markers, network shape matching the LD cards, off-default build sanity, `/examples` payload (recommendation + band + meas range)
- [x] Full-size PyNEC physics pins (main-only `antenna_computation_check` lane): raw-feed benchmark window and matched-network window
- [x] `default_backend` contract test extended (`sinusoidal` allowed; bowtie2x4 still `arrayblock`, single-element designs still `None`)
- [x] Verified live in Chrome: design loads at 406 MHz with geometry preview, warns "B-spline is a poor match" and withholds solve AND sweep, then solves on sinusoidal — Z = 63.6+9.4j over finite ground, SWR 1.34 (the matching network visibly working)
- [x] Full suite: 1,905 passed per-PR lane (2,053 with catalog lane); ruff + format clean; site catalog regenerated via script


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUtqSdTwXJxBzms3jmV16u
