### PR TITLE
Portable trust store: key user-design trust relative to the store's directory

### DIFF
--- a/src/antennaknobs/design_trust.py
+++ b/src/antennaknobs/design_trust.py
@@ -28,6 +28,20 @@ and are loaded by import, not from the user directory.
 The store is a small JSON file (``.trust.json`` in the user design dir, or
 ``$ANTENNAKNOBS_TRUST_FILE``). The env flag ``ANTENNAKNOBS_TRUST_USER_DESIGNS=1``
 is a blanket "trust everything" escape hatch for CI/dev/single-user boxes.
+
+Records are keyed by the design's path **relative to the store's own
+directory** (``"foo.py"``), not its absolute path. The store lives inside the
+design folder, so a relative key means "this file in my own directory" — the
+same identity, but portable: mount the folder into a Docker container at
+``/root/.antennaknobs/designs`` (compose.yaml does) or move it to another
+machine and trust travels with it, where absolute keys silently matched
+nothing. This is NOT folder-level trust — records are still per-file and
+``pinned`` mode still checks the content hash. (``always`` mode was already a
+name-not-content grant, and anyone who can forge the relative key could
+already edit ``.trust.json`` itself — store integrity is assumed either way.)
+Legacy absolute keys are migrated to relative on load; a design outside the
+store's directory (``$ANTENNAKNOBS_TRUST_FILE`` pointing elsewhere) still
+keys by absolute path.
 """
 
 from __future__ import annotations
@@ -51,7 +65,9 @@ __all__ = [
     "store_path",
 ]
 
-_STORE_VERSION = 1
+# v2: design keys are store-dir-relative (portable); v1 keyed absolute paths.
+# The loader migrates v1 keys transparently and never gates on the version.
+_STORE_VERSION = 2
 
 
 def trust_all_enabled() -> bool:
@@ -83,8 +99,38 @@ def content_hash(path: Path) -> str:
 
 
 def _resolved_key(path: Path) -> str:
-    """The store key for a design: its resolved absolute path as a string."""
-    return str(Path(path).resolve())
+    """The store key for a design: its path relative to the store's own
+    directory when it lives there (portable across mount points — see the
+    module docstring), else its resolved absolute path."""
+    resolved = Path(path).resolve()
+    try:
+        return str(resolved.relative_to(store_path().resolve().parent))
+    except ValueError:
+        return str(resolved)
+
+
+def _migrate_keys(designs: dict) -> dict:
+    """Rewrite legacy absolute keys that point inside the store's directory
+    to the relative form (pre-portability stores; a folder that has been
+    mounted at several paths may carry SEVERAL absolute spellings of the
+    same file). On collision an ``always`` record wins over ``pinned`` —
+    both were explicit user grants, and ``always`` is the broader one the
+    user has stated for the file."""
+    store_dir = store_path().resolve().parent
+    migrated: dict = {}
+    for key, rec in designs.items():
+        p = Path(key)
+        if p.is_absolute():
+            try:
+                key = str(p.resolve().relative_to(store_dir))
+            except ValueError:
+                pass  # genuinely outside the store dir: absolute is correct
+        prev = migrated.get(key)
+        if prev is None or (
+            prev.get("mode") == "pinned" and rec.get("mode") == "always"
+        ):
+            migrated[key] = rec
+    return migrated
 
 
 def _load_store() -> dict:
@@ -95,6 +141,7 @@ def _load_store() -> dict:
         return {"version": _STORE_VERSION, "designs": {}}
     if not isinstance(data, dict) or "designs" not in data:
         return {"version": _STORE_VERSION, "designs": {}}
+    data["designs"] = _migrate_keys(data["designs"])
     return data
 
 

--- a/tests/test_design_trust.py
+++ b/tests/test_design_trust.py
@@ -151,6 +151,78 @@ def test_bad_mode_rejected(userdir):
         dt.trust(userdir / "d.py", mode="sometimes")
 
 
+# --- portable (store-dir-relative) keys --------------------------------------
+
+
+def test_store_keys_are_relative(userdir):
+    """New records key on the design's name relative to the store's own dir,
+    not its absolute path — that's what makes trust portable."""
+    import json
+
+    p = userdir / "d.py"
+    p.write_text(CLEAN)
+    dt.trust(p)
+    designs = json.loads(dt.store_path().read_text())["designs"]
+    assert list(designs) == ["d.py"]
+
+
+def test_trust_survives_folder_relocation(userdir, tmp_path_factory, monkeypatch):
+    """The Docker-mount scenario: the whole design folder (store included)
+    appears at a different absolute path — a compose volume at
+    /root/.antennaknobs/designs, a moved home dir. Trust must travel."""
+    import shutil
+
+    p = userdir / "d.py"
+    p.write_text(CLEAN)
+    dt.trust(p, mode="pinned")
+    assert dt.is_trusted(p)
+
+    moved = tmp_path_factory.mktemp("container-mount") / "designs"
+    shutil.copytree(userdir, moved)
+    monkeypatch.setenv("ANTENNAKNOBS_USER_DIR", str(moved))
+    assert dt.is_trusted(moved / "d.py")
+    assert dt.trust_status(moved / "d.py") == "pinned"
+
+
+def test_legacy_absolute_keys_migrate(userdir):
+    """A v1 store (absolute-path keys) still answers lookups, and the first
+    write rewrites it to relative keys."""
+    import json
+
+    p = userdir / "d.py"
+    p.write_text(CLEAN)
+    dt.store_path().write_text(
+        json.dumps({"version": 1, "designs": {str(p.resolve()): {"mode": "always"}}})
+    )
+    assert dt.is_trusted(p)
+    (userdir / "e.py").write_text(CLEAN)
+    dt.trust(userdir / "e.py")  # any write persists the migrated keys
+    designs = json.loads(dt.store_path().read_text())["designs"]
+    assert set(designs) == {"d.py", "e.py"}
+
+
+def test_migration_collision_prefers_always(userdir):
+    """A folder that lived at several mount points can carry several key
+    spellings of the same file; on migration the broader 'always' grant
+    wins over 'pinned'."""
+    import json
+
+    p = userdir / "d.py"
+    p.write_text(CLEAN)
+    dt.store_path().write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "designs": {
+                    str(p.resolve()): {"mode": "pinned", "sha256": "stale-hash"},
+                    "d.py": {"mode": "always"},
+                },
+            }
+        )
+    )
+    assert dt.trust_status(p) == "always"
+
+
 # --- allow / disallow CLI ----------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- Trust records were keyed by absolute path, so mounting the design folder anywhere else — Docker compose's `/root/.antennaknobs/designs` volume being the case that surfaced it — silently invalidated every grant: all user designs fell back to the "needs your OK" panel and the container app looked like it had none.
- Records now key on the design's path **relative to the store's own directory** (`"foo.py"`). The store lives inside the design folder, so this is the same per-file identity — but portable across mount points and machine moves. `pinned` mode still verifies the content hash; per-file granularity is unchanged (this is not folder-level trust).
- Legacy absolute keys migrate transparently on load and are persisted on the next write; collisions from multiple mount-point spellings resolve with `always` beating `pinned`. Designs outside the store's directory (`$ANTENNAKNOBS_TRUST_FILE` pointing elsewhere) still key by absolute path.

## Test plan
- [x] New tests: relative keys written; the Docker relocation scenario (folder copied to a new absolute path → trust travels); v1 absolute-key stores answer lookups and rewrite to relative on first write; collision prefers `always`
- [x] Full suite green (2469 passed); ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2EZMHKcXNVZfVUrGpNXq8