### PR TITLE
docs(site): honest attribution in the convergence guide + consistent efficiency ledgers

### DIFF
--- a/site/src/content/docs/advanced/convergence.md
+++ b/site/src/content/docs/advanced/convergence.md
@@ -93,15 +93,22 @@ default fixes this class; expect a slow drift of a few percent, read the
 admittance if you need a well-conditioned number, and treat the last
 percent as physical uncertainty rather than solver error.
 
-**4. Refinement past the geometry's own scale.** On closely-spaced
-parallel wires — folded elements, fan dipoles, meander rails — the
-thin-wire method breaks when the segment length drops **below the wire
-spacing**. This one is vicious because coarse meshes agree beautifully
-and then refinement makes the answer *worse*: a folded inverted-V in the
-census read 223−30j identically on both bases at N=21…61, then the
-sinusoidal basis went to 280−**1188**j at N=321 while bs2 never moved.
-Response: don't refine such geometry past segment ≈ spacing; prefer the
-d=2 basis, which was immune in every measured case.
+**4. Refinement past the geometry's own scale.** Closely-spaced
+parallel wires — folded elements, fan dipoles, meander rails — are a
+documented soft spot for thin-wire codes: the NEC-2 manual requires
+aligned segments there and concedes the regime was never extensively
+tested, and the classic modeling guidance (Cebik) is to keep segment
+length *equal to* the conductor-to-conductor spacing. Our convergence
+census puts a sharper edge on it: refinement is the danger direction.
+Coarse meshes agree beautifully and then refinement makes the answer
+*worse*: a folded inverted-V in the census read 223−30j identically on
+both bases at N=21…61, then the sinusoidal basis went to
+280−**1188**j at N=321 while bs2 never moved. Response: don't refine
+such geometry past segment ≈ spacing (the gap between the parallel
+wires, not the wire radius); prefer the d=2 basis, which was immune in
+every measured case
+([issue #484](https://github.com/stevenmburns/antennaknobs/issues/484)
+tracks the mechanism).
 
 ## Feeds and ports deserve their own paragraph
 
@@ -138,7 +145,8 @@ the physics doesn't:
    - both crawling in lockstep at high |Z| → class 3, physics — accept
      the band, don't chase it;
    - agreement at coarse N that *breaks* at fine N on parallel-wire
-     geometry → class 4 — back N off to segment ≈ spacing and stay
+     geometry → class 4 — back N off to segment ≈ wire-to-wire
+     spacing and stay
      there.
 4. Report the value both bases agree on, at the coarsest mesh past the
    plateau — that is the defensible number, and the cheapest one.

--- a/site/src/content/docs/advanced/convergence.md
+++ b/site/src/content/docs/advanced/convergence.md
@@ -108,7 +108,10 @@ such geometry past segment ≈ spacing (the gap between the parallel
 wires, not the wire radius); prefer the d=2 basis, which was immune in
 every measured case
 ([issue #484](https://github.com/stevenmburns/antennaknobs/issues/484)
-tracks the mechanism).
+tracks the mechanism). Notably, the failure is not a visible oscillation
+— the current stays smooth — but the folded element's near-λ/4 shorted-stub
+mode sits at an antiresonance pole that amplifies a small feed-zone
+coupling error into a wildly wrong reactance.
 
 ## Feeds and ports deserve their own paragraph
 

--- a/site/src/content/docs/advanced/efhw.md
+++ b/site/src/content/docs/advanced/efhw.md
@@ -47,7 +47,18 @@ At the stock operating point the budget reads (fractions of input power):
 | unun core loss (magnetizing branch) | ~0.6 % |
 | 5 m RG-58 | ~6.0 % |
 | wire loss (I²R), 28 AWG PVC | ~6.1 % |
-| **radiated** | **~87 %** |
+| **structural efficiency** | **~87 %** |
+
+One label deserves care: that ~87 % is **structural efficiency** — the
+input power not burned in components and conductors — and it is the
+number this page's knobs can move. It is *not* the fraction that leaves
+as sky wave: this sloper runs steep and low, and over average ground
+the dirt takes its share of what the structure delivers. The pattern
+integral puts **radiated (incl. ground) at ~32 %** for the stock 20 m
+setup (~39 % for the 40 m variant below — the flatter 30° slope gives
+back more from the dirt's ledger than its extra wire loss costs). Both
+numbers are true, in different ledgers — the accounting is the subject
+of [Three ledgers of efficiency](/advanced/pota-performer/#the-efficiency-claim-true-in-its-ledger).
 
 Three readings worth taking home:
 
@@ -56,7 +67,7 @@ Three readings worth taking home:
    magnetizing Q; the innocent-looking 28 AWG wire burns six times that,
    because the half-wave's current maximum lives in the middle of the
    thin wire. Flip `wire_type` to 18 AWG PVC and the wire row drops to
-   ~1.9 % (efficiency 91 %) — the same gauge story as
+   ~1.9 % (structural efficiency 91 %) — the same gauge story as
    [wire gauge for POTA](/advanced/wire-gauge/), amplified by the
    end-fed's current distribution. The whole antenna still weighs 18 g
    in 28 AWG.
@@ -71,7 +82,7 @@ Three readings worth taking home:
    and the budget shows what it costs.
 
 The unun defaults (`lmag_uH` = 8, `qlmag` = 10) put the core in the
-85–90 % system-efficiency range measured for FT240-43-class 49:1 builds.
+85–90 % efficiency range bench-measured for FT240-43-class 49:1 builds.
 The model is deliberately minimal — a magnetizing branch with finite Q,
 not a full transformer characterization — so treat the (mag) row as the
 shape of the loss, and tune `qlmag` against a measurement if you have
@@ -91,7 +102,7 @@ physics rather than knob-turning:
   essentially omnidirectional), which is exactly how 40 m POTA operates:
   regional skywave, not DX.
 - **The wire loss doubles.** The longer high-current half wave burns
-  ~10 % in I²R (vs ~6 % on 20 m), for 84 % system efficiency. The 100 pF
+  ~10 % in I²R (vs ~6 % on 20 m), for 84 % structural efficiency. The 100 pF
   comp cap is a 20 m-flavored compromise, too — ~200 pF would buy
   SWR 1.19 here, if you'd rather rebuild the unun than accept 1.36.
 

--- a/site/src/content/docs/advanced/station-comparison.md
+++ b/site/src/content/docs/advanced/station-comparison.md
@@ -89,8 +89,8 @@ def build_network(self):
 
 The stock capacitor and inductor values match ~50 Ω at **7.1 MHz (40 m)**, and
 the budget itemizes the price of the matchbox: with Q = 200, about **3.5 % in
-the line and 4 % in the tuner coil — ~92 % radiated**. That's the ladder-line
-promise kept.
+the line and 4 % in the tuner coil — **~92 % accepted by the antenna**. That's
+the ladder-line promise kept.
 
 Now make the wire *too short* — retune for **80 m** (pick 80m in the
 measurement-band selector, dial the frequency to 3.8, then
@@ -142,11 +142,14 @@ side by side:
 | SWR on the feedline | ≈ 1.4 | ≈ 11 |
 | feedline loss | 24 % | 9 % |
 | tuner coil loss | — | 6 % |
-| **radiated** | **76 %** | **84 %** |
+| **antenna (accepted)** | **76 %** | **84 %** |
 
 (Every number on this page is solved the way the workbench solves it by
 default: finite ground — εr = 10, σ = 0.002, reflection-coefficient model —
-with the B-spline d = 2 solver.)
+with the B-spline d = 2 solver. The budget rows are the *network* ledger:
+the fraction of rig power that survives to the antenna terminals. Wire I²R
+and the ground's absorption come out of what's left — for that accounting,
+see [Three ledgers of efficiency](/advanced/pota-performer/#the-efficiency-claim-true-in-its-ledger).)
 
 What the table says:
 
@@ -157,10 +160,10 @@ What the table says:
   coax loss into disaster (Station A's off-resonance beat, above) costs the
   open-wire line 9 % — total, matched loss included.
 - **The coil takes its cut — and B still wins.** 6 % in the tuner inductor is
-  the price of the matchbox, and the doublet station radiates eight points
-  more anyway.
+  the price of the matchbox, and the doublet station delivers eight points
+  more to the antenna anyway.
 - **The tuner protects the rig, not the watts.** Wreck the match on purpose:
-  drag `shunt_l_uH` from 2.56 to 3.0 and the rig sees SWR 5 — yet radiated
+  drag `shunt_l_uH` from 2.56 to 3.0 and the rig sees SWR 5 — yet accepted
   power doesn't drop at all (84.3 % → 85.2 %). The watts were already decided
   out on the line and in the coil; the match just decides whether your
   transmitter is happy delivering them.

--- a/site/src/content/docs/advanced/wire-gauge.md
+++ b/site/src/content/docs/advanced/wire-gauge.md
@@ -51,7 +51,7 @@ the numbers below are the dropdown flipped with everything else constant
 (2:1 SWR window from the band-locked sweep; weight for the full ~10 m of
 wire; loss relative to a perfect conductor):
 
-| wire | weight | 2:1 SWR window | radiated power |
+| wire | weight | 2:1 SWR window | gain vs lossless wire |
 |---|---|---|---|
 | 28 AWG PVC | **17 g** | 550 kHz | −0.36 dB (92 %) |
 | 22 AWG PVC | 53 g | 605 kHz | −0.18 dB (96 %) |


### PR DESCRIPTION
## Summary
- Convergence guide class-4 rewrite: attribute the parallel-wire refinement rule honestly — the close-spaced soft spot is documented lore (NEC-2 manual's aligned-segments guidance, Cebik's segment-length-equals-spacing practice), but the refinement-instability threshold is our census measurement (mechanism tracked in #484, now with a probe-backed stub-pole-amplification explanation — see the new issue comment). Disambiguates "spacing" = conductor-to-conductor gap, not wire radius.
- Efficiency-ledger consistency across the advanced pages: efhw's "radiated ~87%" relabeled **structural efficiency** with freshly-integrated honest numbers (radiated incl. ground ≈ 32% on 20m, ≈ 39% on 40m); station-comparison's network-budget remainder now uses the UI's own **antenna (accepted)** label + ledger cross-link; wire-gauge's table column renamed **gain vs lossless wire**. The pages no longer use "radiated" the way the three-ledgers page criticizes.

## Test plan
- [x] `npm run build` in `site/` passes (21 pages)
- [x] efhw radiated-incl-ground numbers computed with `radiated_fraction` over average ground (same method as the pota-performer tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmgjJwcpzBa3sUzpKj7tKw