### PR TITLE
Group singular enrichment under validation/experimental in the B-spline gear menu (#565)

### DIFF
--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -3299,11 +3299,12 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     if (backend !== "pynec") {
       base.momwire_model = backend;
       const opts = modelOptionsForRequest(backend, currentOpts);
-      // BSplineSolver rejects ground_z + use_singular_enrichment together
-      // (image reaction for enrichment bases isn't worked out yet). Force
-      // enrichment off in the request when ground is active so the user
-      // gets a sensible solve instead of a server error; the gear shows
-      // an inline note.
+      // Enrichment now solves over ground (momwire #167: PEC image reaction,
+      // refl-coef, and Sommerfeld), so this is no longer an error guard — it is
+      // a UX choice. Enrichment is a validation-only knob that is redundant for
+      // the d=2 basis (issue #565), so we keep it off when ground is active
+      // rather than surface a control that can only match or worsen the grounded
+      // production solve; the gear shows the validation note.
       if (isBSplineFamily(backend) && groundActive) {
         opts.use_singular_enrichment = false;
       }
@@ -6174,8 +6175,15 @@ function BSplineFields({
           />
         )}
       </div>
+      <div className="backend-config-section">validation · experimental</div>
+      <p className="backend-config-note">
+        The d=2 basis already resolves K≥3 junctions — enrichment does not
+        improve a d=2 solve, and worsens it at coarse mesh (issue #565). Kept
+        as a validation tool against the low-order (sinusoidal) basis, where the
+        junction singularity genuinely matters. Not needed for production.
+      </p>
       <div className="field">
-        <label className="link-toggle" title="Add (u/h)·log(u/h) singular basis at K ≥ enrichment_min_k junctions; flips O(1/N) → ~O(1/N^(d+1)) on dominant-pair K=3 junctions (most current flowing through two of three wires).">
+        <label className="link-toggle" title="VALIDATION ONLY. Adds (u/h)·log(u/h) singular basis at K ≥ enrichment_min_k junctions. This flips O(1/N) → ~O(1/N^(d+1)) for LOW-ORDER bases (sinusoidal); the d=2 B-spline already converges at that rate on its own, so enrichment is redundant here and adds a coarse-mesh transient. See issue #565.">
           <input
             type="checkbox"
             checked={opts.useSingularEnrichment}

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1660,6 +1660,29 @@ input[type=checkbox] {
   overflow-y: auto;
 }
 
+/* Section divider inside the backend-config body — marks the enrichment block
+   as validation/experimental (issue #565: enrichment is redundant for the d=2
+   basis the product solves on). Mirrors .gear-menu-section, with a rule above
+   so it reads as a distinct group rather than another field. */
+.backend-config-section {
+  margin-top: var(--space-2);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.backend-config-note {
+  margin: 0;
+  color: var(--muted);
+  font-size: var(--text-xs);
+  line-height: 1.5;
+}
+
 .backend-config-footer {
   padding: var(--space-5) var(--space-6);
   border-top: 1px solid var(--border);


### PR DESCRIPTION
Per the #565 finding, keeps the singular-enrichment knob in the web UI but demotes it to validation/experimental so it can't be mistaken for a production convergence aid.

## What

In the B-spline gear menu (`BSplineFields`), the **K≥3 junction singular enrichment** block now sits under a **"validation · experimental"** section header (a ruled divider mirroring the existing gear-menu section style) with an inline note:

> The d=2 basis already resolves K≥3 junctions — enrichment does not improve a d=2 solve, and worsens it at coarse mesh (issue #565). Kept as a validation tool against the low-order (sinusoidal) basis, where the junction singularity genuinely matters. Not needed for production.

The enrichment toggle's tooltip is updated to say the same (it flips O(1/N)→O(1/N^(d+1)) for *low-order* bases; d=2 already converges at that rate, so enrichment is redundant here). **degree, n_qp_pair, and feed-source smoothing stay as ordinary production knobs** — only the enrichment block is demoted.

## Why

This session established (see PR #566) that the d=2 B-spline Galerkin basis fully resolves K≥3 junctions — driving-point impedance *and* near-junction current — so enrichment is redundant for it and adds a coarse-mesh transient. Its only real domain is the low-order sinusoidal solver. Leaving the knob visible-but-labeled preserves it as a validation/research tool without foot-gunning users of the default d=2 solve.

## Also

Corrects a now-stale comment: the frontend force-disables enrichment when ground is active citing "image reaction for enrichment bases isn't worked out yet" — but momwire #167 made enrichment solve over every ground (PEC/refl-coef/Sommerfeld). The force-off is now a UX choice consistent with the validation-only demotion, not an error guard. **Behavior unchanged.**

## Notes

- Frontend **source** only (`App.tsx`, `styles.css`); the static bundle is gitignored and built at deploy (`publish.yml`). Verified with `npm run build` (`tsc --noEmit` + vite) and confirmed the new strings/classes land in the bundle. I did not drive the modal in a browser — it's a copy/grouping change in an existing panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)