### PR TITLE
fix(web): detect and mark multi-feed build_network() designs (#570, #571)

### DIFF
--- a/src/antennaknobs/designs/wire/expanded_lazy_h.py
+++ b/src/antennaknobs/designs/wire/expanded_lazy_h.py
@@ -63,6 +63,13 @@ class Builder(AntennaBuilder):
                     # Reactive junction fed via open-wire line + tuner.
                     "target_z0": 300.0,
                     "default_view": "yz",
+                    # Both element centres ("lo" and "hi") are driven in phase
+                    # through the harness from the single junction source, so
+                    # this is a two-feedpoint antenna. Declaring the feed ports
+                    # marks both in the geometry view and flags multi_feed
+                    # (issues #570/#571) — the drive is via build_network(), so
+                    # the inline-`ex` auto-detector would otherwise see none.
+                    "feed_ports": ["lo", "hi"],
                     "elem_frac": {
                         "min": 0.8,
                         "max": 1.4,

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -1288,28 +1288,51 @@ def _declared_feed_ports(cls) -> list[str]:
     return []
 
 
-def _feed_positions(engine, currents):
-    """One marker per *declared* physical feed port (issue #571), each as
-    ``{"name", "position": [x, y, z]}``. Designs that declare no ``feed_ports``
-    fall back to the single primary feed, so every existing design is
-    unchanged. Named-but-non-feed ports (trap stubs, TL endpoints) are never
-    markers because they are not listed in ``feed_ports``."""
-    feeds = getattr(engine, "_feeds", None) or []
-    feed_names = getattr(engine, "_feed_names", None) or []
-    builder = getattr(engine, "builder", None)
-    declared = _declared_feed_ports(type(builder)) if builder is not None else []
-    out = []
-    if declared and feeds:
-        name_to_idx = {n: i for i, n in enumerate(feed_names) if n}
-        for nm in declared:
-            idx = name_to_idx.get(nm)
-            if idx is None or idx >= len(feeds):
-                continue
-            pos = _position_at(currents, feeds[idx][0], feeds[idx][1])
-            if pos is not None:
-                out.append({"name": nm, "position": pos})
-    if out:
-        return out
+def _feed_positions(engine, currents, multi_feed=False):
+    """One marker per feed (issue #571), each ``{"name", "position": [x,y,z]}``.
+
+    Gated by the resolved ``multi_feed`` flag so markers and the flag always
+    agree — a design that overrides ``multi_feed=False`` (e.g. a common-feed
+    antenna modelled with several driven gaps) shows a single marker.
+
+    When multi-feed:
+    * ``build_network()`` designs → the explicitly declared ``feed_ports``
+      (topology is not trusted — see ``_declared_feed_ports``);
+    * inline-``ex`` designs → every driven ``_feeds`` entry.
+
+    Otherwise a single primary-feed marker, so single-feed designs and
+    ``multi_feed=False`` overrides are unchanged."""
+    if multi_feed:
+        feeds = getattr(engine, "_feeds", None) or []
+        feed_names = getattr(engine, "_feed_names", None) or []
+        builder = getattr(engine, "builder", None)
+        net = None
+        if builder is not None and hasattr(builder, "build_network"):
+            try:
+                net = builder.build_network()
+            except Exception:  # noqa: BLE001
+                net = None
+        out = []
+        if net is not None:
+            name_to_idx = {n: i for i, n in enumerate(feed_names) if n}
+            for nm in _declared_feed_ports(type(builder)):
+                idx = name_to_idx.get(nm)
+                if idx is not None and idx < len(feeds):
+                    pos = _position_at(currents, feeds[idx][0], feeds[idx][1])
+                    if pos is not None:
+                        out.append({"name": nm, "position": pos})
+        elif len(feeds) > 1:
+            for i, feed in enumerate(feeds):
+                pos = _position_at(currents, feed[0], feed[1])
+                if pos is not None:
+                    nm = (
+                        feed_names[i]
+                        if i < len(feed_names) and feed_names[i]
+                        else f"feed {i}"
+                    )
+                    out.append({"name": nm, "position": pos})
+        if out:
+            return out
     pos = _feed_position(engine, currents)
     return [{"name": "feed", "position": pos}] if pos is not None else []
 
@@ -1380,24 +1403,33 @@ def _pynec_feed_position(builder, currents):
     return None
 
 
-def _pynec_feed_positions(builder, currents):
-    """PyNEC analogue of `_feed_positions` (issue #571): one marker per declared
-    physical feed port, matched to its `build_wires()` tuple by name and placed
-    on that wire's centre. Falls back to the single primary feed."""
-    declared = _declared_feed_ports(type(builder))
+def _pynec_feed_positions(builder, currents, multi_feed=False):
+    """PyNEC analogue of `_feed_positions` (issue #571), gated by multi_feed:
+    build_network() designs → declared feed ports (matched to their
+    build_wires() tuple by name); inline-`ex` designs → each `ev`-driven tuple.
+    Each marker sits on its wire's centre. Falls back to the single primary."""
     out = []
-    if declared:
+    if multi_feed:
         tuples = list(builder.build_wires())
-        by_name = {t[4]: i for i, t in enumerate(tuples) if len(t) >= 5 and t[4]}
-        for nm in declared:
-            i = by_name.get(nm)
-            if i is None or i >= len(currents):
-                continue
+        net = builder.build_network() if hasattr(builder, "build_network") else None
+
+        def center(i):
             knots = currents[i].knot_positions
-            if knots.shape[0] < 1:
-                continue
-            k = knots.shape[0] // 2
-            out.append({"name": nm, "position": knots[k].tolist()})
+            return knots[knots.shape[0] // 2].tolist() if knots.shape[0] else None
+
+        if net is not None:
+            by_name = {t[4]: i for i, t in enumerate(tuples) if len(t) >= 5 and t[4]}
+            for nm in _declared_feed_ports(type(builder)):
+                i = by_name.get(nm)
+                if i is not None and i < len(currents) and center(i) is not None:
+                    out.append({"name": nm, "position": center(i)})
+        else:
+            for i, t in enumerate(tuples):
+                if (t[3] if len(t) > 3 else None) is None or i >= len(currents):
+                    continue
+                if center(i) is not None:
+                    nm = t[4] if len(t) >= 5 and t[4] else f"feed {len(out)}"
+                    out.append({"name": nm, "position": center(i)})
     if out:
         return out
     pos = _pynec_feed_position(builder, currents)
@@ -1897,7 +1929,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             "feed_wire_index": feed_wire_idx,
             "feed_knot_index": feed_knot_idx,
             "feed_position": _feed_position(eng, currents),
-            "feed_positions": _feed_positions(eng, currents),
+            "feed_positions": _feed_positions(eng, currents, hints()["multi_feed"]),
             "z_in_re": float(z_primary.real),
             "z_in_im": float(z_primary.imag),
             "design_freq_mhz": design_freq,
@@ -1969,7 +2001,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             "feed_wire_index": feed_wire_idx,
             "feed_knot_index": feed_knot_idx,
             "feed_position": _feed_position(eng, geom),
-            "feed_positions": _feed_positions(eng, geom),
+            "feed_positions": _feed_positions(eng, geom, hints()["multi_feed"]),
             "design_freq_mhz": design_freq,
             "measurement_freq_mhz": meas_freq,
             "lambda_design_m": C_LIGHT / (design_freq * 1e6),
@@ -2060,7 +2092,9 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             "feed_wire_index": feed_wire_idx,
             "feed_knot_index": feed_knot_idx,
             "feed_position": _pynec_feed_position(builder, currents),
-            "feed_positions": _pynec_feed_positions(builder, currents),
+            "feed_positions": _pynec_feed_positions(
+                builder, currents, hints()["multi_feed"]
+            ),
             "z_in_re": float(z_primary.real),
             "z_in_im": float(z_primary.imag),
             "design_freq_mhz": design_freq,

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -1242,6 +1242,19 @@ def _feed_indices(engine, currents) -> tuple[int, int]:
     return pl_idx, j
 
 
+def _position_at(currents, pl_idx, arclen):
+    """Exact 3D point at `arclen` along polyline `pl_idx` of `currents`, or
+    None. Shared by the primary-feed marker and the per-feed-port markers."""
+    if pl_idx >= len(currents):
+        return None
+    knots = currents[pl_idx].knot_positions
+    if knots.shape[0] < 2:
+        return knots[0].tolist() if knots.shape[0] else None
+    deltas = np.linalg.norm(np.diff(knots, axis=0), axis=1)
+    cum = np.concatenate([[0.0], np.cumsum(deltas)])
+    return _interp_polyline(knots, cum, arclen)
+
+
 def _feed_position(engine, currents):
     """Exact 3D feed point for the primary feed — the physical location the
     solver actually feeds, independent of where segment knots fall. Avoids
@@ -1252,15 +1265,53 @@ def _feed_position(engine, currents):
     pf = _primary_feed(engine)
     if pf is None:
         return None
-    pl_idx, arclen = pf
-    if pl_idx >= len(currents):
-        return None
-    knots = currents[pl_idx].knot_positions
-    if knots.shape[0] < 2:
-        return knots[0].tolist() if knots.shape[0] else None
-    deltas = np.linalg.norm(np.diff(knots, axis=0), axis=1)
-    cum = np.concatenate([[0.0], np.cumsum(deltas)])
-    return _interp_polyline(knots, cum, arclen)
+    return _position_at(currents, pf[0], pf[1])
+
+
+def _declared_feed_ports(cls) -> list[str]:
+    """Physical feed-port names a design declares in
+    ``ui_params["feed_ports"]`` — the explicit, robust way to mark a multi-feed
+    antenna whose drive is routed through ``build_network()`` (e.g. a lazy-H
+    whose two element centres are fed in phase through a harness from one
+    source). Topology is deliberately NOT inferred: a log-periodic feeds ~10
+    chained elements from a single point, so "PortOnWire reachable from a
+    source" would wrongly report ten feeds (issues #570 / #571). Empty when a
+    design declares nothing — callers then keep the single-primary behaviour.
+    """
+    try:
+        ui = dict(cls.default_params).get("ui_params", {})
+        ports = ui.get("feed_ports")
+        if isinstance(ports, (list, tuple)):
+            return [str(p) for p in ports]
+    except Exception:  # noqa: BLE001
+        pass
+    return []
+
+
+def _feed_positions(engine, currents):
+    """One marker per *declared* physical feed port (issue #571), each as
+    ``{"name", "position": [x, y, z]}``. Designs that declare no ``feed_ports``
+    fall back to the single primary feed, so every existing design is
+    unchanged. Named-but-non-feed ports (trap stubs, TL endpoints) are never
+    markers because they are not listed in ``feed_ports``."""
+    feeds = getattr(engine, "_feeds", None) or []
+    feed_names = getattr(engine, "_feed_names", None) or []
+    builder = getattr(engine, "builder", None)
+    declared = _declared_feed_ports(type(builder)) if builder is not None else []
+    out = []
+    if declared and feeds:
+        name_to_idx = {n: i for i, n in enumerate(feed_names) if n}
+        for nm in declared:
+            idx = name_to_idx.get(nm)
+            if idx is None or idx >= len(feeds):
+                continue
+            pos = _position_at(currents, feeds[idx][0], feeds[idx][1])
+            if pos is not None:
+                out.append({"name": nm, "position": pos})
+    if out:
+        return out
+    pos = _feed_position(engine, currents)
+    return [{"name": "feed", "position": pos}] if pos is not None else []
 
 
 def _pynec_feed_indices(builder, currents) -> tuple[int, int]:
@@ -1327,6 +1378,30 @@ def _pynec_feed_position(builder, currents):
         mid_seg = (n_seg + 1) // 2  # 1-indexed driven segment
         return (0.5 * (knots[mid_seg - 1] + knots[mid_seg])).tolist()
     return None
+
+
+def _pynec_feed_positions(builder, currents):
+    """PyNEC analogue of `_feed_positions` (issue #571): one marker per declared
+    physical feed port, matched to its `build_wires()` tuple by name and placed
+    on that wire's centre. Falls back to the single primary feed."""
+    declared = _declared_feed_ports(type(builder))
+    out = []
+    if declared:
+        tuples = list(builder.build_wires())
+        by_name = {t[4]: i for i, t in enumerate(tuples) if len(t) >= 5 and t[4]}
+        for nm in declared:
+            i = by_name.get(nm)
+            if i is None or i >= len(currents):
+                continue
+            knots = currents[i].knot_positions
+            if knots.shape[0] < 1:
+                continue
+            k = knots.shape[0] // 2
+            out.append({"name": nm, "position": knots[k].tolist()})
+    if out:
+        return out
+    pos = _pynec_feed_position(builder, currents)
+    return [{"name": "feed", "position": pos}] if pos is not None else []
 
 
 # ---------------------------------------------------------------------------
@@ -1429,21 +1504,33 @@ def _auto_target_z0(cls) -> float:
 
 
 def _auto_multi_feed(cls) -> bool:
-    """Detect whether the design has more than one excited wire.
+    """Detect whether the design has more than one feed.
 
-    Builders that drive >1 feed wire in `build_wires()` get multi_feed=True
-    by default — the response shape switches to include a `feeds` array
-    (per-port Z + V) and the frontend renders the per-feed table.
+    Two conventions, two signals (issue #570):
 
-    Designs can still force the flag via `ui_params["multi_feed"]` — set
-    False to suppress the per-feed table even when multiple excitations
-    exist (e.g. mirror-symmetric arrays where the per-port Z is identical
-    by construction and the extra column adds no information).
+    * Inline-``ex`` designs: >1 wire carries an ``ex`` excitation in
+      ``build_wires()`` — each is an independently driven feed.
+    * ``build_network()`` designs: excitation comes from ``Driven`` sources,
+      not the ``ex`` field, so the inline count is always 0. A network design
+      is multi-feed when it has **>1 source** (=> >1 driving-point impedance in
+      the per-feed table) or it explicitly declares **>1 physical feed port**
+      via ``ui_params["feed_ports"]`` (a harness/split feed driven in phase
+      from one source — one driving-point impedance but two feedpoints on the
+      structure). Reachability over the branch graph is deliberately NOT used:
+      it cannot tell a harness-split lazy-H from a log-periodic's chained
+      feeder (see ``_declared_feed_ports``).
+
+    When multi_feed is True the response shape switches to include a `feeds`
+    array (per-port Z + V) and the frontend renders the per-feed table.
+    Designs can still force the flag via ``ui_params["multi_feed"]``.
     """
     try:
         b = cls()
+        net = b.build_network() if hasattr(b, "build_network") else None
+        if net is not None:
+            return len(net.sources) > 1 or len(_declared_feed_ports(cls)) > 1
         n_feeds = sum(1 for t in b.build_wires() if as_wire(t).ex is not None)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return False
     return n_feeds > 1
 
@@ -1810,6 +1897,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             "feed_wire_index": feed_wire_idx,
             "feed_knot_index": feed_knot_idx,
             "feed_position": _feed_position(eng, currents),
+            "feed_positions": _feed_positions(eng, currents),
             "z_in_re": float(z_primary.real),
             "z_in_im": float(z_primary.imag),
             "design_freq_mhz": design_freq,
@@ -1881,6 +1969,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             "feed_wire_index": feed_wire_idx,
             "feed_knot_index": feed_knot_idx,
             "feed_position": _feed_position(eng, geom),
+            "feed_positions": _feed_positions(eng, geom),
             "design_freq_mhz": design_freq,
             "measurement_freq_mhz": meas_freq,
             "lambda_design_m": C_LIGHT / (design_freq * 1e6),
@@ -1971,6 +2060,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             "feed_wire_index": feed_wire_idx,
             "feed_knot_index": feed_knot_idx,
             "feed_position": _pynec_feed_position(builder, currents),
+            "feed_positions": _pynec_feed_positions(builder, currents),
             "z_in_re": float(z_primary.real),
             "z_in_im": float(z_primary.imag),
             "design_freq_mhz": design_freq,

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1339,6 +1339,11 @@ type SolveResponse = {
   /** Exact 3D feed point for the primary feed; the marker dot uses this so
    *  it stays on the true feed regardless of solver-basis parity. */
   feed_position?: [number, number, number];
+  /** One marker per physical feed port (issue #571). Multi-feed antennas whose
+   *  drive is routed through build_network() (e.g. a lazy-H fed through a
+   *  phasing harness) declare ui_params["feed_ports"] and get one entry per
+   *  element centre here; single-feed designs get a single "feed" entry. */
+  feed_positions?: { name: string; position: [number, number, number] }[];
   z_in_re: number;
   z_in_im: number;
   /** Multi-feed geometries (bowtie 1×2 array) populate this; single-feed
@@ -8323,36 +8328,55 @@ function CurrentCanvas({
         }
       }
 
-      // Feed marker(s). Multi-feed geometries (bowtie 1×2 array) expose
-      // a `feeds[]` array — render one yellow dot per feed and label with
-      // the prescribed voltage phase. Single-feed geometries fall through
-      // to the legacy feed_wire_index / feed_knot_index path.
-      const feedList = result.feeds && result.feeds.length > 0
-        ? result.feeds
-        : [{
-            wire_index: feedWireIdx,
-            knot_index: result.feed_knot_index,
-            feed_position: result.feed_position,
-            v_re: 1, v_im: 0,
-            z_re: result.z_in_re, z_im: result.z_in_im,
-          }];
-      for (let fi = 0; fi < feedList.length; fi++) {
-        const f = feedList[fi];
-        const w_ = result.wires[f.wire_index];
-        // Prefer the exact feed point; fall back to the nearest knot.
-        const pos3d = f.feed_position ?? (w_ ? w_.knot_positions[f.knot_index] : undefined);
-        if (!pos3d) continue;
-        const feed = project(pos3d);
-        ctx!.fillStyle = PC.feed;
-        ctx!.beginPath();
-        ctx!.arc(feed.x, feed.y, 5 * s, 0, Math.PI * 2);
-        ctx!.fill();
-        if (showFeedNames) {
-          ctx!.font = `${feedFontPx}px ui-monospace, monospace`;
-          const label = feedList.length > 1
-            ? `feed ${fi} ∠${Math.round(Math.atan2(f.v_im, f.v_re) * 180 / Math.PI)}°`
-            : "feed";
-          ctx!.fillText(label, feed.x + 8 * s, feed.y - 8 * s);
+      // Feed marker(s). Three sources, in priority order:
+      //  1. `feed_positions[]` (issue #571): one physical feed point per
+      //     declared feed port — a lazy-H fed in phase through a harness has
+      //     two, one per element centre, even though its drive comes from a
+      //     single build_network() source. Rendered with the port name.
+      //  2. `feeds[]` (bowtie 1×2 array): per-feed Z+V, labelled by phase.
+      //  3. the legacy single feed_position / feed_wire_index path.
+      if (result.feed_positions && result.feed_positions.length > 0) {
+        const fps = result.feed_positions;
+        for (let fi = 0; fi < fps.length; fi++) {
+          const feed = project(fps[fi].position);
+          ctx!.fillStyle = PC.feed;
+          ctx!.beginPath();
+          ctx!.arc(feed.x, feed.y, 5 * s, 0, Math.PI * 2);
+          ctx!.fill();
+          if (showFeedNames) {
+            ctx!.font = `${feedFontPx}px ui-monospace, monospace`;
+            const label = fps.length > 1 ? fps[fi].name : "feed";
+            ctx!.fillText(label, feed.x + 8 * s, feed.y - 8 * s);
+          }
+        }
+      } else {
+        const feedList = result.feeds && result.feeds.length > 0
+          ? result.feeds
+          : [{
+              wire_index: feedWireIdx,
+              knot_index: result.feed_knot_index,
+              feed_position: result.feed_position,
+              v_re: 1, v_im: 0,
+              z_re: result.z_in_re, z_im: result.z_in_im,
+            }];
+        for (let fi = 0; fi < feedList.length; fi++) {
+          const f = feedList[fi];
+          const w_ = result.wires[f.wire_index];
+          // Prefer the exact feed point; fall back to the nearest knot.
+          const pos3d = f.feed_position ?? (w_ ? w_.knot_positions[f.knot_index] : undefined);
+          if (!pos3d) continue;
+          const feed = project(pos3d);
+          ctx!.fillStyle = PC.feed;
+          ctx!.beginPath();
+          ctx!.arc(feed.x, feed.y, 5 * s, 0, Math.PI * 2);
+          ctx!.fill();
+          if (showFeedNames) {
+            ctx!.font = `${feedFontPx}px ui-monospace, monospace`;
+            const label = feedList.length > 1
+              ? `feed ${fi} ∠${Math.round(Math.atan2(f.v_im, f.v_re) * 180 / Math.PI)}°`
+              : "feed";
+            ctx!.fillText(label, feed.x + 8 * s, feed.y - 8 * s);
+          }
         }
       }
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -506,7 +506,9 @@ def test_auto_multi_feed_classifies_both_feed_conventions():
     # build_network() harness feed declaring two feed ports
     assert adapter._auto_multi_feed(_design_builder("wire.expanded_lazy_h")) is True
     # build_network() single feed (tuner + line to one gap)
-    assert adapter._auto_multi_feed(_design_builder("wire.doublet_ladder_tuner")) is False
+    assert (
+        adapter._auto_multi_feed(_design_builder("wire.doublet_ladder_tuner")) is False
+    )
     # traps are one-port Loads on named ports, not feeds
     assert adapter._auto_multi_feed(_design_builder("multiband.trap_dipole")) is False
     # log-periodic: one feed, ~10 chained elements — reachability would wrongly

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -488,6 +488,66 @@ def test_solve_dispatches_to_momwire_for_dipole():
     assert out["z_in_re"] > 0
 
 
+def _design_builder(dotted):
+    import importlib
+
+    return importlib.import_module(f"antennaknobs.designs.{dotted}").Builder
+
+
+def test_auto_multi_feed_classifies_both_feed_conventions():
+    """multi_feed detection spans both conventions (issue #570): inline-`ex`
+    designs by their excited-wire count, and build_network() designs by source
+    count OR a declared feed_ports list. Topology is NOT inferred, so a
+    log-periodic's chained feeder stays single-feed."""
+    from antennaknobs.web import adapter
+
+    # inline-`ex` multi-feed (two driven gaps)
+    assert adapter._auto_multi_feed(_design_builder("wire.lazy_h")) is True
+    # build_network() harness feed declaring two feed ports
+    assert adapter._auto_multi_feed(_design_builder("wire.expanded_lazy_h")) is True
+    # build_network() single feed (tuner + line to one gap)
+    assert adapter._auto_multi_feed(_design_builder("wire.doublet_ladder_tuner")) is False
+    # traps are one-port Loads on named ports, not feeds
+    assert adapter._auto_multi_feed(_design_builder("multiband.trap_dipole")) is False
+    # log-periodic: one feed, ~10 chained elements — reachability would wrongly
+    # report ten; declaration-based detection keeps it single-feed.
+    assert adapter._auto_multi_feed(_design_builder("broadband.lpda")) is False
+
+
+def test_solve_emits_one_feed_marker_per_declared_port():
+    """A build_network() lazy-H declaring feed_ports=[lo, hi] gets one feed
+    marker per element centre (issue #571), even though its drive comes from a
+    single source and it reports one driving-point impedance."""
+    out = server.solve(
+        {
+            "geometry": "wire.expanded_lazy_h",
+            "measurement_freq_mhz": 28.57,
+            "design_freq_mhz": 28.57,
+            "momwire_model": "bspline",
+        }
+    )
+    fps = out["feed_positions"]
+    assert [f["name"] for f in fps] == ["lo", "hi"]
+    for f in fps:
+        assert len(f["position"]) == 3
+    assert out["multi_feed"] is True
+
+
+def test_solve_single_feed_reports_one_marker():
+    """Single-feed designs report exactly one feed marker — no regression from
+    the multi-marker path (issue #571)."""
+    out = server.solve(
+        {
+            "geometry": "dipoles.invvee",
+            "measurement_freq_mhz": 28.47,
+            "design_freq_mhz": 28.47,
+            "momwire_model": "bspline",
+        }
+    )
+    assert len(out["feed_positions"]) == 1
+    assert out["multi_feed"] is False
+
+
 def test_solve_open_circuited_feed_is_json_safe():
     """A matching-network slider at a physical open (T-match series C1 = 0 pF
     open-circuits the source; the network core reports Z = ∞, issue #289)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -535,6 +535,22 @@ def test_solve_emits_one_feed_marker_per_declared_port():
     assert out["multi_feed"] is True
 
 
+def test_solve_inline_ex_multifeed_marks_every_feed():
+    """Inline-`ex` multi-feed arrays keep one marker per driven element — the
+    multi-marker path must not collapse them to the single primary (issue #571
+    regression guard). four_square drives four phased verticals."""
+    out = server.solve(
+        {
+            "geometry": "verticals.four_square",
+            "measurement_freq_mhz": 7.15,
+            "design_freq_mhz": 7.15,
+            "momwire_model": "bspline",
+        }
+    )
+    assert out["multi_feed"] is True
+    assert len(out["feed_positions"]) == 4
+
+
 def test_solve_single_feed_reports_one_marker():
     """Single-feed designs report exactly one feed marker — no regression from
     the multi-marker path (issue #571)."""


### PR DESCRIPTION
Fixes #570 and #571.

## Problem

`multi_feed` was detected only by counting inline `ex` excitations
(`_auto_multi_feed`). Designs that route drive through `build_network()` —
source at a virtual node, elements fed through a phasing harness — carry
`ex=None` on every wire, so they counted **zero** feeds and were flagged
single-feed. The UI then showed one generic "feed" marker for a genuinely
two-element lazy-H, and suppressed any per-feed handling.

## What the audit changed

Both issues originally proposed inferring feeds from the network topology
("count `PortOnWire` ports reachable from a source"). Auditing the whole
catalog showed that is **unsafe**:

| design | sources | reachable PortOnWire | correct # feeds |
|---|---|---|---|
| `wire.expanded_lazy_h` | 1 | 2 | **2** (harness split) |
| `broadband.lpda` | 1 | **10** | **1** (chained feeder) |
| `wire.sterba_tl` | 1 | 1 | 1 |
| `wire.doublet_ladder_tuner` | 1 | 1 | 1 |

A log-periodic feeds ~10 chained elements from a single point; reachability
would report ten feeds. Topology alone cannot tell a harness-split lazy-H from
an LPDA feeder. So this PR uses an **explicit declaration** instead:
`ui_params["feed_ports"] = [...]` names the physical feedpoints. It's opt-in,
unambiguous, and LPDA-safe (LPDA declares nothing → stays single-feed).

## Changes

**#570 — flag.** `_auto_multi_feed` now handles `build_network()` designs:
multi-feed when they have `>1` source (⇒ `>1` driving-point impedance in the
per-feed table) **or** declare `>1` `feed_ports`. Inline-`ex` designs are
unchanged.

**#571 — markers.** New `feed_positions` payload (momwire **and** pynec paths):
one `{name, position}` per declared feed port. The geometry view draws a dot
per entry, labelled by port name. Designs that declare nothing fall back to the
single primary-feed marker — **no regression**. A shared `_position_at` helper
backs both the primary and the per-port markers so they can't drift.

Markers are deliberately decoupled from the per-feed **Z-table** (still gated on
`len(zs) > 1`): a harness lazy-H has two feedpoints but one driving-point
impedance, so it shows two dots and one impedance — both correct.

**Catalog.** `wire.expanded_lazy_h` declares `feed_ports=[lo, hi]`, so the
catalog lazy-H now marks both element centres.

## Tests

`test_web_server.py` covers both conventions:
- inline-`ex` multi (`wire.lazy_h`) → multi
- declared-network multi (`wire.expanded_lazy_h`) → multi, two markers `[lo, hi]`
- network single (`wire.doublet_ladder_tuner`) → single
- trap stubs (`multiband.trap_dipole`) → single
- log-periodic (`broadband.lpda`) → single (the reachability trap)
- single-feed design → exactly one marker

All 168 web-server tests pass; frontend `tsc` + `vite build` clean.

## Note on the issues' original approach

Both issues proposed a shared reachability helper. The LPDA counterexample
(surfaced by the catalog audit) invalidated pure reachability, so this PR
substitutes the explicit `feed_ports` declaration as the single source of truth
for both the flag and the markers — same goal, robust across the catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
