### PR TITLE
bench: dead trailing run-config cards — the zepp-80m 'TL artifact' was the reference, not our translation (#449)

### DIFF
--- a/scripts/bench_nec_corpus.py
+++ b/scripts/bench_nec_corpus.py
@@ -562,6 +562,49 @@ def compare(engine_z, ref_z):
 EX6_R_BIG = 2.0e4
 
 
+# Program-control cards that configure a NEC-2 run (as opposed to
+# requesting execution). In batch NEC-2 these take effect at the NEXT
+# XQ/RP execute request — so any that appear after the deck's LAST
+# execute request are dead cards. Whole-deck GUI parsers (xnec2c, 4nec2,
+# our importer) apply them regardless of position (issue #449).
+_RUN_CONFIG_CARDS = frozenset(("LD", "TL", "NT", "GN", "GD", "EX", "FR", "EK", "KH"))
+
+
+def dead_trailing_config(mnemonics) -> list[int]:
+    """Indexes of run-config cards after the last XQ/RP execute request.
+
+    ``mnemonics`` is the deck's card-mnemonic sequence (upper-case, one
+    per card line). Nonempty result = the deck's batch-NEC-2 run differs
+    from its whole-deck-parser intent (issue #449): nec2c executed before
+    reading those cards, so its output silently lacks them — the zepp-80m
+    'TL translation artifact' was exactly this, a reference that solved a
+    disconnected feeder stub with no ground.
+    """
+    execs = [i for i, m in enumerate(mnemonics) if m in ("XQ", "RP")]
+    if not execs:
+        return []
+    return [
+        i
+        for i in range(execs[-1] + 1, len(mnemonics))
+        if mnemonics[i] in _RUN_CONFIG_CARDS
+    ]
+
+
+def has_dead_trailing_config(text: str) -> bool:
+    """Raw-text variant of ``dead_trailing_config`` for gating the
+    original-deck reference run (tolerant of the 4nec2 dialect: only
+    plausible two-letter mnemonics count, stops at EN)."""
+    mnems = []
+    for ln in text.splitlines():
+        s = ln.strip()
+        m = s[:2].upper()
+        if len(s) >= 2 and m.isalpha():
+            mnems.append(m)
+            if m == "EN":
+                break
+    return bool(dead_trailing_config(mnems))
+
+
 def reference_deck(text: str, name: str) -> str:
     """Deck text prepared for the nec2c *reference* run (issue #439).
 
@@ -594,7 +637,14 @@ def reference_deck(text: str, name: str) -> str:
       scaling and geometry transforms are honoured). A whole-structure
       card expands to one ``LD 2`` per tag (radii differ per tag); a
       jacket that doesn't clear its conductor is dropped — the importer
-      leaves that wire bare too.
+      leaves that wire bare too;
+    - run-config cards after the deck's LAST execute request (issue #449
+      — dead in batch NEC-2, which executes at XQ/RP before reading
+      them) are hoisted to just before the FIRST execute request, so the
+      reference solves the configuration the deck's whole-deck-parser
+      author intended (xnec2c saves TL/GN after RP; 31 wild decks carry
+      a trailing GN alone — their unhoisted references silently ran
+      free space).
 
     Raises ``ValueError`` like ``resolve_sy`` on undecipherable decks.
     """
@@ -602,6 +652,12 @@ def reference_deck(text: str, name: str) -> str:
     from momwire import insulation_inductance
 
     lines = resolve_sy(text, name=name).splitlines()
+    dead = dead_trailing_config([ln.split()[0] for ln in lines])
+    if dead:
+        hoisted = [lines[i] for i in dead]
+        lines = [ln for i, ln in enumerate(lines) if i not in set(dead)]
+        first = next(i for i, ln in enumerate(lines) if ln.split()[0] in ("XQ", "RP"))
+        lines[first:first] = hoisted
     # 4nec2 evaluates LD 6 trap loss at the INITIAL FR card's F1 (issue
     # #444) — which may appear after the LD card, so pre-scan for it.
     fr_first_mhz = 299.8  # NEC's no-FR default
@@ -748,11 +804,14 @@ def bench_deck(
 
     # EX 6 decks (issue #442) NEVER use the original-deck reference: nec2c
     # misparses type 6 as a plane wave, so a mixed EX 0 + EX 6 deck could
-    # "succeed" with silently wrong physics. They go straight to the
-    # prepared (emulated) reference.
+    # "succeed" with silently wrong physics. Same for decks with run-config
+    # cards trailing the last execute request (issue #449): batch nec2c
+    # executes BEFORE reading them, so the original run silently drops a
+    # TL, ground, or load the deck intends. Both go straight to the
+    # prepared (emulated / hoisted) reference.
     ex6_feeds = [f.current for f in deck.feeds]
     ref = None
-    if not any(ex6_feeds):
+    if not any(ex6_feeds) and not has_dead_trailing_config(text):
         ref = run_nec2c(deck_path, timeout, mem_bytes)
     if ref is None or ref.get("error"):
         # Resolved-reference retry (issue #439): the deck parses for *us*,

--- a/scripts/bench_nec_corpus.py
+++ b/scripts/bench_nec_corpus.py
@@ -567,7 +567,14 @@ EX6_R_BIG = 2.0e4
 # XQ/RP execute request — so any that appear after the deck's LAST
 # execute request are dead cards. Whole-deck GUI parsers (xnec2c, 4nec2,
 # our importer) apply them regardless of position (issue #449).
-_RUN_CONFIG_CARDS = frozenset(("LD", "TL", "NT", "GN", "GD", "EX", "FR", "EK", "KH"))
+#
+# KH is deliberately NOT here: it's the one program-control card our
+# evaluator ignores outright (NecDeck.ignored), so hoisting it can only
+# make the reference diverge — and a trailing `KH 0` (xnec2c writes one)
+# would set nec2c's interaction-approximation range to zero and wreck
+# the solve (barry.nec: 2.81+71.9j → 0.0+43.5j). Left in place it stays
+# dead on both sides.
+_RUN_CONFIG_CARDS = frozenset(("LD", "TL", "NT", "GN", "GD", "EX", "FR", "EK"))
 
 
 def dead_trailing_config(mnemonics) -> list[int]:

--- a/tests/test_bench_card_order.py
+++ b/tests/test_bench_card_order.py
@@ -59,6 +59,16 @@ def test_detector_ignores_config_between_multi_run_executes():
     assert dead_trailing_config(mnems) == []
 
 
+def test_trailing_kh_is_not_flagged_or_hoisted():
+    """KH stays dead on both sides: our evaluator ignores it, and hoisting
+    xnec2c's trailing `KH 0` would set nec2c's interaction-approximation
+    range to zero and wreck the reference solve (barry.nec)."""
+    kh_deck = ZEPP_MINI.replace("TL 1 1 2 1 450 0\nGN 2 0 0 0 12 0.005\n", "KH 0\n")
+    assert not has_dead_trailing_config(kh_deck)
+    order = [ln.split()[0] for ln in reference_deck(kh_deck, "t").splitlines()]
+    assert order.index("KH") > order.index("RP")
+
+
 def test_reference_deck_hoists_before_first_execute():
     prepared = reference_deck(ZEPP_MINI, "zepp-mini").splitlines()
     order = [ln.split()[0] for ln in prepared]

--- a/tests/test_bench_card_order.py
+++ b/tests/test_bench_card_order.py
@@ -1,0 +1,79 @@
+"""Dead trailing run-config cards (issue #449).
+
+Batch NEC-2 executes at each XQ/RP with the cards read so far; config
+cards after the deck's LAST execute request never take effect. Whole-deck
+parsers (xnec2c, 4nec2, our importer) apply them regardless — zepp-80m's
+"TL translation artifact" was exactly this: nec2c solved a disconnected
+feeder stub with no ground (0 − 41243j), while hoisting its trailing
+TL/GN reproduces our engines' answer to four digits (0.598 − 115.1j).
+The contract here: the bench detects the pattern, refuses the
+original-deck reference, and prepares a hoisted reference that solves
+the deck's intended configuration.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from bench_nec_corpus import (  # noqa: E402
+    dead_trailing_config,
+    has_dead_trailing_config,
+    reference_deck,
+)
+
+ZEPP_MINI = (
+    "CE\n"
+    "GW 1 27 0 0 20 0 0 60.5 1.5e-3\n"
+    "GW 2 1 -0.2 0 0.5 0.2 0 0.5 1.5e-2\n"
+    "GE 1\n"
+    "EX 0 2 1 0 1 0\n"
+    "FR 0 1 0 0 3.0 0\n"
+    "RP 0 19 73 0 0 0 5 5\n"
+    "TL 1 1 2 1 450 0\n"
+    "GN 2 0 0 0 12 0.005\n"
+    "EN\n"
+)
+
+
+def test_detector_flags_trailing_config():
+    assert has_dead_trailing_config(ZEPP_MINI)
+    mnems = ["GW", "GE", "EX", "FR", "RP", "TL", "GN", "EN"]
+    assert dead_trailing_config(mnems) == [5, 6]
+
+
+def test_detector_passes_wellordered_and_execless_decks():
+    ordered = ZEPP_MINI.replace(
+        "RP 0 19 73 0 0 0 5 5\nTL 1 1 2 1 450 0\nGN 2 0 0 0 12 0.005\n",
+        "TL 1 1 2 1 450 0\nGN 2 0 0 0 12 0.005\nRP 0 19 73 0 0 0 5 5\n",
+    )
+    assert not has_dead_trailing_config(ordered)
+    # No execute request at all: nothing can trail it (the bench appends
+    # its own XQ at the end, after every card).
+    assert not has_dead_trailing_config(ZEPP_MINI.replace("RP 0 19 73 0 0 0 5 5\n", ""))
+
+
+def test_detector_ignores_config_between_multi_run_executes():
+    # A legitimate multi-run deck: config between two executes is live,
+    # only cards after the LAST execute are dead.
+    mnems = ["GW", "GE", "EX", "FR", "XQ", "GN", "FR", "XQ", "EN"]
+    assert dead_trailing_config(mnems) == []
+
+
+def test_reference_deck_hoists_before_first_execute():
+    prepared = reference_deck(ZEPP_MINI, "zepp-mini").splitlines()
+    order = [ln.split()[0] for ln in prepared]
+    assert order.index("TL") < order.index("RP")
+    assert order.index("GN") < order.index("RP")
+    # Hoisted cards keep their relative order and land after EX/FR.
+    assert order.index("EX") < order.index("TL") < order.index("GN")
+    # Nothing duplicated or lost.
+    assert order.count("TL") == 1 and order.count("GN") == 1
+
+
+def test_reference_deck_leaves_wellordered_decks_alone():
+    ordered = ZEPP_MINI.replace(
+        "RP 0 19 73 0 0 0 5 5\nTL 1 1 2 1 450 0\nGN 2 0 0 0 12 0.005\n",
+        "TL 1 1 2 1 450 0\nGN 2 0 0 0 12 0.005\nRP 0 19 73 0 0 0 5 5\n",
+    )
+    order = [ln.split()[0] for ln in reference_deck(ordered, "t").splitlines()]
+    assert order.index("TL") < order.index("GN") < order.index("RP")


### PR DESCRIPTION
## Summary
- **Overturns #449's premise: our TL translation was correct all along.** zepp-80m (saved by xnec2c 1.1-beta) places its TL and GN cards *after* the RP execute request; batch NEC-2 executes at RP with the cards read so far, so nec2c and nec2dxs both solved a disconnected 0.4 m feeder stub in free space — the "authoritative" −41 kΩ is just that stub's capacitance. With the trailing cards hoisted, nec2c reproduces our engines' answer to four digits (0.598 − 115.14j vs 0.597 − 115.18j).
- The bench now detects run-config cards trailing the deck's last execute request (`dead_trailing_config`), refuses the original-deck reference for the class — same never-trust rule as EX 6, since nec2c "succeeds" with silently wrong physics — and `reference_deck` hoists the dead cards to just before the first execute request, preserving relative order. Legitimate multi-run decks (config between two executes) are untouched.
- The class is 44 wild decks; 31 carry a trailing GN alone, meaning their previous "successful" references silently ran **free space** against our grounded solves. All 44 now score: zepp-80m ΔΓ 0.0000/0.0003, the GN-trailing family at ≤ 0.02 (most ≤ 0.001); remaining failures are the known nec2++ GEO-rejection class.
- `KH` is deliberately excluded from the hoist set — the validation sweep itself caught that hoisting xnec2c's trailing `KH 0` zeroes nec2c's interaction-approximation range and wrecks the reference (barry.nec: manufactured ΔΓ 0.48; with KH left dead it scores 0.0001 on its verbatim reference). KH is also the one program-control card our evaluator ignores outright.
- The DipTL/CardTL/4SQTL decks #449 grouped into this family have no card-order problem — their artifact is the EX 6 R_BIG emulation interacting with a TL on the driven segment (reference ≈ −20 kΩ = raw readout minus R_BIG), tracked separately.

Closes #449.

## Test plan
- [x] 6 new tests in `tests/test_bench_card_order.py` (detector, multi-run exemption, hoist order, KH exclusion)
- [x] Full test suite green (2279 tests)
- [x] 45-deck class benched end-to-end vs nec2c (pynec + sin): zepp 0.0000, class clean
- [x] barry.nec verbatim-reference control: 0.0001 after KH exclusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
