### PR TITLE
Wild-corpus solve sweep: resource-bounded bench + 3,146-deck results doc (#410)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ src/antennaknobs/web/static/
 .claude/*
 !.claude/skills/
 scripts/sterba_center_driven_pattern.png
+bench_out/

--- a/docs/status/2026-07-17-wild-corpus-solve-sweep.md
+++ b/docs/status/2026-07-17-wild-corpus-solve-sweep.md
@@ -1,0 +1,156 @@
+# 2026-07-17 — wild-corpus solve sweep (3,146 decks, 4 engines, bounded)
+
+## Goal
+
+Issue #410, final leg: run every unique deck of the wild corpus
+(`~/antennas/nec-wild/`, provenance per-source `MANIFEST.md`) through the
+full impedance benchmark — nec2c reference on the original deck, then
+PyNEC / Sinusoidal / BSpline d=1 / BSpline d=2 on the imported geometry —
+under hard resource bounds: **300 s wall-clock per solve** and **8 GB
+RLIMIT_AS** per solve subprocess (and per nec2c run).
+
+Reference build (pinned, per the parse-census caveat): **vanilla nec2c
+1.3.1**, `/usr/bin/nec2c`, md5 `050927160cecf7ee86db907dafac7bbe`. The
+KJ7LNW 1.3 fork disagrees with it on some near-resonance decks; numbers in
+this doc are only comparable against this exact binary.
+
+Tooling (`scripts/bench_nec_corpus.py`, this branch): `--mem-limit-gb`
+(RLIMIT_AS, MEM/TIME/GEO/ERR error taxonomy), TimeoutExpired containment,
+content-md5 dedup in solve mode, corpus-relative row keys, and incremental
+`.jsonl` output that doubles as a resume point. Full results:
+`bench_out/wild-solve-2026-07-17.jsonl` (~5 MB, untracked).
+
+## Headline census
+
+**3,146 unique decks → 1,875 scored against nec2c. Zero sweep crashes
+after hardening, zero engine crashes unaccounted for, one memory-cap trip
+(the bound is real), 38 momwire-timeout decks — all one root cause, now
+understood and filed.**
+
+| outcome | decks | note |
+|---|--:|---|
+| scored vs nec2c | **1,875** | full 4-engine comparison |
+| parse-rejected | 260 | exactly the parse census's designed rejections (91.7% parse rate) |
+| parsed, no nec2c reference | 1,011 | 978 no impedance block (no EX / scattering / report-only decks), 32 nec2c faulty-card aborts, 1 nec2c timeout |
+
+Ground mix of the scored decks: 1,162 free / 533 Sommerfeld / 153 PEC /
+27 refl-coef. Flags: 190 partial-network (`n`), 31 unsupported-ground (`g`).
+
+## Agreement rollup (clean decks: supported ground, full network)
+
+Feed-0 reflection-coefficient distance ΔΓ = |Γ_eng − Γ_nec2c|, Γ at 50 Ω:
+
+| engine | n | median | p90 | ≤0.01 | ≤0.05 | ≤0.2 |
+|---|--:|--:|--:|--:|--:|--:|
+| PyNEC | 1,590 | **0.0002** | 0.0077 | 91% | 96% | 98% |
+| Sinusoidal | 1,620 | 0.0046 | 0.0337 | 65% | 93% | 97% |
+| BSpline d=2 | 1,623 | 0.0084 | 0.1326 | 52% | 79% | 92% |
+| BSpline d=1 | 1,623 | 0.0251 | 0.1977 | 23% | 68% | 89% |
+
+The engine ordering from the 82-deck xnec2c benchmark holds at 20× the
+scale across at least four authoring dialects — strong evidence the
+import pipeline is faithful and the momwire deltas are solver physics
+(mesh-convergence and basis effects), not translation bugs.
+
+## Resource-bound outcomes
+
+- **Memory**: one deck tripped the 8 GB cap (`Tutorial-2/ch-5/5-8.nec`,
+  BSpline d=1 and d=2 → MEM). Biggest successful solves peaked at
+  4.5 GB (bs1) — the cap has real headroom yet actually protects.
+- **Time**: solve medians are ~10–20 ms across engines (p90 ≤ 2 s);
+  nec2c median 0.01 s, max 166 s. The 300 s cap only ever fired on the
+  anchor family below and one nec2c sweep-heavy deck.
+- **Cost of the bounds**: the 38 timeout decks burned ~9.5 h of the
+  ~15 h total wall time — bounded, resumable, and now avoidable (below).
+
+## The one big finding: remote TL-anchor wires × Sommerfeld (38 decks)
+
+Every momwire timeout (38 decks — all three momwire solvers burn the full
+300 s while PyNEC solves in <1 s) is the same classic NEC modeling trick:
+a tiny wire parked ~100–500 λ away so a `TL` card has a far-end segment
+(open/shorted stub emulation), or its dual, a remote EX-driven source
+rack fanned out over TLs — combined with `GN 2` Sommerfeld ground.
+
+Minimal repro (no TL needed — it is pure matrix assembly): a 51-seg
+dipole + one 1-seg wire at 2.1 km solves in 1.27 s without the remote
+wire, >60 s with it, whether the separation is lateral or vertical;
+PyNEC does the same geometry in 0.07 s. Filed as **momwire#157**
+(kernel: likely far outside the Sommerfeld interpolation grid →
+per-element brute quadrature).
+
+Import-side fix filed as **#427** and implemented in **PR #428**
+(review measurements posted there): translate anchor wires to
+`PortVirtual` circuit terminations. PyNEC proves the anchors are
+electrically negligible (Δz ≈ 1 Ω on the repro). With the review's
+relaxed "electrically tiny" gate (`extent < λ/20` instead of
+`n_seg == 1`), 16 of the 38 virtualize; the remaining decks are the
+remote-*source* variant (EX-driven racks, e.g. K8UR's 16 phased sources
+on a 16-seg wire at 16 km) needing `Driven`-on-`PortVirtual` as a
+follow-up. Full deck list in the appendix.
+
+## Accuracy outliers to triage (clean decks, PyNEC ΔΓ > 0.2 — 17 decks)
+
+Worst cases, all with the *engines agreeing with each other* against
+nec2c in the ones spot-checked, suggesting deck-semantics gaps rather
+than solver error:
+
+| ΔΓ | deck | suspicion |
+|--:|---|---|
+| 1.59 | 4nec2/zz_MiniNec/HFshort/TopCap75.nec | MiniNec-dialect ground? |
+| 1.28 / 1.21 | Verticals/{10,7}-dpl-spiralhats-sngnd.nec | dense spiral hats — segmentation semantics |
+| 1.13 | necpp/salt_ground.nec | extreme ground params |
+| 0.93 | Tutorial-2/ch-11/11-4.nec | — |
+| 0.79 | qantenna/zepp-80m.nec | — |
+
+These 17 (0.9% of scored) are the residue worth individual study; the
+list is derivable from the JSON (`dgamma > 0.2`, clean flags).
+
+## Incidents (sweep hardening that came out of this run)
+
+1. **UnicodeDecodeError at deck 1,666**: nec2c emitted a raw `0xff` into
+   its own output file; the strict `read_text()` killed the sweep 8 h in.
+   The `.jsonl` resume point restored all 1,665 rows; fix: tolerant
+   decoding everywhere + a per-deck catch-all so no single deck can end a
+   sweep. Lesson generalized: **wild input contaminates outputs too** —
+   every byte-stream in the loop needs the tolerant path, not just decks.
+2. **Monitor self-match**: the progress watcher's `pgrep -f` pattern
+   matched its own shell, reporting "progress" for 30+ min after the
+   death. Liveness checks must target a recorded PID, not a pattern.
+
+## Caveats
+
+- nec2c is the *reference*, not truth: the 32 faulty-card decks and the
+  17-outlier residue may include nec2c-side quirks (see the 1.3.1 vs
+  KJ7LNW disagreement note in the parse census).
+- Engine solves ran at the single frequency nec2c reported first;
+  sweep-heavy decks are compared at one point only.
+- The 190 `n`-flagged decks (inexpressible LD/TL/NT pieces) are scored
+  best-effort and excluded from the clean rollup.
+
+## Next
+
+1. Land PR #428 (+ relaxed gate) → delete the 38 timeout rows from the
+   jsonl → resume-re-run just that family for scored ΔΓ values.
+2. `Driven`-on-`PortVirtual` follow-up for the remote-source variant.
+3. momwire#157 kernel hardening (benefits genuinely large structures).
+4. Triage the 17-deck outlier residue as its own errand.
+
+## Appendix: the 38 momwire-timeout decks
+
+All `arrl/cebik-models/` unless noted:
+
+Phased-Arrays: 14-shortel-stubs-50-N7CL, 14-zlsporig-1-ZL3MH,
+18-shortel-stubs-50-N7CL, 1r8-2x4elphased-K8UR, 1r8-4elphased-lowbend-K8UR,
+1r8-4elphased-midelbend-K8UR, 21-shortel-stubs-50-N7CL, 21-zlsporig-1-ZL3MH,
+24-shortel-stubs-50-N7CL, 28-shortel-stubs-50-N7CL,
+28-shortel-stubstack-50-N7CL, 28-zlsp-udp-75-W4RNL, 28-zlsporig-1-ZL3MH,
+3r6-2x4elphased-K8UR, 3r6-4elphased-lowbend-K8UR,
+3r6-4elphased-midelbend-K8UR, 3r6-phasedrect-10-N2DT, 5r4-2x4elphased-K8UR,
+5r4-4elphased-lowbend-K8UR, 5r4-4elphased-midelbend-K8UR ·
+Quads: 18-3elquad-14-reversible-AA2NN · VHF-UHF: 50-lazyH-phasedarray ·
+Verticals: 10-3elwireparasitic-sngnd, 10-hsbeam-12, 3r6-hsbeam-reverible-12,
+7-3elwireparasitic-sngnd, 7-hsbeam-12 · Wire-Arrays: 10-3elYagi-14,
+21-coledz-12, 21-coledzlazyh-12, 3r6-3elYagi-14, 3r9-2elYagi-reflload-14,
+3r9-3elYagi-14, 5r4-moxrect-reversible-12-AA2NN, 7-2eldelta-12-K4TX,
+7-3elYagi-14, 7-moxrect-reversible-12-AA2NN ·
+opensource: sokyrad/unsorted/10m efhw narrow rect 28.4mhz.nec

--- a/scripts/bench_nec_corpus.py
+++ b/scripts/bench_nec_corpus.py
@@ -240,7 +240,7 @@ def run_nec2c(deck_path: Path, timeout: float, mem_bytes: int | None = None):
     with tempfile.TemporaryDirectory(prefix="nec_") as d:
         nec = Path(d) / "d.nec"
         out = Path(d) / "d.out"
-        nec.write_text(deck_path.read_text())
+        nec.write_bytes(deck_path.read_bytes())
         t0 = time.perf_counter()
         # nec2c returns non-zero (255) both on a faulty card AND after a NaN
         # solve, and it writes its real diagnostics into the output FILE, not
@@ -258,7 +258,10 @@ def run_nec2c(deck_path: Path, timeout: float, mem_bytes: int | None = None):
         if not out.exists():
             tail = (proc.stderr or b"").decode(errors="replace").strip()[-120:]
             return {"error": f"nec2c produced no output (rc={proc.returncode}) {tail}"}
-        text = out.read_text()
+        # errors="replace": nec2c can emit raw non-UTF-8 bytes into its own
+        # output on some wild decks (seen: 0xff mid-file) — a garbled char in
+        # a diagnostic must not kill the sweep.
+        text = out.read_text(errors="replace")
         lines = text.splitlines()
 
     freq = None
@@ -319,7 +322,7 @@ def worker_main(engine: str, deck_path: str, freq: float, ground_json: str):
             ground = tuple(ground)
 
         deck, net, _ignored = load_deck(
-            Path(deck_path).read_text(), Path(deck_path).name
+            Path(deck_path).read_text(errors="replace"), Path(deck_path).name
         )
         tups = deck.wire_tuples(specs=True)
 
@@ -542,7 +545,7 @@ def bench_deck(
     # rel_name (corpus-relative path) disambiguates wild trees where the same
     # stem appears under several sources.
     row = {"deck": rel_name or deck_path.stem, "error": None}
-    text = deck_path.read_text()
+    text = deck_path.read_text(errors="replace")
     try:
         deck, _net, ignored_net = load_deck(text, deck_path.name)
     except Exception as e:  # noqa: BLE001
@@ -1041,15 +1044,19 @@ def main(argv=None):
         if rel in done:
             continue
         print(f"[{i}/{len(decks)}] {rel} ...", flush=True)
-        row = bench_deck(
-            deck,
-            args.engines,
-            args.timeout,
-            run_with_ground=not args.free_space,
-            allow_intersections=args.allow_wire_intersections,
-            mem_bytes=mem_bytes,
-            rel_name=rel,
-        )
+        try:
+            row = bench_deck(
+                deck,
+                args.engines,
+                args.timeout,
+                run_with_ground=not args.free_space,
+                allow_intersections=args.allow_wire_intersections,
+                mem_bytes=mem_bytes,
+                rel_name=rel,
+            )
+        except Exception as e:  # noqa: BLE001 — a 20 h sweep must survive any
+            # single deck (first bite: nec2c emitting raw 0xff into its output)
+            row = {"deck": rel, "error": f"sweep-level: {type(e).__name__}: {e}"}
         rows.append(row)
         if jsonl:
             with jsonl.open("a") as f:

--- a/scripts/bench_nec_corpus.py
+++ b/scripts/bench_nec_corpus.py
@@ -45,6 +45,16 @@ Usage:
     python scripts/bench_nec_corpus.py --decks 40m-moxon 20m_quad
     python scripts/bench_nec_corpus.py --engines pynec bs2
     python scripts/bench_nec_corpus.py --out results.json --timeout 300
+
+Wild-corpus sweeps (issue #410) additionally want hard resource bounds and
+restartability:
+    python scripts/bench_nec_corpus.py --corpus ~/antennas/nec-wild \\
+        --timeout 300 --mem-limit-gb 8 --out wild.jsonl
+--mem-limit-gb applies RLIMIT_AS to every solve subprocess AND the nec2c
+reference run, so one pathological deck can't OOM the machine. A ``.jsonl``
+--out is written incrementally (one row per line as each deck finishes) and
+is a resume point: re-running with the same --out skips decks already done.
+Solve mode content-dedupes the corpus by md5 exactly like --parse-only.
 """
 
 from __future__ import annotations
@@ -108,6 +118,17 @@ def apply_server_thread_policy() -> int:
     # server, whose module-level call limits every subsequent solve.
     threadpool_limits(limits={"blas": n, "openmp": n})
     return n
+
+
+def _rlimit_preexec(mem_bytes: int):
+    """preexec_fn capping a child's virtual address space (RLIMIT_AS — the
+    same bound as ``ulimit -v``). Allocation past the cap raises MemoryError
+    in Python workers / fails malloc in nec2c instead of OOMing the host."""
+
+    def fn():
+        resource.setrlimit(resource.RLIMIT_AS, (mem_bytes, mem_bytes))
+
+    return fn
 
 
 # --------------------------------------------------------------------------
@@ -210,7 +231,7 @@ def parse_ground(deck_text: str):
 _FREQ_RE = re.compile(r"FREQUENCY\s*:\s*([0-9.Ee+-]+)\s*MHz", re.IGNORECASE)
 
 
-def run_nec2c(deck_path: Path, timeout: float):
+def run_nec2c(deck_path: Path, timeout: float, mem_bytes: int | None = None):
     """Run the original deck through nec2c; return the first-frequency result:
     ``{"freq": MHz, "z": [[re, im], ...], "runtime_s": s, "error": str|None}``.
     Short temp paths sidestep nec2c's fixed filename buffer."""
@@ -225,16 +246,18 @@ def run_nec2c(deck_path: Path, timeout: float):
         # solve, and it writes its real diagnostics into the output FILE, not
         # stderr. So don't gate on the exit code — read the output and classify.
         try:
-            subprocess.run(
+            proc = subprocess.run(
                 ["nec2c", "-i", str(nec), "-o", str(out)],
                 capture_output=True,
                 timeout=timeout,
+                preexec_fn=_rlimit_preexec(mem_bytes) if mem_bytes else None,
             )
         except subprocess.TimeoutExpired:
             return {"error": f"nec2c timeout >{timeout:.0f}s"}
         runtime = time.perf_counter() - t0
         if not out.exists():
-            return {"error": "nec2c produced no output"}
+            tail = (proc.stderr or b"").decode(errors="replace").strip()[-120:]
+            return {"error": f"nec2c produced no output (rc={proc.returncode}) {tail}"}
         text = out.read_text()
         lines = text.splitlines()
 
@@ -376,29 +399,49 @@ def worker_main(engine: str, deck_path: str, freq: float, ground_json: str):
     print(json.dumps(result))
 
 
-def run_engine(engine, deck_path, freq, ground, timeout, allow_intersections=False):
+def run_engine(
+    engine,
+    deck_path,
+    freq,
+    ground,
+    timeout,
+    allow_intersections=False,
+    mem_bytes=None,
+):
     """Dispatch a worker subprocess for one (deck, engine); parse its JSON."""
     env = dict(os.environ)
     if allow_intersections:
         env["PYNEC_ALLOW_INTERSECTIONS"] = "1"
-    proc = subprocess.run(
-        [
-            sys.executable,
-            __file__,
-            "--worker",
-            engine,
-            str(deck_path),
-            repr(float(freq)),
-            json.dumps(ground),
-        ],
-        capture_output=True,
-        text=True,
-        timeout=None if timeout is None else timeout + 15,
-        env=env,
-    )
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                __file__,
+                "--worker",
+                engine,
+                str(deck_path),
+                repr(float(freq)),
+                json.dumps(ground),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=None if timeout is None else timeout + 15,
+            env=env,
+            preexec_fn=_rlimit_preexec(mem_bytes) if mem_bytes else None,
+        )
+    except subprocess.TimeoutExpired:
+        # Wild decks WILL hit the wall-clock cap; that is a result, not a
+        # sweep-stopper (the pre-#410 code let this propagate and killed
+        # the whole run on the first slow deck).
+        return {"error": f"solve timeout >{timeout:.0f}s"}
     if proc.returncode != 0 and not proc.stdout.strip():
         tail = (proc.stderr or "").strip()[-200:]
-        return {"error": f"worker exited {proc.returncode}: {tail}"}
+        note = (
+            " (mem-limit set, likely OOM abort)"
+            if mem_bytes and proc.returncode < 0
+            else ""
+        )
+        return {"error": f"worker exited {proc.returncode}{note}: {tail}"}
     try:
         return json.loads(proc.stdout.strip().splitlines()[-1])
     except (json.JSONDecodeError, IndexError):
@@ -419,18 +462,36 @@ def run_engine(engine, deck_path, freq, ground, timeout, allow_intersections=Fal
 # translation/wrapper bug. Classify them as `geo` so the report distinguishes
 # "engine rejected the geometry" from an actual solve crash.
 _GEO_REJECT_RE = re.compile(r"GEOMETRY DATA ERROR|INTERSECTS WIRE", re.IGNORECASE)
+# RLIMIT_AS trips surface as MemoryError / numpy "Unable to allocate" in the
+# worker, OpenBLAS's "Memory allocation still failed" (exits 1 before Python
+# can catch anything), std::bad_alloc out of the C++ kernels, or (rarely) an
+# abort/SIGSEGV when C code doesn't check malloc — a negative returncode with
+# the limit on.
+_MEM_RE = re.compile(
+    r"MemoryError|bad_alloc|Unable to allocate|Cannot allocate|Out of memory"
+    r"|Memory allocation|likely OOM abort",
+    re.IGNORECASE,
+)
+_TIMEOUT_RE = re.compile(r"solve timeout")
 
 
 def engine_error_kind(res):
-    """Classify an engine result's error into ``None`` (no error), ``"geo"``
-    (nec2++ geometry-intersection rejection — a documented kernel limitation,
-    issue #409), or ``"err"`` (any other failure)."""
+    """Classify an engine result's error: ``None`` (no error), ``"geo"``
+    (nec2++ geometry-intersection rejection — documented kernel limitation,
+    issue #409), ``"mem"`` (hit the --mem-limit-gb cap), ``"timeout"`` (hit
+    the --timeout wall-clock cap), or ``"err"`` (any other failure)."""
     if res is None:
         return "err"
     err = res.get("error")
     if not err:
         return None
-    return "geo" if _GEO_REJECT_RE.search(err) else "err"
+    if _GEO_REJECT_RE.search(err):
+        return "geo"
+    if _TIMEOUT_RE.search(err):
+        return "timeout"
+    if _MEM_RE.search(err):
+        return "mem"
+    return "err"
 
 
 # --------------------------------------------------------------------------
@@ -470,10 +531,17 @@ def compare(engine_z, ref_z):
 
 
 def bench_deck(
-    deck_path: Path, engines, timeout, run_with_ground=True, allow_intersections=False
+    deck_path: Path,
+    engines,
+    timeout,
+    run_with_ground=True,
+    allow_intersections=False,
+    mem_bytes=None,
+    rel_name=None,
 ):
-    name = deck_path.stem
-    row = {"deck": name, "error": None}
+    # rel_name (corpus-relative path) disambiguates wild trees where the same
+    # stem appears under several sources.
+    row = {"deck": rel_name or deck_path.stem, "error": None}
     text = deck_path.read_text()
     try:
         deck, _net, ignored_net = load_deck(text, deck_path.name)
@@ -497,17 +565,22 @@ def bench_deck(
         partial_net_detail=[c for c, _ in ignored_net][:4],
     )
 
-    ref = run_nec2c(deck_path, timeout)
+    ref = run_nec2c(deck_path, timeout, mem_bytes)
     row["nec2c"] = ref
     if ref.get("error"):
         return row
     freq = ref["freq"]
+    if freq is None:
+        row["error"] = "nec2c gave impedance but no parseable FREQUENCY line"
+        return row
     row["freq"] = freq
 
     eng_ground = ground if run_with_ground else "free"
     row["engines"] = {}
     for e in engines:
-        res = run_engine(e, deck_path, freq, eng_ground, timeout, allow_intersections)
+        res = run_engine(
+            e, deck_path, freq, eng_ground, timeout, allow_intersections, mem_bytes
+        )
         if res.get("error") is None and "z" in res:
             res["cmp"] = compare(res["z"], ref["z"])
         else:
@@ -522,6 +595,10 @@ def fmt_dg(res):
     kind = engine_error_kind(res)
     if kind == "geo":
         return "GEO"  # nec2++ geometry-intersection rejection (issue #409)
+    if kind == "mem":
+        return "MEM"  # hit --mem-limit-gb
+    if kind == "timeout":
+        return "TIME"  # hit --timeout
     if kind == "err":
         return "ERR"
     cmp = res.get("cmp") or []
@@ -628,6 +705,8 @@ def print_report(rows, engines):
     ]
     if eng_errs:
         geo = [x for x in eng_errs if x[2] == "geo"]
+        mem = [x for x in eng_errs if x[2] == "mem"]
+        tmo = [x for x in eng_errs if x[2] == "timeout"]
         other = [x for x in eng_errs if x[2] == "err"]
         print("\n" + "=" * 72)
         print(f"ENGINE ERRORS ON REFERENCED DECKS ({len(eng_errs)})")
@@ -638,6 +717,14 @@ def print_report(rows, engines):
                 "genuine kernel limitation, nec2c & momwire accept the geometry:"
             )
             for deck, e, _k, why in geo:
+                print(f"  {deck:<28} {ENGINE_LABEL[e]:<12} {(why or '')[:70]}")
+        if mem:
+            print(f"MEM — hit the memory cap ({len(mem)}):")
+            for deck, e, _k, why in mem:
+                print(f"  {deck:<28} {ENGINE_LABEL[e]:<12} {(why or '')[:70]}")
+        if tmo:
+            print(f"TIME — hit the wall-clock cap ({len(tmo)}):")
+            for deck, e, _k, why in tmo:
                 print(f"  {deck:<28} {ENGINE_LABEL[e]:<12} {(why or '')[:70]}")
         if other:
             print(f"ERR — other engine failures ({len(other)}):")
@@ -776,6 +863,35 @@ def parse_census(decks, corpus, out_path):
         print(f"\nfull census -> {out_path}")
 
 
+def nec2c_fingerprint():
+    """Identify the nec2c build the sweep scores against (census caveat:
+    vanilla 1.3.1 and the KJ7LNW fork disagree on some decks — results are
+    only comparable against the same binary)."""
+    import hashlib
+
+    path = shutil.which("nec2c")
+    if not path:
+        return {"path": None}
+    ver = subprocess.run(["nec2c", "-v"], capture_output=True, text=True).stdout.strip()
+    md5 = hashlib.md5(Path(path).read_bytes()).hexdigest()
+    return {"path": path, "version": ver, "md5": md5}
+
+
+def dedupe_decks(decks):
+    """Content-dedupe (md5, first path wins) — same rule as --parse-only;
+    the wild corpus has ~860 exact duplicates across source mirrors."""
+    import hashlib
+
+    seen: set[str] = set()
+    unique = []
+    for p in decks:
+        h = hashlib.md5(p.read_bytes()).hexdigest()
+        if h not in seen:
+            seen.add(h)
+            unique.append(p)
+    return unique, len(decks) - len(unique)
+
+
 def main(argv=None):
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument(
@@ -802,6 +918,14 @@ def main(argv=None):
         help="per-solve / per-nec2c wall-clock cap (s)",
     )
     ap.add_argument(
+        "--mem-limit-gb",
+        type=float,
+        default=None,
+        help="RLIMIT_AS cap (GB) applied to every solve subprocess and the "
+        "nec2c reference run — one pathological wild deck can't OOM the host "
+        "(issue #410)",
+    )
+    ap.add_argument(
         "--free-space",
         action="store_true",
         help="run engines free-space regardless of the deck's GN",
@@ -814,7 +938,13 @@ def main(argv=None):
         "(issue #409; needs pynec-accel >=1.7.5)",
     )
     ap.add_argument(
-        "--out", type=Path, default=None, help="write full results JSON here"
+        "--out",
+        type=Path,
+        default=None,
+        help="write full results here. A .json path is written once at the "
+        "end; a .jsonl path is written incrementally (one row per deck as it "
+        "finishes) and doubles as a resume point — re-running with the same "
+        "--out skips decks already recorded",
     )
     ap.add_argument(
         "--parse-only",
@@ -853,33 +983,81 @@ def main(argv=None):
         parse_census(decks, corpus, args.out)
         return
 
+    decks, n_dups = dedupe_decks(decks)
+    mem_bytes = int(args.mem_limit_gb * 2**30) if args.mem_limit_gb else None
+
     cores = physical_cpu_count()
+    nec2c_id = nec2c_fingerprint()
     print(f"corpus: {corpus}")
-    print(f"decks: {len(decks)}   engines: {', '.join(args.engines)}")
+    print(
+        f"decks: {len(decks)} (content dups skipped: {n_dups})   "
+        f"engines: {', '.join(args.engines)}"
+    )
+    print(
+        f"bounds: timeout={args.timeout:.0f}s/solve   "
+        f"mem={args.mem_limit_gb or 'unlimited'}"
+        + ("GB (RLIMIT_AS)" if args.mem_limit_gb else "")
+    )
+    print(
+        f"nec2c reference: {nec2c_id.get('version')} at {nec2c_id.get('path')} "
+        f"md5={nec2c_id.get('md5')}"
+    )
     print(
         f"concurrency (mirrors web/server.py): BLAS={cores} OpenMP={cores} "
         f"OMP_WAIT_POLICY={os.environ['OMP_WAIT_POLICY']} "
         f"GOMP_SPINCOUNT={os.environ['GOMP_SPINCOUNT']}   (serial dispatch)"
     )
-    if shutil.which("nec2c") is None:
+    if nec2c_id.get("path") is None:
         sys.exit("nec2c not on PATH — build it and symlink into ~/.local/bin")
 
-    rows = []
+    # Incremental JSONL mode: resume by skipping decks already recorded.
+    jsonl = args.out if args.out and args.out.suffix == ".jsonl" else None
+    done: dict[str, dict] = {}
+    if jsonl and jsonl.exists():
+        for line in jsonl.read_text().splitlines():
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue  # torn final line from a killed run
+            if "_meta" not in rec:
+                done[rec["deck"]] = rec
+        print(f"resume: {len(done)} decks already in {jsonl}, skipping those")
+    elif jsonl:
+        meta = {
+            "_meta": {
+                "corpus": str(corpus),
+                "engines": list(args.engines),
+                "timeout_s": args.timeout,
+                "mem_limit_gb": args.mem_limit_gb,
+                "nec2c": nec2c_id,
+                "started": time.strftime("%Y-%m-%d %H:%M:%S"),
+            }
+        }
+        jsonl.write_text(json.dumps(meta) + "\n")
+
+    rows = list(done.values())
     for i, deck in enumerate(decks, 1):
-        print(f"[{i}/{len(decks)}] {deck.stem} ...", flush=True)
-        rows.append(
-            bench_deck(
-                deck,
-                args.engines,
-                args.timeout,
-                run_with_ground=not args.free_space,
-                allow_intersections=args.allow_wire_intersections,
-            )
+        rel = str(deck.relative_to(corpus))
+        if rel in done:
+            continue
+        print(f"[{i}/{len(decks)}] {rel} ...", flush=True)
+        row = bench_deck(
+            deck,
+            args.engines,
+            args.timeout,
+            run_with_ground=not args.free_space,
+            allow_intersections=args.allow_wire_intersections,
+            mem_bytes=mem_bytes,
+            rel_name=rel,
         )
+        rows.append(row)
+        if jsonl:
+            with jsonl.open("a") as f:
+                f.write(json.dumps(row) + "\n")
 
     print_report(rows, args.engines)
 
-    if args.out:
+    if args.out and not jsonl:
         args.out.write_text(json.dumps(rows, indent=2))
         print(f"\nfull results -> {args.out}")
 


### PR DESCRIPTION
## Summary
- `scripts/bench_nec_corpus.py` grows the bounds a ~3,000-deck wild sweep needs: `--mem-limit-gb` (RLIMIT_AS on every solve worker and the nec2c reference run, with a MEM/TIME/GEO/ERR error taxonomy), TimeoutExpired containment (a slow deck is a result, not a sweep-killer), content-md5 dedup in solve mode, corpus-relative row keys, incremental `.jsonl` output that doubles as a resume point, and a fingerprint of the exact nec2c build (path/version/md5) in the output meta.
- Hardening from the run itself: tolerant decoding on every byte stream (nec2c emitted a raw `0xff` into its own output mid-sweep and killed run 1 at deck 1,666 — the jsonl resume restored all rows) plus a per-deck catch-all.
- `docs/status/2026-07-17-wild-corpus-solve-sweep.md`: full results of the bounded sweep — 3,146 unique decks, 1,875 scored vs pinned vanilla nec2c 1.3.1; PyNEC median ΔΓ 0.0002 (91% ≤ 0.01) with the xnec2c engine ordering holding at 20× scale; one 8 GB memory-cap trip; the 38-deck momwire-timeout family (remote TL-anchor wires × Sommerfeld → momwire#157, #427/PR #428) with the full deck list; 17 clean-deck accuracy outliers left as a triage errand.

## Test plan
- [x] Smoke: MEM classification forced with a 0.5 GB cap; TIME via the TimeoutExpired branch; resume skips completed rows; dedup drops mirrored decks
- [x] Full sweep completed end-to-end over `~/antennas/nec-wild` (resumed once across the UnicodeDecodeError incident, which the hardening commit fixes)
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrXSe3AfQhGgZgcsQoPS7y