### PR TITLE
auto_mesh: meshing you never have to think about (design-density None counts + catalog lint)

### DIFF
--- a/docs/status/2026-07-22-basis-census-rerun.md
+++ b/docs/status/2026-07-22-basis-census-rerun.md
@@ -193,3 +193,21 @@ Default-slot churn (bs2 @ N=15) from the re-mesh is ≤ 2.2 % across all
 eight affected designs — inside their established coarse-mesh error
 bands. After this sweep the only catalog design above ratio 2.6 is the
 deck-faithful elt_whip, and the growth check passes everywhere.
+
+### Semantics note (same day): `nominal_nsegs` becomes a physical density
+
+Design review of `auto_mesh` settled its reference on the principled
+option: a `None` count meshes at **`nominal_nsegs` segments per
+quarter-wavelength at `design_freq`** (declared, or a build-time
+error — never the measurement `freq`, so sweeps can never remesh
+geometry; never the longest wire, whose identity can flip mid-knob-drag
+and jump every count in the design). N is now the same physical density
+on every design — N=15 = λ/60 segments — and mesh ladders are
+comparable across the catalog. There is no "pin" concept: integer
+counts are simply the legacy path, honored verbatim, discouraged, and
+policed by the lint. The trap-wire study that motivated retiring the
+1-segment load-wire convention (stock trap_fan diverges to 25.9 % while
+density-meshed traps converge to 5.4 %, **and the pinned trap biased
+even bs2** — flat at X=+0.7j vs the refined model's +3.6j) is recorded
+in #521; migrating the trap designs needs a small L/C retune and is
+follow-up work.

--- a/docs/status/2026-07-22-basis-census-rerun.md
+++ b/docs/status/2026-07-22-basis-census-rerun.md
@@ -160,3 +160,36 @@ for the #484 junction mechanism. Builder fixes for the
 hentenna/hourglass families are follow-up work under #521 (their bs2
 default-slot readouts barely move; only the sin-family values were
 wrong).
+
+## Addendum 2, 2026-07-23: manual segmentation retired for the offender class (`auto_mesh` + lint)
+
+The defect class recurred often enough (#481, #484, #521, #522) that
+convention became mechanism. `AntennaBuilder.auto_mesh` now resolves
+`None` segment counts to a uniform-density mesh (integer counts remain
+deliberate pins — 1-segment lumped-element ports, deck-faithful
+wires), and the catalog lint enforces the outcome two ways: max/min
+segment-length ratio ≤ 3 over refining wires at N=321, and the ratio
+must not *grow* from N=61 to N=641 (the fixed-count tell that a
+single-rung snapshot misses; twoband_fan's 5-seg links passed 6.7× at
+N=321 but drifted 55.7 → 67.0 Ω up the census ladder). Sole
+exemption: elt_whip's deck-faithful wire list.
+
+The migration swept two more hidden defects the ratio scan exposed —
+**hexbeam** (hard-coded 5-segment tip spacers, ratio 10.7× and
+growing) and **hexbeam_5band** (every band's arms at full nominal
+count, tips at `nominal//21`):
+
+| design | stock gap | migrated gap | verdict |
+|---|--:|--:|---|
+| beams.hexbeam | 3.2 % @321 | **0.1 % @641** | mutual from N=21 — the census's "≤4 % tail" entry was this defect |
+| multiband.hexbeam_5band | 2.7 % @61 (capped) | **0.1 % @161** | mutual |
+| specialty.hentenna_slant | 25.2 % @321 | **1.2 % @321** | mutual |
+| specialty.hentenna | 43.4 % @321 | 12.3 % @641 | slow-X residue (class 1, bs1 ≡ bs2) |
+| specialty.hourglass | 35.3 % @321 | 7.9 % @641 | slow-X residue |
+| specialty.hourglass_slant | 25.5 % @321 | 15.6 % @321 | slow-X residue |
+
+moxon and the hentenna/hourglass arrays inherit via composition.
+Default-slot churn (bs2 @ N=15) from the re-mesh is ≤ 2.2 % across all
+eight affected designs — inside their established coarse-mesh error
+bands. After this sweep the only catalog design above ratio 2.6 is the
+deck-faithful elt_whip, and the growth check passes everywhere.

--- a/site/src/content/docs/advanced/convergence.md
+++ b/site/src/content/docs/advanced/convergence.md
@@ -82,7 +82,10 @@ them poisons the solve — the curve may *diverge* with refinement. (Two
 catalog verticals did exactly this until their radials were made to
 refine with the mesh; the tell was sin/PyNEC marching away from a flat
 bs2 while the meshes decoupled.) Response: refine *uniformly* — in your
-own builders, scale every wire's count with `segs_for`.
+own builders, return `None` segment counts and finish `build_wires`
+with `self.auto_mesh(tups)`, which meshes every wire at one density
+(an integer count is reserved for deliberate pins, like 1-segment
+lumped-element ports).
 
 **3. Physics-limited: the near-open feed.** A feed near a current null
 (|Z| in the thousands of ohms — end-fed designs, some multi-element
@@ -114,9 +117,10 @@ localized error into a wildly wrong reactance (with no visible
 oscillation — the current stays smooth), and coarse meshes agree
 beautifully because the coarse mesh itself keeps every wire above the
 Δ/a floor. Response: when a ladder breaks at fine N, **check per-wire
-Δ/a first** — in your own builders, derive short-wire counts with
-`segs_for` rather than reusing the nominal count (the catalog is now
-linted for exactly this). The d=2 basis is immune — a Galerkin method
+Δ/a first** — in your own builders, let `auto_mesh` assign the counts
+rather than reusing the nominal count on short wires (the catalog is
+now linted for exactly this, both the ratio at fine mesh and its
+growth up the ladder). The d=2 basis is immune — a Galerkin method
 regularizes the reduced-kernel ill-posedness — which is also why a flat
 bs2 next to an exploding sin curve is the tell.
 

--- a/site/src/content/docs/advanced/convergence.md
+++ b/site/src/content/docs/advanced/convergence.md
@@ -81,11 +81,14 @@ refines while another is pinned coarse, and the graded junction between
 them poisons the solve — the curve may *diverge* with refinement. (Two
 catalog verticals did exactly this until their radials were made to
 refine with the mesh; the tell was sin/PyNEC marching away from a flat
-bs2 while the meshes decoupled.) Response: refine *uniformly* — in your
-own builders, return `None` segment counts and finish `build_wires`
-with `self.auto_mesh(tups)`, which meshes every wire at one density
-(an integer count is reserved for deliberate pins, like 1-segment
-lumped-element ports).
+bs2 while the meshes decoupled.) Response: refine *uniformly* — in
+your own builders, return `None` segment counts and finish
+`build_wires` with `self.auto_mesh(tups)`, which meshes every wire at
+the design density: `nominal_nsegs` segments per quarter-wavelength
+at your declared `design_freq` (so N=15 means a segment length of
+λ/60, on every design). Integer counts are still honored verbatim as
+the legacy path, but hand-assigned counts are how every one of these
+defects was written.
 
 **3. Physics-limited: the near-open feed.** A feed near a current null
 (|Z| in the thousands of ohms — end-fed designs, some multi-element

--- a/src/antennaknobs/builder.py
+++ b/src/antennaknobs/builder.py
@@ -169,43 +169,61 @@ class AntennaBuilder:
         even-parity solve bump the count up by one."""
         return max(1, round(self.nominal_nsegs * length / ref))
 
-    def auto_mesh(self, tups, ref=None):
-        """Resolve ``None`` segment counts to a uniform-density mesh.
+    def auto_mesh(self, tups):
+        """Resolve ``None`` segment counts to the design density:
+        ``nominal_nsegs`` segments per quarter-wavelength at
+        ``design_freq``.
 
         The recurring catalog defect class (#481 radials, #484 folded/fan,
-        #521/#522 hentenna/hourglass/moxon) is a builder hand-assigning
-        per-wire counts that leave one wire's segment length out of step
-        with its junction partners — either a short wire carrying the full
-        nominal count (over-dense: Δ/a breakdown, tip-gap poisoning) or a
-        fixed count that the rest of the mesh refines past (a graded
-        junction that worsens with N). This helper removes the arithmetic
-        from builders: pass wire tuples whose count is ``None`` for "mesh
-        me at the design's density" and an int only for a *deliberate* pin
-        (1-segment lumped-element ports, validated deck-faithful counts).
+        #521/#522 hentenna/hourglass/moxon, the trap-wire study) is a
+        builder hand-assigning per-wire counts that leave one wire's
+        segment length out of step with its junction partners — either a
+        short wire carrying the full nominal count (over-dense: Δ/a
+        breakdown, tip-gap poisoning) or a fixed count that the rest of
+        the mesh refines past (a graded junction that worsens with N, and
+        a frozen discretization that biases even the Galerkin bases).
+        This helper removes the arithmetic: mark a wire's count ``None``
+        and it meshes at the design density; every ``None`` wire in every
+        design gets the same segment length for the same N.
 
-        ``ref`` is the length whose wire carries ``nominal_nsegs`` — the
-        design's density scale. Default: the longest auto wire, so
-        ``nominal_nsegs`` means "segments on the longest wire" and every
-        auto wire gets the same segment length via ``segs_for``. Pass an
-        explicit ``ref`` (e.g. a driver arm's length) to keep a design's
-        historical density scale when migrating.
+        The rules, deliberately per-wire with no interactions:
 
-        The catalog lint (``tests/test_delta_a_lint.py``) asserts the
-        resulting mesh is density-uniform for every design, so a builder
-        that bypasses this helper still can't reintroduce the defect
-        silently."""
+        * ``None`` — the wire gets ``max(1, round(N * L / (lambda/4)))``
+          segments, lambda from ``design_freq``. The measurement ``freq``
+          plays no part, so sweeping it never remeshes the geometry.
+        * an int — taken verbatim. This is the legacy path (builders may
+          still compute counts with ``segs_for``); it is allowed but not
+          recommended — the catalog lint polices the outcome either way.
+
+        ``nominal_nsegs`` thereby becomes a physical density: N=15 means
+        a segment length of lambda/60 on every design that uses it, and
+        mesh ladders are comparable across designs. Designs must declare
+        ``design_freq`` (the frequency the geometry is designed for) to
+        use ``None`` counts — a design without one raises here rather
+        than silently guessing a scale."""
         import math as _math
 
         tups = list(tups)
-        if ref is None:
-            auto_lens = [_math.dist(t[0], t[1]) for t in tups if t[2] is None]
-            if not auto_lens:
-                return tups
-            ref = max(auto_lens)
+        if all(t[2] is not None for t in tups):
+            return tups
+        design_freq = getattr(self, "design_freq", None)
+        if not design_freq:
+            raise ValueError(
+                f"{type(self).__name__}: auto_mesh needs a design_freq "
+                "param to define the mesh density (nominal_nsegs segments "
+                "per quarter-wavelength); declare one in default_params "
+                "or give every wire an explicit segment count."
+            )
+        quarter_wave = 0.25 * 299.792458 / float(design_freq)
         return [
             t
             if t[2] is not None
-            else (t[0], t[1], self.segs_for(_math.dist(t[0], t[1]), ref), *t[3:])
+            else (
+                t[0],
+                t[1],
+                self.segs_for(_math.dist(t[0], t[1]), quarter_wave),
+                *t[3:],
+            )
             for t in tups
         ]
 

--- a/src/antennaknobs/builder.py
+++ b/src/antennaknobs/builder.py
@@ -169,6 +169,46 @@ class AntennaBuilder:
         even-parity solve bump the count up by one."""
         return max(1, round(self.nominal_nsegs * length / ref))
 
+    def auto_mesh(self, tups, ref=None):
+        """Resolve ``None`` segment counts to a uniform-density mesh.
+
+        The recurring catalog defect class (#481 radials, #484 folded/fan,
+        #521/#522 hentenna/hourglass/moxon) is a builder hand-assigning
+        per-wire counts that leave one wire's segment length out of step
+        with its junction partners — either a short wire carrying the full
+        nominal count (over-dense: Δ/a breakdown, tip-gap poisoning) or a
+        fixed count that the rest of the mesh refines past (a graded
+        junction that worsens with N). This helper removes the arithmetic
+        from builders: pass wire tuples whose count is ``None`` for "mesh
+        me at the design's density" and an int only for a *deliberate* pin
+        (1-segment lumped-element ports, validated deck-faithful counts).
+
+        ``ref`` is the length whose wire carries ``nominal_nsegs`` — the
+        design's density scale. Default: the longest auto wire, so
+        ``nominal_nsegs`` means "segments on the longest wire" and every
+        auto wire gets the same segment length via ``segs_for``. Pass an
+        explicit ``ref`` (e.g. a driver arm's length) to keep a design's
+        historical density scale when migrating.
+
+        The catalog lint (``tests/test_delta_a_lint.py``) asserts the
+        resulting mesh is density-uniform for every design, so a builder
+        that bypasses this helper still can't reintroduce the defect
+        silently."""
+        import math as _math
+
+        tups = list(tups)
+        if ref is None:
+            auto_lens = [_math.dist(t[0], t[1]) for t in tups if t[2] is None]
+            if not auto_lens:
+                return tups
+            ref = max(auto_lens)
+        return [
+            t
+            if t[2] is not None
+            else (t[0], t[1], self.segs_for(_math.dist(t[0], t[1]), ref), *t[3:])
+            for t in tups
+        ]
+
     def _phasor(self, name):
         """Unit phasor exp(j·phase) for a degrees-valued phase param (e.g.
         phase_lr/phase_tb), or 1 if the param is absent."""

--- a/src/antennaknobs/designs/beams/hexbeam.py
+++ b/src/antennaknobs/designs/beams/hexbeam.py
@@ -69,18 +69,19 @@ class Builder(AntennaBuilder):
         S = (eps * cos30, eps * sin30, 0)
         T = ry(S)
 
-        n_seg0 = self.nominal_nsegs
-        # Feed gap T->S refines with the mesh (issue #435); the driver arm
-        # S->A is the reference-length wire that carries n_seg0.
-        n_seg1 = self.segs_for(math.dist(T, S), math.dist(S, A))
-
+        # Uniform-density mesh (issue #521 class): every wire — arms, the
+        # short tip spacers (whose old hard-coded 5 segments left a graded
+        # junction that worsened with N), and the feed gap — meshes at the
+        # driver arm's density. The arm keeps its historical role as the
+        # wire that carries nominal_nsegs.
         tups = []
-        tups.extend(build_path([S, A, B], n_seg0, None))
-        tups.extend(build_path([C, D], 5, None))
-        tups.extend(build_path([D, E, F, G], n_seg0, None))
-        tups.extend(build_path([G, H], 5, None))
-        tups.extend(build_path([II, J, T], n_seg0, None))
-        tups.append((T, S, n_seg1, 1 + 0j))
+        tups.extend(build_path([S, A, B], None, None))
+        tups.extend(build_path([C, D], None, None))
+        tups.extend(build_path([D, E, F, G], None, None))
+        tups.extend(build_path([G, H], None, None))
+        tups.extend(build_path([II, J, T], None, None))
+        tups.append((T, S, None, 1 + 0j))
+        tups = self.auto_mesh(tups, ref=math.dist(S, A))
 
         new_tups = []
         for xoff, yoff, zoff in [(0, 0, self.base)]:

--- a/src/antennaknobs/designs/beams/hexbeam.py
+++ b/src/antennaknobs/designs/beams/hexbeam.py
@@ -9,6 +9,10 @@ class Builder(AntennaBuilder):
     default_params = MappingProxyType(
         {
             "freq": 28.47,
+            # Geometry is hand-tuned in absolute metres; design_freq only
+            # anchors auto_mesh's density scale (nominal_nsegs per
+            # quarter-wave), so it is hidden from the UI.
+            "design_freq": 28.47,
             "base": 7.0,
             "halfdriver": 2.82,
             "tipspacer_factor": 0.1312,
@@ -16,7 +20,10 @@ class Builder(AntennaBuilder):
             # The opt variant's tip spacer (0.208) sits above the auto ±50%
             # window around the default (≤0.197).
             "ui_params": MappingProxyType(
-                {"tipspacer_factor": {"min": 0.065, "max": 0.25}}
+                {
+                    "tipspacer_factor": {"min": 0.065, "max": 0.25},
+                    "design_freq": {"hidden": True},
+                }
             ),
         }
     )
@@ -72,8 +79,7 @@ class Builder(AntennaBuilder):
         # Uniform-density mesh (issue #521 class): every wire — arms, the
         # short tip spacers (whose old hard-coded 5 segments left a graded
         # junction that worsened with N), and the feed gap — meshes at the
-        # driver arm's density. The arm keeps its historical role as the
-        # wire that carries nominal_nsegs.
+        # design density (nominal_nsegs per design_freq quarter-wave).
         tups = []
         tups.extend(build_path([S, A, B], None, None))
         tups.extend(build_path([C, D], None, None))
@@ -81,7 +87,7 @@ class Builder(AntennaBuilder):
         tups.extend(build_path([G, H], None, None))
         tups.extend(build_path([II, J, T], None, None))
         tups.append((T, S, None, 1 + 0j))
-        tups = self.auto_mesh(tups, ref=math.dist(S, A))
+        tups = self.auto_mesh(tups)
 
         new_tups = []
         for xoff, yoff, zoff in [(0, 0, self.base)]:

--- a/src/antennaknobs/designs/beams/moxon.py
+++ b/src/antennaknobs/designs/beams/moxon.py
@@ -86,29 +86,19 @@ class Builder(AntennaBuilder):
         D = rx(A)
         E, F, G, H, T = ry(D), ry(C), ry(B), ry(A), ry(S)
 
-        n_seg0 = self.nominal_nsegs
-        # Feed gap T->S refines with the mesh (issue #435); the driver arm
-        # S->A is the reference-length wire that carries n_seg0. Every other
-        # wire meshes at the SAME density via segs_for (issue #522): giving
-        # each wire the full nominal count put 6.7x-over-dense segments on
-        # the short folded tails — exactly the facing conductors across the
-        # critical tip gap — and the sin/PyNEC family walked off the
-        # Galerkin value at fine mesh (39.2-21.2j vs 43.6-16.3j at N=321).
-        # At uniform density sin lands on bs2 to 0.0% there.
-        ref = math.dist(S, A)
-        n_seg1 = self.segs_for(math.dist(T, S), ref)
-
+        # Uniform-density mesh (issue #522): giving each wire the full
+        # nominal count put 6.7x-over-dense segments on the short folded
+        # tails — exactly the facing conductors across the critical tip
+        # gap — and the sin/PyNEC family walked off the Galerkin value at
+        # fine mesh (39.2-21.2j vs 43.6-16.3j at N=321). At uniform
+        # driver-arm density sin lands on bs2 to 0.0% there.
         def path(lst):
-            return [
-                (a, b, self.segs_for(math.dist(a, b), ref), None)
-                for a, b in zip(lst[:-1], lst[1:])
-            ]
+            return [(a, b, None, None) for a, b in zip(lst[:-1], lst[1:])]
 
         tups = []
-        tups.append((S, A, n_seg0, None))
-        tups.extend(path([A, B]))
+        tups.extend(path([S, A, B]))
         tups.extend(path([C, D, E, F]))
         tups.extend(path([G, H, T]))
-        tups.append((T, S, n_seg1, 1 + 0j))
+        tups.append((T, S, None, 1 + 0j))
 
-        return tups
+        return self.auto_mesh(tups, ref=math.dist(S, A))

--- a/src/antennaknobs/designs/beams/moxon.py
+++ b/src/antennaknobs/designs/beams/moxon.py
@@ -1,7 +1,5 @@
 """Moxon rectangle — a 2-element beam with folded-back element tips."""
 
-import math
-
 from antennaknobs import AntennaBuilder
 from types import MappingProxyType
 
@@ -20,11 +18,16 @@ class Builder(AntennaBuilder):
     default_params = MappingProxyType(
         {
             "freq": 28.57,
+            # Geometry is hand-tuned in absolute metres; design_freq only
+            # anchors auto_mesh's density scale (nominal_nsegs per
+            # quarter-wave), so it is hidden from the UI.
+            "design_freq": 28.57,
             "base": 7.0,
             "halfdriver": 2.4597430629596713,
             "aspect_ratio": 0.3646010186757216,
             "tipspacer_factor": 0.07729647745945359,
             "t0_factor": 0.4078045966770739,
+            "ui_params": MappingProxyType({"design_freq": {"hidden": True}}),
         }
     )
 
@@ -91,7 +94,7 @@ class Builder(AntennaBuilder):
         # tails — exactly the facing conductors across the critical tip
         # gap — and the sin/PyNEC family walked off the Galerkin value at
         # fine mesh (39.2-21.2j vs 43.6-16.3j at N=321). At uniform
-        # driver-arm density sin lands on bs2 to 0.0% there.
+        # design density sin lands on bs2 to 0.1% there.
         def path(lst):
             return [(a, b, None, None) for a, b in zip(lst[:-1], lst[1:])]
 
@@ -101,4 +104,4 @@ class Builder(AntennaBuilder):
         tups.extend(path([G, H, T]))
         tups.append((T, S, None, 1 + 0j))
 
-        return self.auto_mesh(tups, ref=math.dist(S, A))
+        return self.auto_mesh(tups)

--- a/src/antennaknobs/designs/multiband/hexbeam_5band.py
+++ b/src/antennaknobs/designs/multiband/hexbeam_5band.py
@@ -290,10 +290,10 @@ class Builder(AntennaBuilder):
             raise ValueError(f"n_bands must be in [1, {_MAX_BANDS}], got {n_bands}")
         active_bands = tuple(self.bands)[:n_bands]
 
-        n_seg0 = self.nominal_nsegs
-        # Tip segments stay short; floor at 1 matches single-band hexbeam
-        # (designs/hexbeam.py:66 leaves the tip count at 1 too).
-        n_seg_tip = max(1, self.nominal_nsegs // 21)
+        # Element wires mesh at uniform density via auto_mesh below (issue
+        # #521 class): the old scheme gave every band's arms the full
+        # nominal count (over-densifying the small high bands) and the tips
+        # a nominal//21 count untied to their length.
         # T->S feed gap refines with the mesh (issue #435). |T - S| =
         # 2*_FEED_GAP*sin30 = _FEED_GAP for every band, so one shared count
         # against the design_freq quarter-wave keeps all five feeds equal
@@ -343,11 +343,11 @@ class Builder(AntennaBuilder):
             def build_path(lst, ns):
                 return [(a, b, ns, None) for a, b in zip(lst[:-1], lst[1:])]
 
-            tups.extend(build_path([S, A, B], n_seg0))
-            tups.extend(build_path([C, D], n_seg_tip))
-            tups.extend(build_path([D, E, F, G], n_seg0))
-            tups.extend(build_path([G, H], n_seg_tip))
-            tups.extend(build_path([II, J, T], n_seg0))
+            tups.extend(build_path([S, A, B], None))
+            tups.extend(build_path([C, D], None))
+            tups.extend(build_path([D, E, F, G], None))
+            tups.extend(build_path([G, H], None))
+            tups.extend(build_path([II, J, T], None))
             # The feed wire (one per band). Daisy-chain mode strips the
             # excitation on bands 1..N-1 inside build_tls; multi-feed
             # mode leaves every band's excitation in place.
@@ -362,7 +362,11 @@ class Builder(AntennaBuilder):
                 p0, p1, ns, _ = tups[idx - 1]
                 tups[idx - 1] = (p0, p1, ns, None)
 
-        return tups
+        # Longest auto wire (band 0's largest edge) carries nominal_nsegs;
+        # every band's every edge gets the same segment length. The feed
+        # wires keep their explicit shared count (build_tls attaches
+        # jumpers to their middle segment via _n_seg_feed).
+        return self.auto_mesh(tups)
 
     def build_tls(self):
         """50ohm jumpers between successive band feeds in daisy-chain mode.

--- a/src/antennaknobs/designs/multiband/hexbeam_5band.py
+++ b/src/antennaknobs/designs/multiband/hexbeam_5band.py
@@ -362,10 +362,11 @@ class Builder(AntennaBuilder):
                 p0, p1, ns, _ = tups[idx - 1]
                 tups[idx - 1] = (p0, p1, ns, None)
 
-        # Longest auto wire (band 0's largest edge) carries nominal_nsegs;
-        # every band's every edge gets the same segment length. The feed
-        # wires keep their explicit shared count (build_tls attaches
-        # jumpers to their middle segment via _n_seg_feed).
+        # Every band's every edge meshes at the design density
+        # (nominal_nsegs per design_freq quarter-wave — one segment
+        # length across all five bands). The feed wires keep their
+        # explicit shared count (build_tls attaches jumpers to their
+        # middle segment via _n_seg_feed).
         return self.auto_mesh(tups)
 
     def build_tls(self):

--- a/src/antennaknobs/designs/specialty/hentenna.py
+++ b/src/antennaknobs/designs/specialty/hentenna.py
@@ -2,8 +2,6 @@
 
 from antennaknobs import AntennaBuilder
 from antennaknobs import Transform, TransformStack
-import math
-
 from types import MappingProxyType
 
 
@@ -40,8 +38,6 @@ class Builder(AntennaBuilder):
         def ry(p):
             return p[0], -p[1], p[2]
 
-        n_seg0 = self.nominal_nsegs
-
         """
  C----------------------------A
  |                            |
@@ -75,8 +71,6 @@ class Builder(AntennaBuilder):
         C, D, T = ry(A), ry(B), ry(S)
         E = ry(F)
 
-        n_seg1 = self.segs_for(math.dist(T, S), math.dist(B, A))
-
         st = TransformStack()
         st.push(Transform.translate(0, 0, b))
 
@@ -85,10 +79,14 @@ class Builder(AntennaBuilder):
 
         tups = []
 
-        tups.extend(build_path([B, A, C, D], n_seg0, None))
-        tups.extend(build_path([B, F, E, D], n_seg0, None))
-        tups.extend(build_path([S, B], n_seg0, None))
-        tups.extend(build_path([D, T], n_seg0, None))
-        tups.extend(build_path([T, S], n_seg1, 1 + 0j))
+        tups.extend(build_path([B, A, C, D], None, None))
+        tups.extend(build_path([B, F, E, D], None, None))
+        tups.extend(build_path([S, B], None, None))
+        tups.extend(build_path([D, T], None, None))
+        tups.extend(build_path([T, S], None, 1 + 0j))
+        # Uniform-density mesh (issue #521): the old per-edge nominal
+        # count over-densified the short edges 4-6x; the longest edge now
+        # carries nominal_nsegs and every wire meshes at its density.
+        tups = self.auto_mesh(tups)
 
         return tups

--- a/src/antennaknobs/designs/specialty/hentenna_slant.py
+++ b/src/antennaknobs/designs/specialty/hentenna_slant.py
@@ -129,8 +129,6 @@ class Builder(AntennaBuilder):
         def ry(p):
             return p[0], -p[1], p[2]
 
-        n_seg0 = self.nominal_nsegs
-
         S = (0, eps, wavelength * (mid_height_factor - top_height_factor))
         B = (
             0,
@@ -156,8 +154,6 @@ class Builder(AntennaBuilder):
         C, D, T = ry(A), ry(B), ry(S)
         E = ry(F)
 
-        n_seg1 = self.segs_for(math.dist(T, S), math.dist(B, A))
-
         st = TransformStack()
         st.push(Transform.translate(0, 0, b))
 
@@ -166,10 +162,14 @@ class Builder(AntennaBuilder):
 
         tups = []
 
-        tups.extend(build_path([B, A, AA, C, D], n_seg0, None))
-        tups.extend(build_path([B, F, FF, E, D], n_seg0, None))
-        tups.extend(build_path([S, B], n_seg0, None))
-        tups.extend(build_path([D, T], n_seg0, None))
-        tups.extend(build_path([T, S], n_seg1, 1 + 0j))
+        tups.extend(build_path([B, A, AA, C, D], None, None))
+        tups.extend(build_path([B, F, FF, E, D], None, None))
+        tups.extend(build_path([S, B], None, None))
+        tups.extend(build_path([D, T], None, None))
+        tups.extend(build_path([T, S], None, 1 + 0j))
+        # Uniform-density mesh (issue #521): the old per-edge nominal
+        # count over-densified the short edges 4-6x; the longest edge now
+        # carries nominal_nsegs and every wire meshes at its density.
+        tups = self.auto_mesh(tups)
 
         return tups

--- a/src/antennaknobs/designs/specialty/hourglass.py
+++ b/src/antennaknobs/designs/specialty/hourglass.py
@@ -2,8 +2,6 @@
 
 from antennaknobs import AntennaBuilder
 from antennaknobs import Transform, TransformStack
-import math
-
 from types import MappingProxyType
 
 
@@ -33,8 +31,6 @@ class Builder(AntennaBuilder):
         def rz(p):
             return p[0], p[1], -p[2]
 
-        n_seg0 = self.nominal_nsegs
-
         r"""
  C----------------------------A
   \                          /
@@ -58,8 +54,6 @@ class Builder(AntennaBuilder):
         C, D, T = ry(A), ry(B), ry(S)
         E, F = rz(C), rz(A)
 
-        n_seg1 = self.segs_for(math.dist(T, S), math.dist(B, A))
-
         st = TransformStack()
         st.push(Transform.translate(0, 0, b - A[2]))
 
@@ -68,10 +62,14 @@ class Builder(AntennaBuilder):
 
         tups = []
 
-        tups.extend(build_path([B, A, C, D], n_seg0, None))
-        tups.extend(build_path([B, F, E, D], n_seg0, None))
-        tups.extend(build_path([S, B], n_seg0, None))
-        tups.extend(build_path([D, T], n_seg0, None))
-        tups.extend(build_path([T, S], n_seg1, 1 + 0j))
+        tups.extend(build_path([B, A, C, D], None, None))
+        tups.extend(build_path([B, F, E, D], None, None))
+        tups.extend(build_path([S, B], None, None))
+        tups.extend(build_path([D, T], None, None))
+        tups.extend(build_path([T, S], None, 1 + 0j))
+        # Uniform-density mesh (issue #521): the old per-edge nominal
+        # count over-densified the short edges 4-6x; the longest edge now
+        # carries nominal_nsegs and every wire meshes at its density.
+        tups = self.auto_mesh(tups)
 
         return tups

--- a/src/antennaknobs/designs/specialty/hourglass_slant.py
+++ b/src/antennaknobs/designs/specialty/hourglass_slant.py
@@ -36,8 +36,6 @@ class Builder(AntennaBuilder):
         slant_cos = math.cos(slant_radians)
         slant_sin = math.sin(slant_radians)
 
-        n_seg0 = self.nominal_nsegs
-
         r"""
     Add an invvee like slant, 0 degrees is horizontal
 
@@ -78,8 +76,6 @@ class Builder(AntennaBuilder):
 
         C, D, T, E = ry(A), ry(B), ry(S), ry(F)
 
-        n_seg1 = self.segs_for(math.dist(T, S), math.dist(B, A))
-
         st = TransformStack()
         st.push(Transform.translate(0, 0, b - AA[2]))
 
@@ -88,10 +84,14 @@ class Builder(AntennaBuilder):
 
         tups = []
 
-        tups.extend(build_path([B, A, AA, C, D], n_seg0, None))
-        tups.extend(build_path([B, F, FF, E, D], n_seg0, None))
-        tups.extend(build_path([S, B], n_seg0, None))
-        tups.extend(build_path([D, T], n_seg0, None))
-        tups.extend(build_path([T, S], n_seg1, 1 + 0j))
+        tups.extend(build_path([B, A, AA, C, D], None, None))
+        tups.extend(build_path([B, F, FF, E, D], None, None))
+        tups.extend(build_path([S, B], None, None))
+        tups.extend(build_path([D, T], None, None))
+        tups.extend(build_path([T, S], None, 1 + 0j))
+        # Uniform-density mesh (issue #521): the old per-edge nominal
+        # count over-densified the short edges 4-6x; the longest edge now
+        # carries nominal_nsegs and every wire meshes at its density.
+        tups = self.auto_mesh(tups)
 
         return tups

--- a/tests/test_auto_mesh.py
+++ b/tests/test_auto_mesh.py
@@ -1,0 +1,85 @@
+"""AntennaBuilder.auto_mesh — the design-density meshing contract.
+
+The rulebook (issues #521/#522, deliberately per-wire with no
+interactions): a ``None`` count means "mesh me at the design density"
+— ``nominal_nsegs`` segments per quarter-wavelength at ``design_freq``
+— and an integer count is taken verbatim (the legacy path; allowed,
+not recommended). ``design_freq`` anchors the scale, never the
+measurement ``freq``, so sweeping frequency can never remesh geometry.
+"""
+
+from types import MappingProxyType
+
+import pytest
+
+from antennaknobs import AntennaBuilder
+
+C = 299.792458
+
+
+class _Design(AntennaBuilder):
+    default_params = MappingProxyType({"freq": 21.0, "design_freq": 29.9792458})
+
+
+class _NoDesignFreq(AntennaBuilder):
+    default_params = MappingProxyType({"freq": 21.0})
+
+
+def _wire(length, ns, ex=None):
+    return ((0.0, 0.0, 0.0), (length, 0.0, 0.0), ns, ex)
+
+
+def test_none_counts_mesh_at_quarter_wave_density():
+    # design_freq chosen so lambda/4 = 2.5 m exactly.
+    b = _Design()
+    b.nominal_nsegs = 20  # -> segment length 0.125 m
+    out = b.auto_mesh([_wire(2.5, None), _wire(1.25, None), _wire(0.05, None)])
+    assert [t[2] for t in out] == [20, 10, 1]  # 0.05 m floors at 1
+
+
+def test_integer_counts_taken_verbatim_and_extras_preserved():
+    b = _Design()
+    b.nominal_nsegs = 20
+    tagged = ((0.0, 0.0, 0.0), (1.25, 0.0, 0.0), None, 1 + 0j, "feed")
+    out = b.auto_mesh([_wire(2.5, 7), tagged])
+    assert out[0][2] == 7  # legacy explicit count untouched
+    assert out[1][2] == 10  # None resolved at the same density
+    assert out[1][3] == 1 + 0j and out[1][4] == "feed"  # payload intact
+
+
+def test_all_explicit_is_a_pure_passthrough_without_design_freq():
+    b = _NoDesignFreq()
+    b.nominal_nsegs = 20
+    tups = [_wire(2.5, 7), _wire(1.0, 3)]
+    assert b.auto_mesh(tups) == tups  # no design_freq needed, no change
+
+
+def test_none_count_without_design_freq_raises():
+    b = _NoDesignFreq()
+    b.nominal_nsegs = 20
+    with pytest.raises(ValueError, match="design_freq"):
+        b.auto_mesh([_wire(2.5, None)])
+
+
+def test_measurement_freq_does_not_affect_the_mesh():
+    """Sweeping freq must never remesh the antenna — density is anchored
+    to design_freq only."""
+    b = _Design()
+    b.nominal_nsegs = 20
+    ref = [t[2] for t in b.auto_mesh([_wire(2.5, None), _wire(0.7, None)])]
+    b.freq = 3.5
+    assert [t[2] for t in b.auto_mesh([_wire(2.5, None), _wire(0.7, None)])] == ref
+
+
+def test_density_is_the_same_across_designs():
+    """N means one physical density everywhere: two designs at the same
+    design_freq give the same segment length to same-length wires."""
+
+    class Other(AntennaBuilder):
+        default_params = MappingProxyType({"freq": 7.0, "design_freq": 29.9792458})
+
+    a, o = _Design(), Other()
+    a.nominal_nsegs = o.nominal_nsegs = 15
+    wa = a.auto_mesh([_wire(1.9, None)])
+    wo = o.auto_mesh([_wire(1.9, None)])
+    assert wa[0][2] == wo[0][2]

--- a/tests/test_delta_a_lint.py
+++ b/tests/test_delta_a_lint.py
@@ -38,9 +38,13 @@ DECK_FAITHFUL = {"verticals.elt_whip"}
 
 def _seg_ratio(builder_cls, n):
     """Max/min segment length over the refining (ns > 1) wires at nominal
-    ``n``, or None if fewer than two such wires. 1-segment wires are the
-    deliberate-pin convention (lumped-element ports, taps) and stay out
-    of the ratio."""
+    ``n``, or None if fewer than two such wires. 1-segment wires stay out
+    of the ratio: density rounding legitimately produces them on short
+    wires (max(1, ...)), and a geometry-only scan cannot tell those from
+    legacy fixed counts — the solve-level census polices the latter (cf.
+    the trap-wire study under #521: even a 1-seg load wire left behind
+    by a refining mesh biases the answer, so legacy 1-seg counts are
+    being retired, not blessed)."""
     import math
 
     b = builder_cls()
@@ -121,7 +125,10 @@ def test_segment_density_is_uniform(name):
     (return None counts); a builder that hand-assigns counts must still
     land within the bound. The 3.0 tolerance passes benign rounding
     (short wires quantize to few segments, ~2x worst) and fails every
-    defect this class has produced (4.3-10.7x)."""
+    defect this class has produced (4.3-10.7x). Explicit integer counts
+    are legacy — allowed, not recommended — and get no special
+    treatment here: the mesh they produce must satisfy the same
+    bound."""
     import importlib
 
     if name in DECK_FAITHFUL:
@@ -131,9 +138,9 @@ def test_segment_density_is_uniform(name):
     if r is not None:
         assert r <= 3.0, (
             f"{name}: segment lengths differ {r:.1f}x across wires at "
-            "N=321. Mesh every non-pinned wire at one density — return "
-            "None counts and finish build_wires with self.auto_mesh "
-            "(issues #521/#522)."
+            "N=321. Mesh every wire at one density — return None counts "
+            "and finish build_wires with self.auto_mesh (issues "
+            "#521/#522)."
         )
 
 
@@ -143,7 +150,9 @@ def test_segment_density_ratio_does_not_grow(name):
     ever more graded as N climbs — invisible at N=321's snapshot if the
     count is generous (twoband_fan's 5-seg links passed 6.7x there but
     hit the census as a 55.7->67.0 ohm drift). The tell is the ratio
-    GROWING with N; a healthy mesh's ratio is flat in N."""
+    GROWING with N; a healthy mesh's ratio is flat in N. (auto_mesh
+    designs pass by construction; only legacy explicit counts can trip
+    this.)"""
     import importlib
 
     if name in DECK_FAITHFUL:
@@ -153,10 +162,9 @@ def test_segment_density_ratio_does_not_grow(name):
     if r61 is not None and r641 is not None:
         assert r641 <= r61 * 1.5, (
             f"{name}: segment-length ratio grows {r61:.2f} -> {r641:.2f} "
-            "from N=61 to N=641 — some wire's count is pinned while its "
-            "junction partners refine (issue #484/#521 class). Derive it "
-            "with auto_mesh/segs_for, or pin it at 1 segment if it is a "
-            "deliberate lumped-element port."
+            "from N=61 to N=641 — some wire carries a fixed count while "
+            "its junction partners refine (issue #484/#521 class). Mark "
+            "the count None and let auto_mesh assign it."
         )
 
 

--- a/tests/test_delta_a_lint.py
+++ b/tests/test_delta_a_lint.py
@@ -30,6 +30,31 @@ from antennaknobs.cli import list_builtin_designs  # noqa: E402
 
 CENSUS_TOP_RUNG = 641
 
+# Deck-faithful designs whose wire list reproduces an external model
+# verbatim (mixed hand-chosen counts are the point). Everything else
+# must mesh at uniform density.
+DECK_FAITHFUL = {"verticals.elt_whip"}
+
+
+def _seg_ratio(builder_cls, n):
+    """Max/min segment length over the refining (ns > 1) wires at nominal
+    ``n``, or None if fewer than two such wires. 1-segment wires are the
+    deliberate-pin convention (lumped-element ports, taps) and stay out
+    of the ratio."""
+    import math
+
+    b = builder_cls()
+    b.nominal_nsegs = n
+    segs = [
+        math.dist(w[0], w[1]) / int(w[2])
+        for w in b.build_wires()
+        if int(w[2]) > 1 and math.dist(w[0], w[1]) > 0
+    ]
+    if len(segs) < 2:
+        return None
+    return max(segs) / min(segs)
+
+
 # Fat/short-conductor designs whose radius bounds refinement before the
 # census top rung — physics, not builder defects. Values are the measured
 # headroom (2026-07-22, floor 2.0) rounded DOWN a little so ordinary
@@ -83,6 +108,56 @@ def test_twoband_fan_sin_ladder_stays_flat():
     b.nominal_nsegs = 321
     z = MomwireEngine(b, solver=SinusoidalSolver).impedance()[0]
     assert abs(z - (55.8 - 7.4j)) < 3.0, z
+
+
+@pytest.mark.parametrize("name", sorted(list_builtin_designs()))
+def test_segment_density_is_uniform(name):
+    """Every refining wire in a design must carry roughly the same segment
+    length (issue #521/#522): a wire meshed out of step with its junction
+    partners is the catalog's most-recurring defect class — over-dense
+    short wires (folded links, fan risers, moxon tails) or fixed counts
+    the rest of the mesh refines past (twoband links, hexbeam spacers).
+    Builders get this by construction via ``AntennaBuilder.auto_mesh``
+    (return None counts); a builder that hand-assigns counts must still
+    land within the bound. The 3.0 tolerance passes benign rounding
+    (short wires quantize to few segments, ~2x worst) and fails every
+    defect this class has produced (4.3-10.7x)."""
+    import importlib
+
+    if name in DECK_FAITHFUL:
+        pytest.skip("deck-faithful wire list")
+    mod = importlib.import_module(f"antennaknobs.designs.{name}")
+    r = _seg_ratio(mod.Builder, 321)
+    if r is not None:
+        assert r <= 3.0, (
+            f"{name}: segment lengths differ {r:.1f}x across wires at "
+            "N=321. Mesh every non-pinned wire at one density — return "
+            "None counts and finish build_wires with self.auto_mesh "
+            "(issues #521/#522)."
+        )
+
+
+@pytest.mark.parametrize("name", sorted(list_builtin_designs()))
+def test_segment_density_ratio_does_not_grow(name):
+    """A fixed segment count next to refining wires leaves the junction
+    ever more graded as N climbs — invisible at N=321's snapshot if the
+    count is generous (twoband_fan's 5-seg links passed 6.7x there but
+    hit the census as a 55.7->67.0 ohm drift). The tell is the ratio
+    GROWING with N; a healthy mesh's ratio is flat in N."""
+    import importlib
+
+    if name in DECK_FAITHFUL:
+        pytest.skip("deck-faithful wire list")
+    mod = importlib.import_module(f"antennaknobs.designs.{name}")
+    r61, r641 = _seg_ratio(mod.Builder, 61), _seg_ratio(mod.Builder, 641)
+    if r61 is not None and r641 is not None:
+        assert r641 <= r61 * 1.5, (
+            f"{name}: segment-length ratio grows {r61:.2f} -> {r641:.2f} "
+            "from N=61 to N=641 — some wire's count is pinned while its "
+            "junction partners refine (issue #484/#521 class). Derive it "
+            "with auto_mesh/segs_for, or pin it at 1 segment if it is a "
+            "deliberate lumped-element port."
+        )
 
 
 def test_moxon_sin_ladder_stays_flat():

--- a/tests/test_hexbeam_5band.py
+++ b/tests/test_hexbeam_5band.py
@@ -144,11 +144,15 @@ def test_registered_in_web_examples():
 
 def test_nominal_nsegs_scales_radiator_edges():
     """Standard convergence-flow contract: bumping nominal_nsegs scales
-    the long radiator edges and leaves the feed gap at 1."""
-    b = Builder()
-    b.nominal_nsegs = 41
-    tups = b.build_wires()
-    seg_counts = {t[2] for t in tups}
-    assert 41 in seg_counts  # major radiator scaled with N
-    feeds = _feeds(tups)
-    assert all(f[1][2] == 1 for f in feeds)  # feed gaps stay 1
+    the radiator edges (auto_mesh density: N per design_freq
+    quarter-wave) and leaves the feed gap at 1."""
+    counts = {}
+    for n in (41, 123):
+        b = Builder()
+        b.nominal_nsegs = n
+        tups = b.build_wires()
+        counts[n] = max(t[2] for t in tups)
+        feeds = _feeds(tups)
+        assert all(f[1][2] == 1 for f in feeds)  # feed gaps stay 1
+    # tripling N triples the densest edge's count (within rounding)
+    assert 2.8 < counts[123] / counts[41] < 3.2


### PR DESCRIPTION
## The story
Most of the effort in authoring a catalog design was setting up dynamic meshing — per-wire `segs_for` arithmetic, reference-wire choices, feed-gap conventions — and hand-assigned counts are how every meshing defect in the catalog's history was written (#481, #484, #521, #522, the trap-wire study). After this PR you don't think about meshing: give every wire a `None` count, declare a `design_freq`, and finish `build_wires` with `self.auto_mesh(tups)`.

**Stacked on #523 — merge that first.**

## The rulebook (per-wire, no interactions, no "pin" concept)
- **`None`** → `nominal_nsegs` segments per quarter-wavelength at `design_freq`. N becomes a *physical density* — N=15 means λ/60 segment length on every design — and mesh ladders are comparable across the catalog. `design_freq` is required (build-time error otherwise); the measurement `freq` plays no part, so **sweeping frequency can never remesh geometry**, and there is no longest-wire reference (its identity can flip mid-knob-drag and jump every count).
- **Integer** → taken verbatim. The legacy path: fully backward-compatible, allowed, not recommended. `segs_for` machinery is untouched for explicit dynamic generation.

## Managing the change
- Migrated in this PR: moxon, hexbeam, hexbeam_5band, hentenna ×2, hourglass ×2 (arrays inherit). The ratio scan caught two *hidden* defects on the way (hexbeam's 5-seg tip spacers, 10.7× and growing → **0.1 % @641 mutual**; hexbeam_5band's full-count band arms → **0.1 % @161**). hentenna_slant 25.2 % → 1.2 %. Default-slot churn ≤2.2 % everywhere, measured.
- The rest of the catalog stays on its (correct, lint-clean) explicit counts — migration is incremental and tracked, not big-bang.
- Two-part geometry lint holds the line meanwhile: segment-length ratio ≤3 at N=321 **and** ratio must not grow N=61→641 (the fixed-count tell a snapshot misses). Sole exemption: elt_whip (deck-faithful data).
- Trap-wire study (recorded in the status doc + #521): 1-seg load wires are the same defect class — stock trap_fan diverges to 25.9 % while density-meshed traps converge to 5.4 %, **and the pin biased even bs2** (flat at the wrong X). Load-wire migration needs small L/C retunes → follow-up work, not this PR.
- `tests/test_auto_mesh.py` pins the contract, including freq-cannot-remesh and cross-design density equality.

## Test plan
- [x] Full suite: 2662 passed (auto_mesh contract tests + ~180 parametrized lint checks)
- [x] Ladders re-verified under the λ/4 unit: moxon 0.1 % @321, hexbeam 0.2 % @321, hexbeam_5band 0.1 % @161
- [x] bs2@15 churn measured stock-vs-migrated on all affected designs
- [x] `cd site && npm run build` passes; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iMSNiYKS61YWgLbuPoSKv