### PR TITLE
bench: NT-gyrator EX 6 reference — 4nec2's own emulation, EX6+TL family fully clears

### DIFF
--- a/docs/status/2026-07-19-meshing-rebaseline.md
+++ b/docs/status/2026-07-19-meshing-rebaseline.md
@@ -109,6 +109,36 @@ outlier bar. Three HFActiveFeed decks remain, in two distinct classes:
   land at ΔΓ ≤ 0.0015. Corrected references: **BRDZPR10 34.9 + 45.1j**,
   **ZLTROM10 33.6 + 28.6j**.
 
+### Addendum (2026-07-20): NT-gyrator reference lands, family fully clears (#475)
+
+The 4nec2 cross-check on #463 revealed how the authoring tool itself runs
+`EX 6` on a stock NEC-2 kernel: a phantom wire + `EX 0` + `NT` gyrator
+(Y12 = Y21 = j) forcing the requested current phasor into the real
+segment. That emulation is now the bench's **primary** EX 6 reference
+(superposition and R_BIG remain as fallbacks) — one nec2c solve, native
+TL/NT composition, mixed EX 0 + EX 6 support, readout
+Z = V_row / I_req from the STRUCTURE EXCITATION DATA table. It agrees
+with 4nec2/NEC-2D to all printed digits on 3vertical/2phased and with the
+superposition route to < 0.2 % everywhere both run.
+
+All 15 family rows (the 13 above + 2phased ×2) were re-run in place
+(backup: `wild-solve-2026-07-18-post455.jsonl.pre475` — the `t` flag is
+retired from live rows; they now carry `y`):
+
+| deck | reference (old → gyrator) | worst engine ΔΓ |
+|---|--:|--:|
+| BRDZPR10 | 88.5−11.6j → 34.9+45.1j | 0.0046 (was 0.58 lockstep) |
+| ZLTROM10 | 217.2+15.8j → 33.6+28.6j | 0.0105 (was 0.78 lockstep) |
+| LOGPERTL | 157.6−43.3j → 122.8−60.3j | 0.0073 (was 0.10) |
+| G3TXQ hexbeam | 54.2+6.6j → 44.4−9.9j | 0.0379 (was 0.19) |
+| 3vertical | −18972+258j → 119.2+165.2j | 0.0025 (was 0.43) |
+| the 8 already-clean + 2phased | unchanged (≤ 0.2 %) | ≤ 0.05 |
+
+Every deck in the class is now within the outlier bar on every engine
+(EDZ_TL's bs1 0.178 residue is pre-existing engine fidelity, not
+reference). #464's "engines lockstep-wrong" verdict is fully overturned:
+the engines were right; the reference was the artifact.
+
 ## Catalog re-baseline
 
 The catalog A/B was done PR-by-PR rather than as a separate sweep — every

--- a/scripts/bench_nec_corpus.py
+++ b/scripts/bench_nec_corpus.py
@@ -915,6 +915,219 @@ def superposition_reference(text: str, name: str, timeout: float, mem_bytes=None
     }
 
 
+def _nec2c_network_tables(deck_text: str, timeout: float, mem_bytes=None):
+    """Run nec2c on prepared text and return the first frequency's network
+    readout: ``{"freq": MHz, "struct": {(tag, abs_seg): (V, I, Z)},
+    "aip": {(tag, abs_seg): (V, I, Z)}, "error": str|None}``.
+
+    ``struct`` is the STRUCTURE EXCITATION DATA AT NETWORK CONNECTION POINTS
+    table (printed only when NT/TL cards are present), ``aip`` the ANTENNA
+    INPUT PARAMETERS table. Both key on (tag number, ABSOLUTE segment number)
+    — that is what nec2c prints in its SEG column, not the within-tag rank an
+    EX card uses. Values are complex (voltage, current, impedance) columns.
+    Parsing stops after the first ANTENNA INPUT PARAMETERS block with data so
+    a multi-frequency FR sweep reads like ``run_nec2c``: first frequency only.
+    """
+    if shutil.which("nec2c") is None:
+        return {"error": "nec2c not on PATH"}
+    with tempfile.TemporaryDirectory(prefix="nec_") as d:
+        nec = Path(d) / "d.nec"
+        out = Path(d) / "d.out"
+        nec.write_text(deck_text)
+        try:
+            subprocess.run(
+                ["nec2c", "-i", str(nec), "-o", str(out)],
+                capture_output=True,
+                timeout=timeout,
+                preexec_fn=_rlimit_preexec(mem_bytes) if mem_bytes else None,
+            )
+        except subprocess.TimeoutExpired:
+            return {"error": f"nec2c timeout >{timeout:.0f}s"}
+        if not out.exists():
+            return {"error": "nec2c produced no output"}
+        lines = out.read_text(errors="replace").splitlines()
+
+    def read_rows(i, rows):
+        j = i + 3  # header + units row, then data rows
+        while j < len(lines) and lines[j].strip():
+            toks = lines[j].split()
+            if len(toks) >= 8:
+                try:
+                    tag, seg = int(toks[0]), int(toks[1])
+                    vals = [float(t) for t in toks[2:8]]
+                except ValueError:
+                    j += 1
+                    continue
+                if not all(math.isfinite(v) for v in vals):
+                    return False
+                rows[(tag, seg)] = (
+                    complex(vals[0], vals[1]),
+                    complex(vals[2], vals[3]),
+                    complex(vals[4], vals[5]),
+                )
+            j += 1
+        return True
+
+    freq, struct, aip = None, {}, {}
+    for i, ln in enumerate(lines):
+        m = _FREQ_RE.search(ln)
+        if m:
+            freq = float(m.group(1))
+        if "STRUCTURE EXCITATION DATA AT NETWORK CONNECTION POINTS" in ln:
+            if not read_rows(i, struct):
+                return {"error": "nec2c network solve returned NaN"}
+        elif "ANTENNA INPUT PARAMETERS" in ln:
+            if not read_rows(i, aip):
+                return {"error": "nec2c solve returned NaN"}
+            if aip:
+                return {"freq": freq, "struct": struct, "aip": aip, "error": None}
+    return {"error": "no ANTENNA INPUT PARAMETERS block"}
+
+
+def gyrator_reference(text: str, name: str, deck, timeout: float, mem_bytes=None):
+    """EX 6 current-source reference via 4nec2's NT-gyrator emulation (#475).
+
+    This is byte-for-byte how the authoring tool itself runs an ``EX 6`` deck
+    on a stock NEC-2 kernel (verified against 4nec2/NEC-2D on the #463 decks,
+    agreement <0.2%): per current source, append
+
+    1. a phantom 1-segment wire parked far above the structure (4nec2 uses
+       Z ≈ 9901+n m; here 10x the structure extent + 200 wavelengths);
+    2. an ``NT`` gyrator tying phantom -> real feed segment with Y11=Y22=0,
+       Y12=Y21=j, which forces current -j*V_phantom into the real segment
+       independent of what it is loaded with;
+    3. an ``EX 0`` voltage source V = j*I_req on the phantom, so the delivered
+       current is exactly the requested phasor.
+
+    Unlike the R_BIG emulation (#442) there is nothing to subtract, and unlike
+    the Y-matrix superposition (#463) there is no N-solve linear recovery: the
+    deck's own TL/NT cards compose natively with the gyrators in ONE nec2c
+    solve, and mixed EX 0 + EX 6 decks work too (the voltage cards stay put).
+
+    The readout gotcha: with a gyrator, ANTENNA INPUT PARAMETERS reports the
+    phantom port (nonsense values), and at a feed segment shared with a TL the
+    STRUCTURE EXCITATION DATA row's IMPEDANCE column is V/I_wire — the wire
+    current EXCLUDES what the co-located network carries away, so that column
+    is wrong exactly where it matters. The row's VOLTAGE column is the true
+    port voltage though, and the gyrator forces the port current exactly, so
+    the driving-point impedance is read as Z_i = V_row / I_req,i. Voltage
+    (EX 0) feeds of a mixed deck read their ANTENNA INPUT PARAMETERS row
+    verbatim (nec2c's impedance there already includes network current).
+
+    Returns a ``run_nec2c``-shaped dict (``z`` per feed in EX-card order,
+    ``gyrator``/``resolved_deck`` flags set) or an error dict; ``None`` if the
+    deck has no EX 6 sources (not this path's job).
+    """
+    feeds = deck.feeds
+    if not any(f.current for f in feeds):
+        return None
+    if any(f.current and f.voltage == 0 for f in feeds):
+        return {"error": "gyrator: a feed has zero drive current"}
+    try:
+        base = reference_deck(text, name, ex6="drop").splitlines()
+    except ValueError as e:
+        return {"error": f"gyrator reference_deck: {e}"}
+
+    # Wavelength from the first FR card (same pre-scan as reference_deck).
+    fr_first_mhz = 299.8
+    for ln in base:
+        toks = ln.split()
+        if toks[0] == "FR" and len(toks) > 5:
+            try:
+                fr_first_mhz = float(toks[5]) or fr_first_mhz
+            except ValueError:
+                pass
+            break
+    lam = 299.792458 / fr_first_mhz
+
+    # nec2c numbers segments in wire-definition order; the EX card's
+    # within-tag rank was already resolved to (wire, seg) by the importer,
+    # so the absolute segment number is a cumulative count away.
+    seg_base, acc = [], 0
+    for w in deck.wires:
+        seg_base.append(acc)
+        acc += w.n_seg
+
+    def abs_seg(f):
+        return seg_base[f.wire] + f.seg
+
+    maxtag = max(w.tag for w in deck.wires)
+    maxc = max(abs(c) for w in deck.wires for p in (w.p1, w.p2) for c in p)
+    # Far enough that phantom<->structure coupling is negligible (the phantom
+    # carries ~|Y_phantom*V_port| ~ 1e-4 A per volt), high rather than lateral
+    # so a Sommerfeld ground stays comfortable. Phantom wires only exist in
+    # this nec2c deck — engines never see them (cf. the momwire #157 cap).
+    zbase = 10.0 * maxc + 200.0 * lam
+    plen = lam / 50.0
+    prad = plen / 200.0
+
+    ge_i = next((i for i, ln in enumerate(base) if ln.split()[0] == "GE"), None)
+    if ge_i is None:
+        return {"error": "gyrator: deck has no GE card"}
+    exec_i = next(k for k, ln in enumerate(base) if ln.split()[0] in ("XQ", "RP"))
+
+    gws, nts, exs = [], [], []
+    cur_feeds = [f for f in feeds if f.current]
+    for j, f in enumerate(cur_feeds):
+        ptag = maxtag + 1 + j
+        x0 = j * 10.0 * plen
+        gws.append(f"GW {ptag} 1 {x0!r} 0 {zbase!r} {x0 + plen!r} 0 {zbase!r} {prad!r}")
+        # Port 2 as tag 0 + absolute segment number (NEC's tag-0 convention)
+        # — sidesteps recomputing the within-tag rank.
+        nts.append(f"NT {ptag} 1 0 {abs_seg(f)} 0 0 0 1 0 0")
+        v = 1j * f.voltage  # delivered current at port 2 is -j * V_src
+        exs.append(f"EX 0 {ptag} 1 0 {v.real!r} {v.imag!r}")
+
+    # NEC-2 requires all NT/TL cards of one network configuration to be
+    # contiguous — a network card read after any non-network card DESTROYS
+    # the previous network data (this silently dropped DipTL's TL until the
+    # gyrator NTs were spliced adjacent to it). ALL EX cards go last, just
+    # before the execute request: nec2c also drops voltage sources that
+    # precede an FR or NT card (the same reset family as reference_deck's
+    # LD-after-EX hoist), so a mixed deck's own EX 0 cards are re-emitted
+    # there in original order rather than left in place.
+    last_net = max(
+        (k for k, ln in enumerate(base) if ln.split()[0] in ("TL", "NT")),
+        default=None,
+    )
+    nt_at = last_net + 1 if last_net is not None else exec_i
+    ex_deck = [ln for ln in base[:exec_i] if ln.split()[0] == "EX"]
+    mid = [ln for ln in base[ge_i:nt_at] if ln.split()[0] != "EX"]
+    tail = [ln for ln in base[nt_at:exec_i] if ln.split()[0] != "EX"]
+    out = base[:ge_i] + gws + mid + nts + tail + ex_deck + exs + base[exec_i:]
+    res = _nec2c_network_tables("\n".join(out) + "\n", timeout, mem_bytes)
+    if res.get("error"):
+        return {"error": f"gyrator: {res['error']}"}
+
+    z_out = []
+    for f in feeds:
+        key = (deck.wires[f.wire].tag, abs_seg(f))
+        if f.current:
+            row = res["struct"].get(key)
+            if row is None:
+                return {
+                    "error": f"gyrator: no network-connection row for "
+                    f"tag {key[0]} seg {key[1]}"
+                }
+            z = row[0] / f.voltage  # V_port / I_forced
+        else:
+            row = res["aip"].get(key)
+            if row is None:
+                return {
+                    "error": f"gyrator: no input-parameters row for "
+                    f"tag {key[0]} seg {key[1]}"
+                }
+            z = row[2]
+        z_out.append([z.real, z.imag])
+    return {
+        "freq": res["freq"],
+        "z": z_out,
+        "error": None,
+        "gyrator": True,
+        "resolved_deck": True,
+    }
+
+
 def feeds_sharing_tl_nt(deck) -> list[int]:
     """Indices of ``deck.feeds`` whose driven segment also anchors a ``TL``
     or ``NT`` endpoint (issue #456).
@@ -1005,15 +1218,24 @@ def bench_deck(
     ref = None
     if not any(ex6_feeds) and not has_dead_trailing_config(text):
         ref = run_nec2c(deck_path, timeout, mem_bytes)
+    # EX 6 decks route to the NT-gyrator emulation first (#475): 4nec2's own
+    # way of running a current source on a NEC-2 kernel — one solve, composes
+    # natively with the deck's TL/NT cards, handles mixed EX 0 + EX 6 decks,
+    # and cross-validated against both 4nec2 itself and the superposition
+    # reference (<0.2%). Falls through to superposition, then R_BIG, so
+    # behaviour is never worse than before.
+    if (ref is None or ref.get("error")) and any(ex6_feeds):
+        gyr = gyrator_reference(text, deck_path.name, deck, timeout, mem_bytes)
+        if gyr is not None and not gyr.get("error"):
+            ref = gyr
     # All-current EX 6 decks (issues #463, #464): the R_BIG emulation can't
     # force the port current cleanly whenever a network shares the driven
     # segment — one solve can't hold N simultaneous currents (#463), and even a
     # single source's series R_BIG is bypassed by a co-located TL/NT so the raw
-    # readout is a composition artifact (#464). Build the reference by Y-matrix
-    # superposition instead — native voltage solves compose the true
-    # driving-point impedances, correct for N ≥ 1 with or without a TL. Falls
-    # through to the R_BIG path if it can't run (e.g. no nec2c) so behaviour is
-    # never worse than before.
+    # readout is a composition artifact (#464). Y-matrix superposition —
+    # native voltage solves composing the true driving-point impedances,
+    # correct for N ≥ 1 with or without a TL — remains the fallback when the
+    # gyrator path can't run.
     if (ref is None or ref.get("error")) and sum(ex6_feeds) >= 1 and all(ex6_feeds):
         sup = superposition_reference(text, deck_path.name, timeout, mem_bytes)
         if sup is not None and not sup.get("error"):
@@ -1119,6 +1341,7 @@ def print_report(rows, engines):
         "network, v = remote TL-anchor wire(s) virtualized (#427),"
         " r = reference from resolved deck (#439),"
         " t = mixed EX 6 feed shares a TL/NT segment; R_BIG subtraction skipped (#456),"
+        " y = EX 6 current-source reference via NT-gyrator emulation (#475),"
         " s = EX 6 current-source reference via Y-matrix superposition (#463, #464),"
         " p = gn 2 + near-ground ungrounded wire: pynec known-unreliable (#448)"
     )
@@ -1137,6 +1360,7 @@ def print_report(rows, engines):
             + ("v" if r.get("virtualized_anchors") else "")
             + ("r" if r.get("nec2c", {}).get("resolved_deck") else "")
             + ("t" if r.get("nec2c", {}).get("ex6_tl_shared") else "")
+            + ("y" if r.get("nec2c", {}).get("gyrator") else "")
             + ("s" if r.get("nec2c", {}).get("superposition") else "")
             + ("p" if r.get("pynec_somm_suspect") else "")
         )

--- a/tests/test_bench_ex6_gyrator.py
+++ b/tests/test_bench_ex6_gyrator.py
@@ -1,0 +1,248 @@
+"""EX 6 current-source reference via 4nec2's NT-gyrator emulation (issue #475).
+
+The 4nec2 cross-check on #463 revealed how the authoring tool itself runs an
+``EX 6`` deck on a stock NEC-2 kernel: per source, a phantom 1-segment wire
+parked far away, an ``NT`` gyrator (Y11=Y22=0, Y12=Y21=j) tying phantom to the
+real feed segment, and an ``EX 0`` on the phantom whose voltage carries the
+requested current — the gyrator forces exactly that current into the real
+segment regardless of load. It composes natively with the deck's own TL/NT
+cards in one solve (no R_BIG subtraction, no N-solve superposition recovery)
+and works for mixed EX 0 + EX 6 decks the superposition path must refuse.
+
+Two readout gotchas the tests pin:
+
+  * ANTENNA INPUT PARAMETERS reports the *phantom* port — nonsense values.
+  * At a feed segment shared with a TL, the STRUCTURE EXCITATION DATA row's
+    IMPEDANCE column is V/I_wire, which EXCLUDES the current the co-located
+    network carries away — wrong exactly where the R_BIG emulation was also
+    wrong. The correct readout is Z = V_row / I_requested (the gyrator forces
+    the port current exactly, so the divisor is known without any parsing).
+
+The strongest checks are the physics oracles: the engine drives a real MNA
+current source, so gyrator reference and engine must agree; and the gyrator
+must reproduce the independently-derived Y-matrix superposition reference.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+from pathlib import Path
+
+import pytest
+
+_BNC = Path(__file__).resolve().parent.parent / "scripts" / "bench_nec_corpus.py"
+_spec = importlib.util.spec_from_file_location("bench_nec_corpus", _BNC)
+bnc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bnc)
+
+needs_nec2c = pytest.mark.skipif(
+    shutil.which("nec2c") is None, reason="nec2c not on PATH"
+)
+
+
+def _parse(text, name):
+    from antennaknobs.nec_import import parse_nec
+
+    return parse_nec(text, name=name, network=True)
+
+
+def _engine_z(text, name, freq):
+    from antennaknobs import AntennaBuilder, WireSpec
+    from antennaknobs.engines import MomwireEngine
+    from momwire import SinusoidalSolver
+
+    deck = _parse(text, name)
+
+    class B(AntennaBuilder):
+        default_params = {"freq": freq}
+
+        def build_wires(self):
+            return deck.wire_tuples()
+
+        def build_network(self):
+            return deck.network()
+
+        def build_wire_material(self):
+            return WireSpec(radius=deck.dominant_radius())
+
+    return MomwireEngine(B(), solver=SinusoidalSolver, ground="pec").impedance()
+
+
+# A two-element phased array, both elements driven by EX 6 current sources 90°
+# apart (same deck the superposition tests use).
+_PHASED2 = (
+    "CE\n"
+    "GW 1 15 -30 0 0 -30 0 20 0.05\n"
+    "GW 2 15 30 0 0 30 0 20 0.05\n"
+    "GE 1\nGN 1\n"
+    "EX 6 1 1 0 1 0\n"
+    "EX 6 2 1 0 0 1\n"
+    "FR 0 1 0 0 7 0\nEN\n"
+)
+
+# A single EX 6 whose driven segment (wire 1, seg 1) also anchors a TL — the
+# class where both the R_BIG readout (#464) and the naive structure-table
+# IMPEDANCE column are composition artifacts.
+_TL_SHARED1 = (
+    "CE\n"
+    "GW 1 15 -30 0 0 -30 0 20 0.05\n"
+    "GW 2 15 30 0 0 30 0 20 0.05\n"
+    "GE 1\nGN 1\n"
+    "TL 1 1 2 1 50 5.0\n"
+    "EX 6 1 1 0 1 0\n"
+    "FR 0 1 0 0 7 0\nEN\n"
+)
+
+# Mixed excitation: element 1 voltage-driven (EX 0), element 2 current-driven
+# (EX 6) — the deck shape the superposition path must refuse (it needs every
+# feed to be a current source) but the gyrator composes in one solve.
+_MIXED = (
+    "CE\n"
+    "GW 1 15 -30 0 0 -30 0 20 0.05\n"
+    "GW 2 15 30 0 0 30 0 20 0.05\n"
+    "GE 1\nGN 1\n"
+    "EX 0 1 1 0 1 0\n"
+    "EX 6 2 1 0 0 1\n"
+    "FR 0 1 0 0 7 0\nEN\n"
+)
+
+
+# --------------------------------------------------- pure (no nec2c) contract
+
+
+def test_gyrator_none_for_no_ex6_sources():
+    """A deck with no EX 6 current source is not this path's job."""
+    none = (
+        "CE\nGW 1 15 -30 0 0 -30 0 20 0.05\nGE 1\nGN 1\n"
+        "EX 0 1 1 0 1 0\nFR 0 1 0 0 7 0\nEN\n"
+    )
+    deck = _parse(none, "none")
+    assert bnc.gyrator_reference(none, "none", deck, 60.0, None) is None
+
+
+def test_gyrator_errors_on_zero_drive_current():
+    """A feed with zero drive current has no V/I to report — caught before
+    the solve, not divided-by-zero later."""
+    zero = _PHASED2.replace("EX 6 2 1 0 0 1", "EX 6 2 1 0 0 0")
+    deck = _parse(zero, "zero")
+    res = bnc.gyrator_reference(zero, "zero", deck, 60.0, None)
+    assert res is not None and res.get("error")
+    assert "zero drive current" in res["error"]
+
+
+def test_gyrator_nts_contiguous_with_deck_network(monkeypatch):
+    """NEC-2 destroys previous network data when a network card is read after
+    any non-network card, so the gyrator NTs must be spliced directly adjacent
+    to the deck's own TL/NT block (this silently dropped DipTL's TL before the
+    splice rule). Intercept the prepared deck text and check card adjacency,
+    plus the other construction invariants: one phantom GW per source, EX 0
+    cards last before the execute request, EX value = j * I_req."""
+    captured = {}
+
+    def fake_tables(deck_text, timeout, mem_bytes=None):
+        captured["text"] = deck_text
+        return {"error": "captured"}
+
+    monkeypatch.setattr(bnc, "_nec2c_network_tables", fake_tables)
+    deck = _parse(_TL_SHARED1, "tlshared1")
+    res = bnc.gyrator_reference(_TL_SHARED1, "tlshared1", deck, 60.0, None)
+    assert res["error"] == "gyrator: captured"
+
+    lines = [ln.split() for ln in captured["text"].splitlines() if ln.split()]
+    mnems = [t[0] for t in lines]
+    # network block is contiguous: the deck's TL immediately followed by our NT
+    tl_i = mnems.index("TL")
+    assert mnems[tl_i + 1] == "NT"
+    between = mnems[tl_i : mnems.index("XQ")]
+    # nothing re-enters the network block after it closes
+    assert between.count("TL") + between.count("NT") == 2
+    # one phantom wire (tag 3 = maxtag+1), one EX, EX last before XQ
+    gw_tags = [int(float(t[1])) for t in lines if t[0] == "GW"]
+    assert gw_tags == [1, 2, 3]
+    ex = [t for t in lines if t[0] == "EX"]
+    assert len(ex) == 1 and int(float(ex[0][2])) == 3
+    assert mnems[mnems.index("XQ") - 1] == "EX"
+    # EX value = j * I_req = j * (1+0j) -> (0, 1)
+    assert float(ex[0][5]) == 0.0 and float(ex[0][6]) == 1.0
+    # NT port 2 uses tag-0 + absolute segment (wire 1 seg 1 -> abs 1)
+    nt = next(t for t in lines if t[0] == "NT")
+    assert nt[3] == "0" and int(float(nt[4])) == 1
+    # gyrator admittance Y11=Y22=0, Y12=j
+    assert [float(x) for x in nt[5:11]] == [0.0, 0.0, 0.0, 1.0, 0.0, 0.0]
+
+
+# --------------------------------------------- physics oracles (needs nec2c)
+
+
+@needs_nec2c
+def test_gyrator_matches_engine_on_phased_pair():
+    """The gyrator reference must match what the engine solves for the same
+    current excitation (the engine drives a real MNA current source)."""
+    deck = _parse(_PHASED2, "phased2")
+    gyr = bnc.gyrator_reference(_PHASED2, "phased2", deck, 60.0, None)
+    assert gyr is not None and gyr.get("error") is None
+    assert gyr["gyrator"] is True and gyr["freq"] == pytest.approx(7.0)
+    z_ref = [complex(re, im) for re, im in gyr["z"]]
+    z_eng = _engine_z(_PHASED2, "phased2", 7.0)
+    assert len(z_ref) == len(z_eng) == 2
+    for zr, ze in zip(z_ref, z_eng):
+        assert abs(zr - ze) / abs(ze) < 0.03, f"ref {zr:.1f} vs engine {ze:.1f}"
+
+
+@needs_nec2c
+def test_gyrator_matches_superposition():
+    """Cross-check the two independent EX 6 reference routes against each
+    other: N voltage solves + Y-matrix recovery vs one gyrator solve. In 4nec2
+    they agreed <0.2%; hold the same bar here, on both the phased pair and the
+    TL-shared single source."""
+    for text, name in ((_PHASED2, "phased2"), (_TL_SHARED1, "tlshared1")):
+        deck = _parse(text, name)
+        gyr = bnc.gyrator_reference(text, name, deck, 60.0, None)
+        sup = bnc.superposition_reference(text, name, 60.0, None)
+        assert gyr.get("error") is None and sup.get("error") is None
+        for zg, zs in zip(gyr["z"], sup["z"]):
+            zg, zs = complex(*zg), complex(*zs)
+            assert abs(zg - zs) / abs(zs) < 0.002, f"{name}: {zg:.3f} vs {zs:.3f}"
+
+
+@needs_nec2c
+def test_gyrator_single_source_sharing_tl():
+    """Issue #464's corner: the driven segment also anchors a TL, so most of
+    the forced current bypasses into the line and every V/I_wire readout is a
+    composition artifact. The V_row/I_req readout must recover the true
+    driving-point Z the engine also computes — and must NOT coincide with the
+    R_BIG artifact (guards a silent revert to the #456 raw readout)."""
+    deck = _parse(_TL_SHARED1, "tlshared1")
+    gyr = bnc.gyrator_reference(_TL_SHARED1, "tlshared1", deck, 60.0, None)
+    assert gyr is not None and gyr.get("error") is None
+    assert len(gyr["z"]) == 1
+    z_ref = complex(*gyr["z"][0])
+    z_eng = _engine_z(_TL_SHARED1, "tlshared1", 7.0)[0]
+    assert abs(z_ref - z_eng) / abs(z_eng) < 0.02, f"ref {z_ref:.2f} vs eng {z_eng:.2f}"
+
+    prepared = bnc.reference_deck(_TL_SHARED1, "tlshared1")  # ex6="rbig"
+    raw = bnc.run_nec2c(
+        Path("unused-when-deck_text-given.nec"), 60.0, deck_text=prepared
+    )
+    z_raw = complex(*raw["z"][0])
+    assert abs(z_ref - z_raw) / abs(z_ref) > 0.05, (
+        f"gyrator {z_ref:.2f} suspiciously close to R_BIG artifact {z_raw:.2f}"
+    )
+
+
+@needs_nec2c
+def test_gyrator_mixed_voltage_and_current_feeds():
+    """A mixed EX 0 + EX 6 deck — outside the superposition path's contract
+    (bench_deck only routes all-current decks there) — solves in one pass:
+    the EX 0 feed reads its ANTENNA INPUT PARAMETERS row (network current
+    included), the EX 6 feed reads V_row/I_req from the structure-excitation
+    table, both in EX-card order."""
+    deck = _parse(_MIXED, "mixed")
+    gyr = bnc.gyrator_reference(_MIXED, "mixed", deck, 60.0, None)
+    assert gyr is not None and gyr.get("error") is None
+    z_ref = [complex(re, im) for re, im in gyr["z"]]
+    z_eng = _engine_z(_MIXED, "mixed", 7.0)
+    assert len(z_ref) == len(z_eng) == 2
+    for zr, ze in zip(z_ref, z_eng):
+        assert abs(zr - ze) / abs(ze) < 0.03, f"ref {zr:.1f} vs engine {ze:.1f}"


### PR DESCRIPTION
## Summary
- Adopt 4nec2's NT-gyrator emulation (phantom wire + `EX 0` carrying V = j·I_req + `NT` with Y12=Y21=j) as the **primary** EX 6 current-source reference in `bench_nec_corpus.py` — this is byte-for-byte how the authoring tool runs `EX 6` decks on a stock NEC-2 kernel, verified against 4nec2/NEC-2D on the #463 decks. One nec2c solve, composes natively with the deck's own TL/NT cards, and handles mixed EX 0 + EX 6 decks the superposition path must refuse. Superposition (#463) and R_BIG (#442) remain as fallbacks, in that order.
- Readout: Z_i = V_row / I_req from the `STRUCTURE EXCITATION DATA AT NETWORK CONNECTION POINTS` table. At a TL-shared port the table's IMPEDANCE column is V/I_wire (excludes the current the co-located network carries away) and `ANTENNA INPUT PARAMETERS` shows only the phantom port — both wrong exactly where the R_BIG emulation was also wrong; the voltage column + the exactly-forced current sidestep both.
- Two nec2c card-order traps found and pinned by tests: NT/TL cards of one network configuration must be **contiguous** (a network card after any other card silently destroys prior network data — dropped DipTL's TL), and voltage sources preceding an FR/NT card are dropped (all EX cards re-emitted just before the execute request).
- New report flag `y`; new tests `tests/test_bench_ex6_gyrator.py` (construction contract + physics oracles vs engine MNA current source + gyrator-vs-superposition cross-check <0.2% + mixed-deck oracle).
- Wild corpus: all 15 EX6-family rows re-run in place (backup `.pre475`). **BRDZPR10 ΔΓ 0.584 → 0.0003, ZLTROM10 0.779 → 0.0002, LOGPERTL 0.100 → 0.0001, G3TXQ hexbeam 0.19 → 0.0004** (pynec; all four engines agree) — resolving #464's open question: the engines were right, the old readout was the artifact. The `t`-flagged class is retired from live rows. Status doc addendum included.

Closes #475

## Test plan
- [x] `pytest tests/test_bench_ex6_gyrator.py` (7 passed; oracles need nec2c on PATH)
- [x] `pytest -k "bench or nec_import"` (175 passed)
- [x] 15-deck wild-family re-run through `bench_deck` routing — all take the gyrator path, all clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmgjJwcpzBa3sUzpKj7tKw