### PR TITLE
feat(bench): full-catalog runtime + memory benchmark across engines and ground models

### DIFF
--- a/docs/status/2026-07-19-catalog-perf-benchmark.md
+++ b/docs/status/2026-07-19-catalog-perf-benchmark.md
@@ -1,0 +1,232 @@
+# 2026-07-19 — Full-catalog runtime + peak-RSS benchmark (across ground models)
+
+## TL;DR
+
+`scripts/bench_catalog.py` solves **every built-in design (91) on all four
+engines** (PyNEC / Sinusoidal / BSpline d=1 / BSpline d=2) at each design's
+as-shipped default mesh (`nominal_nsegs=21`), under **four ground models**
+(free / pec / fast-finite / Sommerfeld). One fresh interpreter per solve for a
+clean `getrusage` peak RSS, BLAS+OpenMP pinned to the physical core count
+(mirrors `web/server.py`), an `RLIMIT_AS` cap so a runaway solve fails clean.
+
+**~1448 solves, all succeed** (only `verticals.elt_whip` — the intentional
+4392-seg W8IO stress design — is guard-skipped on the finite grounds).
+
+Headline findings:
+
+- **free → pec → fast-finite are all cheap and stay interactive.** Median solve
+  multiplier over free space is just **1.2× (pec)** and **1.3–1.4× (fast)**.
+  The reflection-coefficient finite ground is nearly free — a fine stand-in for
+  quick iteration. ~80/91 designs stay under 100 ms even on the slowest engine
+  (BSpline d=2) for all three of these models.
+- **Sommerfeld is a cliff, and it is the whole cost story.** Median solve jumps
+  to **9.4× free on PyNEC** but **45–83× free on the momwire bases**.
+- **On Sommerfeld, momwire is ~13× slower than PyNEC** across all three momwire
+  bases (median ~470–490 ms vs PyNEC's 36 ms). NEC's gn 2 interpolation-table
+  Sommerfeld crushes momwire's dense Sommerfeld path. **PyNEC stays interactive
+  on Sommerfeld (median 36 ms); momwire does not (0/90 designs under 100 ms,
+  median ~490 ms, up to ~6 s on the biggest meshes).**
+- **PyNEC's speed lead inverts on networked/large designs** regardless of
+  ground: e.g. `broadband.lpda` is the one design where PyNEC's *Sommerfeld* is
+  slower than momwire's (1589 ms vs ~1200 ms) — its many wires hit PyNEC's
+  multiport-Y reducer. Free-space `lpda`: PyNEC 741 ms vs Sinusoidal 72 ms.
+- **Memory:** floor ~91 MB (import baseline) dominates everything except the big
+  meshes. `pec` costs momwire ~30 % more memory than free (image method). The
+  finite grounds' peak RSS stays modest (≤ 0.7 GB) because `elt_whip` is
+  guard-skipped there; on `free`/`pec` it lifts BSpline d=2 to **10.7 / 13.7 GB**
+  — the one real memory-scaling flag, and the reason for the `--mem-gb` cap.
+
+**Practical takeaway:** for the web UI, `fast`-finite ground is the sweet spot
+for interactive iteration on any engine; **Sommerfeld should route to PyNEC**,
+where it stays sub-100 ms for the vast majority of designs, rather than momwire's
+dense path that puts every solve in the 0.5–6 s range.
+
+## Method
+
+```
+python scripts/bench_catalog.py --out catalog_perf_grounds.json
+```
+
+Ground specs are identical to `profile_ground_models.py` / the web adapter
+(`fast` and `somm` share `DEFAULT_GROUND = ('finite', 10.0, 0.002)` and differ
+only in solve method). Each `(design, ground, engine)` runs in its own
+subprocess: `OMP_WAIT_POLICY=PASSIVE`, `GOMP_SPINCOUNT=0`, BLAS/OpenMP =
+physical cores, serial dispatch, 24 GB `RLIMIT_AS` per solve. Wall-clock is
+`perf_counter()` around `engine.impedance()` (geometry build included, imports
+excluded); peak RSS is `ru_maxrss` for the whole worker (so it **includes** the
+~91 MB import baseline). Finite-ground solves are skipped for designs with
+Σseg > 2000 (only `elt_whip`), logged not hidden.
+
+Scope: default variant per design, each at its own default frequency and mesh.
+
+## Rollup — median / max solve + peak RSS, per ground × engine
+
+| ground | engine | n | median | max | RSS floor | RSS max |
+|---|---|---|---|---|---|---|
+| free | PyNEC | 91 | 3.8 ms | 3172 ms | 91 MB | 422 MB |
+| free | Sinusoidal | 91 | 5.7 ms | 6471 ms | 91 MB | 1958 MB |
+| free | BSpline d=1 | 91 | 9.4 ms | 22182 ms | 91 MB | 5051 MB |
+| free | BSpline d=2 | 91 | 10.8 ms | 58134 ms | 91 MB | 10738 MB |
+| pec | PyNEC | 91 | 4.7 ms | 3968 ms | 91 MB | 422 MB |
+| pec | Sinusoidal | 91 | 6.7 ms | 8153 ms | 91 MB | 2889 MB |
+| pec | BSpline d=1 | 91 | 10.8 ms | 25313 ms | 91 MB | 6457 MB |
+| pec | BSpline d=2 | 91 | 13.7 ms | 67542 ms | 91 MB | 13702 MB |
+| fast | PyNEC | 90 | 5.2 ms | 939 ms | 91 MB | 128 MB |
+| fast | Sinusoidal | 90 | 7.6 ms | 633 ms | 91 MB | 478 MB |
+| fast | BSpline d=1 | 90 | 12.3 ms | 841 ms | 91 MB | 483 MB |
+| fast | BSpline d=2 | 90 | 15.2 ms | 1081 ms | 91 MB | 628 MB |
+| somm | PyNEC | 90 | 35.9 ms | 1589 ms | 91 MB | 128 MB |
+| somm | Sinusoidal | 90 | 469.6 ms | 5419 ms | 92 MB | 626 MB |
+| somm | BSpline d=1 | 90 | 480.8 ms | 5854 ms | 91 MB | 558 MB |
+| somm | BSpline d=2 | 90 | 490.0 ms | 6158 ms | 92 MB | 722 MB |
+
+<sub>`free`/`pec` max cells are `verticals.elt_whip` (guard-skipped on the finite
+grounds — hence n=90 and the far lower finite-ground RSS max).</sub>
+
+### Ground-model cost multiplier (median solve ÷ free-space median)
+
+| | PyNEC | Sinusoidal | BSpline d=1 | BSpline d=2 |
+|---|---|---|---|---|
+| free | 1.0× | 1.0× | 1.0× | 1.0× |
+| pec | 1.2× | 1.2× | 1.2× | 1.3× |
+| fast | 1.4× | 1.3× | 1.3× | 1.4× |
+| **somm** | **9.4×** | **82.7×** | **51.3×** | **45.4×** |
+
+On Sommerfeld, momwire is **~13× slower than PyNEC** (470–490 ms vs 36 ms) on
+every basis.
+
+## Sommerfeld per-design cost (slowest 15; solve ms, max peak RSS MB)
+
+`elt_whip` is guard-skipped here. Note `broadband.lpda` — the sole design where
+PyNEC's Sommerfeld is the *slowest* engine (network reducer overhead).
+
+| design | Σseg | PyNEC | Sinusoidal | BSpline d=1 | BSpline d=2 | RSS |
+|---|---|---|---|---|---|---|
+| `wire.terminated_longwire` | 1006 | 390.4 | 5418.9 | 5854.2 | 6157.5 | 718 |
+| `wire.rhombic` | 1010 | 329.3 | 3353.1 | 3604.0 | 3811.9 | 722 |
+| `arrays.bowtiearray2x4` | 1360 | 653.3 | 2256.1 | 2686.1 | 3125.1 | 674 |
+| `wire.sterba` | 378 | 75.5 | 1261.4 | 1294.9 | 1323.9 | 140 |
+| `broadband.lpda` | 618 | 1588.5 | 1108.6 | 1203.1 | 1290.5 | 327 |
+| `wire.longwire` | 293 | 57.4 | 1226.4 | 1257.1 | 1278.8 | 122 |
+| `arrays.delta_looparray_2x2` | 256 | 50.4 | 1220.0 | 1238.6 | 1252.2 | 117 |
+| `wire.expanded_lazy_h` | 210 | 92.6 | 1207.4 | 1230.4 | 1231.9 | 119 |
+| `arrays.bowtiearray` | 680 | 193.6 | 925.0 | 1065.2 | 1210.7 | 238 |
+| `arrays.yagiarray` | 676 | 201.5 | 884.0 | 1039.7 | 1165.9 | 234 |
+| `arrays.moxonarray` | 592 | 150.5 | 840.7 | 952.5 | 1061.4 | 201 |
+| `arrays.delta_looparray_1x4` | 256 | 53.3 | 908.5 | 922.7 | 957.5 | 117 |
+| `wire.lazy_h` | 170 | 38.6 | 883.4 | 891.1 | 897.4 | 102 |
+| `wire.sterba_tl` | 99 | 281.5 | 873.8 | 881.3 | 882.5 | 98 |
+| `multiband.hexbeam_5band` | 750 | 298.4 | 506.2 | 733.6 | 851.2 | 267 |
+
+## Free-space per-design table (baseline)
+
+Solve times in **ms**; `RSS` is the max peak RSS across the four engines in
+**MB** (≈ the 91 MB import floor for most designs). `Σseg` is the total nominal
+segment count at the default mesh.
+
+| design | Σseg | PyNEC | Sinusoidal | BSpline d=1 | BSpline d=2 | RSS |
+|---|---|---|---|---|---|---|
+| `arrays.bowtiearray` | 680 | 126.6 | 67.3 | 207.0 | 197.3 | 171 |
+| `arrays.bowtiearray1x2` | 340 | 69.7 | 19.2 | 29.5 | 36.3 | 111 |
+| `arrays.bowtiearray2x4` | 1360 | 195.4 | 298.1 | 448.4 | 530.6 | 406 |
+| `arrays.delta_looparray` | 128 | 3.9 | 5.6 | 12.8 | 11.4 | 95 |
+| `arrays.delta_looparray_1x4` | 256 | 11.1 | 12.4 | 20.4 | 27.1 | 103 |
+| `arrays.delta_looparray_1x4_grouped` | 256 | 13.3 | 14.2 | 23.3 | 32.8 | 102 |
+| `arrays.delta_looparray_2x2` | 256 | 10.8 | 12.4 | 24.1 | 31.4 | 102 |
+| `arrays.delta_looparray_network` | 128 | 20.7 | 10.7 | 9.2 | 11.0 | 98 |
+| `arrays.delta_looparray_with_tls` | 129 | 4.2 | 12.3 | 9.4 | 12.0 | 98 |
+| `arrays.folded_invveearray` | 432 | 24.7 | 28.2 | 99.5 | 118.8 | 123 |
+| `arrays.hentenna_array` | 338 | 15.6 | 18.5 | 27.3 | 35.8 | 110 |
+| `arrays.hourglass_array` | 338 | 21.9 | 19.3 | 28.1 | 41.2 | 110 |
+| `arrays.invveearray` | 172 | 5.4 | 7.6 | 12.4 | 15.1 | 97 |
+| `arrays.lumped_coupled_pair` | 80 | 3.7 | 3.7 | 5.3 | 6.3 | 94 |
+| `arrays.moxonarray` | 592 | 41.6 | 53.0 | 129.0 | 151.3 | 150 |
+| `arrays.yagiarray` | 676 | 52.1 | 65.1 | 140.5 | 168.1 | 168 |
+| `beams.hb9cv` | 84 | 3.5 | 4.1 | 5.7 | 6.6 | 93 |
+| `beams.hexbeam` | 158 | 4.7 | 6.4 | 9.9 | 12.6 | 95 |
+| `beams.moxon` | 148 | 4.4 | 5.9 | 8.9 | 10.9 | 94 |
+| `beams.moxon_turnstile` | 296 | 37.1 | 19.7 | 20.8 | 26.0 | 111 |
+| `beams.owa_yagi` | 158 | 4.8 | 6.2 | 9.8 | 12.8 | 96 |
+| `beams.phased_driver_yagi` | 119 | 14.6 | 5.4 | 8.3 | 9.5 | 96 |
+| `beams.yagi` | 169 | 5.3 | 7.0 | 19.7 | 13.3 | 96 |
+| `broadband.discone` | 373 | 19.5 | 22.9 | 34.2 | 67.1 | 115 |
+| `broadband.g5rv` | 127 | 4.5 | 53.9 | 8.5 | 10.7 | 96 |
+| `broadband.lpda` | 618 | 741.1 | 71.8 | 134.6 | 156.8 | 172 |
+| `broadband.t2fd` | 104 | 3.2 | 5.1 | 21.2 | 16.6 | 94 |
+| `dipoles.dipole_turnstile` | 86 | 1.9 | 3.7 | 6.4 | 7.3 | 92 |
+| `dipoles.folded_invvee` | 108 | 4.5 | 4.4 | 7.6 | 9.3 | 94 |
+| `dipoles.folded_invvee_balun` | 108 | 7.1 | 12.0 | 7.4 | 9.0 | 94 |
+| `dipoles.invvee` | 43 | 1.2 | 2.3 | 4.0 | 4.3 | 92 |
+| `dipoles.invvee_coax_station` | 43 | 1.4 | 2.6 | 3.8 | 4.1 | 92 |
+| `dipoles.koch_dipole` | 65 | 1.6 | 4.4 | 10.3 | 11.0 | 92 |
+| `dipoles.ocf_dipole` | 41 | 1.1 | 2.2 | 3.9 | 4.5 | 93 |
+| `dipoles.pota_invvee` | 43 | 1.1 | 2.5 | 4.9 | 5.6 | 93 |
+| `dipoles.short_dipole_loaded` | 21 | 1.1 | 2.1 | 2.8 | 2.9 | 93 |
+| `loops.bisquare` | 184 | 5.9 | 7.1 | 12.6 | 24.0 | 100 |
+| `loops.delta_loop` | 64 | 1.5 | 3.1 | 5.0 | 5.9 | 93 |
+| `loops.delta_loop_flyby` | 64 | 2.4 | 4.1 | 6.1 | 6.8 | 93 |
+| `loops.delta_loop_reflected` | 64 | 2.0 | 3.8 | 5.8 | 6.6 | 94 |
+| `loops.delta_loop_slanted` | 128 | 7.9 | 16.1 | 9.5 | 11.9 | 95 |
+| `loops.delta_loop_topdown` | 64 | 2.2 | 3.8 | 6.1 | 6.8 | 94 |
+| `loops.diamond_loop` | 85 | 1.9 | 3.5 | 6.2 | 7.3 | 93 |
+| `loops.diamond_loop_turnstile` | 170 | 5.4 | 7.1 | 11.9 | 14.5 | 97 |
+| `loops.horizontal_loop` | 89 | 2.1 | 3.5 | 6.5 | 7.3 | 93 |
+| `loops.horizontal_loop_drone` | 85 | 2.0 | 3.7 | 6.3 | 7.2 | 93 |
+| `loops.inv_delta_loop` | 64 | 1.5 | 3.1 | 5.7 | 5.7 | 93 |
+| `loops.quad` | 172 | 5.8 | 7.3 | 11.3 | 14.6 | 98 |
+| `loops.skyloop_lmatch` | 90 | 2.4 | 4.2 | 6.5 | 7.0 | 94 |
+| `loops.triangular_skyloop` | 90 | 2.2 | 3.8 | 7.0 | 8.0 | 94 |
+| `multiband.fandipole` | 421 | 23.4 | 26.4 | 118.3 | 115.0 | 121 |
+| `multiband.hexbeam_5band` | 750 | 63.9 | 79.6 | 150.2 | 186.1 | 186 |
+| `multiband.trap_dipole` | 64 | 1.5 | 3.8 | 5.6 | 6.1 | 93 |
+| `multiband.trap_fan_dipole` | 103 | 3.2 | 6.7 | 10.1 | 10.9 | 94 |
+| `multiband.twoband_fan_dipole` | 105 | 3.1 | 4.4 | 14.9 | 9.6 | 93 |
+| `specialty.bowtie` | 170 | 5.3 | 6.9 | 11.4 | 14.9 | 96 |
+| `specialty.helix` | 53 | 1.5 | 3.9 | 11.4 | 11.9 | 93 |
+| `specialty.hentenna` | 169 | 5.3 | 7.1 | 11.0 | 13.9 | 96 |
+| `specialty.hentenna_slant` | 211 | 7.4 | 8.9 | 23.8 | 19.8 | 98 |
+| `specialty.hourglass` | 169 | 5.5 | 6.9 | 11.2 | 14.3 | 95 |
+| `specialty.hourglass_slant` | 211 | 7.5 | 9.0 | 14.3 | 17.8 | 98 |
+| `verticals.bobtail` | 151 | 4.7 | 5.9 | 10.2 | 13.4 | 96 |
+| `verticals.bruce` | 189 | 6.3 | 7.8 | 12.1 | 16.1 | 96 |
+| `verticals.challenger` | 29 | 1.3 | 2.4 | 4.2 | 4.4 | 94 |
+| `verticals.dominator` | 32 | 1.3 | 2.5 | 4.3 | 4.5 | 92 |
+| `verticals.elt_whip` | 4392 | 2977.9 | 6529.8 | 22775.1 | 61135.7 | 10739 |
+| `verticals.four_square` | 164 | 5.2 | 7.2 | 11.7 | 14.0 | 96 |
+| `verticals.half_square` | 86 | 1.8 | 3.5 | 5.5 | 6.8 | 93 |
+| `verticals.inverted_l` | 42 | 1.1 | 2.7 | 5.5 | 5.9 | 93 |
+| `verticals.inverted_l_tmatch` | 42 | 1.3 | 2.8 | 5.4 | 5.9 | 92 |
+| `verticals.jpole` | 86 | 2.3 | 3.7 | 7.2 | 8.3 | 94 |
+| `verticals.phased_verticals` | 86 | 1.9 | 3.6 | 6.1 | 7.0 | 93 |
+| `verticals.pota_performer` | 36 | 1.2 | 2.5 | 5.7 | 6.2 | 92 |
+| `verticals.raised_vertical` | 64 | 1.4 | 3.1 | 5.1 | 6.0 | 93 |
+| `verticals.rectangle` | 87 | 2.7 | 4.0 | 6.3 | 7.2 | 94 |
+| `verticals.right_angle_delta` | 90 | 2.0 | 3.5 | 6.4 | 8.4 | 93 |
+| `verticals.tri_moxon` | 252 | 51.9 | 14.9 | 19.2 | 30.8 | 106 |
+| `verticals.vertical` | 37 | 1.1 | 2.9 | 5.1 | 5.3 | 92 |
+| `wire.doublet_ladder_tuner` | 43 | 1.4 | 2.7 | 3.8 | 4.1 | 92 |
+| `wire.edz` | 105 | 4.6 | 4.5 | 7.1 | 11.7 | 94 |
+| `wire.efhw_sloper` | 42 | 1.7 | 3.0 | 5.0 | 5.6 | 94 |
+| `wire.expanded_lazy_h` | 210 | 33.2 | 16.9 | 14.0 | 18.3 | 103 |
+| `wire.lazy_h` | 170 | 5.5 | 6.8 | 11.0 | 14.1 | 96 |
+| `wire.longwire` | 293 | 11.0 | 13.4 | 30.6 | 42.2 | 120 |
+| `wire.rhombic` | 1010 | 88.2 | 180.6 | 241.8 | 316.5 | 325 |
+| `wire.sterba` | 378 | 20.2 | 21.4 | 33.9 | 48.7 | 115 |
+| `wire.sterba_tl` | 99 | 17.5 | 6.0 | 10.1 | 10.2 | 94 |
+| `wire.terminated_longwire` | 1006 | 83.2 | 180.4 | 417.8 | 535.3 | 562 |
+| `wire.vbeam` | 169 | 5.4 | 6.7 | 12.5 | 16.8 | 101 |
+| `wire.w8jk` | 106 | 3.1 | 10.7 | 7.2 | 8.9 | 94 |
+| `wire.zepp` | 41 | 1.5 | 2.7 | 3.7 | 4.0 | 94 |
+
+## Reproduce
+
+```
+python scripts/bench_catalog.py                          # all designs+grounds
+python scripts/bench_catalog.py --grounds free fast somm
+python scripts/bench_catalog.py --engines sin bs2 --grounds free somm
+python scripts/bench_catalog.py --designs loops.quad beams.yagi
+```
+
+Numbers above were taken on the development machine (BLAS=OpenMP=4, 31 GB RAM).
+Absolute times drift with hardware; the *ratios* between engines and ground
+models, and the shape of the tail, are the portable findings.

--- a/scripts/bench_catalog.py
+++ b/scripts/bench_catalog.py
@@ -1,0 +1,419 @@
+"""Full-catalog runtime + peak-RSS benchmark: every solver on every design,
+across ground models.
+
+Sizing question this answers: what does a single ``engine.impedance()`` cost —
+wall-clock and resident memory — for each built-in design on each of the four
+engines (PyNEC / Sinusoidal / BSpline d=1 / BSpline d=2), at the design's
+as-shipped default mesh, under each ground model? This is the per-tick cost the
+web UI pays, catalogued across the free → fast-finite → Sommerfeld axis where
+the finite-ground models dominate the runtime.
+
+Ground models (same specs as ``profile_ground_models.py`` / the web adapter):
+
+  free  — free space (no ground)
+  pec   — perfectly conducting plane (image method; no material solve)
+  fast  — reflection-coefficient finite ground  (NEC gn 0 / momwire refl-coef)
+  somm  — Sommerfeld-Norton finite ground        (NEC gn 2 / momwire sommerfeld)
+
+It reuses ``bench_converge.py``'s pure ``solve_design`` for the measurement but
+runs it in its OWN subprocess worker so each solve gets (a) a clean ``getrusage``
+peak RSS from a fresh interpreter, and (b) an ``RLIMIT_AS`` address-space cap so
+a runaway finite-ground solve on a huge design dies with a clean MemoryError
+instead of thrashing the machine into swap. BLAS+OpenMP are pinned to the
+physical core count (mirrors ``web/server.py``); dispatch is serial.
+
+Three caveats, stated up front so the tables aren't misread:
+
+  - **Memory floor.** Peak RSS includes the fixed interpreter + numpy + PyNEC +
+    momwire import cost (~90 MB here), which dwarfs the solve's own allocation on
+    small designs. The rollup prints the observed floor (min peak RSS) so the
+    per-solve *delta* is recoverable; only heavy designs on finite grounds lift
+    RSS meaningfully above it.
+  - **Sommerfeld is the expensive model.** Its cells are seconds, not
+    milliseconds, and its memory can be gigabytes on the biggest meshes — hence
+    the ``--max-seg-finite`` guard, which skips finite-ground solves (free/pec
+    still run) for designs whose Σseg exceeds the cap, logged not hidden. The
+    default cap excludes only ``verticals.elt_whip`` (the intentional 4392-seg
+    W8IO stress design).
+  - **Default variant / default frequency.** One variant per design; each design
+    solved at its own default frequency and mesh.
+
+Usage:
+    python scripts/bench_catalog.py                          # all designs+grounds
+    python scripts/bench_catalog.py --grounds free fast somm
+    python scripts/bench_catalog.py --engines sin bs2 --grounds free somm
+    python scripts/bench_catalog.py --designs loops.quad beams.yagi
+    python scripts/bench_catalog.py --out catalog_perf.json
+"""
+
+from __future__ import annotations
+
+# Mirror bench_nec_corpus.py: libgomp reads these once, before the scientific
+# stack loads. Fresh worker subprocesses inherit them.
+import os
+
+os.environ.setdefault("OMP_WAIT_POLICY", "PASSIVE")
+os.environ.setdefault("GOMP_SPINCOUNT", "0")
+
+import argparse  # noqa: E402
+import json  # noqa: E402
+import resource  # noqa: E402
+import statistics  # noqa: E402
+import subprocess  # noqa: E402
+import sys  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+# Reuse bench_converge.py (which itself reuses bench_nec_corpus.py's harness).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import bench_converge as cvg  # noqa: E402
+import bench_nec_corpus as bnc  # noqa: E402
+
+ENGINE_KEYS = cvg.ENGINE_KEYS  # ("pynec", "sin", "bs1", "bs2")
+ENGINE_LABEL = cvg.ENGINE_LABEL
+
+# Ground specs by CLI label — identical to profile_ground_models.py, so the
+# numbers line up with that tool and the web adapter. `fast` and `somm` share
+# DEFAULT_GROUND's eps_r/sigma and differ only in solve method.
+from antennaknobs.engines.pynec import DEFAULT_GROUND  # noqa: E402
+
+GROUNDS = {
+    "free": "free",
+    "pec": "pec",
+    "fast": ("finite-fast",) + tuple(DEFAULT_GROUND[1:]),
+    "somm": tuple(DEFAULT_GROUND),
+}
+GROUND_ORDER = ("free", "pec", "fast", "somm")
+FINITE_GROUNDS = ("fast", "somm")  # the ones the --max-seg-finite guard gates
+
+# Default finite-ground Σseg cap: excludes only elt_whip (4392) from the
+# expensive finite solves while keeping its free/pec rows and every other design.
+DEFAULT_MAX_SEG_FINITE = 2000
+# Address-space ceiling per worker (GB). A finite-ground solve that would exceed
+# it dies with a clean MemoryError instead of swapping the box. 24 GB on a 31 GB
+# machine leaves headroom for the OS + this driver.
+DEFAULT_MEM_GB = 24.0
+
+
+def all_designs() -> list[str]:
+    """Every built-in design as a sorted ``family.name`` dotted path."""
+    from antennaknobs.cli import list_builtin_designs
+
+    return list_builtin_designs()
+
+
+def default_nseg(design: str) -> int:
+    """The design's as-shipped ``nominal_nsegs`` (framework default, injected at
+    construction — 21 across the current catalog, but read it, don't assume)."""
+    return cvg.load_design(design)().nominal_nsegs
+
+
+# --------------------------------------------------------------------------
+# subprocess worker (fresh interpreter -> clean peak RSS; RLIMIT_AS guard)
+# --------------------------------------------------------------------------
+def worker_main(design, nseg, engine, ground_json, mem_gb):
+    """Runs in a fresh interpreter. Prints one JSON line to stdout. Reuses
+    bench_converge.solve_design for the actual measurement; adds an address-
+    space cap so a runaway finite-ground solve fails cleanly."""
+    result = {"error": None}
+    try:
+        if mem_gb and mem_gb > 0:
+            cap = int(mem_gb * 1024**3)
+            resource.setrlimit(resource.RLIMIT_AS, (cap, cap))
+        cores = bnc.apply_server_thread_policy()
+        ground = json.loads(ground_json)
+        if isinstance(ground, list):
+            ground = tuple(ground)
+        cls = cvg.load_design(design)
+        res = cvg.solve_design(cls, nseg, engine, ground)
+        peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
+        res["peak_rss_mb"] = peak / 1e6
+        res["cores"] = cores
+        result = res
+    except MemoryError:
+        result["error"] = f"MemoryError: exceeded {mem_gb:g} GB cap"
+        result["error_kind"] = "mem"
+    except Exception as e:  # noqa: BLE001 — report, never crash the sweep
+        import traceback
+
+        result["error"] = f"{type(e).__name__}: {e}"
+        result["traceback"] = traceback.format_exc()[-800:]
+    print(json.dumps(result))
+
+
+def run_engine(design, nseg, engine, ground, timeout, mem_gb):
+    """Dispatch a worker subprocess for one (design, nseg, engine, ground)."""
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                __file__,
+                "--worker",
+                design,
+                str(nseg),
+                engine,
+                json.dumps(ground),
+                str(mem_gb),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=None if timeout is None else timeout + 15,
+        )
+    except subprocess.TimeoutExpired:
+        return {"error": f"timeout > {timeout}s", "error_kind": "timeout"}
+    if proc.returncode != 0 and not proc.stdout.strip():
+        tail = (proc.stderr or "").strip()[-200:]
+        # A hard OOM kill (RLIMIT_AS can also trip the OOM killer via SIGKILL).
+        kind = "mem" if proc.returncode in (-9, 137) else "err"
+        return {"error": f"worker exited {proc.returncode}: {tail}", "error_kind": kind}
+    try:
+        return json.loads(proc.stdout.strip().splitlines()[-1])
+    except (json.JSONDecodeError, IndexError):
+        return {"error": f"unparseable worker output: {proc.stdout[-200:]!r}"}
+
+
+# --------------------------------------------------------------------------
+# driver
+# --------------------------------------------------------------------------
+def bench_one(design, engines, grounds, timeout, mem_gb, nseg_override, max_seg_finite):
+    """Solve one design on each (ground, engine); return a row."""
+    try:
+        nseg = nseg_override if nseg_override is not None else default_nseg(design)
+    except Exception as e:  # noqa: BLE001 — a design that won't even construct
+        row = {"design": design, "load_error": f"{type(e).__name__}: {e}"}
+        _print_row(row, engines, grounds)
+        return row
+
+    # Σseg is engine/ground-independent — the honest mesh size and the guard key.
+    seg = cvg.total_nominal_segs(cvg.load_design(design), nseg)
+    row = {"design": design, "nseg": nseg, "total_nominal_segs": seg, "grounds": {}}
+    for g in grounds:
+        if g in FINITE_GROUNDS and max_seg_finite and seg > max_seg_finite:
+            row["grounds"][g] = {
+                e: {
+                    "error": f"skipped: Σseg {seg} > {max_seg_finite}",
+                    "error_kind": "skip",
+                }
+                for e in engines
+            }
+            continue
+        row["grounds"][g] = {
+            e: run_engine(design, nseg, e, GROUNDS[g], timeout, mem_gb) for e in engines
+        }
+    _print_row(row, engines, grounds)
+    return row
+
+
+def _cell(res):
+    """(solve_ms, rss_mb) or None from a worker result."""
+    if not res or res.get("error"):
+        return None
+    return res.get("solve_s", 0.0) * 1e3, res.get("peak_rss_mb", 0.0)
+
+
+def _tag(res):
+    """Short failure tag for a non-successful cell."""
+    kind = (res or {}).get("error_kind")
+    return {"skip": "skip", "mem": "MEM", "timeout": "TIME"}.get(kind, "ERR")
+
+
+def _print_row(row, engines, grounds):
+    if row.get("load_error"):
+        print(f"  {row['design']:<40} LOAD-ERR {row['load_error'][:50]}", flush=True)
+        return
+    seg = row.get("total_nominal_segs")
+    print(
+        f"  {row['design']:<40} Σseg={seg if seg is not None else '??':>5}", flush=True
+    )
+    for g in grounds:
+        cells = []
+        gres = row["grounds"].get(g, {})
+        for e in engines:
+            c = _cell(gres.get(e))
+            if c is None:
+                cells.append(f"{ENGINE_LABEL[e]}={_tag(gres.get(e)):>7}    ")
+            else:
+                cells.append(f"{ENGINE_LABEL[e]}={c[0]:8.1f}ms/{c[1]:5.0f}MB")
+        print(f"      {g:<5} " + "  ".join(cells), flush=True)
+
+
+def print_report(rows, engines, grounds):
+    ok = [r for r in rows if not r.get("load_error")]
+    errs = [r for r in rows if r.get("load_error")]
+
+    # Per (ground, engine) rollup: the headline matrix.
+    print("\n" + "=" * 100)
+    print("ROLLUP — solve wall-clock + peak RSS, per ground model × engine")
+    print("=" * 100)
+    print(
+        f"{'ground':<6} {'engine':<12} {'n':>4} {'median':>9} {'max':>10} "
+        f"{'RSS floor':>10} {'RSS max':>9}"
+    )
+    print("-" * 64)
+    for g in grounds:
+        for e in engines:
+            solves, rss = [], []
+            for r in ok:
+                c = _cell(r["grounds"].get(g, {}).get(e))
+                if c is not None:
+                    solves.append(c[0])
+                    rss.append(c[1])
+            if not solves:
+                print(f"{g:<6} {ENGINE_LABEL[e]:<12} {'0':>4}  (no successful solves)")
+                continue
+            print(
+                f"{g:<6} {ENGINE_LABEL[e]:<12} {len(solves):>4} "
+                f"{statistics.median(solves):>7.1f}ms {max(solves):>8.1f}ms "
+                f"{min(rss):>8.0f}MB {max(rss):>6.0f}MB"
+            )
+        print("-" * 64)
+
+    # Slowest solves overall — where the interactive budget is tightest.
+    print("\n" + "=" * 100)
+    print("SLOWEST 12 (design, ground, engine) SOLVES")
+    print("=" * 100)
+    flat = []
+    for r in ok:
+        for g in grounds:
+            for e in engines:
+                c = _cell(r["grounds"].get(g, {}).get(e))
+                if c is not None:
+                    flat.append(
+                        (c[0], c[1], r["design"], g, e, r.get("total_nominal_segs"))
+                    )
+    for ms, mb, design, g, e, seg in sorted(flat, reverse=True)[:12]:
+        print(
+            f"  {ms:9.1f}ms  {mb:6.0f}MB  Σseg={seg!s:>5}  {design}  "
+            f"[{g}/{ENGINE_LABEL[e]}]"
+        )
+
+    # Failures / skips.
+    fails = []
+    for r in ok:
+        for g in grounds:
+            for e in engines:
+                res = r["grounds"].get(g, {}).get(e)
+                if res and res.get("error"):
+                    fails.append(
+                        (
+                            r["design"],
+                            g,
+                            e,
+                            res.get("error_kind") or "err",
+                            res["error"],
+                        )
+                    )
+    if fails or errs:
+        skips = [f for f in fails if f[3] == "skip"]
+        hard = [f for f in fails if f[3] != "skip"]
+        print("\n" + "=" * 100)
+        print(
+            f"NON-SOLVES: {len(errs)} load, {len(hard)} error/mem/timeout, {len(skips)} guard-skipped"
+        )
+        print("=" * 100)
+        for r in errs:
+            print(f"  LOAD  {r['design']:<40} {r['load_error'][:60]}")
+        for design, g, e, kind, err in hard:
+            print(
+                f"  {kind.upper():<5} {design:<30} [{g}/{ENGINE_LABEL[e]:<10}] {err[:44]}"
+            )
+        if skips:
+            skipped_designs = sorted({d for d, *_ in skips})
+            print(
+                f"  guard-skipped finite grounds (Σseg cap): {', '.join(skipped_designs)}"
+            )
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--worker",
+        nargs=5,
+        metavar=("DESIGN", "NSEG", "ENGINE", "GROUND", "MEM_GB"),
+        help=argparse.SUPPRESS,
+    )
+    ap.add_argument("--designs", nargs="+", default=None)
+    ap.add_argument(
+        "--engines", nargs="+", default=list(ENGINE_KEYS), choices=ENGINE_KEYS
+    )
+    ap.add_argument(
+        "--grounds",
+        nargs="+",
+        default=list(GROUND_ORDER),
+        choices=list(GROUNDS),
+        help="ground models to sweep (default: all four)",
+    )
+    ap.add_argument(
+        "--nseg",
+        type=int,
+        default=None,
+        help="override nominal_nsegs for every design (default: per-design default)",
+    )
+    ap.add_argument(
+        "--max-seg-finite",
+        type=int,
+        default=DEFAULT_MAX_SEG_FINITE,
+        help="skip finite-ground (fast/somm) solves for designs whose Σseg "
+        f"exceeds this (default {DEFAULT_MAX_SEG_FINITE}; 0 = no cap). free/pec "
+        "always run.",
+    )
+    ap.add_argument(
+        "--mem-gb",
+        type=float,
+        default=DEFAULT_MEM_GB,
+        help=f"per-solve address-space cap in GB (default {DEFAULT_MEM_GB}; "
+        "0 = no cap). A solve exceeding it fails clean instead of swapping.",
+    )
+    ap.add_argument("--timeout", type=float, default=600.0)
+    ap.add_argument("--out", type=Path, default=None)
+    args = ap.parse_args(argv)
+
+    if args.worker:
+        design, nseg, engine, ground, mem_gb = args.worker
+        worker_main(design, int(nseg), engine, ground, float(mem_gb))
+        return
+
+    designs = args.designs if args.designs is not None else all_designs()
+    grounds = [g for g in GROUND_ORDER if g in args.grounds]  # canonical order
+    cores = bnc.physical_cpu_count()
+    print(f"catalog runtime + peak-RSS benchmark   designs: {len(designs)}")
+    print(f"engines: {', '.join(ENGINE_LABEL[e] for e in args.engines)}")
+    print(
+        f"grounds: {', '.join(grounds)}   "
+        + (
+            f"mesh: nominal_nsegs={args.nseg}"
+            if args.nseg
+            else "mesh: per-design default"
+        )
+    )
+    print(
+        f"finite-ground Σseg cap: {args.max_seg_finite or 'none'}   "
+        f"per-solve mem cap: {args.mem_gb or 'none'} GB"
+    )
+    print(
+        "concurrency (mirrors web/server.py): "
+        f"BLAS={cores} OpenMP={cores} OMP_WAIT_POLICY=PASSIVE GOMP_SPINCOUNT=0  "
+        "(serial dispatch)"
+    )
+    print("-" * 100)
+
+    rows = [
+        bench_one(
+            d,
+            args.engines,
+            grounds,
+            args.timeout,
+            args.mem_gb,
+            args.nseg,
+            args.max_seg_finite,
+        )
+        for d in designs
+    ]
+    print_report(rows, args.engines, grounds)
+
+    if args.out:
+        args.out.write_text(json.dumps(rows, indent=2))
+        print(f"\nfull results -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bench_catalog.py
+++ b/tests/test_bench_catalog.py
@@ -1,0 +1,117 @@
+"""Unit tests for the full-catalog runtime + peak-RSS benchmark.
+
+Exercises the pure plumbing of ``scripts/bench_catalog.py`` — catalog
+enumeration, per-design default-mesh lookup, the ground-model specs, worker-
+result cell extraction, and the load-error / finite-ground-guard paths —
+without dispatching the (already bench_converge-tested) subprocess worker for
+every design.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+# bench_catalog lives in scripts/, not on the package path — load it by file.
+# (It inserts scripts/ on sys.path itself so its bench_converge import resolves.)
+_BC_PATH = Path(__file__).resolve().parent.parent / "scripts" / "bench_catalog.py"
+_spec = importlib.util.spec_from_file_location("bench_catalog", _BC_PATH)
+bc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bc)
+
+
+def test_all_designs_enumerates_the_catalog():
+    designs = bc.all_designs()
+    assert designs == sorted(designs)  # stable, sorted order
+    assert len(set(designs)) == len(designs)  # no dups
+    for staple in ("loops.quad", "beams.yagi", "verticals.vertical"):
+        assert staple in designs
+    assert all("." in d and " " not in d for d in designs)
+
+
+def test_default_nseg_reads_the_builders_own_value():
+    cls = bc.cvg.load_design("loops.quad")  # reused from bench_converge
+    assert bc.default_nseg("loops.quad") == cls().nominal_nsegs
+
+
+def test_ground_specs_match_the_four_models():
+    """The ground specs must be the same the web adapter / profile tool use, so
+    the numbers are comparable: free, pec, and the two finite models sharing
+    eps_r/sigma and differing only in solve method (fast refl-coef vs somm)."""
+    from antennaknobs.engines.pynec import DEFAULT_GROUND
+
+    assert bc.GROUNDS["free"] == "free"
+    assert bc.GROUNDS["pec"] == "pec"
+    assert bc.GROUNDS["fast"] == ("finite-fast",) + tuple(DEFAULT_GROUND[1:])
+    assert bc.GROUNDS["somm"] == tuple(DEFAULT_GROUND)
+    # fast and somm share the material, differ only in the method label.
+    assert bc.GROUNDS["fast"][1:] == bc.GROUNDS["somm"][1:]
+    assert bc.GROUNDS["fast"][0] != bc.GROUNDS["somm"][0]
+    assert bc.FINITE_GROUNDS == ("fast", "somm")
+
+
+def test_cell_extracts_ms_and_rss_from_a_worker_result():
+    assert bc._cell({"error": None, "solve_s": 0.012, "peak_rss_mb": 137.5}) == (
+        12.0,
+        137.5,
+    )
+
+
+def test_cell_is_none_on_error_or_missing():
+    assert bc._cell(None) is None
+    assert bc._cell({"error": "boom"}) is None
+    assert bc._cell({}) is None
+
+
+def test_tag_maps_error_kinds():
+    assert bc._tag({"error_kind": "skip"}) == "skip"
+    assert bc._tag({"error_kind": "mem"}) == "MEM"
+    assert bc._tag({"error_kind": "timeout"}) == "TIME"
+    assert bc._tag({"error": "x"}) == "ERR"  # unknown/absent kind
+    assert bc._tag(None) == "ERR"
+
+
+def test_bench_one_reports_load_error_without_dispatching_a_worker():
+    """A design that won't construct is caught at mesh lookup and returned as a
+    load_error, so one bad design never aborts the sweep — and no subprocess is
+    spawned (no grounds dict)."""
+    row = bc.bench_one(
+        "loops.not_a_real_design",
+        ["pynec"],
+        ["free"],
+        timeout=5.0,
+        mem_gb=0,
+        nseg_override=None,
+        max_seg_finite=2000,
+    )
+    assert row["design"] == "loops.not_a_real_design"
+    assert "load_error" in row
+    assert "grounds" not in row
+
+
+def test_bench_one_guard_skips_finite_grounds_for_oversized_meshes():
+    """With a tiny Σseg cap, the finite grounds (fast/somm) are guard-skipped
+    without spawning a worker, while free/pec are unaffected. loops.quad's
+    default Σseg (172) exceeds a cap of 1, so fast/somm skip; free would still
+    run — so we pass only finite grounds here to prove the skip needs no
+    subprocess (a real solve would be far slower than this test's budget)."""
+    row = bc.bench_one(
+        "loops.quad",
+        ["pynec", "sin"],
+        ["fast", "somm"],
+        timeout=5.0,
+        mem_gb=0,
+        nseg_override=None,
+        max_seg_finite=1,
+    )
+    assert row["total_nominal_segs"] > 1
+    for g in ("fast", "somm"):
+        for e in ("pynec", "sin"):
+            cell = row["grounds"][g][e]
+            assert cell["error_kind"] == "skip"
+            assert "skipped" in cell["error"]
+
+
+def test_engine_keys_cover_all_four_solvers():
+    assert set(bc.ENGINE_KEYS) == {"pynec", "sin", "bs1", "bs2"}
+    assert all(k in bc.ENGINE_LABEL for k in bc.ENGINE_KEYS)


### PR DESCRIPTION
## Summary
New `scripts/bench_catalog.py` catalogs the interactive per-tick cost of the whole design library: **every built-in design (91) × all four engines (PyNEC / Sinusoidal / BSpline d=1 / d=2) × four ground models (free / pec / fast-finite / Sommerfeld)** — solve wall-clock and peak RSS, at each design's as-shipped default mesh.

It reuses `bench_converge.py`'s pure `solve_design` for the measurement but runs it in its own subprocess worker for a clean `getrusage` peak RSS, plus an `RLIMIT_AS` cap so a runaway finite-ground solve fails clean instead of swapping the box. A Σseg guard skips finite-ground solves for oversized designs (only `elt_whip`, the intentional 4392-seg W8IO stress design).

## Findings (~1448 solves, all pass)
Full write-up in `docs/status/2026-07-19-catalog-perf-benchmark.md`.

| ground | ×free median (PyNEC / Sin / bs1 / bs2) |
|---|---|
| free | 1.0 / 1.0 / 1.0 / 1.0 |
| pec | 1.2 / 1.2 / 1.2 / 1.3 |
| fast | 1.4 / 1.3 / 1.3 / 1.4 |
| **somm** | **9.4 / 82.7 / 51.3 / 45.4** |

- **free / pec / fast-finite are cheap and stay interactive** — ~80/91 designs under 100 ms even on BSpline d=2.
- **Sommerfeld is the whole cost story**, and it **inverts the engine ranking**: momwire's dense Sommerfeld is **~13× slower than PyNEC's** (NEC gn 2 interpolation tables) — median ~480 ms vs 36 ms. PyNEC stays interactive on Sommerfeld; momwire doesn't (0/90 designs < 100 ms).
- PyNEC's speed lead otherwise inverts on networked/large designs (`lpda` free-space: PyNEC 741 ms vs Sinusoidal 72 ms).
- Memory floor ~91 MB (import baseline); only big meshes lift it. `pec` costs momwire ~30% more memory than free; `elt_whip` free/pec bs2 hits 10.7 / 13.7 GB — the one real memory-scaling flag.
- **Takeaway:** fast-finite is the interactive sweet spot; route Sommerfeld to PyNEC.

## Tests
`tests/test_bench_catalog.py` — catalog enumeration, default-mesh lookup, the four ground specs (shared with `profile_ground_models.py`), cell/tag extraction, and the load-error + finite-ground-guard paths (no per-design subprocess dispatch; the worker itself is covered by the bench_converge test).

## Also
An interactive dashboard of the full dataset (sortable, ground toggle, family filter) was rendered as a Claude artifact for exploration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)