### PR TITLE
Fix auto default_view regression for Wire()-idiom designs

### DIFF
--- a/src/antennaknobs/designs/loops/delta_loop_flyby.py
+++ b/src/antennaknobs/designs/loops/delta_loop_flyby.py
@@ -30,6 +30,7 @@ import math
 from types import MappingProxyType
 
 from antennaknobs import AntennaBuilder, Drone
+from antennaknobs.network import as_wire
 
 
 class Builder(AntennaBuilder):
@@ -85,7 +86,7 @@ class Builder(AntennaBuilder):
             return drone.wires()
 
         def total(side):
-            return sum(math.dist(p0, p1) for p0, p1, _ns, _ex in geometry(side))
+            return sum(math.dist(w.p0, w.p1) for w in map(as_wire, geometry(side)))
 
         # Size by total wire length, numerically (the drone builds never use the
         # closed-form top-corner position the shipped delta_loop leans on).
@@ -99,4 +100,4 @@ class Builder(AntennaBuilder):
         def lift(p):
             return (p[0], p[1], p[2] + shift)
 
-        return [(lift(a), lift(b), ns, ex) for a, b, ns, ex in wires]
+        return [w._replace(p0=lift(w.p0), p1=lift(w.p1)) for w in map(as_wire, wires)]

--- a/src/antennaknobs/designs/wire/efhw_sloper.py
+++ b/src/antennaknobs/designs/wire/efhw_sloper.py
@@ -70,6 +70,7 @@ from antennaknobs.network import (
     TL,
     Wire,
     WIRES,
+    as_wire,
 )
 from antennaknobs.station import unun
 
@@ -186,8 +187,8 @@ class Builder(AntennaBuilder):
         # The short gap edge becomes the named "ant" port wire: the port
         # interrupts the current path between counterpoise and radiator —
         # the end-fed's feed.
-        p0, p1, _nsegs, _ev = wires[1]
-        wires[1] = Wire(p0, p1, name="ant")
+        gap = as_wire(wires[1])
+        wires[1] = Wire(gap.p0, gap.p1, name="ant")
         return wires
 
     def build_network(self):

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -1129,9 +1129,10 @@ def _auto_default_view(cls) -> str:
     try:
         b = cls()
         pts = []
-        for p0, p1, _n, _e in b.build_wires():
-            pts.append(p0)
-            pts.append(p1)
+        for t in b.build_wires():
+            w = as_wire(t)
+            pts.append(w.p0)
+            pts.append(w.p1)
         a = np.asarray(pts, dtype=float)
     except Exception:
         return "xy"

--- a/tests/test_design_schemas.py
+++ b/tests/test_design_schemas.py
@@ -20,7 +20,9 @@ import math
 import pytest
 
 import antennaknobs.web.examples  # noqa: F401 — primes the adapter
+from antennaknobs.network import Wire
 from antennaknobs.web.adapter import (
+    _auto_default_view,
     _auto_paramspec,
     _build_builder,
     _make_example,
@@ -114,6 +116,45 @@ def test_variant_values_serialise_for_every_variant(name):
 @pytest.mark.parametrize("name", DESIGN_NAMES)
 def test_default_view_is_a_valid_2d_plane(name):
     assert REGISTRY[name].default_view in {"xy", "yz", "xz"}
+
+
+def test_auto_default_view_reads_wire_idiom_entries():
+    """Regression guard for the #525 stage-2 Wire() migration.
+
+    `_auto_default_view` used to unpack build_wires() entries as strict
+    4-tuples. A `Wire`'s len() is always 6 (defaults fill name/spec), so
+    the unpack raised inside the function's try block and the bare-except
+    fallback silently returned "xy" for every Wire-idiom design — invvee
+    rendered edge-on until the user switched views, and no test noticed
+    because "xy" is a valid plane. Pin the mechanism directly: a Wire-idiom
+    geometry lying in the y-z plane must autodetect "yz".
+    """
+
+    class YZVee:
+        def build_wires(self):
+            return [
+                Wire((0, 0.05, 7.0), (0, 5.0, 4.0), 20, 1.0),
+                Wire((0, -0.05, 7.0), (0, -5.0, 4.0), 20, None),
+            ]
+
+    assert _auto_default_view(YZVee) == "yz"
+
+
+@pytest.mark.parametrize(
+    "name,view",
+    [
+        # These designs carry no ui_params["default_view"] override, so the
+        # value below is the *auto-detected* plane — if the detector silently
+        # falls back to "xy" again, these pins fail where the generic
+        # valid-plane sweep above cannot.
+        ("dipoles.invvee", "yz"),
+        ("loops.delta_loop", "yz"),
+        ("specialty.bowtie", "yz"),
+        ("beams.yagi", "xy"),  # boom on x, elements on y — genuinely xy
+    ],
+)
+def test_auto_default_view_pins(name, view):
+    assert REGISTRY[name].default_view == view
 
 
 @pytest.mark.parametrize("name", DESIGN_NAMES)


### PR DESCRIPTION
## Summary
- The #525 stage-2 `Wire()` migration broke `_auto_default_view`: it still unpacked `build_wires()` entries as strict 4-tuples, but a `Wire`'s `len()` is always 6, so the unpack raised and the bare-except fallback silently returned `"xy"` for every migrated design — `dipoles.invvee` (and ~60 other y-z / x-z designs) rendered edge-on in the 3D view until the user switched planes manually.
- Fix: route entries through `as_wire()`, the normalizer `_auto_multi_feed` already uses (its docstring names exactly this arity trap). 67 of 92 registered designs recover their non-`xy` auto views.
- Regression tests: a synthetic Wire-idiom yz-plane builder must autodetect `yz`, plus concrete view pins for four override-free designs (`invvee`/`delta_loop`/`bowtie` → `yz`, `yagi` → `xy`). The existing sweep only asserted membership in `{xy, yz, xz}`, which a universal fallback satisfies — that's how this slipped through.

## Test plan
- [x] New tests fail on main (4 failed), pass with the fix
- [x] Full suite: 2509 passed + 165 web-server tests passed
- [x] ruff check / format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KV3q7Q9hGKQL4xfbw5qbdt