### PR TITLE
chore: bump momwire pin to 0.18.0 (junction ports)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/sta
 # install below sees its requirement already satisfied, then the package with the
 # web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install "momwire==0.17.0" \
+ && pip install "momwire==0.18.0" \
  && pip install -e ".[web]"
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire==0.17.0",
+    "momwire==0.18.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",


### PR DESCRIPTION
Adopt **momwire 0.18.0** ([release](https://github.com/stevenmburns/momwire/releases/tag/v0.18.0), on PyPI) — the junction-ports feature (momwire #172) that `PortAtEnd` end-attachment depends on.

Updates all three coupled pin sites in one commit (the submodule is the one that's silently missed — see #268/#270):

| Site | Change |
|---|---|
| `pyproject.toml` | `momwire==0.17.0` → `0.18.0` |
| `Dockerfile` | `pip install "momwire==0.18.0"` |
| submodule pointer | `4de5126` → `da8caaa` (the 0.18.0 bump commit) |

PyPI serves 0.18.0 (verified before opening), so wheel-smoke should be green first try.

🤖 Generated with [Claude Code](https://claude.com/claude-code)