### PR TITLE
refactor: move legacy build_tls design to a test fixture; drop its NEC export

### DIFF
--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -130,7 +130,7 @@ whole shape with a `Drone` — see
 | Design | Notes |
 | --- | --- |
 | `multiband.fandipole` | Fan dipole — parallel dipoles off one feed for several bands · variants: `five_band`, `pair_12_10`, `pair_17_15` |
-| `multiband.hexbeam_5band` | Stacked hexbeam: up to 5 concentric hexbeam shapes stacked along z, each sized to its own band's wavelength and driven by its own feed · variants: `opt`, `opt_coupled` |
+| `multiband.hexbeam_5band` | Stacked hexbeam: up to 5 concentric hexbeam shapes stacked along z, each sized to its own band's wavelength, sharing one common feed by default (band 0 driven, the rest coupled up the stack — see the feed-mode note below) · variants: `opt`, `opt_coupled` |
 | `multiband.trap_dipole` | Dual-band trap dipole — Load(parallel=True) showcase for issue #65 |
 | `multiband.trap_fan_dipole` | Four-band trapped fan dipole — combines `fandipole` geometry with the `trap_dipole` Load(parallel=True) idiom · variants: `band0_full`, `band0_inner`, `band1_full`, `band1_inner` |
 | `multiband.twoband_fan_dipole` | Two-band fan (parallel) dipole — two dipoles bonded at a common feed · variants: `current_physical`, `s01`, `s015`, `s01_eps001`, `s02`, `s025`, `s03`, `s05`, `s07` |
@@ -152,7 +152,6 @@ showcase (see [the solver guide](/reference/solver/)):
 | `arrays.delta_looparray_1x4_grouped` | 1x4 delta-loop row with per-group knobs (inner/outer pairs tuned separately) |
 | `arrays.delta_looparray_2x2` | 2x2 phased stack of delta loops |
 | `arrays.delta_looparray_network` | delta_looparray driven by two TLs from a central virtual driver |
-| `arrays.delta_looparray_with_tls` | Delta-loop pair phased through explicit transmission lines (legacy build_tls path) |
 | `arrays.folded_invveearray` | 2x2 phased stack of folded inverted-vees |
 | `arrays.hentenna_array` | Side-by-side hentenna pair (1x2) |
 | `arrays.hourglass_array` | Side-by-side hourglass pair (1x2) |

--- a/src/antennaknobs/designs/arrays/delta_looparray_network.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray_network.py
@@ -1,16 +1,18 @@
 """delta_looparray driven by two TLs from a central virtual driver.
 
-Same antenna geometry as `delta_looparray_with_tls` (two slanted delta loops
-spaced along y), driven the same way (two Z0=100 transmission lines from a
-single driver, lengths set by `twist`). The difference: this Builder uses
-the new port-based network spec (`build_network()`), so
+Same antenna geometry as the legacy `build_tls` variant (two slanted delta
+loops spaced along y), driven the same way (two Z0=100 transmission lines from a
+single driver, lengths set by `twist`). That legacy Builder now lives only as a
+test oracle at `tests/fixtures/delta_looparray_with_tls.py` (it is not a catalog
+design). This Builder is the canonical version: it uses the port-based network
+spec (`build_network()`), so
 
   - there is no dummy `WWW`-`WW` stub wire in `build_wires()`,
   - the loop feed edges are named (`"loop1"`, `"loop2"`),
   - the central driver is a `PortVirtual` — exists only as a row/column
     in the network Y matrix during the nodal reduction.
 
-MomwireEngine produces the same impedance as `delta_looparray_with_tls` to
+MomwireEngine produces the same impedance as the legacy `build_tls` fixture to
 numerical precision; the showcase for the network-spec API in #65.
 """
 

--- a/src/antennaknobs/designs/multiband/hexbeam_5band.py
+++ b/src/antennaknobs/designs/multiband/hexbeam_5band.py
@@ -1,5 +1,6 @@
 """Stacked hexbeam: up to 5 concentric hexbeam shapes stacked along z,
-each sized to its own band's wavelength and driven by its own feed.
+each sized to its own band's wavelength, sharing one common feed by default
+(band 0 driven, the rest coupled up the stack — see the feed-mode note below).
 
 Each band reuses the single-band hexbeam geometry (driver hex with t0/t1
 tip segments, reflector hex, 1-segment T->S feed gap). Per-band sizing

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -187,8 +187,10 @@ class MomwireEngine(SimulationEngine):
         # degree. Set before _coerce_wire_tuples runs.
         self.segment_parity = _parity_for_solver(self._solver, self._solver_kwargs)
 
-        # build_wires() must run before build_tls() — some designs populate
-        # self.tls inside build_wires() (delta_looparray_with_tls).
+        # build_wires() must run before build_tls() — a build_tls design may
+        # populate self.tls inside build_wires() (the legacy path, exercised by
+        # the tests/fixtures/delta_looparray_with_tls oracle; no catalog design
+        # uses build_tls anymore).
         tups = self._coerce_wire_tuples(builder.build_wires())
         self._network = builder.build_network()
         self._tls = [] if self._network is not None else list(builder.build_tls())

--- a/src/antennaknobs/nec_export.py
+++ b/src/antennaknobs/nec_export.py
@@ -127,13 +127,6 @@ def export_nec(
     if l_ins is not None:
         lines.append(f"LD 2 0 0 0 0. {_num(l_ins)} 0.")
 
-    # Legacy build_tls() path -> native NEC TL cards. (The build_network() TL
-    # path uses the multiport-Y reducer and is rejected above.)
-    for idx1, seg1, idx2, seg2, impedance, length in eng.tls:
-        lines.append(
-            f"TL {idx1} {seg1} {idx2} {seg2} {_num(impedance)} {_num(length)} 0 0 0 0"
-        )
-
     gn = _gn(eng.ground)
     if gn:
         lines.append(gn)

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,4 @@
+"""Test-only design fixtures kept out of the shipped catalog (e.g. the legacy
+build_tls oracle). Importable as ``fixtures.<name>`` — ``tests/`` is on
+sys.path under pytest.
+"""

--- a/tests/fixtures/delta_looparray_with_tls.py
+++ b/tests/fixtures/delta_looparray_with_tls.py
@@ -1,4 +1,14 @@
-"""Delta-loop pair phased through explicit transmission lines (legacy build_tls path)."""
+"""Delta-loop pair phased through explicit transmission lines (legacy build_tls path).
+
+TEST FIXTURE, not a catalog design. This is the deliberate oracle for the
+``build_tls()`` → native NEC ``tl_card`` path: it cross-checks that the shared,
+engine-agnostic ``NetworkReducer`` (used by every ``build_network()`` design)
+reproduces NEC's native transmission-line handling. It lives in ``tests/`` so
+it is not shipped in the catalog and not copied as a pattern for new designs —
+new designs should use ``build_network()`` (see ``delta_looparray_network`` for
+the same antenna done that way). Imported by tests as
+``fixtures.delta_looparray_with_tls``.
+"""
 
 from antennaknobs import AntennaBuilder
 import math

--- a/tests/test_momwire_engine.py
+++ b/tests/test_momwire_engine.py
@@ -114,7 +114,7 @@ def test_momwire_multi_feed_impedance_sweep_shape():
 
 
 def test_momwire_tl_card_runs_and_returns_finite_impedance():
-    """delta_looparray_with_tls — the one design with tl_card. MomwireEngine
+    """delta_looparray_with_tls fixture — the sole build_tls oracle. MomwireEngine
     extracts the N-port Y via N independent solves, stamps the TL admittance
     between the right port pairs, then reduces back to the driven port.
     No strict PyNEC match here: NEC2 models the TL as a segment-level
@@ -123,7 +123,7 @@ def test_momwire_tl_card_runs_and_returns_finite_impedance():
     near TL half-wave resonance (the default twist puts one TL at ~0.5λ).
     Validate that the engine produces a finite, passive impedance and
     that the underlying Y matrix is symmetric (reciprocity)."""
-    from antennaknobs.designs.arrays.delta_looparray_with_tls import (
+    from fixtures.delta_looparray_with_tls import (
         Builder as TLBuilder,
     )
 
@@ -145,7 +145,7 @@ def test_momwire_tl_card_passive_port_floats_correctly():
     """With TLs present, the passive (TL-only) ports must satisfy I_ext=0
     in the reduced solution. Reconstruct V from the impedance() solve and
     verify the constraint at every passive port."""
-    from antennaknobs.designs.arrays.delta_looparray_with_tls import (
+    from fixtures.delta_looparray_with_tls import (
         Builder as TLBuilder,
     )
 
@@ -176,7 +176,7 @@ def test_momwire_tl_impedance_sweep_matches_per_freq():
     to within solver noise. Exercises the swept-Y → per-k TL stamp →
     driven-port reduction path that was added once compute_y_matrix_swept
     learned about junctions upstream."""
-    from antennaknobs.designs.arrays.delta_looparray_with_tls import (
+    from fixtures.delta_looparray_with_tls import (
         Builder as TLBuilder,
     )
 
@@ -642,7 +642,7 @@ def test_network_spec_matches_legacy_tls_on_delta_looparray():
     an attachment point for tl_card. Same antenna, same TLs, same drive.
     Impedance should agree to within the stub wire's tiny radiative
     contribution (~0.5%), far-field peak essentially identical."""
-    from antennaknobs.designs.arrays.delta_looparray_with_tls import (
+    from fixtures.delta_looparray_with_tls import (
         Builder as LegacyBuilder,
     )
     from antennaknobs.designs.arrays.delta_looparray_network import (

--- a/tests/test_nec_export.py
+++ b/tests/test_nec_export.py
@@ -77,16 +77,6 @@ def test_export_reducer_network_raises():
         export_nec(NetTLBuilder())
 
 
-def test_export_legacy_tls_emits_tl_cards():
-    """The legacy build_tls() path maps to native NEC TL cards."""
-    from antennaknobs.designs.arrays.delta_looparray_with_tls import (
-        Builder as TLBuilder,
-    )
-
-    deck = export_nec(TLBuilder(), ground="free")
-    assert any(ln.startswith("TL ") for ln in deck.splitlines())
-
-
 def _nec2c_impedances(deck):
     with tempfile.TemporaryDirectory() as d:
         nec = Path(d) / "deck.nec"


### PR DESCRIPTION
Completes the legacy-`build_tls` retirement started in #573. **End state: zero `build_tls` designs in the catalog** — every transmission-line design now uses `build_network()`.

## What & why

`delta_looparray_with_tls` was the last catalog design on the legacy `build_tls()` path. After #573 converted the hexbeam, its only remaining value is as the **oracle** that cross-checks the shared `NetworkReducer` against NEC's native `tl_card`. So it moves **out of the user-facing catalog** into `tests/fixtures/` — preserved as a guard, but no longer browsable or copyable as a pattern for new designs (which should use `build_network()`; `delta_looparray_network` is the same antenna done that way).

## Changes

- **Move**: `delta_looparray_with_tls.py` → `tests/fixtures/` (+ package `__init__`). Imported by tests as `fixtures.delta_looparray_with_tls` (`tests/` is on `sys.path` under pytest). Docstring marks it clearly as the test-only oracle.
- **Repoint** `test_momwire_engine` (the momwire `build_tls` oracle, 4 imports) to the fixture. `test_tl_composition` builds its own inline network, so it needed no change.
- **Drop NEC export of the `build_tls` path**: removed the `TL`-card emit loop in `nec_export.py` and its test — we no longer support exporting this design (the `build_network()` TL path was already export-unsupported by design).
- **Docs**: `delta_looparray_network` docstring + the `momwire` comment now point at the fixture; the hexbeam catalog one-liner corrected to *"one common feed by default"*; `catalog.md` regenerated (design removed, hexbeam line updated).
- Confirmed **no site-doc references** to the legacy TL path — all site TL/network prose describes the current `build_network()` mechanism.

## Tests

Ruff (format + check) clean; 112 tests across nec-export, momwire-engine, tl-composition, catalog-generated, hexbeam, bench-catalog all green. The oracle (`test_tl_composition`, momwire `build_tls` tests) still guards the reducer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)