### PR TITLE
LD 7 insulated-wire loads: WireSpec insulation import + LD 2 bench reference (#447)

### DIFF
--- a/scripts/bench_nec_corpus.py
+++ b/scripts/bench_nec_corpus.py
@@ -624,13 +624,19 @@ def reference_deck(text: str, name: str) -> str:
             return tag_radius
         tag_radius = {}
         try:
-            for w in parse_nec(text, name=name).wires:
-                tag_radius.setdefault(w.tag, w.radius)
+            # network=True so EX 6 current-source decks parse too (the
+            # default mode refuses them; issue #442).
+            wires = parse_nec(text, name=name, network=True).wires
+            found = ((w.tag, w.radius) for w in wires)
         except Exception:  # noqa: BLE001 — fall back to the textual scan
-            for gw in lines:
-                gtoks = gw.split()
-                if gtoks and gtoks[0] == "GW" and len(gtoks) > 8:
-                    tag_radius.setdefault(int(float(gtoks[1])), float(gtoks[8]))
+            found = (
+                (int(float(gtoks[1])), float(gtoks[9]))
+                for gtoks in (gw.split() for gw in lines)
+                if gtoks and gtoks[0] == "GW" and len(gtoks) > 9
+            )
+        for t, a in found:
+            if a > 0.0:  # radius 0 = tapered-wire GC prelude — no emulation
+                tag_radius.setdefault(t, a)
         return tag_radius
 
     out, has_exec, ex6_lds = [], False, []

--- a/scripts/bench_nec_corpus.py
+++ b/scripts/bench_nec_corpus.py
@@ -584,11 +584,22 @@ def reference_deck(text: str, name: str) -> str:
       it to: ``LD 1 tag sf st R_p L C`` with R_p = Q·ωL at the initial
       FR card's frequency (F1 is the coil's unloaded Q, 0 → 100). Same
       conversion as ``nec_import``'s, so engines and reference agree on
-      the physics.
+      the physics;
+    - an ``LD 7`` insulated-wire load (issue #447; 4nec2 dialect, nec2c
+      aborts too — F1 = jacket εr, F2 = jacket outer radius in metres)
+      becomes the ``LD 2`` distributed-series-L′ emulation PR #326
+      validated against the WireSpec insulation model (~1% vf oracle):
+      L′ = ``insulation_inductance(a, b, εr)`` per covered tag, with the
+      conductor radius ``a`` taken from the parsed deck's wires (so GS
+      scaling and geometry transforms are honoured). A whole-structure
+      card expands to one ``LD 2`` per tag (radii differ per tag); a
+      jacket that doesn't clear its conductor is dropped — the importer
+      leaves that wire bare too.
 
     Raises ``ValueError`` like ``resolve_sy`` on undecipherable decks.
     """
-    from antennaknobs.nec_import import resolve_sy
+    from antennaknobs.nec_import import parse_nec, resolve_sy
+    from momwire import insulation_inductance
 
     lines = resolve_sy(text, name=name).splitlines()
     # 4nec2 evaluates LD 6 trap loss at the INITIAL FR card's F1 (issue
@@ -602,6 +613,26 @@ def reference_deck(text: str, name: str) -> str:
             except ValueError:
                 pass
             break
+    tag_radius: dict[int, float] | None = None
+
+    def tag_radii() -> dict[int, float]:
+        """NEC tag → conductor radius, computed lazily on the first LD 7.
+        Preferred source is the fully parsed deck (post-GS/transform radii);
+        a deck ``parse_nec`` refuses falls back to a raw GW-card scan."""
+        nonlocal tag_radius
+        if tag_radius is not None:
+            return tag_radius
+        tag_radius = {}
+        try:
+            for w in parse_nec(text, name=name).wires:
+                tag_radius.setdefault(w.tag, w.radius)
+        except Exception:  # noqa: BLE001 — fall back to the textual scan
+            for gw in lines:
+                gtoks = gw.split()
+                if gtoks and gtoks[0] == "GW" and len(gtoks) > 8:
+                    tag_radius.setdefault(int(float(gtoks[1])), float(gtoks[8]))
+        return tag_radius
+
     out, has_exec, ex6_lds = [], False, []
     for ln in lines:
         toks = ln.split()
@@ -619,6 +650,30 @@ def reference_deck(text: str, name: str) -> str:
                 continue  # trap without inductance — the importer drops it too
             r_p = q * 2.0 * math.pi * fr_first_mhz * 1e6 * le
             out.append(f"LD 1 {tag} {sf} {st} {r_p!r} {le!r} {c!r}")
+            continue
+        if toks[0] == "LD" and len(toks) > 1 and int(float(toks[1])) == 7:
+            tag = int(float(toks[2])) if len(toks) > 2 else 0
+            sf = toks[3] if len(toks) > 3 else "0"
+            st = toks[4] if len(toks) > 4 else "0"
+            eps_r = float(toks[5]) if len(toks) > 5 else 0.0
+            b = float(toks[6]) if len(toks) > 6 else 0.0
+            if b <= 0.0 or eps_r <= 1.0:
+                continue  # no jacket / vacuum jacket — the importer drops it too
+            if tag == 0 and float(sf) == 0:
+                targets, sf, st = sorted(tag_radii()), "0", "0"
+            else:
+                targets = [tag]
+            if not all(t in tag_radii() for t in targets):
+                # A tag with no known radius: keep the card verbatim so
+                # nec2c aborts honestly instead of solving wrong physics.
+                out.append(ln)
+                continue
+            for t in targets:
+                a = tag_radii()[t]
+                if b <= a:
+                    continue  # jacket inside the conductor — importer leaves it bare
+                l_ins = float(insulation_inductance(a, b, eps_r))
+                out.append(f"LD 2 {t} {sf} {st} 0 {l_ins!r} 0")
             continue
         if toks[0] == "EX" and len(toks) > 1 and int(float(toks[1])) == 6:
             tag, seg = toks[2], toks[3] if len(toks) > 3 else "0"

--- a/src/antennaknobs/nec_import.py
+++ b/src/antennaknobs/nec_import.py
@@ -28,9 +28,11 @@ TL cards become ``TL`` branches (crossed lines, zero-length = port
 separation, end shunts — a conductance as a ``Shunt``, a reactive G+jB as a
 fixed 1-port ``Admittance``, issue #423), an NT card becomes its exact
 resistive pi when the Y matrix is all-real (``TwoPort`` + ``Shunt``) or a
-2-port ``Admittance`` when it carries susceptance, and an LD 4 reactive load
-(fixed R+jX) becomes a fixed-complex-Z ``Load`` (issue #422). What cannot be
-expressed exactly — distributed RLC (LD 2/3), range-limited conductivity —
+2-port ``Admittance`` when it carries susceptance, an LD 4 reactive load
+(fixed R+jX) becomes a fixed-complex-Z ``Load`` (issue #422), and 4nec2's
+LD 7 wire insulation becomes per-wire ``WireSpec`` jackets via
+``wire_insulation`` (issue #447). What cannot be expressed exactly —
+distributed RLC (LD 2/3), partial-wire conductivity or insulation ranges —
 stays in ``ignored`` with a per-card reason in ``ignored_detail``.
 ``wire_tuples()`` then emits *named* wires (no legacy
 ``ex`` markers) and ``network()`` returns the matching ``Network``, ready to
@@ -226,6 +228,11 @@ class NecDeck:
     # Ranged LD 5 (issue #388): (wire index, S/m) for every wire an LD 5
     # card covers in full. Baked into wire_tuples(specs=True) specs.
     wire_conductivity: tuple[tuple[int, float], ...] = ()
+    # LD 7 wire insulation (issue #447, 4nec2 dialect): (wire index,
+    # (jacket outer radius m, jacket relative permittivity)) for every
+    # wire an LD 7 card covers in full — a whole-structure card covers
+    # them all. Baked into wire_tuples(specs=True) specs.
+    wire_insulation: tuple[tuple[int, tuple[float, float]], ...] = ()
     # (mnemonic, reason) per card instance that network mode still could not
     # translate — skipped_note() prefers these over the generic descriptions.
     ignored_detail: tuple[tuple[str, str], ...] = ()
@@ -390,9 +397,10 @@ class NecDeck:
 
         ``specs=True`` (issue #388) emits ``Wire`` named tuples instead,
         each carrying a per-wire ``WireSpec`` with the deck wire's OWN
-        radius — no ``dominant_radius()`` compromise — and its effective
+        radius — no ``dominant_radius()`` compromise — its effective
         conductivity (a ranged LD 5 over the whole wire, else the deck's
-        whole-structure LD 5). PyNEC honors both per wire; momwire honors
+        whole-structure LD 5), and its LD 7 insulation jacket when the
+        deck carries one (issue #447). PyNEC honors both per wire; momwire honors
         both too since momwire#147 (complete in momwire 0.13.0 across all
         four solver bases, the H-matrix family included). With
         ``specs=True`` a ``build_wire_material()`` fallback is unnecessary
@@ -430,19 +438,25 @@ class NecDeck:
                 per[f.seg] = (f.voltage, None)
 
         sigma_by_wire = dict(self.wire_conductivity)
+        ins_by_wire = dict(self.wire_insulation)
 
         def spec_for(i, w):
             """Per-wire spec (issue #388): the deck wire's own radius, with
             its effective conductivity baked in — a ranged LD 5 on this wire
-            wins over the whole-structure one. Baking is required: engines
-            treat an explicit spec as complete (no field-level fallback to
-            build_wire_material), so leaving conductivity None would turn a
-            copper deck into PEC wire by wire."""
+            wins over the whole-structure one — and its LD 7 insulation
+            jacket (issue #447), when one covers the wire. Baking is
+            required: engines treat an explicit spec as complete (no
+            field-level fallback to build_wire_material), so leaving
+            conductivity None would turn a copper deck into PEC wire by
+            wire."""
             if not specs:
                 return None
+            ins = ins_by_wire.get(i)
             return _net.WireSpec(
                 radius=w.radius,
                 conductivity=sigma_by_wire.get(i, self.conductivity),
+                insulation_radius=ins[0] if ins else None,
+                insulation_eps_r=ins[1] if ins else None,
             )
 
         tups = []
@@ -1501,6 +1515,7 @@ def _translate_network_cards(
     loaded: set[tuple[int, int]] = set()
     conductivity: float | None = None
     wire_conductivity: dict[int, float] = {}
+    wire_insulation: dict[int, tuple[float, float]] = {}
     for card in lds_raw:
         ldtyp = card.i(0)
         tag, sf, st = card.i(1), card.i(2), card.i(3)
@@ -1584,6 +1599,43 @@ def _translate_network_cards(
                         "type 5 conductivity on a partial-wire segment "
                         "range — per-wire specs cover whole wires only",
                     )
+        elif ldtyp == 7:
+            # 4nec2's insulated-wire extension (issue #447; NEC proper has
+            # no such type — nec2c aborts with IMPROPER LOAD TYPE): F1 is
+            # the jacket's relative permittivity, F2 its outer radius in
+            # metres (either may be an SY expression, e.g. `w1/2`).
+            # WireSpec carries exactly this dielectric-jacket model (the
+            # lossy-wire arc), so a range that covers each touched wire in
+            # full translates per wire like the ranged LD 5 conductivity —
+            # last card wins per wire.
+            eps_r, b = card.f(4), card.f(5)
+            if b <= 0.0 or eps_r <= 1.0:
+                continue  # no jacket, or a vacuum one — electrically a no-op
+            pairs = _segment_range(wires, tag, sf, st, card)
+            by_wire = {}
+            for wi, s in pairs:
+                by_wire.setdefault(wi, set()).add(s)
+            if not all(
+                segs == set(range(1, wires[wi][1] + 1)) for wi, segs in by_wire.items()
+            ):
+                skip(
+                    "LD",
+                    "type 7 insulation on a partial-wire segment "
+                    "range — per-wire specs cover whole wires only",
+                )
+                continue
+            for wi in by_wire:
+                if b <= wires[wi][4]:
+                    # A jacket that doesn't clear the conductor is a deck
+                    # bug; the engines would reject the spec outright, so
+                    # leave the wire bare and say why.
+                    skip(
+                        "LD",
+                        "type 7 insulation whose outer radius does not "
+                        "exceed the wire's conductor radius",
+                    )
+                    continue
+                wire_insulation[wi] = (b, eps_r)
         else:
             skip("LD", f"type {ldtyp} is not recognised")
 
@@ -1593,6 +1645,7 @@ def _translate_network_cards(
         tuple(nts),
         conductivity,
         tuple(sorted(wire_conductivity.items())),
+        tuple(sorted(wire_insulation.items())),
         detail,
         skipped,
         frozenset(virtualized),
@@ -1808,6 +1861,7 @@ def parse_nec(
     nts: tuple[NecNT, ...] = ()
     conductivity: float | None = None
     wire_conductivity: tuple[tuple[int, float], ...] = ()
+    wire_insulation: tuple[tuple[int, tuple[float, float]], ...] = ()
     detail: list[tuple[str, str]] = []
     virtual_anchors: frozenset[int] = frozenset()
     if network:
@@ -1817,6 +1871,7 @@ def parse_nec(
             nts,
             conductivity,
             wire_conductivity,
+            wire_insulation,
             detail,
             skipped,
             virtual_anchors,
@@ -1847,6 +1902,7 @@ def parse_nec(
         nts=nts,
         conductivity=conductivity,
         wire_conductivity=wire_conductivity,
+        wire_insulation=wire_insulation,
         ignored_detail=tuple(detail),
         network_mode=network,
         extended_kernel=extended_kernel,

--- a/tests/test_nec_import_ld7.py
+++ b/tests/test_nec_import_ld7.py
@@ -1,0 +1,162 @@
+"""LD 7 insulated-wire loads (4nec2 dialect, issue #447).
+
+4nec2's type 7 is wire insulation: F1 the jacket's relative
+permittivity, F2 its outer radius in metres. The contract here: the
+importer translates whole-wire LD 7 ranges into per-wire WireSpec
+insulation (the lossy-wire arc's dielectric-jacket model), so an LD 7
+deck and hand-built insulated specs are indistinguishable through an
+engine solve — and the bench reference rewrites LD 7 to the LD 2
+distributed-L' emulation PR #326 validated against that model.
+"""
+
+import pytest
+
+from antennaknobs import AntennaBuilder, WireSpec
+from antennaknobs.engines import MomwireEngine
+from antennaknobs.nec_import import parse_nec
+from momwire import SinusoidalSolver, insulation_inductance
+
+FREQ = 3.68
+EPS_R = 4.5
+B_M = 1e-3  # jacket outer radius; conductor is 0.5 mm
+
+COATED_DECK = (
+    "GW 1 21 0 -19 10 0 0 10 0.0005\n"
+    "GW 2 21 0 0 10 0 19 10 0.0005\n"
+    "GE\n"
+    "EX 0 1 21 0 1 0\n"
+    "LD 7 {tag} {sf} {st} {eps} {b}\n"
+    "FR 0 1 0 0 3.68\nEN\n"
+)
+
+
+def _deck(tag=0, sf=0, st=0, eps=EPS_R, b=B_M):
+    return parse_nec(
+        COATED_DECK.format(tag=tag, sf=sf, st=st, eps=eps, b=b),
+        name="t",
+        network=True,
+    )
+
+
+def _builder(deck):
+    class B(AntennaBuilder):
+        default_params = {"freq": FREQ}
+
+        def build_wires(self):
+            return deck.wire_tuples(specs=True)
+
+        def build_network(self):
+            return deck.network()
+
+    return B()
+
+
+def _z(deck):
+    eng = MomwireEngine(_builder(deck), solver=SinusoidalSolver, ground=None)
+    return eng.impedance()[0]
+
+
+def test_ld7_whole_structure_covers_every_wire():
+    deck = _deck(tag=0)
+    assert deck.wire_insulation == ((0, (B_M, EPS_R)), (1, (B_M, EPS_R)))
+    for w in deck.wire_tuples(specs=True):
+        assert w.spec.insulation_radius == pytest.approx(B_M)
+        assert w.spec.insulation_eps_r == pytest.approx(EPS_R)
+    assert not deck.ignored_detail  # fully expressed — no n-flag residue
+
+
+def test_ld7_whole_wire_range_covers_that_wire_only():
+    deck = _deck(tag=2, sf=1, st=21)
+    assert deck.wire_insulation == ((1, (B_M, EPS_R)),)
+    specs = [w.spec for w in deck.wire_tuples(specs=True)]
+    bare = [s for s in specs if s.insulation_radius is None]
+    coated = [s for s in specs if s.insulation_radius is not None]
+    assert bare and coated
+    assert not deck.ignored_detail
+
+
+def test_ld7_partial_wire_range_is_skipped_labeled():
+    deck = _deck(tag=1, sf=3, st=9)
+    assert deck.wire_insulation == ()
+    assert any("partial-wire" in reason for _c, reason in deck.ignored_detail)
+
+
+def test_ld7_jacket_inside_conductor_is_skipped_labeled():
+    deck = _deck(b=0.0004)  # jacket radius below the 0.5 mm conductor
+    assert deck.wire_insulation == ()
+    assert any("conductor radius" in reason for _c, reason in deck.ignored_detail)
+
+
+def test_ld7_vacuum_or_absent_jacket_is_a_silent_noop():
+    for kwargs in ({"eps": 1.0}, {"b": 0}):
+        deck = _deck(**kwargs)
+        assert deck.wire_insulation == ()
+        assert not deck.ignored_detail
+
+
+def test_ld7_solves_identically_to_hand_built_spec():
+    """Engine oracle: the LD 7 deck and the same geometry with hand-built
+    insulated WireSpecs must produce the same driving-point impedance."""
+    z_ld7 = _z(_deck(tag=0))
+
+    bare = parse_nec(
+        COATED_DECK.format(tag=0, sf=0, st=0, eps=1, b=0), name="b", network=True
+    )
+    spec = WireSpec(radius=0.0005, insulation_radius=B_M, insulation_eps_r=EPS_R)
+    hand = [w._replace(spec=spec) for w in bare.wire_tuples(specs=True)]
+
+    class B(AntennaBuilder):
+        default_params = {"freq": FREQ}
+
+        def build_wires(self):
+            return hand
+
+        def build_network(self):
+            return bare.network()
+
+    z_hand = MomwireEngine(B(), solver=SinusoidalSolver, ground=None).impedance()[0]
+    assert z_ld7 == pytest.approx(z_hand, rel=1e-12)
+
+
+def test_insulation_actually_bites():
+    """Physics sanity: a PVC jacket makes the wire electrically longer, so
+    the coated antenna's reactance must differ visibly from the bare one's."""
+    z_coated = _z(_deck(tag=0))
+    z_bare = _z(_deck(eps=1, b=0))
+    assert abs(z_coated.imag - z_bare.imag) > 5.0
+
+
+def test_reference_deck_emits_ld2_emulation():
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+    from bench_nec_corpus import reference_deck
+
+    prepared = reference_deck(
+        COATED_DECK.format(tag=0, sf=0, st=0, eps=EPS_R, b=B_M), "t"
+    )
+    assert "LD 7" not in prepared
+    ld_lines = [ln for ln in prepared.splitlines() if ln.startswith("LD")]
+    assert len(ld_lines) == 2  # whole-structure card expands per tag
+    l_exp = insulation_inductance(0.0005, B_M, EPS_R)
+    for tag, ld in zip((1, 2), ld_lines):
+        toks = ld.split()
+        assert toks[1] == "2" and toks[2] == str(tag)
+        assert float(toks[5]) == 0.0
+        assert float(toks[6]) == pytest.approx(l_exp)
+
+
+def test_reference_deck_drops_non_clearing_jacket():
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+    from bench_nec_corpus import reference_deck
+
+    prepared = reference_deck(
+        COATED_DECK.format(tag=0, sf=0, st=0, eps=EPS_R, b=0.0004), "t"
+    )
+    # Jacket inside the conductor: the importer leaves the wire bare, so
+    # the reference must too — no LD 7 (nec2c aborts) and no LD 2.
+    assert "LD 7" not in prepared and "LD 2" not in prepared


### PR DESCRIPTION
## Summary
- 4nec2's `LD 7 tag sf st eps_r outer_radius` wire-insulation extension (third wild LD dialect after LD 6, #444) now imports: whole-wire ranges translate to per-wire `WireSpec.insulation_radius/insulation_eps_r` via the new `NecDeck.wire_insulation`, baked into `wire_tuples(specs=True)` like ranged LD 5 conductivity. Partial-wire ranges and jackets that don't clear the conductor skip with labeled reasons; vacuum/absent jackets are silent no-ops.
- The bench reference rewrites LD 7 into the LD 2 distributed-series-L' emulation PR #326 validated (~1% vf oracle): `insulation_inductance` per covered tag, conductor radii from the parsed deck (GS/geometry-transform safe, `network=True` so EX 6 decks parse), raw GW scan as fallback. Whole-structure cards expand to one LD 2 per tag; non-clearing jackets are dropped to match the importer's bare-wire skip.
- All 82 wild LD 7 decks — previously reference-less (nec2c aborts with IMPROPER LOAD TYPE) and n-flagged — now parse cleanly and score against a resolved nec2c reference. Full-corpus sweep: most decks at dGamma <= 0.01; the coated inverted-V exemplar lands at 0.0009, the ranged-card phased loop at 0.0017, and the EX 6 + LD 7 phased array at 0.003. Bare-wire control runs confirm the few larger residuals (40m V3, 2m Hentenna) are pre-existing deck character, not the insulation translation.
- Nine new tests: translation and guard cases, an engine oracle (LD 7 deck == hand-built insulated specs to 1e-12), a physics-bite check (the jacket detunes reactance), and reference-rewrite pinning.

Closes #447.

## Test plan
- [x] `pytest tests/test_nec_import_ld7.py` — 9 new tests pass (0.4 s)
- [x] Full test suite green (2273 tests)
- [x] 82/82 wild LD 7 decks bench end-to-end vs nec2c (pynec + sin engines)
- [x] Bare-wire control benches isolate the insulation contribution on outlier decks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
