### PR TITLE
ci: pin ruff to 0.15.21 (0.16.0 release turned CI red repo-wide)

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -5,9 +5,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      # Pinned: the unpinned action installs the latest ruff, and 0.16.0
+      # (released 2026-07-23, ~90 min after main's last green run) flags
+      # long-standing files repo-wide. Keep in sync with the local dev venv;
+      # bump deliberately alongside a repo-wide `ruff check` cleanup.
       - uses: astral-sh/ruff-action@v1
         with:
+          version: "0.15.21"
           args: "check"
       - uses: astral-sh/ruff-action@v1
         with:
+          version: "0.15.21"
           args: "format --check"


### PR DESCRIPTION
## Summary
- ruff 0.16.0 released today at 19:10 UTC; the unpinned `astral-sh/ruff-action` picked it up and every PR's Ruff check went red on files none of them touch (`docs/ad/`, `scratch/`, `scripts/`, …). Main's last push run (17:56 UTC) was green under 0.15.x.
- Pin the action to **0.15.21** (the version in the local dev venv) for both the `check` and `format --check` steps.
- Adopting 0.16.0 should be its own deliberate PR: bump the pin + fix the new findings repo-wide in one change.

## Test plan
- [x] This PR's own Ruff check runs the pinned version and must go green with zero repo changes — that is the proof the failures were version skew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iMSNiYKS61YWgLbuPoSKv