### PR TITLE
One active solver at a time: per-session single-lane solve scheduler

### DIFF
--- a/docs/status/2026-07-15-single-lane-scheduler-design.md
+++ b/docs/status/2026-07-15-single-lane-scheduler-design.md
@@ -1,0 +1,110 @@
+# Single-lane solve scheduler (#382): design decisions
+
+Status note pinning the decisions before code. The issue's four principles —
+one active solve per session, latest intent wins, cancel means stop
+computing, admission by cost — each get one mechanism, below.
+
+## The primitive: a per-session `SolveLane`, acquired per compute step
+
+A `SolveLane` is a priority-ordered, generation-aware async turnstile
+(`web/lane.py`). Every solve-producing compute — the live `/ws` solve, each
+`/sweep` chunk, each `/converge` point, `/norm_check`, `/pattern`,
+`/pattern_metrics` — runs inside `async with lane.turn(kind, gen) as token:`
+and dispatches to the threadpool with that token. Holding the lane is the
+*only* way to compute, so "no two computations concurrently per session" is
+enforced structurally, not by cooperating heuristics.
+
+Turns are granted by `(priority, arrival)`: live = 0, norm-check/pattern =
+1, sweep/converge = 2. A batch acquires the lane **per chunk/point**, not
+per stream — so a live solve queued during a sweep runs at the very next
+chunk boundary instead of after 41 points, and cancellation of the running
+chunk (below) bounds even that wait.
+
+Rejected alternative: a queue of whole jobs with one worker task. The
+streaming endpoints must yield NDJSON as points complete, which would force
+result plumbing from a detached worker back through per-job channels;
+turn-per-step keeps each endpoint's code shape (async generator) intact and
+gets lane-yielding between chunks for free.
+
+## Sessions: client-minted id, lanes on demand, sessionless = unmanaged
+
+Each App instance (one per workbench tab — A/B compare tabs are separate
+sessions) mints a `_session` UUID and stamps it on every WS payload and
+batch POST. The server keeps `lanes: dict[str, SolveLane]`, created on
+first use and dropped when idle (no runner, no waiters — checked on turn
+exit; disconnect-only sessions can't leak lanes).
+
+A request with no `_session` (curl, scripts, tests that don't care) gets a
+fresh private lane for that request: admission still applies, serialization
+doesn't. Cross-session coupling is explicitly out of scope — hosted safety
+against N sessions is the admission model's job, not the lane's.
+
+## Latest intent wins: one generation counter, all job kinds
+
+The client already stamps live solves with a monotonic `_seq`; batch
+requests now carry the same counter's value at issue time as `_gen`
+(`_seq` and `_gen` unify server-side). The lane tracks the highest
+generation seen. Entering a turn with a newer generation:
+
+- **cancels the running turn** (trips its CancelToken) if it is older —
+  a knob drag kills the in-flight benchmark sweep chunk at its next solver
+  checkpoint, and
+- **supersedes queued waiters** that are older *and of a batch kind* —
+  they raise `Superseded`, their generators end their streams.
+
+Same-kind arrivals supersede each other regardless of generation (the
+client re-issued the sweep; the old stream is already abandoned). The live
+`/ws` reader keeps its existing direct token-trip on newer messages — the
+lane token replaces `current["token"]`, one cancellation channel, two
+trippers.
+
+## Cancel means stop computing
+
+Every turn's CancelToken reaches the solver: `momwire_sweep` and
+`_solve_z_only` grow the `cancel=` parameter `momwire_solve` already has
+(threaded to `_make_momwire_engine`); `_norm_check` passes it to its inner
+`solve()`. PyNEC keeps its start-gate-only contract (no mid-solve abort in
+native code) — admission bounds it instead.
+
+Disconnects trip the same token: each HTTP turn runs a watcher task polling
+`request.is_disconnected()` (~250 ms) for the duration of the turn, so an
+abandoned tab stops a minutes-long chunk at the next checkpoint — today's
+between-chunk checks only fire after the damage. The WS reader's
+disconnect path already trips the token.
+
+## Admission by cost: one mapping, every kind
+
+`web/cost.py` owns the single mapping `admit(kind, req, points) →
+run | warn | refuse` built on the existing `count_basis` estimate. It
+consolidates today's three parallel inventions: the hosted matrix caps
+(`_check_solve_size` becomes a thin wrapper, refuse), the hosted
+point-count caps (refuse, cost × points), and the poor-match recommendation
+(`est_basis > 3000` dense ⇒ warn — the same condition the frontend's
+withhold gate computes independently today).
+
+`warn` is enforced server-side for batches: a warned batch request runs
+only if it carries `_approved: true`, which the client sets exactly when
+the user clicks "Solve anyway" on the existing gate. The gate's UX is
+unchanged; the server stops trusting the client to hold batches back.
+
+## Client: effects declare intent, polling loops die
+
+`runSweep`/`runConverge`/`runNormCheck` lose their 200 ms
+`solvePending() || solveWithheld()` re-poll loops — they fire after their
+debounce and the lane orders them (live wins by priority, so norm-check
+still lands on the live solve's cache entry). The withhold gate becomes
+plain state consulted once at effect time (approval flips state, effects
+re-run) instead of a ref polled on a timer. `solvePending()` reduces to UI
+state (`solving` indicator); per-endpoint AbortControllers stay — an
+aborted fetch is how the server learns to cancel.
+
+## Testing
+
+Lane unit tests use fake async jobs (no solver): concurrency-never ≥ 2
+(instrumented counter), priority order, generation supersession of running
++ queued, same-kind supersession, sessionless isolation, idle cleanup.
+Endpoint tests monkeypatch a slow event-gated fake solver under
+`TestClient`: `/ws` + `/sweep` never overlap, a dropped stream trips the
+token within one checkpoint, warned batches 403 without `_approved`. Cost
+model gets a pure mapping table test. Everything event-driven — no sleeps
+near the suite's 2 s budget.

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -1706,7 +1706,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             wrap="mappingproxy" if req.get("wrap") == "mappingproxy" else "dict",
         )
 
-    def far_field_metrics(req: dict) -> dict:
+    def far_field_metrics(req: dict, cancel=None) -> dict:
         # Scalar metrics for the pattern-compare table. Uses the same builder
         # setup as momwire_solve and the momwire engine (so the numbers match
         # the client-derived lobe on screen), then summarises the full grid.
@@ -1717,7 +1717,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         builder.freq = meas_freq
         if has_design_freq:
             builder.design_freq = design_freq
-        eng = _make_momwire_engine(req, builder)
+        eng = _make_momwire_engine(req, builder, cancel=cancel)
         ff = eng.far_field(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
         metrics = pattern_metrics(ff)
         metrics["measurement_freq_mhz"] = meas_freq
@@ -1737,7 +1737,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         ground = _ground_for_engine(req, 0.0) or "free"
         return _export_nec(builder, ground=ground, freq=meas_freq)
 
-    def momwire_sweep(req: dict, freqs_mhz: list[float]):
+    def momwire_sweep(req: dict, freqs_mhz: list[float], cancel=None):
         builder = _build_builder(cls, req)
         # MomwireEngine reads builder.freq only for the initial wavelength
         # passed to _make_solver — impedance_sweep overrides k per point.
@@ -1747,7 +1747,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         # solve sees. See momwire_solve for the rationale.
         if has_design_freq:
             builder.design_freq = _req_freqs(req)[0]
-        eng = _make_momwire_engine(req, builder)
+        eng = _make_momwire_engine(req, builder, cancel=cancel)
         zs = np.asarray(eng.impedance_sweep(list(freqs_mhz)))
         # Open-circuited points sweep through as inf; clamp for JSON.
         zs = np.where(np.isfinite(zs), zs, complex(Z_OPEN_OHMS, 0.0))

--- a/src/antennaknobs/web/cost.py
+++ b/src/antennaknobs/web/cost.py
@@ -1,0 +1,148 @@
+"""One cost model for every solve-producing job (issue #382).
+
+Admission used to be three parallel inventions: the hosted matrix caps
+(``_check_solve_size``), the hosted point-count caps (inline in ``/sweep``
+and ``/converge``), and the frontend's poor-match withhold gate
+(``comboInappropriate`` in App.tsx, keyed off the server's recommended
+backend). This module is the single mapping they all consult:
+
+    admit(req, kind=..., points=..., use_pynec=..., hosted=..., example=...)
+        -> Admission(verdict = "run" | "warn" | "refuse", reason, est_basis)
+
+- **refuse**: hosted only — the matrix wouldn't fit the live box (per-engine
+  basis caps) or the batch multiplies cost past the point cap. The caller
+  turns this into a 413 / ``SolveTooLargeError``.
+- **warn**: a dense-matrix solver on a benchmark-class mesh (the same
+  ``est_basis > 3000`` condition behind the ``"sinusoidal"`` backend
+  recommendation). The frontend withholds and asks "Solve anyway"; batch
+  endpoints enforce it server-side — a warned batch runs only when the
+  request carries ``_approved: true`` (set exactly when the user clicks
+  through the gate). Applies hosted and local alike: it protects whatever
+  machine is doing the computing.
+- **run**: everything else, including anything whose size can't be estimated
+  (no ``count_basis`` hook / geometry won't build) — the solve path surfaces
+  the real error.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, ""))
+    except ValueError:
+        return default
+
+
+# Hosted live-engine matrix caps (see the sizing notes in issue #345): dense
+# momwire and PyNEC form the full N×N complex matrix; the compressed engines
+# (array-block / H-matrix) don't, so they get more headroom.
+MAX_BASIS = _env_int("ANTENNAKNOBS_MAX_BASIS", 7000)  # dense momwire (~800 MB)
+MAX_BASIS_COMPRESSED = _env_int("ANTENNAKNOBS_MAX_BASIS_COMPRESSED", 9000)
+MAX_BASIS_PYNEC = _env_int("ANTENNAKNOBS_MAX_BASIS_PYNEC", 7000)
+COMPRESSED_MODELS = frozenset({"arrayblock", "hmatrix"})
+
+# Hosted compute levers beyond the matrix cap (issue #346): a client-chosen
+# list length multiplies whole solves. Both sit far above what the UI sends
+# (41-point sweeps, ≤200 optimizer evals).
+MAX_SWEEP_POINTS = _env_int("ANTENNAKNOBS_MAX_SWEEP_POINTS", 500)
+MAX_OPT_EVALS = _env_int("ANTENNAKNOBS_MAX_OPT_EVALS", 500)
+
+# Above this estimated basis count the adapter recommends the sinusoidal
+# backend (`_recommended_backend`); a dense-family solver here is minutes per
+# solve where sinusoidal is seconds. Single source for the "warn" verdict —
+# keep in sync with adapter._SINUSOIDAL_RECOMMEND_MIN_BASIS.
+WARN_MIN_BASIS = 3000
+
+# Job kinds whose "warn" the server enforces (batches of the very solves the
+# gate exists to prevent). The live solve's warn stays a client-side prompt;
+# /pattern is PyNEC-only (never warned); /pattern_metrics solves *other*
+# designs for the compare table at their defaults, which the gate's
+# this-design approval flow doesn't model — lane admission still bounds it.
+ENFORCED_WARN_KINDS = frozenset({"sweep", "converge", "norm_check"})
+
+
+@dataclass(frozen=True)
+class Admission:
+    verdict: str  # "run" | "warn" | "refuse"
+    reason: str | None = None
+    est_basis: int | None = None
+
+
+def estimate_basis(req: dict, example) -> int | None:
+    """Basis-count estimate via the example's geometry-only ``count_basis``
+    hook (cheap — no solve). None when it can't be judged."""
+    if example is None or example.count_basis is None:
+        return None
+    return example.count_basis(req)
+
+
+def admit(
+    req: dict,
+    *,
+    kind: str,
+    use_pynec: bool,
+    hosted: bool,
+    example,
+    points: int = 1,
+) -> Admission:
+    est = estimate_basis(req, example)
+
+    if hosted and points > MAX_SWEEP_POINTS:
+        return Admission(
+            "refuse",
+            f"A {'convergence sweep' if kind == 'converge' else 'sweep'} of "
+            f"{points} points is over the live limit of {MAX_SWEEP_POINTS}. "
+            f"Reduce the {'N' if kind == 'converge' else 'frequency'} count.",
+            est,
+        )
+
+    if hosted and est is not None:
+        if use_pynec:
+            cap, engine, compressed = MAX_BASIS_PYNEC, "PyNEC", False
+        elif req.get("momwire_model") in COMPRESSED_MODELS:
+            cap = MAX_BASIS_COMPRESSED
+            engine, compressed = str(req.get("momwire_model")), True
+        else:
+            cap, engine, compressed = MAX_BASIS, "momwire", False
+        if est > cap:
+            # Dense momwire and PyNEC both form the full N×N matrix; point
+            # users at the compressed engines (which don't) for big arrays.
+            hint = (
+                ""
+                if compressed
+                else " — or switch to the array-block / H-matrix engine, which "
+                "handles larger arrays without a dense matrix"
+            )
+            return Admission(
+                "refuse",
+                f"This solve needs ~{est} wire segments, over the live {engine} "
+                f"limit of {cap}. Reduce 'segments / wire (N)' or pick a smaller "
+                f"design{hint}.",
+                est,
+            )
+
+    # Poor-match combo on a benchmark-class mesh: every b-spline-family
+    # solver (dense or accelerated) is minutes per solve there. Mirrors the
+    # frontend's comboInappropriate() for the "sinusoidal" recommendation;
+    # PyNEC is exempt (native fill, admission-capped above).
+    if (
+        est is not None
+        and est > WARN_MIN_BASIS
+        and not use_pynec
+        and req.get("momwire_model", "bspline") != "sinusoidal"
+    ):
+        noun = f"a batch of {points} solves" if points > 1 else "a solve"
+        return Admission(
+            "warn",
+            f"This design needs ~{est} basis functions — {noun} with the "
+            f"'{req.get('momwire_model', 'bspline')}' solver here can take "
+            "minutes each. Switch to the Sinusoidal solver (recommended), or "
+            "re-send with _approved: true to run anyway.",
+            est,
+        )
+
+    return Admission("run", None, est)

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1668,6 +1668,16 @@ type SolveRequest = {
   /** Monotonic per-tab sequence number for the latest-wins /ws protocol. The
    *  server echoes it back and keeps only the freshest queued request. */
   _seq?: number;
+  /** Solve-lane session id (issue #382): one per workbench tab, minted at
+   *  mount. The server serializes all of a session's solve-producing work
+   *  (live solve, sweeps, converge, norm-check, pattern) on one lane. */
+  _session?: string;
+  /** Batch-request generation: the value of the `_seq` counter when the batch
+   *  was issued, so a newer knob drag (higher live `_seq`) supersedes it. */
+  _gen?: number;
+  /** Set when the user clicked through the poor-match gate ("Solve anyway");
+   *  the server refuses warned batches without it. */
+  _approved?: boolean;
 };
 
 type SweepData = {
@@ -2545,8 +2555,12 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   const backendTouchedRef = useRef(false);
   // True once the user clicked "Solve anyway" for the current design+solver
   // combo, so re-solves (knob drags) don't re-warn. Reset whenever the design or
-  // solver changes (see the reset effect below).
+  // solver changes (see the reset effect below). Mirrored into state so the
+  // sweep/converge/norm-check effects re-fire on approval (issue #382 replaced
+  // their 200 ms re-poll loops with plain effect dependencies); the ref stays
+  // for the imperative reads in the solve path.
   const approvedComboRef = useRef(false);
+  const [comboApproved, setComboApproved] = useState(false);
   // Shown when the current design+solver is a poor match — a dense solver on a
   // large array (slow), or an accelerator on a single element (overkill). The
   // solve is withheld until the user clicks "Solve anyway" or changes the solver
@@ -2704,11 +2718,12 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     preview?.default_backend ?? currentExample?.default_backend,
   );
   // True while the live solve is being withheld by the solver-mismatch gate.
-  // The batch endpoints (sweep / converge / norm-check) defer on this exactly
-  // like they defer on solvePending(): they are batches of the same solves
-  // the gate is protecting the machine from (a dense sweep on a benchmark
-  // mesh is 41 multi-GiB solves). Reads the approval ref, so "Solve anyway"
-  // unblocks their 200 ms re-poll without any effect re-run.
+  // The batch runners (sweep / converge / norm-check) decline to fire on
+  // this: they are batches of the same solves the gate is protecting the
+  // machine from (a dense sweep on a benchmark mesh is 41 multi-GiB solves).
+  // Their effects depend on `comboApproved`, so "Solve anyway" re-fires them;
+  // the server's cost model refuses warned batches without the approval flag
+  // anyway (issue #382) — this gate is UX, not the enforcement.
   function solveWithheld(): boolean {
     return (
       comboInappropriate(backend, recommendedBackend) &&
@@ -2800,6 +2815,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   // "Solve anyway": approve this combo so re-solves don't re-warn, then solve.
   function solveAnyway() {
     approvedComboRef.current = true;
+    setComboApproved(true);
     setSolverWarning(false);
     controlsRef.current = buildRequest();
     requestSolve();
@@ -2810,6 +2826,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   // so clicking Live to resume continues the simulation rather than re-warning.
   function pauseSimulation() {
     approvedComboRef.current = true;
+    setComboApproved(true);
     setSolverWarning(false);
     setAutoSim(false);
   }
@@ -2990,6 +3007,15 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   // refs so they survive StrictMode/HMR socket teardown — the counter must
   // never rewind below what's already been received.
   const seqRef = useRef(0); // last _seq assigned (monotonic, never reset)
+  // Solve-lane session id (issue #382): one per workbench tab (A/B compare
+  // tabs are separate App instances, hence separate sessions). The server
+  // keys its single-lane scheduler on this — everything this tab asks for
+  // runs one-at-a-time server-side, live solve first.
+  const sessionIdRef = useRef<string>(
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `s-${Math.random().toString(36).slice(2)}`,
+  );
   const lastSentSeqRef = useRef(0); // highest _seq put on the wire
   const lastReceivedSeqRef = useRef(0); // highest _seq received or implicitly acked
   const canceledThroughSeqRef = useRef(0); // drop rendering for _seq <= this
@@ -3004,6 +3030,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     // ships the real εr/σ for the pattern either way).
     const groundActive = groundEnabled && backendSupportsGround(backend);
     const base: SolveRequest = {
+      _session: sessionIdRef.current,
       geometry,
       variant: currentVariant,
       solver: backend === "pynec" ? "pynec" : "momwire",
@@ -3383,6 +3410,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   // stale approval. Defined before the solve effect so it runs first.
   useEffect(() => {
     approvedComboRef.current = false;
+    setComboApproved(false);
   }, [geometry, backend, backendOptsKey]);
 
   useEffect(() => {
@@ -3563,9 +3591,8 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     if (!sweepEnabled || !active) {
       return;
     }
-    // runSweep itself waits for the live solve to finish before it starts
-    // (see its guard), so the dwell effectively begins once the heatmap solve
-    // has returned rather than competing with it.
+    // The 500 ms dwell only debounces network churn; ordering against the
+    // live solve is the server lane's job now (live outranks sweeps).
     sweepTimerRef.current = window.setTimeout(runSweep, 500);
     return () => {
       if (sweepTimerRef.current) window.clearTimeout(sweepTimerRef.current);
@@ -3586,6 +3613,10 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     // param — e.g. a band-locked variant. currentValuesKey wouldn't move then,
     // so depend on currentVariant directly to re-run the sweep on switch.
     currentVariant,
+    // The poor-match gate: while it withholds, runSweep declines to issue the
+    // batch; approving ("Solve anyway") or a new recommendation re-fires this
+    // effect (issue #382 — replaces the old 200 ms re-poll loop).
+    comboApproved, recommendedBackend,
   ]);
 
   // Debounced convergence sweep over segments-per-wire. Independent of the
@@ -3603,7 +3634,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     if (!convergeEnabled || !active) {
       return;
     }
-    // Like the sweep, runConverge waits for the live solve before starting.
+    // Debounce only; the server lane orders it behind the live solve.
     convergeTimerRef.current = window.setTimeout(runConverge, 500);
     return () => {
       if (convergeTimerRef.current) window.clearTimeout(convergeTimerRef.current);
@@ -3616,13 +3647,15 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     groundEnabled, groundModel,
     convergeEnabled,
     active,
+    // Poor-match gate (see the sweep effect).
+    comboApproved, recommendedBackend,
   ]);
 
   // Debounced far-field norm consistency check. Same shape as the converge
   // sweep: re-runs on any antenna/param change (which invalidates the norm),
-  // gated by its own overlay checkbox, and defers until the live solve lands
-  // so it reuses that solve's server-cached currents rather than forcing a
-  // re-solve.
+  // gated by its own overlay checkbox. The server lane runs it after the
+  // live solve (priority ordering), so it lands on that solve's cached
+  // currents rather than forcing a re-solve.
   useEffect(() => {
     normCheckAbortRef.current?.abort();
     if (normCheckTimerRef.current) {
@@ -3644,6 +3677,8 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     groundEnabled, groundModel,
     normCheckEnabled,
     active,
+    // Poor-match gate (see the sweep effect).
+    comboApproved, recommendedBackend,
   ]);
 
   // Debounced NEC pattern fetch. PyNEC only — for momwire there's no rp_card
@@ -3669,16 +3704,12 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   ]);
 
   async function runSweep() {
-    // Hold off until the live /ws solve (the one that fills in the heatmap,
-    // impedance, and far field) has returned. Its 41 background freq solves
-    // would otherwise share CPU with it and stretch the time-to-heatmap — the
-    // pain that motivated this on large arrays. Re-poll until the main solve is
-    // idle, then proceed; the input-change effect cancels this timer on the
-    // next change, so rapid edits still debounce.
-    if (solvePending() || solveWithheld()) {
-      sweepTimerRef.current = window.setTimeout(runSweep, 200);
-      return;
-    }
+    // No competition with the live solve to time around anymore: the server's
+    // per-session solve lane (issue #382) runs everything one-at-a-time with
+    // the live solve first, so this just sends. While the poor-match gate is
+    // withholding, don't issue batches of the very solves it's blocking — the
+    // effect re-fires on approval (comboApproved is a dependency).
+    if (solveWithheld()) return;
     sweepTimerRef.current = null;
     sweepAbortRef.current?.abort();
     const controller = new AbortController();
@@ -3737,7 +3768,15 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
       Math.exp(Math.log(fLo) + (i / (N - 1)) * (Math.log(fHi) - Math.log(fLo))),
     );
 
-    const body = { ...buildRequest(), freqs_mhz: freqs };
+    const body = {
+      ...buildRequest(),
+      freqs_mhz: freqs,
+      // Lane metadata (issue #382): issued-at generation (a newer knob drag
+      // supersedes this batch server-side) + the gate's approval, which the
+      // server requires for a warned batch (poor-match combo backstop).
+      _gen: seqRef.current,
+      _approved: approvedComboRef.current,
+    };
     setSweepRunning(true);
     const acc: SweepData = {
       freqs_mhz: [],
@@ -3808,13 +3847,9 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   }
 
   async function runConverge() {
-    // Same as runSweep: defer the converge ladder (another batch of solves)
-    // until the live solve has returned, so it never competes with the solve
-    // that draws the heatmap.
-    if (solvePending() || solveWithheld()) {
-      convergeTimerRef.current = window.setTimeout(runConverge, 200);
-      return;
-    }
+    // Same as runSweep: the server lane serializes and prioritizes; only the
+    // poor-match gate holds this back (effect re-fires on approval).
+    if (solveWithheld()) return;
     convergeTimerRef.current = null;
     convergeAbortRef.current?.abort();
     const controller = new AbortController();
@@ -3823,7 +3858,12 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     // The active slot's nPerWire is irrelevant during a converge sweep —
     // n_values overrides it on the server. We strip `n_per_wire` from the
     // request anyway to make that explicit.
-    const body = { ...buildRequest(), n_values: CONVERGE_N_VALUES };
+    const body = {
+      ...buildRequest(),
+      n_values: CONVERGE_N_VALUES,
+      _gen: seqRef.current,
+      _approved: approvedComboRef.current,
+    };
     setConvergeRunning(true);
     const acc: ConvergeData = {
       n_values: [],
@@ -3929,13 +3969,10 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   }
 
   async function runNormCheck() {
-    // Defer until the live solve has returned, like the sweeps — the pattern
-    // norm reuses that settled solve (a server cache hit), so running before
-    // it lands would miss the cache and re-solve.
-    if (solvePending() || solveWithheld()) {
-      normCheckTimerRef.current = window.setTimeout(runNormCheck, 200);
-      return;
-    }
+    // The pattern norm reuses the settled live solve (a server cache hit):
+    // the lane's live-first priority guarantees that ordering now, no
+    // client-side timing needed. Only the poor-match gate holds this back.
+    if (solveWithheld()) return;
     normCheckTimerRef.current = null;
     normCheckAbortRef.current?.abort();
     const controller = new AbortController();
@@ -3944,7 +3981,11 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
       const resp = await fetch("/norm_check", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(buildRequest()),
+        body: JSON.stringify({
+          ...buildRequest(),
+          _gen: seqRef.current,
+          _approved: approvedComboRef.current,
+        }),
         signal: controller.signal,
       });
       if (!resp.ok) throw new Error(`norm check failed: ${resp.status}`);
@@ -3981,7 +4022,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
       const resp = await fetch("/pattern", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(buildRequest()),
+        body: JSON.stringify({ ...buildRequest(), _gen: seqRef.current }),
         signal: controller.signal,
       });
       if (!resp.ok) throw new Error(`pattern failed: ${resp.status}`);
@@ -3997,17 +4038,6 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     } finally {
       if (patternAbortRef.current === controller) patternAbortRef.current = null;
     }
-  }
-
-  // True while a live /ws solve is outstanding — a request scheduled by the rAF
-  // throttle but not yet sent, or sent and not yet acked by an equal/higher
-  // `_seq`. Sweep/converge hold off on this so their batches of background
-  // solves don't compete with the live solve that draws the heatmap.
-  function solvePending(): boolean {
-    return (
-      solveRafRef.current !== null ||
-      lastSentSeqRef.current > lastReceivedSeqRef.current
-    );
   }
 
   // Mirror the seq counters into `solving` state so the UI can react. Called

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -3807,6 +3807,13 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
           if (!line) continue;
           const pt = JSON.parse(line);
           if (pt.done) continue;
+          // A failed point/chunk ends the stream with {error} instead of
+          // tearing the connection down (e.g. an approved poor-match combo
+          // whose dense fill can't allocate). Keep whatever points landed.
+          if (pt.error) {
+            console.error("sweep error", pt.error);
+            continue;
+          }
           acc.freqs_mhz.push(pt.freq_mhz);
           acc.z_re.push(pt.z_re);
           acc.z_im.push(pt.z_im);

--- a/src/antennaknobs/web/frontend/vite.config.ts
+++ b/src/antennaknobs/web/frontend/vite.config.ts
@@ -30,6 +30,22 @@ export default defineConfig({
       "/": {
         target: "http://127.0.0.1:8000",
         changeOrigin: true,
+        // Propagate client aborts upstream. http-proxy does NOT reliably
+        // destroy its backend request when the browser goes away mid-stream
+        // (closed tab during an NDJSON sweep): the upstream socket lingers,
+        // the backend's request.is_disconnected() stays false, and a
+        // benchmark-mesh sweep grinds on for tens of minutes against a dead
+        // client (found in the #382 acceptance pass — five zombie proxied
+        // streams kept a whip sweep+converge+norm-check burning after the
+        // tab closed). Production doesn't route through this proxy; only
+        // the dev loop needs the hand-off.
+        configure(proxy) {
+          proxy.on("proxyReq", (proxyReq, req, res) => {
+            res.on("close", () => {
+              if (!res.writableFinished) proxyReq.destroy();
+            });
+          });
+        },
         bypass(req) {
           const url = req.url || "";
           // Only GETs can be Vite-owned; any other method is an API call.

--- a/src/antennaknobs/web/lane.py
+++ b/src/antennaknobs/web/lane.py
@@ -1,0 +1,243 @@
+"""Per-session single-lane solve scheduling (issue #382).
+
+One :class:`SolveLane` per client session serializes every solve-producing
+compute — the live ``/ws`` solve, each ``/sweep`` chunk, each ``/converge``
+point, ``/norm_check``, ``/pattern``, ``/pattern_metrics``. Holding the lane
+is the only way to compute, so "no two solver computations run concurrently
+for one session" is structural, not a client-side heuristic.
+
+Turns are granted by ``(priority, arrival)`` — the live solve always
+outranks background batches — and carry the session's *generation*: the
+client's monotonic ``_seq``/``_gen`` counter. Newer generations supersede
+older work (queued turns raise :class:`Superseded`; the running turn's
+CancelToken is tripped so it aborts at the next momwire solver checkpoint).
+A turn of the same kind supersedes its predecessor regardless of generation:
+the client re-issued the job, so the old stream is already abandoned.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import itertools
+from contextlib import asynccontextmanager
+
+# Lane priority per job kind (lower wins). The live solve draws the heatmap
+# the user is staring at; norm-check/pattern are single dwell-triggered
+# solves; sweep/converge are long batches that should soak up whatever the
+# lane has left. Unknown kinds sort last.
+PRIORITY = {
+    "live": 0,
+    "norm_check": 1,
+    "pattern": 1,
+    "pattern_metrics": 1,
+    "sweep": 2,
+    "converge": 2,
+}
+_PRIORITY_DEFAULT = 9
+
+# Kinds where a new arrival supersedes an older one of the same kind: the
+# client holds at most one of each (re-issuing means the old stream is
+# abandoned). pattern_metrics is deliberately absent — the compare table
+# legitimately runs one request per design row at once.
+SAME_KIND_SUPERSEDES = frozenset({"live", "sweep", "converge", "norm_check", "pattern"})
+
+
+class Superseded(Exception):
+    """Newer client intent overtook this turn before it ran; abandon the job.
+
+    Raised out of ``lane.turn(...)`` — never after the turn was granted (a
+    running turn is preempted via its CancelToken instead, surfacing as
+    ``momwire.SolveAborted`` from the solver).
+    """
+
+
+def _default_token_factory():
+    # Deferred so the lane primitive (and its unit tests) don't pay the
+    # momwire import; the server passes real CancelTokens into the solvers.
+    import momwire
+
+    return momwire.CancelToken()
+
+
+class _Turn:
+    __slots__ = ("kind", "gen", "order", "ready", "token")
+
+    def __init__(self, kind: str, gen: int | None, order: int, token) -> None:
+        self.kind = kind
+        self.gen = gen
+        self.order = order
+        self.token = token
+        self.ready: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+
+    @property
+    def rank(self) -> tuple[int, int]:
+        return (PRIORITY.get(self.kind, _PRIORITY_DEFAULT), self.order)
+
+
+class SolveLane:
+    """One serialized compute lane: a priority-ordered, generation-aware
+    turnstile. All bookkeeping happens in synchronous stretches on the event
+    loop (no locks needed); the only awaits are on a turn's grant future."""
+
+    def __init__(self, token_factory=None) -> None:
+        self._token_factory = token_factory or _default_token_factory
+        self.gen = 0  # highest client generation seen
+        self._order = itertools.count()
+        self._running: _Turn | None = None
+        self._waiting: list[_Turn] = []
+
+    @property
+    def idle(self) -> bool:
+        return self._running is None and not self._waiting
+
+    @asynccontextmanager
+    async def turn(self, kind: str, gen: int | None = None):
+        """Wait for exclusive compute rights; yield this turn's CancelToken.
+
+        Raises :class:`Superseded` (possibly immediately — a request carrying
+        a generation older than the lane's is stale on arrival) if newer
+        intent overtakes this turn while it is queued.
+        """
+        t = _Turn(kind, gen, next(self._order), self._token_factory())
+        self._supersede_overtaken_by(t)
+        if t.gen is not None and t.gen < self.gen:
+            raise Superseded  # stale on arrival: a newer generation exists
+        self._waiting.append(t)
+        self._grant_if_free()
+        try:
+            await t.ready
+        except BaseException:
+            # Superseded while queued, or the awaiting task itself was
+            # cancelled (client torn down before the grant — or, in a narrow
+            # race, just after it: release then too).
+            if t in self._waiting:
+                self._waiting.remove(t)
+            self._release(t)
+            raise
+        try:
+            yield t.token
+        finally:
+            self._release(t)
+
+    def advance(self, gen: int | None) -> None:
+        """Fold newer client intent into the lane without taking a turn.
+
+        The /ws reader calls this the moment a newer request lands, so an
+        older running compute (e.g. a benchmark-mesh sweep chunk) is
+        preempted at its next checkpoint right away — the superseding live
+        turn itself won't be admitted until the solver loop gets to it, and
+        waiting for that would leave the stale chunk grinding meanwhile.
+        """
+        if gen is None or gen <= self.gen:
+            return
+        self.gen = gen
+        for w in list(self._waiting):
+            if w.gen is not None and w.gen < self.gen:
+                self._waiting.remove(w)
+                w.ready.set_exception(Superseded())
+        r = self._running
+        if r is not None and r.gen is not None and r.gen < self.gen:
+            r.token.cancel()
+
+    def _supersede_overtaken_by(self, new: _Turn) -> None:
+        if new.gen is not None and new.gen > self.gen:
+            self.gen = new.gen
+        for w in list(self._waiting):
+            if self._overtaken(w, new):
+                self._waiting.remove(w)
+                w.ready.set_exception(Superseded())
+        r = self._running
+        if r is not None and self._overtaken(r, new):
+            # Preempt mid-compute: the solver raises SolveAborted at its next
+            # checkpoint. (PyNEC solves have no checkpoints — they run out
+            # their current call; admission bounds how long that can be.)
+            r.token.cancel()
+
+    def _overtaken(self, old: _Turn, new: _Turn) -> bool:
+        if old.kind == new.kind and old.kind in SAME_KIND_SUPERSEDES:
+            return True  # re-issued job: the old stream is abandoned
+        return old.gen is not None and old.gen < self.gen
+
+    def _grant_if_free(self) -> None:
+        if self._running is not None or not self._waiting:
+            return
+        t = min(self._waiting, key=lambda w: w.rank)
+        self._waiting.remove(t)
+        self._running = t
+        t.ready.set_result(None)
+
+    def _release(self, t: _Turn) -> None:
+        if self._running is t:
+            self._running = None
+        self._grant_if_free()
+
+
+class LaneRegistry:
+    """SolveLanes keyed by client session id.
+
+    Sessions are minted client-side (one UUID per workbench tab) and stamped
+    on every request as ``_session``. A request without one (curl, scripts,
+    old clients) gets a private throwaway lane: admission still applies,
+    serialization doesn't — cross-session coupling is explicitly not this
+    module's job. Idle lanes are dropped on turn exit, so disconnect-only
+    traffic can't leak entries.
+    """
+
+    def __init__(self, token_factory=None) -> None:
+        self._token_factory = token_factory
+        self._lanes: dict[str, SolveLane] = {}
+
+    def lane(self, session: str | None) -> SolveLane:
+        if session is None:
+            return SolveLane(self._token_factory)
+        found = self._lanes.get(session)
+        if found is None:
+            found = self._lanes[session] = SolveLane(self._token_factory)
+        return found
+
+    def advance(self, session: str | None, gen: int | None) -> None:
+        """See :meth:`SolveLane.advance`. No-op for unknown/sessionless keys
+        (nothing to preempt — a lane only exists while work is in it)."""
+        if session is None:
+            return
+        found = self._lanes.get(session)
+        if found is not None:
+            found.advance(gen)
+
+    @asynccontextmanager
+    async def turn(self, session: str | None, kind: str, gen: int | None = None):
+        # No await between the lookup and the waiter registering inside
+        # lane.turn's entry, so a lane can't be reaped out from under a
+        # not-yet-registered waiter.
+        found = self.lane(session)
+        try:
+            async with found.turn(kind, gen) as token:
+                yield token
+        finally:
+            if session is not None and found.idle:
+                self._lanes.pop(session, None)
+
+    def __len__(self) -> int:  # observability + tests
+        return len(self._lanes)
+
+
+@asynccontextmanager
+async def cancel_on_disconnect(request, token, interval: float = 0.25):
+    """Trip ``token`` if the HTTP client goes away mid-compute.
+
+    The streaming endpoints only used to notice a disconnect *between*
+    chunks — useless when one benchmark-mesh chunk takes minutes. This
+    watcher polls ``request.is_disconnected()`` for the duration of a turn,
+    so an abandoned tab stops the burn at the next solver checkpoint.
+    """
+
+    async def _watch() -> None:
+        while not await request.is_disconnected():
+            await asyncio.sleep(interval)
+        token.cancel()
+
+    task = asyncio.create_task(_watch())
+    try:
+        yield
+    finally:
+        task.cancel()

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -870,6 +870,17 @@ async def sweep_endpoint(req: dict, request: Request):
                         superseded_mid_point = token.cancelled
                 except Superseded:
                     return
+                except Exception as exc:  # noqa: BLE001 — solver can fail per point
+                    yield (
+                        json.dumps(
+                            {
+                                "error": user_designs.format_solve_error(exc),
+                                "solver": solver_name,
+                            }
+                        )
+                        + "\n"
+                    )
+                    return
                 yield json.dumps(record) + "\n"
                 if superseded_mid_point:
                     return
@@ -911,6 +922,20 @@ async def sweep_endpoint(req: dict, request: Request):
                                 sweep_fn, req, chunk, cancel=token
                             )
                 except (Superseded, momwire.SolveAborted):
+                    return
+                except Exception as exc:  # noqa: BLE001 — a chunk can fail honestly
+                    # e.g. an approved poor-match combo whose dense fill can't
+                    # allocate: end the stream with the cause instead of
+                    # tearing the NDJSON connection down mid-line.
+                    yield (
+                        json.dumps(
+                            {
+                                "error": user_designs.format_solve_error(exc),
+                                "solver": solver_name,
+                            }
+                        )
+                        + "\n"
+                    )
                     return
                 # Multi-feed sweeps (bowtie array) return a 4-tuple with
                 # per-feed Z appended. Everything else stays on the
@@ -1164,6 +1189,12 @@ async def norm_check_endpoint(req: dict, request: Request):
                 return await run_in_threadpool(_norm_check, req, cancel=token)
     except (Superseded, momwire.SolveAborted):
         return {"available": False}
+    except Exception as exc:  # noqa: BLE001 — the miss path is a full solve
+        # An approved poor-match solve can fail honestly (e.g. the whip's
+        # B-spline J tensor is a 3 GiB allocation): report it like every
+        # other solve endpoint instead of a 500 (found in the #382
+        # acceptance pass under ulimit -v).
+        return {"available": False, "error": user_designs.format_solve_error(exc)}
 
 
 @app.post("/export_nec")

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -37,8 +37,10 @@ from fastapi.staticfiles import StaticFiles
 from starlette.websockets import WebSocketState
 from threadpoolctl import threadpool_limits
 
+from . import cost as _cost
 from . import pynec_backend, user_designs
 from .examples import REGISTRY as EXAMPLES
+from .lane import LaneRegistry, Superseded, cancel_on_disconnect
 
 
 def _physical_cpu_count() -> int:
@@ -609,62 +611,59 @@ _SOLVE_CACHE_MAX = 100
 # is large; that's a responsiveness concern, deliberately not guarded here).
 # All env-overridable for self-hosting on bigger boxes. (_HOSTED and the
 # _env_* helpers live above the FastAPI construction, which also needs them.)
-_MAX_BASIS = _env_int("ANTENNAKNOBS_MAX_BASIS", 7000)  # dense momwire (~800 MB)
-_MAX_BASIS_COMPRESSED = _env_int("ANTENNAKNOBS_MAX_BASIS_COMPRESSED", 9000)
-_MAX_BASIS_PYNEC = _env_int("ANTENNAKNOBS_MAX_BASIS_PYNEC", 7000)
-_COMPRESSED_MODELS = frozenset({"arrayblock", "hmatrix"})
-
-# Hosted compute levers beyond the matrix cap (issue #346): a client-chosen
-# list length or eval budget multiplies whole solves, so even under-cap
-# requests can pin the single vCPU indefinitely. Both limits sit far above
-# what the UI ever sends (41-point sweeps, ≤200 optimizer evals) and are only
-# enforced when hosted; local instances stay unlocked.
-_MAX_SWEEP_POINTS = _env_int("ANTENNAKNOBS_MAX_SWEEP_POINTS", 500)
-_MAX_OPT_EVALS = _env_int("ANTENNAKNOBS_MAX_OPT_EVALS", 500)
+# Caps live in the shared cost model (web/cost.py, issue #382) so admission
+# is one mapping for every job kind; re-exported here because tests and ops
+# docs address them as server._MAX_*.
+_MAX_BASIS = _cost.MAX_BASIS
+_MAX_BASIS_COMPRESSED = _cost.MAX_BASIS_COMPRESSED
+_MAX_BASIS_PYNEC = _cost.MAX_BASIS_PYNEC
+_COMPRESSED_MODELS = _cost.COMPRESSED_MODELS
+_MAX_SWEEP_POINTS = _cost.MAX_SWEEP_POINTS
+_MAX_OPT_EVALS = _cost.MAX_OPT_EVALS
 
 
 class SolveTooLargeError(ValueError):
     """A solve request exceeds the hosted live-engine segment-count cap."""
 
 
+def _admit(req: dict, *, kind: str, use_pynec: bool, points: int = 1):
+    """The shared cost-model verdict for this request (issue #382)."""
+    geometry = req.get("geometry", next(iter(EXAMPLES)))
+    return _cost.admit(
+        req,
+        kind=kind,
+        use_pynec=use_pynec,
+        hosted=_HOSTED,
+        example=EXAMPLES.get(geometry),
+        points=points,
+    )
+
+
 def _check_solve_size(req: dict, *, use_pynec: bool) -> None:
     """Reject a solve whose matrix would be too large for the hosted live engine.
 
     No-op unless running hosted (ANTENNAKNOBS_HOSTED) — local instances are
-    unlocked. Best-effort: counts segments via the geometry-only ``count_basis``
-    hook (cheap — no solve). If the count can't be determined (geometry won't
-    build), return and let the normal solve path surface the real error.
+    unlocked. Thin wrapper over the shared cost model's "refuse" verdict;
+    if the size can't be estimated (geometry won't build), the normal solve
+    path surfaces the real error.
     """
-    if not _HOSTED:
-        return
-    geometry = req.get("geometry", next(iter(EXAMPLES)))
-    ex = EXAMPLES.get(geometry)
-    if ex is None or ex.count_basis is None:
-        return
-    n = ex.count_basis(req)
-    if n is None:
-        return
-    if use_pynec:
-        cap, engine, compressed = _MAX_BASIS_PYNEC, "PyNEC", False
-    elif req.get("momwire_model") in _COMPRESSED_MODELS:
-        cap = _MAX_BASIS_COMPRESSED
-        engine, compressed = str(req.get("momwire_model")), True
-    else:
-        cap, engine, compressed = _MAX_BASIS, "momwire", False
-    if n > cap:
-        # Dense momwire and PyNEC both form the full N×N matrix; point users at
-        # the compressed engines (which don't) for big arrays.
-        hint = (
-            ""
-            if compressed
-            else " — or switch to the array-block / H-matrix engine, which "
-            "handles larger arrays without a dense matrix"
-        )
-        raise SolveTooLargeError(
-            f"This solve needs ~{n} wire segments, over the live {engine} "
-            f"limit of {cap}. Reduce 'segments / wire (N)' or pick a smaller "
-            f"design{hint}."
-        )
+    adm = _admit(req, kind="live", use_pynec=use_pynec)
+    if adm.verdict == "refuse":
+        raise SolveTooLargeError(adm.reason)
+
+
+def _refuse_or_withhold(adm, req: dict) -> None:
+    """Map a batch admission verdict to its HTTP error (no-op on "run").
+
+    "refuse" → 413 (too large for the hosted box, as before). "warn" → 403
+    unless the request carries ``_approved: true`` — the server-side backstop
+    for the frontend's "Solve anyway" gate: a batch of poor-match solves on a
+    benchmark mesh no longer relies on the client politely holding it back.
+    """
+    if adm.verdict == "refuse":
+        raise HTTPException(status_code=413, detail=adm.reason)
+    if adm.verdict == "warn" and not req.get("_approved"):
+        raise HTTPException(status_code=403, detail=adm.reason)
 
 
 # Request fields that are pure metadata and never change the physics. Pop
@@ -680,8 +679,40 @@ _CACHE_KEY_BLOCKLIST = frozenset(
         # not shred the cache hit rate (a scrub back to an earlier value should
         # still hit even though its _seq is higher).
         "_seq",
+        # Solve-lane metadata (issue #382): session identity, batch-request
+        # generation, and the "Solve anyway" approval flag. All scheduling,
+        # zero physics — a norm-check must hit the live solve's cache entry.
+        "_session",
+        "_gen",
+        "_approved",
     }
 )
+
+# Per-session solve lanes (issue #382): every solve-producing compute — the
+# live /ws solve, each /sweep chunk, each /converge point, /norm_check,
+# /pattern, /pattern_metrics — takes a turn on its session's lane, so no two
+# ever run concurrently for one client. /optimize stays outside for now: its
+# evals are cache-skipping and bounded by _MAX_OPT_EVALS, and one whole-run
+# turn would starve live solves — taking a turn per eval is the follow-up.
+_LANES = LaneRegistry()
+
+
+def _lane_key(req: dict) -> tuple[str | None, int | None]:
+    """(session, generation) for the solve lane, tolerating absent/junk values.
+
+    The session id is minted client-side (one per workbench tab); the
+    generation is the client's monotonic solve counter — `_seq` on live /ws
+    requests, `_gen` on batch POSTs (same counter, so a knob drag's live
+    solve supersedes the batches issued for the previous state).
+    """
+    session = req.get("_session")
+    if not isinstance(session, str) or not session:
+        session = None
+    gen = req.get("_gen", req.get("_seq"))
+    if isinstance(gen, bool) or not isinstance(gen, int):
+        gen = None
+    return session, gen
+
 
 # Quantisation grid for floats in the cache key. Slider grids in the UI
 # are coarser than 1e-6, so this still lets back-and-forth scrubs land on
@@ -776,19 +807,14 @@ async def sweep_endpoint(req: dict, request: Request):
     sweep_ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
     use_pynec = req.get("solver") == "pynec" and pynec_backend.HAVE_PYNEC
     solver_name = "pynec" if use_pynec else "momwire"
-    # Hosted size guard, same as the /ws and /converge paths: reject an
-    # over-cap matrix dimension BEFORE the stream starts, as a clean 413,
-    # instead of attempting the N×N allocation per sweep point.
-    try:
-        _check_solve_size(req, use_pynec=use_pynec)
-    except SolveTooLargeError as e:
-        raise HTTPException(status_code=413, detail=str(e)) from e
-    if _HOSTED and len(freqs) > _MAX_SWEEP_POINTS:
-        raise HTTPException(
-            status_code=413,
-            detail=f"A sweep of {len(freqs)} points is over the live limit "
-            f"of {_MAX_SWEEP_POINTS}. Reduce the frequency count.",
-        )
+    # Admission by cost (issue #382), before the stream starts: over-cap
+    # matrix or point count → clean 413 (as before); a dense-family batch on
+    # a benchmark-class mesh → 403 unless the request carries the client
+    # gate's "Solve anyway" approval.
+    _refuse_or_withhold(
+        _admit(req, kind="sweep", use_pynec=use_pynec, points=len(freqs)), req
+    )
+    session, lane_gen = _lane_key(req)
     # Validate the client's solver kwargs up front: this endpoint streams, so
     # an error surfacing mid-generator can't become a clean status code.
     # Imported here (like /optimize's optimizer import): adapter ↔ examples
@@ -815,27 +841,38 @@ async def sweep_endpoint(req: dict, request: Request):
             for f in freqs:
                 if await request.is_disconnected():
                     return
-                if is_multifeed:
-                    primary, feeds_z = await run_in_threadpool(
-                        pynec_backend._sweep_at_multifeed, req, f
-                    )
-                    record = {
-                        "freq_mhz": f,
-                        "z_re": float(primary.real),
-                        "z_im": float(primary.imag),
-                        "feeds_z_re": [float(z_.real) for z_ in feeds_z],
-                        "feeds_z_im": [float(z_.imag) for z_ in feeds_z],
-                        "solver": solver_name,
-                    }
-                else:
-                    z = await run_in_threadpool(pynec_backend._sweep_at, req, f)
-                    record = {
-                        "freq_mhz": f,
-                        "z_re": float(z.real),
-                        "z_im": float(z.imag),
-                        "solver": solver_name,
-                    }
+                try:
+                    # One lane turn per point: a queued live solve gets the
+                    # lane at the next point boundary. PyNEC has no mid-solve
+                    # abort, so a supersession trips the token but the point
+                    # runs out; the post-turn check stops the stream there.
+                    async with _LANES.turn(session, "sweep", lane_gen) as token:
+                        if is_multifeed:
+                            primary, feeds_z = await run_in_threadpool(
+                                pynec_backend._sweep_at_multifeed, req, f
+                            )
+                            record = {
+                                "freq_mhz": f,
+                                "z_re": float(primary.real),
+                                "z_im": float(primary.imag),
+                                "feeds_z_re": [float(z_.real) for z_ in feeds_z],
+                                "feeds_z_im": [float(z_.imag) for z_ in feeds_z],
+                                "solver": solver_name,
+                            }
+                        else:
+                            z = await run_in_threadpool(pynec_backend._sweep_at, req, f)
+                            record = {
+                                "freq_mhz": f,
+                                "z_re": float(z.real),
+                                "z_im": float(z.imag),
+                                "solver": solver_name,
+                            }
+                        superseded_mid_point = token.cancelled
+                except Superseded:
+                    return
                 yield json.dumps(record) + "\n"
+                if superseded_mid_point:
+                    return
         else:
             # momwire's batched sweep is ~10x faster per-call than per-point,
             # but a 5-band fan dipole sweep at n_per_wire=21, 41 freqs takes
@@ -863,7 +900,18 @@ async def sweep_endpoint(req: dict, request: Request):
                     return
                 chunk = freqs[start : start + chunk_size]
                 t0 = time.perf_counter()
-                sweep_result = await run_in_threadpool(sweep_fn, req, chunk)
+                try:
+                    # One lane turn per chunk; the token reaches the solver's
+                    # checkpoints, so a knob drag (newer generation) or a
+                    # dropped connection (the watcher) aborts THIS chunk in
+                    # ~ms instead of after minutes on a benchmark mesh.
+                    async with _LANES.turn(session, "sweep", lane_gen) as token:
+                        async with cancel_on_disconnect(request, token):
+                            sweep_result = await run_in_threadpool(
+                                sweep_fn, req, chunk, cancel=token
+                            )
+                except (Superseded, momwire.SolveAborted):
+                    return
                 # Multi-feed sweeps (bowtie array) return a 4-tuple with
                 # per-feed Z appended. Everything else stays on the
                 # original 2-tuple shape; the legacy z_re / z_im fields
@@ -899,7 +947,7 @@ async def sweep_endpoint(req: dict, request: Request):
     return StreamingResponse(gen(), media_type="application/x-ndjson")
 
 
-def _solve_z_only(req: dict) -> tuple[complex, list[complex] | None]:
+def _solve_z_only(req: dict, cancel=None) -> tuple[complex, list[complex] | None]:
     """Run the geometry-specific solver and return only the input impedance.
 
     Returns (primary_z, feeds_z) where feeds_z is the per-feed Z list for
@@ -910,10 +958,13 @@ def _solve_z_only(req: dict) -> tuple[complex, list[complex] | None]:
     geometry = req.get("geometry", next(iter(EXAMPLES)))
     use_pynec = req.get("solver") == "pynec" and pynec_backend.HAVE_PYNEC
     if use_pynec:
+        # Start-gate only: PyNEC's native solve has no mid-solve abort.
+        if cancel is not None:
+            cancel.raise_if_cancelled()
         res = pynec_backend.solve(req)
     else:
         ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
-        res = ex.momwire_solve(req)
+        res = ex.momwire_solve(req, cancel=cancel)
     primary = complex(res["z_in_re"], res["z_in_im"])
     feeds_list = res.get("feeds")
     feeds_z: list[complex] | None = (
@@ -946,12 +997,14 @@ async def converge_endpoint(req: dict, request: Request):
         ) from None
     use_pynec = req.get("solver") == "pynec" and pynec_backend.HAVE_PYNEC
     solver_name = "pynec" if use_pynec else "momwire"
-    if _HOSTED and len(n_values) > _MAX_SWEEP_POINTS:
-        raise HTTPException(
-            status_code=413,
-            detail=f"A convergence sweep of {len(n_values)} points is over "
-            f"the live limit of {_MAX_SWEEP_POINTS}. Reduce the N count.",
-        )
+    # Admission by cost (issue #382): point-count refuse (413) and the
+    # poor-match warn (403 without approval). The per-N matrix-size refuse
+    # stays inside the loop — est_basis moves with N.
+    _refuse_or_withhold(
+        _admit(req, kind="converge", use_pynec=use_pynec, points=len(n_values)),
+        req,
+    )
+    session, lane_gen = _lane_key(req)
 
     async def gen():
         for n in n_values:
@@ -963,7 +1016,14 @@ async def converge_endpoint(req: dict, request: Request):
                 # Reject N values past the size cap (the convergence sweep is
                 # exactly where someone pushes N high); surfaced per-N below.
                 _check_solve_size(req_n, use_pynec=use_pynec)
-                z, feeds_z = await run_in_threadpool(_solve_z_only, req_n)
+                # One lane turn per point (see /sweep).
+                async with _LANES.turn(session, "converge", lane_gen) as token:
+                    async with cancel_on_disconnect(request, token):
+                        z, feeds_z = await run_in_threadpool(
+                            _solve_z_only, req_n, cancel=token
+                        )
+            except (Superseded, momwire.SolveAborted):
+                return
             except Exception as e:
                 # One-off solver failures (e.g. degenerate geometry at very
                 # small N) or a size rejection shouldn't abort the whole sweep —
@@ -1011,10 +1071,17 @@ async def pattern_endpoint(req: dict):
         _check_solve_size(req, use_pynec=True)
     except SolveTooLargeError as e:
         return {"available": False, "error": str(e)}
-    return await run_in_threadpool(pynec_backend.pattern, req)
+    session, lane_gen = _lane_key(req)
+    try:
+        # PyNEC-only, so the token is a start gate: a queued pattern that a
+        # knob drag overtook dies here instead of grinding a stale solve.
+        async with _LANES.turn(session, "pattern", lane_gen):
+            return await run_in_threadpool(pynec_backend.pattern, req)
+    except Superseded:
+        return {"available": False}
 
 
-def _norm_check(req: dict) -> dict:
+def _norm_check(req: dict, cancel=None) -> dict:
     """Consistency check for the far-field normalisation, dwell-triggered.
 
     The live `directivity_norm` comes from the circuit side (η₀k²/8π·P_in);
@@ -1039,7 +1106,7 @@ def _norm_check(req: dict) -> dict:
     absorption; over PEC/free space it collapses to ~structural efficiency
     (times the solver's self-consistency gap, <0.05 dB on converged designs).
     """
-    out = solve(dict(req))
+    out = solve(dict(req), cancel=cancel)
     if "directivity_norm" not in out or out["directivity_norm"] <= 0:
         return {"available": False}
     ground_on = bool(out.get("ground", False))
@@ -1082,10 +1149,21 @@ def _norm_check(req: dict) -> dict:
 
 
 @app.post("/norm_check")
-async def norm_check_endpoint(req: dict):
+async def norm_check_endpoint(req: dict, request: Request):
     """Field-side vs circuit-side gain-norm consistency check for the
     far-field overlay (dwell-triggered). See `_norm_check`."""
-    return await run_in_threadpool(_norm_check, req)
+    use_pynec = req.get("solver") == "pynec" and pynec_backend.HAVE_PYNEC
+    _refuse_or_withhold(_admit(req, kind="norm_check", use_pynec=use_pynec), req)
+    session, lane_gen = _lane_key(req)
+    try:
+        # The common path is a cache hit on the settled live solve (the lane
+        # runs the live turn first, so the cache is warm by our turn); the
+        # miss path is a full solve, hence the turn + disconnect watcher.
+        async with _LANES.turn(session, "norm_check", lane_gen) as token:
+            async with cancel_on_disconnect(request, token):
+                return await run_in_threadpool(_norm_check, req, cancel=token)
+    except (Superseded, momwire.SolveAborted):
+        return {"available": False}
 
 
 @app.post("/export_nec")
@@ -1139,7 +1217,7 @@ async def params_source_endpoint(req: dict):
 
 
 @app.post("/pattern_metrics")
-async def pattern_metrics_endpoint(req: dict):
+async def pattern_metrics_endpoint(req: dict, request: Request):
     """Scalar far-field metrics for the current antenna, for the compare table.
 
     Reuses the same builder + momwire engine as the live solve, so the metrics
@@ -1157,8 +1235,19 @@ async def pattern_metrics_endpoint(req: dict):
         _check_solve_size(req, use_pynec=False)
     except SolveTooLargeError as e:
         return {"geometry": geometry, "error": str(e)}
+    # Lane turn with NO generation: compare-table rows describe *other*
+    # designs at their defaults, so a knob drag on the live design must not
+    # supersede them — they still serialize with everything else and stop
+    # when their client goes away.
+    session, _ = _lane_key(req)
     try:
-        metrics = await run_in_threadpool(ex.far_field_metrics, req)
+        async with _LANES.turn(session, "pattern_metrics") as token:
+            async with cancel_on_disconnect(request, token):
+                metrics = await run_in_threadpool(
+                    ex.far_field_metrics, req, cancel=token
+                )
+    except (Superseded, momwire.SolveAborted):
+        return {"geometry": geometry, "available": False}
     except Exception as exc:  # noqa: BLE001 — a user design's build_wires can raise
         return {"geometry": geometry, "error": user_designs.format_solve_error(exc)}
     return {"geometry": geometry, "available": True, "metrics": metrics}
@@ -1483,6 +1572,12 @@ async def ws_endpoint(ws: WebSocket):
                 token = current["token"]
                 if token is not None:
                     token.cancel()  # preempt the now-superseded in-flight solve
+                # Newer user state also preempts the session's OLDER batch
+                # work (a running sweep chunk, queued converge points) right
+                # now — the solver loop won't admit this request's turn until
+                # the lane frees, and waiting for that would leave a stale
+                # benchmark-mesh chunk grinding for minutes (issue #382).
+                _LANES.advance(*_lane_key(req))
                 newer.set()
         except WebSocketDisconnect:
             pass
@@ -1503,19 +1598,37 @@ async def ws_endpoint(ws: WebSocket):
             if not mailbox:
                 continue
             req = mailbox.pop()
-            # Publish the token BEFORE dispatch: a reader that fires in the gap
-            # cancels a not-yet-started solve, which then raises SolveAborted at
-            # its first checkpoint — no lost-wakeup window.
-            token = momwire.CancelToken()
-            current["token"] = token
+            session, lane_gen = _lane_key(req)
             try:
-                result = await run_in_threadpool(solve, req, cancel=token)
-            except momwire.SolveAborted:
-                # Superseded (or disconnected) mid-solve: a newer request already
-                # tripped our token. Send nothing — the superseding response will
-                # carry a higher _seq and the client renders monotonically. This
-                # catch MUST precede the generic handler, which would otherwise
-                # ship the abort to the client as a solve-error banner.
+                # The lane turn (issue #382) serializes this solve against the
+                # session's batch work — and outranks it, so at most one chunk
+                # stands between a knob drag and its heatmap. Entering with
+                # this request's generation cancels any older running batch
+                # chunk at its next solver checkpoint.
+                async with _LANES.turn(session, "live", lane_gen) as token:
+                    if closed.is_set():
+                        return
+                    if mailbox:
+                        # Superseded while we waited for the lane: solving this
+                        # request would be wasted work — loop for the newer one.
+                        continue
+                    # Publish the token BEFORE dispatch: a reader that fires in
+                    # the gap cancels a not-yet-started solve, which then raises
+                    # SolveAborted at its first checkpoint — no lost-wakeup
+                    # window. (While we *waited* for the lane there was no token
+                    # to trip; the mailbox check above covers that stretch.)
+                    current["token"] = token
+                    try:
+                        result = await run_in_threadpool(solve, req, cancel=token)
+                    finally:
+                        current["token"] = None
+            except (Superseded, momwire.SolveAborted):
+                # Superseded (or disconnected) mid-solve or mid-wait: a newer
+                # request already overtook this one. Send nothing — the
+                # superseding response will carry a higher _seq and the client
+                # renders monotonically. This catch MUST precede the generic
+                # handler, which would otherwise ship the abort to the client
+                # as a solve-error banner.
                 continue
             except Exception as exc:  # noqa: BLE001 — a user design's build_wires can raise
                 # A solve that raises must not tear down the socket (that drops
@@ -1525,8 +1638,6 @@ async def ws_endpoint(ws: WebSocket):
                     "geometry": req.get("geometry"),
                     "error": user_designs.format_solve_error(exc),
                 }
-            finally:
-                current["token"] = None
             # Echo the sequence number on EVERY response, error path included —
             # the client keys ordering, RTT accounting, and solving-state off it,
             # and a stuck request would leave `solving` true forever if any path

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -737,6 +737,32 @@ def _canonical_solve_key(req: dict) -> str:
     return hashlib.blake2b(blob, digest_size=16).hexdigest()
 
 
+def _shed(fn, *args, **kwargs):
+    """Threadpool shim for every solve-shaped dispatch: format the error
+    while the traceback still exists, then drop the frame chain before the
+    exception crosses the thread boundary.
+
+    An exception that propagates through anyio's worker threads is retained
+    (traceback, frames, and every array those frames reference) for the
+    life of the process — gc.collect() doesn't release it and neither does
+    reusing the pool. One failed benchmark-mesh solve pinned 5.9 GiB that
+    way in the #382 acceptance pass, after which even a 330 MB sinusoidal
+    solve couldn't allocate. Shedding the frames costs the debug traceback
+    in the server log; the user-facing message (which needs the traceback
+    for the user-design file hint) is pre-formatted here and carried on the
+    exception for format_solve_error to find.
+    """
+    try:
+        return fn(*args, **kwargs)
+    except BaseException as exc:
+        if not isinstance(exc, momwire.SolveAborted):
+            exc._formatted_solve_error = user_designs.format_solve_error(exc)
+        exc.__traceback__ = None
+        exc.__context__ = None
+        exc.__cause__ = None
+        raise exc
+
+
 def _solve_uncached(req: dict, cancel=None) -> dict:
     geometry = req.get("geometry", next(iter(EXAMPLES)))
     use_pynec = req.get("solver") == "pynec" and pynec_backend.HAVE_PYNEC
@@ -849,7 +875,7 @@ async def sweep_endpoint(req: dict, request: Request):
                     async with _LANES.turn(session, "sweep", lane_gen) as token:
                         if is_multifeed:
                             primary, feeds_z = await run_in_threadpool(
-                                pynec_backend._sweep_at_multifeed, req, f
+                                _shed, pynec_backend._sweep_at_multifeed, req, f
                             )
                             record = {
                                 "freq_mhz": f,
@@ -860,7 +886,9 @@ async def sweep_endpoint(req: dict, request: Request):
                                 "solver": solver_name,
                             }
                         else:
-                            z = await run_in_threadpool(pynec_backend._sweep_at, req, f)
+                            z = await run_in_threadpool(
+                                _shed, pynec_backend._sweep_at, req, f
+                            )
                             record = {
                                 "freq_mhz": f,
                                 "z_re": float(z.real),
@@ -919,7 +947,7 @@ async def sweep_endpoint(req: dict, request: Request):
                     async with _LANES.turn(session, "sweep", lane_gen) as token:
                         async with cancel_on_disconnect(request, token):
                             sweep_result = await run_in_threadpool(
-                                sweep_fn, req, chunk, cancel=token
+                                _shed, sweep_fn, req, chunk, cancel=token
                             )
                 except (Superseded, momwire.SolveAborted):
                     return
@@ -1045,7 +1073,7 @@ async def converge_endpoint(req: dict, request: Request):
                 async with _LANES.turn(session, "converge", lane_gen) as token:
                     async with cancel_on_disconnect(request, token):
                         z, feeds_z = await run_in_threadpool(
-                            _solve_z_only, req_n, cancel=token
+                            _shed, _solve_z_only, req_n, cancel=token
                         )
             except (Superseded, momwire.SolveAborted):
                 return
@@ -1101,7 +1129,7 @@ async def pattern_endpoint(req: dict):
         # PyNEC-only, so the token is a start gate: a queued pattern that a
         # knob drag overtook dies here instead of grinding a stale solve.
         async with _LANES.turn(session, "pattern", lane_gen):
-            return await run_in_threadpool(pynec_backend.pattern, req)
+            return await run_in_threadpool(_shed, pynec_backend.pattern, req)
     except Superseded:
         return {"available": False}
 
@@ -1186,7 +1214,7 @@ async def norm_check_endpoint(req: dict, request: Request):
         # miss path is a full solve, hence the turn + disconnect watcher.
         async with _LANES.turn(session, "norm_check", lane_gen) as token:
             async with cancel_on_disconnect(request, token):
-                return await run_in_threadpool(_norm_check, req, cancel=token)
+                return await run_in_threadpool(_shed, _norm_check, req, cancel=token)
     except (Superseded, momwire.SolveAborted):
         return {"available": False}
     except Exception as exc:  # noqa: BLE001 — the miss path is a full solve
@@ -1275,7 +1303,7 @@ async def pattern_metrics_endpoint(req: dict, request: Request):
         async with _LANES.turn(session, "pattern_metrics") as token:
             async with cancel_on_disconnect(request, token):
                 metrics = await run_in_threadpool(
-                    ex.far_field_metrics, req, cancel=token
+                    _shed, ex.far_field_metrics, req, cancel=token
                 )
     except (Superseded, momwire.SolveAborted):
         return {"geometry": geometry, "available": False}
@@ -1359,6 +1387,7 @@ async def optimize_endpoint(req: dict):
         return {"geometry": geometry, "error": str(e)}
     try:
         result = await run_in_threadpool(
+            _shed,
             _optimize,
             base,
             free,
@@ -1650,7 +1679,9 @@ async def ws_endpoint(ws: WebSocket):
                     # to trip; the mailbox check above covers that stretch.)
                     current["token"] = token
                     try:
-                        result = await run_in_threadpool(solve, req, cancel=token)
+                        result = await run_in_threadpool(
+                            _shed, solve, req, cancel=token
+                        )
                     finally:
                         current["token"] = None
             except (Superseded, momwire.SolveAborted):

--- a/src/antennaknobs/web/user_designs.py
+++ b/src/antennaknobs/web/user_designs.py
@@ -75,7 +75,14 @@ def format_solve_error(exc: BaseException) -> str:
     error surfaces here rather than in the load panel. Point at the deepest
     frame inside a user-design folder when the failure came from someone's own
     file (the common case); otherwise fall back to just type + message.
+
+    Exceptions that crossed the threadpool have had their frame chain shed
+    (see server._shed — a fat traceback pins the solver's arrays in the
+    worker thread for good) and carry the message pre-formatted instead.
     """
+    pre = getattr(exc, "_formatted_solve_error", None)
+    if pre is not None:
+        return pre
     tb = traceback.extract_tb(exc.__traceback__)
     dirs: list[str] = []
     for d in user_design_dirs():

--- a/tests/test_solve_lane.py
+++ b/tests/test_solve_lane.py
@@ -1,0 +1,558 @@
+"""Single-lane solve scheduler (issue #382): lane, cost model, endpoints.
+
+Lane semantics are tested event-driven on a private event loop (no solver,
+no sleeps); the endpoint tests run the real FastAPI app against a fake
+instant "example" so the whole file stays far under the time budget.
+
+Concurrent-request tests drive the ASGI app in-loop (httpx2 AsyncClient +
+ASGITransport, concurrent tasks in one event loop) — the same shape uvicorn
+gives every request in production. They deliberately avoid TestClient for
+concurrency: its cross-thread blocking portal deadlocks when two streaming
+responses contend (one portal task vanishes without resolving its caller's
+future) — a test-harness artifact, not server behavior. TestClient stays
+for the plain sequential cases.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from types import SimpleNamespace
+
+import httpx2
+import momwire
+import pytest
+from fastapi.testclient import TestClient
+
+from antennaknobs.web import cost, server
+from antennaknobs.web.lane import (
+    LaneRegistry,
+    SolveLane,
+    Superseded,
+    cancel_on_disconnect,
+)
+
+# ---------------------------------------------------------------------------
+# SolveLane semantics
+# ---------------------------------------------------------------------------
+
+
+class FakeToken:
+    def __init__(self) -> None:
+        self.cancelled = False
+
+    def cancel(self) -> None:
+        self.cancelled = True
+
+    def raise_if_cancelled(self) -> None:
+        if self.cancelled:
+            raise momwire.SolveAborted()
+
+
+def _lane() -> SolveLane:
+    return SolveLane(token_factory=FakeToken)
+
+
+def test_lane_never_grants_two_turns_at_once():
+    async def main():
+        lane = _lane()
+        active = 0
+        peak = 0
+
+        async def job(kind, gen):
+            nonlocal active, peak
+            async with lane.turn(kind, gen):
+                active += 1
+                peak = max(peak, active)
+                await asyncio.sleep(0)  # yield while "computing"
+                await asyncio.sleep(0)
+                active -= 1
+
+        await asyncio.gather(
+            job("sweep", 1),
+            job("converge", 1),
+            job("norm_check", 1),
+            job("live", 1),
+            job("sweep", 2),
+            return_exceptions=True,  # some are superseded — irrelevant here
+        )
+        assert peak == 1
+        assert lane.idle
+
+    asyncio.run(main())
+
+
+def test_live_outranks_queued_batches():
+    async def main():
+        lane = _lane()
+        order: list[str] = []
+        release = asyncio.Event()
+
+        async def holder():
+            async with lane.turn("pattern_metrics"):
+                await release.wait()
+
+        async def job(kind):
+            async with lane.turn(kind):
+                order.append(kind)
+
+        h = asyncio.create_task(holder())
+        await asyncio.sleep(0)  # holder takes the lane
+        jobs = [
+            asyncio.create_task(job("sweep")),
+            asyncio.create_task(job("converge")),
+            asyncio.create_task(job("live")),
+            asyncio.create_task(job("norm_check")),
+        ]
+        await asyncio.sleep(0)  # everyone queues
+        release.set()
+        await asyncio.gather(h, *jobs)
+        assert order[0] == "live"
+        assert order[1] == "norm_check"
+        assert set(order[2:]) == {"sweep", "converge"}
+
+    asyncio.run(main())
+
+
+def test_newer_generation_cancels_the_running_turn():
+    async def main():
+        lane = _lane()
+        preempted = asyncio.Event()
+        seen: dict = {}
+
+        async def old_batch():
+            async with lane.turn("sweep", 5) as token:
+                seen["token"] = token
+                await preempted.wait()
+
+        t = asyncio.create_task(old_batch())
+        await asyncio.sleep(0)
+        assert seen["token"].cancelled is False
+
+        async def newer_live():
+            async with lane.turn("live", 6):
+                pass
+
+        live = asyncio.create_task(newer_live())
+        await asyncio.sleep(0)
+        # The knob drag preempts the running chunk right away…
+        assert seen["token"].cancelled is True
+        preempted.set()  # …and the solver would raise SolveAborted about now
+        await asyncio.gather(t, live)
+
+    asyncio.run(main())
+
+
+def test_newer_generation_supersedes_queued_and_stale_arrivals():
+    async def main():
+        lane = _lane()
+        release = asyncio.Event()
+
+        async def holder():
+            async with lane.turn("live", 5):
+                await release.wait()
+
+        h = asyncio.create_task(holder())
+        await asyncio.sleep(0)
+
+        async def queued_old_batch():
+            async with lane.turn("sweep", 5):
+                pass
+
+        q = asyncio.create_task(queued_old_batch())
+        await asyncio.sleep(0)
+
+        async def newer_live():
+            async with lane.turn("live", 7):
+                pass
+
+        n = asyncio.create_task(newer_live())
+        await asyncio.sleep(0)
+        release.set()
+        results = await asyncio.gather(q, n, return_exceptions=True)
+        assert isinstance(results[0], Superseded)  # queued gen-5 batch died
+        assert results[1] is None
+        # A gen older than the lane's is stale on arrival.
+        with pytest.raises(Superseded):
+            async with lane.turn("sweep", 3):
+                pass
+        await h
+
+    asyncio.run(main())
+
+
+def test_same_kind_supersedes_but_pattern_metrics_coexists():
+    async def main():
+        lane = _lane()
+        release = asyncio.Event()
+
+        async def holder():
+            async with lane.turn("live"):
+                await release.wait()
+
+        h = asyncio.create_task(holder())
+        await asyncio.sleep(0)
+
+        async def queued(kind):
+            async with lane.turn(kind):
+                pass
+
+        old_sweep = asyncio.create_task(queued("sweep"))
+        pm1 = asyncio.create_task(queued("pattern_metrics"))
+        pm2 = asyncio.create_task(queued("pattern_metrics"))
+        await asyncio.sleep(0)
+        new_sweep = asyncio.create_task(queued("sweep"))
+        await asyncio.sleep(0)
+        release.set()
+        results = await asyncio.gather(
+            old_sweep, pm1, pm2, new_sweep, return_exceptions=True
+        )
+        assert isinstance(results[0], Superseded)  # re-issued sweep wins
+        assert results[1] is None  # compare-table rows are all legitimate
+        assert results[2] is None
+        assert results[3] is None
+        await h
+
+    asyncio.run(main())
+
+
+def test_advance_preempts_without_taking_a_turn():
+    async def main():
+        registry = LaneRegistry(token_factory=FakeToken)
+        preempted = asyncio.Event()
+        seen: dict = {}
+
+        async def old_chunk():
+            async with registry.turn("tab-1", "sweep", 5) as token:
+                seen["token"] = token
+                await preempted.wait()
+
+        t = asyncio.create_task(old_chunk())
+        await asyncio.sleep(0)
+        # The /ws reader path: newer intent lands, no turn is taken yet.
+        registry.advance("tab-1", 6)
+        assert seen["token"].cancelled is True
+        registry.advance("ghost-session", 9)  # unknown session: no-op
+        preempted.set()
+        await t
+
+    asyncio.run(main())
+
+
+def test_registry_isolates_sessions_and_reaps_idle_lanes():
+    async def main():
+        registry = LaneRegistry(token_factory=FakeToken)
+        both = asyncio.Barrier(2)
+
+        async def job(session):
+            async with registry.turn(session, "sweep"):
+                # Different sessions (and sessionless requests) may compute
+                # concurrently — reaching the barrier proves no shared lane.
+                await asyncio.wait_for(both.wait(), timeout=1)
+
+        await asyncio.gather(job("tab-1"), job("tab-2"))
+        assert len(registry) == 0  # idle lanes reaped on turn exit
+        await asyncio.gather(job(None), job(None))
+        assert len(registry) == 0
+
+    asyncio.run(main())
+
+
+def test_cancel_on_disconnect_trips_the_token():
+    async def main():
+        token = FakeToken()
+        gone = False
+
+        async def is_disconnected():
+            return gone
+
+        request = SimpleNamespace(is_disconnected=is_disconnected)
+        async with cancel_on_disconnect(request, token, interval=0.005):
+            assert token.cancelled is False
+            gone = True
+            await asyncio.sleep(0.03)
+            assert token.cancelled is True
+
+    asyncio.run(main())
+
+
+# ---------------------------------------------------------------------------
+# Cost model: the run/warn/refuse mapping
+# ---------------------------------------------------------------------------
+
+
+def _example(n_basis):
+    return SimpleNamespace(count_basis=lambda req: n_basis)
+
+
+@pytest.mark.parametrize(
+    ("req", "kw", "verdict"),
+    [
+        # Local instances are unlocked: no refuse, whatever the size.
+        ({}, dict(hosted=False, example=_example(10**6)), "warn"),
+        # Hosted matrix caps, per engine class.
+        ({}, dict(hosted=True, example=_example(cost.MAX_BASIS + 1)), "refuse"),
+        (
+            {"momwire_model": "hmatrix"},
+            dict(hosted=True, example=_example(cost.MAX_BASIS + 1)),
+            "warn",  # compressed engines get cap headroom, but a b-spline-
+            # family solver on a benchmark mesh is still a poor match
+        ),
+        (
+            {"momwire_model": "hmatrix"},
+            dict(hosted=True, example=_example(cost.MAX_BASIS_COMPRESSED + 1)),
+            "refuse",  # …but not unlimited
+        ),
+        (
+            {},
+            dict(
+                hosted=True, use_pynec=True, example=_example(cost.MAX_BASIS_PYNEC + 1)
+            ),
+            "refuse",
+        ),
+        # Batch size multiplies cost: hosted point cap, any kind.
+        (
+            {},
+            dict(hosted=True, example=_example(100), points=cost.MAX_SWEEP_POINTS + 1),
+            "refuse",
+        ),
+        # Poor-match combo on a benchmark mesh: warn — dense b-spline family…
+        ({}, dict(hosted=False, example=_example(cost.WARN_MIN_BASIS + 1)), "warn"),
+        (
+            {"momwire_model": "arrayblock"},
+            dict(hosted=False, example=_example(cost.WARN_MIN_BASIS + 1)),
+            "warn",
+        ),
+        # …but sinusoidal and PyNEC are the recommended combos: run.
+        (
+            {"momwire_model": "sinusoidal"},
+            dict(hosted=False, example=_example(cost.WARN_MIN_BASIS + 1)),
+            "run",
+        ),
+        (
+            {},
+            dict(
+                hosted=False, use_pynec=True, example=_example(cost.WARN_MIN_BASIS + 1)
+            ),
+            "run",
+        ),
+        # Small mesh: run; unknown size: run (the solve surfaces real errors).
+        ({}, dict(hosted=True, example=_example(100)), "run"),
+        ({}, dict(hosted=True, example=None), "run"),
+        ({}, dict(hosted=True, example=_example(None)), "run"),
+    ],
+)
+def test_admission_mapping(req, kw, verdict):
+    kw.setdefault("use_pynec", False)
+    kw.setdefault("kind", "sweep")
+    assert cost.admit(req, **kw).verdict == verdict
+
+
+def test_admission_reasons_name_the_lever():
+    over = cost.admit(
+        {}, kind="live", use_pynec=False, hosted=True, example=_example(10**5)
+    )
+    assert "segments / wire" in over.reason
+    warned = cost.admit(
+        {}, kind="sweep", use_pynec=False, hosted=False, example=_example(5000)
+    )
+    assert "Sinusoidal" in warned.reason and warned.est_basis == 5000
+
+
+# ---------------------------------------------------------------------------
+# Endpoints: the lane + admission wired into the real app
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(server.app)
+
+
+class _Meter:
+    """Concurrency meter shared by the fake compute functions."""
+
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.active = 0
+        self.peak = 0
+
+    def __enter__(self):
+        with self.lock:
+            self.active += 1
+            self.peak = max(self.peak, self.active)
+        return self
+
+    def __exit__(self, *exc):
+        with self.lock:
+            self.active -= 1
+
+
+def _fake_example(meter: _Meter, n_basis: int = 100, dwell_s: float = 0.02):
+    """A minimal stand-in for an AntennaExample: instant fake physics with a
+    concurrency meter, honouring the cancel token like momwire does."""
+
+    def momwire_sweep(req, freqs, cancel=None):
+        with meter:
+            time.sleep(dwell_s)
+        if cancel is not None:
+            cancel.raise_if_cancelled()
+        return [50.0] * len(freqs), [0.0] * len(freqs)
+
+    def momwire_solve(req, cancel=None):
+        with meter:
+            time.sleep(dwell_s)
+        if cancel is not None:
+            cancel.raise_if_cancelled()
+        return {"z_in_re": 50.0, "z_in_im": 0.0}
+
+    return SimpleNamespace(
+        multi_feed=False,
+        count_basis=lambda req: n_basis,
+        momwire_sweep=momwire_sweep,
+        momwire_solve=momwire_solve,
+    )
+
+
+def _sweep_lines(resp):
+    return [line for line in resp.text.splitlines() if line.strip()]
+
+
+def _gather_posts(*payloads):
+    """POST all payloads concurrently against the app, in one event loop."""
+
+    async def main():
+        transport = httpx2.ASGITransport(app=server.app)
+        async with httpx2.AsyncClient(
+            transport=transport, base_url="http://lane-test"
+        ) as c:
+            return await asyncio.wait_for(
+                asyncio.gather(*(c.post(path, json=body) for path, body in payloads)),
+                timeout=20,
+            )
+
+    return asyncio.run(main())
+
+
+def test_one_session_never_computes_twice_at_once(monkeypatch):
+    meter = _Meter()
+    monkeypatch.setitem(server.EXAMPLES, "fake.lane", _fake_example(meter))
+    sweep, conv = _gather_posts(
+        (
+            "/sweep",
+            {
+                "geometry": "fake.lane",
+                "_session": "tab-A",
+                "freqs_mhz": [14.0, 14.1, 14.2, 14.3],
+            },
+        ),
+        (
+            "/converge",
+            {"geometry": "fake.lane", "_session": "tab-A", "n_values": [5, 7, 9]},
+        ),
+    )
+    assert sweep.status_code == 200
+    assert conv.status_code == 200
+    # 4 sweep points + 3 converge points all computed…
+    assert len(_sweep_lines(sweep)) == 4 + 1  # + done record
+    assert len(_sweep_lines(conv)) == 3 + 1
+    # …and never two at once: the whole point of the lane.
+    assert meter.peak == 1
+
+
+def test_two_sessions_may_compute_concurrently(monkeypatch):
+    # The inverse guard: the lane must serialize per session, not globally.
+    meter = _Meter()
+    monkeypatch.setitem(
+        server.EXAMPLES, "fake.lane", _fake_example(meter, dwell_s=0.05)
+    )
+    a, b = _gather_posts(
+        (
+            "/sweep",
+            {"geometry": "fake.lane", "_session": "tab-A", "freqs_mhz": [14.0, 14.1]},
+        ),
+        (
+            "/sweep",
+            {"geometry": "fake.lane", "_session": "tab-B", "freqs_mhz": [14.0, 14.1]},
+        ),
+    )
+    assert a.status_code == 200
+    assert b.status_code == 200
+    assert meter.peak == 2
+
+
+def test_warned_batch_needs_approval(client, monkeypatch):
+    meter = _Meter()
+    monkeypatch.setitem(
+        server.EXAMPLES,
+        "fake.big",
+        _fake_example(meter, n_basis=cost.WARN_MIN_BASIS + 1, dwell_s=0.0),
+    )
+    body = {"geometry": "fake.big", "freqs_mhz": [14.0]}
+    refused = client.post("/sweep", json=body)
+    assert refused.status_code == 403
+    assert "Sinusoidal" in refused.json()["detail"]
+    approved = client.post("/sweep", json={**body, "_approved": True})
+    assert approved.status_code == 200
+    # The recommended combo runs without any approval.
+    fine = client.post("/sweep", json={**body, "momwire_model": "sinusoidal"})
+    assert fine.status_code == 200
+
+
+def test_newer_generation_supersedes_a_streaming_sweep(monkeypatch):
+    # An old-generation sweep (client state the user has since changed) is cut
+    # off as soon as a newer-generation request enters the same session's lane.
+    meter = _Meter()
+    first_point_done = threading.Event()
+
+    fake = _fake_example(meter, dwell_s=0.0)
+    inner_sweep = fake.momwire_sweep
+
+    def gated_sweep(req, freqs, cancel=None):
+        if req.get("_gen") == 5 and first_point_done.is_set():
+            # The old stream's SECOND point: sit in the "compute" until the
+            # newer-generation request preempts us via the cancel token (the
+            # lane trips it the moment gen 6 is admitted) — deterministic,
+            # and exactly how a long momwire chunk experiences supersession.
+            deadline = time.time() + 5
+            while cancel is not None and not cancel.cancelled:
+                if time.time() > deadline:
+                    raise AssertionError("never preempted by the newer request")
+                time.sleep(0.005)
+            cancel.raise_if_cancelled()
+        out = inner_sweep(req, freqs, cancel=cancel)
+        if req.get("_gen") == 5:
+            first_point_done.set()
+        return out
+
+    fake.momwire_sweep = gated_sweep
+    monkeypatch.setitem(server.EXAMPLES, "fake.gen", fake)
+
+    old_body = {
+        "geometry": "fake.gen",
+        "_session": "tab-G",
+        "_gen": 5,
+        "freqs_mhz": [14.0, 14.1, 14.2, 14.3],
+    }
+    new_body = {**old_body, "_gen": 6, "freqs_mhz": [14.0]}
+
+    async def main():
+        transport = httpx2.ASGITransport(app=server.app)
+        async with httpx2.AsyncClient(
+            transport=transport, base_url="http://lane-test"
+        ) as c:
+            old_task = asyncio.create_task(c.post("/sweep", json=old_body))
+            # Wait (off-loop event, set by the threadpool fake) until the old
+            # stream's first point has computed and its second is gated.
+            await asyncio.wait_for(asyncio.to_thread(first_point_done.wait), 5)
+            new_resp = await c.post("/sweep", json=new_body)
+            old_resp = await asyncio.wait_for(old_task, 10)
+            return old_resp, new_resp
+
+    old_resp, new_resp = asyncio.run(asyncio.wait_for(main(), timeout=20))
+    assert new_resp.status_code == 200
+    assert len(_sweep_lines(new_resp)) == 1 + 1
+    # The gen-5 stream ended early: its remaining points were never solved.
+    assert old_resp.status_code == 200
+    assert len(_sweep_lines(old_resp)) < 4 + 1


### PR DESCRIPTION
## Summary
- **`web/lane.py` — SolveLane**: a priority-ordered, generation-aware turnstile, one per client session. Every solve-producing compute (live `/ws` solve, each `/sweep` chunk, each `/converge` point, `/norm_check`, `/pattern`, `/pattern_metrics`) takes a turn, so no two ever run concurrently for one session — enforced structurally on the server instead of by cooperating client heuristics. Live outranks norm-check/pattern outranks sweep/converge; batches acquire the lane per chunk/point, so a knob drag waits one chunk boundary at most.
- **Latest intent wins, and cancel means stop computing**: the client's monotonic `_seq` counter doubles as the batch `_gen`; a newer generation supersedes queued turns (they end their streams) and trips the running turn's CancelToken, which now reaches every batch solver (`momwire_sweep`, `_solve_z_only`, `_norm_check`, `far_field_metrics` grew `cancel=`). The `/ws` reader `advance()`s the lane the moment a newer message lands, so a running benchmark-mesh chunk aborts at its next solver checkpoint (~ms) instead of grinding for minutes. `cancel_on_disconnect` watches `request.is_disconnected()` *during* a chunk — an abandoned tab stops the burn mid-chunk, closing the elt_whip memory/CPU accumulation path.
- **`web/cost.py` — one admission mapping** (`run | warn | refuse`) consolidating the hosted matrix caps, hosted point caps, and the poor-match combo condition behind the frontend's withhold gate. Warned batches are now enforced server-side: 403 unless the request carries `_approved: true` (set exactly when the user clicks "Solve anyway") — the server no longer trusts the client to hold batches back.
- **Client declares intent instead of guessing at timing**: every request carries a per-tab `_session` UUID; `runSweep`/`runConverge`/`runNormCheck` lose their 200 ms `solvePending()`/`solveWithheld()` re-poll loops (`solvePending()` deleted) — they fire after their debounce and the lane orders them behind the live solve, which also keeps norm-check landing on the live solve's cache entry. The withhold gate became plain state (`comboApproved`), so approval re-fires the batch effects.
- Out of scope, noted in the design doc (`docs/status/2026-07-15-single-lane-scheduler-design.md`): `/optimize` stays outside the lane (bounded by `_MAX_OPT_EVALS`; per-eval turns are the follow-up), `/geometry` previews stay lane-free (no matrix work).

## Test plan
- [x] `tests/test_solve_lane.py` (26 tests, ~1.2 s): lane grant/priority/supersession/`advance` semantics, the run/warn/refuse admission table, and endpoint-level checks — one session never computes twice at once (concurrency meter peak == 1), two sessions may (peak == 2), warned batches 403 without `_approved`, a newer-generation request cuts off an in-flight older sweep stream. Concurrency tests drive the ASGI app in-loop (httpx2 ASGITransport + `asyncio.gather`, the shape uvicorn gives requests in production; TestClient's cross-thread portal deadlocks on contending streaming responses — harness artifact, documented in the module docstring).
- [x] Full fast suite: 2133 passed.
- [x] Live uvicorn verification: three concurrent same-session batch endpoints complete serialized; `/ws` burst of three knob states squashes to one solve (latest-wins through the lane) with correct `_seq` ack.
- [x] Manual workbench pass on `verticals.elt_whip` under `ulimit -v 8G` (live Chrome via the Vite dev proxy): knob drags during sweeps behave; abandoned tab stops all compute within one solver checkpoint and RSS returns to baseline (337 MB) with no residue.

## Found & fixed during the acceptance pass
- **Process-lifetime leak on failed solves** (pre-existing, every release): an exception crossing `run_in_threadpool` is retained by anyio's worker-thread machinery — traceback, frames, and every array those frames reference — surviving `gc.collect()` and pool reuse. One failed whip B-spline solve pinned 5.9 GiB, after which the whip's legitimate 330 MB sinusoidal matrix could not allocate. Every solve-shaped dispatch now goes through `_shed()`: the user-facing message is formatted while the traceback exists (it rides on the exception for `format_solve_error`), then the frame chain is dropped before the raise crosses threads. Measured: failed attempt retains ~35 MB, follow-up solves succeed.
- **`/norm_check` 500 on solver failure** — it was the only solve endpoint with no generic handler; now returns `{available: false, error}`. `/sweep` similarly ends its NDJSON stream with an `{error}` record instead of tearing the connection down; the client keeps whatever points landed.
- **Vite dev proxy never propagated client aborts**: closing a tab mid-sweep left zombie upstream sockets, so `request.is_disconnected()` stayed false and benchmark sweeps kept burning against a dead client. The proxy now destroys the upstream request on downstream close (dev-only; production serves the SPA from uvicorn directly). Verified with a mid-stream abort through :5173 — compute stops at the next checkpoint (~8 s on the whip).

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)
