### PR TITLE
refactor(designs): dipoles family to auto-mesh Wire() idiom (#525 stage 2)

### DIFF
--- a/src/antennaknobs/designs/dipoles/dipole_turnstile.py
+++ b/src/antennaknobs/designs/dipoles/dipole_turnstile.py
@@ -1,7 +1,7 @@
 """Crossed dipoles fed in phase quadrature (turnstile)."""
 
 from antennaknobs import AntennaBuilder
-import math
+from antennaknobs.network import Wire
 
 from types import MappingProxyType
 
@@ -28,25 +28,17 @@ class Builder(AntennaBuilder):
         length = wavelength * self.length_factor
         x = 0.5 * length
 
-        n_seg0 = self.nominal_nsegs
-
         # Two crossed half-wave dipoles, lower along x at z=base and upper
         # along y at z=base+gap_z. The 1+0j / 0+1j drive is the 90° turnstile
         # phasing that produces (near-)circular polarisation broadside.
-        tups = []
-
         z_lo = self.base
-        n_seg1 = self.segs_for(
-            math.dist((-eps, 0, z_lo), (eps, 0, z_lo)),
-            math.dist((-x, 0, z_lo), (-eps, 0, z_lo)),
-        )
-        tups.extend([((-x, 0, z_lo), (-eps, 0, z_lo), n_seg0, None)])
-        tups.extend([((eps, 0, z_lo), (x, 0, z_lo), n_seg0, None)])
-        tups.extend([((-eps, 0, z_lo), (eps, 0, z_lo), n_seg1, 1 + 0j)])
-
         z_hi = self.base + self.gap_z
-        tups.extend([((0, -x, z_hi), (0, -eps, z_hi), n_seg0, None)])
-        tups.extend([((0, eps, z_hi), (0, x, z_hi), n_seg0, None)])
-        tups.extend([((0, -eps, z_hi), (0, eps, z_hi), n_seg1, 0 + 1j)])
 
-        return tups
+        return [
+            Wire((-x, 0, z_lo), (-eps, 0, z_lo)),
+            Wire((eps, 0, z_lo), (x, 0, z_lo)),
+            Wire((-eps, 0, z_lo), (eps, 0, z_lo), ex=1 + 0j),
+            Wire((0, -x, z_hi), (0, -eps, z_hi)),
+            Wire((0, eps, z_hi), (0, x, z_hi)),
+            Wire((0, -eps, z_hi), (0, eps, z_hi), ex=0 + 1j),
+        ]

--- a/src/antennaknobs/designs/dipoles/folded_invvee.py
+++ b/src/antennaknobs/designs/dipoles/folded_invvee.py
@@ -1,6 +1,7 @@
 """Folded inverted-vee — the folded dipole's impedance step-up, with drooped arms."""
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 import math
 
 from types import MappingProxyType
@@ -30,13 +31,8 @@ class Builder(AntennaBuilder):
         z_sin = math.sin(angle)
         y_cos = math.cos(angle)
 
-        def build_path(lst, ns, ex):
-            return ((a, b, ns, ex) for a, b in zip(lst[:-1], lst[1:]))
-
         def ry(p):
             return p[0], -p[1], p[2]
-
-        n_seg0 = self.nominal_nsegs
 
         """
                     
@@ -69,26 +65,25 @@ class Builder(AntennaBuilder):
 
         D, T, C, t = ry(A), ry(S), ry(B), ry(s)
 
-        n_seg1 = self.segs_for(math.dist(A, B), math.dist(S, A))
-        n_seg2 = self.segs_for(math.dist(T, S), math.dist(S, A))
-
-        tups = []
-
-        tups.extend(build_path([S, A], n_seg0, None))
-        tups.extend(build_path([A, B], n_seg1, None))
-        tups.extend(build_path([B, s], n_seg0, None))
-        # The 0.1 m facing link gets the ARM's density (n_seg2, same length
-        # as the feed wire T-S), not the full nominal count: with n_seg0 a
-        # fine mesh drives this wire's segment length below the wire RADIUS
-        # (N=321: 0.31 mm segs on a 0.5 mm-radius wire, Δ/a = 0.62) — the
-        # classic reduced-kernel ill-posedness, which the folded element's
-        # stub antiresonance then amplifies into a wildly wrong sin/pynec
-        # impedance (issue #484: 280−1188j at N=321; proportional density
-        # holds the ladder flat at 223−30j through N=641).
-        tups.extend(build_path([s, t], n_seg2, None))
-        tups.extend(build_path([t, C], n_seg0, None))
-        tups.extend(build_path([C, D], n_seg1, None))
-        tups.extend(build_path([D, T], n_seg0, None))
-        tups.extend(build_path([T, S], n_seg2, 1 + 0j))
-
-        return tups
+        # Auto-mesh gives every wire the same segment length, which is
+        # exactly what this geometry needs: the two parallel conductors
+        # (S-A / B-s and t-C / D-T) stay density-matched, and the short
+        # facing link s-t and feed T-S get a proportionally small count
+        # instead of the full nominal one. The latter matters — a full
+        # nominal count on the 0.1 m link drives its segment length below
+        # the wire RADIUS at fine meshes (N=321: 0.31 mm segs on a
+        # 0.5 mm-radius wire, Δ/a = 0.62), the classic reduced-kernel
+        # ill-posedness, which the folded element's stub antiresonance
+        # amplifies into a wildly wrong sin/pynec impedance (issue #484:
+        # 280−1188j at N=321; proportional density holds the ladder flat
+        # at 223−30j through N=641).
+        return [
+            Wire(S, A),
+            Wire(A, B),
+            Wire(B, s),
+            Wire(s, t),
+            Wire(t, C),
+            Wire(C, D),
+            Wire(D, T),
+            Wire(T, S, ex=1 + 0j),
+        ]

--- a/src/antennaknobs/designs/dipoles/invvee.py
+++ b/src/antennaknobs/designs/dipoles/invvee.py
@@ -1,6 +1,7 @@
 """Inverted-vee dipole — the default quickstart example."""
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 import math
 
 from types import MappingProxyType
@@ -102,13 +103,8 @@ class Builder(AntennaBuilder):
         z_sin = math.sin(angle)
         y_cos = math.cos(angle)
 
-        def build_path(lst, ns, ex):
-            return ((a, b, ns, ex) for a, b in zip(lst[:-1], lst[1:]))
-
         def ry(p):
             return p[0], -p[1], p[2]
-
-        n_seg0 = self.nominal_nsegs
 
         """
                     
@@ -139,12 +135,8 @@ class Builder(AntennaBuilder):
 
         D, T = ry(A), ry(S)
 
-        n_seg1 = self.segs_for(math.dist(T, S), math.dist(S, A))
-
-        tups = []
-
-        tups.extend(build_path([S, A], n_seg0, None))
-        tups.extend(build_path([D, T], n_seg0, None))
-        tups.extend(build_path([T, S], n_seg1, 1 + 0j))
-
-        return tups
+        return [
+            Wire(S, A),
+            Wire(D, T),
+            Wire(T, S, ex=1 + 0j),
+        ]

--- a/src/antennaknobs/designs/dipoles/koch_dipole.py
+++ b/src/antennaknobs/designs/dipoles/koch_dipole.py
@@ -31,6 +31,7 @@ Geometry, in the framework's (x, y, z) convention:
 """
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 import math
 from types import MappingProxyType
 
@@ -89,7 +90,6 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         span = self.span_frac * wavelength * self.length_factor
         half = span / 2.0
@@ -97,36 +97,18 @@ class Builder(AntennaBuilder):
         it = int(self.iterations)
 
         tups = []
-        # Centre feed: a one-segment driven gap along y at the origin.
-        tups.append(
-            ((0.0, -eps, z), (0.0, eps, z), self.segs_for(2 * eps, quarter), 1 + 0j)
-        )
+        # Centre feed: a short driven gap along y at the origin.
+        tups.append(Wire((0.0, -eps, z), (0.0, eps, z), ex=1 + 0j))
 
         # Right arm: Koch curve from the feed edge (y=+eps) out to the tip,
         # built in the (y, z) plane then emitted as straight chords.
         right = _koch((eps, 0.0), (half, 0.0), it)
         for (ya, za), (yb, zb) in zip(right[:-1], right[1:]):
-            seg = math.hypot(yb - ya, zb - za)
-            tups.append(
-                (
-                    (0.0, ya, z + za),
-                    (0.0, yb, z + zb),
-                    self.segs_for(seg, quarter),
-                    None,
-                )
-            )
+            tups.append(Wire((0.0, ya, z + za), (0.0, yb, z + zb)))
 
         # Left arm: mirror of the right arm in y.
         left = _koch((-eps, 0.0), (-half, 0.0), it)
         for (ya, za), (yb, zb) in zip(left[:-1], left[1:]):
-            seg = math.hypot(yb - ya, zb - za)
-            tups.append(
-                (
-                    (0.0, ya, z + za),
-                    (0.0, yb, z + zb),
-                    self.segs_for(seg, quarter),
-                    None,
-                )
-            )
+            tups.append(Wire((0.0, ya, z + za), (0.0, yb, z + zb)))
 
         return tups

--- a/src/antennaknobs/designs/dipoles/ocf_dipole.py
+++ b/src/antennaknobs/designs/dipoles/ocf_dipole.py
@@ -25,8 +25,8 @@ Geometry, in the framework's (x, y, z) convention:
 """
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 from types import MappingProxyType
-import math
 
 
 class Builder(AntennaBuilder):
@@ -64,7 +64,6 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         length = self.length_frac * wavelength
         z = self.base
@@ -80,17 +79,8 @@ class Builder(AntennaBuilder):
         F1 = (0.0, y_feed + eps, z)
         R = (0.0, y_right, z)
 
-        left_arm = (y_feed - eps) - y_left
-        right_arm = y_right - (y_feed + eps)
-
-        tups = []
-        tups.append(
-            (L, F0, self.segs_for(left_arm, quarter), None)
-        )  # short arm (to -y end)
-        tups.append(
-            (F0, F1, self.segs_for(math.dist(F0, F1), quarter), 1 + 0j)
-        )  # off-centre feed
-        tups.append(
-            (F1, R, self.segs_for(right_arm, quarter), None)
-        )  # long arm (to +y end)
-        return tups
+        return [
+            Wire(L, F0),  # short arm (to -y end)
+            Wire(F0, F1, ex=1 + 0j),  # off-centre feed
+            Wire(F1, R),  # long arm (to +y end)
+        ]

--- a/src/antennaknobs/designs/dipoles/short_dipole_loaded.py
+++ b/src/antennaknobs/designs/dipoles/short_dipole_loaded.py
@@ -12,7 +12,7 @@ dipole at `design_freq` — recompute it if you change `length_factor`.
 """
 
 from antennaknobs import AntennaBuilder
-from antennaknobs.network import Driven, Load, Network, PortOnWire
+from antennaknobs.network import Driven, Load, Network, PortOnWire, Wire
 
 from types import MappingProxyType
 
@@ -35,17 +35,9 @@ class Builder(AntennaBuilder):
         wavelength = 299.792458 / self.design_freq
         half_arm = 0.25 * wavelength * self.length_factor
         # Single straight wire spanning the dipole, feed at the centre.
-        # No `ev` — the Network supplies the source; `name` marks the
+        # No `ex` — the Network supplies the source; `name` marks the
         # segment for PortOnWire resolution.
-        return [
-            (
-                (0, -half_arm, 5),
-                (0, half_arm, 5),
-                self.segs_for(2 * half_arm, 0.25 * wavelength),
-                None,
-                "feed",
-            )
-        ]
+        return [Wire((0, -half_arm, 5), (0, half_arm, 5), name="feed")]
 
     def build_network(self):
         return Network(

--- a/tests/test_momwire_engine.py
+++ b/tests/test_momwire_engine.py
@@ -20,7 +20,10 @@ def test_translator_chains_dipole_into_single_polyline():
     polyline = out["polylines"][0]
     assert polyline.shape == (4, 3), polyline.shape
     # 1-segment feed bridge since issue #457 (proportional segs_for meshing).
-    assert out["edge_segments"] == [[21, 1, 21]]
+    # Arms are 20 since the auto-mesh conversion (#525): each arm is
+    # driver_y - eps long, i.e. slightly under the quarter-wave that
+    # carries the nominal 21 segments.
+    assert out["edge_segments"] == [[20, 1, 20]]
     assert out["feed_wire_index"] == 0
 
     # Feed sits at the geometric centre of the dipole; for the design_freq-sized


### PR DESCRIPTION
## Summary
- Converts the **dipoles** family to the auto-mesh `Wire()` idiom (#525 stage 2): `invvee` (first commit on this branch), `dipole_turnstile`, `folded_invvee`, `koch_dipole`, `ocf_dipole`, `short_dipole_loaded`.
- `koch_dipole`, `ocf_dipole` and `short_dipole_loaded` already computed every count as `segs_for(length, quarter)` — auto-mesh's exact formula — so their conversion is a pure refactor: counts and impedances are bit-identical.
- `folded_invvee` (a #484-census mover): auto-mesh keeps the two parallel conductors density-matched by construction (equal lengths → equal counts, verified 20/20 in the probe), and the 0.1 m facing link + feed get proportional density — exactly what the old hand-rolled `segs_for(..., arm)` arithmetic approximated. The #484 explanatory comment is retained (adapted to the new idiom). Churn is noise-level.
- `short_dipole_loaded` has **no** pinned loading-coil attachment wires to preserve — the coil is a `Network` `Load` branch on the named `feed` wire, so the whole (single-wire) design converts cleanly.
- **Wrappers verified, nothing to convert**: `folded_invvee_balun`, `invvee_coax_station` and `pota_invvee` do no meshing of their own — they inherit geometry from `folded_invvee`/`invvee` and only relabel the driven gap as a named port (or just override params). They pass converted `Wire` tuples through unchanged and their probe impedances are unchanged.

## Known failures — wait for PR #530 before merging
Two `test_web_server` checks fail on this branch **by design**: `test_multi_feed_flag_lights_up_for_array_designs` (`arrays.invveearray` multi_feed flag) and `test_auto_target_z0_scales_by_array_class[arrays.invveearray-200.0]`. Root cause is a framework bug exposed by the Wire idiom: `web/adapter.py` reads the excitation as the *last* tuple field, which on 6-field `Wire` entries is `spec`, not `ex`, so Wire-idiom designs count 0 feeds (this also silently drops `dipole_turnstile`'s 2-feed flag). The fix ships on the auto-mesh-loops branch (**PR #530**, via the `as_wire` choke point) — per coordinator direction this branch does not carry a competing fix. History note: commit c0f5dec7 briefly fixed it here and ca6edf58 reverts that hunk (force-push not available in this session); squash on merge, or drop the pair when tidying.

## Churn (bs2 @ N=21, defaults)

| design (variant) | counts before → after | Z before → after |
|---|---|---|
| invvee (default) | [21,21,1] → [20,20,1] | 55.11−10.26j → 55.11−10.28j |
| invvee (dipole) | [21,21,1] → [20,20,1] | 71.29−5.40j → 71.29−5.42j |
| invvee (three_halves) | [21,21,1] → [62,62,1] | 105.96−0.45j → 106.02+0.47j (density correction, was λ/28) |
| invvee (classic_edz) | [21,21,1] → [53,53,1] | 123.88−683.37j → 123.52−681.78j (density correction) |
| dipole_turnstile | [21,21,1]×2 → [20,20,1]×2 | 69.71−15.99j → 69.70−16.01j (both ports) |
| folded_invvee | [21,1,21,1,21,1,21,1] → [20,1,20,1,20,1,20,1] | 223.30−29.01j → 223.31−28.98j |
| koch_dipole | [1, 2×32] → identical | 35.25+6.03j → identical |
| ocf_dipole | [7,1,33] → identical | 226.39−31.54j → identical |
| short_dipole_loaded | [21] → identical | 13.52−4.06j → identical |
| folded_invvee_balun | [21,…] → [20,…] (inherited) | 46.90−4.23j → 46.90−4.23j |
| invvee_coax_station | [20,20,1] (inherits converted invvee) | 44.15−4.01j (unchanged by this PR) |
| pota_invvee | [20,20,1] (inherits converted invvee) | 54.32−5.17j (unchanged by this PR) |

All within the ~2 % budget; the invvee long-wire variants are the deliberate density corrections already flagged.

## Test assertions changed
- `tests/test_momwire_engine.py::test_translator_chains_dipole_into_single_polyline`: `edge_segments` `[[21, 1, 21]]` → `[[20, 1, 20]]` — each invvee arm is `driver_y − eps`, slightly under the quarter-wave that carries the nominal 21 (density-correct expectation, comment added).

## Test plan
- [x] `ruff check` + `ruff format --check` on all touched files
- [x] Full fast suite in the worktree: 2669 passed, 2 skipped with the adapter fix present; after the deferral revert, green except the two known #530-dependent failures above (`test_delta_a_lint.py` passes)
- [x] Before/after churn probe (table above), memory-capped (`ulimit -v 6291456`)
- [x] `scripts/generate_catalog.py` — catalog.md already up to date (no docstring/param changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
