### PR TITLE
Adopt momwire 0.14.0 — ground-junction end conditions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/sta
 # install below sees its requirement already satisfied, then the package with the
 # web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install "momwire==0.13.0" \
+ && pip install "momwire==0.14.0" \
  && pip install -e ".[web]"
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire==0.13.0",
+    "momwire==0.14.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",


### PR DESCRIPTION
## Summary
- momwire 0.14.0 pin in all three places: `pyproject.toml`, `Dockerfile`, and the `momwire` submodule pointer (at the release's bump commit `adc1c36`).
- Brings in momwire#152 (fixes momwire#151): wire ends touching the ground plane are ground junctions, not free ends — ground-mounted verticals/inverted-Ls/grounded multi-wire junctions solve correctly on every basis (corpus worst offenders: 1858–55227% impedance error vs nec2c → 0.1–0.8%), and Sommerfeld ground contact no longer raises.
- Default-cost audit: no unqualified-request behavior change — the new code path activates only when a wire end lies in `ground_z`, which no catalog design does (reachable via NEC deck imports only), and it adds no matrix size or extra kernel work.

## Test plan
- [x] Full antennaknobs suite against the new momwire source: 1984 passed.
- [x] PyPI already serves momwire 0.14.0 (no wheel-smoke race).
- [x] `git -C momwire log --oneline -1` == the v0.14.0 bump commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSnmgGZUgDsMWkQHNpTogu