### PR TITLE
resolve_sy: 4nec2 decks get a real nec2c reference (#439)

### DIFF
--- a/scripts/bench_nec_corpus.py
+++ b/scripts/bench_nec_corpus.py
@@ -231,16 +231,26 @@ def parse_ground(deck_text: str):
 _FREQ_RE = re.compile(r"FREQUENCY\s*:\s*([0-9.Ee+-]+)\s*MHz", re.IGNORECASE)
 
 
-def run_nec2c(deck_path: Path, timeout: float, mem_bytes: int | None = None):
+def run_nec2c(
+    deck_path: Path,
+    timeout: float,
+    mem_bytes: int | None = None,
+    deck_text: str | None = None,
+):
     """Run the original deck through nec2c; return the first-frequency result:
     ``{"freq": MHz, "z": [[re, im], ...], "runtime_s": s, "error": str|None}``.
-    Short temp paths sidestep nec2c's fixed filename buffer."""
+    Short temp paths sidestep nec2c's fixed filename buffer. ``deck_text``
+    substitutes prepared text (the resolved-reference retry, issue #439) for
+    the file's own bytes."""
     if shutil.which("nec2c") is None:
         return {"error": "nec2c not on PATH"}
     with tempfile.TemporaryDirectory(prefix="nec_") as d:
         nec = Path(d) / "d.nec"
         out = Path(d) / "d.out"
-        nec.write_bytes(deck_path.read_bytes())
+        if deck_text is None:
+            nec.write_bytes(deck_path.read_bytes())
+        else:
+            nec.write_text(deck_text)
         t0 = time.perf_counter()
         # nec2c returns non-zero (255) both on a faulty card AND after a NaN
         # solve, and it writes its real diagnostics into the output FILE, not
@@ -533,6 +543,41 @@ def compare(engine_z, ref_z):
     return out
 
 
+def reference_deck(text: str, name: str) -> str:
+    """Deck text prepared for the nec2c *reference* run (issue #439).
+
+    ``resolve_sy`` materializes the 4nec2 dialect nec2c cannot read (SY
+    symbols, ``'`` comments, ``#AWG`` gauges, fused mnemonics). On top of
+    that, two run-request quirks 4nec2 project decks leave to the GUI:
+
+    - an ``FR`` card with NFRQ = 0 gets the NEC-2 spec's "one assumed"
+      default (``parse_nec`` applies the same normalization);
+    - a deck with no ``XQ``/``RP`` execute request gets an ``XQ`` appended
+      before ``EN``, otherwise nec2c parses everything and computes nothing
+      ("no ANTENNA INPUT PARAMETERS block").
+
+    Raises ``ValueError`` like ``resolve_sy`` on undecipherable decks.
+    """
+    from antennaknobs.nec_import import resolve_sy
+
+    lines = resolve_sy(text, name=name).splitlines()
+    out, has_exec = [], False
+    for ln in lines:
+        toks = ln.split()
+        if toks[0] == "FR" and len(toks) > 2 and float(toks[2]) == 0:
+            toks[2] = "1"
+            ln = " ".join(toks)
+        if toks[0] in ("XQ", "RP"):
+            has_exec = True
+        out.append(ln)
+    if not has_exec:
+        if out and out[-1] == "EN":
+            out.insert(-1, "XQ")
+        else:
+            out += ["XQ", "EN"]
+    return "\n".join(out) + "\n"
+
+
 def bench_deck(
     deck_path: Path,
     engines,
@@ -574,6 +619,21 @@ def bench_deck(
     )
 
     ref = run_nec2c(deck_path, timeout, mem_bytes)
+    if ref.get("error"):
+        # Resolved-reference retry (issue #439): the deck parses for *us*,
+        # so a failed reference run may just be dialect (SY symbols, no
+        # XQ/RP request). Retry nec2c on the prepared text; a success is
+        # labeled, never silently swapped in.
+        try:
+            prepared = reference_deck(text, deck_path.name)
+        except ValueError:
+            prepared = None
+        if prepared is not None:
+            retry = run_nec2c(deck_path, timeout, mem_bytes, deck_text=prepared)
+            if not retry.get("error"):
+                retry["resolved_deck"] = True
+                retry["original_error"] = ref["error"]
+                ref = retry
     row["nec2c"] = ref
     if ref.get("error"):
         return row
@@ -625,11 +685,12 @@ def print_report(rows, engines):
     )
     print(
         "  flags: g = unsupported ground (radials/cliff), n = inexpressible LD/TL/NT "
-        "network, v = remote TL-anchor wire(s) virtualized (#427)"
+        "network, v = remote TL-anchor wire(s) virtualized (#427),"
+        " r = reference from resolved deck (#439)"
     )
     print("=" * 104)
     hdr = (
-        f"{'deck':<34} {'f/MHz':>8} {'grd':>5} {'fl':>3} {'Z_nec2c (feed0)':>19}  "
+        f"{'deck':<34} {'f/MHz':>8} {'grd':>5} {'fl':>4} {'Z_nec2c (feed0)':>19}  "
         + " ".join(f"{ENGINE_LABEL[e]:>11}" for e in engines)
     )
     print(hdr)
@@ -640,11 +701,12 @@ def print_report(rows, engines):
             ("g" if not r.get("ground_supported", True) else "")
             + ("n" if r.get("partial_net") else "")
             + ("v" if r.get("virtualized_anchors") else "")
+            + ("r" if r.get("nec2c", {}).get("resolved_deck") else "")
         )
         cells = " ".join(f"{fmt_dg(r['engines'].get(e)):>11}" for e in engines)
         print(
             f"{r['deck']:<34} {r.get('freq', 0):>8.3f} {r.get('ground') or 'free':>5} "
-            f"{flags:>3} {z0.real:>8.1f}{z0.imag:>+8.1f}j  {cells}"
+            f"{flags:>4} {z0.real:>8.1f}{z0.imag:>+8.1f}j  {cells}"
         )
 
     # runtime + RSS summary per engine (over solves that succeeded)
@@ -673,7 +735,7 @@ def print_report(rows, engines):
     print("\n" + "=" * 72)
     print(
         "AGREEMENT ROLLUP  (feed-0 ΔΓ; clean decks: supported ground, "
-        "fully-expressed network, no virtualized anchors)"
+        "fully-expressed network, no virtualized anchors, verbatim reference)"
     )
     print("=" * 72)
     for e in engines:
@@ -683,6 +745,10 @@ def print_report(rows, engines):
             if r.get("ground_supported", True)
             and not r.get("partial_net")
             and not r.get("virtualized_anchors")
+            # r-flagged decks (reference from our own resolved text, #439)
+            # are a labeled cohort, not the clean baseline: the resolution
+            # and the engines share the SY evaluator, so its bugs cancel
+            and not r["nec2c"].get("resolved_deck")
             and not r["engines"].get(e, {}).get("error")
             and r["engines"][e].get("cmp")
         ]

--- a/src/antennaknobs/nec_import.py
+++ b/src/antennaknobs/nec_import.py
@@ -62,6 +62,7 @@ __all__ = [
     "NecWire",
     "parse_nec",
     "read_nec",
+    "resolve_sy",
 ]
 
 _DEG = math.pi / 180.0
@@ -582,6 +583,112 @@ def read_nec(
         network=network,
         virtualize_anchors=virtualize_anchors,
     )
+
+
+# nec2c-readable plain number. Deliberately stricter than Python's float()
+# (which also takes "nan", "inf" and digit underscores) and excludes Fortran
+# D exponents, so anything unusual is routed through evaluation + reformat.
+_PLAIN_NUM_RE = re.compile(r"[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?\Z")
+
+
+def _format_field(v: float) -> str:
+    """Shortest exact decimal for a resolved card field; integral values are
+    written without a decimal point so integer-read fields stay clean."""
+    if v == int(v) and abs(v) < 1e15:
+        return str(int(v))
+    return repr(v)
+
+
+def resolve_sy(text: str, *, name: str = "NEC deck") -> str:
+    """Resolve a 4nec2-dialect deck into plain NEC-2 card text (issue #439).
+
+    Evaluates every ``SY`` symbol (#417, #424 grammar) in deck order and
+    substitutes each card field that is not already a plain number —
+    symbolic expressions, ``#nn`` AWG gauges, Fortran D exponents — with
+    its numeric value, so the deck becomes readable by reference engines
+    that know nothing of the dialect (vanilla nec2c). Purely lexical: no
+    modelling restrictions apply, and cards ``parse_nec`` would refuse
+    (SP, GF, plane-wave EX, ...) pass through with their fields resolved.
+
+    Tolerant-tokenizer forms nec2c cannot read (#418) are normalized too:
+    ``'`` comment lines and end-of-line comments are dropped, fused
+    mnemonics (``GW1,8,...``) are split, and comma separators become
+    spaces. ``SY`` cards are consumed, not emitted. Comment cards keep
+    their leading position (a ``CE`` is inserted before the first real
+    card if the deck never wrote one); glued mid-deck comments
+    (``cmRP ...`` commented-out cards) are dropped. Text after ``EN`` is
+    dropped. Numbers already plain are kept byte-for-byte.
+
+    Raises ``ValueError`` (with ``name`` and the line number) on a
+    malformed card mnemonic or ``SY`` definition. A card *field* that
+    fails to evaluate is kept verbatim instead (filename fields on
+    GN/WG/GF cards look like expressions but aren't).
+    """
+    syms: dict[str, float] = {}
+    out: list[str] = []
+    in_comments = True
+    wrote_comment = False
+    for line_no, raw in enumerate(text.splitlines(), 1):
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        where = f"{name}, line {line_no}"
+        if stripped.startswith("'"):
+            continue
+        head = stripped[:2].upper()
+        if head == "CM":
+            if in_comments:
+                rest = stripped[2:].strip()
+                out.append(f"CM {rest}" if rest else "CM")
+                wrote_comment = True
+            continue
+        if head == "CE":
+            if in_comments:
+                rest = stripped[2:].strip()
+                out.append(f"CE {rest}" if rest else "CE")
+                in_comments = False
+            continue
+        stripped = stripped.split("'", 1)[0].rstrip()
+        if not stripped:
+            continue
+        tokens = stripped.replace(",", " ").split()
+        if (
+            len(tokens[0]) > 2
+            and tokens[0][:2].isalpha()
+            and tokens[0][2] in "0123456789.+-"
+        ):
+            tokens = [tokens[0][:2], tokens[0][2:], *tokens[1:]]
+        mnemonic = tokens[0].upper()
+        if len(mnemonic) != 2 or not mnemonic.isalpha():
+            raise ValueError(
+                f"{where}: expected a NEC card mnemonic, got {tokens[0]!r}"
+            )
+        if mnemonic == "SY":
+            _define_sy(stripped[2:], syms, where)
+            continue
+        if in_comments:
+            if wrote_comment:
+                out.append("CE")
+            in_comments = False
+        fields = []
+        for tok in tokens[1:]:
+            if _PLAIN_NUM_RE.fullmatch(tok):
+                fields.append(tok)
+                continue
+            try:
+                fields.append(_format_field(_value(tok, where, syms)))
+            except ValueError:
+                # Not everything lettered is an expression: GN/WG/GF cards
+                # carry *filename* fields ("WG radials-vg"). Keep the token
+                # verbatim — the reference engine sees the most faithful
+                # text, and a genuinely undefined symbol in a numeric field
+                # surfaces as that engine's own card error, not a silent
+                # substitution.
+                fields.append(tok)
+        out.append(" ".join([mnemonic, *fields]))
+        if mnemonic == "EN":
+            break
+    return "\n".join(out) + "\n"
 
 
 def _float(token: str, where: str) -> float:

--- a/tests/test_resolve_sy.py
+++ b/tests/test_resolve_sy.py
@@ -1,0 +1,160 @@
+"""Issue #439: ``resolve_sy`` — materialize 4nec2-dialect decks as plain
+NEC-2 text so a reference engine that knows nothing of the dialect (vanilla
+nec2c) can read them.
+
+The contract under test: the resolved text is (a) dialect-free — no SY
+cards, no ``'`` comments, no ``#AWG`` gauges, no fused mnemonics, every
+field a plain decimal — and (b) semantically identical, i.e. ``parse_nec``
+extracts the same wires/feeds/frequency from original and resolved text.
+"""
+
+import math
+
+import pytest
+
+from antennaknobs.nec_import import parse_nec, resolve_sy
+
+
+def _tokens(resolved):
+    return [line.split() for line in resolved.strip().splitlines()]
+
+
+def _assert_plain(resolved):
+    """Every non-comment field must be a number Python's float() accepts."""
+    for toks in _tokens(resolved):
+        assert toks[0].isalpha() and len(toks[0]) == 2 and toks[0].isupper()
+        if toks[0] in ("CM", "CE"):
+            continue
+        assert toks[0] != "SY", "SY card leaked into resolved text"
+        for t in toks[1:]:
+            float(t)  # raises on anything exotic
+
+
+def _assert_same_deck(original, resolved):
+    a = parse_nec(original, name="orig")
+    b = parse_nec(resolved, name="resolved")
+    assert len(a.wires) == len(b.wires)
+    for wa, wb in zip(a.wires, b.wires):
+        assert wa.n_seg == wb.n_seg
+        assert wa.p1 == pytest.approx(wb.p1)
+        assert wa.p2 == pytest.approx(wb.p2)
+        assert wa.radius == pytest.approx(wb.radius)
+    assert [(f.wire, f.seg) for f in a.feeds] == [(f.wire, f.seg) for f in b.feeds]
+    assert a.freq_mhz == pytest.approx(b.freq_mhz)
+
+
+SY_DECK = """CE 4nec2-style deck
+SY h=12.5, len=2*h  'total height
+GW 1 11 0 0 0 0 0 len #14
+GE 0
+EX 0 1 6 0 1.0 0.0
+FR 0 1 0 0 14.1 0
+EN
+"""
+
+
+def test_sy_substitution_round_trip():
+    resolved = resolve_sy(SY_DECK, name="t")
+    _assert_plain(resolved)
+    _assert_same_deck(SY_DECK, resolved)
+    gw = next(t for t in _tokens(resolved) if t[0] == "GW")
+    assert float(gw[8]) == pytest.approx(25.0)  # len = 2*h
+    # AWG 14 radius in metres
+    assert float(gw[9]) == pytest.approx(0.5 * 0.127e-3 * 92 ** (22 / 39))
+
+
+def test_plain_numbers_kept_verbatim():
+    deck = "CE\nGW 1 11 0 0 0 0 0 1.E+01 1.0e-3\nGE 0\nEX 0 1 6 0 1. 0.\nEN\n"
+    resolved = resolve_sy(deck, name="t")
+    gw = next(t for t in _tokens(resolved) if t[0] == "GW")
+    # untouched fields keep their original spelling, exponent style and all
+    assert gw[8] == "1.E+01" and gw[9] == "1.0e-3"
+
+
+def test_comment_conventions_dropped():
+    deck = (
+        "CM a comment\nCE\n"
+        "'GW 9 9 this whole card is commented out\n"
+        "GW 1 11 0 0 0 0 0 10 0.001 'eol comment\n"
+        "cmRP 0 1 1 1000 0 0 0 0\n"
+        "GE 0\nEX 0 1 6 0 1 0\nEN\ntrailing junk after EN\n"
+    )
+    resolved = resolve_sy(deck, name="t")
+    _assert_plain(resolved)
+    lines = resolved.strip().splitlines()
+    assert lines[0] == "CM a comment" and lines[1] == "CE"
+    assert not any("junk" in ln or "commented" in ln for ln in lines)
+    assert sum(ln.startswith("GW") for ln in lines) == 1
+    assert lines[-1] == "EN"
+
+
+def test_fused_mnemonic_and_commas_normalized():
+    deck = "CE\nGW1,11,0,0,0,0,0,10,.001\nGE0\nEX0,1,6,0,1,0\nEN\n"
+    resolved = resolve_sy(deck, name="t")
+    _assert_plain(resolved)
+    _assert_same_deck(deck, resolved)
+
+
+def test_ce_inserted_when_missing():
+    deck = "CM only a CM, no CE\nGW 1 3 0 0 0 0 0 1 .001\nGE 0\nEN\n"
+    lines = resolve_sy(deck, name="t").strip().splitlines()
+    assert lines[0].startswith("CM") and lines[1] == "CE"
+    assert lines[2].startswith("GW")
+
+
+def test_no_comments_no_ce_invented():
+    deck = "GW 1 3 0 0 0 0 0 1 .001\nGE 0\nEN\n"
+    lines = resolve_sy(deck, name="t").strip().splitlines()
+    assert lines[0].startswith("GW")
+
+
+def test_sy_reassignment_mid_deck():
+    deck = (
+        "CE\nSY h=1\nGW 1 3 0 0 0 0 0 h .001\n"
+        "SY h=2\nGW 2 3 1 0 0 1 0 h .001\nGE 0\nEN\n"
+    )
+    resolved = resolve_sy(deck, name="t")
+    gws = [t for t in _tokens(resolved) if t[0] == "GW"]
+    assert float(gws[0][8]) == 1 and float(gws[1][8]) == 2
+
+
+def test_fortran_d_exponent_reformatted():
+    deck = "CE\nGW 1 3 0 0 0 0 0 1.0D+01 .001\nGE 0\nEN\n"
+    gw = next(t for t in _tokens(resolve_sy(deck, name="t")) if t[0] == "GW")
+    assert "D" not in gw[8] and float(gw[8]) == 10
+
+
+def test_unsupported_cards_pass_through_resolved():
+    # parse_nec refuses SP; resolve_sy is lexical and must not
+    deck = "CE\nSY s=0.1\nGW 1 3 0 0 0 0 0 1 .001\nSP 0 0 s 0 0 0\nGE 0\nEN\n"
+    sp = next(t for t in _tokens(resolve_sy(deck, name="t")) if t[0] == "SP")
+    assert float(sp[3]) == pytest.approx(0.1)
+
+
+def test_degrees_trig_and_units():
+    deck = "CE\nSY a=sin(30)\nGW 1 3 0 0 0 0 0 90ft a\nGE 0\nEN\n"
+    gw = next(t for t in _tokens(resolve_sy(deck, name="t")) if t[0] == "GW")
+    assert float(gw[8]) == pytest.approx(90 * 0.3048)  # juxtaposed unit
+    assert float(gw[9]) == pytest.approx(math.sin(math.radians(30)))
+
+
+def test_integral_values_emit_as_integers():
+    deck = "CE\nSY n=3+8\nGW 1 n 0 0 0 0 0 1 .001\nGE 0\nEN\n"
+    gw = next(t for t in _tokens(resolve_sy(deck, name="t")) if t[0] == "GW")
+    assert gw[2] == "11"
+
+
+def test_bad_expression_raises_with_location():
+    with pytest.raises(ValueError, match="line 2"):
+        resolve_sy("CE\nSY h=nosuchfn(3)\nEN\n", name="t")
+
+
+def test_filename_fields_kept_verbatim():
+    # GN's Sommerfeld-grid and WG's output filenames are strings, not
+    # expressions — they must survive untouched, not raise
+    deck = (
+        "CE\nGW 1 3 0 0 0 -2 0 0 .01\nGE -1\n"
+        "GN 2 0 0 0 10. 0.01 SOMEX10.NEC\nWG radials-vg\nEN\n"
+    )
+    resolved = resolve_sy(deck, name="t")
+    assert "SOMEX10.NEC" in resolved and "radials-vg" in resolved


### PR DESCRIPTION
## Summary
- `resolve_sy` in `nec_import`: lexical pass that evaluates SY symbols (#424 evaluator), `#AWG` gauges and D exponents into plain numbers, normalizes quote comments / fused mnemonics / comma separators, and drops SY cards — emitting NEC-2 text vanilla nec2c can read. Filename fields (GN/WG) that look like expressions are kept verbatim. Round-trip `parse_nec` equivalence verified on all 2,867 parseable wild decks (zero mismatches).
- Bench: when nec2c fails on the original deck but our parser succeeds, retry the reference on prepared text — resolved deck + FR NFRQ=0→1 (NEC-2 spec default, same as `parse_nec`) + appended `XQ` when the deck has no execute request (4nec2 leaves the run request to the GUI). Successful retries are labeled (`resolved_deck`, `r` flag) and excluded from the clean rollup because resolution and engines share the SY evaluator.
- Sample of 25 previously reference-less SY decks: 23 now score (the 2 holdouts use 4nec2's `LD 6` load type, which nec2c aborts on — a separate dialect gap, also unrecognized by our importer). End-to-end `bench_deck` spot checks give PyNEC ΔΓ ≤ 0.009.

## Test plan
- [x] `tests/test_resolve_sy.py` — 13 cases: substitution round-trip, verbatim plain numbers, comment conventions, fused mnemonics, CE insertion, mid-deck SY reassignment, D exponents, unsupported-card passthrough, units/degree trig, integer emission, error location, filename passthrough
- [x] Full suite: 2239 passed
- [x] Corpus round-trip smoke: 2,867/2,867 parse-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrXSe3AfQhGgZgcsQoPS7y