### PR TITLE
Auto-meshing joins the stack + the concepts page that tells the story

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -75,6 +75,7 @@ export default defineConfig({
             { label: "The model", slug: "concepts/model" },
             { label: "Write your first design", slug: "concepts/first-builder" },
             { label: "Many ways to express geometry", slug: "concepts/authoring" },
+            { label: "Segmentation you never think about", slug: "concepts/auto-meshing" },
             { label: "Station modelling", slug: "concepts/station-modelling" },
             {
               label: "Writing designs with Claude Code",

--- a/site/src/content/docs/advanced/convergence.md
+++ b/site/src/content/docs/advanced/convergence.md
@@ -82,13 +82,12 @@ them poisons the solve — the curve may *diverge* with refinement. (Two
 catalog verticals did exactly this until their radials were made to
 refine with the mesh; the tell was sin/PyNEC marching away from a flat
 bs2 while the meshes decoupled.) Response: refine *uniformly* — in
-your own builders, return `None` segment counts and finish
-`build_wires` with `self.auto_mesh(tups)`, which meshes every wire at
-the design density: `nominal_nsegs` segments per quarter-wavelength
-at your declared `design_freq` (so N=15 means a segment length of
-λ/60, on every design). Integer counts are still honored verbatim as
-the legacy path, but hand-assigned counts are how every one of these
-defects was written.
+your own builders, just return `None` segment counts; the framework
+meshes every such wire at the design density, `nominal_nsegs`
+segments per quarter-wavelength at your declared `design_freq` (so
+N=15 means a segment length of λ/60, on every design). Integer counts
+are still honored verbatim as the legacy path, but hand-assigned
+counts are how every one of these defects was written.
 
 **3. Physics-limited: the near-open feed.** A feed near a current null
 (|Z| in the thousands of ohms — end-fed designs, some multi-element

--- a/site/src/content/docs/concepts/authoring-with-claude.md
+++ b/site/src/content/docs/concepts/authoring-with-claude.md
@@ -62,8 +62,10 @@ The seeded `CLAUDE.md` is authoritative; in brief, a design file must:
 - Define a class **`Builder`** subclassing `AntennaBuilder`.
 - Provide a **`default_params`** mapping (every key becomes a knob, read as
   `self.<key>` in the build) and a **`build_wires(self)`** method returning
-  `(start, end, n_segments, feed)` tuples — exactly **one** segment carries the
-  feed `1 + 0j`, the rest `None`.
+  `(start, end, n_segments, feed)` tuples — write `None` for `n_segments`
+  (the framework meshes at the design density; never hand-assign counts) and
+  declare a `design_freq` param. Exactly **one** wire carries the feed
+  `1 + 0j`, the rest `None`.
 - Import only from `antennaknobs` and the standard library.
 
 ```python
@@ -83,11 +85,10 @@ class Builder(AntennaBuilder):
         wavelength = 299.792458 / self.design_freq
         h = (wavelength / 4.0) * self.length_factor
         z, eps = self.height, 0.01
-        arm = self.nominal_nsegs
         return [
-            ((0.0, -h, z), (0.0, -eps, z), arm, None),       # left arm
-            ((0.0, eps, z), (0.0, h, z), arm, None),         # right arm
-            ((0.0, -eps, z), (0.0, eps, z), 1, 1 + 0j),      # driven feed gap
+            ((0.0, -h, z), (0.0, -eps, z), None, None),     # left arm
+            ((0.0, eps, z), (0.0, h, z), None, None),       # right arm
+            ((0.0, -eps, z), (0.0, eps, z), None, 1 + 0j),  # driven feed gap
         ]
 ```
 

--- a/site/src/content/docs/concepts/auto-meshing.md
+++ b/site/src/content/docs/concepts/auto-meshing.md
@@ -1,6 +1,6 @@
 ---
 title: "Segmentation you never think about"
-description: The same Moxon rectangle written with explicit segment counts and with automatic meshing — what changed, why, and what the new density rule means.
+description: The same Moxon rectangle written three ways — explicit counts as naturally written, explicit counts done right, and automatic meshing — and what the density rule means.
 ---
 
 A method-of-moments solver chops every wire into segments, and the choice
@@ -10,16 +10,16 @@ design density. This page shows the difference on a real catalog design —
 the Moxon rectangle — because the Moxon is also the design where hand
 segmentation last went wrong.
 
-## The same builder, twice
+## The same builder, three times
 
-Both versions build identical geometry: the two bent elements of a Moxon
-rectangle, computed from `halfdriver`, `aspect_ratio`, and the tip
+All three versions build identical geometry: the two bent elements of a
+Moxon rectangle, computed from `halfdriver`, `aspect_ratio`, and the tip
 spacing, plus a short feed wire across the gap `T→S`. Everything up to
 the wire list — the corner points `S, A, B, C, D…` — is the same code.
 Only the meshing differs.
 
-**Explicit segmentation** (how the catalog's Moxon was actually written,
-until it was found wrong):
+**1. Explicit segmentation, the natural way** (how the catalog's Moxon
+was actually written, until it was found wrong):
 
 ```python
 def build_wires(self):
@@ -41,40 +41,9 @@ def build_wires(self):
     return tups
 ```
 
-**Automatic meshing** (the catalog's Moxon today):
+### What version 1 got wrong
 
-```python
-def build_wires(self):
-    # ... geometry: corner points S, A, B, C, D, E, F, G, H, T ...
-
-    def path(lst):
-        return [(a, b, None, None) for a, b in zip(lst[:-1], lst[1:])]
-
-    tups = []
-    tups.extend(path([S, A, B]))
-    tups.extend(path([C, D, E, F]))
-    tups.extend(path([G, H, T]))
-    tups.append((T, S, None, 1 + 0j))
-    return self.auto_mesh(tups)
-```
-
-Every count is `None`; the builder ends with `self.auto_mesh(tups)`; and
-the design declares one new parameter:
-
-```python
-default_params = MappingProxyType({
-    "freq": 28.57,
-    "design_freq": 28.57,   # anchors the mesh density (see below)
-    # ... the geometry knobs ...
-})
-```
-
-That is the entire migration. No reference-wire choice, no `segs_for`
-arithmetic, no per-wire decisions.
-
-## What the explicit version got wrong
-
-The explicit code above looks disciplined — it even refines the feed gap
+This code looks disciplined — it even refines the feed gap
 properly. Its defect is one habit: **every wire got the full nominal
 count**, long or short. The main elements are 3.8 m; the folded tails are
 0.56 m. Same count on both means the tails ran at **6.7× the density** of
@@ -91,6 +60,87 @@ against a true −30j), fan-dipole feed links hard-coded at 5 segments
 while the arms refined past them, hexbeam tip spacers likewise. Different
 designs, one cause: a hand-assigned count that left one wire's segment
 length out of step with its junction partners.
+
+**2. Explicit segmentation, done right.** Getting the counts correct by
+hand means honoring one invariant: *every wire's count must be
+proportional to its length, at one shared density*. So you must
+
+1. pick a **reference wire** that carries `nominal_nsegs` (here the
+   driver arm `S→A`),
+2. derive **every other wire's** count from its own length at that
+   density (`segs_for(length, ref)` — never reuse the nominal count on a
+   wire of a different length),
+3. and keep doing both forever: every wire added later, every knob whose
+   drag changes a wire's length relative to the reference, has to go
+   back through the same arithmetic.
+
+That version of the Moxon — the fix that was actually shipped — looks
+like this:
+
+```python
+def build_wires(self):
+    # ... geometry: corner points S, A, B, C, D, E, F, G, H, T ...
+
+    n_seg0 = self.nominal_nsegs
+    ref = math.dist(S, A)          # the reference wire's length
+    n_seg1 = self.segs_for(math.dist(T, S), ref)
+
+    def path(lst):
+        return [
+            (a, b, self.segs_for(math.dist(a, b), ref), None)
+            for a, b in zip(lst[:-1], lst[1:])
+        ]
+
+    tups = []
+    tups.append((S, A, n_seg0, None))   # reference: carries nominal_nsegs
+    tups.extend(path([A, B]))           # tail, at the arm's density
+    tups.extend(path([C, D, E, F]))     # reflector run, same density
+    tups.extend(path([G, H, T]))        # tail + arm, same density
+    tups.append((T, S, n_seg1, 1 + 0j)) # feed, same density
+    return tups
+```
+
+This is correct — and it is all bookkeeping. Nothing about it is
+Moxon-specific insight; it is the same invariant every design must
+re-implement, and every line that touches a count is a chance to slip
+back into version 1. The catalog did exactly that five separate times,
+in five different builders, each of which passed review looking like the
+disciplined code above.
+
+**3. Automatic meshing** (the catalog's Moxon today) — the invariant
+moves into the framework, and the builder stops talking about meshing
+entirely:
+
+```python
+def build_wires(self):
+    # ... geometry: corner points S, A, B, C, D, E, F, G, H, T ...
+
+    def path(lst):
+        return [(a, b, None, None) for a, b in zip(lst[:-1], lst[1:])]
+
+    tups = []
+    tups.extend(path([S, A, B]))
+    tups.extend(path([C, D, E, F]))
+    tups.extend(path([G, H, T]))
+    tups.append((T, S, None, 1 + 0j))
+    return tups
+```
+
+Every count is `None` — that's it. Auto-meshing is part of the stack:
+the framework resolves `build_wires` results before any consumer sees
+them, so there is no meshing call to remember. The design declares one
+new parameter:
+
+```python
+default_params = MappingProxyType({
+    "freq": 28.57,
+    "design_freq": 28.57,   # anchors the mesh density (see below)
+    # ... the geometry knobs ...
+})
+```
+
+That is the entire migration. No reference-wire choice, no `segs_for`
+arithmetic, no per-wire decisions, no call to make.
 
 ## The rule behind `None`
 

--- a/site/src/content/docs/concepts/auto-meshing.md
+++ b/site/src/content/docs/concepts/auto-meshing.md
@@ -1,0 +1,136 @@
+---
+title: "Segmentation you never think about"
+description: The same Moxon rectangle written with explicit segment counts and with automatic meshing — what changed, why, and what the new density rule means.
+---
+
+A method-of-moments solver chops every wire into segments, and the choice
+of *how many* used to be part of authoring a design. It is now optional:
+give a wire the segment count `None` and the framework meshes it at the
+design density. This page shows the difference on a real catalog design —
+the Moxon rectangle — because the Moxon is also the design where hand
+segmentation last went wrong.
+
+## The same builder, twice
+
+Both versions build identical geometry: the two bent elements of a Moxon
+rectangle, computed from `halfdriver`, `aspect_ratio`, and the tip
+spacing, plus a short feed wire across the gap `T→S`. Everything up to
+the wire list — the corner points `S, A, B, C, D…` — is the same code.
+Only the meshing differs.
+
+**Explicit segmentation** (how the catalog's Moxon was actually written,
+until it was found wrong):
+
+```python
+def build_wires(self):
+    # ... geometry: corner points S, A, B, C, D, E, F, G, H, T ...
+
+    def build_path(lst, ns, ex):
+        return ((a, b, ns, ex) for a, b in zip(lst[:-1], lst[1:]))
+
+    n_seg0 = self.nominal_nsegs
+    # Feed gap T->S refines with the mesh; the driver arm S->A is the
+    # reference-length wire that carries n_seg0.
+    n_seg1 = self.segs_for(math.dist(T, S), math.dist(S, A))
+
+    tups = []
+    tups.extend(build_path([S, A, B], n_seg0, None))      # arm + tail
+    tups.extend(build_path([C, D, E, F], n_seg0, None))   # reflector run
+    tups.extend(build_path([G, H, T], n_seg0, None))      # tail + arm
+    tups.append((T, S, n_seg1, 1 + 0j))                   # feed
+    return tups
+```
+
+**Automatic meshing** (the catalog's Moxon today):
+
+```python
+def build_wires(self):
+    # ... geometry: corner points S, A, B, C, D, E, F, G, H, T ...
+
+    def path(lst):
+        return [(a, b, None, None) for a, b in zip(lst[:-1], lst[1:])]
+
+    tups = []
+    tups.extend(path([S, A, B]))
+    tups.extend(path([C, D, E, F]))
+    tups.extend(path([G, H, T]))
+    tups.append((T, S, None, 1 + 0j))
+    return self.auto_mesh(tups)
+```
+
+Every count is `None`; the builder ends with `self.auto_mesh(tups)`; and
+the design declares one new parameter:
+
+```python
+default_params = MappingProxyType({
+    "freq": 28.57,
+    "design_freq": 28.57,   # anchors the mesh density (see below)
+    # ... the geometry knobs ...
+})
+```
+
+That is the entire migration. No reference-wire choice, no `segs_for`
+arithmetic, no per-wire decisions.
+
+## What the explicit version got wrong
+
+The explicit code above looks disciplined — it even refines the feed gap
+properly. Its defect is one habit: **every wire got the full nominal
+count**, long or short. The main elements are 3.8 m; the folded tails are
+0.56 m. Same count on both means the tails ran at **6.7× the density** of
+everything else, at every mesh — and the over-dense wires were exactly
+the facing conductors across the Moxon's critical tip gap. At coarse
+meshes nothing showed. Refined, the NEC-style basis walked off the
+converged answer: 39.2−21.2j where the true value is 43.6−16.3j, a 14 %
+error that hid because coarse meshes agreed fine.
+
+The same habit produced every meshing failure in the catalog's history:
+a folded inverted-V whose 10 cm link carried the full count until segment
+length fell below the wire's *radius* (impedance exploded to −1188j
+against a true −30j), fan-dipole feed links hard-coded at 5 segments
+while the arms refined past them, hexbeam tip spacers likewise. Different
+designs, one cause: a hand-assigned count that left one wire's segment
+length out of step with its junction partners.
+
+## The rule behind `None`
+
+There is exactly one rule, applied per wire with no interactions:
+
+> A `None` count meshes the wire at the **design density**:
+> `nominal_nsegs` segments per quarter-wavelength at `design_freq`.
+> An integer count is taken verbatim.
+
+Three consequences worth knowing:
+
+- **N is now a physical unit.** N=15 means a segment length of λ/60 — on
+  this design, on every design. Convergence ladders are comparable
+  across the whole catalog, and the segments-per-wavelength intuition
+  from the NEC world maps directly.
+- **`design_freq`, never `freq`.** The mesh is anchored to the frequency
+  the geometry is *designed* for, not the frequency being measured — so
+  sweeping frequency can never remesh the antenna mid-sweep. A design
+  whose geometry is sized in absolute metres (like the Moxon) declares a
+  `design_freq` purely as its density anchor; wavelength-sized designs
+  already have one. Using `None` without declaring it is a build-time
+  error, not a silent guess.
+- **Uniform density is the whole point.** Every `None` wire in a design
+  gets the same segment length, so no junction ever sees a mesh step —
+  the failure mode above becomes unwritable. A catalog-wide lint
+  enforces the outcome (segment-length ratio bounded at fine mesh, and
+  forbidden from growing up the ladder), so even a builder that keeps
+  explicit counts can't silently reintroduce the bug class.
+
+## When would you still write a count?
+
+Explicit counts remain fully supported — a design written entirely with
+integers behaves exactly as it always did, and `segs_for` is still there
+for computing them. They are the right tool when the mesh itself is
+*data*: a deck-faithful reproduction of an external NEC model, or the
+few validated port models whose counts encode physics still under study.
+For everything else, the recommendation is now simple: write `None`,
+declare `design_freq`, finish with `auto_mesh`, and never think about
+segmentation again.
+
+For the measurement story behind this — the convergence ladders, the
+basis comparisons, and the audit that found the defects — see
+[How many segments?](/advanced/convergence/).

--- a/site/src/content/docs/concepts/first-builder.mdx
+++ b/site/src/content/docs/concepts/first-builder.mdx
@@ -25,12 +25,15 @@ from antennaknobs import AntennaBuilder
 
 
 class Builder(AntennaBuilder):
-    default_params = {"freq": 14.0}  # MHz — the only knob
+    default_params = {
+        "freq": 14.0,         # MHz — measurement frequency
+        "design_freq": 14.0,  # MHz — the band it's designed for (anchors the mesh)
+    }
 
     def build_wires(self):
         y = 5.0  # half-length in metres → a 10 m wire, tip to tip
         return [
-            ((0.0, -y, 0.0), (0.0, y, 0.0), 21, 1 + 0j),
+            ((0.0, -y, 0.0), (0.0, y, 0.0), None, 1 + 0j),
         ]
 ```
 
@@ -38,12 +41,14 @@ That's a complete, loadable design. Drop it in your
 [designs folder](/concepts/authoring-with-claude/#your-designs-folder) as
 `my_dipole.py`, refresh the workbench, and it appears under **Your designs**.
 
-Reading the one wire tuple `((0,-y,0), (0,y,0), 21, 1+0j)` against the
+Reading the one wire tuple `((0,-y,0), (0,y,0), None, 1+0j)` against the
 [`build_wires()` contract](/concepts/model/#the-build_wires-contract):
 
 - **`(0,-y,0)` → `(0,y,0)`** — the two endpoints (metres): a straight wire along
   the **y** axis from −5 m to +5 m, lying on the ground plane (`z = 0`).
-- **`21`** — mesh this wire into 21 segments (more on that in step 4).
+- **`None`** — no segment count: the framework meshes the wire for you, at a
+  density anchored to `design_freq` (step 4 explains the rule — you will never
+  pick a count by hand).
 - **`1 + 0j`** — this wire is the **driven** element; the source sits on it. (A
   structural, undriven wire would carry `None` here.) Exactly one segment in the
   whole design carries the feed — here the wire's own centre segment.
@@ -92,79 +97,80 @@ add `base` to the params and use it as the `z` coordinate:
 ```python
 class Builder(AntennaBuilder):
     default_params = {
-        "freq": 14.0,   # MHz — measurement frequency
-        "base": 10.0,   # metres — height above ground
+        "freq": 14.0,         # MHz — measurement frequency
+        "design_freq": 14.0,  # MHz — mesh anchor
+        "base": 10.0,         # metres — height above ground
     }
 
     def build_wires(self):
         y = 5.0
         z = self.base   # every param is read as self.<name>
         return [
-            ((0.0, -y, z), (0.0, y, z), 21, 1 + 0j),
+            ((0.0, -y, z), (0.0, y, z), None, 1 + 0j),
         ]
 ```
 
 Every key in `default_params` is now a knob in the panel, read inside the build
 as `self.base`. Slide it and watch the pattern lift off the ground. Make sure to enable ground modelling.
 
-## 4. Segment the wire the right way
+## 4. How the mesh gets made
 
-That `21` we've been carrying is the **segment count** — and it deserves an
-explanation, because it's where antenna *modelling* meets antenna *physics*.
+That `None` we've been carrying is the **segment count** — and the reason it's
+`None` deserves an explanation, because it's where antenna *modelling* meets
+antenna *physics*.
 
 The solver is a [Method of Moments](/reference/solver/) engine: it chops each
-wire into `nsegs` short segments, puts an unknown current on each, and solves a
-linear system for them all at once. So `nsegs` is an **accuracy/cost dial**:
+wire into short segments, puts an unknown current on each, and solves a linear
+system for them all at once. So the mesh is an **accuracy/cost dial**:
 
 - **too few** segments and the current distribution is too coarse to be
   trustworthy — the impedance and pattern are wrong;
 - **too many** and the solve is needlessly slow;
 - what matters is that each segment is **short relative to a wavelength**, and
   that segment length stays roughly **constant across every wire** so no part of
-  the antenna is under-meshed.
+  the antenna is under- or over-meshed.
 
-Hardcoding `21` breaks that last rule the moment a wire's length changes. The
-framework gives you the right tool — `segs_for(length, ref)`:
-
-```python
-def build_wires(self):
-    wavelength = 299.792458 / self.freq   # metres; c = 299.792458 m·MHz
-    quarter = wavelength / 4.0            # the reference length
-    y = 5.0
-    z = self.base
-    n = self.segs_for(2 * y, quarter)    # segments scaled to the wire's length
-    return [
-        ((0.0, -y, z), (0.0, y, z), n, 1 + 0j),
-    ]
-```
-
-`segs_for` scales the framework's `nominal_nsegs` (default **21**, the count for
-one reference length) by `length / ref`, so a wire twice as long gets twice the
-segments and segment length stays constant:
+You never manage any of that. A `None` count means the framework meshes the
+wire at the **design density**:
 
 ```text
-n = max(1, round(nominal_nsegs · length / ref))
+n = max(1, round(N · length / (λ/4)))     # λ from design_freq
 ```
 
-The clip at 1 matters for *short* wires: a feed bridge or stub a few
-centimetres long gets exactly one segment instead of being over-meshed —
-segment length stays roughly constant across the whole antenna, which is
-the point.
+where **N** is the workbench's segment slider (`nominal_nsegs`). N is a
+physical unit — N=21 means a segment length of λ/84 on every wire of every
+design — and because every `None` wire gets the *same* segment length, no part
+of the antenna can end up meshed out of step with its neighbours. That
+uniformity is not a nicety: hand-picked counts that broke it are the single
+most common historical bug in our own design catalog (the full story, with the
+same design written both ways, is in
+[Segmentation you never think about](/concepts/auto-meshing/)).
 
-Our 10 m wire is about two quarter-waves long, so it now meshes into **39**
-segments instead of 21 — finer, and it will *track* the length once we make it a
-parameter.
+The mesh is anchored to `design_freq` — the band the antenna is *designed*
+for — never to the measurement `freq`, so sweeping the measurement frequency
+can never re-mesh the geometry under you.
+
+Our 10 m wire is about two quarter-waves long at 14 MHz, so at the default
+N=21 it meshes into **39** segments — and the count will *track* the length
+once we make it a parameter.
+
+<Aside type="note" title="Explicit counts still exist">
+  An integer in the count slot is honored verbatim. You'd only reach for one
+  when the mesh itself is data — reproducing an imported NEC deck wire-for-wire,
+  say. For everything you author, write `None`.
+</Aside>
 
 <Aside type="note" title="You give a count; the solver picks the parity">
   You might expect the feed to need an **odd** count so a centre-fed wire has a
   true middle segment — and for some solvers it does. But which parity lands the
   feed cleanly depends on the basis functions: sinusoidal, PyNEC, and the
   default B-spline (degree-2) solver want odd, while B-spline degree-1 wants
-  **even**. So `segs_for` deliberately doesn't force a parity — it returns the
-  natural count, and each solver nudges the **fed** wire's count by at most one
-  to suit its own basis at solve time. Wires without a feed or named port keep
-  exactly the count you give them, so a deliberately meshed (or imported)
-  geometry is preserved. You size the mesh; the solver gets the feed right.
+  **even**. So the framework deliberately doesn't force a parity — the mesh
+  resolves to its natural count, and each solver nudges the **fed** wire's
+  count by at most one to suit its own basis at solve time. Wires without a
+  feed or named port keep exactly their resolved (or explicitly given) count,
+  so a deliberately meshed or imported geometry is preserved. The framework
+  sizes the mesh; the solver gets the feed right.
 </Aside>
 
 ## 5. Parameterize the length
@@ -179,19 +185,17 @@ from antennaknobs import AntennaBuilder
 class Builder(AntennaBuilder):
     default_params = {
         "freq": 14.6,          # MHz — measurement frequency
+        "design_freq": 14.6,   # MHz — mesh anchor
         "base": 10.0,          # metres — height above ground
         "half_length": 5.0,    # metres — half the wire, tip to centre
         "ui_params": {"default_view": "xz"},
     }
 
     def build_wires(self):
-        wavelength = 299.792458 / self.freq
-        quarter = wavelength / 4.0
         y = self.half_length
         z = self.base
-        n = self.segs_for(2 * y, quarter)
         return [
-            ((0.0, -y, z), (0.0, y, z), n, 1 + 0j),
+            ((0.0, -y, z), (0.0, y, z), None, 1 + 0j),
         ]
 ```
 
@@ -204,8 +208,9 @@ frequency.
 
 `half_length` in raw metres works, but it **freezes** the antenna at one size:
 pick a different band and you're back to hand-tuning the length. The fix is to
-tie every dimension to the **wavelength of the band you're cutting for**. Add a
-`design_freq` knob and size the wire from it.
+tie every dimension to the **wavelength of the band you're cutting for** — and
+you've been carrying exactly the right knob since step 1: `design_freq`, so far
+only anchoring the mesh, now sizes the geometry too.
 
 A half-wave dipole is two **quarter-wave** arms, so the half-length is one
 quarter wavelength — times a `length_factor` near 1.0 that trims a real wire to
@@ -229,9 +234,8 @@ class Builder(AntennaBuilder):
         quarter = wavelength / 4.0
         y = quarter * self.length_factor   # half-length ≈ a quarter wavelength
         z = self.base
-        n = self.segs_for(2 * y, quarter)
         return [
-            ((0.0, -y, z), (0.0, y, z), n, 1 + 0j),
+            ((0.0, -y, z), (0.0, y, z), None, 1 + 0j),
         ]
 ```
 

--- a/site/src/content/docs/concepts/model.md
+++ b/site/src/content/docs/concepts/model.md
@@ -40,7 +40,13 @@ view, and so on).
 ```
 
 - the two endpoints are 3D coordinates (metres),
-- `nsegs` is how many segments to mesh that wire into,
+- `nsegs` is the wire's segment count — write **`None`** and the framework
+  meshes the wire at the design density, `nominal_nsegs` segments per
+  quarter-wavelength at the design's `design_freq` (see
+  [Segmentation you never think about](/concepts/auto-meshing/)); an
+  **integer** is honored verbatim. The rule is strictly per-wire: in a mixed
+  list, `None` wires resolve at the design density and integer wires keep
+  their counts, with no interaction between them,
 - `excitation` is `None` for a structural wire, or a complex value for the
   **driven** segment carrying the source.
 

--- a/site/src/content/docs/concepts/model.md
+++ b/site/src/content/docs/concepts/model.md
@@ -50,6 +50,12 @@ view, and so on).
 - `excitation` is `None` for a structural wire, or a complex value for the
   **driven** segment carrying the source.
 
+A tuple may carry an optional **fifth element, a name** (a string), tagging
+the wire so the network layer can attach to it — a
+[`PortOnWire("feed")`](/concepts/station-modelling/) port, a trap's load, a
+transmission-line endpoint — at that wire's middle segment. Most wires are
+anonymous; you name exactly the ones something attaches to.
+
 That single list is the entire interface to the solver and every renderer —
 nothing downstream cares *how* you produced it, which is what makes the
 [geometry layer so flexible](/concepts/authoring/).

--- a/site/src/content/docs/concepts/model.md
+++ b/site/src/content/docs/concepts/model.md
@@ -56,6 +56,21 @@ the wire so the network layer can attach to it — a
 transmission-line endpoint — at that wire's middle segment. Most wires are
 anonymous; you name exactly the ones something attaches to.
 
+For anything beyond the plain 4-tuple, the recommended spelling is the
+`Wire` named tuple (`from antennaknobs.network import Wire`) — a drop-in
+tuple superset whose fields after the endpoints all default, so keywords
+replace positional `None` placeholders:
+
+```python
+Wire(a, b)                     # structural wire, design density
+Wire(t, s, ex=1 + 0j)          # the feed
+Wire(ti, to, name="trap_b0")   # a named attachment wire
+```
+
+(Plain tuples stay 4–6 fields — there is deliberately no 2/3-tuple form,
+because a bare third element would be ambiguous between a segment count
+and an excitation.)
+
 That single list is the entire interface to the solver and every renderer —
 nothing downstream cares *how* you produced it, which is what makes the
 [geometry layer so flexible](/concepts/authoring/).

--- a/site/src/content/docs/reference/drone-transform.md
+++ b/site/src/content/docs/reference/drone-transform.md
@@ -35,14 +35,17 @@ heading, not the world axes.
 ### Constructor
 
 ```python
-Drone(position=(0.0, 0.0, 0.0), *, nominal_nsegs=21, ref=1.0)
+Drone(position=(0.0, 0.0, 0.0), *, nominal_nsegs=None, ref=None)
 ```
 
 - **`position`** — starting world position `(x, y, z)`.
-- **`nominal_nsegs`** — the segment count a wire of length `ref` receives. Longer
-  wires get proportionally more (see [auto-segmentation](#auto-segmentation)).
-- **`ref`** — the reference length for that scaling, usually a quarter
-  wavelength. Matches `AntennaBuilder`'s convention.
+- **`nominal_nsegs`** / **`ref`** — leave both off (the default): edges are
+  emitted with segment count `None`, and the framework meshes them at the
+  design density when `build_wires` returns
+  ([Segmentation you never think about](/concepts/auto-meshing/)). Passing
+  them switches to legacy in-drone resolution — a wire of length `ref`
+  (usually a quarter wavelength) gets `nominal_nsegs` segments, longer wires
+  proportionally more (see [segmentation](#segmentation)).
 
 ### Pen control
 
@@ -93,11 +96,14 @@ trig:
 | `heading` *(property)* | World-space unit vector the nose points along. |
 | `wires()` | The accumulated edge list, in `build_wires` shape. |
 
-### Auto-segmentation
+### Segmentation
 
-When `forward()` / `close()` / `line_to()` aren't given an explicit `nsegs`, the
-drone picks `max(1, round(nominal_nsegs · |length| / ref))` — the same formula
-as `segs_for`, short moves included. It does **not**
+When `forward()` / `close()` / `line_to()` aren't given an explicit `nsegs`,
+the edge carries `None` and meshes at the design density like any other wire —
+the drone has no meshing opinions of its own. (With the legacy constructor
+args, the drone instead picks `max(1, round(nominal_nsegs · |length| / ref))`
+in-drone — the same formula, anchored to the caller's `ref`.) An explicit
+`nsegs` on a single move is honored verbatim either way. It does **not**
 force a parity — each solver wants a different one (odd for sinusoidal /
 B-spline degree-2 / PyNEC, even for B-spline degree-1) so the feed lands
 cleanly, and the engine coerces the fed wire's count to its own parity at solve

--- a/src/antennaknobs/builder.py
+++ b/src/antennaknobs/builder.py
@@ -240,17 +240,16 @@ class AntennaBuilder:
                 "or give every wire an explicit segment count."
             )
         quarter_wave = 0.25 * 299.792458 / float(design_freq)
-        return [
-            t
-            if t[2] is not None
-            else (
-                t[0],
-                t[1],
-                self.segs_for(_math.dist(t[0], t[1]), quarter_wave),
-                *t[3:],
-            )
-            for t in tups
-        ]
+
+        def resolve(t):
+            if t[2] is not None:
+                return t
+            n = self.segs_for(_math.dist(t[0], t[1]), quarter_wave)
+            if isinstance(t, Wire):
+                return t._replace(n_seg=n)
+            return (t[0], t[1], n, *t[3:])
+
+        return [resolve(t) for t in tups]
 
     def _phasor(self, name):
         """Unit phasor exp(j·phase) for a degrees-valued phase param (e.g.

--- a/src/antennaknobs/builder.py
+++ b/src/antennaknobs/builder.py
@@ -83,6 +83,26 @@ class AntennaBuilder:
     # `self.nominal_nsegs` and scale per-edge segment counts accordingly.
     FRAMEWORK_PARAMS = {"nominal_nsegs": 21}
 
+    def __init_subclass__(cls, **kwargs):
+        """Auto-meshing is part of the stack: every subclass's
+        ``build_wires`` is wrapped so its result passes through
+        :meth:`auto_mesh` before any consumer sees it. A builder can
+        therefore return ``None`` segment counts and never mention
+        meshing; engines, the preview, exporters, and scripts all
+        receive resolved integer counts. The wrap is idempotent — a
+        legacy builder that calls ``auto_mesh`` itself, or returns only
+        explicit counts, passes through unchanged."""
+        super().__init_subclass__(**kwargs)
+        inner = cls.__dict__.get("build_wires")
+        if inner is not None:
+            import functools
+
+            @functools.wraps(inner)
+            def build_wires(self):
+                return self.auto_mesh(list(inner(self)))
+
+            cls.build_wires = build_wires
+
     def __init__(self, params=None):
         # write directly to __dict__ because otherwise __setattr__ goes into infinite loop
         merged = dict(self.FRAMEWORK_PARAMS)
@@ -200,7 +220,12 @@ class AntennaBuilder:
         mesh ladders are comparable across designs. Designs must declare
         ``design_freq`` (the frequency the geometry is designed for) to
         use ``None`` counts — a design without one raises here rather
-        than silently guessing a scale."""
+        than silently guessing a scale.
+
+        Builders never need to call this: ``__init_subclass__`` wraps
+        every subclass's ``build_wires`` so its result passes through
+        here automatically. Calling it explicitly is harmless (the
+        resolution is idempotent)."""
         import math as _math
 
         tups = list(tups)

--- a/src/antennaknobs/designs/beams/hexbeam.py
+++ b/src/antennaknobs/designs/beams/hexbeam.py
@@ -87,7 +87,6 @@ class Builder(AntennaBuilder):
         tups.extend(build_path([G, H], None, None))
         tups.extend(build_path([II, J, T], None, None))
         tups.append((T, S, None, 1 + 0j))
-        tups = self.auto_mesh(tups)
 
         new_tups = []
         for xoff, yoff, zoff in [(0, 0, self.base)]:

--- a/src/antennaknobs/designs/beams/moxon.py
+++ b/src/antennaknobs/designs/beams/moxon.py
@@ -104,4 +104,4 @@ class Builder(AntennaBuilder):
         tups.extend(path([G, H, T]))
         tups.append((T, S, None, 1 + 0j))
 
-        return self.auto_mesh(tups)
+        return tups

--- a/src/antennaknobs/designs/multiband/hexbeam_5band.py
+++ b/src/antennaknobs/designs/multiband/hexbeam_5band.py
@@ -367,7 +367,7 @@ class Builder(AntennaBuilder):
         # length across all five bands). The feed wires keep their
         # explicit shared count (build_tls attaches jumpers to their
         # middle segment via _n_seg_feed).
-        return self.auto_mesh(tups)
+        return tups
 
     def build_tls(self):
         """50ohm jumpers between successive band feeds in daisy-chain mode.

--- a/src/antennaknobs/designs/specialty/hentenna.py
+++ b/src/antennaknobs/designs/specialty/hentenna.py
@@ -84,9 +84,7 @@ class Builder(AntennaBuilder):
         tups.extend(build_path([S, B], None, None))
         tups.extend(build_path([D, T], None, None))
         tups.extend(build_path([T, S], None, 1 + 0j))
-        # Uniform-density mesh (issue #521): the old per-edge nominal
-        # count over-densified the short edges 4-6x; the longest edge now
-        # carries nominal_nsegs and every wire meshes at its density.
-        tups = self.auto_mesh(tups)
+        # Uniform-density mesh (issue #521): None counts resolve to the
+        # design density automatically (auto_mesh is part of the stack).
 
         return tups

--- a/src/antennaknobs/designs/specialty/hentenna_slant.py
+++ b/src/antennaknobs/designs/specialty/hentenna_slant.py
@@ -167,9 +167,7 @@ class Builder(AntennaBuilder):
         tups.extend(build_path([S, B], None, None))
         tups.extend(build_path([D, T], None, None))
         tups.extend(build_path([T, S], None, 1 + 0j))
-        # Uniform-density mesh (issue #521): the old per-edge nominal
-        # count over-densified the short edges 4-6x; the longest edge now
-        # carries nominal_nsegs and every wire meshes at its density.
-        tups = self.auto_mesh(tups)
+        # Uniform-density mesh (issue #521): None counts resolve to the
+        # design density automatically (auto_mesh is part of the stack).
 
         return tups

--- a/src/antennaknobs/designs/specialty/hourglass.py
+++ b/src/antennaknobs/designs/specialty/hourglass.py
@@ -67,9 +67,7 @@ class Builder(AntennaBuilder):
         tups.extend(build_path([S, B], None, None))
         tups.extend(build_path([D, T], None, None))
         tups.extend(build_path([T, S], None, 1 + 0j))
-        # Uniform-density mesh (issue #521): the old per-edge nominal
-        # count over-densified the short edges 4-6x; the longest edge now
-        # carries nominal_nsegs and every wire meshes at its density.
-        tups = self.auto_mesh(tups)
+        # Uniform-density mesh (issue #521): None counts resolve to the
+        # design density automatically (auto_mesh is part of the stack).
 
         return tups

--- a/src/antennaknobs/designs/specialty/hourglass_slant.py
+++ b/src/antennaknobs/designs/specialty/hourglass_slant.py
@@ -89,9 +89,7 @@ class Builder(AntennaBuilder):
         tups.extend(build_path([S, B], None, None))
         tups.extend(build_path([D, T], None, None))
         tups.extend(build_path([T, S], None, 1 + 0j))
-        # Uniform-density mesh (issue #521): the old per-edge nominal
-        # count over-densified the short edges 4-6x; the longest edge now
-        # carries nominal_nsegs and every wire meshes at its density.
-        tups = self.auto_mesh(tups)
+        # Uniform-density mesh (issue #521): None counts resolve to the
+        # design density automatically (auto_mesh is part of the stack).
 
         return tups

--- a/src/antennaknobs/drone.py
+++ b/src/antennaknobs/drone.py
@@ -48,12 +48,19 @@ class Drone:
     nose), local +z is 'up' (the yaw axis), local +y completes a
     right-handed frame ('left')."""
 
-    def __init__(self, position=(0.0, 0.0, 0.0), *, nominal_nsegs=21, ref=1.0):
-        # ``ref`` is the reference length a wire of which gets ``nominal_nsegs``
-        # segments (usually a quarter-wavelength), matching AntennaBuilder.
+    def __init__(self, position=(0.0, 0.0, 0.0), *, nominal_nsegs=None, ref=None):
+        # Segment counts are not the drone's problem by default: edges are
+        # emitted with count None and resolve to the design density
+        # (nominal_nsegs per design_freq quarter-wave) when build_wires
+        # returns — auto-meshing is part of the stack. Passing
+        # ``nominal_nsegs``/``ref`` (the reference length whose wire gets
+        # nominal_nsegs segments) switches to the legacy in-drone
+        # resolution, unchanged for existing callers; ``forward(...,
+        # nsegs=k)`` still pins a single edge verbatim either way.
         self.pose = Transform.translate(*position)
-        self.nominal_nsegs = nominal_nsegs
-        self.ref = ref
+        self._legacy_mesh = nominal_nsegs is not None or ref is not None
+        self.nominal_nsegs = 21 if nominal_nsegs is None else nominal_nsegs
+        self.ref = 1.0 if ref is None else ref
         self._pen = None  # None = up; ("ex", value) when down
         self._origin = None  # world position where the current stroke began
         self._nodes = {}  # labelled positions, dropped by mark()
@@ -105,7 +112,9 @@ class Drone:
     def _emit(self, p0, p1, nsegs):
         if self._pen is not None:
             _, ex = self._pen
-            self.edges.append((p0, p1, nsegs or self._seg(math.dist(p0, p1)), ex))
+            if nsegs is None:
+                nsegs = self._seg(math.dist(p0, p1)) if self._legacy_mesh else None
+            self.edges.append((p0, p1, nsegs, ex))
 
     # -- moves ----------------------------------------------------------
     def forward(self, dist, nsegs=None):

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -236,6 +236,19 @@ class Wire(NamedTuple):
     unpacking, and the ``t[4]``-style name access keep working, and designs
     may freely mix plain 4/5-tuples and ``Wire`` entries in one list.
 
+    With every field after the endpoints defaulted, keyword construction
+    is the recommended brief spelling — ``Wire(a, b)`` is a structural
+    wire at the design density, ``Wire(t, s, ex=1 + 0j)`` the feed,
+    ``Wire(ti, to, name="trap_b0")`` a named attachment wire — with no
+    positional ``None`` placeholders. (Plain tuples stay 4-6 fields;
+    short plain tuples are rejected because a bare third element would
+    be ambiguous between a count and an excitation.)
+
+    ``n_seg=None`` means "mesh me at the design density" — resolved by
+    ``AntennaBuilder.auto_mesh`` as part of the stack (nominal_nsegs
+    segments per design_freq quarter-wave); an integer is honored
+    verbatim.
+
     ``spec=None`` means "the design default": engines fall back to
     ``build_wire_material()``. Precedence, defined once: an explicit
     per-wire ``spec`` wins; the web ``wire_radius`` override only moves
@@ -246,7 +259,7 @@ class Wire(NamedTuple):
 
     p0: tuple
     p1: tuple
-    n_seg: int
+    n_seg: int | None = None
     ex: complex | None = None
     name: str | None = None
     spec: WireSpec | None = None

--- a/tests/test_auto_mesh.py
+++ b/tests/test_auto_mesh.py
@@ -121,3 +121,27 @@ def test_missing_design_freq_raises_at_build_wires():
     b.nominal_nsegs = 20
     with pytest.raises(ValueError, match="design_freq"):
         b.build_wires()
+
+
+def test_drone_edges_resolve_through_the_stack():
+    """A Drone with no meshing args emits None counts; inside a builder
+    they resolve at the design density like any other wire."""
+    from antennaknobs.drone import Drone
+
+    class Loop(_Design):
+        def build_wires(self):
+            d = Drone(position=(0.0, 0.0, 0.0))
+            d.pay_out().forward(2.5).yaw(90).forward(1.25, nsegs=3)
+            return d.edges
+
+    b = Loop()
+    b.nominal_nsegs = 20  # lambda/4 = 2.5 m for _Design's design_freq
+    assert [t[2] for t in b.build_wires()] == [20, 3]
+
+
+def test_drone_legacy_meshing_args_unchanged():
+    from antennaknobs.drone import Drone
+
+    d = Drone(nominal_nsegs=21, ref=1.0)
+    d.pay_out().forward(2.0)
+    assert d.edges[0][2] == 42  # resolved in-drone, exactly as before

--- a/tests/test_auto_mesh.py
+++ b/tests/test_auto_mesh.py
@@ -145,3 +145,34 @@ def test_drone_legacy_meshing_args_unchanged():
     d = Drone(nominal_nsegs=21, ref=1.0)
     d.pay_out().forward(2.0)
     assert d.edges[0][2] == 42  # resolved in-drone, exactly as before
+
+
+def test_wire_keyword_construction_is_the_brief_spelling():
+    """Wire(a, b) / Wire(t, s, ex=...) / Wire(ti, to, name=...) — every
+    field after the endpoints defaults, n_seg to None (design density),
+    and resolution preserves the Wire type (names/specs stay named)."""
+    from antennaknobs.network import Wire
+
+    class Dipole(_Design):
+        def build_wires(self):
+            return [
+                Wire((0.0, -2.5, 0.0), (0.0, -0.05, 0.0)),
+                Wire((0.0, 0.05, 0.0), (0.0, 2.5, 0.0)),
+                Wire((0.0, -0.05, 0.0), (0.0, 0.05, 0.0), ex=1 + 0j, name="feed"),
+            ]
+
+    b = Dipole()
+    b.nominal_nsegs = 20  # lambda/4 = 2.5 m
+    out = b.build_wires()
+    assert [w.n_seg for w in out] == [20, 20, 1]
+    assert all(isinstance(w, Wire) for w in out)
+    assert out[2].ex == 1 + 0j and out[2].name == "feed"
+
+
+def test_short_plain_tuples_stay_rejected():
+    """The brevity lives in Wire keywords, not in 2/3-tuples — a bare
+    third element would be ambiguous between a count and an excitation."""
+    from antennaknobs.network import as_wire
+
+    with pytest.raises(ValueError, match="4-6"):
+        as_wire(((0.0, 0.0, 0.0), (1.0, 0.0, 0.0)))

--- a/tests/test_auto_mesh.py
+++ b/tests/test_auto_mesh.py
@@ -83,3 +83,41 @@ def test_density_is_the_same_across_designs():
     wa = a.auto_mesh([_wire(1.9, None)])
     wo = o.auto_mesh([_wire(1.9, None)])
     assert wa[0][2] == wo[0][2]
+
+
+def test_auto_mesh_is_part_of_the_stack():
+    """Builders never call auto_mesh: build_wires results resolve
+    automatically, so every consumer sees integer counts."""
+
+    class Dipole(_Design):
+        def build_wires(self):
+            return [_wire(2.5, None), _wire(1.25, None, 1 + 0j)]
+
+    b = Dipole()
+    b.nominal_nsegs = 20
+    assert [t[2] for t in b.build_wires()] == [20, 10]
+
+
+def test_explicit_auto_mesh_call_is_idempotent():
+    """Legacy builders that still call auto_mesh themselves get the
+    identical mesh — the wrap resolves an already-resolved list to
+    itself."""
+
+    class Dipole(_Design):
+        def build_wires(self):
+            return self.auto_mesh([_wire(2.5, None), _wire(1.25, 3)])
+
+    b = Dipole()
+    b.nominal_nsegs = 20
+    assert [t[2] for t in b.build_wires()] == [20, 3]
+
+
+def test_missing_design_freq_raises_at_build_wires():
+    class Bad(_NoDesignFreq):
+        def build_wires(self):
+            return [_wire(2.5, None)]
+
+    b = Bad()
+    b.nominal_nsegs = 20
+    with pytest.raises(ValueError, match="design_freq"):
+        b.build_wires()


### PR DESCRIPTION
## Summary
- **`build_wires` results now resolve implicitly**: `AntennaBuilder.__init_subclass__` wraps every subclass's `build_wires` through `auto_mesh`, so builders return `None` counts and never mention meshing — no call to remember, and every consumer (engines, preview, exporters, scripts) sees resolved integer counts with zero call-site changes. Idempotent: explicit `auto_mesh` calls and all-integer legacy builders behave exactly as before. The seven migrated builders drop their now-redundant explicit calls.
- New concepts page **"Segmentation you never think about"** (`concepts/auto-meshing`): the catalog's Moxon written three ways — (1) explicit counts as naturally written (the actual defective code and what it got wrong), (2) explicit counts *done right* (the reference-wire + `segs_for` bookkeeping you must carry forever), (3) automatic (counts `None`, one `design_freq` param, nothing else). Sidebar entry in Concepts.
- Convergence-guide prescription updated to match ("just return None counts").
- Contract tests: implicit resolution, idempotence, missing-`design_freq` error at `build_wires` time.

## Test plan
- [x] Full suite: 2665 passed
- [x] `cd site && npm run build` clean
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iMSNiYKS61YWgLbuPoSKv