### PR TITLE
Station polish: budget-label display renames + calibrated unun presets (#489)

### DIFF
--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -235,7 +235,8 @@ come straight from the MNA network solve (each branch current is an
 explicit unknown, so the watts are read off the solution, not modelled
 separately — see [Station modelling](/concepts/station-modelling/) for
 the network vocabulary; rows from a station *box* are grouped under its
-instance name, e.g. `tuner: Shunt m`), and the same accounting drives
+instance name, e.g. `tuner: Shunt m`, and a design may retitle rows for
+display via `ui_params["budget_labels"]`), and the same accounting drives
 the reported radiation
 efficiency: **every** dissipative branch counts, including resistive
 coupling and matching elements, not just explicit `Load`s. Gain is

--- a/src/antennaknobs/designs/wire/efhw_sloper.py
+++ b/src/antennaknobs/designs/wire/efhw_sloper.py
@@ -130,6 +130,17 @@ class Builder(AntennaBuilder):
                     # Smith chart fast off-resonance — lock the sweep to
                     # the band being measured.
                     "sweep_policy": {"anchor": "meas_freq", "band_locked": True},
+                    # Display names for the power-budget rows (issue #489).
+                    # Keys are the STRUCTURAL labels the solver emits —
+                    # keep in sync with build_network below (the "unun"
+                    # instance and its pri/ant port bindings); unmatched
+                    # rows pass through unchanged.
+                    "budget_labels": {
+                        "unun: Transformer pri→ant": "unun windings",
+                        "unun: Transformer pri→ant (mag)": "unun core (mag)",
+                        "unun: Shunt pri": "unun comp cap",
+                        "TL rig→pri": "feedline",
+                    },
                 }
             ),
         }

--- a/src/antennaknobs/station.py
+++ b/src/antennaknobs/station.py
@@ -110,3 +110,44 @@ def balun(
         ports=("line", "ant"),
         branches=(Transformer(a="line", b="ant", n=n, lmag=lmag, qlmag=qlmag),),
     )
+
+
+# ---------------------------------------------------------------------------
+# Calibrated presets — measured boxes as named values (issue #489).
+#
+# Each preset wraps a factory above with parameters CALIBRATED to a published
+# measurement rather than derived from core datasheets (the `Transformer`
+# loss model's intended use). The catalog designs that source these numbers
+# keep their own knobs (so users can re-tune them); the presets are the same
+# stock values as importable, reusable components for station authors —
+# tests pin preset == design-stock so the two cannot drift apart.
+# ---------------------------------------------------------------------------
+def kj6er_unun_4_1(plus: bool = False) -> Composite:
+    """KJ6ER Challenger's 4:1 unun (2:1 turns), calibrated to his measured
+    insertion loss at 21.35 MHz: stock build −0.34 dB; ``plus=True`` is the
+    upgraded build at −0.24 dB. Source: the Challenger plans' measured
+    table (see ``verticals.challenger``)."""
+    return unun(turns=2.0, lmag_uH=1.75 if plus else 1.22, qlmag=3.0)
+
+
+def kj6er_unun_49_1() -> Composite:
+    """KJ6ER Dominator's stock 49:1 unun (7:1 turns), calibrated to the
+    measured −0.96 dB at 21.35 MHz — the loss figure interrogated in the
+    docs' end-fed pages (see ``verticals.dominator``)."""
+    return unun(turns=7.0, lmag_uH=0.33, qlmag=3.0)
+
+
+def kj6er_unun_56_1() -> Composite:
+    """The Dominator-plus 56:1 unun (7.5:1 turns, MyAntennas-class build),
+    calibrated to the measured −0.40 dB at 21.35 MHz (see
+    ``verticals.dominator``'s ``plus`` variant)."""
+    return unun(turns=7.5, lmag_uH=0.74, qlmag=3.0)
+
+
+def ft240_43_unun_49_1(comp_c_pF: float | None = 100.0) -> Composite:
+    """The generic FT240-43-class 49:1 EFHW unun (7:1 turns, ~3 primary
+    turns → 8 µH magnetizing, core Q ≈ 10), landing in the 85–90 %
+    efficiency range bench-measured for such builds, with the customary
+    100 pF compensation capacitor across the primary (pass ``None`` to
+    omit it). The stock box of ``wire.efhw_sloper``."""
+    return unun(turns=7.0, lmag_uH=8.0, qlmag=10.0, comp_c_pF=comp_c_pF)

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -18,6 +18,15 @@ Reserved keys inside `ui_params`:
                      selector (deck-backed designs fill it from
                      NecDeck.skipped_note() to list the cards the import
                      recorded but did not apply)
+  budget_labels    : dict {structural_label: display_label} — display
+                     renames for power-budget rows (issue #489). Keys are
+                     the STRUCTURAL labels the solver emits ("unun:
+                     Transformer pri→ant (mag)", "TL rig→pri"); values
+                     are what the UI shows ("unun core (mag)",
+                     "feedline"). Exact-match only, unmatched rows pass
+                     through unchanged — the mapping can retitle rows but
+                     never hide one. Tests keep pinning the structural
+                     labels; this is presentation only.
   layout           : dict {columns: int} — pin the knob grid to a fixed
                      column count so per-param `layout` col positions are
                      stable (default: responsive auto-flow packing)
@@ -523,6 +532,22 @@ def _group_spec_from_default(
         default_overrides=default_overrides,
         link_meas_freq_to_param=str(link) if isinstance(link, str) else None,
     )
+
+
+def _budget_rows(eng, builder):
+    """Package the engine's power budget for the UI, applying the design's
+    optional ``ui_params["budget_labels"]`` display renames (issue #489).
+    Structural labels stay authoritative everywhere else (tests pin them);
+    this rename happens only at the presentation boundary. Tiny negative
+    float noise from reactive stamps is clamped to 0."""
+    try:
+        relabel = dict((builder.ui_params or {}).get("budget_labels") or {})
+    except Exception:
+        relabel = {}
+    return [
+        {"label": relabel.get(label, label), "watts": max(0.0, float(w))}
+        for label, w in (getattr(eng, "_excited_power_budget", None) or [])
+    ]
 
 
 def _derive_schema(default_params: dict) -> tuple:
@@ -1462,13 +1487,10 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             # has resistive loads, e.g. a terminated rhombic / T2FD);
             # current_distribution() above populated it on the engine.
             "radiation_efficiency": float(getattr(eng, "_excited_efficiency", 1.0)),
-            # Per-branch network dissipation [(label, watts)] from the MNA
-            # solve (issue #299); empty for plain / lossless designs. Tiny
-            # negative float noise from reactive stamps is clamped to 0.
-            "power_budget": [
-                {"label": label, "watts": max(0.0, float(w))}
-                for label, w in (getattr(eng, "_excited_power_budget", None) or [])
-            ],
+            # Per-branch network dissipation from the MNA solve (issue
+            # #299), with the design's optional display renames applied
+            # (ui_params["budget_labels"], issue #489).
+            "power_budget": _budget_rows(eng, builder),
             # Source input power in watts: the server's gain normaliser is
             # η₀k²/(8π·P_in), which is what makes the plot GAIN (load and
             # ground losses live inside P_in, so no efficiency multiply).
@@ -1632,10 +1654,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             # keeps the far-field plot meaning GAIN. current_distribution()
             # set both from the solved feed/load currents.
             "radiation_efficiency": float(getattr(eng, "_excited_efficiency", 1.0)),
-            "power_budget": [
-                {"label": label, "watts": max(0.0, float(w))}
-                for label, w in (getattr(eng, "_excited_power_budget", None) or [])
-            ],
+            "power_budget": _budget_rows(eng, builder),
             "input_power_w": float(getattr(eng, "_excited_p_in", None) or 0.0),
             **_wire_material_results(builder),
         }

--- a/src/antennaknobs/web/user_design_assets/CLAUDE.md
+++ b/src/antennaknobs/web/user_design_assets/CLAUDE.md
@@ -346,9 +346,17 @@ The stdlib: `t_network_tuner(c1_pF, c2_pF, l_uH, ql)`,
 qlmag, comp_c_pF)`, `balun(n, lmag_uH, qlmag)`, and `bypass()` — a
 pass-through with a box's two-port interface, so swapping a tuner for
 `bypass()` answers "what is this box buying me?" in a one-line change.
+There are also **calibrated presets** — `kj6er_unun_4_1()`,
+`kj6er_unun_49_1()`, `kj6er_unun_56_1()`, `ft240_43_unun_49_1()` —
+published, bench-measured boxes as ready-made values.
+
 A box's internals are private (the T-network's midpoint is `tuner.m`,
 auto-declared), and its loss rows group under the instance name in the
-power budget.
+power budget. To retitle budget rows for display, add a
+`"budget_labels"` dict to `ui_params` mapping the solver's structural
+labels to friendly names, e.g.
+`{"unun: Transformer pri→ant (mag)": "unun core (mag)"}` — exact match,
+unmatched rows pass through unchanged.
 
 Built-in designs to copy from: `dipoles.invvee_coax_station` (just
 coax — the minimal case), `wire.efhw_sloper` (unun + comp cap + coax),

--- a/tests/test_composite_network.py
+++ b/tests/test_composite_network.py
@@ -349,3 +349,98 @@ def test_load_inside_composite_on_real_port():
     z_box = MomwireEngine(Boxed()).impedance()[0]
     z_ref = MomwireEngine(Builder()).impedance()[0]
     assert z_box == pytest.approx(z_ref, rel=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# calibrated presets + budget display renames (issue #489 polish)
+# ---------------------------------------------------------------------------
+def test_kj6er_presets_pin_design_stock_values():
+    """The station presets and the catalog designs source the same
+    published calibrations — Composite equality keeps them from drifting."""
+    from antennaknobs import resolve_variant_params
+    from antennaknobs.designs.verticals.challenger import Builder as Challenger
+    from antennaknobs.designs.verticals.dominator import XFMR_TURNS
+    from antennaknobs.designs.verticals.dominator import Builder as Dominator
+    from antennaknobs.station import (
+        kj6er_unun_4_1,
+        kj6er_unun_49_1,
+        kj6er_unun_56_1,
+    )
+
+    c = Challenger()
+    assert kj6er_unun_4_1() == unun(turns=c.turns, lmag_uH=c.lmag_uH, qlmag=c.qlmag)
+    c_plus = Challenger(params=resolve_variant_params(Challenger, "plus"))
+    assert kj6er_unun_4_1(plus=True) == unun(
+        turns=c_plus.turns, lmag_uH=c_plus.lmag_uH, qlmag=c_plus.qlmag
+    )
+
+    d = Dominator()
+    assert kj6er_unun_49_1() == unun(
+        turns=XFMR_TURNS[d.xfmr_ratio], lmag_uH=d.lmag_uH, qlmag=d.qlmag
+    )
+    d_plus = Dominator(params=resolve_variant_params(Dominator, "plus"))
+    assert kj6er_unun_56_1() == unun(
+        turns=XFMR_TURNS[d_plus.xfmr_ratio],
+        lmag_uH=d_plus.lmag_uH,
+        qlmag=d_plus.qlmag,
+    )
+
+
+def test_ft240_preset_pins_efhw_stock_values():
+    from antennaknobs.designs.wire.efhw_sloper import UNUN_TURNS
+    from antennaknobs.designs.wire.efhw_sloper import Builder as Efhw
+    from antennaknobs.station import ft240_43_unun_49_1
+
+    e = Efhw()
+    assert ft240_43_unun_49_1() == unun(
+        turns=UNUN_TURNS[e.unun_ratio],
+        lmag_uH=e.lmag_uH,
+        qlmag=e.qlmag,
+        comp_c_pF=e.comp_c_pF,
+    )
+
+
+def test_budget_rows_apply_display_renames():
+    """ui_params["budget_labels"] retitles rows at the presentation
+    boundary — exact match, unmatched rows pass through, negatives clamp."""
+    # examples first: entering the package via adapter alone trips the
+    # adapter↔examples import cycle (examples calls register_all mid-import)
+    import antennaknobs.web.examples  # noqa: F401
+
+    from antennaknobs.web.adapter import _budget_rows
+
+    class Eng:
+        _excited_power_budget = [
+            ("unun: Shunt pri", 0.25),
+            ("TL rig→pri", -1e-18),
+        ]
+
+    class WithLabels:
+        ui_params = {"budget_labels": {"unun: Shunt pri": "unun comp cap"}}
+
+    class Bare:
+        pass
+
+    assert _budget_rows(Eng(), WithLabels()) == [
+        {"label": "unun comp cap", "watts": 0.25},
+        {"label": "TL rig→pri", "watts": 0.0},
+    ]
+    assert [r["label"] for r in _budget_rows(Eng(), Bare())] == [
+        "unun: Shunt pri",
+        "TL rig→pri",
+    ]
+
+
+def test_efhw_budget_labels_stay_in_sync_with_structural_labels():
+    """The efhw design's display map keys must match labels the solver
+    actually emits — a renamed port or instance would silently orphan
+    them otherwise."""
+    from antennaknobs.engines.momwire import MomwireEngine
+    from antennaknobs.designs.wire.efhw_sloper import Builder
+
+    b = Builder()
+    eng = MomwireEngine(b)
+    eng.input_power()
+    emitted = {label for label, _w in eng._excited_power_budget}
+    mapped = set(b.ui_params["budget_labels"])
+    assert mapped <= emitted, mapped - emitted


### PR DESCRIPTION
## Summary
- **`ui_params["budget_labels"]`** — a design can retitle power-budget rows for display: a dict mapping the solver's structural labels ("unun: Transformer pri→ant (mag)") to friendly names ("unun core (mag)"). Applied only at the web adapter's presentation boundary (`_budget_rows`, both engine paths); exact-match with pass-through, so a mapping can retitle but never hide a row, and tests keep pinning the structural labels. `wire.efhw_sloper` adopts it, with a sync test asserting its keys match labels the solver actually emits (a renamed port/instance can't silently orphan the map).
- **Calibrated presets in `antennaknobs.station`** — published bench-measured boxes as named `Composite` values: `kj6er_unun_4_1(plus=False)` (−0.34/−0.24 dB), `kj6er_unun_49_1()` (−0.96 dB), `kj6er_unun_56_1()` (−0.40 dB), `ft240_43_unun_49_1()` (the EFHW's stock FT240-43 box). Equality tests pin each preset == the sourcing design's stock composite, so the calibrations cannot drift apart.
- Documented in the scaffold CLAUDE.md (user designs) and the web reference's power-budget section.

## Test plan
- [x] 4 new tests (preset↔design sync ×2, relabel unit test, efhw label-sync); composite suite 23 passed
- [x] Full fast suite: 2353 passed
- [x] ruff + `npm run build` (site) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmgjJwcpzBa3sUzpKj7tKw