### PR TITLE
feat(nec-import): translate LD 4 reactive loads via fixed-complex-Z Load (#422)

### DIFF
--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -366,7 +366,8 @@ class PyNECEngine(SimulationEngine):
             self.excitation_pairs.append((tag, seg, v))
 
     def _emit_load_card(self, br):
-        """Series/parallel RLC on a single segment -> ld_card (type 0/1)."""
+        """Series/parallel RLC on a single segment -> ld_card (type 0/1); a
+        fixed R+jX impedance -> ld_card type 4 (issue #422)."""
         port = self._network.ports[br.port]
         if not isinstance(port, PortOnWire):
             raise ValueError(
@@ -374,6 +375,13 @@ class PyNECEngine(SimulationEngine):
                 "impedance on an antenna segment, which only PortOnWire has"
             )
         tag, seg = self._network_port_loc[br.port]
+        if br.z is not None:
+            # Type 4: fixed series impedance, F1 = R (ohms), F2 = X (ohms).
+            z = complex(br.z)
+            if z == 0:
+                return
+            self.c.ld_card(4, tag, seg, seg, z.real, z.imag, 0.0)
+            return
         r = float(br.r) if br.r is not None else 0.0
         l = float(br.l) if br.l is not None else 0.0
         c = float(br.c) if br.c is not None else 0.0

--- a/src/antennaknobs/nec_import.py
+++ b/src/antennaknobs/nec_import.py
@@ -26,12 +26,13 @@ lumped LD loads become ``Load`` branches on named 1-segment wires, LD 5 wire
 conductivity surfaces as ``NecDeck.conductivity`` (feed it to ``WireSpec``),
 TL cards become ``TL`` branches (crossed lines, zero-length = port
 separation, end shunts — a conductance as a ``Shunt``, a reactive G+jB as a
-fixed 1-port ``Admittance``, issue #423), and an NT card becomes its exact
+fixed 1-port ``Admittance``, issue #423), an NT card becomes its exact
 resistive pi when the Y matrix is all-real (``TwoPort`` + ``Shunt``) or a
-2-port ``Admittance`` when it carries susceptance. What cannot be expressed
-exactly — frequency-independent series reactance (LD 4 with X≠0), distributed
-RLC (LD 2/3), range-limited conductivity — stays in ``ignored`` with a
-per-card reason in ``ignored_detail``. ``wire_tuples()`` then emits *named* wires (no legacy
+2-port ``Admittance`` when it carries susceptance, and an LD 4 reactive load
+(fixed R+jX) becomes a fixed-complex-Z ``Load`` (issue #422). What cannot be
+expressed exactly — distributed RLC (LD 2/3), range-limited conductivity —
+stays in ``ignored`` with a per-card reason in ``ignored_detail``.
+``wire_tuples()`` then emits *named* wires (no legacy
 ``ex`` markers) and ``network()`` returns the matching ``Network``, ready to
 return from ``build_wires`` / ``build_network``.
 
@@ -123,7 +124,11 @@ class NecLoad:
     NEC's per-segment ld_card semantics, so a multi-segment LD range appears
     as one ``NecLoad`` per segment. ``parallel`` distinguishes LD type 1
     (parallel RLC, the trap idiom) from type 0/4 (series). Legs the card
-    left at zero are ``None`` (omitted), matching ``network.Load``."""
+    left at zero are ``None`` (omitted), matching ``network.Load``.
+
+    ``z`` carries an LD type 4 reactive load as a fixed complex impedance
+    R + jX (issue #422); it is mutually exclusive with r/l/c, and a
+    conductance-only type 4 (X = 0) stays a plain ``r`` instead."""
 
     wire: int
     seg: int
@@ -131,6 +136,7 @@ class NecLoad:
     l: float | None  # noqa: E741 — matches network.Load's field name
     c: float | None
     parallel: bool
+    z: complex | None = None
 
 
 @dataclass(frozen=True)
@@ -521,6 +527,7 @@ class NecDeck:
                     l=ld.l,
                     c=ld.c,
                     parallel=ld.parallel,
+                    z=ld.z,
                 )
             )
         for tl in self.tls:
@@ -1378,13 +1385,6 @@ def _translate_network_cards(
         ldtyp = card.i(0)
         tag, sf, st = card.i(1), card.i(2), card.i(3)
         if ldtyp in (0, 1, 4):
-            if ldtyp == 4 and card.f(5) != 0.0:
-                skip(
-                    "LD",
-                    "type 4 fixed reactance is frequency-independent — "
-                    "not representable with R/L/C",
-                )
-                continue
             pairs = _segment_range(wires, tag, sf, st, card)
             if len(pairs) > _LD_EXPAND_MAX:
                 skip(
@@ -1393,10 +1393,21 @@ def _translate_network_cards(
                     f"expands at most {_LD_EXPAND_MAX} into per-segment loads",
                 )
                 continue
-            r = card.f(4) or None
-            le = None if ldtyp == 4 else (card.f(5) or None)
-            c = None if ldtyp == 4 else (card.f(6) or None)
-            if r is None and le is None and c is None:
+            z = None
+            if ldtyp == 4:
+                # Type 4: a fixed series impedance R + jX (F1=R, F2=X). A pure
+                # resistance stays a plain Load(r=R); a reactive one (X != 0,
+                # issue #422) becomes a fixed complex-Z Load.
+                r, x = card.f(4), card.f(5)
+                if x != 0.0:
+                    z, r, le, c = complex(r, x), None, None, None
+                else:
+                    r, le, c = (r or None), None, None
+            else:
+                r = card.f(4) or None
+                le = card.f(5) or None
+                c = card.f(6) or None
+            if r is None and le is None and c is None and z is None:
                 continue  # zero-valued load — a no-op
             for pair in pairs:
                 if pair in connected:
@@ -1410,7 +1421,7 @@ def _translate_network_cards(
                     skip("LD", "a second load on one segment is not merged")
                     continue
                 loaded.add(pair)
-                loads.append(NecLoad(pair[0], pair[1], r, le, c, ldtyp == 1))
+                loads.append(NecLoad(pair[0], pair[1], r, le, c, ldtyp == 1, z=z))
         elif ldtyp in (2, 3):
             skip("LD", f"type {ldtyp} distributed per-metre loading is not translated")
         elif ldtyp == 5:

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -274,6 +274,13 @@ class Load:
     physics as NEC2's ld_card modifying the segment's self-Z. The classic
     dual-band trap dipole uses Load(parallel=True) at a single segment in
     each arm — see designs/multiband/trap_dipole.py.
+
+    `z` sets a FIXED, frequency-independent series impedance R + jX directly
+    (NEC2 `ld_card` type 4, issue #422): unlike the R/L/C legs whose reactance
+    scales with ω, `z` is used verbatim at every frequency. It is mutually
+    exclusive with r/l/c/parallel/ql/qc — a load is either the RLC form or the
+    fixed-Z form, never both. The reactive counterpart to `Admittance` for the
+    *series* (in-the-current-path) case, where a shunt would be wrong.
     """
 
     port: str
@@ -283,6 +290,18 @@ class Load:
     parallel: bool = False
     ql: float | None = None  # coil Q: adds series R = omega*L/Q (issue #298)
     qc: float | None = None  # capacitor Q: adds ESR = 1/(omega*C*Q)
+    z: complex | None = None  # fixed R+jX series impedance (ld_card 4, #422)
+
+    def __post_init__(self):
+        if self.z is not None and any(
+            v not in (None, False)
+            for v in (self.r, self.l, self.c, self.parallel, self.ql, self.qc)
+        ):
+            raise ValueError(
+                "Load.z (fixed complex impedance) is mutually exclusive with "
+                "the r/l/c/parallel/ql/qc legs — a load is either the RLC form "
+                "or the fixed-Z form"
+            )
 
 
 @dataclass(frozen=True)
@@ -513,6 +532,9 @@ def load_series_admittance(br, omega):
     Series mode: y_load = 1/(R + jωL + 1/(jωC)); returns complex inf when
     the series impedance is exactly 0 (series-LC short circuit), which the
     caller treats as "no series element" (the wire is unbroken)."""
+    if br.z is not None:
+        # Fixed R+jX (issue #422): admittance 1/z, inf at z = 0 (a short).
+        return complex(float("inf"), 0.0) if br.z == 0 else 1.0 / complex(br.z)
     if br.parallel:
         return _parallel_rlc_admittance(br.r, br.l, br.c, omega, br.ql, br.qc)
     z = _series_rlc_impedance(br.r, br.l, br.c, omega, br.ql, br.qc)
@@ -531,6 +553,8 @@ def load_impedance(br, omega):
     Z→∞ is the physically-intended open circuit of a trap. Consumers that
     stamp the load into a port-Y matrix should prefer
     `load_series_admittance`, which avoids forming this infinity at all."""
+    if br.z is not None:
+        return complex(br.z)  # fixed R+jX, frequency-independent (issue #422)
     if br.parallel:
         y = _parallel_rlc_admittance(br.r, br.l, br.c, omega, br.ql, br.qc)
         if y == 0:

--- a/tests/test_ld4_reactive_load.py
+++ b/tests/test_ld4_reactive_load.py
@@ -1,0 +1,173 @@
+"""Issue #422: a fixed-complex-Z (frequency-independent) series Load.
+
+A NEC ``LD`` card type 4 is a fixed ``R + jX`` impedance in SERIES with a
+segment's current path. Unlike the shunt-to-common ``Admittance`` (issue #416,
+which handles the reactive NT / TL-end-shunt cases), this is the series sibling:
+it becomes the reducer's group-2 termination, composed with any feed EMF, so on
+a *driven+loaded* segment it correctly adds to the driving-point Z where a shunt
+would be silently wrong.
+
+Two layers, mirroring test_admittance_branch.py: circuit-theory oracles on a
+synthetic antenna Y (fast, no MoM), then a cross-engine MoM check that PyNEC
+(native ld_card type 4) and momwire (reducer stamp) agree once the load is in
+the solve — including the load-on-the-fed-segment case.
+"""
+
+import numpy as np
+import pytest
+
+from antennaknobs import AntennaBuilder, WireSpec
+from antennaknobs.engines import MomwireEngine, PyNECEngine
+from antennaknobs.nec_import import parse_nec
+from antennaknobs.network import (
+    Driven,
+    Load,
+    Network,
+    PortOnWire,
+    PortVirtual,
+    load_impedance,
+)
+from antennaknobs.network_reduce import C_LIGHT, NetworkReducer
+from momwire import SinusoidalSolver
+
+FREQ_MHZ = 28.0
+WL = C_LIGHT / (FREQ_MHZ * 1e6)
+
+
+def synth_y(n, seed):
+    rng = np.random.default_rng(seed)
+    a = rng.normal(size=(n, n)) + 1j * rng.normal(size=(n, n))
+    y = 0.004 * (a + a.T) / 2.0
+    return y + np.eye(n) * (0.02 + 0.008j)
+
+
+def reducer(net, n_real):
+    real = [n for n, p in net.ports.items() if isinstance(p, PortOnWire)]
+    virt = [n for n, p in net.ports.items() if isinstance(p, PortVirtual)]
+    port_to_idx = {n: i for i, n in enumerate(real + virt)}
+    return NetworkReducer(net, port_to_idx, len(real) + len(virt))
+
+
+# ---------------------------------------------------------------------------
+# 1. Primitive: Load.z is a fixed series impedance
+# ---------------------------------------------------------------------------
+def test_fixed_z_load_impedance_is_z_at_every_frequency():
+    br = Load(port="p", z=30.0 - 40.0j)
+    assert load_impedance(br, 2 * np.pi * 10e6) == 30.0 - 40.0j
+    assert load_impedance(br, 2 * np.pi * 30e6) == 30.0 - 40.0j
+
+
+def test_fixed_z_series_load_on_driven_port_adds_to_z():
+    """Z_seen = Z_L + 1/Y00 — the load is in series with the feed (a shunt
+    would instead give 1/(Y00 + 1/Z_L)). Frequency-independent, so identical
+    at two wavelengths despite a reactive Z_L."""
+    y = synth_y(1, 5)
+    z_l = 60.0 + 25.0j
+    net = Network(
+        ports={"f": PortOnWire("f")},
+        branches=[Load(port="f", z=z_l)],
+        sources=[Driven(port="f")],
+    )
+    red = reducer(net, 1)
+    z1 = red.driven_impedance(y, C_LIGHT / 10e6)[0]
+    z2 = red.driven_impedance(y, C_LIGHT / 30e6)[0]
+    assert z1 == pytest.approx(z_l + 1.0 / y[0, 0], rel=1e-12)
+    assert z1 == pytest.approx(z2, rel=1e-12)  # fixed, not jωL-scaled
+
+
+def test_fixed_z_load_rejects_rlc_legs():
+    # z is mutually exclusive with the frequency-dependent R/L/C legs.
+    with pytest.raises(ValueError):
+        Load(port="p", z=10 + 5j, r=3.0)
+    with pytest.raises(ValueError):
+        Load(port="p", z=10 + 5j, l=1e-6)
+    with pytest.raises(ValueError):
+        Load(port="p", z=10 + 5j, parallel=True)
+
+
+# ---------------------------------------------------------------------------
+# 2. nec_import translation of an LD 4 reactive load (issue #422)
+# ---------------------------------------------------------------------------
+def _dipole7(*cards):
+    return (
+        "GW 1 7 0 -3.5 10 0 3.5 10 0.001\nGE 0\nEX 0 1 4 0 1 0\n"
+        + "".join(c + "\n" for c in cards)
+        + "EN\n"
+    )
+
+
+def test_ld4_reactive_translates_to_fixed_z_load():
+    """LD 4 tag s0 s1 R X (X != 0) is no longer dropped — it becomes a fixed
+    complex-Z series Load, exact at every frequency."""
+    deck = parse_nec(_dipole7("LD 4 1 2 2 100 -50"), network=True)
+    assert "LD" not in deck.ignored
+    assert not any(m == "LD" for m, _ in deck.ignored_detail)
+    (ld,) = deck.loads
+    assert ld.z == complex(100.0, -50.0)
+    assert ld.r is None and ld.l is None and ld.c is None
+    (br,) = deck.network().branches
+    assert isinstance(br, Load) and br.z == complex(100.0, -50.0)
+
+
+# ---------------------------------------------------------------------------
+# 3. Cross-engine MoM oracle: PyNEC (native ld_card 4) and momwire (reducer)
+# ---------------------------------------------------------------------------
+def _deck_builder(deck, freq=FREQ_MHZ):
+    class B(AntennaBuilder):
+        default_params = {"freq": freq}
+
+        def build_wires(self):
+            return deck.wire_tuples()
+
+        def build_network(self):
+            return deck.network()
+
+        def build_wire_material(self):
+            return WireSpec(radius=deck.dominant_radius())
+
+    return B()
+
+
+def _mw_z(deck):
+    return MomwireEngine(
+        _deck_builder(deck), solver=SinusoidalSolver, ground="free"
+    ).impedance()[0]
+
+
+def _cross_engine(deck):
+    b = _deck_builder(deck)
+    z_pynec = PyNECEngine(b, ground="free").impedance()[0]
+    z_mw = MomwireEngine(b, solver=SinusoidalSolver, ground="free").impedance()[0]
+    return z_pynec, z_mw
+
+
+def test_ld4_reactive_on_fed_segment_cross_engine_agrees():
+    """The load sits on the FED segment — the case a shunt gets wrong (the
+    ideal source pins the node, so a shunt never reaches the driving-point Z).
+    As a series Load it adds to Z: Z = Z_bare + (120 − 60j), exactly the
+    independent circuit calc, and PyNEC's native ld_card type 4 agrees with
+    momwire's reducer stamp. (Both assertions fail if the load is dropped.)"""
+    deck = parse_nec(_dipole7("LD 4 1 4 4 120 -60"), network=True)
+    z_pynec, z_mw = _cross_engine(deck)
+    assert abs(z_pynec - z_mw) / abs(z_mw) < 0.02
+    z_bare = _mw_z(parse_nec(_dipole7(), network=True))
+    assert z_mw == pytest.approx(z_bare + (120.0 - 60.0j), rel=0.02)
+
+
+def test_ld4_reactive_on_parasitic_segment_cross_engine_agrees():
+    """A reactively-loaded parasite (two-element deck): the load is on an
+    undriven segment; both engines agree, and the reactive load measurably
+    shifts the driven Z (so the test fails if the load is dropped)."""
+    loaded = (
+        "GW 1 7 0 -3.5 10 0 3.5 10 0.001\n"
+        "GW 2 7 1.5 -3.5 10 1.5 3.5 10 0.001\n"
+        "GE 0\n"
+        "EX 0 1 4 0 1 0\n"
+        "{ld}"
+        "EN\n"
+    )
+    deck = parse_nec(loaded.format(ld="LD 4 2 4 4 80 40\n"), network=True)
+    z_pynec, z_mw = _cross_engine(deck)
+    assert abs(z_pynec - z_mw) / abs(z_mw) < 0.02
+    z_bare = _mw_z(parse_nec(loaded.format(ld=""), network=True))
+    assert abs(z_mw - z_bare) > 1.0

--- a/tests/test_nec_import.py
+++ b/tests/test_nec_import.py
@@ -456,16 +456,22 @@ def test_ld_range_expands_per_segment_up_to_cap():
     assert any("12 segments" in why for _m, why in deck.ignored_detail)
 
 
-def test_ld4_pure_resistance_translates_reactance_does_not():
+def test_ld4_resistance_and_reactance_both_translate():
+    # Pure resistance -> a plain series Load(r=R).
     deck = parse_nec(_dipole7("LD 4 1 2 2 50.0 0 0"), network=True)
     assert deck.loads == (
         NecLoad(wire=0, seg=2, r=50.0, l=None, c=None, parallel=False),
     )
+    # Reactance (X != 0) -> a fixed complex-Z series Load (issue #422), no
+    # longer dropped.
     deck = parse_nec(_dipole7("LD 4 1 2 2 50.0 25.0 0"), network=True)
-    assert deck.loads == () and "LD" in deck.ignored
-    assert any("type 4" in why for _m, why in deck.ignored_detail)
-    # The reason surfaces in the UI note (composes with #373).
-    assert "type 4" in deck.skipped_note()
+    (ld,) = deck.loads
+    assert ld.z == complex(50.0, 25.0)
+    assert ld.r is None and ld.l is None and ld.c is None
+    assert "LD" not in deck.ignored
+    assert not any(m == "LD" for m, _ in deck.ignored_detail)
+    (br,) = deck.network().branches
+    assert isinstance(br, Load) and br.z == complex(50.0, 25.0)
 
 
 def test_ld5_whole_structure_becomes_conductivity():


### PR DESCRIPTION
Closes #422.

## What

A NEC `LD` card **type 4** is a fixed, frequency-independent `R + jX` impedance in **series** with a segment's current path. antennaknobs' `Load` only modelled frequency-dependent R/L/C, so `nec_import` **dropped** LD 4 whenever `X ≠ 0` (flagging the deck `n`). This adds a fixed complex-Z to the series `Load` so these translate exactly.

## Why the series `Load`, not the shunt `Admittance` (#416)

An LD 4 is a **series** element, not a shunt to common. It becomes the reducer's group-2 termination, composed with the feed EMF, so on a **driven + loaded** segment it correctly adds to the driving-point impedance: `Z = Z_L + 1/Y₀₀`. A shunt would be silently wrong there — the ideal source pins the node, so the shunt never reaches Z. (The reactive *shunt* cases — NT, TL end-shunts — are #416's `Admittance`; this is the series sibling.)

## Change

- **`network.Load`** gains an optional fixed complex `z`, mutually exclusive with `r/l/c/parallel/ql/qc` (validated in `__post_init__`). `load_impedance` / `load_series_admittance` return it verbatim at every frequency; the reducer termination is **unchanged** (it already routes through `load_impedance`).
- **`PyNECEngine`** emits a fixed-z `Load` as native `ld_card` **type 4** (`R + jX`) — a Load-only network stays on NEC's native load path.
- **`nec_import`** — `LD 4` with `X ≠ 0` → `Load(z=R+jX)` (`X = 0` stays `Load(r=R)`); the type-4 skip is removed; module and `NecLoad` docstrings updated.

## Tests (TDD)

- `test_ld4_reactive_load.py` — the fixed-z series-load circuit oracle (`Z = Z_L + 1/Y₀₀`, frequency-independent), `z`-vs-r/l/c validation, LD-4-jX translation, and **cross-engine PyNEC-vs-momwire agreement** with the load **on the fed segment** (the shunt-would-fail case) and on a parasitic segment — each also asserting the load actually moves Z, so a dropped load fails the test.
- Updated `test_ld4_resistance_and_reactance_both_translate` (the old skip test).
- Regression: nec-import, network-MNA, admittance-branch, finite-Q, and PyNEC/momwire engine suites green.

Series sibling to #416 (shunt `Admittance`); no corpus deck exercises LD 4 jX today, so tested synthetically — relevant for the wild-corpus runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)