### PR TITLE
Reparameterize ELT whip: derive redundant knobs, add a λ/10 coarse variant

### DIFF
--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -77,7 +77,7 @@ whole shape with a `Drone` — see
 | `verticals.bruce` | Bruce array: a series-fed vertically-polarised curtain (L. B. Cebik, W4RNL) |
 | `verticals.challenger` | KJ6ER's "Challenger" — off-center-fed halfwave vertical with 4:1 unun · variants: `band10`, `band12`, `band17`, `band20`, `band6`, `plus` |
 | `verticals.dominator` | KJ6ER's "Dominator" — end-fed halfwave vertical with 49:1 transformer · variants: `band10`, `band12`, `band17`, `plus` |
-| `verticals.elt_whip` | Parametric rebuild of the ELT whip on a 96-inch rounded ground-plane grid — the heavier of the two classic NEC performance benchmarks (``whip_antenna_8ft_groundplane.nec`` from the W8IO NEC benchmarks page, http://www.w8io.com/nec-benchmarks.htm): 434 deck wires, ~4,400 segments |
+| `verticals.elt_whip` | Parametric rebuild of the ELT whip on a 96-inch rounded ground-plane grid — the heavier of the two classic NEC performance benchmarks (``whip_antenna_8ft_groundplane.nec`` from the W8IO NEC benchmarks page, http://www.w8io.com/nec-benchmarks.htm): 434 deck wires, ~4,400 segments · variants: `coarse` |
 | `verticals.four_square` | Four-square phased vertical array -- the diagonal-firing quadrature box (L. B. Cebik, W4RNL) |
 | `verticals.half_square` | Half-square: a vertically-polarised wire antenna (L. B. Cebik, W4RNL) |
 | `verticals.inverted_l` | Inverted-L: a bent, top-loaded vertical (L. B. Cebik, W4RNL) |

--- a/src/antennaknobs/designs/verticals/elt_whip.py
+++ b/src/antennaknobs/designs/verticals/elt_whip.py
@@ -149,9 +149,11 @@ class Builder(AntennaBuilder):
             # leaving that post a plain wire.
             "post_l_nh": 90.0,
             "post_c_pf": 3.0,
-            # Ground-plane grid (deck: 48" radius, 2" mesh, 1" fine mesh). The
-            # fine centre mesh runs at half the grid pitch (fixed 2× subdivision),
-            # so fine_pitch is derived from grid_pitch, not a knob.
+            # Ground-plane grid (deck: 48" radius, 2" mesh, 1" fine mesh) — the
+            # default reproduces the deck verbatim. The fine centre mesh is always
+            # half the grid pitch (fixed 2× subdivision), so fine_pitch is derived
+            # from grid_pitch, not a knob. The `coarse` variant runs a coarser
+            # ground screen for a lighter solve (see its note).
             "plane_radius": 1.2192,
             "grid_pitch": 0.0508,
             "wire_radius": 0.000254,
@@ -178,6 +180,17 @@ class Builder(AntennaBuilder):
             ),
         }
     )
+
+    # Coarser ground screen held just inside the λ/10 wire-grid-as-conductor
+    # rule of thumb: 17 cells across the 48" plane → 71.7 mm pitch ≈ λ/10.3 at
+    # 406 MHz (the default's 50.8 mm is λ/14.5; a full 2× coarsening would reach
+    # λ/7.3 and detune the match). ~1.8× fewer segments (4392 → 2472) — and since
+    # the dense MoM is O(n²) memory / O(n³) time, roughly 3× less memory and ~5×
+    # faster — while the screen still acts as a conductor, so the matched
+    # impedance stays in spec (≈ 57 + 14j vs the default's 60 + 8.5j) and the
+    # bare radiator is unchanged (≈ 1.6 + 33j). Only the passive ground plane is
+    # coarsened; the active feed/cage sleeve keeps its full resolution.
+    coarse_params = MappingProxyType({"grid_pitch": 1.2192 / 17})
 
     def build_wires(self):
         h = self.height

--- a/src/antennaknobs/designs/verticals/elt_whip.py
+++ b/src/antennaknobs/designs/verticals/elt_whip.py
@@ -12,15 +12,22 @@ paths and segment boundaries reproduce the deck to well under 0.1 mm
 truncated literal .216506). The structure:
 
   * **Whip** — a thin lower section (fed on its bottom segment, exactly where
-    the deck's EX card drives it) and a thicker upper section.
+    the deck's EX card drives it) and a thicker upper section, whose segment
+    count scales with ``nominal_nsegs`` via ``segs_for`` (28 at the default
+    mesh, matching the deck; see ``_WHIP_UPPER_REF``).
   * **Cage/sleeve** — a ring of ``num_cage_wires`` verticals at
     ``cage_radius`` around the lower whip, tied by a polygon ring every
-    ``cage_ring_spacing``, bonded to the whip by ``num_spokes`` spokes at
-    ``cage_base`` and to the ground mesh by ``num_posts`` grounded posts.
+    ``cage_ring_spacing``, bonded to the whip by ``num_spokes`` spokes one
+    ring-spacing up and to the ground mesh by ``num_posts`` grounded posts.
   * **Ground plane** — a wire grid at ``grid_pitch``, trimmed to a rounded
     outline of radius ``plane_radius``, with the central row/column and the
-    centre 2x2 cells re-meshed at ``fine_pitch``, and the feed row split
+    centre 2x2 cells re-meshed at half the grid pitch, and the feed row split
     at the post feet (at ``cage_radius``-length segments, as in the deck).
+
+Three quantities the deck fixes are derived rather than exposed as knobs:
+the cage's bottom-ring height (= ``cage_ring_spacing``), the fine-mesh pitch
+(= ``grid_pitch`` / 2), and the upper-whip segment count (from
+``nominal_nsegs``). Reparameterized 2026-07-20.
 
 Every mesh crossing is emitted as a wire *endpoint* junction (unit cell
 edges), so the geometry survives the engines' odd-parity re-segmentation —
@@ -63,6 +70,15 @@ from types import MappingProxyType
 
 from antennaknobs import AntennaBuilder, Wire, WireSpec
 from antennaknobs.network import Driven, Load, Network, PortOnWire
+
+# Reference length for the thick upper whip's segment count. The deck meshes its
+# 15.75" (0.40005 m) top section into 28 segments; dividing that length by the
+# default nominal_nsegs (21) and multiplying back gives a fixed reference so
+# ``segs_for(whip_upper_len, _WHIP_UPPER_REF)`` reproduces the deck's 28 segments
+# at the default mesh and refines proportionally under a convergence sweep. It is
+# a constant, NOT the live ``whip_upper_len`` — that is what lets ``segs_for``
+# track the wire's length rather than pin the count.
+_WHIP_UPPER_REF = 0.40005 * 21 / 28  # ≈ 0.30004 m
 
 # Half-extent of each ground-grid column, in cells: column i (x = i * pitch)
 # runs to y = +/-extent * pitch. Sampled from the source deck's hand-drawn
@@ -113,14 +129,16 @@ class Builder(AntennaBuilder):
         {
             "freq": 406.0,  # MHz — deck FR sweep centre (400-412)
             "height": 1.0,  # metres above the app's ground plane
-            # Whip (deck: 7" thin fed section + 15.75" thick top section)
+            # Whip (deck: 7" thin fed section + 15.75" thick top section). The
+            # upper section's segment count derives from nominal_nsegs via
+            # segs_for (28 at the default mesh); see _WHIP_UPPER_REF.
             "whip_lower_len": 0.1778,
             "whip_upper_len": 0.40005,
-            "whip_upper_segs": 28,
             # Cage/sleeve around the lower whip (deck: 12 wires at 0.25",
-            # rings every 0.5", 2 grounded posts, 4 spokes at z = 0.5")
+            # rings every 0.5", 2 grounded posts, 4 spokes at z = 0.5"). The
+            # cage's bottom ring (and the feed segment) sits one ring-spacing up,
+            # so cage_base is derived from cage_ring_spacing, not a knob.
             "cage_radius": 0.00635,
-            "cage_base": 0.0127,
             "cage_ring_spacing": 0.0127,
             "num_cage_wires": 12,
             "num_posts": 2,
@@ -131,10 +149,11 @@ class Builder(AntennaBuilder):
             # leaving that post a plain wire.
             "post_l_nh": 90.0,
             "post_c_pf": 3.0,
-            # Ground-plane grid (deck: 48" radius, 2" mesh, 1" fine mesh)
+            # Ground-plane grid (deck: 48" radius, 2" mesh, 1" fine mesh). The
+            # fine centre mesh runs at half the grid pitch (fixed 2× subdivision),
+            # so fine_pitch is derived from grid_pitch, not a knob.
             "plane_radius": 1.2192,
             "grid_pitch": 0.0508,
-            "fine_pitch": 0.0254,
             "wire_radius": 0.000254,
             # The thick top whip section's own radius (deck: 0.035");
             # rides as a per-wire spec on just that wire (issue #388).
@@ -150,7 +169,6 @@ class Builder(AntennaBuilder):
                     # tabs honest: (key, label, freq, min, max).
                     "bands": (("406", "406 MHz", 406.0, 400.0, 412.0),),
                     # integer knobs, not continuous lengths
-                    "whip_upper_segs": {"min": 4, "max": 56, "step": 1},
                     "num_cage_wires": {"min": 4, "max": 24, "step": 1},
                     "num_posts": {"min": 0, "max": 4, "step": 1},
                     "num_spokes": {"min": 0, "max": 12, "step": 1},
@@ -165,10 +183,10 @@ class Builder(AntennaBuilder):
         h = self.height
         pitch = self.grid_pitch
         n = max(2, round(self.plane_radius / pitch))  # plane radius, in cells
-        s = max(1, round(pitch / self.fine_pitch))  # fine cells per cell
+        s = 2  # fine cells per coarse cell — fine mesh at grid_pitch / 2
         r = max(1e-6, self.cage_radius)
-        base = self.cage_base
         spacing = self.cage_ring_spacing
+        base = spacing  # cage bottom ring / feed segment: one ring-spacing up
         l1 = self.whip_lower_len
         m_cage = max(3, round(self.num_cage_wires))
         n_posts = max(0, round(self.num_posts))
@@ -208,7 +226,7 @@ class Builder(AntennaBuilder):
             Wire(
                 (0.0, 0.0, l1 + h),
                 (0.0, 0.0, l1 + self.whip_upper_len + h),
-                max(1, round(self.whip_upper_segs)),
+                self.segs_for(self.whip_upper_len, _WHIP_UPPER_REF),
                 spec=WireSpec(radius=self.whip_upper_radius),
             )
         )

--- a/tests/test_elt_whip.py
+++ b/tests/test_elt_whip.py
@@ -77,7 +77,6 @@ def test_shrunken_knobs_build():
             {
                 "plane_radius": 0.6,
                 "grid_pitch": 0.1016,
-                "fine_pitch": 0.0508,
                 "num_cage_wires": 8,
                 "num_posts": 2,
                 "num_spokes": 4,

--- a/tests/test_elt_whip.py
+++ b/tests/test_elt_whip.py
@@ -89,6 +89,24 @@ def test_shrunken_knobs_build():
         assert math.dist(p0, p1) > 1e-9
 
 
+def test_coarse_variant_thins_only_the_ground_plane():
+    """The `coarse` variant coarsens the passive ground screen to just inside
+    the λ/10 rule of thumb — 17 cells across the 48" plane (pitch ≈ λ/10.3 at
+    406 MHz, the coarsest integer count under the limit) — and leaves the active
+    feed/cage sleeve at full resolution: markedly fewer segments than the
+    deck-verbatim default, an unchanged cage, and every wire well-formed."""
+    coarse = Builder(merge_params(Builder.default_params, Builder.coarse_params))
+    assert round(coarse.plane_radius / coarse.grid_pitch) == 17
+    assert coarse.num_cage_wires == Builder.default_params["num_cage_wires"]
+
+    full_segs = sum(_wire(w)[2] for w in Builder().build_wires())
+    coarse_segs = sum(_wire(w)[2] for w in coarse.build_wires())
+    assert coarse_segs == 2472  # 4392 (deck) thinned by the coarser screen
+    assert coarse_segs < 0.7 * full_segs
+    for p0, p1, _nseg, _ex, _name in map(_wire, coarse.build_wires()):
+        assert math.dist(p0, p1) > 1e-9
+
+
 @pytest.mark.antenna_computation_check
 def test_free_space_impedance_matches_benchmark():
     """Full-size PyNEC solves at the deck's 406 MHz centre.


### PR DESCRIPTION
## Summary

Tightens the ELT-whip benchmark design's knob set to just the genuine degrees of freedom, and adds a lighter variant for interactive/CI use. The default remains the deck-verbatim mesh (4067 wires / 4392 segments, byte-identical to `main`).

- **Derive three redundant knobs** (`47c8a63b`): `cage_base` = `cage_ring_spacing` (bottom ring / feed segment sits one ring-spacing up), `fine_pitch` = `grid_pitch / 2` (fixed 2× subdivision), and the upper-whip segment count → `segs_for(whip_upper_len, _WHIP_UPPER_REF)` so it tracks `nominal_nsegs` (28 at the default mesh, matching the deck; convergence sweeps now refine the whip, which they previously couldn't). Geometry verified byte-identical at default and off-default knobs.
- **Add a `coarse` variant** (`c68fadd7`): coarsens *only* the passive ground screen to just inside the λ/10 wire-grid-as-conductor rule of thumb — 17 cells across the 48″ plane → 71.7 mm ≈ λ/10.3 at 406 MHz. Result: 4392 → 2472 segments (~1.8×), and since the dense MoM is O(n²) memory / O(n³) time, roughly 3× less memory and ~5× faster, with the physics preserved (bare ≈ 1.6+33j, matched ≈ 57+14j — both in spec).
- **Why ground-only**: measured (PyNEC, free space) that coarsening the cage sleeve moves the feed and blows the bare impedance to 5+60j for ~12% savings, and a full 2× ground coarsening (λ/7.3, past the rule of thumb) detunes the match to 68+36j. The λ/10-respecting ground-only coarsening is the sweet spot.
- The variant auto-surfaces in the UI via `adapter._discover_variants`; no registration needed.

## Test plan
- [x] `pytest tests/test_elt_whip.py` — 7 passed (build pins for deck counts, well-formedness, shrunken knobs, the new coarse-variant geometry, plus the free-space PyNEC benchmark solve on the full default)
- [x] Default geometry byte-identical to `main` (wire+segment sha256) at default and shrunken-knobs params
- [x] `ruff check` / `ruff format --check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)