### PR TITLE
fix(web): meas-freq VFO snapped to 60 MHz on VHF designs (inverted range)

### DIFF
--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -3396,6 +3396,18 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   const measBandAnchor =
     currentBands.find((b) => b.key === measBand)?.freq_mhz ?? designFreq;
 
+  // Ceiling for anchor-derived frequency windows (the unlocked meas-freq
+  // VFO and un-band-locked sweeps). Historically a hardcoded 60 MHz — an
+  // HF-era bound that survived the 2m/70cm band additions (#497) and
+  // then INVERTED the VFO range on VHF designs (anchor 146: min 116.8 >
+  // max 60, so touching the knob clamped it to 60 MHz). Derive it from
+  // the design's own band table instead, keeping 60 as the floor so
+  // bandless/HF-only designs behave exactly as before.
+  const freqWindowCeiling = Math.max(
+    60,
+    ...currentBands.map((b) => b.max_mhz * 1.25),
+  );
+
   // When the active example changes (or first loads), snap band /
   // designFreq / measFreq to the band whose [min, max] window contains
   // the design's native freq (from the schema's freq ParamSpec). If
@@ -3858,7 +3870,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
       fHi = bandLocked.max_mhz;
     } else {
       fLo = Math.max(0.5, sweepAnchor * (policy?.lo_factor ?? 0.8));
-      fHi = Math.min(60, sweepAnchor * (policy?.hi_factor ?? 1.25));
+      fHi = Math.min(freqWindowCeiling, sweepAnchor * (policy?.hi_factor ?? 1.25));
     }
     const freqs = Array.from({ length: N }, (_, i) =>
       Math.exp(Math.log(fLo) + (i / (N - 1)) * (Math.log(fHi) - Math.log(fLo))),
@@ -4864,7 +4876,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                 max={
                   currentExample?.meas_freq_range_mhz
                     ? currentExample.meas_freq_range_mhz[1]
-                    : Math.min(60, measBandAnchor * 1.25)
+                    : Math.min(freqWindowCeiling, measBandAnchor * 1.25)
                 }
                 step={0.005}
                 precision={3}


### PR DESCRIPTION
## Summary
- **Bug**: on `beams.owa_yagi_6el`, unlocking the measurement frequency and turning the VFO snapped it to 60 MHz. Root cause: the VFO's fallback range was `[anchor·0.8, min(60, anchor·1.25)]` — at a 146 MHz anchor that's `[116.8, 60]`, an **inverted range**, so any knob interaction clamped to the ceiling. The un-band-locked sweep window carried the same HF-era 60 MHz cap (both predate the 2m/70cm bands; 6m topped at 54).
- **Fix**: `freqWindowCeiling` derived from the design's own band table (max band edge × 1.25, floor 60) replaces the constant at both sites — 562.5 MHz for the default amateur set, exactly 60 for bandless designs, so HF behavior is bit-identical (HF anchors never reached the old cap).
- **Verified live** in the workbench (local build + Chrome): the unlocked VFO turns freely through 154+ MHz on the 2m yagi and the unlocked sweep spans 123.5–174.6 MHz; band-locked behavior untouched.

## Test plan
- [x] Live UI verification on owa_yagi_6el (unlock → drag → no 60 MHz snap; sweep window correct)
- [x] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmgjJwcpzBa3sUzpKj7tKw