### PR TITLE
Levee-QTH bracketing recipe + nec2c GD-cliff cross-check harness

### DIFF
--- a/scripts/bench_levee_bracket.py
+++ b/scripts/bench_levee_bracket.py
@@ -1,0 +1,385 @@
+"""Levee-QTH bracketing recipe + nec2c GD-cliff cross-check (issue #535).
+
+A raised-terrain QTH (antenna on a levee/ridge crest) has no honest flat-ground
+model: the ground under the antenna is at one height, the ground the DX lobes
+reflect off is 7-11 m lower and may be a different medium per side (land vs
+water). Until the faceted-terrain far-field ground lands (#534), the honest
+answer is a *bracket* — solve the same design on flat Sommerfeld ground at
+several heights and read each result only inside its validity band:
+
+  - h = h0 above the *crest* surface        -> believe psi >= psi_crest
+    (the specular point d = h/tan(psi) is still on the crest facet)
+  - h = effective height above the *plain*  -> believe psi <= psi_plain
+    (specular point beyond the slope toe; one bracket per side, with that
+    side's medium — this is where every DX lobe lives)
+  - between the two: the slope band, where neither flat model is right;
+    #534's facet machinery is the fix. Here we report both and the gap.
+
+Validity-band geometry (per side)::
+
+    psi_crest = atan(h0 / crest_half_width)
+    x_toe     = crest_half_width + drop / tan(slope)
+    psi_plain = atan((h0 + drop) / x_toe)
+
+Cross-check: classic NEC-2 models exactly this scenario crudely — a two-media
+ground with a straight boundary and a height offset (GN + GD cards, the
+"cliff"). The cliff is pattern-only reflection-coefficient physics with no
+slope facet (a vertical drop at the boundary), which makes it an independent
+reference for the two flat brackets: its pattern should land between them,
+approaching the raised-height bracket at low angles.
+
+nec2c trap (cost us an afternoon; documented so it doesn't cost another):
+the GD card parses fine but is COMPLETELY IGNORED by a normal ``RP 0``
+pattern. The two-media cliff only enters the pattern for the dedicated RP
+modes: I1=2 (linear cliff, the levee case), 3 (circular cliff), 5/6 (same +
+radial screen). GD also takes the standard 4 leading integer fields like
+every other card ("GD 0 0 0 0 eps2 sig2 clt cht") — float-first raises a
+card error.
+
+Outputs: per-band console table (validity bands, first-lobe angles, bracket
+vs cliff gains at the DX angles), optional ``--json`` dump — the golden data
+for #534's single-cliff acceptance gate — and optional ``--plot`` overlay.
+
+Typical run (the motivating QTH, 20 m through 10 m)::
+
+    python scripts/bench_levee_bracket.py --freqs 14.1,18.1,21.2,24.9,28.4
+    python scripts/bench_levee_bracket.py --freqs 21.2 --json levee_goldens.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import math
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+# --------------------------------------------------------------------------
+# terrain geometry -> validity bands
+# --------------------------------------------------------------------------
+
+
+def validity_bands(h0, crest_half_width, slope_deg, drop):
+    """(psi_crest, psi_plain, x_toe, h_eff) for one side, degrees/metres.
+
+    psi above psi_crest: specular point on the crest -> flat model at h0.
+    psi below psi_plain: specular point past the slope toe -> flat model at
+    h_eff = h0 + drop. Between: the slope band (#534 territory).
+    """
+    psi_crest = math.degrees(math.atan2(h0, crest_half_width))
+    x_toe = crest_half_width + drop / math.tan(math.radians(slope_deg))
+    h_eff = h0 + drop
+    psi_plain = math.degrees(math.atan2(h_eff, x_toe))
+    return psi_crest, psi_plain, x_toe, h_eff
+
+
+# --------------------------------------------------------------------------
+# momwire flat-Sommerfeld brackets
+# --------------------------------------------------------------------------
+
+
+def solve_bracket(design, freq, base, ground):
+    """Solve one flat model; return (elevation_deg[], az_max_gain_dBi[], Z)."""
+    from antennaknobs import merge_params
+    from antennaknobs.engines.momwire import MomwireEngine
+    from momwire import BSplineSolver
+
+    mod = importlib.import_module(f"antennaknobs.designs.{design}")
+    b = mod.Builder(
+        merge_params(
+            mod.Builder.default_params,
+            {"design_freq": freq, "freq": freq, "base": base},
+        )
+    )
+    eng = MomwireEngine(
+        b, solver=BSplineSolver, solver_kwargs={"degree": 2}, ground=ground
+    )
+    z = complex(eng.impedance()[0])
+    ff = eng.far_field(n_theta=90, n_phi=72, del_theta=1, del_phi=5)
+    dBi = np.asarray(ff.rings)
+    el = 90.0 - np.asarray(ff.thetas)
+    return el, dBi.max(axis=1), z
+
+
+def first_lobe(el, gain, lo=1.0, hi=45.0):
+    """Elevation of the lowest local maximum in [lo, hi] deg."""
+    m = (el >= lo) & (el <= hi)
+    e, g = el[m], gain[m]
+    order = np.argsort(e)
+    e, g = e[order], g[order]
+    for i in range(1, len(g) - 1):
+        if g[i] >= g[i - 1] and g[i] >= g[i + 1]:
+            return float(e[i]), float(g[i])
+    j = int(np.argmax(g))
+    return float(e[j]), float(g[j])
+
+
+# --------------------------------------------------------------------------
+# nec2c GD-cliff reference
+# --------------------------------------------------------------------------
+
+
+def author_cliff_deck(design, freq, base, ground, cliff, rp_mode):
+    """Export the design to a NEC deck and swap in the cliff cards.
+
+    cliff: None for the flat reference, else (eps2, sigma2, clt, cht).
+    rp_mode: 0 flat reference / 2 linear cliff. The elevation cut is a
+    full-circle pair (phi 0 and 180): with the linear-cliff boundary at
+    x = clt, phi=0 looks out over medium 2, phi=180 back over medium 1.
+    """
+    from antennaknobs import merge_params
+    from antennaknobs.nec_export import export_nec
+
+    mod = importlib.import_module(f"antennaknobs.designs.{design}")
+    b = mod.Builder(
+        merge_params(
+            mod.Builder.default_params,
+            {"design_freq": freq, "freq": freq, "base": base},
+        )
+    )
+    deck = export_nec(b, ground=ground, include_rp=False)
+    lines = deck.splitlines()
+    rp = f"RP {rp_mode} 89 2 1000 1 0 1 180"
+    if cliff is not None:
+        eps2, sig2, clt, cht = cliff
+        lines.insert(-2, f"GD 0 0 0 0 {eps2} {sig2} {clt} {cht}")
+    lines[-2] = rp
+    return "\n".join(lines) + "\n"
+
+
+def run_nec2c_pattern(deck_text, timeout=120.0):
+    """Run nec2c; return {(theta_deg, phi_deg): total_gain_dBi} or None if
+    nec2c is not on PATH."""
+    if shutil.which("nec2c") is None:
+        return None
+    with tempfile.TemporaryDirectory(prefix="levee_") as d:
+        nec = Path(d) / "d.nec"
+        out = Path(d) / "d.out"
+        nec.write_text(deck_text)
+        subprocess.run(
+            ["nec2c", "-i", str(nec), "-o", str(out)],
+            capture_output=True,
+            timeout=timeout,
+        )
+        if not out.exists():
+            raise RuntimeError("nec2c produced no output")
+        text = out.read_text(errors="replace")
+    gains = {}
+    on = False
+    for ln in text.splitlines():
+        if "RADIATION PATTERNS" in ln:
+            on = True
+            continue
+        t = ln.split()
+        if on and len(t) >= 5:
+            try:
+                th, ph, tot = float(t[0]), float(t[1]), float(t[4])
+            except ValueError:
+                continue
+            gains[(th, ph)] = tot
+    if on and not gains:
+        raise RuntimeError("nec2c ran but the pattern did not parse")
+    return gains
+
+
+def cliff_elevation_cut(gains, phi=0.0):
+    """(elevation_deg[], gain_dBi[]) for one azimuth from a nec2c gain map."""
+    pts = sorted(
+        (90.0 - th, g) for (th, ph), g in gains.items() if ph == phi and g > -900
+    )
+    el = np.array([p[0] for p in pts])
+    g = np.array([p[1] for p in pts])
+    return el, g
+
+
+# --------------------------------------------------------------------------
+# report
+# --------------------------------------------------------------------------
+
+REPORT_ANGLES = (5, 10, 15, 20, 30, 45)
+
+
+def gain_at(el, g, angle):
+    return float(g[int(np.argmin(np.abs(el - angle)))])
+
+
+def run_band(args, freq):
+    soil = ("finite", args.soil_eps, args.soil_sigma)
+    water = ("finite", args.water_eps, args.water_sigma)
+
+    sides = {
+        "land": (args.drop_land, soil, (args.soil_eps, args.soil_sigma)),
+        "water": (args.drop_water, water, (args.water_eps, args.water_sigma)),
+    }
+
+    print(f"\n=== {args.design} @ {freq} MHz ===")
+    out = {"freq": freq, "design": args.design, "sides": {}}
+
+    el_c, g_c, z_c = solve_bracket(args.design, freq, args.h0, soil)
+    print(
+        f"crest bracket   h={args.h0:5.2f} m over soil   "
+        f"Z={z_c.real:6.1f}{z_c.imag:+6.1f}j   (impedance to trust)"
+    )
+    out["crest"] = {
+        "h": args.h0,
+        "z": [z_c.real, z_c.imag],
+        "gain": {a: gain_at(el_c, g_c, a) for a in REPORT_ANGLES},
+    }
+
+    for side, (drop, ground, (eps2, sig2)) in sides.items():
+        psi_crest, psi_plain, x_toe, h_eff = validity_bands(
+            args.h0, args.crest_half_width, args.slope_deg, drop
+        )
+        el_e, g_e, _ = solve_bracket(args.design, freq, h_eff, ground)
+        lobe_el, lobe_g = first_lobe(el_e, g_e)
+
+        rec = {
+            "h_eff": h_eff,
+            "psi_crest": psi_crest,
+            "psi_plain": psi_plain,
+            "x_toe": x_toe,
+            "first_lobe": [lobe_el, lobe_g],
+            "bracket_gain": {a: gain_at(el_e, g_e, a) for a in REPORT_ANGLES},
+        }
+
+        print(
+            f"{side:5} bracket   h_eff={h_eff:5.2f} m  "
+            f"valid psi<={psi_plain:4.1f} deg (toe {x_toe:.1f} m out); "
+            f"crest model valid psi>={psi_crest:4.1f} deg; "
+            f"first lobe {lobe_g:5.2f} dBi @ {lobe_el:.0f} deg"
+        )
+
+        if not args.no_nec2c:
+            cliff = (eps2, sig2, args.crest_half_width, drop)
+            deck = author_cliff_deck(args.design, freq, args.h0, soil, cliff, 2)
+            gains = run_nec2c_pattern(deck)
+            if gains is None:
+                print("      nec2c not on PATH -- cliff cross-check skipped")
+            else:
+                el_n, g_n = cliff_elevation_cut(gains, phi=0.0)
+                rec["cliff_gain"] = {a: gain_at(el_n, g_n, a) for a in REPORT_ANGLES}
+                hdr = "      psi:      " + "".join(f"{a:>8}" for a in REPORT_ANGLES)
+                print(hdr)
+                print(
+                    "      bracket:  "
+                    + "".join(f"{rec['bracket_gain'][a]:8.2f}" for a in REPORT_ANGLES)
+                )
+                print(
+                    "      gd-cliff: "
+                    + "".join(f"{rec['cliff_gain'][a]:8.2f}" for a in REPORT_ANGLES)
+                )
+                print(
+                    "      crest:    "
+                    + "".join(f"{out['crest']['gain'][a]:8.2f}" for a in REPORT_ANGLES)
+                )
+
+        out["sides"][side] = rec
+
+    return out, (el_c, g_c)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0], epilog="See module docstring."
+    )
+    ap.add_argument("--design", default="dipoles.invvee")
+    ap.add_argument(
+        "--freqs",
+        default="21.2",
+        help="comma-separated design/measurement freqs in MHz",
+    )
+    ap.add_argument("--h0", type=float, default=6.1, help="pole height above crest, m")
+    ap.add_argument("--crest-half-width", type=float, default=1.5)
+    ap.add_argument("--slope-deg", type=float, default=20.0)
+    ap.add_argument("--drop-land", type=float, default=7.62, help="crest-to-land, m")
+    ap.add_argument("--drop-water", type=float, default=10.67, help="crest-to-water, m")
+    ap.add_argument("--soil-eps", type=float, default=13.0)
+    ap.add_argument("--soil-sigma", type=float, default=0.005)
+    ap.add_argument("--water-eps", type=float, default=80.0, help="fresh water")
+    ap.add_argument("--water-sigma", type=float, default=0.005, help="~5 if brackish")
+    ap.add_argument("--no-nec2c", action="store_true", help="skip the cliff reference")
+    ap.add_argument("--json", default=None, help="write goldens JSON here")
+    ap.add_argument("--plot", default=None, help="write overlay PNG here")
+    args = ap.parse_args()
+
+    freqs = [float(f) for f in args.freqs.split(",")]
+    results = []
+    for f in freqs:
+        band, _ = run_band(args, f)
+        results.append(band)
+
+    if args.json:
+        Path(args.json).write_text(json.dumps(results, indent=2) + "\n")
+        print(f"\ngoldens -> {args.json}")
+
+    if args.plot:
+        plot_overlay(args, freqs[0], Path(args.plot))
+        print(f"overlay -> {args.plot}")
+
+
+def plot_overlay(args, freq, path):
+    """One-band elevation overlay: crest + both effective-height brackets,
+    validity bands shaded, nec2c cliff dashed."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    soil = ("finite", args.soil_eps, args.soil_sigma)
+    water = ("finite", args.water_eps, args.water_sigma)
+    fig, ax = plt.subplots(figsize=(9, 5.5))
+
+    el, g, _ = solve_bracket(args.design, freq, args.h0, soil)
+    ax.plot(el, g, label=f"crest h={args.h0} m (soil)", color="tab:brown")
+
+    for side, drop, ground, color in (
+        ("land", args.drop_land, soil, "tab:green"),
+        ("water", args.drop_water, water, "tab:blue"),
+    ):
+        psi_crest, psi_plain, _, h_eff = validity_bands(
+            args.h0, args.crest_half_width, args.slope_deg, drop
+        )
+        el2, g2, _ = solve_bracket(args.design, freq, h_eff, ground)
+        ax.plot(el2, g2, label=f"{side} h_eff={h_eff:.1f} m", color=color)
+        ax.axvline(psi_plain, color=color, ls=":", lw=1)
+        if not args.no_nec2c:
+            eps2, sig2 = ground[1], ground[2]
+            deck = author_cliff_deck(
+                args.design,
+                freq,
+                args.h0,
+                soil,
+                (eps2, sig2, args.crest_half_width, drop),
+                2,
+            )
+            gains = run_nec2c_pattern(deck)
+            if gains:
+                eln, gn = cliff_elevation_cut(gains, phi=0.0)
+                ax.plot(
+                    eln, gn, ls="--", lw=1, color=color, label=f"{side} nec2c cliff"
+                )
+    ax.axvline(
+        validity_bands(args.h0, args.crest_half_width, args.slope_deg, args.drop_land)[
+            0
+        ],
+        color="tab:brown",
+        ls=":",
+        lw=1,
+    )
+    ax.set_xlim(0, 90)
+    ax.set_xlabel("elevation (deg)")
+    ax.set_ylabel("gain (dBi), azimuth max / cliff cut")
+    ax.set_title(f"{args.design} @ {freq} MHz — levee brackets vs nec2c cliff")
+    ax.grid(alpha=0.3)
+    ax.legend(fontsize=8)
+    fig.tight_layout()
+    fig.savefig(path, dpi=120)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_levee_bracket.py
+++ b/tests/test_levee_bracket.py
@@ -1,0 +1,138 @@
+"""Levee bracketing harness (scripts/bench_levee_bracket.py, issue #535).
+
+Pins the validity-band geometry, the first-lobe picker, and — nec2c-gated —
+the GD-cliff deck authoring, including the trap the harness exists to
+encode: the two-media cliff only affects the pattern under ``RP 2``, never
+``RP 0``. If nec2c's behavior (or our card authoring) drifts, the cliff and
+flat decks stop differing and the low-angle assertion here catches it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import shutil
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+_PATH = Path(__file__).parent.parent / "scripts" / "bench_levee_bracket.py"
+_spec = importlib.util.spec_from_file_location("bench_levee_bracket", _PATH)
+lb = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(lb)
+
+needs_nec2c = pytest.mark.skipif(
+    shutil.which("nec2c") is None, reason="nec2c not on PATH"
+)
+
+
+# The motivating QTH (issue #534/#535): 20 ft pole, 10 ft crest, 20 deg
+# slopes, 25 ft to land / 35 ft to water.
+H0, CHW, SLOPE = 6.1, 1.5, 20.0
+DROP_LAND, DROP_WATER = 7.62, 10.67
+
+
+def test_validity_bands_land_side():
+    psi_crest, psi_plain, x_toe, h_eff = lb.validity_bands(H0, CHW, SLOPE, DROP_LAND)
+    assert psi_crest == pytest.approx(76.2, abs=0.1)
+    assert h_eff == pytest.approx(13.72, abs=0.01)
+    assert x_toe == pytest.approx(22.4, abs=0.1)
+    assert psi_plain == pytest.approx(31.5, abs=0.2)
+
+
+def test_validity_bands_water_side():
+    _, psi_plain, x_toe, h_eff = lb.validity_bands(H0, CHW, SLOPE, DROP_WATER)
+    assert h_eff == pytest.approx(16.77, abs=0.01)
+    assert x_toe == pytest.approx(30.8, abs=0.1)
+    assert psi_plain == pytest.approx(28.6, abs=0.2)
+
+
+def test_validity_bands_flat_limit():
+    """Zero drop degenerates to the flat model: the plain band reaches all
+    the way up to the crest band and h_eff is the pole height itself."""
+    psi_crest, psi_plain, _, h_eff = lb.validity_bands(H0, CHW, SLOPE, 0.0)
+    assert h_eff == H0
+    assert psi_plain == pytest.approx(psi_crest, abs=1e-9)
+
+
+def test_first_lobe_picks_lowest_local_max():
+    el = np.arange(0.0, 46.0)
+    gain = np.sin(np.radians(el * 6)) * 5  # peaks at 15 deg, then again higher
+    lobe_el, lobe_g = lb.first_lobe(el, gain)
+    assert lobe_el == pytest.approx(15.0, abs=1.0)
+    assert lobe_g == pytest.approx(5.0, abs=0.1)
+
+
+def test_first_lobe_monotone_falls_back_to_max():
+    el = np.arange(1.0, 46.0)
+    gain = el * 0.1  # no interior local max
+    lobe_el, _ = lb.first_lobe(el, gain)
+    assert lobe_el == 45.0
+
+
+@needs_nec2c
+def test_cliff_deck_rp2_differs_from_flat_rp0_at_low_angles():
+    """The whole point of RP 2: a water cliff 10.7 m below must raise the
+    low-elevation gain by several dB over the flat crest model — and under
+    RP 0 the very same GD card must do nothing at all."""
+    freq, soil = 21.2, ("finite", 13.0, 0.005)
+    cliff = (80.0, 0.005, CHW, DROP_WATER)
+
+    flat = lb.run_nec2c_pattern(
+        lb.author_cliff_deck("dipoles.invvee", freq, H0, soil, None, 0)
+    )
+    rp0_gd = lb.run_nec2c_pattern(
+        lb.author_cliff_deck("dipoles.invvee", freq, H0, soil, cliff, 0)
+    )
+    rp2 = lb.run_nec2c_pattern(
+        lb.author_cliff_deck("dipoles.invvee", freq, H0, soil, cliff, 2)
+    )
+
+    el_f, g_f = lb.cliff_elevation_cut(flat, phi=0.0)
+    el_0, g_0 = lb.cliff_elevation_cut(rp0_gd, phi=0.0)
+    el_2, g_2 = lb.cliff_elevation_cut(rp2, phi=0.0)
+
+    # RP 0 ignores GD bit-for-bit (the documented nec2c trap).
+    assert np.array_equal(g_f, g_0)
+
+    # RP 2 must lift the low-angle field substantially (measured: +7 to +9 dB
+    # at 5-10 deg for this geometry).
+    for angle, min_lift in ((5.0, 5.0), (10.0, 4.0)):
+        lift = lb.gain_at(el_2, g_2, angle) - lb.gain_at(el_f, g_f, angle)
+        assert lift > min_lift, f"cliff lift at {angle} deg: {lift:.2f} dB"
+
+    # And the cliff should approach the raised-effective-height physics at
+    # low angles: the first lobe lands well below the flat model's.
+    lobe_cliff, _ = lb.first_lobe(el_2, g_2)
+    lobe_flat, _ = lb.first_lobe(el_f, g_f)
+    assert lobe_cliff < lobe_flat
+
+
+def test_deck_has_gd_card_only_when_cliff_given():
+    deck_flat = lb.author_cliff_deck(
+        "dipoles.invvee", 21.2, H0, ("finite", 13.0, 0.005), None, 0
+    )
+    deck_cliff = lb.author_cliff_deck(
+        "dipoles.invvee",
+        21.2,
+        H0,
+        ("finite", 13.0, 0.005),
+        (80.0, 0.005, 1.5, 10.67),
+        2,
+    )
+    assert not any(ln.startswith("GD") for ln in deck_flat.splitlines())
+    gd = [ln for ln in deck_cliff.splitlines() if ln.startswith("GD")]
+    # 4 leading integer fields then eps2 sig2 clt cht — nec2c card format.
+    assert len(gd) == 1 and gd[0].split()[1:5] == ["0", "0", "0", "0"]
+    assert [float(x) for x in gd[0].split()[5:9]] == [80.0, 0.005, 1.5, 10.67]
+    assert any(ln.startswith("RP 2") for ln in deck_cliff.splitlines())
+
+
+def test_specular_distance_geometry():
+    """Sanity: the specular point d = h/tan(psi) crosses the crest edge at
+    psi_crest and the slope toe at psi_plain — the bands tile the quadrant."""
+    psi_crest, psi_plain, x_toe, h_eff = lb.validity_bands(H0, CHW, SLOPE, DROP_LAND)
+    assert H0 / math.tan(math.radians(psi_crest)) == pytest.approx(CHW)
+    assert h_eff / math.tan(math.radians(psi_plain)) == pytest.approx(x_toe)
+    assert 0 < psi_plain < psi_crest < 90


### PR DESCRIPTION
## Summary
- `scripts/bench_levee_bracket.py` — the #535 bracketing recipe: solves a design on flat Sommerfeld ground at crest height and at each side's effective height (land/water media), computes validity bands from the terrain geometry (specular distance vs crest half-width / slope toe), reports first-lobe angles and DX-angle gains, with `--json` goldens and `--plot` overlay.
- nec2c GD-cliff cross-check in the same script: authors two-media cliff decks from `export_nec` output and compares against the brackets. Documents a real nec2c trap discovered en route: **the GD card parses but is silently ignored under `RP 0`** — the cliff only enters the pattern for RP modes 2/3/5/6, and GD takes the standard 4 leading integer fields.
- `tests/test_levee_bracket.py` — pins the validity-band geometry (incl. flat-limit degeneracy), first-lobe picker, deck authoring, and (nec2c-gated) both the RP 0 ignore-GD behavior and the RP 2 low-angle lift.

## Measured (21.2 MHz, the motivating QTH)
- Cliff reference tracks the land bracket within **0.30 dB at every reported angle**, water within ~0.9 dB; lands between the brackets and approaches the raised-height model at low angles — exactly the acceptance behavior #535 predicted.
- First lobes 20m→10m: water 19°→9°, land 23°→11° (issue predicted 18.5°→8.9° / 22.9°→10.9°).

Closes #535. The cliff harness doubles as #534's single-cliff acceptance gate.

## Test plan
- [x] 8/8 tests pass locally (nec2c on PATH)
- [x] Full-band run 14.1–28.4 MHz produces sane tables + overlay
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KV3q7Q9hGKQL4xfbw5qbdt