### PR TITLE
feat(nec-import): translate reactive TL end-shunts via 1-port Admittance (#423)

### DIFF
--- a/src/antennaknobs/nec_import.py
+++ b/src/antennaknobs/nec_import.py
@@ -25,12 +25,13 @@ system can express exactly are translated instead of ignored (issue #385):
 lumped LD loads become ``Load`` branches on named 1-segment wires, LD 5 wire
 conductivity surfaces as ``NecDeck.conductivity`` (feed it to ``WireSpec``),
 TL cards become ``TL`` branches (crossed lines, zero-length = port
-separation, conductance-only end shunts), and an NT card with an all-real Y
-matrix becomes its exact resistive pi (``TwoPort`` + ``Shunt``). What cannot
-be expressed exactly — frequency-independent reactance (LD 4 with X≠0,
-susceptance in TL/NT admittances), distributed RLC (LD 2/3), range-limited
-conductivity — stays in ``ignored`` with a per-card reason in
-``ignored_detail``. ``wire_tuples()`` then emits *named* wires (no legacy
+separation, end shunts — a conductance as a ``Shunt``, a reactive G+jB as a
+fixed 1-port ``Admittance``, issue #423), and an NT card becomes its exact
+resistive pi when the Y matrix is all-real (``TwoPort`` + ``Shunt``) or a
+2-port ``Admittance`` when it carries susceptance. What cannot be expressed
+exactly — frequency-independent series reactance (LD 4 with X≠0), distributed
+RLC (LD 2/3), range-limited conductivity — stays in ``ignored`` with a
+per-card reason in ``ignored_detail``. ``wire_tuples()`` then emits *named* wires (no legacy
 ``ex`` markers) and ``network()`` returns the matching ``Network``, ready to
 return from ``build_wires`` / ``build_network``.
 
@@ -139,17 +140,19 @@ class NecTL:
     becomes ``transposed=True``, matching the ``network.TL`` convention.
     ``length`` is resolved: the card's length, or the straight-line distance
     between the segment midpoints when the card says 0 (NEC semantics).
-    ``shunt_r_*`` carry conductance-only end admittances as 1/G resistances
-    (a card with susceptance on a *real* end admittance is not translated).
+    ``shunt_r_*`` carry conductance-only end admittances as 1/G resistances;
+    a reactive end (susceptance ≠ 0, issue #423) is kept as a complex
+    ``shunt_y_*`` and stamped as a fixed 1-port ``Admittance`` instead — see
+    ``_end_shunt``.
 
     ``virtual_a`` / ``virtual_b`` mark an end that lands on a virtualized
     remote TL-anchor wire (issue #427): that segment carries no geometry, so
     ``network()`` terminates the line on a ``PortVirtual`` circuit node
     instead of a ``PortOnWire``, and the anchor wire is dropped from
-    ``wire_tuples()``. A virtual end may carry susceptance — its full complex
-    end admittance is kept in ``shunt_y_a`` / ``shunt_y_b`` and stamped as a
-    1-port ``Admittance`` on the virtual node (the shorted-stub variant); a
-    zero ``shunt_y`` leaves the node an ideal open (the open-stub variant).
+    ``wire_tuples()``. A virtual end's full complex end admittance is kept in
+    ``shunt_y_a`` / ``shunt_y_b`` and stamped as a 1-port ``Admittance`` on the
+    virtual node (the shorted-stub variant); a zero ``shunt_y`` leaves the node
+    an ideal open (the open-stub variant).
     The ``shunt_r_*`` / ``shunt_y_*`` fields are mutually exclusive per end:
     a real end uses ``shunt_r``, a virtual end uses ``shunt_y``."""
 
@@ -1110,6 +1113,28 @@ def _seg_mid(w, seg: int):
     return [a + (b - a) * t for a, b in zip(w[2], w[3])]
 
 
+def _end_shunt(y: complex, virtual: bool) -> tuple[float | None, complex | None]:
+    """Translate one TL end admittance ``y = G + jB`` into a ``(shunt_r,
+    shunt_y)`` pair for ``NecTL`` — at most one is non-None:
+
+    - conductance-only (``B == 0``, real end) → ``shunt_r = 1/G`` (a
+      frequency-dependent ``Shunt`` in ``network()``);
+    - reactive (``B != 0``, issue #423) or any virtual-node termination
+      (remote TL anchor, issue #427) → ``shunt_y = y``, a fixed 1-port
+      ``Admittance`` carrying the full complex Y, exact at every frequency;
+    - a zero end is an open (both ``None``).
+
+    A reactive end is no longer dropped: NEC's constant ``B`` is
+    frequency-independent, which is exactly what the fixed ``Admittance``
+    primitive (issue #416) expresses.
+    """
+    if y == 0:
+        return None, None
+    if y.imag != 0.0 or virtual:
+        return None, y
+    return 1.0 / y.real, None
+
+
 def _segment_range(wires, tag, sf, st, card):
     """All (wire index, local segment) pairs an LD card's range covers:
     NEC's tag/range addressing — tag 0 + range 0 is the whole structure,
@@ -1265,19 +1290,12 @@ def _translate_network_cards(
         wa, sa = _locate_segment(wires, card.i(0), card.i(1), card)
         wb, sb = _locate_segment(wires, card.i(2), card.i(3), card)
         va, vb = wa in anchors, wb in anchors
-        # End admittances (G+jB). Susceptance on a *real* end can't be
-        # expressed as R/L/C, so it still sinks the TL; a *virtual* end
-        # (remote anchor, issue #427) carries its full complex Y to a 1-port
-        # Admittance on the virtual node, so susceptance there is fine.
-        ya = complex(card.f(6), card.f(7))
-        yb = complex(card.f(8), card.f(9))
-        if (not va and ya.imag != 0.0) or (not vb and yb.imag != 0.0):
-            skip(
-                "TL",
-                "an end admittance has susceptance — NEC's constant B is "
-                "frequency-independent, which R/L/C cannot express",
-            )
-            continue
+        # End admittances G+jB: a conductance-only end becomes a Shunt(1/G),
+        # a reactive one (#423) or a virtual-node termination (#427) a fixed
+        # 1-port Admittance. See _end_shunt — susceptance is expressible now,
+        # so a reactive end no longer sinks the whole TL.
+        shunt_r_a, shunt_y_a = _end_shunt(complex(card.f(6), card.f(7)), va)
+        shunt_r_b, shunt_y_b = _end_shunt(complex(card.f(8), card.f(9)), vb)
         z0 = card.f(4)
         if z0 == 0.0:
             raise card.error("characteristic impedance must be nonzero")
@@ -1295,12 +1313,12 @@ def _translate_network_cards(
                 z0=abs(z0),
                 length=length,
                 transposed=z0 < 0.0,
-                shunt_r_a=None if va else (1.0 / ya.real if ya.real else None),
-                shunt_r_b=None if vb else (1.0 / yb.real if yb.real else None),
+                shunt_r_a=shunt_r_a,
+                shunt_r_b=shunt_r_b,
                 virtual_a=va,
                 virtual_b=vb,
-                shunt_y_a=(ya if ya != 0 else None) if va else None,
-                shunt_y_b=(yb if yb != 0 else None) if vb else None,
+                shunt_y_a=shunt_y_a,
+                shunt_y_b=shunt_y_b,
             )
         )
         if va:

--- a/tests/test_nec_import.py
+++ b/tests/test_nec_import.py
@@ -391,7 +391,7 @@ def test_smoke_parse_xnec2c_examples():
 # ---------------------------------------------------------------------------
 
 from antennaknobs.nec_import import NecLoad, NecNT, NecTL  # noqa: E402
-from antennaknobs.network import TL, Load, Shunt  # noqa: E402
+from antennaknobs.network import TL, Admittance, Load, Shunt  # noqa: E402
 
 
 def _branch_ports(br):
@@ -539,20 +539,39 @@ def test_tl_zero_length_is_port_separation():
     assert deck.tls[0].length == pytest.approx(2.0)
 
 
-def test_tl_end_conductance_becomes_shunt_susceptance_does_not():
+def test_tl_end_conductance_becomes_shunt_reactance_becomes_admittance():
+    # Conductance-only end -> Shunt(r=1/G), unchanged.
     deck = parse_nec(
         TWO_VERTICALS.format(tl="TL 1 2 2 2 73 1.5 0 0 1000.0 0"), network=True
     )
     (tl,) = deck.tls
     assert tl.shunt_r_a is None and tl.shunt_r_b == pytest.approx(1e-3)
+    assert tl.shunt_y_a is None and tl.shunt_y_b is None
     net = deck.network()
     assert Shunt(port="tl1b", r=1e-3) in net.branches
 
+    # Reactive end shunt (B != 0) -> fixed 1-port Admittance, exact at every
+    # frequency (issue #423). The TL is no longer dropped, and carries no
+    # ignored/susceptance note.
     deck = parse_nec(
-        TWO_VERTICALS.format(tl="TL 1 2 2 2 73 1.5 0 0.02 0 0"), network=True
+        TWO_VERTICALS.format(tl="TL 1 2 2 2 73 1.5 0 0 0 0.02"), network=True
     )
-    assert deck.tls == () and "TL" in deck.ignored
-    assert any("susceptance" in why for _m, why in deck.ignored_detail)
+    (tl,) = deck.tls
+    assert tl.shunt_r_b is None and tl.shunt_y_b == complex(0.0, 0.02)
+    assert "TL" not in deck.ignored
+    assert not any(m == "TL" for m, _ in deck.ignored_detail)
+    net = deck.network()
+    assert Admittance(ports=("tl1b",), y=((complex(0.0, 0.02),),)) in net.branches
+
+    # Mixed G + jB -> a single complex Admittance (not Shunt + Admittance).
+    deck = parse_nec(
+        TWO_VERTICALS.format(tl="TL 1 2 2 2 73 1.5 0 0 1000.0 0.02"), network=True
+    )
+    (tl,) = deck.tls
+    assert tl.shunt_r_b is None and tl.shunt_y_b == complex(1000.0, 0.02)
+    net = deck.network()
+    assert Admittance(ports=("tl1b",), y=((complex(1000.0, 0.02),),)) in net.branches
+    assert not any(isinstance(b, Shunt) and b.port == "tl1b" for b in net.branches)
 
 
 def test_nt_real_y_decomposes_into_resistive_pi():
@@ -580,7 +599,6 @@ def test_nt_susceptance_becomes_admittance_and_nt_minus_one_clears():
     # An NT with susceptance is now translated to a general complex-Y branch
     # (issue #416), carrying the full 2x2 short-circuit Y (Y21 = Y12), not
     # ignored.
-    from antennaknobs.network import Admittance
 
     deck = parse_nec(
         TWO_VERTICALS.format(tl="NT 1 2 2 2 0.02 0.01 -0.01 0 0.015 0"),

--- a/tests/test_nec_import_network.py
+++ b/tests/test_nec_import_network.py
@@ -29,7 +29,7 @@ import pytest
 from antennaknobs import AntennaBuilder, WireSpec
 from antennaknobs.engines import MomwireEngine
 from antennaknobs.nec_import import parse_nec
-from antennaknobs.network import Driven, Load, Network, PortOnWire, TL
+from antennaknobs.network import Admittance, Driven, Load, Network, PortOnWire, TL
 from momwire import BSplineSolver
 
 FREQ = 14.1
@@ -133,6 +133,50 @@ def test_imported_tl_matches_hand_built_line():
             return Network(
                 ports={"feed": PortOnWire("feed"), "far": PortOnWire("far")},
                 branches=[TL(a="feed", b="far", z0=300.0, length=5.5, transposed=True)],
+                sources=[Driven(port="feed", voltage=1 + 0j)],
+            )
+
+        def build_wire_material(self):
+            return WireSpec(radius=0.001)
+
+    z_imported = _momwire_z(_deck_builder(deck, radius=0.001))
+    z_hand = _momwire_z(Hand())
+    assert z_imported == pytest.approx(z_hand, rel=1e-9)
+
+
+def test_imported_reactive_tl_end_shunt_matches_hand_built_admittance():
+    # A 300 Ohm line to a rear vertical, its far end terminated by a reactive
+    # shunt G + jB (issue #423): B != 0 is no longer dropped — it becomes a
+    # fixed 1-port Admittance at that port, exact at every frequency.
+    deck = parse_nec(
+        "GW 1 3 0 0 10 0 0 13 0.001\n"
+        "GW 2 3 4 0 10 4 0 13 0.001\n"
+        "GE\n"
+        "EX 0 1 2 0 1 0\n"
+        "TL 1 2 2 2 300 5.5 0 0 0.002 0.01\n"
+        "EN\n",
+        network=True,
+    )
+    assert "TL" not in deck.ignored  # translated, not dropped
+
+    y_end = complex(0.002, 0.01)
+
+    class Hand(AntennaBuilder):
+        default_params = {"freq": FREQ}
+
+        def build_wires(self):
+            return [
+                ((0.0, 0.0, 10.0), (0.0, 0.0, 13.0), 3, None, "feed"),
+                ((4.0, 0.0, 10.0), (4.0, 0.0, 13.0), 3, None, "far"),
+            ]
+
+        def build_network(self):
+            return Network(
+                ports={"feed": PortOnWire("feed"), "far": PortOnWire("far")},
+                branches=[
+                    TL(a="feed", b="far", z0=300.0, length=5.5),
+                    Admittance(ports=("far",), y=((y_end,),)),
+                ],
                 sources=[Driven(port="feed", voltage=1 + 0j)],
             )
 


### PR DESCRIPTION
Closes #423.

## What

A NEC `TL` card can terminate each end with a shunt admittance `G + jB` to common. antennaknobs translated conductance-only ends (`Shunt(r=1/G)`) but **dropped the whole card** when either end carried susceptance, because a frequency-independent `B` isn't expressible as R/L/C. Now that the fixed-Y `Admittance` primitive shipped (#416), a reactive end shunt is a direct 1-port `Admittance(ports=(p,), y=((G+jB,),))` — exact at every frequency.

## How

New `_end_shunt` helper unifies the per-end rule (the same one already used for virtual anchor ends in #427):

- conductance-only real end → `Shunt(r=1/G)` (unchanged),
- reactive end (`B ≠ 0`) **or** any virtual-node termination → complex 1-port `Admittance`,
- zero end → open.

The TL-susceptance skip is removed; the module and `NecTL` docstrings drop TL/NT susceptance from the inexpressible list (NT susceptance was already a 2-port `Admittance` since #416).

## Tests (TDD)

- `test_tl_end_conductance_becomes_shunt_reactance_becomes_admittance` — conductance-only stays `Shunt`; a reactive end (and a mixed `G+jB`) becomes a single 1-port `Admittance`, no `ignored`/`n` flag.
- `test_imported_reactive_tl_end_shunt_matches_hand_built_admittance` — the imported deck agrees with a hand-built `Admittance` network on the driving-point Z through momwire (`rel=1e-9`).
- Full nec-import + anchor + admittance suites green (unchanged conductance-only and virtual-anchor paths).

No new solver code — reuses the `Admittance` primitive (#416); this is purely the importer translation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)