### PR TITLE
chore: release v0.38.0 (BalancedLine transmission-line curtains)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.37.0"
+version = "0.38.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/concepts/station-modelling.md
+++ b/site/src/content/docs/concepts/station-modelling.md
@@ -20,7 +20,7 @@ This page introduces the vocabulary. The worked examples put it to use:
 ## Ports: where the circuit meets the wire
 
 A design's `build_network()` returns a `Network` — ports, branches,
-sources. Ports come in two kinds:
+sources. Ports come in three kinds:
 
 - **`PortOnWire("feed")`** — a real port at a named wire of the
   geometry. This is the seam between the circuit world and the field
@@ -30,6 +30,12 @@ sources. Ports come in two kinds:
   transmitter end of a feedline is the classic one: it exists only in
   the network, and driving it makes every readout — impedance, SWR,
   gain, the power budget — **rig-referenced**.
+- **`PortAtEnd("riser", "p1")`** — a port at a wire's *endpoint*
+  rather than a mid-wire gap. It attaches to the shared junction node
+  at that point without cutting a gap — the way a floating
+  multi-terminal element (a `BalancedLine`) hangs off a conductor's
+  end. momwire-only: NEC-2 has no junction-node port, so the PyNEC
+  backend rejects designs that use it (a declared engine-parity break).
 
 The source (`Driven(port="rig")`) goes wherever your measurement plane
 is. Put it at the antenna feed and you're modelling the antenna; put it
@@ -66,6 +72,7 @@ honest model:
 | branch | what it is |
 |---|---|
 | `TL` / `TL.from_cable` | transmission line — ideal, or a real cable from the `CABLES` catalog (RG-58, RG-8X, window line…) with frequency-dependent matched loss; SWR-multiplied loss *emerges* from the circuit solution rather than a formula |
+| `BalancedLine` | balanced / differential two-conductor line — the pair sibling of `TL`, carrying ±I with the return riding the partner wire (open-wire feeder, the Sterba curtain's offset-pair risers). Set by a single differential impedance `zdiff`; add an optional common-mode path `zcomm` for a pair that also carries end-to-end conductor continuity |
 | `Load` | series R/L/C in a wire's current path — a trap, a terminating resistor |
 | `TwoPort` | series R/L/C between two ports — a tuner's series capacitor |
 | `Shunt` | R/L/C from a port to the common return — a tuner's shunt coil |

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,20 +25,20 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.37.0" icon="star">
-  **Your antenna, on the ground you actually stand on.** Every flat-ground
-  model — Sommerfeld, reflection-coefficient, PEC — assumes the earth is an
-  infinite flat plane at the mast's feet. The new **faceted-terrain ground**
-  drops that assumption: pick a **levee**, **cliff**, or **hillside** preset,
-  set the slopes, drops, and bearings, and the far field reflects off the
-  actual sloped facet each ray's specular point lands on — tilted incidence,
-  per-facet media (water vs. land), full effective height below the drops. The
-  motivating QTH — a 20 ft mast on a levee, fresh water off one slope and
-  farmland off the other — is worked end to end in
-  [Antennas on a levee](/advanced/terrain/). Presets are schema-driven, so
-  adding one is a single Python entry — no frontend rebuild. Also new:
-  **server-side polar cuts**, so every solve returns its azimuth and elevation
-  traces ready to plot. [All release notes →](/reference/releases/)
+<Card title="New in v0.38.0" icon="star">
+  **Transmission-line curtains, built as a circuit.** A Sterba-curtain array is
+  stitched together by transmission-line risers whose feed and phasing you used
+  to have to model as bare wire. The new **`BalancedLine`** element models that
+  riser as what it is — a differential two-conductor line — and its optional
+  **common-mode path** (`zcomm`) restores the conduction path a purely
+  differential stamp drops, so a **`build_network()`** TL Sterba now matches the
+  all-wire reference to a few tenths of a dB (**+15.4 dBi** at n=3), on both the
+  momwire and PyNEC backends. The result ships as the new **`wire.sterba_bl`**
+  catalog design. Also landing: **`PortAtEnd`** ports that attach a floating
+  element at a conductor's very end (not just a mid-wire gap), stricter
+  **network-authoring checks** that reject silent open-gap traps, and **one feed
+  marker per driven port** for multi-feed arrays. Built on **momwire 0.18.0**
+  (junction ports). [All release notes →](/reference/releases/)
 </Card>
 
 ## The whole pitch, in one line


### PR DESCRIPTION
Cuts **v0.38.0** — the BalancedLine / network transmission-line release. Tagging `v0.38.0` after this merges fires the four pipelines (PyPI + GitHub release, Fly simulator, Fly docs, Docker image).

## Release contents (since v0.37.0)
- **`BalancedLine`** differential two-conductor TL element with an optional **common-mode path** (`zcomm`) — a `build_network()` TL Sterba now matches the all-wire reference to a few tenths of a dB (**+15.4 dBi** at n=3), on both momwire and PyNEC (#575/#577/#581/#585)
- new **`wire.sterba_bl`** catalog design (#585)
- **`PortAtEnd`** junction-node ports at conductor ends (#579/#584)
- network-authoring safety: reject unreferenced named wires (#578), normalize port sign convention (#580); **one feed marker per driven port** for multi-feed arrays (#570/#571)
- hexbeam single common feed via `build_network()` (#573)
- singular-enrichment validation/experimental grouping + benchmark probes (#565), near-open convergence probe (#478)
- **momwire 0.18.0** pin (junction ports, #586)

## This commit (release ritual)
1. `pyproject.toml` → `version = "0.38.0"`
2. Refreshed the what's-new card in `index.mdx`
3. De-staled `concepts/station-modelling.md`: ports are now **three kinds** (adds `PortAtEnd`); `BalancedLine` added to the branch-vocabulary table
4. `cd site && npm run build` passes (25 pages)

Catalog page (`reference/catalog.md`) intentionally untouched — it's generated + test-guarded and already landed with #585.

🤖 Generated with [Claude Code](https://claude.com/claude-code)