### PR TITLE
docs: de-stale load-wire guidance after stage 3

### DIFF
--- a/site/src/content/docs/advanced/convergence.md
+++ b/site/src/content/docs/advanced/convergence.md
@@ -191,9 +191,19 @@ the physics doesn't:
   ports this way; they refine like every other wire and hold one
   basis-agreed value.
 - A **lumped load** (termination resistor, trap) is genuinely a point
-  element — keep it on a delta gap, and pin that wire's segment count if
-  refinement disturbs it. Spreading a physical resistor over a finite
-  gap under-counts its dissipation.
+  element — keep it on a delta gap, on a short named wire that meshes at
+  the design density like everything else. The load stays on the wire's
+  *middle segment* as the mesh refines, so the point model survives
+  refinement; pinning the wire's count instead (the old convention)
+  turned out to bias the converged value itself — the catalog's trap
+  study saw a pinned trap hold bs2 flat at the wrong reactance while the
+  density-meshed model converged cleanly. What you should *not* do is
+  spread the load's port current over a finite extent: gap-averaging a
+  physical resistor under-counts its dissipation. The one case still
+  under study is a load at a **near-current-null (high-|Z|) attachment**,
+  where the delta gap's parasitic susceptance competes with the tiny
+  real admittance — the catalog's terminated longwire keeps a validated
+  explicit-count model until that lands (issue #526).
 
 ## A working recipe
 

--- a/site/src/content/docs/concepts/auto-meshing.md
+++ b/site/src/content/docs/concepts/auto-meshing.md
@@ -178,7 +178,7 @@ for computing them. They are the right tool when the mesh itself is
 *data*: a deck-faithful reproduction of an external NEC model, or the
 few validated port models whose counts encode physics still under study.
 For everything else, the recommendation is now simple: write `None`,
-declare `design_freq`, finish with `auto_mesh`, and never think about
+declare `design_freq`, and never think about
 segmentation again.
 
 For the measurement story behind this — the convergence ladders, the


### PR DESCRIPTION
## Summary
- Convergence guide: the lumped-load bullet still taught the retired pin-the-count convention; now teaches the density-meshed load wire (load stays on the middle segment under refinement), explains why pinning biased the limit, and points the remaining high-|Z| case at #526.
- Auto-meshing page: dropped "finish with `auto_mesh`" — the wrap has been implicit in the stack since #524's follow-up.

## Test plan
- [x] `npm run build` clean (24 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iMSNiYKS61YWgLbuPoSKv