### PR TITLE
Add BalancedLine differential two-conductor TL element (#575)

### DIFF
--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -13,6 +13,7 @@ from ..engine import FarField, SimulationEngine, WireCurrents
 from ..network import as_wire
 from ..network import (
     Admittance,
+    BalancedLine,
     Driven,
     Load,
     PortOnWire,
@@ -191,6 +192,18 @@ class PyNECEngine(SimulationEngine):
         self._extended_thin_wire_kernel = extended_thin_wire_kernel
         self.tups = self._coerce_wire_tuples(builder.build_wires())
         self._network = builder.build_network()
+        if self._network is not None and any(
+            isinstance(b, BalancedLine) for b in self._network.branches
+        ):
+            # PyNEC card mapping is out of scope (issue #575): NEC-2 has no
+            # native coupled-line card, so raise rather than silently
+            # mis-modelling the differential pair as single-ended. momwire is
+            # the supported engine for BalancedLine.
+            raise NotImplementedError(
+                "BalancedLine is not supported on PyNECEngine: NEC-2 has no "
+                "native coupled-line card. Run this design on MomwireEngine "
+                "(the differential stamp lives in the shared NetworkReducer)."
+            )
         # Wire material (issue #316): radius + conductor loss from the
         # design's WireSpec. The spec's conductivity is emitted as a global
         # ld_card type 5 (NEC's native wire-loss model — the momwire#131

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -192,18 +192,6 @@ class PyNECEngine(SimulationEngine):
         self._extended_thin_wire_kernel = extended_thin_wire_kernel
         self.tups = self._coerce_wire_tuples(builder.build_wires())
         self._network = builder.build_network()
-        if self._network is not None and any(
-            isinstance(b, BalancedLine) for b in self._network.branches
-        ):
-            # PyNEC card mapping is out of scope (issue #575): NEC-2 has no
-            # native coupled-line card, so raise rather than silently
-            # mis-modelling the differential pair as single-ended. momwire is
-            # the supported engine for BalancedLine.
-            raise NotImplementedError(
-                "BalancedLine is not supported on PyNECEngine: NEC-2 has no "
-                "native coupled-line card. Run this design on MomwireEngine "
-                "(the differential stamp lives in the shared NetworkReducer)."
-            )
         # Wire material (issue #316): radius + conductor loss from the
         # design's WireSpec. The spec's conductivity is emitted as a global
         # ld_card type 5 (NEC's native wire-loss model — the momwire#131
@@ -551,11 +539,16 @@ class PyNECEngine(SimulationEngine):
 
     def _network_uses_reducer(self):
         """True iff the network needs the Y-matrix reduction path — i.e. it
-        has a transmission line (TL), a virtual driver, or a lumped 2-port
-        (TwoPort) that isn't being emitted as a native nt_card. Load-only (and
-        native-nt) networks are handled natively by NEC's ld_card / nt_card."""
+        has a transmission line (TL or BalancedLine), a virtual driver, or a
+        lumped 2-port (TwoPort) that isn't being emitted as a native nt_card.
+        Load-only (and native-nt) networks are handled natively by NEC's
+        ld_card / nt_card."""
         net = self._network
-        if any(isinstance(b, TL) for b in net.branches):
+        # TL and the differential BalancedLine (issue #575) are both pure
+        # NetworkReducer stamps on the antenna Y — no native NEC card is
+        # involved on either engine, so nec2++ serves as an independent MoM
+        # oracle for momwire's sinusoidal-basis Y here just as it does for TL.
+        if any(isinstance(b, (TL, BalancedLine)) for b in net.branches):
             return True
         if any(isinstance(p, PortVirtual) for p in net.ports.values()):
             return True
@@ -612,6 +605,12 @@ class PyNECEngine(SimulationEngine):
                 "native_nt=True cannot emit a TL natively (NEC's tl_card needs "
                 "a real segment on both ends and a virtual driver has none); "
                 "run the default reducer path instead"
+            )
+        if any(isinstance(b, BalancedLine) for b in net.branches):
+            raise ValueError(
+                "native_nt=True cannot emit a BalancedLine natively (NEC-2 has "
+                "no coupled-line card; the differential stamp is a reducer-only "
+                "admittance block); run the default reducer path instead"
             )
         if any(isinstance(p, PortVirtual) for p in net.ports.values()):
             raise ValueError(

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -477,13 +477,75 @@ class Admittance:
             )
 
 
-Branch = Union[TL, Load, TwoPort, Shunt, Transformer, Admittance]
+@dataclass(frozen=True)
+class BalancedLine:
+    """Balanced / differential two-conductor transmission line (issue #575) —
+    the differential sibling of `TL`. Where a `TL(a, b)` is single-ended (each
+    end referenced to the one network common), a BalancedLine models a pair of
+    conductors carrying ±I with the return current riding the *partner* wire:
+    open-wire feeder, twisted pair, the Sterba curtain's offset-pair verticals.
+
+    Four terminals in two pairs — port A = ``(a1, a2)``, port B = ``(b1, b2)``,
+    the two ends of the 2-conductor line. It is characterised by a single
+    **differential impedance ``zdiff``** (the number off the ladder-line spool:
+    300 / 450 / 600 Ω) plus physical ``length``, ``vf``, and optional
+    matched-loss ``k1``/``k2`` — mirroring `TL`. For anyone coming from the
+    microwave even/odd convention, ``zdiff = 2·z0o``.
+
+    Deliberately **differential-ONLY**, not general even/odd coupled: an
+    isolated two-wire pair supports exactly one TEM mode — the differential
+    one. The even ("common") mode needs a third conductor as its return; for
+    risers hanging in space its Z0 is ill-defined, and even-mode current is
+    really antenna-mode current that radiates, which a network branch inherently
+    cannot represent. So the element stamps only the odd-mode block, which
+    structurally forces ``I(a1) = −I(a2)`` at each end — exactly the ±I
+    cancellation the Sterba pair relies on, enforced by construction.
+
+    Stamped through the shared `NetworkReducer` as a frequency-dependent 4×4
+    Group-1 admittance block (see ``network_reduce.balanced_admittance_4x4``):
+    in differential variables it is an ordinary 2-port TL with z0 = zdiff, so
+    the 4×4 is ``tl_admittance_2x2(zdiff, …)`` expanded through the pair
+    incidence — each 2×2 entry ``y`` becomes the block ``y·[[1,−1],[−1,1]]``. It
+    reuses that helper's matched-loss model and half-wave singularity guard: a
+    lossless line at exactly k·vf·λ/2 raises, and real open-wire ``k1`` loss
+    regularises the exactly-λ/2 riser physically (no length-factor fudge).
+
+    **No ``transposed`` flag**: with four explicit terminals a crossover (the
+    Sterba's half-twist) is just wiring port B as ``(b2, b1)`` — visible in the
+    design source.
+
+    The common mode is structurally open (the 4×4 is rank-2 by construction),
+    so each terminal node must be common-mode-determinate from elsewhere —
+    attached to a radiating wire (`PortOnWire`), driven, or wired to a
+    non-BalancedLine branch. A node reachable *only* through BalancedLine
+    terminals is rejected by `Network.__post_init__` (it would make MNA
+    singular at solve time).
+
+    **PyNEC is out of scope**: NEC-2 has no native coupled-line card, so
+    `PyNECEngine` raises `NotImplementedError` rather than mis-modelling.
+    momwire is the supported engine (physics validation is issue #576).
+    """
+
+    a1: str
+    a2: str
+    b1: str
+    b2: str
+    zdiff: float
+    length: float
+    vf: float = 1.0
+    k1: float = 0.0
+    k2: float = 0.0
+
+
+Branch = Union[TL, Load, TwoPort, Shunt, Transformer, Admittance, BalancedLine]
 
 
 def _branch_port_refs(br):
     """Port names a branch references, regardless of branch type."""
     if isinstance(br, Admittance):
         return tuple(br.ports)
+    if isinstance(br, BalancedLine):
+        return (br.a1, br.a2, br.b1, br.b2)
     if hasattr(br, "a"):  # TL, TwoPort, Transformer
         return (br.a, br.b)
     return (br.port,)  # Load, Shunt
@@ -493,6 +555,8 @@ def _rewrite_branch(br, ren):
     """Copy of ``br`` with every port reference passed through ``ren``."""
     if isinstance(br, Admittance):
         return replace(br, ports=tuple(ren(p) for p in br.ports))
+    if isinstance(br, BalancedLine):
+        return replace(br, a1=ren(br.a1), a2=ren(br.a2), b1=ren(br.b1), b2=ren(br.b2))
     if hasattr(br, "a"):  # TL, TwoPort, Transformer
         return replace(br, a=ren(br.a), b=ren(br.b))
     return replace(br, port=ren(br.port))
@@ -838,6 +902,36 @@ class Network:
                 raise ValueError(f"source {src!r} references unknown port")
         if not self.sources:
             raise ValueError("Network has no driven sources")
+        self._validate_common_mode()
+
+    def _validate_common_mode(self):
+        """A `BalancedLine` stamps only the differential block, contributing
+        nothing to its terminals' common mode. A node reachable ONLY through
+        BalancedLine terminals is therefore common-mode floating, which makes
+        the MNA singular at solve time — raise a clear, node-naming error here
+        at build time instead. A node is common-mode-determinate if it is a
+        real `PortOnWire` (an antenna-Y row grounds it), is driven by a source,
+        or is referenced by any non-BalancedLine branch (issue #575)."""
+        balanced = [b for b in self.branches if isinstance(b, BalancedLine)]
+        if not balanced:
+            return
+        determinate = {n for n, p in self.ports.items() if isinstance(p, PortOnWire)}
+        determinate.update(src.port for src in self.sources)
+        for br in self.branches:
+            if not isinstance(br, BalancedLine):
+                determinate.update(_branch_port_refs(br))
+        touched = set()
+        for br in balanced:
+            touched.update(_branch_port_refs(br))
+        floating = sorted(touched - determinate)
+        if floating:
+            raise ValueError(
+                f"node(s) {floating} attach only via BalancedLine terminals, "
+                "whose common mode is structurally open — the MNA would be "
+                "singular. Give each a common-mode return: attach it to a "
+                "radiating wire (PortOnWire), drive it, or wire it to a "
+                "non-BalancedLine branch."
+            )
 
     def _expand_instances(self):
         """Flatten `Instance` items (issue #489): namespace internals,

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -521,9 +521,14 @@ class BalancedLine:
     terminals is rejected by `Network.__post_init__` (it would make MNA
     singular at solve time).
 
-    **PyNEC is out of scope**: NEC-2 has no native coupled-line card, so
-    `PyNECEngine` raises `NotImplementedError` rather than mis-modelling.
-    momwire is the supported engine (physics validation is issue #576).
+    Both engines stamp it through the shared `NetworkReducer` (a pure
+    admittance block, no native NEC card — exactly like `TL`, `Shunt`,
+    `Transformer`, `Admittance`), so PyNEC and momwire agree on it to
+    MoM-basis tolerance and nec2++ serves as an independent oracle for the
+    differential stamp. There is no native-card path: NEC-2 has no coupled-
+    line card, but the reducer never needed one. (Physics validation of the
+    differential *model* against real coupled structures — the isolation
+    oracle and end-to-end TL Sterba — is issue #576.)
     """
 
     a1: str

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -34,6 +34,7 @@ import numpy as np
 from .network import (
     TL,
     Admittance,
+    BalancedLine,
     Driven,
     DrivenCurrent,
     Load,
@@ -90,6 +91,37 @@ def tl_admittance_2x2(z0, length, wavelength, transposed=False, vf=1.0, k1=0.0, 
     scale = 1.0 / (z0 * sh)
     off = 1.0 if transposed else -1.0
     return scale * np.array([[ch, off], [off, ch]], dtype=np.complex128)
+
+
+# The pair incidence: a differential-mode current I into terminal 1 and −I out
+# of terminal 2, driven by the pair voltage v1 − v2. Tensoring the 2×2 TL
+# admittance with this rank-1 block expands each differential port to its two
+# physical terminals (issue #575).
+_DIFF_INCIDENCE = np.array([[1.0, -1.0], [-1.0, 1.0]], dtype=np.complex128)
+
+
+def balanced_admittance_4x4(zdiff, length, wavelength, vf=1.0, k1=0.0, k2=0.0):
+    """Balanced/differential two-conductor TL nodal admittance (issue #575) —
+    a 4×4 Group-1 block over the terminal order ``(a1, a2, b1, b2)`` (port
+    A = (a1, a2), port B = (b1, b2)).
+
+    In differential variables the element is an ordinary 2-port TL with
+    z0 = ``zdiff``, so the 4×4 is that 2×2 expanded through the pair incidence:
+
+        Y_4 = kron(tl_admittance_2x2(zdiff, …), [[1, −1], [−1, 1]])
+
+    i.e. each 2×2 entry ``y`` becomes the block ``y·[[1,−1],[−1,1]]`` over the
+    terminal pair. The construction makes the common mode structurally open
+    (rank 2) and forces ``I(a1) = −I(a2)`` at each end — the ±I differential
+    cancellation, enforced by wiring. There is no ``transposed`` flag: a
+    crossover is wiring port B as ``(b2, b1)``.
+
+    Inherits `tl_admittance_2x2`'s matched-loss model and its half-wave
+    singularity guard — a lossless line at exactly k·vf·λ/2 raises; real
+    open-wire ``k1`` loss regularises it. Grounding conductor 2 at both ends
+    (dropping rows/cols a2, b2) collapses this exactly back to that 2×2."""
+    y2 = tl_admittance_2x2(zdiff, length, wavelength, vf=vf, k1=k1, k2=k2)
+    return np.kron(y2, _DIFF_INCIDENCE)
 
 
 # ---------------------------------------------------------------------------
@@ -346,6 +378,26 @@ class NetworkReducer:
                 G[np.ix_([a, b], [a, b])] += y_tl
                 probes.append(
                     (lab(f"TL {_short(br.a)}→{_short(br.b)}"), "group1", ([a, b], y_tl))
+                )
+            elif isinstance(br, BalancedLine):
+                # Differential 4-terminal line (issue #575): a frequency-
+                # dependent 4×4 Group-1 block, the differential 2×2 TL expanded
+                # through the pair incidence. Common mode is structurally open
+                # (rank 2); the half-wave singularity guard is inherited.
+                idxs = [self.port_to_idx[p] for p in (br.a1, br.a2, br.b1, br.b2)]
+                yb = balanced_admittance_4x4(
+                    br.zdiff, br.length, wavelength, vf=br.vf, k1=br.k1, k2=br.k2
+                )
+                G[np.ix_(idxs, idxs)] += yb
+                probes.append(
+                    (
+                        lab(
+                            f"BalancedLine {_short(br.a1)},{_short(br.a2)}"
+                            f"→{_short(br.b1)},{_short(br.b2)}"
+                        ),
+                        "group1",
+                        (idxs, yb),
+                    )
                 )
             elif isinstance(br, Admittance):
                 # Fixed complex Y stamped verbatim — no ω scaling, no auxiliary

--- a/tests/test_balanced_line.py
+++ b/tests/test_balanced_line.py
@@ -233,36 +233,54 @@ def test_crossover_is_wiring_not_a_flag():
 
 
 # ---------------------------------------------------------------------------
-# 5. PyNEC is out of scope — NEC-2 has no native coupled-line card
+# 5. Cross-engine MoM oracle: PyNEC and momwire agree on the differential stamp
 # ---------------------------------------------------------------------------
 
 
-def test_pynec_raises_not_implemented():
-    """PyNEC card mapping is explicitly out of scope (NEC-2 has no native
-    coupled-line card): PyNECEngine raises NotImplementedError rather than
-    silently mis-modelling. momwire is the supported engine (issue #576)."""
-    from antennaknobs import AntennaBuilder
-    from antennaknobs.engines import PyNECEngine
+class _BalancedFourPortBuilder:
+    """Four parallel port wires with mutual coupling, a BalancedLine stamped
+    across all four terminals, one driven. Not a physically-meaningful antenna
+    — a correctness fixture: same geometry + same network on both engines must
+    agree, proving the differential stamp is a pure (engine-agnostic) reducer
+    block on the antenna Y."""
 
-    class B(AntennaBuilder):
+    def build_wires(self):
+        from antennaknobs.network import Wire
+
+        length = 0.15 * WL
+        ys = {"a1": 0.0, "a2": 0.6, "b1": 1.2, "b2": 1.8}
+        return [
+            Wire((0.0, y, 0.0), (length, y, 0.0), 3, name=name)
+            for name, y in ys.items()
+        ]
+
+    def build_network(self):
+        return Network(
+            ports={n: PortOnWire(n) for n in ("a1", "a2", "b1", "b2")},
+            branches=[
+                BalancedLine("a1", "a2", "b1", "b2", zdiff=450.0, length=0.3 * WL)
+            ],
+            sources=[Driven(port="a1")],
+        )
+
+
+def test_balanced_line_cross_engine_agrees():
+    """BalancedLine is a shared-NetworkReducer stamp with no native NEC card
+    (like TL / Shunt / Transformer / Admittance), so it runs on PyNEC too:
+    nec2++'s antenna Y and momwire's sinusoidal-basis Y, both reduced with the
+    same 4×4 differential block, return the same driving-point impedance to
+    MoM-basis tolerance. nec2++ is thus an independent oracle for the stamp."""
+    from antennaknobs import AntennaBuilder, WireSpec
+    from antennaknobs.engines import MomwireEngine, PyNECEngine
+    from momwire import SinusoidalSolver
+
+    class B(_BalancedFourPortBuilder, AntennaBuilder):
         default_params = {"freq": FREQ_MHZ}
 
-        def build_wires(self):
-            z = 0.0
-            wires = []
-            for i, name in enumerate(("a1", "a2", "b1", "b2")):
-                x = 0.5 * i
-                wires.append(((x, 0.0, z), (x, 0.5, z), 1, None, name))
-            return wires
+        def build_wire_material(self):
+            return WireSpec(radius=0.001)
 
-        def build_network(self):
-            return Network(
-                ports={n: PortOnWire(n) for n in ("a1", "a2", "b1", "b2")},
-                branches=[
-                    BalancedLine("a1", "a2", "b1", "b2", zdiff=450.0, length=0.3 * WL)
-                ],
-                sources=[Driven(port="a1")],
-            )
-
-    with pytest.raises(NotImplementedError, match="BalancedLine"):
-        PyNECEngine(B(), ground="free")
+    builder = B()
+    z_mw = MomwireEngine(builder, solver=SinusoidalSolver, ground="free").impedance()[0]
+    z_pynec = PyNECEngine(builder, ground="free").impedance()[0]
+    assert abs(z_pynec - z_mw) / abs(z_mw) < 0.02

--- a/tests/test_balanced_line.py
+++ b/tests/test_balanced_line.py
@@ -1,0 +1,268 @@
+"""BalancedLine — the differential two-conductor transmission-line element
+(issue #575).
+
+A `BalancedLine` is a purely-differential 4-terminal element: port A =
+(a1, a2), port B = (b1, b2), characterised by a single differential impedance
+`zdiff`. Its stamp is `tl_admittance_2x2(zdiff, …)` incidence-expanded to a
+4×4 Group-1 admittance block — each 2×2 entry `y` becomes the block
+`y·[[1,−1],[−1,1]]` over the terminal pair, i.e. `kron(Y_2x2, [[1,-1],[-1,1]])`.
+The common mode is structurally open (the block is rank-2 by construction).
+
+These tests all have exact expected answers; the physics validation against
+real structures (isolation oracle + end-to-end TL Sterba) is issue #576.
+"""
+
+import numpy as np
+import pytest
+
+from antennaknobs.network import (
+    BalancedLine,
+    Branch,
+    Driven,
+    Network,
+    PortOnWire,
+    PortVirtual,
+    _branch_port_refs,
+)
+from antennaknobs.network_reduce import (
+    C_LIGHT,
+    NetworkReducer,
+    balanced_admittance_4x4,
+    tl_admittance_2x2,
+)
+
+FREQ_MHZ = 28.0
+WL = C_LIGHT / (FREQ_MHZ * 1e6)
+
+
+def synth_y(n, seed):
+    """Reciprocal, diagonally-dominant complex antenna-ish Y (mirrors the
+    test_network_mna helper) so the combined system is well conditioned."""
+    rng = np.random.default_rng(seed)
+    a = rng.normal(size=(n, n)) + 1j * rng.normal(size=(n, n))
+    y = 0.004 * (a + a.T) / 2.0
+    return y + np.eye(n) * (0.02 + 0.008j)
+
+
+def nodal_reference(y_full, driven):
+    """Bare nodal reduction: driven nodes pinned at their EMF, every other
+    node floating with I_ext = 0, currents read as Y·V. Valid because the
+    BalancedLine is a pure finite-admittance stamp."""
+    n = y_full.shape[0]
+    idx = sorted(driven)
+    other = [i for i in range(n) if i not in driven]
+    v = np.zeros(n, dtype=np.complex128)
+    for k, e in driven.items():
+        v[k] = e
+    if other:
+        rhs = -y_full[np.ix_(other, idx)] @ np.array([driven[k] for k in idx])
+        v[other] = np.linalg.solve(y_full[np.ix_(other, other)], rhs)
+    return v, y_full @ v
+
+
+# ---------------------------------------------------------------------------
+# 1. The stamp helper — exact-answer structural properties
+# ---------------------------------------------------------------------------
+
+
+def test_balanced_stamp_is_kron_of_tl_and_diff_incidence():
+    """The 4×4 is exactly the differential 2×2 tensored with the pair
+    incidence [[1,−1],[−1,1]] — the definition, to machine precision."""
+    y2 = tl_admittance_2x2(450.0, 0.3 * WL, WL)
+    y4 = balanced_admittance_4x4(450.0, 0.3 * WL, WL)
+    expected = np.kron(y2, np.array([[1.0, -1.0], [-1.0, 1.0]]))
+    np.testing.assert_allclose(y4, expected, rtol=0, atol=1e-18)
+
+
+def test_degenerate_case_collapses_to_tl_exactly():
+    """Acceptance criterion: grounding conductor 2 at both ends (a2 = b2 =
+    datum → drop those rows/cols) collapses the 4×4 to tl_admittance_2x2 to
+    MACHINE precision, not an approximate check. Rows/cols (a1, b1) = (0, 2)."""
+    y2 = tl_admittance_2x2(450.0, 0.3 * WL, WL)
+    y4 = balanced_admittance_4x4(450.0, 0.3 * WL, WL)
+    collapsed = y4[np.ix_([0, 2], [0, 2])]
+    np.testing.assert_array_equal(collapsed, y2)
+
+
+def test_reciprocity_symmetric():
+    """A reciprocal line: the 4×4 is symmetric (not merely Hermitian)."""
+    y4 = balanced_admittance_4x4(300.0, 0.37 * WL, WL, vf=0.91, k1=0.05)
+    np.testing.assert_allclose(y4, y4.T, rtol=0, atol=1e-18)
+
+
+def test_common_mode_open_and_rank_two():
+    """Differential-only structure: each pair's common mode draws no current
+    (Y·[1,1,0,0] = 0 and Y·[0,0,1,1] = 0), so the block has rank 2."""
+    y4 = balanced_admittance_4x4(450.0, 0.3 * WL, WL)
+    np.testing.assert_allclose(y4 @ np.array([1, 1, 0, 0]), 0, atol=1e-12)
+    np.testing.assert_allclose(y4 @ np.array([0, 0, 1, 1]), 0, atol=1e-12)
+    np.testing.assert_allclose(y4 @ np.array([1, 1, 1, 1]), 0, atol=1e-12)
+    assert np.linalg.matrix_rank(y4, tol=1e-9) == 2
+
+
+def test_lossless_conserves_power():
+    """A lossless line (k1 = k2 = 0) dissipates nothing: ½·Re(v†·Y·v) = 0 for
+    any excitation, because the lossless admittance is purely imaginary."""
+    y4 = balanced_admittance_4x4(450.0, 0.3 * WL, WL)
+    rng = np.random.default_rng(7)
+    v = rng.normal(size=4) + 1j * rng.normal(size=4)
+    p = 0.5 * np.real(np.conj(v) @ (y4 @ v))
+    assert p == pytest.approx(0.0, abs=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# 2. Singularity guard + loss regularisation (inherited from tl_admittance_2x2)
+# ---------------------------------------------------------------------------
+
+
+def test_lossless_half_wave_raises():
+    """A lossless line at exactly λ/2 inherits tl_admittance_2x2's singularity
+    guard (sinh γl → 0) and raises rather than returning garbage."""
+    with pytest.raises(ValueError, match="singular"):
+        balanced_admittance_4x4(450.0, 0.5 * WL, WL)
+
+
+def test_loss_regularizes_exact_half_wave():
+    """Real open-wire loss (k1 > 0) regularises the exactly-λ/2 riser: the
+    stamp is finite and well-conditioned, and it dissipates positive power."""
+    y4 = balanced_admittance_4x4(450.0, 0.5 * WL, WL, k1=0.02)
+    assert np.all(np.isfinite(y4))
+    rng = np.random.default_rng(3)
+    v = rng.normal(size=4) + 1j * rng.normal(size=4)
+    p = 0.5 * np.real(np.conj(v) @ (y4 @ v))
+    assert p > 0.0
+
+
+# ---------------------------------------------------------------------------
+# 3. Dataclass + Network wiring
+# ---------------------------------------------------------------------------
+
+
+def test_balanced_line_in_branch_union():
+    """BalancedLine is a member of the Branch discriminated union."""
+    assert BalancedLine in Branch.__args__
+
+
+def test_branch_port_refs_returns_four_terminals():
+    """All four terminals are reported (used by validation and rename)."""
+    bl = BalancedLine("a1", "a2", "b1", "b2", zdiff=450.0, length=0.3 * WL)
+    assert _branch_port_refs(bl) == ("a1", "a2", "b1", "b2")
+
+
+def test_unknown_terminal_rejected():
+    """__post_init__ validates every terminal against the port dict."""
+    with pytest.raises(ValueError, match="unknown port"):
+        Network(
+            ports={"a1": PortOnWire("a1"), "a2": PortOnWire("a2")},
+            branches=[
+                BalancedLine("a1", "a2", "b1", "b2", zdiff=450.0, length=0.3 * WL)
+            ],
+            sources=[Driven(port="a1")],
+        )
+
+
+def test_common_mode_floating_rejected_at_build_time():
+    """Acceptance criterion: a node attached ONLY via BalancedLine terminals
+    is common-mode floating (the stamp contributes nothing to its common
+    mode). Raise a clear error at build/validate time, naming the node, rather
+    than letting MNA go singular at solve time."""
+    with pytest.raises(ValueError, match="common mode"):
+        Network(
+            ports={
+                "a1": PortOnWire("a1"),
+                "a2": PortOnWire("a2"),
+                "v1": PortVirtual("v1"),
+                "v2": PortVirtual("v2"),
+            },
+            branches=[
+                BalancedLine("a1", "a2", "v1", "v2", zdiff=450.0, length=0.3 * WL)
+            ],
+            sources=[Driven(port="a1")],
+        )
+
+
+def test_all_real_terminals_are_common_mode_determinate():
+    """Four real PortOnWire terminals each carry an antenna-Y row, so the
+    common mode is determinate and no error is raised."""
+    net = Network(
+        ports={n: PortOnWire(n) for n in ("a1", "a2", "b1", "b2")},
+        branches=[BalancedLine("a1", "a2", "b1", "b2", zdiff=450.0, length=0.3 * WL)],
+        sources=[Driven(port="a1")],
+    )
+    assert len(net.branches) == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. Reducer stamp — matches an independent nodal oracle
+# ---------------------------------------------------------------------------
+
+
+def test_reducer_stamp_matches_nodal_reference():
+    """The BalancedLine, stamped as a Group-1 block through NetworkReducer,
+    reproduces the bare nodal reduction: build y_full = antenna Y + the 4×4
+    block by hand and compare driven-port impedances."""
+    net = Network(
+        ports={n: PortOnWire(n) for n in ("a1", "a2", "b1", "b2")},
+        branches=[BalancedLine("a1", "a2", "b1", "b2", zdiff=450.0, length=0.3 * WL)],
+        sources=[Driven(port="a1", voltage=1 + 0j), Driven(port="b1", voltage=0.5j)],
+    )
+    port_to_idx = {n: i for i, n in enumerate(("a1", "a2", "b1", "b2"))}
+    red = NetworkReducer(net, port_to_idx, 4)
+
+    y = synth_y(4, 11)
+    y_full = y.copy()
+    y_full += balanced_admittance_4x4(450.0, 0.3 * WL, WL)  # ports already 0..3
+    v_ref, i_ref = nodal_reference(y_full, {0: 1 + 0j, 2: 0.5j})
+
+    z = red.driven_impedance(y, WL)
+    np.testing.assert_allclose(z, [v_ref[0] / i_ref[0], v_ref[2] / i_ref[2]], rtol=1e-9)
+
+
+def test_crossover_is_wiring_not_a_flag():
+    """No `transposed` flag: a half-twist is wiring port B as (b2, b1). The
+    crossed stamp equals the straight stamp with its B-pair rows/cols swapped."""
+    straight = balanced_admittance_4x4(450.0, 0.3 * WL, WL)
+    # Swap b1 <-> b2 (indices 2, 3): the physical crossover.
+    swap = [0, 1, 3, 2]
+    crossed = straight[np.ix_(swap, swap)]
+    y2 = tl_admittance_2x2(450.0, 0.3 * WL, WL)
+    # Crossed differential incidence flips the transfer sign, exactly what
+    # wiring b as (b2, b1) does.
+    expected = np.kron(y2, np.array([[1.0, -1.0], [-1.0, 1.0]]))[np.ix_(swap, swap)]
+    np.testing.assert_allclose(crossed, expected, atol=1e-18)
+
+
+# ---------------------------------------------------------------------------
+# 5. PyNEC is out of scope — NEC-2 has no native coupled-line card
+# ---------------------------------------------------------------------------
+
+
+def test_pynec_raises_not_implemented():
+    """PyNEC card mapping is explicitly out of scope (NEC-2 has no native
+    coupled-line card): PyNECEngine raises NotImplementedError rather than
+    silently mis-modelling. momwire is the supported engine (issue #576)."""
+    from antennaknobs import AntennaBuilder
+    from antennaknobs.engines import PyNECEngine
+
+    class B(AntennaBuilder):
+        default_params = {"freq": FREQ_MHZ}
+
+        def build_wires(self):
+            z = 0.0
+            wires = []
+            for i, name in enumerate(("a1", "a2", "b1", "b2")):
+                x = 0.5 * i
+                wires.append(((x, 0.0, z), (x, 0.5, z), 1, None, name))
+            return wires
+
+        def build_network(self):
+            return Network(
+                ports={n: PortOnWire(n) for n in ("a1", "a2", "b1", "b2")},
+                branches=[
+                    BalancedLine("a1", "a2", "b1", "b2", zdiff=450.0, length=0.3 * WL)
+                ],
+                sources=[Driven(port="a1")],
+            )
+
+    with pytest.raises(NotImplementedError, match="BalancedLine"):
+        PyNECEngine(B(), ground="free")


### PR DESCRIPTION
Closes #575.

## What

Adds a **purely-differential 4-terminal transmission-line element** to `build_network()`, closing a structural modeling hole. Every existing branch (`TL`, `TwoPort`, `Shunt`) is single-ended — return via the one network common — so none can carry a close-coupled ±I pair whose return rides its *partner* wire (open-wire feeder, twisted pair, the Sterba curtain's offset-pair verticals). It's not a `z0` you can tune; it's a different two-port.

## How

`BalancedLine(a1, a2, b1, b2, zdiff, length, vf=1.0, k1=0.0, k2=0.0)` — port A = `(a1, a2)`, port B = `(b1, b2)`, one differential impedance `zdiff` (`= 2·z0o` for the microwave even/odd convention).

- **Stamp** (`network_reduce.balanced_admittance_4x4`): in differential variables it's an ordinary 2-port TL with `z0 = zdiff`, so the 4×4 Group-1 block is `tl_admittance_2x2(zdiff, …)` tensored with the pair incidence `[[1,−1],[−1,1]]` — `np.kron(Y_2x2, [[1,-1],[-1,1]])`. No new line theory in the reducer.
- **Differential-only** by design: the common mode is structurally open (block is rank 2), forcing `I(a1) = −I(a2)` at each end — the ±I cancellation, enforced by construction. The even mode is radiating antenna-mode current a network branch can't represent.
- **No `transposed` flag**: a crossover (half-twist) is wiring port B as `(b2, b1)` — visible in the design source.
- Inherits `tl_admittance_2x2`'s matched-loss model and half-wave singularity guard; real open-wire `k1` loss regularizes the exactly-λ/2 riser (no `length_factor` fudge). Grounding conductor 2 at both ends collapses the 4×4 **exactly** to the 2×2.
- **Common-mode-floating validation**: a node reachable *only* through BalancedLine terminals is rejected at build time (`Network.__post_init__`) with a node-naming error, rather than surfacing as a singular MNA at solve time.

## Both engines supported

`BalancedLine` is a **shared-`NetworkReducer` stamp with no native NEC card** — exactly like `TL`, `Shunt`, `Transformer`, and `Admittance`, all of which already run on PyNEC through the reducer. So it runs on **both** momwire and PyNEC: each engine produces the antenna's multiport short-circuit Y (momwire's sinusoidal basis / nec2++), and the same 4×4 differential block is stamped on top. Verified — the two independent MoM cores agree on a 4-terminal BalancedLine design to **0.07%** (MoM-basis tolerance), so **nec2++ serves as an independent oracle** for the differential stamp.

(An earlier revision of this PR raised `NotImplementedError` on PyNEC per the issue's "NEC-2 has no coupled-line card" scoping. That reason is real but only rules out a *native-card* path `BalancedLine` never takes — the reducer path is correct on both engines. Enabled after cross-engine verification.)

## Tests

New `tests/test_balanced_line.py` (15 tests, all exact-answer except the cross-engine one): kron identity, degenerate-case machine-precision collapse to `tl_admittance_2x2`, reciprocity, rank/common-mode-open structure, lossless power conservation, half-wave singularity + loss regularization, Branch-union membership, unknown-terminal + common-mode-floating rejection, reducer-vs-nodal-oracle agreement, crossover-by-wiring, and **PyNEC-vs-momwire cross-engine agreement**.

Full suite: **2733 passed, 2 skipped**.

Physics validation of the differential *model* against real coupled structures (MoM isolation oracle + end-to-end TL Sterba reproduction) is tracked separately in #576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)