### PR TITLE
fix(web): gate PyNEC backend option on pynec-accel availability (#429)

### DIFF
--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1428,6 +1428,27 @@ const BACKEND_ORDER: Backend[] = [
   "pynec",
 ];
 
+// PyNEC needs the optional pynec-accel package, so the server reports whether
+// it is installed (`have_pynec` in /examples). When it is not, the UI must not
+// offer it — otherwise the /ws solve silently falls back to momwire (#429).
+// `sinusoidal` is the fallback: it is the momwire basis closest to NEC (the
+// same sinusoidal current expansion), so a default panel or a coerced saved
+// slot still solves the same physics without PyNEC.
+const PYNEC_FALLBACK_BACKEND: Backend = "sinusoidal";
+
+// Backends selectable given the server's capabilities: drops PyNEC when
+// pynec-accel is absent.
+function selectableBackends(havePynec: boolean): Backend[] {
+  return havePynec ? BACKEND_ORDER : BACKEND_ORDER.filter((b) => b !== "pynec");
+}
+
+// Map an unavailable PyNEC selection to the fallback; leave everything else
+// untouched. Applied wherever a backend can arrive from outside the gated
+// picker — default slots, a saved/URL slot, a server recommendation.
+function resolveBackend(b: Backend, havePynec: boolean): Backend {
+  return b === "pynec" && !havePynec ? PYNEC_FALLBACK_BACKEND : b;
+}
+
 // hmatrix (hierarchical H-matrix / ACA) and arrayblock (element-aware block
 // solver for arrays) are accelerators built on the same B-spline basis as
 // bspline; they share its options and request shape, and fall back to the
@@ -1586,6 +1607,24 @@ const DEFAULT_SLOTS: Record<Slot, SlotConfig> = {
     opts: { ...DEFAULT_BACKEND_OPTS.pynec },
   },
 };
+
+// Resolve a slot config against server capabilities (#429): if it names PyNEC
+// and pynec-accel is absent, swap to the fallback backend with that backend's
+// default kwargs, preserving the geometry-sizing (segments/wire, radius) the
+// same way a manual backend swap does. Slot C defaults to PyNEC, so this is
+// what keeps the default panel sensible on a server without it.
+function resolveSlotConfig(cfg: SlotConfig, havePynec: boolean): SlotConfig {
+  const backend = resolveBackend(cfg.backend, havePynec);
+  if (backend === cfg.backend) return cfg;
+  return {
+    backend,
+    opts: {
+      ...DEFAULT_BACKEND_OPTS[backend],
+      nPerWire: cfg.opts.nPerWire,
+      wireRadius: cfg.opts.wireRadius,
+    } as BackendOptsMap[Backend],
+  };
+}
 
 // Translates the camelCase frontend options into the snake_case kwargs the
 // server forwards to each Momwire model class constructor.
@@ -2210,6 +2249,11 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   // repeat-count down and back up preserves the values.
   const [examples, setExamples] = useState<ExampleDescriptor[]>([]);
   const [examplesError, setExamplesError] = useState<string | null>(null);
+  // Whether the server has the optional pynec-accel package (#429). Reported
+  // by /examples on mount; gates the PyNEC backend option. Defaults true so
+  // the common (installed) case never flashes the option off before the fetch
+  // resolves; a false reply then hides it and remaps any PyNEC slot.
+  const [havePynec, setHavePynec] = useState<boolean>(true);
   // User designs that failed to load (bad Python, no Builder, geometry error).
   // Surfaced from /examples so the author / Claude can see and fix them.
   const [loadErrors, setLoadErrors] = useState<DesignLoadError[]>([]);
@@ -2306,6 +2350,25 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   useEffect(() => {
     loadExamples();
   }, [loadExamples]);
+
+  // Backend capabilities (#429), fetched once on mount — server-static, so
+  // unlike the design catalog it is not re-fetched on trust actions. A failed
+  // fetch or an older server without the route leaves havePynec at its `true`
+  // default (prior behavior). Gates the PyNEC backend option.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const c = await (await fetch("/capabilities")).json();
+        if (!cancelled) setHavePynec(c.have_pynec !== false);
+      } catch {
+        /* keep the default; PyNEC stays offered */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Trust a user design from the UI (local-only; the backend refuses when
   // hosted). `stem` is the design name (e.g. "user.my_dipole"); `allowEdits`
@@ -2604,8 +2667,30 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     });
   }
   function resetSlot(slot: Slot) {
-    setSlots((prev) => ({ ...prev, [slot]: DEFAULT_SLOTS[slot] }));
+    setSlots((prev) => ({
+      ...prev,
+      [slot]: resolveSlotConfig(DEFAULT_SLOTS[slot], havePynec),
+    }));
   }
+  // When the server reports no pynec-accel (#429), remap any slot still on
+  // PyNEC — the default slot C, or a saved/URL slot — to the fallback backend,
+  // so the panel never holds a backend the picker no longer offers (which the
+  // /ws solve would silently run as momwire).
+  useEffect(() => {
+    if (havePynec) return;
+    setSlots((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      for (const s of Object.keys(prev) as Slot[]) {
+        const resolved = resolveSlotConfig(prev[s], havePynec);
+        if (resolved !== prev[s]) {
+          next[s] = resolved;
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [havePynec]);
   // band/designFreq/measFreq seed to placeholders; the auto-select
   // effect below picks the first band of the active example and
   // overwrites them once /examples resolves.
@@ -2714,9 +2799,13 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   // The server's per-design solver recommendation ("arrayblock" for grid
   // arrays, "sinusoidal" for benchmark-sized meshes, null otherwise) — used
   // by the withhold gate and to pick the right warning copy.
-  const recommendedBackend = normalizeBackend(
-    preview?.default_backend ?? currentExample?.default_backend,
-  );
+  const recommendedBackend = (() => {
+    const rec = normalizeBackend(
+      preview?.default_backend ?? currentExample?.default_backend,
+    );
+    // Never surface a PyNEC recommendation the server can't honor (#429).
+    return rec ? resolveBackend(rec, havePynec) : null;
+  })();
   // True while the live solve is being withheld by the solver-mismatch gate.
   // The batch runners (sweep / converge / norm-check) decline to fire on
   // this: they are batches of the same solves the gate is protecting the
@@ -4934,6 +5023,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
           <BackendConfigModal
             slot={gearOpen}
             backend={slots[gearOpen].backend}
+            backends={selectableBackends(havePynec)}
             opts={slots[gearOpen].opts}
             onChangeBackend={(b) => {
               backendTouchedRef.current = true;
@@ -5585,6 +5675,7 @@ export function App() {
 type BackendConfigProps = {
   slot: Slot;
   backend: Backend;
+  backends: Backend[];
   opts: BackendOptsMap[Backend];
   onChangeBackend: (b: Backend) => void;
   onPatch: (patch: Partial<BackendOptsMap[Backend]>) => void;
@@ -5595,6 +5686,7 @@ type BackendConfigProps = {
 function BackendConfigModal({
   slot,
   backend,
+  backends,
   opts,
   onChangeBackend,
   onPatch,
@@ -5629,7 +5721,7 @@ function BackendConfigModal({
               <span>{BACKEND_LABEL[backend]}</span>
             </label>
             <div className="geometry-tabs" role="tablist">
-              {BACKEND_ORDER.map((b) => (
+              {backends.map((b) => (
                 <button
                   key={b}
                   role="tab"

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -1547,6 +1547,20 @@ def examples_endpoint():
     return {"examples": out, "errors": load_errors}
 
 
+@app.get("/capabilities")
+def capabilities_endpoint():
+    """Backend feature availability the frontend reads once on mount.
+
+    Kept separate from /examples (the design catalog, re-fetched on every
+    trust action) since capabilities are server-static. Currently just
+    `have_pynec`: PyNEC is an optional backend (needs the pynec-accel
+    package), and when it's absent the UI must not offer it — otherwise the
+    /ws solve silently falls back to momwire (#429). New capability flags
+    (mesh-size caps, engine list, version) belong here too.
+    """
+    return {"have_pynec": pynec_backend.HAVE_PYNEC}
+
+
 def _resolve_user_design_path(stem: str):
     """A ``user.<stem>`` or ``<stem>`` name → the backing user-design file, or
     None. Trusting is a local, single-user action; the shared hosted instance

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -239,6 +239,21 @@ def test_examples_are_sorted_by_label(client: TestClient):
     assert labels == sorted(labels)
 
 
+def test_capabilities_reports_pynec_availability(client: TestClient, monkeypatch):
+    """The frontend gates the PyNEC backend option on this flag (#429): when
+    pynec-accel is absent the UI must not offer PyNEC, so the /ws solve does
+    not silently fall back to momwire. Mirrors pynec_backend.HAVE_PYNEC."""
+    from antennaknobs.web import pynec_backend
+
+    payload = client.get("/capabilities").json()
+    assert payload["have_pynec"] == pynec_backend.HAVE_PYNEC
+
+    monkeypatch.setattr(pynec_backend, "HAVE_PYNEC", False)
+    assert client.get("/capabilities").json()["have_pynec"] is False
+    monkeypatch.setattr(pynec_backend, "HAVE_PYNEC", True)
+    assert client.get("/capabilities").json()["have_pynec"] is True
+
+
 def test_each_example_has_the_keys_the_frontend_reads(client: TestClient):
     payload = client.get("/examples").json()
     required = {


### PR DESCRIPTION
Fixes #429.

## Problem

With `pynec-accel` not installed, the web UI still offered **PyNEC** as a selectable backend. Selecting it did **not** run PyNEC and did **not** error — the `/ws` solve does `use_pynec = req.get("solver") == "pynec" and pynec_backend.HAVE_PYNEC`, so with `HAVE_PYNEC` false it silently ran momwire. The user believed they were seeing PyNEC results.

The CLI already handles this correctly (PyNEC is only in `ENGINE_CLASSES` when available; an explicit request errors), so this brings the UI to the same **availability-gated** contract.

## Change

**Backend** — new `GET /capabilities` endpoint reporting `have_pynec` (mirrors `pynec_backend.HAVE_PYNEC`). Kept separate from `/examples` (the design catalog, re-fetched on every trust action) since capabilities are server-static — and it's the natural home for future capability flags (mesh caps, engine list, version).

**Frontend** (`App.tsx`) — fetch `/capabilities` once on mount, then:
- filter PyNEC out of the selectable backends when unavailable (the backend picker no longer shows it);
- remap any slot still on PyNEC — the default slot **C**, or a saved/URL slot — to the fallback backend (**sinusoidal**, the momwire basis closest to NEC), preserving segments/wire and radius;
- coerce a server PyNEC *recommendation* the same way, so the UI never surfaces an option the server can't honor.

When PyNEC **is** installed, nothing changes — the 3-slot default panel (bspline d2 / d1 / PyNEC) is intact.

## On the backend silent-fallback (deliberately not hard-errored)

Rejecting an explicit unavailable-PyNEC request would mean a hard error across the websocket + two `StreamingResponse` + dict paths — risky on the remote-served backend. The responses already report the **actual** solver honestly (`solver` in the `done` record), and with the UI gated the only way to request PyNEC-when-absent is a stale or hand-crafted client. So the UI gate is the fix; see the discussion on #429 (CLI is the fail-loud reference; the UI now matches its availability gating).

## Verification

- `test_capabilities_reports_pynec_availability` — `/capabilities` mirrors `HAVE_PYNEC` in both states; full web suite green (165 passed).
- Frontend typechecks and builds; gating truth table verified (PyNEC hidden + slots fall back to sinusoidal when absent; unchanged when present).
- The built bundle (`web/static`, gitignored) is produced by CI's `npm run build`; only source changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)