### PR TITLE
refactor(designs): bowtie to auto-mesh Wire() idiom (#525 stage 2)

### DIFF
--- a/src/antennaknobs/designs/specialty/bowtie.py
+++ b/src/antennaknobs/designs/specialty/bowtie.py
@@ -1,13 +1,24 @@
 """Bowtie dipole — triangular fan arms for broadened bandwidth."""
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 import math
 from types import MappingProxyType
 
 
 class Builder(AntennaBuilder):
     default_params = MappingProxyType(
-        {"freq": 28.47, "angle_deg": 28.2625, "base": 9.0, "length": 5.4213}
+        {
+            "freq": 28.47,
+            # Geometry is hand-tuned in absolute metres; design_freq only
+            # anchors auto_mesh's density scale (nominal_nsegs per
+            # quarter-wave), so it is hidden from the UI.
+            "design_freq": 28.47,
+            "angle_deg": 28.2625,
+            "base": 9.0,
+            "length": 5.4213,
+            "ui_params": MappingProxyType({"design_freq": {"hidden": True}}),
+        }
     )
 
     def build_wires(self):
@@ -23,29 +34,25 @@ class Builder(AntennaBuilder):
         y = half * math.cos(theta)
         z = half * math.sin(theta)
 
-        n_seg0 = self.nominal_nsegs
-        n_seg1 = self.segs_for(
-            math.dist((-eps, eps), (eps, eps)), math.dist((-y, z), (-eps, eps))
-        )
-
-        tups = []
-        tups.extend([((-y, 0), (-y, z), n_seg0, None)])
-        tups.extend([((-y, z), (-eps, eps), n_seg0, None)])
-        tups.extend([((-eps, eps), (eps, eps), n_seg1, None)])
-        tups.extend([((eps, eps), (y, z), n_seg0, None)])
-        tups.extend([((y, z), (y, 0), n_seg0, None)])
-        tups.extend([((-y, 0), (-y, -z), n_seg0, None)])
-        tups.extend([((-y, -z), (-eps, -eps), n_seg0, None)])
-        tups.extend([((eps, -eps), (y, -z), n_seg0, None)])
-        tups.extend([((y, -z), (y, 0), n_seg0, None)])
-        tups.extend([((-eps, -eps), (eps, -eps), n_seg1, 1 + 0j)])
+        tups = [
+            ((-y, 0), (-y, z), None),
+            ((-y, z), (-eps, eps), None),
+            ((-eps, eps), (eps, eps), None),
+            ((eps, eps), (y, z), None),
+            ((y, z), (y, 0), None),
+            ((-y, 0), (-y, -z), None),
+            ((-y, -z), (-eps, -eps), None),
+            ((eps, -eps), (y, -z), None),
+            ((y, -z), (y, 0), None),
+            ((-eps, -eps), (eps, -eps), 1 + 0j),
+        ]
 
         new_tups = []
         for yoff, zoff in [(0, self.base)]:
             new_tups.extend(
                 [
-                    ((0, y0 + yoff, z0 + zoff), (0, y1 + yoff, z1 + zoff), ns, ev)
-                    for ((y0, z0), (y1, z1), ns, ev) in tups
+                    Wire((0, y0 + yoff, z0 + zoff), (0, y1 + yoff, z1 + zoff), ex=ev)
+                    for ((y0, z0), (y1, z1), ev) in tups
                 ]
             )
 

--- a/tests/test_segment_convergence.py
+++ b/tests/test_segment_convergence.py
@@ -46,18 +46,18 @@ def test_builder_default_nominal_nsegs():
 
 
 def test_builder_nominal_nsegs_scales_per_edge_counts():
-    """The hardcoded n_seg literals are now expressions in nominal_nsegs.
-    Major edges scale 1:1; minor edges mesh proportionally to their length
-    via segs_for (issue #457 — no more ad-hoc max(3, nominal // 7) floor),
-    so a short bridge stays a valid ≥1-segment mesh at any N."""
+    """Auto-mesh (issue #521): every wire's None count resolves to
+    max(1, round(nominal_nsegs * length / quarter_wave)), so each edge
+    meshes proportionally to its own length at the design density — the
+    long diagonal arms densest, the vertical tips lighter, and the short
+    feed bridge a valid ≥1-segment mesh at any N."""
     b = BowtieBuilder()
     b.nominal_nsegs = 41
     seg_counts = sorted({t[2] for t in b.build_wires()})
-    assert 41 in seg_counts  # major radiator scaled with N
-    assert min(seg_counts) >= 1
+    assert seg_counts == [2, 14, 28]  # bridge / vertical tip / diagonal arm
     b.nominal_nsegs = 7
     small = sorted({t[2] for t in b.build_wires()})
-    assert 7 in small and min(small) == 1  # bridge is proportional, clipped at 1
+    assert small == [1, 2, 5]  # bridge is proportional, clipped at 1
 
 
 # Parity coercion lands an engine attachment on a wire's middle segment, so it


### PR DESCRIPTION
## Summary
- Convert `specialty/bowtie.py` — the only specialty design still hand-meshing (hentenna×2 and hourglass×2 landed in #524) — to the auto-mesh `Wire()` idiom: all ten edges emit `None` counts, retiring `nominal_nsegs`/`segs_for` scaffolding.
- Geometry is hand-tuned in absolute metres, so a hidden `design_freq` (= default `freq`, 28.47 MHz) is added to anchor the density scale, same pattern as `beams/moxon.py`.
- Mesh at N=21: 170 → 86 segments. The legacy code put the full nominal count on every edge regardless of length (over-dense vertical tips); edges now mesh proportionally per λ/4.
- `tests/test_segment_convergence.py::test_builder_nominal_nsegs_scales_per_edge_counts` updated to the density-correct expectation: counts at N=41 are `[2, 14, 28]` (bridge / vertical tip / diagonal arm) and `[1, 2, 5]` at N=7 — the old assertion required the full nominal on the longest edge.
- No variants: bowtie has only `default_params` (probe auto-discovery confirmed).

**Known failure, do not fix here:** 8 `test_web_server.py` multi-feed/z0 tests fail on this branch because `web/adapter.py`'s `_auto_target_z0`/`_auto_multi_feed` read the excitation as the *last* tuple field, which on 6-field `Wire` entries is `spec`, not `ex`. Bowtie is the first `Wire`-emitting element wrapped by `Array*` builders, so the latent bug fires now. The framework fix (via the `as_wire` choke point) lands in PR #530 (auto-mesh-loops); this PR deliberately does not duplicate it. Everything else in the suite is green: 8 failed (all known), 2661 passed, 2 skipped.

## Churn (bs2 @ N=21, defaults)

| variant | seg counts before | after | total | Z before | Z after | churn |
|---|---|---|---|---|---|---|
| `specialty.bowtie` default | `[21,21,1,21,21,21,21,21,21,1]` | `[7,14,1,14,7,7,14,14,7,1]` | 170 → 86 | 187.71+14.34j | 187.68+14.03j | 0.17% |

Downstream array wrappers (consume `bowtie.Builder`, probed for safety):

| design | total segs | Z before (per port) | Z after | max churn |
|---|---|---|---|---|
| `arrays.bowtiearray1x2` | 340 → 172 | 183.00+32.88j ×2 | 182.97+32.55j ×2 | 0.18% |
| `arrays.bowtiearray` | 680 → 360 | 201.07+43.17j / 223.25+36.52j | 200.98+42.81j / 223.23+36.20j | 0.18% |
| `arrays.bowtiearray2x4` | 1360 → 720 | 212.10+37.21j … 234.52+29.15j | 212.02+36.85j … 234.52+28.83j | 0.17% |

All well inside the ~2% budget — density correction only.

## Test plan
- [x] `ruff check` + `ruff format --check` on touched files
- [x] Full fast suite: 2661 passed, 2 skipped; only the 8 known adapter failures above (fixed by PR #530)
- [x] Geometry-density lint (`test_delta_a_lint.py`) green
- [x] Catalog regeneration: no changes (`catalog.md already up to date`)
- [x] Churn probes before/after under `ulimit -v 6291456`, incl. the three bowtie array wrappers

🤖 Generated with [Claude Code](https://claude.com/claude-code)