### PR TITLE
Zoom/pan viewport for the antenna viewer

### DIFF
--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -58,6 +58,35 @@ VFO dial; the rest are smaller). Three ways to change one:
 
 Every turn re-solves and redraws live (when **Live** is on — see below).
 
+## The antenna viewer
+
+The Antenna view draws the wires (with the current heat-map and standing-wave
+envelope overlays) in one of three orthographic projections — **Top (xy)**,
+**Front (xz)**, **Side (yz)** — switched by the buttons in the top-right
+overlay.
+
+The view auto-fits the whole antenna, and you can navigate from there,
+map-style:
+
+- **Zoom** — scroll wheel (desktop) or pinch (touch), anchored at the cursor
+  or pinch centre, up to 10 000×. Fine construction detail — a cage of wires
+  millimetres apart on an antenna metres across, typical of imported NEC
+  decks — is inspectable without touching any knob.
+- **Pan** — drag, once zoomed in. At fit zoom a touch drag stays with the
+  page (on a phone that's the swipe between output screens); after a pinch
+  the canvas owns the gesture until you re-fit.
+- **Re-fit** — double-click / double-tap, the **Fit** button in the
+  bottom-right HUD (next to the live zoom readout), or just zoom all the way
+  back out. Switching projection or design also re-fits — the viewport is
+  anchored in the projected plane, so it wouldn't point anywhere meaningful
+  in another one.
+
+The scale bar under the antenna reads **λ/4** at fit zoom; once zoomed it
+switches to a round metric length (1/2/5 × 10ᵏ m — like a map's) sized to
+about a quarter of the canvas, so it stays readable and true at any
+magnification. Zooming magnifies geometry only: wire strokes, labels, the
+feed dot, and the envelope amplitude keep their size.
+
 ## Live & paused solving
 
 A **Live** toggle sits next to the frequency dial. It looks **depressed when on**

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -61,9 +61,10 @@ Every turn re-solves and redraws live (when **Live** is on — see below).
 ## The antenna viewer
 
 The Antenna view draws the wires (with the current heat-map and standing-wave
-envelope overlays) in one of three orthographic projections — **Top (xy)**,
-**Front (xz)**, **Side (yz)** — switched by the buttons in the top-right
-overlay.
+envelope overlays) in one of four projections — **Top (xy)**, **Front (xz)**,
+**Side (yz)**, and an isometric **Iso** (the classic corner view: x and y
+recede left and right, z stays up) — switched by the buttons in the top-right
+overlay. The ground reference line appears on the two elevation views.
 
 The view auto-fits the whole antenna, and you can navigate from there,
 map-style:
@@ -77,9 +78,15 @@ map-style:
   the canvas owns the gesture until you re-fit.
 - **Re-fit** — double-click / double-tap, the **Fit** button in the
   bottom-right HUD (next to the live zoom readout), or just zoom all the way
-  back out. Switching projection or design also re-fits — the viewport is
-  anchored in the projected plane, so it wouldn't point anywhere meaningful
-  in another one.
+  back out. Switching design also re-fits — the old viewport means nothing
+  for a new geometry.
+- **Turning the view keeps your place** — switching projection carries the
+  zoomed viewport over: the world point at the centre of the canvas stays
+  centred (its depth along the old camera ray taken from the geometry's
+  midpoint), at the same on-screen magnification. Zoom into a feed region in
+  Front view and flip to Side or Iso to see the same region from the other
+  angle. Fit is one double-click away whenever the carried view isn't what
+  you wanted.
 
 The scale bar under the antenna reads **λ/4** at fit zoom; once zoomed it
 switches to a round metric length (1/2/5 × 10ᵏ m — like a map's) sized to

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1804,11 +1804,27 @@ const MOBILE_SCREENS: { id: View | "info"; label: string }[] = [
 
 // Antenna-canvas camera projections. Pick two world axes to map to canvas
 // (horizontal, vertical) and project. The hidden axis is the camera ray.
-type Projection = "xy" | "xz" | "yz";
-const PROJECTIONS: { id: Projection; label: string; horizAxis: 0|1|2; vertAxis: 0|1|2 }[] = [
-  { id: "xy", label: "Top (xy)",   horizAxis: 0, vertAxis: 1 },
-  { id: "xz", label: "Front (xz)", horizAxis: 0, vertAxis: 2 },
-  { id: "yz", label: "Side (yz)",  horizAxis: 1, vertAxis: 2 },
+type Projection = "xy" | "xz" | "yz" | "iso";
+type Vec3 = readonly [number, number, number];
+// Each projection is an orthonormal screen basis: `h` maps to canvas-right,
+// `v` to canvas-up, and the camera ray (toward the viewer) is h×v. The three
+// axis-aligned views keep their original semantics (h/v pick world axes);
+// "iso" is the classic isometric from the (+1,+1,+1) corner — x recedes to
+// the lower-left, y to the lower-right, z stays up — so ground-plane layout
+// and vertical structure are readable in one view.
+const ISO_S2 = Math.SQRT1_2; // 1/√2
+const ISO_S6 = 1 / Math.sqrt(6);
+const PROJECTIONS: { id: Projection; label: string; h: Vec3; v: Vec3 }[] = [
+  { id: "xy", label: "Top (xy)",   h: [1, 0, 0], v: [0, 1, 0] },
+  { id: "xz", label: "Front (xz)", h: [1, 0, 0], v: [0, 0, 1] },
+  { id: "yz", label: "Side (yz)",  h: [0, 1, 0], v: [0, 0, 1] },
+  { id: "iso", label: "Iso", h: [-ISO_S2, ISO_S2, 0], v: [-ISO_S6, -ISO_S6, 2 * ISO_S6] },
+];
+const dot3 = (a: Vec3, b: Vec3): number => a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+const cross3 = (a: Vec3, b: Vec3): Vec3 => [
+  a[1] * b[2] - a[2] * b[1],
+  a[2] * b[0] - a[0] * b[2],
+  a[0] * b[1] - a[1] * b[0],
 ];
 
 // `reattachKey`: the measuring effect early-returns while the ref is detached,
@@ -7361,15 +7377,27 @@ function CurrentCanvas({
     setVpZoom(1);
   };
 
-  // Switching projection re-fits: pan/zoom are anchored in the projected
-  // plane, so a viewport aimed at (say) a feed region in Top view points at
-  // nothing meaningful in Side view. Same for switching designs.
+  // The fit frame of the last completed draw (projection + fit centre/scale).
+  // A projection switch carries the viewport over through it — see draw() —
+  // instead of resetting, so a feature under 400× inspection stays under
+  // inspection when the view turns. Cleared on design switch: the previous
+  // design's frame means nothing for the new geometry.
+  const frameRef = useRef<{
+    projection: Projection;
+    hC: number;
+    vC: number;
+    scale: number;
+  } | null>(null);
+
+  // Switching DESIGNS re-fits: the viewport was aimed at the old geometry.
+  // (Projection switches within a design carry the viewport — see draw().)
   const geometryName = result?.geometry ?? "";
   useEffect(() => {
     resetViewport();
-    // The main draw effect below also depends on `projection` (and re-runs
-    // on any new result), so the re-fit paints without an explicit redraw.
-  }, [projection, geometryName]);
+    frameRef.current = null;
+    // The main draw effect below re-runs on any new result, so the re-fit
+    // paints without an explicit redraw.
+  }, [geometryName]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -7418,31 +7446,45 @@ function CurrentCanvas({
       const barReserveBottom = 40 * s;
       const FILL = 0.85;
 
-      // Camera projection: pick the two world axes to map to canvas
-      // (horizontal, vertical). The hidden axis is the camera ray. App.tsx
-      // sets a per-geometry default (V/fan_dipole → "yz" side, Yagi/moxon/
-      // hexbeam → "xy" top) but the user can override via the projection
-      // toggle in the stage.
+      // Camera projection: an orthonormal screen basis (see PROJECTIONS) —
+      // world point p lands at canvas (h·p, v·p); the camera ray is h×v.
+      // App.tsx sets a per-geometry default (V/fan_dipole → "yz" side,
+      // Yagi/moxon/hexbeam → "xy" top) but the user can override via the
+      // projection toggle in the stage.
       const projSpec = PROJECTIONS.find((p) => p.id === projection)!;
-      const horizAxis = projSpec.horizAxis;
-      const vertAxis = projSpec.vertAxis;
+      const hVec = projSpec.h;
+      const vVec = projSpec.v;
+      // True for the two elevation views (screen-up IS world z), which gates
+      // the ground reference line below; the isometric's tilted up-vector
+      // draws no line (z=0 doesn't project to a horizontal line there).
+      const upIsZ = vVec[0] === 0 && vVec[1] === 0 && vVec[2] === 1;
       let hMin = Infinity, hMax = -Infinity;
       let vMin = Infinity, vMax = -Infinity;
+      // Axis-aligned world bbox too — the projection-switch carry-over needs
+      // a depth estimate along the old camera ray (see below).
+      const bbMin = [Infinity, Infinity, Infinity];
+      const bbMax = [-Infinity, -Infinity, -Infinity];
       for (const wire of result.wires) {
         for (const p of wire.knot_positions) {
-          if (p[horizAxis] < hMin) hMin = p[horizAxis];
-          if (p[horizAxis] > hMax) hMax = p[horizAxis];
-          if (p[vertAxis] < vMin) vMin = p[vertAxis];
-          if (p[vertAxis] > vMax) vMax = p[vertAxis];
+          const ph = dot3(hVec, p);
+          const pv = dot3(vVec, p);
+          if (ph < hMin) hMin = ph;
+          if (ph > hMax) hMax = ph;
+          if (pv < vMin) vMin = pv;
+          if (pv > vMax) vMax = pv;
+          for (let a = 0; a < 3; a++) {
+            if (p[a] < bbMin[a]) bbMin[a] = p[a];
+            if (p[a] > bbMax[a]) bbMax[a] = p[a];
+          }
         }
       }
 
-      // When ground is enabled and the vertical projection axis is z, expand
-      // the visible vertical range to include z=0 so the ground reference
-      // line lands inside the canvas. Without this, antennas sitting well
-      // above the plane push the ground line off-screen.
+      // When ground is enabled and screen-up is world z, expand the visible
+      // vertical range to include z=0 so the ground reference line lands
+      // inside the canvas. Without this, antennas sitting well above the
+      // plane push the ground line off-screen.
       let vEffMin = vMin, vEffMax = vMax;
-      if (result.ground && vertAxis === 2) {
+      if (result.ground && upIsZ) {
         vEffMin = Math.min(vMin, 0);
         vEffMax = Math.max(vMax, 0);
       }
@@ -7465,23 +7507,82 @@ function CurrentCanvas({
       const vC = (vEffMin + vEffMax) / 2;
       const cx = w / 2;
       const cy = h / 2;
+      const vp = vpRef.current;
+
+      // Projection switch with an active zoom: carry the viewport over
+      // instead of resetting. Reconstruct the world point at the old canvas
+      // centre — its two screen coordinates from the old frame, its depth
+      // along the old camera ray from the geometry point nearest that
+      // centre ray (the wire actually under inspection; the bbox centre
+      // would misplace anything off-centre in depth, e.g. an apex feed) —
+      // then aim the new frame at that point, preserving the absolute px/m
+      // scale so the feature keeps its on-screen size (each view has its
+      // own fit scale, so the relative zoom factor is rescaled). If the
+      // carried zoom clamps to 1, it degrades to a plain fit. Design
+      // switches still hard-reset (frameRef is cleared by the effect above).
+      const frame = frameRef.current;
+      if (frame && frame.projection !== projection && vp.zoom > 1) {
+        const old = PROJECTIONS.find((p) => p.id === frame.projection)!;
+        const oldZscale = frame.scale * vp.zoom;
+        const hCtr = frame.hC - vp.panX / oldZscale;
+        const vCtr = frame.vC + vp.panY / oldZscale;
+        const n = cross3(old.h, old.v);
+        let depth = dot3(n, [
+          (bbMin[0] + bbMax[0]) / 2,
+          (bbMin[1] + bbMax[1]) / 2,
+          (bbMin[2] + bbMax[2]) / 2,
+        ]);
+        let best = Infinity;
+        for (const wire of result.wires) {
+          for (const p of wire.knot_positions) {
+            const dh = dot3(old.h, p) - hCtr;
+            const dv = dot3(old.v, p) - vCtr;
+            const d2 = dh * dh + dv * dv;
+            if (d2 < best) {
+              best = d2;
+              depth = dot3(n, p);
+            }
+          }
+        }
+        const P: Vec3 = [
+          old.h[0] * hCtr + old.v[0] * vCtr + n[0] * depth,
+          old.h[1] * hCtr + old.v[1] * vCtr + n[1] * depth,
+          old.h[2] * hCtr + old.v[2] * vCtr + n[2] * depth,
+        ];
+        const zoomNew = Math.min(
+          VIEWPORT_ZOOM_MAX,
+          Math.max(1, (vp.zoom * frame.scale) / scale),
+        );
+        vp.zoom = zoomNew;
+        if (zoomNew > 1) {
+          const zs = scale * zoomNew;
+          vp.panX = (hC - dot3(hVec, P)) * zs;
+          vp.panY = (dot3(vVec, P) - vC) * zs;
+        } else {
+          vp.panX = 0;
+          vp.panY = 0;
+        }
+        setVpZoom(zoomNew);
+      }
+      frameRef.current = { projection, hC, vC, scale };
+
       // Compose the user viewport on top of the fit framing. Only geometry
       // goes through `zscale`; pixel-sized glyphs (strokes, labels, envelope
       // amplitude, feed dot) stay on `s`, so zooming magnifies the antenna
       // without ballooning its annotations.
-      const vp = vpRef.current;
       const zscale = scale * vp.zoom;
       const project = (p: [number, number, number]) => ({
-        x: cx + (p[horizAxis] - hC) * zscale + vp.panX,
-        y: cy + (vC - p[vertAxis]) * zscale + vp.panY, // higher vert value = higher on screen
+        x: cx + (dot3(hVec, p) - hC) * zscale + vp.panX,
+        y: cy + (vC - dot3(vVec, p)) * zscale + vp.panY, // higher vert value = higher on screen
       });
 
-      // Ground reference line at world z=0, drawn only on side projections
-      // (vertAxis === 2) when the backend has ground enabled. Cosmetic — the
-      // math is correct regardless; this just removes the "where is the
-      // ground" guessing game from the side view. vC was adjusted above to
-      // keep this on-canvas, so no bounds check needed here.
-      if (result.ground && vertAxis === 2) {
+      // Ground reference line at world z=0, drawn only on the elevation
+      // views (screen-up is world z) when the backend has ground enabled.
+      // Cosmetic — the math is correct regardless; this just removes the
+      // "where is the ground" guessing game from the side view. vC was
+      // adjusted above to keep this on-canvas, so no bounds check needed
+      // here.
+      if (result.ground && upIsZ) {
         const groundY = cy + vC * zscale + vp.panY;
         ctx!.strokeStyle = `rgba(${PC.groundRgb}, 0.55)`;
         ctx!.lineWidth = 1;

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -6138,6 +6138,7 @@ function ViewPanel({
           showEnvelope={showingPreview ? false : showEnvelope}
           showWireLabels={showWireLabels}
           showFeedNames={showFeedNames}
+          interactive={fill}
         />
       </div>
     );
@@ -7319,6 +7320,12 @@ function SmithChart({
   return <canvas ref={canvasRef} className="smith" />;
 }
 
+// Viewport zoom ceiling. The motivating case (elt_whip, #384) hides 6.35 mm
+// of cage detail inside a 2.44 m extent — a 1:384 scale gap — so the ceiling
+// leaves an order of magnitude of headroom past "inspect the finest catalog
+// detail at canvas size".
+const VIEWPORT_ZOOM_MAX = 10000;
+
 function CurrentCanvas({
   result,
   projection,
@@ -7326,6 +7333,7 @@ function CurrentCanvas({
   showEnvelope,
   showWireLabels,
   showFeedNames,
+  interactive = false,
 }: {
   result: SolveResponse | null;
   projection: Projection;
@@ -7333,9 +7341,35 @@ function CurrentCanvas({
   showEnvelope: boolean;
   showWireLabels: boolean;
   showFeedNames: boolean;
+  // Zoom/pan navigation — main stage only; thumbnails stay inert buttons.
+  interactive?: boolean;
 }) {
   const theme = useContext(ThemeContext); // repaint on theme toggle (dep below)
   const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  // Viewport navigation (map-style: cursor-anchored wheel/pinch zoom, drag
+  // pan, double-click/tap or the Fit button to re-fit — survey in PR #384).
+  // zoom=1, pan=0 IS the auto-fit view, so the fit framing keeps tracking
+  // knob drags and re-solves; zoom composes on top as a pure multiplier.
+  // Lives in a ref (mutated at pointer-event rate, drawn via rAF) with a
+  // React mirror of the zoom level for the HUD chip / touch-action gate.
+  const vpRef = useRef({ zoom: 1, panX: 0, panY: 0 });
+  const [vpZoom, setVpZoom] = useState(1);
+  const redrawRef = useRef<() => void>(() => {});
+  const resetViewport = () => {
+    vpRef.current = { zoom: 1, panX: 0, panY: 0 };
+    setVpZoom(1);
+  };
+
+  // Switching projection re-fits: pan/zoom are anchored in the projected
+  // plane, so a viewport aimed at (say) a feed region in Top view points at
+  // nothing meaningful in Side view. Same for switching designs.
+  const geometryName = result?.geometry ?? "";
+  useEffect(() => {
+    resetViewport();
+    // The main draw effect below also depends on `projection` (and re-runs
+    // on any new result), so the re-fit paints without an explicit redraw.
+  }, [projection, geometryName]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -7431,9 +7465,15 @@ function CurrentCanvas({
       const vC = (vEffMin + vEffMax) / 2;
       const cx = w / 2;
       const cy = h / 2;
+      // Compose the user viewport on top of the fit framing. Only geometry
+      // goes through `zscale`; pixel-sized glyphs (strokes, labels, envelope
+      // amplitude, feed dot) stay on `s`, so zooming magnifies the antenna
+      // without ballooning its annotations.
+      const vp = vpRef.current;
+      const zscale = scale * vp.zoom;
       const project = (p: [number, number, number]) => ({
-        x: cx + (p[horizAxis] - hC) * scale,
-        y: cy + (vC - p[vertAxis]) * scale, // higher vert value = higher on screen
+        x: cx + (p[horizAxis] - hC) * zscale + vp.panX,
+        y: cy + (vC - p[vertAxis]) * zscale + vp.panY, // higher vert value = higher on screen
       });
 
       // Ground reference line at world z=0, drawn only on side projections
@@ -7442,7 +7482,7 @@ function CurrentCanvas({
       // ground" guessing game from the side view. vC was adjusted above to
       // keep this on-canvas, so no bounds check needed here.
       if (result.ground && vertAxis === 2) {
-        const groundY = cy + vC * scale;
+        const groundY = cy + vC * zscale + vp.panY;
         ctx!.strokeStyle = `rgba(${PC.groundRgb}, 0.55)`;
         ctx!.lineWidth = 1;
         ctx!.setLineDash([6, 4]);
@@ -7565,8 +7605,20 @@ function CurrentCanvas({
         }
       }
 
-      // λ/4 scale bar, centered horizontally under the antenna.
-      const barLenPx = (lambdaDesign / 4) * scale;
+      // Scale bar, centered horizontally under the antenna. At fit zoom it
+      // is the familiar λ/4 bar; once zoomed, λ/4 no longer fits on screen,
+      // so it becomes a map-style bar: a nice round length (1/2/5 × 10^k m)
+      // near a quarter of the canvas width, always true to `zscale`.
+      let barWorld = lambdaDesign / 4;
+      let barLabel = `λ/4 = ${(lambdaDesign / 4).toFixed(2)} m`;
+      if (vp.zoom !== 1) {
+        const target = (0.25 * w) / zscale;
+        const pow = Math.pow(10, Math.floor(Math.log10(target)));
+        const mant = target / pow;
+        barWorld = (mant >= 5 ? 5 : mant >= 2 ? 2 : 1) * pow;
+        barLabel = formatMetres(barWorld);
+      }
+      const barLenPx = barWorld * zscale;
       const barX0 = (w - barLenPx) / 2;
       const barY = h - 24 * s;
       ctx!.strokeStyle = PC.label;
@@ -7581,7 +7633,6 @@ function CurrentCanvas({
       ctx!.stroke();
       ctx!.fillStyle = PC.labelBright;
       ctx!.font = `${labelFontPx}px ui-monospace, monospace`;
-      const barLabel = `λ/4 = ${(lambdaDesign / 4).toFixed(2)} m`;
       const labelW = ctx!.measureText(barLabel).width;
       ctx!.fillText(barLabel, (w - labelW) / 2, barY - 8 * s);
     }
@@ -7589,10 +7640,185 @@ function CurrentCanvas({
     onResize();
     const obs = new ResizeObserver(onResize);
     obs.observe(canvas);
-    return () => obs.disconnect();
-  }, [result, projection, showHeatmap, showEnvelope, showWireLabels, showFeedNames, theme]);
+    redrawRef.current = draw;
+    if (!interactive) return () => obs.disconnect();
 
-  return <canvas ref={canvasRef} />;
+    // ---- viewport navigation ------------------------------------------
+    // Draws coalesce to one per frame: pointer/wheel events mutate vpRef
+    // and schedule a rAF repaint.
+    let raf = 0;
+    const scheduleDraw = () => {
+      if (raf) return;
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        draw();
+      });
+    };
+
+    // Zoom by `factor` keeping the canvas point (ax, ay) fixed — the world
+    // point under the cursor/pinch centre stays under it. Zooming all the
+    // way back out lands exactly on the fit view (pan snaps to 0).
+    const applyZoom = (factor: number, ax: number, ay: number) => {
+      const v = vpRef.current;
+      const z = Math.min(VIEWPORT_ZOOM_MAX, Math.max(1, v.zoom * factor));
+      const f = z / v.zoom;
+      const cx = canvas.clientWidth / 2;
+      const cy = canvas.clientHeight / 2;
+      v.panX = ax - cx - (ax - cx - v.panX) * f;
+      v.panY = ay - cy - (ay - cy - v.panY) * f;
+      v.zoom = z;
+      if (z === 1) {
+        v.panX = 0;
+        v.panY = 0;
+      }
+      setVpZoom(z);
+      scheduleDraw();
+    };
+
+    // Wheel zoom, ~1.2× per detent, exponential so trackpads feel smooth.
+    // Native non-passive listener for the same reason as the VFO dial:
+    // React's onWheel can't preventDefault the page scroll.
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const rect = canvas.getBoundingClientRect();
+      const dy = e.deltaMode === 1 ? e.deltaY * 33 : e.deltaY; // line-mode → px
+      applyZoom(Math.exp(-dy * 0.002), e.clientX - rect.left, e.clientY - rect.top);
+    };
+
+    // Pointer state: one pointer drags (pan — only when zoomed, so at fit a
+    // touch drag stays with the mobile carousel swipe), two pinch-zoom.
+    const pointers = new Map<number, { x: number; y: number; downX: number; downY: number }>();
+    let moved = false;
+    let lastTap = { t: 0, x: 0, y: 0 };
+    const posOf = (e: PointerEvent) => {
+      const r = canvas.getBoundingClientRect();
+      return { x: e.clientX - r.left, y: e.clientY - r.top };
+    };
+
+    const onPointerDown = (e: PointerEvent) => {
+      if (e.pointerType === "mouse" && e.button !== 0 && e.button !== 1) return;
+      try {
+        canvas.setPointerCapture(e.pointerId);
+      } catch {
+        // Capture is best-effort: a drag that leaves the canvas just ends.
+      }
+      const p = posOf(e);
+      pointers.set(e.pointerId, { ...p, downX: p.x, downY: p.y });
+      moved = false;
+      if (e.pointerType === "mouse") e.preventDefault(); // middle-click autoscroll
+    };
+
+    const onPointerMove = (e: PointerEvent) => {
+      const prev = pointers.get(e.pointerId);
+      if (!prev) return;
+      const p = posOf(e);
+      if (Math.hypot(p.x - prev.downX, p.y - prev.downY) > 4) moved = true;
+      if (pointers.size === 2) {
+        // Pinch: translate by the midpoint delta, zoom by the distance
+        // ratio about the new midpoint.
+        const other = [...pointers.entries()].find(([id]) => id !== e.pointerId)![1];
+        const oldMid = { x: (prev.x + other.x) / 2, y: (prev.y + other.y) / 2 };
+        const oldDist = Math.hypot(prev.x - other.x, prev.y - other.y) || 1;
+        const newMid = { x: (p.x + other.x) / 2, y: (p.y + other.y) / 2 };
+        const newDist = Math.hypot(p.x - other.x, p.y - other.y) || 1;
+        const v = vpRef.current;
+        v.panX += newMid.x - oldMid.x;
+        v.panY += newMid.y - oldMid.y;
+        applyZoom(newDist / oldDist, newMid.x, newMid.y);
+      } else if (pointers.size === 1 && vpRef.current.zoom > 1) {
+        const v = vpRef.current;
+        v.panX += p.x - prev.x;
+        v.panY += p.y - prev.y;
+        scheduleDraw();
+      }
+      pointers.set(e.pointerId, { ...prev, x: p.x, y: p.y });
+    };
+
+    const onPointerUp = (e: PointerEvent) => {
+      const had = pointers.delete(e.pointerId);
+      try {
+        canvas.releasePointerCapture(e.pointerId);
+      } catch {
+        // Never captured (see above) — nothing to release.
+      }
+      if (!had || moved || e.type === "pointercancel") return;
+      // Clean tap/click: double within 350 ms & 30 px re-fits.
+      const now = performance.now();
+      const p = posOf(e);
+      if (now - lastTap.t < 350 && Math.hypot(p.x - lastTap.x, p.y - lastTap.y) < 30) {
+        resetViewport();
+        scheduleDraw();
+        lastTap = { t: 0, x: 0, y: 0 };
+      } else {
+        lastTap = { t: now, x: p.x, y: p.y };
+      }
+    };
+
+    canvas.addEventListener("wheel", onWheel, { passive: false });
+    canvas.addEventListener("pointerdown", onPointerDown);
+    canvas.addEventListener("pointermove", onPointerMove);
+    canvas.addEventListener("pointerup", onPointerUp);
+    canvas.addEventListener("pointercancel", onPointerUp);
+    return () => {
+      obs.disconnect();
+      if (raf) cancelAnimationFrame(raf);
+      canvas.removeEventListener("wheel", onWheel);
+      canvas.removeEventListener("pointerdown", onPointerDown);
+      canvas.removeEventListener("pointermove", onPointerMove);
+      canvas.removeEventListener("pointerup", onPointerUp);
+      canvas.removeEventListener("pointercancel", onPointerUp);
+    };
+  }, [result, projection, showHeatmap, showEnvelope, showWireLabels, showFeedNames, theme, interactive]);
+
+  const zoomed = vpZoom > 1.001;
+  return (
+    <div className="canvas-viewport">
+      <canvas
+        ref={canvasRef}
+        style={
+          interactive
+            ? {
+                // At fit, touch drags belong to the page (mobile carousel
+                // swipe); pinch is never a browser gesture here, so a
+                // two-finger zoom always reaches us. Once zoomed, the canvas
+                // owns all touches for panning until re-fit.
+                touchAction: zoomed ? "none" : "pan-x pan-y",
+                cursor: zoomed ? "grab" : "zoom-in",
+              }
+            : undefined
+        }
+      />
+      {interactive && (
+        <div className="viewport-hud">
+          {zoomed && (
+            <span className="viewport-zoom">
+              {vpZoom >= 10 ? Math.round(vpZoom) : vpZoom.toFixed(1)}×
+            </span>
+          )}
+          <button
+            className="viewport-fit"
+            disabled={!zoomed}
+            onClick={() => {
+              resetViewport();
+              redrawRef.current();
+            }}
+            title="Zoom to fit (or double-click the canvas)"
+          >
+            Fit
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Nice-number lengths for the zoomed scale bar: pick the readable unit and
+// trim float dust (5×10⁻³ m × 1000 → "5 mm", not "5.000000000000001 mm").
+function formatMetres(v: number): string {
+  const fmt = (x: number, unit: string) => `${parseFloat(x.toPrecision(2))} ${unit}`;
+  if (v >= 1) return fmt(v, "m");
+  if (v >= 0.01) return fmt(v * 100, "cm");
+  return fmt(v * 1000, "mm");
 }
 
 function drawArmEnvelope(

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -2046,6 +2046,57 @@ input[type=checkbox] {
   background: var(--accent-active);
 }
 
+/* Antenna-canvas viewport (zoom/pan) wrapper + HUD. The wrapper fills its
+   host (.antenna-fill / .antenna-thumb size the box) and anchors the
+   bottom-right HUD: a live zoom chip plus the always-visible Fit button. */
+.canvas-viewport {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.viewport-hud {
+  position: absolute;
+  bottom: var(--space-6);
+  right: var(--space-6);
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.viewport-zoom {
+  font: var(--text-xs) var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--muted-2);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: var(--space-2) var(--space-3);
+  box-shadow: 0 2px 10px var(--shadow);
+}
+
+.viewport-fit {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  color: var(--muted);
+  font: var(--text-xs) var(--font-mono);
+  padding: var(--space-2) var(--space-5);
+  cursor: pointer;
+  box-shadow: 0 2px 10px var(--shadow);
+}
+
+.viewport-fit:hover:not(:disabled) {
+  color: var(--fg);
+  background: var(--inset);
+}
+
+.viewport-fit:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
 .link-toggle {
   display: flex;
   gap: var(--space-3);


### PR DESCRIPTION
## Summary
- Adds map-style viewport navigation to the antenna canvas: wheel/pinch zoom anchored at the cursor/pinch centre (up to 10 000×), drag pan once zoomed, double-click/double-tap or an always-visible **Fit** button (with a live zoom chip) to re-fit. Closes #384.
- The viewport composes onto the existing auto-fit framing as a pure multiplier (zoom = 1, pan = 0 *is* the fit view), so knob drags and re-solves keep their framing while zoomed; only geometry magnifies — strokes, labels, feed dot, and envelope amplitude keep their pixel size.
- The scale bar stays truthful under zoom: λ/4 at fit (unchanged look), switching to a map-style nice-number metric bar (1/2/5 × 10ᵏ m, labelled m/cm/mm) once zoomed.
- Docs: new "The antenna viewer" section in the web-workbench reference page.

## Survey note (the issue's investigation step)

Three conventions were compared before implementing:

| Convention | How it navigates | Verdict |
| --- | --- | --- |
| **Map/Figma-style** (Google Maps, Figma, Leaflet) | wheel zoom at cursor, left-drag pan, double-click/button re-fit, pinch on touch | **Chosen.** The antenna canvas has no competing left-drag interaction (nothing to select or lasso), so the most fluid gesture set is free to take. It is also the only convention with a well-established touch story, which the mobile carousel needs. |
| **CAD-style** (KiCad, xnec2c, EZNEC) | wheel zoom at cursor, **middle**-drag pan, zoom-to-fit / zoom-window commands | Middle-drag exists only to keep left-drag for selection — a constraint this canvas doesn't have — and has no touch equivalent. Zoom-window is a modal tool; clunky for repeated inspection. The good part (cursor-anchored wheel zoom, an explicit fit command) is shared with the map convention and kept. |
| **Plot-style** (matplotlib, plotly) | explicit zoom-rectangle tool + reset button | Most discoverable, least fluid: every zoom is a two-click mode round-trip, and there's no pan-while-zoomed without another mode. Wrong fit for "poke around a feed region while dragging knobs". |

Decisions the issue asked to document:
- **Projection switches carry the viewport** (revised after review): the world point at the canvas centre stays centred — depth along the old camera ray taken from the geometry point nearest the centre ray — at the same absolute px/m magnification. Zoom into a feed in Front, flip to Side/Iso, and you're looking at the same region from the new angle. Design switches still hard-reset. (The first cut reset on projection switch too; review found the carry is what the inspect-from-two-angles workflow actually wants, and the nearest-point depth makes it land on the wire under inspection.)
- **Mobile gesture ownership**: the output pane is a horizontal scroll-snap carousel, so at fit zoom the canvas keeps `touch-action: pan-x pan-y` — a one-finger drag stays with the carousel swipe, while a two-finger pinch (never a browser gesture under that value) always reaches the canvas. Once zoomed, `touch-action: none` and one finger pans; re-fitting hands the swipe back. This resolves the pan-vs-scroll fight deterministically instead of guessing intent.

## Implementation notes
- Viewport state lives in a ref mutated at pointer-event rate with rAF-coalesced repaints; a React mirror of the zoom level drives the HUD chip, `touch-action` gate, and cursor.
- Wheel zoom is exponential (~1.2×/detent, line-mode deltas normalised); pinch translates by the midpoint delta and zooms by the distance ratio; zooming fully out snaps pan to 0 so it lands exactly on fit.
- Thumbnails render the same component with `interactive={false}` — inert as before, no HUD.

## Test plan
- [x] `npm run build` (tsc + vite) clean
- [x] Wheel zoom anchored at cursor: HUD chip appears, `touch-action` → `none`, cursor → grab, canvas repaints (verified against the live dev server via scripted events + canvas pixel export)
- [x] Drag pan repaints and preserves zoom; pan is inert at fit zoom
- [x] Pinch: scripted two-pointer spread of 4.2× separation ratio reads exactly "4.2×"
- [x] Double-click and Fit button re-fit; zoom-out-to-1 snaps pan to 0
- [x] Projection switch carries the viewport: invvee Side→Top→Iso keeps the apex feed centred, zoom rescaled by fit-scale ratio (7.4× → 5.6×); design switch resets
- [x] **elt_whip acceptance**: at 403× the 6.35 mm cage wires around the whip are individually resolved, scale bar reads "5 mm"
- [x] Thumbnails: exactly one HUD/interactive canvas on the page
- [ ] Phone check (pinch vs carousel swipe) on the LAN dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUtqSdTwXJxBzms3jmV16u


**Follow-up commits**: projections generalized to orthonormal screen bases, adding a fourth **Iso** view (classic (+1,+1,+1) corner isometric; ground line stays on the two elevation views), and the viewport carry-over described above.
