### PR TITLE
Pass mixed per-wire radii to every momwire solver (momwire 0.13.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire==0.12.0",
+    "momwire==0.13.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",

--- a/src/antennaknobs/designs/verticals/elt_whip.py
+++ b/src/antennaknobs/designs/verticals/elt_whip.py
@@ -52,10 +52,10 @@ Constraints worth knowing:
   * The upper whip carries its own per-wire spec (issue #388) with the
     deck's true 0.035" = 0.889 mm radius (``whip_upper_radius``); everything
     else uses ``wire_radius`` (the deck's 0.254 mm). PyNEC honors both, and
-    momwire's default (BSpline) and sinusoidal solvers honor both since
-    momwire#147 — the whip solves at its true radius. (The H-matrix family
-    still collapses to the length-dominant 0.254 mm with a warning until
-    its block fills are ported.)
+    every momwire solver honors both since momwire#147 (complete in
+    momwire 0.13.0) — the whip solves at its true radius. Measured
+    2026-07-15 at 406 MHz, free space: momwire sinusoidal 63.09+8.09j
+    vs PyNEC 63.02+8.06j through the matching network (0.072 Ω apart).
 """
 
 import math

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -113,22 +113,6 @@ def _solver_supports_wire_loading(solver):
     return getattr(solver, "__name__", None) in _WIRE_LOADING_SOLVERS
 
 
-# Per-wire radius arrays (issue #388 / momwire#147, momwire >= 0.13):
-# SinusoidalSolver validates against PyNEC directly (it reproduces NEC's
-# per-segment radius conventions); the BSpline dense family applies the
-# same observer-surface convention. The H-matrix family's block fills
-# still take one radius — mixed radii there collapse to the
-# length-dominant one with a warning (warn-and-degrade, not crash).
-_PER_WIRE_RADIUS_SOLVERS = (
-    "BSplineSolver",
-    "SinusoidalSolver",
-)
-
-
-def _solver_supports_per_wire_radius(solver):
-    return getattr(solver, "__name__", None) in _PER_WIRE_RADIUS_SOLVERS
-
-
 class MomwireEngine(SimulationEngine):
     supports_far_field = True
 
@@ -230,34 +214,17 @@ class MomwireEngine(SimulationEngine):
             default_radius = 0.0005
         specs = self._polyline_specs
         if any(s is not None for s in specs):
-            # Per-wire radii (momwire#147, landed for BSplineSolver and
-            # SinusoidalSolver): one entry per polyline, passed straight
+            # Per-wire radii (momwire#147, momwire >= 0.13.0 — all four
+            # solver bases): one entry per polyline, passed straight
             # through as momwire's wire_radius array. A uniform list is
             # collapsed to the scalar (momwire does the same internally;
             # keeping the engine's readouts scalar preserves the
-            # pre-#147 API surface for uniform designs). Solvers whose
-            # kernels still take one radius (the H-matrix family) keep
-            # the length-dominant collapse, stated plainly.
+            # pre-#147 API surface for uniform designs).
             radii = [s.radius if s is not None else default_radius for s in specs]
             if len(set(radii)) == 1:
                 self._wire_radius = radii[0]
-            elif _solver_supports_per_wire_radius(self._solver):
-                self._wire_radius = radii
             else:
-                length_by_r: dict[float, float] = {}
-                for r, pl in zip(radii, self._polylines):
-                    ln = float(np.linalg.norm(np.diff(pl, axis=0), axis=1).sum())
-                    length_by_r[r] = length_by_r.get(r, 0.0) + ln
-                self._wire_radius = max(length_by_r.items(), key=lambda kv: kv[1])[0]
-                _logger.warning(
-                    "%s takes a single wire radius until its per-wire "
-                    "radius block fills land (momwire#147); approximating "
-                    "%s's mixed per-wire radii with the length-dominant "
-                    "%.4g m",
-                    getattr(self._solver, "__name__", self._solver),
-                    type(builder).__name__,
-                    self._wire_radius,
-                )
+                self._wire_radius = radii
         else:
             self._wire_radius = default_radius
         # Distributed loading rides only the solvers that model it; warn

--- a/src/antennaknobs/nec_import.py
+++ b/src/antennaknobs/nec_import.py
@@ -333,9 +333,8 @@ class NecDeck:
         radius — no ``dominant_radius()`` compromise — and its effective
         conductivity (a ranged LD 5 over the whole wire, else the deck's
         whole-structure LD 5). PyNEC honors both per wire; momwire honors
-        both too since momwire#147 (BSplineSolver and SinusoidalSolver;
-        the H-matrix family still approximates mixed radii with the
-        length-dominant one until its block fills are ported). With
+        both too since momwire#147 (complete in momwire 0.13.0 across all
+        four solver bases, the H-matrix family included). With
         ``specs=True`` a ``build_wire_material()`` fallback is unnecessary
         (every wire carries its spec) — though a design may still define
         one for the weight readout of spec-less wires it adds itself.

--- a/tests/test_per_wire_specs_engines.py
+++ b/tests/test_per_wire_specs_engines.py
@@ -3,9 +3,8 @@
 PyNEC honors per-wire radius natively (one radius per GW card) and emits
 per-tag LD cards for per-wire conductivity/insulation. momwire honors
 per-wire conductivity/insulation through its per-wire loading arrays, and
-— since momwire#147 — per-wire radius arrays on BSplineSolver and
-SinusoidalSolver (the H-matrix family still collapses mixed radii to the
-length-dominant one with a warning until its block fills are ported).
+— since momwire#147 (complete in momwire 0.13.0) — per-wire radius arrays
+on all four solver bases, including the H-matrix family's block fills.
 
 The bit-identical guard: a design whose per-wire specs all equal the old
 whole-antenna spec must produce identical results to the global-spec path.
@@ -138,18 +137,21 @@ def test_momwire_bspline_mixed_radius_honored():
     assert abs(z_mixed - z_fat) > 5.0
 
 
-def test_momwire_hmatrix_mixed_radius_still_warns_and_collapses(caplog):
-    """The H-matrix family's block fills still take one radius: mixed radii
-    keep the loud length-dominant collapse until momwire#147's remaining
-    increment lands."""
+def test_momwire_hmatrix_mixed_radius_honored(caplog):
+    """The H-matrix family's block fills take per-wire radii since momwire
+    0.13.0 — mixed radii pass through as an array (no length-dominant
+    collapse, no warning) and the solve agrees with the dense BSpline
+    build (same Galerkin formulation, ACA-compressed)."""
     from momwire.hmatrix import HMatrixSolver
 
     thin, fat = WireSpec(radius=0.5e-3), WireSpec(radius=8e-3)
     with caplog.at_level(logging.WARNING):
         eng = MomwireEngine(_dipole_builder(fat, thin, thin), solver=HMatrixSolver)
-    assert any("length-dominant" in r.message for r in caplog.records)
-    # Arms have equal length; the feed edge tips the thin total over.
-    assert eng._wire_radius == pytest.approx(0.5e-3)
+    assert not any("length-dominant" in r.message for r in caplog.records)
+    assert sorted(eng._wire_radius) == pytest.approx([0.5e-3, 8e-3])
+    z_h = _z(MomwireEngine, _dipole_builder(fat, thin, thin), solver=HMatrixSolver)
+    z_d = _z(MomwireEngine, _dipole_builder(fat, thin, thin))
+    assert abs(z_h - z_d) / abs(z_d) < 1e-3
 
 
 def test_per_wire_spec_beats_web_radius_override():


### PR DESCRIPTION
momwire 0.13.0 (momwire#147, closed by momwire#149) completes per-wire radius support across all four solver bases — the H-matrix family's block fills included — so the engine-side gate has no remaining consumer:

- `_solver_supports_per_wire_radius` and the length-dominant collapse (+ warning) are deleted; mixed radii pass through as a per-polyline array for every solver. Uniform lists still collapse to the scalar readout (pre-#147 API surface preserved).
- Pin bumped to `momwire==0.13.0`; submodule gitlink points at the v0.13.0 release commit.
- The hmatrix collapse-warning test becomes an honored-array + dense-parity assertion; docs wording ("still collapses until its block fills are ported") refreshed in `nec_import`, `elt_whip`, and the engine-spec test module.
- `elt_whip` docstring now records the measured whip-deck parity: momwire sinusoidal 63.089+8.087j vs PyNEC 63.021+8.063j at 406 MHz (0.072 Ω apart, 4392 segments, ~2 GB peak — the historical OOM was the numpy mixed-radius fallback that momwire#149 removed).

Full PR lane green locally (1958 passed). Closes the momwire-side follow-up of #388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)