### PR TITLE
2m + 70cm band tabs and a native 6-element 2m OWA yagi (#497)

### DIFF
--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -64,6 +64,7 @@ whole shape with a `Drone` — see
 | `beams.moxon` | Moxon rectangle — a 2-element beam with folded-back element tips · variants: `opt`, `original` |
 | `beams.moxon_turnstile` | Moxon turnstile: two up-firing Moxons in real quadrature (L. B. Cebik, W4RNL, QST Aug 2001 pp |
 | `beams.owa_yagi` | OWA Yagi: 4 elements, whole-band flat 50-ohm feed (NW3Z/WA3FET concept, systematized by L. B. Cebik, W4RNL) |
+| `beams.owa_yagi_6el` | 6-element OWA Yagi — Cebik's 2 m band-flat beam, wavelength-scaled (issue #497's first VHF-native design) · variants: `band70cm` |
 | `beams.phased_driver_yagi` | 40 m wide-band phased-driver wire Yagi (L. B. Cebik, W4RNL, "Wide-Band 40-Meter Yagis", Part 3) |
 | `beams.yagi` | Yagi-Uda parasitic beam (driven element + reflector + directors) |
 <!-- catalog:end beams -->

--- a/src/antennaknobs/designs/beams/owa_yagi_6el.py
+++ b/src/antennaknobs/designs/beams/owa_yagi_6el.py
@@ -1,0 +1,112 @@
+"""6-element OWA Yagi — Cebik's 2 m band-flat beam, wavelength-scaled
+(issue #497's first VHF-native design).
+
+Same NW3Z/WA3FET Optimized Wideband Antenna concept as the 4-element
+`beams.owa_yagi`, in the longer-boom form Cebik published for VHF: a
+reflector, driver, the OWA **coupled resonator** D1 parked ~0.052 λ off
+the driver (vs ~0.14 λ to D2), and three more directors on a ~0.67 λ
+boom. D1 buys almost no gain — it flattens the driving-point impedance
+at 50 Ω across the whole band, so the feed is direct coax.
+
+Source geometry: Cebik's `144-6elOWAYagi` model (ARRL VHF/UHF
+collection) — 6 elements of 3/16" aluminum tube at 146 MHz — held here
+as fractions of the design wavelength so `design_freq` retunes the
+whole beam (the 2m/70cm band tabs, issue #497). The tube radius is a
+wavelength fraction too (0.00116 λ — within 4 % of the 10 m OWA's 1"
+tube fraction: Cebik scaled his tubing with the band), because the
+OWA's bandwidth *depends* on fat elements.
+
+What the model reproduces at the stock 2 m setting (free space,
+momwire bs2, matching the deck solved directly): **SWR(50) ≤ ~1.2 over
+all of 144–148 MHz** while gain holds ~10.1–10.2 dBi and F/B runs
+21–36 dB. As with the 4-el: drag `d1_length_factor` off unity and the
+whole-band match collapses while the pattern barely moves — the
+matching network is that one element.
+
+Geometry (x, y, z): elements parallel to y, boom along +x (the firing
+axis), constant height `base`. The beam fires +x, toward the directors —
+the workbench's forward direction, same as `beams.owa_yagi`.
+"""
+
+from types import MappingProxyType
+
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import WireSpec
+
+
+class Builder(AntennaBuilder):
+    # Cebik's 144-6elOWAYagi, metres -> fractions of the 146 MHz
+    # wavelength: (element half-length, boom position).
+    TABLE = (
+        (0.250614, 0.0),  # reflector
+        (0.247163, 0.125307),  # driver
+        (0.231169, 0.177162),  # D1 -- the coupled resonator (0.052 wl gap)
+        (0.224575, 0.320702),  # D2
+        (0.224575, 0.461174),  # D3
+        (0.216226, 0.670671),  # D4
+    )
+    DRIVER = 1
+    D1 = 2
+
+    default_params = MappingProxyType(
+        {
+            "design_freq": 146.0,
+            "freq": 146.0,
+            "base": 10.0,
+            # Overall element-length scale; unity IS the published design
+            # (unlike the 10 m 4-el, no re-centering was needed — the
+            # native mesh reproduces the deck's window as-is).
+            "length_factor": 1.0,
+            # Scale on D1 alone -- the OWA-mechanism knob.
+            "d1_length_factor": 1.0,
+            "ui_params": MappingProxyType(
+                {
+                    "target_z0": 50.0,
+                    # Single-band beam: snap the GUI sweep to the band.
+                    "sweep_policy": {"band_locked": True},
+                    "default_view": "xy",
+                    "length_factor": {"min": 0.95, "max": 1.05},
+                    "d1_length_factor": {"min": 0.9, "max": 1.1},
+                }
+            ),
+        }
+    )
+
+    # 70 cm: the same fractions at design_freq 435 -- a ~46 cm-boom beam
+    # with ~1.6 mm-diameter elements (the wavelength-fraction tube shrinks
+    # with the band; Cebik's own 432 MHz OWAs use disproportionately fatter
+    # tube and their own tweaked lengths, so this is the *scaled* design,
+    # not his 432 deck).
+    band70cm_params = MappingProxyType({"design_freq": 435.0, "freq": 435.0})
+
+    def build_wire_material(self):
+        # 3/16" aluminum tube at 146 MHz, held as a wavelength fraction
+        # (0.0023813 m / lambda) so the fat-element behaviour survives
+        # rescaling; aluminum conductivity per the source deck's LD 5.
+        wavelength = 299.792458 / self.design_freq
+        return WireSpec(radius=0.0011597 * wavelength, conductivity=2.5e7)
+
+    def build_wires(self):
+        wavelength = 299.792458 / self.design_freq
+        eps = 0.025 * wavelength / 2.053373  # feed-gap half-width, scaled
+        quarter = 0.25 * wavelength
+        b = self.base
+
+        tups = []
+        for i, (half_frac, pos_frac) in enumerate(self.TABLE):
+            half = half_frac * wavelength * self.length_factor
+            if i == self.D1:
+                half *= self.d1_length_factor
+            x = pos_frac * wavelength
+            if i == self.DRIVER:
+                # Driver: one-segment centre gap carries the direct feed.
+                arm = self.segs_for(half - eps, quarter)
+                tups.append(((x, -half, b), (x, -eps, b), arm, None))
+                tups.append(
+                    ((x, -eps, b), (x, eps, b), self.segs_for(2 * eps, quarter), 1 + 0j)
+                )
+                tups.append(((x, eps, b), (x, half, b), arm, None))
+            else:
+                ns = self.segs_for(2 * half, quarter)
+                tups.append(((x, -half, b), (x, half, b), ns, None))
+        return tups

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -11,7 +11,7 @@ Reserved keys inside `ui_params`:
   default_view     : "xy" | "yz" | "xz"  — initial 2D projection
   target_z0        : float — reference impedance for SWR (default 50)
   meas_freq_range  : (lo, hi)  — measurement-freq slider span override
-  bands            : tuple[BandSpec] — band tabs (default HF amateur set)
+  bands            : tuple[BandSpec] — band tabs (default amateur set, 160m–70cm)
   sweep_policy     : (anchor, lo_factor, hi_factor)
   multi_feed       : bool — declare multi-feed response shape
   notes            : str — informational note shown under the antenna
@@ -86,7 +86,7 @@ from momwire import (
 
 from .examples import register
 from .examples._base import (
-    DEFAULT_HF_BANDS,
+    DEFAULT_AMATEUR_BANDS,
     DEFAULT_SWEEP_POLICY,
     AntennaExample,
     BandSpec,
@@ -1299,7 +1299,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
     if bands_override is not None:
         bands = tuple(BandSpec(*b) for b in bands_override)
     else:
-        bands = DEFAULT_HF_BANDS
+        bands = DEFAULT_AMATEUR_BANDS
 
     param_schema = _derive_schema(dp)
     has_design_freq = "design_freq" in dp

--- a/src/antennaknobs/web/examples/_base.py
+++ b/src/antennaknobs/web/examples/_base.py
@@ -179,7 +179,7 @@ class BandSpec:
 
     The solver only sees the resulting `design_freq_mhz` float; bands are
     purely a UI affordance. Examples that target HF amateur bands reuse
-    `DEFAULT_HF_BANDS`; others can supply their own list, or set bands=()
+    `DEFAULT_AMATEUR_BANDS`; others can supply their own list, or set bands=()
     to suppress the row entirely (fan_dipole does this — its per-band
     schema-driven controls own the design frequency).
     """
@@ -225,10 +225,13 @@ class SweepPolicy:
 DEFAULT_SWEEP_POLICY = SweepPolicy()
 
 
-DEFAULT_HF_BANDS: tuple[BandSpec, ...] = (
-    # Full HF amateur set + 6m, low to high. The band dropdown scales to any
-    # number, so designs (especially design_freq-scaled ones) can be placed and
-    # tuned anywhere from 160m up. (key, label, snap-freq, slider-min, -max MHz)
+DEFAULT_AMATEUR_BANDS: tuple[BandSpec, ...] = (
+    # Full HF amateur set + 6m/2m/70cm, low to high (issue #497; formerly
+    # DEFAULT_HF_BANDS). The band dropdown scales to any number, so designs
+    # (especially design_freq-scaled ones) can be placed and tuned anywhere
+    # from 160m through UHF. Edges are US/ITU Region 2 (Region 1's 2m/70cm
+    # allocations fit inside them); snap freqs are the customary mid-band
+    # picks. (key, label, snap-freq, slider-min, -max MHz)
     BandSpec("160m", "160m", 1.900, 1.800, 2.000),
     BandSpec("80m", "80m", 3.750, 3.500, 4.000),
     BandSpec("40m", "40m", 7.150, 7.000, 7.300),
@@ -239,6 +242,8 @@ DEFAULT_HF_BANDS: tuple[BandSpec, ...] = (
     BandSpec("12m", "12m", 24.970, 24.890, 24.990),
     BandSpec("10m", "10m", 28.470, 28.000, 29.700),
     BandSpec("6m", "6m", 50.150, 50.000, 54.000),
+    BandSpec("2m", "2m", 146.000, 144.000, 148.000),
+    BandSpec("70cm", "70cm", 435.000, 420.000, 450.000),
 )
 
 
@@ -339,7 +344,7 @@ class AntennaExample:
     # Design-frequency band tabs offered by the UI. Defaults to the HF
     # amateur set; multi-band examples (fan_dipole) set this to () to
     # suppress the row.
-    bands: tuple[BandSpec, ...] = DEFAULT_HF_BANDS
+    bands: tuple[BandSpec, ...] = DEFAULT_AMATEUR_BANDS
     # Optional override for the measurement-freq slider span. When None,
     # the UI uses a generic ±20%/+25% window around the design freq.
     # Multi-band examples that span the whole HF range set this to e.g.

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -3410,7 +3410,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
       return;
     }
     // Always re-snap on geometry switch — every HF example shares the
-    // DEFAULT_HF_BANDS list, so a sticky band key (e.g. "10m" from the
+    // DEFAULT_AMATEUR_BANDS list, so a sticky band key (e.g. "10m" from the
     // previous 28 MHz design) would otherwise survive a switch into a
     // 14 MHz design and keep the slider parked on the wrong band.
     // (The containing-band / native-freq logic lives in snapForExample,

--- a/tests/test_delta_a_lint.py
+++ b/tests/test_delta_a_lint.py
@@ -39,6 +39,7 @@ CENSUS_TOP_RUNG = 641
 # change.
 FAT_CONDUCTOR_HEADROOM = {
     "beams.owa_yagi": 85,  # measured 92 — fat tube driven element
+    "beams.owa_yagi_6el": 100,  # measured 107 — 3/16"-equivalent tube (2m)
     "verticals.elt_whip": 155,  # measured 169 — deck-faithful whip (#435)
     "verticals.pota_performer": 330,  # measured 360 — stainless whip
     "verticals.challenger": 380,  # measured 413 — aluminum tube

--- a/tests/test_design_schemas.py
+++ b/tests/test_design_schemas.py
@@ -29,7 +29,7 @@ from antennaknobs.web.adapter import (
 )
 from antennaknobs.web.examples import REGISTRY
 from antennaknobs.web.examples._base import (
-    DEFAULT_HF_BANDS,
+    DEFAULT_AMATEUR_BANDS,
     AntennaExample,
     BandSpec,
     ParamGroupSpec,
@@ -134,7 +134,7 @@ def test_bands_default_to_hf_set_unless_overridden(name):
     # Defaulted designs share the HF set object; overrides have their
     # own tuple but still parse as BandSpecs (covered above).
     if "ui_params" not in dict(_builder_cls(name).default_params):
-        assert bands is DEFAULT_HF_BANDS
+        assert bands is DEFAULT_AMATEUR_BANDS
 
 
 @pytest.mark.parametrize("name", DESIGN_NAMES)

--- a/tests/test_owa_yagi_6el.py
+++ b/tests/test_owa_yagi_6el.py
@@ -1,0 +1,56 @@
+"""6-element 2 m OWA yagi (issue #497): the Cebik `144-6elOWAYagi` port.
+
+Anchors from solving the source deck directly through momwire (bs2, free
+space): SWR(50) 1.21 / 1.21 / 1.10 at 144/146/148 MHz, gain 10.1–10.2
+dBi, F/B 21–36 dB. The native wavelength-fraction builder reproduced
+those within a few percent at port time; these tests pin that window.
+"""
+
+import pytest
+
+from antennaknobs import pattern_metrics, resolve_variant_params
+from antennaknobs.designs.beams.owa_yagi_6el import Builder
+from antennaknobs.engines.momwire import MomwireEngine
+
+
+def _swr(builder, freq):
+    builder.freq = freq
+    z = MomwireEngine(builder).impedance()[0]
+    g = abs((z - 50.0) / (z + 50.0))
+    return (1 + g) / (1 - g)
+
+
+def test_discoverable():
+    from antennaknobs.cli import list_builtin_designs
+
+    assert "beams.owa_yagi_6el" in set(list_builtin_designs())
+
+
+def test_band_flat_swr_on_2m():
+    """The OWA promise: direct 50-ohm feed stays flat across ALL of
+    144-148 (deck anchors 1.21/1.21/1.10)."""
+    for f in (144.0, 146.0, 148.0):
+        assert _swr(Builder(), f) < 1.35, f
+
+
+def test_gain_pattern_and_forward_direction():
+    eng = MomwireEngine(Builder())
+    ff = eng.far_field(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
+    m = pattern_metrics(ff)
+    assert 9.7 < m["peak_gain_dbi"] < 10.7  # deck: 10.20 at 146
+    assert m["front_to_back_db"] > 15  # deck: 35.7 at 146
+    assert m["azimuth_deg"] == pytest.approx(0.0, abs=10)  # fires +x
+
+
+def test_d1_is_the_matching_network():
+    """Detune the coupled resonator 8 % and the whole-band match
+    collapses (measured 2.4-4.1 across the band) while stock stays
+    under 1.35 — the OWA mechanism, same demonstration as the 4-el."""
+    params = dict(Builder.default_params)
+    params["d1_length_factor"] = 0.92
+    assert _swr(Builder(params=params), 146.0) > 2.0
+
+
+def test_70cm_scaled_variant_holds_the_match():
+    b = Builder(params=resolve_variant_params(Builder, "band70cm"))
+    assert _swr(b, 435.0) < 1.35

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1130,7 +1130,7 @@ def test_out_of_band_freq_synthesizes_band():
     from types import MappingProxyType
 
     from antennaknobs import AntennaBuilder
-    from antennaknobs.web.adapter import DEFAULT_HF_BANDS, _make_example
+    from antennaknobs.web.adapter import DEFAULT_AMATEUR_BANDS, _make_example
 
     class Uhf(AntennaBuilder):
         default_params = MappingProxyType({"freq": 406.0})
@@ -1164,14 +1164,14 @@ def test_out_of_band_freq_synthesizes_band():
     # Retunable designs keep their list with the synthetic band appended,
     # so the HF tabs stay available for design_freq scaling.
     scaled = _make_example("uhfs", UhfScaled, defer_hints=True)
-    assert scaled.bands[:-1] == DEFAULT_HF_BANDS
+    assert scaled.bands[:-1] == DEFAULT_AMATEUR_BANDS
     assert scaled.bands[-1].freq_mhz == 406.0
 
     class Hf(Uhf):
         default_params = MappingProxyType({"freq": 14.1})
 
     # In-band designs are byte-identical: no synthetic band.
-    assert _make_example("hf", Hf, defer_hints=True).bands == DEFAULT_HF_BANDS
+    assert _make_example("hf", Hf, defer_hints=True).bands == DEFAULT_AMATEUR_BANDS
 
     class Suppressed(Uhf):
         default_params = MappingProxyType(


### PR DESCRIPTION
## Summary
- **Bands (#497)**: `DEFAULT_HF_BANDS` → `DEFAULT_AMATEUR_BANDS` (renamed at every use; the name finally matches the contents) with **2m** (snap 146.0, 144–148) and **70cm** (snap 435.0, 420–450) appended — US/Region 2 edges per the table's existing convention.
- **`beams.owa_yagi_6el`** — a 2m yagi found in the wild corpus and converted: Cebik's `144-6elOWAYagi` (ARRL VHF/UHF collection), ported as wavelength fractions in the same idioms as the 4-el `beams.owa_yagi` (fires +x; 3/16" aluminum tube held as a λ-fraction radius — 0.00116 λ, within 4 % of the 10 m design's 1" tube fraction, i.e. Cebik scaled his tubing with the band; `d1_length_factor` OWA-mechanism knob).
- **Anchored against the source deck** solved directly through momwire: SWR(50) 1.21/1.21/1.10 at 144/146/148 MHz, gain 10.1–10.2 dBi, F/B 21–36 dB — the native builder reproduces everything within a few percent at unity `length_factor` (no re-centering needed). Detuning D1 by 8 % collapses the match to 2.4–4.1 (the OWA mechanism test).
- **`band70cm` variant**: the same fractions at 435 MHz (SWR 1.06–1.21 across 430–440) — the scaled design, deliberately not Cebik's separately-tuned 432 decks.
- Fat-tube Δ/a headroom (107) recorded in the lint's exception table; catalog regenerated.

## Test plan
- [x] 5 new design tests (band-flat SWR, gain/F-B/direction, D1 mechanism, 70cm variant, discoverable)
- [x] Full fast suite: 2464 passed; ruff + site build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmgjJwcpzBa3sUzpKj7tKw