### PR TITLE
fix(web): open-shackle lock glyph — state readable by shape, not just color

### DIFF
--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -4902,7 +4902,17 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                 >
                   <svg className="lock-glyph" viewBox="0 0 16 16" aria-hidden="true">
                     <rect x="3.5" y="7.2" width="9" height="6.3" rx="1.3" />
-                    <path className="shackle" d="M5.3 7.2V5a2.7 2.7 0 0 1 5.4 0v2.2" />
+                    {/* Shackle opens when unlocked (right leg lifts clear of
+                        the body) so the state reads from shape, not just the
+                        muted-vs-accent color. */}
+                    <path
+                      className="shackle"
+                      d={
+                        linkMeas
+                          ? "M5.3 7.2V5a2.7 2.7 0 0 1 5.4 0v2.2"
+                          : "M5.3 7.2V5a2.7 2.7 0 0 1 5.4 0v0.6"
+                      }
+                    />
                   </svg>
                 </button>
               )}


### PR DESCRIPTION
## Summary
- The measurement-frequency lock signaled its state by color alone (muted gray unlocked vs accent locked), which is hard to distinguish in light mode (user report) and a color-vision accessibility gap. The shackle path is now conditional: **closed padlock when locked, visibly open when unlocked** — the glyph shape carries the state, color is reinforcement.
- Verified live in the workbench (DOM-level check of both states + visual): unlocked `aria-pressed=false` renders the open shackle in muted gray, locked renders closed in accent, toggles cleanly.

## Test plan
- [x] Live toggle verification (both states, both directions)
- [x] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmgjJwcpzBa3sUzpKj7tKw