### PR TITLE
bench(somm-sweep): add BSpline d=1 to the Sommerfeld session sweep

### DIFF
--- a/scripts/bench_somm_sweep.py
+++ b/scripts/bench_somm_sweep.py
@@ -61,8 +61,13 @@ import bench_catalog as cat  # noqa: E402
 import bench_converge as cvg  # noqa: E402
 import bench_nec_corpus as bnc  # noqa: E402
 
-ENGINES = ("pynec", "sin", "bs2")
-ENGINE_LABEL = {"pynec": "PyNEC", "sin": "Sinusoidal", "bs2": "BSpline d=2"}
+ENGINES = ("pynec", "sin", "bs1", "bs2")
+ENGINE_LABEL = {
+    "pynec": "PyNEC",
+    "sin": "Sinusoidal",
+    "bs1": "BSpline d=1",
+    "bs2": "BSpline d=2",
+}
 
 N_SWEEP = 21
 SPAN_FRAC = 0.015  # +-1.5% band around the default frequency
@@ -87,9 +92,10 @@ def _solve_once(cls, engine, ground, freq=None):
         eng = PyNECEngine(b, ground=ground)
     elif engine == "sin":
         eng = MomwireEngine(b, solver=SinusoidalSolver, ground=ground)
-    else:  # bs2
+    else:  # bs1 / bs2
+        degree = 1 if engine == "bs1" else 2
         eng = MomwireEngine(
-            b, solver=BSplineSolver, solver_kwargs={"degree": 2}, ground=ground
+            b, solver=BSplineSolver, solver_kwargs={"degree": degree}, ground=ground
         )
     eng.impedance()
 


### PR DESCRIPTION
## Summary
- `bench_somm_sweep.py` covered pynec / sin / bs2 but not `bs1` — the engine whose Sommerfeld dynamic-runtime behavior prompted the check.
- Add `bs1` to `ENGINES`, `ENGINE_LABEL`, and the inline worker so `--engines … bs1` resolves to `BSplineSolver(degree=1)`.

Standalone benchmark-tooling change: no submodule pin bump, no library change.

## Test plan
- [x] `python scripts/bench_somm_sweep.py --engines sin bs1 bs2 --designs dipoles.invvee` runs and reports a bs1 column
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)