### PR TITLE
fix(network): normalize port sign convention to the authored wire direction (#580)

### DIFF
--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -228,6 +228,21 @@ class MomwireEngine(SimulationEngine):
         # feed list 1:1.
         self._feed_W = None
         self._exp_feed_pos = None
+        # Port sign normalization (issue #580): the polyline walker may
+        # traverse a port edge against its authored p0->p1 direction, and a
+        # delta-gap feed's sign convention follows the WALK. d_k = +-1 per
+        # feed records which; normalizing every port to the authored
+        # direction is the diagonal congruence Y_port = D.Y_walk.D with the
+        # matching V_walk = D.V_port on applied voltages — both realised by
+        # folding d_k into the feed weight matrix W (built sign-only here;
+        # rebuilt sign-aware with the distributed-port expansion in
+        # _init_network). With W = D, _solver_feeds applies D going in and
+        # _contract_y applies D..D coming out, so every consumer (network
+        # reducer, legacy build_tls stamps, plain multi-feed excitation)
+        # sees the authored convention.
+        self._feed_dirs = [int(d) for d in translated["feed_dirs"]]
+        if any(d != 1 for d in self._feed_dirs):
+            self._build_feed_expansion(set())
         # Wire material (issues #316/#388): a design-declared WireSpec
         # supplies the default conductor radius plus the distributed-loading
         # kwargs; per-wire specs on individual Wire entries override it wire
@@ -430,11 +445,19 @@ class MomwireEngine(SimulationEngine):
         """Expanded solver-feed positions + the (n_sub × n_feeds) weight
         matrix W for distributed ports. Non-distributed feeds keep a single
         sub-feed with weight 1 (W's column is a unit vector), so the
-        contraction is exact for every port kind."""
+        contraction is exact for every port kind.
+
+        Every weight in a port's column carries that port's walk-direction
+        sign d_k (issue #580): V_solver = W·V applies d_k to the applied
+        voltage(s) and Y_port = Wᵀ·Y_sub·W applies d_k to the port's row AND
+        column, so a single signed W normalizes both congruence sides to the
+        authored p0→p1 convention (all sub-feeds of a distributed port share
+        its d_k — they lie on the same walked edge)."""
         pos, cols = [], []
         for k, ((pl, arc, _v), (epl, eidx)) in enumerate(
             zip(self._feeds, self._feed_edges)
         ):
+            d = float(self._feed_dirs[k])
             if k in dist_idx:
                 poly = self._polylines[epl]
                 lens = np.linalg.norm(np.diff(poly, axis=0), axis=1)
@@ -443,10 +466,10 @@ class MomwireEngine(SimulationEngine):
                 n_sub = int(self._edge_segments[epl][eidx])
                 for i in range(n_sub):
                     pos.append((epl, arc0 + (i + 0.5) * length / n_sub))
-                    cols.append((k, 1.0 / n_sub))
+                    cols.append((k, d / n_sub))
             else:
                 pos.append((pl, arc))
-                cols.append((k, 1.0))
+                cols.append((k, d))
         W = np.zeros((len(pos), len(self._feeds)))
         for row, (k, w) in enumerate(cols):
             W[row, k] = w
@@ -467,8 +490,10 @@ class MomwireEngine(SimulationEngine):
 
     def _contract_y(self, Y):
         """Contract a solver Y (sub-feed granularity) to port granularity;
-        identity when no distributed ports exist. Works on one matrix or a
-        swept (n_k, n, n) stack."""
+        the signed W also normalizes each port's sign convention to the
+        authored wire direction (issue #580). Identity when no distributed
+        ports exist and every port edge was walked as authored. Works on one
+        matrix or a swept (n_k, n, n) stack."""
         if self._feed_W is None:
             return Y
         W = self._feed_W
@@ -664,9 +689,11 @@ class MomwireEngine(SimulationEngine):
             # frequency-dependent) and driven-port reduction. The Y assembly
             # is amortised across frequencies via the upstream swept solve;
             # the per-k post-processing is O(n_p³) and dwarfed by the solve.
-            Y_swept = np.asarray(
-                s.compute_y_matrix_swept(k_array), dtype=np.complex128
-            )  # (n_k, n_p, n_p)
+            Y_swept = self._contract_y(
+                np.asarray(s.compute_y_matrix_swept(k_array), dtype=np.complex128)
+            )  # (n_k, n_p, n_p) — contraction applies the issue-#580 port
+            # signs (legacy TLs have no distributed ports, so W is at most
+            # the diagonal sign matrix; identity when W is None)
             n_driven = sum(
                 1 for i in range(Y_swept.shape[1]) if i not in self._tl_passive_feed_idx
             )
@@ -720,9 +747,10 @@ class MomwireEngine(SimulationEngine):
             self._excited_p_in = 0.5 * float(
                 sum((V[i] * np.conj(I_ports[i])).real for i in driven)
             )
-            feeds_resolved = [
-                (w, arc, complex(V[i])) for i, (w, arc, _v) in enumerate(self._feeds)
-            ]
+            # Through _solver_feeds so each port's resolved voltage picks up
+            # its walk-direction sign (issue #580) exactly like the network
+            # path; identity when every feed was walked as authored.
+            feeds_resolved = self._solver_feeds([complex(v) for v in V])
         else:
             self._excited_efficiency = 1.0
             self._excited_power_budget = []

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -807,7 +807,13 @@ class PyNECEngine(SimulationEngine):
         port: drive that port's gap at 1 V (the other named ports stay
         continuous = shorted) and read the resulting current at every port —
         column j of Y. The geometry's interaction matrix is refactored once
-        per solve; small antennas make the N solves cheap."""
+        per solve; small antennas make the N solves cheap.
+
+        Sign convention (issue #580): each named wire is its own GW card
+        emitted in its authored p0→p1 direction, and NEC's EX drive and
+        current readout follow the segment (= card) direction — so this Y is
+        natively in the authored-direction port convention that
+        MomwireEngine normalizes to via its walk-direction signs."""
         freq = C_LIGHT / wavelength / 1e6
         names = self._real_port_names
         n = len(names)

--- a/src/antennaknobs/geometry.py
+++ b/src/antennaknobs/geometry.py
@@ -47,6 +47,11 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
                           one entry per excited tuple, in registration
                           order. Suitable to pass directly to a
                           momwire solver's feeds=... kwarg.
+        feed_dirs       : list of int — +1/-1 per feed: whether the walk
+                          traversed the authored tuple p0->p1 (+1) or
+                          p1->p0 (-1); engines use it to normalize each
+                          port's sign convention to the authored
+                          direction (issue #580).
         feed_wire_index : int — polyline holding the first excited
                           segment (back-compat: feeds[0][0])
         feed_arclength  : float — arclength of the first feed
@@ -132,6 +137,13 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
     junction_ends = {nid: [] for nid in range(len(nodes)) if is_boundary[nid]}
     # tup_index -> (polyline_index, edge_index_within)
     edge_to_polyline = {}
+    # tup_index -> +1 when the walk traversed the tuple in its authored
+    # p0 -> p1 direction, -1 when reversed. A port edge's delta-gap sign
+    # convention (EMF direction / positive-current direction) follows the
+    # POLYLINE direction, i.e. the walk — so this factor is what an engine
+    # needs to normalize each port to the authored direction (issue #580:
+    # "the port's + terminal is toward p1" is the design-visible contract).
+    edge_walk_dir = {}
 
     def walk_from(start_nid, first_edge):
         path_nodes = [start_nid]
@@ -171,6 +183,9 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
             polyline_specs.append(tup_specs[edges[path_edges[0]][4]])
             for k, e in enumerate(path_edges):
                 edge_to_polyline[edges[e][4]] = (polyline_idx, k)
+                # Edge k was walked path_nodes[k] -> path_nodes[k+1];
+                # authored direction is edges[e][0] -> edges[e][1].
+                edge_walk_dir[edges[e][4]] = 1 if edges[e][0] == path_nodes[k] else -1
             junction_ends[path_nodes[0]].append((polyline_idx, "start"))
             junction_ends[path_nodes[-1]].append((polyline_idx, "end"))
 
@@ -225,6 +240,8 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
         edge_segments.append([cut_n_seg])
         polyline_specs.append(tup_specs[cut_tup_idx])
         edge_to_polyline[cut_tup_idx] = (cut_pl_idx, 0)
+        # The cut polyline is stacked [A, B] = authored p0 -> p1.
+        edge_walk_dir[cut_tup_idx] = 1
 
         # Polyline 1 (long way): walk B → ... → A via the remaining edges.
         # The cut nodes are now polyline boundaries; the walker stops there.
@@ -254,6 +271,7 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
         polyline_specs.append(tup_specs[edges[path_edges[0]][4]])
         for k, e in enumerate(path_edges):
             edge_to_polyline[edges[e][4]] = (loop_pl_idx, k)
+            edge_walk_dir[edges[e][4]] = 1 if edges[e][0] == path_nodes[k] else -1
 
         # Register the cut endpoints as junctions: the cut polyline has
         # path [A, B] so its start=A, end=B; loop polyline was walked
@@ -279,6 +297,7 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
     feeds = []
     feed_names = []
     feed_edges = []
+    feed_dirs = []
     for tup_index, edge in enumerate(edges):
         voltage = edge[3]
         name = tup_names[tup_index]
@@ -295,6 +314,7 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
         )
         feed_names.append(name)
         feed_edges.append((feed_pl, feed_edge_idx))
+        feed_dirs.append(edge_walk_dir[tup_index])
 
     if not feeds:
         raise ValueError("no excitation found in wire list")
@@ -308,6 +328,11 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
         # Which (polyline, edge) each feed sits on — a distributed port
         # (issue #477) needs the whole edge's extent, not just its midpoint.
         "feed_edges": feed_edges,
+        # +1/-1 per feed: whether the walk traversed the authored tuple
+        # p0 -> p1 (+1) or p1 -> p0 (-1). A feed's solver-side sign
+        # convention follows the walk; engines multiply by this factor to
+        # normalize every port to the AUTHORED direction (issue #580).
+        "feed_dirs": feed_dirs,
         # Back-compat scalars — first feed.
         "feed_wire_index": feeds[0][0],
         "feed_arclength": feeds[0][1],

--- a/tests/test_port_polarity.py
+++ b/tests/test_port_polarity.py
@@ -1,0 +1,220 @@
+"""Port sign convention follows the AUTHORED wire direction (issue #580).
+
+`flat_wires_to_polylines` walks the wire graph from boundary nodes; a port
+edge's delta-gap sign convention (EMF direction / positive-current
+direction) follows the polyline walk. Pre-fix the authored p0->p1 direction
+of a named tuple was discarded, so each port's polarity was a traversal
+accident — benign for single-feed designs, load-bearing whenever RELATIVE
+polarity between ports matters (a TL between two ports with one polarity
+flipped is exactly a hidden `transposed` toggle; BalancedLine crossover
+wiring presupposes polarity control). PyNEC always honored the authored
+direction (each tuple is its own GW card; NEC's EX drive and current
+readout follow the card direction), so this was also a live cross-engine
+disagreement on walker-reversed port edges.
+
+The fix: the translator reports `feed_dirs` (+1 when the walk traversed the
+tuple p0->p1, -1 when reversed) and MomwireEngine folds the sign into its
+feed weight matrix W — the diagonal congruence Y_port = D.Y_walk.D with
+V_walk = D.V_port. Contract: "the port's + terminal is toward p1."
+"""
+
+from types import MappingProxyType
+
+import numpy as np
+
+from antennaknobs import AntennaBuilder
+from antennaknobs.geometry import flat_wires_to_polylines
+from antennaknobs.network import TL, Driven, Network, PortOnWire, Wire
+
+FREQ = 28.0
+WL = 299.792458 / FREQ
+ARM = 0.23 * WL
+SEP = 0.15 * WL
+GAP = 0.2
+
+
+# ---------------------------------------------------------------------------
+# 1. Translator: feed_dirs reports the walk direction relative to authoring
+# ---------------------------------------------------------------------------
+
+
+def _chain(feed_reversed=False):
+    """Three collinear wires; the named port wire is embedded MID-CHAIN, so
+    the walker threads through it (the case where the walk used to win)."""
+    lo, hi = (0.0, 1.0, 0.0), (0.0, 2.0, 0.0)
+    f0, f1 = (hi, lo) if feed_reversed else (lo, hi)
+    return [
+        ((0.0, 0.0, 0.0), lo, 5, None),
+        Wire(f0, f1, 3, name="feed"),
+        (hi, (0.0, 3.0, 0.0), 5, None),
+    ]
+
+
+def test_feed_dir_is_plus_one_when_walk_matches_authoring():
+    out = flat_wires_to_polylines(_chain())
+    assert out["feed_dirs"] == [1]
+
+
+def test_feed_dir_is_minus_one_when_authored_against_the_walk():
+    out = flat_wires_to_polylines(_chain(feed_reversed=True))
+    assert out["feed_dirs"] == [-1]
+
+
+def test_feed_dir_tracks_walk_reversal_from_registration_order():
+    """Reversing the LIST order makes the walk start from the other chain
+    end and traverse the (unchanged) authored feed tuple backwards; feed_dirs
+    is exactly the record of that accident."""
+    out = flat_wires_to_polylines(list(reversed(_chain())))
+    assert out["feed_dirs"] == [-1]
+
+
+def test_cycle_cut_port_edge_is_always_authored_direction():
+    """The cycle-cut special case stacks the cut port edge [p0, p1] — the
+    authored direction — so its feed_dir is +1 for either authoring."""
+    a, b, c, d = (
+        (0.0, 0.0, 0.0),
+        (1.0, 0.0, 0.0),
+        (1.0, 1.0, 0.0),
+        (0.0, 1.0, 0.0),
+    )
+    loop = [
+        Wire(a, b, 3, ex=1 + 0j, name="feed"),
+        (b, c, 3, None),
+        (c, d, 3, None),
+        (d, a, 3, None),
+    ]
+    assert flat_wires_to_polylines(loop)["feed_dirs"] == [1]
+    loop[0] = Wire(b, a, 3, ex=1 + 0j, name="feed")
+    assert flat_wires_to_polylines(loop)["feed_dirs"] == [1]
+
+
+# ---------------------------------------------------------------------------
+# 2. Engine-level fixture: two coupled dipoles joined by a TL — relative
+#    port polarity is observable in the driving-point impedance.
+# ---------------------------------------------------------------------------
+
+
+class _TwoDipolesTL(AntennaBuilder):
+    """Parallel dipoles at x=0 ("fa", driven) and x=SEP ("fb"), joined by a
+    TL. Each named feed wire sits mid-chain between two collinear arm wires.
+    `flip_b` reverses the authored direction of fb's wire; `reorder_b` lists
+    dipole b's wires in reverse order (which reverses the WALK through the
+    unchanged authored tuples); `transposed` half-twists the TL."""
+
+    default_params = MappingProxyType(
+        {"freq": FREQ, "transposed": False, "flip_b": False, "reorder_b": False}
+    )
+
+    @staticmethod
+    def _dipole(x, name, flip):
+        lo, hi = (x, -GAP, 10.0), (x, GAP, 10.0)
+        f0, f1 = (hi, lo) if flip else (lo, hi)
+        return [
+            Wire((x, -ARM, 10.0), lo, 15),
+            Wire(f0, f1, 3, name=name),
+            Wire(hi, (x, ARM, 10.0), 15),
+        ]
+
+    def build_wires(self):
+        b = self._dipole(SEP, "fb", self.flip_b)
+        if self.reorder_b:
+            b = b[::-1]
+        return self._dipole(0.0, "fa", False) + b
+
+    def build_network(self):
+        return Network(
+            ports={"fa": PortOnWire("fa"), "fb": PortOnWire("fb")},
+            branches=[
+                TL(
+                    a="fa",
+                    b="fb",
+                    z0=300.0,
+                    length=0.31 * WL,
+                    transposed=self.transposed,
+                )
+            ],
+            sources=[Driven(port="fa", voltage=1 + 0j)],
+        )
+
+
+def _z_momwire(**kw):
+    from antennaknobs.engines import MomwireEngine
+    from momwire import SinusoidalSolver
+
+    builder = _TwoDipolesTL(dict(_TwoDipolesTL.default_params, **kw))
+    return complex(
+        MomwireEngine(builder, solver=SinusoidalSolver, ground="free").impedance()[0]
+    )
+
+
+def _z_pynec(**kw):
+    from antennaknobs.engines import PyNECEngine
+
+    builder = _TwoDipolesTL(dict(_TwoDipolesTL.default_params, **kw))
+    return complex(PyNECEngine(builder, ground="free").impedance()[0])
+
+
+def test_polarity_is_observable():
+    """Sanity for the fixture: the TL's half-twist changes Zin materially,
+    so the tests below are actually exercising relative port polarity."""
+    z_nt, z_t = _z_momwire(), _z_momwire(transposed=True)
+    assert abs(z_t - z_nt) / abs(z_nt) > 0.1
+
+
+def test_authored_direction_is_the_contract():
+    """THE contract statement: reversing port b's authored wire direction is
+    exactly the TL half-twist. Identical mesh — the two cases differ only by
+    the diagonal sign congruence vs the transposed stamp, so they agree to
+    machine precision."""
+    z_twist = _z_momwire(transposed=True)
+    z_flip = _z_momwire(flip_b=True)
+    np.testing.assert_allclose(
+        [z_flip.real, z_flip.imag], [z_twist.real, z_twist.imag], rtol=1e-12
+    )
+    # And flipping BOTH knobs lands back on the untwisted answer.
+    z_both = _z_momwire(flip_b=True, transposed=True)
+    z_base = _z_momwire()
+    np.testing.assert_allclose(
+        [z_both.real, z_both.imag], [z_base.real, z_base.imag], rtol=1e-12
+    )
+
+
+def test_walk_invariance_under_wire_list_reorder():
+    """Reordering build_wires() reverses the walk through dipole b's
+    mid-chain port wire but changes NO authored direction — the result must
+    not move (pre-fix this silently toggled the TL's polarity). The mesh is
+    assembled in a different order, so near-machine rather than exact."""
+    z_base = _z_momwire()
+    z_re = _z_momwire(reorder_b=True)
+    np.testing.assert_allclose(
+        [z_re.real, z_re.imag], [z_base.real, z_base.imag], rtol=1e-8
+    )
+    # Same invariance with the authored flip in play.
+    z_flip = _z_momwire(flip_b=True)
+    z_flip_re = _z_momwire(flip_b=True, reorder_b=True)
+    np.testing.assert_allclose(
+        [z_flip_re.real, z_flip_re.imag], [z_flip.real, z_flip.imag], rtol=1e-8
+    )
+
+
+def test_cross_engine_polarity_agrees():
+    """PyNEC always honored the authored direction (GW cards are authored
+    p0->p1; EX and current readouts follow the card). Pre-fix momwire
+    followed the walker instead, so flip_b disagreed cross-engine by ~66%
+    on this fixture. Post-fix both engines agree to MoM-basis tolerance on
+    every polarity-sensitive variant (pattern of
+    test_balanced_line_cross_engine_agrees)."""
+    for kw in ({"flip_b": True}, {"flip_b": True, "transposed": True}):
+        z_mw = _z_momwire(**kw)
+        z_py = _z_pynec(**kw)
+        assert abs(z_py - z_mw) / abs(z_mw) < 0.02, kw
+
+
+def test_pynec_authored_contract_holds():
+    """Lock the same contract on PyNEC: authored flip == TL half-twist
+    (bit-identical NEC decks up to the swapped card endpoints)."""
+    z_twist = _z_pynec(transposed=True)
+    z_flip = _z_pynec(flip_b=True)
+    np.testing.assert_allclose(
+        [z_flip.real, z_flip.imag], [z_twist.real, z_twist.imag], rtol=1e-9
+    )


### PR DESCRIPTION
## Summary

- **Geometry** (`src/antennaknobs/geometry.py`): `flat_wires_to_polylines` now reports `feed_dirs` — +1/−1 per feed recording whether the polyline walk traversed the authored tuple p0→p1 or reversed. The cycle-cut port edge is stacked `[p0, p1]` and always reports +1.
- **MomwireEngine** (`src/antennaknobs/engines/momwire.py`): normalizes every port's sign convention to the **authored** wire direction via the diagonal congruence `Y_port = D·Y_walk·D`, `V_walk = D·V_port`, with `D = diag(feed_dirs)`. Implemented by folding each port's sign into its column of the feed weight matrix W (built sign-only in `__init__` when any direction is flipped; rebuilt sign-aware by the distributed-port expansion) — a single signed W makes `_solver_feeds` apply D on the way in and `_contract_y` apply D··D on the way out, so both congruence sides come from one touch-point. All sub-feeds of a distributed port share its sign (they lie on the same walked edge).
- **Legacy `build_tls` path: covered, deliberately.** `_compute_y_matrix` already flowed through `_contract_y`; the swept-Y legacy branch in `impedance_sweep` now contracts too, and the legacy excited path resolves feed voltages through `_solver_feeds`. TL stamps and applied voltages therefore sit in the authored convention on every legacy code path.
- **PyNECEngine**: **no code change** — each named wire is its own GW card emitted in authored p0→p1 order, and NEC's EX drive + current readout follow the card direction, so PyNEC was already in the authored convention (documented in `_compute_y_matrix`'s docstring).

## The pre-fix bug, demonstrated

Two coupled dipoles joined by a `TL`, port wires mid-chain between collinear arm wires (28 MHz, free space, sinusoidal basis):

| variant | momwire (pre-fix) | PyNEC | rel. disagreement |
|---|---|---|---|
| baseline | 31.07−79.17j | 31.08−79.08j | 0.11% |
| authored flip of port b | 31.07−79.17j (**ignored**) | 82.42−55.54j (**≡ transposed**) | **66%** |
| wire list merely reordered | 82.45−55.64j (**flipped!**) | 31.08−79.08j (invariant) | **57%** |

So pre-fix this was a **live cross-engine polarity disagreement**: PyNEC honored the authored direction, momwire followed the walker — and momwire's answer changed under a semantically-neutral reordering of `build_wires()`. Post-fix all variants agree at 0.11% (MoM-basis tolerance) and `flip_b` acts exactly as the `transposed` toggle on both engines. "The port's + terminal is toward p1" is now the design-visible contract.

## Catalog impact: none (verified two ways)

A catalog scan found 29 designs with walker-reversed feeds, all polarity-benign:

- single real port (e.g. `beams.hexbeam`, `dipoles.invvee`, `wire.doublet_ladder_tuner`): a 1×1 antenna Y is invariant under ± congruence; the global current-sign flip is unobservable in Z/gain,
- uniformly reversed multiport (`arrays.*`, `multiband.hexbeam_5band`, `verticals.tri_moxon`, …): D = −I, relative polarity unchanged,
- mixed directions (`broadband.t2fd` [1,−1], `wire.rhombic` [1,−1], `multiband.trap_fan_dipole`, `verticals.elt_whip`): all pair the feed with **Load-only** branches whose stamp touches only the port diagonal — sign-invariant.

The full suite (~2740 tests incl. all golden catalog values) passes unchanged — no golden number moved, confirming today's catalog was relying on walker luck only in ways the fix leaves invariant.

## Test plan

- [x] `tests/test_port_polarity.py` (new, 9 tests, <1 s):
  - translator-level exact `feed_dirs` checks: authored-direction match/reverse, reorder-induced walk reversal, cycle-cut is always authored (+1)
  - **contract test**: `TL(transposed=True)` ≡ `TL(transposed=False)` with port b's wire authored reversed, identical mesh, rtol 1e-12 (both directions of the equivalence)
  - **walk-invariance**: permuted `build_wires()` (port wire embedded mid-chain of collinear wires) leaves Z unmoved at rtol 1e-8, with and without the authored flip
  - **cross-engine**: momwire and PyNEC agree <2% on the polarity-sensitive variants (pattern of `test_balanced_line_cross_engine_agrees`); PyNEC's own authored contract locked too
- [x] full suite `python -m pytest tests/ -q -m "not heavy_mesh"`: **2747 passed, 2 skipped, 1 deselected** — no golden number moved
- [x] `ruff check` / `ruff format` clean

Closes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WURGJupsPPBTToicCuTVoa
