### PR TITLE
CI: publish momwire-only Docker image to docker.io on release tags

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -51,11 +51,16 @@ Merge with `/merge-pr` (rebase, CI green first).
 ## Tag and verify
 
 1. On the merged main: `git tag vX.Y.Z && git push origin vX.Y.Z`.
-2. The tag fires THREE pipelines — watch all of them to completion:
+2. The tag fires FOUR pipelines — watch all of them to completion:
    - `publish` → PyPI (Trusted Publishing) + auto-created GitHub release
      (generated notes from PR titles; do NOT `gh release create` manually)
    - `Deploy simulator to Fly.io`
    - `Deploy docs site to Fly.io`
+   - `Publish Docker image` → docker.io `<DOCKERHUB_USERNAME>/antennaknobs`
+     tagged `<version>` + `latest` (momwire-only: built with
+     INCLUDE_PYNEC=0 — pynec-accel is GPL-wrapping and stays an opt-in
+     user layer; the Fly image keeps the default INCLUDE_PYNEC=1).
+     Needs the DOCKERHUB_USERNAME / DOCKERHUB_TOKEN repo secrets.
 3. Verify: PyPI serves X.Y.Z
    (`curl -s https://pypi.org/pypi/antennaknobs/json | python3 -c "import json,sys; print(json.load(sys.stdin)['info']['version'])"`)
    and `gh release view vX.Y.Z` lists the expected PRs.

--- a/.github/workflows/docker-dev-image.yml
+++ b/.github/workflows/docker-dev-image.yml
@@ -1,0 +1,38 @@
+# Publish the DEV-environment image (Dockerfile.dev: Python 3.12 + C++
+# toolchain + Node 22 — no sources) to Docker Hub as
+# <DOCKERHUB_USERNAME>/antennaknobs-dev:latest.
+#
+# Manual-dispatch only, on purpose: the toolchain is stable, so this is
+# built and pushed ONCE and re-run only when Dockerfile.dev changes —
+# it is deliberately not part of the per-release pipeline (contrast
+# docker-publish.yml). Same DOCKERHUB_USERNAME / DOCKERHUB_TOKEN
+# secrets.
+
+name: Publish dev Docker image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  docker-dev:
+    name: build & push antennaknobs-dev
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.dev
+          platforms: linux/amd64
+          push: true
+          tags: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/antennaknobs-dev:latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,63 @@
+# Publish the workbench image to Docker Hub on every release tag.
+#
+# The image is the same multi-stage Dockerfile the Fly deploys use, built
+# with INCLUDE_PYNEC=0: the public image is momwire-only (all MIT/BSD —
+# pynec-accel wraps GPLv2 nec2++ and stays an opt-in layer users add
+# themselves; see the Dockerfile comment). Tags: the release version and
+# `latest`.
+#
+# Requires two repository secrets (Docker Hub → Account Settings →
+# Personal access tokens, scope Read/Write):
+#   DOCKERHUB_USERNAME — the Docker Hub account (also the image namespace)
+#   DOCKERHUB_TOKEN    — an access token for that account
+#
+# workflow_dispatch builds the image WITHOUT pushing — a packaging check
+# runnable on any branch.
+
+name: Publish Docker image
+
+on:
+  workflow_dispatch:
+  push:
+    tags: ["v*"]
+
+jobs:
+  docker:
+    name: build & push to docker.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/antennaknobs
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' }}
+
+      - name: Build (and push on tag)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          # momwire's PyPI wheels are manylinux x86_64; arm64 would fall
+          # back to an sdist build without a toolchain in the runtime
+          # image. Revisit if momwire grows aarch64 wheels.
+          platforms: linux/amd64
+          build-args: |
+            INCLUDE_PYNEC=0
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -64,6 +64,26 @@ docker build -t antennaknobs-nec2 . && docker run --rm -p 8000:8000 antennaknobs
 (`compose.yaml` carries this as a commented-out alternate service —
 uncomment and `docker compose up` builds it for you.)
 
+## Developing antennaknobs itself with Docker
+
+There's a second image for that: **`stevenmburns/antennaknobs-dev`** —
+the full dev toolchain (Python 3.12, the C++ compiler momwire's
+accelerator needs, Node 22 for the Vite frontend) with **no sources**.
+Mount your checkout and follow the README's dev flow inside it:
+
+```bash
+git clone --recurse-submodules https://github.com/stevenmburns/antennaknobs
+docker run -it --rm -v "$PWD/antennaknobs:/work" -w /work   -p 8000:8000 -p 5173:5173 stevenmburns/antennaknobs-dev
+# inside: python -m venv .venv && . .venv/bin/activate
+#         pip install -e ./momwire        # compiles the C++ accelerator
+#         pip install -e ".[web]"
+#         (cd src/antennaknobs/web/frontend && npm ci)
+#         ... then uvicorn on 8000, vite dev on 5173 (README "Running it")
+```
+
+Built from [`Dockerfile.dev`](Dockerfile.dev); published manually and
+rarely (the toolchain is stable), not on every release.
+
 ## Good to know
 
 - **The container runs unlocked**, exactly like a local install: no

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,77 @@
+# Running AntennaKNoBs with Docker
+
+The full web workbench, one command, no Python environment:
+
+```bash
+docker run --rm -p 8000:8000 stevenmburns/antennaknobs:latest
+```
+
+Open **http://localhost:8000** — pick a design, drag a knob.
+
+Images are published to Docker Hub on every release, tagged with the
+release version and `latest`:
+
+```bash
+docker run --rm -p 8000:8000 stevenmburns/antennaknobs:0.34.0   # pin a version
+```
+
+## Or: docker compose (recommended)
+
+The repo's [`compose.yaml`](compose.yaml) takes care of the port mapping
+and mounts your design folder:
+
+```bash
+docker compose up
+```
+
+That's the whole file's job — you can also just download `compose.yaml`
+alone; it pulls the published image, no repo checkout needed.
+
+## Your own designs
+
+The workbench's **"Your designs"** panel serves antenna files from
+`~/.antennaknobs/designs`. In a container that folder is empty unless
+you mount it — `compose.yaml` does this by default:
+
+```yaml
+volumes:
+  - ~/.antennaknobs/designs:/root/.antennaknobs/designs
+```
+
+(or add `-v ~/.antennaknobs/designs:/root/.antennaknobs/designs` to
+`docker run`). Files are shared with any local install: edit on either
+side, refresh the browser. Designs still need your per-file OK before
+they run (the UI prompts); on a single-user machine you can pre-trust
+your own folder with `-e ANTENNAKNOBS_TRUST_USER_DESIGNS=1`.
+
+## What's in the image — and what isn't
+
+The image contains the workbench and the **momwire** engine (the
+default, in-house MoM solver) — everything on the tin works. The
+optional **NEC2 reference engine** (`pynec-accel`, which wraps the
+GPLv2 `nec2++`) is *not* included, keeping the published image
+MIT/BSD-only. Adding it is one layer:
+
+```dockerfile
+FROM stevenmburns/antennaknobs:latest
+RUN pip install "pynec-accel>=1.7.4.post1"
+```
+
+```bash
+docker build -t antennaknobs-nec2 . && docker run --rm -p 8000:8000 antennaknobs-nec2
+```
+
+(`compose.yaml` carries this as a commented-out alternate service —
+uncomment and `docker compose up` builds it for you.)
+
+## Good to know
+
+- **The container runs unlocked**, exactly like a local install: no
+  login, no solve-size limits. Keep it on localhost or a network you
+  control. If you re-host it on the open internet, turn on the shared
+  instance's caps with `-e ANTENNAKNOBS_HOSTED=1`.
+- **Platform**: `linux/amd64`. On Apple Silicon it runs under emulation
+  (slower solves); a native install (`pip install "antennaknobs[web]"`)
+  is the better path there.
+- **Prefer no Docker?** The PyPI wheel ships the same browser UI — see
+  [Install](README.md#install) in the README.

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,8 +58,17 @@ RUN pip install --upgrade pip \
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in
 # its own step. antennaknobs runs fully on momwire alone; this adds the NEC2
-# engine as an alternative.
-RUN pip install "pynec-accel>=1.7.4.post1"
+# engine as an alternative. INCLUDE_PYNEC=1 (default) keeps the historical
+# image contents (the Fly deploys build with the default); the public
+# docker.io image is built with INCLUDE_PYNEC=0 — pynec-accel wraps nec2++
+# (GPLv2), and leaving it out keeps the published image MIT/BSD-only. Users
+# who want the NEC2 engine add one layer:
+#   FROM <user>/antennaknobs:latest
+#   RUN pip install "pynec-accel>=1.7.4.post1"
+ARG INCLUDE_PYNEC=1
+RUN if [ "$INCLUDE_PYNEC" = "1" ]; then \
+      pip install "pynec-accel>=1.7.4.post1"; \
+    fi
 
 EXPOSE 8000
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,35 @@
+# Development environment for antennaknobs itself: the full toolchain,
+# no sources. Mount your checkout and work inside it —
+#
+#   git clone --recurse-submodules https://github.com/stevenmburns/antennaknobs
+#   docker run -it --rm -v "$PWD/antennaknobs:/work" -w /work \
+#     -p 8000:8000 -p 5173:5173 stevenmburns/antennaknobs-dev
+#
+# then the README's dev flow verbatim: python -m venv .venv, pip install -e
+# ./momwire (compiles the C++ accelerator — the toolchain here is why this
+# image exists), pip install -e ".[web]", npm ci + npm run dev in the
+# frontend, uvicorn on 8000 / vite on 5173.
+#
+# Published ONCE (and re-pushed only when the toolchain moves) via the
+# manual `Publish dev Docker image` workflow — it is not part of the
+# per-release pipeline. See DOCKER.md.
+
+# python:<v>-bookworm (non-slim) is buildpack-deps based: gcc/g++/make/git
+# already present, which covers momwire's pybind11 + OpenMP build.
+FROM python:3.12-bookworm
+
+# Node 22 for the Vite 8 frontend dev server: copy the official binaries
+# rather than apt (bookworm's nodejs is far too old).
+COPY --from=node:22-bookworm-slim /usr/local/bin/node /usr/local/bin/node
+COPY --from=node:22-bookworm-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+ && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+ && node --version && npm --version && g++ --version | head -1
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /work
+
+# 8000: uvicorn backend; 5173: vite dev server.
+EXPOSE 8000 5173
+
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -311,6 +311,17 @@ description.
 
 ## Install
 
+### Docker (nothing but Docker required)
+
+```bash
+docker run --rm -p 8000:8000 stevenmburns/antennaknobs:latest
+# -> the full web workbench at http://localhost:8000
+```
+
+Published on every release. See **[DOCKER.md](DOCKER.md)** for the
+compose file, mounting your own designs into the container, and adding
+the optional NEC2 engine.
+
 ### From PyPI (prebuilt wheels — no toolchain)
 
 `antennaknobs` and its C++ engine `momwire` are published to **PyPI** with

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,49 @@
+# Run the antennaknobs workbench from the published Docker image:
+#
+#     docker compose up
+#     -> http://localhost:8000
+#
+# The image is momwire-only and runs UNLOCKED, like a local install (the
+# hosted instance's caps are opt-in — see the commented environment
+# below and docs/deploy.md). Prefer no Docker at all? The PyPI wheel
+# ships the same browser UI: `pip install "antennaknobs[web]"`.
+
+services:
+  antennaknobs:
+    # Override with e.g. ANTENNAKNOBS_IMAGE=myuser/antennaknobs:0.34.0
+    image: ${ANTENNAKNOBS_IMAGE:-stevenmburns/antennaknobs:latest}
+    ports:
+      - "8000:8000"
+    restart: unless-stopped
+    volumes:
+      # Share your local design folder with the container so the "Your
+      # designs" panel works (and edits on either side are the same
+      # files). Comment out to run with built-in designs only.
+      - ~/.antennaknobs/designs:/root/.antennaknobs/designs
+    # environment:
+    #   # Designs still need your per-file OK before they run (the web
+    #   # UI prompts). On a single-user machine you can pre-trust them:
+    #   - ANTENNAKNOBS_TRUST_USER_DESIGNS=1
+    #   # Re-hosting this on the open internet? Turn on the shared
+    #   # instance's solve-size caps and sweep budgets:
+    #   - ANTENNAKNOBS_HOSTED=1
+    # deploy:
+    #   resources:
+    #     limits:
+    #       memory: 2g
+
+  # Want the optional NEC2 reference engine (pynec-accel wraps GPLv2
+  # nec2++, so it is not in the published image)? Comment out the
+  # service above and use this one instead — it builds a local image
+  # with the one extra layer:
+  #
+  # antennaknobs-with-pynec:
+  #   build:
+  #     dockerfile_inline: |
+  #       FROM ${ANTENNAKNOBS_IMAGE:-stevenmburns/antennaknobs:latest}
+  #       RUN pip install "pynec-accel>=1.7.4.post1"
+  #   ports:
+  #     - "8000:8000"
+  #   restart: unless-stopped
+  #   volumes:
+  #     - ~/.antennaknobs/designs:/root/.antennaknobs/designs

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -90,6 +90,14 @@ Differences from the Fly image, on purpose:
 - `linux/amd64` only (momwire's PyPI wheels are manylinux x86_64;
   revisit if it grows aarch64 wheels).
 
+- **Fully unlocked.** The hosted instance's solve-size caps and sweep
+  budgets are opt-in via `ANTENNAKNOBS_HOSTED=1`, which only `fly.toml`
+  sets — the image never does, so a docker.io container runs like a
+  local install: no login, no limits. The corollary from the user-design
+  docs applies: it's meant for localhost or a network you control, not
+  for re-hosting on the open internet as-is (set `ANTENNAKNOBS_HOSTED=1`
+  in the container env if you do).
+
 The workflow needs two repo secrets: `DOCKERHUB_USERNAME` (also the
 image namespace) and `DOCKERHUB_TOKEN` (a Docker Hub access token with
 Read/Write scope). `workflow_dispatch` runs build the image without

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -64,6 +64,37 @@ remotely from your own machine and confirm dragging a knob feels responsive
 before adding the custom domains** — this is the moment to measure the real
 round-trip.
 
+## Public Docker image (docker.io)
+
+Every release tag also publishes the workbench image to Docker Hub
+(`.github/workflows/docker-publish.yml`): `docker.io/<DOCKERHUB_USERNAME>/antennaknobs`,
+tagged with the release version and `latest`.
+
+```bash
+docker run --rm -p 8000:8000 <user>/antennaknobs:latest
+# -> http://localhost:8000
+```
+
+Differences from the Fly image, on purpose:
+
+- Built with `--build-arg INCLUDE_PYNEC=0`: **momwire-only**, so the
+  published image contains only MIT/BSD components (pynec-accel wraps
+  nec2++, which is GPLv2). The app runs fully on momwire; the NEC2
+  engine is an opt-in layer users add themselves:
+
+  ```dockerfile
+  FROM <user>/antennaknobs:latest
+  RUN pip install "pynec-accel>=1.7.4.post1"
+  ```
+
+- `linux/amd64` only (momwire's PyPI wheels are manylinux x86_64;
+  revisit if it grows aarch64 wheels).
+
+The workflow needs two repo secrets: `DOCKERHUB_USERNAME` (also the
+image namespace) and `DOCKERHUB_TOKEN` (a Docker Hub access token with
+Read/Write scope). `workflow_dispatch` runs build the image without
+pushing — a free packaging check on any branch.
+
 ## 3. Custom domains (after the app is verified live)
 
 For each of `antennaknobs.com` and `antennaknobs.dev` (or a subdomain like

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -75,6 +75,16 @@ docker run --rm -p 8000:8000 <user>/antennaknobs:latest
 # -> http://localhost:8000
 ```
 
+Or use the repo's [`compose.yaml`](../compose.yaml) — `docker compose up`
+maps the port, mounts `~/.antennaknobs/designs` into the container (so
+the "Your designs" panel works on your local files), and carries
+commented-out lines for the common opt-ins: pre-trusting your own
+designs, the hosted caps, a memory limit, and a pynec-extension service
+(built inline from the published image). Prefer no Docker at all? The
+PyPI wheel ships the same browser UI: `pip install "antennaknobs[web]"`
+and run uvicorn as in the Dockerfile's CMD (remember `libgomp1` and the
+OMP launch-env pins on a slim system).
+
 Differences from the Fly image, on purpose:
 
 - Built with `--build-arg INCLUDE_PYNEC=0`: **momwire-only**, so the


### PR DESCRIPTION
## Summary
- **`.github/workflows/docker-publish.yml`** — fourth release pipeline: on every `v*` tag, build the existing multi-stage Dockerfile and push `docker.io/<DOCKERHUB_USERNAME>/antennaknobs` tagged `<version>` + `latest`. `workflow_dispatch` builds without pushing (packaging check on any branch). GHA layer caching enabled; `linux/amd64` (momwire's PyPI wheels are manylinux x86_64).
- **`INCLUDE_PYNEC` build arg** (default **1** — Fly's image is byte-identical to before): the public image builds with `0`, making it **momwire-only** so the published artifact contains only MIT/BSD components (pynec-accel wraps GPLv2 nec2++). Users who want the NEC2 engine add one documented layer: `FROM …/antennaknobs:latest` + `RUN pip install pynec-accel`. This is the "make them install it if they want it" resolution of the pynec-dependency question.
- Validated locally: the `INCLUDE_PYNEC=0` image builds, boots, serves the full design registry over HTTP, and `import PyNEC` fails inside while momwire solves — the app's designed momwire-only degradation path.
- `docs/deploy.md` gains a "Public Docker image" section; the release skill now watches FOUR pipelines.

## Before this does anything
The workflow needs two repo secrets (Docker Hub → Account Settings → Personal access tokens, Read/Write scope): **`DOCKERHUB_USERNAME`** (also the image namespace) and **`DOCKERHUB_TOKEN`**. Until they exist, a tag run will fail at login — add them before the next release, or dispatch the workflow manually to test the build-only path.

## Test plan
- [x] Local `docker build --build-arg INCLUDE_PYNEC=0` + container smoke test (HTTP 200, registry served, PyNEC absent)
- [x] Workflow YAML validated; default-arg path leaves the Fly image unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmgjJwcpzBa3sUzpKj7tKw