### PR TITLE
feat(hexbeam): single common feed via build_network(), drop PyNEC-only build_tls

### DIFF
--- a/src/antennaknobs/designs/multiband/hexbeam_5band.py
+++ b/src/antennaknobs/designs/multiband/hexbeam_5band.py
@@ -9,21 +9,25 @@ band 0 (longest wavelength) sits on top and band N-1 sits at base —
 the usual physical convention for stacked Yagi/hexbeam towers.
 
 Two feed modes are exposed via daisy_chain:
-  * False (default) — multi-feed: every band driven independently with
-    V = 1+0j. The response carries one entry in feeds[] per band so the
-    Smith chart shows per-band driving-point Z.
-  * True — daisy-chain: only band 0 is driven externally; the lower
-    bands couple via 50ohm TL jumpers of length z_spacing between
-    successive feeds. build_tls() emits the jumper specs. Momwire engines
-    don't support TLs yet; the frontend greys out the toggle when a
-    momwire slot is active.
+  * True (default) — single feed: only band 0 is driven externally; the
+    lower bands couple up the stack via 50 ohm TL jumpers of length
+    z_spacing between successive feeds. Modelled with build_network() (an
+    engine-agnostic circuit reduction over the antenna's multiport Y), so
+    it works on momwire AND PyNEC — this is the physical "one coax" hexbeam.
+  * False — independent per-band feeds: every band driven separately with
+    V = 1+0j (inline `ex`, no network). The response carries one entry in
+    feeds[] per band so the Smith chart shows each band's own driving-point
+    Z — a tuning aid, not the physical feed.
+
+(Prior to the build_network() rewrite this was a PyNEC-only build_tls()
+daisy chain; momwire could not model the jumpers. That path is gone.)
 """
 
 import math
 from types import MappingProxyType
 
 from antennaknobs import AntennaBuilder
-from antennaknobs.network import Wire
+from antennaknobs.network import Driven, Network, PortOnWire, TL, Wire
 
 C_LIGHT_MHZ_M = 299.792458
 
@@ -201,7 +205,10 @@ class Builder(AntennaBuilder):
             "freq": 14.300,
             "base": 7.0,
             "z_spacing": 0.2,
-            "daisy_chain": False,
+            # Single common feed (band 0 + jumpers up the stack) by default —
+            # the physical one-coax hexbeam. False drives every band
+            # independently for per-band Z study.
+            "daisy_chain": True,
             "n_bands": _MAX_BANDS,
             "bands": (_BAND_20M, _BAND_17M, _BAND_15M, _BAND_12M, _BAND_10M),
             "ui_params": MappingProxyType(
@@ -248,7 +255,7 @@ class Builder(AntennaBuilder):
                         "unit": " m",
                     },
                     "daisy_chain": {
-                        "label": "Daisy-chain feed (PyNEC only)",
+                        "label": "Single common feed (daisy-chain)",
                     },
                 }
             ),
@@ -298,20 +305,15 @@ class Builder(AntennaBuilder):
         # T->S feed gap refines with the mesh (issue #435). |T - S| =
         # 2*_FEED_GAP*sin30 = _FEED_GAP for every band, so one shared count
         # against the design_freq quarter-wave keeps all five feeds equal
-        # (1 segment at the default mesh). Stored for build_tls, which
-        # attaches jumpers to the feed wires' middle segment.
+        # (1 segment at the default mesh).
         wavelength0 = C_LIGHT_MHZ_M / self.design_freq
         n_seg_feed = self.segs_for(_FEED_GAP, 0.25 * wavelength0)
-        self._n_seg_feed = n_seg_feed
 
         tups = []
         # build_wires() emits, per band, six edges from the driver hex,
         # one tip edge on the reflector, three reflector edges, one more
-        # reflector tip, and finally the 1-segment feed across T->S.
-        # The feed tuple's index inside the flat list is recorded so
-        # build_tls() can wire daisy-chain jumpers between successive
-        # feeds without re-running build_wires().
-        self._feed_wire_indices = []
+        # reflector tip, and finally the 1-segment feed across T->S, named
+        # feed{i} so build_network() can reference each band's feedpoint.
 
         for band_idx, band in enumerate(active_bands):
             wavelength = C_LIGHT_MHZ_M / float(band["freq"])
@@ -349,18 +351,14 @@ class Builder(AntennaBuilder):
             tups.extend(build_path([D, E, F, G]))
             tups.extend(build_path([G, H]))
             tups.extend(build_path([II, J, T]))
-            # The feed wire (one per band). Daisy-chain mode strips the
-            # excitation on bands 1..N-1 inside build_tls; multi-feed
-            # mode leaves every band's excitation in place.
-            tups.append(Wire(T, S, n_seg=n_seg_feed, ex=1 + 0j))
-            self._feed_wire_indices.append(len(tups))  # 1-indexed NEC tag
-
-        if self.daisy_chain:
-            # Daisy-chain mode: only band 0 stays excited. The TL jumpers
-            # added in build_tls() couple bands 1..N-1 to their upstream
-            # neighbour.
-            for idx in self._feed_wire_indices[1:]:
-                tups[idx - 1] = tups[idx - 1]._replace(ex=None)
+            # The feed wire (one per band), named feed{i} so build_network()
+            # can reference it. Single-feed mode drives the whole antenna
+            # through build_network() (ex=None; source at feed0 + jumpers up
+            # the stack); independent-feed mode drives every band inline.
+            feed_ex = None if self.daisy_chain else (1 + 0j)
+            tups.append(
+                Wire(T, S, n_seg=n_seg_feed, name=f"feed{band_idx}", ex=feed_ex)
+            )
 
         # Every band's every edge meshes at the design density
         # (nominal_nsegs per design_freq quarter-wave — one segment
@@ -369,23 +367,26 @@ class Builder(AntennaBuilder):
         # middle segment via _n_seg_feed).
         return tups
 
-    def build_tls(self):
-        """50ohm jumpers between successive band feeds in daisy-chain mode.
-        Each tuple is (idx1, seg1, idx2, seg2, impedance, length) — the
-        shape PyNECEngine.tl_card expects. Momwire engines reject any
-        non-empty list (engines/momwire.py:90), which the frontend should
-        guard against by greying out the toggle when a momwire slot is
-        active."""
-        if not getattr(self, "daisy_chain", False):
-            return []
-        # build_wires must run first to populate _feed_wire_indices.
-        if not hasattr(self, "_feed_wire_indices"):
-            self.build_wires()
-        feeds = self._feed_wire_indices
-        # Jumpers land on the middle segment of the n_seg_feed-segment
-        # feed wires (1 when the count is 1, i.e. at the default mesh).
-        seg = (self._n_seg_feed + 1) // 2
-        tls = []
-        for i in range(len(feeds) - 1):
-            tls.append((feeds[i], seg, feeds[i + 1], seg, 50.0, self.z_spacing))
-        return tls
+    def build_network(self):
+        """Single common feed as an engine-agnostic network (replaces the old
+        PyNEC-only build_tls daisy chain). Band 0 is the sole external feed;
+        each successive band couples to its upstream neighbour through a 50 ohm
+        TL jumper of length z_spacing. Returns None in independent-feed mode
+        (daisy_chain=False), where every band is driven inline via `ex` and the
+        engine takes the multi-feed path.
+
+        The jumper TLs and floating (passive) band feeds are reduced over the
+        antenna's multiport Y by the shared NetworkReducer, so the model runs
+        on momwire and PyNEC alike."""
+        if not self.daisy_chain:
+            return None
+        n_bands = int(self.n_bands)
+        feed_names = [f"feed{i}" for i in range(n_bands)]
+        return Network(
+            ports={nm: PortOnWire(nm) for nm in feed_names},
+            branches=[
+                TL(a=feed_names[i], b=feed_names[i + 1], z0=50.0, length=self.z_spacing)
+                for i in range(n_bands - 1)
+            ],
+            sources=[Driven(port=feed_names[0], voltage=1 + 0j)],
+        )

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1032,9 +1032,10 @@ function ParamForm({
   onChange: (path: (string | number)[], value: number | string | boolean) => void;
   pathPrefix?: (string | number)[];
   // Param names that should render as disabled even though they're
-  // visible in the schema. Used to grey out controls whose effect
-  // depends on the active backend (e.g. daisy_chain only works on
-  // PyNEC; momwire engines don't support transmission lines yet).
+  // visible in the schema — e.g. to grey out a control whose effect
+  // depends on the active backend. Currently unused (kept as a general
+  // mechanism); daisy_chain used to rely on it before build_network()
+  // made the single-feed hexbeam engine-agnostic.
   disabledFields?: Set<string>;
   // Optimiser integration (top-level rail only). `settings` overrides a knob's
   // effective min/max/step; `onContext` opens that knob's right-click menu;
@@ -3320,15 +3321,9 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     // `bands: [{band_id, freq, length_factor}, ...]` array; the backend
     // unpacks it in _bands_from_request().
     Object.assign(base, currentValues);
-    // hexbeam_5band's daisy_chain feed mode uses NEC TL cards; momwire
-    // engines reject any non-empty build_tls(). The daisy_chain gear
-    // is greyed out when a momwire slot is active (see the disabled prop
-    // on the schema control), and we belt-and-suspenders force the
-    // request to daisy_chain=false here so a stale value from a
-    // previously-active pynec slot doesn't slip through.
-    if (backend !== "pynec" && "daisy_chain" in base) {
-      base.daisy_chain = false;
-    }
+    // hexbeam_5band's daisy_chain (single common feed) is now modelled with
+    // build_network(), which the shared NetworkReducer solves on momwire and
+    // PyNEC alike — so it is no longer greyed out or forced off on momwire.
     return base;
   }
 
@@ -4796,15 +4791,6 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
               schema={currentSchema}
               values={currentValues}
               onChange={handleUserParamChange}
-              // hexbeam_5band's daisy_chain mode emits NEC TL cards;
-              // momwire engines reject any non-empty build_tls() so the
-              // toggle has no effect there. Grey it out when the active
-              // slot's backend is momwire — the request-build side also
-              // forces daisy_chain=false so a stale value doesn't slip
-              // through.
-              disabledFields={
-                backend !== "pynec" ? new Set(["daisy_chain"]) : undefined
-              }
               // Per-knob optimiser hooks: effective min/max/step come from the
               // knob's menu settings (overriding schema), and right-click opens
               // that menu.

--- a/tests/test_hexbeam_5band.py
+++ b/tests/test_hexbeam_5band.py
@@ -1,6 +1,5 @@
-"""hexbeam_5band Builder: per-band z-stagger, multi-feed shape, daisy-
-chain TL list. Ports the multi-band convention from momwire's
-hexbeam_5band example into antennaknobs's Builder pattern."""
+"""hexbeam_5band Builder: per-band z-stagger, single-feed default, and the
+build_network() daisy-chain feed (replaces the old PyNEC-only build_tls path)."""
 
 from __future__ import annotations
 
@@ -8,29 +7,64 @@ import math
 
 import pytest
 
+from antennaknobs.network import TL
 from antennaknobs.designs.multiband.hexbeam_5band import Builder
 
 
-def _feeds(tups):
-    return [(i + 1, t) for i, t in enumerate(tups) if t[3] is not None]
+def _feed_wires(tups):
+    """The named band-feed wires (feed0..feedN-1), in emission order."""
+    return [t for t in tups if len(t) > 4 and t[4] and str(t[4]).startswith("feed")]
 
 
-def test_default_is_five_bands_multi_feed():
+def test_default_is_single_feed_five_bands():
     b = Builder()
     tups = b.build_wires()
-    feeds = _feeds(tups)
+    feeds = _feed_wires(tups)
     assert b.n_bands == 5
-    assert b.daisy_chain is False
+    assert b.daisy_chain is True  # single common feed by default
     assert len(feeds) == 5
-    assert b.build_tls() == []
+    # Single-feed: no band is driven inline; build_network() drives band 0.
+    assert all(t[3] is None for t in feeds)
+    net = b.build_network()
+    assert net is not None
+    assert [s.port for s in net.sources] == ["feed0"]
+
+
+def test_single_feed_network_jumpers_chain_the_bands():
+    b = Builder()
+    b.z_spacing = 1.2
+    net = b.build_network()
+    tls = [br for br in net.branches if isinstance(br, TL)]
+    assert len(tls) == 4  # N-1 jumpers for 5 bands
+    for tl in tls:
+        assert tl.z0 == 50.0
+        assert tl.length == pytest.approx(1.2)
+    # Each jumper couples successive band feeds up the stack.
+    assert [(tl.a, tl.b) for tl in tls] == [
+        ("feed0", "feed1"),
+        ("feed1", "feed2"),
+        ("feed2", "feed3"),
+        ("feed3", "feed4"),
+    ]
+
+
+def test_independent_feed_mode_drives_every_band_inline():
+    b = Builder()
+    b.daisy_chain = False
+    assert b.build_network() is None  # no network -> inline-ex multi-feed path
+    feeds = _feed_wires(b.build_wires())
+    assert len(feeds) == 5
+    assert all(t[3] is not None for t in feeds)  # every band driven with ex
 
 
 def test_n_bands_slicing_drops_higher_bands():
     b = Builder()
     b.n_bands = 3
     tups = b.build_wires()
-    feeds = _feeds(tups)
-    assert len(feeds) == 3
+    assert len(_feed_wires(tups)) == 3
+    # single feed still drives only band 0, with n_bands-1 = 2 jumpers
+    net = b.build_network()
+    assert len([br for br in net.branches if isinstance(br, TL)]) == 2
     # Same per-band tuple count → exactly n_bands × per_band_tuples.
     b5 = Builder()
     assert len(tups) == len(b5.build_wires()) * 3 // 5
@@ -52,58 +86,18 @@ def test_z_stagger_band0_on_top():
     b.n_bands = 3
     b.z_spacing = 1.5
     b.base = 10.0
-    tups = b.build_wires()
-    # The feed tuple is the last edge added per band; its endpoints
-    # share the same z as the rest of that band.
-    feeds = _feeds(tups)
-    zs = [feed[1][0][2] for feed in feeds]  # z of T knot
-    # Bands emitted in order 0,1,2 → z descends.
+    feeds = _feed_wires(b.build_wires())
+    zs = [t[0][2] for t in feeds]  # z of the T knot (feed wire start)
     assert zs[0] > zs[1] > zs[2]
     assert math.isclose(zs[0] - zs[1], 1.5)
     assert math.isclose(zs[1] - zs[2], 1.5)
     assert math.isclose(zs[-1], 10.0)
 
 
-def test_daisy_chain_strips_excitation_from_lower_bands():
-    b = Builder()
-    b.daisy_chain = True
-    tups = b.build_wires()
-    feeds = _feeds(tups)
-    # Only band 0 (the first feed) keeps a non-None excitation.
-    assert len(feeds) == 1
-
-
-def test_daisy_chain_emits_tl_jumpers():
-    b = Builder()
-    b.daisy_chain = True
-    b.z_spacing = 1.2
-    tls = b.build_tls()
-    assert len(tls) == 4  # N-1 jumpers for 5 bands
-    # Shape PyNECEngine consumes: (idx1, seg1, idx2, seg2, Z, length).
-    for jumper in tls:
-        assert len(jumper) == 6
-        assert jumper[4] == 50.0
-        assert jumper[5] == pytest.approx(1.2)
-    # Each jumper connects successive feed wires; with the build_wires
-    # convention each band emits the same number of tuples so feed
-    # indices increment uniformly.
-    feed_idxs = [j[0] for j in tls] + [tls[-1][2]]
-    diffs = [b - a for a, b in zip(feed_idxs[:-1], feed_idxs[1:])]
-    assert len(set(diffs)) == 1  # uniform stride between feeds
-
-
-def test_daisy_chain_disabled_returns_empty_tls():
-    b = Builder()
-    assert b.daisy_chain is False
-    assert b.build_tls() == []
-
-
 def test_per_band_freq_scales_geometry():
     """Halving the band freq should roughly double its radius (linear in λ)."""
     b = Builder()
     b.n_bands = 2
-    # Use the per-band freq override path: override the second band to
-    # double the first's wavelength.
     bands = (
         {
             "freq": 28.0,
@@ -120,26 +114,21 @@ def test_per_band_freq_scales_geometry():
     )
     b.bands = bands
     tups = b.build_wires()
-    # Take the second-edge-of-each-band (S→A on the driver path); its
-    # length should scale with wavelength.
-    # Band 0's S→A edge is at tuple index 0; band 1's at index 10
-    # (single-band emits 10 tuples).
     per_band = len(tups) // 2
-    s0 = tups[0]
-    s1 = tups[per_band]
+    s0, s1 = tups[0], tups[per_band]
     dist0 = math.dist(s0[0], s0[1])
     dist1 = math.dist(s1[0], s1[1])
-    # Band 1 has half the freq → λ doubles → radius doubles.
     assert dist1 / dist0 == pytest.approx(2.0, rel=0.05)
 
 
-def test_registered_in_web_examples():
-    """Adapter auto-discovers the new design and reports multi_feed."""
+def test_registered_single_feed_by_default():
+    """The auto-discovered example is single-feed by default (one common feed
+    modelled with build_network(), so multi_feed is False)."""
     from antennaknobs.web.examples import REGISTRY
 
     ex = REGISTRY.get("multiband.hexbeam_5band")
     assert ex is not None
-    assert ex.multi_feed is True
+    assert ex.multi_feed is False
 
 
 def test_nominal_nsegs_scales_radiator_edges():
@@ -152,7 +141,5 @@ def test_nominal_nsegs_scales_radiator_edges():
         b.nominal_nsegs = n
         tups = b.build_wires()
         counts[n] = max(t[2] for t in tups)
-        feeds = _feeds(tups)
-        assert all(f[1][2] == 1 for f in feeds)  # feed gaps stay 1
-    # tripling N triples the densest edge's count (within rounding)
+        assert all(t[2] == 1 for t in _feed_wires(tups))  # feed gaps stay 1
     assert 2.8 < counts[123] / counts[41] < 3.2


### PR DESCRIPTION
Rewrites `hexbeam_5band`'s feed so a real multiband hexbeam is what it is — **one common feed** — and modelled on **every engine**, not just PyNEC.

## Background

`hexbeam_5band` stacks up to 5 monoband hexbeams; its single-feed mode used the legacy **`build_tls()`** jumper list, which only PyNEC can solve. So on momwire the toggle was greyed out and forced off, leaving momwire with an *unphysical* 5-independent-feed default (which read as "5 feeds" in the UI — the report that kicked this off).

## Change

Model the single feed with **`build_network()`**: band 0 is the sole external feed; successive bands couple up the stack through 50 Ω `TL` jumpers of length `z_spacing`. The shared `NetworkReducer` solves it over the antenna's multiport Y, so it runs on **momwire and PyNEC** alike — the physical one-coax hexbeam.

- `daisy_chain` now **defaults `True`** (single common feed). `False` keeps the independent per-band inline-`ex` mode for per-band Z study.
- `build_tls()` **removed**; feed wires are named `feed0..feedN-1` so `build_network()` references them; jumpers are `TL` branches with the source at `feed0`.
- **Frontend**: dropped the now-obsolete momwire grey-out / forced `daisy_chain=false`.
- Verified on momwire: default solves to a single driving-point Z (~72−18j @ 10 m) with one feed marker; independent mode still gives 5.

## Scope note — legacy `build_tls`

An audit found only **two** designs ever used `build_tls`: this one and `delta_looparray_with_tls`. After this PR, `delta_looparray_with_tls` is the **last** user — and it exists *deliberately* as the `build_tls`→native-NEC-`tl_card` **oracle** that guards the `NetworkReducer` (`test_tl_composition`). It should stay as that reference (candidate to relocate to a test fixture in a follow-up so it's not copied as a pattern), not be converted.

## Tests

`test_hexbeam_5band` rewritten for the network feed + single-feed default (feeds found by name, jumper TLs asserted, independent mode → `build_network() is None`). Full local runs green: hexbeam, web-server, nec-export, catalog-generated, feedline, serialize, opt-nested. Frontend `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)