### PR TITLE
chore: release v0.33.0 (model the whole station)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.32.0"
+version = "0.33.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/advanced/station-comparison.md
+++ b/site/src/content/docs/advanced/station-comparison.md
@@ -74,20 +74,32 @@ def build_network(self):
     return Network(
         ports={
             "feed": PortOnWire("feed"),
-            "li": PortVirtual("li"),   # line input (tuner output)
-            "m": PortVirtual("m"),     # tee midpoint
+            "li": PortVirtual("li"),  # line input (tuner output)
             "rig": PortVirtual("rig"),
         },
         branches=[
             TL.from_cable("openwire-600", "li", "feed", self.line_len_m),
-            TwoPort(a="rig", b="m", c=self.series_c1_pF * 1e-12),
-            Shunt(port="m", l=self.shunt_l_uH * 1e-6,
-                  ql=self.coil_q if self.coil_q > 0 else None),
-            TwoPort(a="m", b="li", c=self.series_c2_pF * 1e-12),
+            Instance(
+                "tuner",
+                t_network_tuner(
+                    c1_pF=self.series_c1_pF,
+                    c2_pF=self.series_c2_pF,
+                    l_uH=self.shunt_l_uH,
+                    ql=self.coil_q if self.coil_q > 0 else None,
+                ),
+                rig="rig",
+                out="li",
+            ),
         ],
         sources=[Driven(port="rig", voltage=1 + 0j)],
     )
 ```
+
+The tuner is one **station box** (`antennaknobs.station.t_network_tuner`,
+new in v0.33): its tee midpoint is the instance's own internal node, its
+loss rows group under `tuner:` in the budget, and swapping the whole box
+for `bypass()` models the same station without a tuner — see
+[Station modelling](/concepts/station-modelling/).
 
 The stock capacitor and inductor values match ~50 Ω at **7.1 MHz (40 m)**, and
 the budget itemizes the price of the matchbox: with Q = 200, about **3.5 % in

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,18 +25,16 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.32.0" icon="star">
-  **Convergence you can trust.** A catalog-wide convergence census (91
-  designs, meshes from N=7 to 641) reshaped how antennaknobs solves: the
-  default B-spline d=2 basis turns out to be converged at meshes the
-  NEC-style bases need 3–15× more segments to reach, so the **default
-  solve dropped to N=15 — ~35 % faster live ticks, census-validated to
-  the same answers**. Designs the census caught converging wrongly are
-  fixed (refining radials, mesh-stable **distributed ports** for
-  TL-attachment feeds — the Sterba curtain's nine pinned ports now refine
-  freely and land on one basis-agreed value), and the method itself is
-  written up in a new advanced guide:
-  [How many segments?](/advanced/convergence/)
+<Card title="New in v0.33.0" icon="star">
+  **Model the whole station.** Feedline, transformer, and tuner now
+  compose as **reusable station boxes**: instantiate a
+  `t_network_tuner`, an `unun`, or a published *calibrated preset* (the
+  KJ6ER measured boxes) with one line, swap any box for `bypass()` to
+  A/B a station with and without it, and read the power budget with the
+  box's losses grouped under its name. The vocabulary — ports, branches,
+  boxes, and the three efficiency ledgers — has a new concepts guide:
+  [Station modelling](/concepts/station-modelling/), and user designs
+  get the same contract in their scaffolded docs.
   [All release notes →](/reference/releases/)
 </Card>
 


### PR DESCRIPTION
## Summary
- Bump version to **0.33.0**. Theme: **model the whole station** — the #489 arc: `Composite`/`Instance` network components, the `antennaknobs.station` stdlib (tuners, ununs, balun, `bypass()`, calibrated KJ6ER/FT240-43 presets), instance-grouped power-budget rows with `ui_params["budget_labels"]` display renames, the new [Station modelling](https://antennaknobs.dev/concepts/station-modelling/) concepts page, and the user-designs scaffold docs teaching the `build_network` contract.
- What's-new card refreshed; de-stale sweep: station-comparison's T-network snippet now shows the design's actual box-instance form.
- momwire pin unchanged at 0.16.0 (no momwire changes since v0.32.0 — verified submodule sits exactly at the 0.16.0 bump).

## Test plan
- [x] Full fast suite green on the merged feature PRs (#491, #493)
- [x] `npm run build` in `site/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmgjJwcpzBa3sUzpKj7tKw