### PR TITLE
feat(nec-import): virtualize remote TL-anchor wires as PortVirtual terminations (#427)

### DIFF
--- a/scripts/bench_nec_corpus.py
+++ b/scripts/bench_nec_corpus.py
@@ -495,6 +495,11 @@ def bench_deck(
         ground_note=note,
         partial_net=bool(ignored_net),
         partial_net_detail=[c for c, _ in ignored_net][:4],
+        # Remote TL-anchor wires the importer replaced with PortVirtual
+        # terminations (issue #427): the deck solves on momwire engines
+        # instead of hanging (momwire#157), at a residual that matches nec2c
+        # better than meshing the tiny remote wire would. Labeled, not hidden.
+        virtualized_anchors=list(deck.virtual_anchor_tags()),
     )
 
     ref = run_nec2c(deck_path, timeout)
@@ -539,7 +544,8 @@ def print_report(rows, engines):
         "(feed 0; ΔΓ = |Γ_eng − Γ_nec2c|, Γ = (Z−50)/(Z+50))"
     )
     print(
-        "  flags: g = unsupported ground (radials/cliff), n = inexpressible LD/TL/NT network"
+        "  flags: g = unsupported ground (radials/cliff), n = inexpressible LD/TL/NT "
+        "network, v = remote TL-anchor wire(s) virtualized (#427)"
     )
     print("=" * 104)
     hdr = (
@@ -550,8 +556,10 @@ def print_report(rows, engines):
     print("-" * len(hdr))
     for r in ok:
         z0 = _z(r["nec2c"]["z"][0])
-        flags = ("g" if not r.get("ground_supported", True) else "") + (
-            "n" if r.get("partial_net") else ""
+        flags = (
+            ("g" if not r.get("ground_supported", True) else "")
+            + ("n" if r.get("partial_net") else "")
+            + ("v" if r.get("virtualized_anchors") else "")
         )
         cells = " ".join(f"{fmt_dg(r['engines'].get(e)):>11}" for e in engines)
         print(
@@ -585,7 +593,7 @@ def print_report(rows, engines):
     print("\n" + "=" * 72)
     print(
         "AGREEMENT ROLLUP  (feed-0 ΔΓ; clean decks: supported ground, "
-        "fully-expressed network)"
+        "fully-expressed network, no virtualized anchors)"
     )
     print("=" * 72)
     for e in engines:
@@ -594,6 +602,7 @@ def print_report(rows, engines):
             for r in ok
             if r.get("ground_supported", True)
             and not r.get("partial_net")
+            and not r.get("virtualized_anchors")
             and not r["engines"].get(e, {}).get("error")
             and r["engines"][e].get("cmp")
         ]

--- a/src/antennaknobs/nec_import.py
+++ b/src/antennaknobs/nec_import.py
@@ -140,7 +140,18 @@ class NecTL:
     ``length`` is resolved: the card's length, or the straight-line distance
     between the segment midpoints when the card says 0 (NEC semantics).
     ``shunt_r_*`` carry conductance-only end admittances as 1/G resistances
-    (a card with susceptance in an end admittance is not translated)."""
+    (a card with susceptance on a *real* end admittance is not translated).
+
+    ``virtual_a`` / ``virtual_b`` mark an end that lands on a virtualized
+    remote TL-anchor wire (issue #427): that segment carries no geometry, so
+    ``network()`` terminates the line on a ``PortVirtual`` circuit node
+    instead of a ``PortOnWire``, and the anchor wire is dropped from
+    ``wire_tuples()``. A virtual end may carry susceptance — its full complex
+    end admittance is kept in ``shunt_y_a`` / ``shunt_y_b`` and stamped as a
+    1-port ``Admittance`` on the virtual node (the shorted-stub variant); a
+    zero ``shunt_y`` leaves the node an ideal open (the open-stub variant).
+    The ``shunt_r_*`` / ``shunt_y_*`` fields are mutually exclusive per end:
+    a real end uses ``shunt_r``, a virtual end uses ``shunt_y``."""
 
     wire_a: int
     seg_a: int
@@ -151,6 +162,10 @@ class NecTL:
     transposed: bool
     shunt_r_a: float | None
     shunt_r_b: float | None
+    virtual_a: bool = False
+    virtual_b: bool = False
+    shunt_y_a: complex | None = None
+    shunt_y_b: complex | None = None
 
 
 @dataclass(frozen=True)
@@ -207,6 +222,18 @@ class NecDeck:
     # its own formulation, so this is reference fidelity, not a momwire knob.
     # Deck-level: True if any EK card other than `EK -1` (off) appears.
     extended_kernel: bool = False
+    # Wire indices (into ``wires``) detected as remote TL-anchor wires and
+    # virtualized (issue #427): a 1-segment wire parked ≫λ away, referenced
+    # only as a TL far-end termination. They are dropped from wire_tuples()
+    # and their TL end becomes a PortVirtual in network(). Empty unless
+    # parsed with network=True and virtualize_anchors=True.
+    virtual_anchors: frozenset[int] = frozenset()
+
+    def virtual_anchor_tags(self) -> tuple[int, ...]:
+        """The NEC tags of the wires virtualized as TL anchors (issue #427),
+        in wire order — for honest benchmark/UI labeling of decks whose
+        remote anchor geometry the app replaced with a circuit termination."""
+        return tuple(self.wires[i].tag for i in sorted(self.virtual_anchors))
 
     def dominant_radius(self) -> float:
         """The deck's wire radius, length-weighted where wires differ.
@@ -252,6 +279,14 @@ class NecDeck:
             parts.append(f"deck cards not applied: {cards}")
         if self.ground:
             parts.append("the deck models a ground plane")
+        if self.virtual_anchors:
+            tags = ", ".join(str(t) for t in self.virtual_anchor_tags())
+            n = len(self.virtual_anchors)
+            parts.append(
+                f"{n} remote TL-anchor wire{'s' if n > 1 else ''} "
+                f"(tag{'s' if n > 1 else ''} {tags}) modeled as ideal virtual "
+                f"terminations"
+            )
         if not parts:
             return None
         body = "; ".join(parts)
@@ -407,6 +442,10 @@ class NecDeck:
                 tups.append((p0, p1, n, ex))
 
         for i, w in enumerate(self.wires):
+            if i in self.virtual_anchors:
+                # Remote TL-anchor wire (issue #427): no geometry — its TL end
+                # is a PortVirtual in network(), so emit nothing here.
+                continue
             per = marks.get(i, {})
             cutset = self._junction_cuts.get(i, frozenset())
             n = w.n_seg
@@ -460,7 +499,16 @@ class NecDeck:
                 "parse_nec/read_nec with network=True"
             )
         plan = self._port_plan
-        ports = {pname: _net.PortOnWire(pname) for pname in plan.values()}
+        # A port on a virtualized anchor wire (issue #427) is a pure circuit
+        # node (PortVirtual), no geometry; every other port is on a real wire.
+        ports = {
+            pname: (
+                _net.PortVirtual(pname)
+                if wi in self.virtual_anchors
+                else _net.PortOnWire(pname)
+            )
+            for (wi, _seg), pname in plan.items()
+        }
         branches: list = []
         for ld in self.loads:
             branches.append(
@@ -482,6 +530,13 @@ class NecDeck:
                 branches.append(_net.Shunt(port=a, r=tl.shunt_r_a))
             if tl.shunt_r_b is not None:
                 branches.append(_net.Shunt(port=b, r=tl.shunt_r_b))
+            # Virtual-anchor far-end admittance (issue #427): the full complex
+            # end Y as a fixed 1-port Admittance on the virtual node. Absent
+            # (None) leaves the node an ideal open — the open-stub variant.
+            if tl.shunt_y_a is not None:
+                branches.append(_net.Admittance(ports=(a,), y=((tl.shunt_y_a,),)))
+            if tl.shunt_y_b is not None:
+                branches.append(_net.Admittance(ports=(b,), y=((tl.shunt_y_b,),)))
         for nt in self.nts:
             a = plan[(nt.wire_a, nt.seg_a)]
             b = plan[(nt.wire_b, nt.seg_b)]
@@ -503,12 +558,20 @@ class NecDeck:
         return _net.Network(ports=ports, branches=branches, sources=sources)
 
 
-def read_nec(builder, name: str, *, network: bool = False) -> NecDeck:
+def read_nec(
+    builder, name: str, *, network: bool = False, virtualize_anchors: bool = True
+) -> NecDeck:
     """``read_data`` followed by ``parse_nec`` — load a NEC card deck that
     ships next to ``builder``'s design, with the same folder confinement as
     ``read_json``. ``network=True`` translates the deck's expressible
-    LD/TL/NT cards into ``deck.network()`` (see the module docstring)."""
-    return parse_nec(read_data(builder, name), name=name, network=network)
+    LD/TL/NT cards into ``deck.network()`` (see the module docstring);
+    ``virtualize_anchors`` forwards to ``parse_nec`` (issue #427)."""
+    return parse_nec(
+        read_data(builder, name),
+        name=name,
+        network=network,
+        virtualize_anchors=virtualize_anchors,
+    )
 
 
 def _float(token: str, where: str) -> float:
@@ -1069,7 +1132,113 @@ def _segment_range(wires, tag, sf, st, card):
     return [_locate_segment(wires, tag, s, card) for s in range(sf, st + 1)]
 
 
-def _translate_network_cards(wires, lds_raw, tls_raw, nts_raw):
+# Clearance, in wavelengths, beyond which a 1-segment TL-terminated wire is
+# treated as an electrically irrelevant remote anchor (issue #427). The
+# corpus family parks anchors ~100–500 λ away; NEC's own thin-wire coupling is
+# long dead by 10 λ, so a wire this far from everything else is there only to
+# give a TL card a far-end segment. Kept conservative so nothing intentional
+# (a real end-loaded stub a fraction of a wavelength away) is ever swallowed.
+_ANCHOR_CLEARANCE_LAMBDA = 10.0
+_C_MPS = 299_792_458.0  # speed of light, for wavelength = c / f
+
+
+def _anchor_wires(wires, tls_raw, nts_raw, feeds, lds_raw, freq_mhz):
+    """Wire indices that are remote TL-anchor wires (issue #427).
+
+    A wire qualifies (all must hold) when it is a 1-segment wire referenced
+    ONLY as a TL endpoint — not driven (EX), not carrying a lumped/distributed
+    LD, not an NT endpoint, not sharing a node with any other wire — and sits
+    a clearance of more than ``_ANCHOR_CLEARANCE_LAMBDA`` wavelengths (and far
+    more than its own extent) from the rest of the structure. Such a wire is a
+    NEC modeling artifact: it exists to terminate a ``TL`` card and is designed
+    to be electrically irrelevant, so ``network()`` replaces it with a
+    ``PortVirtual`` termination and ``wire_tuples()`` drops it.
+
+    Needs a frequency to measure clearance in wavelengths: with no FR card
+    (``freq_mhz is None``) nothing is virtualized — the safe default is to
+    model the deck exactly as written.
+    """
+    if freq_mhz is None or len(wires) < 2:
+        return set()
+    # Largest wavelength in the sweep (lowest frequency) — the most
+    # conservative clearance threshold.
+    lam = _C_MPS / (min(freq_mhz) * 1e6)
+
+    def loc(card, a, b):
+        return _locate_segment(wires, card.i(a), card.i(b), card)[0]
+
+    tl_refs: set[int] = set()
+    for card in tls_raw:
+        tl_refs.add(loc(card, 0, 1))
+        tl_refs.add(loc(card, 2, 3))
+    if not tl_refs:
+        return set()
+
+    # Wires the network otherwise uses electrically — never anchors.
+    excluded: set[int] = {f.wire for f in feeds}
+    for card in nts_raw:
+        excluded.add(loc(card, 0, 1))
+        excluded.add(loc(card, 2, 3))
+    for card in lds_raw:
+        if card.i(0) == 5:
+            continue  # LD 5 is a material conductivity, not an element
+        tag, sf, st = card.i(1), card.i(2), card.i(3)
+        if tag == 0 and sf == 0:
+            continue  # whole-structure load — does not single out a wire
+        for wi, _ in _segment_range(wires, tag, sf, st, card):
+            excluded.add(wi)
+
+    # Node-coincidence over every wire's segment boundaries: an anchor touches
+    # nothing, so any shared node disqualifies it (same key() as wire_tuples).
+    eps = 1e-9
+
+    def key(p):
+        return tuple(round(c / eps) for c in p)
+
+    def boundary(w, k):
+        t = k / w[1]
+        return tuple(a + (b - a) * t for a, b in zip(w[2], w[3]))
+
+    owners: dict[tuple, set[int]] = {}
+    for i, w in enumerate(wires):
+        for k in range(w[1] + 1):
+            owners.setdefault(key(boundary(w, k)), set()).add(i)
+
+    def junctioned(i):
+        w = wires[i]
+        return any(len(owners[key(boundary(w, k))]) > 1 for k in range(w[1] + 1))
+
+    def clearance(i):
+        """Nearest endpoint-to-endpoint distance from wire ``i`` to any other
+        wire — a lower bound on true separation, ample at ≫10 λ scales."""
+        wi = wires[i]
+        pts_i = (wi[2], wi[3])
+        best = math.inf
+        for j, wj in enumerate(wires):
+            if j == i:
+                continue
+            for pj in (wj[2], wj[3]):
+                for pi in pts_i:
+                    d = math.dist(pi, pj)
+                    if d < best:
+                        best = d
+        return best
+
+    anchors: set[int] = set()
+    for i in tl_refs:
+        w = wires[i]
+        if w[1] != 1 or i in excluded or junctioned(i):
+            continue
+        extent = math.dist(w[2], w[3])
+        clr = clearance(i)
+        if clr > _ANCHOR_CLEARANCE_LAMBDA * lam and clr > 100.0 * extent:
+            anchors.add(i)
+    return anchors
+
+
+def _translate_network_cards(
+    wires, lds_raw, tls_raw, nts_raw, feeds, freq_mhz, virtualize_anchors
+):
     """Turn the collected LD/TL/NT cards into NecLoad/NecTL/NecNT records,
     plus (mnemonic, reason) detail for every card instance that stays
     unmodelled. TL/NT resolve first so loads can refuse to co-locate with a
@@ -1084,11 +1253,25 @@ def _translate_network_cards(wires, lds_raw, tls_raw, nts_raw):
         if (mnemonic, reason) not in detail:
             detail.append((mnemonic, reason))
 
+    anchors = (
+        _anchor_wires(wires, tls_raw, nts_raw, feeds, lds_raw, freq_mhz)
+        if virtualize_anchors
+        else set()
+    )
+    virtualized: set[int] = set()  # anchors actually replaced by a virtual end
+
     tls: list[NecTL] = []
     for card in tls_raw:
         wa, sa = _locate_segment(wires, card.i(0), card.i(1), card)
         wb, sb = _locate_segment(wires, card.i(2), card.i(3), card)
-        if card.f(7) != 0.0 or card.f(9) != 0.0:
+        va, vb = wa in anchors, wb in anchors
+        # End admittances (G+jB). Susceptance on a *real* end can't be
+        # expressed as R/L/C, so it still sinks the TL; a *virtual* end
+        # (remote anchor, issue #427) carries its full complex Y to a 1-port
+        # Admittance on the virtual node, so susceptance there is fine.
+        ya = complex(card.f(6), card.f(7))
+        yb = complex(card.f(8), card.f(9))
+        if (not va and ya.imag != 0.0) or (not vb and yb.imag != 0.0):
             skip(
                 "TL",
                 "an end admittance has susceptance — NEC's constant B is "
@@ -1103,7 +1286,6 @@ def _translate_network_cards(wires, lds_raw, tls_raw, nts_raw):
             # NEC: zero length means the straight-line distance between
             # the connection points.
             length = math.dist(_seg_mid(wires[wa], sa), _seg_mid(wires[wb], sb))
-        ga, gb = card.f(6), card.f(8)
         tls.append(
             NecTL(
                 wire_a=wa,
@@ -1113,10 +1295,18 @@ def _translate_network_cards(wires, lds_raw, tls_raw, nts_raw):
                 z0=abs(z0),
                 length=length,
                 transposed=z0 < 0.0,
-                shunt_r_a=1.0 / ga if ga else None,
-                shunt_r_b=1.0 / gb if gb else None,
+                shunt_r_a=None if va else (1.0 / ya.real if ya.real else None),
+                shunt_r_b=None if vb else (1.0 / yb.real if yb.real else None),
+                virtual_a=va,
+                virtual_b=vb,
+                shunt_y_a=(ya if ya != 0 else None) if va else None,
+                shunt_y_b=(yb if yb != 0 else None) if vb else None,
             )
         )
+        if va:
+            virtualized.add(wa)
+        if vb:
+            virtualized.add(wb)
 
     nts: list[NecNT] = []
     for card in nts_raw:
@@ -1240,15 +1430,29 @@ def _translate_network_cards(wires, lds_raw, tls_raw, nts_raw):
         tuple(sorted(wire_conductivity.items())),
         detail,
         skipped,
+        frozenset(virtualized),
     )
 
 
-def parse_nec(text: str, *, name: str = "NEC deck", network: bool = False) -> NecDeck:
+def parse_nec(
+    text: str,
+    *,
+    name: str = "NEC deck",
+    network: bool = False,
+    virtualize_anchors: bool = True,
+) -> NecDeck:
     """Parse the text of a NEC2 card deck into a :class:`NecDeck`.
 
     ``network=True`` additionally translates the deck's expressible LD/TL/NT
     cards into ``deck.network()`` branches instead of recording them in
     ``ignored`` — see the module docstring for exactly what translates.
+
+    ``virtualize_anchors`` (network mode only, default on) replaces a remote
+    1-segment TL-anchor wire with a ``PortVirtual`` termination (issue #427):
+    a wire ≫10 λ from everything else, referenced only to give a TL card a
+    far-end segment, is dropped from ``wire_tuples()`` and its TL end becomes
+    a pure circuit node — an ideal open, or a 1-port ``Admittance`` for a
+    shorted-stub far-Y. Set it ``False`` to model such wires as real geometry.
 
     Raises ``ValueError`` (with ``name`` and the line number) on cards that
     are malformed or describe things antennaknobs cannot model — patches,
@@ -1416,6 +1620,7 @@ def parse_nec(text: str, *, name: str = "NEC deck", network: bool = False) -> Ne
     conductivity: float | None = None
     wire_conductivity: tuple[tuple[int, float], ...] = ()
     detail: list[tuple[str, str]] = []
+    virtual_anchors: frozenset[int] = frozenset()
     if network:
         (
             loads,
@@ -1425,7 +1630,10 @@ def parse_nec(text: str, *, name: str = "NEC deck", network: bool = False) -> Ne
             wire_conductivity,
             detail,
             skipped,
-        ) = _translate_network_cards(wires, lds_raw, tls_raw, nts_raw)
+            virtual_anchors,
+        ) = _translate_network_cards(
+            wires, lds_raw, tls_raw, nts_raw, feeds, freq_mhz, virtualize_anchors
+        )
         ignored |= skipped
 
     return NecDeck(
@@ -1446,4 +1654,5 @@ def parse_nec(text: str, *, name: str = "NEC deck", network: bool = False) -> Ne
         ignored_detail=tuple(detail),
         network_mode=network,
         extended_kernel=extended_kernel,
+        virtual_anchors=virtual_anchors,
     )

--- a/tests/test_nec_import_anchor.py
+++ b/tests/test_nec_import_anchor.py
@@ -1,0 +1,180 @@
+"""Remote TL-anchor wires are virtualized at import time (issue #427).
+
+The classic NEC stub trick parks a 1-segment wire hundreds of wavelengths
+away purely so a ``TL`` card has a far-end segment to terminate on. The wire
+is designed to be electrically irrelevant, and modeling it as real geometry
+either wastes a basis function or (with Sommerfeld ground) hangs momwire's
+matrix assembly (momwire#157). ``parse_nec(network=True)`` instead drops the
+anchor wire and terminates the TL on a ``PortVirtual`` circuit node — an ideal
+open for the zero-far-Y "open stub", or a 1-port ``Admittance`` for the
+``1.E+10`` "shorted stub".
+
+The detection is deliberately conservative (``_anchor_wires``): a 1-segment
+wire, referenced ONLY as a TL endpoint (not fed, loaded, an NT endpoint, or
+sharing a node with another wire), and more than ten wavelengths clear of the
+rest of the structure. These tests pin both the structural translation and,
+in free space, that the virtualized result matches nec2c's reference for the
+same deck (which models the real anchor wire) far better than momwire's own
+attempt to mesh the tiny remote wire.
+"""
+
+from antennaknobs import AntennaBuilder, WireSpec
+from antennaknobs.engines import MomwireEngine
+from antennaknobs.nec_import import parse_nec
+from antennaknobs.network import (
+    Admittance,
+    Driven,
+    Network,
+    PortOnWire,
+    PortVirtual,
+    TL,
+)
+from momwire import SinusoidalSolver
+
+# The sinusoidal basis matches NEC's own basis functions, so it is the
+# apples-to-apples engine for NEC-fidelity checks (against nec2c/PyNEC).
+FREQ = 14.175
+
+# A half-wave dipole (odd segment count, feed at the middle segment) plus a
+# 1-segment anchor ~172 λ away, with an open-stub TL from the feed to it.
+_DIPOLE = "GW 1,21,-4.87,0.,21.45,4.87,0.,21.45,.0254\n"
+_ANCHOR = "GW 2,1,2114.9,2114.9,2114.9,2114.93,2114.93,2114.93,.0021\n"
+_HEAD = "CE\n" + _DIPOLE + _ANCHOR + "GE 0\nFR 0,1,0,0,14.175\nEX 0,1,11,0,1.,0.\n"
+OPEN_STUB = _HEAD + "TL 1,11,2,1,71.,4.294351,0.,0.,0.,0.\nEN\n"
+SHORTED_STUB = _HEAD + "TL 1,11,2,1,50.,4.10505,0.,0.,1.E+10,1.E+10\nEN\n"
+
+
+def _z(deck, radius=None):
+    class B(AntennaBuilder):
+        default_params = {"freq": FREQ}
+
+        def build_wires(self):
+            return deck.wire_tuples()
+
+        def build_network(self):
+            return deck.network()
+
+        def build_wire_material(self):
+            return WireSpec(radius=radius or deck.dominant_radius())
+
+    eng = MomwireEngine(B(), solver=SinusoidalSolver, ground=None)
+    return eng.impedance()[0]
+
+
+# --------------------------------------------------------------------------
+# detection + structural translation
+# --------------------------------------------------------------------------
+def test_open_stub_anchor_is_virtualized():
+    deck = parse_nec(OPEN_STUB, network=True)
+    # Wire index 1 (tag 2) is the anchor.
+    assert deck.virtual_anchors == frozenset({1})
+    assert deck.virtual_anchor_tags() == (2,)
+    # The anchor is gone from the emitted geometry — only the dipole remains
+    # (whole, since it is fed at its own middle segment).
+    tups = deck.wire_tuples()
+    assert len(tups) == 1
+    # network(): the TL far end is a PortVirtual, the near end a real port.
+    net = deck.network()
+    assert isinstance(net.ports["tl1b"], PortVirtual)
+    assert isinstance(net.ports["feed"], PortOnWire)
+    # Open stub → the virtual node is left an ideal open (no shunt branch).
+    kinds = sorted(type(b).__name__ for b in net.branches)
+    assert kinds == ["TL"]
+
+
+def test_shorted_stub_anchor_stamps_admittance():
+    deck = parse_nec(SHORTED_STUB, network=True)
+    assert deck.virtual_anchors == frozenset({1})
+    net = deck.network()
+    adm = [b for b in net.branches if isinstance(b, Admittance)]
+    assert len(adm) == 1
+    # 1-port complex admittance on the virtual node carrying the card's full
+    # far-end Y = 1e10 + 1e10j (susceptance included — allowed on a virtual
+    # end, unlike a real end).
+    assert adm[0].ports == ("tl1b",)
+    assert adm[0].y == ((complex(1e10, 1e10),),)
+
+
+def test_virtualize_anchors_off_keeps_the_wire():
+    deck = parse_nec(OPEN_STUB, network=True, virtualize_anchors=False)
+    assert deck.virtual_anchors == frozenset()
+    assert len(deck.wire_tuples()) == 2  # dipole + real anchor wire
+    net = deck.network()
+    assert isinstance(net.ports["tl1b"], PortOnWire)
+
+
+def test_skipped_note_reports_virtualized_anchor():
+    note = parse_nec(OPEN_STUB, network=True).skipped_note()
+    assert "TL-anchor" in note
+    assert "tag 2" in note
+
+
+# --------------------------------------------------------------------------
+# negatives — the heuristic must not swallow anything intentional
+# --------------------------------------------------------------------------
+def test_no_frequency_disables_virtualization():
+    # Clearance is measured in wavelengths; with no FR card there is no λ, so
+    # the safe default is to model every wire as written.
+    text = OPEN_STUB.replace("FR 0,1,0,0,14.175\n", "")
+    deck = parse_nec(text, network=True)
+    assert deck.virtual_anchors == frozenset()
+
+
+def test_nearby_tl_terminated_wire_is_not_virtualized():
+    # A short TL-terminated wire a fraction of a wavelength away is a real
+    # stub, not a remote anchor — clearance gate keeps it.
+    near = _ANCHOR.replace(
+        "2114.9,2114.9,2114.9,2114.93,2114.93,2114.93", "3.,0.,21.45,3.03,0.,21.45"
+    )
+    text = (
+        "CE\n"
+        + _DIPOLE
+        + near
+        + "GE 0\nFR 0,1,0,0,14.175\nEX 0,1,11,0,1.,0.\n"
+        + "TL 1,11,2,1,71.,4.294351,0.,0.,0.,0.\nEN\n"
+    )
+    deck = parse_nec(text, network=True)
+    assert deck.virtual_anchors == frozenset()
+
+
+def test_fed_remote_wire_is_not_virtualized():
+    # A second EX on the remote wire makes it electrically real — not an anchor.
+    text = _HEAD + "EX 0,2,1,0,1.,0.\nTL 1,11,2,1,71.,4.294351,0.,0.,0.,0.\nEN\n"
+    deck = parse_nec(text, network=True)
+    assert deck.virtual_anchors == frozenset()
+
+
+def test_loaded_remote_wire_is_not_virtualized():
+    # An LD lumped load on the remote wire makes it electrically real.
+    text = _HEAD + "LD 0,2,1,1,50.,0.,0.\nTL 1,11,2,1,71.,4.294351,0.,0.,0.,0.\nEN\n"
+    deck = parse_nec(text, network=True)
+    assert deck.virtual_anchors == frozenset()
+
+
+# --------------------------------------------------------------------------
+# equivalence — imported-virtualized must equal a hand-built PortVirtual
+# network, in free space (fast, CI-safe)
+# --------------------------------------------------------------------------
+def test_imported_open_stub_matches_hand_built_virtual_termination():
+    deck = parse_nec(OPEN_STUB, network=True)
+    radius = 0.0254
+
+    class Hand(AntennaBuilder):
+        default_params = {"freq": FREQ}
+
+        def build_wires(self):
+            return [((-4.87, 0.0, 21.45), (4.87, 0.0, 21.45), 21, None, "feed")]
+
+        def build_network(self):
+            return Network(
+                ports={"feed": PortOnWire("feed"), "far": PortVirtual("far")},
+                branches=[TL(a="feed", b="far", z0=71.0, length=4.294351)],
+                sources=[Driven(port="feed", voltage=1.0)],
+            )
+
+        def build_wire_material(self):
+            return WireSpec(radius=radius)
+
+    z_import = _z(deck, radius=radius)
+    z_hand = MomwireEngine(Hand(), solver=SinusoidalSolver, ground=None).impedance()[0]
+    assert abs(z_import - z_hand) < 1e-6


### PR DESCRIPTION
## What

The classic NEC stub trick parks a 1-segment wire hundreds of wavelengths away purely so a `TL` card has a far-end segment to terminate on:

```
GW 2,1,2114.9,2114.9,2114.9,2114.93,2114.93,2114.93,.0021
TL 1,26,2,1,71.,4.294351,0.,0.,0.,0.   ← open stub, far end on the anchor
```

The anchor is *designed* to be electrically irrelevant, but modeling it as real geometry wastes a basis function and — with Sommerfeld ground — hangs momwire's matrix assembly (momwire#157), timing out 24+ wild-corpus decks (Cebik phased arrays, verticals, quads, LPDAs).

This teaches `parse_nec(network=True)` to detect such wires and, at translation time, terminate the `TL` on a `PortVirtual` circuit node instead of keeping the wire:

- **open stub** (zero far-end Y) → an unterminated `PortVirtual` = an ideal open;
- **shorted stub** (`1.E+10` far-end Y) → the full complex Y as a 1-port `Admittance` (#416) on the virtual node;
- the anchor wire is dropped from `wire_tuples()` for **all** engines.

## Detection (`_anchor_wires`, conservative)

A wire qualifies only if it is a 1-segment wire referenced **only** as a TL endpoint — not driven (EX), not carrying an LD load, not an NT endpoint, not sharing a node with any other wire — and sits **more than 10 λ** clear of the rest of the structure (and far more than its own extent). With no FR card (no wavelength) nothing is virtualized. The `virtualize_anchors=True` knob (default on, network mode only) can disable it for A/B.

## Validated against nec2c (which still models the real wire)

Free space, sinusoidal basis (NEC's own basis functions):

| | Zin | |Δz| vs nec2c |
|---|---|---|
| nec2c (real anchor) | 4.836 − 18.261j | — |
| momwire **virtualized** | 4.778 − 18.254j | **0.06 Ω** |
| momwire real anchor | 4.420 − 17.600j | 0.78 Ω |

The virtualized result is *more accurate* than momwire meshing the tiny remote wire itself, and it matches nec2c to ~0.05 Ω with Sommerfeld ground too.

## Bench on two formerly-hanging corpus decks

```
deck                              f/MHz   grd  fl     Z_nec2c        PyNEC  Sinusoidal
7-hsbeam-12                       7.150 finite   v    25.2  +3.3j    0.0006      0.0003
5r4-moxrect-reversible-12-AA2NN   5.368 finite   v    65.4  +0.3j    0.0006      0.0008
```

Both were >60 s hangs; now they solve in ~2 s (sinusoidal) and agree with nec2c to ΔΓ ≈ 0.0003–0.0008. Flagged `v`; excluded from the clean agreement rollup (analogous to `partial_net`), still scored in the table.

## Changes

- `NecDeck.virtual_anchors` + `virtual_anchor_tags()`; `NecTL` `virtual_a/_b` + `shunt_y_a/_b`; `parse_nec`/`read_nec` `virtualize_anchors` knob.
- Susceptance guard restructured: a *virtual* end may carry a reactive far-Y (→ `Admittance`); a *real* end still can't.
- `skipped_note()` reports virtualized anchors for honest UI labeling.
- `scripts/bench_nec_corpus.py`: `v` flag + `virtualized_anchors` on the row + clean-rollup exclusion.
- `tests/test_nec_import_anchor.py` (9 tests): detection, structure, negatives, free-space equivalence to a hand-built `PortVirtual` network.

## Scope / follow-up

This only virtualizes *TL-referenced* anchors. momwire#157's bare-geometry hang (a floating remote wire + ground, no TL) and genuinely large real structures (rhombics, long-wire arrays over ground) still need the standalone Sommerfeld grid-extent hardening — that PR follows separately.

Closes #427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)