### PR TITLE
bench: basis-convergence census — BSpline d=2 converged at N=21 on 80% of scorable designs

### DIFF
--- a/docs/status/2026-07-20-basis-convergence-census.md
+++ b/docs/status/2026-07-20-basis-convergence-census.md
@@ -1,0 +1,105 @@
+# Basis-convergence census — sin vs BSpline d=2 (issue #477 follow-up)
+
+**Date:** 2026-07-20
+**Tool:** `scripts/bench_basis_convergence.py` (ladder N = 21/61/161/321,
+free space, seg-cap 4000, RLIMIT 6 GB) + a targeted N = 641 top-up on the
+no-mutual class. Measured with PR #481's radials fix applied (the two
+`verticals` rows are meaningless without it).
+
+## Question
+
+The #477 diagnosis kept finding the same pattern anecdotally: BSpline d=2
+already sits at the converged answer on meshes where sin/PyNEC are far from
+it. Is that a defensible general statement, and where exactly does it hold?
+
+## Method — the mutual-limit criterion
+
+A single basis flat on its own ladder can be flat at the wrong value
+(sterba_tl's pinned ports prove it: flat AND ~5 Ω of X from the
+basis-agreed limit). So a design is only *scored* when the two bases agree
+within 2 % at the finest common rung — the mutual limit Z\* (mean of the
+two finest values). Against Z\* the census reports each basis's error at
+N = 21 and its conv@N. Everything else lands in an explicit "no mutual
+limit" list — the honest *cannot yet say* class, not a silent omission.
+
+## Result — 91 designs
+
+**66 mutual-limit, 24 no-mutual-limit, 1 incomplete** (elt_whip, over the
+seg cap at every rung).
+
+### The scored 66: bs2 converged at N=21 on 80 %
+
+| | sin | bs2 |
+|---|--:|--:|
+| within 2 % of Z\* at N = 21 | 36/66 | **53/66** |
+| conv@N ratio sin/bs2 | median 1.0× (44/66 tie at N=21) | max **15.3×** |
+
+Two-thirds of the catalog (dipoles, loops, yagis, arrays) converges at
+N = 21 on *both* bases — the advantage is not universal and the census says
+so. It concentrates exactly on the port-fed and junction-heavy designs the
+#459 feed-drift census flagged:
+
+| design | Z\* | sin err @21 | bs2 err @21 | conv sin | conv bs2 |
+|---|--:|--:|--:|--:|--:|
+| doublet_ladder_tuner | 42.2−5.6j | 42.5 % | 0.9 % | 321 | 21 |
+| dominator | 30.8+1.0j | 26.2 % | 7.3 % | 321 | 321 |
+| challenger | 31.0+8.0j | 23.2 % | 1.5 % | 321 | 21 |
+| pota_performer | 37.5+3.7j | 18.6 % | 3.2 % | 321 | 61 |
+| skyloop_lmatch | 47.5−6.7j | 14.8 % | 0.4 % | 161 | 21 |
+| triangular_skyloop | 113.9+1.0j | 12.9 % | 0.2 % | 161 | 21 |
+| efhw_sloper | 52.6−3.1j | 11.2 % | 0.7 % | 161 | 21 |
+| inverted_l / vertical (post-#481) | 17.3+0.3j / 22.1+0.2j | 4.5 / 3.9 % | 1.6 / 1.5 % | 161 | 21 |
+
+Honest exceptions inside the scored class — both bases slow together
+(physics-limited, not basis-limited): edz, lazy_h, vbeam, trap_dipole,
+owa_yagi, and dominator's reactance (Z\* has X ≈ 1 Ω, inflating the
+relative metric).
+
+### The unscored 24: dominated by folded/fan junctions
+
+Where the bases had NOT met by N = 321, the N = 641 top-up splits the class:
+
+| design | apart @321 | apart @641 | verdict |
+|---|--:|--:|---|
+| folded_invvee | **515 %** | 63.6 % | closing — sin X −1188j → −173j racing toward the 223−30j bs2 held from N=21 |
+| folded_invvee_balun | 96 % | 34.6 % | closing, same shape |
+| inverted_l_tmatch | 7.2 % | 3.9 % | closing (sin lags, known) |
+| short_dipole_loaded / jpole / zepp | 3–6 % | 2–4 % | slow-closing |
+| trap_fan_dipole | 23.9 % | 25.9 % | **open** |
+| twoband_fan_dipole | 11.4 % | 17.8 % | **open** |
+| sterba_tl (pinned ports) | 2.3 % | 2.3 % | held open by the pins (unpinned, both bases meet at ~72.0−11.6j) |
+| helix | 30.6 % | — | mesh is a design knob (ppt), ladder inapplicable |
+| 11 designs (hentenna/hourglass families, fandipole, discone, moxon, bowtie, hexbeams, terminated_longwire, folded_invveearray) | 15–109 % | seg-capped | unresolved at affordable mesh |
+
+The folded_invvee result is the strongest single data point in the study:
+sin needs *thousands* of segments to resolve a folded element's
+transmission-line mode and is still 64 % away at N = 641, while bs2's
+coarse-mesh value is what sin is converging toward. The still-open fan
+dipoles (multi-wire fan junctions) are the next thing to explain — filed
+observations, not yet a diagnosis.
+
+## Implications
+
+1. **The claim is now defensible and scoped**: on feed/junction-
+   discretization-limited designs — about a third of the catalog — bs2 at
+   N = 21 sits within ~2 % of the mutual limit that sin needs 3–15× more
+   segments to reach; and bs2 was immune to the graded-junction divergence
+   PR #481 fixed. Where convergence is physics-limited (near-open, high-Q:
+   the #478 class), bs2 tracks sin point-for-point and buys nothing.
+2. **A wild-corpus scoring caveat**: nec2c shares sin's basis family. A
+   bs1/bs2 ΔΓ against nec2c at a deck's native coarse mesh partly measures
+   *correlated* sin-family error, not bs2 error — folded/fan-junction decks
+   especially. Prior evidence in the same direction: #436 (bs2 converges
+   2–3× coarser on closed loops).
+3. **Workbench guidance seed**: when the convergence slider on a networked
+   or junction-heavy design won't settle under sin/PyNEC, solve it on
+   BSpline d=2 before concluding the design is at fault.
+
+## Pointers
+
+- #477 — diagnosis comment with the four-class decomposition of the
+  feed-drift cluster; PR #481 (radials fix).
+- #478 — the physics-limited class (zepp's 14 kΩ port belongs to it).
+- #436 — basis-aware loop meshing (same direction, loops).
+- Raw rows: session scratchpad `basis_census.jsonl` / `topup641.jsonl`
+  (regenerate with the script; ~6 min for the main ladder on a laptop).

--- a/scripts/bench_basis_convergence.py
+++ b/scripts/bench_basis_convergence.py
@@ -1,0 +1,231 @@
+"""Basis-convergence census: sin vs BSpline-d2 over the catalog (issue #477).
+
+Answers "which basis converges at the coarser mesh, and where can we even
+tell?" Per design the driving-point impedance (feed 0) is solved up a mesh
+ladder on both bases. A design has a MUTUAL LIMIT when the two bases agree
+within ``--agree-tol`` at the finest common rung — the cross-validation that
+makes a convergence claim meaningful (a single basis flat on its own ladder
+can be flat at the wrong value; two different bases meeting is evidence of
+the true limit). Against that limit the census reports each basis's error at
+the coarsest rung and its conv@N, plus the designs where NO mutual limit
+exists at the finest affordable mesh (the honest "we cannot yet say" list —
+near-open feeds, folded/fan junctions, seg-capped giants).
+
+2026-07-20 findings (see docs/status/2026-07-20-basis-convergence-census.md):
+66/91 designs have a mutual limit; bs2 is within 2% of it at N=21 on 53/66
+vs sin's 36/66, with conv@N advantages up to 15x on port-fed and junction-
+heavy designs; the no-mutual class is dominated by folded/fan-junction
+geometries where sin converges extremely slowly toward the value bs2 holds
+from coarse meshes.
+
+Memory discipline: RLIMIT_AS caps the process (an OOM becomes a recorded
+MemoryError rung, not a dead machine) and ``--seg-cap`` skips rungs whose
+nominal segment total is too large (recorded, not silently dropped).
+
+    python scripts/bench_basis_convergence.py
+    python scripts/bench_basis_convergence.py --ladder 21 61 161 --only wire.zepp
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import resource
+import statistics
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import bench_converge as bc  # noqa: E402 — sibling script, reused ladder machinery
+
+DEFAULT_LADDER = (21, 61, 161, 321)
+DEFAULT_SEG_CAP = 4000
+DEFAULT_MEM_GB = 6.0
+ENGINES = ("sin", "bs2")
+CONVERGE_TOL = 0.02
+AGREE_TOL = 0.02
+
+
+def census_row(design: str, ladder, seg_cap: int) -> dict:
+    """Solve one design up the ladder on both bases; record (N, Z, t, segs)
+    per rung and the skip reasons. Never raises — a dud rung is recorded."""
+    row = {"design": design, "series": {}, "skipped": {}, "error": None}
+    try:
+        cls = bc.load_design(design)
+    except Exception as e:  # noqa: BLE001 — one dud design must not sink the census
+        row["error"] = f"load: {type(e).__name__}: {e}"
+        return row
+    for engine in ENGINES:
+        series, skipped = [], []
+        for nseg in ladder:
+            try:
+                tot = bc.total_nominal_segs(cls, nseg)
+            except Exception as e:  # noqa: BLE001
+                skipped.append([nseg, f"segs: {type(e).__name__}: {e}"])
+                continue
+            if tot > seg_cap:
+                skipped.append([nseg, f"seg-cap {tot}"])
+                continue
+            try:
+                t0 = time.time()
+                res = bc.solve_design(cls, nseg, engine, "free")
+                series.append(
+                    [nseg, res["z"][0][0], res["z"][0][1], time.time() - t0, tot]
+                )
+            except MemoryError:
+                skipped.append([nseg, "MemoryError"])
+            except Exception as e:  # noqa: BLE001
+                skipped.append([nseg, f"{type(e).__name__}: {str(e)[:80]}"])
+        row["series"][engine] = series
+        row["skipped"][engine] = skipped
+    return row
+
+
+def classify(row: dict, agree_tol: float = AGREE_TOL, tol: float = CONVERGE_TOL):
+    """Reduce one census row to its claim summary.
+
+    Returns ``("mutual", stats)``, ``("no_mutual", stats)``, or
+    ``("incomplete", reason)``. ``stats`` for the mutual class carries the
+    mutual limit ``zstar`` (mean of the two finest values), each basis's
+    coarse-rung error and conv@N against it; the no-mutual class carries the
+    two finest values and their disagreement.
+    """
+    if row.get("error"):
+        return "incomplete", row["error"]
+    s = {e: row["series"].get(e) or [] for e in ENGINES}
+    if any(len(s[e]) < 2 for e in ENGINES):
+        why = "; ".join(
+            f"{e}: {row['skipped'][e][0][1] if row['skipped'].get(e) else 'few rungs'}"
+            for e in ENGINES
+        )
+        return "incomplete", why
+    common = sorted(set(n for n, *_ in s["sin"]) & set(n for n, *_ in s["bs2"]))
+    if len(common) < 2:
+        return "incomplete", "no common rungs"
+    nf = common[-1]
+
+    def z_at(e, n):
+        return next(complex(re, im) for nn, re, im, *_ in s[e] if nn == n)
+
+    zs_f, zb_f = z_at("sin", nf), z_at("bs2", nf)
+    agree = abs(zs_f - zb_f) / abs(zb_f)
+    stats = {"nf": nf, "zs_f": zs_f, "zb_f": zb_f, "agree": agree}
+    if agree >= agree_tol:
+        return "no_mutual", stats
+    zstar = 0.5 * (zs_f + zb_f)
+
+    def conv_at(e):
+        return next(
+            (n for n in common if abs(z_at(e, n) - zstar) / abs(zstar) <= tol), None
+        )
+
+    stats.update(
+        zstar=zstar,
+        conv={e: conv_at(e) for e in ENGINES},
+        err_coarse={e: abs(z_at(e, common[0]) - zstar) / abs(zstar) for e in ENGINES},
+        n_coarse=common[0],
+    )
+    return "mutual", stats
+
+
+def print_report(rows, ladder, seg_cap, tol=CONVERGE_TOL, agree_tol=AGREE_TOL):
+    mutual, no_mutual, incomplete = [], [], []
+    for r in rows:
+        kind, st = classify(r, agree_tol, tol)
+        if kind == "mutual":
+            mutual.append((r["design"], st))
+        elif kind == "no_mutual":
+            no_mutual.append((r["design"], st))
+        else:
+            incomplete.append((r["design"], st))
+
+    print(
+        f"\nBASIS-CONVERGENCE CENSUS (issue #477)  ladder={list(ladder)} "
+        f"seg-cap={seg_cap}  engines={'/'.join(ENGINES)}  ground=free"
+    )
+    print(
+        f"  mutual limit = sin and bs2 within {agree_tol:.0%} of each other at the "
+        f"finest common rung; conv@N and coarse-rung errors are vs that limit"
+    )
+    print(
+        f"\n{len(rows)} designs: {len(mutual)} mutual-limit, "
+        f"{len(no_mutual)} no-mutual-limit, {len(incomplete)} incomplete"
+    )
+    flat = {e: sum(1 for _, d in mutual if d["err_coarse"][e] <= tol) for e in ENGINES}
+    for e in ENGINES:
+        print(
+            f"  {e}: within {tol:.0%} of the mutual limit at N={ladder[0]} on "
+            f"{flat[e]}/{len(mutual)}"
+        )
+
+    hdr = (
+        f"\n{'design':34} {'Z* (feed0)':>18} {'agree':>6} "
+        f"{'e21 sin':>8} {'e21 bs2':>8} {'cv sin':>7} {'cv bs2':>7}"
+    )
+    print(hdr)
+    print("-" * len(hdr))
+    for name, d in sorted(mutual, key=lambda t: -t[1]["err_coarse"]["sin"]):
+        z = d["zstar"]
+        cv = {e: str(d["conv"][e]) if d["conv"][e] else f">{d['nf']}" for e in ENGINES}
+        print(
+            f"{name:34} {z.real:8.1f}{z.imag:+8.1f}j {d['agree'] * 100:5.1f}% "
+            f"{d['err_coarse']['sin'] * 100:7.1f}% "
+            f"{d['err_coarse']['bs2'] * 100:7.1f}% {cv['sin']:>7} {cv['bs2']:>7}"
+        )
+
+    ratios = [
+        d["conv"]["sin"] / d["conv"]["bs2"]
+        for _, d in mutual
+        if d["conv"]["sin"] and d["conv"]["bs2"]
+    ]
+    if ratios:
+        print(
+            f"\nconv@N ratio sin/bs2: median {statistics.median(ratios):.1f}x, "
+            f"max {max(ratios):.1f}x, =1 on {sum(1 for r in ratios if r == 1)}"
+            f"/{len(ratios)}"
+        )
+
+    print("\nNO MUTUAL LIMIT at the finest affordable rung (cannot score either):")
+    for name, d in sorted(no_mutual, key=lambda t: -t[1]["agree"]):
+        print(
+            f"  {name:34} sin {d['zs_f']:.1f} vs bs2 {d['zb_f']:.1f} "
+            f"({d['agree'] * 100:.1f}% apart at N={d['nf']})"
+        )
+    if incomplete:
+        print("\nINCOMPLETE:")
+        for name, why in incomplete:
+            print(f"  {name:34} {str(why)[:90]}")
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--ladder", type=int, nargs="+", default=list(DEFAULT_LADDER))
+    ap.add_argument("--seg-cap", type=int, default=DEFAULT_SEG_CAP)
+    ap.add_argument("--mem-limit-gb", type=float, default=DEFAULT_MEM_GB)
+    ap.add_argument("--out", type=Path, help="also write raw rows as JSON lines")
+    ap.add_argument("--only", nargs="+", help="restrict to these dotted designs")
+    args = ap.parse_args(argv)
+
+    cap = int(args.mem_limit_gb * 1e9)
+    resource.setrlimit(resource.RLIMIT_AS, (cap, cap))
+
+    from antennaknobs.cli import list_builtin_designs
+
+    designs = args.only or list_builtin_designs()
+    rows = []
+    out = args.out.open("w") if args.out else None
+    for i, d in enumerate(designs, 1):
+        print(f"[{i}/{len(designs)}] {d} ...", flush=True)
+        row = census_row(d, args.ladder, args.seg_cap)
+        rows.append(row)
+        if out:
+            out.write(json.dumps(row) + "\n")
+            out.flush()
+    if out:
+        out.close()
+    print_report(rows, args.ladder, args.seg_cap)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bench_basis_convergence.py
+++ b/tests/test_bench_basis_convergence.py
@@ -1,0 +1,95 @@
+"""Basis-convergence census classifier (issue #477).
+
+The census's claims rest on ``classify``: a design only enters the scored
+class when the two bases actually meet (the mutual-limit criterion), errors
+and conv@N are measured against that mutual value, and everything else is
+reported as no-mutual or incomplete rather than silently scored. These tests
+pin that reduction on synthetic rows — no solver runs.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_BBC = Path(__file__).resolve().parent.parent / "scripts" / "bench_basis_convergence.py"
+_spec = importlib.util.spec_from_file_location("bench_basis_convergence", _BBC)
+bbc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bbc)
+
+
+def _row(sin, bs2, skipped=None):
+    return {
+        "design": "synthetic",
+        "series": {"sin": sin, "bs2": bs2},
+        "skipped": skipped or {"sin": [], "bs2": []},
+        "error": None,
+    }
+
+
+def test_mutual_limit_conv_and_coarse_error():
+    """sin creeps toward the limit (converged only at the mid rung on), bs2
+    is flat from the coarsest — conv@N and coarse-rung errors say exactly
+    that, and the mutual limit is the mean of the two finest values."""
+    row = _row(
+        sin=[
+            [21, 40.0, 0.0, 0.1, 100],
+            [61, 49.5, 0.0, 0.1, 300],
+            [161, 49.9, 0.0, 0.1, 800],
+        ],
+        bs2=[
+            [21, 50.0, 0.0, 0.1, 100],
+            [61, 50.0, 0.0, 0.1, 300],
+            [161, 50.1, 0.0, 0.1, 800],
+        ],
+    )
+    kind, st = bbc.classify(row)
+    assert kind == "mutual"
+    assert st["zstar"] == complex(50.0, 0.0)  # mean of 49.9 and 50.1
+    assert st["conv"] == {"sin": 61, "bs2": 21}
+    assert st["err_coarse"]["sin"] > 0.15 and st["err_coarse"]["bs2"] < 0.01
+
+
+def test_no_mutual_limit_when_bases_disagree_at_finest():
+    """Bases 20% apart at the finest rung: the design must land in the
+    no-mutual class — neither basis gets scored against the other."""
+    row = _row(
+        sin=[[21, 100.0, 0.0, 0.1, 100], [61, 110.0, 0.0, 0.1, 300]],
+        bs2=[[21, 90.0, 0.0, 0.1, 100], [61, 90.0, 0.0, 0.1, 300]],
+    )
+    kind, st = bbc.classify(row)
+    assert kind == "no_mutual"
+    assert st["agree"] > 0.2
+
+
+def test_never_converged_reported_not_crashed():
+    """Both bases agree at the finest rung but neither coarser rung is within
+    tolerance — conv@N is None (printed as '>finest'), not an exception."""
+    row = _row(
+        sin=[
+            [21, 30.0, 0.0, 0.1, 100],
+            [61, 40.0, 0.0, 0.1, 300],
+            [161, 50.0, 0.0, 0.1, 800],
+        ],
+        bs2=[
+            [21, 70.0, 0.0, 0.1, 100],
+            [61, 60.0, 0.0, 0.1, 300],
+            [161, 50.5, 0.0, 0.1, 800],
+        ],
+    )
+    kind, st = bbc.classify(row)
+    assert kind == "mutual"
+    assert st["conv"]["sin"] == 161 and st["conv"]["bs2"] == 161
+
+
+def test_incomplete_when_an_engine_has_too_few_rungs():
+    """A seg-capped engine (every rung skipped) makes the row incomplete,
+    carrying the first skip reason instead of a bogus score."""
+    row = _row(
+        sin=[[21, 50.0, 0.0, 0.1, 100], [61, 50.0, 0.0, 0.1, 300]],
+        bs2=[],
+        skipped={"sin": [], "bs2": [[21, "seg-cap 9999"], [61, "seg-cap 9999"]]},
+    )
+    kind, why = bbc.classify(row)
+    assert kind == "incomplete"
+    assert "seg-cap 9999" in why


### PR DESCRIPTION
## Summary
- New `scripts/bench_basis_convergence.py`: solves every catalog design's feed-0 impedance up a mesh ladder (N=21…321, seg-cap 4000, RLIMIT 6 GB) on both sin and BSpline d=2, and scores a design **only when the two bases agree at the finest common rung** (the mutual-limit criterion — a lone flat ladder can be flat at the wrong value; sterba_tl's pinned ports prove it). Everything else lands in an explicit no-mutual/incomplete list.
- **Headline (91 designs)**: 66 have a mutual limit. bs2 is within 2% of it already at N=21 on **53/66 (80%)** vs sin's 36/66; conv@N advantage up to **15.3×**, concentrated exactly on the port-fed/junction-heavy designs from the #459 feed-drift census (doublet_ladder_tuner: sin 42.5% off at N=21 vs bs2 0.9%). Two-thirds of the catalog ties at N=21 on both bases — the advantage is real but scoped, and the census says where it stops: physics-limited designs (near-open/high-Q, the #478 class) show no bs2 advantage at all.
- **New finding**: the 24-design no-mutual class is dominated by folded/fan-junction geometries. `folded_invvee`'s bases are 515% apart at N=321, closing to 64% at N=641 with sin racing toward the value bs2 held from N=21 — sin needs extreme meshes to resolve folded elements. `trap_fan_dipole`/`twoband_fan_dipole` remain open at 641 (unexplained); 11 designs exceed the seg cap before the bases can meet.
- Records the wild-corpus caveat: nec2c shares sin's basis family, so bs1/bs2 ΔΓ vs nec2c at native coarse meshes partly measures *correlated* sin-family error.
- Status doc with full tables: `docs/status/2026-07-20-basis-convergence-census.md`. Census values for the two verticals were measured with PR #481's radials fix applied.

## Test plan
- [x] `tests/test_bench_basis_convergence.py` — classifier contract on synthetic rows (mutual/no-mutual/never-converged/incomplete), no solver runs
- [x] Full catalog run completed (~6 min) + N=641 top-up on the no-mutual class, memory-capped throughout
- [x] CLI smoke (`--only dipoles.invvee --ladder 21 61`); ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmgjJwcpzBa3sUzpKj7tKw