### PR TITLE
Release v0.31.0 — Sommerfeld ground, session-fast (momwire 0.15.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/sta
 # install below sees its requirement already satisfied, then the package with the
 # web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install "momwire==0.14.0" \
+ && pip install "momwire==0.15.0" \
  && pip install -e ".[web]"
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire==0.14.0",
+    "momwire==0.15.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.30.0"
+version = "0.31.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,23 +25,18 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.30.0" icon="star">
-  **Bring your `.nec` files.** The deck importer now reads the NEC that's
-  actually out there — 4nec2's symbolic `SY` variables and expressions,
-  `#14`-style wire gauges, current-source feeds (`EX 6`), LC-traps
-  (`LD 6`), insulated-wire loads (`LD 7` → per-wire jackets the solvers
-  model), reactive loads and line terminations, and the extended thin-wire
-  kernel (`EK`) — validated against **3,146 real-world decks** collected
-  from ARRL course material, 4nec2's model library, and the wider web,
-  with 87% now scoring against reference NEC-2 and the median PyNEC deck
-  agreeing to a reflection-coefficient distance of 0.0001. Meshing got
-  principled to match: the segment counts you (or your deck) ask for are
-  the counts that solve — parity nudges touch only fed wires, short
-  bridges mesh proportionally instead of being over-segmented, and feed
-  gaps refine with the convergence slider, so designs like the
-  [quad](/reference/catalog/) and j-pole now converge flat where they
-  used to drift. Ground-connected verticals also solve correctly on the
-  in-house engines (momwire 0.14.0's ground-junction end conditions).
+<Card title="New in v0.31.0" icon="star">
+  **Sommerfeld ground, session-fast.** The most accurate ground model used
+  to be the one you saved for final checks — every solve paid seconds to
+  tabulate its interpolation grid. momwire 0.15.0 restructures that grid:
+  the fill now grows linearly with antenna size instead of quadratically,
+  and one tabulation is reused across a whole band's frequencies. The
+  first solve of a session still pays once; after that, band sweeps and
+  frequency-knob drags run warm at **10–40 ms per tick on the in-house
+  bases — faster than the NEC-2 reference's own steady state on 86 of 90
+  catalog designs**. Big-antenna cold solves dropped too (the
+  1000-segment terminated long-wire: 6.2 s → 3.1 s), and the whole
+  before/after is measured in the repo's session benchmark.
   [All release notes →](/reference/releases/)
 </Card>
 

--- a/site/src/content/docs/reference/solver.mdx
+++ b/site/src/content/docs/reference/solver.mdx
@@ -63,7 +63,12 @@ threading; see the benchmark docs for full tables.
   `free ≈ PEC < reflection-coefficient < Sommerfeld`.** PEC is nearly free
   (image method, no material solve); the reflection-coefficient ground runs
   ~1.5–3× a free-space solve on the dense bases; the full Sommerfeld ground
-  ~2–5× — the reason it stays opt-in in the UI.
+  ~2–5×. Since momwire 0.15.0 that Sommerfeld premium is mostly the *first*
+  solve of a session: the interpolation-grid fill grows linearly with
+  antenna size (not quadratically) and is reused across a band's
+  frequencies, so warm sweep ticks on the momwire bases undercut even
+  PyNEC's per-tick steady state on 86/90 catalog designs — see the
+  [session benchmark](https://github.com/stevenmburns/antennaknobs/blob/main/docs/status/2026-07-19-somm-session-benchmark.md).
 - **ACA earns its place on `rhombic`** — fastest engine free-space (~4.0 s,
   beating PyNEC and every dense basis, scaling ~2×/step where dense solvers go
   ~5×/step), and under Sommerfeld the low-rank structure survives (the smooth

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -196,10 +196,11 @@ The selector describes what the ground **is**, independent of solver:
 Every solver then offers the same method sub-choice — full
 **Sommerfeld/Norton** (most accurate, the reference below ~0.1λ heights)
 vs. the **reflection-coefficient** approximation (the default: much
-faster per solve, and fine above ~0.1λ; Sommerfeld is opt-in because its
-first solve at each frequency builds an interpolation grid — so the
-first sweep takes a few seconds — though repeat solves reuse cached
-grids and run in tens of milliseconds). Since momwire 0.8.0 the choice
+faster per solve, and fine above ~0.1λ; Sommerfeld's first solve of a
+session builds an interpolation grid, but since momwire 0.15.0 that grid
+is reused across a band's frequencies — a sweep pays a few fills on its
+first pass, then every repeat sweep and knob-drag tick runs warm in tens
+of milliseconds). Since momwire 0.8.0 the choice
 is uniform: every momwire solver honours both models (Sommerfeld
 validated against an independent NEC-2 implementation down to 0.02λ —
 within ~2.4 Ω on the B-spline bases, ~0.1 Ω on the sinusoidal basis, and


### PR DESCRIPTION
## Summary
- Adopt momwire 0.15.0 in the three places (pyproject exact pin, Dockerfile, submodule pointer) — brings momwire#159 phases 1+2: Sommerfeld grid fill linear in geometry extent (momwire PR #160) and frequency-axis grid reuse (PR #162). No momwire public API changes; no antennaknobs code changes.
- Release chore: version 0.31.0, what's-new card ("Sommerfeld ground, session-fast"), de-stale sweep of `solver.mdx` + `web.md` (both described the per-frequency, quadratic-fill grid), site builds clean.
- Measured basis: docs/status/2026-07-19-somm-session-benchmark.md — warm sweep ticks 10–40 ms on the momwire bases, beating PyNEC's per-tick steady state on 86/90 designs; cold tail 6.2 → 3.1 s.

## Test plan
- [x] momwire 0.15.0 published and verified on PyPI before this PR (wheel-smoke won't race)
- [x] Full momwire suite (436) + antennaknobs ground oracles passed against the pinned commit (editable submodule == pin)
- [x] `cd site && npm run build` clean
- [ ] CI green, then /merge-pr → tag v0.31.0 → three pipelines + fleet verification → announce

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmgjJwcpzBa3sUzpKj7tKw