### PR TITLE
Surface skipped NEC cards as an informational design note

### DIFF
--- a/site/src/content/docs/reference/nec-import.md
+++ b/site/src/content/docs/reference/nec-import.md
@@ -155,6 +155,13 @@ Expect readouts to differ from a deck's published numbers when those numbers
 relied on its ground, loading, or feedline cards — until you model those with
 antennaknobs' own `Load`/`TL` network branches.
 
+`deck.skipped_note()` turns that record into one human-readable sentence
+("Deck cards not applied: LD (loading), RP (radiation-pattern request); the
+deck models a ground plane — …"), or `None` when the deck carries nothing the
+workbench overrides. Deck-backed design stubs put it under
+`ui_params["notes"]` and the workbench shows it beneath the antenna selector,
+so the mismatch is explained right where the deck is viewed.
+
 Decks the wire-model genuinely cannot represent are rejected with a clear
 error rather than silently approximated: surface patches (`SP`/`SM`), tapered
 wires (`GC`), Green's-function files (`GF`), 4nec2 symbolic variables (`SY`),
@@ -180,6 +187,6 @@ deck = parse_nec(open("some.nec").read(), name="some.nec")
 | `comments` | The `CM` header text, line by line |
 | `ignored` | Mnemonics of run-configuration cards seen but not applied |
 
-plus the two methods the quick start uses: `wire_tuples()` (the deck as
-`build_wires()` tuples; raises if no voltage source drives the antenna) and
-`dominant_radius()`.
+plus three methods: `wire_tuples()` (the deck as `build_wires()` tuples;
+raises if no voltage source drives the antenna), `dominant_radius()`, and
+`skipped_note()` (the not-applied record as one informational sentence).

--- a/src/antennaknobs/nec_import.py
+++ b/src/antennaknobs/nec_import.py
@@ -120,6 +120,33 @@ class NecDeck:
             length_by_radius[w.radius] = length_by_radius.get(w.radius, 0.0) + ln
         return max(length_by_radius.items(), key=lambda kv: kv[1])[0]
 
+    def skipped_note(self) -> str | None:
+        """One human-readable sentence naming the run configuration the deck
+        asked for that the app decides itself: the ``ignored`` cards with
+        their descriptions, plus the deck's ground request (which can come
+        from the GE flag alone, with no GN card). Deck-backed design stubs
+        put this under ``ui_params["notes"]`` so the web UI can tell the
+        user why readouts may differ from the deck's published numbers.
+        None when the deck carries nothing the app overrides.
+        """
+        parts = []
+        if self.ignored:
+            cards = ", ".join(
+                f"{m} ({_IGNORED_CARDS[m]})" if m in _IGNORED_CARDS else m
+                for m in self.ignored
+            )
+            parts.append(f"deck cards not applied: {cards}")
+        if self.ground:
+            parts.append("the deck models a ground plane")
+        if not parts:
+            return None
+        body = "; ".join(parts)
+        return (
+            body[0].upper()
+            + body[1:]
+            + " — the app's own ground/loading/sweep settings are used instead."
+        )
+
     def wire_tuples(self):
         """The deck as ``build_wires()`` tuples: ``(p1, p2, n_seg, ex)``.
 

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -14,6 +14,10 @@ Reserved keys inside `ui_params`:
   bands            : tuple[BandSpec] — band tabs (default HF amateur set)
   sweep_policy     : (anchor, lo_factor, hi_factor)
   multi_feed       : bool — declare multi-feed response shape
+  notes            : str — informational note shown under the antenna
+                     selector (deck-backed designs fill it from
+                     NecDeck.skipped_note() to list the cards the import
+                     recorded but did not apply)
   layout           : dict {columns: int} — pin the knob grid to a fixed
                      column count so per-param `layout` col positions are
                      stable (default: responsive auto-flow packing)
@@ -1217,6 +1221,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
     view_override = _ui_scalar(dp, "default_view", None)
     z0_override = _ui_scalar(dp, "target_z0", None)
     multi_feed_override = _ui_scalar(dp, "multi_feed", None)
+    notes = _ui_scalar(dp, "notes", None)
 
     _hints: dict[str, Any] = {}
 
@@ -1770,6 +1775,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             for v in variants
         },
         variant_ui=variant_ui,
+        notes=str(notes) if notes else None,
         layout=grid_layout,
     )
 

--- a/src/antennaknobs/web/examples/_base.py
+++ b/src/antennaknobs/web/examples/_base.py
@@ -396,6 +396,12 @@ class AntennaExample:
     # for any variant absent here. Kept as an open map so more ui hints can
     # move per-variant later without another /examples contract change.
     variant_ui: dict = field(default_factory=dict)
+    # Optional informational note rendered under the antenna selector —
+    # e.g. a deck-backed design listing the NEC cards the import recorded
+    # but did not apply (NecDeck.skipped_note()). Purely informational,
+    # never a warning; None (the norm) renders nothing. Authored under the
+    # reserved ui_params["notes"] key.
+    notes: Optional[str] = None
     # Optional grid-level layout config for the top-level knob rail.
     # Recognised key today: {"columns": int} — pins the param grid to a
     # fixed column count so per-ParamSpec.layout col positions land

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -160,6 +160,10 @@ type ExampleDescriptor = {
    *  variants. Complex-valued params arrive as {re, im}. */
   variant_values: { [variant: string]: { [key: string]: unknown } };
   sweep_policy: SweepPolicy;
+  /** Informational note shown under the antenna selector — deck-backed
+   *  designs list the NEC cards the import recorded but did not apply.
+   *  null (the norm) renders nothing. */
+  notes?: string | null;
   /** Per-variant UI-hint overrides, keyed by variant name. Only variants
    *  whose derived hints differ from the design-level values appear; look up
    *  the active variant and fall back to the top-level field (e.g.
@@ -4315,6 +4319,9 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
             </select>
           )}
         </div>
+        {currentExample?.notes && (
+          <div className="design-note">{currentExample.notes}</div>
+        )}
         {examplesError && (
           <div className="examples-error">
             Failed to load /examples: {examplesError}

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -825,6 +825,15 @@ button:focus-visible,
   margin: calc(-1 * var(--space-2)) 0 var(--space-4);
 }
 
+/* Informational design note (e.g. NEC cards a deck import didn't apply) —
+   deliberately muted, not a warning: it explains, it doesn't alarm. */
+.design-note {
+  color: var(--muted);
+  font-size: var(--text-xs);
+  line-height: 1.4;
+  margin: calc(-1 * var(--space-2)) 0 var(--space-4);
+}
+
 .examples-error {
   margin: var(--space-4) 0;
   padding: var(--space-4) var(--space-5);

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -1390,6 +1390,7 @@ def examples_endpoint():
                     }
                     for v, h in ex.variant_ui.items()
                 },
+                "notes": ex.notes,
                 "layout": ex.layout,
             }
         )

--- a/src/antennaknobs/web/user_design_assets/CLAUDE.md
+++ b/src/antennaknobs/web/user_design_assets/CLAUDE.md
@@ -130,11 +130,30 @@ configure a NEC *run* rather than the geometry — GN ground, LD loading, TL
 transmission lines, RP/NE output requests — are ignored (listed in
 `deck.ignored`): the app applies its own ground and sweep settings, so expect
 readouts to differ from the deck's published results when it relied on those.
+Tell the user about it in the UI: `deck.skipped_note()` renders that list
+(plus the deck's ground request) as one informational sentence — put it under
+`ui_params["notes"]` and the app shows it beneath the antenna selector.
 Patch antennas (SP/SM) and tapered wires (GC) raise a clear error. The deck's
 FR card is exposed as `deck.freq_mhz = (lo, hi)` — use it to seed `freq` and
-`ui_params["meas_freq_range"]` so the design tunes on the deck's own band
-(see the 40m-trap note above, and `nec_2m_yagi.py` in this folder if present
-for a worked example).
+`ui_params["meas_freq_range"]` so the design tunes on the deck's own band.
+Do the seeding once at import time in a module-level helper, not per build
+(see `nec_2m_yagi.py` in this folder if present for a worked example):
+
+```python
+def _seed_defaults_from_deck(cls):
+    deck = read_nec(cls(), WIRES_FILE)
+    params = dict(cls.default_params)
+    ui = dict(params.get("ui_params", ()))
+    if deck.freq_mhz:
+        lo, hi = deck.freq_mhz
+        params["freq"] = round(0.5 * (lo + hi), 3)
+        ui["meas_freq_range"] = (lo, hi)
+    note = deck.skipped_note()
+    if note:
+        ui["notes"] = note
+    params["ui_params"] = MappingProxyType(ui)
+    cls.default_params = MappingProxyType(params)
+```
 
 ## `default_params`
 

--- a/tests/test_nec_import.py
+++ b/tests/test_nec_import.py
@@ -206,6 +206,37 @@ def test_run_config_cards_are_recorded_not_applied():
     assert deck.ignored == ("GN", "LD", "TL")
 
 
+def test_skipped_note_renders_ignored_cards_and_ground():
+    deck = parse_nec(
+        "GW 1 3 0 -1 1  0 1 1  0.001\n"
+        "GE 1\n"
+        "GN 2 0 0 0 13.0 0.005\n"
+        "LD 5 0 0 0 3.7E+07\n"
+        "EX 0 1 2 0 1 0\nEN\n"
+    )
+    note = deck.skipped_note()
+    # Descriptions come from _IGNORED_CARDS (the single source of truth),
+    # the ground request is called out, and mnemonic case survives.
+    assert note == (
+        "Deck cards not applied: GN (ground parameters), LD (loading); "
+        "the deck models a ground plane — the app's own ground/loading/sweep "
+        "settings are used instead."
+    )
+
+
+def test_skipped_note_ground_flag_only_and_clean_deck():
+    # GE 1 alone (no GN card): ground is requested but nothing is in
+    # `ignored`, so only the ground clause renders.
+    flag_only = parse_nec("GW 1 3 0 0 1  1 0 1  0.001\nGE 1\nEX 0 1 2 0 1 0\nEN\n")
+    assert flag_only.ignored == ()
+    note = flag_only.skipped_note()
+    assert note is not None and note.startswith("The deck models a ground plane")
+
+    # Free-space deck with no run-config cards: nothing to report.
+    clean = parse_nec("GW 1 3 0 0 1  1 0 1  0.001\nGE\nEX 0 1 2 0 1 0\nEN\n")
+    assert clean.skipped_note() is None
+
+
 def test_multiple_feeds_and_complex_voltage():
     deck = parse_nec(
         "GW 1 3 0 0 1  1 0 1  0.001\n"

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -256,6 +256,7 @@ def test_each_example_has_the_keys_the_frontend_reads(client: TestClient):
         "variant_values",
         "sweep_policy",
         "variant_ui",
+        "notes",
     }
     for ex in payload["examples"]:
         missing = required - set(ex.keys())
@@ -1071,6 +1072,39 @@ def test_examples_carry_default_backend(client: TestClient):
     # so a Yagi (and a plain dipole) keep the dense default.
     assert by_name["beams.yagi"]["default_backend"] is None
     assert by_name["dipoles.invvee"]["default_backend"] is None
+
+
+def test_examples_carry_notes(client: TestClient):
+    # `notes` is the informational design note (issue #373): a deck-backed
+    # design fills it from NecDeck.skipped_note() via the reserved
+    # ui_params["notes"] key; no built-in design is deck-backed, so every
+    # example in the catalog ships it null (the frontend renders nothing).
+    payload = client.get("/examples").json()
+    for e in payload["examples"]:
+        assert "notes" in e
+        assert e["notes"] is None
+
+    # The adapter forwards the reserved key verbatim to the example.
+    from types import MappingProxyType
+
+    from antennaknobs import AntennaBuilder
+    from antennaknobs.web.adapter import _make_example
+
+    class Noted(AntennaBuilder):
+        default_params = MappingProxyType(
+            {
+                "freq": 14.0,
+                "ui_params": MappingProxyType(
+                    {"notes": "Deck cards not applied: LD (loading)"}
+                ),
+            }
+        )
+
+        def build_wires(self):
+            return [((0.0, -5.0, 10.0), (0.0, 5.0, 10.0), 15, 1.0)]
+
+    ex = _make_example("noted", Noted, defer_hints=True)
+    assert ex.notes == "Deck cards not applied: LD (loading)"
 
 
 def test_deferred_design_view_is_null_then_arrives_with_preview():


### PR DESCRIPTION
## Summary
- Closes #373: a deck-backed design now shows, under the antenna selector, which NEC run-configuration cards its import recorded but did not apply — the context a user needs when the app's readouts differ from the deck's published numbers.
- `NecDeck.skipped_note()` renders the `ignored` record as one human-readable sentence, with card descriptions taken from `_IGNORED_CARDS` (single source of truth) plus the deck's ground request (which can come from the GE flag alone, with no GN card); returns `None` for a deck that configures nothing the app overrides.
- New reserved `ui_params["notes"]` key flows through `AntennaExample.notes` into the `/examples` payload; the frontend renders it as muted informational text (`.design-note`), and designs without a note render nothing.
- Docs: the user-designs `CLAUDE.md` asset and the site's NEC-import reference now show the pattern — fill the note once at import time in the same module-level helper that seeds `freq` from the deck's FR card. (The seven deck stubs in `~/.antennaknobs/designs` were updated to match and verified live: all seven show their note, built-ins show nothing.)

## Test plan
- [x] `test_nec_import.py`: note wording pins (descriptions from `_IGNORED_CARDS`, mnemonic case preserved, ground-flag-only deck, clean deck → `None`)
- [x] `test_web_server.py`: `notes` in the frontend-keys contract, null for every built-in, adapter forwards the reserved key verbatim
- [x] Full fast suite: 1908 passed; `ruff check` + `format --check` clean; frontend `tsc` + build clean
- [x] Live check: `/examples` carries notes for exactly the seven deck-backed user designs; note renders under the selector in the workbench

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUtqSdTwXJxBzms3jmV16u