### PR TITLE
Adopt pynec-accel 1.7.6: gn 2 near-ground defect fixed at the root, #448 warning retired on fixed installs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
       # shadow it; numpy is already installed above.
       run: |
         pip install pynec-accel --no-index \
-          --find-links https://github.com/stevenmburns/python-necpp/releases/expanded_assets/v1.7.4-accel.3
+          --find-links https://github.com/stevenmburns/python-necpp/releases/expanded_assets/v1.7.6
 
     - name: Install momwire (vendored MoM engine)
       # momwire is still a submodule; its C++ accelerator builds from source here.

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,10 +64,10 @@ RUN pip install --upgrade pip \
 # (GPLv2), and leaving it out keeps the published image MIT/BSD-only. Users
 # who want the NEC2 engine add one layer:
 #   FROM <user>/antennaknobs:latest
-#   RUN pip install "pynec-accel>=1.7.4.post1"
+#   RUN pip install "pynec-accel>=1.7.6"
 ARG INCLUDE_PYNEC=1
 RUN if [ "$INCLUDE_PYNEC" = "1" ]; then \
-      pip install "pynec-accel>=1.7.4.post1"; \
+      pip install "pynec-accel>=1.7.6"; \
     fi
 
 EXPOSE 8000

--- a/scripts/bench_nec_corpus.py
+++ b/scripts/bench_nec_corpus.py
@@ -1284,11 +1284,14 @@ def bench_deck(
         return row
     row["freq"] = freq
 
-    # nec2++/PyNEC's Sommerfeld (gn 2) is known-unreliable when a conductor
-    # sits within 0.1 wavelength of the ground plane without touching it
-    # (issue #448; calibrated on this corpus — all 19 decks where PyNEC broke
-    # against an agreeing nec2c+momwire pair are in this class). A large
-    # pynec dgamma on a flagged deck is the known engine defect, not an
+    # Before pynec-accel 1.7.6, nec2++/PyNEC's Sommerfeld (gn 2) was
+    # unreliable when a conductor sits within 0.1 wavelength of the ground
+    # plane without touching it (issue #448; calibrated on this corpus — all
+    # 19 decks where PyNEC broke against an agreeing nec2c+momwire pair are
+    # in this class; fixed by the INTRP cell-cache repair in
+    # stevenmburns/necpp#5). The flag is kept for provenance when scoring
+    # older PyNEC builds: a large pynec dgamma on a flagged deck under
+    # pynec-accel < 1.7.6 is the known engine defect, not an
     # import/translation signal.
     row["pynec_somm_suspect"] = (
         isinstance(ground, tuple)

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import warnings
 
 import numpy as np
@@ -43,10 +44,27 @@ WIRE_CONDUCTIVITY = None
 DEFAULT_GROUND = ("finite", 10.0, 0.002)  # (kind, dielectric, conductivity)
 
 
+def _pynec_somm_fixed():
+    """True when the installed pynec-accel carries the nec2++ Sommerfeld
+    interpolation fix (stevenmburns/necpp#5, released in pynec-accel 1.7.6):
+    the INTRP cell cache no longer extrapolates stale coefficients across
+    grid-region crossings, which was the whole gn 2 near-ground defect
+    (issue #448). On fixed installs the risk-class warning below is noise;
+    on older installs it still protects the user."""
+    try:
+        from importlib.metadata import version
+
+        m = re.match(r"(\d+)\.(\d+)\.(\d+)", version("pynec-accel"))
+        return m is not None and tuple(int(g) for g in m.groups()) >= (1, 7, 6)
+    except Exception:
+        # Unknown provenance (source build, upstream PyNEC): keep warning.
+        return False
+
+
 def _somm_low_wire_risk(tups, wavelength):
-    """Geometry classes where nec2++'s gn 2 Sommerfeld is known-unreliable
-    (issue #448): near-ground conductor that is not a plain grounded
-    vertical. True when either
+    """Geometry classes where nec2++'s gn 2 Sommerfeld was unreliable before
+    the pynec-accel 1.7.6 interpolation fix (issue #448): near-ground
+    conductor that is not a plain grounded vertical. True when either
 
       (a) some wire endpoint sits in (0, 0.1λ) on a connected component
           with no z = 0 point (low radial fields at small height, hanging
@@ -118,12 +136,15 @@ class PyNECEngine(SimulationEngine):
           ("finite", eps_r, sigma)       — Sommerfeld-Norton finite ground
                                            (default, matches the historical
                                            hard-coded eps_r=10, sigma=0.002).
-                                           CAVEAT (#448): nec2++'s gn 2 is
-                                           known-unreliable for conductors
-                                           within 0.1λ of the plane that
-                                           don't touch it — the engine warns
+                                           CAVEAT (#448): before pynec-accel
+                                           1.7.6, nec2++'s gn 2 was unreliable
+                                           for conductors within 0.1λ of the
+                                           plane that don't touch it — on
+                                           older installs the engine warns
                                            and momwire/nec2c should be
-                                           trusted there.
+                                           trusted there. Fixed by the INTRP
+                                           cell-cache repair in 1.7.6
+                                           (stevenmburns/necpp#5).
           ("finite-fast", eps_r, sigma)  — finite ground via NEC's reflection-
                                            coefficient approximation. Much
                                            cheaper than Sommerfeld and within
@@ -808,41 +829,49 @@ class PyNECEngine(SimulationEngine):
         return c
 
     def _warn_if_somm_low_wires(self, wavelength):
-        """nec2++'s Sommerfeld (gn 2) solve is known-unreliable for conductors
-        that run NEAR the ground plane (issue #448).
+        """nec2++'s Sommerfeld (gn 2) solve was unreliable for conductors
+        that run NEAR the ground plane (issue #448) before pynec-accel
+        1.7.6; warn users of older installs.
 
-        Measured (momwire's golden-capture controls, 2026-07-06, and the
-        wild-corpus triage, 2026-07-20): on identical geometry PyNEC's gn 2
-        agrees with nec2c/nec2dxs/momwire to well under 1% for structure
-        0.1λ and higher, and for plain ground-connected verticals (the
-        z = 0 junction NEC handles specially) — but low radial fields,
-        low-hanging open ends (half-squares, bobtails, slopers), and long
-        low horizontal runs (beverages) put the solve in an erratic
-        regime: reflection-coefficient (gn 0) results on the same deck
-        stay faithful while gn 2 lands ~7–8× off in the real part (e.g.
-        9.5 − 70.9j vs the three-way-agreed 32.1 − 3.5j on a 300 MHz
-        monopole with radials at 0.002λ). The risk predicate below —
+        Root cause (fixed by stevenmburns/necpp#5, shipped in pynec-accel
+        1.7.6): the INTRP interpolation cache extrapolated stale cell
+        coefficients across grid-region crossings, corrupting exactly the
+        source–observer pairs that straddle the r = 0.2λ near-field-grid
+        boundary. Measured before the fix (momwire's golden-capture
+        controls, 2026-07-06, and the wild-corpus triage, 2026-07-20): on
+        identical geometry PyNEC's gn 2 agreed with nec2c/nec2dxs/momwire
+        to well under 1% for structure 0.1λ and higher, and for plain
+        ground-connected verticals (the z = 0 junction NEC handles
+        specially) — but low radial fields, low-hanging open ends
+        (half-squares, bobtails, slopers), and long low horizontal runs
+        (beverages) hit the erratic regime: gn 0 results on the same deck
+        stayed faithful while gn 2 landed ~7–8× off in the real part
+        (e.g. 9.5 − 70.9j vs the three-way-agreed 32.1 − 3.5j on a
+        300 MHz monopole with radials at 0.002λ). The risk predicate —
         a near-ground endpoint on a component not connected to z = 0, OR
-        any low horizontal run — covers all 19 wild-corpus decks where
+        any low horizontal run — covered all 19 wild-corpus decks where
         PyNEC broke against an agreeing nec2c+momwire pair, and exempts
-        plain grounded verticals. The defect is erratic, so a clean
-        result on a flagged geometry is luck, not health: trust momwire
-        or nec2c there. Warns once per engine instance.
+        plain grounded verticals. With 1.7.6 installed the whole class
+        re-scores clean (dΓ ≤ 0.0035 on the 19-deck calibration set) and
+        no warning fires. Warns once per engine instance.
         """
         if self._somm_lowz_warned or not (
             isinstance(self.ground, tuple) and self.ground[0] == "finite"
         ):
             return
+        if _pynec_somm_fixed():
+            return
         if _somm_low_wire_risk(self.tups, wavelength):
             self._somm_lowz_warned = True
             warnings.warn(
-                "PyNEC/nec2++'s Sommerfeld ground (gn 2) is known-"
+                "This PyNEC/nec2++ build's Sommerfeld ground (gn 2) is "
                 "unreliable for conductors running within 0.1 wavelength "
                 "of the ground plane (low radials, low open ends, low "
                 "horizontal runs — antennaknobs #448): results in this "
                 "configuration are erratic even when they look plausible. "
-                "Use a momwire engine (or nec2c) as the reference here, or "
-                "the 'finite-fast' reflection-coefficient ground for "
+                "Upgrade to pynec-accel >= 1.7.6 for the fix, or use a "
+                "momwire engine (or nec2c) as the reference here, or the "
+                "'finite-fast' reflection-coefficient ground for "
                 "comparisons.",
                 RuntimeWarning,
                 stacklevel=3,

--- a/tests/test_pynec_ground.py
+++ b/tests/test_pynec_ground.py
@@ -113,13 +113,24 @@ def test_ge_flag_stays_zero_when_nothing_touches_ground():
 # gn 2 near-ground defect warning (issue #448)
 # ---------------------------------------------------------------------------
 #
-# nec2++'s Sommerfeld solve is known-unreliable for near-ground conductors
-# that aren't plain grounded verticals (measured against nec2c/nec2dxs/
-# momwire agreement on the wild corpus). The engine warns on the calibrated
-# risk predicate; these tests pin when it fires and — as importantly — when
-# it must not.
+# Before pynec-accel 1.7.6, nec2++'s Sommerfeld solve was unreliable for
+# near-ground conductors that aren't plain grounded verticals (measured
+# against nec2c/nec2dxs/momwire agreement on the wild corpus; root cause
+# was the INTRP cell-cache inversion fixed by stevenmburns/necpp#5). The
+# engine warns on the calibrated risk predicate only when the installed
+# pynec-accel predates the fix. The legacy-warn tests below force the
+# old-version path so the predicate stays pinned for users on <1.7.6;
+# separate tests cover the fixed-install behaviour (no warning, and the
+# solve itself lands on the three-way-agreed value).
 
 _GN2 = ("finite", 10.0, 0.002)
+
+
+def _force_legacy(monkeypatch):
+    """Pretend the installed pynec-accel predates the 1.7.6 fix."""
+    from antennaknobs.engines import pynec as _p
+
+    monkeypatch.setattr(_p, "_pynec_somm_fixed", lambda: False)
 
 
 def _warns_gn2(builder, ground):
@@ -135,12 +146,13 @@ def _warns_gn2(builder, ground):
     )
 
 
-def test_somm_low_horizontal_wire_warns_once():
+def test_somm_low_horizontal_wire_warns_once(monkeypatch):
     """A flat dipole at 0.03 wavelength over gn 2 is squarely in the broken
     class (the golden capture's own minimal repro); one warning per engine
     instance even across repeated solves."""
     import warnings as _w
 
+    _force_legacy(monkeypatch)
     eng = PyNECEngine(_flat_dipole(0.3), ground=_GN2)
     with _w.catch_warnings(record=True) as rec:
         _w.simplefilter("always")
@@ -151,13 +163,15 @@ def test_somm_low_horizontal_wire_warns_once():
     assert "#448" in str(hits[0].message)
 
 
-def test_somm_low_hanging_open_end_warns():
+def test_somm_low_hanging_open_end_warns(monkeypatch):
     """Half-square/bobtail/sloper class: a vertical whose open end hangs
     near the plane without touching it (connectivity path of the risk
     predicate — no horizontal wire anywhere near the ground)."""
     from types import MappingProxyType
 
     from antennaknobs import AntennaBuilder
+
+    _force_legacy(monkeypatch)
 
     class HalfSquareish(AntennaBuilder):
         default_params = MappingProxyType({"freq": 28.57})
@@ -174,12 +188,46 @@ def test_somm_low_hanging_open_end_warns():
     assert _warns_gn2(HalfSquareish(), _GN2) == 1
 
 
-def test_somm_warning_exemptions():
+def test_somm_warning_exemptions(monkeypatch):
     """No warning for: elevated structure on gn 2; the same low structure on
     the reflection-coefficient ground (gn 0 stays faithful); and a plain
     ground-connected vertical — even split into wires with an interior
     joint below 0.1 wavelength (the connectivity analysis, not a naive
     endpoint-height test, is what exempts it)."""
+    _force_legacy(monkeypatch)
     assert _warns_gn2(_flat_dipole(4.0), _GN2) == 0
     assert _warns_gn2(_flat_dipole(0.3), ("finite-fast", 10.0, 0.002)) == 0
     assert _warns_gn2(_GroundedMonopole(), _GN2) == 0
+
+
+def _pynec_fixed_installed():
+    from antennaknobs.engines.pynec import _pynec_somm_fixed
+
+    return _pynec_somm_fixed()
+
+
+@pytest.mark.skipif(
+    not _pynec_fixed_installed(), reason="installed pynec-accel predates 1.7.6"
+)
+def test_somm_fixed_install_no_warning_and_accurate():
+    """With pynec-accel >= 1.7.6 (the necpp#5 INTRP fix), the risk class is
+    solved correctly and the #448 warning stays silent. Oracle: the low flat
+    dipole (~0.03λ, squarely the geometry class that used to land ~7×
+    off) must agree with momwire's sinusoidal basis — the same NEC-2 basis
+    family, so this is the matched-basis cross-engine check — on the
+    reflection coefficient to within 2%. The unfixed engine failed this by
+    an order of magnitude."""
+    from antennaknobs.engines import MomwireEngine
+    from momwire import SinusoidalSolver
+
+    assert _warns_gn2(_flat_dipole(0.3), _GN2) == 0
+
+    z_pynec = PyNECEngine(_flat_dipole(0.3), ground=_GN2).impedance()[0]
+    z_sin = MomwireEngine(
+        _flat_dipole(0.3), ground=_GN2, solver=SinusoidalSolver
+    ).impedance()[0]
+
+    def gamma(z):
+        return (z - 50.0) / (z + 50.0)
+
+    assert abs(gamma(z_pynec) - gamma(z_sin)) < 0.02


### PR DESCRIPTION
## Summary
- Adopts **pynec-accel 1.7.6**, which fixes #448 at the root (stevenmburns/necpp#5): nec2++'s INTRP interpolation cache extrapolated stale cell coefficients across grid-region crossings, corrupting exactly the source–observer pairs that straddle the `r = 0.2 λ` near-field-grid boundary — i.e. conductors near the ground that don't touch it. Thread-local cache survival across solves also made results order-dependent; the cache now self-invalidates per grid fill.
- `engines/pynec`: the #448 solve-time RuntimeWarning is now **version-gated** — silent on pynec-accel ≥ 1.7.6, still protective (and pointing at the upgrade) on older installs. Docstrings updated with the root cause.
- Tests: legacy-warn tests pin the risk predicate under a forced old-version path; a new fixed-install test asserts no warning **and** matched-basis agreement (PyNEC vs momwire sinusoidal, ΔΓ < 0.02) on the low flat dipole that used to land ~7× off.
- CI installs from the v1.7.6 release assets; Dockerfile optional-layer floor → ≥ 1.7.6; bench 'p' flag kept for provenance on older builds.

## Corpus re-run (the #448 calibration class, PyNEC 1.7.6 in-pipeline)
All 19 flagged decks re-score clean — ΔΓ vs nec2c now **0.0000–0.0034, median 0.0001** (was 0.086–0.934), including `SLOPER2` (0.0003, was 0.682) via its EX 6 emulation. PyNEC now agrees with nec2c *better than the sinusoidal basis does* on most of these rows. Results: `bench_out/448-recheck-176.jsonl` (local).

## Test plan
- [x] `pytest -m 'not heavy_mesh'`: 2471 passed against 1.7.6
- [x] `tests/test_pynec_ground.py`: 9/9 including the new fixed-install oracle
- [x] 19-deck corpus re-run clean (table above)
- [ ] CI green (also validates the v1.7.6 release-asset install path)

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)