### PR TITLE
Probe singular enrichment over the #521 junction-residue cluster (#565)

### DIFF
--- a/docs/status/2026-07-25-enrichment-cluster-probe.md
+++ b/docs/status/2026-07-25-enrichment-cluster-probe.md
@@ -139,6 +139,50 @@ from a coarse mesh. That reframes #521's remedy hunt:
   probe closer to a junction feed (or on the current distribution near the
   junction) would test the mechanism where it could still bite.
 
+## Catalog-wide follow-up — does *any* design benefit? (does not)
+
+If the cluster does not benefit, is there anywhere in the catalog that does?
+The working hypothesis: enrichment should help where there is a **K≥3 junction
+with appreciable current through ≥3 arms**. `scripts/bench_enrichment_scan.py`
+tests it directly across all 91 designs — it finds the K≥3 junctions, measures
+each junction's **arm-current split** (how many arms carry ≥20 % of the largest
+arm's current), and measures the driving-point enrichment shift with BOTH the
+`raw` and `stable` variants.
+
+**17 designs have a K≥3 junction; the largest `stable`-variant driving-point
+shift across the entire catalog is 0.216 Ω** (on `specialty.helix`, the #521
+curvature outlier — a <1 % effect on a single-junction curved wire, not a clean
+junction case). Every other K≥3 design is ≤ 0.007 Ω. The qualifying-current
+condition is met all over the catalog (fan dipoles `[1.0, 0.77, 0.24]`, T-match
+verticals `[1.0, 0.26, 0.25, 0.25, 0.24]`, the hentenna/hourglass cluster,
+j-poles) — and enrichment still does nothing. **"3 live arms" is necessary but
+not sufficient.**
+
+Two traps this scan exists to expose:
+
+1. **The `raw` variant's coarse-mesh transient masquerades as benefit.** On the
+   fan dipoles `raw` swings the driving point ~2.8 Ω at N=41–161 — the single
+   largest enrichment effect in the catalog — but it is *wrong*: at those meshes
+   sin, bs2, and PyNEC all agree (`trap_fan_dipole` X ≈ 2.3 Ω at N=161) while
+   `raw` alone reads −0.65 Ω, and it snaps back to match everyone by N=321. The
+   `stable`/`tikhonov` variants show ≤ 0.002 Ω there — no transient. A large
+   `raw` |Δ| is an artifact of the raw basis's small-N conditioning, **not**
+   evidence of benefit; the scan prints both variants side by side so it cannot
+   be mistaken again. (This also means a `raw`-only probe would mis-rank the fan
+   dipoles as top beneficiaries — they are not.)
+2. **The extra conditions beyond "3 live arms."** Benefit also needs the feed
+   current to flow *through* the junction singularity (the cluster feeds
+   mid-wire, away from it) AND the junction to be the convergence bottleneck
+   (the fan dipoles are trap-loaded, whole-structure-slow — their reactance is
+   still climbing at N=641, so the junction is not what limits convergence).
+   The purpose-built momwire test hentenna (tiny feed stub *at* the junction,
+   otherwise well-conditioned) meets all three; no catalog geometry does.
+
+Incidental momwire limitation surfaced: `use_singular_enrichment` + distributed
+wire loading raises `NotImplementedError` ("the enrichment bases don't carry the
+loading overlap term"), so lossy-spec designs (`verticals.pota_performer`) cannot
+be enriched today — recorded, not silently dropped.
+
 ## Reproduce
 
 ```
@@ -146,6 +190,7 @@ python scripts/bench_enrichment_probe.py --ladder 21 41 81 161 \
     --grounds free pec sommerfeld --out probe.jsonl
 python scripts/bench_enrichment_probe.py --only specialty.hentenna \
     --variant auto      # demonstrates auto suppressing enrichment (enr↦ = 0)
+python scripts/bench_enrichment_scan.py --out scan.jsonl   # catalog-wide hunt
 ```
 
 Related: #521 (the cluster), #484 (closed — the R-dominated fan-feed drift

--- a/docs/status/2026-07-25-enrichment-cluster-probe.md
+++ b/docs/status/2026-07-25-enrichment-cluster-probe.md
@@ -1,0 +1,153 @@
+# Singular-enrichment probe over the #521 junction-residue cluster (issue #565)
+
+**Date:** 2026-07-25
+**Tool:** `scripts/bench_enrichment_probe.py` (ladder N = 21/41/81/161,
+free space + PEC + Sommerfeld, `enrichment_variant=raw`, seg-cap 6000,
+RLIMIT 8 GB). Runs on an **editable momwire install** (momwire `main`,
+0.16.0, issue #167 complete) — no release/pin bump, by the #565 decision.
+Finite-ground medium: NEC "average" (εr 13, σ 0.005 S/m), lowest wire
+placed 0.1 λ above the plane.
+
+## Question
+
+momwire #167 unblocked the K≥3 singular-enrichment bases over *every* ground
+(PRs #169 PEC / #170 refl-coef / #171 Sommerfeld), so #521's grounded
+junction cluster — **hentenna, hentenna_array, hentenna_slant, hourglass,
+hourglass_slant, hourglass_array, discone** — can finally be probed with the
+correction that targets exactly its suspected defect. #521 named
+junction-collocation as the prime suspect for the cluster's sin↔bs2
+**reactance** disagreement but called it "not yet demonstrated." Singular
+enrichment is the direct test: it is a Galerkin correction at the K≥3
+junctions, and on the *bare-momwire* hentenna it flips R/X convergence from
+O(1/N) to ~O(1/N³) (`test_bspline_d2_hentenna_singular_enrichment`).
+
+The discriminator (#565): does enrichment collapse the sin↔bs2 reactance gap
+toward the Galerkin value, the way it does on that free-space hentenna?
+
+## Method — three bases up a ladder, gap before/after
+
+Per design the driving-point reactance (feed 0) is solved up the ladder on
+**sin**, **bs2** (BSpline d=2, Galerkin), and **bs2+enrichment**. The report
+scores, at the finest common rung:
+
+- **gapB** = |X_sin − X_bs2| — the #521 disagreement *before* enrichment;
+- **gapA** = |X_sin − X_bs2enr| — *after*. gapA ≪ gapB would mean enrichment
+  moved the Galerkin basis toward sin (junction collocation corrupts bs2 too);
+- **enr↦** = |X_bs2enr − X_bs2| — how far the K≥3 correction moved the
+  Galerkin driving-point reactance at all;
+- **stepSin / stepBs2** = |ΔX| across the last mesh doubling — who is still
+  moving, with no asymptotic assumption.
+
+### Two confounds respected (#565 step 4)
+
+1. **`enrichment_variant="auto"` suppresses enrichment** on several of these
+   catalog designs — the auto tap-ratio gate decides the junction is already
+   resolved and returns the plain-bs2 matrix *bit-for-bit*. A naive `auto`
+   probe would report "no effect" everywhere for the wrong reason. The probe
+   defaults to **`raw`** (enrichment always on at K≥3); `raw` is verified
+   distinct from bs2 (hentenna N=21: X 38.590 → 38.703), so a null result here
+   means "enrichment did nothing", never "auto turned it off".
+2. **Feed placement gates the correction's reach.** The catalog hentenna feeds
+   *mid-wire*, electrically removed from its two K=3 rails, so `raw` moves X by
+   ~0.1 Ω at N=21 — versus ~5.6 Ω in the bare-momwire test whose feed stub
+   attaches *at* the junction. Same basis correction, 50× smaller footprint on
+   the driving point, purely from where the feed sits. Real geometry, not a bug.
+
+## Result — the gap persists; enrichment is a driving-point no-op
+
+Free space (PEC and Sommerfeld are identical to within ground's own shift —
+see below):
+
+| design | Nf | X_sin | X_bs2 | gapB | gapA | enr↦ | stepSin | stepBs2 |
+|---|---|---|---|---|---|---|---|---|
+| hentenna         | 161 |  30.57 |  38.89 |  8.32 |  8.32 | 0.001 | 0.93 | 0.049 |
+| hentenna_array   | 161 |  30.40 |  41.26 | 10.86 | 10.87 | 0.003 | 1.07 | 0.010 |
+| hentenna_slant   | 161 |  24.78 |  24.83 |  0.05 |  0.05 | 0.001 | 0.26 | 0.094 |
+| hourglass        | 161 |  23.39 |  28.81 |  5.41 |  5.41 | 0.001 | 0.41 | 0.032 |
+| hourglass_slant  | 161 |  24.85 |  34.50 |  9.65 |  9.65 | 0.001 | 0.80 | 0.075 |
+| hourglass_array  | 161 |  16.22 |  25.80 |  9.58 |  9.59 | 0.003 | 0.82 | 0.017 |
+| discone          | 161 | −26.32 | −31.02 |  4.70 |  4.70 | 0.000 | 2.63 | 0.045 |
+
+Three findings, uniform across the cluster and identical in shape on PEC and
+Sommerfeld ground:
+
+1. **Enrichment does not collapse the gap.** gapA = gapB to two decimals
+   everywhere; enr↦ ≤ 0.003 Ω on X and 0.000 Ω on R (checked separately). The
+   K≥3 junction correction moves the driving-point impedance by essentially
+   nothing — on *every* ground.
+2. **bs2 is already settled; sin is the laggard.** stepBs2 = 0.01–0.09 Ω
+   (Galerkin flat by N=81), while stepSin = 0.4–2.6 Ω — sin is still climbing
+   ~1 Ω per mesh doubling at N=161. The "no mutual limit" #521 flagged is
+   *sin's slow reactance convergence against an already-converged Galerkin
+   value*, not a collocation defect in the Galerkin basis.
+3. **Ground doesn't change the mechanism.** #167's ground-capable enrichment
+   path is reachable and consistent (step 1 confirmed: no `NotImplementedError`
+   on PEC / refl-coef / Sommerfeld), but the gap and the enrichment no-op are
+   the same over ground as in free space — ground shifts every basis's X by a
+   few Ω together and leaves the sin↔bs2 split untouched.
+
+### sin is genuinely non-asymptotic (why extrapolation is refused)
+
+A longer free-space ladder on the hentenna shows sin's per-doubling steps
+**growing**, not shrinking — it is not in an asymptotic regime, so any
+three-point fit of *where sin lands* is a mirage the true sequence blows
+through. bs2 is flat from N=81:
+
+| N | sin X | bs2 X |
+|---|---|---|
+|  21 | 29.23 | 38.59 |
+|  41 | 28.35 | 38.79 |
+|  81 | 29.64 | 38.84 |
+| 161 | 30.57 | 38.89 |
+| 321 | 31.43 | 38.91 |
+| 641 | 32.63 | 38.92 |
+
+The tool's Aitken column is guarded to refuse non-contracting series for
+exactly this reason; it extrapolates only the (genuinely convergent) enriched
+Galerkin basis.
+
+### Outlier: hentenna_slant is not in the cluster
+
+hentenna_slant shows gapB ≈ 0.05–0.13 Ω — sin and bs2 **agree**. Its geometry
+puts both bases on the same limit; it should not be counted among the
+no-mutual-limit residue. discone is the opposite extreme: sin wildly
+unconverged (stepSin ~2.6–2.9 Ω) and capacitive (X ≈ −30 Ω), the largest
+laggard, with the largest R gap (2.5–3.2 Ω) as well.
+
+## Verdict — #565 outcome 2: the gap persists → different class
+
+This is the issue's second outcome: **the X-dominated cluster is a different
+class from #484's R-dominated fan-feed drift, and singular enrichment is the
+wrong remedy for it.** The junction-collocation mechanism, *as probed by
+singular enrichment at the driving point*, is not demonstrated for this
+cluster — because the Galerkin basis already resolves the junctions well
+enough that the correction has nowhere to act, and the catalog feeds sit too
+far from the junctions for a junction correction to reach the port anyway.
+
+What actually drives the cluster's sin↔bs2 reactance gap is the **sinusoidal
+basis's slow reactance convergence**; bs2 already holds the trustworthy limit
+from a coarse mesh. That reframes #521's remedy hunt:
+
+- Don't pursue singular enrichment as the fix for this cluster's gap — it is a
+  no-op at the driving point on every ground.
+- Treat bs2 as the reference limit for these designs (it is flat by N=81); the
+  open work is characterising *why sin converges so slowly* here, not
+  correcting bs2.
+- A residual caveat: a driving-point no-op does not prove the junction basis is
+  perfect in the *current/field* solution — only that the reactance *seen at
+  the feed* is insensitive to the correction, for these feed placements. A
+  probe closer to a junction feed (or on the current distribution near the
+  junction) would test the mechanism where it could still bite.
+
+## Reproduce
+
+```
+python scripts/bench_enrichment_probe.py --ladder 21 41 81 161 \
+    --grounds free pec sommerfeld --out probe.jsonl
+python scripts/bench_enrichment_probe.py --only specialty.hentenna \
+    --variant auto      # demonstrates auto suppressing enrichment (enr↦ = 0)
+```
+
+Related: #521 (the cluster), #484 (closed — the R-dominated fan-feed drift
+this cluster is *not*), #478 (near-open convergence class), momwire #167
+(the ground-capable enrichment this consumes).

--- a/scripts/bench_enrichment_probe.py
+++ b/scripts/bench_enrichment_probe.py
@@ -1,0 +1,457 @@
+"""Singular-enrichment probe over the #521 junction-residue cluster (issue #565).
+
+momwire #167 made the K≥3 singular-enrichment bases (T/X-junction bases,
+``enrichment_min_k=3``) work over EVERY ground — PEC image, fast finite
+(refl-coef), and Sommerfeld — via the image-reaction blocks. Before it,
+``BSplineSolver(use_singular_enrichment=True, ground_z=...)`` raised
+``NotImplementedError``; grounded studies of the junction cluster were locked
+out. This tool is the direct probe that #521 asked for and could not run.
+
+#521's no-mutual-limit residue cluster — **hentenna, hourglass, discone** and
+their arrays — is the singular-enrichment target family: T-junctions (hentenna
+feed↔loop), a degree-4 X-crossing (hourglass), an apex fan (discone), with the
+sin↔bs2 disagreement concentrated in REACTANCE. #521 names junction-collocation
+as the prime suspect but calls it "not yet demonstrated" for these
+mid-structure junctions. Singular enrichment is a Galerkin correction at exactly
+those junctions: on the free-space hentenna it flips R/X convergence from
+O(1/N) to ~O(1/N^(d+1)) (momwire ``test_bspline_d2_hentenna_singular_enrichment``).
+
+For each cluster design this solves the driving-point impedance (feed 0) up a
+mesh ladder on THREE bases — sinusoidal, BSpline-d2 (Galerkin), and
+**BSpline-d2 + singular enrichment** — over free space AND ground (PEC plus a
+finite model at a chosen height). It then scores the discriminator:
+
+  * the sin↔bs2 REACTANCE gap (the #521 disagreement) at the finest rung;
+  * whether enrichment MOVES the bs2 value — toward sin (junction collocation
+    corrupts bs2 too) or barely at all (bs2 already holds the Galerkin limit);
+  * the fitted convergence rate p in Z(N)=Z_inf + C/N^p for bs2 and bs2+enr
+    (the O(1/N^(d+1)) claim) via three-point Richardson on X.
+
+Two confounds this tool is built to respect (issue #565 step 4):
+
+  * ``enrichment_variant="auto"`` SUPPRESSES enrichment on several of these
+    catalog designs (the auto tap-ratio gate decides the junction is already
+    resolved and returns the plain-bs2 matrix bit-for-bit). The probe therefore
+    defaults to ``raw`` — the honest "enrichment always on at K≥3" variant —
+    with ``--variant`` to switch. A no-op result must mean "enrichment did
+    nothing here", never "auto turned it off".
+  * a design's FEED PLACEMENT gates how much a junction correction reaches the
+    driving point. The catalog hentenna feeds mid-wire, far from its two K=3
+    rails, so ``raw`` moves X by ~0.1 Ω at N=21 — versus ~5.6 Ω in the bare
+    momwire test whose feed stub attaches AT the junction. That is a real
+    geometry effect, not a bug; the report states the shift so it is not misread.
+
+Δ/a discipline (issue #484): rungs past a design's thin-wire headroom
+(``bench_delta_a_headroom.n_max``) are skipped and recorded for every basis —
+below the floor the reduced kernel is ill-posed and both bases answer nonsense.
+The cluster's thin-wire designs clear ~2600, so the default ladder is unclamped.
+
+    python scripts/bench_enrichment_probe.py
+    python scripts/bench_enrichment_probe.py --ladder 21 41 81 161 --grounds free pec
+    python scripts/bench_enrichment_probe.py --only specialty.hentenna --variant stable
+    python scripts/bench_enrichment_probe.py --height-wl 0.05 --grounds sommerfeld refl-coef
+"""
+
+from __future__ import annotations
+
+# libgomp reads these once, before numpy/momwire load (mirrors bench_converge).
+import os
+
+os.environ.setdefault("OMP_WAIT_POLICY", "PASSIVE")
+os.environ.setdefault("GOMP_SPINCOUNT", "0")
+
+import argparse  # noqa: E402
+import json  # noqa: E402
+import math  # noqa: E402
+import resource  # noqa: E402
+import sys  # noqa: E402
+import time  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import bench_converge as bc  # noqa: E402 — load_design / total_nominal_segs
+import bench_delta_a_headroom as dah  # noqa: E402 — Δ/a headroom clamp (#484)
+
+# The #521 no-mutual-limit junction-residue cluster (issue #565): T-junctions
+# (hentenna feed↔loop), a degree-4 X-crossing (hourglass), an apex fan
+# (discone), and their arrays.
+CLUSTER = (
+    "specialty.hentenna",
+    "arrays.hentenna_array",
+    "specialty.hentenna_slant",
+    "specialty.hourglass",
+    "specialty.hourglass_slant",
+    "arrays.hourglass_array",
+    "broadband.discone",
+)
+
+# Geometric ladder (doubling), matching the momwire enrichment test's rungs so
+# the three-point Richardson rate is directly comparable to its p≈2.74.
+DEFAULT_LADDER = (21, 41, 81, 161)
+DEFAULT_SEG_CAP = 6000
+DEFAULT_MEM_GB = 8.0
+# Average-ground medium (NEC "average": eps_r 13, sigma 0.005 S/m).
+DEFAULT_EPS_R = 13.0
+DEFAULT_SIGMA = 0.005
+DEFAULT_HEIGHT_WL = 0.1  # lowest wire this many wavelengths above the plane
+# sin, bs2 (Galerkin), bs2+enrichment.
+ENGINES = ("sin", "bs2", "bs2enr")
+
+C_LIGHT = 299_792_458.0
+
+
+def structure_min_z(builder_cls, nseg: int) -> float:
+    """Lowest z over every wire polyline at ``nominal_nsegs=nseg``. The ground
+    plane is placed a fixed height below this so the whole structure sits above
+    it (momwire rejects a plane cutting through a wire)."""
+    from antennaknobs.geometry import flat_wires_to_polylines
+
+    import numpy as np
+
+    b = builder_cls()
+    b.nominal_nsegs = nseg
+    tr = flat_wires_to_polylines(b.build_wires())
+    return min(float(np.asarray(p)[:, 2].min()) for p in tr["polylines"])
+
+
+def ground_spec(kind: str, eps_r: float, sigma: float):
+    """Map a scenario key to the MomwireEngine ``ground`` argument.
+    ``sommerfeld`` -> true finite ground (NEC gn 2); ``refl-coef`` -> the
+    reflection-coefficient approximation (NEC gn 0)."""
+    if kind == "free":
+        return None
+    if kind == "pec":
+        return "pec"
+    if kind == "sommerfeld":
+        return ("finite", eps_r, sigma)
+    if kind == "refl-coef":
+        return ("finite-fast", eps_r, sigma)
+    raise ValueError(f"unknown ground scenario {kind!r}")
+
+
+def solver_kwargs(engine: str, variant: str) -> tuple:
+    """(momwire solver class, solver_kwargs) for an engine key."""
+    from momwire import BSplineSolver, SinusoidalSolver
+
+    if engine == "sin":
+        return SinusoidalSolver, {}
+    if engine == "bs2":
+        return BSplineSolver, {"degree": 2}
+    if engine == "bs2enr":
+        return BSplineSolver, {
+            "degree": 2,
+            "use_singular_enrichment": True,
+            "enrichment_variant": variant,
+        }
+    raise ValueError(f"unknown engine {engine!r}")
+
+
+def solve(builder_cls, nseg, engine, ground_kind, *, variant, eps_r, sigma, height_wl):
+    """Feed-0 driving-point Z for one (design, N, engine, ground). Places the
+    ground plane ``height_wl`` wavelengths below the structure's lowest wire.
+    Returns a complex, or raises (the caller records the failure)."""
+    from antennaknobs.engines.momwire import MomwireEngine
+
+    solver, kw = solver_kwargs(engine, variant)
+    ground = ground_spec(ground_kind, eps_r, sigma)
+
+    b = builder_cls()
+    b.nominal_nsegs = nseg
+    if ground is None:
+        ground_z = 0.0
+    else:
+        wl = C_LIGHT / (b.freq * 1e6)
+        ground_z = structure_min_z(builder_cls, nseg) - height_wl * wl
+
+    eng = MomwireEngine(
+        b, solver=solver, solver_kwargs=kw, ground=ground, ground_z=ground_z
+    )
+    return complex(eng.impedance()[0])
+
+
+def richardson_p(series):
+    """Three-point convergence rate p in Z(N)=Z_inf + C/N^p from the imaginary
+    (reactance) parts of the last three rungs, using the same estimator as the
+    momwire enrichment test:  p = log(|dX_12/dX_23|)/log(N2/N1).
+
+    ``series`` is ``[(N, z), ...]`` ordered by increasing N. Returns None when
+    there are fewer than three rungs or the differences sign-flip (the noise
+    floor was reached — the rate estimate would be meaningless)."""
+    pts = [(n, z) for n, z in series if z is not None]
+    if len(pts) < 3:
+        return None
+    (n1, z1), (n2, z2), (_n3, z3) = pts[-3], pts[-2], pts[-1]
+    d12, d23 = z1.imag - z2.imag, z2.imag - z3.imag
+    if d12 == 0 or d23 == 0 or (d12 * d23) <= 0:
+        return None
+    return math.log(abs(d12 / d23)) / math.log(n2 / n1)
+
+
+def aitken_x_inf(series):
+    """Aitken Δ² extrapolation of the reactance limit X_inf from the last three
+    rungs' X — but ONLY when the sequence is actually contracting toward a limit
+    (|Δ_23| < |Δ_12|). A basis whose per-doubling steps are growing is not in an
+    asymptotic regime; extrapolating it gives a number the true sequence blows
+    straight through (the catalog hentenna's sin basis does exactly this — see
+    the module docstring), so we refuse rather than print a mirage. Returns None
+    on too few rungs, non-contraction, or a vanishing curvature denominator."""
+    pts = [(n, z) for n, z in series if z is not None]
+    if len(pts) < 3:
+        return None
+    x1, x2, x3 = pts[-3][1].imag, pts[-2][1].imag, pts[-1][1].imag
+    d12, d23 = x2 - x1, x3 - x2
+    if abs(d23) >= abs(d12):  # steps not shrinking → not asymptotic, don't extrapolate
+        return None
+    denom = d23 - d12
+    if denom == 0:
+        return None
+    return x3 - d23**2 / denom
+
+
+def last_step(series):
+    """Reactance change across the final mesh doubling, |X(Nf) - X(prev)| — the
+    honest "is this basis still moving?" number that needs no asymptotic
+    assumption. A basis flat here has settled on this ladder; one still stepping
+    (the sin basis on the junction cluster) has not, whatever a fit would say."""
+    pts = [(n, z) for n, z in series if z is not None]
+    if len(pts) < 2:
+        return None
+    return abs(pts[-1][1].imag - pts[-2][1].imag)
+
+
+def probe_row(
+    design, ladder, ground_kinds, seg_cap, *, variant, eps_r, sigma, height_wl
+):
+    """Solve one design across the ladder for every (ground, engine). Never
+    raises — a dud rung is recorded as an error string in place of a value."""
+    row = {"design": design, "variant": variant, "grounds": {}, "error": None}
+    try:
+        cls = bc.load_design(design)
+    except Exception as e:  # noqa: BLE001 — one dud design must not sink the run
+        row["error"] = f"load: {type(e).__name__}: {e}"
+        return row
+    try:
+        headroom = dah.n_max(cls)
+    except Exception:  # noqa: BLE001
+        headroom = None
+    row["headroom"] = headroom
+
+    for gk in ground_kinds:
+        gdata = {e: [] for e in ENGINES}
+        skipped = {e: [] for e in ENGINES}
+        for nseg in ladder:
+            if headroom is not None and nseg > headroom:
+                for e in ENGINES:
+                    skipped[e].append([nseg, f"headroom {headroom}"])
+                continue
+            try:
+                tot = bc.total_nominal_segs(cls, nseg)
+            except Exception as e:  # noqa: BLE001
+                tot = None
+            if tot is not None and tot > seg_cap:
+                for e in ENGINES:
+                    skipped[e].append([nseg, f"seg-cap {tot}"])
+                continue
+            for e in ENGINES:
+                try:
+                    t0 = time.time()
+                    z = solve(
+                        cls,
+                        nseg,
+                        e,
+                        gk,
+                        variant=variant,
+                        eps_r=eps_r,
+                        sigma=sigma,
+                        height_wl=height_wl,
+                    )
+                    gdata[e].append([nseg, z.real, z.imag, time.time() - t0, tot])
+                except MemoryError:
+                    skipped[e].append([nseg, "MemoryError"])
+                except Exception as ex:  # noqa: BLE001
+                    skipped[e].append([nseg, f"{type(ex).__name__}: {str(ex)[:80]}"])
+        row["grounds"][gk] = {"series": gdata, "skipped": skipped}
+    return row
+
+
+def _series_z(series):
+    """[(N, complex Z), ...] from a stored engine series."""
+    return [(n, complex(re, im)) for n, re, im, *_ in series]
+
+
+def score(row, ground_kind):
+    """Reduce one (design, ground) to its discriminator summary, or a reason
+    string if it cannot be scored.
+
+    Returns a dict with, at the finest common rung:
+      * gap_sin_bs2   — |X_sin - X_bs2|            (the #521 disagreement)
+      * gap_sin_enr   — |X_sin - X_bs2enr|         (does enrichment close it?)
+      * enr_shift     — |X_bs2enr - X_bs2|         (how far enrichment moved bs2)
+      * z at the finest rung for each basis, and Richardson p for bs2 / bs2enr.
+    """
+    g = row["grounds"].get(ground_kind)
+    if not g:
+        return None, "no data"
+    s = {e: _series_z(g["series"].get(e, [])) for e in ENGINES}
+    if any(len(s[e]) < 1 for e in ENGINES):
+        why = "; ".join(
+            f"{e}: {g['skipped'][e][0][1] if g['skipped'].get(e) else 'none'}"
+            for e in ENGINES
+            if len(s[e]) < 1
+        )
+        return None, why
+    common = sorted(
+        set(n for n, _ in s["sin"])
+        & set(n for n, _ in s["bs2"])
+        & set(n for n, _ in s["bs2enr"])
+    )
+    if not common:
+        return None, "no common rung"
+    nf = common[-1]
+
+    def z_at(e, n):
+        return next(z for nn, z in s[e] if nn == n)
+
+    zs, zb, ze = z_at("sin", nf), z_at("bs2", nf), z_at("bs2enr", nf)
+    return {
+        "nf": nf,
+        "zs": zs,
+        "zb": zb,
+        "ze": ze,
+        # gap BEFORE enrichment (sin↔bs2) and AFTER (sin↔bs2enr): if enrichment
+        # collapsed the #521 disagreement, gap_after ≪ gap_before. Equal ⇒ the
+        # correction never reached the driving point.
+        "gap_before": abs(zs.imag - zb.imag),
+        "gap_after": abs(zs.imag - ze.imag),
+        "enr_shift": abs(ze.imag - zb.imag),
+        "enr_shift_r": abs(ze.real - zb.real),
+        # who is still moving on this ladder (no asymptotic assumption)
+        "step_sin": last_step(s["sin"]),
+        "step_bs2": last_step(s["bs2"]),
+        # Galerkin convergence rate (the O(1/N^(d+1)) claim); extrapolated
+        # Galerkin limit only when the enriched series is genuinely contracting.
+        "p_bs2": richardson_p(s["bs2"]),
+        "p_enr": richardson_p(s["bs2enr"]),
+        "xinf_enr": aitken_x_inf(s["bs2enr"]),
+    }, None
+
+
+def print_report(rows, ladder, ground_kinds, variant):
+    print(
+        f"\nSINGULAR-ENRICHMENT PROBE (issue #565)  ladder={list(ladder)}  "
+        f"variant={variant}  engines=sin/bs2/bs2enr"
+    )
+    print(
+        "  gapB/gapA = |X_sin - X_bs2| BEFORE and |X_sin - X_bs2enr| AFTER\n"
+        "  enrichment, at the finest common rung. gapA≈gapB ⇒ enrichment did not\n"
+        "  collapse the #521 disagreement.  enr↦ = |X_bs2enr - X_bs2| (how far\n"
+        "  the K≥3 junction correction moved the Galerkin driving-point X).\n"
+        "  stepSin/stepBs2 = |ΔX| across the last mesh doubling — who is still\n"
+        "  moving.  p_enr = enriched Galerkin rate; X∞ = its extrapolated limit\n"
+        "  (blank when the series is not yet contracting)."
+    )
+
+    for gk in ground_kinds:
+        print(f"\n{'=' * 104}\nGROUND: {gk}\n{'=' * 104}")
+        hdr = (
+            f"{'design':28} {'Nf':>4} {'X_sin':>7} {'X_bs2':>7} {'gapB':>6} "
+            f"{'gapA':>6} {'enr↦':>7} {'stepSin':>8} {'stepBs2':>8} "
+            f"{'p_enr':>6} {'X∞_enr':>7}"
+        )
+        print(hdr)
+        print("-" * len(hdr))
+        for row in rows:
+            st, why = score(row, gk)
+            if st is None:
+                print(f"{row['design']:28} —  {str(why)[:50]}")
+                continue
+
+            def fnum(v, w=7, d=2):
+                return f"{v:{w}.{d}f}" if v is not None else f"{'.':>{w}}"
+
+            print(
+                f"{row['design']:28} {st['nf']:>4} "
+                f"{st['zs'].imag:7.2f} {st['zb'].imag:7.2f} "
+                f"{st['gap_before']:6.2f} {st['gap_after']:6.2f} "
+                f"{st['enr_shift']:7.3f} {fnum(st['step_sin'], 8, 3)} "
+                f"{fnum(st['step_bs2'], 8, 3)} {fnum(st['p_enr'], 6)} "
+                f"{fnum(st['xinf_enr'])}"
+            )
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--ladder", type=int, nargs="+", default=list(DEFAULT_LADDER))
+    ap.add_argument(
+        "--grounds",
+        nargs="+",
+        default=["free", "pec", "sommerfeld"],
+        choices=["free", "pec", "sommerfeld", "refl-coef"],
+        help="ground scenarios (finite ones placed --height-wl below the structure)",
+    )
+    ap.add_argument("--only", nargs="+", help="restrict to these dotted designs")
+    ap.add_argument(
+        "--variant",
+        default="raw",
+        choices=["raw", "stable", "tikhonov", "auto"],
+        help="enrichment variant (auto SUPPRESSES enrichment on several cluster "
+        "designs — see module docstring; raw is the honest always-on default)",
+    )
+    ap.add_argument("--eps-r", type=float, default=DEFAULT_EPS_R)
+    ap.add_argument("--sigma", type=float, default=DEFAULT_SIGMA)
+    ap.add_argument("--height-wl", type=float, default=DEFAULT_HEIGHT_WL)
+    ap.add_argument("--seg-cap", type=int, default=DEFAULT_SEG_CAP)
+    ap.add_argument("--mem-limit-gb", type=float, default=DEFAULT_MEM_GB)
+    ap.add_argument("--out", type=Path, help="also write raw rows as JSON lines")
+    args = ap.parse_args(argv)
+
+    cap = int(args.mem_limit_gb * 1e9)
+    resource.setrlimit(resource.RLIMIT_AS, (cap, cap))
+
+    designs = args.only or list(CLUSTER)
+    ladder = sorted(set(args.ladder))
+    print(
+        f"designs: {', '.join(designs)}\n"
+        f"grounds: {', '.join(args.grounds)}   ladder: {ladder}   "
+        f"variant: {args.variant}\n"
+        f"finite medium: eps_r={args.eps_r} sigma={args.sigma}   "
+        f"height: {args.height_wl}λ above the plane"
+    )
+
+    rows = []
+    out = args.out.open("w") if args.out else None
+    for i, d in enumerate(designs, 1):
+        print(f"\n[{i}/{len(designs)}] {d} ...", flush=True)
+        row = probe_row(
+            d,
+            ladder,
+            args.grounds,
+            args.seg_cap,
+            variant=args.variant,
+            eps_r=args.eps_r,
+            sigma=args.sigma,
+            height_wl=args.height_wl,
+        )
+        rows.append(row)
+        if out:
+            out.write(json.dumps(row) + "\n")
+            out.flush()
+        # per-design progress line
+        for gk in args.grounds:
+            st, why = score(row, gk)
+            if st is None:
+                print(f"    {gk:11} — {str(why)[:60]}")
+            else:
+                sstep = st["step_sin"] if st["step_sin"] is not None else float("nan")
+                print(
+                    f"    {gk:11} Nf={st['nf']:<4} gapB={st['gap_before']:6.2f}Ω "
+                    f"gapA={st['gap_after']:6.2f}Ω  enr↦{st['enr_shift']:6.3f}Ω  "
+                    f"stepSin={sstep:5.2f}Ω"
+                )
+    if out:
+        out.close()
+    print_report(rows, ladder, args.grounds, args.variant)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_enrichment_scan.py
+++ b/scripts/bench_enrichment_scan.py
@@ -1,0 +1,282 @@
+"""Which catalog designs benefit from the singular-enrichment basis? (issue #565)
+
+The follow-up to `bench_enrichment_probe.py`: that tool scored the #521 junction
+cluster and found enrichment a driving-point no-op there. This one asks the
+general question across the WHOLE catalog — *is there any design where the K≥3
+junction bases earn their keep?* — and encodes the answer's two traps so the
+next reader does not re-fall into them.
+
+The working hypothesis (Steve): enrichment should help where there is a **K≥3
+junction with appreciable current through at least 3 arms**. This tool tests it
+directly. Per design it:
+
+  1. finds the K≥3 junctions in the translated geometry and, from a bs2 current
+     solve, measures each junction's **arm-current split** — how many arms carry
+     ≥20% of the largest arm's current (the "live arms" count);
+  2. measures the **driving-point enrichment shift** |Z_enr − Z_bs2| with BOTH
+     the `raw` and `stable` variants, at two meshes.
+
+Two traps, both learned the hard way (2026-07-25):
+
+  * **`raw`'s coarse-mesh transient masquerades as benefit.** On the fan dipoles
+    `raw` swings the driving point ~2.8 Ω at N=41–161 — but it is *wrong* (it
+    disagrees with sin/bs2/PyNEC, which all agree) and washes out by N≈321. The
+    `stable` / `tikhonov` variants do not do this. So a large `raw` |Δ| is NOT
+    evidence of benefit; only a persistent **`stable`** shift is. This tool
+    prints both side by side precisely so the artifact is visible, not hidden.
+  * **"3 live arms" is necessary, not sufficient.** Every K≥3 design in the
+    catalog has qualifying junctions (fan dipoles, T-match verticals, the
+    hentenna/hourglass cluster, j-poles), yet `stable` enrichment is a ≤0.01 Ω
+    no-op on all of them: bs2 already resolves the junction. Benefit also needs
+    the feed current to flow *through* the junction singularity AND the junction
+    to be the convergence bottleneck — conditions the purpose-built momwire test
+    hentenna (feed stub at the junction, otherwise well-conditioned) meets but no
+    catalog geometry does.
+
+Incidental limitation surfaced here: momwire raises `NotImplementedError` for
+`use_singular_enrichment` + distributed wire loading ("the enrichment bases
+don't carry the loading overlap term"), so lossy-spec designs (e.g.
+`verticals.pota_performer`) are recorded as skipped, not silently dropped.
+
+    python scripts/bench_enrichment_scan.py
+    python scripts/bench_enrichment_scan.py --meshes 41 81 --only multiband.trap_fan_dipole
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("OMP_WAIT_POLICY", "PASSIVE")
+os.environ.setdefault("GOMP_SPINCOUNT", "0")
+
+import argparse  # noqa: E402
+import importlib  # noqa: E402
+import json  # noqa: E402
+import resource  # noqa: E402
+import sys  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+LIVE_ARM_FRACTION = 0.20  # an arm is "live" if it carries ≥ this × the max arm |I|
+DEFAULT_MESHES = (41, 81)
+DEFAULT_MEM_GB = 8.0
+BASE_KW = {"degree": 2}
+
+
+def _enr_kw(variant):
+    return {"degree": 2, "use_singular_enrichment": True, "enrichment_variant": variant}
+
+
+def load_design(dotted):
+    return importlib.import_module(f"antennaknobs.designs.{dotted}").Builder
+
+
+def kge3_junctions(builder_cls, nseg):
+    """The K≥3 junctions in the translated geometry, plus the max junction
+    degree (0 when the design has no multi-wire junctions at all)."""
+    from antennaknobs.geometry import flat_wires_to_polylines
+
+    b = builder_cls()
+    b.nominal_nsegs = nseg
+    tr = flat_wires_to_polylines(b.build_wires())
+    juncs = tr["junctions"] or []
+    kge3 = [j for j in juncs if len(j) >= 3]
+    maxdeg = max((len(j) for j in juncs), default=0)
+    return kge3, maxdeg
+
+
+def arm_split(builder_cls, nseg, kge3):
+    """For the most-populated K≥3 junction, the sorted arm-current magnitudes
+    normalised to the largest (top arm = 1.0) and the count of live arms
+    (≥ LIVE_ARM_FRACTION of that largest). Solved on the plain bs2 basis — the
+    split is a geometry/excitation property, not an enrichment one."""
+    from antennaknobs.engines.momwire import MomwireEngine
+    from momwire import BSplineSolver
+
+    b = builder_cls()
+    b.nominal_nsegs = nseg
+    cur = MomwireEngine(
+        b, solver=BSplineSolver, solver_kwargs=BASE_KW
+    ).current_distribution()
+
+    best_live, best_split = 0, None
+    for j in kge3:
+        mags = []
+        for wire, end in j:
+            kc = cur[wire].knot_currents
+            mags.append(abs(kc[0] if end == "start" else kc[-1]))
+        top = max(mags) or 1.0
+        live = sum(1 for m in mags if m >= LIVE_ARM_FRACTION * top)
+        if live > best_live:
+            best_live = live
+            best_split = [
+                round(float(m) / float(top), 2) for m in sorted(mags, reverse=True)
+            ]
+    return best_live, best_split
+
+
+def enr_shift(builder_cls, nseg, variant):
+    """|Z_enr − Z_bs2| at feed 0 for one variant, and |Z_bs2|. Raises on a
+    momwire refusal (e.g. enrichment + distributed loading) so the caller can
+    record the reason."""
+    from antennaknobs.engines.momwire import MomwireEngine
+    from momwire import BSplineSolver
+
+    def z(kw):
+        b = builder_cls()
+        b.nominal_nsegs = nseg
+        return complex(
+            MomwireEngine(b, solver=BSplineSolver, solver_kwargs=kw).impedance()[0]
+        )
+
+    zb = z(BASE_KW)
+    ze = z(_enr_kw(variant))
+    return abs(ze - zb), abs(zb)
+
+
+def scan_design(design, meshes):
+    """One catalog design → its K≥3 junction profile and raw/stable enrichment
+    shifts. Never raises; a refusal or dud is recorded as ``skip``."""
+    row = {"design": design, "skip": None}
+    try:
+        cls = load_design(design)
+    except Exception as e:  # noqa: BLE001
+        row["skip"] = f"load: {type(e).__name__}: {e}"
+        return row
+    try:
+        kge3, maxdeg = kge3_junctions(cls, meshes[-1])
+    except Exception as e:  # noqa: BLE001
+        row["skip"] = f"geom: {type(e).__name__}: {e}"
+        return row
+    row["maxdeg"] = maxdeg
+    row["n_kge3"] = len(kge3)
+    if not kge3:
+        return row  # no junction to enrich — reported but not ranked
+    try:
+        row["live"], row["split"] = arm_split(cls, meshes[-1], kge3)
+    except Exception as e:  # noqa: BLE001
+        row["live"], row["split"] = None, None
+        row["skip"] = f"current: {type(e).__name__}: {str(e)[:60]}"
+        return row
+    shifts = {}
+    for n in meshes:
+        cell = {}
+        for variant in ("raw", "stable"):
+            try:
+                d, zb = enr_shift(cls, n, variant)
+                cell[variant] = d
+                cell["zb"] = zb
+            except NotImplementedError as e:
+                row["skip"] = f"enr: {str(e)[:70]}"
+                return row
+            except Exception as e:  # noqa: BLE001
+                cell[variant] = None
+                cell.setdefault("err", f"{type(e).__name__}: {str(e)[:40]}")
+        shifts[n] = cell
+    row["shifts"] = shifts
+    return row
+
+
+def _stable_at(row, mesh):
+    """The stable-variant shift at the finest requested mesh, or -1 to sort
+    junction-free / skipped rows last."""
+    sh = row.get("shifts")
+    if not sh:
+        return -1.0
+    cell = sh.get(mesh) or next(iter(sh.values()))
+    v = cell.get("stable")
+    return v if v is not None else -1.0
+
+
+def print_report(rows, meshes):
+    print(
+        "\nENRICHMENT-BENEFIT SCAN (issue #565)  "
+        f"meshes={list(meshes)}  live-arm fraction={LIVE_ARM_FRACTION:.0%}"
+    )
+    print(
+        "  rawΔ / stblΔ = |Z_enr − Z_bs2| at feed 0 for the raw and stable\n"
+        "  variants. A large rawΔ with a ~0 stblΔ is the raw coarse-mesh\n"
+        "  ARTIFACT, not a benefit — only a persistent stblΔ is real. 'live' =\n"
+        "  arms carrying ≥20% of the junction's largest arm current."
+    )
+    scored = [r for r in rows if r.get("shifts")]
+    other = [r for r in rows if not r.get("shifts")]
+    mf = meshes[-1]
+    hdr = (
+        f"\n{'design':32} {'deg':>3} {'#K3':>4} {'live':>4} "
+        + "  ".join(f"raw@{n:>3} stbl@{n:>3}" for n in meshes)
+        + "  split(top=1.0)"
+    )
+    print(hdr)
+    print("-" * 96)
+    for r in sorted(scored, key=lambda r: -_stable_at(r, mf)):
+        cells = []
+        for n in meshes:
+            c = r["shifts"][n]
+            cells.append(f"{_fmt(c.get('raw')):>7} {_fmt(c.get('stable')):>8}")
+        split = str(r.get("split") or "")
+        print(
+            f"{r['design']:32} {r['maxdeg']:>3} {r['n_kge3']:>4} "
+            f"{(r.get('live') if r.get('live') is not None else '?'):>4} "
+            + "  ".join(cells)
+            + f"  {split}"
+        )
+
+    skipped = [r for r in other if r.get("skip")]
+    if skipped:
+        print("\nSKIPPED (K≥3 present but not scored):")
+        for r in skipped:
+            print(f"  {r['design']:32} {r['skip']}")
+    n_nojunc = sum(1 for r in other if not r.get("skip"))
+    print(
+        f"\n{len(scored)} K≥3 designs scored, {len(skipped)} skipped, "
+        f"{n_nojunc} designs with no K≥3 junction (not shown)."
+    )
+    # headline verdict
+    worst_stable = max((_stable_at(r, mf) for r in scored), default=0.0)
+    print(
+        f"\nLargest stable-variant driving-point shift across the catalog at "
+        f"N={mf}: {worst_stable:.3f} Ω.\n"
+        "A catalog-wide near-zero means bs2 already resolves every junction — "
+        "no design\nbenefits from enrichment at the driving point (the raw "
+        "column's large values are\ncoarse-mesh artifacts that wash out by "
+        "N≈321; see the module docstring)."
+    )
+
+
+def _fmt(v):
+    return f"{v:.3f}" if v is not None else "  ."
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--meshes", type=int, nargs="+", default=list(DEFAULT_MESHES))
+    ap.add_argument("--only", nargs="+", help="restrict to these dotted designs")
+    ap.add_argument("--mem-limit-gb", type=float, default=DEFAULT_MEM_GB)
+    ap.add_argument("--out", type=Path, help="also write raw rows as JSON lines")
+    args = ap.parse_args(argv)
+
+    cap = int(args.mem_limit_gb * 1e9)
+    resource.setrlimit(resource.RLIMIT_AS, (cap, cap))
+
+    from antennaknobs.cli import list_builtin_designs
+
+    meshes = sorted(set(args.meshes))
+    designs = args.only or sorted(list_builtin_designs())
+    rows = []
+    out = args.out.open("w") if args.out else None
+    for i, d in enumerate(designs, 1):
+        print(f"[{i}/{len(designs)}] {d} ...", flush=True)
+        row = scan_design(d, meshes)
+        rows.append(row)
+        if out:
+            out.write(json.dumps(row) + "\n")
+            out.flush()
+    if out:
+        out.close()
+    print_report(rows, meshes)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #565.

## What

Two committed tools + a status writeup on whether the singular-enrichment basis (momwire #167, now ground-capable) helps the #521 junction cluster — and, by extension, any catalog design.

**`scripts/bench_enrichment_probe.py`** — solves the #521 cluster (hentenna/hourglass/discone + arrays) on **sin**, **bs2**, and **bs2+enrichment** up a mesh ladder, over **free space and ground** (PEC + Sommerfeld/refl-coef), scoring the #565 discriminator.

**`scripts/bench_enrichment_scan.py`** — catalog-wide follow-up: finds every K≥3 junction, measures the arm-current split ("live arms"), and measures the driving-point enrichment shift with **both the raw and stable variants**.

## Verdict — #565 outcome 2, and it generalizes

Writeup: `docs/status/2026-07-25-enrichment-cluster-probe.md`.

- **Cluster:** enrichment is a driving-point no-op (enr↦ ≤ 0.003 Ω on X, 0.000 on R, all 7 designs × 3 grounds). It does **not** collapse the sin↔bs2 reactance gap. bs2 is settled by N=81; sin is the laggard (slow reactance convergence against an already-converged Galerkin value). Different class from #484's R-dominated drift.
- **Catalog-wide:** 17 designs have a K≥3 junction; the largest **stable**-variant driving-point shift anywhere is **0.216 Ω** (`specialty.helix`, a curvature outlier). "3 live arms" is met all over the catalog yet enrichment does nothing — **necessary, not sufficient**. Benefit also needs the feed to couple *through* the junction singularity and the junction to be the convergence bottleneck.

## Two confounds the tools exist to expose

1. `enrichment_variant="auto"` **silently suppresses** enrichment on these designs → probe defaults to `raw`, verified `raw ≠ bs2`.
2. The **`raw` variant's coarse-mesh transient masquerades as benefit** — it swings the fan dipoles ~2.8 Ω at N=41–161, but that value is *wrong* (sin/bs2/PyNEC all disagree with it) and washes out by N=321; `stable`/`tikhonov` show ≤0.002 Ω. The scan prints both variants side by side so this can't be mistaken for a real correction. Also surfaced: enrichment + distributed wire loading raises `NotImplementedError` in momwire.

## Notes

- Runs on an **editable momwire install** (momwire `main`, #167 complete). **The momwire pin is deliberately not bumped** — deferred per the #565 decision — so this PR touches no submodule pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)