### PR TITLE
bench: GN 3 MiniNec-style ground maps to pec (fixes a 70-deck mis-scored class)

### DIFF
--- a/scripts/bench_nec_corpus.py
+++ b/scripts/bench_nec_corpus.py
@@ -212,8 +212,19 @@ def parse_ground(deck_text: str):
         spec = ("finite-fast", eps, sig)
     elif iperf == 2:
         spec = ("finite", eps, sig)
+    elif iperf == 3:
+        # 4nec2/EZNEC "MiniNec-style" ground (70 wild decks): currents and
+        # impedance are solved over a PERFECT ground; the eps/sig on the
+        # card only shape the far field. For the impedance comparison the
+        # faithful mapping is therefore pec — and nec2c happens to agree
+        # bit-for-bit, landing type 3 in its perfect-ground branch
+        # (verified on TopCap75: GN 3 and GN 1 give identical Z, while the
+        # old "free" mapping made the deck a fake dG=1.59 outlier).
+        spec = "pec"
     else:
-        return ("free", True, f"unknown IPERF={iperf}")
+        # Genuinely unknown type: solve free-space but FLAG it — silently
+        # counting it as clean made mis-scored decks look like engine error.
+        return ("free", False, f"unknown IPERF={iperf}")
 
     reasons = []
     if nradl > 0:

--- a/tests/test_bench_ground.py
+++ b/tests/test_bench_ground.py
@@ -1,0 +1,44 @@
+"""GN-card → engine ground mapping in the corpus bench (parse_ground).
+
+Regression anchor for the TopCap75 finding: 70 wild decks use 4nec2's
+``GN 3`` MiniNec-style ground, whose impedance semantics are
+perfect-ground (and which vanilla nec2c also lands in its PEC branch —
+GN 3 and GN 1 give bit-identical Z). The old mapping solved them in
+free space and, worse, still counted them as clean comparisons.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from bench_nec_corpus import parse_ground  # noqa: E402
+
+
+def test_gn3_mininec_maps_to_pec_supported():
+    spec, supported, note = parse_ground(
+        "GW 1 3 0 0 0 0 0 1 .001\nGN 3 0 0 0 13 .005\nEN\n"
+    )
+    assert spec == "pec"
+    assert supported is True
+
+
+def test_unknown_iperf_is_flagged_not_clean():
+    spec, supported, note = parse_ground("GN 7 0 0 0 13 .005\nEN\n")
+    assert spec == "free"
+    assert supported is False
+    assert "IPERF=7" in note
+
+
+def test_standard_types_unchanged():
+    assert parse_ground("GN 1\nEN\n")[0] == "pec"
+    assert parse_ground("GN 2 0 0 0 13 .005\nEN\n")[0] == ("finite", 13.0, 0.005)
+    assert parse_ground("GN 0 0 0 0 13 .005\nEN\n")[0] == ("finite-fast", 13.0, 0.005)
+    assert parse_ground("GN -1\nEN\n")[0] == "free"
+    assert parse_ground("GW 1 3 0 0 0 0 0 1 .001\nEN\n") == ("free", True, "")
+
+
+def test_gn3_with_radials_still_flags_screen():
+    spec, supported, note = parse_ground("GN 3 16 0 0 13 .005\nEN\n")
+    assert spec == "pec"
+    assert supported is False
+    assert "radial" in note


### PR DESCRIPTION
## Summary
- Triage of the worst accuracy outlier (TopCap75, ΔΓ 1.59) found it wasn't an engine gap: the deck uses 4nec2/EZNEC's **GN 3 MiniNec-style ground**, which the bench mapped to *free space* while still counting the row clean. MiniNec-ground impedance semantics are perfect-ground, and vanilla nec2c agrees empirically — `GN 3` and `GN 1` produce bit-identical Z on the deck.
- Mapping fixed: `GN 3` → `pec` (supported); genuinely unknown IPERF values now flag `ground_supported=False` instead of silently passing as clean.
- **70 wild decks** carry GN 3; with the fix TopCap75 drops 1.59 → 0.092, and GP80 (1.00), Phased array Trans-line (0.83), Cone (0.68) are in the same to-be-rescored class.

## Test plan
- [x] `tests/test_bench_ground.py` — GN 3 → pec, unknown-IPERF flagging, standard types unchanged, radial screen still flags
- [x] Verified on TopCap75: nec2c GN 3 ≡ GN 1 bit-identical; PyNEC over pec ΔΓ 0.092 vs 1.59 over free

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrXSe3AfQhGgZgcsQoPS7y