### PR TITLE
fix(designs): short-wire density defects behind #484's folded/fan breakdowns + catalog Δ/a lint

### DIFF
--- a/site/src/content/docs/advanced/convergence.md
+++ b/site/src/content/docs/advanced/convergence.md
@@ -93,25 +93,44 @@ default fixes this class; expect a slow drift of a few percent, read the
 admittance if you need a well-conditioned number, and treat the last
 percent as physical uncertainty rather than solver error.
 
-**4. Refinement past the geometry's own scale.** Closely-spaced
-parallel wires — folded elements, fan dipoles, meander rails — are a
-documented soft spot for thin-wire codes: the NEC-2 manual requires
-aligned segments there and concedes the regime was never extensively
-tested, and the classic modeling guidance (Cebik) is to keep segment
-length *equal to* the conductor-to-conductor spacing. Our convergence
-census puts a sharper edge on it: refinement is the danger direction.
-Coarse meshes agree beautifully and then refinement makes the answer
-*worse*: a folded inverted-V in the census read 223−30j identically on
-both bases at N=21…61, then the sinusoidal basis went to
-280−**1188**j at N=321 while bs2 never moved. Response: don't refine
-such geometry past segment ≈ spacing (the gap between the parallel
-wires, not the wire radius); prefer the d=2 basis, which was immune in
-every measured case
-([issue #484](https://github.com/stevenmburns/antennaknobs/issues/484)
-tracks the mechanism). Notably, the failure is not a visible oscillation
-— the current stays smooth — but the folded element's near-λ/4 shorted-stub
-mode sits at an antiresonance pole that amplifies a small feed-zone
-coupling error into a wildly wrong reactance.
+**4. A wire's segments approaching its own radius (Δ/a).** The oldest
+rule in thin-wire MoM is also the one that produced the census's most
+spectacular failure. The thin-wire kernel needs each segment to stay
+long compared to the wire's *radius*: the NEC-2 guideline is Δ/a > 8
+for ~1 % accuracy, "reasonable solutions" down to about 2 — and below
+about 1 the discretized equation is genuinely ill-posed on the
+point-matched sinusoidal/pulse family (sin, PyNEC, nec2c — errors here
+are *correlated* across all three). In practice nobody violates this by
+choosing N too large globally; it happens when a **builder gives a
+short wire a long wire's segment count**. The census's folded
+inverted-V read 223−30j identically on both bases at N=21…61, then the
+sinusoidal basis went to 280−**1188**j at N=321 — and the cause was a
+10 cm link wire silently carrying the full per-wire count, its segments
+down to 0.6× the wire radius. With that one wire meshed proportionally
+the sinusoidal ladder is dead flat at 223−30j through N=641. Two
+amplifiers made the disguise convincing: the folded element's near-λ/4
+shorted-stub mode sits at an antiresonance pole that turns a small
+localized error into a wildly wrong reactance (with no visible
+oscillation — the current stays smooth), and coarse meshes agree
+beautifully because the coarse mesh itself keeps every wire above the
+Δ/a floor. Response: when a ladder breaks at fine N, **check per-wire
+Δ/a first** — in your own builders, derive short-wire counts with
+`segs_for` rather than reusing the nominal count (the catalog is now
+linted for exactly this). The d=2 basis is immune — a Galerkin method
+regularizes the reduced-kernel ill-posedness — which is also why a flat
+bs2 next to an exploding sin curve is the tell.
+
+One genuine residue remains after the Δ/a accounting
+([issue #484](https://github.com/stevenmburns/antennaknobs/issues/484)):
+**multi-wire fan feeds** — several dipole pairs converging on one feed
+wire — where the sinusoidal basis drifts slowly and monotonically at
+fine mesh while bs2 holds flat, with every wire comfortably above the
+Δ/a floor. The traditional close-parallel-wire lore (the NEC-2 manual's
+aligned-segments requirement, Cebik's segment-length ≈ wire-spacing
+practice) points at this regime, but our census hasn't confirmed a
+threshold law. Until the mechanism is pinned down, treat fine-mesh
+sin/pynec drift on fan geometry as suspect and trust the flat d=2
+value.
 
 ## Feeds and ports deserve their own paragraph
 
@@ -147,9 +166,10 @@ the physics doesn't:
      pinned-coarse wires meeting refined ones (class 2);
    - both crawling in lockstep at high |Z| → class 3, physics — accept
      the band, don't chase it;
-   - agreement at coarse N that *breaks* at fine N on parallel-wire
-     geometry → class 4 — back N off to segment ≈ wire-to-wire
-     spacing and stay
-     there.
+   - agreement at coarse N that *breaks* or drifts at fine N while the
+     other slot stays flat → class 4 — check per-wire Δ/a first (a
+     short wire carrying a long wire's segment count is the classic
+     cause; fix the density, don't just back N off), and on fan-feed
+     geometry with healthy Δ/a, trust the flat d=2 value (#484).
 4. Report the value both bases agree on, at the coarsest mesh past the
    plateau — that is the defensible number, and the cheapest one.

--- a/src/antennaknobs/designs/dipoles/folded_invvee.py
+++ b/src/antennaknobs/designs/dipoles/folded_invvee.py
@@ -77,7 +77,15 @@ class Builder(AntennaBuilder):
         tups.extend(build_path([S, A], n_seg0, None))
         tups.extend(build_path([A, B], n_seg1, None))
         tups.extend(build_path([B, s], n_seg0, None))
-        tups.extend(build_path([s, t], n_seg0, None))
+        # The 0.1 m facing link gets the ARM's density (n_seg2, same length
+        # as the feed wire T-S), not the full nominal count: with n_seg0 a
+        # fine mesh drives this wire's segment length below the wire RADIUS
+        # (N=321: 0.31 mm segs on a 0.5 mm-radius wire, Δ/a = 0.62) — the
+        # classic reduced-kernel ill-posedness, which the folded element's
+        # stub antiresonance then amplifies into a wildly wrong sin/pynec
+        # impedance (issue #484: 280−1188j at N=321; proportional density
+        # holds the ladder flat at 223−30j through N=641).
+        tups.extend(build_path([s, t], n_seg2, None))
         tups.extend(build_path([t, C], n_seg0, None))
         tups.extend(build_path([C, D], n_seg1, None))
         tups.extend(build_path([D, T], n_seg0, None))

--- a/src/antennaknobs/designs/multiband/fandipole.py
+++ b/src/antennaknobs/designs/multiband/fandipole.py
@@ -185,14 +185,22 @@ class Builder(AntennaBuilder):
         n_seg0 = self.nominal_nsegs
         # Feed wire (T → S) meshed at the segment density of the longest
         # n_seg0 arm (the reference wire).
-        n_seg1 = self.segs_for(
-            math.dist(T, S), max(math.dist(a, bb) for a, bb in zip(A, B))
-        )
+        ref_arm = max(math.dist(a, bb) for a, bb in zip(A, B))
+        n_seg1 = self.segs_for(math.dist(T, S), ref_arm)
 
         tups = []
         for i in range(n_bands):
-            tups.extend(build_path([S, A[i], B[i]], n_seg0, None))
-            tups.extend(build_path([T, Ay[i], By[i]], n_seg0, None))
+            # The short risers (S→A / T→Ay, ~0.2 m) mesh at the reference
+            # arm's density, NOT the full nominal count: n_seg0 on them
+            # drives fine-mesh segment length near the wire radius (N=321:
+            # 0.65 mm segs = 1.3a) — the reduced-kernel Δ/a floor, which
+            # wrecked the sin/pynec fine-mesh reactance (issue #484).
+            n_riser = self.segs_for(math.dist(S, A[i]), ref_arm)
+            tups.extend(build_path([S, A[i]], n_riser, None))
+            tups.extend(build_path([A[i], B[i]], n_seg0, None))
+            n_riser_y = self.segs_for(math.dist(T, Ay[i]), ref_arm)
+            tups.extend(build_path([T, Ay[i]], n_riser_y, None))
+            tups.extend(build_path([Ay[i], By[i]], n_seg0, None))
         tups.append((T, S, n_seg1, 1 + 0j))
 
         return [

--- a/tests/test_delta_a_lint.py
+++ b/tests/test_delta_a_lint.py
@@ -1,0 +1,91 @@
+"""Catalog-wide Δ/a lint (issue #484): no builder may mesh a wire so
+densely that fine-mesh refinement drives segment length under ~2× the
+wire radius — the reduced-kernel thin-wire floor (NEC-2 guideline: Δ/a > 8
+for <1 % error, "reasonable solutions" down to ~2; below ~1 the discretized
+equation is ill-posed and the sin/pulse/pynec family produces garbage).
+
+The folded_invvee family shipped exactly this defect: a 0.1 m link carrying
+the full nominal count hit Δ/a = 0.62 at N=321, and the folded element's
+stub antiresonance amplified the localized error into a wildly wrong
+impedance (280−1188j vs the true 223−30j) that LOOKED like a convergence
+class of its own — see the #484 mechanism comments. Geometry-only check
+(no solves), so it sweeps every catalog design cheaply.
+"""
+
+import math
+
+import pytest
+
+from antennaknobs.cli import list_builtin_designs
+
+# The refinement rung the #484 breakdowns surfaced at — well past any
+# default, deep enough to expose density defects on short wires.
+N_FINE = 321
+FLOOR = 2.0
+DEFAULT_RADIUS = 0.0005
+
+# Audited exceptions (design name -> why it is allowed under the floor).
+EXEMPT = {
+    # W8IO measurement-fidelity whip: deliberately deck-faithful dense mesh
+    # on a fat tube; audited in #435, solve quality tracked against the
+    # published deck. Δ/a ≈ 1.05 at N=321.
+    "verticals.elt_whip": "deck-faithful dense mesh on fat tube (#435 audit)",
+    # Fat-element OWA yagi: long tube element whose builder doubles the
+    # driven element's count; falls to Δ/a ≈ 0.65 at N=321. Latent —
+    # tracked in #484's audit comment; needs its own meshing decision.
+    "beams.owa_yagi": "fat tube element, tracked in #484 audit",
+}
+
+
+def _min_delta_a(builder_cls):
+    b = builder_cls()
+    b.nominal_nsegs = N_FINE
+    try:
+        mat = b.build_wire_material()
+        default_r = getattr(mat, "radius", DEFAULT_RADIUS) or DEFAULT_RADIUS
+    except Exception:
+        default_r = DEFAULT_RADIUS
+    worst = math.inf
+    worst_wire = None
+    for i, w in enumerate(b.build_wires()):
+        p0, p1, ns = w[0], w[1], w[2]
+        spec = getattr(w, "spec", None)
+        r = getattr(spec, "radius", None) or default_r
+        length = math.dist(p0, p1)
+        if ns <= 0 or length == 0:
+            continue
+        ratio = (length / ns) / r
+        if ratio < worst:
+            worst, worst_wire = ratio, i
+    return worst, worst_wire
+
+
+@pytest.mark.parametrize("name", sorted(list_builtin_designs()))
+def test_no_wire_under_delta_a_floor_at_fine_mesh(name):
+    import importlib
+
+    mod = importlib.import_module(f"antennaknobs.designs.{name}")
+    worst, wire = _min_delta_a(mod.Builder)
+    if name in EXEMPT:
+        pytest.skip(f"exempt: {EXEMPT[name]} (measured Δ/a = {worst:.2f})")
+    assert worst >= FLOOR, (
+        f"{name} wire {wire} hits Δ/a = {worst:.2f} at N={N_FINE} — under "
+        f"the thin-wire floor ({FLOOR}). Give short wires proportional "
+        "density via segs_for (issue #484); do not carry the full nominal "
+        "count on a wire much shorter than the reference arm."
+    )
+
+
+def test_folded_invvee_sin_ladder_stays_flat():
+    """The #484 repro rung: before the density fix the sin basis broke to
+    232.9−230.2j at N=161 (and −1188j at 321). With wire 3 at arm density
+    the ladder holds the basis-agreed 223−30j."""
+    from antennaknobs.engines.momwire import MomwireEngine
+    from momwire import SinusoidalSolver
+
+    from antennaknobs.designs.dipoles.folded_invvee import Builder
+
+    b = Builder()
+    b.nominal_nsegs = 161
+    z = MomwireEngine(b, solver=SinusoidalSolver).impedance()[0]
+    assert abs(z - (223 - 30j)) < 5.0, z


### PR DESCRIPTION
## Summary
- **Root cause found for the folded-family half of #484** (full experiment record in the issue): the census's "class-4 parallel-wire instability" on `folded_invvee` (and `_balun`/`_array`, which inherit its wires) was the classic **Δ/a reduced-kernel ill-posedness** — the builder gave the 0.1 m facing link the full nominal count, hitting 0.31 mm segments on a 0.5 mm-radius wire (Δ/a = 0.62) at N=321 — amplified into 280−1188j by the folded element's stub antiresonance. Not a segment-vs-spacing law: with the link at arm density the sin ladder is **dead flat at 222.9−30j through N=641**, exactly on bs2 (immune throughout — Galerkin regularizes the ill-posedness). Converse smoking gun: over-densifying that one wire alone wrecks an otherwise-coarse solve (850−8289j at N=61).
- **Same fix for `multiband.fandipole`**: ten 0.208 m risers at full nominal (1.3a at N=321) caused its wild fine-mesh reactance drift; fixed, the reactance lands on bs2's sign/magnitude. A residual ~25 % R gap vs bs2 remains — the genuine open remainder of #484, shared with `twoband_fan`/`trap_fan` which have **no** Δ/a violation at all.
- **`tests/test_delta_a_lint.py`**: catalog-wide, geometry-only lint — every design built at N=321, min seg/radius ≥ 2, with audited exemptions (`elt_whip` deck-faithful mesh, `owa_yagi` fat-tube element tracked in #484) — plus the folded_invvee N=161 sin-ladder regression test (0.13 s).
- Follow-ups deliberately not here: convergence-guide class-4 rewrite (pending the 4b fan-drift investigation), census re-run of the fixed rows, owa_yagi meshing decision.

## Test plan
- [x] Fixed-builder ladders verified (folded sin flat N=61…641; fandipole reactance restored)
- [x] New lint: 90 passed, 2 audited skips, 0.6 s total
- [x] Full fast suite: 2443 passed (no default-mesh churn broke expectations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmgjJwcpzBa3sUzpKj7tKw