### PR TITLE
Off-band designs: hierarchical power budget, real tuner coils, and the freq-snap fix

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -91,6 +91,7 @@ export default defineConfig({
             { label: "Wire gauge for POTA", slug: "advanced/wire-gauge" },
             { label: "The end-fed question", slug: "advanced/efhw" },
             { label: "Three ledgers of efficiency", slug: "advanced/pota-performer" },
+            { label: "Cut for one band, worked on another", slug: "advanced/off-band" },
             { label: "How many segments?", slug: "advanced/convergence" },
           ],
         },

--- a/site/src/content/docs/advanced/off-band.md
+++ b/site/src/content/docs/advanced/off-band.md
@@ -60,15 +60,18 @@ match fall apart. Three things to look at:
    notch is sharp (loaded Q ≈ 13). That's the real-world "retune every
    50 kHz" behavior of tuners on short antennas, reproduced from first
    principles.
-3. **The touchiness.** Out of the box the workbench reads SWR ≈ 1.4
-   rather than a flat 1.0, and that gap is itself the lesson: the stock
-   values are tuned against the test suite's reference solve, and the
-   workbench's default solver disagrees with that reference about the
-   bare antenna by only a few percent — which the ~2 kΩ virtual-resistance
-   ride magnifies into several ohms at the input. A high-Q match
-   amplifies *every* small difference, in models and in hardware alike.
-   Nudge `series_c1_pF` and `shunt_l_uH` a hair and you can walk it back
-   to 1.0 — which is precisely what you'd do at the bench.
+3. **The touchiness.** The stock values land SWR ≈ 1.0 in the workbench,
+   but they only *stay* there because they were tuned against the exact
+   solve the workbench runs. Solve the same stock design on a different
+   basis (the test suite's sinusoidal reference, say) and the bare
+   antenna moves by only a few percent — which the ~2 kΩ
+   virtual-resistance ride magnifies to SWR ≈ 1.4 at the input. A high-Q
+   match amplifies *every* small difference, in models and in hardware
+   alike: it's the same reason the physical version of this tuner needs
+   re-dipping when the feedline is re-routed or the ground dries out.
+   Nudge `series_c1_pF` a hair off stock and watch how fast the notch
+   walks away — then walk it back, which is precisely the bench
+   experience.
 
 ## The easy case: a big loop and an L-network
 

--- a/site/src/content/docs/advanced/off-band.md
+++ b/site/src/content/docs/advanced/off-band.md
@@ -1,0 +1,135 @@
+---
+title: "Cut for one band, worked on another"
+description: Off-band designs — how design frequency and measurement frequency separate, what the tuner is really doing, and how to author a design that opens mid-mismatch on purpose.
+---
+
+Real antennas get cut once and worked everywhere. The 10 m inverted-L that
+was perfect in October is what you have when the propagation moves to 12 m;
+the 80 m skyloop is what's in the air when 17 m opens. You don't re-saw the
+wire — you reach for the tuner. Two catalog designs model exactly that
+situation, and they lean on a distinction the workbench keeps carefully:
+**the frequency the antenna is built for is not the frequency you measure
+it at.**
+
+## Two frequencies, two controls
+
+Every design carries both:
+
+- **`design_freq`** sizes the geometry. It's the saw and the tape measure —
+  change it and the wires themselves change length. In the workbench it's
+  the *band tabs* row.
+- **`freq`** is where the measurement happens: the impedance readout, the
+  SWR, the Smith chart, the pattern. In the workbench it's the *dial*.
+
+For most designs the two travel together — the dial is locked to the design
+frequency, and retuning the antenna drags the measurement along. That lock
+is a convenience, not a law. Open it and you can park the dial anywhere
+while the geometry stays frozen: that's "checking what my 10 m antenna
+looks like on 12 m" as a single click.
+
+Off-band designs open **with the lock already open**: geometry parked on
+the band they're cut for, dial parked on the band they're operated on.
+(They have to — snapping both controls to one frequency would silently
+re-saw the antenna for the operating band and dissolve the design's whole
+premise.)
+
+## The hard case: a short antenna and a T-network
+
+[`verticals.inverted_l_tmatch`](/reference/catalog/) is a 10 m inverted-L
+(cut at 28.57 MHz) worked on 12 m. At 24.9 MHz the riser is electrically
+short and the feed sees roughly **11 − 117 j Ω** — low resistance, a big
+capacitive reactance, nowhere near 50 Ω. The classic fix is the ham
+T-tuner: two series capacitors flanking a shunt inductor.
+
+The stock knobs are the *solved* tuner — the design opens as the "after"
+picture, and the interesting move is turning the knobs and watching the
+match fall apart. Three things to look at:
+
+1. **The power budget.** The tuner is a composite box, so its rows sit
+   indented under `tuner` in the readout: *series C1*, *shunt coil*,
+   *series C2*. The coil row is the story — a T-network matches a short
+   antenna by riding a virtual resistance of ~2 kΩ through the tee, which
+   runs high circulating current through the inductor. At the stock coil
+   Q of 200 (a good air-wound coil) that burns **~9 % of everything you
+   feed it**, before a single watt reaches the wire. This is the classic
+   hidden cost of the T-match, and it's why the design ships a *real*
+   coil: set `coil_q` to 0 (ideal) and the loss vanishes — along with the
+   entire budget display, because a lossless network has nothing to
+   report.
+2. **The loaded Q.** The match is narrow — sweep the band and the SWR
+   notch is sharp (loaded Q ≈ 13). That's the real-world "retune every
+   50 kHz" behavior of tuners on short antennas, reproduced from first
+   principles.
+3. **The touchiness.** Out of the box the workbench reads SWR ≈ 1.4
+   rather than a flat 1.0, and that gap is itself the lesson: the stock
+   values are tuned against the test suite's reference solve, and the
+   workbench's default solver disagrees with that reference about the
+   bare antenna by only a few percent — which the ~2 kΩ virtual-resistance
+   ride magnifies into several ohms at the input. A high-Q match
+   amplifies *every* small difference, in models and in hardware alike.
+   Nudge `series_c1_pF` and `shunt_l_uH` a hair and you can walk it back
+   to 1.0 — which is precisely what you'd do at the bench.
+
+## The easy case: a big loop and an L-network
+
+[`loops.skyloop_lmatch`](/reference/catalog/) is the opposite corner: an
+80 m full-wave triangular loop (~85 m of wire) worked on 17 m, where its
+perimeter is ~4.7 λ and the corner feed sits around **225 − 70 j Ω**.
+That's a moderate mismatch, not a desperate one, and a two-element
+L-network handles it: series inductor to the source, shunt capacitor
+across the feed.
+
+Same stock coil Q of 200, very different bill: the L-match runs modest
+circulating current, so the coil burns only **~1 %** and the design opens
+at SWR ≈ 1.15 in the workbench. Comparing the two budget readouts side by
+side is the cleanest illustration in the catalog of why "it matched"
+isn't the same claim as "it matched cheaply": the SWR meter reads ~1 in
+both shacks while the tuner eats nine times more of your power in one of
+them.
+
+## Authoring one
+
+If you're [writing your own design](/concepts/authoring/), an off-band
+design is three decisions:
+
+```python
+class Builder(SomeAntenna):
+    default_params = MappingProxyType({
+        **SomeAntenna.default_params,
+        # 1. Keep the inherited design_freq (the band it's CUT for)
+        #    and set freq to the band it's WORKED on.
+        "freq": 24.9,
+        # 2. Give the matchbox coil a real Q — an ideal matchbox
+        #    dissipates nothing and hides the whole power budget.
+        "coil_q": 200.0,
+        ...
+    })
+
+    def build_network(self):
+        return Network(
+            ports={"feed": PortOnWire("feed"), "in": PortVirtual("in")},
+            branches=[
+                # 3. The matchbox is a station-stdlib composite, so its
+                #    budget rows group under the instance name.
+                Instance("tuner",
+                         t_network_tuner(c1_pF=..., c2_pF=..., l_uH=...,
+                                         ql=self.coil_q or None),
+                         rig="in", out="feed"),
+            ],
+            sources=[Driven(port="in", voltage=1 + 0j)],
+        )
+```
+
+The workbench does the rest from the two frequency defaults: it opens the
+design with the geometry on `design_freq`, the dial on `freq`, and the
+lock open. Tune your stock matchbox values at `freq` — that's where the
+design will be judged — and remember the T-match lesson above: the higher
+the virtual resistance your match rides, the more sensitive the stock
+tune is to *everything*, so quote the reference you tuned against. A
+`ui_params["budget_labels"]` map turns the structural row names into
+friendly ones (`"tuner: Shunt m"` → `"shunt coil"`).
+
+The network vocabulary (ports, branches, boxes) is introduced in
+[Station modelling](/concepts/station-modelling/); the full watt-by-watt
+methodology is worked in
+[Coax vs. ladder line](/advanced/station-comparison/).

--- a/src/antennaknobs/designs/loops/skyloop_lmatch.py
+++ b/src/antennaknobs/designs/loops/skyloop_lmatch.py
@@ -22,9 +22,12 @@ retune `series_L_uH` / `shunt_C_pF` for other bands or a different loop.
 
 `Shunt` — a lumped R/L/C from a single port to the common reference — is the
 element issue #65 deferred as Q2. A matching network was the motivating use
-case; this design is it. A lossless matching network doesn't touch the
-radiation pattern, so the showcase is the impedance/SWR transform, which the
-reducer computes exactly on top of the extracted antenna Y.
+case; this design is it. The showcase is the impedance/SWR transform, which
+the reducer computes exactly on top of the extracted antenna Y. The stock
+coil has Q = 200 (`coil_q = 0` recovers the ideal one); unlike the
+inverted-L's high-Q tee this match runs modest circulating current, so the
+coil burns only ~1 % of the input power — visible in the power-budget
+readout rather than dominating it.
 """
 
 from types import MappingProxyType
@@ -46,19 +49,32 @@ class Builder(TriangularSkyloop):
             **TriangularSkyloop.default_params,
             # Loop is cut for 80 m (inherited design_freq) but operated on 17 m.
             "freq": 18.1,
-            # L-match elements, tuned for ~50 Ω at 18.1 MHz on the stock loop.
-            "series_L_uH": 0.873,  # series arm, input → feed (TwoPort)
-            "shunt_C_pF": 59.57,  # shunt arm, across the feed (Shunt)
+            # L-match elements, tuned for ~50 Ω at 18.1 MHz on the stock
+            # loop WITH the stock Q=200 coil (the ESR barely moves this
+            # match — the loop's feed R needs no big virtual-resistance
+            # ride, unlike inverted_l_tmatch's tee).
+            "series_L_uH": 0.870,  # series arm, input → feed (TwoPort)
+            "shunt_C_pF": 60.01,  # shunt arm, across the feed (Shunt)
             # Coil quality factor (issue #298): adds R = ωL/Q in series with
-            # the matching inductor. 0 = ideal coil (the historical behavior);
-            # real air-wound coils run ~50–400.
-            "coil_q": 0.0,
+            # the matching inductor. Real air-wound coils run ~50–400;
+            # default 200 matches the other tuner designs (0 = ideal coil
+            # is still reachable, but a lossless matchbox hides the whole
+            # power-budget readout).
+            "coil_q": 200.0,
             "ui_params": MappingProxyType(
                 {
                     # Matched to 50 Ω, so the SWR readout shows ~1:1.
                     "target_z0": 50.0,
                     "default_view": "xy",
                     "coil_q": {"min": 0.0, "max": 400.0},
+                    # Display names for the power-budget rows (issue #489).
+                    # Keys are the STRUCTURAL labels the solver emits —
+                    # keep in sync with the "match" instance in
+                    # build_network below.
+                    "budget_labels": {
+                        "match: TwoPort in→feed": "series coil",
+                        "match: Shunt feed": "shunt cap",
+                    },
                 }
             ),
         }

--- a/src/antennaknobs/designs/verticals/inverted_l_tmatch.py
+++ b/src/antennaknobs/designs/verticals/inverted_l_tmatch.py
@@ -23,9 +23,12 @@ interior circuit node with no antenna segment, no TL, nothing but lumped
 Group-2 branches meeting at a KCL row, which no other design exercises.
 The stock coil has Q = 200 (a good air-wound coil; `coil_q = 0` recovers
 the ideal one), and the stock element values are tuned WITH that coil
-loss: they land ~50 Ω / SWR ≈ 1.0004 at 24.9 MHz, burning ~9 % of the
-input power in the coil — the classic hidden T-tuner cost, visible in the
-power-budget readout.
+loss against the workbench's default solve: the design opens at ~50 Ω /
+SWR ≈ 1.0 at 24.9 MHz, burning ~9 % of the input power in the coil — the
+classic hidden T-tuner cost, visible in the power-budget readout. (The
+sinusoidal reference basis reads the same tune at SWR ≈ 1.4 — the ~2 kΩ
+virtual-resistance ride magnifies even basis-level differences in the
+bare antenna Z; see the off-band guide on the site.)
 
 Because the antenna is short (R ≈ 11 Ω) the match must ride a virtual
 resistance of ~2 kΩ, so there is no symmetric-capacitor solution and the
@@ -64,11 +67,14 @@ class Builder(InvertedL):
             "freq": 24.9,
             # T-network elements, tuned for ~50 Ω at 24.9 MHz on the stock
             # inverted-L (virtual resistance ~2 kΩ; see module docstring)
-            # WITH the stock Q=200 coil — the ~0.5 Ω coil ESR shifts the
-            # match, so these differ from the old ideal-coil tune
-            # (20.47 pF / 0.6458 µH).
-            "series_c1_pF": 22.01,  # source-side series capacitor
-            "shunt_l_uH": 0.6305,  # shunt inductor at the tee midpoint
+            # WITH the stock Q=200 coil, against the WORKBENCH default
+            # solve (default basis, free space) — what the design opens as.
+            # The high-Q tee magnifies basis-level differences in the bare
+            # Z_ant, so the sinusoidal reference reads this same tune at
+            # ~43 − 15j (SWR ≈ 1.4); the cross-engine test asserts
+            # ballpark-match there and exact match here.
+            "series_c1_pF": 22.54,  # source-side series capacitor
+            "shunt_l_uH": 0.6132,  # shunt inductor at the tee midpoint
             "series_c2_pF": 254.5,  # antenna-side series capacitor
             # Coil quality factor (issue #298): adds R = ωL/Q in series with
             # the tee's shunt inductor. Real air-wound coils run ~50–400;

--- a/src/antennaknobs/designs/verticals/inverted_l_tmatch.py
+++ b/src/antennaknobs/designs/verticals/inverted_l_tmatch.py
@@ -16,11 +16,16 @@ fixes it with two series capacitors flanking a shunt inductor:
                             │
                      [ L shunt ]── common
 
-The port spec drives a virtual `in` node, chains `TwoPort` capacitors
-through a virtual midpoint `m`, and hangs a `Shunt` inductor off `m`. The
-midpoint is a pure interior circuit node — no antenna segment, no TL,
-nothing but lumped Group-2 branches meeting at a KCL row — which no other
-design exercises. Stock values land ~50 Ω / SWR ≈ 1.0005 at 24.9 MHz.
+The tuner is the station-stdlib `t_network_tuner` composite instanced as
+``"tuner"`` between a virtual `in` node and the feed (issue #489); its tee
+midpoint expands to the instance-internal node ``tuner.m`` — a pure
+interior circuit node with no antenna segment, no TL, nothing but lumped
+Group-2 branches meeting at a KCL row, which no other design exercises.
+The stock coil has Q = 200 (a good air-wound coil; `coil_q = 0` recovers
+the ideal one), and the stock element values are tuned WITH that coil
+loss: they land ~50 Ω / SWR ≈ 1.0004 at 24.9 MHz, burning ~9 % of the
+input power in the coil — the classic hidden T-tuner cost, visible in the
+power-budget readout.
 
 Because the antenna is short (R ≈ 11 Ω) the match must ride a virtual
 resistance of ~2 kΩ, so there is no symmetric-capacitor solution and the
@@ -42,12 +47,12 @@ from types import MappingProxyType
 from antennaknobs.designs.verticals.inverted_l import Builder as InvertedL
 from antennaknobs.network import (
     Driven,
+    Instance,
     Network,
     PortOnWire,
     PortVirtual,
-    Shunt,
-    TwoPort,
 )
+from antennaknobs.station import t_network_tuner
 
 
 class Builder(InvertedL):
@@ -58,16 +63,21 @@ class Builder(InvertedL):
             # operated on 12 m.
             "freq": 24.9,
             # T-network elements, tuned for ~50 Ω at 24.9 MHz on the stock
-            # inverted-L (virtual resistance ~2 kΩ; see module docstring).
-            "series_c1_pF": 20.47,  # source-side series capacitor
-            "shunt_l_uH": 0.6458,  # shunt inductor at the tee midpoint
+            # inverted-L (virtual resistance ~2 kΩ; see module docstring)
+            # WITH the stock Q=200 coil — the ~0.5 Ω coil ESR shifts the
+            # match, so these differ from the old ideal-coil tune
+            # (20.47 pF / 0.6458 µH).
+            "series_c1_pF": 22.01,  # source-side series capacitor
+            "shunt_l_uH": 0.6305,  # shunt inductor at the tee midpoint
             "series_c2_pF": 254.5,  # antenna-side series capacitor
             # Coil quality factor (issue #298): adds R = ωL/Q in series with
-            # the tee's shunt inductor. 0 = ideal coil (the historical
-            # behavior); real air-wound coils run ~50–400. A T-network runs
-            # high circulating current through this coil, so its loss is the
-            # classic hidden tuner cost.
-            "coil_q": 0.0,
+            # the tee's shunt inductor. Real air-wound coils run ~50–400;
+            # default 200 matches doublet_ladder_tuner (0 = ideal coil is
+            # still reachable on the slider, but a lossless matchbox hides
+            # the whole power budget and misstates the classic hidden tuner
+            # cost — a T-network runs high circulating current through this
+            # coil).
+            "coil_q": 200.0,
             "ui_params": MappingProxyType(
                 {
                     # Matched to 50 Ω, so the SWR readout shows ~1:1.
@@ -77,6 +87,15 @@ class Builder(InvertedL):
                     "shunt_l_uH": {"min": 0.1, "max": 2.0},
                     "series_c2_pF": {"min": 50.0, "max": 500.0},
                     "coil_q": {"min": 0.0, "max": 400.0},
+                    # Display names for the power-budget rows (issue #489).
+                    # Keys are the STRUCTURAL labels the solver emits —
+                    # keep in sync with the "tuner" instance in
+                    # build_network below.
+                    "budget_labels": {
+                        "tuner: TwoPort in→m": "series C1",
+                        "tuner: Shunt m": "shunt coil",
+                        "tuner: TwoPort m→feed": "series C2",
+                    },
                 }
             ),
         }
@@ -98,17 +117,23 @@ class Builder(InvertedL):
         return Network(
             ports={
                 "feed": PortOnWire("feed"),
-                "m": PortVirtual("m"),
                 "in": PortVirtual("in"),
             },
             branches=[
-                TwoPort(a="in", b="m", c=self.series_c1_pF * 1e-12),
-                Shunt(
-                    port="m",
-                    l=self.shunt_l_uH * 1e-6,
-                    ql=self.coil_q if self.coil_q > 0 else None,
+                # T-network tuner box (station stdlib composite, issue #489);
+                # its tee midpoint is the instance's own internal node
+                # ("tuner.m" after expansion).
+                Instance(
+                    "tuner",
+                    t_network_tuner(
+                        c1_pF=self.series_c1_pF,
+                        c2_pF=self.series_c2_pF,
+                        l_uH=self.shunt_l_uH,
+                        ql=self.coil_q if self.coil_q > 0 else None,
+                    ),
+                    rig="in",
+                    out="feed",
                 ),
-                TwoPort(a="m", b="feed", c=self.series_c2_pF * 1e-12),
             ],
             sources=[Driven(port="in", voltage=1 + 0j)],
         )

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -539,15 +539,46 @@ def _budget_rows(eng, builder):
     optional ``ui_params["budget_labels"]`` display renames (issue #489).
     Structural labels stay authoritative everywhere else (tests pin them);
     this rename happens only at the presentation boundary. Tiny negative
-    float noise from reactive stamps is clamped to 0."""
-    try:
-        relabel = dict((builder.ui_params or {}).get("budget_labels") or {})
-    except Exception:
-        relabel = {}
-    return [
-        {"label": relabel.get(label, label), "watts": max(0.0, float(w))}
-        for label, w in (getattr(eng, "_excited_power_budget", None) or [])
-    ]
+    float noise from reactive stamps is clamped to 0.
+
+    Each row carries the instance ``path`` its branch came from ("" for
+    top-level rows) so the UI can group and indent a composite's rows
+    under its instance name. The path is recovered from the structural
+    label's "<path>: " prefix — matched against the network's actual
+    instance paths (``branch_paths``), never guessed from the colon alone —
+    and rows resolved to a path drop that prefix from the display label
+    (the group header already names the instance). Renames are keyed on
+    the full structural label and win verbatim."""
+    # The solve path builds the Builder with the reserved ui_params key
+    # STRIPPED from its params (_build_builder), so the instance attribute
+    # usually doesn't exist — fall back to the design class's declared
+    # defaults. (The old `builder.ui_params` attribute read silently
+    # returned nothing in the server path and the renames never applied.)
+    ui = getattr(builder, "ui_params", None)
+    if ui is None:
+        ui = (getattr(type(builder), "default_params", None) or {}).get("ui_params")
+    relabel = dict((ui or {}).get("budget_labels") or {})
+    net = getattr(eng, "_network", None)
+    instance_paths = sorted(
+        {p[:-1] for p in (getattr(net, "branch_paths", None) or []) if p},
+        key=len,
+        reverse=True,  # longest first: "sta.tuner" must beat "sta"
+    )
+    rows = []
+    for label, w in getattr(eng, "_excited_power_budget", None) or []:
+        path = next(
+            (p for p in instance_paths if label.startswith(p + ": ")), ""
+        )
+        if label in relabel:
+            display = relabel[label]
+        elif path:
+            display = label[len(path) + 2 :]
+        else:
+            display = label
+        rows.append(
+            {"label": display, "watts": max(0.0, float(w)), "path": path}
+        )
+    return rows
 
 
 def _derive_schema(default_params: dict) -> tuple:

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -566,18 +566,14 @@ def _budget_rows(eng, builder):
     )
     rows = []
     for label, w in getattr(eng, "_excited_power_budget", None) or []:
-        path = next(
-            (p for p in instance_paths if label.startswith(p + ": ")), ""
-        )
+        path = next((p for p in instance_paths if label.startswith(p + ": ")), "")
         if label in relabel:
             display = relabel[label]
         elif path:
             display = label[len(path) + 2 :]
         else:
             display = label
-        rows.append(
-            {"label": display, "watts": max(0.0, float(w)), "path": path}
-        )
+        rows.append({"label": display, "watts": max(0.0, float(w)), "path": path})
     return rows
 
 
@@ -1852,7 +1848,8 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         meas_freq_range_mhz=tuple(meas_range) if meas_range else None,
         sweep_policy=sweep_policy,
         default_view=field_default_view,
-        default_freq_mhz=float(dp["freq"]) if "freq" in dp else None,
+        default_freq=float(dp["freq"]) if "freq" in dp else None,
+        default_design_freq=(float(dp["design_freq"]) if has_design_freq else None),
         has_design_freq=has_design_freq,
         variants=variants,
         variant_values={

--- a/src/antennaknobs/web/examples/_base.py
+++ b/src/antennaknobs/web/examples/_base.py
@@ -372,7 +372,14 @@ class AntennaExample:
     # first loads, without exposing it as a redundant schema slider.
     # None means "no preferred freq" — frontend falls back to bands[0]
     # or its built-in default.
-    default_freq_mhz: Optional[float] = None
+    default_freq: Optional[float] = None
+    # The design's STOCK design_freq, when it has one. Almost always equal
+    # to default_freq; they differ for off-band designs (a 10 m antenna
+    # deliberately worked on 12 m, e.g. inverted_l_tmatch), where the
+    # design-switch snap must park designFreq here and only the measurement
+    # dial on default_freq — snapping both to default_freq would
+    # silently RESIZE the geometry and destroy the design's premise.
+    default_design_freq: Optional[float] = None
     # True when the Builder has a `design_freq` parameter that scales
     # geometry (design_freq-sized designs). The frontend uses this to show
     # or hide the design-freq band-tab row: hand-tuned absolute

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1331,7 +1331,7 @@ type SolveResponse = {
    *  one entry per TL / TwoPort / Shunt / Load branch, in watts for the
    *  canonical 1 V drive. Absent or all-~0 for plain and lossless
    *  designs; input_power_w is the 100% reference. */
-  power_budget?: { label: string; watts: number }[];
+  power_budget?: { label: string; watts: number; path?: string }[];
   input_power_w?: number;
   k_meas_m_inv?: number;
   // V-specific
@@ -6197,14 +6197,38 @@ function SolveReadout({
             {showBudget && pin && (
               <div title="Fraction of the source input power dissipated in each network branch (from the MNA solve); the antenna row is the remainder that reaches the wires.">
                 <div className="feeds-table-header">power budget</div>
-                {budget.map((b, i) => (
-                  <div className="row" key={`pb-${i}`}>
-                    <span>{b.label}</span>
-                    <span className="val">
-                      {((b.watts / pin) * 100).toFixed(1)}%
-                    </span>
-                  </div>
-                ))}
+                {budget.map((b, i) => {
+                  // Hierarchical rows (issue #489): rows carry the instance
+                  // path of the composite they came from. Start a group
+                  // header whenever the path changes, and indent members
+                  // one step per hierarchy level ("sta.tuner" = depth 2).
+                  const path = b.path ?? "";
+                  const prev = i > 0 ? budget[i - 1].path ?? "" : "";
+                  const depth = path ? path.split(".").length : 0;
+                  return (
+                    <Fragment key={`pb-${i}`}>
+                      {path && path !== prev && (
+                        <div
+                          className="row pb-group"
+                          style={{ paddingLeft: `${(depth - 1) * 12}px` }}
+                        >
+                          <span>{path}</span>
+                        </div>
+                      )}
+                      <div
+                        className="row"
+                        style={
+                          depth ? { paddingLeft: `${depth * 12}px` } : undefined
+                        }
+                      >
+                        <span>{b.label}</span>
+                        <span className="val">
+                          {((b.watts / pin) * 100).toFixed(1)}%
+                        </span>
+                      </div>
+                    </Fragment>
+                  );
+                })}
                 <div className="row" key="pb-ant">
                   <span>antenna (accepted)</span>
                   <span className="val">

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -139,7 +139,8 @@ type ExampleDescriptor = {
   default_view: Projection | null;
   /** The freq this antenna is naturally designed for. Used by the
    *  band-snap-on-example-change effect; null = no preferred freq. */
-  default_freq_mhz: number | null;
+  default_freq: number | null;
+  default_design_freq: number | null;
   /** Recommended solver backend for this design (e.g. "arrayblock" for grid
    *  arrays). The active slot's backend is seeded from this on selection
    *  unless the user has manually picked a backend. null = keep the UI
@@ -317,19 +318,40 @@ function seedDefaults(
 // by one render, fetching its preview with the PREVIOUS design's freqs.
 function snapForExample(
   ex: ExampleDescriptor | undefined,
-): { bandKey: string; freq: number } | null {
+): {
+  bandKey: string;
+  freq: number;
+  measBandKey: string;
+  measFreq: number;
+  offBand: boolean;
+} | null {
   if (!ex || ex.bands.length === 0) return null;
-  const d = ex.default_freq_mhz;
-  const containing =
-    d != null ? ex.bands.find((b) => d >= b.min_mhz && d <= b.max_mhz) : null;
-  const target = containing ?? ex.bands[0];
-  // Use the design's native freq when the band contains it; otherwise the
-  // band's own default. This avoids the small designFreq drift that would
-  // happen if we always snapped to band.freq_mhz (e.g. dipole's 28.57 →
-  // 10m band's 28.470).
+  // The measurement dial parks on the design's native operating freq;
+  // designFreq parks on its STOCK design_freq. They're almost always the
+  // same value, but off-band designs (a 10 m antenna deliberately worked
+  // on 12 m through a tuner, e.g. inverted_l_tmatch) differ — snapping
+  // designFreq to the operating freq would silently RESIZE the geometry
+  // and destroy the design's premise.
+  const m = ex.default_freq;
+  const d = ex.default_design_freq ?? m;
+  const findBand = (f: number | null) =>
+    f != null ? ex.bands.find((b) => f >= b.min_mhz && f <= b.max_mhz) : null;
+  // Use the exact freq when a band contains it; otherwise the band's own
+  // default. This avoids the small designFreq drift that would happen if
+  // we always snapped to band.freq_mhz (e.g. dipole's 28.57 → 10m band's
+  // 28.470).
+  const dBand = findBand(d);
+  const dTarget = dBand ?? ex.bands[0];
+  const designFreq = dBand && d != null ? d : dTarget.freq_mhz;
+  const mBand = findBand(m);
+  const mTarget = mBand ?? dTarget;
+  const measFreq = mBand && m != null ? m : mTarget.freq_mhz;
   return {
-    bandKey: target.key,
-    freq: containing && d != null ? d : target.freq_mhz,
+    bandKey: dTarget.key,
+    freq: designFreq,
+    measBandKey: mTarget.key,
+    measFreq,
+    offBand: measFreq !== designFreq,
   };
 }
 
@@ -2502,10 +2524,20 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
       return { ...prev, [geometry]: base };
     });
     if (typeof vv.freq === "number") {
-      setDesignFreq(vv.freq);
-      // Fixed-geometry designs re-anchor unconditionally: their lock is
-      // inert (measLockable), so only the variant freq is meaningful.
-      if (linkMeas || !currentExample.has_design_freq) setMeasFreq(vv.freq);
+      // A variant's stock design_freq wins when it carries one — freq is
+      // the OPERATING freq, and off-band variants keep the two apart
+      // (see snapForExample).
+      const vd =
+        typeof vv.design_freq === "number" ? vv.design_freq : vv.freq;
+      setDesignFreq(vd);
+      if (vd !== vv.freq) {
+        setLinkMeas(false);
+        setMeasFreq(vv.freq);
+      } else if (linkMeas || !currentExample.has_design_freq) {
+        // Fixed-geometry designs re-anchor unconditionally: their lock is
+        // inert (measLockable), so only the variant freq is meaningful.
+        setMeasFreq(vv.freq);
+      }
     }
   }
   // Stable, primitive-only signature of the active antenna's params for
@@ -3430,13 +3462,21 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     const snap = snapForExample(currentExample)!;
     setBand(snap.bandKey);
     setDesignFreq(snap.freq);
-    // Re-anchor the dial too: always when locked, and also for
-    // fixed-geometry designs — their lock is inert (see measLockable), so
-    // a measFreq left over from the previous design would strand the
-    // measurement outside this design's window entirely.
-    if (linkMeas || !currentExample.has_design_freq) {
-      setMeasFreq(snap.freq);
-      setMeasBand(snap.bandKey);
+    // Off-band designs open with the measurement dial deliberately away
+    // from the design freq (that's the design's premise), so the
+    // follow-design lock must disengage or it would immediately drag the
+    // dial back.
+    if (snap.offBand) {
+      setLinkMeas(false);
+      setMeasFreq(snap.measFreq);
+      setMeasBand(snap.measBandKey);
+    } else if (linkMeas || !currentExample.has_design_freq) {
+      // Re-anchor the dial too: always when locked, and also for
+      // fixed-geometry designs — their lock is inert (see measLockable),
+      // so a measFreq left over from the previous design would strand the
+      // measurement outside this design's window entirely.
+      setMeasFreq(snap.measFreq);
+      setMeasBand(snap.measBandKey);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentExample]);
@@ -3636,8 +3676,8 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     const snap = snapForExample(currentExample);
     if (snap) {
       req.design_freq_mhz = snap.freq;
-      if (linkMeas || !currentExample!.has_design_freq) {
-        req.measurement_freq_mhz = snap.freq;
+      if (snap.offBand || linkMeas || !currentExample!.has_design_freq) {
+        req.measurement_freq_mhz = snap.measFreq;
       }
     }
     previewSigRef.current = JSON.stringify(req);

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1735,6 +1735,12 @@ input[type=checkbox] {
   margin-bottom: var(--space-1);
 }
 
+/* Power-budget instance group header (issue #489 hierarchy): names the
+   composite instance whose indented rows follow. */
+.pb-group {
+  color: var(--muted);
+}
+
 .smith,
 .farfield {
   display: block;

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -1516,7 +1516,8 @@ def examples_endpoint():
                     else None
                 ),
                 "default_view": ex.default_view,
-                "default_freq_mhz": ex.default_freq_mhz,
+                "default_freq": ex.default_freq,
+                "default_design_freq": ex.default_design_freq,
                 "default_backend": ex.default_backend,
                 "has_design_freq": ex.has_design_freq,
                 "variants": list(ex.variants),

--- a/tests/test_composite_network.py
+++ b/tests/test_composite_network.py
@@ -402,16 +402,25 @@ def test_ft240_preset_pins_efhw_stock_values():
 
 def test_budget_rows_apply_display_renames():
     """ui_params["budget_labels"] retitles rows at the presentation
-    boundary — exact match, unmatched rows pass through, negatives clamp."""
+    boundary — exact match, unmatched rows pass through, negatives clamp.
+    Rows carry the instance ``path`` recovered from the structural label's
+    prefix (matched against the network's real instance paths only); rows
+    resolved to a path drop the prefix from the display label unless a
+    rename already retitled them."""
     # examples first: entering the package via adapter alone trips the
     # adapter↔examples import cycle (examples calls register_all mid-import)
     import antennaknobs.web.examples  # noqa: F401
 
     from antennaknobs.web.adapter import _budget_rows
 
+    class Net:
+        branch_paths = ["unun.", "unun.", ""]
+
     class Eng:
+        _network = Net()
         _excited_power_budget = [
             ("unun: Shunt pri", 0.25),
+            ("unun: Transformer pri→ant", 0.05),
             ("TL rig→pri", -1e-18),
         ]
 
@@ -422,11 +431,38 @@ def test_budget_rows_apply_display_renames():
         pass
 
     assert _budget_rows(Eng(), WithLabels()) == [
-        {"label": "unun comp cap", "watts": 0.25},
-        {"label": "TL rig→pri", "watts": 0.0},
+        # renamed: the design's display name wins verbatim
+        {"label": "unun comp cap", "watts": 0.25, "path": "unun"},
+        # unrenamed instance row: prefix stripped, path carries the group
+        {"label": "Transformer pri→ant", "watts": 0.05, "path": "unun"},
+        {"label": "TL rig→pri", "watts": 0.0, "path": ""},
     ]
     assert [r["label"] for r in _budget_rows(Eng(), Bare())] == [
-        "unun: Shunt pri",
+        "Shunt pri",
+        "Transformer pri→ant",
+        "TL rig→pri",
+    ]
+
+    # No network on the engine (older engines, wire-loss extra rows):
+    # nothing to match against, labels pass through whole.
+    class EngNoNet:
+        _excited_power_budget = [("unun: Shunt pri", 0.25)]
+
+    assert _budget_rows(EngNoNet(), Bare()) == [
+        {"label": "unun: Shunt pri", "watts": 0.25, "path": ""}
+    ]
+
+    # The server's _build_builder STRIPS ui_params from the instance's
+    # params, so the labels must come from the class's default_params
+    # fallback — this exact path silently dropped every rename before.
+    class ServerStyleBuilder:
+        default_params = {
+            "ui_params": {"budget_labels": {"unun: Shunt pri": "unun comp cap"}}
+        }
+
+    assert [r["label"] for r in _budget_rows(Eng(), ServerStyleBuilder())] == [
+        "unun comp cap",
+        "Transformer pri→ant",
         "TL rig→pri",
     ]
 

--- a/tests/test_finite_q.py
+++ b/tests/test_finite_q.py
@@ -108,10 +108,10 @@ def test_lossy_shunt_coil_dissipates_power():
 def test_tuner_designs_expose_the_coil_q_knob():
     # coil_q = 0 is the ideal-coil sentinel: the branch carries ql=None
     # (bit-identical to the pre-#298 build); coil_q > 0 lands verbatim in
-    # the branch's ql. Stock defaults differ per design: the L-match ships
-    # ideal (0), the T-match ships a real Q=200 coil.
+    # the branch's ql. Both tuner designs ship a real Q=200 coil stock —
+    # an ideal matchbox dissipates nothing and hides the power budget.
     for builder_cls, lossy_branch, stock_ql in [
-        (LMatchBuilder, TwoPort, None),
+        (LMatchBuilder, TwoPort, 200.0),
         (TMatchBuilder, Shunt, 200.0),
     ]:
         net = builder_cls().build_network()

--- a/tests/test_finite_q.py
+++ b/tests/test_finite_q.py
@@ -106,10 +106,13 @@ def test_lossy_shunt_coil_dissipates_power():
 
 
 def test_tuner_designs_expose_the_coil_q_knob():
-    # Default 0 = ideal coil: the branch carries ql=None (bit-identical).
-    for builder_cls, lossy_branch in [
-        (LMatchBuilder, TwoPort),
-        (TMatchBuilder, Shunt),
+    # coil_q = 0 is the ideal-coil sentinel: the branch carries ql=None
+    # (bit-identical to the pre-#298 build); coil_q > 0 lands verbatim in
+    # the branch's ql. Stock defaults differ per design: the L-match ships
+    # ideal (0), the T-match ships a real Q=200 coil.
+    for builder_cls, lossy_branch, stock_ql in [
+        (LMatchBuilder, TwoPort, None),
+        (TMatchBuilder, Shunt, 200.0),
     ]:
         net = builder_cls().build_network()
         coils = [
@@ -117,16 +120,17 @@ def test_tuner_designs_expose_the_coil_q_knob():
             for b in net.branches
             if isinstance(b, lossy_branch) and getattr(b, "l", None)
         ]
-        assert coils and all(b.ql is None for b in coils)
-        net_q = builder_cls(
-            params={**builder_cls.default_params, "coil_q": 200.0}
-        ).build_network()
-        coils_q = [
-            b
-            for b in net_q.branches
-            if isinstance(b, lossy_branch) and getattr(b, "l", None)
-        ]
-        assert coils_q and all(b.ql == 200.0 for b in coils_q)
+        assert coils and all(b.ql == stock_ql for b in coils)
+        for coil_q, ql in [(200.0, 200.0), (0.0, None)]:
+            net_q = builder_cls(
+                params={**builder_cls.default_params, "coil_q": coil_q}
+            ).build_network()
+            coils_q = [
+                b
+                for b in net_q.branches
+                if isinstance(b, lossy_branch) and getattr(b, "l", None)
+            ]
+            assert coils_q and all(b.ql == ql for b in coils_q)
 
 
 def test_pynec_routes_finite_q_loads_down_the_reducer():

--- a/tests/test_momwire_engine.py
+++ b/tests/test_momwire_engine.py
@@ -1651,16 +1651,18 @@ def _tmatch_bare(params=None):
 
 def test_tmatch_matches_circuit_theory():
     """The T-network must reproduce the exact three-element transform
-    Z_in = X_C1 + (X_L ∥ (X_C2 + Z_ant)) of the bare antenna impedance —
+    Z_in = X_C1 + (Z_L ∥ (X_C2 + Z_ant)) of the bare antenna impedance —
     lumped circuit theory composed on the extracted antenna Y, through a
     tee midpoint that is a pure interior node (no antenna segment, no TL:
-    the only design whose KCL row has no Group-1 stamp at all)."""
+    the only design whose KCL row has no Group-1 stamp at all). The stock
+    coil has finite Q, so Z_L carries its ESR ωL/Q (issue #298)."""
     from antennaknobs.designs.verticals.inverted_l_tmatch import Builder as B
 
     p = B.default_params
     omega = 2.0 * np.pi * p["freq"] * 1e6
     xc1 = 1.0 / (1j * omega * p["series_c1_pF"] * 1e-12)
-    xl = 1j * omega * p["shunt_l_uH"] * 1e-6
+    l = p["shunt_l_uH"] * 1e-6
+    xl = omega * l / p["coil_q"] + 1j * omega * l
     xc2 = 1.0 / (1j * omega * p["series_c2_pF"] * 1e-12)
 
     z_ant = _sinusoidal(_tmatch_bare()).impedance()[0]
@@ -1701,7 +1703,8 @@ def test_tmatch_degenerate_endpoints():
     p = B.default_params
     omega = 2.0 * np.pi * p["freq"] * 1e6
     xc1 = 1.0 / (1j * omega * p["series_c1_pF"] * 1e-12)
-    xl = 1j * omega * p["shunt_l_uH"] * 1e-6
+    l = p["shunt_l_uH"] * 1e-6
+    xl = omega * l / p["coil_q"] + 1j * omega * l  # stock coil ESR included
 
     z = _sinusoidal(B(params={**p, "shunt_l_uH": 0.0})).impedance()[0]
     assert np.allclose(z, xc1, rtol=1e-12), (z, xc1)

--- a/tests/test_momwire_engine.py
+++ b/tests/test_momwire_engine.py
@@ -1674,14 +1674,22 @@ def test_tmatch_matches_circuit_theory():
 @needs_pynec
 def test_inverted_l_tmatch_matches_50ohm_cross_engine():
     """The showcase: a 10 m inverted-L worked on 12 m is a short vertical
-    (~10.8 − 121.7j) but the stock T-network brings it to ~50 Ω. Both
-    engines agree (the match is exact circuit theory on the antenna Y)."""
+    (~11 − 117j) but the stock T-network brings it to ~50 Ω. The stock
+    values are tuned against the WORKBENCH default solve (default basis,
+    free space), where the match is exact; the sinusoidal basis sees the
+    bare antenna a few percent differently and the ~2 kΩ virtual-resistance
+    ride magnifies that to ~43 − 15j — so the matched-basis engines get a
+    ballpark window here, plus the tight engines-agree assertion (the
+    network composition itself is exact circuit theory on the antenna Y)."""
     from antennaknobs.designs.verticals.inverted_l_tmatch import Builder as B
+
+    z_web = MomwireEngine(B(), ground=None).impedance()[0]
+    assert abs(z_web - 50.0) < 2.0, z_web  # the tune the design opens as
 
     z_mom = _sinusoidal(B()).impedance()[0]
     z_nec = PyNECEngine(B(), ground=None).impedance()[0]
     for z in (z_mom, z_nec):
-        assert abs(z.real - 50.0) < 5.0 and abs(z.imag) < 5.0, z  # matched
+        assert abs(z - 50.0) < 20.0, z  # ballpark-matched on this basis
     assert abs(z_mom - z_nec) / abs(z_mom) < 0.01, (z_mom, z_nec)
 
 

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -113,7 +113,7 @@ def test_optimize_real_geometry_improves_resonance():
 
     name = "broadband.g5rv"
     ex = REGISTRY[name]
-    freq = ex.default_freq_mhz or 14.0
+    freq = ex.default_freq or 14.0
     base = {"geometry": name, "measurement_freq_mhz": freq, "design_freq_mhz": freq}
     res = optimize(
         base,

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -265,7 +265,7 @@ def test_each_example_has_the_keys_the_frontend_reads(client: TestClient):
         "bands",
         "meas_freq_range_mhz",
         "default_view",
-        "default_freq_mhz",
+        "default_freq",
         "has_design_freq",
         "variants",
         "variant_values",


### PR DESCRIPTION
## Summary
- **Hierarchical power-budget display**: budget rows now carry the composite instance path they came from (derived from the network's `branch_paths`, robust to display renames); the workbench groups them under a muted instance header and indents one step per hierarchy level. Also fixes a silent v0.33.0 regression: the solve path strips `ui_params` from Builder instances, so `budget_labels` display renames never applied on the live server — now falls back to the design class's defaults, pinned by test.
- **`inverted_l_tmatch` migrated to the station stdlib** (the one design #489 missed): its hand-built tee is now `Instance("tuner", t_network_tuner(...))`. Its `coil_q` defaults to 200 instead of the ideal-coil 0 (which suppressed the entire power budget), stock C1/L retuned for the coil ESR **against the workbench default solve** (opens at 50.00 Ω; the coil visibly burns ~9%). `skyloop_lmatch` gets the same treatment (~1% coil burn — a nice catalog contrast).
- **Off-band freq-snap fix**: the design-switch snap parked both designFreq and the meas dial on the design's operating freq, silently *resizing* off-band designs (the 10 m-cut T-match became a 12 m antenna and opened at ~30 − 300j, looking broken). The descriptor now ships `default_design_freq_mhz` separately; the snap keeps geometry on the cut band, parks only the meas dial on the operating band, and auto-opens the follow-design lock. Variant switches and the preview fetch get the same split.
- **New site article**: `advanced/off-band.md` — "Cut for one band, worked on another": the two-frequency model, T-match vs L-match walkthroughs with the power-budget story, match-sensitivity lesson, and the authoring recipe.

## Test plan
- [x] Full suite green (2465 passed) plus targeted re-runs of the affected suites after the final retune
- [x] Frontend `tsc --noEmit` + vite build; Astro site build (23 pages)
- [x] Live server smoke: tmatch opens at design 28.57 / meas 24.9 → 50.00 − 0.01j with grouped, renamed, indented budget rows; skyloop_lmatch at 3.8 / 18.1 → 47.6 − 6.5j
- [ ] Visual pass over the indented budget display in the workbench

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2EZMHKcXNVZfVUrGpNXq8