### PR TITLE
Trust migration: carry legacy absolute keys across folder relocations

### DIFF
--- a/src/antennaknobs/design_trust.py
+++ b/src/antennaknobs/design_trust.py
@@ -124,7 +124,18 @@ def _migrate_keys(designs: dict) -> dict:
             try:
                 key = str(p.resolve().relative_to(store_dir))
             except ValueError:
-                pass  # genuinely outside the store dir: absolute is correct
+                # The key points outside the store dir. Two cases:
+                # - The folder has been RELOCATED since the record was
+                #   written (a Docker volume at /root/..., a moved home
+                #   dir): the recorded path no longer exists in this
+                #   environment, but a file with that name sits next to
+                #   the store. The default store always lived alongside
+                #   its designs, so treat the record as this folder's own.
+                # - A custom $ANTENNAKNOBS_TRUST_FILE store legitimately
+                #   records out-of-dir designs: those paths still exist
+                #   here, so the guard leaves them keyed absolute.
+                if not p.exists() and (store_dir / p.name).is_file():
+                    key = p.name
         prev = migrated.get(key)
         if prev is None or (
             prev.get("mode") == "pinned" and rec.get("mode") == "always"

--- a/tests/test_design_trust.py
+++ b/tests/test_design_trust.py
@@ -201,6 +201,43 @@ def test_legacy_absolute_keys_migrate(userdir):
     assert set(designs) == {"d.py", "e.py"}
 
 
+def test_legacy_keys_survive_folder_relocation(userdir):
+    """THE Docker case, v0.35.0's actual gap: a v1 store with absolute keys
+    from the OLD location, and the folder now mounted somewhere else. The
+    recorded path doesn't exist here; the file sits next to the store —
+    the record must migrate by name and keep answering."""
+    import json
+
+    p = userdir / "d.py"
+    p.write_text(CLEAN)
+    old_home_key = "/nonexistent/old-home/.antennaknobs/designs/d.py"
+    dt.store_path().write_text(
+        json.dumps({"version": 1, "designs": {old_home_key: {"mode": "always"}}})
+    )
+    assert dt.is_trusted(p)
+    assert dt.trust_status(p) == "always"
+
+
+def test_out_of_dir_records_stay_absolute(userdir, tmp_path_factory, monkeypatch):
+    """A custom $ANTENNAKNOBS_TRUST_FILE store recording a design OUTSIDE
+    the store's directory keeps its absolute key while that path exists —
+    even if a same-named file appears next to the store."""
+    import json
+
+    elsewhere = tmp_path_factory.mktemp("elsewhere")
+    real = elsewhere / "d.py"
+    real.write_text(CLEAN)
+    store = userdir / "custom-trust.json"
+    monkeypatch.setenv("ANTENNAKNOBS_TRUST_FILE", str(store))
+    dt.trust(real, mode="always")
+    # A same-named local file must NOT inherit the out-of-dir grant.
+    imposter = userdir / "d.py"
+    imposter.write_text(CLEAN + "# different file\n")
+    assert dt.is_trusted(real)
+    assert json.loads(store.read_text())["designs"].keys() == {str(real.resolve())}
+    assert not dt.is_trusted(imposter)
+
+
 def test_migration_collision_prefers_always(userdir):
     """A folder that lived at several mount points can carry several key
     spellings of the same file; on migration the broader 'always' grant


### PR DESCRIPTION
## Summary
- v0.35.0's trust-key migration only handled absolute keys that still resolve inside the store's directory — it worked for stores that HADN'T moved, and silently failed for the relocated-folder case (Docker volume at `/root/...`) that motivated portable keys in the first place. Found live while exposing a compose stack: a host-written `.trust.json` matched nothing in the container.
- A legacy absolute key now migrates by basename exactly when the relocation signature holds: the recorded path no longer exists in this environment AND a file of that name sits beside the store. Custom `$ANTENNAKNOBS_TRUST_FILE` stores with genuinely out-of-dir designs keep absolute keys (their paths still exist), and a same-named local file cannot inherit an out-of-dir grant.

## Test plan
- [x] New test reproducing the exact gap: v1 store with old-home absolute keys + folder at a new path → trust answers
- [x] New test pinning the custom-store guard (out-of-dir record stays absolute; imposter file not trusted)
- [x] Full trust suite (23) + web server + screen suites green; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2EZMHKcXNVZfVUrGpNXq8