### PR TITLE
chore: release v0.34.0 (Docker, VHF, and honest meshes)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.33.0"
+version = "0.34.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,16 +25,19 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.33.0" icon="star">
-  **Model the whole station.** Feedline, transformer, and tuner now
-  compose as **reusable station boxes**: instantiate a
-  `t_network_tuner`, an `unun`, or a published *calibrated preset* (the
-  KJ6ER measured boxes) with one line, swap any box for `bypass()` to
-  A/B a station with and without it, and read the power budget with the
-  box's losses grouped under its name. The vocabulary — ports, branches,
-  boxes, and the three efficiency ledgers — has a new concepts guide:
-  [Station modelling](/concepts/station-modelling/), and user designs
-  get the same contract in their scaffolded docs.
+<Card title="New in v0.34.0" icon="star">
+  **Docker, VHF, and honest meshes.** The workbench now ships as a
+  **Docker image** — `docker run -p 8000:8000
+  stevenmburns/antennaknobs` and you're solving, no Python setup
+  ([how-to](https://github.com/stevenmburns/antennaknobs/blob/main/DOCKER.md)).
+  The band tabs reach **2 m and 70 cm**, with a first VHF-native
+  design: Cebik's 6-element 2 m OWA yagi, band-flat at SWR ≤ 1.2
+  across all of 144–148 MHz. And the mesh-integrity arc behind issue
+  #484 landed: a catalog-wide **Δ/a lint** (no wire may refine below
+  the thin-wire floor), per-design refinement headroom, two builder
+  density defects fixed, and the
+  [convergence guide](/advanced/convergence/) rewritten around what
+  the data actually showed.
   [All release notes →](/reference/releases/)
 </Card>
 

--- a/site/src/content/docs/start/quickstart.md
+++ b/site/src/content/docs/start/quickstart.md
@@ -5,8 +5,19 @@ description: Install antennaknobs and solve your first antenna in a few lines of
 
 ## Install
 
-`antennaknobs` and its engine `momwire` are published to PyPI with prebuilt
-wheels — a plain install needs no compiler:
+The fastest path needs nothing but Docker — the published image serves the
+full workbench (new in v0.34):
+
+```bash
+docker run --rm -p 8000:8000 stevenmburns/antennaknobs:latest
+# -> http://localhost:8000
+```
+
+(See [DOCKER.md](https://github.com/stevenmburns/antennaknobs/blob/main/DOCKER.md)
+for compose, mounting your own designs, and the optional NEC2 engine.)
+
+Prefer a Python install? `antennaknobs` and its engine `momwire` are
+published to PyPI with prebuilt wheels — a plain install needs no compiler:
 
 ```bash
 python3 -m venv .venv && source .venv/bin/activate


### PR DESCRIPTION
## Summary
- Bump to **0.34.0**. Theme: **Docker, VHF, and honest meshes** — the docker.io distribution (release image, momwire-only + compose + DOCKER.md + dev image), the 2m/70cm band tabs with `beams.owa_yagi_6el` (#497), and the #484 Δ/a arc (folded/fandipole density fixes, catalog Δ/a lint + per-design headroom, convergence-guide class-4 rewrite).
- What's-new card refreshed; quickstart now leads with the Docker one-liner.
- momwire pin unchanged at 0.16.0 (submodule verified at the 0.16.0 bump).
- First release to exercise the **fourth pipeline** (Publish Docker image) — secrets are in place and were verified by the dev-image dispatch.

## Test plan
- [x] Full fast suite green on all constituent PRs (#496, #498, #499, #500)
- [x] `npm run build` in `site/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmgjJwcpzBa3sUzpKj7tKw