### PR TITLE
fix(bench): skip EX 6 R_BIG subtraction when a TL/NT shares the driven segment (#456)

### DIFF
--- a/scripts/bench_nec_corpus.py
+++ b/scripts/bench_nec_corpus.py
@@ -769,6 +769,27 @@ def reference_deck(text: str, name: str) -> str:
     return "\n".join(out) + "\n"
 
 
+def feeds_sharing_tl_nt(deck) -> list[int]:
+    """Indices of ``deck.feeds`` whose driven segment also anchors a ``TL``
+    or ``NT`` endpoint (issue #456).
+
+    The EX 6 current-source emulation (issue #442) drives ``V = I·R_BIG``
+    behind an ``LD 4`` series ``R_BIG`` and the caller recovers the load by
+    subtracting ``R_BIG`` from nec2c's reported feed impedance — valid only
+    when that series R lands *inside* the readout. When a transmission line
+    (or NT two-port) is anchored on the same segment, it carries the feed
+    current and nec2c's reported V/I is already the true driving-point
+    impedance (the R_BIG term does not appear — verified constant across
+    R_BIG = 1e3…1e6 on DipTL/CardTL/4SQTL). Subtracting there manufactures
+    a ~−R_BIG resistance; the caller must skip it on these feeds.
+    """
+    anchored = set()
+    for c in (*deck.tls, *deck.nts):
+        anchored.add((c.wire_a, c.seg_a))
+        anchored.add((c.wire_b, c.seg_b))
+    return [i for i, f in enumerate(deck.feeds) if (f.wire, f.seg) in anchored]
+
+
 def bench_deck(
     deck_path: Path,
     engines,
@@ -838,11 +859,17 @@ def bench_deck(
                 if any(ex6_feeds):
                     # Undo the current-source emulation: nec2c reported
                     # Z_gap + R_BIG at each EX 6 feed (row order follows
-                    # EX-card order, same as deck.feeds).
+                    # EX-card order, same as deck.feeds) — EXCEPT on a feed
+                    # whose segment also anchors a TL/NT, where the readout is
+                    # already the true impedance and the subtraction must be
+                    # skipped (issue #456).
                     retry["ex6_emulated"] = True
+                    tl_shared = set(feeds_sharing_tl_nt(deck))
+                    if tl_shared:
+                        retry["ex6_tl_shared"] = sorted(tl_shared)
                     if len(retry.get("z") or []) >= len(ex6_feeds):
                         for i, is_cur in enumerate(ex6_feeds):
-                            if is_cur:
+                            if is_cur and i not in tl_shared:
                                 retry["z"][i][0] -= EX6_R_BIG
                 ref = retry
             elif ref is None:
@@ -901,7 +928,8 @@ def print_report(rows, engines):
     print(
         "  flags: g = unsupported ground (radials/cliff), n = inexpressible LD/TL/NT "
         "network, v = remote TL-anchor wire(s) virtualized (#427),"
-        " r = reference from resolved deck (#439)"
+        " r = reference from resolved deck (#439),"
+        " t = EX 6 feed shares a TL/NT segment; R_BIG subtraction skipped (#456)"
     )
     print("=" * 104)
     hdr = (
@@ -917,6 +945,7 @@ def print_report(rows, engines):
             + ("n" if r.get("partial_net") else "")
             + ("v" if r.get("virtualized_anchors") else "")
             + ("r" if r.get("nec2c", {}).get("resolved_deck") else "")
+            + ("t" if r.get("nec2c", {}).get("ex6_tl_shared") else "")
         )
         cells = " ".join(f"{fmt_dg(r['engines'].get(e)):>11}" for e in engines)
         print(

--- a/tests/test_bench_ex6_tl.py
+++ b/tests/test_bench_ex6_tl.py
@@ -1,0 +1,72 @@
+"""EX 6 R_BIG subtraction vs. a TL/NT on the driven segment (issue #456).
+
+The EX 6 current-source emulation (issue #442) drives ``V = I·R_BIG`` behind
+an ``LD 4`` series ``R_BIG`` and ``bench_deck`` recovers the load impedance by
+subtracting ``R_BIG`` from nec2c's reported feed impedance. That subtraction is
+only valid when the series R lands *inside* the readout. On the EZNEC-coax
+family (DipTL/CardTL/4SQTL) the EX 6 feed shares its segment with a ``TL``: the
+line carries the feed current, so nec2c's reported V/I is already the true
+driving-point impedance and the R_BIG term never appears. Subtracting there
+manufactured a ~−R_BIG resistance (≈ −19,980 Ω references, ΔΓ ≈ 1.3–1.6 with
+both engines agreeing against each other). ``feeds_sharing_tl_nt`` identifies
+those feeds so the caller skips the subtraction.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from bench_nec_corpus import feeds_sharing_tl_nt  # noqa: E402
+
+from antennaknobs.nec_import import parse_nec  # noqa: E402
+
+_DIPOLE = "GW 1 11 0 -5 10 0 5 10 0.001\n"  # 11 segs → feedable middle seg 6
+
+
+def _deck(cards: str):
+    return parse_nec(_DIPOLE + "GE\n" + cards + "EN\n", name="t", network=True)
+
+
+def test_tl_on_driven_segment_is_flagged():
+    """DipTL topology in miniature: TL endpoint anchored on the EX 6 feed's
+    own segment → the subtraction must be skipped."""
+    deck = _deck("GW 2 1 0 5 10 0 6 10 0.001\nTL 1 6 2 1 50 1.0\nEX 6 1 6 0 1 0\n")
+    assert feeds_sharing_tl_nt(deck) == [0]
+
+
+def test_tl_elsewhere_is_not_flagged():
+    """A TL that does not touch the feed's segment leaves the standard
+    subtraction in force."""
+    deck = _deck("GW 2 3 0 5 10 0 6 10 0.001\nTL 2 1 2 3 50 1.0\nEX 6 1 6 0 1 0\n")
+    assert feeds_sharing_tl_nt(deck) == []
+
+
+def test_nt_on_driven_segment_is_flagged():
+    """The same steal-the-readout hazard exists for an NT two-port anchored on
+    the driven segment, not just a TL."""
+    deck = _deck(
+        "GW 2 1 0 5 10 0 6 10 0.001\n"
+        "NT 1 6 2 1 0 -0.02 0 0.02 0 -0.02 0\nEX 6 1 6 0 1 0\n"
+    )
+    assert feeds_sharing_tl_nt(deck) == [0]
+
+
+def test_multi_feed_flags_only_the_shared_one():
+    """Row order follows deck.feeds; only the feed whose segment carries the
+    TL is flagged, so the other feed keeps its R_BIG subtraction."""
+    deck = _deck(
+        "GW 2 11 3 -5 10 3 5 10 0.001\nGW 3 1 0 5 10 0 6 10 0.001\n"
+        "TL 1 6 3 1 50 1.0\n"
+        "EX 6 2 6 0 1 0\n"  # feed 0: no TL on its segment
+        "EX 6 1 6 0 1 0\n"  # feed 1: shares its segment with the TL
+    )
+    assert feeds_sharing_tl_nt(deck) == [1]
+
+
+def test_helper_is_source_kind_agnostic():
+    """The helper keys off geometry (feed segment vs. TL/NT endpoint), not the
+    excitation kind — an EX 0 voltage feed on a TL segment is reported too. The
+    caller still gates the actual subtraction on ``feed.current``."""
+    deck = _deck("GW 2 1 0 5 10 0 6 10 0.001\nTL 1 6 2 1 50 1.0\nEX 0 1 6 0 1 0\n")
+    assert deck.feeds[0].current is False
+    assert feeds_sharing_tl_nt(deck) == [0]


### PR DESCRIPTION
## Summary
The EZNEC-modeled-coax family (`DipTL`/`CardTL`/`4SQTL`) benched at ΔΓ 1.28–1.57 with **both engines agreeing against each other** but not the reference — the tell being nonsensical reference impedances ≈ **−19,980 Ω** (a raw nec2c readout of ~10–25 Ω minus `EX6_R_BIG` = 2e4).

Root cause: these decks drive an `EX 6` current source on a segment that also anchors a `TL` (e.g. DipTL: `TL 2 1 4 1 …` + `EX 6 4 1 …` both on wire 4 seg 1). The `EX 6` emulation (issue #442) rewrites the source as `EX 0` with `V = I·R_BIG` behind a series `LD 4 R_BIG`, and `bench_deck` subtracts `R_BIG` back out on the assumption the series R lands inside nec2c's readout. With a TL carrying the feed current, nec2c's reported V/I is **already the true driving-point impedance** — the `R_BIG` term never appears — so the subtraction manufactured a ~−R_BIG resistance.

I verified the raw readout is constant (~27.7 Ω on DipTL) across `R_BIG` = 1e3…1e6 and converges to the engines' current-source impedance, confirming the subtraction must be skipped in this topology rather than being a coincidence.

## Fix
- New `feeds_sharing_tl_nt(deck)` returns the indices of feeds whose driven segment also anchors a `TL`/`NT` endpoint.
- `bench_deck` skips the `R_BIG` subtraction on those feeds and records `ex6_tl_shared`, surfaced as a new `t` flag in the report legend.

## Result
All three decks now bench against sane references with the engines matching:

| deck | ref Z (feed0) | before | after |
|------|---------------|--------|-------|
| 4SQTL | 13.6 + 4.4j | ΔΓ 1.57 | ΔΓ 0.0004 |
| CardTL | 22.6 + 12.8j | ΔΓ 1.36 | ΔΓ 0.0004 |
| DipTL | 27.7 − 9.3j | ΔΓ 1.28 | ΔΓ 0.0007 |

## Note on the secondary suspicion
The issue flagged `CardTL` benching at 299.79 MHz as "possibly the no-FR default". Red herring: the deck genuinely carries `FR ... 299.7925`, which merely coincides with NEC's 1 m default (299.8 MHz). No parse quirk — no change made.

## Tests
`tests/test_bench_ex6_tl.py` — unit-tests the decision function (portable, no nec2c): TL on the driven segment flags, TL elsewhere doesn't, NT on the driven segment flags, multi-feed flags only the shared feed, and the helper is source-kind agnostic.

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)