### PR TITLE
fix(bench): EX 6 + TL on driven segment is a reference bug, not an engine bug (#464)

### DIFF
--- a/docs/status/2026-07-19-meshing-rebaseline.md
+++ b/docs/status/2026-07-19-meshing-rebaseline.md
@@ -94,6 +94,21 @@ outlier bar. Three HFActiveFeed decks remain, in two distinct classes:
   source sharing its port with a TL is the suspect (the same shared-port
   situation the reference-side fix just repaired, one layer down).
 
+  **Resolved (#464) — the diagnosis above was wrong; the bug was the
+  reference, not the engine.** A driving-point impedance is source-type
+  independent (V/I at a port is the same whether you force V or I), and
+  nec2c's *own* 1 V voltage drive with the TL intact reports 34.9 + 45.1j
+  for BRDZPR10 — matching our engines (33.2 + 44.6j), not the 88.5 − 11.6j
+  R_BIG readout. The "R_BIG-invariant ⟹ trustworthy" assumption behind
+  #456's skip is false: when the driven segment is also a TL/NT port, NEC
+  *bypasses* the series `LD 4 R_BIG` (a 20 kΩ load carrying 222 A at
+  R_BIG = 2e4), so the raw readout is a NEC LD-plus-network composition
+  artifact, not an impedance. The fix routes single-source EX 6 decks
+  through the #463 Y-matrix superposition path (native voltage drives, TL
+  intact), which for N = 1 degenerates to one 1 V solve. Both decks now
+  land at ΔΓ ≤ 0.0015. Corrected references: **BRDZPR10 34.9 + 45.1j**,
+  **ZLTROM10 33.6 + 28.6j**.
+
 ## Catalog re-baseline
 
 The catalog A/B was done PR-by-PR rather than as a separate sweep — every

--- a/scripts/bench_nec_corpus.py
+++ b/scripts/bench_nec_corpus.py
@@ -823,24 +823,32 @@ def _nec2c_source_currents(deck_text: str, timeout: float, mem_bytes=None):
 
 
 def superposition_reference(text: str, name: str, timeout: float, mem_bytes=None):
-    """Multi-source EX 6 reference via nec2c Y-matrix superposition (issue #463).
+    """EX 6 current-source reference via nec2c Y-matrix superposition (#463, #464).
 
     nec2c has no port current source, and the single-R_BIG emulation (issue
     #442) cannot force N simultaneous port currents at once — on phased
     active-feed decks (e.g. 3vertical.nec) the reported per-feed V/I comes out
     R_BIG-invariant and wrong, so the R_BIG subtraction manufactures a huge
-    negative resistance. Recover the physics with native voltage drives
-    instead: for each of the N solves, excite every port with an all-nonzero,
-    linearly independent set of gap voltages and read every port's current,
-    giving the port admittance matrix ``Y = I_mat · V_mat⁻¹``; invert to the
-    impedance matrix Z, then compose the driving-point impedances the deck's
-    current excitation produces — ``V = Z·I``, ``Z_i = V_i / I_i``. All-nonzero
-    voltages sidestep NEC's "an all-zero EX defaults to 1 V" quirk; the linear
-    solve is exact for any invertible drive pattern.
+    negative resistance. It also breaks for a *single* EX 6 source whose segment
+    also anchors a TL/NT (issue #464): the network port bypasses the series
+    ``LD 4 R_BIG`` (a 20 kΩ load carrying 200+ A), so the raw readout is a NEC
+    LD-plus-network composition artifact, not the driving-point impedance — and
+    #456's "trust the R_BIG-invariant readout" skip trusts the wrong number.
+
+    Recover the physics with native voltage drives instead: for each of the N
+    solves, excite every port with an all-nonzero, linearly independent set of
+    gap voltages and read every port's current, giving the port admittance
+    matrix ``Y = I_mat · V_mat⁻¹``; invert to the impedance matrix Z, then
+    compose the driving-point impedances the deck's current excitation produces
+    — ``V = Z·I``, ``Z_i = V_i / I_i``. All-nonzero voltages sidestep NEC's "an
+    all-zero EX defaults to 1 V" quirk; the linear solve is exact for any
+    invertible drive pattern. The N = 1 case degenerates to one 1 V solve whose
+    ``Z = V/I`` is exactly the (source-type-independent) driving-point
+    impedance — correct whether or not the segment carries a TL.
 
     Returns a ``run_nec2c``-shaped dict (``z`` per feed in EX-card order,
     ``superposition``/``resolved_deck`` flags set) or an error dict; ``None`` if
-    the deck has fewer than two EX 6 sources (not this path's job).
+    the deck has no EX 6 sources (not this path's job).
     """
     from antennaknobs.nec_import import resolve_sy
 
@@ -857,7 +865,7 @@ def superposition_reference(text: str, name: str, timeout: float, mem_bytes=None
             i_im = float(toks[6]) if len(toks) > 6 else 0.0
             currents.append(complex(i_re, i_im))
     n = len(ports)
-    if n < 2:
+    if n < 1:
         return None
     i_exc = np.array(currents)
     if np.any(i_exc == 0):
@@ -979,13 +987,16 @@ def bench_deck(
     ref = None
     if not any(ex6_feeds) and not has_dead_trailing_config(text):
         ref = run_nec2c(deck_path, timeout, mem_bytes)
-    # Multi-source, all-current EX 6 decks (issue #463): one R_BIG solve can't
-    # force N simultaneous port currents, so the per-feed subtraction breaks
-    # (feed 0 keeps a −R_BIG residue). Build the reference by Y-matrix
-    # superposition — N native voltage solves compose the true driving-point
-    # impedances. Falls through to the R_BIG path if it can't run (e.g. no
-    # nec2c) so behaviour is never worse than before.
-    if (ref is None or ref.get("error")) and sum(ex6_feeds) >= 2 and all(ex6_feeds):
+    # All-current EX 6 decks (issues #463, #464): the R_BIG emulation can't
+    # force the port current cleanly whenever a network shares the driven
+    # segment — one solve can't hold N simultaneous currents (#463), and even a
+    # single source's series R_BIG is bypassed by a co-located TL/NT so the raw
+    # readout is a composition artifact (#464). Build the reference by Y-matrix
+    # superposition instead — native voltage solves compose the true
+    # driving-point impedances, correct for N ≥ 1 with or without a TL. Falls
+    # through to the R_BIG path if it can't run (e.g. no nec2c) so behaviour is
+    # never worse than before.
+    if (ref is None or ref.get("error")) and sum(ex6_feeds) >= 1 and all(ex6_feeds):
         sup = superposition_reference(text, deck_path.name, timeout, mem_bytes)
         if sup is not None and not sup.get("error"):
             ref = sup
@@ -1077,8 +1088,8 @@ def print_report(rows, engines):
         "  flags: g = unsupported ground (radials/cliff), n = inexpressible LD/TL/NT "
         "network, v = remote TL-anchor wire(s) virtualized (#427),"
         " r = reference from resolved deck (#439),"
-        " t = EX 6 feed shares a TL/NT segment; R_BIG subtraction skipped (#456),"
-        " s = multi-source EX 6 reference via Y-matrix superposition (#463)"
+        " t = mixed EX 6 feed shares a TL/NT segment; R_BIG subtraction skipped (#456),"
+        " s = EX 6 current-source reference via Y-matrix superposition (#463, #464)"
     )
     print("=" * 104)
     hdr = (

--- a/tests/test_bench_ex6_superposition.py
+++ b/tests/test_bench_ex6_superposition.py
@@ -1,12 +1,24 @@
-"""Multi-source EX 6 reference via Y-matrix superposition (issue #463).
+"""EX 6 current-source reference via Y-matrix superposition (issues #463, #464).
 
 nec2c has no port current source, and the single-R_BIG emulation (issue #442)
-can't force N simultaneous port currents — on a phased active-feed deck the
-per-feed readout comes out R_BIG-invariant, so the subtraction manufactures a
-huge negative resistance (3vertical.nec: feed 0 reads −18,972 + 258j, engines
-disagree at ΔΓ 0.43). ``superposition_reference`` recovers the physics with
-native voltage drives: N solves → port admittance matrix → invert to Z →
-compose the driving-point impedances V = Z·I for the deck's current vector.
+breaks whenever a network shares the driven segment:
+
+  * Multi-source (#463): one R_BIG solve can't force N simultaneous port
+    currents — on a phased active-feed deck the per-feed readout comes out
+    R_BIG-invariant, so the subtraction manufactures a huge negative resistance
+    (3vertical.nec: feed 0 reads −18,972 + 258j, engines disagree at ΔΓ 0.43).
+  * Single-source sharing a TL (#464): the network port bypasses the series
+    ``LD 4 R_BIG`` (a 20 kΩ load carrying 200+ A), so the raw readout is a NEC
+    LD-plus-network composition artifact, not the driving-point impedance
+    (BRDZPR10.NEC: raw 88.5 − 11.6j vs true 34.9 + 45.1j, engines disagree at
+    ΔΓ 0.58). #456's "trust the R_BIG-invariant readout" skip trusts the wrong
+    number here — the fix is to route these through superposition too.
+
+``superposition_reference`` recovers the physics with native voltage drives: N
+solves → port admittance matrix → invert to Z → compose the driving-point
+impedances V = Z·I for the deck's current vector. The N = 1 case degenerates to
+one 1 V solve whose Z = V/I is the (source-type-independent) driving-point
+impedance, correct with or without a co-located TL.
 
 The strongest check is the physics oracle: a multiport driven by known port
 currents has a driving-point impedance the *engine* also computes (momwire uses
@@ -58,14 +70,30 @@ def test_reference_deck_drop_strips_ex6_emulation():
     assert "GW" in mnems and "XQ" in mnems  # geometry + an execute request remain
 
 
-def test_superposition_none_for_single_source():
-    """One EX 6 feed is not this path's job (the R_BIG emulation handles it) —
-    returns None before any nec2c solve."""
-    one = (
+# A single EX 6 current source whose driven segment (wire 1, seg 1) also anchors
+# a TL to wire 2 — the minimal deck that breaks the single-R_BIG emulation via a
+# co-located network (issue #464). The series R_BIG is bypassed by the TL port,
+# so nec2c's raw readout is a composition artifact, not the driving-point Z.
+_TL_SHARED1 = (
+    "CE\n"
+    "GW 1 15 -30 0 0 -30 0 20 0.05\n"
+    "GW 2 15 30 0 0 30 0 20 0.05\n"
+    "GE 1\nGN 1\n"
+    "TL 1 1 2 1 50 5.0\n"
+    "EX 6 1 1 0 1 0\n"
+    "FR 0 1 0 0 7 0\nEN\n"
+)
+
+
+def test_superposition_none_for_no_ex6_sources():
+    """A deck with no EX 6 current source is not this path's job (the voltage
+    reference or R_BIG emulation handle it) — returns None before any nec2c
+    solve."""
+    none = (
         "CE\nGW 1 15 -30 0 0 -30 0 20 0.05\nGE 1\nGN 1\n"
-        "EX 6 1 1 0 1 0\nFR 0 1 0 0 7 0\nEN\n"
+        "EX 0 1 1 0 1 0\nFR 0 1 0 0 7 0\nEN\n"
     )
-    assert bnc.superposition_reference(one, "one", 60.0, None) is None
+    assert bnc.superposition_reference(none, "none", 60.0, None) is None
 
 
 def test_superposition_errors_on_zero_drive_current():
@@ -114,6 +142,55 @@ def test_superposition_matches_engine_on_phased_pair():
     assert len(z_ref) == len(z_eng) == 2
     for zr, ze in zip(z_ref, z_eng):
         assert abs(zr - ze) / abs(ze) < 0.03, f"ref {zr:.1f} vs engine {ze:.1f}"
+
+
+@needs_nec2c
+def test_superposition_single_source_sharing_tl_matches_engine():
+    """Issue #464: a *single* EX 6 current source whose segment also anchors a
+    TL. The R_BIG emulation's series load is bypassed by the network port, so
+    nec2c's raw readout is a composition artifact, not the driving-point Z —
+    the superposition path (one 1 V solve, TL intact) recovers the true Z, which
+    the engine's real MNA current source also computes. They must agree; the old
+    R_BIG readout would not."""
+    from antennaknobs import AntennaBuilder, WireSpec
+    from antennaknobs.engines import MomwireEngine
+    from antennaknobs.nec_import import parse_nec
+    from momwire import SinusoidalSolver
+
+    sup = bnc.superposition_reference(_TL_SHARED1, "tlshared1", 60.0, None)
+    assert sup is not None and sup.get("error") is None
+    assert sup["superposition"] is True
+    assert len(sup["z"]) == 1  # the N = 1 degenerate case is handled, not skipped
+    z_ref = complex(*sup["z"][0])
+
+    deck = parse_nec(_TL_SHARED1, name="tlshared1", network=True)
+
+    class B(AntennaBuilder):
+        default_params = {"freq": 7.0}
+
+        def build_wires(self):
+            return deck.wire_tuples()
+
+        def build_network(self):
+            return deck.network()
+
+        def build_wire_material(self):
+            return WireSpec(radius=deck.dominant_radius())
+
+    z_eng = MomwireEngine(B(), solver=SinusoidalSolver, ground="pec").impedance()[0]
+    assert abs(z_ref - z_eng) / abs(z_eng) < 0.02, f"ref {z_ref:.2f} vs eng {z_eng:.2f}"
+
+    # Guard against a silent revert to the #456 raw-readout reference: the R_BIG
+    # emulation's readout is materially different from the true driving-point Z,
+    # so the superposition number must NOT coincide with it.
+    prepared = bnc.reference_deck(_TL_SHARED1, "tlshared1")  # ex6="rbig"
+    raw = bnc.run_nec2c(
+        Path("unused-when-deck_text-given.nec"), 60.0, deck_text=prepared
+    )
+    z_raw = complex(*raw["z"][0])
+    assert abs(z_ref - z_raw) / abs(z_ref) > 0.05, (
+        f"superposition {z_ref:.2f} suspiciously close to R_BIG artifact {z_raw:.2f}"
+    )
 
 
 @needs_nec2c


### PR DESCRIPTION
## What #464 turned out to be

Issue #464 filed `BRDZPR10.NEC` / `ZLTROM10.nec` (a single `EX 6` current source whose driven segment also anchors a `TL`) as an **engine-side reducer bug** — both engines disagreed with the nec2c reference at ΔΓ 0.58 / 0.78, in lockstep. **It's the reference that's wrong, not our engines.**

### The proof

A driving-point impedance is **source-type independent**: `V/I` at a port is identical whether you force the voltage or the current. So the cleanest truth is nec2c's *own* plain 1 V voltage drive (TL intact, no R_BIG):

| case | Z reported | segment I |
|------|-----------|-----------|
| TL + plain 1 V drive (**true Z_dp**) | **34.9 + 45.1j** | 0.011 A |
| no-TL + R_BIG (subtract → 58.0) | 20058 + 45.7j | 1.0 A ✓ |
| TL + R_BIG (**the #456 reference**) | **88.5 − 11.6j** | **222 A** |

Our engines give **33.2 + 44.6j** — matching nec2c's own voltage drive, not the 88.5 R_BIG readout.

### The mechanism

The R_BIG emulation (issue #442) works perfectly on an *isolated* segment: it forces ≈1 A and the subtraction recovers Z. But when the driven segment is **also a TL/NT port**, NEC **bypasses** the series `LD 4 R_BIG` — a 20 kΩ load carries 222 A at R_BIG = 2e4 — so the raw readout is a NEC LD-plus-network composition artifact, not an impedance. #456's assumption that an *R_BIG-invariant* readout is trustworthy is false; invariance just means the load dropped out, not that the number is a driving-point impedance.

## The fix

Extend the #463 Y-matrix superposition reference (native voltage drives, TL intact) to **N ≥ 1**. For N = 1 it degenerates to one 1 V solve whose `Z = V/I` is exactly the driving-point impedance — correct with or without a co-located TL. Single-source all-current EX 6 decks now take this path; the R_BIG emulation + `feeds_sharing_tl_nt` skip remains only as a fallback (no nec2c) and for mixed EX 0/EX 6 decks.

Two-line logic change (`n < 2` → `n < 1`; `sum(ex6_feeds) >= 2` → `>= 1`), plus docstrings/legend and a status-note correction.

## Results

- BRDZPR10: ΔΓ 0.584 → **0.0003** (PyNEC), 0.585 → **0.0015** (sin)
- ZLTROM10: ΔΓ 0.779 → **0.0002** / 0.780 → **0.0011**
- No regression on isolated single-source or multi-source decks; full suite **2304 passed**.

## Tests

Adds a single-source-sharing-a-TL physics oracle: the superposition reference must match the engine's real MNA current source, and is guarded against silently coinciding with the R_BIG artifact (so a revert to the #456 path fails the test). The old `single_source → None` contract test is replaced by `no_ex6_sources → None`.

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)