### PR TITLE
SY symbolic variables: evaluate 4nec2 expressions in imported decks

### DIFF
--- a/src/antennaknobs/nec_import.py
+++ b/src/antennaknobs/nec_import.py
@@ -90,7 +90,6 @@ _UNSUPPORTED_CARDS = {
     "SP": "a surface patch (SP)",
     "SM": "a multiple-patch surface (SM)",
     "GF": "a numerical Green's function file (GF)",
-    "SY": "symbolic variables (SY, a 4nec2 extension)",
 }
 
 
@@ -511,13 +510,181 @@ def _float(token: str, where: str) -> float:
             raise ValueError(f"{where}: bad number {token!r}") from None
 
 
+# ---------------------------------------------------------------------------
+# SY symbolic variables (4nec2 extension, issue #417)
+# ---------------------------------------------------------------------------
+# 4nec2's expression language is BASIC-flavored: `^` is power, trig works in
+# DEGREES (the corpus is full of `sin(360*x)`), `sqr` is square root, `atn`
+# arctangent (returning degrees), `int` truncates. Names are matched
+# case-insensitively. Evaluation is a whitelisted ast walk — no eval().
+_SY_FUNCS = {
+    "sin": lambda x: math.sin(math.radians(x)),
+    "cos": lambda x: math.cos(math.radians(x)),
+    "tan": lambda x: math.tan(math.radians(x)),
+    "atn": lambda x: math.degrees(math.atan(x)),
+    "atan": lambda x: math.degrees(math.atan(x)),
+    "sqr": math.sqrt,
+    "sqrt": math.sqrt,
+    "abs": abs,
+    "int": lambda x: float(int(x)),
+    "log": math.log,
+    "exp": math.exp,
+}
+_SY_CONSTANTS = {
+    "pi": math.pi,
+    # 4nec2 predefined unit-scale symbols (`SY r = 1.5 * mm`): factors to
+    # metres. A deck's own SY definition of the same name wins (the symbol
+    # table is consulted before these constants).
+    "mm": 1e-3,
+    "cm": 1e-2,
+    "dm": 0.1,
+    "m": 1.0,
+    "in": 0.0254,
+    "ft": 0.3048,
+    # electrical component suffixes (`SY C=36.6pF`, `SY L=0.5uH`)
+    "pf": 1e-12,
+    "nf": 1e-9,
+    "uf": 1e-6,
+    "nh": 1e-9,
+    "uh": 1e-6,
+    "mh": 1e-3,
+}
+
+
+_SY_IDENT = None
+
+
+def _eval_sy_expr(expr: str, syms: dict, where: str) -> float:
+    """Evaluate one 4nec2 expression against the symbol table."""
+    import ast
+    import re
+
+    global _SY_IDENT
+    if _SY_IDENT is None:
+        # An identifier not glued to a preceding digit/dot (so the exponent
+        # in `1e3` / `.5E-2` is never mistaken for a symbol).
+        _SY_IDENT = re.compile(r"(?<![\w.])[A-Za-z_]\w*")
+
+    # Mangle every identifier before ast.parse: 4nec2 names are
+    # case-insensitive and may be Python keywords (`lambda` is the most
+    # idiomatic antenna symbol there is), which would be a SyntaxError.
+    src = expr.strip().replace("^", "**")
+    # Juxtaposed units — `135 ft`, `1.5 mm`, `61ft` — are implicit
+    # multiplication, but ONLY for the predefined unit names (anything
+    # wider would turn typos into silent products). Glued forms are safe
+    # from exponent confusion: `1e3` stays a number because `e` is not a
+    # unit name.
+    src = re.sub(
+        r"([0-9.])\s*(mm|cm|dm|mh|nh|uh|pf|nf|uf|in|ft|m)\b",
+        r"\1*\2",
+        src,
+        flags=re.IGNORECASE,
+    )
+    src = _SY_IDENT.sub(lambda m: f"_v_{m.group(0).lower()}", src)
+    try:
+        tree = ast.parse(src, mode="eval")
+    except SyntaxError:
+        raise ValueError(f"{where}: SY expression {expr!r} is not valid") from None
+
+    def walk(node):
+        if isinstance(node, ast.Expression):
+            return walk(node.body)
+        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+            return float(node.value)
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.USub, ast.UAdd)):
+            v = walk(node.operand)
+            return -v if isinstance(node.op, ast.USub) else v
+        if isinstance(node, ast.BinOp) and isinstance(
+            node.op, (ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Pow, ast.Mod)
+        ):
+            a, b = walk(node.left), walk(node.right)
+            if isinstance(node.op, ast.Add):
+                return a + b
+            if isinstance(node.op, ast.Sub):
+                return a - b
+            if isinstance(node.op, ast.Mult):
+                return a * b
+            if isinstance(node.op, ast.Div):
+                return a / b
+            if isinstance(node.op, ast.Mod):
+                return math.fmod(a, b)
+            return a**b
+        if isinstance(node, ast.Name):
+            key = node.id.removeprefix("_v_")
+            if key in syms:
+                return syms[key]
+            if key in _SY_CONSTANTS:
+                return _SY_CONSTANTS[key]
+            raise ValueError(f"{where}: undefined symbol {key!r}")
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and not node.keywords
+            and len(node.args) == 1
+        ):
+            fn = _SY_FUNCS.get(node.func.id.removeprefix("_v_"))
+            if fn is not None:
+                return float(fn(walk(node.args[0])))
+            raise ValueError(
+                f"{where}: unknown function "
+                f"{node.func.id.removeprefix('_v_')!r} in SY expression"
+            )
+        raise ValueError(f"{where}: SY expression {expr!r} is not valid")
+
+    return float(walk(tree))
+
+
+def _define_sy(rest: str, syms: dict, where: str) -> None:
+    """Apply one SY card: ``name=expr[, name=expr...]['comment]``."""
+    body = rest.split("'", 1)[0].strip()  # 4nec2 trailing comment
+    if not body:
+        raise ValueError(f"{where}: SY card without an assignment")
+    # Split on top-level commas only (function args never contain commas in
+    # the 4nec2 single-argument vocabulary, but stay paren-aware anyway).
+    parts, depth, start = [], 0, 0
+    for i, ch in enumerate(body):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            parts.append(body[start:i])
+            start = i + 1
+    parts.append(body[start:])
+    for part in parts:
+        if "=" not in part:
+            raise ValueError(f"{where}: SY assignment {part.strip()!r} has no '='")
+        name, expr = part.split("=", 1)
+        name = name.strip()
+        if not name.isidentifier():
+            raise ValueError(f"{where}: SY name {name!r} is not a valid symbol")
+        syms[name.lower()] = _eval_sy_expr(expr, syms, where)
+
+
+def _value(token: str, where: str, syms: dict | None) -> float:
+    """A card field: a plain number, or (when the deck defined SY symbols
+    or the token contains a letter) a 4nec2 expression."""
+    try:
+        return _float(token, where)
+    except ValueError:
+        if syms is not None and any(c.isalpha() or c in "()*/+-^" for c in token):
+            return _eval_sy_expr(token, syms, where)
+        raise
+
+
 class _Card:
     """One card line: mnemonic + zero-padded numeric field access."""
 
-    def __init__(self, mnemonic: str, tokens: list[str], where: str):
+    def __init__(
+        self,
+        mnemonic: str,
+        tokens: list[str],
+        where: str,
+        syms: dict | None = None,
+    ):
         self.mnemonic = mnemonic
         self.where = where
-        self.vals = [_float(t, where) for t in tokens]
+        self.vals = [_value(t, where, syms) for t in tokens]
 
     def f(self, k: int) -> float:
         return self.vals[k] if k < len(self.vals) else 0.0
@@ -962,6 +1129,7 @@ def parse_nec(text: str, *, name: str = "NEC deck", network: bool = False) -> Ne
     freq_mhz: tuple[float, float] | None = None
     ground = False
     extended_kernel = False
+    syms: dict[str, float] = {}  # SY symbol table (#417)
     in_comments = True
 
     geometry = {
@@ -1000,6 +1168,12 @@ def parse_nec(text: str, *, name: str = "NEC deck", network: bool = False) -> Ne
 
         if mnemonic == "EN":
             break
+        if mnemonic == "SY":
+            # 4nec2 symbolic variables (#417): bind name=expr (possibly
+            # several per card, possibly with a trailing ' comment) into the
+            # symbol table consulted by every later card field.
+            _define_sy(stripped[2:], syms, where)
+            continue
         if mnemonic in _UNSUPPORTED_CARDS:
             raise ValueError(
                 f"{where}: this deck uses {_UNSUPPORTED_CARDS[mnemonic]}, "
@@ -1013,7 +1187,7 @@ def parse_nec(text: str, *, name: str = "NEC deck", network: bool = False) -> Ne
             # Collected raw and translated after the loop, once the wire
             # list is final (their tag/segment addressing resolves against
             # the transformed geometry, exactly like EX).
-            card = _Card(mnemonic, tokens[1:], where)
+            card = _Card(mnemonic, tokens[1:], where, syms)
             if mnemonic == "LD":
                 if card.i(0) == -1:
                     lds_raw.clear()  # NEC: nullify all previous loads
@@ -1035,14 +1209,14 @@ def parse_nec(text: str, *, name: str = "NEC deck", network: bool = False) -> Ne
             # ignored. `EK -1` switches back to the standard kernel; any
             # other form turns it on. NEC scopes EK to subsequent geometry;
             # decks in the wild use it globally, so one deck-level flag.
-            card = _Card(mnemonic, tokens[1:], where)
+            card = _Card(mnemonic, tokens[1:], where, syms)
             extended_kernel = card.i(0) != -1
             continue
         if mnemonic in _IGNORED_CARDS:
             ignored.add(mnemonic)
             continue
 
-        card = _Card(mnemonic, tokens[1:], where)
+        card = _Card(mnemonic, tokens[1:], where, syms)
 
         if mnemonic in geometry:
             geometry[mnemonic](card, wires)

--- a/tests/test_nec_import_sy.py
+++ b/tests/test_nec_import_sy.py
@@ -1,0 +1,143 @@
+"""Issue #417: SY symbolic variables (4nec2 extension) — evaluate and
+substitute.
+
+SY was the single largest importer gap in the 2026-07-16 wild-corpus census
+(642 of 1,082 rejections). Real-world usage this suite pins, all observed in
+the corpus: spaces around `=` and inside expressions, trailing `'` comments
+on the SY line, multi-assignment lines (`SY a=1, b=2`), case-insensitive
+references, `^` for power, and 4nec2's BASIC-flavored function set with
+trig in DEGREES (`sin(360*x)`, `atn`, `sqr` = square root).
+"""
+
+import math
+
+import pytest
+
+from antennaknobs.nec_import import parse_nec
+
+
+def _deck(sy_lines, gw_fields="0 0 0 0 0 h 0.001"):
+    sy = "\n".join(sy_lines)
+    return f"""CE test
+{sy}
+GW 1 11 {gw_fields}
+GE 0
+EX 0 1 6 0 1.0 0.0
+EN
+"""
+
+
+def _z_top(deck):
+    return deck.wires[0].p2[2]
+
+
+def test_simple_constant():
+    deck = parse_nec(_deck(["SY h=12.5"]), name="t")
+    assert _z_top(deck) == pytest.approx(12.5)
+
+
+def test_spaces_and_case_insensitive():
+    deck = parse_nec(
+        _deck(["SY W0 = 0.005"], gw_fields="-w0/2 0 0 w0/2 0 0 W0"), name="t"
+    )
+    w = deck.wires[0]
+    assert w.p1[0] == pytest.approx(-0.0025)
+    assert w.p2[0] == pytest.approx(0.0025)
+    assert w.radius == pytest.approx(0.005)
+
+
+def test_arithmetic_with_references():
+    deck = parse_nec(_deck(["SY a=2", "SY h=3*a/2 + 1"]), name="t")
+    assert _z_top(deck) == pytest.approx(4.0)
+
+
+def test_expression_in_card_field():
+    deck = parse_nec(_deck(["SY ph=8"], gw_fields="0 0 0 0 0 3*ph/4 0.001"), name="t")
+    assert _z_top(deck) == pytest.approx(6.0)
+
+
+def test_caret_is_power():
+    deck = parse_nec(_deck(["SY h=2^3"]), name="t")
+    assert _z_top(deck) == pytest.approx(8.0)
+
+
+def test_trig_in_degrees():
+    deck = parse_nec(_deck(["SY h=10*sin(30)"]), name="t")
+    assert _z_top(deck) == pytest.approx(5.0)
+
+
+def test_basic_flavored_functions():
+    deck = parse_nec(_deck(["SY h=sqr(9) + atn(1)/45 + int(1.9)"]), name="t")
+    # sqr = square root (BASIC), atn = arctan in degrees, int truncates.
+    assert _z_top(deck) == pytest.approx(3.0 + 1.0 + 1.0)
+
+
+def test_pi_constant():
+    deck = parse_nec(_deck(["SY h=pi"]), name="t")
+    assert _z_top(deck) == pytest.approx(math.pi)
+
+
+def test_multi_assignment_line():
+    deck = parse_nec(_deck(["SY a=1.5, h=a+0.5"]), name="t")
+    assert _z_top(deck) == pytest.approx(2.0)
+
+
+def test_trailing_quote_comment():
+    deck = parse_nec(_deck(["SY h=0.5*30/1000\t'radiator height, mm to m"]), name="t")
+    assert _z_top(deck) == pytest.approx(0.015)
+
+
+def test_paren_protected_commas_in_multi_assign():
+    deck = parse_nec(_deck(["SY a=30, h=10*sin(a), w=a/30"]), name="t")
+    assert _z_top(deck) == pytest.approx(5.0)
+
+
+def test_unit_scale_symbols():
+    """4nec2 predefines metric/imperial scale symbols: `SY r = 1.5 * mm`
+    (xnec2c's sy_units_spaces fixture). A deck's own definition shadows."""
+    deck = parse_nec(_deck(["SY h = 1.5 * mm"]), name="t")
+    assert _z_top(deck) == pytest.approx(0.0015)
+    shadowed = parse_nec(_deck(["SY mm=2", "SY h=3*mm"]), name="t")
+    assert _z_top(shadowed) == pytest.approx(6.0)
+
+
+def test_juxtaposed_units():
+    """`SY X=135 ft` — implicit multiplication, unit names only (seen in
+    the icecube/W2FMI-style decks)."""
+    deck = parse_nec(_deck(["SY h=135 ft"]), name="t")
+    assert _z_top(deck) == pytest.approx(135 * 0.3048)
+    glued = parse_nec(_deck(["SY h=61ft"]), name="t")
+    assert _z_top(glued) == pytest.approx(61 * 0.3048)
+    # exponent letters are not units
+    sci = parse_nec(_deck(["SY h=1.5e1"]), name="t")
+    assert _z_top(sci) == pytest.approx(15.0)
+    # electrical suffixes (`SY C=36.6pF`) — scale factors like the metric ones
+    cap = parse_nec(_deck(["SY c=36.6pF", "SY h=c*1e9"]), name="t")
+    assert _z_top(cap) == pytest.approx(36.6e-3)
+
+
+def test_python_keyword_symbol_names():
+    """`lambda` is the most idiomatic antenna symbol there is — and a Python
+    keyword. xnec2c's own SY fixtures use it."""
+    deck = parse_nec(_deck(["SY lambda=299.8/14.1", "SY h=lambda/4"]), name="t")
+    assert _z_top(deck) == pytest.approx(299.8 / 14.1 / 4)
+
+
+def test_undefined_symbol_is_clean_rejection():
+    with pytest.raises(ValueError, match="undefined symbol"):
+        parse_nec(_deck([""], gw_fields="0 0 0 0 0 nosuch 0.001"), name="t")
+
+
+def test_bad_sy_expression_is_clean_rejection():
+    with pytest.raises(ValueError, match="SY"):
+        parse_nec(_deck(["SY h=import os"]), name="t")
+
+
+def test_sy_not_listed_as_ignored():
+    deck = parse_nec(_deck(["SY h=1"]), name="t")
+    assert "SY" not in deck.ignored
+
+
+def test_plain_numbers_still_reject_garbage():
+    with pytest.raises(ValueError, match="bad number|undefined symbol"):
+        parse_nec(_deck([""], gw_fields="0 0 0 0 0 12..5 0.001"), name="t")


### PR DESCRIPTION
## Summary
- `nec_import` now evaluates `SY name=expr` bindings and substitutes them in any subsequent card field — the single largest importer gap in the wild-corpus census (642 of 1,082 rejections). Implementation is a whitelisted `ast` walk (no `eval`), with 4nec2's BASIC-flavored semantics pinned test-by-test from real corpus usage: `^` power, **trig in degrees**, `atn`/`sqr`/`int`, case-insensitive names, multi-assignment lines, trailing `'` comments, and predefined unit-scale symbols (`mm`…`ft`, `pF`…`mH`) with juxtaposed/glued products (`135 ft`, `61ft`, `36.6pF`). Python-keyword symbol names (`lambda`!) work via identifier mangling before parse.
- Bad input stays clean: undefined symbols and invalid expressions raise specific `ValueError`s (census-visible, never a crash).

## Results
- Wild-corpus census: rejections **1,082 → 657**, parse rate **65% → 79%**, still **zero crashes** across 3,146 unique decks (the evaluator held against 600+ wild expression decks).
- All five xnec2c SY parser fixtures (`sy_*.nec`, including the issue-82 units/spaces one) parse.
- Remaining SY-adjacent failures are `'`-comments on *geometry* cards — #418's tokenizer work, which compounds with this to reach the projected ~86%.

Closes #417

## Test plan
- [x] TDD: 18 new tests in `tests/test_nec_import_sy.py` written first (13 failed for the right reason pre-implementation), covering every observed wild idiom + rejection paths.
- [x] Full suite: 2007 passed. ruff + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSnmgGZUgDsMWkQHNpTogu