### PR TITLE
Honour the EK extended thin-wire kernel from imported NEC decks

### DIFF
--- a/scripts/bench_nec_corpus.py
+++ b/scripts/bench_nec_corpus.py
@@ -328,7 +328,13 @@ def worker_main(engine: str, deck_path: str, freq: float, ground_json: str):
         t0 = time.perf_counter()
         if engine == "pynec":
             eng = PyNECEngine(
-                builder, ground=ground, check_intersections=not allow_intersections
+                builder,
+                ground=ground,
+                check_intersections=not allow_intersections,
+                # Deck asked for NEC's extended thin-wire kernel (EK):
+                # honour it so fat-wire decks compare kernel-for-kernel
+                # against nec2c, which applies EK (#414).
+                extended_thin_wire_kernel=deck.extended_kernel,
             )
         elif engine == "sin":
             eng = MomwireEngine(builder, solver=SinusoidalSolver, ground=ground)

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -55,6 +55,7 @@ class PyNECEngine(SimulationEngine):
         ground=DEFAULT_GROUND,
         native_nt=False,
         check_intersections=True,
+        extended_thin_wire_kernel=False,
     ):
         """
         ground:
@@ -94,9 +95,19 @@ class PyNECEngine(SimulationEngine):
           validator on; passing False matches nec2c/momwire permissiveness.
           Requires pynec-accel >=1.7.5 (the wrapped set_intersection_check
           knob); older wheels silently keep the check on with a warning.
+
+        extended_thin_wire_kernel: apply NEC's EK card (the extended
+          thin-wire kernel) to the whole structure. Matters for fat wires —
+          radius comparable to segment length (a/h ≳ 0.01) — where the
+          standard thin-wire kernel's reactance drifts by ohms; NEC decks
+          carrying an EK card (`NecDeck.extended_kernel`) should set this so
+          the comparison against nec2c is kernel-for-kernel (issue #414,
+          found via the momwire#156 `1MHz_tower` analysis, where near-
+          resonant loads amplified the kernel difference ~10×).
         """
         super().__init__(builder)
         self._check_intersections = check_intersections
+        self._extended_thin_wire_kernel = extended_thin_wire_kernel
         self.tups = self._coerce_wire_tuples(builder.build_wires())
         self._network = builder.build_network()
         # Wire material (issue #316): radius + conductor loss from the
@@ -189,6 +200,13 @@ class PyNECEngine(SimulationEngine):
             return
         setter(False)
 
+    def _apply_extended_kernel(self, c):
+        """Emit NEC's EK card (extended thin-wire kernel) when requested.
+        Standard PyNEC API; call after geometry_complete like the other
+        program-control cards."""
+        if self._extended_thin_wire_kernel:
+            c.set_extended_thin_wire_kernel(True)
+
     def _build_geometry(self):
         self.c = nec.nec_context()
         geo = self.c.get_geometry()
@@ -223,6 +241,7 @@ class PyNECEngine(SimulationEngine):
         self._network_port_loc = {}
 
         self.c.geometry_complete(self._ge_flag())
+        self._apply_extended_kernel(self.c)
 
         if self._network is not None:
             # Only Load-only networks reach here; TL/virtual-driver
@@ -543,6 +562,7 @@ class PyNECEngine(SimulationEngine):
             if name is not None:
                 loc[name] = (idx, (n_seg + 1) // 2)
         c.geometry_complete(self._ge_flag())
+        self._apply_extended_kernel(c)
         self._emit_wire_material_cards(c)
         self._apply_ground_card(c)
         return c, loc

--- a/src/antennaknobs/nec_import.py
+++ b/src/antennaknobs/nec_import.py
@@ -79,7 +79,6 @@ _IGNORED_CARDS = {
     "PT": "current print control",
     "PQ": "charge print control",
     "KH": "interaction limit",
-    "EK": "extended thin-wire kernel",
     "CP": "coupling request",
     "PL": "plot request",
     "WG": "NGF write request",
@@ -196,6 +195,12 @@ class NecDeck:
     # translate — skipped_note() prefers these over the generic descriptions.
     ignored_detail: tuple[tuple[str, str], ...] = ()
     network_mode: bool = False  # parsed with network=True
+    # Deck asked for NEC's extended thin-wire kernel (EK card, #414). Applied
+    # by the PyNEC engine (`extended_thin_wire_kernel=True`) so fat-wire
+    # decks compare kernel-for-kernel against nec2c; momwire's kernels are
+    # its own formulation, so this is reference fidelity, not a momwire knob.
+    # Deck-level: True if any EK card other than `EK -1` (off) appears.
+    extended_kernel: bool = False
 
     def dominant_radius(self) -> float:
         """The deck's wire radius, length-weighted where wires differ.
@@ -956,6 +961,7 @@ def parse_nec(text: str, *, name: str = "NEC deck", network: bool = False) -> Ne
     nts_raw: list[_Card] = []
     freq_mhz: tuple[float, float] | None = None
     ground = False
+    extended_kernel = False
     in_comments = True
 
     geometry = {
@@ -1023,6 +1029,14 @@ def parse_nec(text: str, *, name: str = "NEC deck", network: bool = False) -> Ne
                     tls_raw.clear()
                 else:
                     nts_raw.append(card)
+            continue
+        if mnemonic == "EK":
+            # Extended thin-wire kernel (#414): honored (via PyNEC), not
+            # ignored. `EK -1` switches back to the standard kernel; any
+            # other form turns it on. NEC scopes EK to subsequent geometry;
+            # decks in the wild use it globally, so one deck-level flag.
+            card = _Card(mnemonic, tokens[1:], where)
+            extended_kernel = card.i(0) != -1
             continue
         if mnemonic in _IGNORED_CARDS:
             ignored.add(mnemonic)
@@ -1105,4 +1119,5 @@ def parse_nec(text: str, *, name: str = "NEC deck", network: bool = False) -> Ne
         wire_conductivity=wire_conductivity,
         ignored_detail=tuple(detail),
         network_mode=network,
+        extended_kernel=extended_kernel,
     )

--- a/tests/test_pynec_extended_kernel.py
+++ b/tests/test_pynec_extended_kernel.py
@@ -1,0 +1,72 @@
+"""Issue #414: EK extended thin-wire kernel — importer flag + PyNEC plumbing.
+
+NEC's EK card switches the kernel from the thin-wire (filament) current
+approximation to the extended kernel, which matters for fat wires (radius
+comparable to segment length). nec2c applies EK; dropping it made fat-wire
+deck comparisons kernel-inconsistent (the `1MHz_tower` five-way scatter,
+momwire#156). The importer now records the card on
+``NecDeck.extended_kernel`` and ``PyNECEngine(extended_thin_wire_kernel=
+True)`` emits it via PyNEC's ``set_extended_thin_wire_kernel``.
+"""
+
+from types import MappingProxyType
+
+import pytest
+
+from antennaknobs import AntennaBuilder, Wire, WireSpec
+from antennaknobs.nec_import import parse_nec
+
+FREQ = 300.0  # MHz -> ~1 m wavelength
+
+
+DECK_TEMPLATE = """CE fat dipole
+GW 1 15 -0.25 0 0 0.25 0 0 {radius}
+GE 0
+{ek}FR 0 1 0 0 300.0
+EX 0 1 8 0 1.0 0.0
+EN
+"""
+
+
+def test_importer_records_ek():
+    deck = parse_nec(DECK_TEMPLATE.format(radius=0.008, ek="EK\n"), name="t")
+    assert deck.extended_kernel
+    assert "EK" not in deck.ignored
+
+
+def test_importer_ek_off_and_absent():
+    off = parse_nec(DECK_TEMPLATE.format(radius=0.008, ek="EK -1\n"), name="t")
+    assert not off.extended_kernel
+    plain = parse_nec(DECK_TEMPLATE.format(radius=0.008, ek=""), name="t")
+    assert not plain.extended_kernel
+
+
+def _fat_dipole_builder():
+    """Half-wave dipole with a/h ~ 0.24 (8 mm radius, ~33 mm segments) —
+    deliberately fat so the two kernels visibly disagree."""
+    spec = WireSpec(radius=0.008)
+
+    class _B(AntennaBuilder):
+        default_params = MappingProxyType({"freq": FREQ})
+
+        def build_wires(self):
+            return [
+                Wire((-0.25, 0.0, 0.0), (0.0, 0.0, 0.0), 7, None, None, spec),
+                Wire((0.0, 0.0, 0.0), (0.25, 0.0, 0.0), 8, 1 + 0j, None, spec),
+            ]
+
+    return _B()
+
+
+def test_extended_kernel_changes_fat_wire_reactance():
+    pytest.importorskip("PyNEC")
+    from antennaknobs.engines.pynec import PyNECEngine
+
+    z_std = PyNECEngine(_fat_dipole_builder(), ground=None).impedance()[0]
+    z_ext = PyNECEngine(
+        _fat_dipole_builder(), ground=None, extended_thin_wire_kernel=True
+    ).impedance()[0]
+    # The kernels must actually differ on a fat wire (ohms — here ~4.7 Ω in
+    # R and ~0.9 Ω in X at a/h ≈ 0.24), while staying the same antenna.
+    assert abs(z_ext - z_std) > 2.0
+    assert abs(z_ext - z_std) < 0.3 * abs(z_std)


### PR DESCRIPTION
## Summary
- `nec_import`: the `EK` card is now recorded on `NecDeck.extended_kernel` (`EK -1` = off, any other form = on) instead of being filed under ignored cards.
- `PyNECEngine(extended_thin_wire_kernel=True)` emits it via PyNEC's `set_extended_thin_wire_kernel` after `geometry_complete` on both context-build paths (main + port-Y measurement contexts).
- `bench_nec_corpus.py` passes the deck's flag through, so EK decks compare kernel-for-kernel against nec2c (which honours EK).
- momwire is untouched by design — its kernels are their own exact-integration formulation; this is reference fidelity for the PyNEC/nec2c comparison.

Measured effect: a fat half-wave dipole (a/h ≈ 0.24) shifts ~4.7 Ω R / ~0.9 Ω X between kernels (pinned by the new test). Honest footnote from the momwire#156 investigation: on `1MHz_tower` EK moves PyNEC only ~0.3%, so it does **not** explain that deck's residual PyNEC-vs-nec2c gap — the near-resonant loads there amplify sub-ohm differences beyond single-cause attribution.

Closes #414

## Test plan
- [x] `tests/test_pynec_extended_kernel.py`: importer records EK on/off/absent; the flag measurably changes a fat-wire solve while staying the same antenna (PyNEC-skipped when absent).
- [x] Full suite: 1989 passed. ruff + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSnmgGZUgDsMWkQHNpTogu