### PR TITLE
chore: release v0.37.0 (the ground you actually stand on)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.36.1"
+version = "0.37.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,19 +25,20 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.36.1" icon="star">
-  **The 3D view faces your antenna again.** v0.36.0's `Wire()` migration
-  silently broke automatic view selection — 67 of 92 designs opened on
-  the x-y plane, so a dipole or inverted-V rendered edge-on until you
-  switched planes by hand. Fixed, with concrete per-design view pins in
-  the test suite so a silent fallback can't slip through again. Still
-  fresh from v0.36.0: **segmentation you never think about** — give a
-  wire the segment count `None` and the framework meshes it at the
-  design density, a conversion that surfaced seven silent meshing
-  defects and raised the basis census to **77/92 designs with a
-  verified mutual convergence limit**. Read the story:
-  [Segmentation you never think about](/concepts/auto-meshing/).
-  [All release notes →](/reference/releases/)
+<Card title="New in v0.37.0" icon="star">
+  **Your antenna, on the ground you actually stand on.** Every flat-ground
+  model — Sommerfeld, reflection-coefficient, PEC — assumes the earth is an
+  infinite flat plane at the mast's feet. The new **faceted-terrain ground**
+  drops that assumption: pick a **levee**, **cliff**, or **hillside** preset,
+  set the slopes, drops, and bearings, and the far field reflects off the
+  actual sloped facet each ray's specular point lands on — tilted incidence,
+  per-facet media (water vs. land), full effective height below the drops. The
+  motivating QTH — a 20 ft mast on a levee, fresh water off one slope and
+  farmland off the other — is worked end to end in
+  [Antennas on a levee](/advanced/terrain/). Presets are schema-driven, so
+  adding one is a single Python entry — no frontend rebuild. Also new:
+  **server-side polar cuts**, so every solve returns its azimuth and elevation
+  traces ready to plot. [All release notes →](/reference/releases/)
 </Card>
 
 ## The whole pitch, in one line


### PR DESCRIPTION
## Summary
Minor release cutting all the faceted-terrain ground work merged since v0.36.1 (tagged yesterday).

- **Version** bumped to `0.37.0`.
- **What's-new card** (`site/src/content/docs/index.mdx`) refreshed to headline the faceted-terrain ground — levee/cliff/hillside presets, per-facet media, server-side polar cuts — and link the [Antennas on a levee](/advanced/terrain/) worked example.
- **Docs de-stale sweep**: clean this cycle. The terrain feature was documented as it landed (`advanced/terrain.md`, `reference/web.md`); #560 is an internal refactor (same presets/knobs/physics), so no behavior page went stale.
- **momwire** stays pinned at `0.16.0` (submodule pointer verified at the `v0.16.0` tag — no drift); no solver upgrade in this batch.

Headline features first shipping in 0.37.0: faceted-terrain far-field ground (#534), server-side polar-chart cuts (#547/#551), and the schema-driven terrain preset registry (#560).

## Test plan
- [x] `cd site && npm run build` passes (25 pages, no broken links)
- [x] `ruff check` / `ruff format --check` clean (unchanged since #560 merge)
- [ ] Tag `v0.37.0` after merge; watch publish + both Fly deploys + Docker image, verify PyPI serves 0.37.0 and fleet convergence

🤖 Generated with [Claude Code](https://claude.com/claude-code)