### PR TITLE
refactor(designs): multiband family to auto-mesh Wire() idiom (#525 stage 2)

### DIFF
--- a/src/antennaknobs/designs/multiband/fandipole.py
+++ b/src/antennaknobs/designs/multiband/fandipole.py
@@ -5,6 +5,7 @@ import math
 from types import MappingProxyType
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +39,10 @@ class Builder(AntennaBuilder):
     default_params = MappingProxyType(
         {
             "freq": _BAND_10M["freq"],
+            # Geometry is sized per band from `bands`; design_freq only
+            # anchors auto_mesh's density scale (nominal_nsegs per
+            # quarter-wave), so it is hidden from the UI.
+            "design_freq": _BAND_10M["freq"],
             "base": 7.0,
             "angle_deg": 26.5651,
             "n_bands": _MAX_BANDS,
@@ -78,6 +83,7 @@ class Builder(AntennaBuilder):
                         "max": _MAX_BANDS,
                         "step": 1,
                     },
+                    "design_freq": {"hidden": True},
                 }
             ),
         }
@@ -130,9 +136,6 @@ class Builder(AntennaBuilder):
             for i in range(360 // (2 * n), 360, 360 // n)
         ][:n_bands]
 
-        def build_path(lst, ns, ex):
-            return ((a, b, ns, ex) for a, b in zip(lst[:-1], lst[1:]))
-
         def ry(p):
             return p[0], -p[1], p[2]
 
@@ -182,33 +185,23 @@ class Builder(AntennaBuilder):
                 (wire_length - lengths[i] / 2) / lengths[i],
             )
 
-        n_seg0 = self.nominal_nsegs
-        # Feed wire (T → S) meshed at the segment density of the longest
-        # n_seg0 arm (the reference wire).
-        ref_arm = max(math.dist(a, bb) for a, bb in zip(A, B))
-        n_seg1 = self.segs_for(math.dist(T, S), ref_arm)
-
+        # Every wire meshes at the design density (auto_mesh: nominal_nsegs
+        # per design_freq quarter-wave). The short risers (S→A / T→Ay,
+        # ~0.2 m) and the feed thereby stay proportional to their length —
+        # a full nominal count on them drives fine-mesh segment length
+        # toward the wire radius (the reduced-kernel Δ/a floor, issue #484).
         tups = []
         for i in range(n_bands):
-            # The short risers (S→A / T→Ay, ~0.2 m) mesh at the reference
-            # arm's density, NOT the full nominal count: n_seg0 on them
-            # drives fine-mesh segment length near the wire radius (N=321:
-            # 0.65 mm segs = 1.3a) — the reduced-kernel Δ/a floor, which
-            # wrecked the sin/pynec fine-mesh reactance (issue #484).
-            n_riser = self.segs_for(math.dist(S, A[i]), ref_arm)
-            tups.extend(build_path([S, A[i]], n_riser, None))
-            tups.extend(build_path([A[i], B[i]], n_seg0, None))
-            n_riser_y = self.segs_for(math.dist(T, Ay[i]), ref_arm)
-            tups.extend(build_path([T, Ay[i]], n_riser_y, None))
-            tups.extend(build_path([Ay[i], By[i]], n_seg0, None))
-        tups.append((T, S, n_seg1, 1 + 0j))
+            tups.append(Wire(S, A[i]))
+            tups.append(Wire(A[i], B[i]))
+            tups.append(Wire(T, Ay[i]))
+            tups.append(Wire(Ay[i], By[i]))
+        tups.append(Wire(T, S, ex=1 + 0j))
 
         return [
-            (
-                (x0, y0, z0 + self.base),
-                (x1, y1, z1 + self.base),
-                ns,
-                ev,
+            w._replace(
+                p0=(w.p0[0], w.p0[1], w.p0[2] + self.base),
+                p1=(w.p1[0], w.p1[1], w.p1[2] + self.base),
             )
-            for ((x0, y0, z0), (x1, y1, z1), ns, ev) in tups
+            for w in tups
         ]

--- a/src/antennaknobs/designs/multiband/trap_dipole.py
+++ b/src/antennaknobs/designs/multiband/trap_dipole.py
@@ -26,7 +26,7 @@ tuned independently; defaults are LC-resonant at design_freq.
 """
 
 from antennaknobs import AntennaBuilder
-from antennaknobs.network import Driven, Load, Network, PortOnWire
+from antennaknobs.network import Driven, Load, Network, PortOnWire, Wire
 
 import math
 from types import MappingProxyType
@@ -96,39 +96,39 @@ class Builder(AntennaBuilder):
         def p(x):
             return (x, 0.0, z)
 
-        # Catalog-norm meshing: nominal_nsegs per quarter-wave via segs_for,
-        # so the convergence slider reaches this design like every other.
+        # Structural wires mesh at the design density (auto_mesh:
+        # nominal_nsegs per design_freq quarter-wave), so the convergence
+        # slider reaches this design like every other. The trap wires keep
+        # their explicit segs_for count (1 segment at the default mesh —
+        # the trap L/C were tuned against that; retiring it is #525
+        # stage 3). The single continuous inner wire spans −X_inner →
+        # +X_inner so the named "feed" middle segment lands exactly at the
+        # geometric centre (x = 0). Splitting the inner span at the origin
+        # would put `feed` on the middle of *one half*, offsetting the
+        # feed point by X_inner/2 — a real asymmetry that broke the
+        # symmetric design. Engine parity coercion bumps to odd/even as
+        # needed.
         quarter = 0.25 * wavelength
-        n_outer = self.segs_for(outer, quarter)
-        # Single continuous inner wire spanning −X_inner → +X_inner so the
-        # named "feed" middle segment lands exactly at the geometric centre
-        # (x = 0). Splitting the inner span at the origin would put `feed`
-        # on the middle of *one half*, offsetting the feed point by
-        # X_inner/2 — a real asymmetry that broke the symmetric design.
-        # Engine parity coercion bumps to odd/even as needed.
-        n_inner = self.segs_for(2 * inner_arm, quarter)
 
         return [
             # Left arm, outer → trap.
-            (p(x_outer_tip_l), p(x_trap_outer_l), n_outer, None),
-            (
+            Wire(p(x_outer_tip_l), p(x_trap_outer_l)),
+            Wire(
                 p(x_trap_outer_l),
                 p(x_trap_inner_l),
-                self.segs_for(trap_seg, quarter),
-                None,
-                "trap_l",
+                n_seg=self.segs_for(trap_seg, quarter),
+                name="trap_l",
             ),
             # Inner span — one wire, feed at middle = origin.
-            (p(x_trap_inner_l), p(x_trap_inner_r), n_inner, None, "feed"),
+            Wire(p(x_trap_inner_l), p(x_trap_inner_r), name="feed"),
             # Right arm, trap → outer.
-            (
+            Wire(
                 p(x_trap_inner_r),
                 p(x_trap_outer_r),
-                self.segs_for(trap_seg, quarter),
-                None,
-                "trap_r",
+                n_seg=self.segs_for(trap_seg, quarter),
+                name="trap_r",
             ),
-            (p(x_trap_outer_r), p(x_outer_tip_r), n_outer, None),
+            Wire(p(x_trap_outer_r), p(x_outer_tip_r)),
         ]
 
     def build_network(self):

--- a/src/antennaknobs/designs/multiband/trap_fan_dipole.py
+++ b/src/antennaknobs/designs/multiband/trap_fan_dipole.py
@@ -34,7 +34,7 @@ exactly as NEC2's ld_card type-1 would.
 """
 
 from antennaknobs import AntennaBuilder
-from antennaknobs.network import Driven, Load, Network, PortOnWire
+from antennaknobs.network import Driven, Load, Network, PortOnWire, Wire
 
 import math
 from types import MappingProxyType
@@ -71,8 +71,8 @@ C_LIGHT_MHZ_M = 299.792458
 # bands largely unchanged. (Band-0 shift has near-zero leverage on
 # Re17 — kept at 1.0.)
 # Length factors tuned against MomwireEngine with BSplineSolver(degree=2)
-# at nominal_nsegs=41. After moving to adaptive per-wire segmentation
-# (target_seg_len = max_wire / nominal_nsegs, see build_wires), both Bs2
+# at nominal_nsegs=41. After moving to per-wire design-density
+# segmentation (now auto_mesh, see build_wires), both Bs2
 # and the (since retired) Triangular basis stay essentially flat across N=21..81 — drift ≤ 0.22 Ω
 # on every band — and agree with each other to ~1 Ω at the converged
 # limit. Sinusoidal still wanders 2–8 Ω over the same N range (basis-
@@ -131,6 +131,11 @@ class Builder(AntennaBuilder):
             # frontend overwrites it from the meas-freq slider on every
             # tick; this default only seeds the very first response.
             "freq": _BAND_15_10["trap_freq"],
+            # Geometry is sized from each band's full_freq / trap_freq /
+            # length factors; design_freq only anchors auto_mesh's density
+            # scale (nominal_nsegs per quarter-wave), so it is hidden from
+            # the UI.
+            "design_freq": _BAND_15_10["trap_freq"],
             "base": 7.0,
             # Same fan-spoke droop angle as fandipole — each spoke drops at
             # this droop angle (deg) from the cone apex outward
@@ -158,6 +163,7 @@ class Builder(AntennaBuilder):
             "ui_params": MappingProxyType(
                 {
                     "n_bands": {"min": 1, "max": 2, "step": 1},
+                    "design_freq": {"hidden": True},
                     "bands": {
                         "label_template": "band {i}",
                         "repeat_count": "n_bands",
@@ -312,55 +318,46 @@ class Builder(AntennaBuilder):
             tip = offset_outward(A[i], q1 + trap_seg + q2)
             spokes.append((trap_in, trap_out, tip))
 
-        # Adaptive segmentation: size each variable-length wire (cone +
-        # inner outer + outer) so segment length is near-constant across
-        # the antenna. nominal_nsegs sets the count for the longest such
-        # wire; everything else scales proportionally. Trap segments are
-        # pinned to 1 (load-port convention — the named port lives on a
-        # single basis function). The feed bridge meshes via n_for like
-        # the rest (1 segment at the default mesh, which is fine for the
-        # BSpline d=2 basis this design is tuned against; the retired
-        # triangular basis couldn't drive a 1-segment feed gap).
-        adaptive_lengths = []
-        for i, (trap_in, trap_out, tip) in enumerate(spokes):
-            adaptive_lengths.append(dist(S, A[i]))
-            adaptive_lengths.append(dist(A[i], trap_in))
-            adaptive_lengths.append(dist(trap_out, tip))
-        target_seg_len = max(adaptive_lengths) / self.nominal_nsegs
-
-        def n_for(length):
-            return max(1, round(length / target_seg_len))
-
+        # Structural wires (cone + inner outer + outer + feed) mesh at the
+        # design density (auto_mesh: nominal_nsegs per design_freq
+        # quarter-wave), so segment length is near-constant across the
+        # antenna. Trap segments are pinned to 1 (load-port convention —
+        # the named port lives on a single basis function, and the trap
+        # L/C were tuned against 1-seg trap wires; retiring the pin is
+        # #525 stage 3). The feed bridge resolves to 1 segment at the
+        # default mesh, which is fine for the BSpline d=2 basis this
+        # design is tuned against; the retired triangular basis couldn't
+        # drive a 1-segment feed gap.
         tups = []
         for i, (trap_in, trap_out, tip) in enumerate(spokes):
             # +y arm
-            tups.append((S, A[i], n_for(dist(S, A[i])), None))
-            tups.append((A[i], trap_in, n_for(dist(A[i], trap_in)), None))
-            tups.append((trap_in, trap_out, 1, None, f"trap_p_b{i}"))
-            tups.append((trap_out, tip, n_for(dist(trap_out, tip)), None))
+            tups.append(Wire(S, A[i]))
+            tups.append(Wire(A[i], trap_in))
+            tups.append(Wire(trap_in, trap_out, n_seg=1, name=f"trap_p_b{i}"))
+            tups.append(Wire(trap_out, tip))
 
             # −y arm (mirror via ry)
             Ay = ry(A[i])
             tin_y = ry(trap_in)
             tout_y = ry(trap_out)
             tip_y = ry(tip)
-            tups.append((T, Ay, n_for(dist(T, Ay)), None))
-            tups.append((Ay, tin_y, n_for(dist(Ay, tin_y)), None))
-            tups.append((tin_y, tout_y, 1, None, f"trap_n_b{i}"))
-            tups.append((tout_y, tip_y, n_for(dist(tout_y, tip_y)), None))
+            tups.append(Wire(T, Ay))
+            tups.append(Wire(Ay, tin_y))
+            tups.append(Wire(tin_y, tout_y, n_seg=1, name=f"trap_n_b{i}"))
+            tups.append(Wire(tout_y, tip_y))
 
         # Feed wire — named "feed", source supplied by build_network().
-        # Meshed via n_for like the rest (1 segment at the default mesh);
-        # the BSpline d=2 basis handles a 1-segment feed cleanly.
-        tups.append((T, S, n_for(dist(T, S)), None, "feed"))
+        tups.append(Wire(T, S, name="feed"))
 
         # Lift to base height.
         zoff = self.base
-        lifted = []
-        for t in tups:
-            (x0, y0, z0), (x1, y1, z1) = t[0], t[1]
-            lifted.append(((x0, y0, z0 + zoff), (x1, y1, z1 + zoff), *t[2:]))
-        return lifted
+        return [
+            w._replace(
+                p0=(w.p0[0], w.p0[1], w.p0[2] + zoff),
+                p1=(w.p1[0], w.p1[1], w.p1[2] + zoff),
+            )
+            for w in tups
+        ]
 
     def build_network(self):
         bands = tuple(self.bands)

--- a/src/antennaknobs/designs/multiband/twoband_fan_dipole.py
+++ b/src/antennaknobs/designs/multiband/twoband_fan_dipole.py
@@ -21,6 +21,7 @@ from math import sqrt
 from types import MappingProxyType
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +88,10 @@ class Builder(AntennaBuilder):
             # The band group's link_meas_freq_to_param wires each band's `freq`
             # leaf to this when a band row is selected.
             "freq": 28.47,
+            # Geometry is hand-tuned per band in absolute metres;
+            # design_freq only anchors auto_mesh's density scale
+            # (nominal_nsegs per quarter-wave), so it is hidden from the UI.
+            "design_freq": 28.47,
             "base": 7.0,
             # In-plane spread of the two bands about the y axis (deg). 0 keeps
             # each band in its own x = ±s/√2 plane (a true parallel fan).
@@ -139,6 +144,7 @@ class Builder(AntennaBuilder):
                         "angle_deg": {"min": 0.0, "max": 60.0},
                     },
                     "s": {"min": 0.05, "max": 0.8, "step": 0.01, "precision": 2},
+                    "design_freq": {"hidden": True},
                     "eps": {"min": 0.001, "max": 0.05, "step": 0.001, "precision": 3},
                     "gap_angle_deg": {"min": 0.0, "max": 30.0},
                 }
@@ -173,7 +179,6 @@ class Builder(AntennaBuilder):
 
         S = (0, eps, 0)
         T = ry(S)
-        n_seg0 = self.nominal_nsegs
 
         # Per band: a junction point G a distance `s` out (band 0 to +x, band 1
         # to -x) and the drooping tip beyond it.
@@ -187,10 +192,11 @@ class Builder(AntennaBuilder):
             junctions.append(G)
             tips.append(tip)
 
-        # Feed gap T->S refines with the mesh (issue #435); band 0's arm
-        # (junction -> tip) is the reference-length wire carrying n_seg0.
+        # Arms and the feed gap mesh at the design density (auto_mesh:
+        # nominal_nsegs per design_freq quarter-wave; the feed gap thereby
+        # refines with the mesh, issue #435). Band 0's arm is the links'
+        # density reference.
         ref_arm = math.dist(junctions[0], tips[0])
-        n_seg1 = self.segs_for(math.dist(T, S), ref_arm)
 
         # The feed-split links must refine WITH the arms (issue #484): a
         # fixed count leaves the G junctions ever more graded as the mesh
@@ -205,23 +211,21 @@ class Builder(AntennaBuilder):
         # 2-band case.
         tups = []
         for G in junctions:
-            tups.append((S, G, n_link, None))
+            tups.append(Wire(S, G, n_seg=n_link))
         for G, tip in zip(junctions, tips):
-            tups.append((G, tip, n_seg0, None))
+            tups.append(Wire(G, tip))
         for G in junctions:
-            tups.append((T, ry(G), n_link, None))
+            tups.append(Wire(T, ry(G), n_seg=n_link))
         for G, tip in zip(junctions, tips):
-            tups.append((ry(G), ry(tip), n_seg0, None))
-        tups.append((T, S, n_seg1, 1 + 0j))
+            tups.append(Wire(ry(G), ry(tip)))
+        tups.append(Wire(T, S, ex=1 + 0j))
 
         return [
-            (
-                (x0, y0, z0 + self.base),
-                (x1, y1, z1 + self.base),
-                ns,
-                ev,
+            w._replace(
+                p0=(w.p0[0], w.p0[1], w.p0[2] + self.base),
+                p1=(w.p1[0], w.p1[1], w.p1[2] + self.base),
             )
-            for ((x0, y0, z0), (x1, y1, z1), ns, ev) in tups
+            for w in tups
         ]
 
 


### PR DESCRIPTION
## Summary
- Converts the multiband family's structural wires to the auto-mesh `Wire()` idiom (`n_seg=None` → nominal_nsegs per design_freq quarter-wave), #525 stage 2.
- **fandipole**: all wires (risers, arms, feed) now mesh at the design density; added a hidden `design_freq` (= default freq, 28.47 MHz — geometry is sized per band). The low-band arms had been carrying a flat nominal count (20m arm at 21 segs where design density says 39), so the 5-band variants see genuine density-correction churn — see below.
- **trap_dipole**: structural arms + inner feed span converted; **trap wires keep their explicit `segs_for` count** (1 seg at the default mesh — the trap L/C were tuned against that; retiring the pin is stage 3). The count formula is identical to auto_mesh's, so this design is bit-for-bit zero churn.
- **trap_fan_dipole**: cone/inner/outer/feed wires converted; **trap wires stay pinned at `n_seg=1`** (load-port convention + stage-3 L/C retune). Added a hidden `design_freq` (= default freq, 28.47 MHz). Replaces the local `target_seg_len`/`n_for` machinery with the design density; counts shift slightly (21→23, 16→18, 4→5) with ≤0.1 % impedance churn.
- **twoband_fan_dipole**: arms + feed gap converted; the **link wires keep `max(5, segs_for(...))` exactly as-is** (validated floor from PR #520). Added a hidden `design_freq` (= default freq, 28.47 MHz).
- **hexbeam_5band**: skipped — already converted in #524 (its explicit `n_seg_feed` is deliberate jumper bookkeeping).

## Churn (bs2 @ N=21, defaults)

| design | variant | total segs before → after | Z before → after (Ω) | \|ΔZ\|/\|Z\| |
|---|---|---|---|---|
| fandipole | default | 221 → 295 | 41.09−25.52j → 42.18−22.98j | 5.7 % † |
| fandipole | five_band | 221 → 295 | 41.09−25.52j → 42.18−22.98j | 5.7 % † |
| fandipole | pair_17_15 | 89 → 123 | 66.16+25.61j → 66.35+26.50j | 1.3 % |
| fandipole | pair_12_10 | 93 → 91 | 69.44+37.83j → 69.43+37.75j | 0.1 % |
| trap_dipole | default | 64 → 64 | 82.63+58.54j → 82.63+58.54j | 0 % |
| trap_fan_dipole | default | 103 → 113 | 53.38−0.84j → 53.37−0.87j | 0.1 % |
| trap_fan_dipole | band0_inner | 103 → 113 | 51.32−1.15j → 51.34−1.07j | 0.2 % |
| trap_fan_dipole | band1_inner | 103 → 113 | 53.38−0.84j → 53.37−0.87j | 0.1 % |
| trap_fan_dipole | band0_full | 103 → 113 | 48.56−0.55j → 48.57−0.53j | 0.05 % |
| trap_fan_dipole | band1_full | 103 → 113 | 48.08−0.56j → 48.08−0.56j | 0 % |
| twoband_fan_dipole | default | 105 → 105 | 56.63−8.79j → 56.62−8.83j | 0.07 % |
| twoband_fan_dipole | s07 | 117 → 87 | 46.87−18.38j → 46.85−18.45j | 0.15 % |
| twoband_fan_dipole | s05 | 105 → 85 | 61.64+29.25j → 61.62+29.17j | 0.1 % |
| twoband_fan_dipole | s03 | 105 → 93 | 97.95+136.28j → 97.88+136.08j | 0.1 % |
| twoband_fan_dipole | s025 | 105 → 95 | 43.78−70.10j → 43.78−70.11j | 0.01 % |
| twoband_fan_dipole | s02 | 105 → 99 | 45.85−63.01j → 45.85−63.02j | 0.01 % |
| twoband_fan_dipole | s015 | 105 → 101 | 48.02−55.71j → 48.02−55.71j | 0 % |
| twoband_fan_dipole | s01 | 105 → 103 | 50.29−48.15j → 50.30−48.14j | 0.02 % |
| twoband_fan_dipole | s01_eps001 | 105 → 103 | 54.09−29.15j → 54.10−29.14j | 0.02 % |
| twoband_fan_dipole | current_physical | 105 → 101 | 238.81+448.27j → 237.96+446.91j | 0.3 % |

† **Genuine density correction, kept deliberately** (over the ~2 % budget). The 5-band fandipole's arms all carried the flat nominal count, so the 20m arm (4.9 m) was meshed at barely half the design density. A bs2 ladder shows both meshings converge to the same limit (~44−19j) and the auto-meshed N=21 point is *closer* to it than the old one:

| N | old (flat-count) | new (auto-mesh) |
|---|---|---|
| 21 | 41.09−25.52j | 42.18−22.98j |
| 41 | 42.78−21.55j | 43.14−20.72j |
| 81 | 43.50−19.88j | 43.90−18.99j |

The pair variants (shorter spread of arm lengths) stay within budget. twoband_fan_dipole's s-sweep variants *lose* segments (their hand-tuned arms are shorter than λ/4 at design_freq) with ≤0.3 % churn — the design was already converged there.

## Test plan
- [x] `ruff check` + `ruff format --check` clean on the four files
- [x] Full fast suite green (memory-capped shell)
- [x] Churn probe before/after on every variant (table above); fandipole over-budget churn ladder-verified as density correction

🤖 Generated with [Claude Code](https://claude.com/claude-code)
