### PR TITLE
Wild-corpus parse census: --parse-only mode + first acceptance results

### DIFF
--- a/docs/status/2026-07-16-wild-corpus-parse-census.md
+++ b/docs/status/2026-07-16-wild-corpus-parse-census.md
@@ -1,0 +1,86 @@
+# 2026-07-16 — wild-corpus parse census (3,146 decks, importer acceptance)
+
+## Goal
+
+Issue #410: run `nec_import` across the wild `.nec` corpus collected from the
+web (`~/antennas/nec-wild/` — ARRL/Cebik course sets, the on5au Cebik archive,
+4nec2's bundled models, G1OJS, nec2c/nec2++ distributions, w8io, community
+sites; per-source `MANIFEST.md` provenance) and classify every outcome. This
+is the *parser* acceptance axis — the xnec2c examples corpus is one program's
+dialect; this corpus spans at least four authoring tools.
+
+Tooling: `scripts/bench_nec_corpus.py --parse-only --corpus DIR [--out x.json]`
+— recursive, content-hash deduped, no solves. Parses with `network=True` (the
+app's path) and falls back to `network=False` exactly like the bench's
+`load_deck`.
+
+## Headline
+
+**4,009 files → 3,146 content-unique decks → zero parser crashes.**
+Every non-parse is a `ValueError` with a designed, specific message. The
+acceptance bar — wild input must never produce an unhandled exception — is
+met with no code changes. (Total census wall time ~20 s; slowest single
+parse 0.26 s.)
+
+| outcome | decks | share |
+|---|--:|--:|
+| parsed, no cards skipped | 73 | 2% |
+| parsed, run-config cards skipped (RP/GN/…) | 1,984 | 63% |
+| parsed via network=False fallback | 7 | 0.2% |
+| rejected with a designed message | 1,082 | 34% |
+| **crashed** | **0** | **0%** |
+
+65% of the wild web parses into solvable geometry today.
+
+## Skipped-card histogram (decks containing ≥1 of the card)
+
+RP 1782 · GN 1340 · LD 138 · NE 106 · NH 99 · XQ 87 · TL 72 · NT 47 · PT 25 ·
+GD 22 · PQ 14 · WG 12 · PL 7 · KH 7 · CP 5 — all run-config/report cards the
+app deliberately decides itself (GN becomes the app's ground setting; LD/TL/NT
+translate on the network path where expressible). EK no longer appears here:
+it is honored since #414.
+
+## Rejection census (1,082 decks, grouped by cause)
+
+| decks | cause | class |
+|--:|---|---|
+| **642** | SY symbolic variables (4nec2 extension) | **the big unlock** |
+| ~242 | tokenizer: `'` inline comments / quoted junk — "expected a NEC card mnemonic, got `'`/`'GW`" (115), "expected mnemonic" other (89), "bad number `'…'`" (38) | **second unlock — one tolerant-tokenizer fix** |
+| 44 | EX plane-wave excitation (scattering run) | correct rejection |
+| 26 | genuinely unrecognised cards | long tail |
+| 19+10 | SP / SM surface patches | out of scope (no patch solver) |
+| 15 | GF numerical Green's function | correct rejection |
+| 13 | GC tapered wire | modelable someday (per-segment radius exists since #388) |
+| 12 | EX non-voltage source types | correct rejection |
+| 10 | CM card after CE | trivial tolerance fix |
+| 9 | GH with zero wire radius | related to GC class |
+| rest | singles/small groups | see JSON |
+
+## Priorities this data sets (filed as issues)
+
+1. **SY symbolic variables — 642 decks (59% of all rejections).** Evaluating
+   `SY name=expr` (arithmetic, `*MM`-style unit suffixes, references to other
+   symbols) plus substitution into card fields would raise the parse rate
+   from 65% → ~86%. 4nec2's own corpus and G1OJS (399 decks) are almost
+   entirely SY-based.
+2. **`'`-comment / junk-line tolerance — ~242 decks.** 4nec2 writes `'` 
+   end-of-line and full-line comments; some exports quote fields. A
+   tokenizer that strips `'`-to-EOL before parsing (plus tolerating the
+   10 CM-after-CE decks) is a small change unlocking ~8% of the corpus,
+   including ARRL's own DIP.NEC.
+3. GC/GH tapered-radius support (22 decks) — natural extension of the
+   per-wire WireSpec machinery; lower value per effort.
+
+## Caveats
+
+- Parse ≠ solve: this census says the geometry translates, not that engines
+  agree on it. The solve/impedance axis stays with the (smaller) xnec2c
+  corpus where a nec2c reference exists per deck; running engines across
+  2,000 wild decks without references is a separate (deliberate) decision.
+- nec2c-reference footnote from the same day: vanilla nec2c 1.3.1 and the
+  KJ7LNW 1.3 fork disagree wildly on some decks (`1MHz_tower`,
+  near-resonance verticals) — any future wild-solve pass must pin WHICH
+  nec2c build it scores against.
+- The corpus has 863 exact-content duplicates across sources (the Cebik
+  classroom set arrived via two mirrors; icecube mirrors 4nec2) — the census
+  dedupes by md5, first path wins.

--- a/scripts/bench_nec_corpus.py
+++ b/scripts/bench_nec_corpus.py
@@ -646,6 +646,136 @@ def print_report(rows, engines):
 
 
 # --------------------------------------------------------------------------
+_NUM_RE = None
+
+
+def _normalize_reason(msg: str) -> str:
+    """Collapse per-deck specifics (numbers, quoted names) so one cause
+    groups into one census line: 'line 42: GW card: tag 17 ...' and
+    'line 7: GW card: tag 3 ...' are the same bug."""
+    global _NUM_RE
+    import re
+
+    if _NUM_RE is None:
+        _NUM_RE = (
+            re.compile(r"[-+]?\d+\.?\d*(?:[eE][-+]?\d+)?"),
+            re.compile(r"'[^']*'"),
+        )
+    num_re, quote_re = _NUM_RE
+    # Drop the "<deckname>, line N:" prefix — the grouping key is the cause,
+    # not which deck tripped it.
+    if ": " in msg:
+        head, tail = msg.split(": ", 1)
+        if "line" in head or head.endswith((".nec", ".NEC", ".inp")):
+            msg = tail
+    out = quote_re.sub("'…'", msg)
+    out = num_re.sub("#", out)
+    return out[:160]
+
+
+def parse_census(decks, corpus, out_path):
+    """Importer acceptance census (issue #410): parse every content-unique
+    deck with network=True (the app's path), falling back to network=False
+    exactly like load_deck does. No solves. A ValueError is a *designed*
+    rejection (the importer said why); any other exception is a parser
+    crash — a bug by definition on wild input."""
+    import hashlib
+    from collections import Counter, defaultdict
+
+    from antennaknobs.nec_import import parse_nec
+
+    seen: dict[str, Path] = {}
+    dup_count = 0
+    results = []
+    skipped_hist: Counter = Counter()
+    reject_groups: dict[tuple[str, str], list[str]] = defaultdict(list)
+    crash_groups: dict[tuple[str, str], list[str]] = defaultdict(list)
+    n_clean = n_skipcards = n_fallback = 0
+    slowest = (0.0, None)
+
+    for p in decks:
+        raw = p.read_bytes()
+        h = hashlib.md5(raw).hexdigest()
+        if h in seen:
+            dup_count += 1
+            continue
+        seen[h] = p
+        rel = str(p.relative_to(corpus))
+        text = raw.decode("utf-8", errors="replace")
+        rec = {"deck": rel}
+        t0 = time.perf_counter()
+        try:
+            deck = parse_nec(text, name=p.name, network=True)
+            rec["status"] = "ok"
+            rec["ignored"] = list(deck.ignored)
+            if deck.ignored:
+                n_skipcards += 1
+                skipped_hist.update(set(deck.ignored))
+            else:
+                n_clean += 1
+        except ValueError as first:
+            try:
+                deck = parse_nec(text, name=p.name, network=False)
+                rec["status"] = "net-fallback"
+                rec["reason"] = str(first)
+                n_fallback += 1
+                skipped_hist.update(set(deck.ignored))
+            except ValueError as e:
+                rec["status"] = "rejected"
+                rec["reason"] = str(e)
+                reject_groups[("ValueError", _normalize_reason(str(e)))].append(rel)
+            except Exception as e:  # noqa: BLE001 — census must survive anything
+                rec["status"] = "crash"
+                rec["reason"] = f"{type(e).__name__}: {e}"
+                crash_groups[(type(e).__name__, _normalize_reason(str(e)))].append(rel)
+        except Exception as e:  # noqa: BLE001
+            rec["status"] = "crash"
+            rec["reason"] = f"{type(e).__name__}: {e}"
+            crash_groups[(type(e).__name__, _normalize_reason(str(e)))].append(rel)
+        dt = time.perf_counter() - t0
+        if dt > slowest[0]:
+            slowest = (dt, rel)
+        rec["parse_s"] = round(dt, 4)
+        results.append(rec)
+
+    n = len(results)
+    n_rej = sum(len(v) for v in reject_groups.values())
+    n_crash = sum(len(v) for v in crash_groups.values())
+    print(f"\ncorpus: {corpus}")
+    print(f"files: {len(decks)}  unique: {n}  (content dups skipped: {dup_count})")
+    print(
+        f"parsed clean: {n_clean}   with skipped cards: {n_skipcards}   "
+        f"network-mode fallback: {n_fallback}   rejected: {n_rej}   "
+        f"CRASHES: {n_crash}"
+    )
+    print(f"slowest parse: {slowest[0]:.2f}s  {slowest[1]}")
+
+    if skipped_hist:
+        print("\nSKIPPED-CARD HISTOGRAM (decks containing the card)")
+        for card, cnt in skipped_hist.most_common():
+            print(f"  {card:4s} {cnt:5d}")
+
+    def _show(title, groups):
+        if not groups:
+            return
+        print(f"\n{title} ({sum(len(v) for v in groups.values())} decks)")
+        for (cls, reason), files in sorted(groups.items(), key=lambda kv: -len(kv[1])):
+            print(f"  {len(files):5d}  {cls}: {reason}")
+            print(f"         e.g. {files[0]}")
+
+    _show("DESIGNED REJECTIONS (grouped)", reject_groups)
+    _show("PARSER CRASHES — bugs by definition (grouped)", crash_groups)
+
+    if out_path:
+        out_path.write_text(
+            json.dumps(
+                {"corpus": str(corpus), "n_files": len(decks), "decks": results},
+                indent=1,
+            )
+        )
+        print(f"\nfull census -> {out_path}")
+
+
 def main(argv=None):
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument(
@@ -686,6 +816,14 @@ def main(argv=None):
     ap.add_argument(
         "--out", type=Path, default=None, help="write full results JSON here"
     )
+    ap.add_argument(
+        "--parse-only",
+        action="store_true",
+        help="importer acceptance census (issue #410): run nec_import over "
+        "every deck in the corpus (recursive, content-deduped) with NO "
+        "solves — classify parsed-clean / cards-skipped / designed "
+        "rejection / parser crash, and print the histograms",
+    )
     args = ap.parse_args(argv)
 
     if args.worker:
@@ -696,7 +834,13 @@ def main(argv=None):
     corpus = args.corpus
     if not corpus.is_dir():
         sys.exit(f"corpus not found: {corpus}")
-    decks = sorted(corpus.glob("*.nec"))
+    # Recursive + .inp so wild corpora (nec-wild trees) work; flat corpora
+    # like the xnec2c examples dir see identical behaviour.
+    decks = sorted(
+        p
+        for p in corpus.rglob("*")
+        if p.is_file() and p.suffix.lower() in (".nec", ".inp")
+    )
     if args.decks:
         want = {d.replace(".nec", "") for d in args.decks}
         decks = [p for p in decks if p.stem in want or p.name in args.decks]
@@ -704,6 +848,10 @@ def main(argv=None):
         decks = decks[: args.limit]
     if not decks:
         sys.exit("no decks selected")
+
+    if args.parse_only:
+        parse_census(decks, corpus, args.out)
+        return
 
     cores = physical_cpu_count()
     print(f"corpus: {corpus}")


### PR DESCRIPTION
## Summary
- `scripts/bench_nec_corpus.py --parse-only --corpus DIR [--out x.json]` (issue #410 item 2): recursive, md5-deduped importer acceptance sweep, no solves. Classifies parsed-clean / run-config-cards-skipped (histogram) / network-mode fallback / designed rejection / parser crash, with rejections grouped by normalized cause. Corpus discovery is now recursive and includes `.inp` (flat corpora see identical behavior).
- First census over `~/antennas/nec-wild` (4,009 files, 3,146 unique): **zero parser crashes** — the acceptance bar is met with no importer changes; 65% of the wild web parses into solvable geometry; full writeup in `docs/status/2026-07-16-wild-corpus-parse-census.md`.
- Triage filed from the data: #417 (SY symbolic variables — 642 decks, 59% of rejections) and #418 (4nec2 `'`-comment tokenizer tolerance — ~250 decks incl. ARRL's DIP.NEC).

Refs #410

## Test plan
- [x] Census validated on the known xnec2c corpus (75 decks: 73 parse with run-config skips, the 2 patch decks reject with designed messages, 0 crashes).
- [x] Solve mode regression-checked (`--decks 2m_yagi --engines sin` unchanged).
- [x] ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSnmgGZUgDsMWkQHNpTogu