### PR TITLE
Engine passes per-wire radii to momwire (BSpline/Sinusoidal); dominant-collapse retired

### DIFF
--- a/docs/status/2026-07-15-per-wire-specs-design.md
+++ b/docs/status/2026-07-15-per-wire-specs-design.md
@@ -75,6 +75,17 @@ the companion-issue PR and then a version-bump hookup here.
    carries its true 0.889 mm radius (PyNEC remeasured: bare 1.49+33.6j,
    matched 59.2+8.5j — inside the calibrated windows).
 4. **Phase 3 (follow-up)**: momwire per-wire radius kernels across all four
-   solver bases + C++ accelerators (companion issue); the PyNEC-vs-momwire
-   mixed-radius parity oracle lands with the kernels, and the momwire
-   engine's dominant-radius collapse is then replaced by the real arrays.
+   solver bases + C++ accelerators (companion issue momwire#147); the
+   PyNEC-vs-momwire mixed-radius parity oracle lands with the kernels, and
+   the momwire engine's dominant-radius collapse is then replaced by the
+   real arrays. *Landed 2026-07-15 for SinusoidalSolver + the BSpline dense
+   family (momwire PR #148): the engine passes per-wire radius arrays to
+   those solvers; the H-matrix family keeps the collapse until its block
+   fills are ported. Two validation findings: (a) the kernel convention is
+   the OBSERVER wire's radius (necpp EFLD's `ai = segment_radius[i]`) — the
+   source-radius convention this note originally proposed was refuted by
+   the oracle; (b) NEC-2 is non-convergent at IN-LINE radius steps (the
+   classic stepped-radius deficiency), so cross-engine parity there is
+   asserted via SinusoidalSolver (which tracks NEC) and via mixed-radius
+   junctions for the Galerkin family — see momwire
+   docs/sinusoidal_basis_design.md "Per-wire radius".*

--- a/site/src/content/docs/reference/nec-import.md
+++ b/site/src/content/docs/reference/nec-import.md
@@ -89,11 +89,12 @@ recipe — plain `wire_tuples()` plus a `build_wire_material()` returning
 `WireSpec(radius=deck.dominant_radius(), conductivity=deck.conductivity)` —
 still works, approximating mixed radii with the length-dominant one.)
 
-Two caveats on per-wire radii: the PyNEC engine honors them exactly (NEC
-takes a radius per wire natively); momwire approximates *mixed* radii with
-the length-dominant one until its per-wire radius kernels land. And the
-`scale` knob stretches geometry only — specs describe physical wire stock
-and are never scaled.
+Two caveats on per-wire radii: both engines honor them — PyNEC natively
+(NEC takes a radius per wire), momwire on its default (BSpline) and
+sinusoidal solvers since momwire#147, with only the opt-in H-matrix
+solver family still approximating *mixed* radii by the length-dominant
+one. And the `scale` knob stretches geometry only — specs describe
+physical wire stock and are never scaled.
 
 ## Following the deck's band
 

--- a/src/antennaknobs/designs/verticals/elt_whip.py
+++ b/src/antennaknobs/designs/verticals/elt_whip.py
@@ -51,10 +51,11 @@ Constraints worth knowing:
     omit that element.
   * The upper whip carries its own per-wire spec (issue #388) with the
     deck's true 0.035" = 0.889 mm radius (``whip_upper_radius``); everything
-    else uses ``wire_radius`` (the deck's 0.254 mm). PyNEC honors both;
-    momwire approximates the pair with the length-dominant radius (the
-    grid dominates, so it solves at 0.254 mm — exactly the old whole-antenna
-    compromise) until its per-wire radius kernels land.
+    else uses ``wire_radius`` (the deck's 0.254 mm). PyNEC honors both, and
+    momwire's default (BSpline) and sinusoidal solvers honor both since
+    momwire#147 — the whip solves at its true radius. (The H-matrix family
+    still collapses to the length-dominant 0.254 mm with a warning until
+    its block fills are ported.)
 """
 
 import math

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -113,6 +113,22 @@ def _solver_supports_wire_loading(solver):
     return getattr(solver, "__name__", None) in _WIRE_LOADING_SOLVERS
 
 
+# Per-wire radius arrays (issue #388 / momwire#147, momwire >= 0.13):
+# SinusoidalSolver validates against PyNEC directly (it reproduces NEC's
+# per-segment radius conventions); the BSpline dense family applies the
+# same observer-surface convention. The H-matrix family's block fills
+# still take one radius — mixed radii there collapse to the
+# length-dominant one with a warning (warn-and-degrade, not crash).
+_PER_WIRE_RADIUS_SOLVERS = (
+    "BSplineSolver",
+    "SinusoidalSolver",
+)
+
+
+def _solver_supports_per_wire_radius(solver):
+    return getattr(solver, "__name__", None) in _PER_WIRE_RADIUS_SOLVERS
+
+
 class MomwireEngine(SimulationEngine):
     supports_far_field = True
 
@@ -214,13 +230,19 @@ class MomwireEngine(SimulationEngine):
             default_radius = 0.0005
         specs = self._polyline_specs
         if any(s is not None for s in specs):
-            # The solver kernels take ONE radius until momwire grows
-            # per-wire radius arrays (the #388 companion issue): a uniform
-            # per-wire radius is honored exactly; mixed radii collapse to
-            # the length-dominant one, stated plainly.
+            # Per-wire radii (momwire#147, landed for BSplineSolver and
+            # SinusoidalSolver): one entry per polyline, passed straight
+            # through as momwire's wire_radius array. A uniform list is
+            # collapsed to the scalar (momwire does the same internally;
+            # keeping the engine's readouts scalar preserves the
+            # pre-#147 API surface for uniform designs). Solvers whose
+            # kernels still take one radius (the H-matrix family) keep
+            # the length-dominant collapse, stated plainly.
             radii = [s.radius if s is not None else default_radius for s in specs]
             if len(set(radii)) == 1:
                 self._wire_radius = radii[0]
+            elif _solver_supports_per_wire_radius(self._solver):
+                self._wire_radius = radii
             else:
                 length_by_r: dict[float, float] = {}
                 for r, pl in zip(radii, self._polylines):
@@ -228,9 +250,11 @@ class MomwireEngine(SimulationEngine):
                     length_by_r[r] = length_by_r.get(r, 0.0) + ln
                 self._wire_radius = max(length_by_r.items(), key=lambda kv: kv[1])[0]
                 _logger.warning(
-                    "momwire solvers take a single wire radius until the "
-                    "per-wire radius kernels land; approximating %s's mixed "
-                    "per-wire radii with the length-dominant %.4g m",
+                    "%s takes a single wire radius until its per-wire "
+                    "radius block fills land (momwire#147); approximating "
+                    "%s's mixed per-wire radii with the length-dominant "
+                    "%.4g m",
+                    getattr(self._solver, "__name__", self._solver),
                     type(builder).__name__,
                     self._wire_radius,
                 )
@@ -245,9 +269,9 @@ class MomwireEngine(SimulationEngine):
             # Per-wire loading (issue #388): one entry per polyline, NaN
             # switching the effect off for that wire (momwire's
             # normalize_per_wire convention). A wire without its own spec
-            # inherits the design default. NOTE: skin loss for per-wire
-            # conductivity is still computed at the single global radius
-            # above — the per-wire radius kernels lift that too.
+            # inherits the design default. Skin loss is evaluated at each
+            # wire's own radius since momwire#147 (the solver receives
+            # the same per-wire radius array as the kernels).
             eff = [s if s is not None else spec for s in specs]
             nan = float("nan")
             cond = np.array(

--- a/src/antennaknobs/nec_import.py
+++ b/src/antennaknobs/nec_import.py
@@ -333,8 +333,9 @@ class NecDeck:
         radius — no ``dominant_radius()`` compromise — and its effective
         conductivity (a ranged LD 5 over the whole wire, else the deck's
         whole-structure LD 5). PyNEC honors both per wire; momwire honors
-        the conductivity and approximates mixed radii with the
-        length-dominant one until its per-wire radius kernels land. With
+        both too since momwire#147 (BSplineSolver and SinusoidalSolver;
+        the H-matrix family still approximates mixed radii with the
+        length-dominant one until its block fills are ported). With
         ``specs=True`` a ``build_wire_material()`` fallback is unnecessary
         (every wire carries its spec) — though a design may still define
         one for the weight readout of spec-less wires it adds itself.

--- a/src/antennaknobs/web/user_design_assets/CLAUDE.md
+++ b/src/antennaknobs/web/user_design_assets/CLAUDE.md
@@ -239,8 +239,8 @@ Wire(start, end, n_segments, feed, spec=TUBE)      # this wire is the fat tube
 
 A wire without a `spec` uses `build_wire_material()` (or the 0.5 mm ideal).
 PyNEC honors per-wire radius and loss exactly; momwire honors per-wire
-loss/insulation and approximates *mixed* radii with the length-dominant one
-until its per-wire radius kernels land. Specs describe physical wire stock —
+loss/insulation and — on its default (BSpline) and sinusoidal solvers —
+per-wire radius too (momwire#147). Specs describe physical wire stock —
 scale knobs and transforms move geometry, never specs.
 
 **Tuning on a band — use `design_freq` (strongly recommended).** To place an

--- a/tests/test_per_wire_specs_engines.py
+++ b/tests/test_per_wire_specs_engines.py
@@ -2,10 +2,10 @@
 
 PyNEC honors per-wire radius natively (one radius per GW card) and emits
 per-tag LD cards for per-wire conductivity/insulation. momwire honors
-per-wire conductivity/insulation through its per-wire loading arrays; the
-radius is still a single scalar until the per-wire radius kernels land
-(companion momwire issue), so a uniform per-wire radius is honored exactly
-and mixed radii collapse to the length-dominant one with a warning.
+per-wire conductivity/insulation through its per-wire loading arrays, and
+— since momwire#147 — per-wire radius arrays on BSplineSolver and
+SinusoidalSolver (the H-matrix family still collapses mixed radii to the
+length-dominant one with a warning until its block fills are ported).
 
 The bit-identical guard: a design whose per-wire specs all equal the old
 whole-antenna spec must produce identical results to the global-spec path.
@@ -81,12 +81,72 @@ def test_pynec_honors_mixed_per_wire_radius():
     assert lo < z_mixed.imag < hi
 
 
-def test_momwire_mixed_radius_warns_and_uses_dominant(caplog):
-    """Until the per-wire radius kernels land, momwire collapses mixed radii
-    to the length-dominant one — loudly."""
+def test_momwire_mixed_radius_passes_per_wire_array(caplog):
+    """With the momwire#147 kernels landed, mixed radii reach the solver as
+    a per-wire list — no dominant-collapse, no warning."""
     thin, fat = WireSpec(radius=0.5e-3), WireSpec(radius=8e-3)
     with caplog.at_level(logging.WARNING):
         eng = MomwireEngine(_dipole_builder(fat, thin, thin))
+    assert not any("length-dominant" in r.message for r in caplog.records)
+    # flat_wires_to_polylines merges the spec-uniform thin feed edge with
+    # the thin right arm: two polylines, one radius each.
+    assert sorted(eng._wire_radius) == pytest.approx([0.5e-3, 8e-3])
+
+
+def test_momwire_sinusoidal_mixed_radius_shift_matches_pynec():
+    """Cross-engine agreement on the mixed-radius EFFECT: the shift
+    z_mixed − z_uniform_thin agrees with PyNEC to ~2 Ω (measured 1.7 Ω;
+    fattening one arm moves Z by ~18 Ω here, so the shift is well
+    resolved). The shift — not absolute Z — is compared because this
+    tiny-feed-edge geometry carries a pre-existing ~8 Ω cross-engine
+    reactance offset from the differing feed models, present for uniform
+    radii too. SinusoidalSolver is the parity solver: it implements NEC's
+    basis and tracks PyNEC through mixed-radius solves (momwire's
+    test_per_wire_radius.py pins the direct absolute parity on clean
+    geometries); the resistance, which the feed-model offset barely
+    touches, is also asserted absolutely."""
+    from momwire.sinusoidal import SinusoidalSolver
+
+    thin, fat = WireSpec(radius=0.5e-3), WireSpec(radius=8e-3)
+    kw = {"solver": SinusoidalSolver}
+    z_thin_nec = _z(PyNECEngine, _dipole_builder(default=thin))
+    z_mix_nec = _z(PyNECEngine, _dipole_builder(fat, thin, thin))
+    z_thin_mw = _z(MomwireEngine, _dipole_builder(default=thin), **kw)
+    z_mix_mw = _z(MomwireEngine, _dipole_builder(fat, thin, thin), **kw)
+    shift_nec = z_mix_nec - z_thin_nec
+    shift_mw = z_mix_mw - z_thin_mw
+    assert abs(shift_nec) > 10.0  # the effect being tracked is large...
+    assert abs(shift_mw - shift_nec) < 3.0  # ...and matched
+    assert z_mix_mw.real == pytest.approx(z_mix_nec.real, abs=1.5)
+
+
+def test_momwire_bspline_mixed_radius_honored():
+    """The default (BSpline) engine feeds mixed radii to its kernels: Z
+    moves well off both uniform-radius answers instead of silently equaling
+    the dominant-radius solve. (Cross-engine absolute parity at an IN-LINE
+    radius step is deliberately not asserted for the Galerkin basis: NEC-2
+    itself is non-convergent at radius steps and the two formulations
+    disagree there — see momwire docs/sinusoidal_basis_design.md
+    "Per-wire radius". Junction-type mixed-radius geometries, e.g. fat
+    vertical + thin radials, are pinned against PyNEC in momwire's own
+    suite.)"""
+    thin, fat = WireSpec(radius=0.5e-3), WireSpec(radius=8e-3)
+    z_thin = _z(MomwireEngine, _dipole_builder(default=thin))
+    z_fat = _z(MomwireEngine, _dipole_builder(default=fat))
+    z_mixed = _z(MomwireEngine, _dipole_builder(fat, thin, thin))
+    assert abs(z_mixed - z_thin) > 5.0
+    assert abs(z_mixed - z_fat) > 5.0
+
+
+def test_momwire_hmatrix_mixed_radius_still_warns_and_collapses(caplog):
+    """The H-matrix family's block fills still take one radius: mixed radii
+    keep the loud length-dominant collapse until momwire#147's remaining
+    increment lands."""
+    from momwire.hmatrix import HMatrixSolver
+
+    thin, fat = WireSpec(radius=0.5e-3), WireSpec(radius=8e-3)
+    with caplog.at_level(logging.WARNING):
+        eng = MomwireEngine(_dipole_builder(fat, thin, thin), solver=HMatrixSolver)
     assert any("length-dominant" in r.message for r in caplog.records)
     # Arms have equal length; the feed edge tips the thin total over.
     assert eng._wire_radius == pytest.approx(0.5e-3)


### PR DESCRIPTION
## Summary
- With the momwire#147 kernels landed (momwire PR stevenmburns/momwire#148 — submodule pointer bumped here to that branch head), `MomwireEngine` passes mixed per-wire radii straight through as a per-polyline `wire_radius` list on the solvers that honor them: `BSplineSolver` (the default) and `SinusoidalSolver`, gated by `_solver_supports_per_wire_radius`. Skin-effect loss now evaluates at each wire's own radius. The H-matrix family still takes one radius, so those solvers keep the loud length-dominant collapse (warn-and-degrade, unchanged behavior).
- Tests: the old warns-and-collapses test becomes four — per-wire list reaches the engine; cross-engine PyNEC agreement on the mixed-radius **shift** via `SinusoidalSolver` (~1.7 Ω on an ~18 Ω effect; R agrees ~0.3 Ω absolutely); default-BSpline mixed radii demonstrably honored; H-matrix collapse path still covered. Absolute cross-basis parity at an *in-line* radius step is deliberately not asserted — NEC-2 is non-convergent there (measured and documented in momwire `docs/sinusoidal_basis_design.md` "Per-wire radius"); junction-type mixed radii are pinned against PyNEC in momwire's own suite.
- Docs: all five "until the per-wire radius kernels land" caveats updated (nec_import docstring, site nec-import page, user-designs CLAUDE.md, elt_whip docstring, design-note rollout section — the last also records the two validation findings: observer-radius kernel convention, and NEC-2's stepped-radius non-convergence).
- The momwire pin stays `==0.12.0` on purpose: CI installs the submodule editable, which satisfies it, so this PR has **no release dependency**. After momwire#148 merges (rebase-merge rewrites SHAs), re-point the submodule to the new main commit; the version/pin bump lands with the momwire release ritual.

## Test plan
- [x] `pytest -m "not antenna_computation_check and not heavy_mesh" tests/` — 1958 passed
- [x] `pytest -m heavy_mesh tests/test_nec_import_network.py` — whip deck with true per-wire radii passes its pinned 5%-of-PyNEC window
- [x] momwire suite (submodule): 409 passed, incl. new per-wire-radius + PyNEC oracle tests
- [ ] After momwire#148 merges: re-point submodule to main, then the momwire release + pin bump PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzumziErt42mhUQBPrR1tP