### PR TITLE
Server-side polar-chart cuts (backend half of #547)

### DIFF
--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import logging
 import math
 import os
 import time
@@ -41,6 +42,8 @@ from . import cost as _cost
 from . import pynec_backend, user_designs
 from .examples import REGISTRY as EXAMPLES
 from .lane import LaneRegistry, Superseded, cancel_on_disconnect
+
+_logger = logging.getLogger(__name__)
 
 
 def _physical_cpu_count() -> int:
@@ -287,6 +290,124 @@ def _moment_segments(out: dict) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     )
 
 
+def _mag2_at_directions(out: dict, rhat: np.ndarray, *, mid=None, dr=None, i_mid=None):
+    """|M_perp|² at arbitrary far-field directions — the single server-side
+    implementation of the pattern physics (issue #547; the frontend's JS
+    copy is being retired against this).
+
+    rhat: (..., 3) unit direction array (any leading shape). With ground on,
+    evaluates the PEC image + per-ray Fresnel correction from the response's
+    ground constants. Returns a real array of rhat's leading shape. Callers
+    that already hold the moment set pass it via mid/dr/i_mid to skip the
+    re-extraction.
+    """
+    k = float(out["k_meas_m_inv"])
+    ground_on = bool(out.get("ground", False))
+    if mid is None:
+        mid, dr, i_mid = _moment_segments(out)
+    rx, ry, rz = rhat[..., 0], rhat[..., 1], rhat[..., 2]
+
+    phase = k * np.einsum("...c,nc->...n", rhat, mid)
+    expp = np.exp(1j * phase)
+    weighted = i_mid[:, None] * dr  # (Nseg, 3)
+    M = np.einsum("...n,nc->...c", expp, weighted)
+    m_dot_r = np.sum(M * rhat, axis=-1)
+    M_perp = M - m_dot_r[..., None] * rhat
+
+    if ground_on:
+        # PEC-image method, then Fresnel-correct the reflected wave per-ray.
+        # Image current: horizontal components flipped, vertical preserved.
+        # This reproduces PEC reflection when ρ_h=-1, ρ_v=+1, and lets us
+        # apply the actual finite-ground coefficients to that same image.
+        mid_img = mid * np.array([1.0, 1.0, -1.0])
+        dr_img = dr * np.array([-1.0, -1.0, 1.0])
+        weighted_img = i_mid[:, None] * dr_img
+        phase_img = k * np.einsum("...c,nc->...n", rhat, mid_img)
+        expp_img = np.exp(1j * phase_img)
+        M_img = np.einsum("...n,nc->...c", expp_img, weighted_img)
+        m_img_dot_r = np.sum(M_img * rhat, axis=-1)
+        M_img_perp = M_img - m_img_dot_r[..., None] * rhat
+
+        # Polarization basis at each ray: ĥ = ẑ × r̂ (perp to plane of
+        # incidence), v̂ = r̂ × ĥ (in plane of incidence, perp to r̂).
+        s = np.sqrt(rx * rx + ry * ry)
+        s_safe = np.where(s > 1e-12, s, 1.0)
+        h_hat = np.stack([-ry / s_safe, rx / s_safe, np.zeros_like(rx)], axis=-1)
+        v_hat = np.stack([-rx * rz / s_safe, -ry * rz / s_safe, s], axis=-1)
+
+        M_img_h = np.sum(M_img_perp * h_hat, axis=-1)
+        M_img_v = np.sum(M_img_perp * v_hat, axis=-1)
+
+        eps_c = out["ground_eps_r"] + 1j * out["ground_eps_im"]
+        cos_ti = rz
+        sin2_ti = s * s
+        Q = np.sqrt(eps_c - sin2_ti)
+        rho_h = (cos_ti - Q) / (cos_ti + Q)
+        rho_v = (eps_c * cos_ti - Q) / (eps_c * cos_ti + Q)
+
+        # Reflected: ρ_v on the v-pol component, −ρ_h on the h-pol component
+        # (the minus sign folds the PEC image's pre-applied horizontal flip
+        # back out so ρ_h=−1 recovers the PEC limit exactly).
+        M_refl = (rho_v * M_img_v)[..., None] * v_hat - (rho_h * M_img_h)[
+            ..., None
+        ] * h_hat
+        M_perp = M_perp + M_refl
+
+    return np.sum(M_perp.real**2 + M_perp.imag**2, axis=-1)
+
+
+# The polar-chart cuts are sampled on this many directions around the full
+# circle — matches the frontend's FARFIELD_N_DIR so the retired JS path and
+# the server cuts are sample-for-sample comparable during the migration.
+_CUT_N_DIR = 180
+
+# dBi floor sentinel for below-horizon samples (JSON can't carry -Infinity).
+_CUT_FLOOR_DBI = -999.0
+
+
+def _pattern_cuts(out: dict, az_elev_deg: float, elev_az_deg: float) -> dict | None:
+    """The two polar-chart traces (issue #547): the azimuth cut at elevation
+    `az_elev_deg` and the great-circle elevation cut through azimuth
+    `elev_az_deg`, each _CUT_N_DIR samples of absolute dBi.
+
+    Both circles are parameterised exactly as the frontend's computeCutDbi:
+    sample i sits at t = 2π·i/N_DIR; the azimuth cut runs the horizon circle
+    at the given elevation, the elevation cut is the vertical circle whose
+    t ∈ (180°, 360°) half dips below the horizon. With ground on, below-
+    horizon samples clamp to _CUT_FLOOR_DBI. Returns None when the response
+    can't support cuts (no wires or no positive gain norm).
+    """
+    norm = float(out.get("directivity_norm") or 0.0)
+    if norm <= 0.0 or not out.get("wires"):
+        return None
+    t = 2.0 * np.pi * np.arange(_CUT_N_DIR) / _CUT_N_DIR
+    ct, st = np.cos(t), np.sin(t)
+
+    az = np.radians(az_elev_deg)
+    az_rhat = np.stack(
+        [np.cos(az) * ct, np.cos(az) * st, np.full_like(t, np.sin(az))], axis=-1
+    )
+    el = np.radians(elev_az_deg)
+    el_rhat = np.stack([np.cos(el) * ct, np.sin(el) * ct, st], axis=-1)
+
+    rhat = np.stack([az_rhat, el_rhat])  # (2, N_DIR, 3)
+    mag2 = _mag2_at_directions(out, rhat)
+    if bool(out.get("ground", False)):
+        mag2 = np.where(rhat[..., 2] < 0.0, 0.0, mag2)
+
+    with np.errstate(divide="ignore"):
+        dbi = 10.0 * np.log10(np.maximum(norm * mag2, 0.0))
+    dbi = np.where(np.isfinite(dbi), dbi, _CUT_FLOOR_DBI)
+    return {
+        "az_elev_deg": float(az_elev_deg),
+        "elev_az_deg": float(elev_az_deg),
+        "n_dir": _CUT_N_DIR,
+        "floor_dbi": _CUT_FLOOR_DBI,
+        "azimuth": [round(float(v), 3) for v in dbi[0]],
+        "elevation": [round(float(v), 3) for v in dbi[1]],
+    }
+
+
 def _pattern_integral_norm(out: dict) -> float:
     """The pattern-integral gain norm (4π/∮|M_perp|²dΩ)·efficiency evaluated
     in CLOSED FORM — no angular grid. Because the radiated power is quadratic
@@ -420,53 +541,7 @@ def _compute_directivity_norm(
     rz = np.broadcast_to(cos_t[:, None], (n_theta, n_phi))
     rhat = np.stack([rx, ry, rz], axis=-1)  # (nθ, nφ, 3)
 
-    phase = k * np.einsum("ijc,nc->ijn", rhat, mid)  # (nθ, nφ, Nseg)
-    expp = np.exp(1j * phase)
-    weighted = i_mid[:, None] * dr  # (Nseg, 3)
-    M = np.einsum("ijn,nc->ijc", expp, weighted)  # (nθ, nφ, 3)
-    m_dot_r = np.sum(M * rhat, axis=-1)
-    M_perp = M - m_dot_r[..., None] * rhat
-
-    if ground_on:
-        # PEC-image method, then Fresnel-correct the reflected wave per-ray.
-        # Image current: horizontal components flipped, vertical preserved.
-        # This reproduces PEC reflection when ρ_h=-1, ρ_v=+1, and lets us
-        # apply the actual finite-ground coefficients to that same image.
-        mid_img = mid * np.array([1.0, 1.0, -1.0])
-        dr_img = dr * np.array([-1.0, -1.0, 1.0])
-        weighted_img = i_mid[:, None] * dr_img
-        phase_img = k * np.einsum("ijc,nc->ijn", rhat, mid_img)
-        expp_img = np.exp(1j * phase_img)
-        M_img = np.einsum("ijn,nc->ijc", expp_img, weighted_img)
-        m_img_dot_r = np.sum(M_img * rhat, axis=-1)
-        M_img_perp = M_img - m_img_dot_r[..., None] * rhat
-
-        # Polarization basis at each ray: ĥ = ẑ × r̂ (perp to plane of
-        # incidence), v̂ = r̂ × ĥ (in plane of incidence, perp to r̂).
-        s = np.sqrt(rx * rx + ry * ry)
-        s_safe = np.where(s > 1e-12, s, 1.0)
-        h_hat = np.stack([-ry / s_safe, rx / s_safe, np.zeros_like(rx)], axis=-1)
-        v_hat = np.stack([-rx * rz / s_safe, -ry * rz / s_safe, s], axis=-1)
-
-        M_img_h = np.sum(M_img_perp * h_hat, axis=-1)  # complex (nθ, nφ)
-        M_img_v = np.sum(M_img_perp * v_hat, axis=-1)
-
-        eps_c = out["ground_eps_r"] + 1j * out["ground_eps_im"]
-        cos_ti = rz
-        sin2_ti = s * s
-        Q = np.sqrt(eps_c - sin2_ti)
-        rho_h = (cos_ti - Q) / (cos_ti + Q)
-        rho_v = (eps_c * cos_ti - Q) / (eps_c * cos_ti + Q)
-
-        # Reflected: ρ_v on the v-pol component, −ρ_h on the h-pol component
-        # (the minus sign folds the PEC image's pre-applied horizontal flip
-        # back out so ρ_h=−1 recovers the PEC limit exactly).
-        M_refl = (rho_v * M_img_v)[..., None] * v_hat - (rho_h * M_img_h)[
-            ..., None
-        ] * h_hat
-        M_perp = M_perp + M_refl
-
-    mag2 = np.sum((M_perp.real**2 + M_perp.imag**2), axis=-1)  # (nθ, nφ)
+    mag2 = _mag2_at_directions(out, rhat, mid=mid, dr=dr, i_mid=i_mid)
 
     # Gauss–Legendre in θ (weight absorbs sin θ) × uniform rectangle in φ.
     dphi = 2 * np.pi / n_phi
@@ -799,13 +874,34 @@ def solve(req: dict, cancel=None) -> dict:
         # tick first populated this cache entry.
         out["solve_ms"] = (time.perf_counter() - t0) * 1e3
         out["cache_hit"] = True
+        _attach_request_cuts(out, req)
         return out
     out = _solve_uncached(req, cancel=cancel)
     out["cache_hit"] = False
     _SOLVE_CACHE[key] = deepcopy(out)
     while len(_SOLVE_CACHE) > _SOLVE_CACHE_MAX:
         _SOLVE_CACHE.popitem(last=False)
+    # After the cache store: cuts depend on the request's cut angles, so the
+    # cached entry stays angle-independent and every request gets fresh cuts.
+    _attach_request_cuts(out, req)
     return out
+
+
+def _attach_request_cuts(out: dict, req: dict) -> None:
+    """Attach the request's polar-chart cuts to a solve response (issue
+    #547). Never lets a cuts failure break the solve — the frontend treats
+    a missing `cuts` field as "compute unavailable"."""
+    try:
+        cuts = _pattern_cuts(
+            out,
+            float(req.get("az_elev_deg", 15.0)),
+            float(req.get("elev_az_deg", 0.0)),
+        )
+    except Exception:
+        _logger.exception("pattern cuts failed; solve response ships without them")
+        cuts = None
+    if cuts is not None:
+        out["cuts"] = cuts
 
 
 @app.post("/sweep")
@@ -1273,6 +1369,35 @@ async def params_source_endpoint(req: dict):
     except Exception as exc:  # noqa: BLE001 — a user design's params can be odd
         return {"geometry": geometry, "error": user_designs.format_solve_error(exc)}
     return {"geometry": geometry, "available": True, "source": source}
+
+
+@app.post("/cuts")
+def cuts_endpoint(req: dict):
+    """Recompute the two polar-chart cuts at new cut angles (issue #547).
+
+    Stateless: the body carries the fields of a previously returned solve
+    response under ``solve`` (wires + k_meas_m_inv + ground constants +
+    directivity_norm — the client already holds all of them) plus
+    ``az_elev_deg`` / ``elev_az_deg``. Returns the same ``cuts`` object the
+    live solve attaches. Sync def → FastAPI threadpool, so a big-mesh cut
+    (~100 ms at 4k segments) never blocks the event loop.
+    """
+    solve_out = req.get("solve")
+    if not isinstance(solve_out, dict):
+        raise HTTPException(status_code=400, detail="missing solve response body")
+    try:
+        cuts = _pattern_cuts(
+            solve_out,
+            float(req.get("az_elev_deg", 15.0)),
+            float(req.get("elev_az_deg", 0.0)),
+        )
+    except (KeyError, TypeError, ValueError) as e:
+        raise HTTPException(status_code=400, detail=f"bad cuts request: {e}") from e
+    if cuts is None:
+        raise HTTPException(
+            status_code=400, detail="solve response cannot support cuts"
+        )
+    return cuts
 
 
 @app.post("/pattern_metrics")

--- a/tests/test_pattern_cuts.py
+++ b/tests/test_pattern_cuts.py
@@ -1,0 +1,189 @@
+"""Server-side polar-chart cuts (issue #547).
+
+The frontend's computeCutDbi (App.tsx) is being retired in favour of
+`server._pattern_cuts`, so these tests pin the physics analytically (a
+Hertzian dipole has closed-form gain), the request plumbing (/ws solve
+attaches cuts; /cuts recomputes them statelessly), and the sample
+parameterisation the polar charts assume (t = 2π·i/N_DIR).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+
+import numpy as np
+import pytest
+from starlette.testclient import TestClient
+
+import antennaknobs.web.server as server
+from antennaknobs.web.server import _mag2_at_directions, _pattern_cuts, app
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _hertzian(dl=0.01, h=0.0, ground=False):
+    """Solve-response stand-in: one z-directed segment of length dl at height
+    h carrying 1 A. Free space: gain 1.5·sin²θ, peak 1.76 dBi; the norm is
+    the closed form 3/(2·|I·dl|²)."""
+    out = {
+        "wires": [
+            {
+                "knot_positions": [[0.0, 0.0, h], [0.0, 0.0, h + dl]],
+                "knot_currents_re": [1.0, 1.0],
+                "knot_currents_im": [0.0, 0.0],
+            }
+        ],
+        "k_meas_m_inv": 0.44,
+        "ground": ground,
+        "ground_eps_r": 13.0,
+        "ground_eps_im": -1.0,
+        "directivity_norm": 3.0 / (2.0 * dl * dl),
+    }
+    return out
+
+
+def test_hertzian_azimuth_cut_at_horizon_is_flat_peak():
+    cuts = _pattern_cuts(_hertzian(), az_elev_deg=0.0, elev_az_deg=0.0)
+    az = np.asarray(cuts["azimuth"])
+    assert np.allclose(az, 10 * math.log10(1.5), atol=1e-3)
+
+
+def test_hertzian_elevation_cut_follows_sin2_theta():
+    cuts = _pattern_cuts(_hertzian(), az_elev_deg=0.0, elev_az_deg=0.0)
+    el = np.asarray(cuts["elevation"])
+    n = cuts["n_dir"]
+    # Sample i sits at t = 2π·i/n; the pattern is 1.5·cos²t (cos t = sin θ).
+    for i in (10, 20, 40, 70):
+        t = 2 * math.pi * i / n
+        expect = 10 * math.log10(1.5 * math.cos(t) ** 2)
+        assert el[i] == pytest.approx(expect, abs=1e-2)
+
+
+def test_hertzian_elevation_cut_peaks_at_horizon_samples():
+    cuts = _pattern_cuts(_hertzian(), az_elev_deg=0.0, elev_az_deg=0.0)
+    el = np.asarray(cuts["elevation"])
+    assert el[0] == pytest.approx(10 * math.log10(1.5), abs=1e-3)
+
+
+def test_ground_floors_below_horizon_samples():
+    cuts = _pattern_cuts(_hertzian(h=1.0, ground=True), 0.0, 0.0)
+    el = np.asarray(cuts["elevation"])
+    n = cuts["n_dir"]
+    below = el[n // 2 + 1 : n - 1]  # t ∈ (180°, 360°) dips below the horizon
+    assert np.all(below == cuts["floor_dbi"])
+    above = el[1 : n // 2]
+    assert np.all(above > cuts["floor_dbi"])
+
+
+def test_pec_limit_vertical_dipole_gains_over_free_space():
+    """Over a near-PEC ground (huge εr) a low vertical Hertzian dipole gains
+    ~+6 dB at low elevation from the in-phase image — the classic result.
+    Uses raw _mag2_at_directions so no norm assumptions intrude."""
+    free = _hertzian(h=0.01)
+    pec = _hertzian(h=0.01, ground=True)
+    pec["ground_eps_r"] = 1e10
+    pec["ground_eps_im"] = 0.0
+    rhat = np.array([[math.cos(math.radians(5)), 0.0, math.sin(math.radians(5))]])
+    m_free = _mag2_at_directions(free, rhat)[0]
+    m_pec = _mag2_at_directions(pec, rhat)[0]
+    assert 10 * math.log10(m_pec / m_free) == pytest.approx(6.0, abs=0.1)
+
+
+def test_cuts_none_without_norm_or_wires():
+    out = _hertzian()
+    out["directivity_norm"] = 0.0
+    assert _pattern_cuts(out, 0.0, 0.0) is None
+    out = _hertzian()
+    out["wires"] = []
+    assert _pattern_cuts(out, 0.0, 0.0) is None
+
+
+def test_directivity_norm_unchanged_by_refactor(client: TestClient):
+    """The norm quadrature now routes through _mag2_at_directions; a live
+    solve's directivity_norm must still be a sane O(1) scalar and the peak
+    dBi from the attached cuts must be physically reasonable for an invvee
+    over soil (a few dBi)."""
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(
+            json.dumps(
+                {
+                    "geometry": "dipoles.invvee",
+                    "measurement_freq_mhz": 28.47,
+                    "momwire_model": "bspline",
+                    "az_elev_deg": 30.0,
+                    "elev_az_deg": 0.0,
+                }
+            )
+        )
+        result = json.loads(ws.receive_text())
+    assert result["directivity_norm"] > 0
+    cuts = result["cuts"]
+    assert cuts["az_elev_deg"] == 30.0 and cuts["elev_az_deg"] == 0.0
+    assert len(cuts["azimuth"]) == cuts["n_dir"] == 180
+    assert len(cuts["elevation"]) == 180
+    peak = max(max(cuts["azimuth"]), max(cuts["elevation"]))
+    assert 0.0 < peak < 15.0
+
+
+def test_cuts_endpoint_matches_solve_attached_cuts(client: TestClient):
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(
+            json.dumps(
+                {
+                    "geometry": "dipoles.invvee",
+                    "measurement_freq_mhz": 28.47,
+                    "momwire_model": "bspline",
+                    "az_elev_deg": 15.0,
+                    "elev_az_deg": 45.0,
+                }
+            )
+        )
+        result = json.loads(ws.receive_text())
+
+    r = client.post(
+        "/cuts", json={"solve": result, "az_elev_deg": 15.0, "elev_az_deg": 45.0}
+    )
+    assert r.status_code == 200
+    assert r.json() == result["cuts"]
+
+    # Different angles produce a different trace.
+    r2 = client.post(
+        "/cuts", json={"solve": result, "az_elev_deg": 40.0, "elev_az_deg": 45.0}
+    )
+    assert r2.json()["azimuth"] != result["cuts"]["azimuth"]
+
+
+def test_cuts_endpoint_rejects_garbage(client: TestClient):
+    assert client.post("/cuts", json={}).status_code == 400
+    assert client.post("/cuts", json={"solve": {"wires": []}}).status_code == 400
+
+
+def test_solve_cache_stays_angle_independent(client: TestClient):
+    """Two solves differing only in cut angles must both carry correct cuts
+    (the second is a cache hit — cuts are attached per-request, after the
+    cache)."""
+    base = {
+        "geometry": "dipoles.invvee",
+        "measurement_freq_mhz": 28.47,
+        "momwire_model": "bspline",
+    }
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(json.dumps({**base, "az_elev_deg": 10.0}))
+        r1 = json.loads(ws.receive_text())
+        ws.send_text(json.dumps({**base, "az_elev_deg": 35.0}))
+        r2 = json.loads(ws.receive_text())
+    assert r1["cuts"]["az_elev_deg"] == 10.0
+    assert r2["cuts"]["az_elev_deg"] == 35.0
+    assert r1["cuts"]["azimuth"] != r2["cuts"]["azimuth"]
+
+
+def test_mag2_directions_shape_generic():
+    out = _hertzian()
+    r1 = _mag2_at_directions(out, np.array([[0.0, 1.0, 0.0]]))
+    r2 = _mag2_at_directions(out, np.stack([np.eye(3), np.eye(3)[::-1]]))  # (2, 3, 3)
+    assert r1.shape == (1,) and r2.shape == (2, 3)
+    assert server._CUT_N_DIR == 180  # frontend FARFIELD_N_DIR parity


### PR DESCRIPTION
## Summary
- Per the #547 interface decision: **no dense grid** — the UI only needs the two polar traces, each 180 samples (1/36 of a grid's cost: ~2 ms for invvee, ~110 ms for rhombic-class meshes).
- `_mag2_at_directions(out, rhat)` — the single server-side far-field physics implementation (direct + PEC image + per-ray Fresnel), extracted from `_compute_directivity_norm`'s quadrature and generic over any direction array; the norm path now routes through it unchanged.
- `/ws` solve responses attach `cuts` per-request (computed after the solve cache, so cached entries stay angle-independent); `POST /cuts` recomputes statelessly for cut-angle drags from the response the client already holds.
- Sample parameterisation matches `computeCutDbi` exactly (t = 2π·i/180, below-horizon floor) so the frontend switchover is a drop-in.

## Test plan
- [x] 11 new tests: analytic Hertzian gates (1.76 dBi flat cut, sin²θ elevation law, +6 dB PEC-image limit), flooring, solve attachment, /cuts parity + rejection, cache angle-independence, N_DIR parity
- [x] Full suite 2705 passed; web-server suite green (norm refactor behavior-identical)
- [x] ruff clean

Progress on #547 (frontend deletion of `computeCutDbi` is the follow-up PR; issue stays open until the JS physics is gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KV3q7Q9hGKQL4xfbw5qbdt