### PR TITLE
Release v0.29.0 — one solver at a time

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.28.0"
+version = "0.29.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,19 +25,19 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.28.0" icon="star">
-  **Every wire can now be its own wire.** Real antennas mix conductors — a
-  fat tubing element with thin radials, a copper radiator on a steel
-  whip — and per-wire `WireSpec`s let a design (or an
-  [imported NEC deck](/reference/nec-import/)) give each wire its own
-  radius, conductivity, and insulation instead of one whole-antenna
-  compromise. The bundled momwire 0.13.0 honors mixed radii across **all
-  four solver bases**, validated against NEC-2 to a fraction of an ohm on
-  a 4,392-segment mixed-radius whip benchmark. NEC imports got smarter
-  too: `LD`/`TL`/`NT` cards translate into the design's matching network,
-  wires shatter cleanly where other wires tap into them mid-span, and
-  anything skipped is stated right in the workbench. Plus: zoom, pan, and
-  an isometric view in the antenna viewer.
+<Card title="New in v0.29.0" icon="star">
+  **One solver at a time.** The workbench now schedules every computation a
+  tab asks for — the live solve, frequency sweeps, convergence ladders,
+  pattern checks — through a single per-session lane on the server, live
+  solve first. Dragging a knob instantly preempts stale background work at
+  the solver's next checkpoint instead of competing with it for cores, so
+  benchmark-sized designs (try the 4,400-segment
+  [ELT whip](/reference/catalog/)) stay responsive while their sweeps grind.
+  Closing the tab now stops the computation, a solve that fails no longer
+  pins its memory for the life of the server, and one cost model decides
+  up front what's safe to run. Under the hood it's four invariants replacing
+  a pile of client-side timing heuristics — the workbench just feels
+  steadier under heavy designs.
   [All release notes →](/reference/releases/)
 </Card>
 

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -163,6 +163,22 @@ instance: a local install is **unlocked** (solve as big as your own machine
 allows, sweep as long as you like). See `docs/deploy.md`.
 :::
 
+### One solve at a time
+
+Everything a workbench tab computes — the live solve, the frequency sweep,
+the convergence ladder, the norm check, the NEC pattern — runs through a
+single **per-session solve lane** on the server, one computation at a time,
+with the live solve always first in line. You'll notice it as steadiness on
+heavy designs: background sweeps never compete with the solve that's drawing
+the heatmap, and a knob turn preempts stale background work at the solver's
+next internal checkpoint (milliseconds to one sweep point, not the rest of
+the batch). Abandoning the tab mid-sweep stops the computation the same way.
+
+When the selected solver is a **poor match** for the design (a dense engine
+on a benchmark-class mesh), the workbench warns and withholds the solve; the
+server holds background batches to the same answer, so a sweep of
+minutes-per-point solves only runs once you've clicked **Solve anyway**.
+
 ## The ground plane
 
 Real antennas hang over real ground, so the workbench starts there: the


### PR DESCRIPTION
## Summary
- Bump version to 0.29.0 — the single-lane solve scheduler release (PR #400, closes the #382 arc): per-session solve lane, latest-intent-wins preemption, cancellation that reaches solver checkpoints, one cost model for admission, plus the three acceptance-pass fixes (threadpool exception-retention leak, /norm_check 500s, Vite proxy abort propagation).
- Refresh the what's-new card on the site front page.
- New "One solve at a time" section in the workbench docs (reference/web.md) covering the lane behavior and the server-enforced poor-match gate.
- momwire pin unchanged (0.13.0).

## Test plan
- [x] Site builds clean (20 pages).
- [x] Full fast suite green on the feature PR; main CI green post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)