### PR TITLE
LD 6 LC-trap loads: 4nec2's Q/L/C conversion in importer + nec2c reference (#444)

### DIFF
--- a/scripts/bench_nec_corpus.py
+++ b/scripts/bench_nec_corpus.py
@@ -567,19 +567,48 @@ def reference_deck(text: str, name: str) -> str:
       plane wave) becomes the classic emulation — ``EX 0`` with
       V = I·``EX6_R_BIG`` behind an ``LD 4`` series ``EX6_R_BIG`` on the
       driven segment. The caller must subtract ``EX6_R_BIG`` from nec2c's
-      reported impedance at that feed (``bench_deck`` does).
+      reported impedance at that feed (``bench_deck`` does);
+    - an ``LD 6`` LC-trap (issue #444; 4nec2 dialect, nec2c aborts with
+      IMPROPER LOAD TYPE) becomes the parallel RLC 4nec2 itself converts
+      it to: ``LD 1 tag sf st R_p L C`` with R_p = Q·ωL at the initial
+      FR card's frequency (F1 is the coil's unloaded Q, 0 → 100). Same
+      conversion as ``nec_import``'s, so engines and reference agree on
+      the physics.
 
     Raises ``ValueError`` like ``resolve_sy`` on undecipherable decks.
     """
     from antennaknobs.nec_import import resolve_sy
 
     lines = resolve_sy(text, name=name).splitlines()
+    # 4nec2 evaluates LD 6 trap loss at the INITIAL FR card's F1 (issue
+    # #444) — which may appear after the LD card, so pre-scan for it.
+    fr_first_mhz = 299.8  # NEC's no-FR default
+    for ln in lines:
+        toks = ln.split()
+        if toks[0] == "FR" and len(toks) > 5:
+            try:
+                fr_first_mhz = float(toks[5]) or fr_first_mhz
+            except ValueError:
+                pass
+            break
     out, has_exec, ex6_lds = [], False, []
     for ln in lines:
         toks = ln.split()
         if toks[0] == "FR" and len(toks) > 2 and float(toks[2]) == 0:
             toks[2] = "1"
             ln = " ".join(toks)
+        if toks[0] == "LD" and len(toks) > 1 and int(float(toks[1])) == 6:
+            tag = toks[2] if len(toks) > 2 else "0"
+            sf = toks[3] if len(toks) > 3 else "0"
+            st = toks[4] if len(toks) > 4 else "0"
+            q = (float(toks[5]) if len(toks) > 5 else 0.0) or 100.0
+            le = float(toks[6]) if len(toks) > 6 else 0.0
+            c = float(toks[7]) if len(toks) > 7 else 0.0
+            if le == 0.0:
+                continue  # trap without inductance — the importer drops it too
+            r_p = q * 2.0 * math.pi * fr_first_mhz * 1e6 * le
+            out.append(f"LD 1 {tag} {sf} {st} {r_p!r} {le!r} {c!r}")
+            continue
         if toks[0] == "EX" and len(toks) > 1 and int(float(toks[1])) == 6:
             tag, seg = toks[2], toks[3] if len(toks) > 3 else "0"
             i_re = float(toks[5]) if len(toks) > 5 else 0.0

--- a/src/antennaknobs/nec_import.py
+++ b/src/antennaknobs/nec_import.py
@@ -1382,7 +1382,14 @@ def _anchor_wires(wires, tls_raw, nts_raw, feeds, lds_raw, freq_mhz):
 
 
 def _translate_network_cards(
-    wires, lds_raw, tls_raw, nts_raw, feeds, freq_mhz, virtualize_anchors
+    wires,
+    lds_raw,
+    tls_raw,
+    nts_raw,
+    feeds,
+    freq_mhz,
+    virtualize_anchors,
+    fr_first_mhz=None,
 ):
     """Turn the collected LD/TL/NT cards into NecLoad/NecTL/NecNT records,
     plus (mnemonic, reason) detail for every card instance that stays
@@ -1497,7 +1504,7 @@ def _translate_network_cards(
     for card in lds_raw:
         ldtyp = card.i(0)
         tag, sf, st = card.i(1), card.i(2), card.i(3)
-        if ldtyp in (0, 1, 4):
+        if ldtyp in (0, 1, 4, 6):
             pairs = _segment_range(wires, tag, sf, st, card)
             if len(pairs) > _LD_EXPAND_MAX:
                 skip(
@@ -1516,6 +1523,22 @@ def _translate_network_cards(
                     z, r, le, c = complex(r, x), None, None, None
                 else:
                     r, le, c = (r or None), None, None
+            elif ldtyp == 6:
+                # 4nec2's LC-trap extension (issue #444): F1 is the coil's
+                # UNLOADED Q (0 → 100, the documented default), F2/F3 = L/C.
+                # 4nec2 converts it internally to a parallel RLC whose loss
+                # resistance is evaluated at the initial FR card's frequency:
+                # R_p = Q·ωL. Same conversion here, so all engines and the
+                # nec2c reference (reference_deck does the text-level twin)
+                # solve the physics 4nec2 would hand its own engine.
+                le = card.f(5) or None
+                c = card.f(6) or None
+                if le is None:
+                    skip("LD", "type 6 LC-trap without inductance")
+                    continue
+                q = card.f(4) or 100.0
+                omega = 2.0 * math.pi * (fr_first_mhz or 299.8) * 1e6
+                r = q * omega * le
             else:
                 r = card.f(4) or None
                 le = card.f(5) or None
@@ -1534,7 +1557,7 @@ def _translate_network_cards(
                     skip("LD", "a second load on one segment is not merged")
                     continue
                 loaded.add(pair)
-                loads.append(NecLoad(pair[0], pair[1], r, le, c, ldtyp == 1, z=z))
+                loads.append(NecLoad(pair[0], pair[1], r, le, c, ldtyp in (1, 6), z=z))
         elif ldtyp in (2, 3):
             skip("LD", f"type {ldtyp} distributed per-metre loading is not translated")
         elif ldtyp == 5:
@@ -1608,6 +1631,7 @@ def parse_nec(
     tls_raw: list[_Card] = []
     nts_raw: list[_Card] = []
     freq_mhz: tuple[float, float] | None = None
+    fr_first_mhz: float | None = None
     ground = False
     extended_kernel = False
     syms: dict[str, float] = {}  # SY symbol table (#417)
@@ -1729,6 +1753,10 @@ def parse_nec(
                 else:  # multiplicative sweep
                     end = start * step ** (nfrq - 1) if step > 0 else start
                 freq_mhz = (min(start, end), max(start, end))
+                # The raw F1 of the initial FR card, pre min/max
+                # normalization — 4nec2 evaluates LD 6 trap loss at
+                # exactly this frequency (issue #444).
+                fr_first_mhz = start
         elif mnemonic == "EX":
             ex_type = card.i(0)
             if ex_type in (1, 2, 3):
@@ -1793,7 +1821,14 @@ def parse_nec(
             skipped,
             virtual_anchors,
         ) = _translate_network_cards(
-            wires, lds_raw, tls_raw, nts_raw, feeds, freq_mhz, virtualize_anchors
+            wires,
+            lds_raw,
+            tls_raw,
+            nts_raw,
+            feeds,
+            freq_mhz,
+            virtualize_anchors,
+            fr_first_mhz,
         )
         ignored |= skipped
 

--- a/tests/test_nec_import_ld6.py
+++ b/tests/test_nec_import_ld6.py
@@ -1,0 +1,126 @@
+"""LD 6 LC-trap loads (4nec2 dialect, issue #444).
+
+The 4nec2 manual defines type 6 as an LC-trap whose F1 is the coil's
+UNLOADED Q (0 → default 100), internally converted to a parallel RLC
+with the loss resistance evaluated at the initial FR card's frequency:
+R_p = Q·ωL. The contract here: our importer performs exactly that
+conversion, so an LD 6 deck and the equivalent hand-written LD 1 deck
+are indistinguishable all the way through an engine solve.
+"""
+
+import math
+
+import pytest
+
+from antennaknobs import AntennaBuilder, WireSpec
+from antennaknobs.engines import MomwireEngine
+from antennaknobs.nec_import import parse_nec
+from momwire import SinusoidalSolver
+
+FREQ = 21.05
+OMEGA = 2.0 * math.pi * FREQ * 1e6
+L_H = 2.86e-6
+C_F = 20e-12
+
+TRAP_DECK = (
+    "GW 1 21 0 -10 15 0 10 15 0.008\nGE\n"
+    "EX 0 1 11 0 1 0\n"
+    "LD 6 1 5 5 {q} {l} {c}\n"
+    "FR 0 1 0 0 21.05\nEN\n"
+)
+
+
+def _ld1_deck(r_p):
+    return (
+        "GW 1 21 0 -10 15 0 10 15 0.008\nGE\n"
+        "EX 0 1 11 0 1 0\n"
+        f"LD 1 1 5 5 {r_p!r} {L_H!r} {C_F!r}\n"
+        "FR 0 1 0 0 21.05\nEN\n"
+    )
+
+
+def _builder(deck):
+    class B(AntennaBuilder):
+        default_params = {"freq": FREQ}
+
+        def build_wires(self):
+            return deck.wire_tuples()
+
+        def build_network(self):
+            return deck.network()
+
+        def build_wire_material(self):
+            return WireSpec(radius=deck.dominant_radius())
+
+    return B()
+
+
+def _z(deck):
+    eng = MomwireEngine(_builder(deck), solver=SinusoidalSolver, ground=None)
+    return eng.impedance()[0]
+
+
+def test_ld6_translates_to_parallel_rlc():
+    deck = parse_nec(TRAP_DECK.format(q=100, l=L_H, c=C_F), name="t", network=True)
+    (load,) = deck.loads
+    assert load.parallel is True
+    assert load.l == pytest.approx(L_H)
+    assert load.c == pytest.approx(C_F)
+    assert load.r == pytest.approx(100.0 * OMEGA * L_H, rel=1e-12)
+    assert not deck.ignored_detail  # fully expressed — no n-flag residue
+
+
+def test_ld6_q_zero_defaults_to_100():
+    deck = parse_nec(TRAP_DECK.format(q=0, l=L_H, c=C_F), name="t", network=True)
+    assert deck.loads[0].r == pytest.approx(100.0 * OMEGA * L_H, rel=1e-12)
+
+
+def test_ld6_without_inductance_is_skipped_not_fatal():
+    deck = parse_nec(TRAP_DECK.format(q=100, l=0, c=C_F), name="t", network=True)
+    assert not deck.loads
+    assert any("LC-trap" in reason for _c, reason in deck.ignored_detail)
+
+
+def test_ld6_solves_identically_to_hand_ld1():
+    """Engine oracle: the LD 6 deck and the LD 1 deck with the same
+    converted R_p must produce the same driving-point impedance."""
+    r_p = 100.0 * OMEGA * L_H
+    z6 = _z(parse_nec(TRAP_DECK.format(q=100, l=L_H, c=C_F), name="a", network=True))
+    z1 = _z(parse_nec(_ld1_deck(r_p), name="b", network=True))
+    assert z6 == pytest.approx(z1, rel=1e-12)
+
+
+def test_trap_actually_bites_at_resonance():
+    """Physics sanity: the 2.86 µH / 20 pF trap resonates at ~21.05 MHz, so
+    at that frequency the trap inserts a large series impedance and the
+    driving-point Z must differ hugely from the unloaded dipole's."""
+    z_trap = _z(
+        parse_nec(TRAP_DECK.format(q=100, l=L_H, c=C_F), name="t", network=True)
+    )
+    z_bare = _z(
+        parse_nec(
+            "GW 1 21 0 -10 15 0 10 15 0.008\nGE\nEX 0 1 11 0 1 0\n"
+            "FR 0 1 0 0 21.05\nEN\n",
+            name="b",
+            network=True,
+        )
+    )
+    assert abs(z_trap - z_bare) > 100.0
+
+
+def test_reference_deck_emits_ld1_twin():
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+    from bench_nec_corpus import reference_deck
+
+    prepared = reference_deck(TRAP_DECK.format(q=100, l=L_H, c=C_F), "t")
+    ld_lines = [ln for ln in prepared.splitlines() if ln.startswith("LD")]
+    (ld,) = ld_lines
+    toks = ld.split()
+    assert toks[1] == "1"  # rewritten to parallel RLC
+    assert float(toks[5]) == pytest.approx(100.0 * OMEGA * L_H, rel=1e-12)
+    assert float(toks[6]) == pytest.approx(L_H)
+    assert float(toks[7]) == pytest.approx(C_F)
+    assert "LD 6" not in prepared


### PR DESCRIPTION
## Summary
- **Semantics settled from the 4nec2 manual + corpus evidence**: LD type 6 is an LC-trap — F1 is the coil's *unloaded Q* (0 → default 100), F2/F3 are L/C, internally converted by 4nec2 to a parallel RLC with loss R_p = Q·ωL at the **initial FR card's frequency**. Corpus Rosetta stone: DUAL2EL.nec writes `SY L=2.86uH / C=20pF / Q=100` → `LD 6 2 1 1 Q L C`, LC resonant exactly at its FR frequency.
- **Importer**: LD 6 folds into the existing per-segment Load path as `parallel=True` with the computed R_p (raw F1 captured before min/max sweep normalization; L=0 traps skipped with a labeled reason). These decks lose their `n` flag.
- **Bench reference**: nec2c aborts on type 6, so `reference_deck` rewrites `LD 6` → its `LD 1` twin with the same R_p (pre-scanning for FR, which may follow the LD card). Unblocks ~102 reference-less wild decks.
- Wild spot checks (PyNEC): TrapDip ΔΓ 0.0003, DUAL2EL 0.0012, Dipol3,5-7 0.0002. MultiTrap (12-trap 160 m vertical at extreme segmentation) disagrees with nec2c at 0.49 with all engines agreeing with each other — the conversion cancels between engines and reference, so that's the known outlier class, not this change.
- Ground-truth confirmation of the R_p convention rides on the Windows 4nec2 cross-check bundle (ld6/ folder).

## Test plan
- [x] `tests/test_nec_import_ld6.py` — 6 cases: parallel-RLC translation + R_p value, Q=0 default, L=0 skip, LD 6 ≡ hand-built LD 1 engine oracle, trap-bites-at-resonance physics sanity, reference_deck LD 1 twin
- [x] Full suite: 2,259 passed
- [x] End-to-end on the 4 wild LD 6 decks (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrXSe3AfQhGgZgcsQoPS7y