### PR TITLE
Schema-driven terrain presets: add a preset in Python without touching the frontend (#560)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ src/antennaknobs/web/static/
 !.claude/skills/
 scripts/sterba_center_driven_pattern.png
 bench_out/
+# Claude Code scratchpad — session-local working files, never shipped
+scratchpad/

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -54,7 +54,8 @@ import math
 import os
 import pathlib
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any
 
@@ -734,52 +735,185 @@ def _terrain_num(t: Mapping, key: str, default: float, lo: float, hi: float) -> 
     return min(max(v, lo), hi)
 
 
-def _terrain_from_request(req: dict) -> Terrain:
-    """Build the faceted-terrain ground from the request's `terrain` preset
-    params (ground_model="terrain"). Three presets, mapping straight onto
-    the antennaknobs.terrain constructors:
+# --- Terrain preset registry (issue #560) --------------------------------
+#
+# One descriptor per preset is the single source of truth for three things
+# that used to be spelled out three times (once per preset, in Python AND in
+# App.tsx): the server-side clamp + constructor mapping, the response
+# chart-orientation marker, and the self-describing field schema the frontend
+# renders its knob panel from (served on GET /capabilities). Adding a preset
+# is now one entry here — no TypeScript, no rebuild beyond the asset build.
 
-      {"preset": "levee", "crest_width_m", "slope_deg", "drop_water_m",
-       "drop_land_m", "water_azimuth_deg"}
-      {"preset": "cliff", "edge_m", "drop_m", "azimuth_deg", "arc_deg"}
-      {"preset": "hillside", "flat_width_m", "up_slope_deg",
-       "down_slope_deg", "downhill_azimuth_deg"}
 
-    Media are fixed at the QTH constants (water 80/0.005 outward of the
-    cliff/water-side toe; land 13/0.005 for crest, slopes and the land
-    plain). Every number is clamped to a sane range so a hand-crafted
-    request can't build a degenerate Terrain."""
+@dataclass(frozen=True)
+class _TerrainField:
+    """One clamped numeric knob of a preset. `min`/`max`/`default` are
+    authoritative server-side (the clamp) AND drive the frontend slider;
+    `label`/`unit`/`step` are presentation the UI reads verbatim. `label`
+    omits the unit — the panel renders it as ``"{label} ({unit})"``."""
+
+    key: str
+    label: str
+    default: float
+    min: float
+    max: float
+    step: float
+    unit: str | None = None
+
+
+@dataclass(frozen=True)
+class _TerrainMarker:
+    """Chart-orientation hint: which field carries the preset's characteristic
+    bearing, and the two side labels drawn on the polar charts. `hide_when_ge`
+    drops the marker for an azimuth-symmetric configuration (a full-circle
+    cliff, arc_deg >= 360)."""
+
+    bearing_key: str
+    label: str
+    opposite: str
+    hide_when_ge: tuple[str, float] | None = None
+
+
+@dataclass(frozen=True)
+class _TerrainPreset:
+    name: str
+    label: str  # radio label shown in the panel
+    tooltip: str  # radio hover text
+    media_note: str  # read-only media line under the knobs
+    fields: tuple[_TerrainField, ...]
+    build: Callable[[Mapping[str, float]], Terrain]
+    marker: _TerrainMarker | None = None
+
+
+_TERRAIN_MEDIA_NOTE = "media: water εr=80 σ=0.005 · land/crest εr=13 σ=0.005"
+
+
+def _build_levee(v: Mapping[str, float]) -> Terrain:
+    return levee_terrain(
+        crest_width=v["crest_width_m"],
+        slope_deg=v["slope_deg"],
+        drop_water=v["drop_water_m"],
+        drop_land=v["drop_land_m"],
+        water=_TERRAIN_WATER,
+        land=_TERRAIN_LAND,
+        water_azimuth=v["water_azimuth_deg"],
+    )
+
+
+def _build_cliff(v: Mapping[str, float]) -> Terrain:
+    return cliff_terrain(
+        edge=v["edge_m"],
+        drop=v["drop_m"],
+        inner=_TERRAIN_LAND,
+        outer=_TERRAIN_WATER,
+        azimuth=v["azimuth_deg"],
+        arc=v["arc_deg"],
+    )
+
+
+def _build_hillside(v: Mapping[str, float]) -> Terrain:
+    return hillside_terrain(
+        flat_width=v["flat_width_m"],
+        up_slope_deg=v["up_slope_deg"],
+        down_slope_deg=v["down_slope_deg"],
+        medium=_TERRAIN_LAND,
+        downhill_azimuth=v["downhill_azimuth_deg"],
+    )
+
+
+_TERRAIN_PRESETS: tuple[_TerrainPreset, ...] = (
+    _TerrainPreset(
+        name="levee",
+        label="levee",
+        tooltip=(
+            "A raised crest with two sloped sides: water drop_water below on "
+            "the water bearing, land drop_land below opposite. Crest and slopes "
+            "are earth; water starts at the toe."
+        ),
+        media_note=_TERRAIN_MEDIA_NOTE,
+        fields=(
+            _TerrainField("crest_width_m", "crest width", 3.0, 0.1, 1e3, 0.5, "m"),
+            _TerrainField("slope_deg", "slope", 20.0, 1.0, 89.0, 1.0, "°"),
+            _TerrainField("drop_water_m", "drop to water", 10.7, 0.01, 1e3, 0.5, "m"),
+            _TerrainField("drop_land_m", "drop to land", 7.6, 0.01, 1e3, 0.5, "m"),
+            _TerrainField(
+                "water_azimuth_deg", "water bearing", 0.0, -360.0, 360.0, 5.0, "°"
+            ),
+        ),
+        build=_build_levee,
+        marker=_TerrainMarker("water_azimuth_deg", "water", "land"),
+    ),
+    _TerrainPreset(
+        name="cliff",
+        label="cliff",
+        tooltip=(
+            "Flat earth out to the cliff edge, then a sheer drop to water. "
+            "arc < 360° restricts the cliff to a sector facing the bearing."
+        ),
+        media_note=_TERRAIN_MEDIA_NOTE,
+        fields=(
+            _TerrainField("edge_m", "cliff edge", 10.0, 0.1, 1e4, 1.0, "m"),
+            _TerrainField("drop_m", "drop", 10.0, 0.01, 1e3, 0.5, "m"),
+            _TerrainField("azimuth_deg", "bearing", 0.0, -360.0, 360.0, 5.0, "°"),
+            _TerrainField("arc_deg", "arc", 360.0, 1.0, 360.0, 15.0, "°"),
+        ),
+        build=_build_cliff,
+        marker=_TerrainMarker(
+            "azimuth_deg", "cliff", "flat", hide_when_ge=("arc_deg", 360.0)
+        ),
+    ),
+    _TerrainPreset(
+        name="hillside",
+        label="hillside",
+        tooltip=(
+            "A flat bench on a hillside: ground rises at the uphill slope on "
+            "one side, falls at the downhill slope on the other (facing the "
+            "downhill bearing). No bottom needed — the slope itself is the "
+            "reflector, so effective height grows as the elevation drops. Below "
+            "the uphill slope angle the model can't see the hill's shadowing."
+        ),
+        media_note="media: earth εr=13 σ=0.005",
+        fields=(
+            _TerrainField("flat_width_m", "flat width", 20.0, 0.1, 1e3, 1.0, "m"),
+            _TerrainField("up_slope_deg", "uphill slope", 15.0, 1.0, 89.0, 1.0, "°"),
+            _TerrainField(
+                "down_slope_deg", "downhill slope", 10.0, 1.0, 89.0, 1.0, "°"
+            ),
+            _TerrainField(
+                "downhill_azimuth_deg", "downhill bearing", 0.0, -360.0, 360.0, 5.0, "°"
+            ),
+        ),
+        build=_build_hillside,
+        marker=_TerrainMarker("downhill_azimuth_deg", "downhill", "uphill"),
+    ),
+)
+_TERRAIN_PRESET_BY_NAME = {p.name: p for p in _TERRAIN_PRESETS}
+_DEFAULT_TERRAIN_PRESET = _TERRAIN_PRESETS[0]  # levee
+
+
+def _clamped_terrain(req: dict) -> tuple[_TerrainPreset, dict[str, float]]:
+    """Resolve the request's `terrain` block to (preset, clamped values).
+    Unknown or missing preset falls back to levee; every field is clamped to
+    the descriptor's range so a hand-crafted request can't build a degenerate
+    Terrain."""
     t = req.get("terrain") or {}
     if not isinstance(t, Mapping):
         t = {}
-    if t.get("preset") == "cliff":
-        return cliff_terrain(
-            edge=_terrain_num(t, "edge_m", 10.0, 0.1, 1e4),
-            drop=_terrain_num(t, "drop_m", 10.0, 0.01, 1e3),
-            inner=_TERRAIN_LAND,
-            outer=_TERRAIN_WATER,
-            azimuth=_terrain_num(t, "azimuth_deg", 0.0, -360.0, 360.0),
-            arc=_terrain_num(t, "arc_deg", 360.0, 1.0, 360.0),
-        )
-    if t.get("preset") == "hillside":
-        return hillside_terrain(
-            flat_width=_terrain_num(t, "flat_width_m", 20.0, 0.1, 1e3),
-            up_slope_deg=_terrain_num(t, "up_slope_deg", 15.0, 1.0, 89.0),
-            down_slope_deg=_terrain_num(t, "down_slope_deg", 10.0, 1.0, 89.0),
-            medium=_TERRAIN_LAND,
-            downhill_azimuth=_terrain_num(
-                t, "downhill_azimuth_deg", 0.0, -360.0, 360.0
-            ),
-        )
-    return levee_terrain(
-        crest_width=_terrain_num(t, "crest_width_m", 3.0, 0.1, 1e3),
-        slope_deg=_terrain_num(t, "slope_deg", 20.0, 1.0, 89.0),
-        drop_water=_terrain_num(t, "drop_water_m", 10.7, 0.01, 1e3),
-        drop_land=_terrain_num(t, "drop_land_m", 7.6, 0.01, 1e3),
-        water=_TERRAIN_WATER,
-        land=_TERRAIN_LAND,
-        water_azimuth=_terrain_num(t, "water_azimuth_deg", 0.0, -360.0, 360.0),
-    )
+    preset = _TERRAIN_PRESET_BY_NAME.get(t.get("preset"), _DEFAULT_TERRAIN_PRESET)
+    values = {
+        f.key: _terrain_num(t, f.key, f.default, f.min, f.max) for f in preset.fields
+    }
+    return preset, values
+
+
+def _terrain_from_request(req: dict) -> Terrain:
+    """Build the faceted-terrain ground from the request's `terrain` preset
+    params (ground_model="terrain"). The preset registry maps the clamped
+    field values straight onto the antennaknobs.terrain constructors; media
+    are fixed at the QTH constants (water 80/0.005 outward of the cliff/water-
+    side toe; land 13/0.005 for crest, slopes and the land plain)."""
+    preset, values = _clamped_terrain(req)
+    return preset.build(values)
 
 
 def _terrain_marker(req: dict) -> dict | None:
@@ -789,29 +923,48 @@ def _terrain_marker(req: dict) -> dict | None:
     instead of being inferred from lobes (which can legitimately peak
     toward the other side — e.g. a hillside's uphill mid-angle lobes).
     None when the terrain is azimuth-symmetric (full-circle cliff)."""
-    t = req.get("terrain") or {}
-    if not isinstance(t, Mapping):
-        t = {}
-    preset = t.get("preset", "levee")
-    if preset == "cliff":
-        if _terrain_num(t, "arc_deg", 360.0, 1.0, 360.0) >= 360.0:
+    preset, values = _clamped_terrain(req)
+    m = preset.marker
+    if m is None:
+        return None
+    if m.hide_when_ge is not None:
+        key, threshold = m.hide_when_ge
+        if values[key] >= threshold:
             return None
-        return {
-            "bearing_deg": _terrain_num(t, "azimuth_deg", 0.0, -360.0, 360.0),
-            "label": "cliff",
-            "opposite": "flat",
-        }
-    if preset == "hillside":
-        return {
-            "bearing_deg": _terrain_num(t, "downhill_azimuth_deg", 0.0, -360.0, 360.0),
-            "label": "downhill",
-            "opposite": "uphill",
-        }
     return {
-        "bearing_deg": _terrain_num(t, "water_azimuth_deg", 0.0, -360.0, 360.0),
-        "label": "water",
-        "opposite": "land",
+        "bearing_deg": values[m.bearing_key],
+        "label": m.label,
+        "opposite": m.opposite,
     }
+
+
+def terrain_presets_schema() -> list[dict]:
+    """The self-describing preset catalog served on GET /capabilities: each
+    preset's radio label + tooltip, its ordered field schema (key, label,
+    unit, default, min/max/step), and the read-only media note. The frontend
+    renders its whole terrain knob panel from this — a Python-only preset
+    needs no TypeScript."""
+    return [
+        {
+            "name": p.name,
+            "label": p.label,
+            "tooltip": p.tooltip,
+            "media_note": p.media_note,
+            "fields": [
+                {
+                    "key": f.key,
+                    "label": f.label,
+                    "unit": f.unit,
+                    "default": f.default,
+                    "min": f.min,
+                    "max": f.max,
+                    "step": f.step,
+                }
+                for f in p.fields
+            ],
+        }
+        for p in _TERRAIN_PRESETS
+    ]
 
 
 def _pack_terrain(t: Terrain) -> dict:

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1539,45 +1539,33 @@ type FiniteGroundMethod = "sommerfeld" | "fast";
 // (+ the method wherever finite ground is supported).
 type GroundModel = "sommerfeld" | "fast" | "pec" | "terrain";
 
-// Terrain preset parameters, sent as the request's `terrain` object when
-// ground_model === "terrain". Media are fixed server-side (water 80/0.005,
-// land + crest 13/0.005) — the panel shows them read-only.
-type TerrainPreset = "levee" | "cliff" | "hillside";
-type TerrainParams = {
-  // levee
-  crest_width_m: number;
-  slope_deg: number;
-  drop_water_m: number;
-  drop_land_m: number;
-  water_azimuth_deg: number;
-  // cliff
-  edge_m: number;
-  drop_m: number;
-  azimuth_deg: number;
-  arc_deg: number;
-  // hillside
-  flat_width_m: number;
-  up_slope_deg: number;
-  down_slope_deg: number;
-  downhill_azimuth_deg: number;
+// Terrain preset schema, served by GET /capabilities (issue #560). The
+// frontend renders the whole terrain knob panel from this — the presets,
+// their field ranges/labels/units, and the read-only media note all live
+// server-side (adapter.terrain_presets_schema), so a Python-only preset needs
+// no TypeScript. Media are fixed server-side (water 80/0.005, land + crest
+// 13/0.005); each preset's media_note describes its own.
+type TerrainFieldSchema = {
+  key: string;
+  label: string; // omits the unit; the panel renders "{label} ({unit})"
+  unit: string | null;
+  default: number;
+  min: number;
+  max: number;
+  step: number;
 };
-// Levee defaults are the motivating QTH (issues #534/#535): a 3 m crest
-// with 20° slopes, water 10.7 m below one side, land 7.6 m below the other.
-const TERRAIN_DEFAULTS: TerrainParams = {
-  crest_width_m: 3.0,
-  slope_deg: 20,
-  drop_water_m: 10.7,
-  drop_land_m: 7.6,
-  water_azimuth_deg: 0,
-  edge_m: 10,
-  drop_m: 10,
-  azimuth_deg: 0,
-  arc_deg: 360,
-  flat_width_m: 20,
-  up_slope_deg: 15,
-  down_slope_deg: 10,
-  downhill_azimuth_deg: 0,
+type TerrainPresetSchema = {
+  name: string;
+  label: string; // radio label
+  tooltip: string; // radio hover text
+  media_note: string;
+  fields: TerrainFieldSchema[];
 };
+// Terrain knob values keyed by field key, sent (spread) as the request's
+// `terrain` object when ground_model === "terrain". One flat bag across all
+// presets so edits survive preset flips; an unset key falls back to the
+// schema default and the server clamps every number.
+type TerrainParams = Record<string, number>;
 
 function backendSupportsGround(b: Backend): boolean {
   return b === "sinusoidal" || isBSplineFamily(b) || b === "pynec";
@@ -1792,7 +1780,7 @@ type SolveRequest = {
   ground_model?: GroundModel;
   /** Terrain preset params when ground_model === "terrain" (issue #534);
    *  the server clamps every number, so raw knob state is fine to send. */
-  terrain?: { preset: TerrainPreset } & Partial<TerrainParams>;
+  terrain?: { preset: string; [key: string]: number | string };
   /** Cut angles for the server-attached polar traces (issue #547). */
   az_elev_deg?: number;
   elev_az_deg?: number;
@@ -2375,6 +2363,13 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   // the common (installed) case never flashes the option off before the fetch
   // resolves; a false reply then hides it and remaps any PyNEC slot.
   const [havePynec, setHavePynec] = useState<boolean>(true);
+  // Terrain preset catalog (issue #560), reported by /capabilities on mount.
+  // Empty until it resolves (and on any older server without the field), which
+  // gates the terrain ground option off — the panel is rendered entirely from
+  // this schema, so there is nothing to show without it.
+  const [terrainPresets, setTerrainPresets] = useState<TerrainPresetSchema[]>(
+    [],
+  );
   // User designs that failed to load (bad Python, no Builder, geometry error).
   // Surfaced from /examples so the author / Claude can see and fix them.
   const [loadErrors, setLoadErrors] = useState<DesignLoadError[]>([]);
@@ -2481,7 +2476,12 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     (async () => {
       try {
         const c = await (await fetch("/capabilities")).json();
-        if (!cancelled) setHavePynec(c.have_pynec !== false);
+        if (!cancelled) {
+          setHavePynec(c.have_pynec !== false);
+          setTerrainPresets(
+            Array.isArray(c.terrain_presets) ? c.terrain_presets : [],
+          );
+        }
       } catch {
         /* keep the default; PyNEC stays offered */
       }
@@ -2864,9 +2864,8 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     useState<FiniteGroundMethod>("fast");
   // Terrain preset + knobs (groundType === "terrain"; momwire only). One
   // flat params object for both presets so values survive preset flips.
-  const [terrainPreset, setTerrainPreset] = useState<TerrainPreset>("levee");
-  const [terrainParams, setTerrainParams] =
-    useState<TerrainParams>(TERRAIN_DEFAULTS);
+  const [terrainPreset, setTerrainPreset] = useState<string>("levee");
+  const [terrainParams, setTerrainParams] = useState<TerrainParams>({});
   // Wire value derived for the server protocol (see GroundModel). A
   // terrain selection quietly degrades to the finite method on any future
   // backend without terrain support (all current ground-capable backends
@@ -5198,7 +5197,8 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                         ? "Perfectly conducting ground (image method, NEC ITYPE=1) — matches every backend's model='PEC' for apples-to-apples engine comparison."
                         : "Perfectly conducting ground (image method) — matches PyNEC's PEC model for apples-to-apples engine comparison.",
                     ],
-                    ...(backendSupportsTerrain(backend)
+                    ...(backendSupportsTerrain(backend) &&
+                    terrainPresets.length > 0
                       ? [
                           [
                             "terrain",
@@ -5256,198 +5256,58 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                     ))}
                   </div>
                 )}
-              {groundType === "terrain" && backendSupportsTerrain(backend) && (
-                <div style={{ marginLeft: "1.2em" }}>
-                  <div role="radiogroup" aria-label="Terrain preset">
-                    {(
-                      [
-                        [
-                          "levee",
-                          "levee",
-                          "A raised crest with two sloped sides: water drop_water below on the water bearing, land drop_land below opposite. Crest and slopes are earth; water starts at the toe.",
-                        ],
-                        [
-                          "cliff",
-                          "cliff",
-                          "Flat earth out to the cliff edge, then a sheer drop to water. arc < 360° restricts the cliff to a sector facing the bearing.",
-                        ],
-                        [
-                          "hillside",
-                          "hillside",
-                          "A flat bench on a hillside: ground rises at the uphill slope on one side, falls at the downhill slope on the other (facing the downhill bearing). No bottom needed — the slope itself is the reflector, so effective height grows as the elevation drops. Below the uphill slope angle the model can't see the hill's shadowing.",
-                        ],
-                      ] as [TerrainPreset, string, string][]
-                    ).map(([value, label, title]) => (
-                      <label key={value} className="link-toggle" title={title}>
-                        <input
-                          type="radio"
-                          name="terrain-preset"
-                          checked={terrainPreset === value}
-                          onChange={() => setTerrainPreset(value)}
+              {groundType === "terrain" &&
+                backendSupportsTerrain(backend) &&
+                terrainPresets.length > 0 &&
+                (() => {
+                  // Whole panel driven by the /capabilities schema (issue
+                  // #560): radio list, per-preset knobs and media note all
+                  // come from terrainPresets. Fall back to the first preset if
+                  // the parked name is absent (a server-side rename).
+                  const activePreset =
+                    terrainPresets.find((p) => p.name === terrainPreset) ??
+                    terrainPresets[0];
+                  return (
+                    <div style={{ marginLeft: "1.2em" }}>
+                      <div role="radiogroup" aria-label="Terrain preset">
+                        {terrainPresets.map((p) => (
+                          <label
+                            key={p.name}
+                            className="link-toggle"
+                            title={p.tooltip}
+                          >
+                            <input
+                              type="radio"
+                              name="terrain-preset"
+                              checked={activePreset.name === p.name}
+                              onChange={() => setTerrainPreset(p.name)}
+                            />
+                            {p.label}
+                          </label>
+                        ))}
+                      </div>
+                      {activePreset.fields.map((f) => (
+                        <NumberField
+                          key={f.key}
+                          label={f.unit ? `${f.label} (${f.unit})` : f.label}
+                          value={terrainParams[f.key] ?? f.default}
+                          min={f.min}
+                          max={f.max}
+                          step={f.step}
+                          onChange={(v) =>
+                            setTerrainParams((p) => ({ ...p, [f.key]: v }))
+                          }
                         />
-                        {label}
-                      </label>
-                    ))}
-                  </div>
-                  {terrainPreset === "levee" ? (
-                    <>
-                      <NumberField
-                        label="crest width (m)"
-                        value={terrainParams.crest_width_m}
-                        min={0.1}
-                        max={1000}
-                        step={0.5}
-                        onChange={(v) =>
-                          setTerrainParams((p) => ({ ...p, crest_width_m: v }))
-                        }
-                      />
-                      <NumberField
-                        label="slope (°)"
-                        value={terrainParams.slope_deg}
-                        min={1}
-                        max={89}
-                        step={1}
-                        onChange={(v) =>
-                          setTerrainParams((p) => ({ ...p, slope_deg: v }))
-                        }
-                      />
-                      <NumberField
-                        label="drop to water (m)"
-                        value={terrainParams.drop_water_m}
-                        min={0.01}
-                        max={1000}
-                        step={0.5}
-                        onChange={(v) =>
-                          setTerrainParams((p) => ({ ...p, drop_water_m: v }))
-                        }
-                      />
-                      <NumberField
-                        label="drop to land (m)"
-                        value={terrainParams.drop_land_m}
-                        min={0.01}
-                        max={1000}
-                        step={0.5}
-                        onChange={(v) =>
-                          setTerrainParams((p) => ({ ...p, drop_land_m: v }))
-                        }
-                      />
-                      <NumberField
-                        label="water bearing (°)"
-                        value={terrainParams.water_azimuth_deg}
-                        min={-360}
-                        max={360}
-                        step={5}
-                        onChange={(v) =>
-                          setTerrainParams((p) => ({
-                            ...p,
-                            water_azimuth_deg: v,
-                          }))
-                        }
-                      />
-                    </>
-                  ) : terrainPreset === "cliff" ? (
-                    <>
-                      <NumberField
-                        label="cliff edge (m)"
-                        value={terrainParams.edge_m}
-                        min={0.1}
-                        max={10000}
-                        step={1}
-                        onChange={(v) =>
-                          setTerrainParams((p) => ({ ...p, edge_m: v }))
-                        }
-                      />
-                      <NumberField
-                        label="drop (m)"
-                        value={terrainParams.drop_m}
-                        min={0.01}
-                        max={1000}
-                        step={0.5}
-                        onChange={(v) =>
-                          setTerrainParams((p) => ({ ...p, drop_m: v }))
-                        }
-                      />
-                      <NumberField
-                        label="bearing (°)"
-                        value={terrainParams.azimuth_deg}
-                        min={-360}
-                        max={360}
-                        step={5}
-                        onChange={(v) =>
-                          setTerrainParams((p) => ({ ...p, azimuth_deg: v }))
-                        }
-                      />
-                      <NumberField
-                        label="arc (°)"
-                        value={terrainParams.arc_deg}
-                        min={1}
-                        max={360}
-                        step={15}
-                        onChange={(v) =>
-                          setTerrainParams((p) => ({ ...p, arc_deg: v }))
-                        }
-                      />
-                    </>
-                  ) : (
-                    <>
-                      <NumberField
-                        label="flat width (m)"
-                        value={terrainParams.flat_width_m}
-                        min={0.1}
-                        max={1000}
-                        step={1}
-                        onChange={(v) =>
-                          setTerrainParams((p) => ({ ...p, flat_width_m: v }))
-                        }
-                      />
-                      <NumberField
-                        label="uphill slope (°)"
-                        value={terrainParams.up_slope_deg}
-                        min={1}
-                        max={89}
-                        step={1}
-                        onChange={(v) =>
-                          setTerrainParams((p) => ({ ...p, up_slope_deg: v }))
-                        }
-                      />
-                      <NumberField
-                        label="downhill slope (°)"
-                        value={terrainParams.down_slope_deg}
-                        min={1}
-                        max={89}
-                        step={1}
-                        onChange={(v) =>
-                          setTerrainParams((p) => ({
-                            ...p,
-                            down_slope_deg: v,
-                          }))
-                        }
-                      />
-                      <NumberField
-                        label="downhill bearing (°)"
-                        value={terrainParams.downhill_azimuth_deg}
-                        min={-360}
-                        max={360}
-                        step={5}
-                        onChange={(v) =>
-                          setTerrainParams((p) => ({
-                            ...p,
-                            downhill_azimuth_deg: v,
-                          }))
-                        }
-                      />
-                    </>
-                  )}
-                  <div
-                    style={{ fontSize: "0.85em", opacity: 0.65 }}
-                    title="Media are fixed in this version; the geometry knobs above are the live parameters."
-                  >
-                    {terrainPreset === "hillside"
-                      ? "media: earth εr=13 σ=0.005"
-                      : "media: water εr=80 σ=0.005 · land/crest εr=13 σ=0.005"}
-                  </div>
-                </div>
-              )}
+                      ))}
+                      <div
+                        style={{ fontSize: "0.85em", opacity: 0.65 }}
+                        title="Media are fixed in this version; the geometry knobs above are the live parameters."
+                      >
+                        {activePreset.media_note}
+                      </div>
+                    </div>
+                  );
+                })()}
             </>
           )}
         </div>

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -1954,13 +1954,20 @@ def capabilities_endpoint():
     """Backend feature availability the frontend reads once on mount.
 
     Kept separate from /examples (the design catalog, re-fetched on every
-    trust action) since capabilities are server-static. Currently just
-    `have_pynec`: PyNEC is an optional backend (needs the pynec-accel
-    package), and when it's absent the UI must not offer it — otherwise the
-    /ws solve silently falls back to momwire (#429). New capability flags
-    (mesh-size caps, engine list, version) belong here too.
+    trust action) since capabilities are server-static. `have_pynec`: PyNEC
+    is an optional backend (needs the pynec-accel package), and when it's
+    absent the UI must not offer it — otherwise the /ws solve silently falls
+    back to momwire (#429). `terrain_presets`: the self-describing terrain
+    preset catalog (issue #560) the frontend renders its knob panel from, so
+    a Python-only preset needs no TypeScript. New capability flags (mesh-size
+    caps, engine list, version) belong here too.
     """
-    return {"have_pynec": pynec_backend.HAVE_PYNEC}
+    from .adapter import terrain_presets_schema
+
+    return {
+        "have_pynec": pynec_backend.HAVE_PYNEC,
+        "terrain_presets": terrain_presets_schema(),
+    }
 
 
 def _resolve_user_design_path(stem: str):

--- a/tests/test_web_terrain.py
+++ b/tests/test_web_terrain.py
@@ -149,6 +149,50 @@ def test_terrain_marker_orientation_hint():
     assert m == {"bearing_deg": 10.0, "label": "cliff", "opposite": "flat"}
 
 
+def test_terrain_presets_schema_catalog(client):
+    """The self-describing preset catalog (issue #560): served on
+    /capabilities, one entry per preset with its ordered field schema. The
+    frontend renders its whole knob panel from this — a Python-only preset
+    needs no TypeScript."""
+    schema = adapter.terrain_presets_schema()
+    assert [p["name"] for p in schema] == ["levee", "cliff", "hillside"]
+    levee = schema[0]
+    assert [f["key"] for f in levee["fields"]] == [
+        "crest_width_m",
+        "slope_deg",
+        "drop_water_m",
+        "drop_land_m",
+        "water_azimuth_deg",
+    ]
+    crest = levee["fields"][0]
+    assert (crest["label"], crest["unit"]) == ("crest width", "m")
+    assert (crest["default"], crest["min"], crest["max"], crest["step"]) == (
+        3.0,
+        0.1,
+        1e3,
+        0.5,
+    )
+    # The catalog rides /capabilities so the frontend learns presets on mount.
+    served = client.get("/capabilities").json()["terrain_presets"]
+    assert served == schema
+
+
+def test_schema_bounds_are_the_authoritative_clamp():
+    """The descriptor's min/max are the same numbers _terrain_from_request
+    clamps to — one source of truth, so a UI slider and the server agree. An
+    out-of-range knob lands on the schema bound, not a degenerate Terrain."""
+    for preset in adapter.terrain_presets_schema():
+        for f in preset["fields"]:
+            _, values = adapter._clamped_terrain(
+                _terrain_req(preset=preset["name"], **{f["key"]: 1e12})
+            )
+            assert values[f["key"]] == f["max"]
+            _, values = adapter._clamped_terrain(
+                _terrain_req(preset=preset["name"], **{f["key"]: -1e12})
+            )
+            assert values[f["key"]] == f["min"]
+
+
 def test_pynec_terrain_maps_to_crest_medium_sommerfeld():
     """The PyNEC terrain hybrid (issue #553): NEC has no facet model, but
     the #534 recipe solves currents over flat Sommerfeld at the crest


### PR DESCRIPTION
## Summary
Closes #560. Terrain ground presets (levee/cliff/hillside) were defined three times — the clamp + constructor mapping in `adapter.py`, the chart marker, and the entire knob panel (radio list, per-preset `NumberField`s, tooltips, media note) hardcoded again in `App.tsx`. Adding a preset meant a Python constructor + adapter mapping + a TypeScript patch + rebuild.

- **Server-side registry** (`adapter.py`): one `_TerrainPreset` descriptor per preset is now the single source of truth — field schema (key/label/unit/min/max/step/default), constructor binding, and marker metadata. `_terrain_from_request` and `_terrain_marker` read the registry; behavior is unchanged (all existing terrain tests pass untouched).
- **Bootstrap exposure**: `terrain_presets_schema()` folds the catalog into `GET /capabilities` so the frontend learns the presets at load time.
- **Generic panel** (`App.tsx`): the terrain panel renders the radio list, knobs, and media note entirely from the schema. Terrain state is now a flat `{preset, values}` bag; unset knobs fall back to the schema default and the server clamps every number (server-side validation stays authoritative). The terrain ground option is gated on the schema loading, so an older server without the field simply doesn't offer terrain.
- The request wire format (`terrain: {preset, ...params}`) is unchanged, so there is no protocol change. The bearing marker (#559) already shipped on the solve response and is untouched.

A new preset is now **one Python entry** in `_TERRAIN_PRESETS` — no TypeScript, no rebuild beyond the release's normal asset build.

## Test plan
- [x] `pytest tests/test_web_terrain.py tests/test_terrain_ground.py` — 46 pass, incl. two new cases (catalog on `/capabilities`; schema bounds are the authoritative clamp)
- [x] Full web suite: 213 pass
- [x] `ruff check` / `ruff format --check` clean
- [x] Frontend `tsc --noEmit` + `vite build` succeed
- [x] Verified `/capabilities` ships all three presets and their field labels/units/ranges match the previously-hardcoded values exactly; marker orientation (incl. full-circle-cliff suppression) preserved
- [ ] Visual smoke of the terrain panel on the deployed site after the next asset refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)