### PR TITLE
Release v0.35.0 (cut for one band, worked on another)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.34.1"
+version = "0.35.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,22 +25,20 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.34.1" icon="star">
-  **Docker, VHF, and honest meshes.** The workbench now ships as a
-  **Docker image** — `docker run -p 8000:8000
-  stevenmburns/antennaknobs` and you're solving, no Python setup
-  ([how-to](https://github.com/stevenmburns/antennaknobs/blob/main/DOCKER.md)).
-  The band tabs reach **2 m and 70 cm**, with a first VHF-native
-  design: Cebik's 6-element 2 m OWA yagi, band-flat at SWR ≤ 1.2
-  across all of 144–148 MHz. And the mesh-integrity arc behind issue
-  #484 landed: a catalog-wide **Δ/a lint** (no wire may refine below
-  the thin-wire floor), per-design refinement headroom, two builder
-  density defects fixed, and the
-  [convergence guide](/advanced/convergence/) rewritten around what
-  the data actually showed.
-  (v0.34.1 patches two VHF-workbench rough edges the new bands exposed:
-  the unlocked measurement-frequency dial no longer snaps to a stale
-  60 MHz ceiling, and the lock icon now visibly opens when unlocked.)
+<Card title="New in v0.35.0" icon="star">
+  **Cut for one band, worked on another.** Off-band designs — a 10 m
+  inverted-L worked on 12 m through a T-network, an 80 m skyloop run on
+  17 m — now open the way they're meant to be seen: geometry on the band
+  they're cut for, the dial on the band they're worked, the tuner already
+  doing its job (a frequency-snap bug used to silently re-size them).
+  Both matchbox designs ship **real Q = 200 coils**, so the power budget
+  shows the true tuner cost — ~9 % of your watts burned in the T-match's
+  coil vs ~1 % in the L-match — and budget rows now **group indented
+  under their station box**. Trust decisions for your own designs travel
+  with the folder now, so the
+  [Docker workbench](https://github.com/stevenmburns/antennaknobs/blob/main/DOCKER.md)
+  sees them without re-allowing. New study:
+  [Cut for one band, worked on another](/advanced/off-band/).
   [All release notes →](/reference/releases/)
 </Card>
 

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -161,7 +161,10 @@ A design file in `~/.antennaknobs/designs/` is a full Python program that runs
 with your user privileges, so it **does not run until you allow it** — like
 VS Code's workspace-trust prompt. The decision is remembered per file, by its
 contents: a new file always asks first, and an allowed file that later changes
-asks again.
+asks again. Decisions live in `.trust.json` inside the design folder and are
+keyed relative to it, so they travel with the folder — mount it into the
+[Docker container](https://github.com/stevenmburns/antennaknobs/blob/main/DOCKER.md)
+or move it to a new machine and your allowed designs stay allowed.
 
 ```bash
 # A design someone sent you: review it first, then allow that exact version

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -39,7 +39,12 @@ is the runbook.
 ## Driving a knob
 
 Each parameter in a design is a knob (the big one is the measurement-frequency
-VFO dial; the rest are smaller). Three ways to change one:
+VFO dial; the rest are smaller). The dial is normally locked to the design
+frequency; **off-band designs** — an antenna cut for one band and worked on
+another through a tuner (see
+[Cut for one band, worked on another](/advanced/off-band/)) — open with the
+lock open and the dial already parked on their operating band. Three ways to
+change a knob:
 
 - **Drag** — press on the knob and move the mouse **vertically** (up to
   increase, down to decrease). Horizontal motion is ignored, so a natural hand
@@ -234,9 +239,10 @@ with the fraction of the source's input power it dissipates, plus an
 come straight from the MNA network solve (each branch current is an
 explicit unknown, so the watts are read off the solution, not modelled
 separately — see [Station modelling](/concepts/station-modelling/) for
-the network vocabulary; rows from a station *box* are grouped under its
-instance name, e.g. `tuner: Shunt m`, and a design may retitle rows for
-display via `ui_params["budget_labels"]`), and the same accounting drives
+the network vocabulary). Rows from a station *box* are grouped under a
+header naming its instance and indented beneath it — one indent step per
+nesting level — and a design may retitle rows for display via
+`ui_params["budget_labels"]`. The same accounting drives
 the reported radiation
 efficiency: **every** dissipative branch counts, including resistive
 coupling and matching elements, not just explicit `Load`s. Gain is


### PR DESCRIPTION
## Summary
- Bump version to 0.35.0
- Refresh the what's-new card for the off-band release (hierarchical power budget, real tuner coils, off-band snap fix, portable trust store, new advanced study)
- De-stale sweep: web.md power-budget grouping + off-band dial behavior, cli.md trust portability

## Test plan
- [x] Site builds (23 pages)
- [x] Web server tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2EZMHKcXNVZfVUrGpNXq8