### PR TITLE
verticals: radials refine with the mesh — fixes the census's top drift entry (inverted_l_tmatch)

### DIFF
--- a/src/antennaknobs/designs/verticals/inverted_l.py
+++ b/src/antennaknobs/designs/verticals/inverted_l.py
@@ -72,7 +72,12 @@ class Builder(AntennaBuilder):
         horiz = self.horiz_frac * wavelength * self.length_factor
         z = self.base
 
-        n_seg_radials = 5
+        # Radials refine with the mesh like every other wire (issue #477; the
+        # old hard-coded 5 left 0.5 m radial segments meeting millimetre riser
+        # segments at the feed junction on fine meshes — a graded-junction
+        # ratio the pulse/sinusoidal bases handle badly, so PyNEC/sin diverged
+        # up the convergence ladder while BSpline d=2 stayed flat).
+        n_seg_radials = self.segs_for(quarter, quarter)
         n_radials = 4
         radial_len = quarter  # quarter-wave radials, like a ground-plane vert
 

--- a/src/antennaknobs/designs/verticals/vertical.py
+++ b/src/antennaknobs/designs/verticals/vertical.py
@@ -29,7 +29,10 @@ class Builder(AntennaBuilder):
         n_seg1 = self.segs_for(
             math.dist((0, 0, 0), (0, 0, eps)), math.dist((0, 0, eps), (0, 0, z))
         )
-        n_seg_radials = 5
+        # Radials refine with the mesh (issue #477): hard-coding the count let
+        # coarse radial segments meet fine riser segments at the feed junction
+        # on refined meshes, dragging PyNEC/sin off BSpline's converged value.
+        n_seg_radials = self.segs_for(self.length, self.length)
         n_radials = 3
         # Radials run the full self.length (not a quarter-wave): self.length is
         # already the ~quarter-wave radiator length, so the radials match the


### PR DESCRIPTION
## Summary
- `inverted_l` and `vertical` hard-coded their radial segment counts at 5, leaving ~0.5 m radial segments meeting millimetre riser segments at the feed junction on refined meshes (130:1 adjacent-segment ratio at N=641). PyNEC/sin diverge at such graded junctions while BSpline d=2 stays flat — this is the actual root cause of the #459 feed-drift census's top entry (`inverted_l_tmatch`, 94% drift: the T-network's loaded Q≈13 amplifies the ~25% port error).
- Radials now use `segs_for` like every other wire (a missed member of the #435 density-alignment class). All three engines converge to the same answer: vertical ~22.05 Ω, inverted_l ~17.3+0.4j, inverted_l_tmatch ~64.7+23.6j; sin/pynec ladders flatten by N≈161 where they previously never settled.
- Default-mesh (N=21) churn, authored → refined (bs2 unchanged everywhere):
  | design | sin before | sin after |
  |---|---|---|
  | vertical | 21.09−1.46j | 22.28−0.69j |
  | inverted_l | 16.78−1.30j | 17.52−0.43j |
  | inverted_l_tmatch | 50.81+2.02j | 52.96+0.89j |
- `helix`'s 5-segment ground-screen radials are deliberately untouched (audited-appropriate in #435; screen density is its own knob).
- Note for #477 follow-up: at the converged mesh the T-network's stock element values land ~64.7+23.6j rather than the ~50 Ω they were tuned for on the old mesh — retuning the tee is a separate design decision.

## Test plan
- [x] Extended ladders (N=21…641, sin/bs2/pynec, memory-capped) on all three designs — divergence gone, engines agree
- [x] `pytest -k "design or catalog or vertical or momwire_engine or web_server"` (1712 passed) + tmatch/finite_q/cli tests
- [x] `scripts/generate_catalog.py` — no catalog drift; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmgjJwcpzBa3sUzpKj7tKw