### PR TITLE
chore: release v0.28.0 (per-wire wire specs)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/sta
 # install below sees its requirement already satisfied, then the package with the
 # web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install "momwire==0.12.0" \
+ && pip install "momwire==0.13.0" \
  && pip install -e ".[web]"
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.27.1"
+version = "0.28.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,17 +25,19 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.27.1" icon="star">
-  **Big decks won't sink your machine.** A benchmark-grade NEC import — a
-  4,671-segment whip on a 96-inch ground-plane grid — used to exhaust the
-  memory of a 15 GB workstation on the dense solver and crash outright on
-  the compressed ones. The bundled momwire 0.12.0 hardens every engine in
-  the family: chunked dense assembly, fixed H-matrix compression on
-  junction-heavy meshes, and a graceful array-solver fallback bring the
-  whole [solver line-up](/reference/solver/) through that deck in at most
-  4.6 GB. The web backend also now sizes its solver thread pools
-  correctly at runtime — large-deck factorizations run up to 2.2× faster
-  on multi-core machines, with knob-drag latency untouched.
+<Card title="New in v0.28.0" icon="star">
+  **Every wire can now be its own wire.** Real antennas mix conductors — a
+  fat tubing element with thin radials, a copper radiator on a steel
+  whip — and per-wire `WireSpec`s let a design (or an
+  [imported NEC deck](/reference/nec-import/)) give each wire its own
+  radius, conductivity, and insulation instead of one whole-antenna
+  compromise. The bundled momwire 0.13.0 honors mixed radii across **all
+  four solver bases**, validated against NEC-2 to a fraction of an ohm on
+  a 4,392-segment mixed-radius whip benchmark. NEC imports got smarter
+  too: `LD`/`TL`/`NT` cards translate into the design's matching network,
+  wires shatter cleanly where other wires tap into them mid-span, and
+  anything skipped is stated right in the workbench. Plus: zoom, pan, and
+  an isometric view in the antenna viewer.
   [All release notes →](/reference/releases/)
 </Card>
 

--- a/site/src/content/docs/reference/nec-import.md
+++ b/site/src/content/docs/reference/nec-import.md
@@ -89,12 +89,11 @@ recipe — plain `wire_tuples()` plus a `build_wire_material()` returning
 `WireSpec(radius=deck.dominant_radius(), conductivity=deck.conductivity)` —
 still works, approximating mixed radii with the length-dominant one.)
 
-Two caveats on per-wire radii: both engines honor them — PyNEC natively
-(NEC takes a radius per wire), momwire on its default (BSpline) and
-sinusoidal solvers since momwire#147, with only the opt-in H-matrix
-solver family still approximating *mixed* radii by the length-dominant
-one. And the `scale` knob stretches geometry only — specs describe
-physical wire stock and are never scaled.
+Two notes on per-wire radii: both engines honor them fully — PyNEC
+natively (NEC takes a radius per wire), and every momwire solver since
+momwire 0.13.0, the compressed H-matrix family included. And the `scale`
+knob stretches geometry only — specs describe physical wire stock and
+are never scaled.
 
 ## Following the deck's band
 


### PR DESCRIPTION
Release PR per the ritual (precedent: #265, #269):

- `version = "0.28.0"` — theme: **per-wire wire specs**. Since v0.27.1: per-wire `WireSpec`s across the stack (#388) with momwire 0.13.0 honoring mixed radii on all four solver bases; NEC-import network translation (`LD`/`TL`/`NT` → branches) and cross-wire junction shattering (#385); skipped-card notes in the workbench (#373); ELT whip benchmark in the catalog; antenna-viewer zoom/pan + isometric view (#384); out-of-band design fixes (#390); test time-budget guardrail (#393).
- `Dockerfile` momwire pin → 0.13.0 (the third place of the pin upgrade — #397 covered pyproject + submodule only).
- What's-new card refreshed to v0.28.0; `nec-import.md`'s H-matrix length-dominant caveat removed (stale since momwire 0.13.0).
- Site builds clean (`astro check && astro build`, 20 pages).

Tag v0.28.0 follows on merge (publish + both Fly deploys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)