### PR TITLE
chore: adopt momwire 0.17.0 (enrichment over every ground model)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/sta
 # install below sees its requirement already satisfied, then the package with the
 # web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install "momwire==0.16.0" \
+ && pip install "momwire==0.17.0" \
  && pip install -e ".[web]"
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire==0.16.0",
+    "momwire==0.17.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",


### PR DESCRIPTION
Bumps the momwire pin **0.16.0 → 0.17.0** in all three required places (the trap from #268/#270):

- \`pyproject.toml\` — \`momwire==0.17.0\`
- \`Dockerfile\` — \`pip install "momwire==0.17.0"\`
- \`momwire\` submodule pointer — \`57bd98f → ce76ffe\` (tag \`v0.17.0\`)

### What 0.17.0 brings

The #167 series (momwire): image-reaction blocks so the **K≥3 singular-enrichment bases now solve over every ground model** — PEC image, fast-finite (refl-coef), and Sommerfeld — where before enrichment was free-space only.

### Default-cost note

Enrichment is opt-in (\`use_singular_enrichment=False\` by default), so the unqualified request path is byte-for-byte unchanged — no default latency smoke required. The #565 diagnostic work already confirmed enrichment is a driving-point no-op vs bs2 across the catalog; the web knob is labelled validation/experimental accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)