### PR TITLE
Fix SyntaxWarning from right_angle_delta's ASCII-art docstring

### DIFF
--- a/src/antennaknobs/designs/verticals/right_angle_delta.py
+++ b/src/antennaknobs/designs/verticals/right_angle_delta.py
@@ -1,4 +1,4 @@
-"""Right-Angle Delta: the coax-friendly SCV delta (L. B. Cebik, W4RNL).
+r"""Right-Angle Delta: the coax-friendly SCV delta (L. B. Cebik, W4RNL).
 
 From Cebik's "SCVs: A Family Album" -- the same self-contained-vertical
 family as the catalog's `half_square`, `bobtail`, and `bruce`: closed or


### PR DESCRIPTION
## Summary
- The right-angle delta's docstring diagram (`F   \`) raised `SyntaxWarning: invalid escape sequence '\ '` on first import — surfaced in the Docker container logs, where modules aren't pre-compiled.
- Raw docstring (`r"""`), matching the catalog's other art-bearing modules. A package-wide `compileall` sweep with SyntaxWarnings forced on confirms this was the only instance, and zero remain.

## Test plan
- [x] `compileall` sweep: 0 SyntaxWarnings package-wide
- [x] Docstring art verified intact after the raw-string change
- [x] Delta/right-angle test selection green (291 passed); ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2EZMHKcXNVZfVUrGpNXq8