### PR TITLE
Tolerant NEC tokenizer: quote comments, fused mnemonics, glued CM, AWG gauges

### DIFF
--- a/docs/status/2026-07-16-wild-corpus-parse-census.md
+++ b/docs/status/2026-07-16-wild-corpus-parse-census.md
@@ -71,6 +71,22 @@ it is honored since #414.
 3. GC/GH tapered-radius support (22 decks) — natural extension of the
    per-wire WireSpec machinery; lower value per effort.
 
+## Addendum (same day): after #417 + #418
+
+The two filed unlocks landed hours later and beat their projections:
+
+| pass | rejected | parse rate |
+|---|--:|--:|
+| initial census | 1,082 | 65% |
+| + #417 SY symbolic variables | 657 | 79% |
+| + #418 tolerant tokenizer (quote comments, fused mnemonics, glued CM, `#AWG`) | **260** | **91.7%** |
+
+Still zero crashes on every pass. The remaining 260 are dominated by
+genuinely-unsupported physics (current-source EX 63, plane-wave EX 45,
+SP/SM/GF patches, unrecognised NEC-4-era cards) plus a ~57-deck residue of
+mnemonic junk and exotic SY forms — census them again after the next
+importer change, not before.
+
 ## Caveats
 
 - Parse ≠ solve: this census says the geometry translates, not that engines

--- a/src/antennaknobs/nec_import.py
+++ b/src/antennaknobs/nec_import.py
@@ -673,8 +673,17 @@ def _define_sy(rest: str, syms: dict, where: str) -> None:
 
 
 def _value(token: str, where: str, syms: dict | None) -> float:
-    """A card field: a plain number, or (when the deck defined SY symbols
+    """A card field: a plain number, 4nec2's ``#nn`` AWG wire-gauge
+    shorthand (a radius, in metres), or (when the deck defined SY symbols
     or the token contains a letter) a 4nec2 expression."""
+    if token.startswith("#"):
+        # AWG gauge n -> diameter 0.127 mm * 92^((36-n)/39); field is a
+        # radius. 4nec2 writes `#14`-style GW radius fields (#418).
+        try:
+            gauge = int(token[1:])
+        except ValueError:
+            raise ValueError(f"{where}: bad wire gauge {token!r}") from None
+        return 0.5 * 0.127e-3 * 92.0 ** ((36.0 - gauge) / 39.0)
     try:
         return _float(token, where)
     except ValueError:
@@ -1151,7 +1160,6 @@ def parse_nec(text: str, *, name: str = "NEC deck", network: bool = False) -> Ne
     ground = False
     extended_kernel = False
     syms: dict[str, float] = {}  # SY symbol table (#417)
-    in_comments = True
 
     geometry = {
         "GW": _gw,
@@ -1168,24 +1176,42 @@ def parse_nec(text: str, *, name: str = "NEC deck", network: bool = False) -> Ne
         if not stripped:
             continue
         where = f"{name}, line {line_no}"
+        # 4nec2 comment convention (#418): a leading ' comments out the
+        # whole line (including commented-out cards, `'GW ...`); anywhere
+        # else ' starts an end-of-line comment. CM/CE lines are exempt —
+        # their free text legitimately contains apostrophes.
+        if stripped.startswith("'"):
+            continue
+        if stripped[:2].upper() == "CM":
+            # NEC identifies cards by the first two columns, so a glued
+            # "CMtext..." is a comment too (wild decks write "cmRP ..." to
+            # comment out cards). Tolerated after CE as well (#418).
+            comments.append(stripped[2:].strip())
+            continue
+        if stripped[:2].upper() != "CE":
+            stripped = stripped.split("'", 1)[0].rstrip()
+            if not stripped:
+                continue
         # Cards are free-format in practice: mnemonic, then numbers separated
         # by spaces and/or commas.
         tokens = stripped.replace(",", " ").split()
+        # Fused mnemonics (#418): ARRL-era decks glue the mnemonic to the
+        # first field ("GW1,8,...", "GE1", "EX5,1,..."). Split when two
+        # alphabetic characters run straight into a number.
+        if (
+            len(tokens[0]) > 2
+            and tokens[0][:2].isalpha()
+            and tokens[0][2] in "0123456789.+-"
+        ):
+            tokens = [tokens[0][:2], tokens[0][2:], *tokens[1:]]
         mnemonic = tokens[0].upper()
         if len(mnemonic) != 2 or not mnemonic.isalpha():
             raise ValueError(
                 f"{where}: expected a NEC card mnemonic, got {tokens[0]!r}"
             )
 
-        if mnemonic == "CM":
-            if not in_comments:
-                raise ValueError(f"{where}: CM card after the CE end-of-comments card")
-            comments.append(stripped[2:].strip())
-            continue
         if mnemonic == "CE":
-            in_comments = False
             continue
-        in_comments = False
 
         if mnemonic == "EN":
             break

--- a/tests/test_nec_import_comments.py
+++ b/tests/test_nec_import_comments.py
@@ -1,0 +1,138 @@
+"""Issue #418: tolerant tokenization — 4nec2 `'` comments, fused mnemonics,
+CM after CE.
+
+Second-largest wild-corpus rejection class (~290 decks post-#417). Every
+form pinned here was observed verbatim in the corpus: full-line `'` comments
+(including commented-out cards like `'GW ...`), trailing `' comment` after
+card fields (`GS 0 0 0.3048 ' All in ft.`), ARRL's fused mnemonics
+(`GW1,8,...` / `GE1` / `GN1` / `EX5,1,...` — DIP.NEC's entire body), and CM
+cards appearing after CE (icecube Catenary.nec).
+"""
+
+import pytest
+
+from antennaknobs.nec_import import parse_nec
+
+
+BASE = """CE test
+GW 1 11 0 0 0 0 0 5 0.001
+GE 0
+EX 0 1 6 0 1.0 0.0
+EN
+"""
+
+
+def test_full_line_quote_comments_skipped():
+    deck = parse_nec(
+        "CE t\n"
+        "'\n"
+        "' free-standing comment\n"
+        "'GW 9 9 commented-out card, never parsed\n"
+        "GW 1 11 0 0 0 0 0 5 0.001\n"
+        "GE 0\n"
+        "EX 0 1 6 0 1 0\n"
+        "EN\n",
+        name="t",
+    )
+    assert len(deck.wires) == 1
+    assert deck.wires[0].tag == 1
+
+
+def test_trailing_quote_comment_on_cards():
+    deck = parse_nec(
+        "CE t\n"
+        "GW 1 11 0 0 0 0 0 5 0.001 'radiator, don't touch\n"
+        "GS 0 0 0.3048 ' All in ft.\n"
+        "GE 0 'no ground\n"
+        "EX 0 1 6 0 1 0\n"
+        "EN\n",
+        name="t",
+    )
+    # GS scaled the 5 m wire by 0.3048
+    assert deck.wires[0].p2[2] == pytest.approx(5 * 0.3048)
+
+
+def test_cm_comment_text_keeps_apostrophes():
+    deck = parse_nec("CM it's a dipole; don't strip this ' text\n" + BASE, name="t")
+    assert "it's a dipole; don't strip this ' text" in deck.comments
+
+
+def test_cm_after_ce_tolerated():
+    deck = parse_nec(
+        "CE t\nCM late comment, 4nec2 writes these\n"
+        "GW 1 11 0 0 0 0 0 5 0.001\nGE 0\nEX 0 1 6 0 1 0\nEN\n",
+        name="t",
+    )
+    assert len(deck.wires) == 1
+    assert "late comment, 4nec2 writes these" in deck.comments
+
+
+def test_fused_mnemonics_arrl_style():
+    """ARRL DIP.NEC verbatim shape: mnemonic glued to the first field."""
+    deck = parse_nec(
+        "CM DIPOLE OVER IDEAL EARTH\n"
+        "CE\n"
+        "GW1,8,-1.,0.,1.,1.,0.,1.,.0001\n"
+        "GE1\n"
+        "GN1\n"
+        "FR0,3,0,0,70.,5.\n"
+        "EX5,1,4,0,1000.,0.\n"
+        "EN\n",
+        name="t",
+    )
+    assert len(deck.wires) == 1
+    assert deck.wires[0].n_seg == 8
+    assert deck.ground  # GE1 + GN1
+    assert deck.feeds[0].seg == 4
+    assert deck.freq_mhz == (70.0, 80.0)
+
+
+def test_fused_negative_field():
+    deck = parse_nec(
+        "CE t\nGW1,11,0,0,0,0,0,5,.001\nGE0\nEX0,1,6,0,1.,0.\nEN\n", name="t"
+    )
+    assert deck.wires[0].p2[2] == pytest.approx(5.0)
+
+
+def test_junk_mnemonics_still_reject():
+    with pytest.raises(ValueError, match="mnemonic"):
+        parse_nec("CE t\nFOO1 2 3\nEN\n", name="t")
+    with pytest.raises(ValueError, match="unrecognised"):
+        parse_nec("CE t\nQZ 1 2\nEN\n", name="t")
+
+
+def test_glued_cm_is_a_comment():
+    """NEC identifies cards by the first two columns: `cmRP ...` (however
+    cased, no space) is a comment — wild decks use it to comment out cards."""
+    deck = parse_nec(
+        "CM head\nCE\ncmRP 0 19 37 1000 0 0 5 10\n"
+        "GW 1 11 0 0 0 0 0 5 0.001\nGE 0\nEX 0 1 6 0 1 0\nEN\n",
+        name="t",
+    )
+    assert len(deck.wires) == 1
+    assert any(c.startswith("RP 0 19") for c in deck.comments)
+
+
+def test_awg_gauge_radius():
+    """4nec2's `#nn` AWG shorthand in a radius field: gauge 12 wire has
+    diameter 0.127mm * 92^(24/39) ~ 2.053 mm."""
+    deck = parse_nec(
+        "CE t\nGW 1 11 0 0 0 0 0 5 #12\nGE 0\nEX 0 1 6 0 1 0\nEN\n",
+        name="t",
+    )
+    assert deck.wires[0].radius == pytest.approx(0.5 * 0.127e-3 * 92.0 ** (24.0 / 39.0))
+    with pytest.raises(ValueError, match="wire gauge"):
+        parse_nec(
+            "CE t\nGW 1 11 0 0 0 0 0 5 #junk\nGE 0\nEX 0 1 6 0 1 0\nEN\n",
+            name="t",
+        )
+
+
+def test_quote_only_junk_no_longer_fatal():
+    """The census's 'bad number' quote class: a quote glued to a field."""
+    deck = parse_nec(
+        "CE t\nGW 1 11 0 0 0 0 0 5 0.001'comment glued to the radius\n"
+        "GE 0\nEX 0 1 6 0 1 0\nEN\n",
+        name="t",
+    )
+    assert deck.wires[0].radius == pytest.approx(0.001)


### PR DESCRIPTION
## Summary
- **`'` comments** (4nec2 convention): a leading `'` comments out the whole line — including commented-out cards (`'GW ...`) — and elsewhere `'` starts an end-of-line comment, glued or spaced. CM/CE lines are exempt so comment text keeps its apostrophes. Zero risk to strict decks: `'` has no meaning in NEC2 card format.
- **Fused mnemonics**: `GW1,8,...` / `GE1` / `GN1` / `EX5,1,...` (ARRL's DIP.NEC is built entirely of these) — two alphabetic characters running straight into a number split into mnemonic + first field.
- **CM by column, not token**: NEC identifies cards by the first two columns, so glued `cmRP ...` is a comment; CM after CE is now tolerated (strict-ordering error removed).
- **`#nn` AWG shorthand** in radius fields (4nec2): gauge → radius via 0.127 mm · 92^((36−n)/39) / 2, with a clean error for `#junk`.

## Results
- Wild-corpus census: rejections **657 → 260**, parse rate **79% → 91.7%** (65% at the start of the day; zero crashes on all three passes across 3,146 unique decks). Census doc gains a same-day addendum table.
- Remaining 260 rejections are dominated by genuinely-unsupported physics: current-source EX (63), plane-wave EX (45), SP/SM patches, GF, NEC-4-era cards.

Closes #418

## Test plan
- [x] TDD: 10 new tests in `tests/test_nec_import_comments.py` written first (6 failed for the right reason), each pinned to a verbatim corpus form; junk-mnemonic rejection preserved.
- [x] Full suite: 2023 passed. ruff + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSnmgGZUgDsMWkQHNpTogu