### PR TITLE
PyNEC terrain hybrid: crest-medium GN 2 currents + facet far field, with NEC-rp switch

### DIFF
--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -844,11 +844,13 @@ def _pynec_ground_spec(req: dict):
     if model == "fast":
         return ("finite-fast",) + DEFAULT_GROUND[1:]
     if model == "terrain":
-        # The UI hides terrain for PyNEC; a hand-crafted request gets an
-        # honest error instead of a silent flat-ground substitution.
-        raise ValueError(
-            "terrain ground is not supported by the PyNEC engine — use a momwire solver"
-        )
+        # PyNEC terrain hybrid (issue #553): NEC-2 has no facet model, but
+        # the #534 recipe never lets the facets touch the current solve —
+        # impedance/currents run over flat Sommerfeld at the CREST medium,
+        # which NEC solves natively (GN 2). The facets enter afterward in
+        # the server's far-field composition, fed by the `ground_terrain`
+        # field pynec_solve attaches to the response.
+        return ("finite",) + _terrain_from_request(req).crest_medium
     return DEFAULT_GROUND
 
 
@@ -1794,6 +1796,14 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             "input_power_w": float(getattr(eng, "_excited_p_in", None) or 0.0),
             **_wire_material_results(builder),
         }
+        if _requested_ground_model(req) == "terrain":
+            # PyNEC terrain hybrid (issue #553): the engine solved over the
+            # crest-medium Sommerfeld spec (so ground_eps_r/sigma above are
+            # already the crest constants); re-stamp the applied label and
+            # attach the facet model so the server's cut physics applies the
+            # per-facet reflection — the same response contract as momwire.
+            out["ground_model_applied"] = "terrain"
+            out["ground_terrain"] = _pack_terrain(_terrain_from_request(req))
         if hints()["multi_feed"] and len(zs) > 1:
             # PyNECEngine.excitation_pairs is [(tag, sub_seg, voltage)];
             # pull the voltage off each so per-feed phase comes through.

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1504,8 +1504,8 @@ function isBSplineFamily(b: Backend): boolean {
 
 // The UI separates WHAT the ground is from HOW it's solved. GroundType is
 // the shared, backend-agnostic choice: a finite ground (εr=10, σ=0.002), a
-// perfectly conducting one, or a faceted terrain (levee/cliff presets —
-// momwire only). It never promises more than the physics — each backend
+// perfectly conducting one, or a faceted terrain (levee/cliff presets).
+// It never promises more than the physics — each backend
 // solves it as best it can: PyNEC and the plain B-spline backend offer a
 // method sub-choice (Sommerfeld-Norton vs the reflection-coefficient
 // approximation) — since momwire 0.8.0 every momwire backend honours both,
@@ -1562,10 +1562,13 @@ function backendSupportsGround(b: Backend): boolean {
   return b === "sinusoidal" || isBSplineFamily(b) || b === "pynec";
 }
 
-// Faceted terrain needs the momwire engine (per-facet far field + crest
-// Sommerfeld impedance); PyNEC has no equivalent and the server rejects it.
+// Every ground-capable backend supports terrain. Momwire applies the
+// per-facet far field natively; PyNEC runs the hybrid (issue #553): NEC
+// solves the currents over crest-medium Sommerfeld — exactly what the
+// terrain recipe feeds the current solve anyway — and the server's cut
+// physics applies the facet reflection to those currents.
 function backendSupportsTerrain(b: Backend): boolean {
-  return backendSupportsGround(b) && b !== "pynec";
+  return backendSupportsGround(b);
 }
 
 // Coerce a server-supplied backend name into something this UI knows.
@@ -2844,9 +2847,9 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   const [terrainParams, setTerrainParams] =
     useState<TerrainParams>(TERRAIN_DEFAULTS);
   // Wire value derived for the server protocol (see GroundModel). A
-  // terrain selection quietly degrades to the finite method on backends
-  // without terrain support (PyNEC) — the radio is hidden there, but the
-  // state can still say "terrain" from a backend flip mid-comparison.
+  // terrain selection quietly degrades to the finite method on any future
+  // backend without terrain support (all current ground-capable backends
+  // have it — PyNEC via the #553 hybrid).
   const groundModel: GroundModel =
     groundType === "pec"
       ? "pec"
@@ -2991,6 +2994,10 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   // solver's power-balance error. Cheap (closed form), so on by default;
   // the checkbox hides the overlay. `normCheck` is null while off or pending.
   const [normCheckEnabled, setNormCheckEnabled] = useState(true);
+  // NEC rp_card exact-pattern overlay (PyNEC backend only). User-switchable;
+  // forced off (and the switch greyed) over a terrain ground, where NEC's
+  // flat-ground rp pattern would silently disagree with the facet traces.
+  const [necOverlayEnabled, setNecOverlayEnabled] = useState(true);
   const [normCheck, setNormCheck] = useState<NormCheckData | null>(null);
   // NEC's rp_card pattern, fetched on a debounce so we don't fire one per
   // slider tick. Overlaid on the cuts as a comparison line.
@@ -3928,10 +3935,19 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
 
   // Debounced NEC pattern fetch. PyNEC only — for momwire there's no rp_card
   // equivalent. Tracks measurement freq too (unlike the impedance sweep).
+  // Held off entirely over terrain (the rp pattern is flat-ground only) and
+  // when the user switches the overlay off.
   useEffect(() => {
     if (patternTimerRef.current) window.clearTimeout(patternTimerRef.current);
     setPattern(null);
-    if (backend !== "pynec" || !active) return;
+    if (
+      backend !== "pynec" ||
+      !active ||
+      !necOverlayEnabled ||
+      groundModel === "terrain"
+    ) {
+      return;
+    }
     patternTimerRef.current = window.setTimeout(() => {
       runPattern();
       patternTimerRef.current = null;
@@ -3945,6 +3961,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     currentValuesKey,
     designFreq, measFreq,
     groundEnabled, groundModel,
+    necOverlayEnabled,
     active,
   ]);
 
@@ -5534,6 +5551,27 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                     onChange={(e) => setNormCheckEnabled(e.target.checked)}
                   />
                   norm check
+                </label>
+              )}
+              {!isMobile && backend === "pynec" && (
+                <label
+                  className="overlay-checkbox"
+                  style={
+                    groundModel === "terrain" ? { opacity: 0.45 } : undefined
+                  }
+                  title={
+                    groundModel === "terrain"
+                      ? "NEC's rp_card pattern is flat-ground only (no facet model), so the exact-pattern overlay is unavailable over terrain — the terrain traces come from the server's facet physics instead."
+                      : "Overlay NEC's own rp_card far-field pattern (dashed cyan) as an exact reference for this engine's ground model."
+                  }
+                >
+                  <input
+                    type="checkbox"
+                    checked={necOverlayEnabled && groundModel !== "terrain"}
+                    disabled={groundModel === "terrain"}
+                    onChange={(e) => setNecOverlayEnabled(e.target.checked)}
+                  />
+                  NEC rp
                 </label>
               )}
               {/* Over a finite ground the norm gap IS physics (structural

--- a/tests/test_web_terrain.py
+++ b/tests/test_web_terrain.py
@@ -101,9 +101,13 @@ def test_garbage_terrain_params_clamp_to_defaults():
     )
 
 
-def test_pynec_rejects_terrain_explicitly():
-    with pytest.raises(ValueError, match="PyNEC"):
-        _pynec_ground_spec(_terrain_req())
+def test_pynec_terrain_maps_to_crest_medium_sommerfeld():
+    """The PyNEC terrain hybrid (issue #553): NEC has no facet model, but
+    the #534 recipe solves currents over flat Sommerfeld at the crest
+    medium anyway — which NEC does natively (GN 2). The facets ride the
+    response's ground_terrain into the server's cut physics."""
+    spec = _pynec_ground_spec(_terrain_req())
+    assert spec == ("finite",) + adapter._TERRAIN_LAND
 
 
 # --- server cut physics -----------------------------------------------------
@@ -218,6 +222,41 @@ def test_ws_solve_with_terrain(client: TestClient):
     bad = dict(result)
     bad["ground_terrain"] = {"sectors": [{"az0": 0.0, "az1": 360.0, "facets": []}]}
     assert client.post("/cuts", json={"solve": bad}).status_code == 400
+
+
+def test_pynec_terrain_solve_matches_momwire(client: TestClient):
+    """End-to-end #553 hybrid: a PyNEC terrain solve carries the same
+    response contract as momwire (applied label, crest constants, packed
+    facets, cuts), and the two engines' terrain traces agree to engine
+    tolerance — same facet physics over independently solved currents."""
+    from antennaknobs.web import pynec_backend
+
+    if not pynec_backend.HAVE_PYNEC:
+        pytest.skip("pynec-accel not installed")
+
+    base = {
+        "geometry": "dipoles.invvee",
+        "measurement_freq_mhz": 21.2,
+        "ground": True,
+        "ground_model": "terrain",
+        "terrain": {"preset": "levee", "water_azimuth_deg": 0.0},
+        "az_elev_deg": 15.0,
+        "elev_az_deg": 0.0,
+    }
+    nec = _solve_ws(client, {**base, "solver": "pynec"})
+    assert "error" not in nec
+    assert nec["ground_model_applied"] == "terrain"
+    eps_r, sigma = adapter._TERRAIN_LAND
+    assert nec["ground_eps_r"] == eps_r and nec["ground_sigma"] == sigma
+    assert len(nec["ground_terrain"]["sectors"]) == 2
+
+    mom = _solve_ws(client, {**base, "solver": "momwire", "momwire_model": "bspline"})
+    el_nec = np.asarray(nec["cuts"]["elevation"])
+    el_mom = np.asarray(mom["cuts"]["elevation"])
+    assert abs(el_nec.max() - el_mom.max()) < 1.0
+    # The terrain asymmetry (water side up at the lowest angle) shows in
+    # both engines' traces.
+    assert el_nec[2] > el_nec[88] and el_mom[2] > el_mom[88]
 
 
 def test_nec_export_falls_back_to_crest_medium():


### PR DESCRIPTION
## Summary
- Enables the terrain ground on the PyNEC backend (issue #553): NEC solves the currents over flat Sommerfeld at the crest medium — exactly what the #534 recipe feeds the current solve — and the response carries `ground_terrain`, so the server's cut physics applies the per-facet reflection to NEC's currents. Same response contract as momwire; the explicit rejection is gone.
- Adds a user-facing **"NEC rp" switch** in the far-field overlay bar (PyNEC only) controlling the `rp_card` exact-pattern overlay. Over terrain it is forced off and greyed with an explanatory tooltip — NEC's flat-ground pattern would silently disagree with the facet traces — and the `/pattern` fetch is gated on the switch so disabled means no wasted solves.
- Cross-engine test: PyNEC and momwire terrain elevation traces agree within 1 dB and both show the water/land low-angle asymmetry; the request→spec mapping test replaces the old rejection test.

## Test plan
- [x] `tests/test_web_terrain.py` 11 passed (incl. the PyNEC end-to-end, pynec-accel present)
- [x] cuts/web/terrain suites: 189 passed
- [x] `tsc --noEmit` + `vite build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KV3q7Q9hGKQL4xfbw5qbdt