### PR TITLE
Verify Fly fleet convergence after every deploy

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -59,6 +59,16 @@ Merge with `/merge-pr` (rebase, CI green first).
 3. Verify: PyPI serves X.Y.Z
    (`curl -s https://pypi.org/pypi/antennaknobs/json | python3 -c "import json,sys; print(json.load(sys.stdin)['info']['version'])"`)
    and `gh release view vX.Y.Z` lists the expected PRs.
+4. Both deploy workflows end with a **Verify fleet convergence** step
+   (issue #403): every Fly machine must actually be running the image just
+   released — flyd can silently revert a machine seconds after a "healthy"
+   deploy, leaving the edge serving two app versions (this shipped three
+   green-but-skewed releases before it was caught). If that step fails,
+   the named machine is stuck on an old image: replace it
+   (`flyctl machine clone <good-id> -a <app>` then
+   `flyctl machine destroy <stuck-id> -a <app> --force`) and re-run the
+   workflow. `scripts/verify_fly_fleet.sh <app> <url>` runs the same check
+   from a dev box.
 
 ## Announce
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -43,3 +43,11 @@ jobs:
         run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DOCS }}
+
+      # Same convergence check as the simulator deploy (issue #403): a machine
+      # can silently revert to its old image after a "successful" deploy.
+      - name: Verify fleet convergence
+        if: steps.token.outputs.skip != 'true'
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DOCS }}
+        run: scripts/verify_fly_fleet.sh antennaknobs-docs https://antennaknobs.dev

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -67,3 +67,13 @@ jobs:
           done
           echo "::error::flyctl deploy failed after 3 attempts"
           exit 1
+
+      # A green deploy does not prove the fleet converged: flyd can revert a
+      # machine's update seconds after flyctl declares it healthy, leaving the
+      # edge load-balancing between app versions (issue #403 — it took three
+      # "successful" releases to notice). Verify what is actually running.
+      - name: Verify fleet convergence
+        if: steps.token.outputs.skip != 'true'
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_SIMULATOR }}
+        run: scripts/verify_fly_fleet.sh antennaknobs https://app.antennaknobs.dev

--- a/scripts/verify_fly_fleet.sh
+++ b/scripts/verify_fly_fleet.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Post-deploy fleet-convergence check for a Fly app (issue #403).
+#
+# A green `flyctl deploy` does NOT prove the fleet converged: flyd can revert
+# a machine's update several seconds AFTER flyctl declares it healthy (the
+# revert restores the old image, whose app also passes health checks). One
+# machine of the simulator pair silently rejected every deploy for three
+# releases this way — the edge then load-balanced users between two app
+# versions, and a page could even fetch new index.html from one machine and
+# 404 its hashed asset on the other.
+#
+# Usage: verify_fly_fleet.sh <fly-app-name> <public-base-url>
+# Needs: flyctl (authed via FLY_API_TOKEN), jq, curl.
+# FLEET_SETTLE_SECONDS overrides the post-deploy settle wait (default 30).
+set -euo pipefail
+
+app=$1
+url=${2%/}
+
+# Let any pending flyd revert land before we look (observed ~6-10 s after
+# "Machine ... is now in a good state").
+sleep "${FLEET_SETTLE_SECONDS:-30}"
+
+want=$(flyctl releases -a "$app" --json | jq -r '.[0].ImageRef')
+tag=${want##*:}
+machines=$(flyctl machines list -a "$app" --json)
+
+echo "release image: $want"
+jq -r '.[] | "machine \(.id) state=\(.state) image=\(.image_ref.tag)"' <<<"$machines"
+
+# .image_ref is the image the machine is ACTUALLY running (post-revert it
+# differs from .config.image, which only records what the update requested).
+if ! jq -e --arg tag "$tag" 'length > 0 and all(.[]; .image_ref.tag == $tag)' \
+    <<<"$machines" >/dev/null; then
+  echo "::error::fleet did not converge: a machine is not running $tag (flyd revert? see issue #403 — replace the stuck machine with 'fly machine clone' + 'fly machine destroy', then re-run this workflow)"
+  exit 1
+fi
+
+# Edge smoke: the page and the hashed asset it references must be servable
+# end to end through the load balancer. Sampled a few times so a skewed
+# fleet (should the count ever grow past one machine) can't hide behind a
+# lucky first request.
+for _ in 1 2 3 4; do
+  page=$(curl -fsS "$url/")
+  asset=$(grep -oE '(assets|_astro)/[A-Za-z0-9._@-]+\.(js|css)' <<<"$page" | head -1 || true)
+  if [ -n "$asset" ]; then
+    curl -fsS -o /dev/null "$url/$asset" \
+      || { echo "::error::$url/ references $asset but fetching it failed"; exit 1; }
+  fi
+done
+echo "fleet converged on $tag and $url serves consistently"


### PR DESCRIPTION
## Summary
- A green `flyctl deploy` does not prove the fleet converged: flyd can revert a machine's update seconds after flyctl declares it healthy, and the reverted (old) app passes health checks too. One simulator machine silently rejected every deploy from 2026-07-14 through v0.29.0 — three green releases while the edge load-balanced users between two app versions (and could serve new `index.html` whose hashed asset the old machine 404'd).
- New `scripts/verify_fly_fleet.sh <app> <url>`: settles past the revert window (30 s, overridable), asserts every machine's **running** image (`.image_ref`, not the merely-requested `.config.image`) matches the latest release's `ImageRef`, then smoke-fetches the public page and the hashed asset it references through the load balancer.
- Both deploy workflows (simulator `fly-deploy.yml` + docs `deploy-docs.yml`) end with a **Verify fleet convergence** step running that script — a stuck machine now fails the pipeline instead of shipping skew.
- Release skill: verify section documents the new step and the recovery (`fly machine clone` the good machine, `fly machine destroy` the stuck one, re-run).

Closes #403

## Test plan
- [x] Script run locally against both live apps: simulator (1 machine, converged) and docs (2 machines incl. one stopped, converged) — both pass, including the edge asset fetch.
- [x] Workflow YAML parse-checked; script is executable.
- [ ] Real end-to-end exercise happens on the next `v*` tag — the step is additive and cannot affect the deploy itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSnmgGZUgDsMWkQHNpTogu