### PR TITLE
BalancedLine common-mode path (zcomm) + wire.sterba_bl catalog promotion with derived backend-capability signalling

### DIFF
--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -106,6 +106,7 @@ whole shape with a `Drone` — see
 | `wire.longwire` | Resonant multi-wavelength long-wire (L. B. Cebik, W4RNL) |
 | `wire.rhombic` | Terminated rhombic: a traveling-wave directional long-wire (L. B. Cebik, W4RNL, "Long-Wire Antennas" / "The Terminated Vee-Beam and Rhombic") |
 | `wire.sterba` | Sterba curtain: a broadside, bidirectional, horizontally-polarised curtain array (E. J. Sterba, Bell Labs, 1930s) |
+| `wire.sterba_bl` | Sterba curtain with balanced-line risers — the faithful TL Sterba |
 | `wire.sterba_tl` | Sterba curtain, transmission-line sister design of `sterba.py` |
 | `wire.terminated_longwire` | Terminated end-fed long-wire: the directional single wire (L. B. Cebik, W4RNL, "Long-Wire Antennas", Part 2) |
 | `wire.vbeam` | Resonant V-beam: two long wires splayed into a V (L. B. Cebik, W4RNL) |

--- a/src/antennaknobs/designs/wire/sterba_bl.py
+++ b/src/antennaknobs/designs/wire/sterba_bl.py
@@ -1,0 +1,207 @@
+"""Sterba curtain with balanced-line risers — the faithful TL Sterba.
+
+The third member of the Sterba family: where `wire.sterba` models the whole
+curtain as wires (verticals as tightly-spaced offset pairs) and
+`wire.sterba_tl` is a deliberately one-high single-conductor study (~4 dB
+short of the curtain by construction), this design keeps `wire.sterba`'s
+exact two-conductor radiator geometry and replaces every INTERIOR riser pair
+with a `BalancedLine` network element — reproducing the all-wire curtain's
+broadside gain within ~0.2 dB at n_cells = 3 (+15.4 vs +15.2 dBi over
+average ground) and scaling n_cells 1 → 7 broadside like the original.
+
+Construction (issues #575/#576/#579):
+  - Both conductors' horizontal spans are real wires, authored as two named
+    halves per span so each interior boundary is a NODE. The two
+    single-conductor END verticals stay real wires, as in `wire.sterba`.
+  - Four `PortAtEnd` junction ports per boundary attach one `BalancedLine`
+    by physical conductor pairing: port A = the two top-rail ends, port B =
+    the two bottom-rail ends, conductor 1 = the A-conductor riser. The
+    Sterba crossover is that wiring — no polarity flags.
+  - `zdiff` defaults to the analytic pair impedance (η0/π)·acosh(s/2a); real
+    open-wire loss `k1` regularises the exactly-λ/2 line (no length-factor
+    fudge, unlike `sterba_tl`); `end_corr` is the measured pair end effect.
+  - `zcomm` enables the element's common-mode path. This is load-bearing:
+    the physical riser pair also provides conductor continuity, and in the
+    multi-loop curtain that boundary condition — a λ/2 CM *repeater*
+    (V → −V, I → −I regardless of impedance) — is what phases the outer
+    spans. Differential-only (zcomm = 0) drops ~5 dB with the beam steered
+    ~35° off broadside. Because the risers are resonant, the result is
+    insensitive to the `zcomm` value (measured identical 25–400 Ω).
+
+Engine support: **momwire only.** `PortAtEnd` resolves to a junction-node
+port (current injection into the KCL row; the row's Lagrange multiplier is
+the voltage dual) — NEC-2 has no equivalent card (NT attaches to segment
+interiors), so `PyNECEngine` rejects the design at construction and the UI
+offers only momwire backends for it.
+
+Known model residual: the CM stamp neither radiates nor dissipates the real
+pair's small antenna-mode current, so the model runs progressively hot at
+high n (+0.2 dB at n=3 → +0.8 dB at n=7 vs the all-wire curtain).
+"""
+
+import math
+from types import MappingProxyType
+
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import (
+    BalancedLine,
+    Driven,
+    Network,
+    PortAtEnd,
+    PortOnWire,
+    Wire,
+)
+
+ETA0_OVER_PI = 376.730313668 / math.pi
+WIRE_RADIUS = 0.0005
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "design_freq": 28.47,
+            "freq": 28.47,
+            "base": 7.0,
+            "length_factor": 1.0,
+            # Odd; number of full half-wave middle sections per rail.
+            "n_cells": 3,
+            # Riser-pair conductor spacing in metres (sets the analytic zdiff).
+            "spacing": 0.04,
+            # 0 -> analytic (η0/π)·acosh(spacing/2a) from the pair geometry.
+            "zdiff": 0.0,
+            # Common-mode path impedance; the λ/2 risers make the result
+            # insensitive to the value. 0 -> differential-only (the documented
+            # ~5 dB failure — exposed for the modelling study, not for use).
+            "zcomm": 200.0,
+            # Open-wire matched loss (dB/100ft·√MHz): physically regularises
+            # the exactly-λ/2 stamp singularity.
+            "k1": 0.02,
+            # Measured pair end-effect elongation (m), from the #576 oracle.
+            "end_corr": 0.030,
+            "ui_params": MappingProxyType(
+                {
+                    # Same feed class as wire.sterba: ~600 ohm at the central
+                    # gap, open-wire line to a tuner.
+                    "target_z0": 600.0,
+                    # Narrowband 10m antenna: snap the GUI sweep to the band.
+                    "sweep_policy": {"band_locked": True},
+                    "n_cells": {"min": 1, "max": 7, "step": 2},
+                    "spacing": {"min": 0.01, "max": 0.2, "step": 0.01},
+                    # zcomm insensitivity is the point; give the slider the
+                    # measured-flat range so users can see it for themselves.
+                    "zcomm": {"min": 0.0, "max": 400.0, "step": 25.0},
+                }
+            ),
+        }
+    )
+
+    # ---- layout ---------------------------------------------------------
+    def _layout(self):
+        wl = 299.792458 / self.design_freq
+        h = 0.5 * wl * self.length_factor
+        q = 0.5 * h
+        n = int(self.n_cells)
+        assert n >= 1 and n % 2 == 1, "n_cells must be a positive odd integer"
+        n_sections = n + 2
+        yb = [0.0, q] + [q + k * h for k in range(1, n + 1)] + [2 * q + n * h]
+        return wl, h, n_sections, yb
+
+    def _lvl(self, i, cond):
+        """Rail of conductor `cond` ('A'/'B') on span i — A on top for even
+        spans, exactly wire.sterba's interleave."""
+        _, h, _, _ = self._layout()
+        a_top = i % 2 == 0
+        top, bot = self.base + h, self.base
+        if cond == "A":
+            return top if a_top else bot
+        return bot if a_top else top
+
+    def _feed_cond(self, n_sections):
+        """The bottom-rail conductor of the central span carries the feed."""
+        center = (n_sections - 1) // 2
+        return center, ("A" if self._lvl(center, "A") == self.base else "B")
+
+    def build_wires(self):
+        _, h, n_sections, yb = self._layout()
+        s = self.spacing
+        pe = 0.2  # feed-gap edge length (m)
+        center, feed_cond = self._feed_cond(n_sections)
+
+        tups = []
+        for cond in ("A", "B"):
+            x = 0.0 if cond == "A" else s
+            for i in range(n_sections):
+                z = self._lvl(i, cond)
+                y0, y1 = yb[i], yb[i + 1]
+                # Only halves whose outer end meets an interior boundary are
+                # named (#578: unreferenced names would be open gaps).
+                la = f"{cond}{i}a" if i > 0 else None
+                lb = f"{cond}{i}b" if i < n_sections - 1 else None
+                if cond == feed_cond and i == center:
+                    yc = 0.5 * (y0 + y1)
+                    tups.append(Wire((x, y0, z), (x, yc - 0.5 * pe, z), name=la))
+                    tups.append(
+                        Wire(
+                            (x, yc - 0.5 * pe, z), (x, yc + 0.5 * pe, z), name="feed"
+                        )  # fmt: skip
+                    )
+                    tups.append(Wire((x, yc + 0.5 * pe, z), (x, y1, z), name=lb))
+                else:
+                    ym = 0.5 * (y0 + y1)
+                    tups.append(Wire((x, y0, z), (x, ym, z), name=la))
+                    tups.append(Wire((x, ym, z), (x, y1, z), name=lb))
+        # Single-conductor end closures, real wires exactly as wire.sterba
+        # (the small x offset folded into the diagonal). Each closure endpoint
+        # shares its node with a span end.
+        tups.append(Wire((0.0, 0.0, self._lvl(0, "A")), (s, 0.0, self._lvl(0, "B"))))
+        yl = yb[-1]
+        tups.append(
+            Wire(
+                (0.0, yl, self._lvl(n_sections - 1, "A")),
+                (s, yl, self._lvl(n_sections - 1, "B")),
+            )  # fmt: skip
+        )
+        return tups
+
+    def build_network(self):
+        _, h, n_sections, yb = self._layout()
+        zd = self.zdiff if self.zdiff else (
+            ETA0_OVER_PI * math.acosh(self.spacing / (2.0 * WIRE_RADIUS))
+        )  # fmt: skip
+        length = h + self.end_corr
+        top = self.base + h
+        ports = {"feed": PortOnWire("feed", distributed=True)}
+        branches = []
+        for k in range(1, n_sections):
+            i = k - 1
+            # Four span ends meet at boundary k. Pair by RAIL: port A = the
+            # two TOP-rail ends, port B = the two BOTTOM-rail ends;
+            # conductor 1 = the A-conductor riser (a1 <-> b1).
+            pa = f"eA{k}"  # A-conductor: span i right end
+            pa2 = f"eA{k}n"  # A-conductor: span k left end
+            pb = f"eB{k}"  # B-conductor: span i right end
+            pb2 = f"eB{k}n"  # B-conductor: span k left end
+            ports[pa] = PortAtEnd(f"A{i}b", end="p1")
+            ports[pa2] = PortAtEnd(f"A{k}a", end="p0")
+            ports[pb] = PortAtEnd(f"B{i}b", end="p1")
+            ports[pb2] = PortAtEnd(f"B{k}a", end="p0")
+            a_top = self._lvl(i, "A") == top
+            a1, b1 = (pa, pa2) if a_top else (pa2, pa)
+            a2, b2 = (pb2, pb) if a_top else (pb, pb2)
+            branches.append(
+                BalancedLine(
+                    a1=a1,
+                    a2=a2,
+                    b1=b1,
+                    b2=b2,
+                    zdiff=zd,
+                    length=length,
+                    k1=self.k1,
+                    zcomm=self.zcomm or None,
+                )  # fmt: skip
+            )
+        return Network(
+            ports=ports,
+            branches=branches,
+            sources=[Driven(port="feed", voltage=1 + 0j)],
+        )

--- a/src/antennaknobs/designs/wire/sterba_tl.py
+++ b/src/antennaknobs/designs/wire/sterba_tl.py
@@ -5,6 +5,14 @@ Where `wire.sterba` models the curtain as a single continuous wire
 the vertical phasing sections as **ideal transmission lines** via
 `build_network()`.
 
+NOTE: this is deliberately the one-high single-conductor STUDY — it
+plateaus ~4 dB below the true curtain by construction (see the design
+notes below). The faithful TL curtain is `wire.sterba_bl`: the full
+two-conductor geometry with `BalancedLine` risers on `PortAtEnd` junction
+ports, which reproduces `wire.sterba`'s gain within ~0.2 dB (momwire
+only). This design stays in the catalog as the simplest network-TL
+worked example.
+
 Simplified single-conductor form: a flat meander at x=0 made of
 `n_cells + 2` horizontal sections (a quarter-wave at each end, `n_cells`
 half-waves in the middle) at alternating heights — bottom rail (z = base)

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -22,7 +22,7 @@ as tiny stub wires at sensible locations.
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
-from typing import NamedTuple, Union
+from typing import NamedTuple, Optional, Union
 
 
 @dataclass(frozen=True)
@@ -524,34 +524,57 @@ class BalancedLine:
     matched-loss ``k1``/``k2`` — mirroring `TL`. For anyone coming from the
     microwave even/odd convention, ``zdiff = 2·z0o``.
 
-    Deliberately **differential-ONLY**, not general even/odd coupled: an
-    isolated two-wire pair supports exactly one TEM mode — the differential
-    one. The even ("common") mode needs a third conductor as its return; for
-    risers hanging in space its Z0 is ill-defined, and even-mode current is
-    really antenna-mode current that radiates, which a network branch inherently
-    cannot represent. So the element stamps only the odd-mode block, which
-    structurally forces ``I(a1) = −I(a2)`` at each end — exactly the ±I
-    cancellation the Sterba pair relies on, enforced by construction.
+    **Differential by default, with an optional common-mode path** (``zcomm``,
+    issue #576). The default ``zcomm=None`` stamps only the odd-mode block,
+    which structurally forces ``I(a1) = −I(a2)`` at each end — exactly the ±I
+    cancellation the Sterba pair relies on, enforced by construction. That
+    default follows the physics of an isolated pair: it supports exactly one
+    TEM mode (the differential one); the even ("common") mode's return is a
+    third conductor that isn't there, its Z0 is ill-defined, and even-mode
+    current is really antenna-mode current that radiates, which a network
+    branch cannot faithfully represent.
+
+    BUT — the #576 end-to-end finding — a differential-only stamp also
+    deletes the pair's *conductor continuity*: a real pair, however tightly
+    coupled, still transports its end-to-end common-mode boundary condition,
+    and in multi-loop structures (the multi-bay Sterba curtain) that
+    constraint is load-bearing even where the CM *current* is small (measured
+    5–15% of DM there, yet its removal costs 5 dB and steers the beam). Set
+    ``zcomm`` — the pair-driven-as-one-conductor CM impedance — to add the
+    orthogonal even-mode block and restore the path. Honesty notes: at
+    resonant lengths (≈ k·vf·λ/2, e.g. the Sterba's risers) the CM line is a
+    repeater and results are insensitive to the value (measured identical
+    over 25–400 Ω), so any plausible number is fine; away from resonance
+    ``zcomm`` is a genuine approximation for a radiating path — estimate it
+    from geometry and treat results accordingly. The CM stamp still cannot
+    radiate; a structure whose riser antenna-mode current matters beyond its
+    boundary condition needs real wires.
 
     Stamped through the shared `NetworkReducer` as a frequency-dependent 4×4
     Group-1 admittance block (see ``network_reduce.balanced_admittance_4x4``):
     in differential variables it is an ordinary 2-port TL with z0 = zdiff, so
     the 4×4 is ``tl_admittance_2x2(zdiff, …)`` expanded through the pair
-    incidence — each 2×2 entry ``y`` becomes the block ``y·[[1,−1],[−1,1]]``. It
-    reuses that helper's matched-loss model and half-wave singularity guard: a
-    lossless line at exactly k·vf·λ/2 raises, and real open-wire ``k1`` loss
+    incidence — each 2×2 entry ``y`` becomes the block ``y·[[1,−1],[−1,1]]``;
+    ``zcomm`` adds ``kron(tl_admittance_2x2(zcomm, …), ¼·ones)``, which
+    annihilates differential vectors — the exact even/odd decomposition, no
+    cross-terms, so the differential behaviour is untouched. It reuses that
+    helper's matched-loss model and half-wave singularity guard: a lossless
+    line at exactly k·vf·λ/2 raises, and real open-wire ``k1`` loss
     regularises the exactly-λ/2 riser physically (no length-factor fudge).
 
     **No ``transposed`` flag**: with four explicit terminals a crossover (the
-    Sterba's half-twist) is just wiring port B as ``(b2, b1)`` — visible in the
-    design source.
+    Sterba's half-twist) is just wiring port B as ``(b2, b1)`` — visible in
+    the design source. (A crossover flips only the differential sign; the CM
+    block is symmetric under it.)
 
-    The common mode is structurally open (the 4×4 is rank-2 by construction),
-    so each terminal node must be common-mode-determinate from elsewhere —
-    attached to a radiating wire (`PortOnWire`), driven, or wired to a
-    non-BalancedLine branch. A node reachable *only* through BalancedLine
-    terminals is rejected by `Network.__post_init__` (it would make MNA
-    singular at solve time).
+    With ``zcomm=None`` the common mode is structurally open (the 4×4 is
+    rank-2 by construction), so each terminal node must be
+    common-mode-determinate from elsewhere — attached to a radiating wire
+    (`PortOnWire`), driven, or wired to a non-BalancedLine branch. A node
+    reachable *only* through CM-open BalancedLine terminals is rejected by
+    `Network.__post_init__` (it would make MNA singular at solve time); a
+    ``zcomm``-carrying BalancedLine is itself a common-mode return, so its
+    terminals count as determinate.
 
     Both engines stamp it through the shared `NetworkReducer` (a pure
     admittance block, no native NEC card — exactly like `TL`, `Shunt`,
@@ -572,6 +595,7 @@ class BalancedLine:
     vf: float = 1.0
     k1: float = 0.0
     k2: float = 0.0
+    zcomm: Optional[float] = None
 
 
 Branch = Union[TL, Load, TwoPort, Shunt, Transformer, Admittance, BalancedLine]
@@ -980,26 +1004,29 @@ class Network:
         self._validate_common_mode()
 
     def _validate_common_mode(self):
-        """A `BalancedLine` stamps only the differential block, contributing
-        nothing to its terminals' common mode. A node reachable ONLY through
-        BalancedLine terminals is therefore common-mode floating, which makes
-        the MNA singular at solve time — raise a clear, node-naming error here
-        at build time instead. A node is common-mode-determinate if it is a
-        real `PortOnWire` or `PortAtEnd` (an antenna-Y row grounds it), is
-        driven by a source, or is referenced by any non-BalancedLine branch
-        (issue #575)."""
-        balanced = [b for b in self.branches if isinstance(b, BalancedLine)]
-        if not balanced:
+        """A CM-open `BalancedLine` (``zcomm=None``) stamps only the
+        differential block, contributing nothing to its terminals' common
+        mode. A node reachable ONLY through such terminals is common-mode
+        floating, which makes the MNA singular at solve time — raise a clear,
+        node-naming error here at build time instead. A node is
+        common-mode-determinate if it is a real `PortOnWire` or `PortAtEnd`
+        (an antenna-Y row grounds it), is driven by a source, or is
+        referenced by any non-BalancedLine branch or by a ``zcomm``-carrying
+        BalancedLine (its CM block is itself a return) — issues #575/#576."""
+        cm_open = [
+            b for b in self.branches if isinstance(b, BalancedLine) and b.zcomm is None
+        ]
+        if not cm_open:
             return
         determinate = {
             n for n, p in self.ports.items() if isinstance(p, (PortOnWire, PortAtEnd))
         }
         determinate.update(src.port for src in self.sources)
         for br in self.branches:
-            if not isinstance(br, BalancedLine):
+            if not (isinstance(br, BalancedLine) and br.zcomm is None):
                 determinate.update(_branch_port_refs(br))
         touched = set()
-        for br in balanced:
+        for br in cm_open:
             touched.update(_branch_port_refs(br))
         floating = sorted(touched - determinate)
         if floating:
@@ -1007,8 +1034,8 @@ class Network:
                 f"node(s) {floating} attach only via BalancedLine terminals, "
                 "whose common mode is structurally open — the MNA would be "
                 "singular. Give each a common-mode return: attach it to a "
-                "radiating wire (PortOnWire), drive it, or wire it to a "
-                "non-BalancedLine branch."
+                "radiating wire (PortOnWire), drive it, wire it to a "
+                "non-BalancedLine branch, or set zcomm on the BalancedLine."
             )
 
     def _expand_instances(self):

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -99,29 +99,55 @@ def tl_admittance_2x2(z0, length, wavelength, transposed=False, vf=1.0, k1=0.0, 
 # physical terminals (issue #575).
 _DIFF_INCIDENCE = np.array([[1.0, -1.0], [-1.0, 1.0]], dtype=np.complex128)
 
+# The common-mode incidence: the pair driven as one conductor. CM current is
+# the TOTAL I₁ + I₂ (splitting equally) and CM voltage the pair AVERAGE, so
+# each terminal carries ¼ of the 2×2 CM entry: I(a1) = ¼·(y·(v_a1 + v_a2) + …).
+# Orthogonal to _DIFF_INCIDENCE (it annihilates differential vectors), so the
+# two blocks superpose without cross-terms — the even/odd decomposition.
+_COMM_INCIDENCE = np.full((2, 2), 0.25, dtype=np.complex128)
 
-def balanced_admittance_4x4(zdiff, length, wavelength, vf=1.0, k1=0.0, k2=0.0):
-    """Balanced/differential two-conductor TL nodal admittance (issue #575) —
-    a 4×4 Group-1 block over the terminal order ``(a1, a2, b1, b2)`` (port
-    A = (a1, a2), port B = (b1, b2)).
+
+def balanced_admittance_4x4(
+    zdiff, length, wavelength, vf=1.0, k1=0.0, k2=0.0, zcomm=None
+):
+    """Balanced two-conductor TL nodal admittance (issues #575/#576) — a 4×4
+    Group-1 block over the terminal order ``(a1, a2, b1, b2)`` (port A =
+    (a1, a2), port B = (b1, b2)).
 
     In differential variables the element is an ordinary 2-port TL with
-    z0 = ``zdiff``, so the 4×4 is that 2×2 expanded through the pair incidence:
+    z0 = ``zdiff``, so the differential block is that 2×2 expanded through the
+    pair incidence:
 
         Y_4 = kron(tl_admittance_2x2(zdiff, …), [[1, −1], [−1, 1]])
 
     i.e. each 2×2 entry ``y`` becomes the block ``y·[[1,−1],[−1,1]]`` over the
-    terminal pair. The construction makes the common mode structurally open
-    (rank 2) and forces ``I(a1) = −I(a2)`` at each end — the ±I differential
-    cancellation, enforced by wiring. There is no ``transposed`` flag: a
-    crossover is wiring port B as ``(b2, b1)``.
+    terminal pair. With ``zcomm=None`` that is the whole stamp: the common
+    mode is structurally open (rank 2) and ``I(a1) = −I(a2)`` is forced at
+    each end — the ±I differential cancellation, enforced by wiring. There is
+    no ``transposed`` flag: a crossover is wiring port B as ``(b2, b1)``.
+
+    ``zcomm`` (issue #576's end-to-end finding) adds the orthogonal
+    common-mode block — the pair driven as ONE conductor against the network
+    common, an ordinary 2-port TL with z0 = ``zcomm`` over (I₁+I₂, ½(v₁+v₂)):
+
+        Y_4 += kron(tl_admittance_2x2(zcomm, …), ¼·ones(2, 2))
+
+    The ¼-ones incidence annihilates differential vectors, so the CM block
+    never perturbs the differential behaviour — the exact even/odd
+    decomposition of an ideal coupled pair. See `network.BalancedLine` for
+    when (and how honestly) a CM path can be modelled at all.
 
     Inherits `tl_admittance_2x2`'s matched-loss model and its half-wave
     singularity guard — a lossless line at exactly k·vf·λ/2 raises; real
     open-wire ``k1`` loss regularises it. Grounding conductor 2 at both ends
-    (dropping rows/cols a2, b2) collapses this exactly back to that 2×2."""
+    (dropping rows/cols a2, b2) collapses the ``zcomm=None`` stamp exactly
+    back to that 2×2."""
     y2 = tl_admittance_2x2(zdiff, length, wavelength, vf=vf, k1=k1, k2=k2)
-    return np.kron(y2, _DIFF_INCIDENCE)
+    y4 = np.kron(y2, _DIFF_INCIDENCE)
+    if zcomm is not None:
+        yc = tl_admittance_2x2(zcomm, length, wavelength, vf=vf, k1=k1, k2=k2)
+        y4 = y4 + np.kron(yc, _COMM_INCIDENCE)
+    return y4
 
 
 # ---------------------------------------------------------------------------
@@ -380,13 +406,20 @@ class NetworkReducer:
                     (lab(f"TL {_short(br.a)}→{_short(br.b)}"), "group1", ([a, b], y_tl))
                 )
             elif isinstance(br, BalancedLine):
-                # Differential 4-terminal line (issue #575): a frequency-
+                # Balanced 4-terminal line (issues #575/#576): a frequency-
                 # dependent 4×4 Group-1 block, the differential 2×2 TL expanded
                 # through the pair incidence. Common mode is structurally open
-                # (rank 2); the half-wave singularity guard is inherited.
+                # (rank 2) unless the element declares a `zcomm` CM path; the
+                # half-wave singularity guard is inherited.
                 idxs = [self.port_to_idx[p] for p in (br.a1, br.a2, br.b1, br.b2)]
                 yb = balanced_admittance_4x4(
-                    br.zdiff, br.length, wavelength, vf=br.vf, k1=br.k1, k2=br.k2
+                    br.zdiff,
+                    br.length,
+                    wavelength,
+                    vf=br.vf,
+                    k1=br.k1,
+                    k2=br.k2,
+                    zcomm=br.zcomm,
                 )
                 G[np.ix_(idxs, idxs)] += yb
                 probes.append(

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -70,7 +70,7 @@ from antennaknobs.builder import (
     diff_params,
     resolve_variant_params,
 )
-from antennaknobs.network import as_wire
+from antennaknobs.network import PortAtEnd, as_wire
 
 try:
     from antennaknobs.engines.pynec import DEFAULT_GROUND, PyNECEngine
@@ -1607,6 +1607,33 @@ _SINUSOIDAL_RECOMMEND_MIN_BASIS = 3000
 
 
 @lru_cache(maxsize=None)
+def _required_backends(cls) -> tuple[str, ...] | None:
+    """Backend allowlist a design is restricted to, or None (no restriction).
+
+    Today's only restriction: a design whose network has any `PortAtEnd`
+    resolves to junction-node ports, which only the dense B-spline solver
+    implements (momwire#172 — the sinusoidal and iterative HMatrix/
+    ArrayBlock solvers raise NotImplementedError, and NEC-2 has no
+    equivalent card at all, so `PyNECEngine` rejects the design at
+    construction, issue #579). DERIVED from the flattened network spec
+    rather than declared per design, so the capability cannot drift from
+    what the design actually does. The frontend disables the other backend
+    tabs (with an explanatory tooltip) and coerces an active disallowed
+    selection to the first allowed entry on design switch; the solvers'
+    hard errors remain the enforcement. Any failure to build the network
+    falls back to None — the design's real error surfaces through the
+    normal solve path. A future momwire release that widens junction-port
+    support only needs to widen this tuple."""
+    try:
+        net = _build_builder(cls, {}).build_network()
+    except Exception:
+        return None
+    if net is not None and any(isinstance(p, PortAtEnd) for p in net.ports.values()):
+        return ("bspline",)
+    return None
+
+
+@lru_cache(maxsize=None)
 def _recommended_backend(cls) -> str | None:
     """Recommend a default solver for the design, or None to let the UI keep
     its own default (the dense B-spline path).
@@ -1756,7 +1783,15 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
                 if multi_feed_override is not None
                 else _auto_multi_feed(cls)
             )
-            _hints["default_backend"] = _recommended_backend(cls)
+            # A backend restriction trumps the fit-based recommendation: the
+            # recommender's geometry heuristics (array detection, mesh size)
+            # don't know about solver capabilities, and recommending a
+            # backend the design cannot run would seed a guaranteed failure.
+            required = _required_backends(cls)
+            _hints["requires_backends"] = required
+            _hints["default_backend"] = (
+                required[0] if required else _recommended_backend(cls)
+            )
         return _hints
 
     # Grid-level layout config (reserved ui_params["layout"]). A dict today
@@ -2280,11 +2315,16 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         # of snapping to a wrong "xy" and then flipping when the preview lands.
         field_default_view = str(view_override) if view_override is not None else None
         field_default_backend = None
+        # Provisional None for deferred (user) designs: every backend tab
+        # stays enabled, and a PortAtEnd user design surfaces the solver's
+        # hard error through the normal solve-error banner instead.
+        field_requires_backends = None
     else:
         h = hints()
         field_multi_feed = h["multi_feed"]
         field_default_view = h["default_view"]
         field_default_backend = h["default_backend"]
+        field_requires_backends = h["requires_backends"]
 
     return AntennaExample(
         name=name,
@@ -2294,6 +2334,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         momwire_geometry=momwire_geometry,
         count_basis=count_basis,
         default_backend=field_default_backend,
+        requires_backends=field_requires_backends,
         pynec_solve=pynec_solve,
         pynec_build=pynec_build,
         pynec_pattern_excite=pynec_pattern_excite,

--- a/src/antennaknobs/web/examples/_base.py
+++ b/src/antennaknobs/web/examples/_base.py
@@ -309,6 +309,16 @@ class AntennaExample:
     # UI keep its own default. Surfaced in the /examples schema; the frontend
     # seeds the active slot's backend from it on antenna selection.
     default_backend: Optional[str] = None
+    # Backend allowlist when the design is restricted to specific solver
+    # backends; None = no restriction. Today: designs with PortAtEnd
+    # junction ports report ("bspline",) — only the dense B-spline solver
+    # implements junction ports (momwire#172), and NEC-2 has no equivalent
+    # card at all (PyNECEngine rejects such designs at construction, issue
+    # #579). Derived from the network spec by the adapter, not declared.
+    # The frontend disables the other backend tabs for such designs (with a
+    # tooltip) and coerces a disallowed active selection on switch; the
+    # solvers' hard errors remain the enforcement.
+    requires_backends: Optional[tuple[str, ...]] = None
     pynec_build: Optional[PynecBuildFn] = None
     pynec_solve: Optional[SolveFn] = None
     # Render the geometry as a NEC2 .nec card deck (str) for the current

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -148,6 +148,15 @@ type ExampleDescriptor = {
    *  this UI has retired (e.g. "triangular"); run it through
    *  normalizeBackend before use. */
   default_backend: string | null;
+  /** Backend allowlist when the design is restricted to specific solvers,
+   *  else null. Today: designs with PortAtEnd junction ports report
+   *  ["bspline"] — only the dense B-spline solver implements junction
+   *  ports (momwire#172), and NEC-2 has no equivalent card (issue #579).
+   *  Derived server-side from the design's network spec. The UI disables
+   *  the other backend tabs and withholds the solve with a hard (not
+   *  "solve anyway") gate when the active backend is disallowed; the
+   *  solvers' errors remain the enforcement. */
+  requires_backends: string[] | null;
   /** True when the Builder has a `design_freq` param that scales
    *  geometry (design_freq-sized designs). When false, the design-freq
    *  band-tab row is hidden because dragging it would be a no-op. */
@@ -1510,6 +1519,29 @@ function selectableBackends(havePynec: boolean): Backend[] {
 function resolveBackend(b: Backend, havePynec: boolean): Backend {
   return b === "pynec" && !havePynec ? PYNEC_FALLBACK_BACKEND : b;
 }
+
+// Per-design backend allowlist (`requires_backends` on the descriptor —
+// e.g. ["bspline"] for designs with PortAtEnd junction ports, which only
+// the B-spline solver implements; NEC-2 has no equivalent card at all).
+// null/undefined = no restriction. Unlike the missing-pynec-accel case
+// (#429) this is per-design, and unlike comboInappropriate it is a HARD
+// incompatibility: the disallowed solvers raise, so the gate offers
+// "switch", never "solve anyway".
+function backendAllowed(
+  b: Backend,
+  required: string[] | null | undefined,
+): boolean {
+  return !required || required.includes(b);
+}
+
+// One-line explanation for why a design is backend-restricted, used by the
+// disabled tabs' tooltip and the hard withhold gate. Today the only
+// restriction cause is junction ports, so the copy is specific; broaden it
+// if _required_backends ever grows another cause.
+const RESTRICTED_BACKEND_REASON =
+  "This design attaches network elements at conductor ends (junction-node " +
+  "ports) — only the B-spline solver implements them, and NEC-2 has no " +
+  "equivalent card.";
 
 // hmatrix (hierarchical H-matrix / ACA) and arrayblock (element-aware block
 // solver for arrays) are accelerators built on the same B-spline basis as
@@ -2962,17 +2994,29 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
     // Never surface a PyNEC recommendation the server can't honor (#429).
     return rec ? resolveBackend(rec, havePynec) : null;
   })();
+  // The active design's backend allowlist (null = unrestricted). Only
+  // catalog designs carry it — user designs defer their hints, so a
+  // restricted user design surfaces the solver's hard error through the
+  // normal solve-error banner instead.
+  const requiredBackends = currentExample?.requires_backends ?? null;
+  // Hard incompatibility: the active backend cannot run this design at all
+  // (the solver raises). Distinct from comboInappropriate, which is a
+  // performance mismatch the user may override.
+  const backendDisallowed = !backendAllowed(backend, requiredBackends);
   // True while the live solve is being withheld by the solver-mismatch gate.
   // The batch runners (sweep / converge / norm-check) decline to fire on
   // this: they are batches of the same solves the gate is protecting the
   // machine from (a dense sweep on a benchmark mesh is 41 multi-GiB solves).
   // Their effects depend on `comboApproved`, so "Solve anyway" re-fires them;
   // the server's cost model refuses warned batches without the approval flag
-  // anyway (issue #382) — this gate is UX, not the enforcement.
+  // anyway (issue #382) — this gate is UX, not the enforcement. A
+  // backend-disallowed design withholds unconditionally: there is no
+  // approval path around a solver that raises.
   function solveWithheld(): boolean {
     return (
-      comboInappropriate(backend, recommendedBackend) &&
-      !approvedComboRef.current
+      backendDisallowed ||
+      (comboInappropriate(backend, recommendedBackend) &&
+        !approvedComboRef.current)
     );
   }
   // Set when the selected design fails to solve/build — most often a user
@@ -3737,6 +3781,14 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
           })
           .catch(() => {});
       }
+      return;
+    }
+    // Hard gate first: the active backend cannot run this design at all
+    // (e.g. junction-port designs on anything but B-spline — the solver
+    // raises). Same withhold UI, but the banner offers "switch", never
+    // "solve anyway". The app still never switches the solver itself.
+    if (backendDisallowed) {
+      setSolverWarning(true);
       return;
     }
     // Withhold the solve when the design/solver combo is a poor match and the
@@ -5309,6 +5361,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
             slot={gearOpen}
             backend={slots[gearOpen].backend}
             backends={selectableBackends(havePynec)}
+            requiredBackends={requiredBackends}
             opts={slots[gearOpen].opts}
             onChangeBackend={(b) => {
               backendTouchedRef.current = true;
@@ -5338,7 +5391,52 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
             Cancel solve
           </button>
         )}
-        {solverWarning && (
+        {solverWarning && backendDisallowed && (
+          <div
+            className="solver-suggest"
+            role="alertdialog"
+            aria-label="Solver unavailable for this design"
+          >
+            <span className="solver-suggest-title">
+              {BACKEND_LABEL[backend]} can't run this design
+            </span>
+            <span className="solver-suggest-sub">
+              {RESTRICTED_BACKEND_REASON} Switch to{" "}
+              {(requiredBackends ?? [])
+                .map((r) => normalizeBackend(r))
+                .filter((r): r is Backend => r !== null)
+                .map((r) => BACKEND_LABEL[r])
+                .join(" / ") || "a supported solver"}{" "}
+              to solve it, or pause to keep editing.
+            </span>
+            <div className="solver-suggest-actions">
+              {(() => {
+                const target = normalizeBackend(requiredBackends?.[0]);
+                return target ? (
+                  <button
+                    type="button"
+                    className="solver-suggest-primary"
+                    onClick={() => {
+                      backendTouchedRef.current = true;
+                      setSlotBackend(activeSlot, target);
+                    }}
+                  >
+                    Switch to {BACKEND_LABEL[target]}
+                  </button>
+                ) : null;
+              })()}
+              <button
+                type="button"
+                className="solver-suggest-secondary"
+                onClick={pauseSimulation}
+                title="Stop auto-solving so you can keep editing; click Live to resume."
+              >
+                Pause simulation
+              </button>
+            </div>
+          </div>
+        )}
+        {solverWarning && !backendDisallowed && (
           <div
             className="solver-suggest"
             role="alertdialog"
@@ -5988,6 +6086,11 @@ type BackendConfigProps = {
   slot: Slot;
   backend: Backend;
   backends: Backend[];
+  /** Per-design backend allowlist (`requires_backends`); null = all of
+   *  `backends` selectable. Disallowed tabs render disabled with a tooltip
+   *  explaining why, rather than disappearing — the picker stays stable
+   *  across design switches and the restriction itself is the signal. */
+  requiredBackends: string[] | null;
   opts: BackendOptsMap[Backend];
   onChangeBackend: (b: Backend) => void;
   onPatch: (patch: Partial<BackendOptsMap[Backend]>) => void;
@@ -5999,6 +6102,7 @@ function BackendConfigModal({
   slot,
   backend,
   backends,
+  requiredBackends,
   opts,
   onChangeBackend,
   onPatch,
@@ -6033,17 +6137,22 @@ function BackendConfigModal({
               <span>{BACKEND_LABEL[backend]}</span>
             </label>
             <div className="geometry-tabs" role="tablist">
-              {backends.map((b) => (
-                <button
-                  key={b}
-                  role="tab"
-                  aria-selected={backend === b}
-                  className={backend === b ? "active" : ""}
-                  onClick={() => onChangeBackend(b)}
-                >
-                  {BACKEND_LABEL[b]}
-                </button>
-              ))}
+              {backends.map((b) => {
+                const allowed = backendAllowed(b, requiredBackends);
+                return (
+                  <button
+                    key={b}
+                    role="tab"
+                    aria-selected={backend === b}
+                    className={backend === b ? "active" : ""}
+                    disabled={!allowed}
+                    title={allowed ? undefined : RESTRICTED_BACKEND_REASON}
+                    onClick={() => allowed && onChangeBackend(b)}
+                  >
+                    {BACKEND_LABEL[b]}
+                  </button>
+                );
+              })}
             </div>
           </div>
 

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -1920,6 +1920,11 @@ def examples_endpoint():
                 "default_freq": ex.default_freq,
                 "default_design_freq": ex.default_design_freq,
                 "default_backend": ex.default_backend,
+                "requires_backends": (
+                    list(ex.requires_backends)
+                    if ex.requires_backends is not None
+                    else None
+                ),
                 "has_design_freq": ex.has_design_freq,
                 "variants": list(ex.variants),
                 "variant_values": dict(ex.variant_values),

--- a/tests/test_balanced_line.py
+++ b/tests/test_balanced_line.py
@@ -284,3 +284,107 @@ def test_balanced_line_cross_engine_agrees():
     z_mw = MomwireEngine(builder, solver=SinusoidalSolver, ground="free").impedance()[0]
     z_pynec = PyNECEngine(builder, ground="free").impedance()[0]
     assert abs(z_pynec - z_mw) / abs(z_mw) < 0.02
+
+
+# ---------------------------------------------------------------------------
+# 6. The optional common-mode path (zcomm, issue #576)
+# ---------------------------------------------------------------------------
+
+
+def test_zcomm_stamp_is_dm_plus_cm_kron():
+    """With zcomm, the 4×4 is exactly the differential kron plus the CM 2×2
+    tensored with ¼·ones — the even/odd decomposition, to machine precision."""
+    y_dm = tl_admittance_2x2(450.0, 0.3 * WL, WL)
+    y_cm = tl_admittance_2x2(200.0, 0.3 * WL, WL)
+    y4 = balanced_admittance_4x4(450.0, 0.3 * WL, WL, zcomm=200.0)
+    expected = np.kron(y_dm, np.array([[1.0, -1.0], [-1.0, 1.0]])) + np.kron(
+        y_cm, np.full((2, 2), 0.25)
+    )
+    np.testing.assert_allclose(y4, expected, rtol=0, atol=1e-18)
+
+
+def test_zcomm_never_perturbs_differential_behaviour():
+    """The ¼·ones incidence annihilates differential vectors, so the response
+    to any pure-differential excitation is IDENTICAL with and without zcomm —
+    no cross-terms between the modes."""
+    y_plain = balanced_admittance_4x4(450.0, 0.3 * WL, WL)
+    y_cm = balanced_admittance_4x4(450.0, 0.3 * WL, WL, zcomm=200.0)
+    for v in (np.array([1, -1, 0, 0]), np.array([0, 0, 1, -1])):
+        np.testing.assert_allclose(y_cm @ v, y_plain @ v, rtol=0, atol=1e-18)
+
+
+def test_zcomm_common_mode_is_the_cm_tl():
+    """Driving a pair with a pure common vector reproduces the CM 2×2 TL over
+    (total current, average voltage): the pair current splits equally and the
+    totals equal tl_admittance_2x2(zcomm)'s column."""
+    y_cm = tl_admittance_2x2(200.0, 0.3 * WL, WL)
+    y4 = balanced_admittance_4x4(450.0, 0.3 * WL, WL, zcomm=200.0)
+    i = y4 @ np.array([1.0, 1.0, 0.0, 0.0])  # V_cm(A) = 1, V_cm(B) = 0
+    assert i[0] == pytest.approx(i[1])  # splits equally
+    assert i[2] == pytest.approx(i[3])
+    assert i[0] + i[1] == pytest.approx(y_cm[0, 0])
+    assert i[2] + i[3] == pytest.approx(y_cm[1, 0])
+
+
+def test_zcomm_stamp_is_full_rank():
+    """DM (rank 2) plus its orthogonal CM complement (rank 2) span all four
+    terminal directions: the stamp is rank 4 — no floating mode left."""
+    y4 = balanced_admittance_4x4(450.0, 0.3 * WL, WL, zcomm=200.0)
+    assert np.linalg.matrix_rank(y4, tol=1e-9) == 4
+
+
+def test_zcomm_crossover_flips_only_the_differential_sign():
+    """Swapping (b1, b2) — the physical crossover — leaves the CM block
+    untouched: the swapped-minus-straight difference is identical with and
+    without zcomm."""
+    swap = [0, 1, 3, 2]
+    plain = balanced_admittance_4x4(450.0, 0.3 * WL, WL)
+    with_cm = balanced_admittance_4x4(450.0, 0.3 * WL, WL, zcomm=200.0)
+    d_plain = plain[np.ix_(swap, swap)] - plain
+    d_cm = with_cm[np.ix_(swap, swap)] - with_cm
+    np.testing.assert_allclose(d_cm, d_plain, rtol=0, atol=1e-18)
+
+
+def test_zcomm_terminals_count_as_cm_determinate():
+    """The exact network test_common_mode_floating_rejected_at_build_time
+    rejects becomes valid once the BalancedLine carries a zcomm: its CM block
+    is itself the return, so the virtual far end is determinate."""
+    net = Network(
+        ports={
+            "a1": PortOnWire("a1"),
+            "a2": PortOnWire("a2"),
+            "v1": PortVirtual("v1"),
+            "v2": PortVirtual("v2"),
+        },
+        branches=[
+            BalancedLine(
+                "a1", "a2", "v1", "v2", zdiff=450.0, length=0.3 * WL, zcomm=200.0
+            )
+        ],
+        sources=[Driven(port="a1")],
+    )
+    assert len(net.branches) == 1
+
+
+def test_reducer_passes_zcomm_through():
+    """NetworkReducer stamps the zcomm-augmented block: same nodal-reference
+    oracle as the differential case, with the CM block in y_full."""
+    net = Network(
+        ports={n: PortOnWire(n) for n in ("a1", "a2", "b1", "b2")},
+        branches=[
+            BalancedLine(
+                "a1", "a2", "b1", "b2", zdiff=450.0, length=0.3 * WL, zcomm=200.0
+            )
+        ],
+        sources=[Driven(port="a1", voltage=1 + 0j), Driven(port="b1", voltage=0.5j)],
+    )
+    port_to_idx = {n: i for i, n in enumerate(("a1", "a2", "b1", "b2"))}
+    red = NetworkReducer(net, port_to_idx, 4)
+
+    y = synth_y(4, 11)
+    y_full = y.copy()
+    y_full += balanced_admittance_4x4(450.0, 0.3 * WL, WL, zcomm=200.0)
+    v_ref, i_ref = nodal_reference(y_full, {0: 1 + 0j, 2: 0.5j})
+
+    z = red.driven_impedance(y, WL)
+    np.testing.assert_allclose(z, [v_ref[0] / i_ref[0], v_ref[2] / i_ref[2]], rtol=1e-9)

--- a/tests/test_balanced_line_physics.py
+++ b/tests/test_balanced_line_physics.py
@@ -25,10 +25,16 @@ to model*, against full-wave MoM solves:
    cell is common-mode dominated (CM/DM ≈ 2.3, measured while developing
    these tests), which is why the oracle must be the full structure.
 
-The end-to-end BalancedLine-riser Sterba is NOT here: issue #576's
-validation found the blocker is attachment semantics (a `PortOnWire` gap
-cannot faithfully attach a floating element at a conductor END), not the
-element or its premise — see the issue thread for the evidence trail.
+4. The end-to-end BalancedLine-riser curtain (one Sterba bay, risers as
+   4-terminal elements on `PortAtEnd` junction ports) reproduces the all-wire
+   `wire.sterba`'s broadside gain — but ONLY with the element's ``zcomm``
+   common-mode path enabled. This is the #576 end-to-end finding: the pair's
+   conductor continuity is a load-bearing boundary condition in the
+   multi-loop curtain even though its CM current is small (test 3), and at
+   the risers' resonant λ/2 length the CM transport is a repeater —
+   insensitive to the ``zcomm`` value, which the test also asserts.
+   (History: #576 first found the attachment blocker, solved by #579's end
+   ports; then the differential-only residual, solved by ``zcomm``.)
 """
 
 import math
@@ -209,3 +215,143 @@ def test_sterba_offset_pair_risers_carry_differential_current():
         dm = np.max(np.abs(i1 - i2))
         ratios.append(cm / dm)
     assert all(r < 0.2 for r in ratios), ratios
+
+
+# ---------------------------------------------------------------------------
+# 4. End-to-end: a one-bay BL-riser curtain reproduces wire.sterba — with zcomm
+# ---------------------------------------------------------------------------
+
+
+class _MiniSterbaTL(AntennaBuilder):
+    """One Sterba bay (n_cells = 1) with wire.sterba's exact radiator layout —
+    two interleaved conductors, sections λ/4 + λ/2 + λ/4, physical
+    single-conductor end closures — and each interior riser pair replaced by
+    a BalancedLine across four `PortAtEnd` junction ports, wired by physical
+    conductor pairing (port A = the two top-rail ends, conductor 1 = the
+    A-conductor riser). The scratchpad `sterba_bl.py` riser="end" builder,
+    specialised to one bay."""
+
+    default_params = MappingProxyType(
+        {
+            "design_freq": FREQ,
+            "freq": FREQ,
+            "base": 7.0,
+            "spacing": 0.04,
+            "zcomm": 200.0,
+            "k1": 0.02,  # real open-wire loss regularises the λ/2 stamp
+            "end_corr": 0.030,  # measured pair end-effect elongation (m)
+        }
+    )
+
+    def _layout(self):
+        h = 0.5 * WL
+        q = 0.5 * h
+        yb = [0.0, q, q + h, 2 * q + h]
+        return h, yb
+
+    def _lvl(self, i, cond):
+        h, _ = self._layout()
+        a_top = i % 2 == 0
+        top, bot = self.base + h, self.base
+        if cond == "A":
+            return top if a_top else bot
+        return bot if a_top else top
+
+    def build_wires(self):
+        h, yb = self._layout()
+        s, pe = self.spacing, 0.2
+        tups = []
+        for cond, x in (("A", 0.0), ("B", s)):
+            for i in range(3):
+                z = self._lvl(i, cond)
+                y0, y1 = yb[i], yb[i + 1]
+                la = f"{cond}{i}a" if i > 0 else None
+                lb = f"{cond}{i}b" if i < 2 else None
+                if cond == "A" and i == 1:  # feed span (bottom-rail conductor)
+                    yc = 0.5 * (y0 + y1)
+                    tups.append(Wire((x, y0, z), (x, yc - 0.5 * pe, z), name=la))
+                    tups.append(
+                        Wire(
+                            (x, yc - 0.5 * pe, z), (x, yc + 0.5 * pe, z), name="feed"
+                        )  # fmt: skip
+                    )
+                    tups.append(Wire((x, yc + 0.5 * pe, z), (x, y1, z), name=lb))
+                else:
+                    ym = 0.5 * (y0 + y1)
+                    tups.append(Wire((x, y0, z), (x, ym, z), name=la))
+                    tups.append(Wire((x, ym, z), (x, y1, z), name=lb))
+        tups.append(Wire((0.0, 0.0, self._lvl(0, "A")), (s, 0.0, self._lvl(0, "B"))))
+        yl = yb[-1]
+        tups.append(Wire((0.0, yl, self._lvl(2, "A")), (s, yl, self._lvl(2, "B"))))
+        return tups
+
+    def build_network(self):
+        from antennaknobs.network import BalancedLine, PortAtEnd
+
+        h, _ = self._layout()
+        zd = analytic_zdiff(self.spacing)
+        ports = {"feed": PortOnWire("feed", distributed=True)}
+        branches = []
+        top = self.base + h
+        for k in (1, 2):
+            i = k - 1
+            pa, pa2 = f"eA{k}", f"eA{k}n"
+            pb, pb2 = f"eB{k}", f"eB{k}n"
+            ports[pa] = PortAtEnd(f"A{i}b", end="p1")
+            ports[pa2] = PortAtEnd(f"A{k}a", end="p0")
+            ports[pb] = PortAtEnd(f"B{i}b", end="p1")
+            ports[pb2] = PortAtEnd(f"B{k}a", end="p0")
+            a_top = self._lvl(i, "A") == top
+            a1, b1 = (pa, pa2) if a_top else (pa2, pa)
+            a2, b2 = (pb2, pb) if a_top else (pb, pb2)
+            branches.append(
+                BalancedLine(
+                    a1=a1,
+                    a2=a2,
+                    b1=b1,
+                    b2=b2,
+                    zdiff=zd,
+                    length=h + self.end_corr,
+                    k1=self.k1,
+                    zcomm=self.zcomm,
+                )  # fmt: skip
+            )
+        return Network(
+            ports=ports,
+            branches=branches,
+            sources=[Driven(port="feed", voltage=1 + 0j)],
+        )
+
+
+def _peak(eng):
+    ff = eng.far_field(n_theta=45, n_phi=72, del_theta=2, del_phi=5)
+    rings = np.asarray(ff.rings)
+    _, j = np.unravel_index(np.argmax(rings), rings.shape)
+    return float(ff.max_gain), float(np.asarray(ff.phis)[j])
+
+
+@pytest.mark.antenna_computation_check
+def test_bl_riser_curtain_reproduces_wire_sterba_with_zcomm():
+    """The #576 end-to-end acceptance at one bay, free space: the BL-riser
+    curtain must land within 0.5 dB of the all-wire wire.sterba and fire
+    BROADSIDE. Differential-only (zcomm=None) fails the gain bound (−0.9 dB
+    at one bay, from the ±90°-per-boundary span-phase fanout that at n≥3
+    grows to −5 dB with the beam steered to az 35°); the CM path restores
+    it. At the risers' λ/2 length the CM line is a repeater, so the result
+    must be insensitive to the zcomm value — the reason no zdiff/zcomm
+    tuning is needed or possible."""
+    import importlib
+
+    ster = importlib.import_module("antennaknobs.designs.wire.sterba").Builder
+    bp = ster(dict(ster.default_params, n_cells=1))
+    gain_phys, az_phys = _peak(MomwireEngine(bp, ground=None))
+    assert min(az_phys % 180.0, 180.0 - az_phys % 180.0) <= 10.0  # broadside
+
+    b100 = _MiniSterbaTL(dict(_MiniSterbaTL.default_params, zcomm=100.0))
+    gain_100, az_100 = _peak(MomwireEngine(b100, ground=None))
+    assert min(az_100 % 180.0, 180.0 - az_100 % 180.0) <= 10.0
+    assert abs(gain_100 - gain_phys) < 0.5
+
+    b400 = _MiniSterbaTL(dict(_MiniSterbaTL.default_params, zcomm=400.0))
+    gain_400, _az = _peak(MomwireEngine(b400, ground=None))
+    assert abs(gain_400 - gain_100) < 0.1  # λ/2 repeater: zcomm-insensitive

--- a/tests/test_balanced_line_physics.py
+++ b/tests/test_balanced_line_physics.py
@@ -222,105 +222,15 @@ def test_sterba_offset_pair_risers_carry_differential_current():
 # ---------------------------------------------------------------------------
 
 
-class _MiniSterbaTL(AntennaBuilder):
-    """One Sterba bay (n_cells = 1) with wire.sterba's exact radiator layout —
-    two interleaved conductors, sections λ/4 + λ/2 + λ/4, physical
-    single-conductor end closures — and each interior riser pair replaced by
-    a BalancedLine across four `PortAtEnd` junction ports, wired by physical
-    conductor pairing (port A = the two top-rail ends, conductor 1 = the
-    A-conductor riser). The scratchpad `sterba_bl.py` riser="end" builder,
-    specialised to one bay."""
+def _catalog_curtain(n_cells, **overrides):
+    """The promoted catalog design (wire.sterba_bl): wire.sterba's exact
+    radiator layout with every interior riser pair replaced by a BalancedLine
+    across four `PortAtEnd` junction ports, wired by physical conductor
+    pairing (port A = the two top-rail ends, conductor 1 = the A-conductor
+    riser). This test IS the design's physics regression."""
+    from antennaknobs.designs.wire.sterba_bl import Builder
 
-    default_params = MappingProxyType(
-        {
-            "design_freq": FREQ,
-            "freq": FREQ,
-            "base": 7.0,
-            "spacing": 0.04,
-            "zcomm": 200.0,
-            "k1": 0.02,  # real open-wire loss regularises the λ/2 stamp
-            "end_corr": 0.030,  # measured pair end-effect elongation (m)
-        }
-    )
-
-    def _layout(self):
-        h = 0.5 * WL
-        q = 0.5 * h
-        yb = [0.0, q, q + h, 2 * q + h]
-        return h, yb
-
-    def _lvl(self, i, cond):
-        h, _ = self._layout()
-        a_top = i % 2 == 0
-        top, bot = self.base + h, self.base
-        if cond == "A":
-            return top if a_top else bot
-        return bot if a_top else top
-
-    def build_wires(self):
-        h, yb = self._layout()
-        s, pe = self.spacing, 0.2
-        tups = []
-        for cond, x in (("A", 0.0), ("B", s)):
-            for i in range(3):
-                z = self._lvl(i, cond)
-                y0, y1 = yb[i], yb[i + 1]
-                la = f"{cond}{i}a" if i > 0 else None
-                lb = f"{cond}{i}b" if i < 2 else None
-                if cond == "A" and i == 1:  # feed span (bottom-rail conductor)
-                    yc = 0.5 * (y0 + y1)
-                    tups.append(Wire((x, y0, z), (x, yc - 0.5 * pe, z), name=la))
-                    tups.append(
-                        Wire(
-                            (x, yc - 0.5 * pe, z), (x, yc + 0.5 * pe, z), name="feed"
-                        )  # fmt: skip
-                    )
-                    tups.append(Wire((x, yc + 0.5 * pe, z), (x, y1, z), name=lb))
-                else:
-                    ym = 0.5 * (y0 + y1)
-                    tups.append(Wire((x, y0, z), (x, ym, z), name=la))
-                    tups.append(Wire((x, ym, z), (x, y1, z), name=lb))
-        tups.append(Wire((0.0, 0.0, self._lvl(0, "A")), (s, 0.0, self._lvl(0, "B"))))
-        yl = yb[-1]
-        tups.append(Wire((0.0, yl, self._lvl(2, "A")), (s, yl, self._lvl(2, "B"))))
-        return tups
-
-    def build_network(self):
-        from antennaknobs.network import BalancedLine, PortAtEnd
-
-        h, _ = self._layout()
-        zd = analytic_zdiff(self.spacing)
-        ports = {"feed": PortOnWire("feed", distributed=True)}
-        branches = []
-        top = self.base + h
-        for k in (1, 2):
-            i = k - 1
-            pa, pa2 = f"eA{k}", f"eA{k}n"
-            pb, pb2 = f"eB{k}", f"eB{k}n"
-            ports[pa] = PortAtEnd(f"A{i}b", end="p1")
-            ports[pa2] = PortAtEnd(f"A{k}a", end="p0")
-            ports[pb] = PortAtEnd(f"B{i}b", end="p1")
-            ports[pb2] = PortAtEnd(f"B{k}a", end="p0")
-            a_top = self._lvl(i, "A") == top
-            a1, b1 = (pa, pa2) if a_top else (pa2, pa)
-            a2, b2 = (pb2, pb) if a_top else (pb, pb2)
-            branches.append(
-                BalancedLine(
-                    a1=a1,
-                    a2=a2,
-                    b1=b1,
-                    b2=b2,
-                    zdiff=zd,
-                    length=h + self.end_corr,
-                    k1=self.k1,
-                    zcomm=self.zcomm,
-                )  # fmt: skip
-            )
-        return Network(
-            ports=ports,
-            branches=branches,
-            sources=[Driven(port="feed", voltage=1 + 0j)],
-        )
+    return Builder(dict(Builder.default_params, n_cells=n_cells, **overrides))
 
 
 def _peak(eng):
@@ -347,11 +257,11 @@ def test_bl_riser_curtain_reproduces_wire_sterba_with_zcomm():
     gain_phys, az_phys = _peak(MomwireEngine(bp, ground=None))
     assert min(az_phys % 180.0, 180.0 - az_phys % 180.0) <= 10.0  # broadside
 
-    b100 = _MiniSterbaTL(dict(_MiniSterbaTL.default_params, zcomm=100.0))
+    b100 = _catalog_curtain(1, zcomm=100.0)
     gain_100, az_100 = _peak(MomwireEngine(b100, ground=None))
     assert min(az_100 % 180.0, 180.0 - az_100 % 180.0) <= 10.0
     assert abs(gain_100 - gain_phys) < 0.5
 
-    b400 = _MiniSterbaTL(dict(_MiniSterbaTL.default_params, zcomm=400.0))
+    b400 = _catalog_curtain(1, zcomm=400.0)
     gain_400, _az = _peak(MomwireEngine(b400, ground=None))
     assert abs(gain_400 - gain_100) < 0.1  # λ/2 repeater: zcomm-insensitive

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1148,13 +1148,19 @@ def test_geometry_endpoint_returns_wires_without_solving(client: TestClient):
 def test_examples_carry_default_backend(client: TestClient):
     # Every example exposes default_backend (str | null). Grid arrays recommend
     # the array-block accelerator; benchmark-sized meshes recommend the
-    # sinusoidal solver (see _SINUSOIDAL_RECOMMEND_MIN_BASIS); other designs
-    # keep the UI default (null) so their basis/results are unchanged.
+    # sinusoidal solver (see _SINUSOIDAL_RECOMMEND_MIN_BASIS); backend-
+    # restricted designs (requires_backends) get their allowlist's first
+    # entry (the fit-based recommendation could name a backend the design
+    # cannot run); other designs keep the UI default (null) so their
+    # basis/results are unchanged.
     payload = client.get("/examples").json()
     by_name = {e["name"]: e for e in payload["examples"]}
     for e in payload["examples"]:
         assert "default_backend" in e
-        assert e["default_backend"] in (None, "arrayblock", "sinusoidal")
+        if e["requires_backends"] is not None:
+            assert e["default_backend"] == e["requires_backends"][0]
+        else:
+            assert e["default_backend"] in (None, "arrayblock", "sinusoidal")
     assert by_name["arrays.bowtiearray2x4"]["default_backend"] == "arrayblock"
     assert by_name["verticals.elt_whip"]["default_backend"] == "sinusoidal"
     # A plain single-element design keeps the default.
@@ -1165,6 +1171,27 @@ def test_examples_carry_default_backend(client: TestClient):
     # so a Yagi (and a plain dipole) keep the dense default.
     assert by_name["beams.yagi"]["default_backend"] is None
     assert by_name["dipoles.invvee"]["default_backend"] is None
+
+
+def test_examples_carry_requires_backends(client: TestClient):
+    """Backend allowlist (issue #579): a design whose network has PortAtEnd
+    junction ports is restricted to the B-spline solver — the only one that
+    implements junction ports (momwire#172; NEC-2 has no equivalent card).
+    The flag is DERIVED from the network spec by the adapter, so it appears
+    exactly on the designs that need it; the frontend disables the other
+    backend tabs and hard-gates the solve on it. Its default_backend must
+    also be the allowed solver, not the array-detector's recommendation
+    (the curtain's repeated spans look like a grid array to it)."""
+    payload = client.get("/examples").json()
+    by_name = {e["name"]: e for e in payload["examples"]}
+    for e in payload["examples"]:
+        assert "requires_backends" in e
+    assert by_name["wire.sterba_bl"]["requires_backends"] == ["bspline"]
+    assert by_name["wire.sterba_bl"]["default_backend"] == "bspline"
+    # The unrestricted Sterba siblings stay unrestricted — including the
+    # network-TL one (TL/BalancedLine on PortOnWire gaps run everywhere).
+    assert by_name["wire.sterba"]["requires_backends"] is None
+    assert by_name["wire.sterba_tl"]["requires_backends"] is None
 
 
 def test_examples_carry_notes(client: TestClient):


### PR DESCRIPTION
## Summary

**Commit 1 — the element fix.** Root-causes the #576 end-to-end residual (BL-riser Sterba at +10.1 dBi az 35° vs wire.sterba's +15.2 az 180°): the differential-only rank-2 stamp deletes the riser pair's **common-mode conduction path**. The validated premise proved the CM *current* is small (5–15% of DM) — not that the *path* is removable: in the multi-loop curtain the λ/2 pair is a CM repeater (V→−V, I→−I regardless of Z0), and that boundary condition is what phases the outer spans. The competing hypothesis (relative polarity of a BL across four `PortAtEnd` junction ports) was refuted first by a phase-probing anchor testbed (Zin is blind to pair-polarity flips; transported current phase matches an all-metal feeder to 0.2°) and a hand-solved MNA replicating the engine to 1e-13. Adds `BalancedLine.zcomm: Optional[float] = None` — default keeps the differential-only stamp byte-for-byte; setting it adds the orthogonal even-mode block `kron(tl_admittance_2x2(zcomm, …), ¼·ones)`, which annihilates differential vectors (exact even/odd decomposition, unit-tested to machine precision). At resonant lengths results are zcomm-insensitive (measured identical 25–400 Ω). Revises #575's "deliberately differential-ONLY" decision with measurements. Evidence scripts in `scratchpad/sterba-tl/` (`h1_anchor.py`, `n1_surgery.py`, `scaling_check.py`).

**Commit 2 — catalog promotion + capability signalling.** New design **`wire.sterba_bl`**: wire.sterba's exact two-conductor radiator geometry with every interior riser pair replaced by a BalancedLine (analytic zdiff, zcomm CM path, real k1 loss, measured end_corr — no tuned parameters) on four `PortAtEnd` junction ports per boundary. **+15.39 dBi az 180 / Zin 674 Ω at n=3 avg ground vs physical +15.22 / 618 Ω**; broadside scaling n 1..7 (+12.8/+15.4/+16.6/+17.9 vs +13.0/+15.2/+16.2/+17.1); the documented high-n hot bias is in the docstring. `wire.sterba_tl` stays as the one-high network-TL study with a pointer.

**How the UI signals the engine restriction:** junction ports run **only on the dense B-spline solver** (momwire#172 — sinusoidal and the iterative accelerators raise; NEC-2 has no equivalent card at all), so a boolean "momwire-only" would have been wrong. The adapter **derives** a `requires_backends: ["bspline"]` allowlist by detecting `PortAtEnd` in the design's flattened network — the capability cannot drift from what the design does — and overrides `default_backend` (the array detector misfires on the curtain's repeated spans and would recommend arrayblock, which raises). Served via `/examples`. Frontend: disallowed backend tabs render **disabled with an explanatory tooltip** (stable picker — the restriction itself is the signal); an active disallowed selection **hard-withholds the solve** with "Switch to B-spline" / "Pause" actions — never "Solve anyway", since the solver raises; batch runners decline through the same gate. `/export_nec` already returns a clean 422. User designs defer their hints and keep the solver's hard error via the normal banner.

## Test plan
- [x] `tests/test_balanced_line.py` — 7 exact-answer zcomm unit tests (22 total pass)
- [x] `tests/test_balanced_line_physics.py` — e2e regression now exercises the **catalog design itself** (one-bay curtain vs wire.sterba: broadside, 0.5 dB, zcomm-insensitive; ~2 s)
- [x] `tests/test_web_server.py` — `/examples` payload asserts the derived allowlist on `wire.sterba_bl`, its absence on the unrestricted siblings, and `default_backend == requires_backends[0]` for restricted designs
- [x] catalog page regenerated (`scripts/generate_catalog.py`); catalog tests green
- [x] frontend `tsc --noEmit` + `vite build` clean
- [x] full suite `-m "not heavy_mesh"`: green (2778 passed + regenerated-catalog fixes)
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fjzwpcwtqgHZjRhnXft8y