### PR TITLE
chore: release v0.32.0 (convergence you can trust)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/sta
 # install below sees its requirement already satisfied, then the package with the
 # web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install "momwire==0.15.0" \
+ && pip install "momwire==0.16.0" \
  && pip install -e ".[web]"
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire==0.15.0",
+    "momwire==0.16.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.31.0"
+version = "0.32.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,18 +25,18 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.31.0" icon="star">
-  **Sommerfeld ground, session-fast.** The most accurate ground model used
-  to be the one you saved for final checks — every solve paid seconds to
-  tabulate its interpolation grid. momwire 0.15.0 restructures that grid:
-  the fill now grows linearly with antenna size instead of quadratically,
-  and one tabulation is reused across a whole band's frequencies. The
-  first solve of a session still pays once; after that, band sweeps and
-  frequency-knob drags run warm at **10–40 ms per tick on the in-house
-  bases — faster than the NEC-2 reference's own steady state on 86 of 90
-  catalog designs**. Big-antenna cold solves dropped too (the
-  1000-segment terminated long-wire: 6.2 s → 3.1 s), and the whole
-  before/after is measured in the repo's session benchmark.
+<Card title="New in v0.32.0" icon="star">
+  **Convergence you can trust.** A catalog-wide convergence census (91
+  designs, meshes from N=7 to 641) reshaped how antennaknobs solves: the
+  default B-spline d=2 basis turns out to be converged at meshes the
+  NEC-style bases need 3–15× more segments to reach, so the **default
+  solve dropped to N=15 — ~35 % faster live ticks, census-validated to
+  the same answers**. Designs the census caught converging wrongly are
+  fixed (refining radials, mesh-stable **distributed ports** for
+  TL-attachment feeds — the Sterba curtain's nine pinned ports now refine
+  freely and land on one basis-agreed value), and the method itself is
+  written up in a new advanced guide:
+  [How many segments?](/advanced/convergence/)
   [All release notes →](/reference/releases/)
 </Card>
 


### PR DESCRIPTION
## Summary
Release PR for **v0.32.0 — convergence you can trust**. Two commits per the ritual:
1. **momwire pin 0.15.0 → 0.16.0** (pyproject exact pin + Dockerfile + submodule pointer): singular enrichment through the Y-matrix path (momwire#165) — the workbench enrichment toggle now works on networked designs.
2. **Version 0.32.0 + what's-new card** (de-stale sweep already merged via #486).

Release contents since v0.31.0: distributed finite-gap ports (#485, sterba_tl/zepp mesh-stable), census-derived workbench defaults bs2@N=15 / bs1@N=20 (#483), verticals radials convergence fix (#481), basis-convergence + feed-drift censuses with status docs (#482, census tooling), elt_whip coarse variant, PyNEC gn 2 near-ground warning (#473), NT-gyrator EX 6 bench reference (#476), the advanced convergence guide + site de-stale (#486).

## Test plan
- [x] Site builds (21 pages)
- [x] momwire 0.16.0 verified on PyPI before this PR (wheel-smoke won't race)
- [ ] Post-merge: tag v0.32.0 → watch publish + both deploys + fleet convergence, then announce

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmgjJwcpzBa3sUzpKj7tKw