### PR TITLE
refactor(designs): terminated_longwire to auto-mesh — the last exemption falls (#526, #525 stage 4)

### DIFF
--- a/site/src/content/docs/advanced/convergence.md
+++ b/site/src/content/docs/advanced/convergence.md
@@ -199,11 +199,15 @@ the physics doesn't:
   study saw a pinned trap hold bs2 flat at the wrong reactance while the
   density-meshed model converged cleanly. What you should *not* do is
   spread the load's port current over a finite extent: gap-averaging a
-  physical resistor under-counts its dissipation. The one case still
-  under study is a load at a **near-current-null (high-|Z|) attachment**,
+  physical resistor under-counts its dissipation. Even the historically
+  hardest case — a load at a **near-current-null (high-|Z|) attachment**,
   where the delta gap's parasitic susceptance competes with the tiny
-  real admittance — the catalog's terminated longwire keeps a validated
-  explicit-count model until that lands (issue #526).
+  real admittance — turned out to be mesh-stable under this treatment:
+  the catalog's terminated longwire kept pinned counts for years on
+  evidence that refinement made its readout drift, but re-probing on the
+  modern port machinery showed the density-meshed model reaching a clean
+  mutual limit where the pinned one left the bases permanently apart
+  (issue #526). The old drift was the port readout, not the physics.
 
 ## A working recipe
 

--- a/src/antennaknobs/designs/wire/terminated_longwire.py
+++ b/src/antennaknobs/designs/wire/terminated_longwire.py
@@ -43,7 +43,7 @@ contribution shaping the low-angle response.
 """
 
 from antennaknobs import AntennaBuilder
-from antennaknobs.network import Driven, Load, Network, PortOnWire
+from antennaknobs.network import Driven, Load, Network, PortOnWire, Wire
 from types import MappingProxyType
 
 
@@ -87,7 +87,6 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         wavelength = 299.792458 / self.design_freq
-        quarter = 0.25 * wavelength
 
         L = self.length_frac * wavelength
         h = self.height_frac * wavelength
@@ -100,25 +99,27 @@ class Builder(AntennaBuilder):
         T1 = (L, 0.0, pe)
         GT = (L, 0.0, 0.0)  # terminated-leg ground end
 
-        leg = self.segs_for(h - pe, quarter)
-        # Feed/termination edges mesh at catalog density like everything
-        # else (issue #435) — 2 segments at the default mesh.
-        # Feed/term edges stay PINNED at one segment, deliberately exempt
-        # from the issue-#435 refine-with-the-mesh rule: the feed here is
-        # near-open (|Z| ≈ 5 kΩ), where the delta-gap readout diverges as
-        # the gap segment shrinks — refining turns a flat ladder
-        # (~960−5240j) into a 20%+ drift that never settles. A fixed gap
-        # is the mesh-stable model of this feed.
-        pe_seg = 1
+        # Every wire — the feed/termination edges included — meshes at the
+        # design density (#525 stage 4, closing #526's chief case). The
+        # edges were long pinned at one segment on evidence that refining
+        # them turned a flat ladder into a 20 %+ drift; re-probing on the
+        # modern port machinery (MNA network + PortOnWire keeping the
+        # source/load on the wire's middle segment as it refines) shows
+        # the opposite: with density-meshed edges bs2 and sin converge to
+        # the *same* value (mutual limit 436−44j at N=161 on the 3 λ
+        # variant) where the pinned model left the bases ~2.4 % apart
+        # forever, and the Cebik anchors (terminator dissipation, SWR(600),
+        # gain/F-B) are unchanged at the default mesh. The old drift was
+        # an artifact of the pre-MNA port readout, not physics.
         return [
             # Near leg: driven edge at the ground end, then up to the run.
-            (G0, F1, pe_seg, None, "feed"),
-            (F1, A, leg, None, None),
+            Wire(G0, F1, name="feed"),
+            Wire(F1, A),
             # The long horizontal run.
-            (A, B, self.segs_for(L, quarter), None, None),
+            Wire(A, B),
             # Far leg down to the termination edge at the ground end.
-            (B, T1, leg, None, None),
-            (T1, GT, pe_seg, None, "term"),
+            Wire(B, T1),
+            Wire(T1, GT, name="term"),
         ]
 
     def build_network(self):

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -1815,7 +1815,7 @@ def test_tlw_topology_grounded_legs():
     tups = b.build_wires()
     grounded = [t for t in tups if t[0][2] == 0.0 or t[1][2] == 0.0]
     assert len(grounded) == 2
-    names = {t[4] for t in tups if len(t) == 5 and t[4]}
+    names = {t[4] for t in tups if len(t) >= 5 and t[4]}
     assert names == {"feed", "term"}
     net = b.build_network()
     (load,) = [br for br in net.branches if isinstance(br, Load)]


### PR DESCRIPTION
## Summary
- **terminated_longwire converts to the auto-mesh `Wire()` idiom** — including the feed/termination edges that stayed pinned at 1 segment through stages 2–3 as the catalog's one validated explicit-count model.
- The pin dated to #459-era ladders where refining those edges turned a flat readout into a 20 %+ drift. Re-probing on the modern port machinery (#526 candidate 1: point `Load` on a density-meshed wire, with `PortOnWire` keeping it on the middle segment under refinement — exactly the treatment that fixed trap_fan) shows the drift is gone:

| model | bs2 ladder (3 λ, PEC) | sin ladder | verdict |
|---|---|---|---|
| pinned (old) | flat 437−33j | creeps to 446−26j | bases never meet (~2.4 % apart) |
| density (new) | 437−39j → 436−44j | 436−36j → **436−44j** | **mutual limit at N=161** |

- Cebik anchors re-validated: terminator dissipation 0.726 (was 0.724; test window 0.60–0.85), SWR(600) 1.36 unchanged, all seven tlw far-field/topology tests pass. The old drift was the pre-MNA port readout, not the physics — candidate 2 (distributed resistive loading) is not needed.
- Convergence guide's high-|Z| paragraph updated from "still under study" to the resolution.
- One test arity fix (`len(t) == 5` → `>= 5` on 6-field `Wire`).

The catalog's remaining explicit counts are now only: elt_whip (deck-faithful — mesh is data, permanent), delta_looparray_with_tls + hexbeam_5band (midpoint/jumper indexing), twoband_fan_dipole (validated floor).

## Test plan
- [x] All tlw Cebik anchor tests pass (7/7)
- [x] Full suite green (2669 passed, 2 skipped), memory-capped
- [x] Density lint green
- [x] Site builds (24 pages)

Closes #526.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iMSNiYKS61YWgLbuPoSKv