### PR TITLE
refactor(designs): wire family to auto-mesh Wire() idiom (#525 stage 2)

### DIFF
--- a/src/antennaknobs/designs/wire/doublet_ladder_tuner.py
+++ b/src/antennaknobs/designs/wire/doublet_ladder_tuner.py
@@ -41,6 +41,7 @@ from antennaknobs.network import (
     Network,
     PortOnWire,
     PortVirtual,
+    as_wire,
 )
 from antennaknobs.station import t_network_tuner
 from antennaknobs.designs.dipoles.invvee import Builder as InvVee
@@ -109,11 +110,11 @@ class Builder(InvVee):
         # driven gap becomes the named "feed" port and loses its inline
         # excitation — the source lives at the virtual rig node.
         wires = []
-        for p0, p1, nseg, ev, *rest in super().build_wires():
-            if ev is not None:
-                wires.append((p0, p1, nseg, None, "feed"))
+        for w in map(as_wire, super().build_wires()):
+            if w.ex is not None:
+                wires.append(w._replace(ex=None, name="feed"))
             else:
-                wires.append((p0, p1, nseg, ev, *rest))
+                wires.append(w)
         return wires
 
     def build_network(self):

--- a/src/antennaknobs/designs/wire/edz.py
+++ b/src/antennaknobs/designs/wire/edz.py
@@ -43,7 +43,7 @@ The matching section is an electrical element (a `TL` branch), not geometry.
 """
 
 from antennaknobs import AntennaBuilder
-from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL
+from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL, Wire
 from types import MappingProxyType
 
 
@@ -95,7 +95,6 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         length = self.elem_frac * wavelength * self.length_factor
         half = length / 2.0
@@ -105,13 +104,12 @@ class Builder(AntennaBuilder):
         C0 = (0.0, -eps, z)
         C1 = (0.0, eps, z)
         R = (0.0, half, z)
-        arm = self.segs_for(half - eps, quarter)
         # Centre-fed doublet; the named centre gap "feed" is the antenna-side
         # port the matching section connects to (no direct voltage source).
         return [
-            (L, C0, arm, None, None),
-            (C0, C1, self.segs_for(2 * eps, quarter), None, "feed"),
-            (C1, R, arm, None, None),
+            Wire(L, C0),
+            Wire(C0, C1, name="feed"),
+            Wire(C1, R),
         ]
 
     def build_network(self):

--- a/src/antennaknobs/designs/wire/efhw_sloper.py
+++ b/src/antennaknobs/designs/wire/efhw_sloper.py
@@ -68,6 +68,7 @@ from antennaknobs.network import (
     PortOnWire,
     PortVirtual,
     TL,
+    Wire,
     WIRES,
 )
 from antennaknobs.station import unun
@@ -169,18 +170,13 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
         length = 0.5 * wavelength * self.length_factor
 
         # Fly it: face −x so the radiator climbs toward −x and the sloper's
         # downhill main lobe lands on +x; counterpoise in to the feed
         # point, pitch up by the rise angle (Drone pitch is nose-down
         # positive), gap wire, radiator.
-        d = Drone(
-            (self.cp_len_m, 0.0, self.h_feed),
-            nominal_nsegs=self.nominal_nsegs,
-            ref=quarter,
-        )
+        d = Drone((self.cp_len_m, 0.0, self.h_feed))
         d.face((-1.0, 0.0, 0.0))
         d.pay_out().forward(self.cp_len_m)
         d.pitch(-self.slope_deg)
@@ -190,8 +186,8 @@ class Builder(AntennaBuilder):
         # The short gap edge becomes the named "ant" port wire: the port
         # interrupts the current path between counterpoise and radiator —
         # the end-fed's feed.
-        p0, p1, nsegs, _ev = wires[1]
-        wires[1] = (p0, p1, nsegs, None, "ant")
+        p0, p1, _nsegs, _ev = wires[1]
+        wires[1] = Wire(p0, p1, name="ant")
         return wires
 
     def build_network(self):

--- a/src/antennaknobs/designs/wire/expanded_lazy_h.py
+++ b/src/antennaknobs/designs/wire/expanded_lazy_h.py
@@ -38,7 +38,7 @@ The structure is planar in x = 0; the harness is electrical (TL branches).
 """
 
 from antennaknobs import AntennaBuilder
-from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL
+from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL, Wire
 from types import MappingProxyType
 
 
@@ -86,7 +86,6 @@ class Builder(AntennaBuilder):
         eps = 0.05
 
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         elem = self.elem_frac * wavelength
         spacing = self.spacing_frac * wavelength
@@ -94,16 +93,16 @@ class Builder(AntennaBuilder):
 
         def element(z, name):
             """A 1.25 wl horizontal wire along y at height z with a named
-            one-segment centre port (the harness attaches here; no direct
-            voltage source)."""
+            centre port (the harness attaches here; no direct voltage
+            source)."""
             L = (0.0, -half, z)
             R = (0.0, half, z)
             C0 = (0.0, -eps, z)
             C1 = (0.0, eps, z)
             return [
-                (L, C0, self.segs_for(half - eps, quarter), None, None),
-                (C0, C1, self.segs_for(2 * eps, quarter), None, name),
-                (C1, R, self.segs_for(half - eps, quarter), None, None),
+                Wire(L, C0),
+                Wire(C0, C1, name=name),
+                Wire(C1, R),
             ]
 
         tups = []

--- a/src/antennaknobs/designs/wire/lazy_h.py
+++ b/src/antennaknobs/designs/wire/lazy_h.py
@@ -30,8 +30,8 @@ The structure is planar in x = 0.
 """
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 from types import MappingProxyType
-import math
 
 
 class Builder(AntennaBuilder):
@@ -68,7 +68,6 @@ class Builder(AntennaBuilder):
         eps = 0.05
 
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         elem = self.elem_frac * wavelength
         spacing = self.spacing_frac * wavelength
@@ -76,15 +75,15 @@ class Builder(AntennaBuilder):
 
         def element(z):
             """A 1 wl horizontal wire along y at height z, centre-fed in
-            phase (one-segment driven gap at y = 0)."""
+            phase (driven gap at y = 0)."""
             L = (0.0, -half, z)
             R = (0.0, half, z)
             C0 = (0.0, -eps, z)
             C1 = (0.0, eps, z)
             return [
-                (L, C0, self.segs_for(half - eps, quarter), None),
-                (C0, C1, self.segs_for(math.dist(C0, C1), quarter), 1 + 0j),
-                (C1, R, self.segs_for(half - eps, quarter), None),
+                Wire(L, C0),
+                Wire(C0, C1, ex=1 + 0j),
+                Wire(C1, R),
             ]
 
         tups = []

--- a/src/antennaknobs/designs/wire/longwire.py
+++ b/src/antennaknobs/designs/wire/longwire.py
@@ -32,8 +32,8 @@ The structure is a single straight conductor in x = 0, z = base.
 """
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 from types import MappingProxyType
-import math
 
 
 class Builder(AntennaBuilder):
@@ -76,30 +76,26 @@ class Builder(AntennaBuilder):
         eps = 0.05
 
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         length = self.length_frac * wavelength * self.length_factor
         half = length / 2
 
         z = self.base
 
-        # Single straight wire along y, with a one-segment driven gap at the
-        # centre (the current maximum). Split into a passive left half, the
-        # driven gap, and a passive right half (cf. half_square / lazy_h
-        # centre-feed idiom).
+        # Single straight wire along y, with a driven gap at the centre (the
+        # current maximum). Split into a passive left half, the driven gap,
+        # and a passive right half (cf. half_square / lazy_h centre-feed
+        # idiom).
         left_end = (0.0, -half, z)
         gap_m = (0.0, -eps, z)
         gap_p = (0.0, eps, z)
         right_end = (0.0, half, z)
 
-        tups = []
-        # Left half (end -> -eps), passive.
-        tups.append((left_end, gap_m, self.segs_for(half - eps, quarter), None))
-        # Driven feed gap across the centre.
-        tups.append(
-            (gap_m, gap_p, self.segs_for(math.dist(gap_m, gap_p), quarter), 1 + 0j)
-        )
-        # Right half (+eps -> end), passive.
-        tups.append((gap_p, right_end, self.segs_for(half - eps, quarter), None))
-
-        return tups
+        return [
+            # Left half (end -> -eps), passive.
+            Wire(left_end, gap_m),
+            # Driven feed gap across the centre.
+            Wire(gap_m, gap_p, ex=1 + 0j),
+            # Right half (+eps -> end), passive.
+            Wire(gap_p, right_end),
+        ]

--- a/src/antennaknobs/designs/wire/rhombic.py
+++ b/src/antennaknobs/designs/wire/rhombic.py
@@ -32,7 +32,7 @@ polarised.
 """
 
 from antennaknobs import AntennaBuilder
-from antennaknobs.network import Driven, Load, Network, PortOnWire
+from antennaknobs.network import Driven, Load, Network, PortOnWire, Wire
 import math
 from types import MappingProxyType
 
@@ -79,7 +79,6 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05  # half-gap at the feed / termination apexes
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         L = self.leg_factor * wavelength
         tilt = math.radians(self.tilt_deg)
@@ -87,7 +86,6 @@ class Builder(AntennaBuilder):
         w = L * math.sin(tilt)
         z = self.base
 
-        leg = self.segs_for(L, quarter)
         FU = (0.0, eps, z)  # feed apex, upper terminal
         FL = (0.0, -eps, z)  # feed apex, lower terminal
         SU = (d, w, z)  # upper side apex
@@ -97,14 +95,14 @@ class Builder(AntennaBuilder):
 
         return [
             # feed gap at the rear apex (driven via build_network)
-            (FU, FL, self.segs_for(2 * eps, quarter), None, "feed"),
+            Wire(FU, FL, name="feed"),
             # four legs
-            (FU, SU, leg, None, None),  # rear upper
-            (FL, SD, leg, None, None),  # rear lower
-            (SU, TU, leg, None, None),  # front upper
-            (SD, TL, leg, None, None),  # front lower
+            Wire(FU, SU),  # rear upper
+            Wire(FL, SD),  # rear lower
+            Wire(SU, TU),  # front upper
+            Wire(SD, TL),  # front lower
             # termination gap at the far apex (resistor via build_network)
-            (TU, TL, self.segs_for(2 * eps, quarter), None, "term"),
+            Wire(TU, TL, name="term"),
         ]
 
     def build_network(self):

--- a/src/antennaknobs/designs/wire/sterba.py
+++ b/src/antennaknobs/designs/wire/sterba.py
@@ -36,6 +36,7 @@ gain falls off quickly below ~0.96 as the half-wave phasing breaks down.
 """
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 import math
 from types import MappingProxyType
 
@@ -141,7 +142,6 @@ class Builder(AntennaBuilder):
             p0 = loop[k]
             p1 = loop[(k + 1) % N]
             seg_len = math.dist(p0, p1)
-            nseg = self.segs_for(seg_len, h)
 
             is_horizontal = abs(p0[2] - p1[2]) < 1e-9
             at_bottom = abs(p0[2] - bot) < 1e-9 and abs(p1[2] - bot) < 1e-9
@@ -157,11 +157,9 @@ class Builder(AntennaBuilder):
             ev = None
             if is_feed:
                 feed_count += 1
-                if nseg % 2 == 0:
-                    nseg += 1  # odd -> a segment sits exactly at centre
                 ev = 1 + 0j
 
-            tups.append((p0, p1, nseg, ev))
+            tups.append(Wire(p0, p1, ex=ev))
 
         assert feed_count == 1, f"expected exactly one feed edge, got {feed_count}"
 

--- a/src/antennaknobs/designs/wire/vbeam.py
+++ b/src/antennaknobs/designs/wire/vbeam.py
@@ -31,6 +31,7 @@ Geometry, in the framework's (x, y, z) convention:
 """
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 from types import MappingProxyType
 import math
 
@@ -71,7 +72,6 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         leg = self.leg_frac * wavelength
         theta = math.radians(self.half_apex_deg)
@@ -80,24 +80,15 @@ class Builder(AntennaBuilder):
         z = self.base
 
         # Apex near the origin, legs opening toward +x at +/- theta off the
-        # bisector. A one-segment driven gap bridges the two inner ends.
+        # bisector. A driven gap bridges the two inner ends.
         inner_p = (eps * dx, eps * dy, z)  # toward +y leg
         inner_m = (eps * dx, -eps * dy, z)  # toward -y leg
         end_p = (leg * dx, leg * dy, z)
         end_m = (leg * dx, -leg * dy, z)
 
-        arm = self.segs_for(leg - eps, quarter)
-
-        tups = []
-        # Driven gap across the apex between the two legs' inner ends.
-        tups.append(
-            (
-                inner_m,
-                inner_p,
-                self.segs_for(math.dist(inner_m, inner_p), quarter),
-                1 + 0j,
-            )
-        )
-        tups.append((inner_p, end_p, arm, None))  # +y leg
-        tups.append((inner_m, end_m, arm, None))  # -y leg
-        return tups
+        return [
+            # Driven gap across the apex between the two legs' inner ends.
+            Wire(inner_m, inner_p, ex=1 + 0j),
+            Wire(inner_p, end_p),  # +y leg
+            Wire(inner_m, end_m),  # -y leg
+        ]

--- a/src/antennaknobs/designs/wire/w8jk.py
+++ b/src/antennaknobs/designs/wire/w8jk.py
@@ -34,6 +34,7 @@ Geometry, in the framework's (x, y, z) convention:
 """
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 from types import MappingProxyType
 
 
@@ -72,7 +73,6 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         elem = self.elem_frac * wavelength
         spacing = self.spacing_frac * wavelength
@@ -86,9 +86,9 @@ class Builder(AntennaBuilder):
             C0 = (x, -eps, z)
             C1 = (x, eps, z)
             return [
-                (L, C0, self.segs_for(half - eps, quarter), None),
-                (C0, C1, self.segs_for(2 * eps, quarter), voltage),
-                (C1, R, self.segs_for(half - eps, quarter), None),
+                Wire(L, C0),
+                Wire(C0, C1, ex=voltage),
+                Wire(C1, R),
             ]
 
         tups = []

--- a/src/antennaknobs/designs/wire/zepp.py
+++ b/src/antennaknobs/designs/wire/zepp.py
@@ -43,7 +43,7 @@ The tuned feeder is an electrical element (a `TL` branch), not geometry.
 """
 
 from antennaknobs import AntennaBuilder
-from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL
+from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL, Wire
 from types import MappingProxyType
 
 
@@ -91,22 +91,16 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         length = self.length_frac * wavelength * self.length_factor
         z = self.base
 
-        # End feed: a one-segment named gap "ant" at y=0 (the open end / voltage
+        # End feed: a short named gap "ant" at y=0 (the open end / voltage
         # antinode), then the half-wave radiator running out to y=+length.
         # No direct voltage source -- the tuned stub drives this port.
         return [
-            ((0.0, 0.0, z), (0.0, eps, z), self.segs_for(eps, quarter), None, "ant"),
-            (
-                (0.0, eps, z),
-                (0.0, length, z),
-                self.segs_for(length - eps, quarter),
-                None,
-            ),
+            Wire((0.0, 0.0, z), (0.0, eps, z), name="ant"),
+            Wire((0.0, eps, z), (0.0, length, z)),
         ]
 
     def build_network(self):

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -1186,12 +1186,13 @@ def _edz_bare():
     """The EDZ with its centre gap driven directly (matching section removed),
     to read the raw feedpoint the series section transforms."""
     from antennaknobs.designs.wire.edz import Builder
+    from antennaknobs.network import as_wire
 
     class Bare(Builder):
         def build_wires(self):
             return [
-                (t[0], t[1], t[2], 1 + 0j) if len(t) == 5 and t[4] == "feed" else t[:4]
-                for t in super().build_wires()
+                w._replace(ex=1 + 0j, name=None) if w.name == "feed" else w
+                for w in map(as_wire, super().build_wires())
             ]
 
         def build_network(self):


### PR DESCRIPTION
## Summary
- Convert the wire family (11 designs) to the auto-mesh `Wire()` idiom: `edz`, `expanded_lazy_h`, `lazy_h`, `longwire`, `rhombic`, `sterba`, `vbeam`, `w8jk`, `zepp`, `efhw_sloper`, `doublet_ladder_tuner`.
- **efhw_sloper** (Drone-based): dropped the `nominal_nsegs=`/`ref=` Drone constructor args (no per-move `nsegs=` pins existed); the "ant" gap edge is now `Wire(..., name="ant")`. Zero churn on both variants.
- **doublet_ladder_tuner**: has no counts of its own (geometry inherited from `dipoles.invvee`); its feed-rename loop now goes through `as_wire`/`_replace` instead of positional unpacking, preserving the `"feed"` port name exactly and carrying any parent `spec` through. Its churn will arrive with the dipoles-family InvVee conversion, not here.
- **Phased feeds preserved exactly**: `lazy_h` (two in-phase `ex=1+0j` centre feeds), `w8jk` (`ex=-1+0j` rear / `ex=+1+0j` front), `expanded_lazy_h` (named `lo`/`hi` harness ports) — emission order unchanged in every file (probe Z bit-identical, including both entries of each two-feed design).
- **sterba** — the one real density correction: its old mesh reference was the half-wave unit `h = λ/2·length_factor`, i.e. half the catalog density and length_factor-dependent. Counts double; bs2@21 Z moves 1.33% of |Z| (within the ~2% budget) and the post-conversion ladder converges smoothly (N=11: 612.97+217.34j → N=27: 618.87+209.61j). The manual odd-count coercion on its fed section is dropped — engines coerce fed-wire parity at solve time (#450).
- **Skipped (exempt)**: `terminated_longwire.py`, `sterba_tl.py` — validated models, #525 stage 4 / #526.
- **Test change**: `_edz_bare` in `tests/test_cebik_designs.py` discriminated the feed wire by tuple arity (`len(t) == 5`), which a `Wire` NamedTuple (len always 6) breaks; rewired through `as_wire`/`_replace`, the supported normalization path.

## Churn (bs2 @ N=21, defaults)

| design | variant | counts before | counts after | Z before | Z after |
|---|---|---|---|---|---|
| doublet_ladder_tuner | default | [21, 21, 1] | [21, 21, 1] | 41.90 −5.88j | 41.90 −5.88j |
| doublet_ladder_tuner | classic_edz | [21, 21, 1] | [21, 21, 1] | 7.50 −143.26j | 7.50 −143.26j |
| doublet_ladder_tuner | dipole | [21, 21, 1] | [21, 21, 1] | 8.37 −86.00j | 8.37 −86.00j |
| doublet_ladder_tuner | three_halves | [21, 21, 1] | [21, 21, 1] | 11.87 −85.84j | 11.87 −85.84j |
| edz | default | [52, 1, 52] | [52, 1, 52] | 52.52 +0.18j | 52.52 +0.18j |
| efhw_sloper | default | [4, 1, 37] | [4, 1, 37] | 52.27 −3.17j | 52.27 −3.17j |
| efhw_sloper | band40 | [4, 1, 37] | [4, 1, 37] | 66.85 −5.53j | 66.85 −5.53j |
| expanded_lazy_h | default | [52, 1, 52] ×2 | [52, 1, 52] ×2 | 28.00 +267.61j | 28.00 +267.61j |
| lazy_h | default | [42, 1, 42] ×2 | [42, 1, 42] ×2 | 4686.14 −2426.67j (both feeds) | 4686.14 −2426.67j (both feeds) |
| longwire | default | [146, 1, 146] | [146, 1, 146] | 131.54 −12.97j | 131.54 −12.97j |
| rhombic | default | [1, 252×4, 1] | [1, 252×4, 1] | 687.74 −207.68j | 687.74 −207.68j |
| **sterba** | default | 378 total (ref = λ/2·lf) | **756 total (ref = λ/4)** | 612.02 +218.25j | **617.71 +211.73j (Δ 1.33%)** |
| vbeam | default | [1, 84, 84] | [1, 84, 84] | 2219.96 −2870.60j | 2219.96 −2870.60j |
| w8jk | default | [26, 1, 26] ×2 | [26, 1, 26] ×2 | 24.95 +526.52j (both feeds) | 24.95 +526.52j (both feeds) |
| zepp | default | [1, 40] | [1, 40] | 2.60 +20.44j | 2.60 +20.44j |

The `#435` ladder-repaired designs (`edz`, `zepp`) and the harmonized non-TL `sterba` were measured specifically: edz/zepp are churn-free by construction (their `segs_for` already used the quarter-wave reference, so the whole ladder is formula-identical at every N); sterba's shift is the density correction described above.

## Known cross-branch issue (not fixed here)
A sibling family conversion found a framework bug where `web/adapter.py` read a wire's excitation as the *last* tuple field — on 6-field `Wire` entries that's `spec`, which can break z0/multi-feed handling on array-wrapper and multi-feed designs. That fix already lives on the `auto-mesh-loops` branch (PR #530, via the `as_wire` choke point) and is deliberately **not** duplicated in this PR. For the record: this branch's full suite (including `test_web_server`) passed with the converted phased-feed designs (`w8jk`, `lazy_h`), so the failure did not manifest here — but if it appears in the web UI before #530 merges, that is the known bug, not this conversion.

## Test plan
- [x] `ruff check` + `ruff format --check` on all touched files
- [x] Full fast suite: 2668 passed, 2 skipped, 1 pre-existing-idiom failure (`test_edz_bare_centre_high_r_strongly_capacitive`, arity-based helper) fixed in this PR; wire-family subset re-run green (35 passed)
- [x] Geometry-density lint (`tests/test_delta_a_lint.py`) passes
- [x] Before/after churn probe (bs2@21, all variants incl. efhw_sloper band40 and inherited InvVee variants of doublet_ladder_tuner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
