### PR TITLE
Census re-run with Δ/a headroom clamp + twoband_fan link fix (#484 close-out)

### DIFF
--- a/docs/status/2026-07-22-basis-census-rerun.md
+++ b/docs/status/2026-07-22-basis-census-rerun.md
@@ -1,0 +1,130 @@
+# Basis-census re-run + the fan-feed mechanism (issue #484 close-out)
+
+**Date:** 2026-07-22
+**Tool:** `scripts/bench_basis_convergence.py`, now Δ/a-headroom-clamped
+(ladder N = 21/61/161/321/641 for every design, rungs past
+`bench_delta_a_headroom.n_max` recorded as skipped; free space, seg-cap
+4000, RLIMIT 6 GB). Raw rows: `bench_out/basis-census-2026-07-22.jsonl`.
+
+## Why a re-run
+
+The 2026-07-20 census carried three recorded debts: the folded/fandipole
+rows predated the #496 Δ/a builder fixes, fat-conductor designs' fine
+rungs ran below the thin-wire floor (the headroom caveat from PR #498),
+and the 641 rung existed only as a hand top-up on the no-mutual class.
+All three are paid here — plus one new fix this run flushed out
+(twoband_fan below).
+
+## Headline — 92 designs
+
+**72 mutual-limit, 19 no-mutual-limit, 1 incomplete** (elt_whip, over
+the seg cap at every rung). Was 66 / 24 / 1 of 91 on 2026-07-20.
+
+| | sin | bs2 |
+|---|--:|--:|
+| within 2 % of Z\* at N = 21 | 40/72 | **58/72 (81 %)** |
+| conv@N ratio sin/bs2 | median 1.0× (50/72 tie) | max **15.3×** |
+
+The default-mesh decision (bs2 @ N=15 in slot A) survives the re-run
+unchanged: four out of five scorable designs are converged out of the box.
+
+### Who moved into the scored class, and why
+
+| design | now | why it moved |
+|---|---|---|
+| folded_invvee | Z\* 222.9−30.3j, sin conv@**21**, agree 0.0 % | #496 Δ/a fix — the 2026-07-20 census's worst row (515 % apart @321) is now the *cleanest*: both bases flat and identical through N=641 |
+| folded_invvee_balun | 46.7−4.2j, conv@21 both | inherits the same fix |
+| folded_invveearray | 191.8−8.1j, conv@21 both | same |
+| beams.owa_yagi | 47.5+1.4j, agree 1.2 % @61 | headroom clamp — its ladder now stops at N\_max=92 instead of solving garbage rungs below the Δ/a floor; the "owa_yagi meshing decision" resolves itself |
+| wire.zepp | 2.6+16.3j, agree 0.1 % | #485 distributed port + the full 641 rung for both bases |
+| wire.sterba_tl | 77.4−29.8j, agree 0.0 % @61 | #485 pins retired — the unpinned ports converge to the basis-agreed value |
+
+## twoband_fan_dipole: the census's "4b" drift was one more fixed-count wire
+
+The unexplained monotonic drift (sin 55.7 → **67.0** Ω up the ladder,
+bs2 flat at 56.9) turned out to be the `inverted_l_tmatch` class-1
+pattern hiding in a Δ/a-clean file: the four feed-split links carried a
+**hard-coded 5 segments** while the arms refined past them, leaving the
+split junctions ever more graded. (Δ/a audits can't catch this — the
+links never get short relative to their *radius*, only coarse relative
+to their *junction partners*.) Fixed: links now refine at arm density
+(floor 5, so the default N=21 mesh is byte-identical). Ladder, free
+space:
+
+| N | sin stock | pynec stock | sin fixed | bs2 |
+|--:|--|--|--|--|
+| 161 | 55.7−7.5j | 55.7−7.3j | 54.1−7.2j | 56.9−7.7j |
+| 321 | **63.4**−8.6j | **63.4**−8.5j | 55.8−7.4j | 56.9−7.5j |
+| 641 | **67.0**−9.0j | **67.0**−9.1j | 55.1−7.0j | 56.9−7.4j |
+
+PyNEC tracks sin to 0.05 Ω throughout — the drift was never
+implementation-specific. Regression test pins N=321
+(`tests/test_delta_a_lint.py`).
+
+## The residue is junction fan degree — spacing is refuted
+
+With the builder defects gone, three discriminators pin what remains of
+the fan-feed class (full tables in the #484 thread; probes were ladder
+solves on modified builders):
+
+1. **Spacing sweep** (twoband's re-tuned s01…s07 variants, element
+   planes 0.14 m → 1.0 m apart, fixed builder): sin↔bs2 gap flat at
+   ~3–5 % with **no trend in s**. The close-parallel-wire lore (NEC-2
+   aligned-segments rule, Cebik's seg-length ≈ spacing practice) does
+   not explain this class — 4a killed it for the folded family, this
+   kills it for the fan family.
+2. **Fan-degree scan** (fandipole's `n_bands` 1→5, junction degree
+   2→6): the one-element control converges clean (gap 3 % @321); every
+   multi-element variant *diverges with refinement*, fine-mesh sin R
+   falling monotonically with degree — 62.6 / 48.8 / 45.8 / 44.7 /
+   **42.2** Ω against a bs2 that never moves from ~60.3.
+3. **bs1 third opinion**: d=1 triangle Galerkin — independent of both
+   sin collocation and d=2 — lands on bs2 to **0.1 %** and is flat from
+   N=21. Two independent Galerkin families mutually agreed vs two
+   collocation implementations drifting in lockstep: the Galerkin value
+   is the credible limit, and the sin/NEC family is ~30 % low on R for
+   a five-element fan at fine mesh. bs1's immunity despite its C⁰
+   junctions also sharpens the mechanism: **Galerkin Z-stationarity is
+   the protective property** (collocation takes junction-charge error
+   at first order in Z; a shared feed junction multiplies the error
+   sites by the fan degree), not the C¹ continuity previously credited.
+
+`multiband.fandipole` (29.8 % apart) and `multiband.trap_fan_dipole`
+(25.9 %) therefore stay in the no-mutual list *by mechanism*, not by
+mystery — read them on the B-spline bases. trap_fan adds one open
+sub-question: its 1-seg trap wires (deliberate lumped-element ports)
+also grade against refining neighbours, so its number mixes both
+effects.
+
+## The remaining no-mutual 19, by class
+
+- **Junction-topology-heavy, X-dominated gaps (8):** the hentenna /
+  hourglass families + their arrays and slants (22–43 % apart, almost
+  entirely reactance), specialty.bowtie (5.4 %). All are T/X-junction
+  geometries — *consistent with* the junction-collocation mechanism but
+  not yet degree-scanned; the natural next probe if anyone needs these
+  at fine mesh. discone (15 %, an apex fan of degree 8+) likely the
+  same story.
+- **4b structural (2):** fandipole, trap_fan_dipole (diagnosed above).
+- **Deliberate exemptions (2):** terminated_longwire (#459 near-open
+  feed — its pin is the validated model), helix (mesh is a design knob).
+- **Unexplained moderate (1):** beams.moxon (14.3 % @321; bent-corner
+  geometry, Δ/a healthy at that rung).
+- **The ≤4 % tail (6):** twoband_fan (3.3 % — its junction-degree-3
+  residue), inverted_l_tmatch, short_dipole_loaded, hexbeam,
+  hexbeam_5band, jpole. All slow-closing; none moving away.
+
+## Implications
+
+1. The #484 arc is complete: 4a (Δ/a builder defects) fixed and linted,
+   4b (fan-feed drift) fixed where it was a builder defect and
+   *diagnosed as a family-level collocation limitation* where it
+   wasn't. The convergence guide's class-4 section now states the
+   mechanism and the prescription (trust the B-spline bases on fan-fed
+   multiband geometry).
+2. **Wild-corpus caveat, extended:** nec2c is not an independent
+   referee on fan-fed decks at fine mesh — it shares the collocation
+   family's junction error, exactly as it shared #448's class. At
+   catalog-default meshes the error is a few percent.
+3. The census tool now enforces the headroom clamp by construction, so
+   no future run can quietly score sub-floor rungs.

--- a/scripts/bench_basis_convergence.py
+++ b/scripts/bench_basis_convergence.py
@@ -22,6 +22,14 @@ Memory discipline: RLIMIT_AS caps the process (an OOM becomes a recorded
 MemoryError rung, not a dead machine) and ``--seg-cap`` skips rungs whose
 nominal segment total is too large (recorded, not silently dropped).
 
+Δ/a discipline (issue #484): rungs past a design's thin-wire headroom
+(``bench_delta_a_headroom.n_max`` — the largest N before some wire's
+segment length falls under 2x its radius) are skipped and recorded, for
+BOTH bases. Below the floor the reduced kernel is ill-posed; sin answers
+there are meaningless and bs2's Galerkin regularization merely hides the
+same defect. The 2026-07-20 census ran fat-conductor designs' fine rungs
+below the floor — this clamp is that run's recorded caveat, enforced.
+
     python scripts/bench_basis_convergence.py
     python scripts/bench_basis_convergence.py --ladder 21 61 161 --only wire.zepp
 """
@@ -38,6 +46,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import bench_converge as bc  # noqa: E402 — sibling script, reused ladder machinery
+import bench_delta_a_headroom as dah  # noqa: E402 — Δ/a headroom clamp (#484)
 
 DEFAULT_LADDER = (21, 61, 161, 321)
 DEFAULT_SEG_CAP = 4000
@@ -56,9 +65,17 @@ def census_row(design: str, ladder, seg_cap: int) -> dict:
     except Exception as e:  # noqa: BLE001 — one dud design must not sink the census
         row["error"] = f"load: {type(e).__name__}: {e}"
         return row
+    try:
+        headroom = dah.n_max(cls)
+    except Exception:  # noqa: BLE001 — a design n_max can't size never blocks it
+        headroom = None
+    row["headroom"] = headroom
     for engine in ENGINES:
         series, skipped = [], []
         for nseg in ladder:
+            if headroom is not None and nseg > headroom:
+                skipped.append([nseg, f"headroom {headroom}"])
+                continue
             try:
                 tot = bc.total_nominal_segs(cls, nseg)
             except Exception as e:  # noqa: BLE001

--- a/site/src/content/docs/advanced/convergence.md
+++ b/site/src/content/docs/advanced/convergence.md
@@ -120,17 +120,30 @@ linted for exactly this). The d=2 basis is immune — a Galerkin method
 regularizes the reduced-kernel ill-posedness — which is also why a flat
 bs2 next to an exploding sin curve is the tell.
 
-One genuine residue remains after the Δ/a accounting
+One genuine residue survives the Δ/a accounting, and it is now pinned
 ([issue #484](https://github.com/stevenmburns/antennaknobs/issues/484)):
-**multi-wire fan feeds** — several dipole pairs converging on one feed
-wire — where the sinusoidal basis drifts slowly and monotonically at
-fine mesh while bs2 holds flat, with every wire comfortably above the
-Δ/a floor. The traditional close-parallel-wire lore (the NEC-2 manual's
-aligned-segments requirement, Cebik's segment-length ≈ wire-spacing
-practice) points at this regime, but our census hasn't confirmed a
-threshold law. Until the mechanism is pinned down, treat fine-mesh
-sin/pynec drift on fan geometry as suspect and trust the flat d=2
-value.
+**multi-wire fan feeds** — several dipole pairs sharing one feed wire —
+where the point-matched family drifts slowly and monotonically at fine
+mesh while the Galerkin bases hold flat, with every wire comfortably
+above the Δ/a floor. Three discriminating experiments settled what
+drives it. Varying the element spacing over a 7× range moves the error
+not at all — the traditional close-parallel-wire lore (the NEC-2
+manual's aligned-segments requirement, Cebik's segment-length ≈
+wire-spacing practice) does **not** explain this class. What does is
+the **junction fan degree**: a one-element control converges cleanly,
+and the fine-mesh error grows monotonically with each dipole pair
+added to the shared feed junction (a five-band fan reads ~30 % low on
+R at N=321). And it is a property of the *method family*, not one
+implementation: our sinusoidal solver and PyNEC (nec2++) drift in
+lockstep to a fraction of an ohm, while d=1 and d=2 B-splines — two
+independent Galerkin bases — sit flat on the same value from N=21.
+(That d=1 shares the immunity despite its merely-C⁰ junctions
+identifies Galerkin's stationary impedance as the protective property:
+collocation takes junction-charge error at first order in Z, and a
+shared feed junction multiplies the error sites by the fan degree.)
+Response: on fan-fed multiband geometry, read the fine-mesh answer on
+the B-spline bases — and remember nec2c inherits the same family bias,
+so it is not an independent referee here.
 
 ## Closed loops: room below the default
 

--- a/src/antennaknobs/designs/multiband/twoband_fan_dipole.py
+++ b/src/antennaknobs/designs/multiband/twoband_fan_dipole.py
@@ -189,18 +189,27 @@ class Builder(AntennaBuilder):
 
         # Feed gap T->S refines with the mesh (issue #435); band 0's arm
         # (junction -> tip) is the reference-length wire carrying n_seg0.
-        n_seg1 = self.segs_for(math.dist(T, S), math.dist(junctions[0], tips[0]))
+        ref_arm = math.dist(junctions[0], tips[0])
+        n_seg1 = self.segs_for(math.dist(T, S), ref_arm)
+
+        # The feed-split links must refine WITH the arms (issue #484): a
+        # fixed count leaves the G junctions ever more graded as the mesh
+        # refines, and sin/PyNEC drift monotonically off the bs2 value
+        # (55.7 -> 67.0 ohm over the census ladder) while a proportional
+        # link mesh stays flat. The floor of 5 keeps the links at least as
+        # fine as they always were, so the default (N=21) mesh is unchanged.
+        n_link = max(5, self.segs_for(math.dist(S, junctions[0]), ref_arm))
 
         # Emit in the original order: +y junctions, +y arms, -y junctions,
         # -y arms, then the feed gap — so the wire list is unchanged for the
         # 2-band case.
         tups = []
         for G in junctions:
-            tups.append((S, G, 5, None))
+            tups.append((S, G, n_link, None))
         for G, tip in zip(junctions, tips):
             tups.append((G, tip, n_seg0, None))
         for G in junctions:
-            tups.append((T, ry(G), 5, None))
+            tups.append((T, ry(G), n_link, None))
         for G, tip in zip(junctions, tips):
             tups.append((ry(G), ry(tip), n_seg0, None))
         tups.append((T, S, n_seg1, 1 + 0j))

--- a/tests/test_delta_a_lint.py
+++ b/tests/test_delta_a_lint.py
@@ -67,6 +67,23 @@ def test_design_scales_to_census_top_rung(name):
     )
 
 
+def test_twoband_fan_sin_ladder_stays_flat():
+    """The #484 "4b" repro rung: with the feed-split links at a fixed 5
+    segments the sin basis drifted monotonically off the Galerkin value as
+    the arms refined past them (63.4 Ω at N=321, 67.0 at 641, vs the
+    bs1/bs2-agreed ~56 Ω). With the links refining at arm density the
+    ladder holds ~55.8−7.4j at N=321."""
+    from momwire import SinusoidalSolver
+
+    from antennaknobs.designs.multiband.twoband_fan_dipole import Builder
+    from antennaknobs.engines.momwire import MomwireEngine
+
+    b = Builder()
+    b.nominal_nsegs = 321
+    z = MomwireEngine(b, solver=SinusoidalSolver).impedance()[0]
+    assert abs(z - (55.8 - 7.4j)) < 3.0, z
+
+
 def test_folded_invvee_sin_ladder_stays_flat():
     """The #484 repro rung: before the density fix the sin basis broke to
     232.9−230.2j at N=161 (and −1188j at 321). With wire 3 at arm density


### PR DESCRIPTION
## Summary
- `bench_basis_convergence.py` now clamps every design's ladder at its Δ/a headroom (`bench_delta_a_headroom.n_max`), recording skipped rungs — enforcing the caveat PR #498 recorded about the 2026-07-20 census scoring sub-floor rungs on fat-conductor designs.
- `twoband_fan_dipole`: the four feed-split links carried a hard-coded 5 segments while the arms refined past them — the census's unexplained "4b" drift on this design (sin/PyNEC 55.7→67.0 Ω, bs2 flat). Links now refine at arm density (floor 5 keeps the default N=21 mesh byte-identical); regression test pins the N=321 rung.
- Full-catalog census re-run (ladder to 641, headroom-clamped): **72/92 mutual-limit (was 66/91)**, bs2 within 2 % at N=21 on 58/72. The folded family, owa_yagi, zepp, and sterba_tl all move into the scored class. Status doc: `docs/status/2026-07-22-basis-census-rerun.md`.
- Convergence guide class-4 residue paragraph rewritten to the now-pinned mechanism: the fan-feed drift is **junction-fan-degree collocation error** — flat in element spacing (parallel-wire lore refuted), growing with each element added to a shared feed junction, identical across sin+PyNEC, absent on both Galerkin bases (bs1's C⁰ immunity pins the protection on Z-stationarity). Prescription: read fan-fed multiband fine-mesh answers on the B-spline bases; nec2c shares the family bias.

Closes #484.

## Test plan
- [x] Full suite: 2473 passed (includes the new `test_twoband_fan_sin_ladder_stays_flat` and the catalog Δ/a lint)
- [x] Census smoke: headroom skip recorded in JSONL (`owa_yagi` rungs >92 skipped as "headroom 92")
- [x] `cd site && npm run build` passes with the guide edit
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iMSNiYKS61YWgLbuPoSKv