### PR TITLE
Web UI terrain ground — levee/cliff presets over the #534 engine

### DIFF
--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -77,6 +77,7 @@ except ImportError:
     PyNECEngine = None
     DEFAULT_GROUND = ("finite", 10.0, 0.002)
 from antennaknobs.engines.momwire import MomwireEngine
+from antennaknobs.terrain import Terrain, cliff_terrain, levee_terrain
 from momwire import (
     ArrayBlockSolver,
     BSplineSolver,
@@ -711,6 +712,84 @@ def _requested_ground_model(req: dict):
     return model
 
 
+# Fixed terrain media (v1 of the web exposure, issue #534's QTH numbers):
+# the panel shows them read-only; editable media are a possible follow-up.
+_TERRAIN_WATER = (80.0, 0.005)
+_TERRAIN_LAND = (13.0, 0.005)
+
+
+def _terrain_num(t: Mapping, key: str, default: float, lo: float, hi: float) -> float:
+    """One clamped, finite terrain parameter — client input is untrusted."""
+    try:
+        v = float(t.get(key, default))
+    except (TypeError, ValueError):
+        v = default
+    if not math.isfinite(v):
+        v = default
+    return min(max(v, lo), hi)
+
+
+def _terrain_from_request(req: dict) -> Terrain:
+    """Build the faceted-terrain ground from the request's `terrain` preset
+    params (ground_model="terrain"). Two presets, mapping straight onto the
+    antennaknobs.terrain constructors:
+
+      {"preset": "levee", "crest_width_m", "slope_deg", "drop_water_m",
+       "drop_land_m", "water_azimuth_deg"}
+      {"preset": "cliff", "edge_m", "drop_m", "azimuth_deg", "arc_deg"}
+
+    Media are fixed at the QTH constants (water 80/0.005 outward of the
+    cliff/water-side toe; land 13/0.005 for crest, slopes and the land
+    plain). Every number is clamped to a sane range so a hand-crafted
+    request can't build a degenerate Terrain."""
+    t = req.get("terrain") or {}
+    if not isinstance(t, Mapping):
+        t = {}
+    if t.get("preset") == "cliff":
+        return cliff_terrain(
+            edge=_terrain_num(t, "edge_m", 10.0, 0.1, 1e4),
+            drop=_terrain_num(t, "drop_m", 10.0, 0.01, 1e3),
+            inner=_TERRAIN_LAND,
+            outer=_TERRAIN_WATER,
+            azimuth=_terrain_num(t, "azimuth_deg", 0.0, -360.0, 360.0),
+            arc=_terrain_num(t, "arc_deg", 360.0, 1.0, 360.0),
+        )
+    return levee_terrain(
+        crest_width=_terrain_num(t, "crest_width_m", 3.0, 0.1, 1e3),
+        slope_deg=_terrain_num(t, "slope_deg", 20.0, 1.0, 89.0),
+        drop_water=_terrain_num(t, "drop_water_m", 10.7, 0.01, 1e3),
+        drop_land=_terrain_num(t, "drop_land_m", 7.6, 0.01, 1e3),
+        water=_TERRAIN_WATER,
+        land=_TERRAIN_LAND,
+        water_azimuth=_terrain_num(t, "water_azimuth_deg", 0.0, -360.0, 360.0),
+    )
+
+
+def _pack_terrain(t: Terrain) -> dict:
+    """JSON-safe terrain description shipped on the solve response. The
+    server's cut physics (server._mag2_at_directions) rebuilds the Terrain
+    from this to run the per-direction specular-facet reflection — the
+    response must be self-contained because /cuts is stateless."""
+    return {
+        "sectors": [
+            {
+                "az0": float(s.az0),
+                "az1": float(s.az1),
+                "facets": [
+                    [
+                        f.x1 if f.x1 is None else float(f.x1),
+                        float(f.z1),
+                        float(f.eps_r),
+                        float(f.sigma),
+                    ]
+                    for f in s.facets
+                ],
+            }
+            for s in t.sectors
+        ]
+    }
+
+
 def _ground_for_engine(req: dict, ground_z: float):
     """Map the frontend's ground knobs to MomwireEngine's ground spec —
     same three-way model as `_pynec_ground_spec`, one shared selector
@@ -730,6 +809,11 @@ def _ground_for_engine(req: dict, ground_z: float):
         return "pec"
     if model == "fast":
         return ("finite-fast",) + DEFAULT_GROUND[1:]
+    if model == "terrain":
+        # Faceted terrain (issue #534): impedance solves flat Sommerfeld on
+        # the crest medium; the far field applies per-direction specular-
+        # facet reflection (engine far_field and server cuts alike).
+        return ("terrain", _terrain_from_request(req))
     return DEFAULT_GROUND
 
 
@@ -759,6 +843,12 @@ def _pynec_ground_spec(req: dict):
         return "pec"
     if model == "fast":
         return ("finite-fast",) + DEFAULT_GROUND[1:]
+    if model == "terrain":
+        # The UI hides terrain for PyNEC; a hand-crafted request gets an
+        # honest error instead of a silent flat-ground substitution.
+        raise ValueError(
+            "terrain ground is not supported by the PyNEC engine — use a momwire solver"
+        )
     return DEFAULT_GROUND
 
 
@@ -833,6 +923,43 @@ def _make_pynec_engine(req: dict, builder):
 # while staying away from float overflow. Matches momwire/web/server.py.
 _PEC_GROUND_EPS_R = 1.0e10
 _PEC_GROUND_SIGMA = 0.0
+
+
+def _momwire_ground_fields(eng) -> dict:
+    """Ground-describing response fields for a momwire solve.
+
+    Ships the eps_r/sigma of the ground the engine actually solved over,
+    exactly like the PyNEC branch: the server's far-field cut applies the
+    PEC image + Fresnel with these, so finite grounds get their real
+    constants while ground_model="pec" and free space keep the PEC
+    placeholders (ρ→−1). A faceted terrain ships its crest medium there
+    (what the impedance solve used) plus the packed facet model under
+    `ground_terrain` for the per-direction cut physics.
+
+    `ground_model_applied` is what the impedance solve actually used, for
+    honest UI wording: "sommerfeld" (any momwire solver + "finite", momwire
+    >= 0.8.0), "refl-coef" ("finite-fast"), "pec-image", "free" — or
+    "terrain" (crest-medium Sommerfeld impedance + faceted far field)."""
+    g = eng._ground
+    if isinstance(g, tuple) and g[0] == "terrain":
+        eps_r, sigma = g[1].crest_medium
+        return {
+            "ground_eps_r": eps_r,
+            "ground_sigma": sigma,
+            "ground_model_applied": "terrain",
+            "ground_terrain": _pack_terrain(g[1]),
+        }
+    if isinstance(g, tuple) and len(g) == 3:
+        eps_r, sigma = g[1], g[2]
+    else:
+        eps_r, sigma = _PEC_GROUND_EPS_R, _PEC_GROUND_SIGMA
+    return {
+        "ground_eps_r": eps_r,
+        "ground_sigma": sigma,
+        "ground_model_applied": (
+            "free" if g is None else (eng._ground_model or "pec-image")
+        ),
+    }
 
 
 def _pack_wires(currents) -> list[dict]:
@@ -1483,28 +1610,9 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             "solve_ms": solve_ms,
             "ground": bool(req.get("ground", False)),
             "height_m": 0.0,
-            # Ship the eps_r/sigma of the ground the engine actually solved
-            # over, exactly like the PyNEC branch: the frontend's far-field
-            # cut applies PEC image + Fresnel with these, so finite grounds
-            # get their real constants while ground_model="pec" and free
-            # space keep the PEC placeholders (ρ→−1).
-            "ground_eps_r": (
-                eng._ground[1]
-                if isinstance(eng._ground, tuple) and len(eng._ground) == 3
-                else _PEC_GROUND_EPS_R
-            ),
-            "ground_sigma": (
-                eng._ground[2]
-                if isinstance(eng._ground, tuple) and len(eng._ground) == 3
-                else _PEC_GROUND_SIGMA
-            ),
-            # What the impedance solve actually used, for honest UI wording:
-            # "sommerfeld" (any momwire solver + "finite", momwire >= 0.8.0),
-            # "refl-coef" (the "finite-fast" spec), "pec-image"
-            # (model="pec"), or "free".
-            "ground_model_applied": (
-                "free" if eng._ground is None else (eng._ground_model or "pec-image")
-            ),
+            # Ground constants + applied-model label (+ the packed terrain
+            # when the spec is faceted) — see _momwire_ground_fields.
+            **_momwire_ground_fields(eng),
             "z0_ohms": hints()["target_z0"],
             # Geometry-derived UI hints, folded into the response so user
             # designs (which defer them) get correct values the moment they're
@@ -1782,6 +1890,12 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         if has_design_freq:
             builder.design_freq = design_freq
         ground = _ground_for_engine(req, 0.0) or "free"
+        if isinstance(ground, tuple) and ground[0] == "terrain":
+            # A NEC deck can't carry the facet model (and the GD card is
+            # silently ignored under RP 0 anyway — see
+            # scripts/bench_levee_bracket.py): export the crest medium as
+            # the flat finite ground the impedance solve uses.
+            ground = ("finite",) + ground[1].crest_medium
         return _export_nec(builder, ground=ground, freq=meas_freq)
 
     def momwire_sweep(req: dict, freqs_mhz: list[float], cancel=None):

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1362,6 +1362,10 @@ type SolveResponse = {
   ground_eps_r?: number;
   ground_sigma?: number;
   ground_eps_im?: number;
+  /** Packed faceted-terrain description when the solve ran over a terrain
+   *  ground (issue #534). Opaque to the frontend — it rides back to the
+   *  server inside /cuts bodies, where the per-facet physics lives. */
+  ground_terrain?: unknown;
   /** What the impedance solve actually used. Momwire: "refl-coef" |
    *  "pec-image" | "free"; PyNEC adds "sommerfeld". Authoritative — the
    *  readout's ground row shows this rather than re-deriving it from
@@ -1499,14 +1503,17 @@ function isBSplineFamily(b: Backend): boolean {
 }
 
 // The UI separates WHAT the ground is from HOW it's solved. GroundType is
-// the shared, backend-agnostic choice: a finite ground (εr=10, σ=0.002) or
-// a perfectly conducting one. It never promises more than the physics —
-// each backend solves it as best it can: PyNEC and the plain B-spline
-// backend offer a method sub-choice (Sommerfeld-Norton vs the
-// reflection-coefficient approximation) — since momwire 0.8.0 every
-// momwire backend honours both, so the choice is uniform across solvers;
-// either way the finite constants reach the far-field Fresnel cut.
-type GroundType = "finite" | "pec";
+// the shared, backend-agnostic choice: a finite ground (εr=10, σ=0.002), a
+// perfectly conducting one, or a faceted terrain (levee/cliff presets —
+// momwire only). It never promises more than the physics — each backend
+// solves it as best it can: PyNEC and the plain B-spline backend offer a
+// method sub-choice (Sommerfeld-Norton vs the reflection-coefficient
+// approximation) — since momwire 0.8.0 every momwire backend honours both,
+// so the choice is uniform across solvers; either way the finite constants
+// reach the far-field Fresnel cut. Terrain solves impedance on the crest
+// medium (Sommerfeld) and applies per-direction specular-facet reflection
+// in the far field (issue #534).
+type GroundType = "finite" | "pec" | "terrain";
 // Finite-ground solve method, shown for every finite-ground backend:
 // PyNEC (NEC ITYPE=2 vs ITYPE=0) and, since momwire 0.8.0, every momwire
 // solver (true Sommerfeld on bspline dense, sinusoidal field-based, and
@@ -1518,10 +1525,47 @@ type GroundType = "finite" | "pec";
 type FiniteGroundMethod = "sommerfeld" | "fast";
 // The wire value (`ground_model` on SolveRequest): derived from groundType
 // (+ the method wherever finite ground is supported).
-type GroundModel = "sommerfeld" | "fast" | "pec";
+type GroundModel = "sommerfeld" | "fast" | "pec" | "terrain";
+
+// Terrain preset parameters, sent as the request's `terrain` object when
+// ground_model === "terrain". Media are fixed server-side (water 80/0.005,
+// land + crest 13/0.005) — the panel shows them read-only.
+type TerrainPreset = "levee" | "cliff";
+type TerrainParams = {
+  // levee
+  crest_width_m: number;
+  slope_deg: number;
+  drop_water_m: number;
+  drop_land_m: number;
+  water_azimuth_deg: number;
+  // cliff
+  edge_m: number;
+  drop_m: number;
+  azimuth_deg: number;
+  arc_deg: number;
+};
+// Defaults are the motivating QTH (issues #534/#535): a 3 m levee crest
+// with 20° slopes, water 10.7 m below one side, land 7.6 m below the other.
+const TERRAIN_DEFAULTS: TerrainParams = {
+  crest_width_m: 3.0,
+  slope_deg: 20,
+  drop_water_m: 10.7,
+  drop_land_m: 7.6,
+  water_azimuth_deg: 0,
+  edge_m: 10,
+  drop_m: 10,
+  azimuth_deg: 0,
+  arc_deg: 360,
+};
 
 function backendSupportsGround(b: Backend): boolean {
   return b === "sinusoidal" || isBSplineFamily(b) || b === "pynec";
+}
+
+// Faceted terrain needs the momwire engine (per-facet far field + crest
+// Sommerfeld impedance); PyNEC has no equivalent and the server rejects it.
+function backendSupportsTerrain(b: Backend): boolean {
+  return backendSupportsGround(b) && b !== "pynec";
 }
 
 // Coerce a server-supplied backend name into something this UI knows.
@@ -1722,6 +1766,9 @@ type SolveRequest = {
   ground: boolean;
   ground_fast: boolean;
   ground_model?: GroundModel;
+  /** Terrain preset params when ground_model === "terrain" (issue #534);
+   *  the server clamps every number, so raw knob state is fine to send. */
+  terrain?: { preset: TerrainPreset } & Partial<TerrainParams>;
   /** Cut angles for the server-attached polar traces (issue #547). */
   az_elev_deg?: number;
   elev_az_deg?: number;
@@ -2791,13 +2838,31 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   // seconds per solve on the B-spline backend).
   const [finiteGroundMethod, setFiniteGroundMethod] =
     useState<FiniteGroundMethod>("fast");
-  // Wire value derived for the server protocol (see GroundModel).
+  // Terrain preset + knobs (groundType === "terrain"; momwire only). One
+  // flat params object for both presets so values survive preset flips.
+  const [terrainPreset, setTerrainPreset] = useState<TerrainPreset>("levee");
+  const [terrainParams, setTerrainParams] =
+    useState<TerrainParams>(TERRAIN_DEFAULTS);
+  // Wire value derived for the server protocol (see GroundModel). A
+  // terrain selection quietly degrades to the finite method on backends
+  // without terrain support (PyNEC) — the radio is hidden there, but the
+  // state can still say "terrain" from a backend flip mid-comparison.
   const groundModel: GroundModel =
     groundType === "pec"
       ? "pec"
-      : backendSupportsGround(backend)
-        ? finiteGroundMethod
-        : "fast";
+      : groundType === "terrain" && backendSupportsTerrain(backend)
+        ? "terrain"
+        : backendSupportsGround(backend)
+          ? finiteGroundMethod
+          : "fast";
+
+  // Solve-effect dep for the terrain knobs: only bites while terrain is
+  // the active model, so parked levee state never re-solves a flat-ground
+  // setup (and vice versa).
+  const terrainKey =
+    groundModel === "terrain"
+      ? JSON.stringify([terrainPreset, terrainParams])
+      : "";
 
   // One-line tab-hover summary: design · solver N=segs · ground model.
   // Every backend honours the selected method (momwire >= 0.8.0), so the
@@ -2807,9 +2872,11 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     ? "free space"
     : groundModel === "pec"
       ? "PEC ground"
-      : groundModel === "fast"
-        ? "reflection-coef ground"
-        : "Sommerfeld ground";
+      : groundModel === "terrain"
+        ? `terrain (${terrainPreset})`
+        : groundModel === "fast"
+          ? "reflection-coef ground"
+          : "Sommerfeld ground";
   const tabSummary = `${(currentExample?.label ?? geometry) || "new design"} · ${backendDisplayLabel(backend, currentOpts)} N=${nPerWire} · ${groundSummary}`;
   useEffect(() => {
     reportSummary(id, tabSummary);
@@ -3199,6 +3266,9 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
       az_elev_deg: azElevDeg,
       elev_az_deg: elevAzDeg,
     };
+    if (base.ground_model === "terrain") {
+      base.terrain = { preset: terrainPreset, ...terrainParams };
+    }
     if (backend !== "pynec") {
       base.momwire_model = backend;
       const opts = modelOptionsForRequest(backend, currentOpts);
@@ -3661,7 +3731,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     geometry, previewReady, backend, backendOptsKey,
     currentValuesKey,
     designFreq, measFreq,
-    groundEnabled, groundModel,
+    groundEnabled, groundModel, terrainKey,
   ]);
 
   // Antenna switch: drop the previous antenna's results immediately so nothing
@@ -5062,6 +5132,15 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                         ? "Perfectly conducting ground (image method, NEC ITYPE=1) — matches every backend's model='PEC' for apples-to-apples engine comparison."
                         : "Perfectly conducting ground (image method) — matches PyNEC's PEC model for apples-to-apples engine comparison.",
                     ],
+                    ...(backendSupportsTerrain(backend)
+                      ? [
+                          [
+                            "terrain",
+                            "terrain",
+                            "Faceted terrain (levee or cliff preset): impedance solves Sommerfeld on the crest medium; the far field reflects off the facet each ray's specular point lands on — tilted incidence, per-facet media, full effective height below the drops.",
+                          ] as [GroundType, string, string],
+                        ]
+                      : []),
                   ] as [GroundType, string, string][]
                 ).map(([value, label, title]) => (
                   <label key={value} className="link-toggle" title={title}>
@@ -5111,6 +5190,142 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                     ))}
                   </div>
                 )}
+              {groundType === "terrain" && backendSupportsTerrain(backend) && (
+                <div style={{ marginLeft: "1.2em" }}>
+                  <div role="radiogroup" aria-label="Terrain preset">
+                    {(
+                      [
+                        [
+                          "levee",
+                          "levee",
+                          "A raised crest with two sloped sides: water drop_water below on the water bearing, land drop_land below opposite. Crest and slopes are earth; water starts at the toe.",
+                        ],
+                        [
+                          "cliff",
+                          "cliff",
+                          "Flat earth out to the cliff edge, then a sheer drop to water. arc < 360° restricts the cliff to a sector facing the bearing.",
+                        ],
+                      ] as [TerrainPreset, string, string][]
+                    ).map(([value, label, title]) => (
+                      <label key={value} className="link-toggle" title={title}>
+                        <input
+                          type="radio"
+                          name="terrain-preset"
+                          checked={terrainPreset === value}
+                          onChange={() => setTerrainPreset(value)}
+                        />
+                        {label}
+                      </label>
+                    ))}
+                  </div>
+                  {terrainPreset === "levee" ? (
+                    <>
+                      <NumberField
+                        label="crest width (m)"
+                        value={terrainParams.crest_width_m}
+                        min={0.1}
+                        max={1000}
+                        step={0.5}
+                        onChange={(v) =>
+                          setTerrainParams((p) => ({ ...p, crest_width_m: v }))
+                        }
+                      />
+                      <NumberField
+                        label="slope (°)"
+                        value={terrainParams.slope_deg}
+                        min={1}
+                        max={89}
+                        step={1}
+                        onChange={(v) =>
+                          setTerrainParams((p) => ({ ...p, slope_deg: v }))
+                        }
+                      />
+                      <NumberField
+                        label="drop to water (m)"
+                        value={terrainParams.drop_water_m}
+                        min={0.01}
+                        max={1000}
+                        step={0.5}
+                        onChange={(v) =>
+                          setTerrainParams((p) => ({ ...p, drop_water_m: v }))
+                        }
+                      />
+                      <NumberField
+                        label="drop to land (m)"
+                        value={terrainParams.drop_land_m}
+                        min={0.01}
+                        max={1000}
+                        step={0.5}
+                        onChange={(v) =>
+                          setTerrainParams((p) => ({ ...p, drop_land_m: v }))
+                        }
+                      />
+                      <NumberField
+                        label="water bearing (°)"
+                        value={terrainParams.water_azimuth_deg}
+                        min={-360}
+                        max={360}
+                        step={5}
+                        onChange={(v) =>
+                          setTerrainParams((p) => ({
+                            ...p,
+                            water_azimuth_deg: v,
+                          }))
+                        }
+                      />
+                    </>
+                  ) : (
+                    <>
+                      <NumberField
+                        label="cliff edge (m)"
+                        value={terrainParams.edge_m}
+                        min={0.1}
+                        max={10000}
+                        step={1}
+                        onChange={(v) =>
+                          setTerrainParams((p) => ({ ...p, edge_m: v }))
+                        }
+                      />
+                      <NumberField
+                        label="drop (m)"
+                        value={terrainParams.drop_m}
+                        min={0.01}
+                        max={1000}
+                        step={0.5}
+                        onChange={(v) =>
+                          setTerrainParams((p) => ({ ...p, drop_m: v }))
+                        }
+                      />
+                      <NumberField
+                        label="bearing (°)"
+                        value={terrainParams.azimuth_deg}
+                        min={-360}
+                        max={360}
+                        step={5}
+                        onChange={(v) =>
+                          setTerrainParams((p) => ({ ...p, azimuth_deg: v }))
+                        }
+                      />
+                      <NumberField
+                        label="arc (°)"
+                        value={terrainParams.arc_deg}
+                        min={1}
+                        max={360}
+                        step={15}
+                        onChange={(v) =>
+                          setTerrainParams((p) => ({ ...p, arc_deg: v }))
+                        }
+                      />
+                    </>
+                  )}
+                  <div
+                    style={{ fontSize: "0.85em", opacity: 0.65 }}
+                    title="Media are fixed in this version; the geometry knobs above are the live parameters."
+                  >
+                    media: water εr=80 σ=0.005 · land/crest εr=13 σ=0.005
+                  </div>
+                </div>
+              )}
             </>
           )}
         </div>
@@ -6134,6 +6349,9 @@ const GROUND_APPLIED_LABEL: Record<string, string> = {
   "refl-coef": "refl-coef",
   "pec-image": "PEC image",
   free: "free space",
+  // Faceted terrain: impedance ran crest-medium Sommerfeld; the far field
+  // reflects per-direction off the facets (issue #534).
+  terrain: "terrain (crest Somm.)",
 };
 
 function formatOhms(v: number): string {

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -38,6 +38,8 @@ from fastapi.staticfiles import StaticFiles
 from starlette.websockets import WebSocketState
 from threadpoolctl import threadpool_limits
 
+from antennaknobs.terrain import Facet, Sector, Terrain, specular_cut
+
 from . import cost as _cost
 from . import pynec_backend, user_designs
 from .examples import REGISTRY as EXAMPLES
@@ -290,6 +292,69 @@ def _moment_segments(out: dict) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     )
 
 
+def _terrain_from_packed(d: dict) -> Terrain:
+    """Rebuild the faceted terrain from a response's `ground_terrain` field
+    (the adapter's _pack_terrain). Validation lives in the terrain
+    dataclasses — bad client data raises ValueError/TypeError/KeyError,
+    which the /cuts endpoint maps to a 400."""
+    return Terrain(
+        sectors=tuple(
+            Sector(
+                az0=float(s["az0"]),
+                az1=float(s["az1"]),
+                facets=tuple(
+                    Facet(
+                        x1=None if f[0] is None else float(f[0]),
+                        z1=float(f[1]),
+                        eps_r=float(f[2]),
+                        sigma=float(f[3]),
+                    )
+                    for f in s["facets"]
+                ),
+            )
+            for s in d["sectors"]
+        )
+    )
+
+
+def _terrain_ray_geometry(terrain: Terrain, rhat, mid, dr, i_mid):
+    """Per-ray specular-facet data for a faceted terrain: surface height z_f
+    at each ray's specular point, facet downward tilt beta, and the facet
+    medium (eps_r, sigma), all over rhat's leading shape. Mirrors the
+    engine's grid-based branch (engines/momwire.py _evaluate_M_perp) for
+    arbitrary direction sets; h_ref is the same current-weighted mean
+    segment height (the web ground plane sits at z=0)."""
+    w = np.abs(i_mid) * np.linalg.norm(dr, axis=1)
+    wsum = float(np.sum(w))
+    h_ref = float((np.sum(w * mid[:, 2]) / wsum) if wsum > 0 else np.mean(mid[:, 2]))
+
+    shape = rhat.shape[:-1]
+    rxf = rhat[..., 0].ravel()
+    ryf = rhat[..., 1].ravel()
+    rzf = rhat[..., 2].ravel()
+    theta = np.arccos(np.clip(rzf, -1.0, 1.0))
+    sec_idx = terrain.sector_for(np.degrees(np.arctan2(ryf, rxf)))
+    z_f = np.empty(theta.shape)
+    beta = np.empty(theta.shape)
+    eps = np.empty(theta.shape)
+    sig = np.empty(theta.shape)
+    for i, sector in enumerate(terrain.sectors):
+        rays = sec_idx == i
+        if not np.any(rays):
+            continue
+        zf_t, b_t, e_t, s_t = specular_cut(sector, theta[rays], h_ref)
+        z_f[rays] = zf_t
+        beta[rays] = b_t
+        eps[rays] = e_t
+        sig[rays] = s_t
+    return (
+        z_f.reshape(shape),
+        beta.reshape(shape),
+        eps.reshape(shape),
+        sig.reshape(shape),
+    )
+
+
 def _mag2_at_directions(out: dict, rhat: np.ndarray, *, mid=None, dr=None, i_mid=None):
     """|M_perp|² at arbitrary far-field directions — the single server-side
     implementation of the pattern physics (issue #547; the frontend's JS
@@ -358,9 +423,32 @@ def _mag2_at_directions(out: dict, rhat: np.ndarray, *, mid=None, dr=None, i_mid
         M_img_h = np.sum(M_img_perp * h_hat, axis=-1)
         M_img_v = np.sum(M_img_perp * v_hat, axis=-1)
 
-        eps_c = out["ground_eps_r"] + 1j * out["ground_eps_im"]
-        cos_ti = rz
-        sin2_ti = s * s
+        terr = out.get("ground_terrain")
+        if terr:
+            # Faceted terrain (issue #534): per ray, find the facet the
+            # specular point lands on, shift the image plane to the facet
+            # surface (an extra 2·k·z_f·cosθ path phase — z_f ≤ 0 below
+            # the crest, so the reflected wave rides the full effective
+            # height), tilt the incidence angle by the facet slope, and
+            # evaluate Fresnel with the facet's medium.
+            z_f, beta, eps_g, sig_g = _terrain_ray_geometry(
+                _terrain_from_packed(terr), rhat, mid, dr, i_mid
+            )
+            pf = np.exp(2j * k * z_f * rz)
+            M_img_h = M_img_h * pf
+            M_img_v = M_img_v * pf
+            omega = 2.0 * np.pi * float(out["measurement_freq_mhz"]) * 1e6
+            eps_c = eps_g + 1j * (-sig_g / (omega * _EPS0))
+            th_loc = np.clip(np.arccos(np.clip(rz, -1.0, 1.0)) - beta, 0.0, np.pi / 2)
+            # On untilted facets keep the flat branch's exact trig route
+            # (rz / s·s) so a single-flat-facet terrain reproduces the plain
+            # finite ground bit-for-bit (mirrors the engine, #534 gate 1).
+            cos_ti = np.where(beta == 0.0, rz, np.cos(th_loc))
+            sin2_ti = np.where(beta == 0.0, s * s, np.sin(th_loc) ** 2)
+        else:
+            eps_c = out["ground_eps_r"] + 1j * out["ground_eps_im"]
+            cos_ti = rz
+            sin2_ti = s * s
         Q = np.sqrt(eps_c - sin2_ti)
         rho_h = (cos_ti - Q) / (cos_ti + Q)
         rho_v = (eps_c * cos_ti - Q) / (eps_c * cos_ti + Q)

--- a/tests/test_web_terrain.py
+++ b/tests/test_web_terrain.py
@@ -1,0 +1,235 @@
+"""Web exposure of the faceted-terrain ground (issue #534, UI half).
+
+Covers the request → engine mapping (levee/cliff presets, clamped inputs),
+the response contract (`ground_terrain` + crest constants + applied label),
+and the server cut physics' terrain branch — including the single-flat-facet
+bit-identity gate that pins it to the plain finite ground.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+
+import numpy as np
+import pytest
+from starlette.testclient import TestClient
+
+from antennaknobs.terrain import Terrain
+from antennaknobs.web.server import _EPS0, _pattern_cuts, app
+
+# Imported after server: adapter and examples import each other cyclically,
+# and only the examples-first entry order (which server triggers) resolves.
+import antennaknobs.web.adapter as adapter  # noqa: E402
+from antennaknobs.web.adapter import (  # noqa: E402
+    _ground_for_engine,
+    _pack_terrain,
+    _pynec_ground_spec,
+    _terrain_from_request,
+)
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _terrain_req(**terrain) -> dict:
+    return {"ground": True, "ground_model": "terrain", "terrain": terrain}
+
+
+# --- request -> engine mapping ---------------------------------------------
+
+
+def test_ground_for_engine_builds_levee_by_default():
+    spec = _ground_for_engine(_terrain_req(), 0.0)
+    assert isinstance(spec, tuple) and spec[0] == "terrain"
+    t = spec[1]
+    assert isinstance(t, Terrain)
+    assert len(t.sectors) == 2
+    assert t.crest_medium == adapter._TERRAIN_LAND
+
+
+def test_levee_params_flow_through():
+    t = _terrain_from_request(
+        _terrain_req(
+            preset="levee",
+            crest_width_m=4.0,
+            slope_deg=30.0,
+            drop_water_m=12.0,
+            drop_land_m=6.0,
+            water_azimuth_deg=90.0,
+        )
+    )
+    water = t.sectors[0]
+    assert (water.az0, water.az1) == (0.0, 180.0)  # water_azimuth ± 90
+    crest = water.facets[0]
+    assert crest.x1 == pytest.approx(2.0)  # half the crest width
+    toe = water.facets[1]
+    assert toe.z1 == pytest.approx(-12.0)
+    run = toe.x1 - crest.x1
+    assert math.degrees(math.atan2(12.0, run)) == pytest.approx(30.0)
+    assert water.facets[2].eps_r == adapter._TERRAIN_WATER[0]
+
+
+def test_cliff_preset_and_arc():
+    t = _terrain_from_request(
+        _terrain_req(preset="cliff", edge_m=8.0, drop_m=5.0, arc_deg=360.0)
+    )
+    assert len(t.sectors) == 1
+    assert t.sectors[0].facets[0].x1 == pytest.approx(8.0)
+    t2 = _terrain_from_request(
+        _terrain_req(preset="cliff", edge_m=8.0, drop_m=5.0, arc_deg=120.0)
+    )
+    assert len(t2.sectors) == 2  # cliff sector + flat remainder
+
+
+def test_garbage_terrain_params_clamp_to_defaults():
+    t = _terrain_from_request(
+        _terrain_req(
+            preset="levee",
+            crest_width_m="not-a-number",
+            slope_deg=float("nan"),
+            drop_water_m=-5.0,  # clamps to the positive floor
+        )
+    )
+    assert isinstance(t, Terrain)  # constructors' invariants all hold
+    assert t.sectors[0].facets[0].x1 == pytest.approx(1.5)  # default 3 m crest
+    # Not a dict at all -> pure defaults.
+    assert isinstance(
+        _terrain_from_request({"ground": True, "terrain": "junk"}), Terrain
+    )
+
+
+def test_pynec_rejects_terrain_explicitly():
+    with pytest.raises(ValueError, match="PyNEC"):
+        _pynec_ground_spec(_terrain_req())
+
+
+# --- server cut physics -----------------------------------------------------
+
+
+def _hertzian_over(terrain: Terrain | None, *, h=6.1, dl=0.01, freq_mhz=21.2):
+    """Vertical Hertzian dipole at height h; ground constants at the crest
+    medium so the flat and terrain paths share identical inputs."""
+    eps_r, sigma = adapter._TERRAIN_LAND
+    omega = 2.0 * np.pi * freq_mhz * 1e6
+    out = {
+        "wires": [
+            {
+                "knot_positions": [[0.0, 0.0, h], [0.0, 0.0, h + dl]],
+                "knot_currents_re": [1.0, 1.0],
+                "knot_currents_im": [0.0, 0.0],
+            }
+        ],
+        "measurement_freq_mhz": freq_mhz,
+        "k_meas_m_inv": omega / 299_792_458.0,
+        "ground": True,
+        "ground_eps_r": eps_r,
+        "ground_sigma": sigma,
+        "ground_eps_im": -sigma / (omega * _EPS0),
+        "directivity_norm": 3.0 / (2.0 * dl * dl),
+    }
+    if terrain is not None:
+        out["ground_terrain"] = _pack_terrain(terrain)
+    return out
+
+
+def test_flat_terrain_cuts_bit_identical_to_finite_ground():
+    """Gate 1 of #534, at the cuts layer: a single flat facet of the same
+    medium must reproduce the plain finite-ground trace exactly."""
+    from antennaknobs.terrain import flat_terrain
+
+    flat = _pattern_cuts(_hertzian_over(None), 15.0, 30.0)
+    terr = _pattern_cuts(
+        _hertzian_over(flat_terrain(*adapter._TERRAIN_LAND)), 15.0, 30.0
+    )
+    assert terr["azimuth"] == flat["azimuth"]
+    assert terr["elevation"] == flat["elevation"]
+
+
+def test_levee_water_side_beats_land_side_at_lowest_angle():
+    """Gate 3 of #534, at the cuts layer: the water side's greater drop
+    (larger effective height) lifts the lowest-angle field. At higher
+    elevations the two sides' lobe structures interleave (their nulls
+    differ), so only the lowest sampled angle is a robust invariant.
+    Elevation cut through the water bearing: 4 deg toward water (i=2) vs
+    4 deg above the opposite horizon toward land (i=88)."""
+    from antennaknobs.terrain import flat_terrain, levee_terrain
+
+    t = levee_terrain(crest_width=3.0, slope_deg=20.0, drop_water=10.7, drop_land=7.6)
+    el = _pattern_cuts(_hertzian_over(t), 15.0, 0.0)["elevation"]
+    assert el[2] > el[88] + 1.0
+    # And both sides differ from the flat crest-medium model — the facets
+    # are actually in play, not just the crest Sommerfeld constants.
+    el_flat = _pattern_cuts(
+        _hertzian_over(flat_terrain(*adapter._TERRAIN_LAND)), 15.0, 0.0
+    )["elevation"]
+    assert abs(el[2] - el_flat[2]) > 1.0 and abs(el[88] - el_flat[88]) > 1.0
+
+
+def test_terrain_zenith_sample_stays_finite_and_smooth():
+    from antennaknobs.terrain import levee_terrain
+
+    t = levee_terrain(crest_width=3.0, slope_deg=20.0, drop_water=10.7, drop_land=7.6)
+    el = _pattern_cuts(_hertzian_over(t), 15.0, 0.0)["elevation"]
+    # Vertical dipole: zenith is a null; neighbours bound it smoothly.
+    assert el[45] <= min(el[44], el[46])
+
+
+# --- end-to-end -------------------------------------------------------------
+
+
+def _solve_ws(client: TestClient, req: dict) -> dict:
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(json.dumps(req))
+        return json.loads(ws.receive_text())
+
+
+def test_ws_solve_with_terrain(client: TestClient):
+    result = _solve_ws(
+        client,
+        {
+            "geometry": "dipoles.invvee",
+            "measurement_freq_mhz": 21.2,
+            "momwire_model": "bspline",
+            "ground": True,
+            "ground_model": "terrain",
+            "terrain": {"preset": "levee", "water_azimuth_deg": 0.0},
+            "az_elev_deg": 15.0,
+            "elev_az_deg": 0.0,
+        },
+    )
+    assert "error" not in result
+    assert result["ground_model_applied"] == "terrain"
+    eps_r, sigma = adapter._TERRAIN_LAND
+    assert result["ground_eps_r"] == eps_r and result["ground_sigma"] == sigma
+    assert len(result["ground_terrain"]["sectors"]) == 2
+    assert len(result["cuts"]["elevation"]) == 180
+
+    # /cuts stays stateless for terrain responses: new angles round-trip.
+    r = client.post(
+        "/cuts", json={"solve": result, "az_elev_deg": 25.0, "elev_az_deg": 90.0}
+    )
+    assert r.status_code == 200
+    assert r.json()["azimuth"] != result["cuts"]["azimuth"]
+
+    # Corrupt facet data -> a clean 400, not a 500.
+    bad = dict(result)
+    bad["ground_terrain"] = {"sectors": [{"az0": 0.0, "az1": 360.0, "facets": []}]}
+    assert client.post("/cuts", json={"solve": bad}).status_code == 400
+
+
+def test_nec_export_falls_back_to_crest_medium():
+    from antennaknobs.web.server import EXAMPLES
+
+    deck = EXAMPLES["dipoles.invvee"].nec_export(
+        {
+            "geometry": "dipoles.invvee",
+            "ground": True,
+            "ground_model": "terrain",
+            "terrain": {"preset": "levee"},
+        }
+    )
+    gn = [ln for ln in deck.splitlines() if ln.startswith("GN")]
+    assert gn and "1.300000E+01" in gn[0] and "5.000000E-03" in gn[0]


### PR DESCRIPTION
## Summary
- Adds a third ground type to the simulator, **terrain**, exposing the faceted-terrain ground merged in #548: a "levee" preset (crest width, slope, drop-to-water, drop-to-land, water bearing — defaulted to the motivating QTH) and a "cliff" preset (edge, drop, bearing, arc), momwire backends only. Media are fixed at the QTH constants and shown read-only.
- The server maps the preset params (clamped) onto `levee_terrain`/`cliff_terrain` and ships the packed facet model on the response (`ground_terrain`), keeping `/cuts` stateless; `_mag2_at_directions` grows the per-ray specular-facet branch (image-plane height phase, tilted incidence, per-facet Fresnel) mirroring the engine.
- Honest edges: PyNEC + terrain is an explicit error (no silent flat-ground substitution); NEC export falls back to the crest medium with a comment on the RP-0/GD trap; the impedance readout reports "terrain (crest Somm.)".
- Tests: single-flat-facet trace is bit-identical to the plain finite ground (gate 1 at the cuts layer), levee water side beats land side at the lowest sampled angle and both differ from the flat model (gate 3), zenith stays smooth, ws end-to-end + `/cuts` roundtrip + garbage-facet 400, preset/clamp mapping, PyNEC rejection, NEC-export fallback.

## Test plan
- [x] Full suite: 2716 passed, 2 skipped
- [x] `tsc --noEmit` + `vite build` clean
- [x] ruff check/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KV3q7Q9hGKQL4xfbw5qbdt