### PR TITLE
chore: release v0.30.0 (bring your .nec files)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.29.0"
+version = "0.30.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,19 +25,23 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.29.0" icon="star">
-  **One solver at a time.** The workbench now schedules every computation a
-  tab asks for — the live solve, frequency sweeps, convergence ladders,
-  pattern checks — through a single per-session lane on the server, live
-  solve first. Dragging a knob instantly preempts stale background work at
-  the solver's next checkpoint instead of competing with it for cores, so
-  benchmark-sized designs (try the 4,400-segment
-  [ELT whip](/reference/catalog/)) stay responsive while their sweeps grind.
-  Closing the tab now stops the computation, a solve that fails no longer
-  pins its memory for the life of the server, and one cost model decides
-  up front what's safe to run. Under the hood it's four invariants replacing
-  a pile of client-side timing heuristics — the workbench just feels
-  steadier under heavy designs.
+<Card title="New in v0.30.0" icon="star">
+  **Bring your `.nec` files.** The deck importer now reads the NEC that's
+  actually out there — 4nec2's symbolic `SY` variables and expressions,
+  `#14`-style wire gauges, current-source feeds (`EX 6`), LC-traps
+  (`LD 6`), insulated-wire loads (`LD 7` → per-wire jackets the solvers
+  model), reactive loads and line terminations, and the extended thin-wire
+  kernel (`EK`) — validated against **3,146 real-world decks** collected
+  from ARRL course material, 4nec2's model library, and the wider web,
+  with 87% now scoring against reference NEC-2 and the median PyNEC deck
+  agreeing to a reflection-coefficient distance of 0.0001. Meshing got
+  principled to match: the segment counts you (or your deck) ask for are
+  the counts that solve — parity nudges touch only fed wires, short
+  bridges mesh proportionally instead of being over-segmented, and feed
+  gaps refine with the convergence slider, so designs like the
+  [quad](/reference/catalog/) and j-pole now converge flat where they
+  used to drift. Ground-connected verticals also solve correctly on the
+  in-house engines (momwire 0.14.0's ground-junction end conditions).
   [All release notes →](/reference/releases/)
 </Card>
 

--- a/site/src/content/docs/reference/nec-import.md
+++ b/site/src/content/docs/reference/nec-import.md
@@ -180,11 +180,15 @@ the trap dipole and station designs use), wherever it can express them
 | Card | Translation |
 | --- | --- |
 | `LD` type 0/1 (lumped series/parallel RLC) | A `Load` per segment in the card's range (expanded up to 8 segments), on a named 1-segment wire split out of the host wire |
-| `LD` type 4 with X = 0 (pure resistance) | `Load(r=…)` |
+| `LD` type 4 (fixed impedance) | `Load(r=…)` when X = 0; a fixed complex-Z `Load` when reactive |
 | `LD` type 5 over the whole structure (wire conductivity) | `deck.conductivity`, baked into every `wire_tuples(specs=True)` spec (or feed it to `WireSpec` in `build_wire_material`) |
 | `LD` type 5 on a tag/range covering whole wires | Per-wire conductivity (`deck.wire_conductivity`), baked into those wires' `specs=True` specs — a ranged card wins over the whole-structure one |
-| `TL` | A `TL` branch: negative z0 (NEC's crossed line) becomes `transposed=True`, zero length resolves to the port separation, conductance-only end admittances become `Shunt(r=1/G)` |
+| `LD` type 6 (4nec2 LC-trap) | The parallel RLC 4nec2 itself converts it to: `R_p = Q·ωL` at the deck's first `FR` frequency (F1 is the coil's unloaded Q, 0 → 100) |
+| `LD` type 7 (4nec2 wire insulation) | Per-wire dielectric jackets (`deck.wire_insulation` → `WireSpec.insulation_radius/eps_r`) for wires the card covers in full — the solvers model the insulated-wire velocity factor |
+| `EX` type 6 (4nec2 current source) | A `DrivenCurrent` source — the forced complex current drives the network exactly as 4nec2 would |
+| `TL` | A `TL` branch: negative z0 (NEC's crossed line) becomes `transposed=True`, zero length resolves to the port separation, conductance-only end admittances become `Shunt(r=1/G)`, reactive ones a fixed 1-port `Admittance` |
 | `NT` with an all-real Y matrix | Its exact resistive pi: a series `TwoPort` between the ports plus a `Shunt` at each |
+| `NT` with susceptance | The full 2×2 complex Y as an `Admittance` branch |
 
 `deck.wire_tuples()` then emits *named* wires at every attachment point (no
 legacy `ex` markers) and `deck.network()` returns the matching `Network` —
@@ -193,10 +197,8 @@ the deck's `EX` cards become its `Driven` sources — ready to return from
 network cards still works identically: `network()` is then just the drive.
 
 What cannot be translated exactly stays out, with a per-card reason in
-`deck.ignored_detail` (rendered by `skipped_note()`): frequency-independent
-reactance (`LD` 4 with X ≠ 0, susceptance in `TL`/`NT` admittances — NEC's
-constant-B convention has no R/L/C equivalent), distributed per-metre RLC
-(`LD` 2/3), an `LD` 5 range covering only *part* of a wire's segments
+`deck.ignored_detail` (rendered by `skipped_note()`): distributed per-metre
+RLC (`LD` 2/3), an `LD` 5/7 range covering only *part* of a wire's segments
 (per-wire specs cover whole wires only), and an `LD` landing on a segment
 that also has a `TL`/`NT` connection (NEC composes those in series inside
 the segment, which the port model doesn't express).
@@ -224,8 +226,22 @@ so the mismatch is explained right where the deck is viewed.
 
 Decks the wire-model genuinely cannot represent are rejected with a clear
 error rather than silently approximated: surface patches (`SP`/`SM`), tapered
-wires (`GC`), Green's-function files (`GF`), 4nec2 symbolic variables (`SY`),
-and plane-wave or current-source excitation (only voltage feeds exist here).
+wires (`GC`), Green's-function files (`GF`), and plane-wave excitation.
+
+## The 4nec2 dialect
+
+Real-world decks are mostly written *for 4nec2*, and the importer reads that
+dialect natively: `SY` symbolic variables with full expressions (BASIC-style
+— trig in degrees, `^` power, unit suffixes like `1.5*mm` or `36.6pF`),
+`'`-comments, fused mnemonics (`GW1,8,…`), and `#14`-style AWG wire-gauge
+radii. A deck's `EK` card (extended thin-wire kernel) is honoured by the
+PyNEC engine so fat-wire decks solve kernel-for-kernel with NEC. A remote
+1-segment wire parked hundreds of wavelengths away purely to terminate a
+`TL` card is recognised and replaced by a virtual circuit node (the deck
+solves in seconds instead of meshing an electrically irrelevant wire; the
+substitution is named in `skipped_note()`). This dialect support was
+validated against a 3,146-deck corpus of published models — ARRL course
+material, 4nec2's own library, and the wider web.
 
 ## Programmatic use
 
@@ -241,7 +257,7 @@ deck = parse_nec(open("some.nec").read(), name="some.nec")
 | `NecDeck` field | Meaning |
 | --- | --- |
 | `wires` | `tuple[NecWire, ...]` — every straight wire after all transforms (`tag`, `n_seg`, `p1`, `p2`, `radius`) |
-| `feeds` | `tuple[NecFeed, ...]` — each `EX` voltage source resolved onto a wire (`wire` index, 1-based `seg`, complex `voltage`) |
+| `feeds` | `tuple[NecFeed, ...]` — each `EX` source resolved onto a wire (`wire` index, 1-based `seg`, complex `voltage`; `current=True` marks a 4nec2 `EX 6` forced current) |
 | `freq_mhz` | The `FR` card's sweep range as `(lo, hi)` MHz, or `None` |
 | `ground` | `True` if the deck requested a ground plane (`GE` flag or a `GN` card) |
 | `comments` | The `CM` header text, line by line |

--- a/src/antennaknobs/nec_import.py
+++ b/src/antennaknobs/nec_import.py
@@ -38,10 +38,11 @@ stays in ``ignored`` with a per-card reason in ``ignored_detail``.
 ``ex`` markers) and ``network()`` returns the matching ``Network``, ready to
 return from ``build_wires`` / ``build_network``.
 
-Excitation: only voltage sources (EX type 0 and 5) can drive an antenna in
-antennaknobs; plane-wave and current-source excitations raise. The engine
-feeds a wire tuple at its middle segment, so ``NecDeck.wire_tuples`` splits a
-wire whose EX segment is off-centre into colinear pieces that preserve the
+Excitation: voltage sources (EX type 0 and 5) drive an antenna in any mode,
+and 4nec2's EX type 6 current source (issue #442) drives it in network mode
+as a ``DrivenCurrent``; plane-wave excitations raise. The engine feeds a
+wire tuple at its middle segment, so ``NecDeck.wire_tuples`` splits a wire
+whose EX segment is off-centre into colinear pieces that preserve the
 deck's exact segment boundaries and put the feed on its own 1-segment wire.
 """
 


### PR DESCRIPTION
## Summary
- Version 0.29.0 → 0.30.0; momwire pin unchanged (0.14.0).
- What's-new card: the NEC-import dialect arc (validated against the 3,146-deck wild corpus) + the principled-meshing arc.
- De-stale sweep: `reference/nec-import.md` updated for everything the importer learned this cycle (SY/EX 6/LD 4-6-7/NT-Y/EK/anchor virtualization); the module docstring's stale voltage-only excitation claim fixed.
- Site builds clean (20 pages).

## Test plan
- [x] `npm run build` green
- [x] nec_import test subset green (133)
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)