### PR TITLE
refactor(designs): arrays family to auto-mesh Wire() idiom (#525 stage 2)

### DIFF
--- a/src/antennaknobs/designs/arrays/delta_looparray_network.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray_network.py
@@ -15,7 +15,7 @@ numerical precision; the showcase for the network-spec API in #65.
 """
 
 from antennaknobs import AntennaBuilder, Transform, TransformStack
-from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL
+from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL, Wire
 
 import math
 from types import MappingProxyType
@@ -44,24 +44,14 @@ class Builder(AntennaBuilder):
         cos_t = math.cos(angle)
         tan_t = math.tan(angle)
 
-        def build_path(lst, ns, ex, name=None):
-            pairs = list(zip(lst[:-1], lst[1:]))
-            for i, (a, c) in enumerate(pairs):
-                # Only the centre feed-edge of the gap gets the name.
-                yield (a, c, ns, ex, name if i == 0 and len(pairs) == 1 else None)
-
         def ry(p):
             return p[0], -p[1], p[2]
-
-        n_seg0 = self.nominal_nsegs
 
         # y of the top corner (half the top-edge width), in closed form.
         y = (cos_t * (driver - 2 * eps) + 2 * eps) / (2 * (cos_t + 1))
         S = (0, eps, b - (y - eps) * tan_t)
         A = (0, y, b)
         B, T = ry(A), ry(S)
-
-        n_seg1 = self.segs_for(math.dist(T, S), math.dist(S, A))
 
         st = TransformStack()
         st.push(Transform.translate(0, 0, b))
@@ -70,14 +60,18 @@ class Builder(AntennaBuilder):
         SS, AA, BB, TT = st.hit(S), st.hit(A), st.hit(B), st.hit(T)
         SSS, AAA, BBB, TTT = ry(SS), ry(AA), ry(BB), ry(TT)
 
-        tups = []
-        # Loop 1: SS → AA → BB → TT perimeter (no feed), then TT → SS named.
-        tups.extend(build_path([SS, AA, BB, TT], n_seg0, None))
-        tups.extend(build_path([TT, SS], n_seg1, None, name="loop1"))
-        # Loop 2: mirror.
-        tups.extend(build_path([SSS, AAA, BBB, TTT], n_seg0, None))
-        tups.extend(build_path([SSS, TTT], n_seg1, None, name="loop2"))
-        return tups
+        return [
+            # Loop 1: SS → AA → BB → TT perimeter (no feed), then TT → SS named.
+            Wire(SS, AA),
+            Wire(AA, BB),
+            Wire(BB, TT),
+            Wire(TT, SS, name="loop1"),
+            # Loop 2: mirror.
+            Wire(SSS, AAA),
+            Wire(AAA, BBB),
+            Wire(BBB, TTT),
+            Wire(SSS, TTT, name="loop2"),
+        ]
 
     def build_network(self):
         wavelength = 299.792458 / self.design_freq

--- a/src/antennaknobs/designs/arrays/delta_looparray_with_tls.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray_with_tls.py
@@ -4,6 +4,7 @@ from antennaknobs import AntennaBuilder
 import math
 
 from antennaknobs import Transform, TransformStack
+from antennaknobs.network import Wire
 
 from types import MappingProxyType
 
@@ -37,13 +38,8 @@ class Builder(AntennaBuilder):
         cos_theta = math.cos(angle)
         tan_theta = math.tan(angle)
 
-        def build_path(lst, ns, ex):
-            return ((a, b, ns, ex) for a, b in zip(lst[:-1], lst[1:]))
-
         def ry(p):
             return p[0], -p[1], p[2]
-
-        n_seg0 = self.nominal_nsegs
 
         # y of the top corner (half the top-edge width), in closed form.
         y = (cos_theta * (driver - 2 * eps) + 2 * eps) / (2 * (cos_theta + 1))
@@ -64,6 +60,9 @@ class Builder(AntennaBuilder):
 
         B, T = ry(A), ry(S)
 
+        # The three TL-endpoint wires keep a concrete count: the tl tuples
+        # below index their midpoint segments, so their counts must be known
+        # at build time (same policy as sterba_tl's TL ports).
         n_seg1 = self.segs_for(math.dist(T, S), math.dist(S, A))
 
         st = TransformStack()
@@ -75,20 +74,23 @@ class Builder(AntennaBuilder):
 
         SSS, AAA, BBB, TTT = ry(SS), ry(AA), ry(BB), ry(TT)
 
-        tups = []
-
-        tups.extend(build_path([SS, AA, BB, TT], n_seg0, None))
-        tups.extend(build_path([TT, SS], n_seg1, 1 + 0j))
-
-        tups.extend(build_path([SSS, AAA, BBB, TTT], n_seg0, None))
-        tups.extend(build_path([SSS, TTT], n_seg1, 1 + 0j))
+        tups = [
+            Wire(SS, AA),
+            Wire(AA, BB),
+            Wire(BB, TT),
+            Wire(TT, SS, n_seg=n_seg1, ex=1 + 0j),
+            Wire(SSS, AAA),
+            Wire(AAA, BBB),
+            Wire(BBB, TTT),
+            Wire(SSS, TTT, n_seg=n_seg1, ex=1 + 0j),
+        ]
 
         WW = (SS[0], eps, SS[1])
         WWW = ry(WW)
 
         self.tls = []
 
-        tups.extend(build_path([WWW, WW], n_seg1, 1 + 0j))
+        tups.append(Wire(WWW, WW, n_seg=n_seg1, ex=1 + 0j))
 
         feedpoints = [
             (idx, x) for idx, x in enumerate(tups, start=1) if x[3] is not None
@@ -101,10 +103,10 @@ class Builder(AntennaBuilder):
             self.del_y + wavelength * self.twist,
         )
 
-        for (idx, (p0, p1, nsegs, ev)), tl_length in zip(feedpoints[:2], tl_lengths):
+        for (idx, w), tl_length in zip(feedpoints[:2], tl_lengths):
             self.tls.append(
-                (idx, (nsegs + 1) // 2, len(tups), (n_seg1 + 1) // 2, 100, tl_length)
+                (idx, (w.n_seg + 1) // 2, len(tups), (n_seg1 + 1) // 2, 100, tl_length)
             )
-            tups[idx - 1] = (p0, p1, nsegs, None)
+            tups[idx - 1] = w._replace(ex=None)
 
         return tups

--- a/src/antennaknobs/designs/arrays/lumped_coupled_pair.py
+++ b/src/antennaknobs/designs/arrays/lumped_coupled_pair.py
@@ -22,7 +22,7 @@ cross-check pins first).
 """
 
 from antennaknobs import AntennaBuilder
-from antennaknobs.network import Driven, Network, PortOnWire, TwoPort
+from antennaknobs.network import Driven, Network, PortOnWire, TwoPort, Wire
 
 from types import MappingProxyType
 
@@ -49,14 +49,13 @@ class Builder(AntennaBuilder):
         half_arm = 0.25 * wavelength * self.length_factor
         spacing = self.spacing_factor * wavelength
         z = self.base
-        tups = []
-        n_seg = self.segs_for(2 * half_arm, 0.25 * wavelength)
-        for x, name in ((0.0, "front"), (-spacing, "rear")):
-            # One straight wire per dipole, feed edge at the centre. No `ev` —
+        return [
+            # One straight wire per dipole, feed edge at the centre. No `ex` —
             # the Network supplies the source (front) and the coupling terminal
             # (rear); `name` marks each centre segment for PortOnWire lookup.
-            tups.append(((x, -half_arm, z), (x, half_arm, z), n_seg, None, name))
-        return tups
+            Wire((x, -half_arm, z), (x, half_arm, z), name=name)
+            for x, name in ((0.0, "front"), (-spacing, "rear"))
+        ]
 
     def build_network(self):
         return Network(


### PR DESCRIPTION
## Summary

- Converted the only three arrays-family files still carrying explicit meshing to the auto-mesh `Wire()` idiom (#525 stage 2):
  - **delta_looparray_network.py** — full conversion: perimeter edges and the named feed edges (`loop1`/`loop2`) all emit `Wire()` at the design density. Names, network ports/sources, and wire emission order preserved exactly.
  - **delta_looparray_with_tls.py** — perimeter wires converted to `Wire()`; the **three TL-endpoint wires** (two loop feed edges + the `WWW`–`WW` virtual-driver stub) keep a concrete `segs_for` count, now with a comment: the `self.tls` tuples index their midpoint segments (`(n_seg+1)//2`) at build time, so those counts must be known — same policy as sterba_tl's TL ports. The feedpoint scan and excitation-clearing loop were adapted to `Wire` entries (`w._replace(ex=None)`); TL tuple format and emission order unchanged.
  - **lumped_coupled_pair.py** — `front`/`rear` named dipole wires to `Wire()`. The old `segs_for(2*half_arm, 0.25*wavelength)` is exactly the auto-mesh formula, so counts are identical (40/40) and churn is zero.
- Verified the rest of the family (**bowtiearray, bowtiearray1x2, bowtiearray2x4, delta_looparray, delta_looparray_1x4, delta_looparray_1x4_grouped, delta_looparray_2x2, folded_invveearray, hentenna_array, hourglass_array, invveearray, moxonarray, yagiarray**) composes base builders and carries **no** explicit meshing — zero grep hits for `nominal_nsegs`/`segs_for`/`nsegs=`, and the before/after probe shows byte-identical segment counts and impedance for every composition variant.
- Density correction (called out per the churn budget policy): the two delta-looparray TL/network designs' perimeter edges were meshed edge-relative at 21/edge (segment length 0.177 m vs the design density 0.125 m). Auto-mesh corrects them to 30/29/30 per edge. The impedance barely notices (0.01 ohm) because the feed edges (0.1 m, 1 segment) are unchanged, and the two sister designs still agree with each other to the same 0.02 ohm they did before.
- Sibling heads-up (PR #530 web/adapter `ex`-on-6-field-Wire bug): **no such failures surfaced here** — the full `test_web_server.py` passed on this branch.

## Churn (bs2 @ N=21, defaults)

| design / variant | segs before → after | Z before → after |
|---|---|---|
| delta_looparray_network default | 128 → 180 (perimeter 21 → 30/29/30) | 55.23 −3.26j → 55.23 −3.27j |
| delta_looparray_with_tls default | 129 → 181 (perimeter 21 → 30/29/30) | 55.21 −3.42j → 55.21 −3.43j |
| lumped_coupled_pair default | 80 → 80 (40/40 unchanged) | 70.09 −18.06j → 70.09 −18.06j |
| bowtiearray default | 680 → 680 | 201.07 +43.17j (unchanged) |
| bowtiearray1x2 default | 340 → 340 | 183.00 +32.88j (unchanged) |
| bowtiearray2x4 default | 1360 → 1360 | 212.10 +37.21j (unchanged) |
| delta_looparray default / dy3 / dy35 / dy45 | 128 → 128 | 107.90 −4.44j / 122.20 +26.30j / 97.43 +38.01j / 96.61 +37.24j (all unchanged) |
| delta_looparray_1x4 default | 256 → 256 | 190.60 +40.27j (unchanged) |
| delta_looparray_1x4_grouped default | 256 → 256 | 265.73 +60.08j (unchanged) |
| delta_looparray_2x2 default | 256 → 256 | 207.86 +55.25j (unchanged) |
| folded_invveearray default | 352 → 352 | 192.01 −7.25j (unchanged) |
| hentenna_array default | 246 → 246 | 92.97 +41.13j (unchanged) |
| hourglass_array default | 294 → 294 | 99.15 +25.83j (unchanged) |
| invveearray default / old | 172 → 172 | 47.21 −8.91j / 55.75 −52.28j (unchanged) |
| moxonarray default | 324 → 324 | 40.45 −26.62j (unchanged) |
| yagiarray default | 676 → 676 | 83.44 +0.98j (unchanged) |

## Test plan

- [x] `ruff check` + `ruff format --check` on `src/antennaknobs/designs/arrays/` — clean
- [x] Full fast suite: 2669 passed, 2 skipped (no test assertions changed; `test_delta_a_lint.py` green; no catalog regeneration needed)
- [x] Time-budget guardrail flagged `test_pynec_path_also_reports_radiation_efficiency` at 6.83s during a run concurrent with sibling agents' suites; re-run on a quiet machine: 4.57s, under the 5s ceiling — contention noise, not a regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)
