### PR TITLE
Composite station components: Composite/Instance networks + station stdlib (#489)

### DIFF
--- a/src/antennaknobs/__init__.py
+++ b/src/antennaknobs/__init__.py
@@ -17,6 +17,8 @@ __all__ = [
     "WireSpec",
     "Wire",
     "as_wire",
+    "Composite",
+    "Instance",
     "plot_patterns",
     "compare_patterns",
     "pattern_metrics",
@@ -48,7 +50,7 @@ from .builder import (
 )
 from .design_data import read_data, read_json
 from .nec_import import read_nec
-from .network import Wire, WireSpec, as_wire
+from .network import Composite, Instance, Wire, WireSpec, as_wire
 from .transform import Transform, TransformStack
 from .drone import Drone
 from .sim import Antenna

--- a/src/antennaknobs/designs/dipoles/folded_invvee_balun.py
+++ b/src/antennaknobs/designs/dipoles/folded_invvee_balun.py
@@ -23,11 +23,12 @@ from antennaknobs.network import (
     CABLES,
     TL,
     Driven,
+    Instance,
     Network,
     PortOnWire,
     PortVirtual,
-    Transformer,
 )
+from antennaknobs.station import balun
 from antennaknobs.designs.dipoles.folded_invvee import Builder as FoldedInvVee
 
 
@@ -78,12 +79,15 @@ class Builder(FoldedInvVee):
             },
             branches=[
                 TL.from_cable(self.cable, "rig", "bal", self.line_len_m),
-                Transformer(
-                    a="bal",
-                    b="feed",
-                    n=self.balun_n,
-                    lmag=self.lmag_uH * 1e-6,
-                    qlmag=self.qlmag if self.qlmag > 0 else None,
+                Instance(
+                    "balun",
+                    balun(
+                        n=self.balun_n,
+                        lmag_H=self.lmag_uH * 1e-6,
+                        qlmag=self.qlmag if self.qlmag > 0 else None,
+                    ),
+                    line="bal",
+                    ant="feed",
                 ),
             ],
             sources=[Driven(port="rig", voltage=1 + 0j)],

--- a/src/antennaknobs/designs/dipoles/folded_invvee_balun.py
+++ b/src/antennaknobs/designs/dipoles/folded_invvee_balun.py
@@ -83,7 +83,7 @@ class Builder(FoldedInvVee):
                     "balun",
                     balun(
                         n=self.balun_n,
-                        lmag_H=self.lmag_uH * 1e-6,
+                        lmag_uH=self.lmag_uH,
                         qlmag=self.qlmag if self.qlmag > 0 else None,
                     ),
                     line="bal",

--- a/src/antennaknobs/designs/loops/skyloop_lmatch.py
+++ b/src/antennaknobs/designs/loops/skyloop_lmatch.py
@@ -32,12 +32,12 @@ from types import MappingProxyType
 from antennaknobs.designs.loops.triangular_skyloop import Builder as TriangularSkyloop
 from antennaknobs.network import (
     Driven,
+    Instance,
     Network,
     PortOnWire,
     PortVirtual,
-    Shunt,
-    TwoPort,
 )
+from antennaknobs.station import l_network_tuner
 
 
 class Builder(TriangularSkyloop):
@@ -86,12 +86,19 @@ class Builder(TriangularSkyloop):
         (Z_in = Z_ant). `coil_q > 0` gives the series inductor a finite Q
         (R = ωL/Q, issue #298), turning the matchbox lossy the way a real
         tuner is; 0 keeps the ideal coil."""
-        ql = self.coil_q if self.coil_q > 0 else None
         return Network(
             ports={"feed": PortOnWire("feed"), "in": PortVirtual("in")},
             branches=[
-                TwoPort(a="in", b="feed", l=self.series_L_uH * 1e-6, ql=ql),
-                Shunt(port="feed", c=self.shunt_C_pF * 1e-12),
+                Instance(
+                    "match",
+                    l_network_tuner(
+                        series_l_H=self.series_L_uH * 1e-6,
+                        shunt_c_F=self.shunt_C_pF * 1e-12,
+                        ql=self.coil_q if self.coil_q > 0 else None,
+                    ),
+                    rig="in",
+                    out="feed",
+                ),
             ],
             sources=[Driven(port="in", voltage=1 + 0j)],
         )

--- a/src/antennaknobs/designs/loops/skyloop_lmatch.py
+++ b/src/antennaknobs/designs/loops/skyloop_lmatch.py
@@ -92,8 +92,8 @@ class Builder(TriangularSkyloop):
                 Instance(
                     "match",
                     l_network_tuner(
-                        series_l_H=self.series_L_uH * 1e-6,
-                        shunt_c_F=self.shunt_C_pF * 1e-12,
+                        series_l_uH=self.series_L_uH,
+                        shunt_c_pF=self.shunt_C_pF,
                         ql=self.coil_q if self.coil_q > 0 else None,
                     ),
                     rig="in",

--- a/src/antennaknobs/designs/verticals/challenger.py
+++ b/src/antennaknobs/designs/verticals/challenger.py
@@ -144,7 +144,7 @@ class Builder(AntennaBuilder):
                     "unun",
                     unun(
                         turns=self.turns,
-                        lmag_H=self.lmag_uH * 1e-6,
+                        lmag_uH=self.lmag_uH,
                         qlmag=self.qlmag if self.qlmag > 0 else None,
                     ),
                     line="rig",

--- a/src/antennaknobs/designs/verticals/challenger.py
+++ b/src/antennaknobs/designs/verticals/challenger.py
@@ -35,12 +35,13 @@ from types import MappingProxyType
 from antennaknobs import AntennaBuilder
 from antennaknobs.network import (
     Driven,
+    Instance,
     Network,
     PortOnWire,
     PortVirtual,
-    Transformer,
     WireSpec,
 )
+from antennaknobs.station import unun
 
 _IN = 0.0254
 
@@ -139,13 +140,16 @@ class Builder(AntennaBuilder):
         return Network(
             ports={"ant": PortOnWire("ant"), "rig": PortVirtual("rig")},
             branches=[
-                Transformer(
-                    a="rig",
-                    b="ant",
-                    n=1.0 / self.turns,
-                    lmag=self.lmag_uH * 1e-6,
-                    qlmag=self.qlmag if self.qlmag > 0 else None,
-                )
+                Instance(
+                    "unun",
+                    unun(
+                        turns=self.turns,
+                        lmag_H=self.lmag_uH * 1e-6,
+                        qlmag=self.qlmag if self.qlmag > 0 else None,
+                    ),
+                    line="rig",
+                    ant="ant",
+                ),
             ],
             sources=[Driven(port="rig", voltage=1 + 0j)],
         )

--- a/src/antennaknobs/designs/verticals/dominator.py
+++ b/src/antennaknobs/designs/verticals/dominator.py
@@ -142,7 +142,7 @@ class Builder(AntennaBuilder):
                     "unun",
                     unun(
                         turns=XFMR_TURNS[self.xfmr_ratio],
-                        lmag_H=self.lmag_uH * 1e-6,
+                        lmag_uH=self.lmag_uH,
                         qlmag=self.qlmag if self.qlmag > 0 else None,
                     ),
                     line="rig",

--- a/src/antennaknobs/designs/verticals/dominator.py
+++ b/src/antennaknobs/designs/verticals/dominator.py
@@ -30,12 +30,13 @@ from types import MappingProxyType
 from antennaknobs import AntennaBuilder
 from antennaknobs.network import (
     Driven,
+    Instance,
     Network,
     PortOnWire,
     PortVirtual,
-    Transformer,
     WireSpec,
 )
+from antennaknobs.station import unun
 
 _IN = 0.0254
 
@@ -134,17 +135,19 @@ class Builder(AntennaBuilder):
         ]
 
     def build_network(self):
-        turns = XFMR_TURNS[self.xfmr_ratio]
         return Network(
             ports={"ant": PortOnWire("ant"), "rig": PortVirtual("rig")},
             branches=[
-                Transformer(
-                    a="rig",
-                    b="ant",
-                    n=1.0 / turns,
-                    lmag=self.lmag_uH * 1e-6,
-                    qlmag=self.qlmag if self.qlmag > 0 else None,
-                )
+                Instance(
+                    "unun",
+                    unun(
+                        turns=XFMR_TURNS[self.xfmr_ratio],
+                        lmag_H=self.lmag_uH * 1e-6,
+                        qlmag=self.qlmag if self.qlmag > 0 else None,
+                    ),
+                    line="rig",
+                    ant="ant",
+                ),
             ],
             sources=[Driven(port="rig", voltage=1 + 0j)],
         )

--- a/src/antennaknobs/designs/wire/doublet_ladder_tuner.py
+++ b/src/antennaknobs/designs/wire/doublet_ladder_tuner.py
@@ -14,7 +14,8 @@ the transmitter.
 Stock values match ~50 Ω at 7.1 MHz (40 m) over the workbench-default
 finite-fast ground (εr=10, σ=0.002): the readout shows SWR ≈ 1 while the
 budget itemizes where the watts actually go — with Q = 200 about 3.5 % in
-the line and 4 % in the tuner coil, ~92 % radiated. Retune for 80 m
+the line and 4 % in the tuner coil, ~92 % accepted by the antenna. Retune
+for 80 m
 (3.8 MHz: C1 ≈ 38.8 pF, L ≈ 32.6 µH, C2 stays at 500 pF) and the same
 doublet is electrically short: the line's SWR loss climbs to ~17 % and the
 coil to ~15 % — a third of the power never leaves the shack — the honest
@@ -129,9 +130,9 @@ class Builder(InvVee):
                 Instance(
                     "tuner",
                     t_network_tuner(
-                        c1_F=self.series_c1_pF * 1e-12,
-                        c2_F=self.series_c2_pF * 1e-12,
-                        l_H=self.shunt_l_uH * 1e-6,
+                        c1_pF=self.series_c1_pF,
+                        c2_pF=self.series_c2_pF,
+                        l_uH=self.shunt_l_uH,
                         ql=self.coil_q if self.coil_q > 0 else None,
                     ),
                     rig="rig",

--- a/src/antennaknobs/designs/wire/doublet_ladder_tuner.py
+++ b/src/antennaknobs/designs/wire/doublet_ladder_tuner.py
@@ -36,12 +36,12 @@ from types import MappingProxyType
 from antennaknobs.network import (
     TL,
     Driven,
+    Instance,
     Network,
     PortOnWire,
     PortVirtual,
-    Shunt,
-    TwoPort,
 )
+from antennaknobs.station import t_network_tuner
 from antennaknobs.designs.dipoles.invvee import Builder as InvVee
 
 
@@ -120,18 +120,23 @@ class Builder(InvVee):
             ports={
                 "feed": PortOnWire("feed"),
                 "li": PortVirtual("li"),  # line input (tuner output)
-                "m": PortVirtual("m"),  # tee midpoint
                 "rig": PortVirtual("rig"),
             },
             branches=[
                 TL.from_cable("openwire-600", "li", "feed", self.line_len_m),
-                TwoPort(a="rig", b="m", c=self.series_c1_pF * 1e-12),
-                Shunt(
-                    port="m",
-                    l=self.shunt_l_uH * 1e-6,
-                    ql=self.coil_q if self.coil_q > 0 else None,
+                # T-network tuner box; its tee midpoint is the instance's
+                # own internal node ("tuner.m" after expansion).
+                Instance(
+                    "tuner",
+                    t_network_tuner(
+                        c1_F=self.series_c1_pF * 1e-12,
+                        c2_F=self.series_c2_pF * 1e-12,
+                        l_H=self.shunt_l_uH * 1e-6,
+                        ql=self.coil_q if self.coil_q > 0 else None,
+                    ),
+                    rig="rig",
+                    out="li",
                 ),
-                TwoPort(a="m", b="li", c=self.series_c2_pF * 1e-12),
             ],
             sources=[Driven(port="rig", voltage=1 + 0j)],
         )

--- a/src/antennaknobs/designs/wire/efhw_sloper.py
+++ b/src/antennaknobs/designs/wire/efhw_sloper.py
@@ -63,14 +63,14 @@ from antennaknobs import AntennaBuilder, Drone
 from antennaknobs.network import (
     CABLES,
     Driven,
+    Instance,
     Network,
     PortOnWire,
     PortVirtual,
-    Shunt,
     TL,
-    Transformer,
     WIRES,
 )
+from antennaknobs.station import unun
 
 # unun_ratio dropdown → transformer turns ratio (feed side : rig side).
 # Impedance steps down by turns²: 49:1, 64:1, 225:4 (= 56.25:1).
@@ -184,26 +184,26 @@ class Builder(AntennaBuilder):
         return wires
 
     def build_network(self):
-        turns = UNUN_TURNS[self.unun_ratio]
-        branches = [
-            # Step-down unun: rig side "pri" sees Z_feed / turns².
-            Transformer(
-                a="pri",
-                b="ant",
-                n=1.0 / turns,
-                lmag=self.lmag_uH * 1e-6,
-                qlmag=self.qlmag if self.qlmag > 0 else None,
-            ),
-        ]
-        if self.comp_c_pF > 0:
-            branches.append(Shunt(port="pri", c=self.comp_c_pF * 1e-12))
-        branches.append(TL.from_cable(self.cable, "rig", "pri", self.line_len_m))
         return Network(
             ports={
                 "ant": PortOnWire("ant"),
-                "pri": PortVirtual("pri"),
+                "pri": PortVirtual("pri"),  # unun line-side terminals
                 "rig": PortVirtual("rig"),
             },
-            branches=branches,
+            branches=[
+                # Step-down unun: the line side "pri" sees Z_feed / turns².
+                Instance(
+                    "unun",
+                    unun(
+                        turns=UNUN_TURNS[self.unun_ratio],
+                        lmag_H=self.lmag_uH * 1e-6,
+                        qlmag=self.qlmag if self.qlmag > 0 else None,
+                        comp_c_F=self.comp_c_pF * 1e-12 if self.comp_c_pF > 0 else None,
+                    ),
+                    line="pri",
+                    ant="ant",
+                ),
+                TL.from_cable(self.cable, "rig", "pri", self.line_len_m),
+            ],
             sources=[Driven(port="rig", voltage=1 + 0j)],
         )

--- a/src/antennaknobs/designs/wire/efhw_sloper.py
+++ b/src/antennaknobs/designs/wire/efhw_sloper.py
@@ -196,9 +196,9 @@ class Builder(AntennaBuilder):
                     "unun",
                     unun(
                         turns=UNUN_TURNS[self.unun_ratio],
-                        lmag_H=self.lmag_uH * 1e-6,
+                        lmag_uH=self.lmag_uH,
                         qlmag=self.qlmag if self.qlmag > 0 else None,
-                        comp_c_F=self.comp_c_pF * 1e-12 if self.comp_c_pF > 0 else None,
+                        comp_c_pF=self.comp_c_pF if self.comp_c_pF > 0 else None,
                     ),
                     line="pri",
                     ant="ant",

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -21,7 +21,7 @@ as tiny stub wires at sensible locations.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import NamedTuple, Union
 
 
@@ -476,6 +476,173 @@ def _branch_port_refs(br):
     return (br.port,)  # Load, Shunt
 
 
+def _rewrite_branch(br, ren):
+    """Copy of ``br`` with every port reference passed through ``ren``."""
+    if isinstance(br, Admittance):
+        return replace(br, ports=tuple(ren(p) for p in br.ports))
+    if hasattr(br, "a"):  # TL, TwoPort, Transformer
+        return replace(br, a=ren(br.a), b=ren(br.b))
+    return replace(br, port=ren(br.port))
+
+
+# ---------------------------------------------------------------------------
+# Composite components (issue #489): reusable sub-networks with hierarchy
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class Composite:
+    """A reusable sub-network template: a formal port interface plus a body
+    of branches (and, optionally, nested :class:`Instance` s) that reference
+    either those formal ports or private internal nodes.
+
+    Design record: issue #489. The model follows the convergent shape of
+    the HCL survey there ("generators are code, modules are data", Hdl21):
+    a Composite is plain data; *factory functions* like
+    ``station.t_network_tuner(...)`` are the parameter mechanism, so there
+    is no template registry and no formal-parameter machinery — Python
+    call arguments are the parameter list.
+
+    - ``ports`` are the formal external ports. At instantiation each formal
+      is bound to a name in the parent's namespace (`Instance` kwargs — the
+      Verilog named port map).
+    - Any other name a body branch references is an internal node, private
+      to the instance: expansion namespaces it as ``"<instance>.<name>"``
+      and declares it as a `PortVirtual` automatically. Internals cannot be
+      referenced from outside (boundary hygiene — the ROHD lesson).
+    - ``aliases`` merge two of the composite's own names into one electrical
+      node (union-find at expansion). This is how a body connects a formal
+      directly to another formal (a pass-through such as ``station.bypass()``)
+      or surfaces one internal node under several formal names — cases a
+      branch body cannot express (see the #489 aliasing note). SPICE's
+      0 V-source idiom is deliberately NOT the mechanism: aliasing is a
+      naming fact, not an element.
+    - Bodies contain only branches and nested instances. Sources (`Driven`)
+      and geometry ports live at the top level of the design's `Network`.
+    """
+
+    ports: tuple[str, ...]
+    branches: tuple = ()
+    aliases: tuple[tuple[str, str], ...] = ()
+
+    def __post_init__(self):
+        if len(set(self.ports)) != len(self.ports):
+            raise ValueError(f"duplicate formal port in {self.ports!r}")
+        for item in self.branches:
+            if not isinstance(item, (*Branch.__args__, Instance)):
+                raise ValueError(
+                    f"Composite bodies hold branches or Instances, got {item!r}"
+                    " (sources and geometry ports belong in the Network)"
+                )
+
+
+class Instance:
+    """One instantiation of a :class:`Composite` inside a `Network` (or
+    inside another Composite): ``Instance("tuner1", t_network_tuner(...),
+    rig="rig", out="li")``.
+
+    - ``name`` becomes the namespace prefix for the composite's internal
+      nodes (``"tuner1.m"``) and the power-budget attribution path.
+    - Keyword arguments are the formal/actual port map: every formal port
+      of the composite must be bound to a port name in the parent's
+      namespace (binding one actual to several formals is legal and simply
+      fuses them). Missing or extra formals raise immediately.
+    """
+
+    def __init__(self, name: str, of: Composite, **portmap: str):
+        if not name or "." in name:
+            raise ValueError(
+                f"instance name {name!r} must be non-empty and contain no '.'"
+                " (dots are the namespace separator)"
+            )
+        formals, bound = set(of.ports), set(portmap)
+        if formals != bound:
+            missing, extra = formals - bound, bound - formals
+            raise ValueError(
+                f"instance {name!r} port map mismatch:"
+                + (f" missing formals {sorted(missing)}" if missing else "")
+                + (f" unknown formals {sorted(extra)}" if extra else "")
+                + f"; composite ports are {of.ports!r}"
+            )
+        self.name = name
+        self.of = of
+        self.portmap = dict(portmap)
+
+
+def _expand_instance(inst, formal_to_final, prefix, flat, paths, aliases, internals):
+    """Recursively flatten ``inst`` into ``flat``/``paths``, collecting alias
+    pairs and auto-created internal node names. ``formal_to_final`` maps the
+    composite's formals to FINAL (fully resolved) names; ``prefix`` is the
+    instance path ("tuner1." / "sta.tuner1.")."""
+
+    def resolve(n):
+        if n in formal_to_final:
+            return formal_to_final[n]
+        final = prefix + n
+        internals.add(final)
+        return final
+
+    for item in inst.of.branches:
+        if isinstance(item, Instance):
+            child_map = {f: resolve(a) for f, a in item.portmap.items()}
+            _expand_instance(
+                item, child_map, prefix + item.name + ".",
+                flat, paths, aliases, internals,
+            )  # fmt: skip
+        else:
+            flat.append(_rewrite_branch(item, resolve))
+            paths.append(prefix)
+    for a, b in inst.of.aliases:
+        aliases.append((resolve(a), resolve(b)))
+
+
+def _resolve_aliases(pairs, ports):
+    """Union-find over alias ``pairs``; returns a rename map name → canonical.
+
+    Canonical preference (deterministic): a real `PortOnWire` name beats any
+    virtual (its name is welded to geometry and must never be rewritten),
+    then top-level names beat instance-internal ones (fewer dots), then the
+    shorter / lexicographically-smaller name. Merging two real ports is an
+    error — two distinct geometry locations cannot be fused by naming."""
+    parent = {}
+
+    def find(x):
+        parent.setdefault(x, x)
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for a, b in pairs:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    classes = {}
+    for n in parent:
+        classes.setdefault(find(n), []).append(n)
+
+    rename = {}
+    for members in classes.values():
+        real = [n for n in members if isinstance(ports.get(n), PortOnWire)]
+        if len(real) > 1:
+            raise ValueError(
+                f"aliases merge distinct geometry ports {sorted(real)} — "
+                "two real feed locations cannot be fused by naming"
+            )
+        canon = min(
+            members,
+            key=lambda n: (
+                0 if n in real else 1,
+                n.count("."),
+                len(n),
+                n,
+            ),
+        )
+        for n in members:
+            if n != canon:
+                rename[n] = canon
+    return rename
+
+
 def _series_rlc_impedance(r, l, c, omega, ql=None, qc=None):
     """Series R + jωL + 1/(jωC). Any of r/l/c may be None (omitted term).
 
@@ -618,7 +785,15 @@ class Network:
     """Complete network spec returned by `build_network()`.
 
     ports:    dict mapping name → Port (real or virtual)
-    branches: list of Branch (TL / Load / TwoPort)
+    branches: list of Branch (TL / Load / TwoPort / …) — may also contain
+              `Instance` items (issue #489), which are flattened in
+              ``__post_init__``: internal nodes become auto-declared
+              `PortVirtual` s named "<instance>.<node>", composite aliases
+              are resolved by node merging, and each flattened branch's
+              instance path lands in ``branch_paths`` (same order as
+              ``branches``; "" for top-level branches) for power-budget
+              attribution. Engines and reducers only ever see plain
+              branches.
     sources:  list of Source (currently just Driven)
 
     The engine's job: assemble the antenna Y matrix at the real ports,
@@ -629,8 +804,12 @@ class Network:
     ports: dict[str, Port]
     branches: list[Branch] = field(default_factory=list)
     sources: list[Source] = field(default_factory=list)
+    branch_paths: list[str] = field(default_factory=list)
 
     def __post_init__(self):
+        if self.branch_paths:
+            raise ValueError("branch_paths is derived — do not pass it")
+        self._expand_instances()
         for name, port in self.ports.items():
             if port.name != name:
                 raise ValueError(
@@ -646,3 +825,52 @@ class Network:
                 raise ValueError(f"source {src!r} references unknown port")
         if not self.sources:
             raise ValueError("Network has no driven sources")
+
+    def _expand_instances(self):
+        """Flatten `Instance` items (issue #489): namespace internals,
+        resolve aliases, stamp per-branch instance paths."""
+        flat, paths, alias_pairs, internals = [], [], [], set()
+        for item in self.branches:
+            if isinstance(item, Instance):
+                for actual in item.portmap.values():
+                    if actual not in self.ports:
+                        raise ValueError(
+                            f"instance {item.name!r} binds to unknown port "
+                            f"{actual!r} — actuals must be declared Network "
+                            "ports"
+                        )
+                _expand_instance(
+                    item, dict(item.portmap), item.name + ".",
+                    flat, paths, alias_pairs, internals,
+                )  # fmt: skip
+            else:
+                flat.append(item)
+                paths.append("")
+        self.branches = flat
+        self.branch_paths = paths
+        for n in sorted(internals):
+            if n in self.ports:
+                raise ValueError(f"internal node {n!r} collides with a port")
+            self.ports[n] = PortVirtual(n)
+        if not alias_pairs:
+            return
+        rename = _resolve_aliases(alias_pairs, self.ports)
+        if not rename:
+            return
+        ren = lambda n: rename.get(n, n)  # noqa: E731
+        self.branches = [_rewrite_branch(br, ren) for br in self.branches]
+        self.ports = {n: p for n, p in self.ports.items() if n not in rename}
+        merged_sources = []
+        for src in self.sources:
+            src = replace(src, port=ren(src.port))
+            for prev in merged_sources:
+                if prev.port == src.port:
+                    if prev != src:
+                        raise ValueError(
+                            f"aliasing merged conflicting sources on port "
+                            f"{src.port!r}: {prev!r} vs {src!r}"
+                        )
+                    break
+            else:
+                merged_sources.append(src)
+        self.sources = merged_sources

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -322,7 +322,16 @@ class NetworkReducer:
         elements = []
         loads_by_node = {}
         probes = []
-        for br in self.network.branches:
+        # Instance paths (issue #489): branch_paths aligns with branches
+        # ("" for top-level). Budget labels get a "tuner1: " prefix and the
+        # instance's own namespace stripped from its port names, so a
+        # composite's rows group under its instance name.
+        branch_paths = getattr(self.network, "branch_paths", None) or [""] * len(
+            self.network.branches
+        )
+        for br, _bpath in zip(self.network.branches, branch_paths):
+            _short = lambda n, p=_bpath: n[len(p) :] if p and n.startswith(p) else n  # noqa: E731
+            lab = lambda s, p=_bpath: f"{p[:-1]}: {s}" if p else s  # noqa: E731
             if isinstance(br, TL):
                 a, b = self.port_to_idx[br.a], self.port_to_idx[br.b]
                 y_tl = tl_admittance_2x2(
@@ -335,7 +344,9 @@ class NetworkReducer:
                     k2=br.k2,
                 )
                 G[np.ix_([a, b], [a, b])] += y_tl
-                probes.append((f"TL {br.a}→{br.b}", "group1", ([a, b], y_tl)))
+                probes.append(
+                    (lab(f"TL {_short(br.a)}→{_short(br.b)}"), "group1", ([a, b], y_tl))
+                )
             elif isinstance(br, Admittance):
                 # Fixed complex Y stamped verbatim — no ω scaling, no auxiliary
                 # current (issue #416). A pure node-admittance block, exactly
@@ -344,11 +355,21 @@ class NetworkReducer:
                 yb = np.array(br.y, dtype=np.complex128)
                 G[np.ix_(idxs, idxs)] += yb
                 probes.append(
-                    (f"Admittance {'→'.join(br.ports)}", "group1", (idxs, yb))
+                    (
+                        lab(f"Admittance {'→'.join(map(_short, br.ports))}"),
+                        "group1",
+                        (idxs, yb),
+                    )
                 )
             elif isinstance(br, TwoPort):
                 a, b = self.port_to_idx[br.a], self.port_to_idx[br.b]
-                probes.append((f"TwoPort {br.a}→{br.b}", "group2", len(elements)))
+                probes.append(
+                    (
+                        lab(f"TwoPort {_short(br.a)}→{_short(br.b)}"),
+                        "group2",
+                        len(elements),
+                    )
+                )
                 elements.append(
                     _series_group2(a, b, br.r, br.l, br.c, omega, ql=br.ql, qc=br.qc)
                 )
@@ -360,10 +381,16 @@ class NetworkReducer:
                     )
                     G[k, k] += y_sh
                     probes.append(
-                        (f"Shunt {br.port}", "group1", ([k], np.array([[y_sh]])))
+                        (
+                            lab(f"Shunt {_short(br.port)}"),
+                            "group1",
+                            ([k], np.array([[y_sh]])),
+                        )
                     )
                 else:
-                    probes.append((f"Shunt {br.port}", "group2", len(elements)))
+                    probes.append(
+                        (lab(f"Shunt {_short(br.port)}"), "group2", len(elements))
+                    )
                     elements.append(
                         _series_group2(
                             k, None, br.r, br.l, br.c, omega, ql=br.ql, qc=br.qc
@@ -382,7 +409,13 @@ class NetworkReducer:
                 # Ideal ratio + winding R referred to side a: the auxiliary
                 # current j is i_a (into winding A); KCL carries j out of a
                 # and n·j into b; constitutive row v_a − n·v_b − r_w·j = 0.
-                probes.append((f"Transformer {br.a}→{br.b}", "group2", len(elements)))
+                probes.append(
+                    (
+                        lab(f"Transformer {_short(br.a)}→{_short(br.b)}"),
+                        "group2",
+                        len(elements),
+                    )
+                )
                 elements.append(
                     _Group2Element(
                         a,
@@ -404,7 +437,7 @@ class NetworkReducer:
                     G[a, a] += y_mag
                     probes.append(
                         (
-                            f"Transformer {br.a}→{br.b} (mag)",
+                            lab(f"Transformer {_short(br.a)}→{_short(br.b)} (mag)"),
                             "group1",
                             ([a], np.array([[y_mag]])),
                         )

--- a/src/antennaknobs/station.py
+++ b/src/antennaknobs/station.py
@@ -1,0 +1,110 @@
+"""Standard library of station building blocks (issue #489): matchboxes,
+transformers, and pass-throughs as reusable `Composite` components.
+
+Each factory is an ordinary Python function returning a `Composite` — the
+function arguments ARE the component's parameter list ("generators are
+code, modules are data"). Designs instantiate them by name with a
+formal/actual port map:
+
+    from antennaknobs.network import Instance
+    from antennaknobs.station import t_network_tuner, bypass
+
+    branches = [
+        Instance("tuner", t_network_tuner(c1_F=..., c2_F=..., l_H=...),
+                 rig="rig", out="li"),
+        TL.from_cable("openwire-600", "li", "feed", 20.0),
+    ]
+
+Swapping a box for `bypass()` (same two-port interface, wires straight
+through) turns any "with/without the matchbox" comparison into a one-line
+change.
+
+Units are SI throughout (farads, henries, ohms) — matching the branch
+classes, NOT the pF/µH conventions design knobs use; convert at the call
+site where the knob's unit is visible.
+"""
+
+from __future__ import annotations
+
+from .network import Composite, Shunt, Transformer, TwoPort
+
+
+def bypass() -> Composite:
+    """A two-port that wires its input straight to its output — the
+    pass-through with a matchbox's interface (formals ``a``/``b``).
+    Implemented as a pure alias (node merge), not a 0 Ω element: no extra
+    MNA unknown, no budget row, electrically *identical* to not being
+    there. Use it to A/B a station with and without its tuner/balun
+    without touching anything else."""
+    return Composite(ports=("a", "b"), aliases=(("a", "b"),))
+
+
+def t_network_tuner(
+    c1_F: float, c2_F: float, l_H: float, ql: float | None = None
+) -> Composite:
+    """The classic T-network ("high-pass tee") antenna tuner: series C1
+    from ``rig`` to an internal tee midpoint, shunt L to common at the
+    midpoint, series C2 on to ``out``. `ql` gives the coil a finite Q
+    (R = ωL/Q, issue #298) — the coil is where a real T-network burns
+    its watts. Formals: ``rig`` (transmitter side), ``out`` (line side)."""
+    return Composite(
+        ports=("rig", "out"),
+        branches=(
+            TwoPort(a="rig", b="m", c=c1_F),
+            Shunt(port="m", l=l_H, ql=ql),
+            TwoPort(a="m", b="out", c=c2_F),
+        ),
+    )
+
+
+def l_network_tuner(
+    series_l_H: float, shunt_c_F: float, ql: float | None = None
+) -> Composite:
+    """L-match: series L from ``rig`` to ``out``, shunt C across ``out``
+    (the load side — the arrangement that steps a higher load R down to
+    the rig). Degenerate values are physics, not errors (issue #285): a
+    0 H series arm is an ideal short and a 0 F shunt is an open, so both
+    arms at zero make this an inert pass-through. Formals: ``rig``,
+    ``out``."""
+    return Composite(
+        ports=("rig", "out"),
+        branches=(
+            TwoPort(a="rig", b="out", l=series_l_H, ql=ql),
+            Shunt(port="out", c=shunt_c_F),
+        ),
+    )
+
+
+def unun(
+    turns: float,
+    lmag_H: float | None = None,
+    qlmag: float | None = None,
+    comp_c_F: float | None = None,
+) -> Composite:
+    """Step-down unun (the EFHW / OCF box): an ideal ``turns``:1
+    transformer — the ``line`` side sees Z_ant/turns² — with the minimal
+    loss model of `Transformer` (magnetizing inductance ``lmag_H`` shunted
+    across the line side, finite-Q core loss ``qlmag``), plus the optional
+    compensation capacitor ``comp_c_F`` across the line-side terminals
+    that commercial 49:1 builds carry. Formals: ``line`` (rig/feedline
+    side), ``ant`` (high-Z antenna side)."""
+    branches: tuple = (
+        Transformer(a="line", b="ant", n=1.0 / turns, lmag=lmag_H, qlmag=qlmag),
+    )
+    if comp_c_F:
+        branches += (Shunt(port="line", c=comp_c_F),)
+    return Composite(ports=("line", "ant"), branches=branches)
+
+
+def balun(
+    n: float, lmag_H: float | None = None, qlmag: float | None = None
+) -> Composite:
+    """Balun as an ideal ``a:b`` ratio transformer with the minimal loss
+    model (magnetizing branch on the ``line`` side): ``n`` is the
+    line:antenna voltage ratio, so a 4:1 impedance balun stepping a
+    ~300 Ω feed down to ~75 Ω line is ``balun(n=0.5)`` — same convention
+    as `Transformer` itself. Formals: ``line``, ``ant``."""
+    return Composite(
+        ports=("line", "ant"),
+        branches=(Transformer(a="line", b="ant", n=n, lmag=lmag_H, qlmag=qlmag),),
+    )

--- a/src/antennaknobs/station.py
+++ b/src/antennaknobs/station.py
@@ -10,7 +10,7 @@ formal/actual port map:
     from antennaknobs.station import t_network_tuner, bypass
 
     branches = [
-        Instance("tuner", t_network_tuner(c1_F=..., c2_F=..., l_H=...),
+        Instance("tuner", t_network_tuner(c1_pF=..., c2_pF=..., l_uH=...),
                  rig="rig", out="li"),
         TL.from_cable("openwire-600", "li", "feed", 20.0),
     ]
@@ -19,9 +19,9 @@ Swapping a box for `bypass()` (same two-port interface, wires straight
 through) turns any "with/without the matchbox" comparison into a one-line
 change.
 
-Units are SI throughout (farads, henries, ohms) — matching the branch
-classes, NOT the pF/µH conventions design knobs use; convert at the call
-site where the knob's unit is visible.
+Units are radio-work units — picofarads and microhenries, matching the
+design-knob conventions (`series_c1_pF`, `lmag_uH`, …) — converted to the
+branch classes' SI at construction. Ohms and Q are dimensionless-as-usual.
 """
 
 from __future__ import annotations
@@ -40,7 +40,7 @@ def bypass() -> Composite:
 
 
 def t_network_tuner(
-    c1_F: float, c2_F: float, l_H: float, ql: float | None = None
+    c1_pF: float, c2_pF: float, l_uH: float, ql: float | None = None
 ) -> Composite:
     """The classic T-network ("high-pass tee") antenna tuner: series C1
     from ``rig`` to an internal tee midpoint, shunt L to common at the
@@ -50,15 +50,15 @@ def t_network_tuner(
     return Composite(
         ports=("rig", "out"),
         branches=(
-            TwoPort(a="rig", b="m", c=c1_F),
-            Shunt(port="m", l=l_H, ql=ql),
-            TwoPort(a="m", b="out", c=c2_F),
+            TwoPort(a="rig", b="m", c=c1_pF * 1e-12),
+            Shunt(port="m", l=l_uH * 1e-6, ql=ql),
+            TwoPort(a="m", b="out", c=c2_pF * 1e-12),
         ),
     )
 
 
 def l_network_tuner(
-    series_l_H: float, shunt_c_F: float, ql: float | None = None
+    series_l_uH: float, shunt_c_pF: float, ql: float | None = None
 ) -> Composite:
     """L-match: series L from ``rig`` to ``out``, shunt C across ``out``
     (the load side — the arrangement that steps a higher load R down to
@@ -69,42 +69,44 @@ def l_network_tuner(
     return Composite(
         ports=("rig", "out"),
         branches=(
-            TwoPort(a="rig", b="out", l=series_l_H, ql=ql),
-            Shunt(port="out", c=shunt_c_F),
+            TwoPort(a="rig", b="out", l=series_l_uH * 1e-6, ql=ql),
+            Shunt(port="out", c=shunt_c_pF * 1e-12),
         ),
     )
 
 
 def unun(
     turns: float,
-    lmag_H: float | None = None,
+    lmag_uH: float | None = None,
     qlmag: float | None = None,
-    comp_c_F: float | None = None,
+    comp_c_pF: float | None = None,
 ) -> Composite:
     """Step-down unun (the EFHW / OCF box): an ideal ``turns``:1
     transformer — the ``line`` side sees Z_ant/turns² — with the minimal
-    loss model of `Transformer` (magnetizing inductance ``lmag_H`` shunted
+    loss model of `Transformer` (magnetizing inductance ``lmag_uH`` shunted
     across the line side, finite-Q core loss ``qlmag``), plus the optional
-    compensation capacitor ``comp_c_F`` across the line-side terminals
+    compensation capacitor ``comp_c_pF`` across the line-side terminals
     that commercial 49:1 builds carry. Formals: ``line`` (rig/feedline
     side), ``ant`` (high-Z antenna side)."""
+    lmag = lmag_uH * 1e-6 if lmag_uH is not None else None
     branches: tuple = (
-        Transformer(a="line", b="ant", n=1.0 / turns, lmag=lmag_H, qlmag=qlmag),
+        Transformer(a="line", b="ant", n=1.0 / turns, lmag=lmag, qlmag=qlmag),
     )
-    if comp_c_F:
-        branches += (Shunt(port="line", c=comp_c_F),)
+    if comp_c_pF:
+        branches += (Shunt(port="line", c=comp_c_pF * 1e-12),)
     return Composite(ports=("line", "ant"), branches=branches)
 
 
 def balun(
-    n: float, lmag_H: float | None = None, qlmag: float | None = None
+    n: float, lmag_uH: float | None = None, qlmag: float | None = None
 ) -> Composite:
     """Balun as an ideal ``a:b`` ratio transformer with the minimal loss
     model (magnetizing branch on the ``line`` side): ``n`` is the
     line:antenna voltage ratio, so a 4:1 impedance balun stepping a
     ~300 Ω feed down to ~75 Ω line is ``balun(n=0.5)`` — same convention
     as `Transformer` itself. Formals: ``line``, ``ant``."""
+    lmag = lmag_uH * 1e-6 if lmag_uH is not None else None
     return Composite(
         ports=("line", "ant"),
-        branches=(Transformer(a="line", b="ant", n=n, lmag=lmag_H, qlmag=qlmag),),
+        branches=(Transformer(a="line", b="ant", n=n, lmag=lmag, qlmag=qlmag),),
     )

--- a/tests/test_challenger_dominator.py
+++ b/tests/test_challenger_dominator.py
@@ -49,7 +49,7 @@ def _mag_loss_db(builder):
     eng = MomwireEngine(builder, **WORKBENCH)
     eng.current_distribution()
     budget = dict(eng._excited_power_budget)
-    frac = max(0.0, budget["Transformer rig→ant (mag)"]) / eng._excited_p_in
+    frac = max(0.0, budget["unun: Transformer rig→ant (mag)"]) / eng._excited_p_in
     return -10.0 * np.log10(1.0 - frac)
 
 

--- a/tests/test_composite_network.py
+++ b/tests/test_composite_network.py
@@ -1,0 +1,351 @@
+"""Composite network components (issue #489): expansion, namespacing,
+aliasing, budget attribution, and stdlib-box equivalence oracles.
+
+The design record lives in issue #489: composites follow the convergent
+HCL-survey shape ("generators are code, modules are data") — factory
+functions parameterize, `Instance` kwargs are the formal/actual port map,
+expansion flattens at Network construction so engines only ever see plain
+branches.
+"""
+
+import pytest
+
+from antennaknobs.network import (
+    TL,
+    Composite,
+    Driven,
+    Instance,
+    Load,
+    Network,
+    PortOnWire,
+    PortVirtual,
+    Shunt,
+    TwoPort,
+)
+from antennaknobs.station import bypass, t_network_tuner, unun
+
+
+def _ports(**kinds):
+    out = {}
+    for name, kind in kinds.items():
+        out[name] = PortOnWire(name) if kind == "real" else PortVirtual(name)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# expansion mechanics
+# ---------------------------------------------------------------------------
+def test_expansion_namespaces_internals_and_stamps_paths():
+    net = Network(
+        ports=_ports(feed="real", li="virt", rig="virt"),
+        branches=[
+            Instance(
+                "tuner",
+                t_network_tuner(c1_F=30e-12, c2_F=500e-12, l_H=2.5e-6, ql=200),
+                rig="rig",
+                out="li",
+            ),
+            TL(a="li", b="feed", z0=600, length=20.0),
+        ],
+        sources=[Driven(port="rig")],
+    )
+    # tee midpoint became a namespaced auto-declared virtual port
+    assert isinstance(net.ports["tuner.m"], PortVirtual)
+    assert net.branch_paths == ["tuner.", "tuner.", "tuner.", ""]
+    # flattened branches reference final names
+    tp1, sh, tp2, tl = net.branches
+    assert (tp1.a, tp1.b) == ("rig", "tuner.m")
+    assert sh.port == "tuner.m"
+    assert (tp2.a, tp2.b) == ("tuner.m", "li")
+    assert isinstance(tl, TL)
+
+
+def test_nested_instances_compose_paths():
+    box = Composite(
+        ports=("rig", "ant"),
+        branches=(
+            Instance("un", unun(7.0, lmag_H=8e-6), line="mid", ant="ant"),
+            TL(a="rig", b="mid", z0=50, length=5.0),
+        ),
+    )
+    net = Network(
+        ports=_ports(ant="real", rig="virt"),
+        branches=[Instance("sta", box, rig="rig", ant="ant")],
+        sources=[Driven(port="rig")],
+    )
+    assert "sta.mid" in net.ports
+    assert net.branch_paths == ["sta.un.", "sta."]
+
+
+def test_binding_one_actual_to_two_formals_fuses():
+    # parent-side fan-in needs no aliasing: kwargs may repeat an actual
+    box = Composite(ports=("a", "b"), branches=(TwoPort(a="a", b="b", r=50.0),))
+    net = Network(
+        ports=_ports(feed="real", n="virt"),
+        branches=[Instance("x", box, a="n", b="n")],
+        sources=[Driven(port="feed")],
+    )
+    (br,) = net.branches
+    assert (br.a, br.b) == ("n", "n")
+
+
+# ---------------------------------------------------------------------------
+# aliasing
+# ---------------------------------------------------------------------------
+def test_bypass_merges_nodes_and_moves_source():
+    net = Network(
+        ports=_ports(feed="real", rig="virt"),
+        branches=[Instance("t", bypass(), a="rig", b="feed")],
+        sources=[Driven(port="rig", voltage=2 + 0j)],
+    )
+    # the virtual node folded into the real port; no branches remain
+    assert set(net.ports) == {"feed"}
+    assert net.branches == []
+    assert net.sources == [Driven(port="feed", voltage=2 + 0j)]
+
+
+def test_internal_fanout_to_two_formals():
+    """One internal node surfacing under two formal names (the #489
+    aliasing case 2): the whole class merges onto the real actual."""
+    splitter = Composite(
+        ports=("inp", "out_a", "out_b"),
+        branches=(TwoPort(a="inp", b="n1", r=10.0),),
+        aliases=(("n1", "out_a"), ("n1", "out_b")),
+    )
+    net = Network(
+        ports=_ports(fa="real", vb="virt", rig="virt"),
+        branches=[Instance("sp", splitter, inp="rig", out_a="fa", out_b="vb")],
+        sources=[Driven(port="rig")],
+    )
+    (br,) = net.branches
+    assert (br.a, br.b) == ("rig", "fa")  # canonical = the real port
+    assert "vb" not in net.ports and "sp.n1" not in net.ports
+
+
+def test_alias_two_real_ports_rejected():
+    with pytest.raises(ValueError, match="geometry ports"):
+        Network(
+            ports=_ports(fa="real", fb="real", rig="virt"),
+            branches=[Instance("t", bypass(), a="fa", b="fb")],
+            sources=[Driven(port="rig")],
+        )
+
+
+def test_internal_alias_canonicalizes_to_external_name():
+    # one internal node surfacing under one formal: canonical is the
+    # bound (top-level) name, the internal name disappears
+    box = Composite(
+        ports=("inp", "out"),
+        branches=(TwoPort(a="inp", b="n1", r=10.0),),
+        aliases=(("n1", "out"),),
+    )
+    net = Network(
+        ports=_ports(feed="real", rig="virt"),
+        branches=[Instance("x", box, inp="rig", out="feed")],
+        sources=[Driven(port="rig")],
+    )
+    (br,) = net.branches
+    assert (br.a, br.b) == ("rig", "feed")
+    assert "x.n1" not in net.ports
+
+
+def test_conflicting_sources_after_merge_rejected():
+    with pytest.raises(ValueError, match="conflicting sources"):
+        Network(
+            ports=_ports(feed="real", a="virt", b="virt"),
+            branches=[
+                Instance("t", bypass(), a="a", b="b"),
+                TwoPort(a="b", b="feed", r=1.0),
+            ],
+            sources=[
+                Driven(port="a", voltage=1 + 0j),
+                Driven(port="b", voltage=2 + 0j),
+            ],
+        )
+
+
+# ---------------------------------------------------------------------------
+# validation
+# ---------------------------------------------------------------------------
+def test_instance_portmap_must_cover_formals():
+    box = bypass()
+    with pytest.raises(ValueError, match="missing formals"):
+        Instance("t", box, a="x")
+    with pytest.raises(ValueError, match="unknown formals"):
+        Instance("t", box, a="x", b="y", c="z")
+
+
+def test_instance_name_rules():
+    with pytest.raises(ValueError, match="no '.'"):
+        Instance("a.b", bypass(), a="x", b="y")
+
+
+def test_instance_actual_must_be_declared_port():
+    with pytest.raises(ValueError, match="unknown port"):
+        Network(
+            ports=_ports(feed="real"),
+            branches=[Instance("t", bypass(), a="feed", b="nope")],
+            sources=[Driven(port="feed")],
+        )
+
+
+def test_composite_rejects_sources_in_body():
+    with pytest.raises(ValueError, match="branches or Instances"):
+        Composite(ports=("a",), branches=(Driven(port="a"),))
+
+
+def test_top_level_typo_still_caught():
+    # instance expansion must not weaken top-level port validation
+    with pytest.raises(ValueError, match="unknown port"):
+        Network(
+            ports=_ports(feed="real"),
+            branches=[Shunt(port="feeed", c=1e-12)],
+            sources=[Driven(port="feed")],
+        )
+
+
+# ---------------------------------------------------------------------------
+# solve-level equivalence + budget attribution (engine oracle)
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="module")
+def _tuner_engines():
+    """The doublet_ladder_tuner design solved twice: hand-built branches
+    (the pre-#489 idiom) vs the stdlib t_network_tuner instance."""
+    from antennaknobs.engines.momwire import MomwireEngine
+    from antennaknobs.designs.wire.doublet_ladder_tuner import Builder
+
+    class HandBuilt(Builder):
+        def build_network(self):
+            return Network(
+                ports=_ports(feed="real", li="virt", m="virt", rig="virt"),
+                branches=[
+                    TL.from_cable("openwire-600", "li", "feed", self.line_len_m),
+                    TwoPort(a="rig", b="m", c=self.series_c1_pF * 1e-12),
+                    Shunt(
+                        port="m",
+                        l=self.shunt_l_uH * 1e-6,
+                        ql=self.coil_q if self.coil_q > 0 else None,
+                    ),
+                    TwoPort(a="m", b="li", c=self.series_c2_pF * 1e-12),
+                ],
+                sources=[Driven(port="rig", voltage=1 + 0j)],
+            )
+
+    return MomwireEngine(Builder()), MomwireEngine(HandBuilt())
+
+
+def test_stdlib_tuner_matches_hand_built(_tuner_engines):
+    eng_box, eng_hand = _tuner_engines
+    z_box, z_hand = eng_box.impedance()[0], eng_hand.impedance()[0]
+    assert z_box == pytest.approx(z_hand, rel=1e-12)
+
+
+def test_budget_rows_carry_instance_prefix(_tuner_engines):
+    eng_box, _ = _tuner_engines
+    eng_box.input_power()  # triggers the excited solve + budget
+    labels = [label for label, _w in eng_box._excited_power_budget]
+    assert any(label.startswith("tuner: ") for label in labels), labels
+    # the box's own namespace is stripped inside its rows
+    assert "tuner: Shunt m" in labels, labels
+
+
+def test_bypass_equals_bare_antenna():
+    """A bypassed matchbox is electrically absent: Z equals the bare
+    antenna's driving-point Z exactly."""
+    from antennaknobs.engines.momwire import MomwireEngine
+    from antennaknobs.designs.loops.skyloop_lmatch import Builder
+
+    class Bypassed(Builder):
+        def build_network(self):
+            return Network(
+                ports=_ports(feed="real", **{"in": "virt"}),
+                branches=[Instance("match", bypass(), a="in", b="feed")],
+                sources=[Driven(port="in", voltage=1 + 0j)],
+            )
+
+    class Bare(Builder):
+        def build_network(self):
+            return Network(
+                ports=_ports(feed="real"),
+                branches=[],
+                sources=[Driven(port="feed", voltage=1 + 0j)],
+            )
+
+    z_byp = MomwireEngine(Bypassed()).impedance()[0]
+    z_bare = MomwireEngine(Bare()).impedance()[0]
+    assert z_byp == pytest.approx(z_bare, rel=1e-12)
+
+
+def test_l_network_zero_arms_is_passthrough():
+    """The stdlib L-match with both arms at zero is inert (issue #285
+    degenerate-endpoint physics carried through the composite)."""
+    from antennaknobs.engines.momwire import MomwireEngine
+    from antennaknobs.designs.loops.skyloop_lmatch import Builder
+
+    b = Builder(params=dict(Builder.default_params))
+    b.series_L_uH = 0.0
+    b.shunt_C_pF = 0.0
+    z = MomwireEngine(b).impedance()[0]
+
+    class Bare(Builder):
+        def build_network(self):
+            return Network(
+                ports=_ports(feed="real"),
+                branches=[],
+                sources=[Driven(port="feed", voltage=1 + 0j)],
+            )
+
+    z_bare = MomwireEngine(Bare()).impedance()[0]
+    assert z == pytest.approx(z_bare, rel=1e-9)
+
+
+def test_unun_pynec_boxed_equals_hand_built():
+    """The composite path is engine-agnostic: on PyNEC's reducer path,
+    challenger's unun instance solves identically to the same network
+    written as raw branches (cross-engine physics is out of scope here —
+    this oracles only the expansion)."""
+    from antennaknobs.network import Transformer
+    from antennaknobs.engines.pynec import PyNECEngine
+    from antennaknobs.designs.verticals.challenger import Builder
+
+    class HandBuilt(Builder):
+        def build_network(self):
+            return Network(
+                ports=_ports(ant="real", rig="virt"),
+                branches=[
+                    Transformer(
+                        a="rig",
+                        b="ant",
+                        n=1.0 / self.turns,
+                        lmag=self.lmag_uH * 1e-6,
+                        qlmag=self.qlmag if self.qlmag > 0 else None,
+                    )
+                ],
+                sources=[Driven(port="rig", voltage=1 + 0j)],
+            )
+
+    z_box = PyNECEngine(Builder(), ground=None).impedance()[0]
+    z_hand = PyNECEngine(HandBuilt(), ground=None).impedance()[0]
+    assert z_box == pytest.approx(z_hand, rel=1e-9)
+
+
+def test_load_inside_composite_on_real_port():
+    """A Load in a composite body bound to a real port lands on the wire
+    (the termination path), same as a top-level Load."""
+    from antennaknobs.engines.momwire import MomwireEngine
+    from antennaknobs.designs.broadband.t2fd import Builder
+
+    class Boxed(Builder):
+        def build_network(self):
+            term_box = Composite(
+                ports=("t",), branches=(Load(port="t", r=self.term_r),)
+            )
+            return Network(
+                ports=_ports(feed="real", term="real"),
+                branches=[Instance("res", term_box, t="term")],
+                sources=[Driven(port="feed", voltage=1 + 0j)],
+            )
+
+    z_box = MomwireEngine(Boxed()).impedance()[0]
+    z_ref = MomwireEngine(Builder()).impedance()[0]
+    assert z_box == pytest.approx(z_ref, rel=1e-12)

--- a/tests/test_composite_network.py
+++ b/tests/test_composite_network.py
@@ -41,7 +41,7 @@ def test_expansion_namespaces_internals_and_stamps_paths():
         branches=[
             Instance(
                 "tuner",
-                t_network_tuner(c1_F=30e-12, c2_F=500e-12, l_H=2.5e-6, ql=200),
+                t_network_tuner(c1_pF=30, c2_pF=500, l_uH=2.5, ql=200),
                 rig="rig",
                 out="li",
             ),
@@ -64,7 +64,7 @@ def test_nested_instances_compose_paths():
     box = Composite(
         ports=("rig", "ant"),
         branches=(
-            Instance("un", unun(7.0, lmag_H=8e-6), line="mid", ant="ant"),
+            Instance("un", unun(7.0, lmag_uH=8), line="mid", ant="ant"),
             TL(a="rig", b="mid", z0=50, length=5.0),
         ),
     )

--- a/tests/test_efhw_sloper.py
+++ b/tests/test_efhw_sloper.py
@@ -61,9 +61,9 @@ def test_budget_itemizes_unun_line_and_wire():
     cap burn nothing; efficiency in the measured-EFHW range."""
     eng = MomwireEngine(Builder(), **GROUND)
     fr = _budget_fractions(eng)
-    assert fr["Transformer pri→ant"] < 1e-9  # no winding R by default
-    assert fr["Shunt pri"] < 1e-9  # ideal comp cap
-    assert 0.002 < fr["Transformer pri→ant (mag)"] < 0.05  # core loss
+    assert fr["unun: Transformer pri→ant"] < 1e-9  # no winding R by default
+    assert fr["unun: Shunt pri"] < 1e-9  # ideal comp cap
+    assert 0.002 < fr["unun: Transformer pri→ant (mag)"] < 0.05  # core loss
     assert 0.02 < fr["TL rig→pri"] < 0.15  # 5 m RG-58
     assert 0.02 < fr["wire loss (I²R)"] < 0.15  # 28 AWG half wave
     assert 0.80 < eng._excited_efficiency < 0.95  # measured 0.873

--- a/tests/test_station_designs.py
+++ b/tests/test_station_designs.py
@@ -73,9 +73,9 @@ def test_doublet_station_matches_fifty_ohms_with_coil_dominated_loss():
     (z,) = eng.impedance()
     assert abs(z - 50.0) < 1.0  # stock tune lands the rig at ~50 Ω
     fr = _budget_fractions(eng)
-    coil = fr["Shunt m"]
+    coil = fr["tuner: Shunt m"]
     line = fr["TL li→feed"]
-    caps = fr["TwoPort rig→m"] + fr["TwoPort m→li"]
+    caps = fr["tuner: TwoPort rig→m"] + fr["tuner: TwoPort m→li"]
     # The coil is the tuner's loss; the (ideal) caps burn nothing.
     assert coil > 0.02
     assert caps < 1e-6
@@ -85,12 +85,12 @@ def test_doublet_station_matches_fifty_ohms_with_coil_dominated_loss():
 
 
 def test_doublet_coil_loss_scales_with_q():
-    frac_q200 = _budget_fractions(_momwire(DoubletStation()))["Shunt m"]
+    frac_q200 = _budget_fractions(_momwire(DoubletStation()))["tuner: Shunt m"]
     frac_q100 = _budget_fractions(_momwire(_with_params(DoubletStation, coil_q=100.0)))[
-        "Shunt m"
+        "tuner: Shunt m"
     ]
     frac_ideal = _budget_fractions(_momwire(_with_params(DoubletStation, coil_q=0.0)))[
-        "Shunt m"
+        "tuner: Shunt m"
     ]
     assert frac_ideal < 1e-9
     # Halving Q ~doubles the coil's share (the match shifts slightly, so

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -119,8 +119,8 @@ def test_folded_invvee_balun_showcase():
     fr = {
         label: max(0.0, w) / eng._excited_p_in for label, w in eng._excited_power_budget
     }
-    assert fr["Transformer bal→feed"] < 1e-9  # ideal ratio burns nothing
-    assert 0.0 < fr["Transformer bal→feed (mag)"] < 0.01  # tiny at 28 MHz
+    assert fr["balun: Transformer bal→feed"] < 1e-9  # ideal ratio burns nothing
+    assert 0.0 < fr["balun: Transformer bal→feed (mag)"] < 0.01  # tiny at 28 MHz
     assert fr["TL rig→bal"] > 0.25  # RG-8X at 10 m, the familiar ~31%
 
     pynec = pytest.importorskip("antennaknobs.engines.pynec")


### PR DESCRIPTION
## Summary
- **`Composite`/`Instance` in `network.py`** (design record: #489 — HCL survey, Hdl21 addendum, aliasing note): a Composite is a formal port interface + body of branches/nested instances; `Instance` kwargs are the Verilog-style formal/actual port map. Expansion happens at `Network` construction — internal nodes are namespaced (`tuner.m`) and auto-declared `PortVirtual`, composite `aliases` resolve by global union-find node merge (real ports always canonical; merging two real ports or conflicting merged sources rejected with clear errors), and per-branch instance paths land in `Network.branch_paths`. Engines and reducers only ever see flat branches — zero solver changes.
- **`station.py` stdlib**: `bypass()` (pure-alias pass-through — swap any box out for a one-line with/without A-B), `t_network_tuner`, `l_network_tuner`, `unun` (optional comp cap), `balun`. Factory args are the parameter list ("generators are code, modules are data"), in radio units — picofarads/microhenries matching design-knob conventions.
- **Power-budget attribution**: probe labels carry the instance prefix with the box's own namespace stripped — `"tuner: Shunt m"`, `"unun: Transformer pri→ant (mag)"`. A `ui_params`-based display-renaming mechanism is noted in #489 as follow-up.
- **Six designs migrated** (the catalog's box-shaped networks): efhw_sloper, doublet_ladder_tuner, skyloop_lmatch, challenger, dominator, folded_invvee_balun. Impedances verified bit-identical to pre-migration (worst case 3.5e-14, branch-order float noise). TL-only feeds and single-Load designs deliberately left as bare branches.
- This is a design experiment (#489) — the API may still move; formal port names are deliberately ad-hoc per box for now.

## Test plan
- [x] `tests/test_composite_network.py` — 19 tests: expansion mechanics, aliasing (bypass merge, internal fan-out, canonicalization, real+real rejection), validation errors, hand-built-vs-boxed equivalence oracles on both engines, budget prefixes
- [x] Full fast suite green: 2349 passed
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmgjJwcpzBa3sUzpKj7tKw