### PR TITLE
Add fixed complex-Y Admittance network branch primitive (#416)

### DIFF
--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -10,6 +10,7 @@ from momwire import insulation_inductance, wire_internal_impedance
 from ..engine import FarField, SimulationEngine, WireCurrents
 from ..network import as_wire
 from ..network import (
+    Admittance,
     Driven,
     Load,
     PortOnWire,
@@ -438,8 +439,10 @@ class PyNECEngine(SimulationEngine):
             return True
         # A Shunt to common has no native NEC card (there's no 1-port
         # shunt-to-common primitive); always reduce it. Same for the ideal
-        # Transformer (issue #301): no NEC card expresses the ideal ratio.
-        if any(isinstance(b, (Shunt, Transformer)) for b in net.branches):
+        # Transformer (issue #301): no NEC card expresses the ideal ratio, and
+        # the fixed complex-Y Admittance (issue #416) — a general 1-/2-port Y
+        # with no native 1-port card — always takes the reducer stamp too.
+        if any(isinstance(b, (Shunt, Transformer, Admittance)) for b in net.branches):
             return True
         # A finite-Q Load (issue #298) needs R = ωL/Q re-derived at every
         # frequency; ld_card takes fixed R/L/C baked into one context, which

--- a/src/antennaknobs/nec_import.py
+++ b/src/antennaknobs/nec_import.py
@@ -156,21 +156,27 @@ class NecTL:
 
 @dataclass(frozen=True)
 class NecNT:
-    """One translated NT card (``network=True``): an all-real Y matrix,
-    decomposed into its exact resistive pi — a series resistance between the
-    ports (from −Y12) plus a shunt resistance at each port (Y11+Y12,
-    Y22+Y12). Real Y-parameters are frequency-independent, so the pi is
-    exact at every frequency; an NT with susceptance anywhere is not
-    translated (that needs a general YMatrix branch — future work).
-    ``None`` legs are absent elements."""
+    """One translated NT card (``network=True``).
+
+    All-real Y matrix: decomposed into its exact resistive pi — a series
+    resistance between the ports (from −Y12) plus a shunt resistance at each
+    port (Y11+Y12, Y22+Y12); real Y-parameters are frequency-independent so the
+    pi is exact at every frequency. ``series_r`` / ``shunt_r_*`` carry it and
+    ``y`` is ``None``.
+
+    Y matrix with susceptance anywhere: no resistive pi exists, so the full 2×2
+    complex short-circuit admittance is kept in ``y`` (issue #416) and the
+    resistive-pi fields are ``None``. ``network()`` emits it as a general
+    ``Admittance`` branch. ``None`` pi legs are absent elements."""
 
     wire_a: int
     seg_a: int
     wire_b: int
     seg_b: int
-    series_r: float | None
-    shunt_r_a: float | None
-    shunt_r_b: float | None
+    series_r: float | None = None
+    shunt_r_a: float | None = None
+    shunt_r_b: float | None = None
+    y: tuple[tuple[complex, complex], tuple[complex, complex]] | None = None
 
 
 @dataclass(frozen=True)
@@ -474,6 +480,11 @@ class NecDeck:
         for nt in self.nts:
             a = plan[(nt.wire_a, nt.seg_a)]
             b = plan[(nt.wire_b, nt.seg_b)]
+            if nt.y is not None:
+                # Complex Y (susceptance present): the full 2×2 as one general
+                # Admittance branch (issue #416).
+                branches.append(_net.Admittance(ports=(a, b), y=nt.y))
+                continue
             if nt.series_r is not None:
                 branches.append(_net.TwoPort(a=a, b=b, r=nt.series_r))
             if nt.shunt_r_a is not None:
@@ -825,21 +836,31 @@ def _translate_network_cards(wires, lds_raw, tls_raw, nts_raw):
     for card in nts_raw:
         wa, sa = _locate_segment(wires, card.i(0), card.i(1), card)
         wb, sb = _locate_segment(wires, card.i(2), card.i(3), card)
-        if any(card.f(k) != 0.0 for k in (5, 7, 9)):
-            skip(
-                "NT",
-                "Y-parameters have susceptance — needs a general Y-matrix "
-                "branch, which only a real (resistive) Y avoids",
-            )
-            continue
-        y11, y12, y22 = card.f(4), card.f(6), card.f(8)
+        # NEC's NT card is reciprocal: it gives Y11, Y12, Y22 (real+imag each)
+        # and Y21 = Y12.
+        y11 = complex(card.f(4), card.f(5))
+        y12 = complex(card.f(6), card.f(7))
+        y22 = complex(card.f(8), card.f(9))
         if y11 == y12 == y22 == 0.0:
             skip("NT", "all-zero Y-parameters")
             continue
-        # Exact resistive pi: series −Y12 between the ports, shunts
-        # Y11+Y12 / Y22+Y12 at each. Real Y is frequency-independent, so
-        # this holds at every frequency.
-        ys, ya, yb = -y12, y11 + y12, y22 + y12
+        if card.f(5) or card.f(7) or card.f(9):
+            # Susceptance anywhere: no resistive pi. Keep the full complex Y —
+            # network() emits it as a general Admittance branch (issue #416).
+            nts.append(
+                NecNT(
+                    wire_a=wa,
+                    seg_a=sa,
+                    wire_b=wb,
+                    seg_b=sb,
+                    y=((y11, y12), (y12, y22)),
+                )
+            )
+            continue
+        # All-real Y → exact resistive pi: series −Y12 between the ports,
+        # shunts Y11+Y12 / Y22+Y12 at each. Real Y is frequency-independent,
+        # so this holds at every frequency.
+        ys, ya, yb = -y12.real, y11.real + y12.real, y22.real + y12.real
         nts.append(
             NecNT(
                 wire_a=wa,

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -389,11 +389,53 @@ class Transformer:
     qlmag: float | None = None
 
 
-Branch = Union[TL, Load, TwoPort, Shunt, Transformer]
+@dataclass(frozen=True)
+class Admittance:
+    """A fixed, frequency-INDEPENDENT complex admittance branch (issue #416) —
+    the general primitive a reactive NT card, a reactive TL end-shunt, and a
+    fixed-jX (LD 4) load reduce to. Unlike Load/TwoPort/Shunt, whose reactance
+    scales with ω, this short-circuit admittance matrix is stamped verbatim at
+    every frequency.
+
+    ``ports`` names the port(s) the branch spans and ``y`` is the matching
+    admittance matrix in siemens (``len(ports) × len(ports)``, indexed to
+    ``ports``):
+
+    - 1-port ``ports=(p,)``, ``y=((yval,),)`` — a fixed ``y`` from the port
+      node to the datum, the fixed-admittance sibling of ``Shunt`` (a reactive
+      TL end-shunt, or a fixed-Z load folded as ``y = 1/Z``).
+    - 2-port ``ports=(a, b)``, ``y=((y11, y12), (y21, y22))`` — the full 2×2
+      short-circuit admittance, exactly NEC's NT-card Y (reciprocal decks give
+      ``y21 = y12``, but a general matrix is accepted).
+
+    Both engines stamp it through the shared ``NetworkReducer`` as a Group-1
+    node-admittance block (no ω scaling, no auxiliary current), so it composes
+    with every other branch and itemises in the power budget. There is no
+    native NEC card for a 1-port shunt-to-common and PyNEC's ``nt_card`` maps
+    the 2-port, but the default path on both engines is the reducer (like
+    ``Shunt`` / ``Transformer``)."""
+
+    ports: tuple[str, ...]
+    y: tuple[tuple[complex, ...], ...]
+
+    def __post_init__(self):
+        n = len(self.ports)
+        if n == 0:
+            raise ValueError("Admittance needs at least one port")
+        if len(self.y) != n or any(len(row) != n for row in self.y):
+            raise ValueError(
+                f"Admittance y must be {n}×{n} to match ports {self.ports}; "
+                f"got {len(self.y)}×{len(self.y[0]) if self.y else 0}"
+            )
+
+
+Branch = Union[TL, Load, TwoPort, Shunt, Transformer, Admittance]
 
 
 def _branch_port_refs(br):
     """Port names a branch references, regardless of branch type."""
+    if isinstance(br, Admittance):
+        return tuple(br.ports)
     if hasattr(br, "a"):  # TL, TwoPort, Transformer
         return (br.a, br.b)
     return (br.port,)  # Load, Shunt

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -33,6 +33,7 @@ import numpy as np
 
 from .network import (
     TL,
+    Admittance,
     Driven,
     Load,
     PortOnWire,
@@ -318,6 +319,16 @@ class NetworkReducer:
                 )
                 G[np.ix_([a, b], [a, b])] += y_tl
                 probes.append((f"TL {br.a}→{br.b}", "group1", ([a, b], y_tl)))
+            elif isinstance(br, Admittance):
+                # Fixed complex Y stamped verbatim — no ω scaling, no auxiliary
+                # current (issue #416). A pure node-admittance block, exactly
+                # like TL's 2×2 and the parallel Shunt's 1×1.
+                idxs = [self.port_to_idx[p] for p in br.ports]
+                yb = np.array(br.y, dtype=np.complex128)
+                G[np.ix_(idxs, idxs)] += yb
+                probes.append(
+                    (f"Admittance {'→'.join(br.ports)}", "group1", (idxs, yb))
+                )
             elif isinstance(br, TwoPort):
                 a, b = self.port_to_idx[br.a], self.port_to_idx[br.b]
                 probes.append((f"TwoPort {br.a}→{br.b}", "group2", len(elements)))

--- a/tests/test_admittance_branch.py
+++ b/tests/test_admittance_branch.py
@@ -1,0 +1,175 @@
+"""Issue #416: a general fixed complex-Y (frequency-independent) branch.
+
+`Admittance` stamps a fixed short-circuit admittance matrix verbatim into the
+`NetworkReducer` (group-1 node-admittance block) — the branch a reactive NT
+card, a reactive TL end-shunt, or a fixed-jX load reduce to. Unlike
+Load/TwoPort/Shunt, whose reactance scales with ω, the Y is used as-is at every
+frequency.
+
+Two layers, mirroring test_network_mna.py: circuit-theory oracles on a
+synthetic antenna Y (fast, no MoM), then a cross-engine MoM check that PyNEC and
+momwire agree once the branch is in the solve.
+"""
+
+import numpy as np
+import pytest
+
+from antennaknobs import AntennaBuilder, WireSpec
+from antennaknobs.engines import MomwireEngine, PyNECEngine
+from antennaknobs.nec_import import parse_nec
+from antennaknobs.network import (
+    Admittance,
+    Driven,
+    Network,
+    PortOnWire,
+    PortVirtual,
+)
+from antennaknobs.network_reduce import C_LIGHT, NetworkReducer
+from momwire import SinusoidalSolver
+
+FREQ_MHZ = 28.0
+WL = C_LIGHT / (FREQ_MHZ * 1e6)
+
+
+def synth_y(n, seed):
+    """Reciprocal, diagonally-dominant complex antenna Y (well conditioned)."""
+    rng = np.random.default_rng(seed)
+    a = rng.normal(size=(n, n)) + 1j * rng.normal(size=(n, n))
+    y = 0.004 * (a + a.T) / 2.0
+    return y + np.eye(n) * (0.02 + 0.008j)
+
+
+def reducer(net, n_real):
+    real = [n for n, p in net.ports.items() if isinstance(p, PortOnWire)]
+    virt = [n for n, p in net.ports.items() if isinstance(p, PortVirtual)]
+    port_to_idx = {n: i for i, n in enumerate(real + virt)}
+    return NetworkReducer(net, port_to_idx, len(real) + len(virt))
+
+
+def nodal_reference(y_full, driven):
+    """Bare nodal reduction: driven nodes pinned at their EMF, the rest
+    floating (I_ext = 0), currents I = Y·V. Exact when every element is a
+    finite admittance stamp — which `Admittance` is."""
+    n = y_full.shape[0]
+    idx = sorted(driven)
+    other = [i for i in range(n) if i not in driven]
+    v = np.zeros(n, dtype=np.complex128)
+    for k, e in driven.items():
+        v[k] = e
+    if other:
+        rhs = -y_full[np.ix_(other, idx)] @ np.array([driven[k] for k in idx])
+        v[other] = np.linalg.solve(y_full[np.ix_(other, other)], rhs)
+    return v, y_full @ v
+
+
+# ---------------------------------------------------------------------------
+# 1. Circuit-theory oracles (synthetic antenna Y)
+# ---------------------------------------------------------------------------
+def test_admittance_2port_matches_augmented_nodal_solve():
+    """A driven port + a fixed complex 2-port Admittance to a floating port:
+    since the branch is a pure group-1 stamp, the exact reference is the bare
+    nodal solve of the augmented admittance (antenna Y + the branch Y-block)."""
+    y = synth_y(2, 11)
+    yadm = np.array([[0.02 + 0.01j, -0.01 + 0.002j], [-0.01 + 0.002j, 0.015 - 0.004j]])
+    net = Network(
+        ports={"a": PortOnWire("a"), "b": PortOnWire("b")},
+        branches=[Admittance(ports=("a", "b"), y=tuple(map(tuple, yadm)))],
+        sources=[Driven(port="a")],
+    )
+    z = reducer(net, 2).driven_impedance(y, WL)[0]
+    v, i = nodal_reference(y + yadm, {0: 1 + 0j})
+    assert z == pytest.approx(v[0] / i[0], rel=1e-9)
+
+
+def test_admittance_1port_is_fixed_shunt_to_common():
+    """A 1-port Admittance at the driven port adds its y to the node: the
+    fixed-admittance sibling of Shunt. Z = 1/(Y₀₀ + y)."""
+    y = synth_y(1, 3)
+    ysh = 0.003 - 0.002j
+    net = Network(
+        ports={"a": PortOnWire("a")},
+        branches=[Admittance(ports=("a",), y=((ysh,),))],
+        sources=[Driven(port="a")],
+    )
+    z = reducer(net, 1).driven_impedance(y, WL)[0]
+    assert z == pytest.approx(1.0 / (y[0, 0] + ysh), rel=1e-12)
+
+
+def test_admittance_is_frequency_independent():
+    """The Y is stamped as-is at every frequency — unlike a Shunt capacitor
+    whose jωC scales. With a fixed synthetic antenna Y, a pure-susceptance
+    Admittance gives the identical driving-point impedance at two wavelengths."""
+    y = synth_y(1, 7)
+    ysh = 1j * 0.004  # fixed susceptance
+    net = Network(
+        ports={"a": PortOnWire("a")},
+        branches=[Admittance(ports=("a",), y=((ysh,),))],
+        sources=[Driven(port="a")],
+    )
+    red = reducer(net, 1)
+    z1 = red.driven_impedance(y, C_LIGHT / 10e6)[0]
+    z2 = red.driven_impedance(y, C_LIGHT / 30e6)[0]
+    assert z1 == pytest.approx(z2, rel=1e-12)
+    assert z1 == pytest.approx(1.0 / (y[0, 0] + ysh), rel=1e-12)
+
+
+def test_admittance_rejects_shape_mismatch():
+    with pytest.raises((ValueError, AssertionError)):
+        Admittance(ports=("a", "b"), y=((0.01,),))  # 2 ports, 1×1 matrix
+
+
+# ---------------------------------------------------------------------------
+# 2. nec_import translation of a reactive NT card (issue #416)
+# ---------------------------------------------------------------------------
+_REACTIVE_NT_DECK = """\
+GW 1 5 0 -1 0 0 1 0 0.001
+GW 2 5 1 -1 0 1 1 0 0.001
+GE 0
+EX 0 1 3 0 1 0
+NT 1 3 2 3 0.02 0.01 -0.01 0 0.015 0
+EN
+"""
+
+
+def test_reactive_nt_translates_to_admittance():
+    """An NT card with susceptance is no longer dropped — it becomes an
+    Admittance carrying the full complex short-circuit Y (Y21 = Y12)."""
+    deck = parse_nec(_REACTIVE_NT_DECK, network=True)
+    assert "NT" not in deck.ignored
+    assert not any(m == "NT" for m, _ in deck.ignored_detail)
+    adm = [b for b in deck.network().branches if isinstance(b, Admittance)]
+    assert len(adm) == 1
+    np.testing.assert_allclose(
+        np.array(adm[0].y, dtype=complex),
+        [[0.02 + 0.01j, -0.01 + 0j], [-0.01 + 0j, 0.015 + 0j]],
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Cross-engine MoM oracle: PyNEC and momwire agree with the branch in-solve
+# ---------------------------------------------------------------------------
+def _deck_builder(deck, freq=FREQ_MHZ):
+    class B(AntennaBuilder):
+        default_params = {"freq": freq}
+
+        def build_wires(self):
+            return deck.wire_tuples()
+
+        def build_network(self):
+            return deck.network()
+
+        def build_wire_material(self):
+            return WireSpec(radius=deck.dominant_radius())
+
+    return B()
+
+
+def test_reactive_nt_cross_engine_agrees():
+    """The reactive 2-port is stamped through the shared NetworkReducer on both
+    engines, so PyNEC (nec2++ antenna Y) and momwire (sinusoidal Y) return the
+    same driving-point impedance to the MoM-basis tolerance."""
+    deck = parse_nec(_REACTIVE_NT_DECK, network=True)
+    builder = _deck_builder(deck)
+    z_pynec = PyNECEngine(builder, ground="free").impedance()[0]
+    z_mw = MomwireEngine(builder, solver=SinusoidalSolver, ground="free").impedance()[0]
+    assert abs(z_pynec - z_mw) / abs(z_mw) < 0.02

--- a/tests/test_nec_import.py
+++ b/tests/test_nec_import.py
@@ -576,12 +576,21 @@ def test_nt_real_y_decomposes_into_resistive_pi():
     }
 
 
-def test_nt_susceptance_is_ignored_and_nt_minus_one_clears():
+def test_nt_susceptance_becomes_admittance_and_nt_minus_one_clears():
+    # An NT with susceptance is now translated to a general complex-Y branch
+    # (issue #416), carrying the full 2x2 short-circuit Y (Y21 = Y12), not
+    # ignored.
+    from antennaknobs.network import Admittance
+
     deck = parse_nec(
         TWO_VERTICALS.format(tl="NT 1 2 2 2 0.02 0.01 -0.01 0 0.015 0"),
         network=True,
     )
-    assert deck.nts == () and "NT" in deck.ignored
+    assert "NT" not in deck.ignored
+    (nt,) = deck.nts
+    assert nt.y == ((0.02 + 0.01j, -0.01 + 0j), (-0.01 + 0j, 0.015 + 0j))
+    (adm,) = [b for b in deck.network().branches if isinstance(b, Admittance)]
+    assert adm.ports == ("feed", "nt1b")
     # NT -1 cancels all previous network AND transmission-line data.
     deck = parse_nec(
         TWO_VERTICALS.format(tl="TL 1 2 2 2 73 1.5 0 0 0 0\nNT -1 0 0 0 0 0 0 0 0 0"),


### PR DESCRIPTION
Closes #416.

## Problem
antennaknobs' network branches (`Load`/`TwoPort`/`Shunt`) modeled only **frequency-dependent** R/L/C, so any fixed frequency-independent susceptance had no exact branch — `nec_import` left it in `ignored` and flagged the deck `n` (excluded from the accuracy rollup). The corpus's one reactive matching network (`20m_dipole_NT_50ohm`) was dropped, leaving every engine ~1.1 off nec2c.

## What this adds
A general **`Admittance`** branch — a fixed complex short-circuit admittance matrix stamped verbatim at every frequency:
- **1-port** `ports=(p,)`, `y=((y,),)` — fixed admittance to common (the fixed sibling of `Shunt`).
- **2-port** `ports=(a,b)`, `y=((y11,y12),(y21,y22))` — the full NT-card Y.

It reuses machinery that already existed, so the change is small:
- **`network_reduce.py`** — stamped in `apply_branches` as a **Group-1 node-admittance block** (exactly like TL's 2×2 and the parallel-`Shunt`'s 1×1); the existing group1 `branch_power` itemises it in the power budget for free.
- **`pynec.py`** — routes any `Admittance` through the shared `NetworkReducer` (like `Shunt`/`Transformer`); momwire uses the same reducer, so **both engines agree**.
- **`nec_import.py`** — an NT card with susceptance keeps its full complex 2×2 `Y` (`NecNT.y`) and `network()` emits an `Admittance`. The all-real NT resistive-pi path is untouched.

## Result on the corpus
`20m_dipole_NT_50ohm` (a **purely reactive** 50 Ω matching network) loses its `n` flag and enters the clean rollup — all four engines now land on nec2c:

| | PyNEC | Sin | Bs1 | Bs2 |
|---|--:|--:|--:|--:|
| ΔΓ (was: `n`, excluded, ~1.1 off) | **0.0001** | 0.0006 | 0.0091 | 0.0019 |

## Tests
`tests/test_admittance_branch.py` — circuit-theory oracles (2-port vs augmented nodal solve, 1-port shunt, frequency-independence, shape validation), NT-susceptance → `Admittance` translation, and a PyNEC-vs-momwire cross-engine MoM check. Updated the one existing test that asserted the old drop-behavior. 174 network/import/engine tests + 186 design tests green.

## Follow-ups (noted in the issue)
Reactive **TL end-shunts** and fixed-**jX LD 4** loads map onto this same primitive (1-port form) — natural next steps, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)