### PR TITLE
PyNEC gn 2 near-ground defect (#448): diagnosis, solve-time warning, corpus flag

### DIFF
--- a/scripts/bench_nec_corpus.py
+++ b/scripts/bench_nec_corpus.py
@@ -936,6 +936,24 @@ def feeds_sharing_tl_nt(deck) -> list[int]:
     return [i for i, f in enumerate(deck.feeds) if (f.wire, f.seg) in anchored]
 
 
+def _has_near_ground_ungrounded_wire(deck, freq_mhz: float) -> bool:
+    """The geometry class where nec2++/PyNEC's gn 2 Sommerfeld is known-
+    unreliable (issue #448): near-ground conductor that is not a plain
+    grounded vertical. Delegates to the engine's own risk predicate
+    (`engines.pynec._somm_low_wire_risk` — the same one behind the
+    RuntimeWarning PyNECEngine emits at solve time) so the flag and the
+    warning can never drift apart."""
+    try:
+        from antennaknobs.engines.pynec import _somm_low_wire_risk
+    except ImportError:  # PyNEC absent: no pynec rows to annotate anyway
+        return False
+    try:
+        tups = deck.wire_tuples(specs=True)
+    except Exception:  # noqa: BLE001 — a flag, never a crash
+        return False
+    return bool(_somm_low_wire_risk(tups, 299.792458 / freq_mhz))
+
+
 def bench_deck(
     deck_path: Path,
     engines,
@@ -1044,6 +1062,18 @@ def bench_deck(
         return row
     row["freq"] = freq
 
+    # nec2++/PyNEC's Sommerfeld (gn 2) is known-unreliable when a conductor
+    # sits within 0.1 wavelength of the ground plane without touching it
+    # (issue #448; calibrated on this corpus — all 19 decks where PyNEC broke
+    # against an agreeing nec2c+momwire pair are in this class). A large
+    # pynec dgamma on a flagged deck is the known engine defect, not an
+    # import/translation signal.
+    row["pynec_somm_suspect"] = (
+        isinstance(ground, tuple)
+        and ground[0] == "finite"
+        and _has_near_ground_ungrounded_wire(deck, freq)
+    )
+
     eng_ground = ground if run_with_ground else "free"
     row["engines"] = {}
     for e in engines:
@@ -1089,7 +1119,8 @@ def print_report(rows, engines):
         "network, v = remote TL-anchor wire(s) virtualized (#427),"
         " r = reference from resolved deck (#439),"
         " t = mixed EX 6 feed shares a TL/NT segment; R_BIG subtraction skipped (#456),"
-        " s = EX 6 current-source reference via Y-matrix superposition (#463, #464)"
+        " s = EX 6 current-source reference via Y-matrix superposition (#463, #464),"
+        " p = gn 2 + near-ground ungrounded wire: pynec known-unreliable (#448)"
     )
     print("=" * 104)
     hdr = (
@@ -1107,6 +1138,7 @@ def print_report(rows, engines):
             + ("r" if r.get("nec2c", {}).get("resolved_deck") else "")
             + ("t" if r.get("nec2c", {}).get("ex6_tl_shared") else "")
             + ("s" if r.get("nec2c", {}).get("superposition") else "")
+            + ("p" if r.get("pynec_somm_suspect") else "")
         )
         cells = " ".join(f"{fmt_dg(r['engines'].get(e)):>11}" for e in engines)
         print(

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -205,7 +205,11 @@ is uniform: every momwire solver honours both models (Sommerfeld
 validated against an independent NEC-2 implementation down to 0.02λ —
 within ~2.4 Ω on the B-spline bases, ~0.1 Ω on the sinusoidal basis, and
 the accelerators solve it on their fast paths), and PyNEC honours both
-natively. The far-field pattern uses the real εr/σ on every basis.
+natively — with one caveat: PyNEC's (nec2++'s) Sommerfeld solve is
+known-unreliable for conductors within 0.1λ of the ground that don't
+touch it (low radials, half-squares, slopers — the engine warns; use a
+momwire engine as the reference in that configuration). The far-field
+pattern uses the real εr/σ on every basis.
 Whatever runs, the solve readout's **ground** row reports the model that
 was actually used, and over a finite ground the
 [norm check](#norm-check--is-the-solve-trustworthy) readout becomes a

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 
 import numpy as np
 import PyNEC as nec
@@ -42,6 +43,58 @@ WIRE_CONDUCTIVITY = None
 DEFAULT_GROUND = ("finite", 10.0, 0.002)  # (kind, dielectric, conductivity)
 
 
+def _somm_low_wire_risk(tups, wavelength):
+    """Geometry classes where nec2++'s gn 2 Sommerfeld is known-unreliable
+    (issue #448): near-ground conductor that is not a plain grounded
+    vertical. True when either
+
+      (a) some wire endpoint sits in (0, 0.1λ) on a connected component
+          with no z = 0 point (low radial fields at small height, hanging
+          open ends of half-squares / bobtails / slopers), or
+      (b) some wire runs horizontally (> 0.05λ horizontal extent) with
+          both endpoints below 0.1λ (beverages and other low runs, which
+          break even when their ends ARE grounded).
+
+    Ground-connected verticals — including ones split into several wires
+    with interior joints below 0.1λ — are exempt via the connectivity
+    analysis in (a); they are the empirically clean class. Calibrated on
+    the wild corpus (2026-07-20): the union covers 19/19 decks where
+    PyNEC's gn 2 broke against an agreeing nec2c+momwire pair.
+    """
+    lo, hi = 1e-6 * wavelength, 0.1 * wavelength
+
+    # (b) low horizontal run
+    for tup in tups:
+        p1, p2 = tup[0], tup[1]
+        horiz = float(np.hypot(p2[0] - p1[0], p2[1] - p1[1]))
+        if horiz > 0.05 * wavelength and max(float(p1[2]), float(p2[2])) < hi:
+            return True
+
+    # (a) near-ground endpoint on an ungrounded component: union-find over
+    # (rounded) endpoint coordinates.
+    pts: dict = {}
+
+    def pid(pt):
+        key = (round(float(pt[0]), 6), round(float(pt[1]), 6), round(float(pt[2]), 6))
+        return pts.setdefault(key, len(pts))
+
+    edges = [(pid(t[0]), pid(t[1])) for t in tups]
+    parent = list(range(len(pts)))
+
+    def find(a):
+        while parent[a] != a:
+            parent[a] = parent[parent[a]]
+            a = parent[a]
+        return a
+
+    for a, b in edges:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+    grounded = {find(i) for key, i in pts.items() if key[2] <= lo}
+    return any(lo < key[2] < hi and find(i) not in grounded for key, i in pts.items())
+
+
 class PyNECEngine(SimulationEngine):
     supports_far_field = True
     # NEC's source placement uses (n_seg+1)//2, which lands on the centre
@@ -64,7 +117,13 @@ class PyNECEngine(SimulationEngine):
           "pec"                          — perfectly conducting ground
           ("finite", eps_r, sigma)       — Sommerfeld-Norton finite ground
                                            (default, matches the historical
-                                           hard-coded eps_r=10, sigma=0.002)
+                                           hard-coded eps_r=10, sigma=0.002).
+                                           CAVEAT (#448): nec2++'s gn 2 is
+                                           known-unreliable for conductors
+                                           within 0.1λ of the plane that
+                                           don't touch it — the engine warns
+                                           and momwire/nec2c should be
+                                           trusted there.
           ("finite-fast", eps_r, sigma)  — finite ground via NEC's reflection-
                                            coefficient approximation. Much
                                            cheaper than Sommerfeld and within
@@ -130,6 +189,8 @@ class PyNECEngine(SimulationEngine):
         # Network, the engine drives ex_card/tl_card calls off the spec instead.
         self.tls = [] if self._network is not None else builder.build_tls()
         self.ground = ground
+        # One warning per instance for the gn 2 near-ground defect (#448).
+        self._somm_lowz_warned = False
         self.excitation_pairs = None
         # Fraction of input power radiated; set by current_distribution() when
         # the design carries resistive loads (e.g. a terminated rhombic). The
@@ -715,7 +776,49 @@ class PyNECEngine(SimulationEngine):
             c.ex_card(0, tag, seg, 0, v.real, v.imag, 0, 0, 0, 0)
         return c
 
+    def _warn_if_somm_low_wires(self, wavelength):
+        """nec2++'s Sommerfeld (gn 2) solve is known-unreliable for conductors
+        that run NEAR the ground plane (issue #448).
+
+        Measured (momwire's golden-capture controls, 2026-07-06, and the
+        wild-corpus triage, 2026-07-20): on identical geometry PyNEC's gn 2
+        agrees with nec2c/nec2dxs/momwire to well under 1% for structure
+        0.1λ and higher, and for plain ground-connected verticals (the
+        z = 0 junction NEC handles specially) — but low radial fields,
+        low-hanging open ends (half-squares, bobtails, slopers), and long
+        low horizontal runs (beverages) put the solve in an erratic
+        regime: reflection-coefficient (gn 0) results on the same deck
+        stay faithful while gn 2 lands ~7–8× off in the real part (e.g.
+        9.5 − 70.9j vs the three-way-agreed 32.1 − 3.5j on a 300 MHz
+        monopole with radials at 0.002λ). The risk predicate below —
+        a near-ground endpoint on a component not connected to z = 0, OR
+        any low horizontal run — covers all 19 wild-corpus decks where
+        PyNEC broke against an agreeing nec2c+momwire pair, and exempts
+        plain grounded verticals. The defect is erratic, so a clean
+        result on a flagged geometry is luck, not health: trust momwire
+        or nec2c there. Warns once per engine instance.
+        """
+        if self._somm_lowz_warned or not (
+            isinstance(self.ground, tuple) and self.ground[0] == "finite"
+        ):
+            return
+        if _somm_low_wire_risk(self.tups, wavelength):
+            self._somm_lowz_warned = True
+            warnings.warn(
+                "PyNEC/nec2++'s Sommerfeld ground (gn 2) is known-"
+                "unreliable for conductors running within 0.1 wavelength "
+                "of the ground plane (low radials, low open ends, low "
+                "horizontal runs — antennaknobs #448): results in this "
+                "configuration are erratic even when they look plausible. "
+                "Use a momwire engine (or nec2c) as the reference here, or "
+                "the 'finite-fast' reflection-coefficient ground for "
+                "comparisons.",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+
     def _set_freq_and_execute(self):
+        self._warn_if_somm_low_wires(C_LIGHT / (self.builder.freq * 1e6))
         self.c.fr_card(0, 1, self.builder.freq, 0)
         self.c.xq_card(0)
 
@@ -753,6 +856,7 @@ class PyNECEngine(SimulationEngine):
     def impedance(self, sum_currents=False):
         if self._use_reducer:
             wl = C_LIGHT / (self.builder.freq * 1e6)
+            self._warn_if_somm_low_wires(wl)
             return self._reducer.driven_impedance(self._compute_y_matrix(wl), wl)
         self._set_freq_and_execute()
         return self._impedances_at(0, sum_currents=sum_currents)
@@ -761,6 +865,8 @@ class PyNECEngine(SimulationEngine):
         freqs = np.asarray(freqs, dtype=float)
         if freqs.ndim != 1 or freqs.size == 0:
             raise ValueError("freqs must be a 1-D non-empty array")
+        # Shortest wavelength in the sweep flags the most wires — check once.
+        self._warn_if_somm_low_wires(C_LIGHT / (float(freqs.max()) * 1e6))
         if self._use_reducer:
             zs = np.empty((freqs.size, self._reducer.n_driven), dtype=np.complex128)
             for k, f in enumerate(freqs):

--- a/tests/test_pynec_ground.py
+++ b/tests/test_pynec_ground.py
@@ -107,3 +107,79 @@ def test_ge_flag_stays_zero_when_nothing_touches_ground():
     assert eng_free._ge_flag() == 0
     eng_gnd = PyNECEngine(_GroundedMonopole(), ground="pec")
     assert eng_gnd._ge_flag() == 1
+
+
+# ---------------------------------------------------------------------------
+# gn 2 near-ground defect warning (issue #448)
+# ---------------------------------------------------------------------------
+#
+# nec2++'s Sommerfeld solve is known-unreliable for near-ground conductors
+# that aren't plain grounded verticals (measured against nec2c/nec2dxs/
+# momwire agreement on the wild corpus). The engine warns on the calibrated
+# risk predicate; these tests pin when it fires and — as importantly — when
+# it must not.
+
+_GN2 = ("finite", 10.0, 0.002)
+
+
+def _warns_gn2(builder, ground):
+    import warnings as _w
+
+    with _w.catch_warnings(record=True) as rec:
+        _w.simplefilter("always")
+        PyNECEngine(builder, ground=ground).impedance()
+    return sum(
+        1
+        for x in rec
+        if issubclass(x.category, RuntimeWarning) and "gn 2" in str(x.message)
+    )
+
+
+def test_somm_low_horizontal_wire_warns_once():
+    """A flat dipole at 0.03 wavelength over gn 2 is squarely in the broken
+    class (the golden capture's own minimal repro); one warning per engine
+    instance even across repeated solves."""
+    import warnings as _w
+
+    eng = PyNECEngine(_flat_dipole(0.3), ground=_GN2)
+    with _w.catch_warnings(record=True) as rec:
+        _w.simplefilter("always")
+        eng.impedance()
+        eng.impedance()
+    hits = [x for x in rec if "gn 2" in str(x.message)]
+    assert len(hits) == 1
+    assert "#448" in str(hits[0].message)
+
+
+def test_somm_low_hanging_open_end_warns():
+    """Half-square/bobtail/sloper class: a vertical whose open end hangs
+    near the plane without touching it (connectivity path of the risk
+    predicate — no horizontal wire anywhere near the ground)."""
+    from types import MappingProxyType
+
+    from antennaknobs import AntennaBuilder
+
+    class HalfSquareish(AntennaBuilder):
+        default_params = MappingProxyType({"freq": 28.57})
+
+        def build_wires(self):
+            lam = 299.792458 / 28.57
+            top = 0.3 * lam
+            return [
+                ((0.0, 0.0, 0.3), (0.0, 0.0, top), 15, 1 + 0j),  # hangs at 0.3 m
+                ((0.0, 0.0, top), (0.0, 0.5 * lam, top), 21, None),
+                ((0.0, 0.5 * lam, top), (0.0, 0.5 * lam, 0.3), 15, None),
+            ]
+
+    assert _warns_gn2(HalfSquareish(), _GN2) == 1
+
+
+def test_somm_warning_exemptions():
+    """No warning for: elevated structure on gn 2; the same low structure on
+    the reflection-coefficient ground (gn 0 stays faithful); and a plain
+    ground-connected vertical — even split into wires with an interior
+    joint below 0.1 wavelength (the connectivity analysis, not a naive
+    endpoint-height test, is what exempts it)."""
+    assert _warns_gn2(_flat_dipole(4.0), _GN2) == 0
+    assert _warns_gn2(_flat_dipole(0.3), ("finite-fast", 10.0, 0.002)) == 0
+    assert _warns_gn2(_GroundedMonopole(), _GN2) == 0


### PR DESCRIPTION
## Summary
- **Root cause found — the issue's framing was wrong.** The 7–8× real-part divergence is not a high-|Z|/anti-resonance failure: it is nec2++'s *documented* Sommerfeld low-height breakage (momwire golden-capture, 2026-07-06) surfacing in the wild corpus. Controls: gn 0 on identical geometry agrees <1%; gn 2 diverges; raising the structure +0.2λ heals gn 2 to <0.5%. (The "free-space so ground isn't the factor" note in the issue came from a same-named Tutorial-1 deck.)
- **Corpus calibration**: 19 finite-ground decks have PyNEC ΔΓ>0.05 while momwire-sin agrees with nec2c <0.02 — all in one class: near-ground conductor that isn't a plain grounded vertical. Risk predicate = (endpoint in (0,0.1λ) on an ungrounded component) ∪ (low horizontal run); 19/19 covered, grounded verticals exempt via connectivity.
- `PyNECEngine` warns once per instance on gn 2 + flagged geometry; `bench_nec_corpus` rows gain `pynec_somm_suspect` (flag `p`) delegating to the same predicate; `web.md` carries the caveat.
- Upstream defect is in nec2++ (`pynec-accel`); tracked separately for a real fix.

## Test plan
- [x] New warning tests: fires once on the golden-repro low dipole and a hanging-open-end half-square-alike; exempt: elevated gn 2, gn 0, split grounded monopole
- [x] Full suite 2300 passed; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmgjJwcpzBa3sUzpKj7tKw