### PR TITLE
refactor(designs): loops family to auto-mesh Wire() idiom (#525 stage 2)

### DIFF
--- a/src/antennaknobs/designs/loops/bisquare.py
+++ b/src/antennaknobs/designs/loops/bisquare.py
@@ -29,6 +29,7 @@ Geometry, in the framework's (x, y, z) convention:
 """
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 from types import MappingProxyType
 import math
 
@@ -71,7 +72,6 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         side = self.side_frac * wavelength * self.length_factor
         # Square standing on a corner: the half-diagonal is side / sqrt(2).
@@ -82,19 +82,17 @@ class Builder(AntennaBuilder):
         Tc = (0.0, 0.0, self.base + 2 * hd)  # top corner
         Lc = (0.0, -hd, self.base + hd)  # left corner
 
-        ns = self.segs_for(side, quarter)
         feed = 2 * eps
         # Feed gap on the lower-right side, a short `feed` distance up from the
         # bottom corner along the Bc -> Rc direction (unit (0, 1, 1)/sqrt(2)).
         u = hd / side  # = 1/sqrt(2)
         F = (0.0, feed * u, self.base + feed * u)
 
-        tups = []
-        tups.append(
-            (Bc, F, self.segs_for(feed, quarter), 1 + 0j)
-        )  # driven gap at the corner (length `feed` along the side)
-        tups.append((F, Rc, self.segs_for(side - feed, quarter), None))
-        tups.append((Rc, Tc, ns, None))  # upper-right side
-        tups.append((Tc, Lc, ns, None))  # upper-left side
-        tups.append((Lc, Bc, ns, None))  # lower-left side
-        return tups
+        return [
+            # driven gap at the corner (length `feed` along the side)
+            Wire(Bc, F, ex=1 + 0j),
+            Wire(F, Rc),  # rest of the lower-right side
+            Wire(Rc, Tc),  # upper-right side
+            Wire(Tc, Lc),  # upper-left side
+            Wire(Lc, Bc),  # lower-left side
+        ]

--- a/src/antennaknobs/designs/loops/delta_loop.py
+++ b/src/antennaknobs/designs/loops/delta_loop.py
@@ -4,6 +4,7 @@ import math
 from types import MappingProxyType
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 
 
 class Builder(AntennaBuilder):
@@ -35,13 +36,8 @@ class Builder(AntennaBuilder):
         cos_theta = math.cos(angle)
         tan_theta = math.tan(angle)
 
-        def build_path(lst, ns, ex):
-            return ((a, b, ns, ex) for a, b in zip(lst[:-1], lst[1:]))
-
         def ry(p):
             return p[0], -p[1], p[2]
-
-        n_seg0 = self.nominal_nsegs
 
         d = driver
         # y of the top corner (half the top-edge width), in closed form from the
@@ -64,11 +60,9 @@ class Builder(AntennaBuilder):
 
         B, T = ry(A), ry(S)
 
-        n_seg1 = self.segs_for(math.dist(T, S), math.dist(S, A))
-
-        tups = []
-
-        tups.extend(build_path([S, A, B, T], n_seg0, None))
-        tups.extend(build_path([T, S], n_seg1, 1 + 0j))
-
-        return tups
+        return [
+            Wire(S, A),
+            Wire(A, B),
+            Wire(B, T),
+            Wire(T, S, ex=1 + 0j),
+        ]

--- a/src/antennaknobs/designs/loops/delta_loop_flyby.py
+++ b/src/antennaknobs/designs/loops/delta_loop_flyby.py
@@ -59,32 +59,29 @@ class Builder(AntennaBuilder):
 
         eps = 0.05
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
         target = self.length_factor * wavelength
-        n_body = self.nominal_nsegs
 
         def geometry(side):
             # Fly the whole loop with the feed at z = 0 -- the top height is
             # added by the z-offset pass below, not known during the flight.
             S = (0.0, eps, 0.0)  # right feed terminal; loop is planar in x = 0
-            drone = Drone(position=S, nominal_nsegs=n_body, ref=quarter)
+            drone = Drone(position=S)
 
             # Nose out along the top edge, then tilt up onto the right slant.
             drone.face(heading=(0.0, 1.0, 0.0), up=(1.0, 0.0, 0.0))
             drone.yaw(self.angle_deg)
 
             drone.pay_out()
-            drone.forward(side, nsegs=n_body)  # S -> A  (right slant, given length)
+            drone.forward(side)  # S -> A  (right slant, given length)
             drone.yaw(180.0 - self.angle_deg)  # exterior angle at A
             # A -> B: fly through the symmetry plane y = 0 to an equal distance
             # past it, landing on the mirror corner -- the top edge, no length
             # computed and nothing reflected.
-            drone.forward_through_plane((0.0, 1.0, 0.0, 0.0), nsegs=n_body)
+            drone.forward_through_plane((0.0, 1.0, 0.0, 0.0))
             drone.yaw(180.0 - self.angle_deg)  # exterior angle at B
-            drone.forward(side, nsegs=n_body)  # B -> T  (left slant, given length)
-            n_feed = self.segs_for(math.dist(drone.position, S), side)
+            drone.forward(side)  # B -> T  (left slant, given length)
             drone.feed(1 + 0j)
-            drone.close(nsegs=n_feed)  # T -> S  (driven feed gap, fly home)
+            drone.close()  # T -> S  (driven feed gap, fly home)
             return drone.wires()
 
         def total(side):

--- a/src/antennaknobs/designs/loops/delta_loop_reflected.py
+++ b/src/antennaknobs/designs/loops/delta_loop_reflected.py
@@ -34,6 +34,7 @@ import math
 from types import MappingProxyType
 
 from antennaknobs import AntennaBuilder, Drone
+from antennaknobs.network import Wire
 
 
 class Builder(AntennaBuilder):
@@ -64,13 +65,9 @@ class Builder(AntennaBuilder):
         eps = 0.05
         wavelength = 299.792458 / self.design_freq
         target = self.length_factor * wavelength
-        n0 = self.nominal_nsegs
 
         def ry(p):
             return (p[0], -p[1], p[2])
-
-        def build_path(lst, ns, ex):
-            return [(a, b, ns, ex) for a, b in zip(lst[:-1], lst[1:])]
 
         def geometry(side):
             # Build with the feed at z = 0 (no top height involved yet). Fly the
@@ -84,21 +81,25 @@ class Builder(AntennaBuilder):
                 .position
             )
             B, T = ry(A), ry(S)
-            n1 = self.segs_for(math.dist(T, S), math.dist(S, A))
-            return build_path([S, A, B, T], n0, None) + build_path([T, S], n1, 1 + 0j)
+            return [
+                Wire(S, A),
+                Wire(A, B),
+                Wire(B, T),
+                Wire(T, S, ex=1 + 0j),
+            ]
 
         def total(side):
-            return sum(math.dist(p0, p1) for p0, p1, _ns, _ex in geometry(side))
+            return sum(math.dist(w.p0, w.p1) for w in geometry(side))
 
         # Size by total wire length, numerically (no closed-form corner position).
         side = brentq(lambda s: total(s) - target, 1e-3, 2.0 * wavelength)
         wires = geometry(side)
 
         # z-offset pass: lift the whole loop so the top edge seats at `base`.
-        top_z = max(p[2] for e in wires for p in (e[0], e[1]))
+        top_z = max(p[2] for w in wires for p in (w.p0, w.p1))
         shift = self.base - top_z
 
         def lift(p):
             return (p[0], p[1], p[2] + shift)
 
-        return [(lift(a), lift(b), ns, ex) for a, b, ns, ex in wires]
+        return [w._replace(p0=lift(w.p0), p1=lift(w.p1)) for w in wires]

--- a/src/antennaknobs/designs/loops/delta_loop_slanted.py
+++ b/src/antennaknobs/designs/loops/delta_loop_slanted.py
@@ -4,6 +4,7 @@ from antennaknobs import AntennaBuilder
 import math
 
 from antennaknobs import Transform, TransformStack
+from antennaknobs.network import Wire
 
 from types import MappingProxyType
 
@@ -45,13 +46,8 @@ class Builder(AntennaBuilder):
         cos_theta = math.cos(angle)
         tan_theta = math.tan(angle)
 
-        def build_path(lst, ns, ex):
-            return ((a, b, ns, ex) for a, b in zip(lst[:-1], lst[1:]))
-
         def ry(p):
             return p[0], -p[1], p[2]
-
-        n_seg0 = self.nominal_nsegs
 
         d = driver
         h = (cos_theta * (d - 2 * eps) + 2 * eps) / (2 * (cos_theta + 1))
@@ -81,14 +77,13 @@ class Builder(AntennaBuilder):
 
         SSS, AAA, BBB, TTT = ry(SS), ry(AA), ry(BB), ry(TT)
 
-        n_seg1 = self.segs_for(math.dist(TT, SS), math.dist(SS, AA))
-
-        tups = []
-
-        tups.extend(build_path([SS, AA, BB, TT], n_seg0, None))
-        tups.extend(build_path([TT, SS], n_seg1, 1 + 0j))
-
-        tups.extend(build_path([SSS, AAA, BBB, TTT], n_seg0, None))
-        tups.extend(build_path([SSS, TTT], n_seg1, 1 + 0j))
-
-        return tups
+        return [
+            Wire(SS, AA),
+            Wire(AA, BB),
+            Wire(BB, TT),
+            Wire(TT, SS, ex=1 + 0j),
+            Wire(SSS, AAA),
+            Wire(AAA, BBB),
+            Wire(BBB, TTT),
+            Wire(SSS, TTT, ex=1 + 0j),
+        ]

--- a/src/antennaknobs/designs/loops/delta_loop_topdown.py
+++ b/src/antennaknobs/designs/loops/delta_loop_topdown.py
@@ -27,6 +27,7 @@ import math
 from types import MappingProxyType
 
 from antennaknobs import AntennaBuilder, Drone
+from antennaknobs.network import Wire
 
 
 class Builder(AntennaBuilder):
@@ -57,36 +58,34 @@ class Builder(AntennaBuilder):
 
         eps = 0.05
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
         target = self.length_factor * wavelength
-        n0 = self.nominal_nsegs
 
         def ry(p):
             return (p[0], -p[1], p[2])
-
-        def build_path(lst, ns, ex):
-            return [(a, b, ns, ex) for a, b in zip(lst[:-1], lst[1:])]
 
         def geometry(half_top):
             # Start at the top centre; fly the right half pen-up to find its two
             # vertices -- out to the top corner A, then down the slant until it
             # crosses the feed plane y = eps. The top is at `base` from move one.
-            drone = Drone(nominal_nsegs=n0, ref=quarter)
+            drone = Drone()
             drone.move_to((0.0, 0.0, self.base))
             drone.face(heading=(0.0, 1.0, 0.0), up=(1.0, 0.0, 0.0))
             A = drone.forward(half_top).position
             drone.yaw(180.0 + self.angle_deg)  # turn down onto the slant
             S = drone.forward_to_plane((0.0, 1.0, 0.0, eps)).position
             B, T = ry(A), ry(S)
-            n1 = self.segs_for(math.dist(T, S), math.dist(A, B))
 
-            # build_path stitches the four corners into the perimeter and feed
-            # gap -- the same helper delta_loop and delta_loop_reflected use. No
+            # Stitch the four corners into the perimeter and feed gap. No
             # second drone pass: the flight only found the points A and S.
-            return build_path([S, A, B, T], n0, None) + build_path([T, S], n1, 1 + 0j)
+            return [
+                Wire(S, A),
+                Wire(A, B),
+                Wire(B, T),
+                Wire(T, S, ex=1 + 0j),
+            ]
 
         def total(half_top):
-            return sum(math.dist(p0, p1) for p0, p1, _ns, _ex in geometry(half_top))
+            return sum(math.dist(w.p0, w.p1) for w in geometry(half_top))
 
         # Solve the top half-width so the total wire length hits the target.
         half_top = brentq(lambda w: total(w) - target, eps, wavelength)

--- a/src/antennaknobs/designs/loops/diamond_loop.py
+++ b/src/antennaknobs/designs/loops/diamond_loop.py
@@ -1,6 +1,7 @@
 """Full-wave diamond (square) loop fed at the bottom corner."""
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 import math
 
 from types import MappingProxyType
@@ -38,13 +39,8 @@ class Builder(AntennaBuilder):
         cos_theta = math.cos(angle)
         tan_theta = math.tan(angle)
 
-        def build_path(lst, ns, ex):
-            return ((a, b, ns, ex) for a, b in zip(lst[:-1], lst[1:]))
-
         def ry(p):
             return p[0], -p[1], p[2]
-
-        n_seg0 = self.nominal_nsegs
 
         d = driver
         # Apex height, solved from the constraint that the total wire perimeter
@@ -77,11 +73,10 @@ class Builder(AntennaBuilder):
 
         C, T = ry(A), ry(S)
 
-        n_seg1 = self.segs_for(math.dist(T, S), math.dist(A, B))
-
-        tups = []
-
-        tups.extend(build_path([S, A, B, C, T], n_seg0, None))
-        tups.extend(build_path([T, S], n_seg1, 1 + 0j))
-
-        return tups
+        return [
+            Wire(S, A),
+            Wire(A, B),
+            Wire(B, C),
+            Wire(C, T),
+            Wire(T, S, ex=1 + 0j),
+        ]

--- a/src/antennaknobs/designs/loops/diamond_loop_turnstile.py
+++ b/src/antennaknobs/designs/loops/diamond_loop_turnstile.py
@@ -1,6 +1,7 @@
 """Two diamond loops crossed and fed in phase quadrature (turnstile)."""
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 import math
 
 from types import MappingProxyType
@@ -29,16 +30,11 @@ class Builder(AntennaBuilder):
         cos_theta = math.cos(angle)
         tan_theta = math.tan(angle)
 
-        def build_path(lst, ns, ex):
-            return ((a, b, ns, ex) for a, b in zip(lst[:-1], lst[1:]))
-
         def ry(p):
             return p[0], -p[1], p[2]
 
         def rx(p):
             return -p[0], p[1], p[2]
-
-        n_seg0 = self.nominal_nsegs
 
         d = driver
         # Apex height, solved from the constraint that the total wire perimeter
@@ -70,19 +66,25 @@ class Builder(AntennaBuilder):
         S = (0, eps, b - (2 * h - eps) * tan_theta)
         C, T = ry(A), ry(S)
 
-        n_seg1 = self.segs_for(math.dist(T, S), math.dist(A, B))
-
-        tups = []
-
-        tups.extend(build_path([S, A, B, C, T], n_seg0, None))
-        tups.extend(build_path([T, S], n_seg1, 1 + 0j))
+        tups = [
+            Wire(S, A),
+            Wire(A, B),
+            Wire(B, C),
+            Wire(C, T),
+            Wire(T, S, ex=1 + 0j),
+        ]
 
         B = (0, 0, eps + b)
         A = (h, 0, eps + b - tan_theta * h)
         S = (eps, 0, eps + b - (2 * h - eps) * tan_theta)
         C, T = rx(A), rx(S)
 
-        tups.extend(build_path([S, A, B, C, T], n_seg0, None))
-        tups.extend(build_path([T, S], n_seg1, 1 + 0j))
+        tups += [
+            Wire(S, A),
+            Wire(A, B),
+            Wire(B, C),
+            Wire(C, T),
+            Wire(T, S, ex=1 + 0j),
+        ]
 
         return tups

--- a/src/antennaknobs/designs/loops/horizontal_loop.py
+++ b/src/antennaknobs/designs/loops/horizontal_loop.py
@@ -33,6 +33,7 @@ Geometry, in the framework's (x, y, z) convention:
 """
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 from types import MappingProxyType
 
 
@@ -77,15 +78,11 @@ class Builder(AntennaBuilder):
         eps = 0.05
 
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         side = self.side_frac * wavelength * self.length_factor
         h = side / 2.0
         z = self.base
 
-        # Keep the per-segment length roughly uniform across wires (good NEC
-        # practice at the corner junctions). Odd counts so the side centre
-        # falls on a segment.
         # Four corners of the flat square, all at z = base.
         A = (-h, -h, z)
         B = (h, -h, z)
@@ -97,15 +94,13 @@ class Builder(AntennaBuilder):
         F0 = (-h, -feed / 2.0, z)  # gap start, just below the midpoint
         F1 = (-h, feed / 2.0, z)  # gap end, just above the midpoint
 
-        tups = []
         # Side A->D split into: A->gap-start (passive), gap (driven, 1 seg),
         # gap-end->D (passive). The remaining three sides close the loop.
-        tups.append((A, F0, self.segs_for(h - feed / 2.0, quarter), None))
-        tups.append((F0, F1, self.segs_for(feed, quarter), 1 + 0j))  # driven gap
-        tups.append((F1, D, self.segs_for(h - feed / 2.0, quarter), None))
-        tups.append((D, C, self.segs_for(side, quarter), None))  # top side
-        tups.append((C, B, self.segs_for(side, quarter), None))  # right side
-        tups.append(
-            (B, A, self.segs_for(side, quarter), None)
-        )  # bottom side, closes the loop
-        return tups
+        return [
+            Wire(A, F0),
+            Wire(F0, F1, ex=1 + 0j),  # driven gap
+            Wire(F1, D),
+            Wire(D, C),  # top side
+            Wire(C, B),  # right side
+            Wire(B, A),  # bottom side, closes the loop
+        ]

--- a/src/antennaknobs/designs/loops/horizontal_loop_drone.py
+++ b/src/antennaknobs/designs/loops/horizontal_loop_drone.py
@@ -65,11 +65,7 @@ class Builder(AntennaBuilder):
         # horizontal and yaw(90) turns stay in the z = base plane -- no trig.
         # Start just past corner A on side A->B; we'll fly back to the matching
         # point on side D->A and let the driven segment bridge the corner.
-        drone = Drone(
-            position=(-h + inset, -h, self.base),
-            nominal_nsegs=self.nominal_nsegs,
-            ref=quarter,
-        )
+        drone = Drone(position=(-h + inset, -h, self.base))
 
         drone.pay_out()
         drone.forward(side - inset)  # -> B   (rest of side A->B)

--- a/src/antennaknobs/designs/loops/inv_delta_loop.py
+++ b/src/antennaknobs/designs/loops/inv_delta_loop.py
@@ -1,6 +1,7 @@
 """Inverted delta loop — the triangle flipped so the feed edge sits at the top."""
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 import math
 
 from types import MappingProxyType
@@ -35,13 +36,8 @@ class Builder(AntennaBuilder):
         cos_theta = math.cos(angle)
         tan_theta = math.tan(angle)
 
-        def build_path(lst, ns, ex):
-            return ((a, b, ns, ex) for a, b in zip(lst[:-1], lst[1:]))
-
         def ry(p):
             return p[0], -p[1], p[2]
-
-        n_seg0 = self.nominal_nsegs
 
         d = driver
         h = (cos_theta * (d - 2 * eps) + 2 * eps) / (2 * (cos_theta + 1))
@@ -63,11 +59,9 @@ class Builder(AntennaBuilder):
 
         B, T = ry(A), ry(S)
 
-        n_seg1 = self.segs_for(math.dist(T, S), math.dist(S, A))
-
-        tups = []
-
-        tups.extend(build_path([S, A, B, T], n_seg0, None))
-        tups.extend(build_path([T, S], n_seg1, 1 + 0j))
-
-        return tups
+        return [
+            Wire(S, A),
+            Wire(A, B),
+            Wire(B, T),
+            Wire(T, S, ex=1 + 0j),
+        ]

--- a/src/antennaknobs/designs/loops/quad.py
+++ b/src/antennaknobs/designs/loops/quad.py
@@ -35,6 +35,7 @@ The loops lie in planes of constant x.
 """
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 from types import MappingProxyType
 
 
@@ -77,7 +78,6 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         side_d = self.driver_circ * wavelength / 4
         side_r = self.reflector_circ * wavelength / 4
@@ -97,16 +97,15 @@ class Builder(AntennaBuilder):
             BR = (x, half, z0)
             TR = (x, half, z1)
             TL = (x, -half, z1)
-            ns = self.segs_for(side, quarter)
             wires = []
             if fed:
-                wires.append((BL, BR, ns, 1 + 0j))
+                wires.append(Wire(BL, BR, ex=1 + 0j))
             else:
-                wires.append((BL, BR, ns, None))
+                wires.append(Wire(BL, BR))
             # remaining three sides (passive for both loops)
-            wires.append((BR, TR, ns, None))
-            wires.append((TR, TL, ns, None))
-            wires.append((TL, BL, ns, None))
+            wires.append(Wire(BR, TR))
+            wires.append(Wire(TR, TL))
+            wires.append(Wire(TL, BL))
             return wires
 
         tups = []

--- a/src/antennaknobs/designs/loops/triangular_skyloop.py
+++ b/src/antennaknobs/designs/loops/triangular_skyloop.py
@@ -97,7 +97,6 @@ class Builder(AntennaBuilder):
         eps = 0.05
 
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         # Equilateral triangle, so each side is a third of the perimeter; the
         # perimeter is length_factor wavelengths (length_factor = 1 -> a nominal
@@ -118,19 +117,15 @@ class Builder(AntennaBuilder):
         # face() is needed: back up half a gap, lay the driven chamfer
         # straddling the vertex, then alternate -60 deg yaws between runs and
         # chamfers, staying in the z = base plane throughout.
-        drone = Drone(
-            position=(0.0, 0.0, self.base),
-            nominal_nsegs=self.nominal_nsegs,
-            ref=quarter,
-        )
+        drone = Drone(position=(0.0, 0.0, self.base))
         drone.jump(-gap / 2.0)
 
         drone.feed(1 + 0j).forward(gap)  # driven chamfer across apex
         drone.pay_out()
         drone.yaw(-60).forward(run)  # -> v_right
-        drone.yaw(-60).forward(gap, nsegs=1)  # passive chamfer across v_right
+        drone.yaw(-60).forward(gap)  # passive chamfer across v_right
         drone.yaw(-60).forward(run)  # -> v_left
-        drone.yaw(-60).forward(gap, nsegs=1)  # passive chamfer across v_left
+        drone.yaw(-60).forward(gap)  # passive chamfer across v_left
         drone.yaw(-60).close()  # final run, home to the apex chamfer
 
         return drone.wires()

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -1087,7 +1087,7 @@ def _auto_target_z0(cls) -> float:
         return 50.0
     try:
         b = cls()
-        n_feeds = sum(1 for *_, ev in b.build_wires() if ev is not None)
+        n_feeds = sum(1 for t in b.build_wires() if as_wire(t).ex is not None)
     except Exception:
         return 50.0
     return 50.0 * max(1, n_feeds)
@@ -1107,7 +1107,7 @@ def _auto_multi_feed(cls) -> bool:
     """
     try:
         b = cls()
-        n_feeds = sum(1 for *_, ev in b.build_wires() if ev is not None)
+        n_feeds = sum(1 for t in b.build_wires() if as_wire(t).ex is not None)
     except Exception:
         return False
     return n_feeds > 1

--- a/tests/test_drone.py
+++ b/tests/test_drone.py
@@ -241,7 +241,7 @@ def _undirected(builder):
     """{(sorted endpoint pair, is_driven)} for a design's wires, ignoring
     edge order, direction, and segment count."""
     out = set()
-    for p0, p1, _ns, ex in builder.build_wires():
+    for p0, p1, _ns, ex, *_rest in builder.build_wires():
         a = tuple(round(c, 9) for c in p0)
         b = tuple(round(c, 9) for c in p1)
         out.add((tuple(sorted([a, b])), ex is not None))


### PR DESCRIPTION
## Summary
- Converts the entire `loops` family to the auto-mesh `Wire()` idiom (`delta_loop` was already converted on this branch; this adds the other twelve designs).
- Coordinate builders (`bisquare`, `delta_loop_slanted`, `diamond_loop`, `diamond_loop_turnstile`, `horizontal_loop`, `inv_delta_loop`, `quad`) drop their `segs_for`/`nominal_nsegs`/`build_path` scaffolding and return `Wire()` entries with `None` counts.
- Drone builders (`delta_loop_flyby`, `delta_loop_topdown`, `horizontal_loop_drone`, `triangular_skyloop`) drop the `nominal_nsegs=`/`ref=` constructor args; per-move `nsegs=` pins removed too (`triangular_skyloop`'s two `nsegs=1` chamfer pins carried no "deliberate" marker, and the auto count resolves to 1 at any realistic density — zero churn). `delta_loop_reflected` keeps its pen-up point-finder `Drone` and returns `Wire()` entries.
- **Preserved / untouched**: `skyloop_lmatch.py` has no meshing code of its own — it inherits `triangular_skyloop` geometry and renames the driven chamfer to the network port `"feed"` (name preserved exactly; L-match network untouched). Its solve is byte-identical before/after.
- **Framework fix that this branch exposed** (second commit): `_auto_target_z0` / `_auto_multi_feed` in `web/adapter.py` unpacked the excitation as the *last* tuple field (`*_, ev`); a `Wire` NamedTuple's last field is `spec`, so arrays wrapping a Wire-converted design (e.g. `arrays.delta_looparray` over `loops.delta_loop`) counted zero feeds and fell back to 50 Ω / single-feed — 4 `test_web_server` z0 tests were red on this branch before this PR's fix. Fixed via the `as_wire` choke point.
- Docstring note: `delta_loop_reflected`/`delta_loop_topdown` module docstrings still narrate the (now removed) `build_path` helper; left as-is per the no-docstring-edits rule of this migration.
- `quad` (#435 fed-bottom-merge watchlist): counts and impedance are **byte-identical** before/after — its `segs_for(side, quarter)` was already exactly the auto-mesh density.

## Churn (bs2 @ N=21, defaults)

| design | variant | segs before → after | Z before → after |
|---|---|---|---|
| delta_loop | default | [21,21,21,1] → [30,29,30,1] | 110.50+43.46j → 110.51+43.54j |
| delta_loop | z200 | [21,21,21,1] → [26,38,26,1] | 226.41+36.80j → 226.25+36.41j |
| bisquare | default | [1,45,46,46,46] → unchanged | 119.70+388.80j → unchanged |
| delta_loop_flyby | default | [21,21,21,1] → [30,29,30,1] | 110.50+43.46j → 110.51+43.54j |
| delta_loop_reflected | default | [21,21,21,1] → [30,29,30,1] | 110.50+43.46j → 110.51+43.54j |
| delta_loop_topdown | default | [21,21,21,1] → [30,29,30,1] | 110.50+43.46j → 110.51+43.54j |
| delta_loop_slanted | default | [21,21,21,1]×2 → [31,29,31,1]×2 | 108.59+54.91j → 108.59+54.98j |
| delta_loop_slanted | slant0 | [21,21,21,1]×2 → [30,30,30,1]×2 | 114.23+41.65j → 114.24+41.74j |
| delta_loop_slanted | slant30 | [21,21,21,1]×2 → [32,26,32,1]×2 | 98.06+49.73j → 98.05+49.76j |
| diamond_loop | default / z200 | [21,21,21,21,1] → [22,23,23,22,1] | 220.46+58.75j → 220.46+58.77j |
| diamond_loop | z100 | [21,21,21,21,1] → [22,23,23,22,1] | 98.48+44.87j → 98.48+44.86j |
| diamond_loop_turnstile | default | [21,21,21,21,1]×2 → [22,23,23,22,1]×2 | 98.57+44.88j → 98.57+44.87j |
| horizontal_loop | default | [11,1,11,22,22,22] → unchanged | 124.84-2.11j → unchanged |
| horizontal_loop_drone | default | [21,21,21,21,1] → unchanged | 106.73-150.94j → unchanged |
| inv_delta_loop | default / z100 | [21,21,21,1] → [31,28,31,1] | 95.96+49.27j → 95.95+49.33j |
| inv_delta_loop | z200 | [21,21,21,1] → [27,37,27,1] | 217.48+66.77j → 217.40+66.61j |
| quad | default | [22,22,22,22,21,21,21,21] → unchanged | 130.11-0.47j → unchanged |
| skyloop_lmatch | default / band_locked | [1,29,1,29,1,29] → unchanged | 47.61-6.41j → unchanged |
| triangular_skyloop | default / band_locked | [1,29,1,29,1,29] → unchanged | 113.77+1.12j → unchanged |

Max churn 0.18 Ω (inv_delta_loop z200, |Z|≈228 → 0.08%), far inside the ~2% budget. The delta-loop-shaped designs pick up their correct per-length densities: the drone twins now mesh identically to the shipped `delta_loop`, and inv_delta_loop/slanted/diamond previously ran a uniform 21 segments per edge regardless of edge length.

## Test plan
- [x] `ruff check` / `ruff format --check` clean on all touched files
- [x] Full suite: 2665 passed / 4 failed pre-fix → adapter fix lands, `test_web_server.py` + `test_drone.py` + `test_delta_a_lint.py` re-run 475 passed, 2 skipped
- [x] Test assertion updated: `tests/test_drone.py::_undirected` unpacks with `*_rest` so 6-field `Wire` entries and plain 4-tuples both pass (was a hard 4-way unpack; red on this branch since the delta_loop commit)
- [x] Churn probe (bs2@21, free space, `ulimit -v` capped) before/after — table above
- [x] No catalog regeneration needed (no catalog-generation test complaints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)