### PR TITLE
refactor(designs): beams family to auto-mesh Wire() idiom (#525 stage 2)

### DIFF
--- a/src/antennaknobs/designs/beams/hb9cv.py
+++ b/src/antennaknobs/designs/beams/hb9cv.py
@@ -34,7 +34,7 @@ in place of the ideal line). Treat F/B as "real but shallow" in this model.
 """
 
 from antennaknobs import AntennaBuilder
-from antennaknobs.network import Driven, Network, PortOnWire, TL
+from antennaknobs.network import Driven, Network, PortOnWire, TL, Wire
 from types import MappingProxyType
 
 
@@ -96,11 +96,10 @@ class Builder(AntennaBuilder):
             C0 = (x, -eps, z)
             C1 = (x, eps, z)
             R = (x, h, z)
-            arm = self.segs_for(h - eps, quarter)
             return [
-                (L, C0, arm, None, None),
-                (C0, C1, self.segs_for(2 * eps, quarter), None, name),
-                (C1, R, arm, None, None),
+                Wire(L, C0),
+                Wire(C0, C1, name=name),
+                Wire(C1, R),
             ]
 
         tups = []

--- a/src/antennaknobs/designs/beams/moxon_turnstile.py
+++ b/src/antennaknobs/designs/beams/moxon_turnstile.py
@@ -49,7 +49,7 @@ Free space or over ground, the dome looks up.
 
 from antennaknobs import AntennaBuilder
 from antennaknobs.designs.beams.moxon import Builder as Moxon
-from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL
+from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL, Wire
 from types import MappingProxyType
 
 
@@ -111,11 +111,14 @@ class Builder(AntennaBuilder):
     def _moxon_outline(self):
         """The reused beams.moxon wire list, scaled to this design's
         frequency, in the Moxon's own planar coordinates (u = beam axis,
-        reflector at -short/2 and driver at +short/2; v = element run)."""
+        reflector at -short/2 and driver at +short/2; v = element run).
+        Only geometry and the excitation flag are carried: this design
+        meshes the outline itself (auto_mesh at its own design_freq /
+        nominal_nsegs), so the borrowed builder's counts are dropped."""
         m = Moxon(dict(Moxon.default_params, base=0.0))
         s = 28.57 / self.design_freq * self.length_factor
         return [
-            ((t[0][0] * s, t[0][1] * s), (t[1][0] * s, t[1][1] * s), t[2], t[3])
+            ((t[0][0] * s, t[0][1] * s), (t[1][0] * s, t[1][1] * s), t[3])
             for t in m.build_wires()
         ]
 
@@ -139,12 +142,12 @@ class Builder(AntennaBuilder):
         # reflector (u min) lands at `base`.
         u0 = min(min(t[0][0], t[1][0]) for t in self._moxon_outline())
         tups = []
-        for (au, av), (bu, bv), n, ev in self._moxon_outline():
+        for (au, av), (bu, bv), ev in self._moxon_outline():
             p0 = place(au - u0, av)
             p1 = place(bu - u0, bv)
             p0 = (p0[0], p0[1], p0[2] + lift)
             p1 = (p1[0], p1[1], p1[2] + lift)
-            tups.append((p0, p1, n, None, name if ev is not None else None))
+            tups.append(Wire(p0, p1, name=name if ev is not None else None))
         return tups
 
     def build_wires(self):

--- a/src/antennaknobs/designs/beams/owa_yagi.py
+++ b/src/antennaknobs/designs/beams/owa_yagi.py
@@ -39,7 +39,7 @@ Geometry, in the framework's (x, y, z) convention:
 """
 
 from antennaknobs import AntennaBuilder
-from antennaknobs.network import WireSpec
+from antennaknobs.network import Wire, WireSpec
 from types import MappingProxyType
 
 
@@ -97,7 +97,6 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
         b = self.base
 
         tups = []
@@ -107,14 +106,10 @@ class Builder(AntennaBuilder):
                 half *= self.d1_length_factor
             x = pos_frac * wavelength
             if i == self.DRIVER:
-                # Driver: one-segment centre gap carries the direct feed.
-                arm = self.segs_for(half - eps, quarter)
-                tups.append(((x, -half, b), (x, -eps, b), arm, None))
-                tups.append(
-                    ((x, -eps, b), (x, eps, b), self.segs_for(2 * eps, quarter), 1 + 0j)
-                )
-                tups.append(((x, eps, b), (x, half, b), arm, None))
+                # Driver: the short centre-gap wire carries the direct feed.
+                tups.append(Wire((x, -half, b), (x, -eps, b)))
+                tups.append(Wire((x, -eps, b), (x, eps, b), ex=1 + 0j))
+                tups.append(Wire((x, eps, b), (x, half, b)))
             else:
-                ns = self.segs_for(2 * half, quarter)
-                tups.append(((x, -half, b), (x, half, b), ns, None))
+                tups.append(Wire((x, -half, b), (x, half, b)))
         return tups

--- a/src/antennaknobs/designs/beams/owa_yagi_6el.py
+++ b/src/antennaknobs/designs/beams/owa_yagi_6el.py
@@ -31,7 +31,7 @@ the workbench's forward direction, same as `beams.owa_yagi`.
 from types import MappingProxyType
 
 from antennaknobs import AntennaBuilder
-from antennaknobs.network import WireSpec
+from antennaknobs.network import Wire, WireSpec
 
 
 class Builder(AntennaBuilder):
@@ -89,7 +89,6 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         wavelength = 299.792458 / self.design_freq
         eps = 0.025 * wavelength / 2.053373  # feed-gap half-width, scaled
-        quarter = 0.25 * wavelength
         b = self.base
 
         tups = []
@@ -99,14 +98,10 @@ class Builder(AntennaBuilder):
                 half *= self.d1_length_factor
             x = pos_frac * wavelength
             if i == self.DRIVER:
-                # Driver: one-segment centre gap carries the direct feed.
-                arm = self.segs_for(half - eps, quarter)
-                tups.append(((x, -half, b), (x, -eps, b), arm, None))
-                tups.append(
-                    ((x, -eps, b), (x, eps, b), self.segs_for(2 * eps, quarter), 1 + 0j)
-                )
-                tups.append(((x, eps, b), (x, half, b), arm, None))
+                # Driver: the short centre-gap wire carries the direct feed.
+                tups.append(Wire((x, -half, b), (x, -eps, b)))
+                tups.append(Wire((x, -eps, b), (x, eps, b), ex=1 + 0j))
+                tups.append(Wire((x, eps, b), (x, half, b)))
             else:
-                ns = self.segs_for(2 * half, quarter)
-                tups.append(((x, -half, b), (x, half, b), ns, None))
+                tups.append(Wire((x, -half, b), (x, half, b)))
         return tups

--- a/src/antennaknobs/designs/beams/phased_driver_yagi.py
+++ b/src/antennaknobs/designs/beams/phased_driver_yagi.py
@@ -43,7 +43,7 @@ Horizontally polarised.
 """
 
 from antennaknobs import AntennaBuilder
-from antennaknobs.network import Driven, Network, PortOnWire, TL, WireSpec
+from antennaknobs.network import Driven, Network, PortOnWire, TL, Wire, WireSpec
 from types import MappingProxyType
 
 
@@ -102,7 +102,6 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
         lf = self.length_factor
 
         tups = []
@@ -110,21 +109,20 @@ class Builder(AntennaBuilder):
             half = half_frac * wavelength * lf
             x = pos_frac * wavelength
             z = self.base
-            arm = self.segs_for(half - eps, quarter)
             L = (x, -half, z)
             C0 = (x, -eps, z)
             C1 = (x, eps, z)
             R = (x, half, z)
             if i == self.DIR:
                 # Parasitic director: one unbroken wire.
-                tups.append((L, R, 2 * arm + 1, None, None))
+                tups.append(Wire(L, R))
                 continue
             # Both drivers carry a centre gap: the forward one is the feed,
             # the rear one takes the far end of the phase line.
             name = "feed" if i == self.FWD else "rear"
-            tups.append((L, C0, arm, None, None))
-            tups.append((C0, C1, self.segs_for(2 * eps, quarter), None, name))
-            tups.append((C1, R, arm, None, None))
+            tups.append(Wire(L, C0))
+            tups.append(Wire(C0, C1, name=name))
+            tups.append(Wire(C1, R))
         return tups
 
     def build_network(self):

--- a/src/antennaknobs/designs/beams/yagi.py
+++ b/src/antennaknobs/designs/beams/yagi.py
@@ -1,6 +1,7 @@
 """Yagi-Uda parasitic beam (driven element + reflector + directors)."""
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 import math
 
 from types import MappingProxyType
@@ -36,13 +37,8 @@ class Builder(AntennaBuilder):
         z_sin = math.sin(angle)
         y_cos = math.cos(angle)
 
-        def build_path(lst, ns, ex):
-            return ((a, b, ns, ex) for a, b in zip(lst[:-1], lst[1:]))
-
         def ry(p):
             return p[0], -p[1], p[2]
-
-        n_seg0 = self.nominal_nsegs
 
         """
     B                    
@@ -73,19 +69,18 @@ class Builder(AntennaBuilder):
 
         C, D, T = ry(B), ry(A), ry(S)
 
-        n_seg1 = self.segs_for(math.dist(T, S), math.dist(S, A))
-
-        tups = []
-
-        tups.extend(build_path([S, A], n_seg0, None))
-        tups.extend(build_path([B, U, C], n_seg0, None))
-        tups.extend(build_path([D, T], n_seg0, None))
-        tups.extend(build_path([T, S], n_seg1, 1 + 0j))
+        tups = [
+            Wire(S, A),
+            Wire(B, U),
+            Wire(U, C),
+            Wire(D, T),
+            Wire(T, S, ex=1 + 0j),
+        ]
 
         for i in range(self.n_directors):
             U = (boom_x * (1 + i), 0, b)
             B = (boom_x * (1 + i), director_y * y_cos, b - director_y * z_sin)
             C = ry(B)
-            tups.extend(build_path([B, U, C], n_seg0, None))
+            tups.extend([Wire(B, U), Wire(U, C)])
 
         return tups

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -1914,7 +1914,7 @@ def test_moxon_turnstile_quadrature_currents():
     eng = PyNECEngine(b, ground=None)
     cur = eng.current_distribution()
     feed_idx = [
-        i for i, t in enumerate(b.build_wires()) if len(t) == 5 and t[4] is not None
+        i for i, t in enumerate(b.build_wires()) if len(t) >= 5 and t[4] is not None
     ]
     ia, ib = (cur[i].knot_currents[1] for i in feed_idx)
     ratio = abs(ib) / abs(ia)
@@ -1975,7 +1975,7 @@ def test_moxon_turnstile_network_topology():
     assert isinstance(src, Driven) and src.port == "shack"
     # Two crossed elements: the two driver gaps run perpendicular.
     tups = b.build_wires()
-    gaps = [t for t in tups if len(t) == 5 and t[4] is not None]
+    gaps = [t for t in tups if len(t) >= 5 and t[4] is not None]
     assert {g[4] for g in gaps} == {"feed_a", "feed_b"}
 
 
@@ -2077,7 +2077,7 @@ def test_pdy_topology_phased_driver_cell():
 
     b = Builder()
     tups = b.build_wires()
-    names = {t[4]: t for t in tups if len(t) == 5 and t[4]}
+    names = {t[4]: t for t in tups if len(t) >= 5 and t[4]}
     assert set(names) == {"feed", "rear"}
     wavelength = 299.792458 / b.design_freq
     halves = [h for h, _ in b.TABLE]


### PR DESCRIPTION
## Summary

- Convert the six remaining beams designs — `hb9cv`, `moxon_turnstile`, `owa_yagi`, `owa_yagi_6el`, `phased_driver_yagi`, `yagi` — from explicit `segs_for`/`nominal_nsegs` counts to None-count `Wire()` entries resolved by `auto_mesh` (`moxon` and `hexbeam` were already converted in #524).
- Geometry math, parameters, variants, docstrings, wire names (`feed`/`rear`, `feed_a`/`feed_b`, `rear`/`front`), excitations, and emission order preserved exactly. `owa_yagi_6el` already had `design_freq` (146 / 435 for the 70 cm variant) — no hidden param needed; every other design had one too.
- **Real ladder fix in `moxon_turnstile`**: its `_moxon_outline` reused the inner `beams.moxon` builder's resolved counts, which froze the element mesh at the framework default density regardless of the turnstile's own `nominal_nsegs` (at nominal 42 it still produced the 21-density counts `[15, 5, 6, 30, ...]`; converted it correctly yields `[30, 9, 12, 62, ...]`) — its convergence ladder never actually refined the elements before. The outline now carries geometry + excitation flag only.
- `yagi` previously gave every element the flat nominal count; after conversion each element gets its own density-correct count (driver arms and directors 21 → 19 at defaults; reflector stays 21) — expected density correction.
- `phased_driver_yagi`'s director retired its `2*arm + 1` odd-count pin (39 → 38); it is a parasite with no feed, no comment marked the parity deliberate, and the impedance moved 0.02%.
- Test assertions: three `test_cebik_designs.py` filters located named wires with `len(t) == 5 and t[4]`, which misses 6-field `Wire` entries; relaxed to `len(t) >= 5` (`t[4]` is the name in both shapes).

## Churn (bs2 @ N=21, defaults)

| design (variant) | counts before | counts after | Z before | Z after |
|---|---|---|---|---|
| hb9cv | [21, 1, 21, 20, 1, 20] | identical | 42.22+60.46j | identical |
| moxon_turnstile | [15, 5, 6, 30, 6, 5, 15, 1] ×2 | [15, 5, 6, **31**, 6, 5, 15, 1] ×2 | 50.08+0.00j | 50.08+0.00j |
| owa_yagi | [42, 20, 1, 20, 39, 36] | identical | 47.21+1.22j | identical |
| owa_yagi_6el | [42, 20, 2, 20, 39, 38, 38, 36] | identical | 49.95+9.29j | identical |
| owa_yagi_6el (band70cm) | [42, 20, 2, 20, 39, 38, 38, 36] | identical | 49.92+9.30j | identical |
| phased_driver_yagi | [20, 1, 20, 19, 1, 19, **39**] | [20, 1, 20, 19, 1, 19, **38**] | 49.95+5.99j | 49.94+5.99j |
| yagi | [21, 21, 21, 21, 1, 21, 21, 21, 21] | [**19**, 21, 21, **19**, 1, **19**, **19**, **19**, **19**] | 34.51−36.64j | 34.51−36.69j |

All within the ~2% budget (worst: yagi at 0.1%).

## Known failure (framework, not this branch)

`test_web_server.py::test_auto_target_z0_scales_by_array_class[arrays.yagiarray-200.0]` fails on this branch: `web/adapter.py`'s `_auto_target_z0`/`_auto_multi_feed` read the excitation as the last tuple field, which on 6-field `Wire` entries is `spec`. This is a known framework bug already fixed on the `auto-mesh-loops` branch (PR #530) via the `as_wire` choke point; deliberately not duplicated here.

## Test plan

- [x] `ruff check` + `ruff format --check` clean on all touched files
- [x] Churn probe (all variants, bs2 @ N=21, under `ulimit -v 6291456`) before/after — table above
- [x] Full fast suite: 2665 passed, 2 skipped; 3 name-filter failures fixed by the test-assertion update above; 1 remaining known failure covered by PR #530
- [x] `tests/test_delta_a_lint.py` (geometry-density lint) fully green — 280 passed in the targeted re-run
- [x] Catalog unchanged (it lists names/docstrings only) — no regeneration needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)