### PR TITLE
fix(engine): coerce segment parity only on fed wires — spiral-hat import (#450)

### DIFF
--- a/src/antennaknobs/engine.py
+++ b/src/antennaknobs/engine.py
@@ -80,6 +80,12 @@ class SimulationEngine(ABC):
             # flip on the spiral-hat verticals (issue #450). Preserve unmarked
             # wires' n_seg verbatim; NEC-2 and every momwire basis accept any
             # per-edge count (the count only has to be valid, i.e. ≥ 1).
+            # Catalog consequence: a native design whose ``segs_for`` lands an
+            # EVEN count on an unfed wire now keeps it (was silently bumped to
+            # odd), so its impedance shifts a hair under the odd-parity engines,
+            # and a knob move can flip an unfed wire's parity mid-sweep — a
+            # ~0.01 Ω wobble, not a bug. Measured design deltas: 0.00 Ω for
+            # PyNEC/Sinusoidal/BSpline-d2, 0.05 Ω for the d=1 tent basis.
             marked = w.ex is not None or w.name is not None
             n_new = self.coerce_n_seg(w.n_seg, parity) if marked else max(1, w.n_seg)
             if n_new != w.n_seg and (w.n_seg, n_new) not in seen:

--- a/src/antennaknobs/engine.py
+++ b/src/antennaknobs/engine.py
@@ -69,7 +69,19 @@ class SimulationEngine(ABC):
         out = []
         for t in tups:
             w = as_wire(t)
-            n_new = self.coerce_n_seg(w.n_seg, parity)
+            # Parity coercion exists to land an engine attachment on a wire's
+            # middle segment: a feed's delta gap (odd parity) or an even-parity
+            # solver's midpoint. Only wires that HOST an attachment — a legacy
+            # EX (``ex``) or a named network port (``name``: feed/load/TL/NT) —
+            # need it. Coercing an UNMARKED wire's segment count is gratuitous,
+            # and for a deck whose author chose an exact mesh (nec_import) on a
+            # tightly-coupled structure like a capacity hat it changes the
+            # modeled coupling enough to corrupt the impedance — reactance sign
+            # flip on the spiral-hat verticals (issue #450). Preserve unmarked
+            # wires' n_seg verbatim; NEC-2 and every momwire basis accept any
+            # per-edge count (the count only has to be valid, i.e. ≥ 1).
+            marked = w.ex is not None or w.name is not None
+            n_new = self.coerce_n_seg(w.n_seg, parity) if marked else max(1, w.n_seg)
             if n_new != w.n_seg and (w.n_seg, n_new) not in seen:
                 seen.add((w.n_seg, n_new))
                 _logger.info(

--- a/tests/test_nec_import_spiralhat_450.py
+++ b/tests/test_nec_import_spiralhat_450.py
@@ -14,13 +14,21 @@ nec2c reference (run on the original deck): 25.02 − 64.50j.
 
 from __future__ import annotations
 
+from collections import Counter
+
 import pytest
 
 from antennaknobs import AntennaBuilder, WireSpec
 from antennaknobs.nec_import import parse_nec
+from antennaknobs.network import as_wire
 
-pytest.importorskip("PyNEC")
-from antennaknobs.engines.pynec import PyNECEngine  # noqa: E402
+# The bug lived in the shared coercion path and hit BOTH engines, so the
+# regression pins momwire too and stays alive where PyNEC is absent — momwire is
+# the core engine, PyNEC only skips its own test.
+from antennaknobs.engines.momwire import MomwireEngine  # noqa: E402
+from momwire import SinusoidalSolver  # noqa: E402
+
+_GROUND = ("finite", 13.0, 0.005)
 
 # The 10 MHz spiral-hat vertical dipole (Cebik). Fed at the base segment of a
 # fat central mast (tag 12), with square capacity hats above and below built
@@ -78,24 +86,46 @@ def _import_builder(deck):
     return B()
 
 
-def test_spiralhat_import_matches_nec2c_reactance_sign():
-    """The imported vertical must land near nec2c's 25.0 − 64.5j — capacitive
-    (X < 0), not the pre-fix inductive 33.9 + 116j."""
-    deck = parse_nec(_SPIRALHAT_10, name="spiralhat10", network=True)
-    z = PyNECEngine(_import_builder(deck), ground=("finite", 13.0, 0.005)).impedance()[
-        0
-    ]
+def _assert_near_nec2c(z):
+    """nec2c on the original deck: 25.02 − 64.50j (capacitive)."""
     assert z.imag < 0, f"reactance sign flipped (issue #450): Z={z:.2f}"
     assert z.real == pytest.approx(25.0, abs=2.0), f"R off nec2c: Z={z:.2f}"
     assert z.imag == pytest.approx(-64.5, abs=3.0), f"X off nec2c: Z={z:.2f}"
 
 
-def test_spiralhat_hat_wires_keep_even_segment_count():
-    """The even-segment hat wires (unfed) survive import+coercion unchanged —
-    the fix is preserving their count, not re-meshing them (issue #450)."""
+def test_spiralhat_import_momwire_sinusoidal_matches_nec2c():
+    """momwire (Sinusoidal basis) on the imported deck tracks nec2c — pins the
+    momwire half of the shared-coercion fix, and keeps the regression alive
+    without PyNEC (issue #450)."""
     deck = parse_nec(_SPIRALHAT_10, name="spiralhat10", network=True)
-    eng = PyNECEngine(_import_builder(deck), ground=("finite", 13.0, 0.005))
-    # Hat wires were authored with 2 or 4 segments; none should have been
-    # bumped to an odd count. The only odd-forced wire is the 1-seg fed base.
-    counts = sorted({t[2] for t in eng.tups})
-    assert 4 in counts and 2 in counts, f"hat segment counts altered: {counts}"
+    eng = MomwireEngine(_import_builder(deck), solver=SinusoidalSolver, ground=_GROUND)
+    _assert_near_nec2c(eng.impedance()[0])
+
+
+def test_spiralhat_import_pynec_matches_nec2c():
+    """PyNEC (NEC-2 kernel) on the imported deck tracks nec2c — the other half
+    of the shared-coercion fix (issue #450)."""
+    pytest.importorskip("PyNEC")
+    from antennaknobs.engines.pynec import PyNECEngine
+
+    deck = parse_nec(_SPIRALHAT_10, name="spiralhat10", network=True)
+    _assert_near_nec2c(
+        PyNECEngine(_import_builder(deck), ground=_GROUND).impedance()[0]
+    )
+
+
+def test_spiralhat_wires_keep_authored_segment_counts():
+    """The unfed hat wires (authored 2, 4) and the unfed mast remainder (20)
+    survive import+coercion unchanged; only the 1-seg fed base is odd-forced
+    (already odd). Asserting the EXACT count multiset — not mere membership —
+    so a partial bump (a 4 sneaking to 5) is caught (issue #450)."""
+    deck = parse_nec(_SPIRALHAT_10, name="spiralhat10", network=True)
+    eng = MomwireEngine(_import_builder(deck), solver=SinusoidalSolver, ground=_GROUND)
+    counts = Counter(
+        as_wire(t).n_seg for t in eng._coerce_wire_tuples(deck.wire_tuples())
+    )
+    # 6×2-seg + 16×4-seg hat wires, the 20-seg mast remainder, the 1-seg fed
+    # base = 24 wires. No wire bumped to an odd 3 / 5 / 21.
+    assert counts == {1: 1, 2: 6, 4: 16, 20: 1}, (
+        f"segment counts altered: {dict(counts)}"
+    )

--- a/tests/test_nec_import_spiralhat_450.py
+++ b/tests/test_nec_import_spiralhat_450.py
@@ -1,0 +1,101 @@
+"""Regression for issue #450: a spiral capacity-hat vertical imported from a
+NEC deck must reproduce the NEC-2 driving-point impedance.
+
+The hats are dense stacks of short, tightly-coupled wires the deck meshes with
+EVEN segment counts (2, 4). The engines used to blanket-coerce every wire to
+their basis parity (odd for PyNEC / Sinusoidal), bumping those hat wires 2→3 and
+4→5; on this tightly-coupled structure that shifted the modelled capacitance
+enough to flip the driving-point reactance sign (nec2c 25.0 − 64.5j vs a buggy
+33.9 + 116.0j). Coercion now touches only the fed wire, so the imported geometry
+tracks NEC again.
+
+nec2c reference (run on the original deck): 25.02 − 64.50j.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from antennaknobs import AntennaBuilder, WireSpec
+from antennaknobs.nec_import import parse_nec
+
+pytest.importorskip("PyNEC")
+from antennaknobs.engines.pynec import PyNECEngine  # noqa: E402
+
+# The 10 MHz spiral-hat vertical dipole (Cebik). Fed at the base segment of a
+# fat central mast (tag 12), with square capacity hats above and below built
+# from even-segment wires — the trigger for the coercion bug.
+_SPIRALHAT_10 = """\
+CM vert dpl w/spiral hat: 10 MHz
+CE
+GW 1,2,.2638504,.2638504,1.066679,.4221607,.4221607,1.066679,.0010262
+GW 2,4,.4221607,.4221607,1.066679,.4221607,-.4221607,1.013909,.0010262
+GW 3,4,.4221607,-.4221607,1.013909,-.4221607,-.4221607,1.013909,.0010262
+GW 4,4,-.4221607,-.4221607,1.013909,-.4221607,.4221607,1.013909,.0010262
+GW 5,4,-.4221607,.4221607,1.013909,.4221607,.4221607,1.013909,.0010262
+GW 6,4,.4221607,.4221607,1.013909,.4221607,-.4221607,.9611391,.0010262
+GW 7,4,.4221607,-.4221607,.9611391,-.4221607,-.4221607,.9611391,.0010262
+GW 8,4,-.4221607,-.4221607,.9611391,-.4221607,.4221607,.9611391,.0010262
+GW 9,4,-.4221607,.4221607,.9611391,.4221607,.4221607,.9611391,.0010262
+GW 10,2,.4221607,.4221607,.9611391,.4221607,0.,.9611391,.0010262
+GW 11,2,.4221607,0.,.9611391,0.,0.,.9611391,.0010262
+GW 12,21,0.,0.,.9611391,0.,0.,4.7244,.0111125
+GW 13,2,0.,0.,4.7244,.4221607,0.,4.724539,.0010262
+GW 14,2,.4221607,0.,4.724539,.4221607,.4221607,4.724539,.0010262
+GW 15,4,.4221607,.4221607,4.724539,-.4221607,.4221607,4.724539,.0010262
+GW 16,4,-.4221607,.4221607,4.724539,-.4221607,-.4221607,4.724539,.0010262
+GW 17,4,-.4221607,-.4221607,4.724539,.4221607,-.4221607,4.724539,.0010262
+GW 18,4,.4221607,-.4221607,4.724539,.4221607,.4221607,4.671769,.0010262
+GW 19,4,.4221607,.4221607,4.671769,-.4221607,.4221607,4.671769,.0010262
+GW 20,4,-.4221607,.4221607,4.671769,-.4221607,-.4221607,4.671769,.0010262
+GW 21,4,-.4221607,-.4221607,4.671769,.4221607,-.4221607,4.671769,.0010262
+GW 22,4,.4221607,-.4221607,4.671769,.4221607,.4221607,4.618999,.0010262
+GW 23,2,.4221607,.4221607,4.618999,.2638504,.2638504,4.588519,.0010262
+GE 1
+FR 0,1,0,0,10.125
+GN 2,0,0,0,13.,.005
+EX 0,12,1,0,1.414214,0.
+EN
+"""
+
+
+def _import_builder(deck):
+    tups = deck.wire_tuples(specs=True)
+    net = deck.network()
+
+    class B(AntennaBuilder):
+        default_params = {"freq": 10.125}
+
+        def build_wires(self):
+            return tups
+
+        def build_network(self):
+            return net
+
+        def build_wire_material(self):
+            return WireSpec(radius=deck.dominant_radius())
+
+    return B()
+
+
+def test_spiralhat_import_matches_nec2c_reactance_sign():
+    """The imported vertical must land near nec2c's 25.0 − 64.5j — capacitive
+    (X < 0), not the pre-fix inductive 33.9 + 116j."""
+    deck = parse_nec(_SPIRALHAT_10, name="spiralhat10", network=True)
+    z = PyNECEngine(_import_builder(deck), ground=("finite", 13.0, 0.005)).impedance()[
+        0
+    ]
+    assert z.imag < 0, f"reactance sign flipped (issue #450): Z={z:.2f}"
+    assert z.real == pytest.approx(25.0, abs=2.0), f"R off nec2c: Z={z:.2f}"
+    assert z.imag == pytest.approx(-64.5, abs=3.0), f"X off nec2c: Z={z:.2f}"
+
+
+def test_spiralhat_hat_wires_keep_even_segment_count():
+    """The even-segment hat wires (unfed) survive import+coercion unchanged —
+    the fix is preserving their count, not re-meshing them (issue #450)."""
+    deck = parse_nec(_SPIRALHAT_10, name="spiralhat10", network=True)
+    eng = PyNECEngine(_import_builder(deck), ground=("finite", 13.0, 0.005))
+    # Hat wires were authored with 2 or 4 segments; none should have been
+    # bumped to an odd count. The only odd-forced wire is the 1-seg fed base.
+    counts = sorted({t[2] for t in eng.tups})
+    assert 4 in counts and 2 in counts, f"hat segment counts altered: {counts}"

--- a/tests/test_per_wire_specs.py
+++ b/tests/test_per_wire_specs.py
@@ -163,15 +163,20 @@ def test_coerce_preserves_shape_and_spec():
     p0, p1 = (0, 0, 0.0), (0, 0, 1.0)
     out = eng._coerce_wire_tuples(
         [
-            (p0, p1, 4, None),
-            (p0, p1, 4, 1 + 0j, "feed"),
-            Wire(p0, p1, 4, None, spec=THICK),
+            (p0, p1, 4, None),  # unmarked plain 4-tuple
+            (p0, p1, 4, 1 + 0j, "feed"),  # marked (ex + name)
+            Wire(p0, p1, 4, None, spec=THICK),  # unmarked Wire
+            Wire(p0, p1, 4, 2 + 0j, "feed2", THICK),  # marked Wire
         ]
     )
-    assert out[0] == (p0, p1, 5, None) and type(out[0]) is tuple
+    # Only marked wires (a feed EX or a named network port) are coerced to the
+    # engine's parity, so the attachment lands on the middle segment; an
+    # unmarked wire keeps its exact segment count (issue #450). Shape and spec
+    # are preserved either way: a plain tuple stays plain, a Wire stays a Wire.
+    assert out[0] == (p0, p1, 4, None) and type(out[0]) is tuple
     assert out[1] == (p0, p1, 5, 1 + 0j, "feed") and type(out[1]) is tuple
-    assert isinstance(out[2], Wire)
-    assert out[2].n_seg == 5 and out[2].spec is THICK
+    assert isinstance(out[2], Wire) and out[2].n_seg == 4 and out[2].spec is THICK
+    assert isinstance(out[3], Wire) and out[3].n_seg == 5 and out[3].spec is THICK
 
 
 # --------------------------------------------------------- array builders

--- a/tests/test_segment_convergence.py
+++ b/tests/test_segment_convergence.py
@@ -57,28 +57,33 @@ def test_builder_nominal_nsegs_scales_per_edge_counts():
     assert min(seg_counts) >= 3  # floor on minor edges holds at small N
 
 
-def test_momwire_default_coerces_to_odd_parity():
-    """The default solver (BSplineSolver degree=2) wants odd-segment counts;
-    the engine bumps any even build_wires() output up to odd before the
-    solver sees it."""
-    b = BowtieBuilder()
-    b.nominal_nsegs = 20  # even
-    eng = MomwireEngine(b)  # default BSplineSolver d=2 → parity="odd"
-    seg_lists = eng._edge_segments
-    all_segs = [n for wire in seg_lists for n in wire]
-    assert all(n % 2 == 1 for n in all_segs), (
-        f"default engine left even segs: {all_segs}"
-    )
+# Parity coercion lands an engine attachment on a wire's middle segment, so it
+# applies to the FED wire only; unfed wires keep their exact segment count
+# (issue #450 — coercing unfed, tightly-coupled wires like capacity hats shifts
+# their modelled coupling enough to flip the impedance sign). These check the
+# per-solver parity is right AND that the fed/unfed split is honoured.
+_P0, _P1 = (0, 0, 0.0), (0, 0, 1.0)
 
 
-def test_momwire_bspline_d1_coerces_to_even_parity():
-    """BSplineSolver degree=1 (tent basis) wants even-segment counts."""
-    b = BowtieBuilder()
-    b.nominal_nsegs = 21  # odd
-    eng = MomwireEngine(b, solver_kwargs={"degree": 1})
-    seg_lists = eng._edge_segments
-    all_segs = [n for wire in seg_lists for n in wire]
-    assert all(n % 2 == 0 for n in all_segs), f"d=1 engine left odd segs: {all_segs}"
+def test_momwire_default_coerces_fed_odd_preserves_unfed():
+    """The default solver (BSplineSolver degree=2) wants odd so the feed lands
+    on a segment midpoint. The fed even wire is bumped to odd; an unfed even
+    wire is preserved (issue #450)."""
+    eng = MomwireEngine(BowtieBuilder())  # default BSplineSolver d=2
+    assert eng.segment_parity == "odd"
+    out = eng._coerce_wire_tuples([(_P0, _P1, 4, None), (_P0, _P1, 4, 1 + 0j, "feed")])
+    assert out[0][2] == 4  # unfed even wire preserved
+    assert out[1][2] == 5  # fed even wire bumped to odd
+
+
+def test_momwire_bspline_d1_coerces_fed_even_preserves_unfed():
+    """BSplineSolver degree=1 (tent basis) wants even. Fed odd wire → even;
+    unfed odd wire preserved."""
+    eng = MomwireEngine(BowtieBuilder(), solver_kwargs={"degree": 1})
+    assert eng.segment_parity == "even"
+    out = eng._coerce_wire_tuples([(_P0, _P1, 5, None), (_P0, _P1, 5, 1 + 0j, "feed")])
+    assert out[0][2] == 5  # unfed odd wire preserved
+    assert out[1][2] == 6  # fed odd wire bumped to even
 
 
 def test_pynec_engine_segment_parity_is_odd():
@@ -86,17 +91,16 @@ def test_pynec_engine_segment_parity_is_odd():
     assert PyNECEngine.segment_parity == "odd"
 
 
-def test_momwire_sinusoidal_uses_odd_parity():
+def test_momwire_sinusoidal_coerces_fed_odd_preserves_unfed():
     from momwire import SinusoidalSolver
 
-    b = InvVeeBuilder()
-    b.nominal_nsegs = 20  # even, will get bumped to 21 by sinusoidal
-    eng = MomwireEngine(b, solver=SinusoidalSolver)
+    eng = MomwireEngine(InvVeeBuilder(), solver=SinusoidalSolver)
     assert eng.segment_parity == "odd"
-    all_segs = [n for wire in eng._edge_segments for n in wire]
-    assert all(n % 2 == 1 for n in all_segs), (
-        f"sinusoidal engine left even segs: {all_segs}"
+    out = eng._coerce_wire_tuples(
+        [(_P0, _P1, 20, None), (_P0, _P1, 20, 1 + 0j, "feed")]
     )
+    assert out[0][2] == 20  # unfed even wire preserved (would have been 21)
+    assert out[1][2] == 21  # fed even wire bumped to odd
 
 
 def test_nominal_nsegs_changes_solver_geometry():


### PR DESCRIPTION
## Summary

Fixes #450 — the spiral capacity-hat verticals (`10/7-dpl-spiralhats-sngnd`) whose **imported** geometry disagreed with both independent NEC-2 codes (nec2c, nec2dxs), reactance sign flipped and magnitude ~2×.

## Root cause — not the geometry translation

The issue suspected `nec_import`'s geometry handling. A segment-level diff cleared it: the imported wire list is faithful (coords, segment counts, radii, feed position all match), and PyNEC on the *raw* deck matches nec2c (24.99 − 64.55j). The fault was downstream, in the engines' **segment-parity coercion**.

`SimulationEngine._coerce_wire_tuples` blanket-coerced **every** wire to the engine's basis parity (odd for PyNEC/Sinusoidal). But coercion only exists to land a feed's delta gap on a wire's middle segment — it's needed on the **fed** wire only. These decks mesh their dense, tightly-coupled capacity-hat wires with **even** counts (2, 4); bumping them to 3, 5 shifted the modelled hat capacitance enough to flip the driving-point reactance:

| basis | before (blanket coerce) | after (fed-only) | nec2c |
|---|--:|--:|--:|
| PyNEC | 33.86 +116.0j ✗ | **24.99 −64.55j** ✓ | 25.02 −64.50j |
| momwire Sinusoidal | 33.93 +116.0j ✗ | **25.04 −64.51j** ✓ | 25.02 −64.50j |

Both our engines agreed on the wrong answer precisely because they shared the coerced mesh — exactly the "two of ours vs two independent codes" signature in the issue.

## The fix

Coerce parity only on wires carrying a feed `ex` or a named network port; preserve unmarked wires' exact segment count. NEC-2 and every momwire basis accept any per-edge count, so this is loss-free for the solvers, and same-basis A/B (HMatrix vs dense BSpline) still mesh identically since both apply the same rule.

**Native designs unaffected:** measured old-vs-new impedance Δ = 0.00 for PyNEC / Sinusoidal / BSpline-d2, 0.05 Ω for the tent basis. The whole suite (2275 tests) passes; the only changes were the parity unit tests, updated to the fed-only contract.

## Tests

- `test_nec_import_spiralhat_450` — inline-deck regression: imported spiral-hat vertical lands on nec2c's 25.0 − 64.5j (capacitive), not the pre-fix +116j; hat wires keep their even segment counts.
- Updated `test_per_wire_specs` and `test_segment_convergence` parity tests to assert fed-wire-only coercion.

## Test plan

- [x] Full suite: 2275 passed
- [x] Both spiralhat decks (10-dpl @ 10.125 MHz, 7-dpl @ 7 MHz) match nec2c to < 0.1 Ω on PyNEC and momwire-Sinusoidal
- [x] ruff clean

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)