### PR TITLE
docs(site): Station modelling concepts page

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -75,6 +75,7 @@ export default defineConfig({
             { label: "The model", slug: "concepts/model" },
             { label: "Write your first design", slug: "concepts/first-builder" },
             { label: "Many ways to express geometry", slug: "concepts/authoring" },
+            { label: "Station modelling", slug: "concepts/station-modelling" },
             {
               label: "Writing designs with Claude Code",
               slug: "concepts/authoring-with-claude",

--- a/site/src/content/docs/advanced/station-comparison.md
+++ b/site/src/content/docs/advanced/station-comparison.md
@@ -9,7 +9,9 @@ open-wire line, and let the tuner sort it out — ladder line shrugs off SWR*.
 Both camps are right, and both are paying for something. This example models
 both stations **end to end — rig, feedline, matching, wire** — reads the
 folklore off the [power budget](/reference/web/#power-budget) as numbers, and
-finishes with the two stations head to head on the same band, 20 m.
+finishes with the two stations head to head on the same band, 20 m. (New to
+the network layer? The vocabulary — ports, branches, boxes — is introduced
+in [Station modelling](/concepts/station-modelling/).)
 
 Two catalog designs (new in v0.22) carry the comparison:
 

--- a/site/src/content/docs/concepts/station-modelling.md
+++ b/site/src/content/docs/concepts/station-modelling.md
@@ -122,6 +122,6 @@ where you reconcile it.
 
 Open [`wire.doublet_ladder_tuner`](https://app.antennaknobs.dev/) —
 an 88 ft doublet, 100 ft of open-wire line, and a lossy T-network,
-referenced to the rig. Watch the power budget's `tuner:` rows as you
-drag the capacitor knobs: the SWR meter and the watts tell different
-stories, and this page is the vocabulary for reading both.
+referenced to the rig. Watch the tuner's rows in the power budget as
+you drag the capacitor knobs: the SWR meter and the watts tell
+different stories, and this page is the vocabulary for reading both.

--- a/site/src/content/docs/concepts/station-modelling.md
+++ b/site/src/content/docs/concepts/station-modelling.md
@@ -1,0 +1,127 @@
+---
+title: "Station modelling"
+description: Model the whole signal chain — feedline, transformer, matchbox, antenna — as one circuit, and read where every watt goes.
+---
+
+An antenna is never fed directly. Between the transmitter and the wire
+there is a feedline, often a transformer, sometimes a tuner — and every
+one of those pieces moves the impedance the rig sees and takes a cut of
+the power. antennaknobs models the **whole station** as one system: the
+antenna is solved as a multiport by the field solver, and everything
+else is a circuit stamped on top of it, solved simultaneously. Nothing
+is a correction factor; the SWR at the rig, the loss in the coax, and
+the current arriving at the feedpoint all come out of one solution.
+
+This page introduces the vocabulary. The worked examples put it to use:
+[two stations compared head-to-head](/advanced/station-comparison/),
+[the end-fed question](/advanced/efhw/), and
+[three ledgers of efficiency](/advanced/pota-performer/).
+
+## Ports: where the circuit meets the wire
+
+A design's `build_network()` returns a `Network` — ports, branches,
+sources. Ports come in two kinds:
+
+- **`PortOnWire("feed")`** — a real port at a named wire of the
+  geometry. This is the seam between the circuit world and the field
+  world: the MoM solve produces the antenna's multiport impedance at
+  exactly these gaps.
+- **`PortVirtual("rig")`** — a pure circuit node with no geometry. The
+  transmitter end of a feedline is the classic one: it exists only in
+  the network, and driving it makes every readout — impedance, SWR,
+  gain, the power budget — **rig-referenced**.
+
+The source (`Driven(port="rig")`) goes wherever your measurement plane
+is. Put it at the antenna feed and you're modelling the antenna; put it
+at the far end of the feedline and you're modelling the station.
+
+## Branches: the circuit vocabulary
+
+Between ports run **branches**, each a physical element with a minimal,
+honest model:
+
+| branch | what it is |
+|---|---|
+| `TL` / `TL.from_cable` | transmission line — ideal, or a real cable from the `CABLES` catalog (RG-58, RG-8X, window line…) with frequency-dependent matched loss; SWR-multiplied loss *emerges* from the circuit solution rather than a formula |
+| `Load` | series R/L/C in a wire's current path — a trap, a terminating resistor |
+| `TwoPort` | series R/L/C between two ports — a tuner's series capacitor |
+| `Shunt` | R/L/C from a port to the common return — a tuner's shunt coil |
+| `Transformer` | ideal ratio + magnetizing branch with core-loss Q — the balun/unun model, calibrated against measured insertion loss rather than derived from core datasheets |
+
+Reactive elements accept a finite **Q** (`ql`, `qc`, `qlmag`), and that
+is where real matchboxes and transformers burn power. Degenerate values
+are physics, not errors: a 0 H series arm is an ideal short, a 0 F
+shunt is an open — sliders can sweep straight through them.
+
+## Boxes: reusable station components
+
+You could assemble every tuner from raw branches — but the common boxes
+ship pre-built in `antennaknobs.station`, and designs instantiate them
+by name:
+
+```python
+from antennaknobs.network import Instance, TL
+from antennaknobs.station import t_network_tuner
+
+branches = [
+    Instance(
+        "tuner",
+        t_network_tuner(c1_pF=81.2, c2_pF=500, l_uH=4.218, ql=200),
+        rig="rig",      # formal → actual port map
+        out="li",
+    ),
+    TL.from_cable("openwire-600", "li", "feed", 30.48),
+]
+```
+
+A box (`Composite`) has a formal port interface and a private inside:
+the tuner's tee midpoint exists as `tuner.m`, invisible to the rest of
+the design. The stdlib today: `t_network_tuner`, `l_network_tuner`,
+`unun` (with the compensation capacitor real 49:1 builds carry),
+`balun` — all parameterized in radio units (picofarads, microhenries)
+— plus one special member:
+
+- **`bypass()`** — a box-shaped nothing: it wires its input straight to
+  its output. Swap any tuner or balun for `bypass()` and you get the
+  same station *without* that box, in a one-line change — the honest
+  way to answer "what is this component actually buying me?"
+
+Boxes are ordinary values made by ordinary functions, so a design can
+also define its own — a measured, calibrated component wrapped once and
+reused across variants.
+
+## The power budget: where the watts go
+
+Because every branch current is an explicit unknown in the circuit
+solve, dissipation is *read off the solution*, branch by branch. The
+workbench shows it as the [power budget](/reference/web/#power-budget):
+one row per lossy element, grouped by box (`tuner: Shunt m`), an
+**antenna (accepted)** row for what survives to the wires, and — with a
+finite ground selected — the honest bottom line, **radiated (incl.
+ground)**.
+
+Those are the [three ledgers of
+efficiency](/advanced/pota-performer/#the-efficiency-claim-true-in-its-ledger)
+in one display: the network's cut, the structure's cut, and the dirt's
+cut. A station that is "matched at 1.1:1" can still be delivering half
+its power to the feedline and the ionosphere none the wiser — the
+budget is what makes that visible while you turn the knobs.
+
+## What the model deliberately isn't
+
+The circuit layer is **minimal on purpose**. The transformer is an
+ideal ratio plus one magnetizing branch — enough to reproduce a
+published insertion-loss curve's shape, calibrated to a measurement,
+not a full core characterization. Line loss is the cable-table
+matched-loss model. Component Q is constant with frequency. Each of
+these is the simplest model that makes the power budget honest; when a
+measurement disagrees, the knobs (`qlmag`, `ql`, cable choice) are
+where you reconcile it.
+
+## Try it
+
+Open [`wire.doublet_ladder_tuner`](https://app.antennaknobs.dev/) —
+an 88 ft doublet, 100 ft of open-wire line, and a lossy T-network,
+referenced to the rig. Watch the power budget's `tuner:` rows as you
+drag the capacitor knobs: the SWR meter and the watts tell different
+stories, and this page is the vocabulary for reading both.

--- a/site/src/content/docs/concepts/station-modelling.md
+++ b/site/src/content/docs/concepts/station-modelling.md
@@ -35,6 +35,29 @@ The source (`Driven(port="rig")`) goes wherever your measurement plane
 is. Put it at the antenna feed and you're modelling the antenna; put it
 at the far end of the feedline and you're modelling the station.
 
+The whole contract in one place — the simplest station in the catalog
+(`dipoles.invvee_coax_station`, a resonant inverted vee on a real coax
+run) returns exactly this:
+
+```python
+from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL
+
+def build_network(self):
+    return Network(
+        ports={"feed": PortOnWire("feed"), "rig": PortVirtual("rig")},
+        branches=[
+            TL.from_cable(self.cable, "rig", "feed", self.line_len_m),
+        ],
+        sources=[Driven(port="rig", voltage=1 + 0j)],
+    )
+```
+
+Three fields, always: **ports** (every name a branch or source may
+reference), **branches**, **sources**. The one geometry-side
+obligation: a `PortOnWire` name must match a *named wire* in
+`build_wires()` — a short wire tagged `"feed"` whose middle segment
+becomes the port's gap.
+
 ## Branches: the circuit vocabulary
 
 Between ports run **branches**, each a physical element with a minimal,

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -233,7 +233,10 @@ with the fraction of the source's input power it dissipates, plus an
 **antenna (accepted)** row for what actually reaches the wires. The rows
 come straight from the MNA network solve (each branch current is an
 explicit unknown, so the watts are read off the solution, not modelled
-separately), and the same accounting drives the reported radiation
+separately — see [Station modelling](/concepts/station-modelling/) for
+the network vocabulary; rows from a station *box* are grouped under its
+instance name, e.g. `tuner: Shunt m`), and the same accounting drives
+the reported radiation
 efficiency: **every** dissipative branch counts, including resistive
 coupling and matching elements, not just explicit `Load`s. Gain is
 normalised by input power, so network loss already shows up in dBi;

--- a/src/antennaknobs/web/user_design_assets/CLAUDE.md
+++ b/src/antennaknobs/web/user_design_assets/CLAUDE.md
@@ -215,7 +215,10 @@ Return a list of straight wire segments. Each entry is:
 - `n_segments` — how finely to subdivide that wire. Use `self.nominal_nsegs`
   for the main radiator; fewer for short stubs (`max(1, self.nominal_nsegs // 7)`).
 - `feed` — `1 + 0j` on the **single** segment the transmitter drives, `None`
-  everywhere else. Exactly one segment in the whole antenna is the feed.
+  everywhere else. Exactly one segment in the whole antenna is the feed —
+  unless the design models its feed system with `build_network` (see that
+  section below), in which case the drive moves into the network and the
+  feed wire is *named* instead.
 
 **Feed convention:** put the feed on a tiny segment between two points a
 small `eps` (e.g. 0.01 m) apart, with the radiator arms running outward from
@@ -261,6 +264,95 @@ prefer `design_freq`. If you must keep fixed dimensions, instead widen the
 measurement slider to the target band by adding
 `"meas_freq_range": (low_mhz, high_mhz)` to `ui_params` (e.g. `(6.5, 8.0)` for
 40m).
+
+## `build_network(self)` — feedline, transformer, tuner (optional)
+
+Without this method, the design is driven directly at its `build_wires`
+feed segment. Adding `build_network` models the rest of the station — a
+coax or ladder-line run, a balun/unun, a matchbox — as a circuit solved
+*together with* the antenna, and re-references every readout (impedance,
+SWR, gain, the power budget) to wherever the source sits. The concepts
+are explained on the docs site under **Station modelling**.
+
+Two changes, always together:
+
+1. In `build_wires`, the driven segment **loses its inline drive** and
+   instead *names* its wire with a 5-element tuple:
+   `(start, end, n_segments, None, "feed")`. The name declares a port;
+   which port is driven is now the network's business (so the "exactly
+   one feed segment" rule above applies only to network-less designs).
+2. Add `build_network` returning a `Network` — three fields, always:
+
+```python
+from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL
+
+    def build_network(self):
+        return Network(
+            ports={
+                "feed": PortOnWire("feed"),  # the named wire from build_wires
+                "rig": PortVirtual("rig"),   # circuit-only node: the rig end
+            },
+            branches=[
+                TL.from_cable("RG-8X", "rig", "feed", 20.0),  # 20 m of coax
+            ],
+            sources=[Driven(port="rig", voltage=1 + 0j)],
+        )
+```
+
+- `ports` declares **every** name a branch or source references.
+  `PortOnWire` must match a named wire (the port is a gap at that wire's
+  middle segment — give the feed its own short wire, as in
+  `TEMPLATE.py`); `PortVirtual` is a node with no geometry. Driving a
+  virtual `rig` node is what makes the readouts rig-referenced.
+- `branches` come from `antennaknobs.network`: `TL` / `TL.from_cable`
+  (the `CABLES` catalog: `"RG-58"`, `"RG-8X"`, `"window-450"`,
+  `"openwire-600"`, …), `Load` (series R/L/C in a wire — a trap, a
+  terminating resistor), `TwoPort`, `Shunt`, `Transformer`. Reactive
+  elements take a finite Q (`ql`, `qc`, `qlmag`) — that is where real
+  boxes burn power, and the app itemizes it in the power budget.
+- `sources` is usually one `Driven`.
+
+**Prefer the pre-built boxes** in `antennaknobs.station` over raw
+branches for the common cases — a tuner or transformer is one
+`Instance`, parameterized in radio units (pF / µH), with keyword
+arguments mapping the box's formal ports to your port names:
+
+```python
+from antennaknobs.network import Driven, Instance, Network, PortOnWire, PortVirtual, TL
+from antennaknobs.station import unun
+
+    def build_network(self):
+        return Network(
+            ports={
+                "ant": PortOnWire("ant"),
+                "pri": PortVirtual("pri"),   # unun's line-side terminals
+                "rig": PortVirtual("rig"),
+            },
+            branches=[
+                Instance(
+                    "unun",
+                    unun(turns=7.0, lmag_uH=8.0, qlmag=10.0),  # a 49:1
+                    line="pri",  # formal → actual port map
+                    ant="ant",
+                ),
+                TL.from_cable("RG-58", "rig", "pri", 5.0),
+            ],
+            sources=[Driven(port="rig", voltage=1 + 0j)],
+        )
+```
+
+The stdlib: `t_network_tuner(c1_pF, c2_pF, l_uH, ql)`,
+`l_network_tuner(series_l_uH, shunt_c_pF, ql)`, `unun(turns, lmag_uH,
+qlmag, comp_c_pF)`, `balun(n, lmag_uH, qlmag)`, and `bypass()` — a
+pass-through with a box's two-port interface, so swapping a tuner for
+`bypass()` answers "what is this box buying me?" in a one-line change.
+A box's internals are private (the T-network's midpoint is `tuner.m`,
+auto-declared), and its loss rows group under the instance name in the
+power budget.
+
+Built-in designs to copy from: `dipoles.invvee_coax_station` (just
+coax — the minimal case), `wire.efhw_sloper` (unun + comp cap + coax),
+`wire.doublet_ladder_tuner` (ladder line + T-network tuner).
 
 ## Arrays of identical elements (advanced)
 

--- a/src/antennaknobs/web/user_design_assets/TEMPLATE.py
+++ b/src/antennaknobs/web/user_design_assets/TEMPLATE.py
@@ -27,6 +27,18 @@ THE RULES (keep it this simple)
 - Every built-in design follows these same rules, so any file from the
   installed package's ``antennaknobs/designs/`` folders also works here
   verbatim — copying one in is a great way to start a variation.
+
+GOING FURTHER: THE WHOLE STATION
+--------------------------------
+A design can also model its feed system — coax, a balun/unun, a tuner —
+by adding an optional ``build_network(self)`` method: the wire that was
+driven below instead gets a NAME (a 5th tuple element, with the drive set
+to ``None``), and the network drives it through real feedline and matchbox
+components, re-referencing SWR and the power budget to the rig. See the
+"build_network" section of CLAUDE.md in this folder for the contract and
+the pre-built boxes in ``antennaknobs.station``; built-in examples:
+``dipoles.invvee_coax_station`` (just coax), ``wire.efhw_sloper``
+(49:1 unun + coax).
 """
 
 from types import MappingProxyType


### PR DESCRIPTION
## Summary
- New concepts-level page `concepts/station-modelling` (#489, step 3 of the arc): the network layer's vocabulary for users — real vs virtual ports and rig-referencing, the full `build_network()` contract shown on the catalog's simplest station (ports / branches / sources, plus the named-wire obligation), the branch table with the minimal-model philosophy, station **boxes** (`Composite`/`Instance`, the `station` stdlib in radio units, `bypass()` for with/without A-Bs), and the power budget's instance-grouped rows tied to the three efficiency ledgers. Ends with an explicit "what the model deliberately isn't" section.
- Sidebar entry after the authoring pages; inbound cross-links from the station-comparison worked example and the web reference's power-budget section (which now also documents the `tuner: Shunt m` grouping format).
- Written deliberately as the API's fossilization test after #491 — the only vocabulary gap it surfaced is the budget-label display renaming already recorded as a follow-up on #489.

## Test plan
- [x] `npm run build` in `site/` passes (22 pages)
- [x] Code example verified verbatim against `dipoles.invvee_coax_station`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmgjJwcpzBa3sUzpKj7tKw