### PR TITLE
chore: release v0.36.0 — segmentation you never think about

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.35.2"
+version = "0.36.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/concepts/authoring-with-claude.md
+++ b/site/src/content/docs/concepts/authoring-with-claude.md
@@ -70,6 +70,7 @@ The seeded `CLAUDE.md` is authoritative; in brief, a design file must:
 
 ```python
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 
 
 class Builder(AntennaBuilder):
@@ -86,9 +87,9 @@ class Builder(AntennaBuilder):
         h = (wavelength / 4.0) * self.length_factor
         z, eps = self.height, 0.01
         return [
-            ((0.0, -h, z), (0.0, -eps, z), None, None),     # left arm
-            ((0.0, eps, z), (0.0, h, z), None, None),       # right arm
-            ((0.0, -eps, z), (0.0, eps, z), None, 1 + 0j),  # driven feed gap
+            Wire((0.0, -h, z), (0.0, -eps, z)),               # left arm
+            Wire((0.0, eps, z), (0.0, h, z)),                 # right arm
+            Wire((0.0, -eps, z), (0.0, eps, z), ex=1 + 0j),   # driven feed gap
         ]
 ```
 

--- a/site/src/content/docs/concepts/auto-meshing.md
+++ b/site/src/content/docs/concepts/auto-meshing.md
@@ -116,17 +116,17 @@ def build_wires(self):
     # ... geometry: corner points S, A, B, C, D, E, F, G, H, T ...
 
     def path(lst):
-        return [(a, b, None, None) for a, b in zip(lst[:-1], lst[1:])]
+        return [Wire(a, b) for a, b in zip(lst[:-1], lst[1:])]
 
     tups = []
     tups.extend(path([S, A, B]))
     tups.extend(path([C, D, E, F]))
     tups.extend(path([G, H, T]))
-    tups.append((T, S, None, 1 + 0j))
+    tups.append(Wire(T, S, ex=1 + 0j))
     return tups
 ```
 
-Every count is `None` — that's it. Auto-meshing is part of the stack:
+No `Wire()` here mentions a count at all — the field defaults to `None`. Auto-meshing is part of the stack:
 the framework resolves `build_wires` results before any consumer sees
 them, so there is no meshing call to remember. The design declares one
 new parameter:

--- a/site/src/content/docs/concepts/auto-meshing.md
+++ b/site/src/content/docs/concepts/auto-meshing.md
@@ -1,81 +1,83 @@
 ---
 title: "Segmentation you never think about"
-description: The same Moxon rectangle written three ways — explicit counts as naturally written, explicit counts done right, and automatic meshing — and what the density rule means.
+description: Wires mesh themselves at the design density — the rule behind the `None` default, why uniform density matters, and when an explicit count is still the right tool.
 ---
 
-A method-of-moments solver chops every wire into segments, and the choice
-of *how many* used to be part of authoring a design. It is now optional:
-give a wire the segment count `None` and the framework meshes it at the
-design density. This page shows the difference on a real catalog design —
-the Moxon rectangle — because the Moxon is also the design where hand
-segmentation last went wrong.
-
-## The same builder, three times
-
-All three versions build identical geometry: the two bent elements of a
-Moxon rectangle, computed from `halfdriver`, `aspect_ratio`, and the tip
-spacing, plus a short feed wire across the gap `T→S`. Everything up to
-the wire list — the corner points `S, A, B, C, D…` — is the same code.
-Only the meshing differs.
-
-**1. Explicit segmentation, the natural way** (how the catalog's Moxon
-was actually written, until it was found wrong):
+A method-of-moments solver chops every wire into segments, and the
+trustworthiness of everything it computes rides on those segments being
+short enough — and evenly sized. In antennaknobs that is the framework's
+job, not the design's: a `Wire` that doesn't give a segment count (the
+field defaults to `None`) is meshed at the **design density**
+automatically. Here is a real catalog design, the Moxon rectangle — two
+bent elements computed from `halfdriver`, `aspect_ratio`, and the tip
+spacing, plus a short feed wire across the gap `T→S`:
 
 ```python
 def build_wires(self):
     # ... geometry: corner points S, A, B, C, D, E, F, G, H, T ...
 
-    def build_path(lst, ns, ex):
-        return ((a, b, ns, ex) for a, b in zip(lst[:-1], lst[1:]))
-
-    n_seg0 = self.nominal_nsegs
-    # Feed gap T->S refines with the mesh; the driver arm S->A is the
-    # reference-length wire that carries n_seg0.
-    n_seg1 = self.segs_for(math.dist(T, S), math.dist(S, A))
+    def path(lst):
+        return [Wire(a, b) for a, b in zip(lst[:-1], lst[1:])]
 
     tups = []
-    tups.extend(build_path([S, A, B], n_seg0, None))      # arm + tail
-    tups.extend(build_path([C, D, E, F], n_seg0, None))   # reflector run
-    tups.extend(build_path([G, H, T], n_seg0, None))      # tail + arm
-    tups.append((T, S, n_seg1, 1 + 0j))                   # feed
+    tups.extend(path([S, A, B]))
+    tups.extend(path([C, D, E, F]))
+    tups.extend(path([G, H, T]))
+    tups.append(Wire(T, S, ex=1 + 0j))
     return tups
 ```
 
-### What version 1 got wrong
+No `Wire()` here mentions a count. The framework resolves `build_wires`
+results before any consumer sees them, so there is no meshing call to
+remember either. The builder's only meshing obligation is to declare the
+frequency that anchors the density:
 
-This code looks disciplined — it even refines the feed gap
-properly. Its defect is one habit: **every wire got the full nominal
-count**, long or short. The main elements are 3.8 m; the folded tails are
-0.56 m. Same count on both means the tails ran at **6.7× the density** of
-everything else, at every mesh — and the over-dense wires were exactly
-the facing conductors across the Moxon's critical tip gap. At coarse
-meshes nothing showed. Refined, the NEC-style basis walked off the
-converged answer: 39.2−21.2j where the true value is 43.6−16.3j, a 14 %
-error that hid because coarse meshes agreed fine.
+```python
+default_params = MappingProxyType({
+    "freq": 28.57,
+    "design_freq": 28.57,   # anchors the mesh density (see below)
+    # ... the geometry knobs ...
+})
+```
 
-The same habit produced every meshing failure in the catalog's history:
-a folded inverted-V whose 10 cm link carried the full count until segment
-length fell below the wire's *radius* (impedance exploded to −1188j
-against a true −30j), fan-dipole feed links hard-coded at 5 segments
-while the arms refined past them, hexbeam tip spacers likewise. Different
-designs, one cause: a hand-assigned count that left one wire's segment
-length out of step with its junction partners.
+## The rule behind `None`
 
-**2. Explicit segmentation, done right.** Getting the counts correct by
-hand means honoring one invariant: *every wire's count must be
-proportional to its length, at one shared density*. So you must
+There is exactly one rule, applied per wire with no interactions:
 
-1. pick a **reference wire** that carries `nominal_nsegs` (here the
-   driver arm `S→A`),
-2. derive **every other wire's** count from its own length at that
-   density (`segs_for(length, ref)` — never reuse the nominal count on a
-   wire of a different length),
-3. and keep doing both forever: every wire added later, every knob whose
-   drag changes a wire's length relative to the reference, has to go
-   back through the same arithmetic.
+> A `None` count meshes the wire at the **design density**:
+> `nominal_nsegs` segments per quarter-wavelength at `design_freq`.
+> An integer count is taken verbatim.
 
-That version of the Moxon — the fix that was actually shipped — looks
-like this:
+Three consequences worth knowing:
+
+- **N is a physical unit.** N=15 means a segment length of λ/60 — on
+  this design, on every design. Convergence ladders are comparable
+  across the whole catalog, and the segments-per-wavelength intuition
+  from the NEC world maps directly.
+- **`design_freq`, never `freq`.** The mesh is anchored to the frequency
+  the geometry is *designed* for, not the frequency being measured — so
+  sweeping frequency can never remesh the antenna mid-sweep. A design
+  whose geometry is sized in absolute metres (like the Moxon) declares a
+  `design_freq` purely as its density anchor; wavelength-sized designs
+  already have one. Using `None` without declaring it is a build-time
+  error, not a silent guess.
+- **Uniform density is the whole point.** Every `None` wire in a design
+  gets the same segment length, so no junction ever sees a mesh step —
+  the failure mode described below becomes unwritable. A catalog-wide
+  lint enforces the outcome (segment-length ratio bounded at fine mesh,
+  and forbidden from growing up the ladder), so even a builder that
+  keeps explicit counts can't silently introduce a density mismatch.
+
+## The bookkeeping this replaces
+
+Meshing a multi-wire design by hand has one invariant: *every wire's
+count must be proportional to its length, at one shared density*.
+Maintaining it means picking a **reference wire** that carries
+`nominal_nsegs`, deriving **every other wire's** count from its own
+length at that density (`segs_for(length, ref)` — never reusing the
+nominal count on a wire of a different length), and re-running that
+arithmetic for every wire added later and every knob whose drag changes
+a length ratio. For the Moxon it looks like this:
 
 ```python
 def build_wires(self):
@@ -100,87 +102,35 @@ def build_wires(self):
     return tups
 ```
 
-This is correct — and it is all bookkeeping. Nothing about it is
-Moxon-specific insight; it is the same invariant every design must
-re-implement, and every line that touches a count is a chance to slip
-back into version 1. The catalog did exactly that five separate times,
-in five different builders, each of which passed review looking like the
-disciplined code above.
+This is correct — and it is all bookkeeping, none of it Moxon-specific
+insight. Every line that touches a count is a chance to slip into the
+natural-looking shortcut: giving **every wire the full nominal count**,
+long or short.
 
-**3. Automatic meshing** (the catalog's Moxon today) — the invariant
-moves into the framework, and the builder stops talking about meshing
-entirely:
-
-```python
-def build_wires(self):
-    # ... geometry: corner points S, A, B, C, D, E, F, G, H, T ...
-
-    def path(lst):
-        return [Wire(a, b) for a, b in zip(lst[:-1], lst[1:])]
-
-    tups = []
-    tups.extend(path([S, A, B]))
-    tups.extend(path([C, D, E, F]))
-    tups.extend(path([G, H, T]))
-    tups.append(Wire(T, S, ex=1 + 0j))
-    return tups
-```
-
-No `Wire()` here mentions a count at all — the field defaults to `None`. Auto-meshing is part of the stack:
-the framework resolves `build_wires` results before any consumer sees
-them, so there is no meshing call to remember. The design declares one
-new parameter:
-
-```python
-default_params = MappingProxyType({
-    "freq": 28.57,
-    "design_freq": 28.57,   # anchors the mesh density (see below)
-    # ... the geometry knobs ...
-})
-```
-
-That is the entire migration. No reference-wire choice, no `segs_for`
-arithmetic, no per-wire decisions, no call to make.
-
-## The rule behind `None`
-
-There is exactly one rule, applied per wire with no interactions:
-
-> A `None` count meshes the wire at the **design density**:
-> `nominal_nsegs` segments per quarter-wavelength at `design_freq`.
-> An integer count is taken verbatim.
-
-Three consequences worth knowing:
-
-- **N is now a physical unit.** N=15 means a segment length of λ/60 — on
-  this design, on every design. Convergence ladders are comparable
-  across the whole catalog, and the segments-per-wavelength intuition
-  from the NEC world maps directly.
-- **`design_freq`, never `freq`.** The mesh is anchored to the frequency
-  the geometry is *designed* for, not the frequency being measured — so
-  sweeping frequency can never remesh the antenna mid-sweep. A design
-  whose geometry is sized in absolute metres (like the Moxon) declares a
-  `design_freq` purely as its density anchor; wavelength-sized designs
-  already have one. Using `None` without declaring it is a build-time
-  error, not a silent guess.
-- **Uniform density is the whole point.** Every `None` wire in a design
-  gets the same segment length, so no junction ever sees a mesh step —
-  the failure mode above becomes unwritable. A catalog-wide lint
-  enforces the outcome (segment-length ratio bounded at fine mesh, and
-  forbidden from growing up the ladder), so even a builder that keeps
-  explicit counts can't silently reintroduce the bug class.
+On the Moxon that shortcut is quietly disastrous. The main elements are
+3.8 m and the folded tails are 0.56 m, so one shared count runs the
+tails at **6.7× the density** of everything else — and the over-dense
+wires are exactly the facing conductors across the Moxon's critical tip
+gap. At coarse meshes nothing shows. Refined, the NEC-style basis walks
+away from the converged answer: 39.2−21.2j where the true value is
+43.6−16.3j, a 14 % error that coarse-mesh agreement never hints at. The
+same mismatch bites wherever a short wire — a feed link, a tip spacer, a
+folded element's connecting stub — meets long ones at a hand-assigned
+count; in the worst case, a 10 cm link's segment length falls below the
+wire's *radius* and the reported impedance explodes to −1188j against a
+true −30j. Uniform density makes the entire class of mistakes
+unwritable, which is why it is the default rather than a convention.
 
 ## When would you still write a count?
 
-Explicit counts remain fully supported — a design written entirely with
-integers behaves exactly as it always did, and `segs_for` is still there
-for computing them. They are the right tool when the mesh itself is
-*data*: a deck-faithful reproduction of an external NEC model, or the
-few validated port models whose counts encode physics still under study.
-For everything else, the recommendation is now simple: write `None`,
-declare `design_freq`, and never think about
-segmentation again.
+Explicit counts are fully supported — an integer count is honored
+verbatim, and `segs_for` is still there for computing one. They are the
+right tool when the mesh itself is *data*: a deck-faithful reproduction
+of an external NEC model, or the few validated port models whose counts
+encode physics still under study. For everything else the
+recommendation is simple: write `None`, declare `design_freq`, and never
+think about segmentation again.
 
-For the measurement story behind this — the convergence ladders, the
-basis comparisons, and the audit that found the defects — see
+For the measurement story behind the density rule — the convergence
+ladders and the basis comparisons — see
 [How many segments?](/advanced/convergence/).

--- a/site/src/content/docs/concepts/first-builder.mdx
+++ b/site/src/content/docs/concepts/first-builder.mdx
@@ -22,6 +22,7 @@ wire, no geometry parameters at all:
 
 ```python
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 
 
 class Builder(AntennaBuilder):
@@ -33,7 +34,7 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         y = 5.0  # half-length in metres → a 10 m wire, tip to tip
         return [
-            ((0.0, -y, 0.0), (0.0, y, 0.0), None, 1 + 0j),
+            Wire((0.0, -y, 0.0), (0.0, y, 0.0), ex=1 + 0j),
         ]
 ```
 
@@ -41,16 +42,16 @@ That's a complete, loadable design. Drop it in your
 [designs folder](/concepts/authoring-with-claude/#your-designs-folder) as
 `my_dipole.py`, refresh the workbench, and it appears under **Your designs**.
 
-Reading the one wire tuple `((0,-y,0), (0,y,0), None, 1+0j)` against the
+Reading the one `Wire((0,-y,0), (0,y,0), ex=1+0j)` against the
 [`build_wires()` contract](/concepts/model/#the-build_wires-contract):
 
 - **`(0,-y,0)` → `(0,y,0)`** — the two endpoints (metres): a straight wire along
   the **y** axis from −5 m to +5 m, lying on the ground plane (`z = 0`).
-- **`None`** — no segment count: the framework meshes the wire for you, at a
-  density anchored to `design_freq` (step 4 explains the rule — you will never
-  pick a count by hand).
-- **`1 + 0j`** — this wire is the **driven** element; the source sits on it. (A
-  structural, undriven wire would carry `None` here.) Exactly one segment in the
+- **no segment count** — you didn't pass one, so the framework meshes the wire
+  for you, at a density anchored to `design_freq` (step 4 explains the rule —
+  you will never pick a count by hand).
+- **`ex=1 + 0j`** — this wire is the **driven** element; the source sits on it.
+  (A structural, undriven wire is just `Wire(a, b)`.) Exactly one segment in the
   whole design carries the feed — here the wire's own centre segment.
 
 <Aside type="note" title="Why the feed has no separate wire">
@@ -106,7 +107,7 @@ class Builder(AntennaBuilder):
         y = 5.0
         z = self.base   # every param is read as self.<name>
         return [
-            ((0.0, -y, z), (0.0, y, z), None, 1 + 0j),
+            Wire((0.0, -y, z), (0.0, y, z), ex=1 + 0j),
         ]
 ```
 
@@ -155,9 +156,9 @@ N=21 it meshes into **39** segments — and the count will *track* the length
 once we make it a parameter.
 
 <Aside type="note" title="Explicit counts still exist">
-  An integer in the count slot is honored verbatim. You'd only reach for one
-  when the mesh itself is data — reproducing an imported NEC deck wire-for-wire,
-  say. For everything you author, write `None`.
+  An integer count — `Wire(a, b, n_seg=28)` — is honored verbatim. You'd only
+  reach for one when the mesh itself is data — reproducing an imported NEC deck
+  wire-for-wire, say. For everything you author, leave the count off.
 </Aside>
 
 <Aside type="note" title="You give a count; the solver picks the parity">
@@ -180,6 +181,7 @@ adjustable — slide it longer to drop the resonant frequency, shorter to raise 
 
 ```python
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 
 
 class Builder(AntennaBuilder):
@@ -195,7 +197,7 @@ class Builder(AntennaBuilder):
         y = self.half_length
         z = self.base
         return [
-            ((0.0, -y, z), (0.0, y, z), None, 1 + 0j),
+            Wire((0.0, -y, z), (0.0, y, z), ex=1 + 0j),
         ]
 ```
 
@@ -218,6 +220,7 @@ true resonance:
 
 ```python
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 
 
 class Builder(AntennaBuilder):
@@ -235,7 +238,7 @@ class Builder(AntennaBuilder):
         y = quarter * self.length_factor   # half-length ≈ a quarter wavelength
         z = self.base
         return [
-            ((0.0, -y, z), (0.0, y, z), None, 1 + 0j),
+            Wire((0.0, -y, z), (0.0, y, z), ex=1 + 0j),
         ]
 ```
 

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,20 +25,20 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.35.2" icon="star">
-  **The NEC-2 reference you can trust near the ground.** A long-standing
-  nec2++ transcription bug — the Sommerfeld interpolation cache
-  extrapolated stale coefficients whenever a source–observer pair
-  crossed the near-field grid boundary — made PyNEC unreliable for
-  low radials, hanging open ends, and low horizontal runs over real
-  ground. We found the root cause, fixed it upstream
-  (pynec-accel 1.7.6), and re-scored the wild corpus: **every deck in
-  the affected class now matches nec2c/nec2dxs/momwire to four digits**,
-  and the workbench's solve-time warning retires itself on fixed
-  installs. Also new in the docs: on single closed loops the default
-  B-spline basis is converged at a **2–3× coarser mesh** than the
-  sinusoidal basis needs — see
-  [How many segments?](/advanced/convergence/).
+<Card title="New in v0.36.0" icon="star">
+  **Segmentation you never think about.** Give a wire the segment count
+  `None` and the framework meshes it at the design density —
+  `nominal_nsegs` segments per quarter-wavelength at `design_freq`,
+  resolved automatically before any solver sees the wires. The whole
+  catalog is converted, and doing so surfaced **seven silent meshing
+  defects** hand-assigned counts had hidden for months (a curtain at
+  half density, a bowtie at double, a beam whose convergence ladder
+  never actually refined…). N is now a physical unit — N=15 means
+  λ/60 segments on *every* design — and the basis census improved to
+  **77/92 designs with a verified mutual convergence limit**. Even the
+  catalog's hardest port model, the terminated longwire's high-|Z|
+  feed, turned out mesh-stable under the new treatment. Read the story:
+  [Segmentation you never think about](/concepts/auto-meshing/).
   [All release notes →](/reference/releases/)
 </Card>
 

--- a/site/src/content/docs/reference/solver.mdx
+++ b/site/src/content/docs/reference/solver.mdx
@@ -105,10 +105,12 @@ threading; see the benchmark docs for full tables.
 
 Method-of-moments discretizes each wire into **segments**, and the solve builds
 one **basis function** per segment. The **segments / wire (N)** control in the
-workbench sets the nominal count; antennaknobs scales it per wire by length, so a
-long radiator gets proportionally more segments than a short stub. The total
-basis-function count — the sum across every wire — is the **dimension of the
-impedance matrix** the solver fills and factors.
+workbench sets the design's mesh **density**: every wire gets N segments per
+quarter-wavelength (at the design frequency), so a long radiator gets
+proportionally more segments than a short stub — and N means the same physical
+segment length on every design (N=15 ≈ λ/60). The total basis-function count —
+the sum across every wire — is the **dimension of the impedance matrix** the
+solver fills and factors.
 
 That matrix is what sets both accuracy and cost:
 

--- a/site/src/content/docs/start/quickstart.md
+++ b/site/src/content/docs/start/quickstart.md
@@ -3,10 +3,10 @@ title: Quickstart
 description: Install antennaknobs and solve your first antenna in a few lines of Python.
 ---
 
-## Install
+## Run the workbench with Docker
 
 The fastest path needs nothing but Docker — the published image serves the
-full workbench (new in v0.34):
+full workbench, no install (new in v0.34):
 
 ```bash
 docker run --rm -p 8000:8000 stevenmburns/antennaknobs:latest
@@ -16,8 +16,11 @@ docker run --rm -p 8000:8000 stevenmburns/antennaknobs:latest
 (See [DOCKER.md](https://github.com/stevenmburns/antennaknobs/blob/main/DOCKER.md)
 for compose, mounting your own designs, and the optional NEC2 engine.)
 
-Prefer a Python install? `antennaknobs` and its engine `momwire` are
-published to PyPI with prebuilt wheels — a plain install needs no compiler:
+## Install with Python
+
+To use the library — or hack on designs in your editor — install from PyPI.
+`antennaknobs` and its engine `momwire` ship prebuilt wheels, so a plain
+install needs no compiler:
 
 ```bash
 python3 -m venv .venv && source .venv/bin/activate
@@ -35,7 +38,7 @@ pip install "pynec-accel>=1.7.4.post2"
 ```
 :::
 
-## Launch the web workbench
+This install serves the same web workbench as the Docker image:
 
 ```bash
 uvicorn antennaknobs.web.server:app      # then open http://127.0.0.1:8000

--- a/src/antennaknobs/designs/beams/hexbeam.py
+++ b/src/antennaknobs/designs/beams/hexbeam.py
@@ -1,6 +1,7 @@
 """Hex beam — a W-folded 2-element beam on a hexagonal spreader footprint."""
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 import math
 from types import MappingProxyType
 
@@ -53,8 +54,8 @@ class Builder(AntennaBuilder):
         cos30 = math.sqrt(3) / 2
         # x is the beam direction
 
-        def build_path(lst, ns, ex):
-            return ((a, b, ns, ex) for a, b in zip(lst[:-1], lst[1:]))
+        def build_path(lst, ex=None):
+            return (Wire(a, b, ex=ex) for a, b in zip(lst[:-1], lst[1:]))
 
         def rx(p):
             return -p[0], p[1], p[2]
@@ -81,25 +82,19 @@ class Builder(AntennaBuilder):
         # junction that worsened with N), and the feed gap — meshes at the
         # design density (nominal_nsegs per design_freq quarter-wave).
         tups = []
-        tups.extend(build_path([S, A, B], None, None))
-        tups.extend(build_path([C, D], None, None))
-        tups.extend(build_path([D, E, F, G], None, None))
-        tups.extend(build_path([G, H], None, None))
-        tups.extend(build_path([II, J, T], None, None))
-        tups.append((T, S, None, 1 + 0j))
+        tups.extend(build_path([S, A, B]))
+        tups.extend(build_path([C, D]))
+        tups.extend(build_path([D, E, F, G]))
+        tups.extend(build_path([G, H]))
+        tups.extend(build_path([II, J, T]))
+        tups.append(Wire(T, S, ex=1 + 0j))
 
-        new_tups = []
-        for xoff, yoff, zoff in [(0, 0, self.base)]:
-            new_tups.extend(
-                [
-                    (
-                        (x0 + xoff, y0 + yoff, z0 + zoff),
-                        (x1 + xoff, y1 + yoff, z1 + zoff),
-                        ns,
-                        ex,
-                    )
-                    for ((x0, y0, z0), (x1, y1, z1), ns, ex) in tups
-                ]
+        # Lift the whole (z=0-planar) hex up to the mast height.
+        zoff = self.base
+        return [
+            w._replace(
+                p0=(w.p0[0], w.p0[1], w.p0[2] + zoff),
+                p1=(w.p1[0], w.p1[1], w.p1[2] + zoff),
             )
-
-        return new_tups
+            for w in tups
+        ]

--- a/src/antennaknobs/designs/beams/moxon.py
+++ b/src/antennaknobs/designs/beams/moxon.py
@@ -1,6 +1,7 @@
 """Moxon rectangle — a 2-element beam with folded-back element tips."""
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 from types import MappingProxyType
 
 
@@ -96,12 +97,12 @@ class Builder(AntennaBuilder):
         # fine mesh (39.2-21.2j vs 43.6-16.3j at N=321). At uniform
         # design density sin lands on bs2 to 0.1% there.
         def path(lst):
-            return [(a, b, None, None) for a, b in zip(lst[:-1], lst[1:])]
+            return [Wire(a, b) for a, b in zip(lst[:-1], lst[1:])]
 
         tups = []
         tups.extend(path([S, A, B]))
         tups.extend(path([C, D, E, F]))
         tups.extend(path([G, H, T]))
-        tups.append((T, S, None, 1 + 0j))
+        tups.append(Wire(T, S, ex=1 + 0j))
 
         return tups

--- a/src/antennaknobs/designs/dipoles/folded_invvee_balun.py
+++ b/src/antennaknobs/designs/dipoles/folded_invvee_balun.py
@@ -20,6 +20,7 @@ it; the geometry knobs are the stock folded-invvee ones.
 from types import MappingProxyType
 
 from antennaknobs.network import (
+    as_wire,
     CABLES,
     TL,
     Driven,
@@ -62,13 +63,10 @@ class Builder(FoldedInvVee):
     def build_wires(self):
         # Stock folded inv-vee geometry; the driven gap becomes the named
         # "feed" port (the source lives at the virtual rig node).
-        wires = []
-        for p0, p1, nseg, ev, *rest in super().build_wires():
-            if ev is not None:
-                wires.append((p0, p1, nseg, None, "feed"))
-            else:
-                wires.append((p0, p1, nseg, ev, *rest))
-        return wires
+        return [
+            w._replace(ex=None, name="feed") if w.ex is not None else w
+            for w in map(as_wire, super().build_wires())
+        ]
 
     def build_network(self):
         return Network(

--- a/src/antennaknobs/designs/dipoles/invvee_coax_station.py
+++ b/src/antennaknobs/designs/dipoles/invvee_coax_station.py
@@ -27,7 +27,15 @@ lossy tuner).
 
 from types import MappingProxyType
 
-from antennaknobs.network import CABLES, TL, Driven, Network, PortOnWire, PortVirtual
+from antennaknobs.network import (
+    CABLES,
+    TL,
+    Driven,
+    Network,
+    PortOnWire,
+    PortVirtual,
+    as_wire,
+)
 from antennaknobs.designs.dipoles.invvee import Builder as InvVee
 
 
@@ -59,13 +67,10 @@ class Builder(InvVee):
         # Stock inv-vee geometry; the driven gap becomes the named "feed"
         # port and loses its inline excitation — the source lives at the
         # virtual rig end of the line instead.
-        wires = []
-        for p0, p1, nseg, ev, *rest in super().build_wires():
-            if ev is not None:
-                wires.append((p0, p1, nseg, None, "feed"))
-            else:
-                wires.append((p0, p1, nseg, ev, *rest))
-        return wires
+        return [
+            w._replace(ex=None, name="feed") if w.ex is not None else w
+            for w in map(as_wire, super().build_wires())
+        ]
 
     def build_network(self):
         return Network(

--- a/src/antennaknobs/designs/loops/skyloop_lmatch.py
+++ b/src/antennaknobs/designs/loops/skyloop_lmatch.py
@@ -34,6 +34,7 @@ from types import MappingProxyType
 
 from antennaknobs.designs.loops.triangular_skyloop import Builder as TriangularSkyloop
 from antennaknobs.network import (
+    as_wire,
     Driven,
     Instance,
     Network,
@@ -85,12 +86,10 @@ class Builder(TriangularSkyloop):
         # the driven chamfer as the network's "feed" port and clear its inline
         # excitation, since the L-match network supplies the source at the
         # virtual `in` node instead.
-        wires = []
-        for p0, p1, nseg, ex, *rest in super().build_wires():
-            wires.append(
-                (p0, p1, nseg, None, "feed") if ex is not None else (p0, p1, nseg, ex)
-            )
-        return wires
+        return [
+            w._replace(ex=None, name="feed") if w.ex is not None else w
+            for w in map(as_wire, super().build_wires())
+        ]
 
     def build_network(self):
         r"""L-match, stamped LITERALLY at whatever the sliders say: the MNA

--- a/src/antennaknobs/designs/multiband/hexbeam_5band.py
+++ b/src/antennaknobs/designs/multiband/hexbeam_5band.py
@@ -23,6 +23,7 @@ import math
 from types import MappingProxyType
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 
 C_LIGHT_MHZ_M = 299.792458
 
@@ -340,18 +341,18 @@ class Builder(AntennaBuilder):
             J = at_z(anchors["J"])
             T = at_z(anchors["T"])
 
-            def build_path(lst, ns):
-                return [(a, b, ns, None) for a, b in zip(lst[:-1], lst[1:])]
+            def build_path(lst):
+                return [Wire(a, b) for a, b in zip(lst[:-1], lst[1:])]
 
-            tups.extend(build_path([S, A, B], None))
-            tups.extend(build_path([C, D], None))
-            tups.extend(build_path([D, E, F, G], None))
-            tups.extend(build_path([G, H], None))
-            tups.extend(build_path([II, J, T], None))
+            tups.extend(build_path([S, A, B]))
+            tups.extend(build_path([C, D]))
+            tups.extend(build_path([D, E, F, G]))
+            tups.extend(build_path([G, H]))
+            tups.extend(build_path([II, J, T]))
             # The feed wire (one per band). Daisy-chain mode strips the
             # excitation on bands 1..N-1 inside build_tls; multi-feed
             # mode leaves every band's excitation in place.
-            tups.append((T, S, n_seg_feed, 1 + 0j))
+            tups.append(Wire(T, S, n_seg=n_seg_feed, ex=1 + 0j))
             self._feed_wire_indices.append(len(tups))  # 1-indexed NEC tag
 
         if self.daisy_chain:
@@ -359,8 +360,7 @@ class Builder(AntennaBuilder):
             # added in build_tls() couple bands 1..N-1 to their upstream
             # neighbour.
             for idx in self._feed_wire_indices[1:]:
-                p0, p1, ns, _ = tups[idx - 1]
-                tups[idx - 1] = (p0, p1, ns, None)
+                tups[idx - 1] = tups[idx - 1]._replace(ex=None)
 
         # Every band's every edge meshes at the design density
         # (nominal_nsegs per design_freq quarter-wave — one segment

--- a/src/antennaknobs/designs/specialty/helix.py
+++ b/src/antennaknobs/designs/specialty/helix.py
@@ -38,6 +38,7 @@ Geometry, in the framework's (x, y, z) convention:
 """
 
 from antennaknobs import AntennaBuilder
+from antennaknobs.network import Wire
 import math
 from types import MappingProxyType
 
@@ -101,7 +102,7 @@ class Builder(AntennaBuilder):
         tups = []
 
         # Base feed: a one-segment driven gap at the foot, against the radials.
-        tups.append(((0.0, 0.0, z0), (0.0, 0.0, z0 + eps), 1, 1 + 0j))
+        tups.append(Wire((0.0, 0.0, z0), (0.0, 0.0, z0 + eps), n_seg=1, ex=1 + 0j))
 
         # Helix: a space curve from the top of the feed gap upward. Each chord
         # is a straight segment between successive points on the winding; the
@@ -116,7 +117,7 @@ class Builder(AntennaBuilder):
             y = radius * math.sin(ang)
             z = zbot + (axial * i / n_pts)
             cur = (x, y, z)
-            tups.append((prev, cur, 1, None))
+            tups.append(Wire(prev, cur, n_seg=1))
             prev = cur
 
         # Elevated quarter-wave radials from the feedpoint (cf. vertical.py).
@@ -126,6 +127,6 @@ class Builder(AntennaBuilder):
             theta = 2 * math.pi / n_radials * j
             rx = quarter * math.cos(theta)
             ry = quarter * math.sin(theta)
-            tups.append(((0.0, 0.0, z0), (rx, ry, z0), n_seg_radials, None))
+            tups.append(Wire((0.0, 0.0, z0), (rx, ry, z0), n_seg=n_seg_radials))
 
         return tups

--- a/src/antennaknobs/designs/specialty/hentenna.py
+++ b/src/antennaknobs/designs/specialty/hentenna.py
@@ -2,6 +2,7 @@
 
 from antennaknobs import AntennaBuilder
 from antennaknobs import Transform, TransformStack
+from antennaknobs.network import Wire
 from types import MappingProxyType
 
 
@@ -74,16 +75,18 @@ class Builder(AntennaBuilder):
         st = TransformStack()
         st.push(Transform.translate(0, 0, b))
 
-        def build_path(lst, ns, ex):
-            return ((st.hit(a), st.hit(b), ns, ex) for a, b in zip(lst[:-1], lst[1:]))
+        def build_path(lst, ex=None):
+            return (
+                Wire(st.hit(a), st.hit(b), ex=ex) for a, b in zip(lst[:-1], lst[1:])
+            )
 
         tups = []
 
-        tups.extend(build_path([B, A, C, D], None, None))
-        tups.extend(build_path([B, F, E, D], None, None))
-        tups.extend(build_path([S, B], None, None))
-        tups.extend(build_path([D, T], None, None))
-        tups.extend(build_path([T, S], None, 1 + 0j))
+        tups.extend(build_path([B, A, C, D]))
+        tups.extend(build_path([B, F, E, D]))
+        tups.extend(build_path([S, B]))
+        tups.extend(build_path([D, T]))
+        tups.extend(build_path([T, S], ex=1 + 0j))
         # Uniform-density mesh (issue #521): None counts resolve to the
         # design density automatically (auto_mesh is part of the stack).
 

--- a/src/antennaknobs/designs/specialty/hentenna_slant.py
+++ b/src/antennaknobs/designs/specialty/hentenna_slant.py
@@ -42,6 +42,7 @@ import math
 from types import MappingProxyType
 
 from antennaknobs import AntennaBuilder, Transform, TransformStack
+from antennaknobs.network import Wire
 
 
 class Builder(AntennaBuilder):
@@ -157,16 +158,18 @@ class Builder(AntennaBuilder):
         st = TransformStack()
         st.push(Transform.translate(0, 0, b))
 
-        def build_path(lst, ns, ex):
-            return ((st.hit(a), st.hit(b), ns, ex) for a, b in zip(lst[:-1], lst[1:]))
+        def build_path(lst, ex=None):
+            return (
+                Wire(st.hit(a), st.hit(b), ex=ex) for a, b in zip(lst[:-1], lst[1:])
+            )
 
         tups = []
 
-        tups.extend(build_path([B, A, AA, C, D], None, None))
-        tups.extend(build_path([B, F, FF, E, D], None, None))
-        tups.extend(build_path([S, B], None, None))
-        tups.extend(build_path([D, T], None, None))
-        tups.extend(build_path([T, S], None, 1 + 0j))
+        tups.extend(build_path([B, A, AA, C, D]))
+        tups.extend(build_path([B, F, FF, E, D]))
+        tups.extend(build_path([S, B]))
+        tups.extend(build_path([D, T]))
+        tups.extend(build_path([T, S], ex=1 + 0j))
         # Uniform-density mesh (issue #521): None counts resolve to the
         # design density automatically (auto_mesh is part of the stack).
 

--- a/src/antennaknobs/designs/specialty/hourglass.py
+++ b/src/antennaknobs/designs/specialty/hourglass.py
@@ -2,6 +2,7 @@
 
 from antennaknobs import AntennaBuilder
 from antennaknobs import Transform, TransformStack
+from antennaknobs.network import Wire
 from types import MappingProxyType
 
 
@@ -57,16 +58,18 @@ class Builder(AntennaBuilder):
         st = TransformStack()
         st.push(Transform.translate(0, 0, b - A[2]))
 
-        def build_path(lst, ns, ex):
-            return ((st.hit(a), st.hit(b), ns, ex) for a, b in zip(lst[:-1], lst[1:]))
+        def build_path(lst, ex=None):
+            return (
+                Wire(st.hit(a), st.hit(b), ex=ex) for a, b in zip(lst[:-1], lst[1:])
+            )
 
         tups = []
 
-        tups.extend(build_path([B, A, C, D], None, None))
-        tups.extend(build_path([B, F, E, D], None, None))
-        tups.extend(build_path([S, B], None, None))
-        tups.extend(build_path([D, T], None, None))
-        tups.extend(build_path([T, S], None, 1 + 0j))
+        tups.extend(build_path([B, A, C, D]))
+        tups.extend(build_path([B, F, E, D]))
+        tups.extend(build_path([S, B]))
+        tups.extend(build_path([D, T]))
+        tups.extend(build_path([T, S], ex=1 + 0j))
         # Uniform-density mesh (issue #521): None counts resolve to the
         # design density automatically (auto_mesh is part of the stack).
 

--- a/src/antennaknobs/designs/specialty/hourglass_slant.py
+++ b/src/antennaknobs/designs/specialty/hourglass_slant.py
@@ -4,6 +4,7 @@ import math
 
 from antennaknobs import AntennaBuilder
 from antennaknobs import Transform, TransformStack
+from antennaknobs.network import Wire
 
 from types import MappingProxyType
 
@@ -79,16 +80,18 @@ class Builder(AntennaBuilder):
         st = TransformStack()
         st.push(Transform.translate(0, 0, b - AA[2]))
 
-        def build_path(lst, ns, ex):
-            return ((st.hit(a), st.hit(b), ns, ex) for a, b in zip(lst[:-1], lst[1:]))
+        def build_path(lst, ex=None):
+            return (
+                Wire(st.hit(a), st.hit(b), ex=ex) for a, b in zip(lst[:-1], lst[1:])
+            )
 
         tups = []
 
-        tups.extend(build_path([B, A, AA, C, D], None, None))
-        tups.extend(build_path([B, F, FF, E, D], None, None))
-        tups.extend(build_path([S, B], None, None))
-        tups.extend(build_path([D, T], None, None))
-        tups.extend(build_path([T, S], None, 1 + 0j))
+        tups.extend(build_path([B, A, AA, C, D]))
+        tups.extend(build_path([B, F, FF, E, D]))
+        tups.extend(build_path([S, B]))
+        tups.extend(build_path([D, T]))
+        tups.extend(build_path([T, S], ex=1 + 0j))
         # Uniform-density mesh (issue #521): None counts resolve to the
         # design density automatically (auto_mesh is part of the stack).
 


### PR DESCRIPTION
## Summary
- Version 0.35.2 → **0.36.0**.
- What's-new card: the auto-mesh paradigm — `None` counts mesh at the design density, resolved in the stack; the whole catalog converted (#525 stages 1–4, PRs #523/#524/#527–#533/#536–#538/#540/#542); seven silent meshing defects surfaced and fixed; census improved to **77/92 mutual-limit** (bs2 converged at N=21 on 63); terminated_longwire's high-|Z| model resolved (#526).
- Solver reference: documents N as a physical density (N segments per quarter-wave at design_freq; N=15 ≈ λ/60 on every design).
- Docs de-stale for the arc landed earlier in #541/#542 (convergence guide, auto-meshing page).
- momwire pin unchanged (0.16.0).

## Test plan
- [x] Site builds (24 pages)
- [x] Main is green through #542 (full suite 2669 passed)
- [ ] After merge: tag v0.36.0 → watch all four pipelines → verify PyPI + fleet convergence → announcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iMSNiYKS61YWgLbuPoSKv