### PR TITLE
Faceted-terrain far-field ground — levee/ridge QTH with per-facet media

### DIFF
--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -13,6 +13,7 @@ from momwire import BSplineSolver
 from ..engine import FarField, SimulationEngine, WireCurrents
 from ..geometry import flat_wires_to_polylines
 from ..network import PortOnWire, PortVirtual, as_wire
+from ..terrain import Terrain, specular_cut
 from ..network_reduce import NetworkReducer, tl_admittance_2x2
 
 _logger = logging.getLogger(__name__)
@@ -74,6 +75,16 @@ def _normalise_ground(ground):
         # fall back to their best available one — see the ground-model
         # mapping in __init__.
         return (ground[0],) + tuple(ground[1:])
+    if (
+        isinstance(ground, tuple)
+        and len(ground) == 2
+        and ground[0] == "terrain"
+        and isinstance(ground[1], Terrain)
+    ):
+        # Faceted-terrain far-field ground (issue #534). The impedance
+        # solve runs flat Sommerfeld with the crest facet's medium; the
+        # far field reflects per-direction off the specular facet.
+        return ground
     raise ValueError(f"unrecognised ground spec: {ground!r}")
 
 
@@ -155,6 +166,14 @@ class MomwireEngine(SimulationEngine):
                                      "finite" to ~2 ohm above ~0.1λ heights
                                      but diverges hard below (~22 ohm at
                                      0.05λ, >100 ohm at 0.02λ).
+          ("terrain", Terrain)     — faceted-terrain far field (issue #534,
+                                     antennaknobs.terrain): per-direction
+                                     specular-facet reflection with per-facet
+                                     media and height offsets (levee/ridge
+                                     QTHs). The impedance solve runs flat
+                                     Sommerfeld with the crest medium; the
+                                     single-flat-facet terrain reproduces
+                                     ("finite", eps_r, sigma) exactly.
         """
         super().__init__(builder)
 
@@ -309,6 +328,16 @@ class MomwireEngine(SimulationEngine):
         self._ground_eps = None
         self._ground_model = None
         if (
+            self._ground is not None
+            and self._ground[0] == "terrain"
+            and _solver_supports_ground_eps(self._solver)
+        ):
+            # Terrain: the matrix never sees the facets — near-field ground
+            # interaction is crest-local, so the impedance solve runs true
+            # Sommerfeld with the crest medium (issue #534).
+            self._ground_eps = self._ground[1].crest_medium
+            self._ground_model = "sommerfeld"
+        elif (
             self._ground is not None
             and self._ground[0] in ("finite", "finite-fast")
             and _solver_supports_ground_eps(self._solver)
@@ -820,9 +849,8 @@ class MomwireEngine(SimulationEngine):
             M_perp = M_perp + M_img_perp
             return np.sum(M_perp.real**2 + M_perp.imag**2, axis=-1)
 
-        # ("finite", eps_r, sigma): polarisation basis at each ray and
-        # Fresnel reflection on the image wave.
-        _, eps_r, sigma = self._ground
+        # ("finite", eps_r, sigma) / ("terrain", Terrain): polarisation basis
+        # at each ray and Fresnel reflection on the image wave.
         # Vertical (TM, in-plane) and horizontal (TE, out-of-plane)
         # polarisation unit vectors for the reflected ray, written straight
         # from the azimuth/zenith angles rather than from the horizontal
@@ -843,9 +871,53 @@ class MomwireEngine(SimulationEngine):
         M_img_v = np.sum(M_img_perp * v_hat, axis=-1)
 
         omega = 2 * np.pi * freq_hz
-        eps_c = eps_r - 1j * sigma / (omega * EPS0)
-        cos_ti = rz
-        sin2_ti = s * s
+        if self._ground[0] == "terrain":
+            # Faceted terrain (issue #534): per direction, find the facet
+            # the specular point lands on, shift the image plane to the
+            # facet surface (an extra 2·k·z_f·cosθ path phase — z_f ≤ 0
+            # below the crest, so the reflected wave rides the full
+            # effective height), tilt the incidence angle by the facet
+            # slope, and evaluate Fresnel with the facet's medium. The
+            # image itself stays the z=ground_z mirror built above; the
+            # plane shift factors out as a per-direction scalar phase.
+            terrain = self._ground[1]
+            w = np.abs(i_mid) * np.linalg.norm(dr, axis=1)
+            wsum = float(np.sum(w))
+            h_ref = (
+                float(
+                    (np.sum(w * mid[:, 2]) / wsum) if wsum > 0 else np.mean(mid[:, 2])
+                )
+                - z0
+            )
+            sec_idx = terrain.sector_for(np.degrees(phi))
+            z_f = np.empty(rx.shape)
+            beta_g = np.empty(rx.shape)
+            eps_g = np.empty(rx.shape)
+            sig_g = np.empty(rx.shape)
+            for i, sector in enumerate(terrain.sectors):
+                cols = sec_idx == i
+                if not np.any(cols):
+                    continue
+                zf_t, b_t, e_t, s_t = specular_cut(sector, theta, h_ref)
+                z_f[:, cols] = zf_t[:, None]
+                beta_g[:, cols] = b_t[:, None]
+                eps_g[:, cols] = e_t[:, None]
+                sig_g[:, cols] = s_t[:, None]
+            pf = np.exp(2j * k * z_f * cos_t_g)
+            M_img_h = M_img_h * pf
+            M_img_v = M_img_v * pf
+            th_loc = np.clip(theta[:, None] - beta_g, 0.0, np.pi / 2)
+            # On untilted facets keep the exact same trig route as the flat
+            # branch (rz / s·s) so the single-flat-facet terrain reproduces
+            # ("finite", eps, sigma) bit-for-bit — issue #534 gate 1.
+            cos_ti = np.where(beta_g == 0.0, rz, np.cos(th_loc))
+            sin2_ti = np.where(beta_g == 0.0, s * s, np.sin(th_loc) ** 2)
+            eps_c = eps_g - 1j * sig_g / (omega * EPS0)
+        else:
+            _, eps_r, sigma = self._ground
+            eps_c = eps_r - 1j * sigma / (omega * EPS0)
+            cos_ti = rz
+            sin2_ti = s * s
         Q = np.sqrt(eps_c - sin2_ti)
         rho_h = (cos_ti - Q) / (cos_ti + Q)
         rho_v = (eps_c * cos_ti - Q) / (eps_c * cos_ti + Q)

--- a/src/antennaknobs/terrain.py
+++ b/src/antennaknobs/terrain.py
@@ -1,0 +1,287 @@
+"""Faceted-terrain far-field ground (issue #534).
+
+A terrain ground describes the surface *around* the antenna site as a
+piecewise-linear height profile per azimuth sector, each facet carrying its
+own medium. It is part of the **ground model**, not the antenna (a design
+should be droppable onto any QTH) and not the solver (terrain never touches
+the MoM matrix): the engine maps ``("terrain", Terrain(...))`` into
+
+  - the impedance/current solve: flat Sommerfeld ground with the *crest*
+    facet's medium (near-field ground interaction is crest-local), and
+  - the far-field composition: per-direction specular-facet reflection —
+    find the facet the specular point lands on, tilt the incidence angle by
+    the facet slope, apply that facet's Fresnel coefficients, and add the
+    facet's height offset to the reflected path phase.
+
+Conventions
+-----------
+- Distances ``x`` are metres outward from the mast axis along the azimuth
+  cut; heights ``z`` are metres relative to the crest plane (the engine's
+  ``ground_z``), negative below it. The profile starts at ``(x=0, z=0)``.
+- Azimuths are degrees CCW from +x, matching the engine's ``phi``.
+- A facet's ``x1=None`` means it extends to infinity; every sector's last
+  facet must be infinite (the terrain covers the whole ground plane).
+- The specular point for elevation ``psi`` sits ``(h_ref - z)/tan(psi)``
+  out from the mast; facets are scanned outward and the first one whose
+  span contains its own specular point wins. ``h_ref`` is the reference
+  source height (the engine uses the current-weighted mean segment height).
+
+The flat single-facet terrain reproduces the plain ``("finite", eps, sigma)``
+ground bit-for-bit — that is acceptance gate 1 of issue #534 and a test.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class Facet:
+    """One span of the terrain cut: from the previous facet's outer edge
+    (or the mast axis) out to ``x1``, ending at height ``z1``."""
+
+    x1: float | None  # outer edge, m from the mast axis; None = infinity
+    z1: float  # surface height at x1, m relative to the crest plane
+    eps_r: float
+    sigma: float
+
+    def __post_init__(self):
+        if self.x1 is not None and self.x1 <= 0:
+            raise ValueError(f"facet x1 must be positive, got {self.x1}")
+        if self.eps_r < 1:
+            raise ValueError(f"facet eps_r must be >= 1, got {self.eps_r}")
+        if self.sigma < 0:
+            raise ValueError(f"facet sigma must be >= 0, got {self.sigma}")
+
+
+@dataclass(frozen=True)
+class Sector:
+    """The terrain cut applied over the CCW azimuth arc az0 -> az1 (deg)."""
+
+    az0: float
+    az1: float
+    facets: tuple[Facet, ...]
+
+    def __post_init__(self):
+        object.__setattr__(self, "facets", tuple(self.facets))
+        if not self.facets:
+            raise ValueError("sector needs at least one facet")
+        if self.facets[-1].x1 is not None:
+            raise ValueError("the last facet must be infinite (x1=None)")
+        xs = [f.x1 for f in self.facets[:-1]]
+        if any(f is None for f in xs):
+            raise ValueError("only the last facet may be infinite")
+        if any(b <= a for a, b in zip(xs, xs[1:])):
+            raise ValueError(f"facet edges must increase outward, got {xs}")
+
+    @property
+    def arc_deg(self) -> float:
+        a = (self.az1 - self.az0) % 360.0
+        return a if a > 0 else 360.0
+
+
+@dataclass(frozen=True)
+class Terrain:
+    """A full-circle set of terrain sectors. Sectors must tile 360 degrees
+    and agree on the crest (innermost facet) medium — that medium is the
+    flat-Sommerfeld ground the impedance solve runs on."""
+
+    sectors: tuple[Sector, ...]
+
+    def __post_init__(self):
+        object.__setattr__(self, "sectors", tuple(self.sectors))
+        if not self.sectors:
+            raise ValueError("terrain needs at least one sector")
+        if abs(sum(s.arc_deg for s in self.sectors) - 360.0) > 1e-9:
+            raise ValueError(
+                "sectors must tile 360 deg, got arcs "
+                f"{[s.arc_deg for s in self.sectors]}"
+            )
+        # No-overlap: walking CCW from each sector's start must land on
+        # another sector's start (single-cover tiling).
+        starts = sorted(s.az0 % 360.0 for s in self.sectors)
+        ends = sorted((s.az0 + s.arc_deg) % 360.0 for s in self.sectors)
+        if any(abs(a - b) > 1e-9 for a, b in zip(starts, ends)):
+            raise ValueError("sector arcs overlap or leave a gap")
+        m0 = self.crest_medium
+        for s in self.sectors:
+            m = (s.facets[0].eps_r, s.facets[0].sigma)
+            if m != m0:
+                raise ValueError(
+                    "all sectors must share the crest medium (it is the "
+                    f"impedance-solve ground): {m} != {m0}"
+                )
+
+    @property
+    def crest_medium(self) -> tuple[float, float]:
+        f = self.sectors[0].facets[0]
+        return (f.eps_r, f.sigma)
+
+    def sector_for(self, phi_deg):
+        """Vectorized sector index per azimuth (degrees)."""
+        phi = np.asarray(phi_deg, dtype=float) % 360.0
+        idx = np.full(phi.shape, -1, dtype=int)
+        for i, s in enumerate(self.sectors):
+            rel = (phi - s.az0) % 360.0
+            idx = np.where((idx < 0) & (rel < s.arc_deg - 1e-12), i, idx)
+        # Boundary directions (rel == arc) belong to the next sector; any
+        # residual -1 can only be a float-boundary artifact — assign to the
+        # sector whose start it sits on.
+        if np.any(idx < 0):
+            for i, s in enumerate(self.sectors):
+                rel = (phi - s.az0) % 360.0
+                idx = np.where((idx < 0) & (rel <= s.arc_deg + 1e-9), i, idx)
+        return idx
+
+
+def facet_arrays(sector: Sector):
+    """(x0, x1, z0, z1, beta, eps, sigma) numpy views of a sector's facets.
+    ``beta`` is the downward tilt in radians (positive = surface descends
+    outward); the infinite facet's x1 is +inf."""
+    n = len(sector.facets)
+    x0 = np.empty(n)
+    x1 = np.empty(n)
+    z0 = np.empty(n)
+    z1 = np.empty(n)
+    eps = np.empty(n)
+    sig = np.empty(n)
+    prev_x, prev_z = 0.0, 0.0
+    for i, f in enumerate(sector.facets):
+        x0[i], z0[i] = prev_x, prev_z
+        x1[i] = math.inf if f.x1 is None else f.x1
+        z1[i] = f.z1
+        eps[i], sig[i] = f.eps_r, f.sigma
+        prev_x, prev_z = x1[i], f.z1
+    with np.errstate(invalid="ignore"):
+        beta = np.arctan2(z0 - z1, x1 - x0)  # inf run -> beta 0 for last facet
+    beta[np.isinf(x1)] = 0.0
+    return x0, x1, z0, z1, beta, eps, sig
+
+
+def specular_cut(sector: Sector, theta, h_ref):
+    """Per-direction reflection geometry for one sector.
+
+    theta: zenith angles, radians, array. h_ref: source reference height
+    above the crest plane, metres.
+
+    Returns (z_f, beta, eps_r, sigma) arrays over theta: the surface height
+    at the specular point (relative to the crest plane), the facet's
+    downward tilt, and the facet medium. Facets are scanned outward; the
+    first facet whose span contains its own specular point wins (the
+    infinite outer facet catches everything else).
+    """
+    theta = np.asarray(theta, dtype=float)
+    x0, x1, z0, z1, beta, eps, sig = facet_arrays(sector)
+    zmid = np.where(np.isinf(x1), z1, 0.5 * (z0 + z1))
+    tan_t = np.tan(np.clip(theta, 0.0, np.pi / 2 - 1e-12))
+
+    # x_s per (theta, facet): specular distance using each facet's own height.
+    x_s = (h_ref - zmid[None, :]) * tan_t[..., None]
+    hit = x_s <= x1[None, :]
+    # First outward hit per theta (argmax of the boolean scan; the last
+    # facet's x1=inf guarantees at least one True).
+    fi = np.argmax(hit, axis=-1)
+
+    xs = np.take_along_axis(x_s, fi[..., None], axis=-1)[..., 0]
+    fx0, fx1 = x0[fi], x1[fi]
+    fz0, fz1 = z0[fi], z1[fi]
+    fbeta = beta[fi]
+    run = fx1 - fx0
+    frac = np.zeros_like(xs)
+    finite = np.isfinite(run) & (run > 0)
+    frac[finite] = np.clip((xs[finite] - fx0[finite]) / run[finite], 0.0, 1.0)
+    z_f = np.where(np.isfinite(run), fz0 + frac * (fz1 - fz0), fz1)
+    return z_f, fbeta, eps[fi], sig[fi]
+
+
+def flat_terrain(eps_r: float, sigma: float) -> Terrain:
+    """The degenerate single-facet terrain — must reproduce the plain
+    ("finite", eps_r, sigma) ground exactly (issue #534 gate 1)."""
+    return Terrain(
+        sectors=(Sector(az0=0.0, az1=360.0, facets=(Facet(None, 0.0, eps_r, sigma),)),)
+    )
+
+
+def cliff_terrain(
+    *,
+    edge: float,
+    drop: float,
+    inner: tuple[float, float],
+    outer: tuple[float, float],
+    azimuth: float = 0.0,
+    arc: float = 360.0,
+) -> Terrain:
+    """A single vertical cliff: ``inner`` medium out to ``edge`` m, then a
+    sheer drop to ``outer`` medium ``drop`` m below — the NEC-2 GD-card
+    geometry (#534 gate 2). ``arc`` < 360 restricts the cliff to a sector
+    facing ``azimuth`` (the rest stays flat inner medium)."""
+    eps_i, sig_i = inner
+    eps_o, sig_o = outer
+    cliff = Sector(
+        az0=azimuth - arc / 2,
+        az1=azimuth + arc / 2,
+        facets=(
+            Facet(edge, 0.0, eps_i, sig_i),
+            # near-vertical drop: 1 mm of run per `drop` of fall keeps the
+            # facet edges strictly increasing without a degenerate span
+            Facet(edge + 1e-3, -drop, eps_i, sig_i),
+            Facet(None, -drop, eps_o, sig_o),
+        ),
+    )
+    if arc >= 360.0:
+        return Terrain(sectors=(cliff,))
+    flat = Sector(
+        az0=azimuth + arc / 2,
+        az1=azimuth - arc / 2,
+        facets=(Facet(None, 0.0, eps_i, sig_i),),
+    )
+    return Terrain(sectors=(cliff, flat))
+
+
+def levee_terrain(
+    *,
+    crest_width: float,
+    slope_deg: float,
+    drop_water: float,
+    drop_land: float,
+    water: tuple[float, float] = (80.0, 0.005),
+    land: tuple[float, float] = (13.0, 0.005),
+    crest: tuple[float, float] | None = None,
+    water_azimuth: float = 0.0,
+) -> Terrain:
+    """The motivating QTH (issues #534/#535): a levee crest with 20-ish
+    degree slopes, water ``drop_water`` m below on the side facing
+    ``water_azimuth`` and land ``drop_land`` m below on the other.
+
+    The crest and both slopes are earth (``crest``, defaulting to the land
+    medium); the water medium starts at the water-side toe.
+    """
+    crest = land if crest is None else crest
+    half = crest_width / 2.0
+    run = 1.0 / math.tan(math.radians(slope_deg))
+
+    def side(drop, toe_medium):
+        eps_t, sig_t = toe_medium
+        return (
+            Facet(half, 0.0, *crest),
+            Facet(half + drop * run, -drop, *crest),
+            Facet(None, -drop, eps_t, sig_t),
+        )
+
+    return Terrain(
+        sectors=(
+            Sector(
+                az0=water_azimuth - 90.0,
+                az1=water_azimuth + 90.0,
+                facets=side(drop_water, water),
+            ),
+            Sector(
+                az0=water_azimuth + 90.0,
+                az1=water_azimuth + 270.0,
+                facets=side(drop_land, land),
+            ),
+        )
+    )

--- a/tests/test_terrain_ground.py
+++ b/tests/test_terrain_ground.py
@@ -1,0 +1,238 @@
+"""Faceted-terrain far-field ground (issue #534).
+
+The three acceptance gates from the issue, plus the terrain type system:
+
+1. Flat-profile limit reproduces ("finite", eps, sigma) bit-identically —
+   impedance and the full far-field grid.
+2. Single-cliff limit tracks nec2c's classic GN+GD cliff ground (via the
+   #535 harness deck authoring) to a small constant offset.
+3. The levee scenario shows the physics: crest-pinned impedance, water/land
+   azimuth asymmetry, low-angle lobes at the full effective height, and
+   agreement of all models at crest-governed high elevations.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from antennaknobs import merge_params
+from antennaknobs.designs.dipoles.invvee import Builder
+from antennaknobs.engines.momwire import MomwireEngine
+from antennaknobs.terrain import (
+    Facet,
+    Sector,
+    Terrain,
+    cliff_terrain,
+    flat_terrain,
+    levee_terrain,
+    specular_cut,
+)
+from momwire import BSplineSolver
+
+needs_nec2c = pytest.mark.skipif(
+    shutil.which("nec2c") is None, reason="nec2c not on PATH"
+)
+
+# The motivating QTH (issues #534/#535).
+F, H0 = 21.2, 6.1
+SOIL, WATER = (13.0, 0.005), (80.0, 0.005)
+QTH = dict(crest_width=3.0, slope_deg=20.0, drop_water=10.67, drop_land=7.62)
+
+
+def _engine(ground):
+    p = merge_params(Builder.default_params, {"design_freq": F, "freq": F, "base": H0})
+    return MomwireEngine(
+        Builder(p), solver=BSplineSolver, solver_kwargs={"degree": 2}, ground=ground
+    )
+
+
+def _grid(eng):
+    ff = eng.far_field(n_theta=90, n_phi=72, del_theta=1, del_phi=5)
+    return 90.0 - np.asarray(ff.thetas), np.asarray(ff.rings)
+
+
+def _at(el, cut, angle):
+    return float(cut[int(np.argmin(np.abs(el - angle)))])
+
+
+# ---------------------------------------------------------------------------
+# type system
+# ---------------------------------------------------------------------------
+
+
+def test_terrain_rejects_gap_and_overlap():
+    s = (Facet(None, 0.0, 13.0, 0.005),)
+    with pytest.raises(ValueError, match="tile 360"):
+        Terrain(sectors=(Sector(0, 180, s),))
+    with pytest.raises(ValueError, match="tile 360|overlap"):
+        Terrain(sectors=(Sector(0, 270, s), Sector(180, 270, s)))
+
+
+def test_terrain_rejects_mismatched_crest_media():
+    with pytest.raises(ValueError, match="crest medium"):
+        Terrain(
+            sectors=(
+                Sector(0, 180, (Facet(None, 0.0, 13.0, 0.005),)),
+                Sector(180, 360, (Facet(None, 0.0, 80.0, 0.005),)),
+            )
+        )
+
+
+def test_sector_rejects_finite_last_facet_and_bad_order():
+    with pytest.raises(ValueError, match="infinite"):
+        Sector(0, 360, (Facet(5.0, 0.0, 13.0, 0.005),))
+    with pytest.raises(ValueError, match="increase"):
+        Sector(
+            0,
+            360,
+            (
+                Facet(5.0, 0.0, 13.0, 0.005),
+                Facet(2.0, -1.0, 13.0, 0.005),
+                Facet(None, -1.0, 13.0, 0.005),
+            ),
+        )
+
+
+def test_sector_for_wraps_azimuth():
+    t = levee_terrain(**QTH, water_azimuth=0.0)
+    # Water sector spans -90..90: phi 0 and 350 are water (index 0),
+    # phi 180 is land (index 1).
+    assert list(t.sector_for([0.0, 350.0, 180.0, 90.0])) == [0, 0, 1, 1]
+    assert t.crest_medium == SOIL
+
+
+# ---------------------------------------------------------------------------
+# specular geometry
+# ---------------------------------------------------------------------------
+
+
+def test_specular_cut_band_structure_matches_qth_geometry():
+    """Facet selection reproduces the #535 validity-band angles: crest facet
+    above ~76 deg elevation, water plain below ~28.6, slope between."""
+    t = levee_terrain(**QTH)
+    water = t.sectors[0]
+
+    def one(psi_deg):
+        theta = np.radians([90.0 - psi_deg])
+        z_f, beta, eps, sig = specular_cut(water, theta, H0)
+        return float(z_f[0]), float(beta[0]), float(eps[0])
+
+    z, b, e = one(80.0)  # crest band
+    assert z == 0.0 and b == 0.0 and e == SOIL[0]
+    z, b, e = one(50.0)  # slope band
+    assert -10.67 < z < 0.0 and b == pytest.approx(np.radians(20.0)) and e == SOIL[0]
+    z, b, e = one(20.0)  # water plain
+    assert z == pytest.approx(-10.67) and b == 0.0 and e == WATER[0]
+
+
+def test_specular_cut_zenith_hits_the_crest():
+    t = levee_terrain(**QTH)
+    z_f, beta, eps, _ = specular_cut(t.sectors[0], np.array([0.0]), H0)
+    assert z_f[0] == 0.0 and beta[0] == 0.0 and eps[0] == SOIL[0]
+
+
+# ---------------------------------------------------------------------------
+# gate 1: flat limit, bit-identical
+# ---------------------------------------------------------------------------
+
+
+def test_flat_terrain_reproduces_finite_ground_bit_identically():
+    e_fin = _engine(("finite", *SOIL))
+    e_ter = _engine(("terrain", flat_terrain(*SOIL)))
+    assert complex(e_fin.impedance()[0]) == complex(e_ter.impedance()[0])
+    _, g_fin = _grid(e_fin)
+    _, g_ter = _grid(e_ter)
+    assert np.array_equal(g_fin, g_ter)
+
+
+# ---------------------------------------------------------------------------
+# gate 2: single cliff vs nec2c GN+GD (via the #535 harness)
+# ---------------------------------------------------------------------------
+
+
+@needs_nec2c
+def test_cliff_terrain_tracks_nec2c_gd_cliff():
+    lb_path = Path(__file__).parent.parent / "scripts" / "bench_levee_bracket.py"
+    spec = importlib.util.spec_from_file_location("lb", lb_path)
+    lb = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(lb)
+
+    deck = lb.author_cliff_deck(
+        "dipoles.invvee", F, H0, ("finite", *SOIL), (*WATER, 1.5, 10.67), 2
+    )
+    el_n, g_n = lb.cliff_elevation_cut(lb.run_nec2c_pattern(deck), phi=0.0)
+
+    t = cliff_terrain(edge=1.5, drop=10.67, inner=SOIL, outer=WATER)
+    el_t, grid = _grid(_engine(("terrain", t)))
+    g_t = grid[:, 0]  # phi = 0, over the cliff
+
+    # Measured 2026-07-24: constant -0.11 dB across 3..60 deg (the medium-1
+    # refl-coef vs Sommerfeld offset). Gate generously at 0.5 dB.
+    for a in (3, 5, 8, 10, 15, 20, 30, 45, 60):
+        d = _at(el_t, g_t, a) - _at(el_n, g_n, a)
+        assert abs(d) < 0.5, f"terrain vs nec2c cliff at {a} deg: {d:+.2f} dB"
+
+
+# ---------------------------------------------------------------------------
+# gate 3: the levee scenario
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def levee():
+    e_ter = _engine(("terrain", levee_terrain(**QTH)))
+    e_crest = _engine(("finite", *SOIL))
+    z_ter = complex(e_ter.impedance()[0])
+    z_crest = complex(e_crest.impedance()[0])
+    el, grid = _grid(e_ter)
+    _, g_crest = _grid(e_crest)
+    return z_ter, z_crest, el, grid, g_crest
+
+
+def test_levee_impedance_is_the_crest_sommerfeld_impedance(levee):
+    z_ter, z_crest, *_ = levee
+    assert z_ter == z_crest
+
+
+def test_levee_azimuth_asymmetry_water_beats_land_low(levee):
+    el, grid = levee[2], levee[3]
+    water, land = grid[:, 0], grid[:, 36]  # phi 0 / 180
+    assert _at(el, water, 5) > _at(el, land, 5) + 0.5
+    assert _at(el, water, 10) > _at(el, land, 10) + 0.5
+
+
+def test_levee_low_angle_rides_the_full_effective_height(levee):
+    """Below the water-side toe angle the terrain pattern must track the
+    flat model at h_eff = 16.77 m over water — within ~1.5 dB (same-azimuth
+    cut; the residual is the slope-facet transition tail)."""
+    el, grid = levee[2], levee[3]
+    p = merge_params(
+        Builder.default_params, {"design_freq": F, "freq": F, "base": H0 + 10.67}
+    )
+    eng = MomwireEngine(
+        Builder(p),
+        solver=BSplineSolver,
+        solver_kwargs={"degree": 2},
+        ground=("finite", *WATER),
+    )
+    el_e, g_eff = _grid(eng)
+    for a in (5, 8, 10):
+        d = _at(el, grid[:, 0], a) - _at(el_e, g_eff[:, 0], a)
+        assert abs(d) < 1.5, f"terrain vs h_eff flat model at {a} deg: {d:+.2f} dB"
+
+
+def test_levee_high_angles_are_crest_governed(levee):
+    """Above the crest threshold (~76 deg) every azimuth reflects off the
+    crest facet: terrain == flat crest model, both sides equal."""
+    el, grid, g_crest = levee[2], levee[3], levee[4]
+    for a in (80, 85):
+        w = _at(el, grid[:, 0], a)
+        ln = _at(el, grid[:, 36], a)
+        c = _at(el, g_crest[:, 0], a)
+        assert w == pytest.approx(ln, abs=1e-9)
+        assert w == pytest.approx(c, abs=1e-9)


### PR DESCRIPTION
## Summary
- New `antennaknobs.terrain` module: `Facet`/`Sector`/`Terrain` frozen dataclasses — a piecewise-linear height profile per azimuth sector, each facet carrying its own `(eps_r, sigma)` — with validation (sectors tile 360°, shared crest medium, last facet infinite) and three constructors: `levee_terrain()` (the motivating QTH in one call), `cliff_terrain()` (the NEC GD geometry), `flat_terrain()` (the degenerate limit).
- `MomwireEngine` accepts `ground=("terrain", Terrain(...))`: the impedance solve runs true Sommerfeld with the **crest** medium (terrain never touches the matrix — it's far-field-only physics); the far field reflects per-direction off the **specular facet** — facet height offset as a `2·k·z_f·cosθ` image-plane phase, incidence tilted by the facet slope, Fresnel with the facet medium.
- Architecture per discussion: terrain is part of the **ground model** — not the antenna (designs stay site-independent) and not the solver (currents are crest-local). Engine-only for now; web exposure blocked on #547 (JS pattern math relocation).

## Acceptance gates (issue #534, all in `tests/test_terrain_ground.py`)
1. **Flat limit**: single-facet terrain reproduces `("finite", eps, sigma)` **bit-for-bit** — impedance and the full far-field grid (`np.array_equal`).
2. **Single cliff vs nec2c GN+GD** (via the #535 harness): constant −0.11 dB offset across 3–60° elevation; gated at 0.5 dB.
3. **Levee physics**: impedance = crest Sommerfeld exactly; water beats land at low angles (azimuth asymmetry); low angles track the h_eff=16.8 m flat model within 1.5 dB; above ~76° both sides equal the flat crest model to 1e-9.

## Test plan
- [x] 12 new tests pass (type validation, specular band structure, all three gates)
- [x] Full suite: 2694 passed (finite-ground far field untouched bitwise — the shared-code restructure keeps `rz`/`s·s` trig routes)
- [x] ruff clean

Closes #534.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KV3q7Q9hGKQL4xfbw5qbdt