### PR TITLE
chore: release v0.34.1 (VHF workbench patches)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.34.0"
+version = "0.34.1"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,7 +25,7 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.34.0" icon="star">
+<Card title="New in v0.34.1" icon="star">
   **Docker, VHF, and honest meshes.** The workbench now ships as a
   **Docker image** — `docker run -p 8000:8000
   stevenmburns/antennaknobs` and you're solving, no Python setup
@@ -38,6 +38,9 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
   density defects fixed, and the
   [convergence guide](/advanced/convergence/) rewritten around what
   the data actually showed.
+  (v0.34.1 patches two VHF-workbench rough edges the new bands exposed:
+  the unlocked measurement-frequency dial no longer snaps to a stale
+  60 MHz ceiling, and the lock icon now visibly opens when unlocked.)
   [All release notes →](/reference/releases/)
 </Card>
 


### PR DESCRIPTION
## Summary
- Patch release: **#504** (unlocked meas-freq VFO snapped to a stale 60 MHz ceiling on VHF designs — inverted range; now derived from the band table), **#505** (lock glyph visibly opens when unlocked — light-mode state readability), **#503** (LICENSE file relicensed to MIT, matching the metadata that always said MIT).
- Version bump + a one-line addendum on the what's-new card. momwire unchanged (0.16.0).

## Test plan
- [x] Both fixes verified live in the workbench before merge
- [x] `npm run build` in `site/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmgjJwcpzBa3sUzpKj7tKw