### PR TITLE
PortAtEnd: junction-node ports at conductor ends (#579)

### DIFF
--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -13,6 +13,7 @@ from momwire import BSplineSolver
 from ..engine import FarField, SimulationEngine, WireCurrents
 from ..geometry import flat_wires_to_polylines
 from ..network import (
+    PortAtEnd,
     PortOnWire,
     PortVirtual,
     as_wire,
@@ -215,7 +216,24 @@ class MomwireEngine(SimulationEngine):
                         tups[tag - 1] = as_wire(t)._replace(ex=0 + 0j)
                         augmented_tags.add(tag)
 
-        translated = flat_wires_to_polylines(tups)
+        # End ports (issue #579): PortAtEnd entries resolve to junction-node
+        # ports (momwire#172). Collected before translation so the geometry
+        # layer can synthesize the end junctions and leave those wires
+        # gapless. Order of appearance in net.ports fixes the engine's
+        # end-port ordering everywhere.
+        self._end_ports = (
+            [
+                (name, port.wire, port.end)
+                for name, port in self._network.ports.items()
+                if isinstance(port, PortAtEnd)
+            ]
+            if self._network is not None
+            else []
+        )
+
+        translated = flat_wires_to_polylines(
+            tups, end_ports=[(w, e) for _n, w, e in self._end_ports]
+        )
         self._polylines = translated["polylines"]
         self._edge_segments = translated["edge_segments"]
         self._polyline_specs = translated["polyline_specs"]
@@ -223,6 +241,10 @@ class MomwireEngine(SimulationEngine):
         self._feed_names = translated["feed_names"]
         self._feed_edges = translated["feed_edges"]
         self._junctions = translated["junctions"]
+        # Junction index per end port, in self._end_ports order.
+        self._end_port_junctions = [
+            translated["end_port_junctions"][(w, e)] for _n, w, e in self._end_ports
+        ]
         # Distributed-port expansion (issue #477): None until _init_network
         # finds a PortOnWire(distributed=True); every other path treats the
         # feed list 1:1.
@@ -411,8 +433,13 @@ class MomwireEngine(SimulationEngine):
                     )
                 port_to_idx[name] = feed_name_to_idx[name]
 
-        # Virtual ports are indexed after the real feeds.
+        # End ports follow the gap feeds (matching momwire's solver-side
+        # [feeds..., junction_ports...] Y ordering, issue #579), then the
+        # virtual ports.
         next_idx = len(self._feeds)
+        for name, _wire, _end in self._end_ports:
+            port_to_idx[name] = next_idx
+            next_idx += 1
         for name, port in net.ports.items():
             if isinstance(port, PortVirtual):
                 port_to_idx[name] = next_idx
@@ -492,11 +519,23 @@ class MomwireEngine(SimulationEngine):
         """Contract a solver Y (sub-feed granularity) to port granularity;
         the signed W also normalizes each port's sign convention to the
         authored wire direction (issue #580). Identity when no distributed
-        ports exist and every port edge was walked as authored. Works on one
-        matrix or a swept (n_k, n, n) stack."""
+        ports exist and every port edge was walked as authored. End-port
+        rows (issue #579) trail the solver's feed rows and pass through
+        unweighted — a junction-node port has no sub-feed expansion and no
+        walk-sign ambiguity (a KCL row's outflow convention is geometric) —
+        so W extends by an identity block. Works on one matrix or a swept
+        (n_k, n, n) stack."""
         if self._feed_W is None:
             return Y
         W = self._feed_W
+        n_end = len(self._end_port_junctions)
+        if n_end:
+            W = np.block(
+                [
+                    [W, np.zeros((W.shape[0], n_end))],
+                    [np.zeros((n_end, W.shape[1])), np.eye(n_end)],
+                ]
+            )
         if Y.ndim == 3:
             return np.einsum("ia,kij,jb->kab", W, Y, W)
         return W.T @ Y @ W
@@ -514,7 +553,21 @@ class MomwireEngine(SimulationEngine):
             kw["ground_model"] = "sommerfeld"
         return kw
 
-    def _make_solver(self, *, wavelength):
+    def _make_solver(self, *, wavelength, end_port_voltages=None):
+        """Solver instance. ``end_port_voltages`` (issue #579): per-end-port
+        complex voltages in `self._end_ports` order; None means 0 V on every
+        end port (the Y-matrix path enumerates ports, so drive levels are
+        irrelevant there)."""
+        kw = {}
+        if self._end_port_junctions:
+            volts = (
+                end_port_voltages
+                if end_port_voltages is not None
+                else [0j] * len(self._end_port_junctions)
+            )
+            kw["junction_ports"] = [
+                (j, complex(v)) for j, v in zip(self._end_port_junctions, volts)
+            ]
         return self._solver(
             wires=self._polylines,
             n_per_edge_per_wire=self._edge_segments,
@@ -524,6 +577,7 @@ class MomwireEngine(SimulationEngine):
             ground_z=self._ground_z,
             junctions=self._junctions or None,
             cancel=self._cancel,
+            **kw,
             **self._loading_kwargs,
             **self._ground_solver_kwargs(),
             **self._solver_kwargs,
@@ -592,7 +646,11 @@ class MomwireEngine(SimulationEngine):
         """
         sim = self._make_excited_solver(wavelength=wavelength)
         v_key = tuple((complex(v).real, complex(v).imag) for *_, v in sim.feeds)
-        key = (float(wavelength), v_key)
+        jp_key = tuple(
+            (int(j), complex(v).real, complex(v).imag)
+            for j, v in getattr(sim, "junction_ports", []) or []
+        )
+        key = (float(wavelength), v_key, jp_key)
         cached = getattr(self, "_solved_cache", None)
         if cached is not None and cached[0] == key:
             sim, coeffs, z = cached[1]
@@ -734,6 +792,14 @@ class MomwireEngine(SimulationEngine):
             feeds_resolved = self._solver_feeds(
                 [complex(V_full[i]) for i in range(len(self._feeds))]
             )
+            # End-port voltages (issue #579) follow the gap feeds in the
+            # reducer's port ordering; force them in the excited solver so
+            # the current distribution / far field see the branch-induced
+            # node drive exactly like the gap ports do.
+            n_f = len(self._feeds)
+            end_port_voltages = [
+                complex(V_full[n_f + k]) for k in range(len(self._end_ports))
+            ]
         elif self._tls:
             self._excited_efficiency = 1.0
             self._excited_power_budget = []
@@ -758,6 +824,13 @@ class MomwireEngine(SimulationEngine):
             # the excited solve's driving-point impedance(s) on demand.
             self._excited_p_in = None
             return self._make_solver(wavelength=wavelength)
+        kw = {}
+        if self._end_port_junctions:
+            # Legacy build_tls designs have no end ports, so this only
+            # fires on the network path where end_port_voltages is set.
+            kw["junction_ports"] = [
+                (j, v) for j, v in zip(self._end_port_junctions, end_port_voltages)
+            ]
         return self._solver(
             wires=self._polylines,
             n_per_edge_per_wire=self._edge_segments,
@@ -767,6 +840,7 @@ class MomwireEngine(SimulationEngine):
             ground_z=self._ground_z,
             junctions=self._junctions or None,
             cancel=self._cancel,
+            **kw,
             **self._loading_kwargs,
             **self._ground_solver_kwargs(),
             **self._solver_kwargs,

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -16,6 +16,7 @@ from ..network import (
     BalancedLine,
     Driven,
     Load,
+    PortAtEnd,
     PortOnWire,
     PortVirtual,
     Shunt,
@@ -193,6 +194,19 @@ class PyNECEngine(SimulationEngine):
         self._extended_thin_wire_kernel = extended_thin_wire_kernel
         self.tups = self._coerce_wire_tuples(builder.build_wires())
         self._network = builder.build_network()
+        # End ports are momwire-only (issue #579): NEC-2 has no junction-node
+        # port — NT/TL cards attach to segment interiors, and synthesizing a
+        # stub would reintroduce the exact attachment artifact PortAtEnd
+        # exists to eliminate (#576). Hard error, by design decision; such
+        # designs declare the parity break in design_trust.
+        if self._network is not None and any(
+            isinstance(p, PortAtEnd) for p in self._network.ports.values()
+        ):
+            raise ValueError(
+                "this design uses PortAtEnd (a junction-node port), which "
+                "NEC-2 cannot represent — run it on the momwire engine "
+                "(issue #579)"
+            )
         # Wire material (issue #316): radius + conductor loss from the
         # design's WireSpec. The spec's conductivity is emitted as a global
         # ld_card type 5 (NEC's native wire-loss model — the momwire#131

--- a/src/antennaknobs/geometry.py
+++ b/src/antennaknobs/geometry.py
@@ -37,8 +37,19 @@ def _round_point(p, eps):
     return tuple(round(float(c) / eps) * eps for c in p)
 
 
-def flat_wires_to_polylines(tups, *, eps=1e-6):
+def flat_wires_to_polylines(tups, *, eps=1e-6, end_ports=None):
     """Convert flat wire tuples to momwire polyline form.
+
+    ``end_ports`` (issue #579): iterable of ``(wire_name, "p0"|"p1")`` pairs
+    naming wire ENDPOINTS that must become junction-node ports. Each such
+    node is forced to be a polyline boundary (so momwire gives it junction
+    directional bases) and its shared-node group is emitted in `junctions`
+    even when only one polyline end lives there (a lone conductor end — the
+    1-entry groups momwire#172 made legal). A name that appears in
+    ``end_ports`` is NOT registered as a gap-feed port edge (no delta gap is
+    cut in it); it identifies the wire only. The returned
+    ``end_port_junctions`` maps each ``(wire_name, end)`` to its junction
+    index — pass those straight to a momwire solver's ``junction_ports=``.
 
     Returns a dict with keys:
         polylines       : list of (M, 3) np.ndarray
@@ -62,6 +73,8 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
                           shared-node groups, suitable to pass directly
                           to a momwire solver's junctions=... kwarg. Empty list
                           if every component is a simple path.
+        end_port_junctions : dict (wire_name, "p0"|"p1") -> junction index
+                          for every requested end port (issue #579).
     """
     if not tups:
         raise ValueError("no wires to translate")
@@ -96,6 +109,38 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
         tup_names.append(name)
         tup_specs.append(spec)
 
+    # End ports (issue #579): resolve each (wire_name, "p0"|"p1") to its
+    # node id. These names identify wires only — they are excluded from
+    # gap-feed registration below, and their nodes are forced to be
+    # polyline boundaries so momwire can host a junction port there.
+    end_ports = list(end_ports or [])
+    end_port_names = set()
+    end_port_nodes = []  # (name, which, node_id)
+    if end_ports:
+        name_to_tup = {}
+        for i, nm in enumerate(tup_names):
+            if nm is not None:
+                name_to_tup.setdefault(nm, []).append(i)
+        for nm, which in end_ports:
+            if which not in ("p0", "p1"):
+                raise ValueError(
+                    f"end port on {nm!r}: end must be 'p0' or 'p1', got {which!r}"
+                )
+            idxs = name_to_tup.get(nm)
+            if not idxs:
+                raise ValueError(
+                    f"end port references wire name {nm!r} but no build_wires() "
+                    f"tuple carries that name"
+                )
+            if len(idxs) > 1:
+                raise ValueError(
+                    f"end port references wire name {nm!r} which is carried by "
+                    f"{len(idxs)} tuples — end-port wire names must be unique"
+                )
+            a, b, *_ = edges[idxs[0]]
+            end_port_names.add(nm)
+            end_port_nodes.append((nm, which, a if which == "p0" else b))
+
     # adj[nid] = list of (other_node, edge_index), in registration order.
     adj = [[] for _ in nodes]
     for ei, (a, b, _, _, _) in enumerate(edges):
@@ -122,6 +167,14 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
             e0, e1 = neigh[0][1], neigh[1][1]
             if tup_specs[edges[e0][4]] != tup_specs[edges[e1][4]]:
                 is_boundary[nid] = True
+
+    # An end-port node is a boundary too (issue #579): the port must land on
+    # a junction node, so a degree-2 node splits its chain here (registered
+    # as a 2-entry junction below — KCL still carries the current through,
+    # and the port injects into the shared node). Degree-1 nodes become
+    # 1-entry junction groups (legal since momwire#172).
+    for _nm, _which, nid in end_port_nodes:
+        is_boundary[nid] = True
 
     edge_seen = [False] * len(edges)
 
@@ -282,8 +335,19 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
         junction_ends[cut_b].append((loop_pl_idx, "start"))
 
     # Junctions = nodes where >= 2 polylines meet. Single-end records
-    # (degree-1 free ends) and lone polyline starts aren't junctions.
-    junctions = [ends for ends in junction_ends.values() if len(ends) >= 2]
+    # (degree-1 free ends) and lone polyline starts aren't junctions —
+    # EXCEPT end-port nodes (issue #579), whose group is emitted even with a
+    # single member so a momwire junction port can live there.
+    end_port_nids = {nid for _nm, _w, nid in end_port_nodes}
+    junctions = []
+    junction_index_of_node = {}
+    for nid, ends in junction_ends.items():
+        if len(ends) >= 2 or (nid in end_port_nids and len(ends) >= 1):
+            junction_index_of_node[nid] = len(junctions)
+            junctions.append(ends)
+    end_port_junctions = {
+        (nm, which): junction_index_of_node[nid] for nm, which, nid in end_port_nodes
+    }
 
     # Locate the excitation(s) and convert each to (polyline_idx,
     # arclength, voltage). PyNEC feeds at segment `(n_seg+1)//2` of the
@@ -301,6 +365,10 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
     for tup_index, edge in enumerate(edges):
         voltage = edge[3]
         name = tup_names[tup_index]
+        # An end-port name identifies its wire for the junction port only —
+        # no gap is cut in the wire (issue #579), so it is not a port edge.
+        if name in end_port_names:
+            name = None
         if voltage is None and name is None:
             continue
         feed_pl, feed_edge_idx = edge_to_polyline[tup_index]
@@ -316,7 +384,7 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
         feed_edges.append((feed_pl, feed_edge_idx))
         feed_dirs.append(edge_walk_dir[tup_index])
 
-    if not feeds:
+    if not feeds and not end_port_nodes:
         raise ValueError("no excitation found in wire list")
 
     return {
@@ -333,9 +401,11 @@ def flat_wires_to_polylines(tups, *, eps=1e-6):
         # convention follows the walk; engines multiply by this factor to
         # normalize every port to the AUTHORED direction (issue #580).
         "feed_dirs": feed_dirs,
-        # Back-compat scalars — first feed.
-        "feed_wire_index": feeds[0][0],
-        "feed_arclength": feeds[0][1],
-        "feed_voltage": feeds[0][2],
+        # Back-compat scalars — first feed (None when the design is driven
+        # entirely through end ports, issue #579).
+        "feed_wire_index": feeds[0][0] if feeds else None,
+        "feed_arclength": feeds[0][1] if feeds else None,
+        "feed_voltage": feeds[0][2] if feeds else None,
         "junctions": junctions,
+        "end_port_junctions": end_port_junctions,
     }

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -76,7 +76,39 @@ class PortVirtual:
 # externally-authored design importing it keeps working.
 PortAtEdge = PortOnWire
 
-Port = Union[PortOnWire, PortVirtual]
+
+@dataclass(frozen=True)
+class PortAtEnd:
+    """Port AT a wire ENDPOINT (issue #579) — the attachment a floating
+    multi-terminal element (`BalancedLine`) needs and a `PortOnWire` gap
+    cannot provide (a gap is a series insertion; issue #576's validation
+    mapped the dead-end-stub and bridge-idiom failure modes).
+
+    ``wire`` names a `build_wires()` tuple (names must be unique); ``end``
+    picks its authored ``"p0"`` or ``"p1"`` endpoint. The port resolves to
+    the shared NODE at that point: geometry translation forces a polyline
+    boundary there and momwire hosts a junction port (momwire#172) — the
+    node's KCL row becomes the port's drive/readout vector, so driving the
+    port injects current INTO the node and the port voltage is the node's
+    Lagrange dual. When several wire ends coincide at the point, the port
+    attaches to the whole shared junction group (declare it on ONE of the
+    wires). Unlike `PortOnWire`, no gap is cut in the wire — the name only
+    identifies the geometry, and a wire name may be referenced by either
+    port kind, not both.
+
+    momwire-only: NEC-2 has no junction-node port (NT/TL cards attach to
+    segment interiors), so `PyNECEngine` rejects designs using this port
+    type — a deliberate, declared engine-parity break."""
+
+    wire: str
+    end: str = "p1"
+
+    def __post_init__(self):
+        if self.end not in ("p0", "p1"):
+            raise ValueError(f"PortAtEnd end must be 'p0' or 'p1', got {self.end!r}")
+
+
+Port = Union[PortOnWire, PortAtEnd, PortVirtual]
 
 
 @dataclass(frozen=True)
@@ -582,15 +614,23 @@ def validate_named_wires_referenced(named_wires, network):
     Engines call this once the flattened network and the final wire list are
     both known (composite expansion has already namespaced port names).
     """
-    port_names = {n for n, p in network.ports.items() if isinstance(p, PortOnWire)}
-    orphaned = sorted(set(named_wires) - {None} - port_names)
+    gap_names = {n for n, p in network.ports.items() if isinstance(p, PortOnWire)}
+    end_names = {p.wire for p in network.ports.values() if isinstance(p, PortAtEnd)}
+    both = sorted(gap_names & end_names)
+    if both:
+        raise ValueError(
+            f"wire name(s) {both} are referenced by both a PortOnWire and a "
+            "PortAtEnd — a gap port cuts a delta gap in the wire while an "
+            "end port must leave it gapless (issue #579); use separate wires."
+        )
+    orphaned = sorted(set(named_wires) - {None} - gap_names - end_names)
     if orphaned:
         raise ValueError(
             f"named wire(s) {orphaned} are not referenced by any PortOnWire "
-            "in build_network(); a named wire becomes a port edge, and an "
-            "unreferenced port is an OPEN gap that cuts the wire there "
-            "(issue #578). Reference each name in Network.ports, or drop "
-            "the name."
+            "or PortAtEnd in build_network(); a named wire becomes a port "
+            "edge, and an unreferenced port is an OPEN gap that cuts the "
+            "wire there (issue #578). Reference each name in Network.ports, "
+            "or drop the name."
         )
 
 
@@ -731,7 +771,7 @@ def _resolve_aliases(pairs, ports):
 
     rename = {}
     for members in classes.values():
-        real = [n for n in members if isinstance(ports.get(n), PortOnWire)]
+        real = [n for n in members if isinstance(ports.get(n), (PortOnWire, PortAtEnd))]
         if len(real) > 1:
             raise ValueError(
                 f"aliases merge distinct geometry ports {sorted(real)} — "
@@ -920,7 +960,10 @@ class Network:
             raise ValueError("branch_paths is derived — do not pass it")
         self._expand_instances()
         for name, port in self.ports.items():
-            if port.name != name:
+            # A PortAtEnd is keyed by its PORT name alone; its `wire` field
+            # names geometry, not the port (two end ports may share a wire),
+            # so there is no redundant name field to cross-check.
+            if not isinstance(port, PortAtEnd) and port.name != name:
                 raise ValueError(
                     f"port dict key {name!r} doesn't match Port.name {port.name!r}"
                 )
@@ -942,12 +985,15 @@ class Network:
         BalancedLine terminals is therefore common-mode floating, which makes
         the MNA singular at solve time — raise a clear, node-naming error here
         at build time instead. A node is common-mode-determinate if it is a
-        real `PortOnWire` (an antenna-Y row grounds it), is driven by a source,
-        or is referenced by any non-BalancedLine branch (issue #575)."""
+        real `PortOnWire` or `PortAtEnd` (an antenna-Y row grounds it), is
+        driven by a source, or is referenced by any non-BalancedLine branch
+        (issue #575)."""
         balanced = [b for b in self.branches if isinstance(b, BalancedLine)]
         if not balanced:
             return
-        determinate = {n for n, p in self.ports.items() if isinstance(p, PortOnWire)}
+        determinate = {
+            n for n, p in self.ports.items() if isinstance(p, (PortOnWire, PortAtEnd))
+        }
         determinate.update(src.port for src in self.sources)
         for br in self.branches:
             if not isinstance(br, BalancedLine):

--- a/tests/test_port_at_end.py
+++ b/tests/test_port_at_end.py
@@ -1,0 +1,206 @@
+"""PortAtEnd (issue #579) — junction-node ports at conductor ends.
+
+A `PortAtEnd(wire_name, end)` resolves to the NODE at a wire's authored
+endpoint: geometry translation forces a polyline boundary there and momwire
+hosts a junction port (momwire#172 — the node's KCL row becomes the port's
+drive/readout vector). This is the attachment a floating multi-terminal
+element needs and a `PortOnWire` gap cannot provide (issue #576 mapped the
+dead-end-stub and bridge-idiom failure modes).
+
+The physics oracle here is the previously-IMPOSSIBLE case: a BalancedLine
+feeding a dipole through end ports at the arm roots. With stub attachment
+this read as an open line (zdiff-insensitive, −j336 Ω); through end ports it
+must match ideal transmission-line theory — the same load must be recovered
+through different zdiff values, and an off-quarter-wave length must land on
+the TL transform formula.
+"""
+
+import cmath
+from types import MappingProxyType
+
+import pytest
+
+from antennaknobs import AntennaBuilder
+from antennaknobs.geometry import flat_wires_to_polylines
+from antennaknobs.network import (
+    BalancedLine,
+    Driven,
+    Network,
+    PortAtEnd,
+    PortOnWire,
+    PortVirtual,
+    Wire,
+)
+
+FREQ = 28.47
+WL = 299.792458 / FREQ
+ARM = 0.24 * WL
+SPACING = 0.042
+
+
+# ---------------------------------------------------------------------------
+# geometry translation
+# ---------------------------------------------------------------------------
+
+
+def test_end_port_synthesizes_lone_end_junction():
+    out = flat_wires_to_polylines(
+        [
+            Wire((0, 0, 0), (0, 1, 0), n_seg=5, name="a"),
+            Wire((0, 1, 0), (0, 2, 0), n_seg=5, ex=1 + 0j),
+        ],
+        end_ports=[("a", "p0")],
+    )
+    # the two collinear wires chain into one polyline whose start hosts a
+    # 1-entry junction group; the name registered no gap feed
+    assert out["junctions"] == [[(0, "start")]]
+    assert out["end_port_junctions"] == {("a", "p0"): 0}
+    assert out["feed_names"] == [None]
+
+
+def test_end_port_splits_mid_chain_node_into_two_entry_junction():
+    out = flat_wires_to_polylines(
+        [
+            Wire((0, 0, 0), (0, 1, 0), n_seg=5, name="a"),
+            Wire((0, 1, 0), (0, 2, 0), n_seg=5, ex=1 + 0j),
+        ],
+        end_ports=[("a", "p1")],
+    )
+    # the shared node is forced to be a boundary: two polylines meet there
+    # and KCL still carries the current through
+    j = out["end_port_junctions"][("a", "p1")]
+    assert len(out["junctions"][j]) == 2
+
+
+def test_end_port_unknown_or_ambiguous_name_rejected():
+    wires = [Wire((0, 0, 0), (0, 1, 0), n_seg=5, ex=1 + 0j)]
+    with pytest.raises(ValueError, match="no build_wires"):
+        flat_wires_to_polylines(wires, end_ports=[("nope", "p0")])
+    dup = [
+        Wire((0, 0, 0), (0, 1, 0), n_seg=5, name="a"),
+        Wire((1, 0, 0), (1, 1, 0), n_seg=5, name="a"),
+        Wire((2, 0, 0), (2, 1, 0), n_seg=5, ex=1 + 0j),
+    ]
+    with pytest.raises(ValueError, match="unique"):
+        flat_wires_to_polylines(dup, end_ports=[("a", "p0")])
+
+
+def test_port_at_end_validates_end_token():
+    with pytest.raises(ValueError, match="'p0' or 'p1'"):
+        PortAtEnd("w", end="start")
+
+
+# ---------------------------------------------------------------------------
+# the physics oracle: BalancedLine-fed dipole through end ports
+# ---------------------------------------------------------------------------
+
+
+class _BLDipole(AntennaBuilder):
+    """Two separated dipole arms fed through a BalancedLine whose far end is
+    a differentially-driven virtual pair — the exact testbed that was blocked
+    by stub attachment in #576's validation."""
+
+    default_params = MappingProxyType(
+        {
+            "design_freq": FREQ,
+            "freq": FREQ,
+            "zd": 500.0,
+            "blen": 0.25 * WL,
+        }
+    )
+
+    def build_wires(self):
+        s = SPACING
+        z = 0.25 * WL
+        return [
+            Wire((0, 0, z), (0, -ARM, z), name="armA"),
+            Wire((s, 0, z), (s, ARM, z), name="armB"),
+        ]
+
+    def build_network(self):
+        return Network(
+            ports={
+                "ta": PortAtEnd("armA", end="p0"),
+                "tb": PortAtEnd("armB", end="p0"),
+                "s1": PortVirtual("s1"),
+                "s2": PortVirtual("s2"),
+            },
+            branches=[
+                BalancedLine(
+                    a1="s1", a2="s2", b1="ta", b2="tb", zdiff=self.zd, length=self.blen
+                )  # fmt: skip
+            ],
+            sources=[
+                Driven(port="s1", voltage=0.5 + 0j),
+                Driven(port="s2", voltage=-0.5 + 0j),
+            ],
+        )
+
+
+def _zdiff_in(zd, blen):
+    from antennaknobs.engines.momwire import MomwireEngine
+
+    b = _BLDipole(dict(_BLDipole.default_params, zd=zd, blen=blen))
+    eng = MomwireEngine(b, ground=None)
+    return 2 * complex(eng.impedance()[0])
+
+
+@pytest.mark.antenna_computation_check
+def test_balanced_line_through_end_ports_obeys_tl_theory():
+    """Quarter-wave transform recovers the SAME physical load through two
+    different zdiff values (Z_L = zdiff²/Z_in), the load is the expected
+    dipole-class impedance, and an off-quarter length lands on the full TL
+    transform formula with that load. Stub attachment failed every one of
+    these (zdiff-insensitive open-line signature)."""
+    lq = 0.25 * WL
+    z500 = _zdiff_in(500.0, lq)
+    z200 = _zdiff_in(200.0, lq)
+    zl_a = 500.0**2 / z500
+    zl_b = 200.0**2 / z200
+    assert abs(zl_a - zl_b) / abs(zl_a) < 0.02  # same load either way
+    assert 50.0 < zl_a.real < 90.0  # a dipole, not an open
+
+    l15 = 0.15 * WL
+    z15 = _zdiff_in(500.0, l15)
+    t = cmath.tan(2 * cmath.pi * l15 / WL)
+    expect = 500.0 * (zl_a + 1j * 500.0 * t) / (500.0 + 1j * zl_a * t)
+    assert abs(z15 - expect) / abs(expect) < 0.02
+
+
+# ---------------------------------------------------------------------------
+# guards
+# ---------------------------------------------------------------------------
+
+
+def test_pynec_rejects_port_at_end():
+    from antennaknobs.engines.pynec import PyNECEngine
+
+    with pytest.raises(ValueError, match="momwire"):
+        PyNECEngine(_BLDipole())
+
+
+def test_wire_name_shared_between_port_kinds_rejected():
+    class B(_BLDipole):
+        def build_network(self):
+            net = super().build_network()
+            ports = dict(net.ports)
+            ports["armA"] = PortOnWire("armA")
+            return Network(
+                ports=ports, branches=list(net.branches), sources=list(net.sources)
+            )
+
+    from antennaknobs.engines.momwire import MomwireEngine
+
+    with pytest.raises(ValueError, match="both"):
+        MomwireEngine(B())
+
+
+def test_unreferenced_named_wire_still_rejected_alongside_end_ports():
+    class B(_BLDipole):
+        def build_wires(self):
+            return super().build_wires() + [Wire((1, 0, 0), (1, 1, 0), name="stray")]
+
+    from antennaknobs.engines.momwire import MomwireEngine
+
+    with pytest.raises(ValueError, match="stray"):
+        MomwireEngine(B())


### PR DESCRIPTION
## Summary
- New `PortAtEnd(wire_name, end="p0"|"p1")` port type — the end-attachment #576's validation showed `PortOnWire` gaps cannot provide. Resolves to the NODE at a wire's authored endpoint; `flat_wires_to_polylines` forces a polyline boundary there, emits the shared-node group (1-entry groups included, per momwire#172), leaves the wire gapless, and returns an `end_port_junctions` map.
- `MomwireEngine` wires end ports into the solver's `junction_ports` across the Y, swept, and excited paths (end ports trail gap feeds in port order; identity block in the W contraction — a KCL row's outflow convention is geometric, so no #580-style sign ambiguity). `PyNECEngine` hard-errors on `PortAtEnd` (design decision on #579: NEC-2 has no junction-node port).
- #578's validator now recognizes `PortAtEnd` references, rejects a wire name shared between the two port kinds — and during development it caught a real would-be-open-gap bug in the Sterba builder, exactly as designed.
- Requires momwire ≥ the junction-ports feature (momwire#173 + #174, both on momwire main; the venv uses the editable checkout).

## Physics oracle (in the tests)
A BalancedLine feeding a dipole through end ports — the exact testbed the stub idiom failed (zdiff-insensitive open-line signature, −j336 Ω) — now recovers the same dipole load through two different zdiff values (Z_L = zdiff²/Z_in agree < 2 %, Z_L ≈ 70 Ω) and matches the full TL transform formula at an off-quarter length to < 2 % (spot value 177.8+607.9j vs 178+608j predicted).

## End-to-end Sterba status (documented on #579)
With attachment now provably faithful, the multi-bay BL Sterba still lands at +10.1 dBi az 35° vs +15.2 az 180 — and the residual is *not* attachment: it is insensitive to zdiff, element length (±5°), and crossover wiring, and shows an antisymmetric ±90° per-boundary phase progression. Also established en route: the all-wire curtain's s→0 limit HOLDS (+15.2 at s=0.004 with adequate mesh — the apparent collapse at default density is a segments≫spacing artifact worth knowing about), so the differential-only premise is sound and the remaining defect is in how the element transport composes in the multi-loop curtain. Evidence (measured transport ratios) on the issue.

## Test plan
- [x] `tests/test_port_at_end.py` (8 tests): geometry synthesis (lone end, mid-chain split, gapless names, error cases), the TL-theory oracle, PyNEC rejection, both-port-kinds rejection, #578 interplay.
- [x] Full suite `-m "not heavy_mesh"`: 2755 passed.
- [x] ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WURGJupsPPBTToicCuTVoa