### PR TITLE
Feed-drift census (#459): the fixed-feed exemption class is the 2 known, not more

### DIFF
--- a/docs/status/2026-07-20-feed-drift-census.md
+++ b/docs/status/2026-07-20-feed-drift-census.md
@@ -1,0 +1,119 @@
+# Feed-drift census — issue #459
+
+**Date:** 2026-07-20
+**Tool:** `scripts/bench_feed_drift.py` (PyNEC, free space, ladder N = 21/61/161, seg-cap 3000)
+
+## Question
+
+#459 asks whether the two designs carrying pinned-feed exemptions
+(`wire/terminated_longwire`, `wire/sterba_tl`) are the only members of the
+"high-Z fixed-feed" class, or whether other catalog designs silently drift under
+mesh refinement because their feed sits at a mesh-unstable point (a near-open
+delta-gap, or a TL/NT attachment port). #435 made feed segments refine with the
+mesh across the catalog; the two exemptions were the drifts *caught* at the
+time. The census sweeps all 91 designs to find the ones that weren't.
+
+## Method
+
+Per design, solve the driving-point impedance up an N-ladder and ask two things:
+does it still move at the finest mesh (no plateau within 2 % of the finest), and
+is the feed at a mesh-unstable point — |Z| > 500 Ω (near a current null) or a
+TL/NT/transformer port. Both true ⇒ **suspect**. Free space keeps it cheap; the
+delta-gap segment sensitivity is a *local* effect, and a ground spot-check
+(below) confirms the drift is ground-independent.
+
+**Validation:** the two known exemptions read CONVERGED — `terminated_longwire`
+(|Z| = 5295 Ω, conv@21) and `sterba_tl` (conv@21). Their pins hold the feed
+segment fixed, so the ladder is flat; they correctly do *not* re-flag. A
+regression that unpinned them would put them back on the suspect list.
+
+## Result — the class is ~10 designs, not 2
+
+**Near-open feeds (high |Z|, same physics as `terminated_longwire`):**
+
+| design | \|Z\| | drift | converges? |
+|---|--:|--:|---|
+| `arrays.delta_looparray_with_tls` | 16 703 Ω | 100 % | never |
+| `wire.lazy_h` | 5 044 Ω | 14.7 % | never |
+| `wire.vbeam` | 3 516 Ω | 4.9 % | never |
+| `wire.rhombic` | 717 Ω | 3.3 % | @61 (borderline — drops off) |
+
+**TL/NT-port feeds (drift tied to the port attachment, not the feed |Z|):**
+
+| design | \|Z\| | drift (free) | drift (pec) |
+|---|--:|--:|--:|
+| `verticals.dominator` | 32 Ω | 31.7 % | 30.7 % |
+| `verticals.challenger` | 33 Ω | 24.8 % | 23.4 % |
+| `wire.zepp` | 23 Ω | 22.2 % | 22.1 % |
+| `wire.doublet_ladder_tuner`, `verticals.inverted_l_tmatch`, `loops.skyloop_lmatch`, `wire.efhw_sloper`, `wire.edz`, `broadband.lpda` | — | 6–94 % | (same class) |
+
+The pec column shows the port drift is **not** a free-space artifact — it
+persists identically over ground. These want #459's question 2: a
+length-normalized TL/NT port stamp so port impedance stops scaling with the port
+segment.
+
+**Not this class** (drift from other causes, listed for the record):
+`dipoles.short_dipole_loaded` drifts 137 % at |Z| = 17 Ω — a lumped-load
+convergence issue, not the feed. `elt_whip` was skipped (benchmark-scale, over
+the seg cap); `bowtiearray2x4` skipped its two finer rungs.
+
+## The bs2 basis-extension levers do not (yet) fix it
+
+Two momwire BSpline-d2 features looked like they might make a near-open feed
+converge *without* pinning (so the design could refine like everything else):
+
+- `feed_smoothing_factor` (cos² source bump): its width is `α · h_feed_segment`,
+  i.e. it **scales with the segment**, so under refinement it shrinks with the
+  gap and does not decouple from the mesh. On refined `terminated_longwire` it
+  made the drift *worse* (|Z| 4626 → 3673 vs the delta-gap 3809 → 3527).
+- `use_singular_enrichment` (extra end basis): raises
+  `NotImplementedError` in `compute_y_matrix` — the enrichment path isn't wired
+  into the Y-matrix (network) solve the reducer uses.
+
+Both would need momwire work to help here: a *fixed physical* smoothing width
+(independent of the segment), or enrichment plumbed through the Y-matrix path.
+That is #459 question 1/2 territory (momwire-side), not a builder change.
+
+## Confirmatory pin-test — the heuristic over-flags
+
+The suspect predicate (drift + high-|Z|/port) is *necessary but not sufficient*.
+The decisive question is: **does pinning the feed to a fixed-length segment
+flatten the ladder?** Re-running each suspect refined-vs-pinned (PyNEC, free
+space, feed edges forced to 1 segment):
+
+| design | drift authored | drift pinned | pinning fixes it? |
+|---|--:|--:|---|
+| `wire.rhombic` | 2.4 % | 0.7 % | yes (but already converged @61) |
+| `wire.lazy_h` | 14.7 % | 6.9 % | no — still drifting |
+| `wire.vbeam` | 4.9 % | 7.5 % | no — worse |
+| `verticals.dominator` | 31.7 % | 31.7 % | no — unchanged |
+| `wire.doublet_ladder_tuner` | 44.2 % | 44.2 % | no — unchanged |
+| `verticals.challenger`, `wire.zepp`, `inverted_l_tmatch`, `skyloop_lmatch`, `efhw_sloper`, `edz`, `lpda` | 3–94 % | ≈ or worse | no |
+
+**Only `terminated_longwire` is genuinely pin-fixable** (confirmed separately:
+pinned ladder flat at ~960 − 5240j, ~1 %). The difference is structural: its fed
+edge is a *substantial* 0.3 m segment, so refining it shrinks a real gap and
+pinning holds it fixed. The near-open wire antennas (`lazy_h`, `vbeam`) already
+have ~1-segment gaps — their drift is the **arms refining at a high-Q operating
+point**, not the feed, so pinning is a no-op. The TL/NT-port cluster is unmoved
+by feed pinning (`dominator`, `doublet_ladder_tuner` identical), so its drift is
+the *port attachment*, not the driven segment.
+
+## Conclusion & recommendation
+
+1. **The fixed-feed exemption class is just the two already pinned**
+   (`terminated_longwire`, `sterba_tl`). #459 question 3 answer: **no latent
+   pin-fixable members.** No new helper application is warranted; a helper that
+   only re-expresses two existing magic-number pins is churn.
+2. **The census's other drifters are two *different* phenomena**, not #459's
+   fixed-feed class:
+   - **Near-open high-Q** (`lazy_h`, `vbeam`, `delta_looparray_with_tls`): the
+     whole current distribution is mesh-sensitive at a near-open resonance;
+     inherent, not a feed model. Worth its own issue if the workbench slider on
+     these needs to read as "converging."
+   - **TL/NT-port** (`dominator`, `challenger`, `zepp`, `doublet_ladder_tuner`,
+     `inverted_l_tmatch`, `skyloop_lmatch`, `efhw_sloper`, `edz`, `lpda`): drift
+     tied to the port attachment, ground-independent, not fixed by pinning →
+     #459 question 2 (momwire length-normalized port stamp). Filed separately.
+3. The census tool stays as the regression metric — but read it *with* the
+   pin-test; the flag is a candidate, not a verdict.

--- a/scripts/bench_feed_drift.py
+++ b/scripts/bench_feed_drift.py
@@ -1,0 +1,189 @@
+"""Feed-drift census (issue #459).
+
+Sweeps every catalog design's driving-point impedance across a mesh ladder and
+flags the ones that FAIL to converge because the feed sits at a mesh-unstable
+point — a near-open (high-|Z|) delta-gap or a TL/NT attachment port. Refining
+such a feed shrinks the driven segment, and the delta-gap readout at a current
+null diverges as the gap closes (the classic NEC end-fed sensitivity); a
+fixed-length driven segment is the mesh-stable model of that feed (issue #435
+closed the general refine-with-the-mesh rule, and #459 tracks the exemptions).
+
+The census exists to answer #459's open question 3 — "are there other latent
+members?" — beyond the two already carrying pinned-count exemptions
+(``wire/terminated_longwire``, ``wire/sterba_tl``). A design is a suspect when
+its impedance is still moving at the finest mesh AND its feed is either
+high-|Z| (near a current null) or a network port. Those two already pin their
+feeds, so they should read CONVERGED here — their presence in the suspect list
+would mean an exemption regressed.
+
+Method: PyNEC, free space (the feed-segment sensitivity is a local delta-gap
+effect, independent of ground), so the sweep stays cheap. Per design the ladder
+is solved bottom-up; a rung whose nominal segment total exceeds ``--seg-cap`` is
+skipped (recorded, not silently dropped) so the few benchmark-scale designs
+don't dominate the runtime.
+
+    python scripts/bench_feed_drift.py
+    python scripts/bench_feed_drift.py --ladder 21 61 161 --seg-cap 4000
+    python scripts/bench_feed_drift.py --engine sin
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import bench_converge as bc  # noqa: E402 — sibling script, reused ladder machinery
+
+DEFAULT_LADDER = (21, 61, 161)
+DEFAULT_SEG_CAP = 3000
+# |Z| this far above the 50 Ω reference reads as a near-open feed (near a
+# current null), where the delta-gap readout is segment-length sensitive.
+NEAR_OPEN_OHMS = 500.0
+CONVERGE_TOL = 0.02
+
+
+def feed_is_network_port(cls) -> bool:
+    """True when a driven port also anchors a TL / NT / transformer branch —
+    the port-segment-size sensitivity #459 question 2 is about (a plain lumped
+    ``Load``/``Shunt`` on the feed does not count)."""
+    from antennaknobs.network import TL, Admittance, TwoPort, Transformer
+
+    try:
+        b = cls()
+        net = b.build_network() if hasattr(b, "build_network") else None
+    except Exception:  # noqa: BLE001 — a design that can't build a network can't qualify
+        return False
+    if net is None:
+        return False
+    feed_ports = {s.port for s in net.sources}
+    for br in net.branches:
+        if not isinstance(br, (TL, Admittance, TwoPort, Transformer)):
+            continue
+        refs = set()
+        for attr in ("a", "b", "port"):
+            if hasattr(br, attr):
+                refs.add(getattr(br, attr))
+        if getattr(br, "ports", None):
+            refs |= set(br.ports)
+        if refs & feed_ports:
+            return True
+    return False
+
+
+def census_row(design: str, ladder, engine: str, ground: str, seg_cap: int) -> dict:
+    """Solve one design up the ladder; return its drift/convergence summary."""
+    cls = bc.load_design(design)
+    series, skipped = [], []
+    for nseg in ladder:
+        tot = bc.total_nominal_segs(cls, nseg)
+        if tot > seg_cap:
+            skipped.append(nseg)
+            continue
+        try:
+            res = bc.solve_design(cls, nseg, engine, ground)
+            series.append((nseg, complex(*res["z"][0])))
+        except Exception as e:  # noqa: BLE001 — one dud design must not sink the census
+            skipped.append(nseg)
+            if not series:
+                # keep the first error to explain a fully-empty row
+                skipped_err = f"{type(e).__name__}: {e}"
+                return {
+                    "design": design,
+                    "series": [],
+                    "skipped": skipped,
+                    "error": skipped_err,
+                    "net_port": False,
+                }
+    net_port = feed_is_network_port(cls)
+    row = {
+        "design": design,
+        "series": series,
+        "skipped": skipped,
+        "error": None,
+        "net_port": net_port,
+    }
+    if len(series) >= 2:
+        z_fin = series[-1][1]
+        z_coarse = series[0][1]
+        row["z_fine"] = z_fin
+        row["drift"] = abs(z_fin - z_coarse) / (abs(z_fin) or 1.0)
+        row["converged_at"] = bc.nseg_to_converge(series, tol=CONVERGE_TOL)
+    return row
+
+
+def is_suspect(row: dict) -> bool:
+    """Still moving at the finest mesh AND fed at a mesh-unstable point."""
+    if row.get("error") or "drift" not in row:
+        return False
+    if row["converged_at"] is not None:
+        return False  # plateaued on this ladder — not a feed-drift member
+    z = row["z_fine"]
+    return abs(z) > NEAR_OPEN_OHMS or row["net_port"]
+
+
+def print_report(rows, ladder, engine, ground, seg_cap):
+    print(
+        f"\nFEED-DRIFT CENSUS (issue #459)  engine={engine}  ground={ground}  "
+        f"ladder={list(ladder)}  seg-cap={seg_cap}"
+    )
+    print(
+        "  suspect = still moving at the finest mesh (>|ΔZ| "
+        f"{CONVERGE_TOL:.0%} vs finest) AND feed is near-open (|Z|>"
+        f"{NEAR_OPEN_OHMS:.0f}Ω) or a TL/NT port"
+    )
+    ranked = sorted(
+        (r for r in rows if "drift" in r), key=lambda r: r["drift"], reverse=True
+    )
+    print(
+        f"\n{'design':34} {'|Z_fine|':>9} {'drift':>7} {'conv@N':>7} {'port':>5}  flag"
+    )
+    print("-" * 78)
+    for r in ranked:
+        z = r["z_fine"]
+        conv = r["converged_at"]
+        flag = "◄ SUSPECT" if is_suspect(r) else ""
+        print(
+            f"{r['design']:34} {abs(z):9.0f} {r['drift'] * 100:6.1f}% "
+            f"{(str(conv) if conv else '—'):>7} {('yes' if r['net_port'] else ''):>5}  {flag}"
+        )
+    suspects = [r for r in ranked if is_suspect(r)]
+    print(f"\n{len(suspects)} suspect(s):")
+    for r in suspects:
+        z = r["z_fine"]
+        why = []
+        if abs(z) > NEAR_OPEN_OHMS:
+            why.append(f"near-open |Z|={abs(z):.0f}Ω")
+        if r["net_port"]:
+            why.append("TL/NT port")
+        print(f"  {r['design']:34} {', '.join(why)}")
+    incomplete = [r for r in rows if r.get("error") or len(r["series"]) < 2]
+    if incomplete:
+        print(f"\n{len(incomplete)} design(s) with <2 usable rungs (skipped/errored):")
+        for r in incomplete:
+            note = r["error"] or f"skipped rungs {r['skipped']}"
+            print(f"  {r['design']:34} {note}")
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--ladder", type=int, nargs="+", default=list(DEFAULT_LADDER))
+    ap.add_argument("--engine", default="pynec", choices=bc.ENGINE_KEYS)
+    ap.add_argument("--ground", default="free")
+    ap.add_argument("--seg-cap", type=int, default=DEFAULT_SEG_CAP)
+    ap.add_argument("--only", nargs="+", help="restrict to these dotted designs")
+    args = ap.parse_args(argv)
+
+    from antennaknobs.cli import list_builtin_designs
+
+    designs = args.only or list_builtin_designs()
+    rows = []
+    for i, d in enumerate(designs, 1):
+        print(f"[{i}/{len(designs)}] {d} ...", flush=True)
+        rows.append(census_row(d, args.ladder, args.engine, args.ground, args.seg_cap))
+    print_report(rows, args.ladder, args.engine, args.ground, args.seg_cap)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bench_feed_drift.py
+++ b/tests/test_bench_feed_drift.py
@@ -1,0 +1,79 @@
+"""Feed-drift census tool (scripts/bench_feed_drift.py, issue #459).
+
+Cheap unit pins: the network-port classifier, the suspect predicate, and one
+end-to-end census row on a small design. The full 91-design sweep is a manual
+diagnostic, not a per-PR test.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_BFD = Path(__file__).resolve().parent.parent / "scripts" / "bench_feed_drift.py"
+_spec = importlib.util.spec_from_file_location("bench_feed_drift", _BFD)
+bfd = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bfd)
+
+
+def test_feed_is_network_port_true_for_tl_port_feed():
+    """A design whose feed shares a TL/NT/transformer port is flagged; a plain
+    driven dipole is not."""
+    from antennaknobs.designs.wire.zepp import Builder as Zepp
+    from antennaknobs.designs.dipoles.invvee import Builder as Invvee
+
+    assert bfd.feed_is_network_port(Zepp) is True  # ladder-line TL port feed
+    assert bfd.feed_is_network_port(Invvee) is False  # plain delta-gap dipole
+
+
+def test_feed_is_network_port_ignores_lumped_load_on_feed():
+    """A lumped Load/Shunt on the feed is not a TL/NT port — terminated_longwire
+    feeds a plain wire (its Load sits on the *term* port, not the feed)."""
+    from antennaknobs.designs.wire.terminated_longwire import Builder
+
+    assert bfd.feed_is_network_port(Builder) is False
+
+
+def test_is_suspect_requires_drift_and_mesh_unstable_feed():
+    """Suspect = still moving at the finest mesh AND (near-open |Z| or TL port).
+    A converged row, or a drifting-but-benign (low |Z|, no port) row, is not."""
+    near_open_drift = {
+        "error": None,
+        "drift": 0.15,
+        "converged_at": None,
+        "z_fine": complex(400.0, -5000.0),
+        "net_port": False,
+    }
+    assert bfd.is_suspect(near_open_drift) is True
+
+    converged = {**near_open_drift, "converged_at": 61}
+    assert bfd.is_suspect(converged) is False
+
+    benign = {**near_open_drift, "z_fine": complex(50.0, 5.0), "net_port": False}
+    assert bfd.is_suspect(benign) is False
+
+    port_drift = {**benign, "net_port": True}
+    assert bfd.is_suspect(port_drift) is True
+
+
+def test_census_row_converges_on_a_clean_dipole():
+    """End-to-end on one small, well-behaved design: a plain dipole converges on
+    the ladder and is not a suspect."""
+    row = bfd.census_row(
+        "dipoles.invvee", ladder=(21, 61), engine="pynec", ground="free", seg_cap=3000
+    )
+    assert row["error"] is None
+    assert len(row["series"]) == 2
+    assert row["converged_at"] is not None  # plateaus
+    assert bfd.is_suspect(row) is False
+
+
+def test_census_row_skips_rungs_over_the_seg_cap():
+    """A seg-cap below the design's coarse mesh skips every rung — recorded, not
+    silently dropped — leaving no usable series."""
+    row = bfd.census_row(
+        "dipoles.invvee", ladder=(21, 61), engine="pynec", ground="free", seg_cap=1
+    )
+    assert row["skipped"] == [21, 61]
+    assert row["series"] == []
+    assert "drift" not in row


### PR DESCRIPTION
## Summary

Answers #459's open question 3 — "are there other latent members of the high-Z fixed-feed exemption class?" — with a census tool and a confirmatory pin-test. The answer is **no**: the two designs already carrying pinned-feed exemptions (`terminated_longwire`, `sterba_tl`) are the whole class.

- **New tool** `scripts/bench_feed_drift.py` sweeps all 91 catalog designs' convergence ladders (PyNEC, free space) and flags those still moving at the finest mesh whose feed is mesh-unstable — near-open (|Z| > 500 Ω) or a TL/NT/transformer port. It validates against the two known exemptions: both read **converged** (their pins hold the feed segment fixed), so they correctly don't re-flag.
- **Confirmatory pin-test** (in the status doc) is the decisive step: the heuristic flags 13 suspects, but forcing each one's feed to a fixed 1-segment length flattens **only** `terminated_longwire`. The near-open wire antennas (`lazy_h`, `vbeam`) already have ~1-segment gaps — their drift is the arms refining at a high-Q resonance, not the feed — and the TL/NT-port cluster is unmoved by feed pinning, so its drift is the port attachment. Two *different* phenomena, not the fixed-feed class.
- **No helper built**: with no latent pin-fixable members, a helper re-expressing two existing magic-number pins would be churn.
- Recorded that the bs2 basis-extension levers don't fix this as-is (`feed_smoothing_factor` width scales with the segment; `use_singular_enrichment` raises `NotImplementedError` in the Y-matrix path).

## Follow-ups filed

- **#477** — TL/NT-port stamp (momwire, #459 Q2): the port cluster (`dominator`, `challenger`, `zepp`, …) drifts ground-independently and isn't pin-fixable → needs a length-normalized port stamp.
- **#478** — near-open high-Q convergence (`lazy_h`, `vbeam`, `delta_looparray_with_tls`): whole-structure mesh sensitivity at a near-open resonance; inherent, not a feed model.

## Test plan
- [x] `pytest tests/test_bench_feed_drift.py` — 5 passed (network-port classifier, suspect predicate, end-to-end census row, seg-cap skip)
- [x] Census validates against the two known exemptions (both read converged)
- [x] `ruff check` / `ruff format --check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)