### PR TITLE
refactor(designs): broadband family to auto-mesh Wire() idiom (#525 stage 2)

### DIFF
--- a/src/antennaknobs/designs/broadband/discone.py
+++ b/src/antennaknobs/designs/broadband/discone.py
@@ -31,6 +31,7 @@ Geometry, in the framework's (x, y, z) convention:
 """
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 import math
 from types import MappingProxyType
 
@@ -79,7 +80,6 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         cone = self.cone_frac * wavelength
         ang = math.radians(self.cone_half_angle_deg)
@@ -95,35 +95,14 @@ class Builder(AntennaBuilder):
         tups = []
         # Feed: a one-segment driven gap between the disc centre and the cone
         # apex (the coax point of a discone).
-        tups.append(
-            (
-                (0.0, 0.0, z_disc),
-                (0.0, 0.0, z_apex),
-                self.segs_for(2 * eps, quarter),
-                1 + 0j,
-            )
-        )
+        tups.append(Wire((0.0, 0.0, z_disc), (0.0, 0.0, z_apex), ex=1 + 0j))
 
         for i in range(m):
             phi = 2 * math.pi / m * i
             c, s = math.cos(phi), math.sin(phi)
             # Disc radial: horizontal, out from the centre.
-            tups.append(
-                (
-                    (0.0, 0.0, z_disc),
-                    (disc_r * c, disc_r * s, z_disc),
-                    self.segs_for(disc_r, quarter),
-                    None,
-                )
-            )
+            tups.append(Wire((0.0, 0.0, z_disc), (disc_r * c, disc_r * s, z_disc)))
             # Cone slant wire: down and out from the apex.
-            tups.append(
-                (
-                    (0.0, 0.0, z_apex),
-                    (cone_r * c, cone_r * s, z_cone_base),
-                    self.segs_for(cone, quarter),
-                    None,
-                )
-            )
+            tups.append(Wire((0.0, 0.0, z_apex), (cone_r * c, cone_r * s, z_cone_base)))
 
         return tups

--- a/src/antennaknobs/designs/broadband/g5rv.py
+++ b/src/antennaknobs/designs/broadband/g5rv.py
@@ -35,7 +35,7 @@ The matching line is an electrical element (a network branch), not geometry.
 """
 
 from antennaknobs import AntennaBuilder
-from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL
+from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL, Wire
 from types import MappingProxyType
 
 
@@ -90,7 +90,6 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         top = self.top_frac * wavelength * self.length_factor
         half = top / 2.0
@@ -100,13 +99,12 @@ class Builder(AntennaBuilder):
         C0 = (0.0, -eps, z)
         C1 = (0.0, eps, z)
         R = (0.0, half, z)
-        arm = self.segs_for(half - eps, quarter)
         # Centre-fed doublet; the named centre gap "feed" is the antenna-side
         # port the matched line connects to (no direct voltage source here).
         return [
-            (L, C0, arm, None, None),
-            (C0, C1, self.segs_for(2 * eps, quarter), None, "feed"),
-            (C1, R, arm, None, None),
+            Wire(L, C0),
+            Wire(C0, C1, name="feed"),
+            Wire(C1, R),
         ]
 
     def build_network(self):

--- a/src/antennaknobs/designs/broadband/lpda.py
+++ b/src/antennaknobs/designs/broadband/lpda.py
@@ -45,7 +45,7 @@ Horizontally polarised.
 """
 
 from antennaknobs import AntennaBuilder
-from antennaknobs.network import Driven, Network, PortOnWire, TL
+from antennaknobs.network import Driven, Network, PortOnWire, TL, Wire
 from types import MappingProxyType
 
 
@@ -112,8 +112,6 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
         half, x = self._layout()
         n = int(self.n_elements)
         z = self.base
@@ -126,11 +124,10 @@ class Builder(AntennaBuilder):
             C0 = (xk, -eps, z)
             C1 = (xk, eps, z)
             R = (xk, h, z)
-            arm = self.segs_for(h - eps, quarter)
             # left arm, named centre gap (a feeder port), right arm
-            tups.append((L, C0, arm, None, None))
-            tups.append((C0, C1, self.segs_for(2 * eps, quarter), None, f"d{k}"))
-            tups.append((C1, R, arm, None, None))
+            tups.append(Wire(L, C0))
+            tups.append(Wire(C0, C1, name=f"d{k}"))
+            tups.append(Wire(C1, R))
         return tups
 
     def build_network(self):

--- a/src/antennaknobs/designs/broadband/t2fd.py
+++ b/src/antennaknobs/designs/broadband/t2fd.py
@@ -30,7 +30,7 @@ far wire.
 """
 
 from antennaknobs import AntennaBuilder
-from antennaknobs.network import Driven, Load, Network, PortOnWire
+from antennaknobs.network import Driven, Load, Network, PortOnWire, Wire
 import math
 from types import MappingProxyType
 
@@ -90,9 +90,6 @@ class Builder(AntennaBuilder):
             # slopes up by `tilt`; the fold spacing (x) stays horizontal.
             return (x, y * math.cos(tilt), y * math.sin(tilt) + self.base)
 
-        arm = self.segs_for(half - eps, quarter)
-        short = self.segs_for(s, quarter)
-
         # near wire (feed) at x=0; far wire (termination) at x=s
         nL, nR = P(0.0, -half), P(0.0, half)
         nF0, nF1 = P(0.0, -eps), P(0.0, eps)
@@ -101,16 +98,17 @@ class Builder(AntennaBuilder):
 
         return [
             # near (feed) wire: left arm, feed gap, right arm
-            (nL, nF0, arm, None, None),
-            (nF0, nF1, self.segs_for(2 * eps, quarter), None, "feed"),
-            (nF1, nR, arm, None, None),
+            Wire(nL, nF0),
+            Wire(nF0, nF1, name="feed"),
+            Wire(nF1, nR),
             # far (termination) wire: left arm, load gap, right arm
-            (fL, fT0, arm, None, None),
-            (fT0, fT1, self.segs_for(2 * eps, quarter), None, "term"),
-            (fT1, fR, arm, None, None),
+            Wire(fL, fT0),
+            # Termination-resistor wire: count kept explicit (#525 stage 3).
+            Wire(fT0, fT1, n_seg=self.segs_for(2 * eps, quarter), name="term"),
+            Wire(fT1, fR),
             # end shorts joining the two wires
-            (nL, fL, short, None, None),
-            (nR, fR, short, None, None),
+            Wire(nL, fL),
+            Wire(nR, fR),
         ]
 
     def build_network(self):

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -460,8 +460,8 @@ def test_t2fd_folded_with_termination():
     from antennaknobs.network import Driven, Load
 
     tups = Builder().build_wires()
-    feeds = [t for t in tups if len(t) == 5 and t[4] == "feed"]
-    terms = [t for t in tups if len(t) == 5 and t[4] == "term"]
+    feeds = [t for t in tups if len(t) >= 5 and t[4] == "feed"]
+    terms = [t for t in tups if len(t) >= 5 and t[4] == "term"]
     assert len(feeds) == 1 and len(terms) == 1
     net = Builder().build_network()
     (load,) = [br for br in net.branches if isinstance(br, Load)]


### PR DESCRIPTION
## Summary
- Convert the four broadband designs — `discone`, `g5rv`, `lpda`, `t2fd` — from `segs_for` arithmetic to the auto-mesh `Wire()` idiom (`None` counts resolved at design density). Wire emission order, names (`feed`, `term`, `d0..d9`), and `ex` payloads unchanged.
- **Preserved**: t2fd's termination-resistor wire keeps its explicit `segs_for(2*eps, quarter)` count with the `"term"` name (retiring it is #525 stage 3, commented in-source). g5rv's matching section is a `Network` TL branch, not geometry — no wire counts to watch.
- **discone (#521 apex-fan candidate)**: converted normally; the geometry-density lint passes and no apex-fan finding fired. Its only churn is a genuine density correction: the 12 cone slant wires drop 23 → 22 segments because `auto_mesh` measures the true wire length (apex sits `2*eps` below the disc) where the old `segs_for` call used the nominal slant-length parameter.
- **lpda (memory-critical)**: probed at default N=21 only, all solves under `ulimit -v 6291456`. Element counts and total (618) are byte-identical before/after.
- Test change: `test_t2fd_folded_with_termination` filtered named wires by `len(t) == 5` (legacy 5-tuple arity); relaxed to `len(t) >= 5` so the 6-field `Wire` NamedTuple matches. No other test on these designs is arity-sensitive.

## Churn (bs2 @ N=21, defaults)

| design | segment counts before → after | total | Z before → after |
|---|---|---|---|
| discone | `[1, (8, 23)×12]` → `[1, (8, 22)×12]` | 373 → 361 | 18.12−30.70j → 18.12−30.69j (Δ~0.03% of \|Z\|) |
| g5rv | `[63, 1, 63]` (unchanged) | 127 | 113.63−56.89j (unchanged) |
| lpda | `[47,1,47, 42,1,42, 38,1,38, 34,1,34, 31,1,31, 27,1,27, 25,1,25, 22,1,22, 20,1,20, 18,1,18]` (unchanged) | 618 | 54.29+6.82j (unchanged) |
| t2fd | `[25, 1, 25, 25, 1, 25, 1, 1]` (unchanged) | 104 | 1351.81−306.18j (unchanged) |

No variant overlays exist in this family (defaults only).

## Test plan
- [x] `ruff check` + `ruff format --check` clean on touched files
- [x] Full fast suite: 2668 passed, 1 failed → the t2fd arity assertion above, fixed; broadband-focused re-run 28 passed
- [x] `tests/test_delta_a_lint.py` passes (discone included)
- [x] All solves memory-capped (`ulimit -v 6291456`); lpda probed at default N=21 only

🤖 Generated with [Claude Code](https://claude.com/claude-code)