### PR TITLE
network: distributed finite-gap ports — sterba_tl unpinned, zepp stabilized (#477)

### DIFF
--- a/src/antennaknobs/designs/wire/sterba_tl.py
+++ b/src/antennaknobs/designs/wire/sterba_tl.py
@@ -102,15 +102,18 @@ class Builder(AntennaBuilder):
 
         def edge(ya, yb_, z, name):
             seg_len = abs(yb_ - ya)
-            # Named TL-port edges stay PINNED at 3 segments, deliberately
-            # exempt from the issue-#435 refine-with-the-mesh rule: with 3
-            # the convergence ladder is flat (72.9−16.5j from N=41 up),
-            # while segs_for-refined ports drift away and never settle —
-            # the TL attachment wants a mesh-stable port segment, not a
-            # shrinking one.
-            ns = 3 if name is not None else max(5, round(n0 * seg_len / h))
-            if name is not None and ns % 2 == 0:
-                ns += 1
+            # Named TL-port edges refine like every other wire: the
+            # distributed ports in build_network() span the edge's fixed
+            # physical extent, so the port model no longer narrows as the
+            # mesh refines (issue #477). This retired the old 3-segment
+            # pin, whose flat ladder was flat at a basis-DEPENDENT value
+            # (sin 72.96−16.59j vs bs2 72.64−14.89j); the finite-gap port
+            # is flat at the value the bases agree on.
+            ns = (
+                max(1, round(n0 * seg_len / h))
+                if name is not None
+                else max(5, round(n0 * seg_len / h))
+            )
             tups.append(((0.0, ya, z), (0.0, yb_, z), ns, None, name))
 
         for i in range(n_sections):
@@ -144,15 +147,18 @@ class Builder(AntennaBuilder):
         z0 = self.z0
         length = self._tl_length
 
-        ports = {"feed": PortOnWire("feed")}
+        # Every port is a distributed (finite-gap) port over its short named
+        # edge (issue #477): mesh-stable by construction, so the edges can
+        # refine and the ladder is flat at the basis-agreed value.
+        ports = {"feed": PortOnWire("feed", distributed=True)}
         branches = []
         # One TL per junction j (1..n_sections-1): connects the right-end
         # port of section j-1 to the left-end port of section j — the
         # half-wave vertical phasing line, now ideal.
         for j in range(1, n_sections):
             a, b = f"p{j}_a", f"p{j}_b"
-            ports[a] = PortOnWire(a)
-            ports[b] = PortOnWire(b)
+            ports[a] = PortOnWire(a, distributed=True)
+            ports[b] = PortOnWire(b, distributed=True)
             branches.append(TL(a=a, b=b, z0=z0, length=length))
 
         return Network(

--- a/src/antennaknobs/designs/wire/zepp.py
+++ b/src/antennaknobs/designs/wire/zepp.py
@@ -114,7 +114,10 @@ class Builder(AntennaBuilder):
         stub_len = self.stub_len_frac * wavelength
         return Network(
             ports={
-                "ant": PortOnWire("ant"),  # high-Z end of the radiator
+                # high-Z end of the radiator; distributed = the port is the
+                # named wire's fixed physical extent, so the readout no
+                # longer jumps when the mesh subdivides it (issue #477)
+                "ant": PortOnWire("ant", distributed=True),
                 "shack": PortVirtual("shack"),  # bottom of the tuned stub
             },
             branches=[

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -195,7 +195,13 @@ class MomwireEngine(SimulationEngine):
         self._polyline_specs = translated["polyline_specs"]
         self._feeds = translated["feeds"]
         self._feed_names = translated["feed_names"]
+        self._feed_edges = translated["feed_edges"]
         self._junctions = translated["junctions"]
+        # Distributed-port expansion (issue #477): None until _init_network
+        # finds a PortOnWire(distributed=True); every other path treats the
+        # feed list 1:1.
+        self._feed_W = None
+        self._exp_feed_pos = None
         # Wire material (issues #316/#388): a design-declared WireSpec
         # supplies the default conductor radius plus the distributed-loading
         # kwargs; per-wire specs on individual Wire entries override it wire
@@ -360,6 +366,77 @@ class MomwireEngine(SimulationEngine):
 
         self._reducer = NetworkReducer(net, port_to_idx, next_idx)
 
+        # Finite-gap (distributed) ports — issue #477. A distributed port
+        # is realised as one delta-gap sub-feed per SEGMENT of its named
+        # wire, voltages split by length (constant E over the wire's fixed
+        # physical extent), and the antenna Y contracted back to port
+        # granularity by congruence: Y_port = Wᵀ·Y_sub·W, with W's column
+        # for a port holding the length weights h_i/L (uniform segments →
+        # 1/S). The weighted current readout Σ wᵢ·Iᵢ is the bilinear dual
+        # of the voltage split, so port power Σ V*·I is preserved and the
+        # reducer sees an ordinary port row. Everything downstream —
+        # reducer, sweeps, excited state — keeps feed-granularity code
+        # untouched; only the solver feed list and the Y contraction know.
+        dist_idx = {
+            i
+            for i, n in enumerate(self._feed_names)
+            if n
+            and isinstance(net.ports.get(n), PortOnWire)
+            and net.ports[n].distributed
+        }
+        if dist_idx:
+            self._build_feed_expansion(dist_idx)
+
+    def _build_feed_expansion(self, dist_idx):
+        """Expanded solver-feed positions + the (n_sub × n_feeds) weight
+        matrix W for distributed ports. Non-distributed feeds keep a single
+        sub-feed with weight 1 (W's column is a unit vector), so the
+        contraction is exact for every port kind."""
+        pos, cols = [], []
+        for k, ((pl, arc, _v), (epl, eidx)) in enumerate(
+            zip(self._feeds, self._feed_edges)
+        ):
+            if k in dist_idx:
+                poly = self._polylines[epl]
+                lens = np.linalg.norm(np.diff(poly, axis=0), axis=1)
+                arc0 = float(lens[:eidx].sum())
+                length = float(lens[eidx])
+                n_sub = int(self._edge_segments[epl][eidx])
+                for i in range(n_sub):
+                    pos.append((epl, arc0 + (i + 0.5) * length / n_sub))
+                    cols.append((k, 1.0 / n_sub))
+            else:
+                pos.append((pl, arc))
+                cols.append((k, 1.0))
+        W = np.zeros((len(pos), len(self._feeds)))
+        for row, (k, w) in enumerate(cols):
+            W[row, k] = w
+        self._exp_feed_pos = pos
+        self._feed_W = W
+
+    def _solver_feeds(self, voltages=None):
+        """The feed list handed to momwire solvers: per-feed (wire, arc, V),
+        expanded to sub-feeds with length-split voltages when distributed
+        ports exist. ``voltages`` (per ORIGINAL feed, in feed order)
+        defaults to the translated feed voltages."""
+        if voltages is None:
+            voltages = [v for *_, v in self._feeds]
+        if self._feed_W is None:
+            return [(w, a, complex(v)) for (w, a, _v), v in zip(self._feeds, voltages)]
+        v_exp = self._feed_W @ np.asarray(voltages, dtype=np.complex128)
+        return [(w, a, complex(v)) for (w, a), v in zip(self._exp_feed_pos, v_exp)]
+
+    def _contract_y(self, Y):
+        """Contract a solver Y (sub-feed granularity) to port granularity;
+        identity when no distributed ports exist. Works on one matrix or a
+        swept (n_k, n, n) stack."""
+        if self._feed_W is None:
+            return Y
+        W = self._feed_W
+        if Y.ndim == 3:
+            return np.einsum("ia,kij,jb->kab", W, Y, W)
+        return W.T @ Y @ W
+
     def _ground_solver_kwargs(self):
         """Extra ground kwargs for solver construction. Only spliced in when
         set (free-space / PEC solves pass no ground_eps)."""
@@ -377,7 +454,7 @@ class MomwireEngine(SimulationEngine):
         return self._solver(
             wires=self._polylines,
             n_per_edge_per_wire=self._edge_segments,
-            feeds=self._feeds,
+            feeds=self._solver_feeds(),
             wavelength=wavelength,
             wire_radius=self._wire_radius,
             ground_z=self._ground_z,
@@ -430,10 +507,14 @@ class MomwireEngine(SimulationEngine):
         """Multi-port short-circuit Y at the configured feeds. Builds one
         solver with the full feed list and calls momwire's compute_y_matrix,
         which since the junction-aware-y-matrix PR handles closed-loop /
-        tee-junction antennas correctly (one LU + N back-subs per Y)."""
-        return np.asarray(
-            self._make_solver(wavelength=wavelength).compute_y_matrix(),
-            dtype=np.complex128,
+        tee-junction antennas correctly (one LU + N back-subs per Y).
+        Distributed ports solve at sub-feed granularity and contract back
+        to one row/column per port (issue #477)."""
+        return self._contract_y(
+            np.asarray(
+                self._make_solver(wavelength=wavelength).compute_y_matrix(),
+                dtype=np.complex128,
+            )
         )
 
     def _solved_excited(self, wavelength):
@@ -529,9 +610,9 @@ class MomwireEngine(SimulationEngine):
         s = self._make_solver(wavelength=self._wavelength_for(freqs[0]))
         k_array = 2.0 * np.pi * freqs * 1e6 / C_LIGHT
         if self._network is not None:
-            Y_swept = np.asarray(
-                s.compute_y_matrix_swept(k_array), dtype=np.complex128
-            )  # (n_k, n_real, n_real)
+            Y_swept = self._contract_y(
+                np.asarray(s.compute_y_matrix_swept(k_array), dtype=np.complex128)
+            )  # (n_k, n_real, n_real) at port granularity
             zs = np.empty((freqs.size, self._reducer.n_driven), dtype=np.complex128)
             for ki, freq in enumerate(freqs):
                 Y_total = self._reducer.apply_branches(
@@ -584,10 +665,9 @@ class MomwireEngine(SimulationEngine):
                 self._excited_p_in,
                 self._excited_power_budget,
             ) = self._reducer.excited_state(Y, wavelength)
-            feeds_resolved = [
-                (w, arc, complex(V_full[i]))
-                for i, (w, arc, _v) in enumerate(self._feeds)
-            ]
+            feeds_resolved = self._solver_feeds(
+                [complex(V_full[i]) for i in range(len(self._feeds))]
+            )
         elif self._tls:
             self._excited_efficiency = 1.0
             self._excited_power_budget = []

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -525,6 +525,11 @@ class PyNECEngine(SimulationEngine):
             return True
         if any(isinstance(p, PortVirtual) for p in net.ports.values()):
             return True
+        # A distributed (finite-gap) port spans every segment of its named
+        # wire (issue #477); there is no native single-EX equivalent, so it
+        # always reduces (the Y contraction lives on that path).
+        if any(isinstance(p, PortOnWire) and p.distributed for p in net.ports.values()):
+            return True
         # A Shunt to common has no native NEC card (there's no 1-port
         # shunt-to-common primitive); always reduce it. Same for the ideal
         # Transformer (issue #301): no NEC card expresses the ideal ratio, and
@@ -611,6 +616,26 @@ class PyNECEngine(SimulationEngine):
                 port_to_idx[name] = next_idx
                 next_idx += 1
         self._reducer = NetworkReducer(net, port_to_idx, next_idx)
+
+        # Per-port drive points (issue #477): a delta-gap port drives its
+        # wire's middle segment with the full port voltage; a distributed
+        # (finite-gap) port drives EVERY segment of its named wire with the
+        # length-split voltage V/S (constant field over the wire's fixed
+        # physical extent) and reads the weighted current Σ wᵢIᵢ — the
+        # bilinear dual, so the port row of Y is the congruence-contracted
+        # sub-feed block and port power is preserved. Mirrors
+        # MomwireEngine's expansion so cross-engine rows mean the same
+        # thing. Weights per (1-based sub-segment): [(seg, w)].
+        name_to_tup = {t[4]: t for t in self.tups if len(t) >= 5 and t[4] is not None}
+        self._port_drive_points = {}
+        for name in self._real_port_names:
+            n_seg = int(name_to_tup[name][2])
+            if net.ports[name].distributed:
+                self._port_drive_points[name] = [
+                    (s, 1.0 / n_seg) for s in range(1, n_seg + 1)
+                ]
+            else:
+                self._port_drive_points[name] = [((n_seg + 1) // 2, 1.0)]
 
     def _make_real_context(self):
         """A fresh nec_context with only the real build_wires() geometry, wire
@@ -752,13 +777,18 @@ class PyNECEngine(SimulationEngine):
         Y = np.zeros((n, n), dtype=np.complex128)
         for j, drv in enumerate(names):
             c, loc = self._make_real_context()
-            tag, seg = loc[drv]
-            c.ex_card(0, tag, seg, 0, 1.0, 0.0, 0, 0, 0, 0)
+            tag = loc[drv][0]
+            for seg, w in self._port_drive_points[drv]:
+                c.ex_card(0, tag, seg, 0, w, 0.0, 0, 0, 0, 0)
             c.fr_card(0, 1, freq, 0)
             c.xq_card(0)
             sc = c.get_structure_currents(0)
             for i, name in enumerate(names):
-                Y[i, j] = self._port_current(sc, *loc[name])
+                tag_i = loc[name][0]
+                Y[i, j] = sum(
+                    w * self._port_current(sc, tag_i, seg)
+                    for seg, w in self._port_drive_points[name]
+                )
             del c
         return Y
 
@@ -771,9 +801,10 @@ class PyNECEngine(SimulationEngine):
         V = self._reducer.resolve_voltages(self._reducer.apply_branches(Y, wavelength))
         c, loc = self._make_real_context()
         for i, name in enumerate(self._real_port_names):
-            tag, seg = loc[name]
+            tag = loc[name][0]
             v = complex(V[i])
-            c.ex_card(0, tag, seg, 0, v.real, v.imag, 0, 0, 0, 0)
+            for seg, w in self._port_drive_points[name]:
+                c.ex_card(0, tag, seg, 0, (w * v).real, (w * v).imag, 0, 0, 0, 0)
         return c
 
     def _warn_if_somm_low_wires(self, wavelength):

--- a/src/antennaknobs/geometry.py
+++ b/src/antennaknobs/geometry.py
@@ -278,6 +278,7 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
     # placeholder, voltage gets set later by `build_network()`).
     feeds = []
     feed_names = []
+    feed_edges = []
     for tup_index, edge in enumerate(edges):
         voltage = edge[3]
         name = tup_names[tup_index]
@@ -293,6 +294,7 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
             (feed_pl, feed_arclength, complex(voltage if voltage is not None else 0))
         )
         feed_names.append(name)
+        feed_edges.append((feed_pl, feed_edge_idx))
 
     if not feeds:
         raise ValueError("no excitation found in wire list")
@@ -303,6 +305,9 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
         "polyline_specs": polyline_specs,
         "feeds": feeds,
         "feed_names": feed_names,
+        # Which (polyline, edge) each feed sits on — a distributed port
+        # (issue #477) needs the whole edge's extent, not just its midpoint.
+        "feed_edges": feed_edges,
         # Back-compat scalars — first feed.
         "feed_wire_index": feeds[0][0],
         "feed_arclength": feeds[0][1],

--- a/src/antennaknobs/nec_export.py
+++ b/src/antennaknobs/nec_export.py
@@ -84,9 +84,10 @@ def export_nec(
     eng = PyNECEngine(builder, ground=ground)
     if eng._use_reducer:
         raise NotImplementedError(
-            "NEC export of TL/virtual-driver networks is not supported: "
-            "PyNECEngine solves those by a multiport-Y reduction, not native "
-            "NEC cards, so there is no faithful single-deck representation."
+            "NEC export of TL/virtual-driver networks (and distributed "
+            "finite-gap ports, issue #477) is not supported: PyNECEngine "
+            "solves those by a multiport-Y reduction, not native NEC cards, "
+            "so there is no faithful single-deck representation."
         )
     freq = builder.freq if freq is None else float(freq)
 

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -40,10 +40,26 @@ class PortOnWire:
     `PortVirtual`, a pure circuit node): it becomes one row/column of the
     antenna's multiport short-circuit Y that the network stamps onto.
 
+    ``distributed=True`` makes the port a FINITE gap spanning the whole
+    named wire instead of a delta gap on one segment: the excitation is a
+    constant field over the wire's fixed physical length (one sub-feed per
+    segment, voltages split by length), and the port row of Y is the
+    length-weighted contraction of the sub-feed rows. A delta gap's
+    readout moves whenever mesh refinement subdivides the port wire (the
+    gap narrows with the segment — issue #477's port-drift class:
+    sterba_tl's pinned ports, zepp's jump when its port wire first
+    subdivides); the finite gap's width is set by geometry, not by the
+    mesh, so the port impedance is mesh-stable by construction and the
+    port wire may refine like every other wire. The value it converges to
+    is the finite-gap answer for THAT physical width — for the short port
+    stubs this models, within a couple percent of the delta-gap limit,
+    and (unlike the pinned delta gap) basis-independent.
+
     Formerly `PortAtEdge` ("edge" in the wire-graph sense, which read as
     "wire end"); that name remains as a deprecated alias."""
 
     name: str
+    distributed: bool = False
 
 
 @dataclass(frozen=True)

--- a/tests/test_distributed_port.py
+++ b/tests/test_distributed_port.py
@@ -1,0 +1,156 @@
+"""Distributed (finite-gap) ports — issue #477.
+
+A ``PortOnWire(distributed=True)`` spans its named wire's fixed physical
+extent instead of a delta gap on one (mesh-dependent) segment: one sub-feed
+per segment with length-split voltages, and the port row of the antenna Y
+contracted back by congruence (Y_port = Wᵀ·Y_sub·W). The port impedance is
+then mesh-stable by construction — the class of drift these tests pin is a
+port readout that MOVES whenever refinement subdivides the port wire (zepp's
+jump the first time its 0.05 m port wire goes 1 → 3 segments; sterba_tl's
+old 3-segment pins, which were flat at basis-DEPENDENT values).
+
+The oracles run the real designs at modest meshes: engines must agree with
+each other, coarse rungs must degenerate exactly to the delta gap while the
+port wire is still one segment, and the fine-mesh value must be stable
+where the delta-gap model drifts.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from antennaknobs.engines.momwire import MomwireEngine
+from antennaknobs.network import Network, PortOnWire
+from momwire import BSplineSolver, SinusoidalSolver
+
+try:  # optional accelerated backend, mirrors the other engine test guards
+    from antennaknobs.engines.pynec import PyNECEngine
+
+    _HAS_PYNEC = True
+except Exception:  # noqa: BLE001 — pynec-accel absent
+    _HAS_PYNEC = False
+
+needs_pynec = pytest.mark.skipif(not _HAS_PYNEC, reason="pynec-accel not installed")
+
+
+def _zepp(nseg, distributed=True):
+    from antennaknobs.designs.wire.zepp import Builder
+
+    if distributed:
+        b = Builder()
+    else:
+
+        class ZeppDelta(Builder):
+            def build_network(self):
+                net = super().build_network()
+                ports = dict(net.ports)
+                ports["ant"] = PortOnWire("ant")  # back to a delta gap
+                return Network(ports=ports, branches=net.branches, sources=net.sources)
+
+        b = ZeppDelta()
+    b.nominal_nsegs = nseg
+    return b
+
+
+def _sin(b):
+    return MomwireEngine(b, solver=SinusoidalSolver, ground="free")
+
+
+def _bs2(b):
+    return MomwireEngine(
+        b, solver=BSplineSolver, solver_kwargs={"degree": 2}, ground="free"
+    )
+
+
+def test_coarse_mesh_degenerates_to_delta_gap():
+    """While the port wire is still ONE segment, the distributed port is
+    exactly the delta gap (one sub-feed, weight 1) — bit-identical Z, so
+    turning the flag on cannot churn coarse-mesh results."""
+    z_dist = _sin(_zepp(21, distributed=True)).impedance()[0]
+    z_delta = _sin(_zepp(21, distributed=False)).impedance()[0]
+    assert z_dist == z_delta
+
+
+def test_weight_matrix_shape_and_column_sums():
+    """The expansion's W: one column per original feed, columns sum to 1
+    (length-split voltages), and only the distributed port has >1 sub-feed."""
+    eng = _sin(_zepp(161))  # "ant" subdivides at this rung
+    W = eng._feed_W
+    assert W is not None
+    n_sub, n_orig = W.shape
+    assert n_orig == len(eng._feeds) and n_sub > n_orig
+    assert np.allclose(W.sum(axis=0), 1.0)
+    # every row belongs to exactly one port
+    assert np.all((W > 0).sum(axis=1) == 1)
+
+
+def test_contract_y_congruence():
+    """_contract_y is the exact congruence Wᵀ·Y·W, on one matrix and on a
+    swept stack."""
+    eng = _sin(_zepp(161))
+    W = eng._feed_W
+    rng = np.random.default_rng(7)
+    Y = rng.normal(size=(W.shape[0], W.shape[0])) + 1j * rng.normal(
+        size=(W.shape[0], W.shape[0])
+    )
+    assert np.allclose(eng._contract_y(Y), W.T @ Y @ W)
+    stack = np.stack([Y, 2 * Y])
+    got = eng._contract_y(stack)
+    assert np.allclose(got[0], W.T @ Y @ W) and np.allclose(got[1], 2 * (W.T @ Y @ W))
+
+
+def test_port_impedance_mesh_stable_where_delta_gap_drifts():
+    """The regression this feature exists for: refine zepp past the rung
+    where its port wire subdivides. The delta-gap readout moves several ohms
+    of reactance and keeps moving; the distributed port stays put (and the
+    N=321 value is the same one bs2 lands on — basis-agreeing)."""
+    z_161 = _sin(_zepp(161)).impedance()[0]
+    z_321 = _sin(_zepp(321)).impedance()[0]
+    assert abs(z_321 - z_161) / abs(z_321) < 0.01, (z_161, z_321)
+
+    # the delta-gap model on the same rungs is NOT stable (guards against
+    # this test passing vacuously on a design change)
+    zd_161 = _sin(_zepp(161, distributed=False)).impedance()[0]
+    zd_321 = _sin(_zepp(321, distributed=False)).impedance()[0]
+    assert abs(zd_321 - zd_161) / abs(zd_321) > 0.02, (zd_161, zd_321)
+
+    z_bs2 = _bs2(_zepp(321)).impedance()[0]
+    assert abs(z_321 - z_bs2) / abs(z_bs2) < 0.01, (z_321, z_bs2)
+
+
+def test_sterba_tl_unpinned_flat_and_basis_agreeing():
+    """sterba_tl's nine TL ports ran pinned at 3 segments because refining
+    them drifted — and the pinned ladders were flat at basis-DEPENDENT
+    values ~5 ohm of X apart. With distributed ports the edges refine, the
+    ladder is flat by N=61, and sin agrees with bs2."""
+    from antennaknobs.designs.wire.sterba_tl import Builder
+
+    def z_at(engine, n):
+        b = Builder()
+        b.nominal_nsegs = n
+        return engine(b).impedance()[0]
+
+    z61, z161 = z_at(_sin, 61), z_at(_sin, 161)
+    assert abs(z161 - z61) / abs(z161) < 0.01, (z61, z161)
+    zb = z_at(_bs2, 161)
+    assert abs(z161 - zb) / abs(zb) < 0.01, (z161, zb)
+
+
+def test_excited_state_and_far_field_on_distributed_port():
+    """The excited path splits the resolved port voltage across the
+    sub-feeds; the far field must normalise to a finite, sane gain (a
+    broken split shows up as zero excitation or wild gain)."""
+    eng = _sin(_zepp(161))
+    ff = eng.far_field(n_theta=30, n_phi=72, del_theta=3, del_phi=5)
+    assert np.isfinite(ff.max_gain) and 0.0 < ff.max_gain < 6.0
+
+
+@needs_pynec
+def test_pynec_matches_momwire_on_distributed_port():
+    """Cross-engine oracle: PyNEC's sub-segment EX drive + weighted current
+    readout is the same contraction — the engines must agree at a rung
+    where the port wire has subdivided."""
+    z_mom = _sin(_zepp(161)).impedance()[0]
+    z_nec = PyNECEngine(_zepp(161), ground=None).impedance()[0]
+    assert abs(z_mom - z_nec) / abs(z_nec) < 0.02, (z_mom, z_nec)


### PR DESCRIPTION
## Summary
- **`PortOnWire(distributed=True)`**: the port spans its named wire's fixed *physical* extent instead of a delta gap on one mesh-dependent segment — one sub-feed per segment with length-split voltages, port Y row contracted by congruence (Y_port = WᵀY_subW, weighted-current readout as the bilinear dual so port power is preserved). Mesh-stable by construction; degenerates **bit-identically** to the delta gap while the port wire is one segment. This is the surviving scope of #477 after the diagnosis: the port-drift class was exactly "readout moves when the port wire subdivides."
- **Engine-level implementation**: momwire engines expand the solver feed list and contract Y — works unchanged for sin/bs1/bs2/hmatrix and the swept path, no momwire release needed. PyNEC drives every sub-segment EX with split voltages and reads the weighted current on the reducer path (distributed ports always reduce). `nec_export` rejects them alongside TL/virtual networks.
- **sterba_tl: all nine 3-segment port pins retired.** Edges refine like everything else; the ladder is flat from N≈61 at **77.4−29.8j on sin, bs2, AND pynec** — one basis-agreed value, where the pins were flat at basis-*dependent* values 5 Ω of X apart (sin 72.96−16.59j vs bs2 72.64−14.89j).
- **zepp: the 1→3-segment port-subdivision jump is gone.** All three engines flat at 2.60+16.3j (the delta-gap X drifted 17→26+ without settling).
- **terminated_longwire measured and deliberately NOT adopted**: its termination Load is a genuine point element — the gap-averaged current under-dissipates and inflated gain by 2.5 dB against the Cebik-anchored tests. Its pinned delta gap stays (the census's one genuinely pin-fixable design).
- Note: sterba_tl/zepp recorded catalog values shift (model change, documented in the design comments): sterba_tl 72.9−16.5j → 77.4−29.8j, zepp X ≈ 17.6 → 16.3 — from basis-dependent/drifting to converged basis-agreed.

## Test plan
- [x] `tests/test_distributed_port.py` (7): delta-gap degeneration, W invariants, congruence contraction, zepp mesh-stability + delta-gap counter-guard, sterba flat+basis-agreement, far-field path, pynec cross-engine oracle
- [x] Ladders N=21…641 on sterba_tl/zepp, N=21…321 terminated_longwire, three engines, memory-capped
- [x] `pytest -k "network or momwire_engine or pynec or sterba or zepp or web_server or draw or serialize or design"` — 1795 passed; catalog regen clean; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmgjJwcpzBa3sUzpKj7tKw