### PR TITLE
refactor(designs): retire load-wire pins and hand floors (#525 stage 3)

### DIFF
--- a/src/antennaknobs/designs/broadband/t2fd.py
+++ b/src/antennaknobs/designs/broadband/t2fd.py
@@ -78,7 +78,6 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         D = self.length_frac * wavelength
         s = self.spacing_frac * wavelength
@@ -103,8 +102,11 @@ class Builder(AntennaBuilder):
             Wire(nF1, nR),
             # far (termination) wire: left arm, load gap, right arm
             Wire(fL, fT0),
-            # Termination-resistor wire: count kept explicit (#525 stage 3).
-            Wire(fT0, fT1, n_seg=self.segs_for(2 * eps, quarter), name="term"),
+            # Termination-resistor wire meshes at the design density like
+            # every other wire (#525 stage 3; its old segs_for count was
+            # the identical formula, and the load stays on the middle
+            # segment as it refines).
+            Wire(fT0, fT1, name="term"),
             Wire(fT1, fR),
             # end shorts joining the two wires
             Wire(nL, fL),

--- a/src/antennaknobs/designs/multiband/trap_dipole.py
+++ b/src/antennaknobs/designs/multiband/trap_dipole.py
@@ -96,38 +96,26 @@ class Builder(AntennaBuilder):
         def p(x):
             return (x, 0.0, z)
 
-        # Structural wires mesh at the design density (auto_mesh:
-        # nominal_nsegs per design_freq quarter-wave), so the convergence
-        # slider reaches this design like every other. The trap wires keep
-        # their explicit segs_for count (1 segment at the default mesh —
-        # the trap L/C were tuned against that; retiring it is #525
-        # stage 3). The single continuous inner wire spans −X_inner →
+        # Every wire meshes at the design density (auto_mesh:
+        # nominal_nsegs per design_freq quarter-wave), the trap wires
+        # included — their old explicit segs_for count was the identical
+        # formula, so this is a pure spelling change (#525 stage 3); the
+        # load still lands on the trap wire's middle segment as it
+        # refines. The single continuous inner wire spans −X_inner →
         # +X_inner so the named "feed" middle segment lands exactly at the
         # geometric centre (x = 0). Splitting the inner span at the origin
         # would put `feed` on the middle of *one half*, offsetting the
         # feed point by X_inner/2 — a real asymmetry that broke the
         # symmetric design. Engine parity coercion bumps to odd/even as
         # needed.
-        quarter = 0.25 * wavelength
-
         return [
             # Left arm, outer → trap.
             Wire(p(x_outer_tip_l), p(x_trap_outer_l)),
-            Wire(
-                p(x_trap_outer_l),
-                p(x_trap_inner_l),
-                n_seg=self.segs_for(trap_seg, quarter),
-                name="trap_l",
-            ),
+            Wire(p(x_trap_outer_l), p(x_trap_inner_l), name="trap_l"),
             # Inner span — one wire, feed at middle = origin.
             Wire(p(x_trap_inner_l), p(x_trap_inner_r), name="feed"),
             # Right arm, trap → outer.
-            Wire(
-                p(x_trap_inner_r),
-                p(x_trap_outer_r),
-                n_seg=self.segs_for(trap_seg, quarter),
-                name="trap_r",
-            ),
+            Wire(p(x_trap_inner_r), p(x_trap_outer_r), name="trap_r"),
             Wire(p(x_trap_outer_r), p(x_outer_tip_r)),
         ]
 

--- a/src/antennaknobs/designs/multiband/trap_fan_dipole.py
+++ b/src/antennaknobs/designs/multiband/trap_fan_dipole.py
@@ -82,6 +82,13 @@ C_LIGHT_MHZ_M = 299.792458
 # N=81), which is its own discretization story.
 # Final SWR50 at target freqs (Bs2 @ N=41): 17m=1.04, 15m=1.02, 12m=1.19, 10m=1.13.
 # Plan to verify by measurement after build.
+# Stage-3 note (#525): retiring the trap wires' 1-seg pin leaves every
+# Bs2@41 band SWR bit-identical (the 0.05 m trap wire still resolves to
+# one segment below N≈150) while fixing the fine-mesh limit the study
+# flagged — bs2 X now converges to ~+3.2j instead of sitting flat at the
+# biased +0.6j, sin's gap at N=321 drops 25.9 % → ~7 %, and the honest
+# converged SWR50 stays ≤ 1.10 on all four bands, so the L/C values
+# above remain valid without a retune.
 _BAND_17_12 = {
     "full_freq": 18.1575,
     "trap_freq": 24.97,
@@ -318,22 +325,24 @@ class Builder(AntennaBuilder):
             tip = offset_outward(A[i], q1 + trap_seg + q2)
             spokes.append((trap_in, trap_out, tip))
 
-        # Structural wires (cone + inner outer + outer + feed) mesh at the
-        # design density (auto_mesh: nominal_nsegs per design_freq
-        # quarter-wave), so segment length is near-constant across the
-        # antenna. Trap segments are pinned to 1 (load-port convention —
-        # the named port lives on a single basis function, and the trap
-        # L/C were tuned against 1-seg trap wires; retiring the pin is
-        # #525 stage 3). The feed bridge resolves to 1 segment at the
-        # default mesh, which is fine for the BSpline d=2 basis this
-        # design is tuned against; the retired triangular basis couldn't
-        # drive a 1-segment feed gap.
+        # Every wire — trap segments included — meshes at the design
+        # density (auto_mesh: nominal_nsegs per design_freq quarter-wave),
+        # so segment length is near-constant across the antenna. The trap
+        # wires resolve to 1 segment at the default/tuning meshes (0.05 m
+        # ≪ λ/4) and only start subdividing above N≈150, where the load
+        # keeps landing on the wire's middle segment; the trap-wire study
+        # (#484/#525 stage 3) showed the old hard 1-seg pin biased the
+        # fine-mesh limit (bs2 X flat at the wrong value) and drove the
+        # sin↔bs2 gap to 25.9 % instead of converging. The feed bridge
+        # resolves to 1 segment at the default mesh, which is fine for
+        # the BSpline d=2 basis this design is tuned against; the retired
+        # triangular basis couldn't drive a 1-segment feed gap.
         tups = []
         for i, (trap_in, trap_out, tip) in enumerate(spokes):
             # +y arm
             tups.append(Wire(S, A[i]))
             tups.append(Wire(A[i], trap_in))
-            tups.append(Wire(trap_in, trap_out, n_seg=1, name=f"trap_p_b{i}"))
+            tups.append(Wire(trap_in, trap_out, name=f"trap_p_b{i}"))
             tups.append(Wire(trap_out, tip))
 
             # −y arm (mirror via ry)
@@ -343,7 +352,7 @@ class Builder(AntennaBuilder):
             tip_y = ry(tip)
             tups.append(Wire(T, Ay))
             tups.append(Wire(Ay, tin_y))
-            tups.append(Wire(tin_y, tout_y, n_seg=1, name=f"trap_n_b{i}"))
+            tups.append(Wire(tin_y, tout_y, name=f"trap_n_b{i}"))
             tups.append(Wire(tout_y, tip_y))
 
         # Feed wire — named "feed", source supplied by build_network().

--- a/src/antennaknobs/designs/verticals/challenger.py
+++ b/src/antennaknobs/designs/verticals/challenger.py
@@ -153,8 +153,8 @@ class Builder(AntennaBuilder):
             # Gap wire at the whip base carries the "ant" port.
             Wire((0, 0, h), (0, 0, h + eps), name="ant"),
             Wire((0, 0, h + eps), (0, 0, h + self.whip_len_m)),
-            # Counterpoise keeps its validated floored allocation (#525
-            # stage 3 retires the remaining hand counts).
+            # Counterpoise meshes at the design density like every other
+            # wire (#525 stage 3 retired the old max(5, N//3) hand floor).
             Wire(
                 (0, 0, h),
                 (
@@ -162,7 +162,6 @@ class Builder(AntennaBuilder):
                     0.0,
                     h - self.cp_len_m * math.sin(droop),
                 ),
-                n_seg=max(5, self.nominal_nsegs // 3),
             ),
         ]
 

--- a/src/antennaknobs/designs/verticals/dominator.py
+++ b/src/antennaknobs/designs/verticals/dominator.py
@@ -141,8 +141,8 @@ class Builder(AntennaBuilder):
             # Gap wire at the whip base carries the "ant" port.
             Wire((0, 0, h), (0, 0, h + eps), name="ant"),
             Wire((0, 0, h + eps), (0, 0, h + self.whip_len_m)),
-            # Counterpoise keeps its validated floored allocation (#525
-            # stage 3 retires the remaining hand counts).
+            # Counterpoise meshes at the design density like every other
+            # wire (#525 stage 3 retired the old max(7, N//2) hand floor).
             Wire(
                 (0, 0, h),
                 (
@@ -150,7 +150,6 @@ class Builder(AntennaBuilder):
                     0.0,
                     h - self.cp_len_m * math.sin(droop),
                 ),
-                n_seg=max(7, self.nominal_nsegs // 2),
             ),
         ]
 

--- a/src/antennaknobs/designs/verticals/jpole.py
+++ b/src/antennaknobs/designs/verticals/jpole.py
@@ -68,7 +68,6 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         radiator = self.radiator_frac * wavelength
         stub = self.stub_frac * wavelength
@@ -83,9 +82,11 @@ class Builder(AntennaBuilder):
         # Leg A at x = 0 carries the radiator on top; leg B at x = gap is the
         # short open-ended stub leg.
         return [
-            # Bottom short bar bridging the two legs (deliberately pinned at
-            # one segment; retiring it is #525 stage 3).
-            Wire((0.0, 0.0, z_short), (gap, 0.0, z_short), n_seg=1),
+            # Bottom short bar bridging the two legs, meshed at the design
+            # density like everything else (#525 stage 3 retired its old
+            # 1-segment pin; at the default mesh the density gives the
+            # same answer anyway).
+            Wire((0.0, 0.0, z_short), (gap, 0.0, z_short)),
             # Leg A: short -> tap node -> stub top, then the radiator
             # continues up.
             Wire((0.0, 0.0, z_short), (0.0, 0.0, z_tap)),
@@ -95,13 +96,9 @@ class Builder(AntennaBuilder):
             Wire((gap, 0.0, z_short), (gap, 0.0, z_tap)),
             Wire((gap, 0.0, z_tap), (gap, 0.0, z_stub_top)),
             # Feed: a driven bridge between the two legs at the tap, meshed
-            # proportionally like every other edge so the delta gap refines
-            # with the mesh (issue #435 — its empirical 2-segment default
-            # comes from exactly this density; kept on segs_for verbatim).
-            Wire(
-                (0.0, 0.0, z_tap),
-                (gap, 0.0, z_tap),
-                n_seg=self.segs_for(gap, quarter),
-                ex=1 + 0j,
-            ),
+            # at the design density like every other edge so the delta gap
+            # refines with the mesh (issue #435 — its empirical 2-segment
+            # default comes from exactly this density; the old explicit
+            # segs_for spelling was the identical formula, #525 stage 3).
+            Wire((0.0, 0.0, z_tap), (gap, 0.0, z_tap), ex=1 + 0j),
         ]

--- a/src/antennaknobs/designs/verticals/pota_performer.py
+++ b/src/antennaknobs/designs/verticals/pota_performer.py
@@ -171,9 +171,8 @@ class Builder(AntennaBuilder):
         phis = (
             [0.0] if n == 1 else [-self.radial_span_deg / 2, self.radial_span_deg / 2]
         )
-        # Radials keep their validated floored allocation (#525 stage 3
-        # retires the remaining hand counts).
-        r_seg = max(5, self.nominal_nsegs // 3)
+        # Radials mesh at the design density like every other wire (#525
+        # stage 3 retired the old max(5, N//3) hand floor).
         for phi_deg in phis:
             p = math.radians(phi_deg)
             end = (
@@ -181,5 +180,5 @@ class Builder(AntennaBuilder):
                 self.radial_len_m * math.cos(droop) * math.sin(p),
                 h - self.radial_len_m * math.sin(droop),
             )
-            tups.append(Wire((0, 0, h), end, n_seg=r_seg))
+            tups.append(Wire((0, 0, h), end))
         return tups


### PR DESCRIPTION
## Summary
- **trap_fan_dipole**: the two `n_seg=1` trap-wire pins become density-meshed (`None`). The 0.05 m trap wires still resolve to 1 segment below N≈150, so counts at the default and tuning meshes are unchanged and **every documented Bs2@41 band SWR is bit-identical** — but the fine-mesh limit is now honest, reproducing the trap-wire study exactly: bs2 X converges to ~+3.2j instead of sitting flat at the biased +0.6j, and sin's N=321 sin↔bs2 gap drops **25.9 % → ~7 %** (now converging instead of diverging). Converged SWR50 stays ≤ 1.10 on all four bands, so **no L/C retune was needed** — the tuning-mesh invariance did the work the stage plan budgeted a retune for.
- **trap_dipole**, **jpole feed tap**, **t2fd termination wire**: their `segs_for(len, quarter)` spellings are the auto-mesh formula verbatim — converted to `None`, verified bit-identical (counts and Z).
- **jpole bottom bar**: 1-seg pin retired (2 segs at default); Z identical to 0.01 Ω across the ladder.
- **KJ6ER floors retired** (challenger `max(5, N//3)`, dominator `max(7, N//2)`, pota_performer `max(5, N//3)`): dominator's counterpoise was genuinely under-dense (10 → 27 segs at N=21); impedance churn ≤ 0.2 Ω on all three.

## Measurements (bs2, free space)
| design | counts@21 before → after | Z@21 before → after | Z@161 before → after |
|---|---|---|---|
| trap_fan | unchanged | 53.37−0.87j (identical) | 53.69+0.39j → 54.15+2.17j |
| trap_dipole | unchanged | identical | identical |
| jpole | bar 1→2 | 66.58+25.14j (identical) | 66.10+25.07j (identical) |
| t2fd | unchanged | 1351.81−306.18j (identical) | identical |
| challenger | cp 7→10 | 31.05+7.61j → 31.05+7.65j | 31.13+7.94j → 31.13+7.98j |
| dominator | cp 10→27 | 30.58+3.10j → 30.62+2.91j | 30.85+0.88j → 30.85+0.85j |
| pota_performer | radials 7→18 | 37.44+2.48j → 37.47+2.69j | 37.59+3.36j → 37.60+3.47j |

trap_fan band SWR50 at the tuning mesh (bs2@41): 17m 1.028, 15m 1.038, 12m 1.031, 10m 1.071 — identical before/after. At bs2@161: 1.038 / 1.038 / 1.072 / 1.094.

Remaining explicit counts in the catalog are now only the documented keeps: elt_whip (deck-faithful), terminated_longwire (#526), delta_looparray_with_tls + hexbeam_5band (midpoint/jumper indexing), twoband_fan_dipole (validated floor).

## Test plan
- [x] Full suite green (2669 passed, 2 skipped), memory-capped shell
- [x] Density lint (test_delta_a_lint) green
- [x] Before/after ladders (bs2 + sin, N=21…321) on all six designs; trap_fan band SWRs at bs2@41 and @161
- [x] ruff check / format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iMSNiYKS61YWgLbuPoSKv