### PR TITLE
Test time-budget audit + guardrail (#393)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,12 @@ jobs:
       # `antennaknobs.web` subpackage (pip install -e . above), so it no longer
       # depends on the repo root being on sys.path the way the old top-level
       # `web/` package did.
-      run: python -m pytest -m "not antenna_computation_check and not heavy_mesh" tests/
+      # --durations surfaces the slowest tests each run; the conftest
+      # time-budget guardrail (issue #393) additionally flags any unmarked
+      # test over the 5 s ceiling. Set ANTENNAKNOBS_ENFORCE_TIME_BUDGET=1
+      # here to turn that into a hard failure once the CI numbers are
+      # calibrated.
+      run: python -m pytest -m "not antenna_computation_check and not heavy_mesh" --durations=15 tests/
 
     - name: Full suite + coverage (push to main only)
       # The complete suite, including the per-design solver catalogs, with
@@ -101,7 +106,7 @@ jobs:
       # accumulated RSS). They run manually: `python -m pytest -m heavy_mesh`
       # after nec-import or engine changes.
       if: github.event_name == 'push'
-      run: coverage run --source=src/ -m pytest -m "not heavy_mesh" tests/
+      run: coverage run --source=src/ -m pytest -m "not heavy_mesh" --durations=15 tests/
 
     - name: Coverage comment
       if: github.event_name == 'push'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+## Testing
+
+### Time budget
+
+The test suite is kept fast so PR feedback stays tight. The rule:
+
+- **An individual test should finish in ~2 s, with a 5 s hard ceiling** on CI
+  hardware.
+- The **PR fast lane** (`.github/workflows/test.yml`) should complete its
+  `pytest` step in about **2 minutes**.
+
+If a test is legitimately heavier than the ceiling, don't leave it in the fast
+lane — give it one of two markers:
+
+| marker | when | runs |
+|---|---|---|
+| `antenna_computation_check` | a per-design solve that's part of broad catalog coverage (the same solve path repeated design after design) | main only, not per-PR |
+| `heavy_mesh` | a benchmark-sized solve (thousands of segments, GBs of RSS, ≫5 s) — not a unit test | never in CI; run manually with `pytest -m heavy_mesh` |
+
+So a test over the ceiling gets **made faster**, **demoted to
+`antenna_computation_check`**, or **demoted to `heavy_mesh`**. Prefer making it
+faster (smaller mesh, coarser far-field grid, fewer solver calls) when the test
+still discriminates the behavior it guards — e.g. a peak-gain comparison across
+two backends is invariant to far-field grid step, so a coarse grid keeps the
+check while cutting the cost.
+
+### The guardrail
+
+`tests/conftest.py` surfaces any **unmarked** test whose call phase exceeds the
+ceiling: a loud terminal section lists the offenders at the end of the run. CI
+also prints `--durations=15`. Two env vars tune it:
+
+- `ANTENNAKNOBS_TIME_BUDGET_CEILING_S` — override the 5 s ceiling.
+- `ANTENNAKNOBS_ENFORCE_TIME_BUDGET=1` — turn the report into a hard failure
+  (off by default, since absolute call times drift with hardware; CI can enable
+  it once the numbers are calibrated).
+
+### Lanes
+
+- **Fast lane (PRs):** `pytest -m "not antenna_computation_check and not heavy_mesh" tests/`
+- **Full lane (push to main):** `pytest -m "not heavy_mesh" tests/` (adds the
+  per-design catalog + coverage)
+- **Benchmarks (manual):** `pytest -m heavy_mesh`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,3 +38,49 @@ HAS_PYNEC = importlib.util.find_spec("PyNEC") is not None
 needs_pynec = pytest.mark.skipif(
     not HAS_PYNEC, reason="PyNEC not installed (engine unavailable on this platform)"
 )
+
+
+# --------------------------------------------------------------------------
+# Test time-budget guardrail (issue #393)
+# --------------------------------------------------------------------------
+# Suite rule: an individual *unmarked* test finishes in ~2 s, 5 s hard
+# ceiling. Per-design catalog solves live behind `antenna_computation_check`
+# (main-only lane); benchmark-sized solves behind `heavy_mesh` (manual-only).
+# This hook surfaces any unmarked test whose call phase breaches the ceiling,
+# so a slow test can't drift into the PR fast lane unnoticed. It reports by
+# default (a loud terminal section); set ANTENNAKNOBS_ENFORCE_TIME_BUDGET=1 to
+# also fail the run. Kept opt-in for hard-fail because absolute call times
+# drift with hardware — CI can enable it once the numbers are calibrated.
+TIME_BUDGET_CEILING_S = float(os.environ.get("ANTENNAKNOBS_TIME_BUDGET_CEILING_S", "5.0"))
+_TIME_BUDGET_EXEMPT_MARKERS = ("antenna_computation_check", "heavy_mesh")
+_time_budget_offenders: list[tuple[str, float]] = []
+
+
+def pytest_runtest_logreport(report):
+    if report.when != "call" or report.duration <= TIME_BUDGET_CEILING_S:
+        return
+    if any(m in report.keywords for m in _TIME_BUDGET_EXEMPT_MARKERS):
+        return
+    _time_budget_offenders.append((report.nodeid, report.duration))
+
+
+def pytest_terminal_summary(terminalreporter):
+    if not _time_budget_offenders:
+        return
+    tr = terminalreporter
+    tr.section("test time-budget guardrail (issue #393)", sep="!", red=True, bold=True)
+    tr.line(
+        f"{len(_time_budget_offenders)} unmarked test(s) over the "
+        f"{TIME_BUDGET_CEILING_S:.0f}s ceiling:"
+    )
+    for nodeid, dur in sorted(_time_budget_offenders, key=lambda x: -x[1]):
+        tr.line(f"  {dur:6.2f}s  {nodeid}")
+    tr.line(
+        "Fix: make it faster, or mark it 'antenna_computation_check' "
+        "(main-only) / 'heavy_mesh' (manual-only). See the pyproject markers."
+    )
+
+
+def pytest_sessionfinish(session, exitstatus):
+    if _time_budget_offenders and os.environ.get("ANTENNAKNOBS_ENFORCE_TIME_BUDGET"):
+        session.exitstatus = pytest.ExitCode.TESTS_FAILED

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,9 @@ needs_pynec = pytest.mark.skipif(
 # default (a loud terminal section); set ANTENNAKNOBS_ENFORCE_TIME_BUDGET=1 to
 # also fail the run. Kept opt-in for hard-fail because absolute call times
 # drift with hardware — CI can enable it once the numbers are calibrated.
-TIME_BUDGET_CEILING_S = float(os.environ.get("ANTENNAKNOBS_TIME_BUDGET_CEILING_S", "5.0"))
+TIME_BUDGET_CEILING_S = float(
+    os.environ.get("ANTENNAKNOBS_TIME_BUDGET_CEILING_S", "5.0")
+)
 _TIME_BUDGET_EXEMPT_MARKERS = ("antenna_computation_check", "heavy_mesh")
 _time_budget_offenders: list[tuple[str, float]] = []
 

--- a/tests/test_momwire_engine.py
+++ b/tests/test_momwire_engine.py
@@ -592,12 +592,17 @@ def test_momwire_multifeed_far_field_matches_pynec():
     test; observed delta is ~0.02 dBi on both phasings."""
     from antennaknobs.designs.arrays.bowtiearray1x2 import Builder as B12
 
+    # A 30x120 (3 deg) grid resolves the peak lobe well enough for the
+    # 0.1 dBi check: both backends sample the SAME grid, so any
+    # discretization bias cancels in the difference (the observed delta is
+    # 0.038 dBi and is invariant to grid step from 1 to 3 deg). Keeps this
+    # RHS-ordering guard in the fast PR lane at a fraction of the 90x360 cost.
     for phase_lr_deg in (0.0, 90.0):
         b = B12()
         b.phase_lr = phase_lr_deg
-        ff_p = MomwireEngine(b).far_field(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
+        ff_p = MomwireEngine(b).far_field(n_theta=30, n_phi=120, del_theta=3, del_phi=3)
         ff_n = PyNECEngine(b, ground=None).far_field(
-            n_theta=90, n_phi=360, del_theta=1, del_phi=1
+            n_theta=30, n_phi=120, del_theta=3, del_phi=3
         )
         assert abs(ff_p.max_gain - ff_n.max_gain) < 0.1, (
             f"phase={phase_lr_deg}: momwire={ff_p.max_gain}, pynec={ff_n.max_gain}"


### PR DESCRIPTION
Closes #393.

## Durations audit (local, 8-core)

**Fast lane (PR)** — `pytest -m "not antenna_computation_check and not heavy_mesh"`:
- Before: **44s**, slowest `test_momwire_multifeed_far_field_matches_pynec` **3.15s** (the only unmarked test over the ~2s guideline; ~6s on 2× CI would breach the 5s ceiling).
- After: **38.8s**, slowest `test_cli_optimize` **2.07s**. No unmarked test over the ceiling.

**Full lane (main)** — `pytest -m "not heavy_mesh"`: **2m19s**, 2096 passed. Every test over 5s is *already* marked `antenna_computation_check` (`test_cebik_designs` catalog + `test_elt_whip`) — main-only, the sanctioned demotion. Nothing unmarked breaches the ceiling.

## Changes

1. **`test_momwire_multifeed_far_field_matches_pynec`: 3.15s → 0.53s.** It computed four 90×360 far-field patterns but only asserts peak gain. Both backends sample the same grid, so discretization bias cancels — the delta is 0.038 dBi and invariant from 1° to 3° step. Coarsened to 30×120; the test stays in the fast lane where it guards multi-feed RHS ordering.

2. **Guardrail (`tests/conftest.py`).** Surfaces any *unmarked* test whose call phase exceeds the 5s ceiling as a loud terminal section pointing at the markers. Env knobs: `ANTENNAKNOBS_ENFORCE_TIME_BUDGET=1` makes it a hard failure (off by default — absolute times drift with hardware; CI can enable once calibrated), `ANTENNAKNOBS_TIME_BUDGET_CEILING_S` overrides the ceiling. Verified in report-only, enforce, and clean modes.

3. **CI (`test.yml`).** Both lanes now print `--durations=15`.

4. **`CONTRIBUTING.md`.** New doc: the 2s/5s rule, the two markers, the three lanes, and the guardrail env vars.

## Acceptance criteria
- [x] Durations report captured for both lanes (above)
- [x] No unmarked test exceeds 5s; the one straggler optimized, catalog stragglers already marked
- [x] PR-lane pytest step ≤ ~2 min (38.8s local)
- [x] Guardrail surfaces new slow tests (conftest + `--durations` in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)