### PR TITLE
Moxon: uniform-density meshing fixes the fine-mesh sin walk-away (#522)

### DIFF
--- a/docs/status/2026-07-22-basis-census-rerun.md
+++ b/docs/status/2026-07-22-basis-census-rerun.md
@@ -128,3 +128,35 @@ effects.
    catalog-default meshes the error is a few percent.
 3. The census tool now enforces the headroom clamp by construction, so
    no future run can quietly score sub-floor rungs.
+
+## Addendum 2026-07-23: moxon was the same defect; the T/X cluster is mostly the same defect
+
+A reader question — "are the segment lengths roughly the same size at
+every N?" — cracked both follow-up issues the same day they were filed.
+
+**beams.moxon (#522): pure density defect, resolved.** The builder gave
+every wire the full nominal count, running the short folded tails 6.7×
+over-dense — precisely the facing conductors across the critical tip
+gap. At uniform driver-arm density (`segs_for`), sin lands on bs2 to
+**0.0 % at N=321** (43.5−16.4j; stock read 39.2−21.2j), the census row
+scores mutual (Z\* 43.6−16.3j, 0.1 % agree), and the measured Δ/a
+headroom jumps 563 → **1844** — the "fat-conductor" lint floor was an
+artifact of the defect. moxonarray composes the same builder and scores
+too (0.3 %). The critical-coupling-amplifier hypothesis in #522 was
+wrong; the tip gap only marked where the over-dense wires sat.
+
+**The hentenna/hourglass cluster (#521): density-dominant, with a
+characterized residue.** The whole cluster carries the same signature
+(4.3–6.2× density mismatch at N=321). A generic uniform-density rebuild
+collapses the gaps — hentenna 43.4 % → 14.2 %, hourglass 35.3 % →
+9.2 % at N=321 — and the residue is **slow monotonic sin X-convergence
+toward the Galerkin value** (hentenna sin +30.7 → +31.8 over 321→641,
+target +38.9; R agrees to 0.5 % throughout), while bs1 ≡ bs2 to three
+digits at every rung. So after the density fix the cluster is class-1
+(slow convergence, trust the flat Galerkin value), not a divergence.
+**broadband.discone is the exception**: its mesh is already uniform
+(ratio 1.05), so its 15 % gap stands as the genuine apex-fan candidate
+for the #484 junction mechanism. Builder fixes for the
+hentenna/hourglass families are follow-up work under #521 (their bs2
+default-slot readouts barely move; only the sin-family values were
+wrong).

--- a/src/antennaknobs/designs/beams/moxon.py
+++ b/src/antennaknobs/designs/beams/moxon.py
@@ -53,9 +53,6 @@ class Builder(AntennaBuilder):
         tipspacer = short * self.tipspacer_factor
         t0 = short * self.t0_factor
 
-        def build_path(lst, ns, ex):
-            return ((a, b, ns, ex) for a, b in zip(lst[:-1], lst[1:]))
-
         def rx(p):
             return -p[0], p[1], p[2]
 
@@ -91,13 +88,27 @@ class Builder(AntennaBuilder):
 
         n_seg0 = self.nominal_nsegs
         # Feed gap T->S refines with the mesh (issue #435); the driver arm
-        # S->A is the reference-length wire that carries n_seg0.
-        n_seg1 = self.segs_for(math.dist(T, S), math.dist(S, A))
+        # S->A is the reference-length wire that carries n_seg0. Every other
+        # wire meshes at the SAME density via segs_for (issue #522): giving
+        # each wire the full nominal count put 6.7x-over-dense segments on
+        # the short folded tails — exactly the facing conductors across the
+        # critical tip gap — and the sin/PyNEC family walked off the
+        # Galerkin value at fine mesh (39.2-21.2j vs 43.6-16.3j at N=321).
+        # At uniform density sin lands on bs2 to 0.0% there.
+        ref = math.dist(S, A)
+        n_seg1 = self.segs_for(math.dist(T, S), ref)
+
+        def path(lst):
+            return [
+                (a, b, self.segs_for(math.dist(a, b), ref), None)
+                for a, b in zip(lst[:-1], lst[1:])
+            ]
 
         tups = []
-        tups.extend(build_path([S, A, B], n_seg0, None))
-        tups.extend(build_path([C, D, E, F], n_seg0, None))
-        tups.extend(build_path([G, H, T], n_seg0, None))
+        tups.append((S, A, n_seg0, None))
+        tups.extend(path([A, B]))
+        tups.extend(path([C, D, E, F]))
+        tups.extend(path([G, H, T]))
         tups.append((T, S, n_seg1, 1 + 0j))
 
         return tups

--- a/tests/test_delta_a_lint.py
+++ b/tests/test_delta_a_lint.py
@@ -43,8 +43,9 @@ FAT_CONDUCTOR_HEADROOM = {
     "verticals.elt_whip": 155,  # measured 169 — deck-faithful whip (#435)
     "verticals.pota_performer": 330,  # measured 360 — stainless whip
     "verticals.challenger": 380,  # measured 413 — aluminum tube
-    "arrays.moxonarray": 515,  # measured 561 — fat moxon elements
-    "beams.moxon": 515,  # measured 563
+    # moxon / moxonarray were listed here at 515 ("fat elements") until the
+    # #522 density fix revealed the low headroom was the DEFECT, not the
+    # conductors: with every wire at driver-arm density they measure ~1840.
     "verticals.dominator": 525,  # measured 571 — one aluminum tube
     "specialty.hourglass": 545,  # measured 593 — short crossing rails
 }
@@ -82,6 +83,23 @@ def test_twoband_fan_sin_ladder_stays_flat():
     b.nominal_nsegs = 321
     z = MomwireEngine(b, solver=SinusoidalSolver).impedance()[0]
     assert abs(z - (55.8 - 7.4j)) < 3.0, z
+
+
+def test_moxon_sin_ladder_stays_flat():
+    """The #522 repro rung: with every wire carrying the full nominal count
+    the short folded tails ran 6.7x over-dense (right at the critical tip
+    gap) and sin walked off the Galerkin value (39.2−21.2j at N=321 vs the
+    bs1/bs2-agreed 43.5−16.4j). At uniform driver-arm density sin lands on
+    bs2 to 0.0% there."""
+    from momwire import SinusoidalSolver
+
+    from antennaknobs.designs.beams.moxon import Builder
+    from antennaknobs.engines.momwire import MomwireEngine
+
+    b = Builder()
+    b.nominal_nsegs = 321
+    z = MomwireEngine(b, solver=SinusoidalSolver).impedance()[0]
+    assert abs(z - (43.5 - 16.4j)) < 2.0, z
 
 
 def test_folded_invvee_sin_ladder_stays_flat():


### PR DESCRIPTION
## Summary
- `beams.moxon` gave every wire the full nominal count — the short folded tails ran **6.7× over-dense** (segment ratio 6.73 at every N), right at the critical tip gap, and the sin/PyNEC family walked off the Galerkin value at fine mesh (39.2−21.2j vs 43.6−16.3j at N=321). All wires now mesh at driver-arm density via `segs_for`.
- Result: sin lands on bs2 to **0.0 % at N=321** (43.5−16.4j); the census rows score mutual (moxon Z\* 43.6−16.3j at 0.1 % agree, moxonarray 0.3 % — the array composes the same builder).
- Measured Δ/a headroom jumps **563 → 1844**: the `FAT_CONDUCTOR_HEADROOM` entries for moxon/moxonarray were artifacts of the defect, now removed (both designs scale past the census top rung naturally).
- Regression test pins the N=321 sin rung; status-doc addendum records this plus the #521 cluster findings (hentenna/hourglass gaps are density-dominant with a characterized slow-sin-X residue; discone is the one uniform-mesh survivor).

Closes #522.

## Test plan
- [x] Full suite: 2474 passed (new `test_moxon_sin_ladder_stays_flat`, catalog Δ/a lint green with the raised moxon headroom)
- [x] Census re-run of both rows: mutual-limit, 0.1 % / 0.3 % agreement
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iMSNiYKS61YWgLbuPoSKv