### PR TITLE
Reject named wires that no PortOnWire references — silent open-gap trap (#578)

### DIFF
--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -12,7 +12,12 @@ from momwire import BSplineSolver
 
 from ..engine import FarField, SimulationEngine, WireCurrents
 from ..geometry import flat_wires_to_polylines
-from ..network import PortOnWire, PortVirtual, as_wire
+from ..network import (
+    PortOnWire,
+    PortVirtual,
+    as_wire,
+    validate_named_wires_referenced,
+)
 from ..terrain import Terrain, specular_cut
 from ..network_reduce import NetworkReducer, tl_admittance_2x2
 
@@ -372,9 +377,12 @@ class MomwireEngine(SimulationEngine):
     def _init_network(self):
         """Build the port-index map (real feeds first, virtual ports after)
         and the engine-agnostic NetworkReducer that stamps the branches and
-        reduces to driven-port impedance. Validates that every PortOnWire
-        resolves to a translated feed name."""
+        reduces to driven-port impedance. Validates the name/port contract in
+        both directions: every PortOnWire resolves to a translated feed name,
+        and every named wire is referenced by a PortOnWire (issue #578 — an
+        unreferenced name would be a silent open gap cutting the wire)."""
         net = self._network
+        validate_named_wires_referenced(self._feed_names, net)
         feed_name_to_idx = {n: i for i, n in enumerate(self._feed_names) if n}
 
         port_to_idx = {}

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -24,6 +24,7 @@ from ..network import (
     TwoPort,
     _series_rlc_impedance,
     load_impedance,
+    validate_named_wires_referenced,
 )
 from ..network_reduce import C_LIGHT, NetworkReducer
 
@@ -629,10 +630,13 @@ class PyNECEngine(SimulationEngine):
 
     def _init_network(self):
         """Build the port-index map (real PortOnWire ports first, virtual
-        ports after) and the NetworkReducer. Validates that every PortOnWire
-        names an edge in build_wires()."""
+        ports after) and the NetworkReducer. Validates the name/port contract
+        in both directions: every PortOnWire names an edge in build_wires(),
+        and every named wire is referenced by a PortOnWire (issue #578 — an
+        unreferenced name would be a silent open gap cutting the wire)."""
         net = self._network
         named = {t[4] for t in self.tups if len(t) >= 5 and t[4] is not None}
+        validate_named_wires_referenced(named, net)
         self._real_port_names = [
             n for n, p in net.ports.items() if isinstance(p, PortOnWire)
         ]

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -567,6 +567,33 @@ def _rewrite_branch(br, ren):
     return replace(br, port=ren(br.port))
 
 
+def validate_named_wires_referenced(named_wires, network):
+    """Reject named ``build_wires()`` wires that no `PortOnWire` references
+    (issue #578).
+
+    The geometry layer registers EVERY named wire as a port edge; a port row
+    the network never references is left electrically open, and an open
+    series gap CUTS the current path at that wire. The failure is silent and
+    masquerades as plausible physics (the solve succeeds with the structure
+    partitioned), so it is an init-time error. A wire named purely for
+    documentation is almost certainly this bug; a deliberately-open gap
+    should be an explicit `Load`/branch on a referenced port.
+
+    Engines call this once the flattened network and the final wire list are
+    both known (composite expansion has already namespaced port names).
+    """
+    port_names = {n for n, p in network.ports.items() if isinstance(p, PortOnWire)}
+    orphaned = sorted(set(named_wires) - {None} - port_names)
+    if orphaned:
+        raise ValueError(
+            f"named wire(s) {orphaned} are not referenced by any PortOnWire "
+            "in build_network(); a named wire becomes a port edge, and an "
+            "unreferenced port is an OPEN gap that cuts the wire there "
+            "(issue #578). Reference each name in Network.ports, or drop "
+            "the name."
+        )
+
+
 # ---------------------------------------------------------------------------
 # Composite components (issue #489): reusable sub-networks with hierarchy
 # ---------------------------------------------------------------------------

--- a/tests/test_orphaned_named_wire.py
+++ b/tests/test_orphaned_named_wire.py
@@ -1,0 +1,76 @@
+"""A named build_wires() wire that no PortOnWire references is rejected at
+engine init (issue #578).
+
+The geometry layer registers every named wire as a port edge; on the
+reducer path an unreferenced port row is left electrically open, and an
+open series gap CUTS the current path at that wire. The failure was silent
+and looked like plausible physics (found during #576's validation: a
+dipole fed through a physical line read −j46 kΩ — the isolated feed
+bridge — because the line's attachment stubs carried names the reference
+variant's network didn't use). It is now an init-time ValueError on the
+paths where the cut would happen: momwire always (networks always reduce
+there), PyNEC on its reducer path (the native-card path places no ex card
+for an unreferenced name, so the segment stays plain wire — harmless, and
+deliberately not validated).
+"""
+
+from types import MappingProxyType
+
+import pytest
+
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import Driven, Network, PortOnWire, PortVirtual, TL, Wire
+
+FREQ = 28.47
+ARM = 0.24 * 299.792458 / FREQ
+
+
+class _Dipole(AntennaBuilder):
+    """Center-fed dipole; `stray_name` adds a named-but-unreferenced stub."""
+
+    default_params = MappingProxyType(
+        {"design_freq": FREQ, "freq": FREQ, "stray_name": None}
+    )
+
+    def build_wires(self):
+        g = 0.2
+        return [
+            Wire((0, -ARM, 10.0), (0, -g, 10.0), name=self.stray_name),
+            Wire((0, -g, 10.0), (0, g, 10.0), name="feed"),
+            Wire((0, g, 10.0), (0, ARM, 10.0)),
+        ]
+
+    def build_network(self):
+        # A TL stub keeps the network on the reducer path for BOTH engines
+        # (PyNEC's native path would not call the reducer, and there an
+        # unreferenced name is genuinely harmless).
+        return Network(
+            ports={
+                "feed": PortOnWire("feed", distributed=True),
+                "stub": PortVirtual("stub"),
+            },
+            branches=[TL(a="feed", b="stub", z0=300.0, length=0.01)],
+            sources=[Driven(port="stub", voltage=1 + 0j)],
+        )
+
+
+def test_momwire_rejects_orphaned_named_wire():
+    from antennaknobs.engines.momwire import MomwireEngine
+
+    with pytest.raises(ValueError, match="issue #578"):
+        MomwireEngine(_Dipole(dict(_Dipole.default_params, stray_name="oops")))
+
+
+def test_pynec_reducer_path_rejects_orphaned_named_wire():
+    from antennaknobs.engines.pynec import PyNECEngine
+
+    with pytest.raises(ValueError, match="issue #578"):
+        PyNECEngine(_Dipole(dict(_Dipole.default_params, stray_name="oops")))
+
+
+def test_fully_referenced_names_pass():
+    from antennaknobs.engines.momwire import MomwireEngine
+
+    eng = MomwireEngine(_Dipole())
+    z = complex(eng.impedance()[0])
+    assert z.real > 1.0  # solves; a cut dipole would read as a tiny capacitor


### PR DESCRIPTION
## Summary
- A named `build_wires()` tuple becomes a port edge; on the reducer path an unreferenced port row is an open series gap that silently cuts the wire, with the solve succeeding on the partitioned structure (the trap that cost a day in #576's validation).
- Adds `validate_named_wires_referenced()` in `network.py`, called from both engines' `_init_network` — momwire whenever a network exists, PyNEC on its reducer path only (the native-card path places no ex card for an unreferenced name, so the segment stays plain wire; harmless and deliberately unvalidated).
- Regression tests: both engines raise on an orphaned name; a fully-referenced design still solves. Full suite green — no catalog design had a latent orphaned name.

Closes #578

## Test plan
- [x] `pytest tests/test_orphaned_named_wire.py` (3 passed)
- [x] Full suite `-m "not heavy_mesh"`: 2738 passed, 2 skipped
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WURGJupsPPBTToicCuTVoa