### PR TITLE
Terrain knobs invalidate the norm check; cut angles leave the solve-cache key

### DIFF
--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -3927,6 +3927,11 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     currentValuesKey,
     designFreq, measFreq,
     groundEnabled, groundModel,
+    // The pattern integral runs over the facets, so terrain knob changes
+    // invalidate it (unlike the impedance-only sweep/converge effects,
+    // which are legitimately terrain-param-independent — every preset
+    // shares the crest medium the impedance solve uses).
+    terrainKey,
     normCheckEnabled,
     active,
     // Poor-match gate (see the sweep effect).

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -868,6 +868,12 @@ _CACHE_KEY_BLOCKLIST = frozenset(
         "_session",
         "_gen",
         "_approved",
+        # Polar-cut angles (issue #547): cuts are attached per-request AFTER
+        # the cache, so the cached entry is angle-independent by design.
+        # Leaving these in the key meant every cut-dial drag silently
+        # invalidated cache hits for all subsequent knob scrubs.
+        "az_elev_deg",
+        "elev_az_deg",
     }
 )
 

--- a/tests/test_pattern_cuts.py
+++ b/tests/test_pattern_cuts.py
@@ -204,6 +204,17 @@ def test_solve_cache_stays_angle_independent(client: TestClient):
     assert r1["cuts"]["az_elev_deg"] == 10.0
     assert r2["cuts"]["az_elev_deg"] == 35.0
     assert r1["cuts"]["azimuth"] != r2["cuts"]["azimuth"]
+    # The angles are blocklisted from the cache key, so the second request
+    # is a genuine hit — a cut-dial drag must not shred the solve cache.
+    assert r2["cache_hit"] is True
+
+
+def test_solve_cache_key_ignores_cut_angles():
+    from antennaknobs.web.server import _canonical_solve_key
+
+    a = {"geometry": "dipoles.invvee", "az_elev_deg": 10.0, "elev_az_deg": 0.0}
+    b = {"geometry": "dipoles.invvee", "az_elev_deg": 35.0, "elev_az_deg": 90.0}
+    assert _canonical_solve_key(a) == _canonical_solve_key(b)
 
 
 def test_mag2_directions_shape_generic():


### PR DESCRIPTION
## Summary
- Audit prompted by "switching terrain models should refire a solve": the live solve **does** refire correctly (verified: preset switch → cache miss → distinct cuts), and impedance/SWR/sweep legitimately don't move (all presets share the crest medium, and terrain impedance is crest-Sommerfeld by design). The genuinely broken piece was the **norm-check effect** — its deps lacked the terrain fields, so radiated % and the dotted overlay showed the previous terrain's numbers until an unrelated knob change. `terrainKey` added to its deps; sweep/converge deliberately left terrain-independent (impedance-only), with a comment explaining why.
- Second find from the same audit: `az_elev_deg`/`elev_az_deg` were part of the solve-cache key although cuts attach per-request after the cache — so any cut-dial drag silently invalidated cache hits for every subsequent knob scrub. Blocklisted, with a key-equality test and a strengthened ws test asserting the angle-differing second solve is a genuine `cache_hit`.

## Test plan
- [x] `tests/test_pattern_cuts.py` + `tests/test_web_server.py` + `tests/test_web_terrain.py`: 189 passed
- [x] `tsc --noEmit` + `vite build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KV3q7Q9hGKQL4xfbw5qbdt