### PR TITLE
web: solve_id cuts cache + ws cuts transport — cut dials without re-uploading solve bodies

### DIFF
--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1356,6 +1356,12 @@ type SolveResponse = {
    *  can't support them (no wires / no gain norm) or from geometry previews;
    *  new angles are fetched from POST /cuts (see useCutTraces). */
   cuts?: PatternCuts;
+  /** Advisory key into the server's cuts-source cache (issue #551). When
+   *  present, cut refetches send this ~100-byte id (over /ws or POST /cuts)
+   *  instead of re-uploading the full solve body; a server-side miss
+   *  (restart, eviction) falls back to the stateless full-body POST, so
+   *  pinned ghosts from dead sessions still work. */
+  solve_id?: string;
   directivity_norm?: number;
   ground?: boolean;
   height_m?: number;
@@ -4423,8 +4429,22 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     if (!active) return;
     const ws = new WebSocket(WS_URL);
     wsRef.current = ws;
+    // This socket's cuts sender (issue #551). A stable identity per socket
+    // so the close/cleanup handlers only deregister their OWN sender — a
+    // stale socket's late onclose must not tear down the transport a newer
+    // socket just registered.
+    const cutsSender = (msg: string): boolean => {
+      if (ws.readyState !== WebSocket.OPEN) return false;
+      ws.send(msg);
+      return true;
+    };
+    const dropCutsSender = () => {
+      if (cutsWsSend === cutsSender) cutsWsSend = null;
+      flushCutsWsPending();
+    };
     ws.onopen = () => {
       setStatus("open");
+      cutsWsSend = cutsSender;
       // A prior socket's in-flight responses can never arrive on this new one.
       // Treat everything sent so far as received so `solving` can't stick true,
       // drop stale RTT timers, then send fresh current state. StrictMode and HMR
@@ -4436,6 +4456,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     };
     ws.onclose = () => {
       setStatus("closed");
+      dropCutsSender();
       // No solve can progress while disconnected — collapse the outstanding
       // count so the busy bar can't spin under a "closed" status (reconnect
       // re-arms it via onopen).
@@ -4444,11 +4465,18 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     };
     ws.onerror = () => {
       setStatus("closed");
+      dropCutsSender();
       lastReceivedSeqRef.current = lastSentSeqRef.current;
       setSolving(false);
     };
     ws.onmessage = (ev) => {
-      const data: SolveResponse = JSON.parse(ev.data);
+      const data: SolveResponse & Partial<CutsWsMessage> = JSON.parse(ev.data);
+      if (data._kind === "cuts") {
+        // Cuts sidecar response (issue #551) — never a solve; route it
+        // before any _seq/solving bookkeeping.
+        resolveCutsWsMessage(data as CutsWsMessage);
+        return;
+      }
       const seq = data._seq ?? 0;
       // One socket delivers in order, and the server may skip-send superseded
       // results — so a higher `_seq` implicitly acknowledges every lower one.
@@ -4497,6 +4525,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
         cancelAnimationFrame(solveRafRef.current);
         solveRafRef.current = null;
       }
+      dropCutsSender(); // ws.close() fires onclose async; don't leave a dead sender up
       ws.close();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -7016,6 +7045,95 @@ function cachedCuts(
   return cutsCache.get(cutsKey(result, azElevDeg, elevAzDeg)) ?? null;
 }
 
+// Cuts over the live /ws socket (issue #551): when the socket is open it
+// doubles as the cuts transport — a ~100-byte {_kind:"cuts", solve_id}
+// message replaces the full-body POST (warm ws measured ~2× cheaper than
+// HTTP through a tunnel, and the server answers from its cuts-source
+// cache). The socket effect registers a sender here on open and clears it
+// on close; fetchCuts falls back to HTTP when it's absent or doesn't
+// answer.
+let cutsWsSend: ((msg: string) => boolean) | null = null;
+// Outcome of a ws cuts round trip. "miss" (server says unknown id) skips
+// the pointless HTTP id retry — the same cache would 404 — and goes
+// straight to the full-body backstop; "unavailable" (no socket, timeout,
+// socket died) still tries the tiny HTTP id request first.
+type CutsWsReply =
+  | { status: "ok"; cuts: PatternCuts }
+  | { status: "miss" }
+  | { status: "unavailable" };
+const cutsWsPending = new Map<string, (reply: CutsWsReply) => void>();
+// Generous vs the ~100 ms worst-case big-mesh cut compute: a timeout only
+// fires when the socket is wedged, and the HTTP fallback then still
+// delivers — slower, never wrong.
+const CUTS_WS_TIMEOUT_MS = 1500;
+
+function cutsWsPendingKey(solveId: string, az: number, el: number): string {
+  return `${solveId}:${az}:${el}`;
+}
+
+function requestCutsViaWs(
+  solveId: string,
+  azElevDeg: number,
+  elevAzDeg: number,
+): Promise<CutsWsReply> {
+  const send = cutsWsSend;
+  if (!send) return Promise.resolve({ status: "unavailable" });
+  const key = cutsWsPendingKey(solveId, azElevDeg, elevAzDeg);
+  return new Promise((resolve) => {
+    const timer = window.setTimeout(() => {
+      cutsWsPending.delete(key);
+      resolve({ status: "unavailable" });
+    }, CUTS_WS_TIMEOUT_MS);
+    cutsWsPending.set(key, (reply) => {
+      window.clearTimeout(timer);
+      cutsWsPending.delete(key);
+      resolve(reply);
+    });
+    if (
+      !send(
+        JSON.stringify({
+          _kind: "cuts",
+          solve_id: solveId,
+          az_elev_deg: azElevDeg,
+          elev_az_deg: elevAzDeg,
+        }),
+      )
+    ) {
+      window.clearTimeout(timer);
+      cutsWsPending.delete(key);
+      resolve({ status: "unavailable" });
+    }
+  });
+}
+
+/** Server cuts message arriving on the /ws socket — routed here by the
+ *  socket effect's onmessage before any solve handling. */
+type CutsWsMessage = {
+  _kind: "cuts";
+  solve_id: string;
+  az_elev_deg: number;
+  elev_az_deg: number;
+  ok: boolean;
+  cuts?: PatternCuts;
+};
+
+function resolveCutsWsMessage(data: CutsWsMessage): void {
+  const key = cutsWsPendingKey(data.solve_id, data.az_elev_deg, data.elev_az_deg);
+  const pending = cutsWsPending.get(key);
+  if (!pending) return; // timed out / superseded — fallback already running
+  pending(data.ok && data.cuts ? { status: "ok", cuts: data.cuts } : { status: "miss" });
+}
+
+/** Socket died: nothing pending will ever be answered on it. Resolving as
+ *  "unavailable" sends every waiter down the HTTP path immediately instead
+ *  of eating the full timeout. (A rare pending riding a *newer* socket gets
+ *  flushed too — it just falls back to HTTP: slower, never wrong.) */
+function flushCutsWsPending(): void {
+  for (const pending of Array.from(cutsWsPending.values())) {
+    pending({ status: "unavailable" });
+  }
+}
+
 function fetchCuts(
   result: SolveResponse,
   azElevDeg: number,
@@ -7024,16 +7142,36 @@ function fetchCuts(
   const key = cutsKey(result, azElevDeg, elevAzDeg);
   const inFlight = cutsInFlight.get(key);
   if (inFlight) return inFlight;
-  const p = fetch("/cuts", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      solve: result,
-      az_elev_deg: azElevDeg,
-      elev_az_deg: elevAzDeg,
-    }),
-  })
-    .then((r) => (r.ok ? (r.json() as Promise<PatternCuts>) : null))
+  const postCuts = (body: object): Promise<Response> =>
+    fetch("/cuts", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...body,
+        az_elev_deg: azElevDeg,
+        elev_az_deg: elevAzDeg,
+      }),
+    });
+  const p = (async (): Promise<PatternCuts | null> => {
+    // Transport ladder (issue #551): ws id → HTTP id → HTTP full body.
+    // Every rung is strictly a fallback of the one above; the full-body
+    // POST remains the correctness backstop (it's how pre-#551 responses
+    // and pins from dead server sessions resolve).
+    const solveId = result.solve_id;
+    if (solveId) {
+      const viaWs = await requestCutsViaWs(solveId, azElevDeg, elevAzDeg);
+      if (viaWs.status === "ok") return viaWs.cuts;
+      if (viaWs.status === "unavailable") {
+        const r = await postCuts({ solve_id: solveId });
+        if (r.ok) return (await r.json()) as PatternCuts;
+        if (r.status !== 404) return null; // 400: cuts genuinely unsupported
+      }
+      // ws said "miss" (or HTTP id 404'd): the server lost this solve —
+      // only the full body can answer now.
+    }
+    const r = await postCuts({ solve: result });
+    return r.ok ? ((await r.json()) as PatternCuts) : null;
+  })()
     .then((cuts) => {
       if (cuts) {
         if (cutsCache.size >= CUTS_CACHE_MAX) {
@@ -7074,13 +7212,19 @@ function useCutTraces(
     );
     if (missing.length === 0) return;
     let cancelled = false;
+    // When every missing trace can go over the ws id path (~100 bytes, and
+    // the server squashes per-solve latest-wins), a much tighter debounce
+    // makes cut drags feel live; the original 120 ms guard stays for the
+    // full-body HTTP fallback, whose requests are 10 KB–300 KB (issue #551).
+    const delay =
+      cutsWsSend && missing.every((r) => r.solve_id) ? 30 : 120;
     const h = window.setTimeout(() => {
       Promise.all(missing.map((r) => fetchCuts(r, azElevDeg, elevAzDeg))).then(
         () => {
           if (!cancelled) setFetchTick((t) => t + 1);
         },
       );
-    }, 120);
+    }, delay);
     return () => {
       cancelled = true;
       window.clearTimeout(h);

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -492,7 +492,15 @@ _CUT_N_DIR = 180
 _CUT_FLOOR_DBI = -999.0
 
 
-def _pattern_cuts(out: dict, az_elev_deg: float, elev_az_deg: float) -> dict | None:
+def _pattern_cuts(
+    out: dict,
+    az_elev_deg: float,
+    elev_az_deg: float,
+    *,
+    mid=None,
+    dr=None,
+    i_mid=None,
+) -> dict | None:
     """The two polar-chart traces (issue #547): the azimuth cut at elevation
     `az_elev_deg` and the great-circle elevation cut through azimuth
     `elev_az_deg`, each _CUT_N_DIR samples of absolute dBi.
@@ -503,9 +511,13 @@ def _pattern_cuts(out: dict, az_elev_deg: float, elev_az_deg: float) -> dict | N
     t ∈ (180°, 360°) half dips below the horizon. With ground on, below-
     horizon samples clamp to _CUT_FLOOR_DBI. Returns None when the response
     can't support cuts (no wires or no positive gain norm).
+
+    Callers that already hold the moment set (the solve_id cache, issue
+    #551) pass it via mid/dr/i_mid; `out` then only needs the scalar/ground
+    fields and may omit `wires`.
     """
     norm = float(out.get("directivity_norm") or 0.0)
-    if norm <= 0.0 or not out.get("wires"):
+    if norm <= 0.0 or (mid is None and not out.get("wires")):
         return None
     t = 2.0 * np.pi * np.arange(_CUT_N_DIR) / _CUT_N_DIR
     ct, st = np.cos(t), np.sin(t)
@@ -518,7 +530,7 @@ def _pattern_cuts(out: dict, az_elev_deg: float, elev_az_deg: float) -> dict | N
     el_rhat = np.stack([np.cos(el) * ct, np.sin(el) * ct, st], axis=-1)
 
     rhat = np.stack([az_rhat, el_rhat])  # (2, N_DIR, 3)
-    mag2 = _mag2_at_directions(out, rhat)
+    mag2 = _mag2_at_directions(out, rhat, mid=mid, dr=dr, i_mid=i_mid)
     if bool(out.get("ground", False)):
         mag2 = np.where(rhat[..., 2] < 0.0, 0.0, mag2)
 
@@ -533,6 +545,77 @@ def _pattern_cuts(out: dict, az_elev_deg: float, elev_az_deg: float) -> dict | N
         "azimuth": [round(float(v), 3) for v in dbi[0]],
         "elevation": [round(float(v), 3) for v in dbi[1]],
     }
+
+
+# Server-side cuts sources (issue #551): solve_id → the pre-extracted data
+# _pattern_cuts needs, so /cuts and the ws cuts channel can recompute cut
+# traces from a ~100-byte request instead of a re-uploaded solve body
+# (~92 B/segment on the wire — 60 KB+ for the dense meshes where cut-dial
+# latency is actually felt, times one request per pinned ghost).
+#
+# The id is ADVISORY, never authoritative: on a miss (server restart,
+# eviction) the server answers 404 / ok=false and the client falls back to
+# the stateless full-body request. Pins deliberately outlive sessions, so
+# ghosts must never silently die with this cache. Assumes a single server
+# process (true for uvicorn and the Docker image); a multi-worker deployment
+# would need sticky routing or a shared store.
+_CUTS_SRC_CACHE: "OrderedDict[str, dict]" = OrderedDict()
+# Entries hold the numpy moment set at ~64 B/segment, so even 64 entries of
+# a 4k-segment mesh bound the cache near ~16 MB.
+_CUTS_SRC_CACHE_MAX = 64
+
+# The scalar/ground fields _pattern_cuts reads besides the moment set.
+_CUTS_SRC_FIELDS = (
+    "k_meas_m_inv",
+    "ground",
+    "ground_eps_r",
+    "ground_eps_im",
+    "ground_terrain",
+    "measurement_freq_mhz",
+    "directivity_norm",
+)
+
+
+def _remember_cuts_source(solve_id: str, out: dict) -> None:
+    """Store (or LRU-refresh) the cuts source for a solve response. Never
+    raises — a response the cuts math can't digest simply isn't cached and
+    the client's full-body fallback still works."""
+    if solve_id in _CUTS_SRC_CACHE:
+        _CUTS_SRC_CACHE.move_to_end(solve_id)
+        return
+    if float(out.get("directivity_norm") or 0.0) <= 0.0 or not out.get("wires"):
+        return
+    try:
+        mid, dr, i_mid = _moment_segments(out)
+    except Exception:
+        _logger.exception("cuts-source extraction failed; solve_id not cached")
+        return
+    src = {k: out[k] for k in _CUTS_SRC_FIELDS if k in out}
+    src["_mid"], src["_dr"], src["_i_mid"] = mid, dr, i_mid
+    _CUTS_SRC_CACHE[solve_id] = src
+    while len(_CUTS_SRC_CACHE) > _CUTS_SRC_CACHE_MAX:
+        _CUTS_SRC_CACHE.popitem(last=False)
+
+
+def _cuts_from_source(
+    solve_id: str, az_elev_deg: float, elev_az_deg: float
+) -> dict | None:
+    """Cuts computed from the server-side source for `solve_id`, or None on
+    a cache miss (callers map that to 404 / ok=false). Only sources with a
+    positive norm are ever cached, so None never means "can't support cuts"
+    here."""
+    src = _CUTS_SRC_CACHE.get(solve_id)
+    if src is None:
+        return None
+    _CUTS_SRC_CACHE.move_to_end(solve_id)
+    return _pattern_cuts(
+        src,
+        az_elev_deg,
+        elev_az_deg,
+        mid=src["_mid"],
+        dr=src["_dr"],
+        i_mid=src["_i_mid"],
+    )
 
 
 def _pattern_integral_norm(out: dict) -> float:
@@ -1010,13 +1093,22 @@ def solve(req: dict, cancel=None) -> dict:
         # tick first populated this cache entry.
         out["solve_ms"] = (time.perf_counter() - t0) * 1e3
         out["cache_hit"] = True
+        # solve_id (issue #551): the canonical key itself — already an opaque
+        # 128-bit blake2b digest, so it doubles as the advisory cuts-cache
+        # handle the client sends back instead of the full solve body. The
+        # hit path re-remembers so an evicted cuts source repopulates from
+        # the (larger) solve cache without a re-solve.
+        out["solve_id"] = key
+        _remember_cuts_source(key, out)
         _attach_request_cuts(out, req)
         return out
     out = _solve_uncached(req, cancel=cancel)
     out["cache_hit"] = False
+    out["solve_id"] = key
     _SOLVE_CACHE[key] = deepcopy(out)
     while len(_SOLVE_CACHE) > _SOLVE_CACHE_MAX:
         _SOLVE_CACHE.popitem(last=False)
+    _remember_cuts_source(key, out)
     # After the cache store: cuts depend on the request's cut angles, so the
     # cached entry stays angle-independent and every request gets fresh cuts.
     _attach_request_cuts(out, req)
@@ -1539,16 +1631,38 @@ async def params_source_endpoint(req: dict):
 def cuts_endpoint(req: dict):
     """Recompute the two polar-chart cuts at new cut angles (issue #547).
 
-    Stateless: the body carries the fields of a previously returned solve
-    response under ``solve`` (wires + k_meas_m_inv + ground constants +
-    directivity_norm — the client already holds all of them) plus
-    ``az_elev_deg`` / ``elev_az_deg``. Returns the same ``cuts`` object the
-    live solve attaches. Sync def → FastAPI threadpool, so a big-mesh cut
-    (~100 ms at 4k segments) never blocks the event loop.
+    Two request shapes:
+
+    - ``{solve_id, az_elev_deg, elev_az_deg}`` (issue #551): ~100-byte fast
+      path against the server-side cuts-source cache. 404 on an unknown id
+      (restart, eviction) — the client then retries with the full body.
+    - ``{solve, az_elev_deg, elev_az_deg}``: stateless backstop — the body
+      carries the fields of a previously returned solve response under
+      ``solve`` (wires + k_meas_m_inv + ground constants + directivity_norm
+      — the client already holds all of them).
+
+    Returns the same ``cuts`` object the live solve attaches. Sync def →
+    FastAPI threadpool, so a big-mesh cut (~100 ms at 4k segments) never
+    blocks the event loop.
     """
     solve_out = req.get("solve")
     if not isinstance(solve_out, dict):
-        raise HTTPException(status_code=400, detail="missing solve response body")
+        solve_id = req.get("solve_id")
+        if not (isinstance(solve_id, str) and solve_id):
+            raise HTTPException(status_code=400, detail="missing solve response body")
+        try:
+            cuts = _cuts_from_source(
+                solve_id,
+                float(req.get("az_elev_deg", 15.0)),
+                float(req.get("elev_az_deg", 0.0)),
+            )
+        except (KeyError, TypeError, ValueError) as e:
+            raise HTTPException(
+                status_code=400, detail=f"bad cuts request: {e}"
+            ) from e
+        if cuts is None:
+            raise HTTPException(status_code=404, detail="unknown solve_id")
+        return cuts
     try:
         cuts = _pattern_cuts(
             solve_out,
@@ -1920,6 +2034,18 @@ async def ws_endpoint(ws: WebSocket):
     mailbox: list[dict] = []  # size-1: newest unsolved request only
     newer = asyncio.Event()  # set when the mailbox is (re)filled
     closed = asyncio.Event()  # set when the socket disconnects
+    # Cuts sidecar (issue #551): tiny `{_kind:"cuts", solve_id, angles}`
+    # messages ride this same socket (warm ws was ~2× cheaper than HTTP
+    # through the tunnel) and are answered from the server-side cuts-source
+    # cache. Latest-wins PER SOLVE — keyed by solve_id — because one cut-dial
+    # change legitimately needs cuts for the live trace AND every pinned
+    # ghost; a single-slot mailbox would let the last-sent ghost starve the
+    # others. Newer angles for the same solve overwrite the queued entry.
+    cuts_box: dict[str, dict] = {}
+    cuts_newer = asyncio.Event()
+    # Two tasks send on this socket (solver loop + cuts worker); ws.send_text
+    # isn't safe to interleave, so every send takes this lock.
+    send_lock = asyncio.Lock()
     # In-flight solve's cancel token, shared between the reader and the solver
     # loop (both coroutines on this event loop, so no lock needed — the token's
     # flag is the only thing the threadpool worker touches). The reader trips it
@@ -1932,6 +2058,16 @@ async def ws_endpoint(ws: WebSocket):
         try:
             while True:
                 req = json.loads(await ws.receive_text())
+                if req.get("_kind") == "cuts":
+                    # Cuts request: route to the sidecar. Deliberately does
+                    # NOT touch the solve mailbox, the cancel token, or the
+                    # session lane — a cut-dial drag must never preempt a
+                    # running solve.
+                    sid = req.get("solve_id")
+                    if isinstance(sid, str) and sid:
+                        cuts_box[sid] = req
+                        cuts_newer.set()
+                    continue
                 mailbox[:] = [req]  # overwrite → squash anything unsolved
                 token = current["token"]
                 if token is not None:
@@ -1951,8 +2087,58 @@ async def ws_endpoint(ws: WebSocket):
             if token is not None:
                 token.cancel()  # disconnect: free the threadpool worker promptly
             newer.set()  # wake the solver so it can observe `closed` and exit
+            cuts_newer.set()  # same for the cuts worker
+
+    async def cuts_worker() -> None:
+        # Drains the per-solve cuts box in arrival order. Each computation is
+        # small (~1 ms typical, ~100 ms at 4k segments) but still runs in the
+        # threadpool so a big-mesh cut never blocks the event loop — and by
+        # extension the reader's latest-wins squashing.
+        while True:
+            await cuts_newer.wait()
+            cuts_newer.clear()
+            while cuts_box:
+                if closed.is_set():
+                    return
+                sid = next(iter(cuts_box))
+                creq = cuts_box.pop(sid)
+                resp: dict = {
+                    "_kind": "cuts",
+                    "solve_id": sid,
+                    "az_elev_deg": creq.get("az_elev_deg"),
+                    "elev_az_deg": creq.get("elev_az_deg"),
+                }
+                try:
+                    cuts = await run_in_threadpool(
+                        _cuts_from_source,
+                        sid,
+                        float(creq.get("az_elev_deg", 15.0)),
+                        float(creq.get("elev_az_deg", 0.0)),
+                    )
+                except Exception:  # noqa: BLE001 — junk angles must not kill the socket
+                    _logger.exception("ws cuts request failed")
+                    cuts = None
+                # Unknown id (restart/eviction) or junk request → ok:false;
+                # the client falls back to the stateless POST /cuts.
+                resp["ok"] = cuts is not None
+                if cuts is not None:
+                    resp["cuts"] = cuts
+                if sid in cuts_box:
+                    # Newer angles for this solve arrived while we computed —
+                    # skip the doomed send; the fresh response supersedes it.
+                    continue
+                if closed.is_set() or ws.client_state != WebSocketState.CONNECTED:
+                    return
+                try:
+                    async with send_lock:
+                        await ws.send_text(json.dumps(resp))
+                except (WebSocketDisconnect, RuntimeError):
+                    return
+            if closed.is_set():
+                return
 
     reader_task = asyncio.create_task(reader())
+    cuts_task = asyncio.create_task(cuts_worker())
     try:
         while True:
             await newer.wait()
@@ -2025,11 +2211,13 @@ async def ws_endpoint(ws: WebSocket):
             if closed.is_set() or ws.client_state != WebSocketState.CONNECTED:
                 return
             try:
-                await ws.send_text(json.dumps(result))
+                async with send_lock:
+                    await ws.send_text(json.dumps(result))
             except (WebSocketDisconnect, RuntimeError):
                 return
     finally:
         reader_task.cancel()
+        cuts_task.cancel()
 
 
 # Serve the built React frontend (web/static, produced by `npm run build` in

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -1657,9 +1657,7 @@ def cuts_endpoint(req: dict):
                 float(req.get("elev_az_deg", 0.0)),
             )
         except (KeyError, TypeError, ValueError) as e:
-            raise HTTPException(
-                status_code=400, detail=f"bad cuts request: {e}"
-            ) from e
+            raise HTTPException(status_code=400, detail=f"bad cuts request: {e}") from e
         if cuts is None:
             raise HTTPException(status_code=404, detail="unknown solve_id")
         return cuts

--- a/tests/test_pattern_cuts.py
+++ b/tests/test_pattern_cuts.py
@@ -223,3 +223,136 @@ def test_mag2_directions_shape_generic():
     r2 = _mag2_at_directions(out, np.stack([np.eye(3), np.eye(3)[::-1]]))  # (2, 3, 3)
     assert r1.shape == (1,) and r2.shape == (2, 3)
     assert server._CUT_N_DIR == 180  # the cut-trace sample-count contract
+
+
+# ---- solve_id cuts cache + ws cuts transport (issue #551) ----
+
+_SOLVE_REQ = {
+    "geometry": "dipoles.invvee",
+    "measurement_freq_mhz": 28.47,
+    "momwire_model": "bspline",
+    "az_elev_deg": 15.0,
+    "elev_az_deg": 45.0,
+}
+
+
+def _ws_solve(client: TestClient, req=_SOLVE_REQ) -> dict:
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(json.dumps(req))
+        return json.loads(ws.receive_text())
+
+
+def test_solve_id_cuts_match_full_body(client: TestClient):
+    """A solve response carries solve_id, and the ~100-byte id-only /cuts
+    request returns byte-identical cuts to the stateless full-body path."""
+    result = _ws_solve(client)
+    solve_id = result.get("solve_id")
+    assert isinstance(solve_id, str) and solve_id
+
+    full = client.post(
+        "/cuts", json={"solve": result, "az_elev_deg": 22.0, "elev_az_deg": 5.0}
+    )
+    by_id = client.post(
+        "/cuts", json={"solve_id": solve_id, "az_elev_deg": 22.0, "elev_az_deg": 5.0}
+    )
+    assert full.status_code == 200 and by_id.status_code == 200
+    assert by_id.json() == full.json()
+
+
+def test_cuts_unknown_solve_id_is_404(client: TestClient):
+    r = client.post(
+        "/cuts",
+        json={"solve_id": "0" * 32, "az_elev_deg": 0.0, "elev_az_deg": 0.0},
+    )
+    assert r.status_code == 404
+
+
+def test_cuts_source_repopulates_from_solve_cache_hit(client: TestClient):
+    """Eviction of the cuts source must heal on the next solve of the same
+    request — the solve-cache HIT path re-remembers, no re-solve needed."""
+    result = _ws_solve(client)
+    server._CUTS_SRC_CACHE.pop(result["solve_id"], None)
+    miss = client.post(
+        "/cuts",
+        json={"solve_id": result["solve_id"], "az_elev_deg": 1.0, "elev_az_deg": 2.0},
+    )
+    assert miss.status_code == 404
+
+    again = _ws_solve(client)  # same request → cache hit → source repopulated
+    assert again["cache_hit"] is True and again["solve_id"] == result["solve_id"]
+    healed = client.post(
+        "/cuts",
+        json={"solve_id": result["solve_id"], "az_elev_deg": 1.0, "elev_az_deg": 2.0},
+    )
+    assert healed.status_code == 200
+
+
+def test_ws_cuts_channel_matches_http(client: TestClient):
+    """Cuts requested over the /ws sidecar match the HTTP endpoint, and the
+    solve mailbox is untouched (a later solve on the same socket still
+    works)."""
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(json.dumps(_SOLVE_REQ))
+        result = json.loads(ws.receive_text())
+        ws.send_text(
+            json.dumps(
+                {
+                    "_kind": "cuts",
+                    "solve_id": result["solve_id"],
+                    "az_elev_deg": 40.0,
+                    "elev_az_deg": 10.0,
+                }
+            )
+        )
+        msg = json.loads(ws.receive_text())
+        # The socket still solves after a cuts message.
+        ws.send_text(json.dumps({**_SOLVE_REQ, "az_elev_deg": 20.0}))
+        result2 = json.loads(ws.receive_text())
+
+    assert msg["_kind"] == "cuts"
+    assert msg["ok"] is True
+    assert msg["solve_id"] == result["solve_id"]
+    assert msg["az_elev_deg"] == 40.0 and msg["elev_az_deg"] == 10.0
+    http = client.post(
+        "/cuts", json={"solve": result, "az_elev_deg": 40.0, "elev_az_deg": 10.0}
+    )
+    assert msg["cuts"] == http.json()
+    assert result2["cuts"]["az_elev_deg"] == 20.0
+
+
+def test_ws_cuts_unknown_id_answers_ok_false(client: TestClient):
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(
+            json.dumps(
+                {
+                    "_kind": "cuts",
+                    "solve_id": "f" * 32,
+                    "az_elev_deg": 0.0,
+                    "elev_az_deg": 0.0,
+                }
+            )
+        )
+        msg = json.loads(ws.receive_text())
+    assert msg["_kind"] == "cuts" and msg["ok"] is False and "cuts" not in msg
+
+
+def test_ws_cuts_junk_angles_answers_ok_false(client: TestClient):
+    """Garbage angles must produce ok:false, not a torn-down socket."""
+    result = _ws_solve(client)
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(
+            json.dumps(
+                {
+                    "_kind": "cuts",
+                    "solve_id": result["solve_id"],
+                    "az_elev_deg": "garbage",
+                    "elev_az_deg": None,
+                }
+            )
+        )
+        msg = json.loads(ws.receive_text())
+        # Socket survives for real work.
+        ws.send_text(json.dumps(_SOLVE_REQ))
+        again = json.loads(ws.receive_text())
+    assert msg["ok"] is False
+    assert "wires" in again


### PR DESCRIPTION
## Summary
- Implements #551: every solve response is stamped with an advisory `solve_id` (the canonical solve key), and the server keeps a capped LRU (64 entries) of pre-extracted cuts sources — the numpy moment set (~64 B/segment) plus the scalar/ground fields `_pattern_cuts` reads — so cut-dial changes no longer re-upload the full solve body (~92 B/segment on the wire; 11.6 KB for a moxon, 60 KB+ for dense meshes, times one request per pinned ghost).
- `/cuts` accepts `{solve_id, az_elev_deg, elev_az_deg}` (~100 bytes) and answers 404 on a miss; the stateless full-body request stays as the correctness backstop, so pinned ghosts survive server restarts and eviction. The solve-cache HIT path re-remembers evicted sources without a re-solve.
- Cut requests also ride the existing `/ws` socket (measured ~2× cheaper than HTTP through a tunnel): a cuts sidecar worker answers `{_kind:"cuts", solve_id, angles}` messages with latest-wins queuing **per solve_id** — so the live trace and every pinned ghost get cuts at the new angles without starving each other — and never touches the solve mailbox, cancel token, or session lane. Solver-loop and sidecar sends are serialized by a lock.
- Frontend `fetchCuts` climbs a transport ladder: ws id → HTTP id → HTTP full body. A ws "miss" verdict skips the pointless HTTP-id retry; timeouts and socket teardown resolve pending waiters immediately. When every missing trace has the id path available, the cut-drag debounce tightens 120 ms → 30 ms.

Real-server smoke (uvicorn + real websocket client): ws cuts request is 106 bytes vs the moxon's 11.6 KB body; all three transports return byte-identical cuts; unknown id → 404; the socket still solves after cuts messages interleave.

Closes #551.

## Test plan
- [x] `tests/test_pattern_cuts.py` — 6 new tests: id-only `/cuts` matches full-body byte-for-byte; unknown id → 404; evicted source heals from a solve-cache hit; ws sidecar matches HTTP and leaves the solve path working; unknown id / junk angles over ws answer `ok:false` without tearing down the socket
- [x] Full suite: 2730 passed, 2 skipped
- [x] Frontend `tsc --noEmit` + vite build clean; ruff check/format clean
- [ ] After deploy: verify cut drags through the tunnel use the ws path (server log quiet on POST /cuts) and pinned ghosts from a pre-deploy session still resolve via the full-body fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)