### PR TITLE
Terrain bearing marker on the polar charts

### DIFF
--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -782,6 +782,38 @@ def _terrain_from_request(req: dict) -> Terrain:
     )
 
 
+def _terrain_marker(req: dict) -> dict | None:
+    """Chart-orientation hint for the response's terrain: the preset's
+    characteristic bearing plus labels for its two sides, drawn on the
+    polar charts so "which way is the water/downhill" reads off the chart
+    instead of being inferred from lobes (which can legitimately peak
+    toward the other side — e.g. a hillside's uphill mid-angle lobes).
+    None when the terrain is azimuth-symmetric (full-circle cliff)."""
+    t = req.get("terrain") or {}
+    if not isinstance(t, Mapping):
+        t = {}
+    preset = t.get("preset", "levee")
+    if preset == "cliff":
+        if _terrain_num(t, "arc_deg", 360.0, 1.0, 360.0) >= 360.0:
+            return None
+        return {
+            "bearing_deg": _terrain_num(t, "azimuth_deg", 0.0, -360.0, 360.0),
+            "label": "cliff",
+            "opposite": "flat",
+        }
+    if preset == "hillside":
+        return {
+            "bearing_deg": _terrain_num(t, "downhill_azimuth_deg", 0.0, -360.0, 360.0),
+            "label": "downhill",
+            "opposite": "uphill",
+        }
+    return {
+        "bearing_deg": _terrain_num(t, "water_azimuth_deg", 0.0, -360.0, 360.0),
+        "label": "water",
+        "opposite": "land",
+    }
+
+
 def _pack_terrain(t: Terrain) -> dict:
     """JSON-safe terrain description shipped on the solve response. The
     server's cut physics (server._mag2_at_directions) rebuilds the Terrain
@@ -944,7 +976,7 @@ _PEC_GROUND_EPS_R = 1.0e10
 _PEC_GROUND_SIGMA = 0.0
 
 
-def _momwire_ground_fields(eng) -> dict:
+def _momwire_ground_fields(eng, req: dict) -> dict:
     """Ground-describing response fields for a momwire solve.
 
     Ships the eps_r/sigma of the ground the engine actually solved over,
@@ -962,11 +994,15 @@ def _momwire_ground_fields(eng) -> dict:
     g = eng._ground
     if isinstance(g, tuple) and g[0] == "terrain":
         eps_r, sigma = g[1].crest_medium
+        gt = _pack_terrain(g[1])
+        marker = _terrain_marker(req)
+        if marker:
+            gt["marker"] = marker
         return {
             "ground_eps_r": eps_r,
             "ground_sigma": sigma,
             "ground_model_applied": "terrain",
-            "ground_terrain": _pack_terrain(g[1]),
+            "ground_terrain": gt,
         }
     if isinstance(g, tuple) and len(g) == 3:
         eps_r, sigma = g[1], g[2]
@@ -1631,7 +1667,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             "height_m": 0.0,
             # Ground constants + applied-model label (+ the packed terrain
             # when the spec is faceted) — see _momwire_ground_fields.
-            **_momwire_ground_fields(eng),
+            **_momwire_ground_fields(eng, req),
             "z0_ohms": hints()["target_z0"],
             # Geometry-derived UI hints, folded into the response so user
             # designs (which defer them) get correct values the moment they're
@@ -1820,7 +1856,11 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             # attach the facet model so the server's cut physics applies the
             # per-facet reflection — the same response contract as momwire.
             out["ground_model_applied"] = "terrain"
-            out["ground_terrain"] = _pack_terrain(_terrain_from_request(req))
+            gt = _pack_terrain(_terrain_from_request(req))
+            marker = _terrain_marker(req)
+            if marker:
+                gt["marker"] = marker
+            out["ground_terrain"] = gt
         if hints()["multi_feed"] and len(zs) > 1:
             # PyNECEngine.excitation_pairs is [(tag, sub_seg, voltage)];
             # pull the voltage off each so per-feed phase comes through.

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1363,9 +1363,15 @@ type SolveResponse = {
   ground_sigma?: number;
   ground_eps_im?: number;
   /** Packed faceted-terrain description when the solve ran over a terrain
-   *  ground (issue #534). Opaque to the frontend — it rides back to the
-   *  server inside /cuts bodies, where the per-facet physics lives. */
-  ground_terrain?: unknown;
+   *  ground (issue #534). The facet data is opaque to the frontend — it
+   *  rides back to the server inside /cuts bodies, where the per-facet
+   *  physics lives — but the optional `marker` orientation hint is drawn
+   *  on the polar charts (the preset's characteristic bearing + labels for
+   *  its two sides; absent for azimuth-symmetric terrains). */
+  ground_terrain?: {
+    sectors?: unknown;
+    marker?: { bearing_deg: number; label: string; opposite: string };
+  };
   /** What the impedance solve actually used. Momwire: "refl-coef" |
    *  "pec-image" | "free"; PyNEC adds "sommerfeld". Authoritative — the
    *  readout's ground row shows this rather than re-deriving it from
@@ -7281,6 +7287,60 @@ function FarFieldChart({
     }
 
     if (!result) return;
+
+    // Terrain orientation marker: the terrain's characteristic bearing
+    // (water / downhill / cliff side), so orientation reads off the chart
+    // instead of being inferred from lobes — which can legitimately peak
+    // toward the OTHER side (a hillside's mid-angle lobes point uphill;
+    // downhill only wins below the first-lobe band).
+    const terrainMarker = result.ground_terrain?.marker;
+    if (terrainMarker) {
+      ctx.font = "10px ui-monospace, monospace";
+      if (cut === "xy") {
+        // Inward tick + label at the bearing; dimmer label opposite.
+        const a = (terrainMarker.bearing_deg * Math.PI) / 180;
+        const ca = Math.cos(a);
+        const sa = Math.sin(a);
+        ctx.strokeStyle = PC.labelStrong;
+        ctx.lineWidth = 1.5;
+        ctx.beginPath();
+        ctx.moveTo(cx + ca * R, cy - sa * R);
+        ctx.lineTo(cx + ca * (R - 8), cy - sa * (R - 8));
+        ctx.stroke();
+        const place = (label: string, dirx: number, diry: number) => {
+          const tw = ctx.measureText(label).width;
+          // Sit the label just inside the rim along the bearing, nudged
+          // toward the centre so it doesn't collide with the axis labels.
+          ctx.fillText(
+            label,
+            cx + dirx * (R - 24) - tw / 2,
+            cy - diry * (R - 24) + 4,
+          );
+        };
+        ctx.fillStyle = PC.labelStrong;
+        place(terrainMarker.label, ca, sa);
+        ctx.fillStyle = PC.labelDim;
+        place(terrainMarker.opposite, -ca, -sa);
+      } else {
+        // Elevation cut: label which terrain side each horizon points into
+        // (the right rim is the cut bearing elevAzDeg).
+        const rel =
+          ((((elevAzDeg - terrainMarker.bearing_deg) % 360) + 540) % 360) -
+          180;
+        const rightLabel =
+          Math.abs(rel) <= 90 ? terrainMarker.label : terrainMarker.opposite;
+        const leftLabel =
+          Math.abs(rel) <= 90 ? terrainMarker.opposite : terrainMarker.label;
+        ctx.fillStyle = PC.labelStrong;
+        ctx.fillText(
+          rightLabel,
+          cx + R - ctx.measureText(rightLabel).width - 2,
+          cy - 5,
+        );
+        ctx.fillStyle = PC.labelDim;
+        ctx.fillText(leftLabel, cx - R + 2, cy - 5);
+      }
+    }
 
     // Draw one dBi trace around the polar cut (sample i at t = 2π·i/n, the
     // server cuts' parameterisation). The live lobe closes + fills; pinned

--- a/tests/test_web_terrain.py
+++ b/tests/test_web_terrain.py
@@ -135,6 +135,20 @@ def test_hillside_downhill_lifts_low_angles_over_flat():
     assert el[40] == el_flat[40]
 
 
+def test_terrain_marker_orientation_hint():
+    """The chart-orientation marker: preset bearing + side labels, absent
+    for the azimuth-symmetric full-circle cliff."""
+    from antennaknobs.web.adapter import _terrain_marker
+
+    m = _terrain_marker(_terrain_req(preset="hillside", downhill_azimuth_deg=45.0))
+    assert m == {"bearing_deg": 45.0, "label": "downhill", "opposite": "uphill"}
+    m = _terrain_marker(_terrain_req(preset="levee", water_azimuth_deg=-90.0))
+    assert m == {"bearing_deg": -90.0, "label": "water", "opposite": "land"}
+    assert _terrain_marker(_terrain_req(preset="cliff", arc_deg=360.0)) is None
+    m = _terrain_marker(_terrain_req(preset="cliff", arc_deg=120.0, azimuth_deg=10.0))
+    assert m == {"bearing_deg": 10.0, "label": "cliff", "opposite": "flat"}
+
+
 def test_pynec_terrain_maps_to_crest_medium_sommerfeld():
     """The PyNEC terrain hybrid (issue #553): NEC has no facet model, but
     the #534 recipe solves currents over flat Sommerfeld at the crest
@@ -287,6 +301,7 @@ def test_ws_solve_with_terrain(client: TestClient):
     eps_r, sigma = adapter._TERRAIN_LAND
     assert result["ground_eps_r"] == eps_r and result["ground_sigma"] == sigma
     assert len(result["ground_terrain"]["sectors"]) == 2
+    assert result["ground_terrain"]["marker"]["label"] == "water"
     assert len(result["cuts"]["elevation"]) == 180
 
     # /cuts stays stateless for terrain responses: new angles round-trip.


### PR DESCRIPTION
## Summary
- Draws the terrain's characteristic bearing on the far-field charts, prompted by a real misread: a hillside's mid-angle lobes legitimately peak *uphill* (downhill only wins below the first-lobe band), so lobe direction is not a reliable orientation cue.
- The solve response's `ground_terrain` gains a small `marker` hint (bearing + side labels per preset: water/land, downhill/uphill, cliff/flat; omitted for the azimuth-symmetric full-circle cliff), attached on both momwire and PyNEC-hybrid paths and inert through `/cuts` round-trips.
- Azimuth chart: rim tick + strong label at the bearing, dim mirrored opposite label. Elevation chart: horizon ends labeled with the terrain side each points into, tracking the cut-bearing dial.
- Placement verified with headless-browser screenshots (bearing 45°, both charts).

## Test plan
- [x] `tests/test_web_terrain.py`: 15 passed (marker hint per preset + ws attachment)
- [x] `tsc --noEmit` + `vite build` clean; screenshots inspected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KV3q7Q9hGKQL4xfbw5qbdt