### PR TITLE
docs: closed loops converge 2–3× coarser on BSpline d=2 — surface it, close #436 docs-only

### DIFF
--- a/site/src/content/docs/advanced/convergence.md
+++ b/site/src/content/docs/advanced/convergence.md
@@ -132,6 +132,29 @@ threshold law. Until the mechanism is pinned down, treat fine-mesh
 sin/pynec drift on fan geometry as suspect and trust the flat d=2
 value.
 
+## Closed loops: room below the default
+
+One geometry class earns a specific note because the payoff runs the
+*other* way — not "raise N until it settles" but "you may lower it".
+On single closed-loop designs the d=2 basis reaches the converged
+impedance at a mesh ~2–3× coarser than the sinusoidal basis needs
+([convergence anchor](https://github.com/stevenmburns/antennaknobs/blob/main/docs/status/2026-07-18-quad-convergence-anchor.md),
+free space; "converged" = within 2 % of the finest rung):
+
+| design | sinusoidal | B-spline d=2 |
+|---|--:|--:|
+| `loops.diamond_loop` (square loop) | N≥21 | N≥7 |
+| `loops.delta_loop` (triangle) | N≥15 | N≥7 |
+
+A dense solve scales as (basis count)², so 2–3× fewer segments is a
+~4–9× cheaper solve at equal accuracy — on bs2 a single-loop design can
+run *below* the N=15 default without losing the answer. Verify with the
+convergence sweep as usual, and don't generalize the discount: it is
+loop-specific. On open linear structures (`beams.yagi`) and the
+two-element quad, every basis converges at the same N — which is why
+the workbench applies no automatic basis-dependent coarsening. The
+slider is yours.
+
 ## Feeds and ports deserve their own paragraph
 
 The driving-point readout is the most mesh-sensitive number in the whole

--- a/site/src/content/docs/reference/solver.mdx
+++ b/site/src/content/docs/reference/solver.mdx
@@ -96,7 +96,9 @@ threading; see the benchmark docs for full tables.
   scorable designs**, where the sinusoidal basis needs 3–15× more
   segments to arrive at the same value — which is why d=2 at N=15 is the
   workbench's default solve. On port-fed, junction-heavy, and
-  closely-spaced-wire geometry the gap is largest; details and how to
+  closely-spaced-wire geometry the gap is largest, and single closed
+  loops converge on d=2 as coarse as N=7 — ~2–3× below the sinusoidal
+  basis; details and how to
   check your own design: [How many segments?](/advanced/convergence/)
 
 ## Segments & convergence


### PR DESCRIPTION
## Summary
- Adds a **"Closed loops: room below the default"** section to the advanced convergence guide: on single closed loops (`loops.delta_loop`, `loops.diamond_loop`) the d=2 basis is converged at **N≥7** where the sinusoidal basis needs N≥15–21 (~2–3× coarser mesh → ~4–9× cheaper dense solve at equal accuracy), per the [quad convergence anchor](https://github.com/stevenmburns/antennaknobs/blob/main/docs/status/2026-07-18-quad-convergence-anchor.md) (#408 part 3, PR #434).
- Includes the explicit caveat from #436: the discount is **loop-specific** — `beams.yagi` and the corrected two-element quad show no basis rate advantage — which is why the workbench applies no automatic basis-dependent mesh coarsening.
- Enriches the basis-census bullet in `reference/solver.mdx` with the closed-loop N=7 datum.
- Resolves #436 via its option 1 (docs/guidance only). Options 2–3 declined — rationale in an issue comment: the census-driven per-basis defaults (bs2@15/bs1@20, PR #483) superseded the default-mesh idea, and the cost-model warn gate only fires at est_basis > 3000, far above any loop design that would benefit.

Closes #436

## Test plan
- [ ] `npm run build` in `site/` succeeds (CI site lane)
- [ ] Rendered pages read correctly: /advanced/convergence/ new section + /reference/solver/ census bullet

🤖 Generated with [Claude Code](https://claude.com/claude-code)