### PR TITLE
refactor(designs): verticals family to auto-mesh Wire() idiom (#525 stage 2)

### DIFF
--- a/src/antennaknobs/designs/verticals/bobtail.py
+++ b/src/antennaknobs/designs/verticals/bobtail.py
@@ -44,6 +44,7 @@ The structure is planar in x = 0.
 """
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 from types import MappingProxyType
 
 
@@ -92,7 +93,6 @@ class Builder(AntennaBuilder):
         eps = 0.05
 
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         vert = self.vert_frac * wavelength * self.length_factor
         span = self.span_frac * wavelength * self.length_factor
@@ -100,68 +100,22 @@ class Builder(AntennaBuilder):
         z_bot = self.base
         z_top = self.base + vert
 
-        tups = []
-
-        # Top phasing wire: -span -> 0 -> +span, split at the centre so the
-        # centre vertical shares the junction node.
-        tups.append(
-            (
-                (0.0, -span, z_top),
-                (0.0, 0.0, z_top),
-                self.segs_for(span, quarter),
-                None,
-            )
-        )
-        tups.append(
-            ((0.0, 0.0, z_top), (0.0, span, z_top), self.segs_for(span, quarter), None)
-        )
-
-        # Outer verticals (passive, open at the bottom).
-        tups.append(
-            (
-                (0.0, -span, z_top),
-                (0.0, -span, z_bot),
-                self.segs_for(vert, quarter),
-                None,
-            )
-        )
-        tups.append(
-            (
-                (0.0, span, z_top),
-                (0.0, span, z_bot),
-                self.segs_for(vert, quarter),
-                None,
-            )
-        )
-
-        # Centre vertical: a one-segment driven gap tapped `feed_height_frac`
-        # of the way up (a current maximum), with passive wire above and below.
-        # zf is the lower edge of the gap.
+        # Centre vertical's driven gap taps `feed_height_frac` of the way up
+        # (a current maximum), with passive wire above and below. zf is the
+        # lower edge of the gap.
         feed = 2 * eps
         zf = z_bot + self.feed_height_frac * (vert - feed)
-        tups.append(
-            (
-                (0.0, 0.0, z_top),
-                (0.0, 0.0, zf + feed),
-                self.segs_for(z_top - (zf + feed), quarter),
-                None,
-            )
-        )
-        tups.append(
-            (
-                (0.0, 0.0, zf + feed),
-                (0.0, 0.0, zf),
-                self.segs_for(feed, quarter),
-                1 + 0j,
-            )
-        )
-        tups.append(
-            (
-                (0.0, 0.0, zf),
-                (0.0, 0.0, z_bot),
-                self.segs_for(zf - z_bot, quarter),
-                None,
-            )
-        )
 
-        return tups
+        return [
+            # Top phasing wire: -span -> 0 -> +span, split at the centre so
+            # the centre vertical shares the junction node.
+            Wire((0.0, -span, z_top), (0.0, 0.0, z_top)),
+            Wire((0.0, 0.0, z_top), (0.0, span, z_top)),
+            # Outer verticals (passive, open at the bottom).
+            Wire((0.0, -span, z_top), (0.0, -span, z_bot)),
+            Wire((0.0, span, z_top), (0.0, span, z_bot)),
+            # Centre vertical: passive above, driven gap, passive below.
+            Wire((0.0, 0.0, z_top), (0.0, 0.0, zf + feed)),
+            Wire((0.0, 0.0, zf + feed), (0.0, 0.0, zf), ex=1 + 0j),
+            Wire((0.0, 0.0, zf), (0.0, 0.0, z_bot)),
+        ]

--- a/src/antennaknobs/designs/verticals/bruce.py
+++ b/src/antennaknobs/designs/verticals/bruce.py
@@ -45,7 +45,7 @@ Geometry, in the framework's (x, y, z) convention:
 """
 
 from antennaknobs import AntennaBuilder
-import math
+from antennaknobs.network import Wire
 from types import MappingProxyType
 
 
@@ -99,7 +99,6 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         vert = self.vert_frac * wavelength * self.length_factor
         horiz = self.horiz_frac * wavelength * self.length_factor
@@ -128,37 +127,13 @@ class Builder(AntennaBuilder):
 
         tups = []
         for k, ((ya, za), (yb, zb)) in enumerate(zip(nodes[:-1], nodes[1:])):
-            seg = math.hypot(yb - ya, zb - za)
             if k == fa:
                 # Split the end riser: passive below, 1-seg driven gap, passive
                 # above (a current-maximum-style tap, but on a current minimum).
-                tups.append(
-                    (
-                        (0.0, ya, za),
-                        (0.0, ya, zf),
-                        self.segs_for(zf - za, quarter),
-                        None,
-                    )
-                )
-                tups.append(
-                    (
-                        (0.0, ya, zf),
-                        (0.0, ya, zf + 2 * eps),
-                        self.segs_for(2 * eps, quarter),
-                        1 + 0j,
-                    )
-                )
-                tups.append(
-                    (
-                        (0.0, ya, zf + 2 * eps),
-                        (0.0, yb, zb),
-                        self.segs_for(zb - (zf + 2 * eps), quarter),
-                        None,
-                    )
-                )
+                tups.append(Wire((0.0, ya, za), (0.0, ya, zf)))
+                tups.append(Wire((0.0, ya, zf), (0.0, ya, zf + 2 * eps), ex=1 + 0j))
+                tups.append(Wire((0.0, ya, zf + 2 * eps), (0.0, yb, zb)))
             else:
-                tups.append(
-                    ((0.0, ya, za), (0.0, yb, zb), self.segs_for(seg, quarter), None)
-                )
+                tups.append(Wire((0.0, ya, za), (0.0, yb, zb)))
 
         return tups

--- a/src/antennaknobs/designs/verticals/challenger.py
+++ b/src/antennaknobs/designs/verticals/challenger.py
@@ -39,6 +39,7 @@ from antennaknobs.network import (
     Network,
     PortOnWire,
     PortVirtual,
+    Wire,
     WireSpec,
 )
 from antennaknobs.station import unun
@@ -54,6 +55,11 @@ class Builder(AntennaBuilder):
         {
             # 15M — the band the plans publish detailed 4NEC2 claims for.
             "freq": 21.35,
+            # Geometry is per-band absolute inches; design_freq only anchors
+            # auto_mesh's density scale (nominal_nsegs per quarter-wave at
+            # the band the lengths are cut for), so it is hidden from the
+            # UI. Each band variant restates it alongside its freq.
+            "design_freq": 21.35,
             # "Computer Model" columns: 12" pigtail + whip = total radiator.
             "whip_len_m": 205 * _IN,
             "cp_len_m": 65 * _IN,
@@ -69,6 +75,7 @@ class Builder(AntennaBuilder):
                 {
                     "target_z0": 50.0,
                     "default_view": "xz",
+                    "design_freq": {"hidden": True},
                     "whip_len_m": {"min": 1.0, "max": 8.0, "unit": "m"},
                     "cp_len_m": {"min": 0.3, "max": 3.0, "unit": "m"},
                     "h_feed": {"min": 0.3, "max": 1.5, "unit": "m"},
@@ -86,21 +93,48 @@ class Builder(AntennaBuilder):
     # Challenger+: Palomar Bullet 4:1, measured −0.24 dB.
     plus_params = MappingProxyType({"lmag_uH": 1.75, "qlmag": 3.0})
 
-    # Per-band "Computer Model" radiator/counterpoise lengths.
+    # Per-band "Computer Model" radiator/counterpoise lengths. design_freq
+    # tracks the band so the auto-mesh density follows the wavelength the
+    # lengths are cut for.
     band20_params = MappingProxyType(
-        {"freq": 14.25, "whip_len_m": 304 * _IN, "cp_len_m": 99 * _IN}
+        {
+            "freq": 14.25,
+            "design_freq": 14.25,
+            "whip_len_m": 304 * _IN,
+            "cp_len_m": 99 * _IN,
+        }
     )
     band17_params = MappingProxyType(
-        {"freq": 18.14, "whip_len_m": 240 * _IN, "cp_len_m": 76 * _IN}
+        {
+            "freq": 18.14,
+            "design_freq": 18.14,
+            "whip_len_m": 240 * _IN,
+            "cp_len_m": 76 * _IN,
+        }
     )
     band12_params = MappingProxyType(
-        {"freq": 24.94, "whip_len_m": 175 * _IN, "cp_len_m": 56 * _IN}
+        {
+            "freq": 24.94,
+            "design_freq": 24.94,
+            "whip_len_m": 175 * _IN,
+            "cp_len_m": 56 * _IN,
+        }
     )
     band10_params = MappingProxyType(
-        {"freq": 28.40, "whip_len_m": 154 * _IN, "cp_len_m": 49 * _IN}
+        {
+            "freq": 28.40,
+            "design_freq": 28.40,
+            "whip_len_m": 154 * _IN,
+            "cp_len_m": 49 * _IN,
+        }
     )
     band6_params = MappingProxyType(
-        {"freq": 51.00, "whip_len_m": 87 * _IN, "cp_len_m": 26 * _IN}
+        {
+            "freq": 51.00,
+            "design_freq": 51.00,
+            "whip_len_m": 87 * _IN,
+            "cp_len_m": 26 * _IN,
+        }
     )
 
     # Transformer turns ratio: 4:1 impedance = 2:1 turns, rig side low.
@@ -116,23 +150,19 @@ class Builder(AntennaBuilder):
         droop = math.asin(min(1.0, max(0.0, h - self.cp_end_h) / self.cp_len_m))
 
         return [
-            (
-                (0, 0, h),
-                (0, 0, h + eps),
-                self.segs_for(eps, self.whip_len_m),
-                None,
-                "ant",
-            ),
-            ((0, 0, h + eps), (0, 0, h + self.whip_len_m), self.nominal_nsegs, None),
-            (
+            # Gap wire at the whip base carries the "ant" port.
+            Wire((0, 0, h), (0, 0, h + eps), name="ant"),
+            Wire((0, 0, h + eps), (0, 0, h + self.whip_len_m)),
+            # Counterpoise keeps its validated floored allocation (#525
+            # stage 3 retires the remaining hand counts).
+            Wire(
                 (0, 0, h),
                 (
                     self.cp_len_m * math.cos(droop),
                     0.0,
                     h - self.cp_len_m * math.sin(droop),
                 ),
-                max(5, self.nominal_nsegs // 3),
-                None,
+                n_seg=max(5, self.nominal_nsegs // 3),
             ),
         ]
 

--- a/src/antennaknobs/designs/verticals/dominator.py
+++ b/src/antennaknobs/designs/verticals/dominator.py
@@ -34,6 +34,7 @@ from antennaknobs.network import (
     Network,
     PortOnWire,
     PortVirtual,
+    Wire,
     WireSpec,
 )
 from antennaknobs.station import unun
@@ -54,6 +55,11 @@ class Builder(AntennaBuilder):
         {
             # 15M reference band ("Computer Model" columns).
             "freq": 21.35,
+            # Geometry is per-band absolute inches; design_freq only anchors
+            # auto_mesh's density scale (nominal_nsegs per quarter-wave at
+            # the band the lengths are cut for), so it is hidden from the
+            # UI. Each band variant restates it alongside its freq.
+            "design_freq": 21.35,
             "whip_len_m": 272 * _IN,
             "cp_len_m": 175 * _IN,
             # Feed 48–52" up ("I recommend the feedpoint be elevated
@@ -73,6 +79,7 @@ class Builder(AntennaBuilder):
                 {
                     "target_z0": 50.0,
                     "default_view": "xz",
+                    "design_freq": {"hidden": True},
                     "whip_len_m": {"min": 2.0, "max": 8.5, "unit": "m"},
                     "cp_len_m": {"min": 1.0, "max": 6.0, "unit": "m"},
                     "h_feed": {"min": 0.3, "max": 1.6, "unit": "m"},
@@ -93,15 +100,32 @@ class Builder(AntennaBuilder):
         {"xfmr_ratio": "56:1", "lmag_uH": 0.74, "qlmag": 3.0}
     )
 
-    # Per-band "Computer Model" radiator/counterpoise lengths.
+    # Per-band "Computer Model" radiator/counterpoise lengths. design_freq
+    # tracks the band so the auto-mesh density follows the wavelength the
+    # lengths are cut for.
     band17_params = MappingProxyType(
-        {"freq": 18.14, "whip_len_m": 315 * _IN, "cp_len_m": 206 * _IN}
+        {
+            "freq": 18.14,
+            "design_freq": 18.14,
+            "whip_len_m": 315 * _IN,
+            "cp_len_m": 206 * _IN,
+        }
     )
     band12_params = MappingProxyType(
-        {"freq": 24.94, "whip_len_m": 233 * _IN, "cp_len_m": 150 * _IN}
+        {
+            "freq": 24.94,
+            "design_freq": 24.94,
+            "whip_len_m": 233 * _IN,
+            "cp_len_m": 150 * _IN,
+        }
     )
     band10_params = MappingProxyType(
-        {"freq": 28.40, "whip_len_m": 204 * _IN, "cp_len_m": 132 * _IN}
+        {
+            "freq": 28.40,
+            "design_freq": 28.40,
+            "whip_len_m": 204 * _IN,
+            "cp_len_m": 132 * _IN,
+        }
     )
 
     def build_wire_material(self):
@@ -114,23 +138,19 @@ class Builder(AntennaBuilder):
         droop = math.asin(min(1.0, max(0.0, h - self.cp_end_h) / self.cp_len_m))
 
         return [
-            (
-                (0, 0, h),
-                (0, 0, h + eps),
-                self.segs_for(eps, self.whip_len_m),
-                None,
-                "ant",
-            ),
-            ((0, 0, h + eps), (0, 0, h + self.whip_len_m), self.nominal_nsegs, None),
-            (
+            # Gap wire at the whip base carries the "ant" port.
+            Wire((0, 0, h), (0, 0, h + eps), name="ant"),
+            Wire((0, 0, h + eps), (0, 0, h + self.whip_len_m)),
+            # Counterpoise keeps its validated floored allocation (#525
+            # stage 3 retires the remaining hand counts).
+            Wire(
                 (0, 0, h),
                 (
                     self.cp_len_m * math.cos(droop),
                     0.0,
                     h - self.cp_len_m * math.sin(droop),
                 ),
-                max(7, self.nominal_nsegs // 2),
-                None,
+                n_seg=max(7, self.nominal_nsegs // 2),
             ),
         ]
 

--- a/src/antennaknobs/designs/verticals/four_square.py
+++ b/src/antennaknobs/designs/verticals/four_square.py
@@ -49,6 +49,7 @@ Geometry, in the framework's (x, y, z) convention:
 """
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 from types import MappingProxyType
 
 
@@ -106,7 +107,6 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         elem = self.elem_frac * wavelength * self.length_factor
         spacing = self.spacing_frac * wavelength
@@ -122,9 +122,9 @@ class Builder(AntennaBuilder):
             C0 = (x, y, zc - eps)
             C1 = (x, y, zc + eps)
             return [
-                (B, C0, self.segs_for(half - eps, quarter), None),
-                (C0, C1, self.segs_for(2 * eps, quarter), voltage),
-                (C1, T, self.segs_for(half - eps, quarter), None),
+                Wire(B, C0),
+                Wire(C0, C1, ex=voltage),
+                Wire(C1, T),
             ]
 
         side = complex(self.side_mag) * (-1j)

--- a/src/antennaknobs/designs/verticals/half_square.py
+++ b/src/antennaknobs/designs/verticals/half_square.py
@@ -30,6 +30,7 @@ The structure is planar in x = 0.
 """
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 from types import MappingProxyType
 
 
@@ -70,7 +71,6 @@ class Builder(AntennaBuilder):
         eps = 0.05
 
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         vert = self.vert_frac * wavelength * self.length_factor
         horiz = self.horiz_frac * wavelength * self.length_factor
@@ -79,10 +79,6 @@ class Builder(AntennaBuilder):
         z_bot = self.base
         z_top = self.base + vert
 
-        # Keep the per-segment length roughly uniform across wires of
-        # different lengths (good NEC practice at the corner junctions):
-        # scale each wire's segment count by its length relative to a
-        # quarter wave. Odd counts so the centre falls on a segment.
         # A short feed gap just below the left top corner, at the current
         # maximum. One segment carries the excitation (cf. moxon.py).
         feed = 2 * eps
@@ -92,14 +88,13 @@ class Builder(AntennaBuilder):
         D = (0.0, y_right, z_top)
         B = (0.0, y_right, z_bot)
 
-        tups = []
-        # Left leg (bottom -> just below corner), passive.
-        tups.append((A, F, self.segs_for(vert - feed, quarter), None))
-        # Feed segment at the corner, driven.
-        tups.append((F, C, self.segs_for(feed, quarter), 1 + 0j))
-        # Top wire, passive.
-        tups.append((C, D, self.segs_for(horiz, quarter), None))
-        # Right leg (corner -> bottom), passive.
-        tups.append((D, B, self.segs_for(vert, quarter), None))
-
-        return tups
+        return [
+            # Left leg (bottom -> just below corner), passive.
+            Wire(A, F),
+            # Feed segment at the corner, driven.
+            Wire(F, C, ex=1 + 0j),
+            # Top wire, passive.
+            Wire(C, D),
+            # Right leg (corner -> bottom), passive.
+            Wire(D, B),
+        ]

--- a/src/antennaknobs/designs/verticals/inverted_l.py
+++ b/src/antennaknobs/designs/verticals/inverted_l.py
@@ -29,6 +29,7 @@ Geometry, in the framework's (x, y, z) convention:
 """
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 import math
 from types import MappingProxyType
 
@@ -77,39 +78,22 @@ class Builder(AntennaBuilder):
         # segments at the feed junction on fine meshes — a graded-junction
         # ratio the pulse/sinusoidal bases handle badly, so PyNEC/sin diverged
         # up the convergence ladder while BSpline d=2 stayed flat).
-        n_seg_radials = self.segs_for(quarter, quarter)
         n_radials = 4
         radial_len = quarter  # quarter-wave radials, like a ground-plane vert
 
         tups = []
         # Base feed: a one-segment driven gap at the foot of the riser, against
         # the radial counterpoise (cf. designs/vertical.py).
-        tups.append(
-            ((0.0, 0.0, z), (0.0, 0.0, z + eps), self.segs_for(eps, quarter), 1 + 0j)
-        )
+        tups.append(Wire((0.0, 0.0, z), (0.0, 0.0, z + eps), ex=1 + 0j))
         # Vertical riser, then the horizontal top section.
-        tups.append(
-            (
-                (0.0, 0.0, z + eps),
-                (0.0, 0.0, z + vert),
-                self.segs_for(vert, quarter),
-                None,
-            )
-        )
-        tups.append(
-            (
-                (0.0, 0.0, z + vert),
-                (0.0, horiz, z + vert),
-                self.segs_for(horiz, quarter),
-                None,
-            )
-        )
+        tups.append(Wire((0.0, 0.0, z + eps), (0.0, 0.0, z + vert)))
+        tups.append(Wire((0.0, 0.0, z + vert), (0.0, horiz, z + vert)))
 
         # Elevated radials spreading from the feedpoint in the x/y plane.
         for i in range(n_radials):
             theta = 2 * math.pi / n_radials * i
             rx = radial_len * math.cos(theta)
             ry = radial_len * math.sin(theta)
-            tups.append(((0.0, 0.0, z), (rx, ry, z), n_seg_radials, None))
+            tups.append(Wire((0.0, 0.0, z), (rx, ry, z)))
 
         return tups

--- a/src/antennaknobs/designs/verticals/inverted_l_tmatch.py
+++ b/src/antennaknobs/designs/verticals/inverted_l_tmatch.py
@@ -54,6 +54,7 @@ from antennaknobs.network import (
     Network,
     PortOnWire,
     PortVirtual,
+    as_wire,
 )
 from antennaknobs.station import t_network_tuner
 
@@ -111,13 +112,10 @@ class Builder(InvertedL):
         # Reuse the inverted-L geometry verbatim; rename the driven base gap
         # as the network's "feed" port and clear its inline excitation — the
         # T-network supplies the source at the virtual `in` node instead.
-        wires = []
-        for p0, p1, nseg, ev, *rest in super().build_wires():
-            if ev is not None:
-                wires.append((p0, p1, nseg, None, "feed"))
-            else:
-                wires.append((p0, p1, nseg, ev, *rest))
-        return wires
+        return [
+            w._replace(ex=None, name="feed") if w.ex is not None else w
+            for w in map(as_wire, super().build_wires())
+        ]
 
     def build_network(self):
         return Network(

--- a/src/antennaknobs/designs/verticals/jpole.py
+++ b/src/antennaknobs/designs/verticals/jpole.py
@@ -28,6 +28,7 @@ Geometry, in the framework's (x, y, z) convention:
 """
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 from types import MappingProxyType
 
 
@@ -81,49 +82,26 @@ class Builder(AntennaBuilder):
 
         # Leg A at x = 0 carries the radiator on top; leg B at x = gap is the
         # short open-ended stub leg.
-        tups = []
-        # Bottom short bar bridging the two legs.
-        tups.append(((0.0, 0.0, z_short), (gap, 0.0, z_short), 1, None))
-
-        # Leg A: short -> tap node -> stub top, then the radiator continues up.
-        tups.append(
-            ((0.0, 0.0, z_short), (0.0, 0.0, z_tap), self.segs_for(tap, quarter), None)
-        )
-        tups.append(
-            (
+        return [
+            # Bottom short bar bridging the two legs (deliberately pinned at
+            # one segment; retiring it is #525 stage 3).
+            Wire((0.0, 0.0, z_short), (gap, 0.0, z_short), n_seg=1),
+            # Leg A: short -> tap node -> stub top, then the radiator
+            # continues up.
+            Wire((0.0, 0.0, z_short), (0.0, 0.0, z_tap)),
+            Wire((0.0, 0.0, z_tap), (0.0, 0.0, z_stub_top)),
+            Wire((0.0, 0.0, z_stub_top), (0.0, 0.0, z_rad_top)),
+            # Leg B: short -> tap node -> stub top (open).
+            Wire((gap, 0.0, z_short), (gap, 0.0, z_tap)),
+            Wire((gap, 0.0, z_tap), (gap, 0.0, z_stub_top)),
+            # Feed: a driven bridge between the two legs at the tap, meshed
+            # proportionally like every other edge so the delta gap refines
+            # with the mesh (issue #435 — its empirical 2-segment default
+            # comes from exactly this density; kept on segs_for verbatim).
+            Wire(
                 (0.0, 0.0, z_tap),
-                (0.0, 0.0, z_stub_top),
-                self.segs_for(stub - tap, quarter),
-                None,
-            )
-        )
-        tups.append(
-            (
-                (0.0, 0.0, z_stub_top),
-                (0.0, 0.0, z_rad_top),
-                self.segs_for(radiator, quarter),
-                None,
-            )
-        )
-
-        # Leg B: short -> tap node -> stub top (open).
-        tups.append(
-            ((gap, 0.0, z_short), (gap, 0.0, z_tap), self.segs_for(tap, quarter), None)
-        )
-        tups.append(
-            (
                 (gap, 0.0, z_tap),
-                (gap, 0.0, z_stub_top),
-                self.segs_for(stub - tap, quarter),
-                None,
-            )
-        )
-
-        # Feed: a driven bridge between the two legs at the tap, meshed
-        # proportionally like every other edge so the delta gap refines
-        # with the mesh (issue #435).
-        tups.append(
-            ((0.0, 0.0, z_tap), (gap, 0.0, z_tap), self.segs_for(gap, quarter), 1 + 0j)
-        )
-
-        return tups
+                n_seg=self.segs_for(gap, quarter),
+                ex=1 + 0j,
+            ),
+        ]

--- a/src/antennaknobs/designs/verticals/phased_verticals.py
+++ b/src/antennaknobs/designs/verticals/phased_verticals.py
@@ -35,6 +35,7 @@ Geometry, in the framework's (x, y, z) convention:
 """
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 from types import MappingProxyType
 
 
@@ -80,7 +81,6 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         elem = self.elem_frac * wavelength
         spacing = self.spacing_frac * wavelength
@@ -94,9 +94,9 @@ class Builder(AntennaBuilder):
             C0 = (x, 0.0, zc - eps)
             C1 = (x, 0.0, zc + eps)
             return [
-                (B, C0, self.segs_for(half - eps, quarter), None),
-                (C0, C1, self.segs_for(2 * eps, quarter), voltage),
-                (C1, T, self.segs_for(half - eps, quarter), None),
+                Wire(B, C0),
+                Wire(C0, C1, ex=voltage),
+                Wire(C1, T),
             ]
 
         tups = []

--- a/src/antennaknobs/designs/verticals/pota_performer.py
+++ b/src/antennaknobs/designs/verticals/pota_performer.py
@@ -50,7 +50,7 @@ import math
 from types import MappingProxyType
 
 from antennaknobs import AntennaBuilder
-from antennaknobs.network import WireSpec
+from antennaknobs.network import Wire, WireSpec
 
 _IN = 0.0254
 
@@ -66,6 +66,11 @@ class Builder(AntennaBuilder):
             # Whip/radial lengths straight from the plans' per-band table
             # (144" / 120"); no retune, the point is duplicating HIS numbers.
             "freq": 21.35,
+            # Geometry is per-band absolute inches; design_freq only anchors
+            # auto_mesh's density scale (nominal_nsegs per quarter-wave at
+            # the band the lengths are cut for), so it is hidden from the
+            # UI. Each band variant restates it alongside its freq.
+            "design_freq": 21.35,
             "whip_len_m": 144 * _IN,
             "radial_len_m": 120 * _IN,
             "h_feed": 52 * _IN,
@@ -78,6 +83,7 @@ class Builder(AntennaBuilder):
                 {
                     "target_z0": 50.0,
                     "default_view": "xz",
+                    "design_freq": {"hidden": True},
                     # Max covers band20's 207" = 5.26 m (17' whip + stud).
                     "whip_len_m": {"min": 1.0, "max": 5.3, "unit": "m"},
                     "radial_len_m": {"min": 0.5, "max": 5.1, "unit": "m"},
@@ -98,20 +104,47 @@ class Builder(AntennaBuilder):
     single_radial_params = MappingProxyType({"n_radials": 1})
 
     # Per-band whip/radial lengths from the plans (target freqs + inches).
+    # design_freq tracks the band so the auto-mesh density follows the
+    # wavelength the lengths are cut for.
     band20_params = MappingProxyType(
-        {"freq": 14.25, "whip_len_m": 207 * _IN, "radial_len_m": 198 * _IN}
+        {
+            "freq": 14.25,
+            "design_freq": 14.25,
+            "whip_len_m": 207 * _IN,
+            "radial_len_m": 198 * _IN,
+        }
     )
     band17_params = MappingProxyType(
-        {"freq": 18.14, "whip_len_m": 165 * _IN, "radial_len_m": 149 * _IN}
+        {
+            "freq": 18.14,
+            "design_freq": 18.14,
+            "whip_len_m": 165 * _IN,
+            "radial_len_m": 149 * _IN,
+        }
     )
     band12_params = MappingProxyType(
-        {"freq": 24.94, "whip_len_m": 126 * _IN, "radial_len_m": 96 * _IN}
+        {
+            "freq": 24.94,
+            "design_freq": 24.94,
+            "whip_len_m": 126 * _IN,
+            "radial_len_m": 96 * _IN,
+        }
     )
     band10_params = MappingProxyType(
-        {"freq": 28.40, "whip_len_m": 113 * _IN, "radial_len_m": 80 * _IN}
+        {
+            "freq": 28.40,
+            "design_freq": 28.40,
+            "whip_len_m": 113 * _IN,
+            "radial_len_m": 80 * _IN,
+        }
     )
     band6_params = MappingProxyType(
-        {"freq": 51.00, "whip_len_m": 64 * _IN, "radial_len_m": 43 * _IN}
+        {
+            "freq": 51.00,
+            "design_freq": 51.00,
+            "whip_len_m": 64 * _IN,
+            "radial_len_m": 43 * _IN,
+        }
     )
 
     def build_wire_material(self):
@@ -128,8 +161,8 @@ class Builder(AntennaBuilder):
         tups = [
             # Gap wire at the whip base carries the port (ev on its one
             # segment); the whip proper stacks on top of it.
-            ((0, 0, h), (0, 0, h + eps), self.segs_for(eps, self.whip_len_m), 1 + 0j),
-            ((0, 0, h + eps), (0, 0, h + self.whip_len_m), self.nominal_nsegs, None),
+            Wire((0, 0, h), (0, 0, h + eps), ex=1 + 0j),
+            Wire((0, 0, h + eps), (0, 0, h + self.whip_len_m)),
         ]
 
         n = int(self.n_radials)
@@ -138,6 +171,8 @@ class Builder(AntennaBuilder):
         phis = (
             [0.0] if n == 1 else [-self.radial_span_deg / 2, self.radial_span_deg / 2]
         )
+        # Radials keep their validated floored allocation (#525 stage 3
+        # retires the remaining hand counts).
         r_seg = max(5, self.nominal_nsegs // 3)
         for phi_deg in phis:
             p = math.radians(phi_deg)
@@ -146,5 +181,5 @@ class Builder(AntennaBuilder):
                 self.radial_len_m * math.cos(droop) * math.sin(p),
                 h - self.radial_len_m * math.sin(droop),
             )
-            tups.append(((0, 0, h), end, r_seg, None))
+            tups.append(Wire((0, 0, h), end, n_seg=r_seg))
         return tups

--- a/src/antennaknobs/designs/verticals/raised_vertical.py
+++ b/src/antennaknobs/designs/verticals/raised_vertical.py
@@ -1,6 +1,7 @@
 """Elevated quarter-wave vertical, fed above ground."""
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 
 import math
 from types import MappingProxyType
@@ -10,10 +11,15 @@ class Builder(AntennaBuilder):
     default_params = MappingProxyType(
         {
             "freq": 14.27,
+            # Geometry is hand-tuned in absolute metres; design_freq only
+            # anchors auto_mesh's density scale (nominal_nsegs per
+            # quarter-wave), so it is hidden from the UI.
+            "design_freq": 14.27,
             "length": 5.2245,
             "radial_factor": 0.9545,
             "theta": 110.0,
             "base": 3.0,
+            "ui_params": MappingProxyType({"design_freq": {"hidden": True}}),
         }
     )
 
@@ -21,15 +27,12 @@ class Builder(AntennaBuilder):
         eps = 0.05
 
         z = self.length
-
-        n_seg0 = self.nominal_nsegs
-        # Driven gap at the riser foot refines with the mesh (issue #435);
-        # the riser above it (length z - eps) carries n_seg0.
-        n_seg1 = self.segs_for(eps, z - eps)
+        base = self.base
 
         tups = []
-        tups.extend([((0, 0, 0), (0, 0, eps), n_seg1, 1 + 0j)])
-        tups.extend([((0, 0, eps), (0, 0, z), n_seg0, None)])
+        # Driven gap at the riser foot; the riser stacks on top of it.
+        tups.append(Wire((0, 0, base), (0, 0, base + eps), ex=1 + 0j))
+        tups.append(Wire((0, 0, base + eps), (0, 0, base + z)))
 
         # ±45° spread of the two sloping radials
         radial_angle = math.pi / 4
@@ -43,11 +46,6 @@ class Builder(AntennaBuilder):
             y = r * math.sin(phi) * math.sin(theta)
             rz = r * math.cos(theta)
 
-            tups.extend([((0, 0, 0), (x, y, rz), n_seg0, None)])
+            tups.append(Wire((0, 0, base), (x, y, rz + base)))
 
-        base = self.base
-        new_tups = []
-        for (x0, y0, z0), (x1, y1, z1), n_seg, ev in tups:
-            new_tups.append(((x0, y0, z0 + base), (x1, y1, z1 + base), n_seg, ev))
-
-        return new_tups
+        return tups

--- a/src/antennaknobs/designs/verticals/rectangle.py
+++ b/src/antennaknobs/designs/verticals/rectangle.py
@@ -49,7 +49,7 @@ element (a `TL` branch), not geometry.
 """
 
 from antennaknobs import AntennaBuilder
-from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL
+from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL, Wire
 from types import MappingProxyType
 
 
@@ -100,7 +100,6 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
         lf = self.length_factor
 
         w = self.horiz_frac * wavelength * lf
@@ -119,16 +118,15 @@ class Builder(AntennaBuilder):
         F0 = (0.0, -half_w, zb + (v - pe) / 2)
         F1 = (0.0, -half_w, zb + (v + pe) / 2)
 
-        leg = self.segs_for((v - pe) / 2, quarter)
         return [
             # Left short side: bottom corner -> feed edge -> top corner.
-            (A, F0, leg, None, None),
-            (F0, F1, self.segs_for(pe, quarter), None, "feed"),
-            (F1, D, leg, None, None),
+            Wire(A, F0),
+            Wire(F0, F1, name="feed"),
+            Wire(F1, D),
             # Top, right side, and bottom close the loop.
-            (D, C, self.segs_for(w, quarter), None, None),
-            (C, B, self.segs_for(v, quarter), None, None),
-            (B, A, self.segs_for(w, quarter), None, None),
+            Wire(D, C),
+            Wire(C, B),
+            Wire(B, A),
         ]
 
     def build_network(self):

--- a/src/antennaknobs/designs/verticals/right_angle_delta.py
+++ b/src/antennaknobs/designs/verticals/right_angle_delta.py
@@ -39,6 +39,7 @@ The structure is planar in x = 0.
 """
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 from types import MappingProxyType
 
 
@@ -83,7 +84,6 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
         lf = self.length_factor
 
         w = self.base_frac * wavelength * lf
@@ -115,10 +115,10 @@ class Builder(AntennaBuilder):
 
         return [
             # Left side: apex -> feed edge -> base corner (driven mid-side).
-            (T, F0, self.segs_for(d, quarter), None),
-            (F0, F1, self.segs_for(pe, quarter), 1 + 0j),
-            (F1, A, self.segs_for(s - d, quarter), None),
+            Wire(T, F0),
+            Wire(F0, F1, ex=1 + 0j),
+            Wire(F1, A),
             # Horizontal base and right side close the delta.
-            (A, B, self.segs_for(w, quarter), None),
-            (B, T, self.segs_for(s, quarter), None),
+            Wire(A, B),
+            Wire(B, T),
         ]

--- a/src/antennaknobs/designs/verticals/tri_moxon.py
+++ b/src/antennaknobs/designs/verticals/tri_moxon.py
@@ -50,6 +50,7 @@ from antennaknobs.network import (
     PortVirtual,
     Shunt,
     TL,
+    Wire,
     WireSpec,
 )
 import math
@@ -115,7 +116,6 @@ class Builder(AntennaBuilder):
         """Wire tuples for rectangle k (1-3), standing in the vertical
         plane at azimuth (k-1)*120 deg, reflector nearest the post."""
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
         lf = self.length_factor
 
         a = self.a_frac * wavelength * lf
@@ -136,29 +136,18 @@ class Builder(AntennaBuilder):
         zm = zb + a / 2
         pe = 0.1  # feed-edge length, m
 
-        vert = self.segs_for(a, quarter)
-        half_drv = self.segs_for(a / 2 - pe / 2, quarter)
-        tail_b = self.segs_for(b, quarter)
-        tail_d = self.segs_for(d, quarter)
-
         return [
             # Reflector: vertical + fold-back tails toward the driver.
-            (at(r_ref, zb), at(r_ref, zt), vert, None, None),
-            (at(r_ref, zt), at(r_ref + d, zt), tail_d, None, None),
-            (at(r_ref, zb), at(r_ref + d, zb), tail_d, None, None),
+            Wire(at(r_ref, zb), at(r_ref, zt)),
+            Wire(at(r_ref, zt), at(r_ref + d, zt)),
+            Wire(at(r_ref, zb), at(r_ref + d, zb)),
             # Driver: vertical in two halves around the mid-height feed gap,
             # plus its tails back toward the reflector (gap C left open).
-            (at(r_drv, zb), at(r_drv, zm - pe / 2), half_drv, None, None),
-            (
-                at(r_drv, zm - pe / 2),
-                at(r_drv, zm + pe / 2),
-                self.segs_for(pe, quarter),
-                None,
-                f"feed_{k}",
-            ),
-            (at(r_drv, zm + pe / 2), at(r_drv, zt), half_drv, None, None),
-            (at(r_drv, zt), at(r_drv - b, zt), tail_b, None, None),
-            (at(r_drv, zb), at(r_drv - b, zb), tail_b, None, None),
+            Wire(at(r_drv, zb), at(r_drv, zm - pe / 2)),
+            Wire(at(r_drv, zm - pe / 2), at(r_drv, zm + pe / 2), name=f"feed_{k}"),
+            Wire(at(r_drv, zm + pe / 2), at(r_drv, zt)),
+            Wire(at(r_drv, zt), at(r_drv - b, zt)),
+            Wire(at(r_drv, zb), at(r_drv - b, zb)),
         ]
 
     def build_wires(self):

--- a/src/antennaknobs/designs/verticals/vertical.py
+++ b/src/antennaknobs/designs/verticals/vertical.py
@@ -1,6 +1,7 @@
 """Quarter-wave vertical over ground."""
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 
 import math
 from types import MappingProxyType
@@ -10,13 +11,22 @@ class Builder(AntennaBuilder):
     default_params = MappingProxyType(
         {
             "freq": 28.57,
+            # Geometry is hand-tuned in absolute metres; design_freq only
+            # anchors auto_mesh's density scale (nominal_nsegs per
+            # quarter-wave), so it is hidden from the UI.
+            "design_freq": 28.57,
             "length": 2.619,
             "base": 0.5,
             # Auto-view rule picks xy (x/y are the two largest spans
             # since the three radials spread in x/y), but the radiator
             # itself is vertical — yz reads the elevation profile
             # naturally.
-            "ui_params": MappingProxyType({"default_view": "yz"}),
+            "ui_params": MappingProxyType(
+                {
+                    "default_view": "yz",
+                    "design_freq": {"hidden": True},
+                }
+            ),
         }
     )
 
@@ -24,34 +34,26 @@ class Builder(AntennaBuilder):
         eps = 0.05
 
         z = self.length
+        base = self.base
 
-        n_seg0 = self.nominal_nsegs
-        n_seg1 = self.segs_for(
-            math.dist((0, 0, 0), (0, 0, eps)), math.dist((0, 0, eps), (0, 0, z))
-        )
+        n_radials = 3
         # Radials refine with the mesh (issue #477): hard-coding the count let
         # coarse radial segments meet fine riser segments at the feed junction
         # on refined meshes, dragging PyNEC/sin off BSpline's converged value.
-        n_seg_radials = self.segs_for(self.length, self.length)
-        n_radials = 3
         # Radials run the full self.length (not a quarter-wave): self.length is
         # already the ~quarter-wave radiator length, so the radials match the
         # radiator and form an equal-length elevated counterpoise.
 
         tups = []
-        tups.extend([((0, 0, 0), (0, 0, eps), n_seg1, 1 + 0j)])
-        tups.extend([((0, 0, eps), (0, 0, z), n_seg0, None)])
+        # Driven gap at the riser foot; the riser stacks on top of it.
+        tups.append(Wire((0, 0, base), (0, 0, base + eps), ex=1 + 0j))
+        tups.append(Wire((0, 0, base + eps), (0, 0, base + z)))
 
         for i in range(n_radials):
             theta = 2 * math.pi / n_radials * i
 
             x, y = self.length * math.cos(theta), self.length * math.sin(theta)
 
-            tups.extend([((0, 0, 0), (x, y, 0), n_seg_radials, None)])
+            tups.append(Wire((0, 0, base), (x, y, base)))
 
-        base = self.base
-        new_tups = []
-        for (x0, y0, z0), (x1, y1, z1), n_seg, ev in tups:
-            new_tups.append(((x0, y0, z0 + base), (x1, y1, z1 + base), n_seg, ev))
-
-        return new_tups
+        return tups

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -150,11 +150,12 @@ def test_bobtail_tap_position_sets_impedance():
 def test_bobtail_only_centre_element_is_fed():
     """Exactly one driven gap; the outer verticals are passive."""
     from antennaknobs.designs.verticals.bobtail import Builder
+    from antennaknobs.network import as_wire
 
-    feeds = [t for t in Builder().build_wires() if t[3] is not None]
+    feeds = [w for w in map(as_wire, Builder().build_wires()) if w.ex is not None]
     assert len(feeds) == 1
     # The fed gap sits on the centre vertical (y = 0).
-    (x0, y0, _), (x1, y1, _), _, _ = feeds[0]
+    (_, y0, _), (_, y1, _) = feeds[0].p0, feeds[0].p1
     assert y0 == 0.0 and y1 == 0.0
 
 
@@ -1565,12 +1566,13 @@ def _rectangle_bare():
     """The rectangle with its side gap driven directly (matching section
     removed), to read the raw very-low-R feedpoint the transformer steps up."""
     from antennaknobs.designs.verticals.rectangle import Builder
+    from antennaknobs.network import as_wire
 
     class Bare(Builder):
         def build_wires(self):
             return [
-                (t[0], t[1], t[2], 1 + 0j) if len(t) == 5 and t[4] == "feed" else t[:4]
-                for t in super().build_wires()
+                w._replace(ex=1 + 0j, name=None) if w.name == "feed" else w
+                for w in map(as_wire, super().build_wires())
             ]
 
         def build_network(self):
@@ -1653,10 +1655,11 @@ def test_rectangle_is_a_wide_closed_loop_fed_mid_short_side():
     12.8' proportions, aspect > 3.5), with the single port gap centred on one
     short VERTICAL side -- the current maximum that makes it an SCV."""
     from antennaknobs.designs.verticals.rectangle import Builder
+    from antennaknobs.network import as_wire
 
     b = Builder()
     tups = b.build_wires()
-    ports = [t for t in tups if len(t) == 5 and t[4] == "feed"]
+    ports = [w for w in map(as_wire, tups) if w.name == "feed"]
     assert len(ports) == 1
     (p,) = ports
     # The port edge is vertical (spans z, constant y) and sits mid-side.
@@ -2207,7 +2210,7 @@ def test_tri_moxon_idle_feedlines_are_shorted_quarter_waves():
     open circuit at the parked feedpoint that 'modeling shows' works best.
     Geometry: three AWG-14 wire rectangles 120 degrees apart, reflectors
     48 inches off the post, Cebik's A/E proportions."""
-    from antennaknobs.network import Driven, PortVirtual, Shunt, TL
+    from antennaknobs.network import Driven, PortVirtual, Shunt, TL, as_wire
 
     b = _tm()
     net = b.build_network()
@@ -2226,7 +2229,7 @@ def test_tri_moxon_idle_feedlines_are_shorted_quarter_waves():
     # Geometry: 3 feed gaps, element verticals A ~ 0.364 wl tall, driver
     # radius = post spacing + E, thin AWG-14 wire.
     tups = b.build_wires()
-    names = {t[4] for t in tups if len(t) == 5 and t[4]}
+    names = {w.name for w in map(as_wire, tups) if w.name}
     assert names == {"feed_1", "feed_2", "feed_3"}
     assert abs(b.a_frac - 0.364) < 0.01
     assert abs(b.e_frac - 0.1329) < 0.005

--- a/tests/test_delta_a_lint.py
+++ b/tests/test_delta_a_lint.py
@@ -70,12 +70,17 @@ FAT_CONDUCTOR_HEADROOM = {
     "beams.owa_yagi": 85,  # measured 92 — fat tube driven element
     "beams.owa_yagi_6el": 100,  # measured 107 — 3/16"-equivalent tube (2m)
     "verticals.elt_whip": 155,  # measured 169 — deck-faithful whip (#435)
-    "verticals.pota_performer": 330,  # measured 360 — stainless whip
-    "verticals.challenger": 380,  # measured 413 — aluminum tube
+    # The KJ6ER whips re-measured 2026-07-23 after the auto-mesh conversion
+    # (#525 stage 2): the halfwave whips now carry their density-correct
+    # count (~1.5-2 quarter-waves' worth instead of one nominal), so the
+    # same physical Δ/a floor is reached at a proportionally lower nominal
+    # N. The conductors are unchanged.
+    "verticals.pota_performer": 330,  # measured 350 — stainless whip
+    "verticals.challenger": 270,  # measured 292 — aluminum tube
     # moxon / moxonarray were listed here at 515 ("fat elements") until the
     # #522 density fix revealed the low headroom was the DEFECT, not the
     # conductors: with every wire at driver-arm density they measure ~1840.
-    "verticals.dominator": 525,  # measured 571 — one aluminum tube
+    "verticals.dominator": 270,  # measured 292 — one aluminum tube
     "specialty.hourglass": 545,  # measured 593 — short crossing rails
 }
 


### PR DESCRIPTION
## Summary
- Converts all 16 non-exempt `designs/verticals/` builders to the auto-mesh `Wire()` idiom (part of #525 stage 2). `verticals/elt_whip.py` untouched (deck-faithful, permanent exemption).
- **Twelve designs are formula-identical conversions** — their counts were already `segs_for(length, quarter)`, so `Wire(n_seg=None)` produces byte-identical meshes and impedances: bobtail, bruce, four_square, half_square, inverted_l, inverted_l_tmatch, jpole, phased_verticals, rectangle, right_angle_delta, tri_moxon, vertical.
  - The #459-class basis-census outliers **bobtail** and **half_square** show exactly zero churn.
  - **inverted_l_tmatch** (T-match tee magnifies basis diffs ~25×): zero churn, 50.00−0.01j on both sides — the underlying mesh is unchanged.
  - **four_square / phased_verticals / tri_moxon**: wire names, complex excitations, and emission order preserved exactly.
- **Hidden `design_freq` added** (moxon precedent) to the absolute-metre designs: challenger, dominator, pota_performer (restated in each band variant so mesh density follows the band each cut is for), raised_vertical, vertical.
- **Genuine density corrections** (called out per the guide): the KJ6ER halfwave whips carried a single nominal count — challenger 21→31, dominator 21→41 at defaults; pota_performer's quarter-wave whip 21→22; raised_vertical radials 21→20. All churn ≤ 0.7% of |Z| (budget ~2%).
- **Preserved pins** (#525 stage 3 scope, commented in-code): KJ6ER counterpoise/radial floors (`max(5, N//3)`, `max(7, N//2)`); jpole's 1-seg bottom short bar and its #435 empirical feed tap (`segs_for(gap, quarter)`, 2 segments at default N).
- Known framework bug NOT touched here: web adapter reading excitation off the last tuple field of 6-field `Wire` entries — already fixed on the auto-mesh-loops branch (PR #530 via `as_wire`). `test_web_server` passes on this branch; the adapter feed-index paths index `t[3]`/`t[4]` positionally, which is Wire-correct.

## Churn (bs2 @ N=21, defaults, free space)
Designs not listed: counts and Z byte-identical before → after.

| design | variant | counts before → after | Z before → after | churn |
|---|---|---|---|---|
| challenger | default | [1,21,7] → [1,31,7] | 31.05+7.55j → 31.05+7.61j | 0.2% |
| challenger | plus | [1,21,7] → [1,31,7] | 32.31+6.20j → 32.32+6.26j | 0.2% |
| challenger | band20 | [1,21,7] → [1,31,7] | 27.74+4.55j → 27.73+4.60j | 0.2% |
| challenger | band17 | [1,21,7] → [1,31,7] | 29.93+4.52j → 29.93+4.57j | 0.2% |
| challenger | band12 | [1,21,7] → [1,31,7] | 31.81+7.78j → 31.82+7.84j | 0.2% |
| challenger | band10 | [1,21,7] → [1,31,7] | 33.15+8.77j → 33.17+8.84j | 0.2% |
| challenger | band6 | [1,21,7] → [1,31,7] | 39.16+9.90j → 39.23+9.99j | 0.3% |
| dominator | default | [1,21,10] → [1,41,10] | 30.56+3.25j → 30.58+3.10j | 0.5% |
| dominator | plus | [1,21,10] → [1,41,10] | 28.03−8.93j → 27.93−9.06j | 0.6% |
| dominator | band17 | [1,21,10] → [1,40,10] | 26.24+11.64j → 26.32+11.56j | 0.4% |
| dominator | band12 | [1,21,10] → [1,41,10] | 30.63−0.78j → 30.61−0.95j | 0.6% |
| dominator | band10 | [1,21,10] → [1,41,10] | 30.20−2.45j → 30.17−2.64j | 0.6% |
| pota_performer | default | [1,21,7,7] → [1,22,7,7] | 37.44+2.46j → 37.44+2.48j | 0.05% |
| pota_performer | omni | [1,21,7,7] → [1,22,7,7] | 30.91−4.04j → 30.91−4.02j | 0.06% |
| pota_performer | single_radial | [1,21,7] → [1,22,7] | 44.01−29.57j → 44.01−29.55j | 0.04% |
| pota_performer | band20 | [1,21,7,7] (unchanged) | 35.00+1.12j (identical) | 0% |
| pota_performer | band17 | [1,21,7,7] (unchanged) | 35.75−0.47j (identical) | 0% |
| pota_performer | band12 | [1,21,7,7] → [1,22,7,7] | 38.82−0.09j → 38.82−0.07j | 0.05% |
| pota_performer | band10 | [1,21,7,7] → [1,22,7,7] | 40.87+1.07j → 40.87+1.10j | 0.07% |
| pota_performer | band6 | [1,21,7,7] → [1,23,7,7] | 48.79+11.15j → 48.81+11.20j | 0.1% |
| raised_vertical | default | [1,21,21,21] → [1,21,20,20] | 42.89−1.06j → 42.89−1.07j | 0.03% |

## Test changes
- `tests/test_cebik_designs.py`: four assertions used `len(t) == 5` arity checks / whole-tuple unpacking, which misread `Wire` entries (their `len()` is always 6 — exactly the pitfall `as_wire`'s docstring names). Rewritten on the `as_wire` choke point; the physics assertions are unchanged.
- `tests/test_delta_a_lint.py`: `FAT_CONDUCTOR_HEADROOM` re-measured for the KJ6ER whips — challenger 380 → 270 (measured 292), dominator 525 → 270 (measured 292), pota_performer floor kept at 330 (re-measured 350, comment updated). The whips now carry density-correct counts (~1.5–2 quarter-waves' worth instead of one nominal), so the same physical Δ/a floor is reached at a proportionally lower *nominal* N; the conductors are unchanged and a real density regression still craters the measurement by an order of magnitude.

## Test plan
- [x] `ruff check` + `ruff format --check` on all touched files
- [x] Full fast suite: 2663 passed before test-side fixes; the 6 failures (4 cebik arity checks, 2 headroom recalibrations) addressed above, affected modules re-run green (439 passed, 2 skipped)
- [x] Churn probe (bs2 @ N=21) before/after across all 34 design×variant rows — table above, max churn 0.6%

🤖 Generated with [Claude Code](https://claude.com/claude-code)