### PR TITLE
Hillside terrain preset: a bench on a slope — no bottom reference needed

### DIFF
--- a/src/antennaknobs/terrain.py
+++ b/src/antennaknobs/terrain.py
@@ -241,6 +241,79 @@ def cliff_terrain(
     return Terrain(sectors=(cliff, flat))
 
 
+def hillside_terrain(
+    *,
+    flat_width: float,
+    up_slope_deg: float,
+    down_slope_deg: float,
+    medium: tuple[float, float] = (13.0, 0.005),
+    downhill_azimuth: float = 0.0,
+    drop: float = 150.0,
+    rise: float = 100.0,
+    n_facets: int = 10,
+) -> Terrain:
+    """A bench on a hillside: a flat terrace ``flat_width`` wide, the ground
+    rising at ``up_slope_deg`` on one side and falling at ``down_slope_deg``
+    on the other (the side facing ``downhill_azimuth``), all one ``medium``.
+
+    Unlike the levee there is no natural "bottom" to reference — and none is
+    needed: the slope itself is the reflector, so the effective height grows
+    continuously as the elevation angle drops (the specular point walks down
+    the hill). Each slope is subdivided into ``n_facets`` pieces —
+    ``specular_cut`` locates facets by their midpoint height, so a long
+    slope needs subdivision to track the continuous tilted-mirror solution —
+    and capped at ``drop``/``rise`` metres of relief before flattening; at
+    HF the caps only matter below ~1-2 degrees of elevation.
+
+    Honest limit: toward the *uphill* side below ``up_slope_deg`` of
+    elevation the real sky is shadowed by the hill. The specular model has
+    no diffraction, so it reports grazing-cancelled reflection there instead
+    of blockage — don't trust that band.
+    """
+    if not 0.0 < up_slope_deg < 90.0 or not 0.0 < down_slope_deg < 90.0:
+        raise ValueError("hillside slopes must be in (0, 90) degrees")
+    if n_facets < 1:
+        raise ValueError(f"n_facets must be >= 1, got {n_facets}")
+    half = flat_width / 2.0
+    eps, sig = medium
+
+    def ramp(slope_deg: float, dz_total: float) -> tuple[Facet, ...]:
+        run = abs(dz_total) / math.tan(math.radians(slope_deg))
+        return tuple(
+            Facet(
+                half + run * (i + 1) / n_facets,
+                dz_total * (i + 1) / n_facets,
+                eps,
+                sig,
+            )
+            for i in range(n_facets)
+        )
+
+    bench = Facet(half, 0.0, eps, sig)
+    return Terrain(
+        sectors=(
+            Sector(
+                az0=downhill_azimuth - 90.0,
+                az1=downhill_azimuth + 90.0,
+                facets=(
+                    bench,
+                    *ramp(down_slope_deg, -drop),
+                    Facet(None, -drop, eps, sig),
+                ),
+            ),
+            Sector(
+                az0=downhill_azimuth + 90.0,
+                az1=downhill_azimuth + 270.0,
+                facets=(
+                    bench,
+                    *ramp(up_slope_deg, +rise),
+                    Facet(None, +rise, eps, sig),
+                ),
+            ),
+        )
+    )
+
+
 def levee_terrain(
     *,
     crest_width: float,

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -77,7 +77,12 @@ except ImportError:
     PyNECEngine = None
     DEFAULT_GROUND = ("finite", 10.0, 0.002)
 from antennaknobs.engines.momwire import MomwireEngine
-from antennaknobs.terrain import Terrain, cliff_terrain, levee_terrain
+from antennaknobs.terrain import (
+    Terrain,
+    cliff_terrain,
+    hillside_terrain,
+    levee_terrain,
+)
 from momwire import (
     ArrayBlockSolver,
     BSplineSolver,
@@ -731,12 +736,14 @@ def _terrain_num(t: Mapping, key: str, default: float, lo: float, hi: float) -> 
 
 def _terrain_from_request(req: dict) -> Terrain:
     """Build the faceted-terrain ground from the request's `terrain` preset
-    params (ground_model="terrain"). Two presets, mapping straight onto the
-    antennaknobs.terrain constructors:
+    params (ground_model="terrain"). Three presets, mapping straight onto
+    the antennaknobs.terrain constructors:
 
       {"preset": "levee", "crest_width_m", "slope_deg", "drop_water_m",
        "drop_land_m", "water_azimuth_deg"}
       {"preset": "cliff", "edge_m", "drop_m", "azimuth_deg", "arc_deg"}
+      {"preset": "hillside", "flat_width_m", "up_slope_deg",
+       "down_slope_deg", "downhill_azimuth_deg"}
 
     Media are fixed at the QTH constants (water 80/0.005 outward of the
     cliff/water-side toe; land 13/0.005 for crest, slopes and the land
@@ -753,6 +760,16 @@ def _terrain_from_request(req: dict) -> Terrain:
             outer=_TERRAIN_WATER,
             azimuth=_terrain_num(t, "azimuth_deg", 0.0, -360.0, 360.0),
             arc=_terrain_num(t, "arc_deg", 360.0, 1.0, 360.0),
+        )
+    if t.get("preset") == "hillside":
+        return hillside_terrain(
+            flat_width=_terrain_num(t, "flat_width_m", 20.0, 0.1, 1e3),
+            up_slope_deg=_terrain_num(t, "up_slope_deg", 15.0, 1.0, 89.0),
+            down_slope_deg=_terrain_num(t, "down_slope_deg", 10.0, 1.0, 89.0),
+            medium=_TERRAIN_LAND,
+            downhill_azimuth=_terrain_num(
+                t, "downhill_azimuth_deg", 0.0, -360.0, 360.0
+            ),
         )
     return levee_terrain(
         crest_width=_terrain_num(t, "crest_width_m", 3.0, 0.1, 1e3),

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1530,7 +1530,7 @@ type GroundModel = "sommerfeld" | "fast" | "pec" | "terrain";
 // Terrain preset parameters, sent as the request's `terrain` object when
 // ground_model === "terrain". Media are fixed server-side (water 80/0.005,
 // land + crest 13/0.005) — the panel shows them read-only.
-type TerrainPreset = "levee" | "cliff";
+type TerrainPreset = "levee" | "cliff" | "hillside";
 type TerrainParams = {
   // levee
   crest_width_m: number;
@@ -1543,8 +1543,13 @@ type TerrainParams = {
   drop_m: number;
   azimuth_deg: number;
   arc_deg: number;
+  // hillside
+  flat_width_m: number;
+  up_slope_deg: number;
+  down_slope_deg: number;
+  downhill_azimuth_deg: number;
 };
-// Defaults are the motivating QTH (issues #534/#535): a 3 m levee crest
+// Levee defaults are the motivating QTH (issues #534/#535): a 3 m crest
 // with 20° slopes, water 10.7 m below one side, land 7.6 m below the other.
 const TERRAIN_DEFAULTS: TerrainParams = {
   crest_width_m: 3.0,
@@ -1556,6 +1561,10 @@ const TERRAIN_DEFAULTS: TerrainParams = {
   drop_m: 10,
   azimuth_deg: 0,
   arc_deg: 360,
+  flat_width_m: 20,
+  up_slope_deg: 15,
+  down_slope_deg: 10,
+  downhill_azimuth_deg: 0,
 };
 
 function backendSupportsGround(b: Backend): boolean {
@@ -5222,6 +5231,11 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                           "cliff",
                           "Flat earth out to the cliff edge, then a sheer drop to water. arc < 360° restricts the cliff to a sector facing the bearing.",
                         ],
+                        [
+                          "hillside",
+                          "hillside",
+                          "A flat bench on a hillside: ground rises at the uphill slope on one side, falls at the downhill slope on the other (facing the downhill bearing). No bottom needed — the slope itself is the reflector, so effective height grows as the elevation drops. Below the uphill slope angle the model can't see the hill's shadowing.",
+                        ],
                       ] as [TerrainPreset, string, string][]
                     ).map(([value, label, title]) => (
                       <label key={value} className="link-toggle" title={title}>
@@ -5291,7 +5305,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                         }
                       />
                     </>
-                  ) : (
+                  ) : terrainPreset === "cliff" ? (
                     <>
                       <NumberField
                         label="cliff edge (m)"
@@ -5334,12 +5348,63 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                         }
                       />
                     </>
+                  ) : (
+                    <>
+                      <NumberField
+                        label="flat width (m)"
+                        value={terrainParams.flat_width_m}
+                        min={0.1}
+                        max={1000}
+                        step={1}
+                        onChange={(v) =>
+                          setTerrainParams((p) => ({ ...p, flat_width_m: v }))
+                        }
+                      />
+                      <NumberField
+                        label="uphill slope (°)"
+                        value={terrainParams.up_slope_deg}
+                        min={1}
+                        max={89}
+                        step={1}
+                        onChange={(v) =>
+                          setTerrainParams((p) => ({ ...p, up_slope_deg: v }))
+                        }
+                      />
+                      <NumberField
+                        label="downhill slope (°)"
+                        value={terrainParams.down_slope_deg}
+                        min={1}
+                        max={89}
+                        step={1}
+                        onChange={(v) =>
+                          setTerrainParams((p) => ({
+                            ...p,
+                            down_slope_deg: v,
+                          }))
+                        }
+                      />
+                      <NumberField
+                        label="downhill bearing (°)"
+                        value={terrainParams.downhill_azimuth_deg}
+                        min={-360}
+                        max={360}
+                        step={5}
+                        onChange={(v) =>
+                          setTerrainParams((p) => ({
+                            ...p,
+                            downhill_azimuth_deg: v,
+                          }))
+                        }
+                      />
+                    </>
                   )}
                   <div
                     style={{ fontSize: "0.85em", opacity: 0.65 }}
                     title="Media are fixed in this version; the geometry knobs above are the live parameters."
                   >
-                    media: water εr=80 σ=0.005 · land/crest εr=13 σ=0.005
+                    {terrainPreset === "hillside"
+                      ? "media: earth εr=13 σ=0.005"
+                      : "media: water εr=80 σ=0.005 · land/crest εr=13 σ=0.005"}
                   </div>
                 </div>
               )}

--- a/tests/test_terrain_ground.py
+++ b/tests/test_terrain_ground.py
@@ -29,6 +29,7 @@ from antennaknobs.terrain import (
     Terrain,
     cliff_terrain,
     flat_terrain,
+    hillside_terrain,
     levee_terrain,
     specular_cut,
 )
@@ -148,6 +149,46 @@ def test_flat_terrain_reproduces_finite_ground_bit_identically():
     _, g_fin = _grid(e_fin)
     _, g_ter = _grid(e_ter)
     assert np.array_equal(g_fin, g_ter)
+
+
+def test_hillside_terrain_structure():
+    """Bench + subdivided rising/falling ramps, one medium, tiled sectors.
+    The uphill sector carries genuinely positive facet heights — rising
+    terrain is legal in the model (the specular scan just never lands on a
+    facet above the source at high elevation)."""
+    t = hillside_terrain(flat_width=20.0, up_slope_deg=15.0, down_slope_deg=10.0)
+    assert len(t.sectors) == 2
+    down, up = t.sectors
+    assert down.facets[0].x1 == pytest.approx(10.0)  # bench half-width
+    assert down.facets[-1].x1 is None and down.facets[-1].z1 == pytest.approx(-150.0)
+    assert up.facets[-1].z1 == pytest.approx(100.0)  # rises above the bench
+    assert all(f.z1 >= 0 for f in up.facets)
+    assert t.crest_medium == (13.0, 0.005)
+    # Ramp subdivision: strictly increasing edges, monotone heights.
+    zs = [f.z1 for f in down.facets[1:-1]]
+    assert all(b < a for a, b in zip(zs, zs[1:]))
+    # Downhill ramp run matches the slope: total 150 m drop at 10 deg.
+    run = down.facets[-2].x1 - down.facets[0].x1
+    assert np.degrees(np.arctan2(150.0, run)) == pytest.approx(10.0)
+    with pytest.raises(ValueError, match="slopes"):
+        hillside_terrain(flat_width=20.0, up_slope_deg=0.0, down_slope_deg=10.0)
+
+
+def test_hillside_specular_height_grows_downhill():
+    """The hillside's defining physics: with no bottom to reference, the
+    specular height z_f still deepens continuously as elevation drops —
+    the slope itself is the reflector."""
+    t = hillside_terrain(flat_width=20.0, up_slope_deg=15.0, down_slope_deg=10.0)
+    theta = np.radians(90.0 - np.array([45.0, 30.0, 20.0, 10.0]))
+    z_f, beta, _, _ = specular_cut(t.sectors[0], theta, h_ref=6.1)
+    assert z_f[0] == 0.0 and beta[0] == 0.0  # 45 deg: still on the bench
+    ramp = slice(1, None)  # 30/20/10 deg: on the descending ramp
+    assert np.all(z_f[ramp] < 0) and np.all(np.diff(z_f[ramp]) < 0)
+    assert np.allclose(np.degrees(beta[ramp]), 10.0)
+    # Below the modeled relief the ray falls onto the flat bottom: full
+    # 150 m depth, untilted — the cap only bites at the lowest angles.
+    z_lo, b_lo, _, _ = specular_cut(t.sectors[0], np.radians([87.0]), h_ref=6.1)
+    assert z_lo[0] == pytest.approx(-150.0) and b_lo[0] == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_web_terrain.py
+++ b/tests/test_web_terrain.py
@@ -101,6 +101,40 @@ def test_garbage_terrain_params_clamp_to_defaults():
     )
 
 
+def test_hillside_params_flow_through():
+    t = _terrain_from_request(
+        _terrain_req(
+            preset="hillside",
+            flat_width_m=30.0,
+            up_slope_deg=25.0,
+            down_slope_deg=8.0,
+            downhill_azimuth_deg=180.0,
+        )
+    )
+    down, up = t.sectors
+    assert (down.az0, down.az1) == (90.0, 270.0)  # downhill_azimuth ± 90
+    assert down.facets[0].x1 == pytest.approx(15.0)
+    run = down.facets[-2].x1 - down.facets[0].x1
+    assert math.degrees(math.atan2(150.0, run)) == pytest.approx(8.0)
+    assert up.facets[-1].z1 > 0
+    assert t.crest_medium == adapter._TERRAIN_LAND
+
+
+def test_hillside_downhill_lifts_low_angles_over_flat():
+    """The hillside's payoff at the cuts layer: toward the downhill side the
+    low-angle field beats flat ground by several dB (the specular point
+    walks down the slope, growing the effective height), while well above
+    the slope band the bench governs and terrain equals flat exactly."""
+    from antennaknobs.terrain import hillside_terrain
+
+    t = hillside_terrain(flat_width=20.0, up_slope_deg=15.0, down_slope_deg=10.0)
+    el = _pattern_cuts(_hertzian_over(t), 15.0, 0.0)["elevation"]
+    el_flat = _pattern_cuts(_hertzian_over(None), 15.0, 0.0)["elevation"]
+    assert el[2] > el_flat[2] + 3.0  # 4 deg toward the downhill side
+    # 80 deg: the specular point sits on the flat bench -> identical values.
+    assert el[40] == el_flat[40]
+
+
 def test_pynec_terrain_maps_to_crest_medium_sommerfeld():
     """The PyNEC terrain hybrid (issue #553): NEC has no facet model, but
     the #534 recipe solves currents over flat Sommerfeld at the crest


### PR DESCRIPTION
## Summary
- Adds the third canned terrain, **hillside**: a flat bench with the ground rising at *uphill slope* on one side and falling at *downhill slope* on the other (facing *downhill bearing*), one earth medium. Unlike levee/cliff there is no drop-to-water to anchor — and none is needed: the slope itself is the reflector, so the specular point walks down the hill as elevation drops and the effective height grows continuously. Probe (invvee, 6.1 m, 15 m): 6+ dBi held down to 8° toward the downhill side vs −10 dBi on flat ground, converging with flat above 30° where the bench governs.
- `antennaknobs.terrain.hillside_terrain()`: slopes subdivided into 10 facets (the specular scan uses facet midpoint heights, so long slopes need subdivision), relief capped at 150 m drop / 100 m rise (only bites below ~2° at HF). Rising facets (z1 > 0) are legal and now exercised.
- Documented honest limit (docstring + UI tooltip): below the uphill slope angle the real sky is shadowed by the hill; the specular model reports grazing-cancellation, not blockage.
- Web UI: "hillside" preset radio with the four knobs; media fixed at earth 13/0.005.

## Test plan
- [x] terrain + web-terrain suites: 27 passed (constructor structure, specular band walk bench→ramp→capped floor, request mapping, low-angle lift at the cuts layer, exact bench equality at 80°)
- [x] `tsc --noEmit` + `vite build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KV3q7Q9hGKQL4xfbw5qbdt