### PR TITLE
builder: segs_for clips at 1 segment, not 3 — proportional meshing for short wires (#457)

### DIFF
--- a/src/antennaknobs/builder.py
+++ b/src/antennaknobs/builder.py
@@ -151,7 +151,13 @@ class AntennaBuilder:
         Scales `self.nominal_nsegs` (the segment count for a reference-length
         wire) by `length / ref`, so longer wires get proportionally more
         segments and the segment length stays roughly constant. `ref` is
-        usually a quarter-wavelength; the count is floored at 3.
+        usually a quarter-wavelength; the count is clipped at 1 (issue #457
+        — the old floor of 3 defeated the constant-segment-length goal on
+        short wires, and on short *fat* wires could push the segment length
+        below the wire radius, outside thin-wire-kernel validity). A fed
+        wire's count is still parity-coerced at solve time, so the delta
+        gap always has a middle segment to land on; since issue #450 an
+        unfed wire keeps this count verbatim.
 
         Parity is intentionally NOT forced here. Each solver wants a particular
         segment parity so the feed lands on (or symmetrically across) the
@@ -161,7 +167,7 @@ class AntennaBuilder:
         natural count and letting the solver round is why this is `segs_for`,
         not the old `odd_nsegs`: baking in odd here would just make an
         even-parity solve bump the count up by one."""
-        return max(3, round(self.nominal_nsegs * length / ref))
+        return max(1, round(self.nominal_nsegs * length / ref))
 
     def _phasor(self, name):
         """Unit phasor exp(j·phase) for a degrees-valued phase param (e.g.

--- a/src/antennaknobs/designs/arrays/delta_looparray_network.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray_network.py
@@ -54,13 +54,14 @@ class Builder(AntennaBuilder):
             return p[0], -p[1], p[2]
 
         n_seg0 = self.nominal_nsegs
-        n_seg1 = max(3, self.nominal_nsegs // 7)
 
         # y of the top corner (half the top-edge width), in closed form.
         y = (cos_t * (driver - 2 * eps) + 2 * eps) / (2 * (cos_t + 1))
         S = (0, eps, b - (y - eps) * tan_t)
         A = (0, y, b)
         B, T = ry(A), ry(S)
+
+        n_seg1 = self.segs_for(math.dist(T, S), math.dist(S, A))
 
         st = TransformStack()
         st.push(Transform.translate(0, 0, b))

--- a/src/antennaknobs/designs/arrays/delta_looparray_with_tls.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray_with_tls.py
@@ -44,7 +44,6 @@ class Builder(AntennaBuilder):
             return p[0], -p[1], p[2]
 
         n_seg0 = self.nominal_nsegs
-        n_seg1 = max(3, self.nominal_nsegs // 7)
 
         # y of the top corner (half the top-edge width), in closed form.
         y = (cos_theta * (driver - 2 * eps) + 2 * eps) / (2 * (cos_theta + 1))
@@ -64,6 +63,8 @@ class Builder(AntennaBuilder):
         A = (0, y, b)
 
         B, T = ry(A), ry(S)
+
+        n_seg1 = self.segs_for(math.dist(T, S), math.dist(S, A))
 
         st = TransformStack()
         st.push(Transform.translate(0, 0, b))
@@ -102,7 +103,7 @@ class Builder(AntennaBuilder):
 
         for (idx, (p0, p1, nsegs, ev)), tl_length in zip(feedpoints[:2], tl_lengths):
             self.tls.append(
-                (idx, (n_seg1 + 1) // 2, len(tups), (n_seg1 + 1) // 2, 100, tl_length)
+                (idx, (nsegs + 1) // 2, len(tups), (n_seg1 + 1) // 2, 100, tl_length)
             )
             tups[idx - 1] = (p0, p1, nsegs, None)
 

--- a/src/antennaknobs/designs/beams/yagi.py
+++ b/src/antennaknobs/designs/beams/yagi.py
@@ -43,7 +43,6 @@ class Builder(AntennaBuilder):
             return p[0], -p[1], p[2]
 
         n_seg0 = self.nominal_nsegs
-        n_seg1 = max(3, self.nominal_nsegs // 7)
 
         """
     B                    
@@ -73,6 +72,8 @@ class Builder(AntennaBuilder):
         B = (-boom_x, reflector_y * y_cos, b - reflector_y * z_sin)
 
         C, D, T = ry(B), ry(A), ry(S)
+
+        n_seg1 = self.segs_for(math.dist(T, S), math.dist(S, A))
 
         tups = []
 

--- a/src/antennaknobs/designs/dipoles/dipole_turnstile.py
+++ b/src/antennaknobs/designs/dipoles/dipole_turnstile.py
@@ -1,6 +1,7 @@
 """Crossed dipoles fed in phase quadrature (turnstile)."""
 
 from antennaknobs import AntennaBuilder
+import math
 
 from types import MappingProxyType
 
@@ -28,7 +29,6 @@ class Builder(AntennaBuilder):
         x = 0.5 * length
 
         n_seg0 = self.nominal_nsegs
-        n_seg1 = max(3, self.nominal_nsegs // 7)
 
         # Two crossed half-wave dipoles, lower along x at z=base and upper
         # along y at z=base+gap_z. The 1+0j / 0+1j drive is the 90° turnstile
@@ -36,6 +36,10 @@ class Builder(AntennaBuilder):
         tups = []
 
         z_lo = self.base
+        n_seg1 = self.segs_for(
+            math.dist((-eps, 0, z_lo), (eps, 0, z_lo)),
+            math.dist((-x, 0, z_lo), (-eps, 0, z_lo)),
+        )
         tups.extend([((-x, 0, z_lo), (-eps, 0, z_lo), n_seg0, None)])
         tups.extend([((eps, 0, z_lo), (x, 0, z_lo), n_seg0, None)])
         tups.extend([((-eps, 0, z_lo), (eps, 0, z_lo), n_seg1, 1 + 0j)])

--- a/src/antennaknobs/designs/dipoles/folded_invvee.py
+++ b/src/antennaknobs/designs/dipoles/folded_invvee.py
@@ -37,7 +37,6 @@ class Builder(AntennaBuilder):
             return p[0], -p[1], p[2]
 
         n_seg0 = self.nominal_nsegs
-        n_seg1 = max(3, self.nominal_nsegs // 7)
 
         """
                     
@@ -70,6 +69,9 @@ class Builder(AntennaBuilder):
 
         D, T, C, t = ry(A), ry(S), ry(B), ry(s)
 
+        n_seg1 = self.segs_for(math.dist(A, B), math.dist(S, A))
+        n_seg2 = self.segs_for(math.dist(T, S), math.dist(S, A))
+
         tups = []
 
         tups.extend(build_path([S, A], n_seg0, None))
@@ -79,6 +81,6 @@ class Builder(AntennaBuilder):
         tups.extend(build_path([t, C], n_seg0, None))
         tups.extend(build_path([C, D], n_seg1, None))
         tups.extend(build_path([D, T], n_seg0, None))
-        tups.extend(build_path([T, S], n_seg1, 1 + 0j))
+        tups.extend(build_path([T, S], n_seg2, 1 + 0j))
 
         return tups

--- a/src/antennaknobs/designs/dipoles/invvee.py
+++ b/src/antennaknobs/designs/dipoles/invvee.py
@@ -109,7 +109,6 @@ class Builder(AntennaBuilder):
             return p[0], -p[1], p[2]
 
         n_seg0 = self.nominal_nsegs
-        n_seg1 = max(3, self.nominal_nsegs // 7)
 
         """
                     
@@ -139,6 +138,8 @@ class Builder(AntennaBuilder):
         A = (0, eps + (driver_y - eps) * y_cos, b - (driver_y - eps) * z_sin)
 
         D, T = ry(A), ry(S)
+
+        n_seg1 = self.segs_for(math.dist(T, S), math.dist(S, A))
 
         tups = []
 

--- a/src/antennaknobs/designs/loops/delta_loop.py
+++ b/src/antennaknobs/designs/loops/delta_loop.py
@@ -42,7 +42,6 @@ class Builder(AntennaBuilder):
             return p[0], -p[1], p[2]
 
         n_seg0 = self.nominal_nsegs
-        n_seg1 = max(3, self.nominal_nsegs // 7)
 
         d = driver
         # y of the top corner (half the top-edge width), in closed form from the
@@ -64,6 +63,8 @@ class Builder(AntennaBuilder):
         A = (0, y, b)
 
         B, T = ry(A), ry(S)
+
+        n_seg1 = self.segs_for(math.dist(T, S), math.dist(S, A))
 
         tups = []
 

--- a/src/antennaknobs/designs/loops/delta_loop_flyby.py
+++ b/src/antennaknobs/designs/loops/delta_loop_flyby.py
@@ -62,7 +62,6 @@ class Builder(AntennaBuilder):
         quarter = 0.25 * wavelength
         target = self.length_factor * wavelength
         n_body = self.nominal_nsegs
-        n_feed = max(3, self.nominal_nsegs // 7)
 
         def geometry(side):
             # Fly the whole loop with the feed at z = 0 -- the top height is
@@ -83,6 +82,7 @@ class Builder(AntennaBuilder):
             drone.forward_through_plane((0.0, 1.0, 0.0, 0.0), nsegs=n_body)
             drone.yaw(180.0 - self.angle_deg)  # exterior angle at B
             drone.forward(side, nsegs=n_body)  # B -> T  (left slant, given length)
+            n_feed = self.segs_for(math.dist(drone.position, S), side)
             drone.feed(1 + 0j)
             drone.close(nsegs=n_feed)  # T -> S  (driven feed gap, fly home)
             return drone.wires()

--- a/src/antennaknobs/designs/loops/delta_loop_reflected.py
+++ b/src/antennaknobs/designs/loops/delta_loop_reflected.py
@@ -65,7 +65,6 @@ class Builder(AntennaBuilder):
         wavelength = 299.792458 / self.design_freq
         target = self.length_factor * wavelength
         n0 = self.nominal_nsegs
-        n1 = max(3, self.nominal_nsegs // 7)
 
         def ry(p):
             return (p[0], -p[1], p[2])
@@ -85,6 +84,7 @@ class Builder(AntennaBuilder):
                 .position
             )
             B, T = ry(A), ry(S)
+            n1 = self.segs_for(math.dist(T, S), math.dist(S, A))
             return build_path([S, A, B, T], n0, None) + build_path([T, S], n1, 1 + 0j)
 
         def total(side):

--- a/src/antennaknobs/designs/loops/delta_loop_slanted.py
+++ b/src/antennaknobs/designs/loops/delta_loop_slanted.py
@@ -52,7 +52,6 @@ class Builder(AntennaBuilder):
             return p[0], -p[1], p[2]
 
         n_seg0 = self.nominal_nsegs
-        n_seg1 = max(3, self.nominal_nsegs // 7)
 
         d = driver
         h = (cos_theta * (d - 2 * eps) + 2 * eps) / (2 * (cos_theta + 1))
@@ -81,6 +80,8 @@ class Builder(AntennaBuilder):
         SS, AA, BB, TT = st.hit(S), st.hit(A), st.hit(B), st.hit(T)
 
         SSS, AAA, BBB, TTT = ry(SS), ry(AA), ry(BB), ry(TT)
+
+        n_seg1 = self.segs_for(math.dist(TT, SS), math.dist(SS, AA))
 
         tups = []
 

--- a/src/antennaknobs/designs/loops/delta_loop_topdown.py
+++ b/src/antennaknobs/designs/loops/delta_loop_topdown.py
@@ -60,7 +60,6 @@ class Builder(AntennaBuilder):
         quarter = 0.25 * wavelength
         target = self.length_factor * wavelength
         n0 = self.nominal_nsegs
-        n1 = max(3, self.nominal_nsegs // 7)
 
         def ry(p):
             return (p[0], -p[1], p[2])
@@ -79,6 +78,7 @@ class Builder(AntennaBuilder):
             drone.yaw(180.0 + self.angle_deg)  # turn down onto the slant
             S = drone.forward_to_plane((0.0, 1.0, 0.0, eps)).position
             B, T = ry(A), ry(S)
+            n1 = self.segs_for(math.dist(T, S), math.dist(A, B))
 
             # build_path stitches the four corners into the perimeter and feed
             # gap -- the same helper delta_loop and delta_loop_reflected use. No

--- a/src/antennaknobs/designs/loops/diamond_loop.py
+++ b/src/antennaknobs/designs/loops/diamond_loop.py
@@ -45,7 +45,6 @@ class Builder(AntennaBuilder):
             return p[0], -p[1], p[2]
 
         n_seg0 = self.nominal_nsegs
-        n_seg1 = max(3, self.nominal_nsegs // 7)
 
         d = driver
         # Apex height, solved from the constraint that the total wire perimeter
@@ -77,6 +76,8 @@ class Builder(AntennaBuilder):
         S = (0, eps, b - (2 * h - eps) * tan_theta)
 
         C, T = ry(A), ry(S)
+
+        n_seg1 = self.segs_for(math.dist(T, S), math.dist(A, B))
 
         tups = []
 

--- a/src/antennaknobs/designs/loops/diamond_loop_turnstile.py
+++ b/src/antennaknobs/designs/loops/diamond_loop_turnstile.py
@@ -39,7 +39,6 @@ class Builder(AntennaBuilder):
             return -p[0], p[1], p[2]
 
         n_seg0 = self.nominal_nsegs
-        n_seg1 = max(3, self.nominal_nsegs // 7)
 
         d = driver
         # Apex height, solved from the constraint that the total wire perimeter
@@ -70,6 +69,8 @@ class Builder(AntennaBuilder):
         A = (0, h, b - tan_theta * h)
         S = (0, eps, b - (2 * h - eps) * tan_theta)
         C, T = ry(A), ry(S)
+
+        n_seg1 = self.segs_for(math.dist(T, S), math.dist(A, B))
 
         tups = []
 

--- a/src/antennaknobs/designs/loops/inv_delta_loop.py
+++ b/src/antennaknobs/designs/loops/inv_delta_loop.py
@@ -42,7 +42,6 @@ class Builder(AntennaBuilder):
             return p[0], -p[1], p[2]
 
         n_seg0 = self.nominal_nsegs
-        n_seg1 = max(3, self.nominal_nsegs // 7)
 
         d = driver
         h = (cos_theta * (d - 2 * eps) + 2 * eps) / (2 * (cos_theta + 1))
@@ -63,6 +62,8 @@ class Builder(AntennaBuilder):
         A = (0, h, b - (h - eps) * tan_theta)
 
         B, T = ry(A), ry(S)
+
+        n_seg1 = self.segs_for(math.dist(T, S), math.dist(S, A))
 
         tups = []
 

--- a/src/antennaknobs/designs/multiband/fandipole.py
+++ b/src/antennaknobs/designs/multiband/fandipole.py
@@ -183,12 +183,11 @@ class Builder(AntennaBuilder):
             )
 
         n_seg0 = self.nominal_nsegs
-        # The feed wire (T → S) keeps n_seg=3: some bases need an
-        # interior knot at the feed (n_seg=1 left the retired triangular
-        # solver with zero interior knots and a crash), and 3 matches the
-        # convention the rest of the design library uses for short feed
-        # wires.
-        n_seg1 = max(3, self.nominal_nsegs // 7)
+        # Feed wire (T → S) meshed at the segment density of the longest
+        # n_seg0 arm (the reference wire).
+        n_seg1 = self.segs_for(
+            math.dist(T, S), max(math.dist(a, bb) for a, bb in zip(A, B))
+        )
 
         tups = []
         for i in range(n_bands):

--- a/src/antennaknobs/designs/multiband/trap_dipole.py
+++ b/src/antennaknobs/designs/multiband/trap_dipole.py
@@ -98,7 +98,7 @@ class Builder(AntennaBuilder):
 
         # Target ~40 MoM segments per wavelength on the radiating arms.
         seg_len = wavelength / 40
-        n_outer = max(3, int(round(outer / seg_len)))
+        n_outer = max(1, int(round(outer / seg_len)))
         # Single continuous inner wire spanning −X_inner → +X_inner so the
         # named "feed" middle segment lands exactly at the geometric centre
         # (x = 0). Splitting the inner span at the origin would put `feed`

--- a/src/antennaknobs/designs/specialty/bowtie.py
+++ b/src/antennaknobs/designs/specialty/bowtie.py
@@ -24,7 +24,9 @@ class Builder(AntennaBuilder):
         z = half * math.sin(theta)
 
         n_seg0 = self.nominal_nsegs
-        n_seg1 = max(3, self.nominal_nsegs // 7)
+        n_seg1 = self.segs_for(
+            math.dist((-eps, eps), (eps, eps)), math.dist((-y, z), (-eps, eps))
+        )
 
         tups = []
         tups.extend([((-y, 0), (-y, z), n_seg0, None)])

--- a/src/antennaknobs/designs/specialty/hentenna.py
+++ b/src/antennaknobs/designs/specialty/hentenna.py
@@ -2,6 +2,7 @@
 
 from antennaknobs import AntennaBuilder
 from antennaknobs import Transform, TransformStack
+import math
 
 from types import MappingProxyType
 
@@ -40,7 +41,6 @@ class Builder(AntennaBuilder):
             return p[0], -p[1], p[2]
 
         n_seg0 = self.nominal_nsegs
-        n_seg1 = max(3, self.nominal_nsegs // 7)
 
         """
  C----------------------------A
@@ -74,6 +74,8 @@ class Builder(AntennaBuilder):
 
         C, D, T = ry(A), ry(B), ry(S)
         E = ry(F)
+
+        n_seg1 = self.segs_for(math.dist(T, S), math.dist(B, A))
 
         st = TransformStack()
         st.push(Transform.translate(0, 0, b))

--- a/src/antennaknobs/designs/specialty/hentenna_slant.py
+++ b/src/antennaknobs/designs/specialty/hentenna_slant.py
@@ -130,7 +130,6 @@ class Builder(AntennaBuilder):
             return p[0], -p[1], p[2]
 
         n_seg0 = self.nominal_nsegs
-        n_seg1 = max(3, self.nominal_nsegs // 7)
 
         S = (0, eps, wavelength * (mid_height_factor - top_height_factor))
         B = (
@@ -156,6 +155,8 @@ class Builder(AntennaBuilder):
 
         C, D, T = ry(A), ry(B), ry(S)
         E = ry(F)
+
+        n_seg1 = self.segs_for(math.dist(T, S), math.dist(B, A))
 
         st = TransformStack()
         st.push(Transform.translate(0, 0, b))

--- a/src/antennaknobs/designs/specialty/hourglass.py
+++ b/src/antennaknobs/designs/specialty/hourglass.py
@@ -2,6 +2,7 @@
 
 from antennaknobs import AntennaBuilder
 from antennaknobs import Transform, TransformStack
+import math
 
 from types import MappingProxyType
 
@@ -33,7 +34,6 @@ class Builder(AntennaBuilder):
             return p[0], p[1], -p[2]
 
         n_seg0 = self.nominal_nsegs
-        n_seg1 = max(3, self.nominal_nsegs // 7)
 
         r"""
  C----------------------------A
@@ -57,6 +57,8 @@ class Builder(AntennaBuilder):
 
         C, D, T = ry(A), ry(B), ry(S)
         E, F = rz(C), rz(A)
+
+        n_seg1 = self.segs_for(math.dist(T, S), math.dist(B, A))
 
         st = TransformStack()
         st.push(Transform.translate(0, 0, b - A[2]))

--- a/src/antennaknobs/designs/specialty/hourglass_slant.py
+++ b/src/antennaknobs/designs/specialty/hourglass_slant.py
@@ -37,7 +37,6 @@ class Builder(AntennaBuilder):
         slant_sin = math.sin(slant_radians)
 
         n_seg0 = self.nominal_nsegs
-        n_seg1 = max(3, self.nominal_nsegs // 7)
 
         r"""
     Add an invvee like slant, 0 degrees is horizontal
@@ -78,6 +77,8 @@ class Builder(AntennaBuilder):
         )
 
         C, D, T, E = ry(A), ry(B), ry(S), ry(F)
+
+        n_seg1 = self.segs_for(math.dist(T, S), math.dist(B, A))
 
         st = TransformStack()
         st.push(Transform.translate(0, 0, b - AA[2]))

--- a/src/antennaknobs/designs/verticals/vertical.py
+++ b/src/antennaknobs/designs/verticals/vertical.py
@@ -26,7 +26,9 @@ class Builder(AntennaBuilder):
         z = self.length
 
         n_seg0 = self.nominal_nsegs
-        n_seg1 = max(3, self.nominal_nsegs // 7)
+        n_seg1 = self.segs_for(
+            math.dist((0, 0, 0), (0, 0, eps)), math.dist((0, 0, eps), (0, 0, z))
+        )
         n_seg_radials = 5
         n_radials = 3
         # Radials run the full self.length (not a quarter-wave): self.length is

--- a/src/antennaknobs/designs/wire/sterba.py
+++ b/src/antennaknobs/designs/wire/sterba.py
@@ -143,7 +143,7 @@ class Builder(AntennaBuilder):
             p0 = loop[k]
             p1 = loop[(k + 1) % N]
             seg_len = math.dist(p0, p1)
-            nseg = max(3, round(n0 * seg_len / h))
+            nseg = max(1, round(n0 * seg_len / h))
 
             is_horizontal = abs(p0[2] - p1[2]) < 1e-9
             at_bottom = abs(p0[2] - bot) < 1e-9 and abs(p1[2] - bot) < 1e-9

--- a/tests/test_drone.py
+++ b/tests/test_drone.py
@@ -307,8 +307,9 @@ def test_delta_loop_reflected_uses_build_path_topology():
     assert len(ws) == 4
     driven = [e for e in ws if e[3] is not None]
     assert len(driven) == 1 and driven[0][3] == 1 + 0j
-    # The feed uses the original delta_loop n_seg1 = max(3, nominal // 7).
-    assert driven[0][2] == max(3, DeltaLoopReflected().nominal_nsegs // 7)
+    # The feed bridge meshes proportionally to its length via segs_for
+    # (issue #457): a 0.1 m bridge against a metres-long slant is 1 segment.
+    assert driven[0][2] == 1
 
     # Built with the feed at z = 0, then lifted so the top seats at `base`.
     top_z = max(p[2] for e in ws for p in (e[0], e[1]))

--- a/tests/test_momwire_engine.py
+++ b/tests/test_momwire_engine.py
@@ -19,7 +19,8 @@ def test_translator_chains_dipole_into_single_polyline():
     assert len(out["polylines"]) == 1
     polyline = out["polylines"][0]
     assert polyline.shape == (4, 3), polyline.shape
-    assert out["edge_segments"] == [[21, 3, 21]]
+    # 1-segment feed bridge since issue #457 (proportional segs_for meshing).
+    assert out["edge_segments"] == [[21, 1, 21]]
     assert out["feed_wire_index"] == 0
 
     # Feed sits at the geometric centre of the dipole; for the design_freq-sized

--- a/tests/test_segment_convergence.py
+++ b/tests/test_segment_convergence.py
@@ -47,14 +47,17 @@ def test_builder_default_nominal_nsegs():
 
 def test_builder_nominal_nsegs_scales_per_edge_counts():
     """The hardcoded n_seg literals are now expressions in nominal_nsegs.
-    Verifies major edges scale 1:1 while minor edges keep their floor."""
+    Major edges scale 1:1; minor edges mesh proportionally to their length
+    via segs_for (issue #457 — no more ad-hoc max(3, nominal // 7) floor),
+    so a short bridge stays a valid ≥1-segment mesh at any N."""
     b = BowtieBuilder()
     b.nominal_nsegs = 41
     seg_counts = sorted({t[2] for t in b.build_wires()})
     assert 41 in seg_counts  # major radiator scaled with N
+    assert min(seg_counts) >= 1
     b.nominal_nsegs = 7
-    seg_counts = sorted({t[2] for t in b.build_wires()})
-    assert min(seg_counts) >= 3  # floor on minor edges holds at small N
+    small = sorted({t[2] for t in b.build_wires()})
+    assert 7 in small and min(small) == 1  # bridge is proportional, clipped at 1
 
 
 # Parity coercion lands an engine attachment on a wire's middle segment, so it

--- a/tests/test_segment_convergence.py
+++ b/tests/test_segment_convergence.py
@@ -115,3 +115,53 @@ def test_nominal_nsegs_changes_solver_geometry():
         return sum(sum(w) for w in eng._edge_segments)
 
     assert total_segs(11) < total_segs(21) < total_segs(41)
+
+
+# ------------------------------------------------- segs_for clip (issue #457)
+
+
+def test_segs_for_scales_proportionally_and_clips_at_one():
+    """The count tracks length/ref so segment length stays roughly constant;
+    the old floor of 3 over-meshed short wires (segment length could fall
+    below a fat wire's radius). Clip is 1 — a wire always gets a mesh."""
+    b = BowtieBuilder()
+    assert b.nominal_nsegs == 21
+    ref = 10.0
+    assert b.segs_for(ref, ref) == 21  # reference length → nominal
+    assert b.segs_for(0.5 * ref, ref) == 10  # proportional, no parity forcing
+    assert b.segs_for(0.05 * ref, ref) == 1  # was 3 pre-#457
+    assert b.segs_for(0.0, ref) == 1  # degenerate stays a valid mesh
+
+
+def test_short_unfed_edges_solve_consistently_across_engines():
+    """Validity oracle for 1- and 2-segment unfed edges (issue #457): with
+    the floor gone (and #450 no longer re-bumping unfed wires), every basis
+    must handle a 1-seg and a 2-seg edge. A dipole with two short unmarked
+    stubs must land all four engines on the same driving-point impedance."""
+    from types import MappingProxyType
+
+    from momwire import BSplineSolver, SinusoidalSolver
+
+    from antennaknobs import AntennaBuilder
+
+    class B(AntennaBuilder):
+        default_params = MappingProxyType({"freq": 14.0})
+
+        def build_wires(self):
+            return [
+                ((0, 0, 10.0), (0, 0, 20.0), 21, 1 + 0j),
+                ((0, 0, 20.0), (0.4, 0, 20.0), 1, None),  # 1-seg stub
+                ((0, 0, 10.0), (0.8, 0, 10.0), 2, None),  # 2-seg stub
+            ]
+
+    z_ref = PyNECEngine(B(), ground=None).impedance()[0]
+    engines = {
+        "sin": MomwireEngine(B(), solver=SinusoidalSolver, ground=None),
+        "bs1": MomwireEngine(B(), solver_kwargs={"degree": 1}, ground=None),
+        "bs2": MomwireEngine(B(), solver=BSplineSolver, ground=None),
+    }
+    for name, eng in engines.items():
+        z = eng.impedance()[0]
+        assert abs(z - z_ref) / abs(z_ref) < 0.05, (
+            f"{name} diverged on short unfed edges: {z:.2f} vs PyNEC {z_ref:.2f}"
+        )


### PR DESCRIPTION
## Summary
- `Builder.segs_for` now clips at **1** segment instead of 3, so short wires get a count proportional to their length — the floor defeated the constant-segment-length goal, and on short fat wires could push segment length below the wire radius (outside thin-wire-kernel validity). Effective now that #450 preserves unfed wires' counts; fed wires still get parity-coerced so the delta gap always has a middle segment.
- **The ad-hoc `max(3, nominal_nsegs // 7)` idiom is retired catalog-wide**: all 21 sites now mesh their feed bridges / short edges via `self.segs_for(bridge_length, element_length)` with lengths measured off the design's own points (`math.dist`), plus floor-only fixes in `trap_dipole` and `sterba`. (`elt_whip`'s `max(3, …)` is a cage-wire *count* and stays.) Per-file care: `delta_loop_topdown`'s ref uses the top edge (brentq's bracket probe can collapse the slant to zero), and `delta_looparray_with_tls`'s TL attachment indices now derive from each wire's own captured count.
- **Catalog impact, A/B vs main (40 designs × pynec + sin, zero errors):** every mesh change is 3→1 (or 3→2, koch) on a short bridge; median |ΔZ| ≈ 1 Ω with both engines in lockstep. The three largest movers all vindicate the change:
  - **fandipole** (21%): the old meshing never plateaus on the convergence ladder (35.9→37.8→42.5 Ω, still drifting) while the new one sits flat at ~28 Ω through N=81 — and the old 5-segment 2 cm bridge trips nec2++'s intersection validator at N=41, which made fandipole convergence sweeps *impossible* on PyNEC.
  - **jpole** (6%): ladders identically from N=81 up; at default N=21 the new mesh starts closer to the converged value.
  - **t2fd/koch/bowtie family** (≤2.2%): mesh-fidelity scale.
- New tests: `segs_for` contract (proportionality, clip at 1, degenerate 0-length) and a cross-engine validity oracle running 1- and 2-segment unfed edges through PyNEC/sin/bs1/bs2 (within 5%). Three tests that pinned the old counts updated to the proportional contract.

Closes #457.

## Test plan
- [x] Full suite: 2284 passed (after updating the three count-pinning tests)
- [x] Differential mesh survey vs main across the whole catalog (40 designs, all diffs 3→1/3→2)
- [x] Impedance A/B on all 40 affected designs × pynec+sin — zero errors, engines in lockstep
- [x] jpole + fandipole convergence ladders old vs new
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
