### PR TITLE
fix(bench): Y-matrix superposition reference for multi-source EX 6 decks (#463)

### DIFF
--- a/scripts/bench_nec_corpus.py
+++ b/scripts/bench_nec_corpus.py
@@ -81,6 +81,8 @@ import tempfile  # noqa: E402
 import time  # noqa: E402
 from pathlib import Path  # noqa: E402
 
+import numpy as np  # noqa: E402
+
 XNEC2C_EXAMPLES = Path.home() / "antennas" / "xnec2c" / "examples"
 Z0 = 50.0  # system impedance for the reflection-coefficient metric (issue #407)
 ENGINE_KEYS = ("pynec", "sin", "bs1", "bs2")
@@ -612,7 +614,7 @@ def has_dead_trailing_config(text: str) -> bool:
     return bool(dead_trailing_config(mnems))
 
 
-def reference_deck(text: str, name: str) -> str:
+def reference_deck(text: str, name: str, ex6: str = "rbig") -> str:
     """Deck text prepared for the nec2c *reference* run (issue #439).
 
     ``resolve_sy`` materializes the 4nec2 dialect nec2c cannot read (SY
@@ -745,6 +747,11 @@ def reference_deck(text: str, name: str) -> str:
                 out.append(f"LD 2 {t} {sf} {st} 0 {l_ins!r} 0")
             continue
         if toks[0] == "EX" and len(toks) > 1 and int(float(toks[1])) == 6:
+            if ex6 == "drop":
+                # The superposition reference (issue #463) supplies its own
+                # voltage-drive excitation, so strip the deck's EX 6 cards and
+                # emit no R_BIG emulation.
+                continue
             tag, seg = toks[2], toks[3] if len(toks) > 3 else "0"
             i_re = float(toks[5]) if len(toks) > 5 else 0.0
             i_im = float(toks[6]) if len(toks) > 6 else 0.0
@@ -767,6 +774,137 @@ def reference_deck(text: str, name: str) -> str:
         else:
             out += ["XQ", "EN"]
     return "\n".join(out) + "\n"
+
+
+def _nec2c_source_currents(deck_text: str, timeout: float, mem_bytes=None):
+    """Run nec2c on prepared text and return each source's complex current in
+    EX-card order (the ANTENNA INPUT PARAMETERS ``CURRENT`` column), plus the
+    frequency: ``{"freq": MHz, "currents": [complex, ...], "error": str|None}``.
+    A sibling of ``run_nec2c`` that reads current instead of impedance — the
+    superposition reference (issue #463) drives voltages and measures currents.
+    """
+    if shutil.which("nec2c") is None:
+        return {"error": "nec2c not on PATH"}
+    with tempfile.TemporaryDirectory(prefix="nec_") as d:
+        nec = Path(d) / "d.nec"
+        out = Path(d) / "d.out"
+        nec.write_text(deck_text)
+        try:
+            subprocess.run(
+                ["nec2c", "-i", str(nec), "-o", str(out)],
+                capture_output=True,
+                timeout=timeout,
+                preexec_fn=_rlimit_preexec(mem_bytes) if mem_bytes else None,
+            )
+        except subprocess.TimeoutExpired:
+            return {"error": f"nec2c timeout >{timeout:.0f}s"}
+        if not out.exists():
+            return {"error": "nec2c produced no output"}
+        lines = out.read_text(errors="replace").splitlines()
+    freq = None
+    for i, ln in enumerate(lines):
+        m = _FREQ_RE.search(ln)
+        if m:
+            freq = float(m.group(1))
+        if "ANTENNA INPUT PARAMETERS" in ln:
+            cur = []
+            j = i + 3  # header + units row, then data rows
+            while j < len(lines) and lines[j].strip():
+                toks = lines[j].split()
+                if len(toks) >= 6:
+                    try:
+                        cur.append(complex(float(toks[4]), float(toks[5])))
+                    except ValueError:
+                        return {"error": "nec2c current parse failed"}
+                j += 1
+            if cur:
+                return {"freq": freq, "currents": cur, "error": None}
+    return {"error": "no ANTENNA INPUT PARAMETERS block"}
+
+
+def superposition_reference(text: str, name: str, timeout: float, mem_bytes=None):
+    """Multi-source EX 6 reference via nec2c Y-matrix superposition (issue #463).
+
+    nec2c has no port current source, and the single-R_BIG emulation (issue
+    #442) cannot force N simultaneous port currents at once — on phased
+    active-feed decks (e.g. 3vertical.nec) the reported per-feed V/I comes out
+    R_BIG-invariant and wrong, so the R_BIG subtraction manufactures a huge
+    negative resistance. Recover the physics with native voltage drives
+    instead: for each of the N solves, excite every port with an all-nonzero,
+    linearly independent set of gap voltages and read every port's current,
+    giving the port admittance matrix ``Y = I_mat · V_mat⁻¹``; invert to the
+    impedance matrix Z, then compose the driving-point impedances the deck's
+    current excitation produces — ``V = Z·I``, ``Z_i = V_i / I_i``. All-nonzero
+    voltages sidestep NEC's "an all-zero EX defaults to 1 V" quirk; the linear
+    solve is exact for any invertible drive pattern.
+
+    Returns a ``run_nec2c``-shaped dict (``z`` per feed in EX-card order,
+    ``superposition``/``resolved_deck`` flags set) or an error dict; ``None`` if
+    the deck has fewer than two EX 6 sources (not this path's job).
+    """
+    from antennaknobs.nec_import import resolve_sy
+
+    try:
+        resolved = resolve_sy(text, name=name).splitlines()
+    except ValueError as e:
+        return {"error": f"superposition resolve_sy: {e}"}
+    ports, currents = [], []
+    for ln in resolved:
+        toks = ln.split()
+        if toks and toks[0] == "EX" and len(toks) > 1 and int(float(toks[1])) == 6:
+            ports.append((toks[2], toks[3] if len(toks) > 3 else "0"))
+            i_re = float(toks[5]) if len(toks) > 5 else 0.0
+            i_im = float(toks[6]) if len(toks) > 6 else 0.0
+            currents.append(complex(i_re, i_im))
+    n = len(ports)
+    if n < 2:
+        return None
+    i_exc = np.array(currents)
+    if np.any(i_exc == 0):
+        return {"error": "superposition: a feed has zero drive current"}
+    try:
+        base = reference_deck(text, name, ex6="drop").splitlines()
+    except ValueError as e:
+        return {"error": f"superposition reference_deck: {e}"}
+    exec_i = next(
+        (
+            k
+            for k, ln in enumerate(base)
+            if ln.split()[:1] and ln.split()[0] in ("XQ", "RP")
+        ),
+        len(base),
+    )
+    # Drive matrix: 1 on the diagonal, 0.5 off — all nonzero (dodges the zero-EX
+    # quirk) and well conditioned (det = (0.5n + 0.5)·0.5^(n-1) > 0) at any n.
+    v_mat = np.full((n, n), 0.5) + np.eye(n) * 0.5
+    i_mat = np.zeros((n, n), dtype=complex)
+    freq = None
+    for j in range(n):
+        ex = [
+            f"EX 0 {ports[k][0]} {ports[k][1]} 0 {float(v_mat[k, j])!r} 0"
+            for k in range(n)
+        ]
+        deck_j = "\n".join(base[:exec_i] + ex + base[exec_i:]) + "\n"
+        res = _nec2c_source_currents(deck_j, timeout, mem_bytes)
+        if res.get("error"):
+            return {"error": f"superposition solve {j}: {res['error']}"}
+        cur = res["currents"]
+        if len(cur) != n:
+            return {"error": f"superposition solve {j}: {len(cur)} sources, want {n}"}
+        i_mat[:, j] = cur
+        freq = res["freq"]
+    try:
+        z = np.linalg.inv(i_mat @ np.linalg.inv(v_mat))
+    except np.linalg.LinAlgError as e:
+        return {"error": f"superposition: singular matrix ({e})"}
+    z_dp = (z @ i_exc) / i_exc
+    return {
+        "freq": freq,
+        "z": [[zz.real, zz.imag] for zz in z_dp],
+        "error": None,
+        "superposition": True,
+        "resolved_deck": True,
+    }
 
 
 def feeds_sharing_tl_nt(deck) -> list[int]:
@@ -841,6 +979,16 @@ def bench_deck(
     ref = None
     if not any(ex6_feeds) and not has_dead_trailing_config(text):
         ref = run_nec2c(deck_path, timeout, mem_bytes)
+    # Multi-source, all-current EX 6 decks (issue #463): one R_BIG solve can't
+    # force N simultaneous port currents, so the per-feed subtraction breaks
+    # (feed 0 keeps a −R_BIG residue). Build the reference by Y-matrix
+    # superposition — N native voltage solves compose the true driving-point
+    # impedances. Falls through to the R_BIG path if it can't run (e.g. no
+    # nec2c) so behaviour is never worse than before.
+    if (ref is None or ref.get("error")) and sum(ex6_feeds) >= 2 and all(ex6_feeds):
+        sup = superposition_reference(text, deck_path.name, timeout, mem_bytes)
+        if sup is not None and not sup.get("error"):
+            ref = sup
     if ref is None or ref.get("error"):
         # Resolved-reference retry (issue #439): the deck parses for *us*,
         # so a failed reference run may just be dialect (SY symbols, no
@@ -929,7 +1077,8 @@ def print_report(rows, engines):
         "  flags: g = unsupported ground (radials/cliff), n = inexpressible LD/TL/NT "
         "network, v = remote TL-anchor wire(s) virtualized (#427),"
         " r = reference from resolved deck (#439),"
-        " t = EX 6 feed shares a TL/NT segment; R_BIG subtraction skipped (#456)"
+        " t = EX 6 feed shares a TL/NT segment; R_BIG subtraction skipped (#456),"
+        " s = multi-source EX 6 reference via Y-matrix superposition (#463)"
     )
     print("=" * 104)
     hdr = (
@@ -946,6 +1095,7 @@ def print_report(rows, engines):
             + ("v" if r.get("virtualized_anchors") else "")
             + ("r" if r.get("nec2c", {}).get("resolved_deck") else "")
             + ("t" if r.get("nec2c", {}).get("ex6_tl_shared") else "")
+            + ("s" if r.get("nec2c", {}).get("superposition") else "")
         )
         cells = " ".join(f"{fmt_dg(r['engines'].get(e)):>11}" for e in engines)
         print(

--- a/tests/test_bench_ex6_superposition.py
+++ b/tests/test_bench_ex6_superposition.py
@@ -1,0 +1,128 @@
+"""Multi-source EX 6 reference via Y-matrix superposition (issue #463).
+
+nec2c has no port current source, and the single-R_BIG emulation (issue #442)
+can't force N simultaneous port currents — on a phased active-feed deck the
+per-feed readout comes out R_BIG-invariant, so the subtraction manufactures a
+huge negative resistance (3vertical.nec: feed 0 reads −18,972 + 258j, engines
+disagree at ΔΓ 0.43). ``superposition_reference`` recovers the physics with
+native voltage drives: N solves → port admittance matrix → invert to Z →
+compose the driving-point impedances V = Z·I for the deck's current vector.
+
+The strongest check is the physics oracle: a multiport driven by known port
+currents has a driving-point impedance the *engine* also computes (momwire uses
+a real MNA current source, no resistor), so the superposition reference and the
+engine must agree.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+from pathlib import Path
+
+import pytest
+
+_BNC = Path(__file__).resolve().parent.parent / "scripts" / "bench_nec_corpus.py"
+_spec = importlib.util.spec_from_file_location("bench_nec_corpus", _BNC)
+bnc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bnc)
+
+needs_nec2c = pytest.mark.skipif(
+    shutil.which("nec2c") is None, reason="nec2c not on PATH"
+)
+
+# A two-element phased array, both elements driven by EX 6 current sources 90°
+# apart — the minimal multi-source deck that breaks the single-R_BIG emulation.
+_PHASED2 = (
+    "CE\n"
+    "GW 1 15 -30 0 0 -30 0 20 0.05\n"
+    "GW 2 15 30 0 0 30 0 20 0.05\n"
+    "GE 1\nGN 1\n"
+    "EX 6 1 1 0 1 0\n"
+    "EX 6 2 1 0 0 1\n"
+    "FR 0 1 0 0 7 0\nEN\n"
+)
+
+
+# --------------------------------------------------- pure (no nec2c) contract
+
+
+def test_reference_deck_drop_strips_ex6_emulation():
+    """``ex6="drop"`` removes the EX 6 cards and emits neither the EX 0 voltage
+    twin nor the LD 4 R_BIG series resistor — the superposition path supplies
+    its own excitation."""
+    prepared = bnc.reference_deck(_PHASED2, "phased2", ex6="drop")
+    mnems = [ln.split()[0] for ln in prepared.splitlines() if ln.split()]
+    assert "EX" not in mnems  # no excitation left behind
+    assert not any(ln.startswith("LD 4") for ln in prepared.splitlines())
+    assert "GW" in mnems and "XQ" in mnems  # geometry + an execute request remain
+
+
+def test_superposition_none_for_single_source():
+    """One EX 6 feed is not this path's job (the R_BIG emulation handles it) —
+    returns None before any nec2c solve."""
+    one = (
+        "CE\nGW 1 15 -30 0 0 -30 0 20 0.05\nGE 1\nGN 1\n"
+        "EX 6 1 1 0 1 0\nFR 0 1 0 0 7 0\nEN\n"
+    )
+    assert bnc.superposition_reference(one, "one", 60.0, None) is None
+
+
+def test_superposition_errors_on_zero_drive_current():
+    """A feed with zero drive current has no V/I to report — caught before the
+    solve, not divided-by-zero later."""
+    zero = _PHASED2.replace("EX 6 2 1 0 0 1", "EX 6 2 1 0 0 0")
+    res = bnc.superposition_reference(zero, "zero", 60.0, None)
+    assert res is not None and res.get("error")
+    assert "zero drive current" in res["error"]
+
+
+# --------------------------------------------- physics oracle (needs nec2c)
+
+
+@needs_nec2c
+def test_superposition_matches_engine_on_phased_pair():
+    """The reference the superposition builds must match what the engine solves
+    for the same current excitation (the engine drives a real MNA current
+    source). Agreement to a few percent pins the whole Y→Z→compose chain."""
+    from antennaknobs import AntennaBuilder, WireSpec
+    from antennaknobs.engines import MomwireEngine
+    from antennaknobs.nec_import import parse_nec
+    from momwire import SinusoidalSolver
+
+    sup = bnc.superposition_reference(_PHASED2, "phased2", 60.0, None)
+    assert sup is not None and sup.get("error") is None
+    assert sup["superposition"] is True and sup["freq"] == pytest.approx(7.0)
+    z_ref = [complex(re, im) for re, im in sup["z"]]
+
+    deck = parse_nec(_PHASED2, name="phased2", network=True)
+
+    class B(AntennaBuilder):
+        default_params = {"freq": 7.0}
+
+        def build_wires(self):
+            return deck.wire_tuples()
+
+        def build_network(self):
+            return deck.network()
+
+        def build_wire_material(self):
+            return WireSpec(radius=deck.dominant_radius())
+
+    z_eng = MomwireEngine(B(), solver=SinusoidalSolver, ground="pec").impedance()
+
+    assert len(z_ref) == len(z_eng) == 2
+    for zr, ze in zip(z_ref, z_eng):
+        assert abs(zr - ze) / abs(ze) < 0.03, f"ref {zr:.1f} vs engine {ze:.1f}"
+
+
+@needs_nec2c
+def test_superposition_reference_is_physical():
+    """Sanity floor: the composed driving-point impedances are finite with
+    positive resistance — the exact failure the R_BIG bug produced was a huge
+    *negative* resistance (−18,972 Ω), so a positive real part is the first
+    thing that must hold."""
+    sup = bnc.superposition_reference(_PHASED2, "phased2", 60.0, None)
+    assert sup is not None and not sup.get("error")
+    for re, im in sup["z"]:
+        assert re > 0.0, f"non-physical negative resistance: {re}+{im}j"


### PR DESCRIPTION
## Summary
Follow-up to #456. On phased active-feed decks with **multiple simultaneous EX 6 current sources** (`opensource/4nec2/HFActiveFeed/3vertical.nec`), the R_BIG emulation (#442) produced a nonsensical reference — feed 0 read **−18,972 + 258j** — with both engines agreeing against it at ΔΓ 0.43.

**Root cause:** nec2c has no port current source, so the emulation fakes one with `V = I·R_BIG` behind a series `R_BIG` and subtracts `R_BIG` back out. That works for a single source but **can't force N simultaneous port currents** — the per-feed readout comes out completely `R_BIG`-invariant (verified constant across `R_BIG` = 1e3…1e6) and unrelated to the true impedance, so the subtraction manufactures the −R_BIG residue.

## Fix — Y-matrix superposition
For a deck with **≥2 EX 6 feeds, all current sources**, build the reference from native voltage drives instead:
1. Drive the ports with N all-nonzero, linearly-independent gap-voltage patterns (native `EX 0`), reading every port's current → port admittance `Y = I·V⁻¹`.
2. Invert to the impedance matrix `Z`.
3. Compose the driving-point impedances the deck's current vector produces: `V = Z·I`, `Zᵢ = Vᵢ/Iᵢ`.

All-nonzero voltages sidestep NEC's "all-zero EX defaults to 1 V" quirk; the linear solve is exact for any invertible drive pattern. No `R_BIG` anywhere — matching the intuition that the *engines* need no resistor (they drive a real MNA current source).

## Result

| deck | before | after | flag |
|------|--------|-------|------|
| `3vertical.nec` (3 sources) | ref −18,972+258j, ΔΓ 0.43 | ref **119.2+165.2j**, ΔΓ **0.0000 / 0.0007** | `s` |
| `2phased.nec` (2 sources) | broken | ΔΓ **0.0002 / 0.0150** | `s` |

Single-source and TL-shared (#456) decks are untouched — the gate requires ≥2 all-current feeds. The `s` flag marks superposition references in the report.

## Tests
`tests/test_bench_ex6_superposition.py`:
- `ex6="drop"` strips the EX 6 emulation (pure).
- single-source → `None`; zero drive current → error (pure, pre-solve).
- **physics oracle** (nec2c-gated): the superposition reference matches momwire's Sinusoidal solve on a phased pair to <3% — pinning the whole Y→Z→compose chain.
- physicality floor: positive resistance (the bug's signature was negative R).

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)