### PR TITLE
Per-wire sizes and specs: Wire named tuple with per-wire WireSpec (#388)

### DIFF
--- a/docs/status/2026-07-15-per-wire-specs-design.md
+++ b/docs/status/2026-07-15-per-wire-specs-design.md
@@ -58,14 +58,23 @@ monopole + thin radials, (c) the W8IO whip benchmark deck.
 
 ## Rollout
 
-1. **Phase 1 (this PR)**: `Wire` + `as_wire`, translate-layer specs,
-   coercion/array passthrough — no engine behavior change; existing designs
-   bit-identical.
+This PR lands phases 1, 2, and 4; the momwire kernels (phase 3) follow as
+the companion-issue PR and then a version-bump hookup here.
+
+1. **Phase 1**: `Wire` + `as_wire`, translate-layer specs, coercion/array
+   passthrough — no engine behavior change; existing designs bit-identical.
 2. **Phase 2**: PyNEC per-wire radius (native GW card) + per-tag LD 5
-   conductivity; momwire per-polyline conductivity/insulation via the
-   existing `_wire_loading` arrays; radius still scalar.
-3. **Phase 3**: momwire per-wire radius kernels (companion issue), oracle
-   tests land with the kernels.
-4. **Phase 4**: `nec_import` uses true per-wire radii (no more
-   `dominant_radius()` compromise) and translates ranged LD 5; per-wire
-   length/weight readouts; docs + `elt_whip` showcase.
+   conductivity/insulation cards; momwire per-polyline conductivity/
+   insulation via the existing `_wire_loading` arrays; radius still scalar
+   (uniform per-wire radii honored exactly, mixed collapse to the
+   length-dominant with a warning).
+3. **Phase 4**: `wire_tuples(specs=True)` imports decks with true per-wire
+   radii (no `dominant_radius()` compromise; plain `wire_tuples()`
+   unchanged), ranged whole-wire LD 5 becomes per-wire conductivity,
+   per-wire length/weight readouts, docs, and the `elt_whip` upper whip
+   carries its true 0.889 mm radius (PyNEC remeasured: bare 1.49+33.6j,
+   matched 59.2+8.5j — inside the calibrated windows).
+4. **Phase 3 (follow-up)**: momwire per-wire radius kernels across all four
+   solver bases + C++ accelerators (companion issue); the PyNEC-vs-momwire
+   mixed-radius parity oracle lands with the kernels, and the momwire
+   engine's dominant-radius collapse is then replaced by the real arrays.

--- a/docs/status/2026-07-15-per-wire-specs-design.md
+++ b/docs/status/2026-07-15-per-wire-specs-design.md
@@ -1,0 +1,71 @@
+# Per-wire sizes and specs (#388): design decisions
+
+Status note pinning the decisions for the per-wire `WireSpec` work before
+code review. Companion momwire issue: per-wire radius arrays across all four
+solver bases (filed separately; the kernels gate full #388 acceptance).
+
+## The type: `NamedTuple`, not a model class
+
+`Wire` is a `typing.NamedTuple` (`p0, p1, n_seg, ex=None, name=None,
+spec=None`) living next to `WireSpec` in `network.py`. Rationale:
+
+- A `Wire` **is** a tuple: indexing, unpacking, and the `t[4]`-style name
+  access in existing consumers keep working, so plain 4/5-tuples and `Wire`
+  entries mix freely in one `build_wires()` list — the issue's
+  strictly-additive requirement.
+- No new dependency; matches the codebase pattern (frozen dataclasses +
+  tuples). A pydantic-style model was considered and rejected: it is not a
+  sequence (every indexing consumer breaks), it validates on every
+  construction in a hot path (~4k wires per knob drag on the whip
+  benchmark), and its strengths (JSON parsing, schema) have no application —
+  wires never cross a serialization boundary as wires.
+- The one hazard — `len()` is always 6, so 4/5-arity checks misread it — is
+  contained by a single normalizer choke point: `as_wire(entry) -> Wire`.
+  Consumers call it instead of inspecting `len()`.
+
+## Precedence (defined once)
+
+explicit per-wire `spec` → web `wire_radius` override →
+`build_wire_material()` → 0.5 mm PEC ideal.
+
+The web override *moves the default* only; it never overrides an explicit
+per-wire spec.
+
+## Scaling semantics
+
+Transforms, array placement, and scale knobs move geometry, never specs.
+A `spec` describes the physical wire stock (gauge, jacket, weight); a
+scaled antenna is still built from the same stock. Designs wanting scaled
+radii construct their specs from their own scale knob.
+
+## Spec changes split polylines
+
+momwire consumes per-wire arrays (one value per polyline), so
+`flat_wires_to_polylines` treats a spec change at a degree-2 node as a
+polyline boundary and registers the node as a 2-entry KCL junction —
+the same mechanism as a cycle cut. Every polyline therefore carries exactly
+one spec (`polyline_specs` in the translate result). Mixed-spec loops are
+opened by their spec boundaries before the pure-cycle handler runs.
+
+## momwire mixed-radius kernel convention (to validate, not assume)
+
+Proposed: self terms use the wire's own radius; mutual terms between
+distinct wires use the source wire's radius for the surface offset
+(observation on the axis) — the classic thin-wire reduced kernel. NEC
+solves mixed-radius decks natively and is the parity oracle; the convention
+freezes only when the oracle agrees on (a) a two-radius dipole, (b) a fat
+monopole + thin radials, (c) the W8IO whip benchmark deck.
+
+## Rollout
+
+1. **Phase 1 (this PR)**: `Wire` + `as_wire`, translate-layer specs,
+   coercion/array passthrough — no engine behavior change; existing designs
+   bit-identical.
+2. **Phase 2**: PyNEC per-wire radius (native GW card) + per-tag LD 5
+   conductivity; momwire per-polyline conductivity/insulation via the
+   existing `_wire_loading` arrays; radius still scalar.
+3. **Phase 3**: momwire per-wire radius kernels (companion issue), oracle
+   tests land with the kernels.
+4. **Phase 4**: `nec_import` uses true per-wire radii (no more
+   `dominant_radius()` compromise) and translates ranged LD 5; per-wire
+   length/weight readouts; docs + `elt_whip` showcase.

--- a/site/src/content/docs/reference/nec-import.md
+++ b/site/src/content/docs/reference/nec-import.md
@@ -27,7 +27,7 @@ Drop the deck next to a small design stub in `~/.antennaknobs/designs/`:
 ```python
 # my_yagi.py — my_yagi.nec sits next to it
 from types import MappingProxyType
-from antennaknobs import AntennaBuilder, WireSpec, read_nec
+from antennaknobs import AntennaBuilder, read_nec
 
 WIRES_FILE = "my_yagi.nec"
 
@@ -43,20 +43,18 @@ class Builder(AntennaBuilder):
         deck = read_nec(self, WIRES_FILE, network=True)
         s, h = self.scale, self.height
         lift = lambda p: (p[0] * s, p[1] * s, p[2] * s + h)
-        # Tuples are (p1, p2, n, ex) or (p1, p2, n, ex, name) — the named
-        # ones carry the deck's feed and network attachment points.
-        return [(lift(t[0]), lift(t[1]), *t[2:]) for t in deck.wire_tuples()]
+        # specs=True: `Wire` entries, each carrying ITS OWN radius from the
+        # deck's GW card (and LD 5 conductivity) — a fat driven element
+        # with thin radials solves faithfully, wire by wire. The named
+        # entries carry the deck's feed and network attachment points.
+        return [
+            w._replace(p0=lift(w.p0), p1=lift(w.p1))
+            for w in deck.wire_tuples(specs=True)
+        ]
 
     def build_network(self):
         # The deck's EX drive plus its translated LD/TL/NT cards (see below).
         return read_nec(self, WIRES_FILE, network=True).network()
-
-    def build_wire_material(self):
-        # Keep the deck's element radius — don't skip this (see below) —
-        # and its LD 5 wire conductivity when the deck declares one.
-        deck = read_nec(self, WIRES_FILE, network=True)
-        return WireSpec(radius=deck.dominant_radius() * self.scale,
-                        conductivity=deck.conductivity)
 ```
 
 `read_nec(self, name)` has the same folder confinement as `read_json`: it can
@@ -80,13 +78,22 @@ meaningful for the optimizer to hold onto — those need dimensions expressed
 as parameters, which is exactly what porting the deck to a native
 `AntennaBuilder` gives you.
 
-And one method is not optional: **`build_wire_material`**. The solvers
-default to an idealized 0.5 mm wire; a real deck's 5 mm Yagi elements have
-very different reactance. `deck.dominant_radius()` returns the deck's radius
-(length-weighted when wires differ) — feeding it to `WireSpec` is what makes
-the import faithful. On the xnec2c 2 m Yagi example deck, the imported
-geometry matches the independent `nec2c` solver to **0.011 Ω** *with* the
-deck's radius, and misses by **35 Ω** without it.
+And the radius is not optional. The solvers default to an idealized 0.5 mm
+wire; a real deck's 5 mm Yagi elements have very different reactance. On the
+xnec2c 2 m Yagi example deck, the imported geometry matches the independent
+`nec2c` solver to **0.011 Ω** *with* the deck's radius, and misses by
+**35 Ω** without it. `wire_tuples(specs=True)` (above) handles this per
+wire: every emitted `Wire` carries a `WireSpec` with that GW card's own
+radius, so even a mixed-radius deck keeps its reactance. (The pre-#388
+recipe — plain `wire_tuples()` plus a `build_wire_material()` returning
+`WireSpec(radius=deck.dominant_radius(), conductivity=deck.conductivity)` —
+still works, approximating mixed radii with the length-dominant one.)
+
+Two caveats on per-wire radii: the PyNEC engine honors them exactly (NEC
+takes a radius per wire natively); momwire approximates *mixed* radii with
+the length-dominant one until its per-wire radius kernels land. And the
+`scale` knob stretches geometry only — specs describe physical wire stock
+and are never scaled.
 
 ## Following the deck's band
 
@@ -174,7 +181,8 @@ the trap dipole and station designs use), wherever it can express them
 | --- | --- |
 | `LD` type 0/1 (lumped series/parallel RLC) | A `Load` per segment in the card's range (expanded up to 8 segments), on a named 1-segment wire split out of the host wire |
 | `LD` type 4 with X = 0 (pure resistance) | `Load(r=…)` |
-| `LD` type 5 over the whole structure (wire conductivity) | `deck.conductivity` — feed it to `WireSpec` in `build_wire_material` |
+| `LD` type 5 over the whole structure (wire conductivity) | `deck.conductivity`, baked into every `wire_tuples(specs=True)` spec (or feed it to `WireSpec` in `build_wire_material`) |
+| `LD` type 5 on a tag/range covering whole wires | Per-wire conductivity (`deck.wire_conductivity`), baked into those wires' `specs=True` specs — a ranged card wins over the whole-structure one |
 | `TL` | A `TL` branch: negative z0 (NEC's crossed line) becomes `transposed=True`, zero length resolves to the port separation, conductance-only end admittances become `Shunt(r=1/G)` |
 | `NT` with an all-real Y matrix | Its exact resistive pi: a series `TwoPort` between the ports plus a `Shunt` at each |
 
@@ -188,7 +196,8 @@ What cannot be translated exactly stays out, with a per-card reason in
 `deck.ignored_detail` (rendered by `skipped_note()`): frequency-independent
 reactance (`LD` 4 with X ≠ 0, susceptance in `TL`/`NT` admittances — NEC's
 constant-B convention has no R/L/C equivalent), distributed per-metre RLC
-(`LD` 2/3), range-limited conductivity, and an `LD` landing on a segment
+(`LD` 2/3), an `LD` 5 range covering only *part* of a wire's segments
+(per-wire specs cover whole wires only), and an `LD` landing on a segment
 that also has a `TL`/`NT` connection (NEC composes those in series inside
 the segment, which the port model doesn't express).
 

--- a/src/antennaknobs/__init__.py
+++ b/src/antennaknobs/__init__.py
@@ -15,6 +15,8 @@ __all__ = [
     "read_json",
     "read_nec",
     "WireSpec",
+    "Wire",
+    "as_wire",
     "plot_patterns",
     "compare_patterns",
     "pattern_metrics",
@@ -46,7 +48,7 @@ from .builder import (
 )
 from .design_data import read_data, read_json
 from .nec_import import read_nec
-from .network import WireSpec
+from .network import Wire, WireSpec, as_wire
 from .transform import Transform, TransformStack
 from .drone import Drone
 from .sim import Antenna

--- a/src/antennaknobs/builder.py
+++ b/src/antennaknobs/builder.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping
 
 from .core import save_or_show
+from .network import Wire, as_wire
 import numpy as np
 
 # matplotlib (pyplot + the mplot3d Line3DCollection) is imported lazily inside
@@ -192,6 +193,27 @@ class AntennaBuilder:
         save_or_show(plt, fn)
 
 
+def _shift_entry(t, yoff, zoff, new_ex):
+    """Translate one ``build_wires()`` entry by (0, yoff, zoff) for array
+    placement, replacing a non-None excitation with ``new_ex(old_ex)``
+    (each array builder has its own replace-vs-multiply phasor convention,
+    so the policy comes in as a callable). Preserves the entry's shape:
+    plain 4/5-tuples stay plain, ``Wire`` entries keep ``name`` and
+    ``spec`` untouched — per-wire specs ride through array placement and
+    are never scaled (issue #388: a spec is physical wire stock, not
+    geometry)."""
+    w = as_wire(t)
+    (x0, y0, z0), (x1, y1, z1) = w.p0, w.p1
+    moved = w._replace(
+        p0=(x0, y0 + yoff, z0 + zoff),
+        p1=(x1, y1 + yoff, z1 + zoff),
+        ex=new_ex(w.ex) if w.ex is not None else w.ex,
+    )
+    if isinstance(t, Wire) or len(t) == 6:
+        return moved
+    return tuple(moved)[: len(t)]
+
+
 class Array2x2Builder(AntennaBuilder):
     def __init__(self, element_builder, params=None):
         self.__dict__["element_builder"] = element_builder
@@ -242,17 +264,11 @@ class Array2x2Builder(AntennaBuilder):
                 (self.del_z, tups_top, 1),
                 (-self.del_z, tups_bot, phasor_tb),
             ):
-                for (x0, y0, z0), (x1, y1, z1), ns, ex in tups:
-                    new_tups.extend(
-                        [
-                            (
-                                (x0, y0 + yoff, z0 + zoff),
-                                (x1, y1 + yoff, z1 + zoff),
-                                ns,
-                                ph0 * ph1 if ex is not None else ex,
-                            )
-                        ]
-                    )
+                # 2x2 convention: the element's drive is REPLACED by the
+                # array phasor (unit magnitude), not multiplied.
+                new_tups.extend(
+                    _shift_entry(t, yoff, zoff, lambda ex, p=ph0 * ph1: p) for t in tups
+                )
 
         return new_tups
 
@@ -326,15 +342,8 @@ class Array2x4Builder(AntennaBuilder):
             for zoff, tups in pairs:
                 ph_tb = 1 if zoff > 0 else phasor_tb
                 new_tups.extend(
-                    [
-                        (
-                            (x0, y0 + yoff, z0 + zoff),
-                            (x1, y1 + yoff, z1 + zoff),
-                            ns,
-                            ph_lr * ph_tb * ex if ex is not None else ex,
-                        )
-                        for ((x0, y0, z0), (x1, y1, z1), ns, ex) in tups
-                    ]
+                    _shift_entry(t, yoff, zoff, lambda ex, p=ph_lr * ph_tb: p * ex)
+                    for t in tups
                 )
 
         return new_tups
@@ -397,15 +406,8 @@ class Array1x4Builder(AntennaBuilder):
         ):
             for zoff, tups in pairs:
                 new_tups.extend(
-                    [
-                        (
-                            (x0, y0 + yoff, z0 + zoff),
-                            (x1, y1 + yoff, z1 + zoff),
-                            ns,
-                            ph_lr * ex if ex is not None else ex,
-                        )
-                        for ((x0, y0, z0), (x1, y1, z1), ns, ex) in tups
-                    ]
+                    _shift_entry(t, yoff, zoff, lambda ex, p=ph_lr: p * ex)
+                    for t in tups
                 )
 
         return new_tups
@@ -468,15 +470,8 @@ class Array1x4GroupedBuilder(AntennaBuilder):
         ):
             for zoff, tups in pairs:
                 new_tups.extend(
-                    [
-                        (
-                            (x0, y0 + yoff, z0 + zoff),
-                            (x1, y1 + yoff, z1 + zoff),
-                            ns,
-                            ph_lr * ex if ex is not None else ex,
-                        )
-                        for ((x0, y0, z0), (x1, y1, z1), ns, ex) in tups
-                    ]
+                    _shift_entry(t, yoff, zoff, lambda ex, p=ph_lr: p * ex)
+                    for t in tups
                 )
 
         return new_tups
@@ -533,14 +528,10 @@ class Array1x2Builder(AntennaBuilder):
         # shifted the whole array — inert in free space — now removed.)
         new_tups = []
         for yoff, ph0 in ((-self.del_y, 1), (self.del_y, phasor_lr)):
-            for (x0, y0, z0), (x1, y1, z1), ns, ex in tups_top:
-                new_tups.append(
-                    (
-                        (x0, y0 + yoff, z0),
-                        (x1, y1 + yoff, z1),
-                        ns,
-                        ph0 if ex is not None else ex,
-                    )
-                )
+            # 1x2 convention: like the 2x2, the drive is REPLACED by the
+            # array phasor. No z offset (see the comment above).
+            new_tups.extend(
+                _shift_entry(t, yoff, 0.0, lambda ex, p=ph0: p) for t in tups_top
+            )
 
         return new_tups

--- a/src/antennaknobs/designs/verticals/elt_whip.py
+++ b/src/antennaknobs/designs/verticals/elt_whip.py
@@ -49,15 +49,18 @@ Constraints worth knowing:
     post and ``post_c_pf`` (deck: 3 pF) in series with the second — the
     cage's two grounded legs are the matching network. Set a knob to 0 to
     omit that element.
-  * Remaining deviation: engines take a single wire radius (default: the
-    deck's length-dominant 0.254 mm; the upper whip's 0.889 mm is
-    approximated).
+  * The upper whip carries its own per-wire spec (issue #388) with the
+    deck's true 0.035" = 0.889 mm radius (``whip_upper_radius``); everything
+    else uses ``wire_radius`` (the deck's 0.254 mm). PyNEC honors both;
+    momwire approximates the pair with the length-dominant radius (the
+    grid dominates, so it solves at 0.254 mm — exactly the old whole-antenna
+    compromise) until its per-wire radius kernels land.
 """
 
 import math
 from types import MappingProxyType
 
-from antennaknobs import AntennaBuilder, WireSpec
+from antennaknobs import AntennaBuilder, Wire, WireSpec
 from antennaknobs.network import Driven, Load, Network, PortOnWire
 
 # Half-extent of each ground-grid column, in cells: column i (x = i * pitch)
@@ -132,6 +135,9 @@ class Builder(AntennaBuilder):
             "grid_pitch": 0.0508,
             "fine_pitch": 0.0254,
             "wire_radius": 0.000254,
+            # The thick top whip section's own radius (deck: 0.035");
+            # rides as a per-wire spec on just that wire (issue #388).
+            "whip_upper_radius": 0.000889,
             "ui_params": MappingProxyType(
                 {
                     "default_view": "xz",
@@ -194,10 +200,16 @@ class Builder(AntennaBuilder):
             (0.0, 0.0, l1 + h),
             max(1, round((l1 - base) / spacing)),
         )
-        add(
-            (0.0, 0.0, l1 + h),
-            (0.0, 0.0, l1 + self.whip_upper_len + h),
-            max(1, round(self.whip_upper_segs)),
+        # The thick top section keeps the deck's own 0.035" radius as a
+        # per-wire spec; every other wire falls back to `wire_radius` via
+        # build_wire_material (issue #388).
+        wires.append(
+            Wire(
+                (0.0, 0.0, l1 + h),
+                (0.0, 0.0, l1 + self.whip_upper_len + h),
+                max(1, round(self.whip_upper_segs)),
+                spec=WireSpec(radius=self.whip_upper_radius),
+            )
         )
 
         # --- cage: verticals in ring-to-ring pieces, a polygon per ring ---

--- a/src/antennaknobs/engine.py
+++ b/src/antennaknobs/engine.py
@@ -4,6 +4,8 @@ from typing import ClassVar, Literal, NamedTuple
 
 import numpy as np
 
+from .network import Wire, as_wire
+
 _logger = logging.getLogger(__name__)
 
 SegmentParity = Literal["odd", "even", "any"]
@@ -66,22 +68,26 @@ class SimulationEngine(ABC):
         seen = set()
         out = []
         for t in tups:
-            p0, p1, n_seg, ev = t[0], t[1], t[2], t[3]
-            name = t[4] if len(t) >= 5 else None
-            n_new = self.coerce_n_seg(n_seg, parity)
-            if n_new != n_seg and (n_seg, n_new) not in seen:
-                seen.add((n_seg, n_new))
+            w = as_wire(t)
+            n_new = self.coerce_n_seg(w.n_seg, parity)
+            if n_new != w.n_seg and (w.n_seg, n_new) not in seen:
+                seen.add((w.n_seg, n_new))
                 _logger.info(
                     "%s bumped n_seg=%d → %d for %s parity",
                     type(self).__name__,
-                    n_seg,
+                    w.n_seg,
                     n_new,
                     parity,
                 )
-            if name is None:
-                out.append((p0, p1, n_new, ev))
+            # Preserve the entry's original shape: plain tuples stay plain
+            # (so tests and shape-sensitive callers see what they passed),
+            # Wire entries keep name and spec.
+            if isinstance(t, Wire) or len(t) == 6:
+                out.append(w._replace(n_seg=n_new))
+            elif len(t) == 5:
+                out.append((w.p0, w.p1, n_new, w.ex, w.name))
             else:
-                out.append((p0, p1, n_new, ev, name))
+                out.append((w.p0, w.p1, n_new, w.ex))
         return out
 
     @abstractmethod

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -192,27 +192,103 @@ class MomwireEngine(SimulationEngine):
         translated = flat_wires_to_polylines(tups)
         self._polylines = translated["polylines"]
         self._edge_segments = translated["edge_segments"]
+        self._polyline_specs = translated["polyline_specs"]
         self._feeds = translated["feeds"]
         self._feed_names = translated["feed_names"]
         self._junctions = translated["junctions"]
-        # Wire material (issue #316): a design-declared WireSpec supplies the
-        # conductor radius plus the distributed-loading kwargs. Precedence
-        # for the radius: an explicit non-default `wire_radius` (the web
-        # model-options control) wins; the stock 0.0005 acts as "auto" so a
-        # spec design's skin-effect loss is computed at its real radius.
+        # Wire material (issues #316/#388): a design-declared WireSpec
+        # supplies the default conductor radius plus the distributed-loading
+        # kwargs; per-wire specs on individual Wire entries override it wire
+        # by wire. Precedence for the default radius: an explicit non-default
+        # `wire_radius` (the web model-options control) wins over
+        # build_wire_material(); the stock 0.0005 acts as "auto" so a spec
+        # design's skin-effect loss is computed at its real radius. An
+        # explicit per-wire spec beats both — the web override only moves
+        # the default.
         self._wire_spec = builder.build_wire_material()
         if wire_radius != 0.0005 and wire_radius is not None:
-            self._wire_radius = wire_radius
+            default_radius = wire_radius
         elif self._wire_spec is not None:
-            self._wire_radius = self._wire_spec.radius
+            default_radius = self._wire_spec.radius
         else:
-            self._wire_radius = 0.0005
+            default_radius = 0.0005
+        specs = self._polyline_specs
+        if any(s is not None for s in specs):
+            # The solver kernels take ONE radius until momwire grows
+            # per-wire radius arrays (the #388 companion issue): a uniform
+            # per-wire radius is honored exactly; mixed radii collapse to
+            # the length-dominant one, stated plainly.
+            radii = [s.radius if s is not None else default_radius for s in specs]
+            if len(set(radii)) == 1:
+                self._wire_radius = radii[0]
+            else:
+                length_by_r: dict[float, float] = {}
+                for r, pl in zip(radii, self._polylines):
+                    ln = float(np.linalg.norm(np.diff(pl, axis=0), axis=1).sum())
+                    length_by_r[r] = length_by_r.get(r, 0.0) + ln
+                self._wire_radius = max(length_by_r.items(), key=lambda kv: kv[1])[0]
+                _logger.warning(
+                    "momwire solvers take a single wire radius until the "
+                    "per-wire radius kernels land; approximating %s's mixed "
+                    "per-wire radii with the length-dominant %.4g m",
+                    type(builder).__name__,
+                    self._wire_radius,
+                )
+        else:
+            self._wire_radius = default_radius
         # Distributed loading rides only the solvers that model it; warn
         # once (not raise) so a matched-basis sinusoidal comparison of a
         # lossy design still solves — as the ideal wire, stated plainly.
         self._loading_kwargs = {}
         spec = self._wire_spec
-        if spec is not None and (
+        if any(s is not None for s in specs):
+            # Per-wire loading (issue #388): one entry per polyline, NaN
+            # switching the effect off for that wire (momwire's
+            # normalize_per_wire convention). A wire without its own spec
+            # inherits the design default. NOTE: skin loss for per-wire
+            # conductivity is still computed at the single global radius
+            # above — the per-wire radius kernels lift that too.
+            eff = [s if s is not None else spec for s in specs]
+            nan = float("nan")
+            cond = np.array(
+                [
+                    e.conductivity
+                    if e is not None and e.conductivity is not None
+                    else nan
+                    for e in eff
+                ]
+            )
+            ins_r = np.array(
+                [
+                    e.insulation_radius
+                    if e is not None and e.insulation_radius is not None
+                    else nan
+                    for e in eff
+                ]
+            )
+            ins_eps = np.array(
+                [
+                    e.insulation_eps_r
+                    if e is not None and e.insulation_radius is not None
+                    else nan
+                    for e in eff
+                ]
+            )
+            wants_loading = bool(np.isfinite(cond).any() or np.isfinite(ins_r).any())
+            if wants_loading and _solver_supports_wire_loading(self._solver):
+                if np.isfinite(cond).any():
+                    self._loading_kwargs["wire_conductivity"] = cond
+                if np.isfinite(ins_r).any():
+                    self._loading_kwargs["insulation_radius"] = ins_r
+                    self._loading_kwargs["insulation_eps_r"] = ins_eps
+            elif wants_loading:
+                _logger.warning(
+                    "%s doesn't model distributed wire loading; solving the "
+                    "design's %s wire as ideal (PEC, bare)",
+                    getattr(self._solver, "__name__", self._solver),
+                    type(builder).__name__,
+                )
+        elif spec is not None and (
             spec.conductivity is not None or spec.insulation_radius is not None
         ):
             if _solver_supports_wire_loading(self._solver):

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -12,7 +12,7 @@ from momwire import BSplineSolver
 
 from ..engine import FarField, SimulationEngine, WireCurrents
 from ..geometry import flat_wires_to_polylines
-from ..network import PortOnWire, PortVirtual
+from ..network import PortOnWire, PortVirtual, as_wire
 from ..network_reduce import NetworkReducer, tl_admittance_2x2
 
 _logger = logging.getLogger(__name__)
@@ -183,9 +183,10 @@ class MomwireEngine(SimulationEngine):
             for tag1, _seg1, tag2, _seg2, _z0, _length in self._tls:
                 for tag in (tag1, tag2):
                     t = tups[tag - 1]
-                    p0, p1, n_seg, ev = t[0], t[1], t[2], t[3]
-                    if ev is None:
-                        tups[tag - 1] = (p0, p1, n_seg, 0 + 0j)
+                    if t[3] is None:
+                        # Preserve any name/spec fields while nullifying the
+                        # feed (as_wire keeps them; only ex changes).
+                        tups[tag - 1] = as_wire(t)._replace(ex=0 + 0j)
                         augmented_tags.add(tag)
 
         translated = flat_wires_to_polylines(tups)

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -8,6 +8,7 @@ import PyNEC as nec
 from momwire import insulation_inductance, wire_internal_impedance
 
 from ..engine import FarField, SimulationEngine, WireCurrents
+from ..network import as_wire
 from ..network import (
     Driven,
     Load,
@@ -167,7 +168,7 @@ class PyNECEngine(SimulationEngine):
                 n_seg,
                 p0[0], p0[1], p0[2],
                 p1[0], p1[1], p1[2],
-                self._wire_radius,
+                self._radius_for(t),
                 1.0,
                 1.0,
             )  # fmt: skip
@@ -200,24 +201,51 @@ class PyNECEngine(SimulationEngine):
         for tag, sub_index, voltage in self.excitation_pairs:
             self.c.ex_card(0, tag, sub_index, 0, voltage.real, voltage.imag, 0, 0, 0, 0)
 
-    def _insulation_l_per_m(self):
+    def _radius_for(self, t):
+        """Wire-card radius for one build_wires() entry: its own spec's
+        radius when it carries one (issue #388 — NEC takes a radius per GW
+        card natively), else the whole-antenna default."""
+        spec = as_wire(t).spec
+        return spec.radius if spec is not None else self._wire_radius
+
+    def _insulation_l_per_m(self, spec=None, radius=None):
         """The spec jacket's distributed series inductance [H/m] (King's
         quasi-static insulated-antenna limit — the same L' momwire loads),
-        or None for bare/ideal wire."""
-        spec = self._wire_spec
+        or None for bare/ideal wire. With no arguments, the design default;
+        per-wire callers pass that wire's spec and conductor radius."""
+        if spec is None:
+            spec = self._wire_spec
+        if radius is None:
+            radius = self._wire_radius
         if spec is None or not spec.insulation_radius:
             return None
         return insulation_inductance(
-            self._wire_radius, spec.insulation_radius, spec.insulation_eps_r
+            radius, spec.insulation_radius, spec.insulation_eps_r
         )
 
     def _emit_wire_material_cards(self, c):
-        """Global (all-segments) LD cards for the design's wire material:
-        conductor loss as type 5, insulation as type 2 (distributed series
-        R/L/C per metre — only the H/m slot is used). NEC connects multiple
-        loads on a segment in series, so the two stack. Spec conductivity
-        from the design wins; the module constant stays as the manual
-        all-designs oracle override (see its comment above)."""
+        """LD cards for the design's wire material: conductor loss as type
+        5, insulation as type 2 (distributed series R/L/C per metre — only
+        the H/m slot is used). NEC connects multiple loads on a segment in
+        series, so the two stack — which is exactly why the per-wire and
+        global paths are exclusive: a global card plus a per-tag card would
+        double the loss on that wire.
+
+        With no per-wire specs (issue #388), one global all-segments card
+        per effect, exactly as before. When any wire carries its own spec,
+        every wire gets per-tag cards from its effective spec (its own, or
+        the design default for spec-less wires)."""
+        if any(as_wire(t).spec is not None for t in self.tups):
+            for tag, t in enumerate(self.tups, start=1):
+                w = as_wire(t)
+                eff = w.spec if w.spec is not None else self._wire_spec
+                sigma = eff.conductivity if eff is not None else WIRE_CONDUCTIVITY
+                if sigma is not None:
+                    c.ld_card(5, tag, 0, 0, sigma, 0.0, 0.0)
+                l_ins = self._insulation_l_per_m(eff, self._radius_for(t))
+                if l_ins is not None:
+                    c.ld_card(2, tag, 0, 0, 0.0, l_ins, 0.0)
+            return
         sigma = (
             self._wire_spec.conductivity
             if self._wire_spec is not None
@@ -468,7 +496,7 @@ class PyNECEngine(SimulationEngine):
                 p1[0],
                 p1[1],
                 p1[2],
-                self._wire_radius,
+                self._radius_for(t),
                 1.0,
                 1.0,
             )

--- a/src/antennaknobs/geometry.py
+++ b/src/antennaknobs/geometry.py
@@ -28,6 +28,8 @@ from __future__ import annotations
 
 import numpy as np
 
+from .network import as_wire
+
 
 def _round_point(p, eps):
     # Quantize endpoints onto an eps-spaced grid so 1e-14 floating-point
@@ -71,24 +73,23 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
             nodes.append(np.asarray(p, dtype=float))
         return node_of[key]
 
-    # Names are an optional 5th tuple field. None (or absent) means
-    # "unnamed"; otherwise a string identifying this edge as a network
-    # port in `build_network()`.
+    # Names are an optional 5th field, per-wire specs an optional 6th
+    # (issue #388); entries may be plain 4/5-tuples or `Wire` named tuples,
+    # normalized here at the single choke point.
     tup_names = []
+    tup_specs = []
     for i, t in enumerate(tups):
-        if len(t) == 4:
-            p0, p1, n_seg, ev = t
-            name = None
-        elif len(t) == 5:
-            p0, p1, n_seg, ev, name = t
-        else:
-            raise ValueError(f"tuple {i}: expected 4- or 5-tuple, got {len(t)}")
+        try:
+            p0, p1, n_seg, ev, name, spec = as_wire(t)
+        except ValueError as e:
+            raise ValueError(f"tuple {i}: {e}") from None
         a = node_id(p0)
         b = node_id(p1)
         if a == b:
             raise ValueError(f"tuple {i}: degenerate edge (p0==p1 within eps)")
         edges.append((a, b, int(n_seg), ev, i))
         tup_names.append(name)
+        tup_specs.append(spec)
 
     # adj[nid] = list of (other_node, edge_index), in registration order.
     adj = [[] for _ in nodes]
@@ -105,10 +106,26 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
     # polyline and starts another. Walk every edge out of every boundary
     # node, threading through degree-2 nodes until the next boundary.
     is_boundary = [len(a) != 2 for a in adj]
+
+    # A wire-spec change is a polyline boundary too (issue #388): momwire
+    # consumes one spec per wire, so a degree-2 node whose two edges carry
+    # different specs must end one polyline and start another. The node is
+    # then registered as a 2-entry junction below — exactly like a cycle
+    # cut — so KCL still carries the current through it.
+    for nid, neigh in enumerate(adj):
+        if not is_boundary[nid]:
+            e0, e1 = neigh[0][1], neigh[1][1]
+            if tup_specs[edges[e0][4]] != tup_specs[edges[e1][4]]:
+                is_boundary[nid] = True
+
     edge_seen = [False] * len(edges)
 
     polylines = []
     edge_segments = []
+    # One spec per polyline: uniform by construction, since a spec change
+    # at a degree-2 node was marked as a boundary above and any other
+    # meeting point is a junction (a boundary already).
+    polyline_specs = []
     # junction_ends[node_id] -> list of (polyline_index, "start"|"end").
     # Filled as we walk; only meaningful for degree>=3 nodes, but we
     # collect it for all boundary nodes and filter later.
@@ -151,6 +168,7 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
             polyline_idx = len(polylines)
             polylines.append(np.stack([nodes[n] for n in path_nodes], axis=0))
             edge_segments.append([edges[e][2] for e in path_edges])
+            polyline_specs.append(tup_specs[edges[path_edges[0]][4]])
             for k, e in enumerate(path_edges):
                 edge_to_polyline[edges[e][4]] = (polyline_idx, k)
             junction_ends[path_nodes[0]].append((polyline_idx, "start"))
@@ -205,6 +223,7 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
         cut_pl_idx = len(polylines)
         polylines.append(np.stack([nodes[cut_a], nodes[cut_b]], axis=0))
         edge_segments.append([cut_n_seg])
+        polyline_specs.append(tup_specs[cut_tup_idx])
         edge_to_polyline[cut_tup_idx] = (cut_pl_idx, 0)
 
         # Polyline 1 (long way): walk B → ... → A via the remaining edges.
@@ -232,6 +251,7 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
         loop_pl_idx = len(polylines)
         polylines.append(np.stack([nodes[n] for n in path_nodes], axis=0))
         edge_segments.append([edges[e][2] for e in path_edges])
+        polyline_specs.append(tup_specs[edges[path_edges[0]][4]])
         for k, e in enumerate(path_edges):
             edge_to_polyline[edges[e][4]] = (loop_pl_idx, k)
 
@@ -280,6 +300,7 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
     return {
         "polylines": polylines,
         "edge_segments": edge_segments,
+        "polyline_specs": polyline_specs,
         "feeds": feeds,
         "feed_names": feed_names,
         # Back-compat scalars — first feed.

--- a/src/antennaknobs/nec_export.py
+++ b/src/antennaknobs/nec_export.py
@@ -93,9 +93,10 @@ def export_nec(
     title = title or f"{type(builder).__module__}.{type(builder).__qualname__}"
     lines = [f"CM {title}", "CM exported by antennaknobs.nec_export", "CE"]
 
-    # --- geometry: one GW per resolved wire tuple, then GE ---
+    # --- geometry: one GW per resolved wire tuple, then GE. GW carries a
+    # radius natively, so a per-wire spec (issue #388) exports faithfully ---
     for tag, t in enumerate(eng.tups, start=1):
-        lines.append(_gw(tag, t[2], t[0], t[1], eng._wire_radius))
+        lines.append(_gw(tag, t[2], t[0], t[1], eng._radius_for(t)))
     lines.append("GE 0")
 
     # --- Load branches -> LD cards (type 0 series / 1 parallel RLC) ---

--- a/src/antennaknobs/nec_import.py
+++ b/src/antennaknobs/nec_import.py
@@ -189,6 +189,9 @@ class NecDeck:
     tls: tuple[NecTL, ...] = ()
     nts: tuple[NecNT, ...] = ()
     conductivity: float | None = None  # whole-structure LD 5, S/m
+    # Ranged LD 5 (issue #388): (wire index, S/m) for every wire an LD 5
+    # card covers in full. Baked into wire_tuples(specs=True) specs.
+    wire_conductivity: tuple[tuple[int, float], ...] = ()
     # (mnemonic, reason) per card instance that network mode still could not
     # translate — skipped_note() prefers these over the generic descriptions.
     ignored_detail: tuple[tuple[str, str], ...] = ()
@@ -315,7 +318,7 @@ class NecDeck:
                 cuts[i] = frozenset(shared)
         return cuts
 
-    def wire_tuples(self):
+    def wire_tuples(self, specs: bool = False):
         """The deck as ``build_wires()`` tuples.
 
         Default mode: ``(p1, p2, n_seg, ex)`` with the deck's EX voltages as
@@ -324,6 +327,17 @@ class NecDeck:
         *named* wire instead, ``(p1, p2, n_seg, None, name)``, and no tuple
         carries ``ex`` (the drive comes from ``network()``'s ``Driven``
         sources).
+
+        ``specs=True`` (issue #388) emits ``Wire`` named tuples instead,
+        each carrying a per-wire ``WireSpec`` with the deck wire's OWN
+        radius — no ``dominant_radius()`` compromise — and its effective
+        conductivity (a ranged LD 5 over the whole wire, else the deck's
+        whole-structure LD 5). PyNEC honors both per wire; momwire honors
+        the conductivity and approximates mixed radii with the
+        length-dominant one until its per-wire radius kernels land. With
+        ``specs=True`` a ``build_wire_material()`` fallback is unnecessary
+        (every wire carries its spec) — though a design may still define
+        one for the weight readout of spec-less wires it adds itself.
 
         Wires are split into colinear pieces on the deck's exact segment
         boundaries in two situations: a marked (fed / port) segment that is
@@ -355,21 +369,46 @@ class NecDeck:
                     )
                 per[f.seg] = (f.voltage, None)
 
+        sigma_by_wire = dict(self.wire_conductivity)
+
+        def spec_for(i, w):
+            """Per-wire spec (issue #388): the deck wire's own radius, with
+            its effective conductivity baked in — a ranged LD 5 on this wire
+            wins over the whole-structure one. Baking is required: engines
+            treat an explicit spec as complete (no field-level fallback to
+            build_wire_material), so leaving conductivity None would turn a
+            copper deck into PEC wire by wire."""
+            if not specs:
+                return None
+            return _net.WireSpec(
+                radius=w.radius,
+                conductivity=sigma_by_wire.get(i, self.conductivity),
+            )
+
         tups = []
+
+        def emit(p0, p1, n, ex, pname=None, spec=None):
+            if spec is not None:
+                tups.append(_net.Wire(p0, p1, n, ex, pname, spec))
+            elif pname:
+                tups.append((p0, p1, n, ex, pname))
+            else:
+                tups.append((p0, p1, n, ex))
+
         for i, w in enumerate(self.wires):
             per = marks.get(i, {})
             cutset = self._junction_cuts.get(i, frozenset())
             n = w.n_seg
+            spec = spec_for(i, w)
             if not per and not cutset:
-                tups.append((w.p1, w.p2, n, None))
+                emit(w.p1, w.p2, n, None, spec=spec)
                 continue
             if not cutset and len(per) == 1 and n % 2 == 1:
                 (seg, (ex, pname)) = next(iter(per.items()))
                 if seg == (n + 1) // 2:
                     # Marked at the wire's middle segment — the engine's
                     # native attachment position; keep the wire whole.
-                    whole = (w.p1, w.p2, n, ex)
-                    tups.append(whole + (pname,) if pname else whole)
+                    emit(w.p1, w.p2, n, ex, pname, spec)
                     continue
 
             def point(k, w=w, n=n):
@@ -391,10 +430,9 @@ class NecDeck:
                 mark = per.get(b) if count == 1 else None
                 if mark is not None:
                     ex, pname = mark
-                    piece = (point(prev), point(b), 1, ex)
-                    tups.append(piece + (pname,) if pname else piece)
+                    emit(point(prev), point(b), 1, ex, pname, spec)
                 else:
-                    tups.append((point(prev), point(b), count, None))
+                    emit(point(prev), point(b), count, None, spec=spec)
                 prev = b
         return tups
 
@@ -820,6 +858,7 @@ def _translate_network_cards(wires, lds_raw, tls_raw, nts_raw):
     loads: list[NecLoad] = []
     loaded: set[tuple[int, int]] = set()
     conductivity: float | None = None
+    wire_conductivity: dict[int, float] = {}
     for card in lds_raw:
         ldtyp = card.i(0)
         tag, sf, st = card.i(1), card.i(2), card.i(3)
@@ -863,15 +902,38 @@ def _translate_network_cards(wires, lds_raw, tls_raw, nts_raw):
             if tag == 0 and sf == 0:
                 conductivity = card.f(4)
             else:
-                skip(
-                    "LD",
-                    "type 5 conductivity on a tag/segment range — the "
-                    "engines take one whole-antenna conductivity",
-                )
+                # Ranged conductivity (issue #388): whole wires can carry
+                # their own WireSpec conductivity, so a range that covers
+                # each touched wire in full translates per wire (NEC's
+                # last-card-wins per segment becomes last-wins per wire).
+                pairs = _segment_range(wires, tag, sf, st, card)
+                by_wire: dict[int, set[int]] = {}
+                for wi, s in pairs:
+                    by_wire.setdefault(wi, set()).add(s)
+                if all(
+                    segs == set(range(1, wires[wi][1] + 1))
+                    for wi, segs in by_wire.items()
+                ):
+                    for wi in by_wire:
+                        wire_conductivity[wi] = card.f(4)
+                else:
+                    skip(
+                        "LD",
+                        "type 5 conductivity on a partial-wire segment "
+                        "range — per-wire specs cover whole wires only",
+                    )
         else:
             skip("LD", f"type {ldtyp} is not recognised")
 
-    return tuple(loads), tuple(tls), tuple(nts), conductivity, detail, skipped
+    return (
+        tuple(loads),
+        tuple(tls),
+        tuple(nts),
+        conductivity,
+        tuple(sorted(wire_conductivity.items())),
+        detail,
+        skipped,
+    )
 
 
 def parse_nec(text: str, *, name: str = "NEC deck", network: bool = False) -> NecDeck:
@@ -1012,11 +1074,18 @@ def parse_nec(text: str, *, name: str = "NEC deck", network: bool = False) -> Ne
     tls: tuple[NecTL, ...] = ()
     nts: tuple[NecNT, ...] = ()
     conductivity: float | None = None
+    wire_conductivity: tuple[tuple[int, float], ...] = ()
     detail: list[tuple[str, str]] = []
     if network:
-        loads, tls, nts, conductivity, detail, skipped = _translate_network_cards(
-            wires, lds_raw, tls_raw, nts_raw
-        )
+        (
+            loads,
+            tls,
+            nts,
+            conductivity,
+            wire_conductivity,
+            detail,
+            skipped,
+        ) = _translate_network_cards(wires, lds_raw, tls_raw, nts_raw)
         ignored |= skipped
 
     return NecDeck(
@@ -1033,6 +1102,7 @@ def parse_nec(text: str, *, name: str = "NEC deck", network: bool = False) -> Ne
         tls=tls,
         nts=nts,
         conductivity=conductivity,
+        wire_conductivity=wire_conductivity,
         ignored_detail=tuple(detail),
         network_mode=network,
     )

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -22,7 +22,7 @@ as tiny stub wires at sensible locations.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Union
+from typing import NamedTuple, Union
 
 
 @dataclass(frozen=True)
@@ -212,6 +212,44 @@ def wire_from_catalog(name):
     if name not in WIRES:
         raise KeyError(f"unknown wire {name!r}; available: {', '.join(sorted(WIRES))}")
     return WIRES[name]
+
+
+class Wire(NamedTuple):
+    """One ``build_wires()`` entry, named (issue #388). A drop-in superset
+    of the plain-tuple contract: a ``Wire`` IS a tuple, so indexing,
+    unpacking, and the ``t[4]``-style name access keep working, and designs
+    may freely mix plain 4/5-tuples and ``Wire`` entries in one list.
+
+    ``spec=None`` means "the design default": engines fall back to
+    ``build_wire_material()``. Precedence, defined once: an explicit
+    per-wire ``spec`` wins; the web ``wire_radius`` override only moves
+    the default. Transforms, array placement, and scale knobs never scale
+    a ``spec`` — it describes the physical wire stock the antenna is
+    built from, not the geometry.
+    """
+
+    p0: tuple
+    p1: tuple
+    n_seg: int
+    ex: complex | None = None
+    name: str | None = None
+    spec: WireSpec | None = None
+
+
+def as_wire(t) -> Wire:
+    """Normalize one ``build_wires()`` entry — plain 4/5/6-tuple or
+    ``Wire`` — to a ``Wire``. This is the single choke point for
+    tuple-shape discrimination: consumers should call this instead of
+    inspecting ``len(t)``, because a ``Wire``'s defaults make its ``len()``
+    always 6, which an arity check misreads."""
+    if isinstance(t, Wire):
+        return t
+    if not 4 <= len(t) <= 6:
+        raise ValueError(
+            "build_wires() entry must have 4-6 fields "
+            f"(p0, p1, n_seg, ex[, name[, spec]]), got {len(t)}"
+        )
+    return Wire(*t)
 
 
 # Reserved for follow-up PR — sketched here so the discriminated-union

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -60,6 +60,7 @@ from antennaknobs.builder import (
     diff_params,
     resolve_variant_params,
 )
+from antennaknobs.network import as_wire
 
 try:
     from antennaknobs.engines.pynec import DEFAULT_GROUND, PyNECEngine
@@ -712,20 +713,28 @@ def _pynec_ground_spec(req: dict):
 def _wire_material_results(builder) -> dict:
     """Wire length + weight response fields (issue #318) for designs that
     declare a wire material: total conductor run from build_wires(), weight
-    from the catalog's grams/meter (jacket included). {} when the design
-    has no material — the fields (and their Info-pane rows) only exist for
-    wire_type designs."""
-    spec = builder.build_wire_material()
-    if spec is None:
+    from the catalog's grams/meter (jacket included). Per-wire specs
+    (issue #388) sum wire by wire — a wire's own spec wins, spec-less wires
+    fall back to the design default. {} when the design declares no
+    material anywhere — the fields (and their Info-pane rows) only exist
+    for designs with a wire material."""
+    default = builder.build_wire_material()
+    tups = list(builder.build_wires())
+    specs = [as_wire(t).spec for t in tups]
+    if default is None and not any(s is not None for s in specs):
         return {}
-    length = 0.0
-    for t in builder.build_wires():
+    length = weight = 0.0
+    for t, s in zip(tups, specs):
         p0 = np.asarray(t[0], dtype=float)
         p1 = np.asarray(t[1], dtype=float)
-        length += float(np.linalg.norm(p1 - p0))
+        ln = float(np.linalg.norm(p1 - p0))
+        length += ln
+        eff = s if s is not None else default
+        if eff is not None:
+            weight += ln * eff.weight_g_per_m
     return {
         "wire_length_m": length,
-        "wire_weight_g": length * spec.weight_g_per_m,
+        "wire_weight_g": weight,
     }
 
 

--- a/src/antennaknobs/web/user_design_assets/CLAUDE.md
+++ b/src/antennaknobs/web/user_design_assets/CLAUDE.md
@@ -114,24 +114,25 @@ transmission lines, and (resistive) NT networks into the app's own
 `build_network` branches, so the deck's matching/phasing actually acts:
 
 ```python
-from antennaknobs import AntennaBuilder, WireSpec, read_nec
+from antennaknobs import AntennaBuilder, read_nec
 
 class Builder(AntennaBuilder):
     def build_wires(self):
-        return read_nec(self, "my_yagi.nec", network=True).wire_tuples()
+        # specs=True: every wire keeps ITS OWN radius from the deck's GW
+        # card (and its LD 5 conductivity), so a mixed-radius deck — a fat
+        # driven element with thin radials — solves faithfully. No
+        # build_wire_material() needed; each wire carries its spec.
+        return read_nec(self, "my_yagi.nec", network=True).wire_tuples(specs=True)
 
     def build_network(self):
         # the deck's EX drive + its translated LD/TL/NT cards
         return read_nec(self, "my_yagi.nec", network=True).network()
-
-    def build_wire_material(self):
-        # keep the deck's element radius — the default 0.5 mm idealization
-        # would shift the reactance badly on thick VHF elements — and its
-        # LD 5 wire conductivity when the deck declares one
-        deck = read_nec(self, "my_yagi.nec", network=True)
-        return WireSpec(radius=deck.dominant_radius(),
-                        conductivity=deck.conductivity)
 ```
+
+(Without `specs=True` you get plain tuples and one whole-antenna wire
+material: pair `wire_tuples()` with a `build_wire_material()` returning
+`WireSpec(radius=deck.dominant_radius(), conductivity=deck.conductivity)` —
+the pre-#388 recipe, still fully supported.)
 
 Wires (GW/GA arcs/GH helices) and the geometry transforms (GM, GX, GR, GS —
 including xnec2c's tag-range GS) are honoured, the deck's EX voltage sources
@@ -220,6 +221,27 @@ Return a list of straight wire segments. Each entry is:
 small `eps` (e.g. 0.01 m) apart, with the radiator arms running outward from
 those two points. Wires connect where they share an endpoint, so the arms and
 the feed segment must share their centre points exactly. See `TEMPLATE.py`.
+
+**Per-wire sizes (optional).** A design that mixes conductors — a fat
+aluminium element with thin wire radials — can give any entry its own
+`WireSpec` by returning a `Wire` named tuple instead of a plain tuple; the
+two mix freely in one list:
+
+```python
+from antennaknobs import AntennaBuilder, Wire, WireSpec
+
+TUBE = WireSpec(radius=6e-3)                       # 12 mm boom element
+WIRE = WireSpec(radius=1e-3, conductivity=5.8e7)   # copper radial
+
+(start, end, n_segments, feed)                     # plain tuple: design default
+Wire(start, end, n_segments, feed, spec=TUBE)      # this wire is the fat tube
+```
+
+A wire without a `spec` uses `build_wire_material()` (or the 0.5 mm ideal).
+PyNEC honors per-wire radius and loss exactly; momwire honors per-wire
+loss/insulation and approximates *mixed* radii with the length-dominant one
+until its per-wire radius kernels land. Specs describe physical wire stock —
+scale knobs and transforms move geometry, never specs.
 
 **Tuning on a band — use `design_freq` (strongly recommended).** To place an
 antenna on a band *and be able to tune it there*, add a `design_freq` param

--- a/tests/test_elt_whip.py
+++ b/tests/test_elt_whip.py
@@ -14,13 +14,16 @@ import math
 
 import pytest
 
-from antennaknobs import merge_params
+from antennaknobs import as_wire, merge_params
 from antennaknobs.designs.verticals.elt_whip import Builder
 
 
 def _wire(w):
-    """Normalize a build_wires tuple: (p0, p1, nseg, ex, name-or-None)."""
-    return (*w, None) if len(w) == 4 else w
+    """Normalize a build_wires entry: (p0, p1, nseg, ex, name-or-None).
+    Entries may be plain tuples or Wire named tuples (the upper whip
+    carries a per-wire spec since #388)."""
+    t = as_wire(w)
+    return (t.p0, t.p1, t.n_seg, t.ex, t.name)
 
 
 def test_default_build_reproduces_deck_counts():
@@ -93,10 +96,12 @@ def test_free_space_impedance_matches_benchmark():
 
     With the posts' elements zeroed the feed must reproduce the raw
     benchmark impedance every engine agreed on in the 2026-07-14 run
-    (Z ≈ 1.38 + 33.5j free space); with the deck's LD values the network
-    transforms that to a ~50 Ω-class match (measured 63.0 + 8.1j). A
-    geometry or network-stamping regression moves either far outside its
-    window."""
+    (Z ≈ 1.38 + 33.5j free space at one whole-antenna radius; 1.49 + 33.6j
+    remeasured 2026-07-15 with the upper whip's true 0.889 mm per-wire
+    radius, #388); with the deck's LD values the network transforms that
+    to a ~50 Ω-class match (63.0 + 8.1j single-radius, 59.2 + 8.5j
+    per-wire). A geometry or network-stamping regression moves either far
+    outside its window."""
     pytest.importorskip("PyNEC")
     from antennaknobs.engines import PyNECEngine
 

--- a/tests/test_per_wire_specs.py
+++ b/tests/test_per_wire_specs.py
@@ -1,0 +1,220 @@
+"""Phase-1 tests for issue #388: the `Wire` named tuple, the `as_wire`
+normalizer choke point, spec-aware polyline translation, and spec/name
+passthrough in the array builders and parity coercion.
+
+Engine *consumption* of per-wire specs (radius per wire on PyNEC/momwire)
+is a later phase; these tests pin the contract that makes it possible:
+plain 4/5-tuples remain valid forever, may be mixed with `Wire` entries,
+and a `Wire` rides through every transform with `name`/`spec` intact.
+"""
+
+from types import MappingProxyType
+
+import numpy as np
+import pytest
+
+from antennaknobs import AntennaBuilder, Wire, WireSpec, as_wire
+from antennaknobs.builder import Array1x2Builder, _shift_entry
+from antennaknobs.geometry import flat_wires_to_polylines
+
+THICK = WireSpec(radius=5e-3)
+THIN = WireSpec(radius=0.5e-3)
+
+
+# ---------------------------------------------------------------- as_wire
+
+
+def test_as_wire_accepts_all_shapes():
+    p0, p1 = (0.0, 0.0, 0.0), (0.0, 0.0, 1.0)
+    assert as_wire((p0, p1, 3, None)) == Wire(p0, p1, 3)
+    assert as_wire((p0, p1, 3, 1 + 0j, "feed")) == Wire(p0, p1, 3, 1 + 0j, "feed")
+    assert as_wire((p0, p1, 3, None, None, THIN)) == Wire(p0, p1, 3, spec=THIN)
+    w = Wire(p0, p1, 3, spec=THICK)
+    assert as_wire(w) is w
+
+
+def test_as_wire_rejects_bad_arity():
+    with pytest.raises(ValueError, match="4-6 fields"):
+        as_wire(((0, 0, 0), (0, 0, 1), 3))
+    with pytest.raises(ValueError, match="4-6 fields"):
+        as_wire(((0, 0, 0), (0, 0, 1), 3, None, None, None, "extra"))
+
+
+def test_wire_is_tuple_compatible():
+    """The compatibility contract: a Wire behaves as the 4/5-tuple code
+    expects — indexing, unpacking the first four, and name at index 4."""
+    w = Wire((0, 0, 0), (0, 0, 1), 7, 1 + 0j, "port", THICK)
+    assert isinstance(w, tuple)
+    p0, p1, n, ev = w[0], w[1], w[2], w[3]
+    assert (p0, p1, n, ev) == ((0, 0, 0), (0, 0, 1), 7, 1 + 0j)
+    assert (w[4] if len(w) >= 5 else None) == "port"
+    assert w.spec is THICK
+
+
+# ------------------------------------------------- polyline translation
+
+
+def _dipole_tups(spec_mid=None, as_named=False):
+    """Three colinear edges along z with the feed in the middle; optionally
+    a different spec on the middle edge, optionally as Wire entries."""
+    a, b, c, d = (0, 0, 0.0), (0, 0, 1.0), (0, 0, 2.0), (0, 0, 3.0)
+    tups = [
+        (a, b, 5, None),
+        (b, c, 5, 1 + 0j),
+        (c, d, 5, None),
+    ]
+    if as_named:
+        tups = [Wire(*t) for t in tups]
+    if spec_mid is not None:
+        tups[1] = Wire(b, c, 5, 1 + 0j, spec=spec_mid)
+    return tups
+
+
+def test_plain_and_named_translate_identically():
+    plain = flat_wires_to_polylines(_dipole_tups())
+    named = flat_wires_to_polylines(_dipole_tups(as_named=True))
+    assert len(plain["polylines"]) == len(named["polylines"]) == 1
+    np.testing.assert_array_equal(plain["polylines"][0], named["polylines"][0])
+    assert plain["edge_segments"] == named["edge_segments"]
+    assert plain["feeds"] == named["feeds"]
+    assert plain["junctions"] == named["junctions"]
+    assert plain["polyline_specs"] == [None]
+    assert named["polyline_specs"] == [None]
+
+
+def test_spec_change_splits_polyline_with_junctions():
+    """A spec change at a degree-2 node becomes a polyline boundary and a
+    KCL junction, so momwire can carry one spec per wire."""
+    out = flat_wires_to_polylines(_dipole_tups(spec_mid=THICK))
+    assert len(out["polylines"]) == 3
+    # Each polyline carries exactly its edge's spec.
+    from collections import Counter
+
+    assert Counter(out["polyline_specs"]) == Counter([None, None, THICK])
+    # The two spec-change nodes are 2-entry junctions (current continuity).
+    assert len(out["junctions"]) == 2
+    assert all(len(j) == 2 for j in out["junctions"])
+
+
+def test_equal_specs_do_not_split():
+    """Specs compare by value (frozen dataclass): two separately built but
+    equal specs must NOT fragment the polyline."""
+    a, b, c = (0, 0, 0.0), (0, 0, 1.0), (0, 0, 2.0)
+    tups = [
+        Wire(a, b, 5, 1 + 0j, spec=WireSpec(radius=1e-3)),
+        Wire(b, c, 5, None, spec=WireSpec(radius=1e-3)),
+    ]
+    out = flat_wires_to_polylines(tups)
+    assert len(out["polylines"]) == 1
+    assert out["polyline_specs"] == [WireSpec(radius=1e-3)]
+
+
+def test_mixed_spec_loop_still_translates():
+    """A closed loop whose edges differ in spec: the spec boundaries open
+    the cycle before the pure-cycle handler ever sees it."""
+    pts = [(0, 0, 0.0), (1, 0, 0.0), (1, 1, 0.0), (0, 1, 0.0)]
+    tups = [
+        Wire(pts[0], pts[1], 3, 1 + 0j, spec=THICK),
+        Wire(pts[1], pts[2], 3, None, spec=THIN),
+        Wire(pts[2], pts[3], 3, None, spec=THIN),
+        Wire(pts[3], pts[0], 3, None, spec=THICK),
+    ]
+    out = flat_wires_to_polylines(tups)
+    # Two spec-uniform chains (THICK pair split by the feed edge is allowed
+    # to be more pieces; what matters is uniformity per polyline).
+    for pl_spec, segs in zip(out["polyline_specs"], out["edge_segments"]):
+        assert pl_spec in (THICK, THIN)
+    total_edges = sum(len(s) for s in out["edge_segments"])
+    assert total_edges == 4
+
+
+def test_uniform_loop_unchanged_by_spec_field():
+    """A uniform-spec loop takes the pure-cycle path exactly as before."""
+    pts = [(0, 0, 0.0), (1, 0, 0.0), (1, 1, 0.0), (0, 1, 0.0)]
+    plain = [
+        (pts[0], pts[1], 3, 1 + 0j),
+        (pts[1], pts[2], 3, None),
+        (pts[2], pts[3], 3, None),
+        (pts[3], pts[0], 3, None),
+    ]
+    named = [Wire(*t, spec=THIN) for t in plain]
+    out_p = flat_wires_to_polylines(plain)
+    out_n = flat_wires_to_polylines(named)
+    assert len(out_p["polylines"]) == len(out_n["polylines"]) == 2
+    for a, b in zip(out_p["polylines"], out_n["polylines"]):
+        np.testing.assert_array_equal(a, b)
+    assert out_n["polyline_specs"] == [THIN, THIN]
+
+
+# ------------------------------------------------------- parity coercion
+
+
+def test_coerce_preserves_shape_and_spec():
+    class _Stub:
+        segment_parity = "odd"
+
+        # borrow the real implementations
+        from antennaknobs.engine import SimulationEngine as _S
+
+        coerce_n_seg = staticmethod(_S.coerce_n_seg)
+        _coerce_wire_tuples = _S._coerce_wire_tuples
+
+    eng = _Stub()
+    p0, p1 = (0, 0, 0.0), (0, 0, 1.0)
+    out = eng._coerce_wire_tuples(
+        [
+            (p0, p1, 4, None),
+            (p0, p1, 4, 1 + 0j, "feed"),
+            Wire(p0, p1, 4, None, spec=THICK),
+        ]
+    )
+    assert out[0] == (p0, p1, 5, None) and type(out[0]) is tuple
+    assert out[1] == (p0, p1, 5, 1 + 0j, "feed") and type(out[1]) is tuple
+    assert isinstance(out[2], Wire)
+    assert out[2].n_seg == 5 and out[2].spec is THICK
+
+
+# --------------------------------------------------------- array builders
+
+
+class _Elem(AntennaBuilder):
+    default_params = MappingProxyType({"freq": 14.1})
+
+    def build_wires(self):
+        return [
+            Wire((0, 0, 10.0), (0, 0, 11.0), 5, 1 + 0j, "feed", THICK),
+            ((0, 0, 11.0), (0, 0, 12.0), 5, None),
+        ]
+
+
+class _Pair(Array1x2Builder):
+    default_params = MappingProxyType({"freq": 14.1, "del_y": 2.0, "phase_lr": 180.0})
+
+    def __init__(self, params=None):
+        super().__init__(_Elem, params)
+
+
+def test_array_builder_passes_name_and_spec_through():
+    tups = _Pair().build_wires()
+    assert len(tups) == 4
+    named = [t for t in tups if isinstance(t, Wire)]
+    plain = [t for t in tups if not isinstance(t, Wire)]
+    assert len(named) == 2 and len(plain) == 2
+    for w in named:
+        assert w.spec is THICK
+        assert w.name == "feed"
+        assert w.ex is not None  # replaced by the array phasor
+    for t in plain:
+        assert len(t) == 4  # plain entries stay plain 4-tuples
+
+
+def test_shift_entry_conventions():
+    w = Wire((0, 1, 2.0), (0, 3, 4.0), 5, 2 + 0j, "p", THIN)
+    replaced = _shift_entry(w, 1.0, -1.0, lambda ex: 9j)
+    assert replaced.p0 == (0, 2, 1.0) and replaced.p1 == (0, 4, 3.0)
+    assert replaced.ex == 9j and replaced.spec is THIN and replaced.name == "p"
+    # None excitation is never passed to the policy callable
+    passive = _shift_entry(
+        ((0, 0, 0), (0, 0, 1.0), 3, None), 0.0, 0.0, lambda ex: 1 / 0
+    )
+    assert passive == ((0, 0, 0), (0, 0, 1.0), 3, None) and len(passive) == 4

--- a/tests/test_per_wire_specs_engines.py
+++ b/tests/test_per_wire_specs_engines.py
@@ -1,0 +1,148 @@
+"""Phase-2 tests for issue #388: engines consuming per-wire WireSpecs.
+
+PyNEC honors per-wire radius natively (one radius per GW card) and emits
+per-tag LD cards for per-wire conductivity/insulation. momwire honors
+per-wire conductivity/insulation through its per-wire loading arrays; the
+radius is still a single scalar until the per-wire radius kernels land
+(companion momwire issue), so a uniform per-wire radius is honored exactly
+and mixed radii collapse to the length-dominant one with a warning.
+
+The bit-identical guard: a design whose per-wire specs all equal the old
+whole-antenna spec must produce identical results to the global-spec path.
+"""
+
+import logging
+from types import MappingProxyType
+
+import pytest
+
+from antennaknobs import AntennaBuilder, Wire, WireSpec
+from antennaknobs.engines import MomwireEngine, PyNECEngine
+
+COPPER = 5.8e7
+FREQ = 14.1
+ARM = 5.0
+EPS = 0.05
+Z0 = 10.0
+
+
+def _dipole_builder(spec_left=None, spec_feed=None, spec_right=None, default=None):
+    """A horizontal dipole at z=10 m: left arm, 1-seg feed edge, right arm,
+    each optionally carrying its own WireSpec; `default` becomes the
+    design's build_wire_material()."""
+
+    class _Dip(AntennaBuilder):
+        default_params = MappingProxyType({"freq": FREQ})
+
+        def build_wires(self):
+            def entry(p0, p1, n, ex, spec):
+                if spec is None:
+                    return (p0, p1, n, ex)
+                return Wire(p0, p1, n, ex, None, spec)
+
+            return [
+                entry((0, -ARM, Z0), (0, -EPS, Z0), 21, None, spec_left),
+                entry((0, -EPS, Z0), (0, EPS, Z0), 1, 1 + 0j, spec_feed),
+                entry((0, EPS, Z0), (0, ARM, Z0), 21, None, spec_right),
+            ]
+
+        def build_wire_material(self):
+            return default
+
+    return _Dip()
+
+
+def _z(engine_cls, builder, **kw):
+    return engine_cls(builder, **kw).impedance()[0]
+
+
+# ------------------------------------------------------------- radius
+
+
+@pytest.mark.parametrize("engine_cls", [PyNECEngine, MomwireEngine])
+def test_uniform_per_wire_radius_equals_global_spec(engine_cls):
+    """Per-wire specs that all equal the whole-antenna spec: identical Z."""
+    s = WireSpec(radius=2e-3)
+    z_global = _z(engine_cls, _dipole_builder(default=s))
+    z_perwire = _z(engine_cls, _dipole_builder(s, s, s))
+    assert z_perwire == z_global
+
+
+def test_pynec_honors_mixed_per_wire_radius():
+    """NEC takes a radius per GW card: fat left arm + thin right arm must
+    move Z off both uniform answers (and stay finite/sane)."""
+    thin, fat = WireSpec(radius=0.5e-3), WireSpec(radius=8e-3)
+    z_thin = _z(PyNECEngine, _dipole_builder(default=thin))
+    z_fat = _z(PyNECEngine, _dipole_builder(default=fat))
+    z_mixed = _z(PyNECEngine, _dipole_builder(fat, thin, thin))
+    assert z_mixed != z_thin and z_mixed != z_fat
+    # The mixed reactance lands between the two uniform extremes.
+    lo, hi = sorted((z_thin.imag, z_fat.imag))
+    assert lo < z_mixed.imag < hi
+
+
+def test_momwire_mixed_radius_warns_and_uses_dominant(caplog):
+    """Until the per-wire radius kernels land, momwire collapses mixed radii
+    to the length-dominant one — loudly."""
+    thin, fat = WireSpec(radius=0.5e-3), WireSpec(radius=8e-3)
+    with caplog.at_level(logging.WARNING):
+        eng = MomwireEngine(_dipole_builder(fat, thin, thin))
+    assert any("length-dominant" in r.message for r in caplog.records)
+    # Arms have equal length; the feed edge tips the thin total over.
+    assert eng._wire_radius == pytest.approx(0.5e-3)
+
+
+def test_per_wire_spec_beats_web_radius_override():
+    """Issue #388 precedence: the web wire_radius override moves the
+    DEFAULT only; an explicit per-wire spec wins."""
+    s = WireSpec(radius=2e-3)
+    eng = MomwireEngine(_dipole_builder(s, s, s), wire_radius=1e-3)
+    assert eng._wire_radius == pytest.approx(2e-3)
+    # ...while a design with only a global spec still yields to the override
+    eng2 = MomwireEngine(_dipole_builder(default=s), wire_radius=1e-3)
+    assert eng2._wire_radius == pytest.approx(1e-3)
+
+
+# -------------------------------------------------------- conductivity
+
+
+@pytest.mark.parametrize("engine_cls", [PyNECEngine, MomwireEngine])
+def test_uniform_per_wire_conductivity_equals_global_spec(engine_cls):
+    s = WireSpec(radius=1e-3, conductivity=COPPER)
+    z_global = _z(engine_cls, _dipole_builder(default=s))
+    z_perwire = _z(engine_cls, _dipole_builder(s, s, s))
+    assert z_perwire == pytest.approx(z_global, rel=1e-9)
+
+
+@pytest.mark.parametrize("engine_cls", [PyNECEngine, MomwireEngine])
+def test_one_lossy_arm_sits_between_pec_and_all_lossy(engine_cls):
+    """Per-wire conductivity really is per wire: one copper arm adds about
+    half the loss resistance of two copper arms."""
+    pec = WireSpec(radius=1e-3)
+    lossy = WireSpec(radius=1e-3, conductivity=1e5)  # poor conductor: visible R
+    r_pec = _z(engine_cls, _dipole_builder(pec, pec, pec)).real
+    r_all = _z(engine_cls, _dipole_builder(lossy, pec, lossy)).real
+    r_one = _z(engine_cls, _dipole_builder(lossy, pec, pec)).real
+    assert r_pec < r_one < r_all
+    added_one, added_all = r_one - r_pec, r_all - r_pec
+    assert added_one == pytest.approx(added_all / 2, rel=0.15)
+
+
+# ------------------------------------------------------------- insulation
+
+
+def test_momwire_per_wire_insulation_tunes_long():
+    """A jacket adds distributed series L, so at fixed frequency X RISES
+    (the antenna behaves electrically longer; resonance moves down).
+    Insulating one arm adds half the reactance shift of insulating both,
+    and uniform per-wire insulation matches the global-spec path exactly."""
+    bare = WireSpec(radius=1e-3)
+    ins = WireSpec(radius=1e-3, insulation_radius=3e-3, insulation_eps_r=3.5)
+    assert _z(MomwireEngine, _dipole_builder(ins, ins, ins)) == _z(
+        MomwireEngine, _dipole_builder(default=ins)
+    )
+    x_bare = _z(MomwireEngine, _dipole_builder(bare, bare, bare)).imag
+    x_all = _z(MomwireEngine, _dipole_builder(ins, bare, ins)).imag
+    x_one = _z(MomwireEngine, _dipole_builder(ins, bare, bare)).imag
+    assert x_bare < x_one < x_all
+    assert x_one - x_bare == pytest.approx((x_all - x_bare) / 2, rel=0.05)

--- a/tests/test_per_wire_specs_import.py
+++ b/tests/test_per_wire_specs_import.py
@@ -1,0 +1,126 @@
+"""Phase-4 tests for issue #388: NEC decks import with true per-wire radii
+(`wire_tuples(specs=True)`), ranged LD 5 translates to per-wire
+conductivity, and the web length/weight readout sums per wire."""
+
+from pathlib import Path
+from types import MappingProxyType
+
+import pytest
+
+from antennaknobs import AntennaBuilder, Wire, WireSpec
+from antennaknobs.nec_import import parse_nec
+
+import antennaknobs.web.examples  # noqa: F401 — primes the adapter (import order)
+from antennaknobs.web.adapter import _wire_material_results
+
+TWO_RADIUS = (
+    "GW 1 5 0 0 0  1 0 0  0.001\nGW 2 5 1 0 0  2 0 0  0.004\nGE\nEX 0 1 3 0 1 0\nEN\n"
+)
+
+
+def test_default_wire_tuples_stay_plain():
+    tups = parse_nec(TWO_RADIUS).wire_tuples()
+    assert all(type(t) is tuple and len(t) == 4 for t in tups)
+
+
+def test_specs_true_carries_each_wires_own_radius():
+    tups = parse_nec(TWO_RADIUS).wire_tuples(specs=True)
+    assert all(isinstance(t, Wire) for t in tups)
+    assert [t.spec.radius for t in tups] == [0.001, 0.004]
+    # PEC deck: no LD 5 anywhere -> conductivity stays None
+    assert all(t.spec.conductivity is None for t in tups)
+
+
+def test_split_pieces_inherit_the_parent_wires_spec():
+    # Feed off-middle forces a split of wire 1 into three pieces; all
+    # three carry wire 1's spec, wire 2 keeps its own.
+    deck = parse_nec(
+        "GW 1 10 0 0 0  10 0 0  0.002\n"
+        "GW 2 4 10 0 0  14 0 0  0.005\n"
+        "GE\n"
+        "EX 0 1 3 0 1 0\n"
+        "EN\n"
+    )
+    tups = deck.wire_tuples(specs=True)
+    radii = [t.spec.radius for t in tups]
+    assert radii == [0.002, 0.002, 0.002, 0.005]
+    assert [t.n_seg for t in tups] == [2, 1, 7, 4]
+
+
+def test_ranged_ld5_becomes_per_wire_conductivity():
+    deck = parse_nec(
+        "GW 1 5 0 0 0  1 0 0  0.001\n"
+        "GW 2 5 1 0 0  2 0 0  0.002\n"
+        "GE\n"
+        "LD 5 0 0 0 5.8e7\n"  # whole structure
+        "LD 5 2 0 0 3.5e7\n"  # all of tag 2 — expressible per wire
+        "EX 0 1 3 0 1 0\n"
+        "EN\n",
+        network=True,
+    )
+    assert deck.conductivity == pytest.approx(5.8e7)
+    assert deck.wire_conductivity == ((1, pytest.approx(3.5e7)),)
+    # No LD entry may remain unexplained: the ranged card translated.
+    assert not any(m == "LD" for m, _ in deck.ignored_detail)
+    sigmas = [t.spec.conductivity for t in deck.wire_tuples(specs=True)]
+    assert sigmas == [pytest.approx(5.8e7), pytest.approx(3.5e7)]
+
+
+def test_partial_wire_ld5_still_skipped_with_reason():
+    deck = parse_nec(
+        "GW 1 5 0 0 0  1 0 0  0.001\n"
+        "GE\n"
+        "LD 5 1 2 3 1e7\n"  # segments 2-3 of 5 only
+        "EX 0 1 3 0 1 0\n"
+        "EN\n",
+        network=True,
+    )
+    assert deck.wire_conductivity == ()
+    assert any(
+        m == "LD" and "partial-wire" in reason for m, reason in deck.ignored_detail
+    )
+
+
+def test_whip_benchmark_imports_with_true_radii():
+    """The motivating deck: 0.010\" grid + 0.035\" whip (GS-scaled to
+    metres). specs=True must carry both radii — no dominant_radius()."""
+    text = (
+        Path(__file__).parent / "data" / "whip_antenna_8ft_groundplane.nec"
+    ).read_text()
+    deck = parse_nec(text, name="whip", network=True)
+    tups = deck.wire_tuples(specs=True)
+    radii = {round(t.spec.radius, 9) for t in tups}
+    assert radii == {round(0.010 * 0.0254, 9), round(0.035 * 0.0254, 9)}
+    thick_len = sum(1 for t in tups if t.spec.radius == pytest.approx(0.035 * 0.0254))
+    assert thick_len >= 1  # the whip's upper section survives the splits
+
+
+def test_wire_material_readout_sums_per_wire():
+    heavy = WireSpec(radius=1e-3, weight_g_per_m=5.0)
+    light = WireSpec(radius=1e-3, weight_g_per_m=1.0)
+
+    class _B(AntennaBuilder):
+        default_params = MappingProxyType({"freq": 14.1})
+
+        def build_wires(self):
+            return [
+                Wire((0, 0, 0.0), (0, 0, 1.0), 3, 1 + 0j, None, heavy),  # 1 m
+                ((0, 0, 1.0), (0, 0, 3.0), 3, None),  # 2 m, falls to default
+            ]
+
+        def build_wire_material(self):
+            return light
+
+    out = _wire_material_results(_B())
+    assert out["wire_length_m"] == pytest.approx(3.0)
+    assert out["wire_weight_g"] == pytest.approx(1 * 5.0 + 2 * 1.0)
+
+    class _NoDefault(_B):
+        def build_wire_material(self):
+            return None
+
+    out2 = _wire_material_results(_NoDefault())
+    # per-wire specs alone are enough to surface the readout; spec-less
+    # wires count toward length but contribute no weight
+    assert out2["wire_length_m"] == pytest.approx(3.0)
+    assert out2["wire_weight_g"] == pytest.approx(5.0)


### PR DESCRIPTION
## Summary
- `build_wires()` entries may now be `Wire` named tuples (`p0, p1, n_seg, ex, name, spec`) carrying an optional per-wire `WireSpec`, mixed freely with the plain 4/5-tuples, which remain valid forever. `as_wire()` is the single tuple-shape choke point; the polyline translator splits chains at spec changes (2-entry KCL junction) so every momwire wire is spec-uniform. Parity coercion, the TL feed-augmentation, and all array builders pass `name`/`spec` through untouched.
- Engines consume specs: PyNEC takes each wire's own radius on its GW card and per-tag LD 5/LD 2 material cards (exclusive with the global-card path — NEC stacks series loads); momwire routes per-wire conductivity/insulation through its existing per-wire loading arrays, honors a *uniform* per-wire radius exactly, and collapses mixed radii to the length-dominant one with a warning until its per-wire radius kernels land (companion momwire issue — see below). Precedence, defined once: explicit per-wire spec → web `wire_radius` override → `build_wire_material()` → 0.5 mm ideal.
- `deck.wire_tuples(specs=True)` imports NEC decks with each GW card's true radius (the whip benchmark drops the `dominant_radius()` compromise) and bakes in effective conductivity; ranged LD 5 covering whole wires translates to per-wire conductivity instead of landing in `ignored`. `elt_whip`'s upper whip now carries the deck's true 0.889 mm radius (PyNEC full-size remeasured: bare 1.49+33.6j, matched 59.2+8.5j — inside the calibrated windows).
- Guard rails: designs whose per-wire specs equal the old whole-antenna spec produce identical results on both engines; plain-tuple designs are bit-identical (PR-lane suite 1955 passed). Design decisions (NamedTuple over a model class, no spec scaling, kernel-convention plan) are pinned in `docs/status/2026-07-15-per-wire-specs-design.md`.

Closes the antennaknobs side of #388. The momwire per-wire radius kernels (all four solver bases + C++ accelerators, PyNEC parity oracle) are the follow-up; companion issue: stevenmburns/momwire#147.

## Test plan
- [x] `pytest -m "not antenna_computation_check and not heavy_mesh" tests/` — 1955 passed
- [x] New suites: `test_per_wire_specs.py` (type/translate/passthrough), `test_per_wire_specs_engines.py` (engine consumption, precedence, identical-results guards), `test_per_wire_specs_import.py` (deck import, ranged LD 5, readouts)
- [x] Manual full-size elt_whip PyNEC solve re-measured after the per-wire radius change (windows updated in-docstring)
- [ ] After the momwire kernels land: mixed-radius PyNEC↔momwire parity oracle + drop the dominant-radius collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Tr3v82jpNG85CPTDoKrNJ
