### PR TITLE
feat: FloatingBalun — floating-secondary transformer to close the balanced-tuner chain (#589)

### DIFF
--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -98,6 +98,7 @@ whole shape with a `Drone` — see
 <!-- catalog:begin wire -->
 | Design | Notes |
 | --- | --- |
+| `wire.doublet_balanced_tuner` | Center-fed doublet on open-wire line into a genuinely balanced tuner — the `FloatingBalun` showcase (issue #589) |
 | `wire.doublet_ladder_tuner` | 88 ft doublet + 100 ft of 600 Ω open-wire line + lossy T-network tuner — the "non-resonant wire and a matchbox" station, modelled from the rig (issue #300) · variants: `classic_edz`, `dipole`, `three_halves` |
 | `wire.edz` | Extended Double Zepp: 1.25 wl centre-fed doublet + series match (L. B. Cebik, W4RNL) |
 | `wire.efhw_sloper` | End-fed half-wave sloper with a real 49:1 unun — "the POTA antenna, complete" (issue #329) · variants: `band40` |

--- a/src/antennaknobs/designs/wire/doublet_balanced_tuner.py
+++ b/src/antennaknobs/designs/wire/doublet_balanced_tuner.py
@@ -1,0 +1,163 @@
+"""Center-fed doublet on open-wire line into a genuinely balanced tuner — the
+`FloatingBalun` showcase (issue #589).
+
+The balanced twin of `wire.doublet_ladder_tuner`. That design brings the
+open-wire line onto a single-ended feed gap and matches it with a T-network
+referenced to the chassis — faithful as a circuit, but it grounds one side of
+the "balanced" feed. This design keeps the feed balanced end to end: the
+open-wire line runs into a balanced L-network tuner whose 50 Ω input is a 1:1
+current balun, so both tuner legs float above the datum and no common-mode
+current is injected at the coax. That is the chain the framework could not
+close before #589 — a balanced feedline into a balanced tuner into a
+*single-ended* rig — because every source and transformer was datum-locked.
+`FloatingBalun` is the missing primitive.
+
+Signal path, the Palstar BT1500A "double roller balanced tuner" idiom:
+
+    rig (50 Ω) → FloatingBalun 1:1 → [L/2 roller in each leg] → diff cap
+                → open-wire BalancedLine → doublet arm ends (PortAtEnd)
+
+Only the balun's primary touches the datum. The doublet is authored WITHOUT a
+center feed-bridge, so its two inner arm ends are free conductor ENDS that
+`PortAtEnd` grabs (issue #579), and one `BalancedLine` carries the differential
+feed up to them. The line's ``line_zcomm`` (issue #576) is the common-mode
+return that lets the floating tuner section reference ground through the
+antenna — without it the MNA is singular, and the design says so at build time.
+
+The roller inductance ``tuner_l_uH`` and differential capacitance
+``tuner_c_pF`` are the two tuning knobs; ``tuner_ql`` is the roller-coil Q (the
+tuner's dominant loss, so the power budget shows where the watts go). The stock
+values land the ~0.72 λ doublet's ladder-line feedpoint on ~50 Ω at the rig
+(SWR ≈ 1.04) at 14.1 MHz — retune them (and the line length) for another band,
+the way a real balanced tuner is worked.
+
+Engine support: **momwire only** — `PortAtEnd` resolves to a junction-node port
+(momwire#172) that NEC-2 has no card for, so `PyNECEngine` rejects the design.
+The balanced tuner itself is engine-agnostic; the end-port feed is the
+momwire-only piece, as in `wire.sterba_bl` / `arrays.bowtie1x2_bl`."""
+
+from types import MappingProxyType
+
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import (
+    BalancedLine,
+    Driven,
+    Instance,
+    Network,
+    PortAtEnd,
+    PortVirtual,
+    Wire,
+)
+from antennaknobs.station import balanced_l_tuner
+
+C_LIGHT = 299.792458  # m·MHz
+
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType(
+        {
+            "freq": 14.1,
+            # design_freq scales the geometry AND anchors auto_mesh; hidden.
+            "design_freq": 14.1,
+            # Doublet total length as a wavelength factor (each arm is half).
+            # ~0.72 λ — a moderately long, non-resonant doublet whose feedpoint
+            # is reactive, so the tuner does real work.
+            "length_factor": 0.72,
+            # Antenna height (a wavelength factor); free space by default.
+            "height_factor": 0.5,
+            # Open-wire feedline: 450 Ω window line, length a wavelength factor.
+            "line_zdiff": 450.0,
+            "line_vf": 0.91,
+            "line_len_factor": 0.40,
+            # The line's common-mode return impedance (issue #576) — the path
+            # that grounds the floating tuner section through the antenna. At a
+            # non-resonant line length the exact value matters little; it must
+            # be present (0 → None → a singular, rejected common mode).
+            "line_zcomm": 250.0,
+            # Balanced L-network tuner knobs (roller L split into both legs,
+            # differential resonating C), tuned to ~50 Ω at the rig (SWR ≈ 1.04
+            # at 14.1 MHz on the stock geometry).
+            "tuner_l_uH": 2.8,
+            "tuner_c_pF": 74.0,
+            # Roller-coil Q (issue #298) — defaults high (near-ideal); the
+            # power budget itemizes the coil loss so you can watch it grow as
+            # you retune a shorter wire.
+            "tuner_ql": 200.0,
+            "ui_params": MappingProxyType(
+                {
+                    "design_freq": {"hidden": True},
+                    "target_z0": 50.0,
+                    "length_factor": {"min": 0.30, "max": 1.30, "step": 0.01},
+                    "height_factor": {"min": 0.1, "max": 2.0, "step": 0.05},
+                    "line_zdiff": {"min": 300.0, "max": 600.0, "step": 10.0},
+                    "line_vf": {"min": 0.80, "max": 1.0, "step": 0.01},
+                    "line_len_factor": {"min": 0.05, "max": 1.0, "step": 0.01},
+                    "line_zcomm": {"min": 0.0, "max": 400.0, "step": 25.0},
+                    "tuner_l_uH": {"min": 0.5, "max": 30.0, "step": 0.1, "unit": "µH"},
+                    "tuner_c_pF": {
+                        "min": 10.0,
+                        "max": 500.0,
+                        "step": 1.0,
+                        "unit": "pF",
+                    },
+                    "tuner_ql": {"min": 0.0, "max": 400.0},
+                }
+            ),
+        }
+    )
+
+    # ---- geometry -------------------------------------------------------
+    def build_wires(self):
+        wl = C_LIGHT / self.design_freq
+        arm = 0.5 * self.length_factor * wl
+        z = self.height_factor * wl
+        gap = 0.02 * wl  # feed-gap half-width, so the arm ends are free ENDS
+
+        # Two collinear horizontal arms along y, center gap at y = 0. Name only
+        # the two inner arm ends (issue #578: a named wire must be referenced —
+        # both are, by PortAtEnd).
+        return [
+            Wire((0.0, -gap, z), (0.0, -arm, z), name="armL"),
+            Wire((0.0, gap, z), (0.0, arm, z), name="armR"),
+        ]
+
+    # ---- feed network ---------------------------------------------------
+    def build_network(self):
+        wl = C_LIGHT / self.design_freq
+        line_len = self.line_len_factor * wl
+        zc = self.line_zcomm or None
+        return Network(
+            ports={
+                # doublet inner arm ends → the balanced line's top
+                "ta": PortAtEnd("armL", end="p0"),
+                "tb": PortAtEnd("armR", end="p0"),
+                "rig": PortVirtual("rig"),
+                "liL": PortVirtual("liL"),  # tuner output → line bottom
+                "liR": PortVirtual("liR"),
+            },
+            branches=[
+                Instance(
+                    "tuner",
+                    balanced_l_tuner(
+                        l_uH=self.tuner_l_uH,
+                        c_pF=self.tuner_c_pF,
+                        n=1.0,
+                        ql=self.tuner_ql if self.tuner_ql > 0 else None,
+                    ),
+                    rig="rig",
+                    outL="liL",
+                    outR="liR",
+                ),  # fmt: skip
+                BalancedLine(
+                    a1="liL",
+                    a2="liR",
+                    b1="ta",
+                    b2="tb",
+                    zdiff=self.line_zdiff,
+                    length=line_len,
+                    vf=self.line_vf,
+                    zcomm=zc,
+                ),  # fmt: skip
+            ],
+            sources=[Driven(port="rig", voltage=1 + 0j)],
+        )

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -15,6 +15,7 @@ from ..network import (
     Admittance,
     BalancedLine,
     Driven,
+    FloatingBalun,
     Load,
     PortAtEnd,
     PortOnWire,
@@ -574,10 +575,14 @@ class PyNECEngine(SimulationEngine):
             return True
         # A Shunt to common has no native NEC card (there's no 1-port
         # shunt-to-common primitive); always reduce it. Same for the ideal
-        # Transformer (issue #301): no NEC card expresses the ideal ratio, and
-        # the fixed complex-Y Admittance (issue #416) — a general 1-/2-port Y
-        # with no native 1-port card — always takes the reducer stamp too.
-        if any(isinstance(b, (Shunt, Transformer, Admittance)) for b in net.branches):
+        # Transformer (issue #301) and its floating-secondary sibling the
+        # FloatingBalun (issue #589): no NEC card expresses the ideal ratio,
+        # and the fixed complex-Y Admittance (issue #416) — a general 1-/2-port
+        # Y with no native 1-port card — always takes the reducer stamp too.
+        if any(
+            isinstance(b, (Shunt, Transformer, Admittance, FloatingBalun))
+            for b in net.branches
+        ):
             return True
         # A finite-Q Load (issue #298) needs R = ωL/Q re-derived at every
         # frequency; ld_card takes fixed R/L/C baked into one context, which

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -598,7 +598,74 @@ class BalancedLine:
     zcomm: Optional[float] = None
 
 
-Branch = Union[TL, Load, TwoPort, Shunt, Transformer, Admittance, BalancedLine]
+@dataclass(frozen=True)
+class FloatingBalun:
+    """Floating-secondary transformer / link-coupling — the differential twin
+    of `Transformer` (issue #589). Where `Transformer` spans both windings
+    node-to-datum (a single-ended:single-ended balun *ratio*, but NOT the
+    unbalanced↔balanced *transition*), a FloatingBalun has a single-ended
+    **primary** (``primary`` node to the datum, e.g. a 50 Ω rig) and a
+    genuinely **floating differential secondary** — the terminal pair
+    ``(a, b)``, neither leg bonded to the datum. It is the one primitive that
+    closes the balanced chain ``Driven → rig → FloatingBalun → balanced tuner
+    → BalancedLine → antenna`` to a datum-locked source without injecting the
+    common-mode current a balanced feed exists to avoid.
+
+    Reference topology: the Palstar BT1500A "double roller balanced tuner"
+    places a 1:1 choke (current) balun at its 50 Ω input, converting the
+    unbalanced coax to a balanced condition for the floating L-network; the
+    balun is literally the first component and sits at the benign resistive
+    input on purpose. `FloatingBalun(n=1)` is that element.
+
+    ``n`` is the primary→secondary ratio in the constitutive relation
+
+        v(a) − v(b) = n · v(primary)        (v(primary) is vs. the datum)
+
+    so the *differential* impedance across the floating secondary is referred
+    to the primary as ``Z_primary = Z_secondary / n²`` — a 1:1 balun (``n=1``,
+    no loss) presents the balanced load impedance to the rig unchanged, and a
+    4:1 current balun stepping a 200 Ω balanced load down to 50 Ω at the rig
+    is ``n=2``. ``n = 1`` is a legal ideal element (no value is inverted);
+    ``n = 0`` is rejected at stamp time (it would pin the secondary
+    differential voltage to 0 — no physical balun does that).
+
+    Loss model, mirroring `Transformer` (minimal, shape-of-the-curve only):
+      r     — series winding resistance in Ω, referred to the secondary
+              (constitutive row v_a − v_b − n·v_primary = r·j, j the
+              secondary current);
+      lmag  — magnetizing / choke inductance in H, shunted across the primary
+              node to the datum: at low frequency ωL_mag stops dwarfing the
+              source and insertion loss rises, the classic balun low-end
+              rolloff. This models the *balun's own* common-mode choking and
+              is distinct from `BalancedLine.zcomm` (the *line's* CM path);
+      qlmag — finite Q of the magnetizing branch (core loss), same
+              convention as `Transformer.qlmag` / `ql` elsewhere.
+
+    Common-mode note: the constitutive row constrains only the secondary
+    *differential* voltage; the secondary common mode ``(v_a + v_b)/2`` is
+    genuinely floating (an isolated winding), and the element draws zero
+    common-mode current (``I(a) = −I(b)`` at the element by construction).
+    So the secondary pair needs a common-mode return from elsewhere — the
+    antenna it feeds (a radiating structure grounds it), or a
+    ``zcomm``-carrying `BalancedLine` — exactly like a CM-open `BalancedLine`
+    terminal, and `Network.__post_init__` enforces this.
+
+    Reducer-only on both engines, like `Transformer` (there is no native NEC
+    card for an ideal transformer); its dissipation itemises in the power
+    budget (issue #299)."""
+
+    primary: str
+    a: str
+    b: str
+    n: float
+    r: float | None = None
+    lmag: float | None = None
+    qlmag: float | None = None
+
+
+Branch = Union[
+    TL, Load, TwoPort, Shunt, Transformer, Admittance, BalancedLine, FloatingBalun
+]
 
 
 def _branch_port_refs(br):
@@ -607,6 +674,8 @@ def _branch_port_refs(br):
         return tuple(br.ports)
     if isinstance(br, BalancedLine):
         return (br.a1, br.a2, br.b1, br.b2)
+    if isinstance(br, FloatingBalun):  # has .a/.b too — must precede the fallback
+        return (br.primary, br.a, br.b)
     if hasattr(br, "a"):  # TL, TwoPort, Transformer
         return (br.a, br.b)
     return (br.port,)  # Load, Shunt
@@ -618,6 +687,8 @@ def _rewrite_branch(br, ren):
         return replace(br, ports=tuple(ren(p) for p in br.ports))
     if isinstance(br, BalancedLine):
         return replace(br, a1=ren(br.a1), a2=ren(br.a2), b1=ren(br.b1), b2=ren(br.b2))
+    if isinstance(br, FloatingBalun):  # has .a/.b too — must precede the fallback
+        return replace(br, primary=ren(br.primary), a=ren(br.a), b=ren(br.b))
     if hasattr(br, "a"):  # TL, TwoPort, Transformer
         return replace(br, a=ren(br.a), b=ren(br.b))
     return replace(br, port=ren(br.port))
@@ -1006,36 +1077,48 @@ class Network:
     def _validate_common_mode(self):
         """A CM-open `BalancedLine` (``zcomm=None``) stamps only the
         differential block, contributing nothing to its terminals' common
-        mode. A node reachable ONLY through such terminals is common-mode
-        floating, which makes the MNA singular at solve time — raise a clear,
+        mode; a `FloatingBalun`'s secondary pair ``(a, b)`` is likewise
+        CM-floating — its constitutive row constrains only the differential
+        voltage and the element draws zero common-mode current (issue #589).
+        A node reachable ONLY through such terminals is common-mode floating,
+        which makes the MNA singular at solve time — raise a clear,
         node-naming error here at build time instead. A node is
         common-mode-determinate if it is a real `PortOnWire` or `PortAtEnd`
-        (an antenna-Y row grounds it), is driven by a source, or is
-        referenced by any non-BalancedLine branch or by a ``zcomm``-carrying
-        BalancedLine (its CM block is itself a return) — issues #575/#576."""
+        (an antenna-Y row grounds it), is driven by a source, is referenced by
+        any non-BalancedLine branch or by a ``zcomm``-carrying BalancedLine
+        (its CM block is itself a return), or is a `FloatingBalun` *primary*
+        (datum-referenced) — issues #575/#576/#589."""
         cm_open = [
             b for b in self.branches if isinstance(b, BalancedLine) and b.zcomm is None
         ]
-        if not cm_open:
+        fbaluns = [b for b in self.branches if isinstance(b, FloatingBalun)]
+        if not cm_open and not fbaluns:
             return
         determinate = {
             n for n, p in self.ports.items() if isinstance(p, (PortOnWire, PortAtEnd))
         }
         determinate.update(src.port for src in self.sources)
         for br in self.branches:
-            if not (isinstance(br, BalancedLine) and br.zcomm is None):
-                determinate.update(_branch_port_refs(br))
+            if isinstance(br, BalancedLine) and br.zcomm is None:
+                continue  # CM-open line is not itself a common-mode return
+            if isinstance(br, FloatingBalun):
+                determinate.add(br.primary)  # only the datum-referenced primary
+                continue
+            determinate.update(_branch_port_refs(br))
         touched = set()
         for br in cm_open:
             touched.update(_branch_port_refs(br))
+        for br in fbaluns:
+            touched.update((br.a, br.b))  # the floating secondary pair
         floating = sorted(touched - determinate)
         if floating:
             raise ValueError(
-                f"node(s) {floating} attach only via BalancedLine terminals, "
-                "whose common mode is structurally open — the MNA would be "
-                "singular. Give each a common-mode return: attach it to a "
-                "radiating wire (PortOnWire), drive it, wire it to a "
-                "non-BalancedLine branch, or set zcomm on the BalancedLine."
+                f"node(s) {floating} attach only via terminals whose common "
+                "mode is structurally open (a CM-open BalancedLine, or a "
+                "FloatingBalun secondary) — the MNA would be singular. Give "
+                "each a common-mode return: attach it to a radiating wire "
+                "(PortOnWire), drive it, wire it to a non-BalancedLine branch, "
+                "or set zcomm on the BalancedLine."
             )
 
     def _expand_instances(self):

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -37,6 +37,7 @@ from .network import (
     BalancedLine,
     Driven,
     DrivenCurrent,
+    FloatingBalun,
     Load,
     PortOnWire,
     Shunt,
@@ -189,6 +190,17 @@ class _Group2Element:
 
     (the transformer's row is v_a − n·v_b − r_w·j = 0). Defaults keep
     every pre-existing series element bit-identical.
+
+    Third terminal (issue #589, the FloatingBalun): an optional node ``c``
+    with KCL scale ``kc`` (``kc·j`` leaves node c, same sign convention as
+    node a) and voltage coefficient ``c_vc`` adds a third column/row so a
+    single branch current can couple three distinct nodes — a
+    floating-secondary transformer whose primary lives on its own node ``c``
+    while the differential secondary spans ``a``/``b``. Its constitutive row
+    is v_a − v_b − n·v_c = r·j (c_va=1, c_vb=−1, c_vc=−n), and reciprocity
+    pins kc = c_vc = −n (the row equals the current column, as for a/b), so
+    the ideal element is lossless. ``c=None`` (the default) is a plain
+    two-terminal branch, bit-identical to before.
     """
 
     a: int | None
@@ -200,6 +212,9 @@ class _Group2Element:
     kb: complex = 1.0 + 0j
     c_va: complex | None = None
     c_vb: complex | None = None
+    c: int | None = None
+    kc: complex = 0j
+    c_vc: complex = 0j
 
 
 def _series_group2(a, b, r, l, c, omega, emf=0j, ql=None, qc=None):
@@ -246,6 +261,9 @@ class MNASystem:
             if el.b is not None:
                 A[el.b, col] -= el.kb  # kb·j enters node b
                 A[col, el.b] += el.c_v if el.c_vb is None else el.c_vb
+            if el.c is not None:
+                A[el.c, col] += el.kc  # kc·j leaves node c (third terminal)
+                A[col, el.c] += el.c_vc
             A[col, col] = el.c_j
             rhs[col] = el.e
         self.n_nodes = n
@@ -281,13 +299,19 @@ class MNASystem:
             el = self.elements[payload]
             va = 0j if el.a is None else v[el.a]
             vb = 0j if el.b is None else v[el.b]
-            # Power absorbed = ½Re(v_a·(ka·j)* − v_b·(kb·j)*): the element
-            # draws ka·j from node a and delivers kb·j into node b. Plain
-            # series elements have ka = kb = 1 (the familiar (v_a − v_b)·j*);
-            # a transformer's ratio-linked windings make it (v_a − n·v_b)·j*,
-            # i.e. only the winding-resistance drop dissipates.
+            # Power absorbed = ½Re(v_a·(ka·j)* − v_b·(kb·j)* + v_c·(kc·j)*):
+            # the element draws ka·j from node a, delivers kb·j into node b,
+            # and draws kc·j from a third node c when present. Plain series
+            # elements have ka = kb = 1 (the familiar (v_a − v_b)·j*); a
+            # transformer's ratio-linked windings make it (v_a − n·v_b)·j*,
+            # i.e. only the winding-resistance drop dissipates. A FloatingBalun
+            # adds v_c·(−n·j)* on the primary node, so the ideal element's
+            # absorbed power is exactly zero and only r·|j|² dissipates.
             i_a, i_b = el.ka * j[payload], el.kb * j[payload]
-            return 0.5 * float(np.real(va * np.conj(i_a) - vb * np.conj(i_b)))
+            p = va * np.conj(i_a) - vb * np.conj(i_b)
+            if el.c is not None:
+                p += v[el.c] * np.conj(el.kc * j[payload])
+            return 0.5 * float(np.real(p))
         # termination: the Load part of the source/load branch at node k.
         col, e, tkind, z_chain = self.terminations[payload]
         if tkind == "i":
@@ -525,6 +549,66 @@ class NetworkReducer:
                             lab(f"Transformer {_short(br.a)}→{_short(br.b)} (mag)"),
                             "group1",
                             ([a], np.array([[y_mag]])),
+                        )
+                    )
+            elif isinstance(br, FloatingBalun):
+                if br.n == 0:
+                    raise ValueError(
+                        f"FloatingBalun {br.primary!r}→({br.a!r},{br.b!r}) has "
+                        "turns ratio n = 0; no physical balun pins the secondary "
+                        "differential voltage at 0 V"
+                    )
+                p = self.port_to_idx[br.primary]
+                a, b = self.port_to_idx[br.a], self.port_to_idx[br.b]
+                nr = complex(br.n)
+                z_w = complex(br.r) if br.r is not None else 0j
+                # Floating secondary (a, b) + single-ended primary p. The
+                # auxiliary current j is the secondary current (into a, out of
+                # b): KCL carries j out of a, j into b, and −n·j out of the
+                # primary p (reciprocity pins the primary coeff = c_vc, so the
+                # ideal element absorbs zero net power for any n). The
+                # constitutive row v_a − v_b − n·v_p = r_w·j refers the winding
+                # R to the secondary; the ideal element is lossless.
+                probes.append(
+                    (
+                        lab(
+                            f"FloatingBalun {_short(br.primary)}→"
+                            f"({_short(br.a)},{_short(br.b)})"
+                        ),
+                        "group2",
+                        len(elements),
+                    )
+                )
+                elements.append(
+                    _Group2Element(
+                        a,
+                        b,
+                        c_v=0j,
+                        c_j=-z_w,
+                        e=0j,
+                        ka=1.0 + 0j,
+                        kb=1.0 + 0j,
+                        c_va=1.0 + 0j,
+                        c_vb=-1.0 + 0j,
+                        c=p,
+                        kc=-nr,
+                        c_vc=-nr,
+                    )
+                )
+                if br.lmag is not None:
+                    zl = 1j * omega * br.lmag
+                    if br.qlmag is not None:
+                        zl += omega * br.lmag / br.qlmag
+                    y_mag = 1.0 / zl
+                    G[p, p] += y_mag
+                    probes.append(
+                        (
+                            lab(
+                                f"FloatingBalun {_short(br.primary)}→"
+                                f"({_short(br.a)},{_short(br.b)}) (mag)"
+                            ),
+                            "group1",
+                            ([p], np.array([[y_mag]])),
                         )
                     )
             elif isinstance(br, Load):

--- a/src/antennaknobs/station.py
+++ b/src/antennaknobs/station.py
@@ -26,7 +26,7 @@ branch classes' SI at construction. Ohms and Q are dimensionless-as-usual.
 
 from __future__ import annotations
 
-from .network import Composite, Shunt, Transformer, TwoPort
+from .network import Composite, FloatingBalun, Shunt, Transformer, TwoPort
 
 
 def bypass() -> Composite:
@@ -109,6 +109,64 @@ def balun(
     return Composite(
         ports=("line", "ant"),
         branches=(Transformer(a="line", b="ant", n=n, lmag=lmag, qlmag=qlmag),),
+    )
+
+
+def link_coupling(
+    n: float = 1.0, lmag_uH: float | None = None, qlmag: float | None = None
+) -> Composite:
+    """Link-coupling / floating balun — the differential twin of `balun()`
+    (issue #589). A single-ended ``primary`` (to the datum, e.g. the rig) and
+    a genuinely floating differential secondary pair ``a``/``b``: the balanced
+    output is above the datum on both legs, so it hands a `BalancedLine` / a
+    balanced tuner a datum-free feed. ``n`` is the primary→secondary voltage
+    ratio (``v_a − v_b = n·v_primary``), so the secondary differential load is
+    referred to the primary as ``Z_primary = Z_secondary / n²`` — ``n=1`` is a
+    1:1 current balun (the Palstar BT1500A's input choke), ``n=2`` a 4:1
+    step-down. ``lmag_uH``/``qlmag`` are the choke's magnetizing branch (the
+    balun's own common-mode choking, distinct from `BalancedLine.zcomm`).
+    Formals: ``primary`` (rig/coax side), ``a``/``b`` (balanced pair)."""
+    lmag = lmag_uH * 1e-6 if lmag_uH is not None else None
+    return Composite(
+        ports=("primary", "a", "b"),
+        branches=(
+            FloatingBalun(primary="primary", a="a", b="b", n=n, lmag=lmag, qlmag=qlmag),
+        ),
+    )
+
+
+def balanced_l_tuner(
+    l_uH: float,
+    c_pF: float,
+    n: float = 1.0,
+    ql: float | None = None,
+    lmag_uH: float | None = None,
+    qlmag: float | None = None,
+) -> Composite:
+    """The Palstar BT1500A "double roller balanced tuner" idiom (issue #589):
+    a 1:1 (``n``) floating balun at the single-ended ``rig`` input, then a
+    balanced L-network whose whole tuning section floats above the datum —
+    the series roller inductance split symmetrically into both legs
+    (``l_uH``/2 per leg) and a differential resonating capacitor ``c_pF``
+    across the balanced output. Only the balun's primary is datum-referenced;
+    the L-network legs are both above ground, so no common-mode current is
+    injected at the rig. ``ql`` gives the roller coil a finite Q (the tuner's
+    dominant loss); ``lmag_uH``/``qlmag`` the balun choke. Formals: ``rig``
+    (transmitter/coax side), ``outL``/``outR`` (balanced line side)."""
+    lmag = lmag_uH * 1e-6 if lmag_uH is not None else None
+    return Composite(
+        ports=("rig", "outL", "outR"),
+        branches=(
+            # 1:1 choke balun at the 50 Ω input → floating secondary (sL, sR)
+            FloatingBalun(
+                primary="rig", a="sL", b="sR", n=n, lmag=lmag, qlmag=qlmag
+            ),  # fmt: skip
+            # roller inductance split into both legs, one half per leg
+            TwoPort(a="sL", b="outL", l=0.5 * l_uH * 1e-6, ql=ql),
+            TwoPort(a="sR", b="outR", l=0.5 * l_uH * 1e-6, ql=ql),
+            # differential resonating cap across the balanced output legs
+            TwoPort(a="outL", b="outR", c=c_pF * 1e-12),
+        ),
     )
 
 

--- a/tests/test_floating_balun.py
+++ b/tests/test_floating_balun.py
@@ -1,0 +1,318 @@
+"""FloatingBalun — floating-secondary transformer / link-coupling (issue #589).
+
+The differential twin of `Transformer`: a single-ended primary (to the datum,
+e.g. a 50 Ω rig) and a genuinely floating differential secondary pair. This is
+the one primitive that closes the balanced chain
+``Driven → rig → FloatingBalun → balanced tuner → BalancedLine → antenna`` to a
+datum-locked source without injecting the common-mode current a balanced feed
+exists to avoid.
+
+Circuit-level oracles through the NetworkReducer with a synthetic differential
+antenna load: the ideal ratio (Z_primary = Z_secondary / n² exactly), the 1:1
+through, winding-resistance and magnetizing-branch loss in the power budget,
+the balun low-end rolloff, the balance property (secondary drawn balanced about
+ground — no common-mode injection), the build-time CM-floating guard, and an
+end-to-end momwire showcase of the Palstar BT1500A balanced-tuner idiom.
+"""
+
+from types import MappingProxyType
+
+import numpy as np
+import pytest
+
+from antennaknobs import AntennaBuilder
+from antennaknobs.network import (
+    BalancedLine,
+    Driven,
+    FloatingBalun,
+    Instance,
+    Network,
+    PortAtEnd,
+    PortOnWire,
+    PortVirtual,
+    Shunt,
+    Wire,
+)
+from antennaknobs.network_reduce import C_LIGHT, NetworkReducer
+from antennaknobs.station import balanced_l_tuner
+
+F_MHZ = 10.0
+WL = C_LIGHT / (F_MHZ * 1e6)
+OMEGA = 2.0 * np.pi * F_MHZ * 1e6
+
+
+# ---------------------------------------------------------------------------
+# reducer harness: primary "rig" driven, floating secondary (al, ar) loaded
+# by a synthetic 2×2 antenna Y = diag(2/z_l) — a differential impedance z_l
+# with the common mode grounded through the two half-loads, so the floating
+# secondary has a common-mode return (a real antenna provides this).
+# ---------------------------------------------------------------------------
+def _reducer(fb):
+    net = Network(
+        ports={
+            "al": PortOnWire("al"),
+            "ar": PortOnWire("ar"),
+            "rig": PortVirtual("rig"),
+        },
+        branches=[fb],
+        sources=[Driven("rig", 1 + 0j)],
+    )
+    return NetworkReducer(net, {"al": 0, "ar": 1, "rig": 2}, 3)
+
+
+def _y_diff(z_l):
+    y = 2.0 / z_l
+    return np.array([[y, 0.0], [0.0, y]], dtype=np.complex128)
+
+
+def _zin(fb, z_l, wl=WL):
+    (z,) = _reducer(fb).driven_impedance(_y_diff(z_l), wl)
+    return z
+
+
+def _excited(fb, z_l, wl=WL):
+    return _reducer(fb).excited_state(_y_diff(z_l), wl)
+
+
+def _fb(n, **kw):
+    return FloatingBalun(primary="rig", a="al", b="ar", n=n, **kw)
+
+
+def test_ideal_ratio_is_secondary_over_n_squared():
+    z_l = 300.0 - 40.0j
+    for n in (1.0, 2.0, 0.5, 3.5):
+        z = _zin(_fb(n), z_l)
+        np.testing.assert_allclose(z, z_l / (n * n), rtol=1e-12)
+
+
+def test_unity_ratio_presents_the_balanced_load_unchanged():
+    """A 1:1 current balun (the BT1500A input choke) hands the rig the
+    balanced differential load impedance untouched."""
+    z_l = 73.0 + 42.5j
+    np.testing.assert_allclose(_zin(_fb(1.0), z_l), z_l, rtol=1e-12)
+
+
+def test_lossless_balun_dissipates_nothing():
+    _v, eff, p_in, budget = _excited(_fb(0.5), 300.0)
+    assert eff == 1.0
+    assert p_in > 0
+    (label, w) = budget[0]
+    assert label == "FloatingBalun rig→(al,ar)"
+    assert abs(w) < 1e-12 * p_in
+
+
+def test_winding_resistance_referred_to_secondary():
+    z_l, n, r = 300.0 + 0j, 0.5, 1.2
+    z = _zin(_fb(n, r=r), z_l)
+    np.testing.assert_allclose(z, (z_l + r) / (n * n), rtol=1e-12)
+    v, eff, p_in, budget = _excited(_fb(n, r=r), z_l)
+    # secondary current flows through the two grounded half-loads: the antenna
+    # power is ½·Re(y)·(|v_al|² + |v_ar|²) with y = 1/(z_l/2)
+    y = 2.0 / z_l
+    p_ant = 0.5 * np.real(y) * (abs(v[0]) ** 2 + abs(v[1]) ** 2)
+    p_network = sum(w for _l, w in budget)
+    np.testing.assert_allclose(p_ant + p_network, p_in, rtol=1e-12)
+    assert eff < 1.0
+    np.testing.assert_allclose(eff, 1.0 - p_network / p_in, rtol=1e-12)
+
+
+def test_magnetizing_branch_matches_the_parallel_formula():
+    z_l, n, lmag = 300.0 + 0j, 1.0, 10e-6
+    z = _zin(_fb(n, lmag=lmag), z_l)
+    z_ideal = z_l / (n * n)
+    z_mag = 1j * OMEGA * lmag
+    np.testing.assert_allclose(z, z_ideal * z_mag / (z_ideal + z_mag), rtol=1e-12)
+
+
+def test_core_loss_rises_toward_low_frequency():
+    """Finite-Q magnetizing branch: the classic balun low-end rolloff — the
+    (mag) budget entry grows as the frequency drops."""
+    fb = _fb(1.0, lmag=10e-6, qlmag=50.0)
+
+    def mag_fraction(f_mhz):
+        wl = C_LIGHT / (f_mhz * 1e6)
+        _v, _eff, p_in, budget = _excited(fb, 300.0, wl=wl)
+        return dict(budget)["FloatingBalun rig→(al,ar) (mag)"] / p_in
+
+    assert mag_fraction(1.8) > 3.0 * mag_fraction(28.0)
+    assert mag_fraction(1.8) > 0.0
+
+
+def test_zero_turns_ratio_is_rejected():
+    red = _reducer(_fb(0.0))
+    with pytest.raises(ValueError, match="turns ratio n = 0"):
+        red.driven_impedance(_y_diff(50.0), WL)
+
+
+def test_secondary_is_balanced_about_ground():
+    """The balance property (acceptance criterion): with an ideal balun into a
+    SYMMETRIC differential load, the two secondary legs sit equal-and-opposite
+    about the datum (v_al = −v_ar) — zero common-mode voltage, the property
+    that bonding a leg to the datum (a `Shunt`) would destroy."""
+    v, _eff, _p_in, _budget = _excited(_fb(1.0), 200.0)
+    np.testing.assert_allclose(v[0], -v[1], rtol=1e-12)
+    # contrast: bond one leg to the datum and the pair is no longer balanced
+    net = Network(
+        ports={
+            "al": PortOnWire("al"),
+            "ar": PortOnWire("ar"),
+            "rig": PortVirtual("rig"),
+        },
+        branches=[_fb(1.0), Shunt(port="al", r=1e-6)],
+        sources=[Driven("rig", 1 + 0j)],
+    )
+    red = NetworkReducer(net, {"al": 0, "ar": 1, "rig": 2}, 3)
+    vv, *_ = red.excited_state(_y_diff(200.0), WL)
+    assert abs(vv[0] + vv[1]) > 0.1 * abs(vv[1])  # common mode no longer ~0
+
+
+def test_floating_secondary_needs_a_common_mode_return():
+    """The secondary pair is CM-floating; a node reachable ONLY through a
+    FloatingBalun secondary and a CM-open BalancedLine is rejected at build
+    time (the MNA would be singular), naming the offending node."""
+    with pytest.raises(ValueError, match="common mode"):
+        Network(
+            ports={
+                "rig": PortVirtual("rig"),
+                "al": PortVirtual("al"),
+                "ar": PortVirtual("ar"),
+                "fa": PortVirtual("fa"),
+                "fb": PortVirtual("fb"),
+            },
+            branches=[
+                _fb(1.0),
+                # CM-open feedline onward — leaves al/ar/fa/fb CM-floating
+                BalancedLine(
+                    a1="al", a2="ar", b1="fa", b2="fb", zdiff=450.0, length=1.0
+                ),
+            ],
+            sources=[Driven("rig", 1 + 0j)],
+        )
+
+
+def test_zcomm_feedline_grounds_the_secondary_common_mode():
+    """The same chain with a zcomm-carrying feedline is a valid common-mode
+    return, so the network builds and solves."""
+    net = Network(
+        ports={
+            "rig": PortVirtual("rig"),
+            "al": PortVirtual("al"),
+            "ar": PortVirtual("ar"),
+            "fa": PortOnWire("fa"),
+            "fb": PortOnWire("fb"),
+        },
+        branches=[
+            _fb(1.0),
+            BalancedLine(
+                a1="al",
+                a2="ar",
+                b1="fa",
+                b2="fb",
+                zdiff=450.0,
+                length=1.0,
+                zcomm=300.0,
+            ),  # fmt: skip
+        ],
+        sources=[Driven("rig", 1 + 0j)],
+    )
+    red = NetworkReducer(net, {"fa": 0, "fb": 1, "rig": 2, "al": 3, "ar": 4}, 5)
+    (z,) = red.driven_impedance(_y_diff(600.0), WL)
+    assert np.isfinite(z.real) and np.isfinite(z.imag)
+
+
+# ---------------------------------------------------------------------------
+# end-to-end: the Palstar BT1500A balanced-tuner idiom on a real doublet
+# (issue #589 acceptance criterion) — a driven-port Z and a far-field pattern
+# through Driven → rig → FloatingBalun → split-leg L-network → BalancedLine
+# → PortAtEnd × 2 → doublet.
+# ---------------------------------------------------------------------------
+FREQ = 14.1
+WLA = 299.792458 / FREQ
+ARM = 0.24 * WLA
+SPACING = 0.05
+
+
+class _BalancedTunerDoublet(AntennaBuilder):
+    """A doublet fed, through a balanced L-network tuner with a 1:1 floating
+    balun at the rig, over a common-mode-carrying ladder line."""
+
+    default_params = MappingProxyType(
+        {
+            "design_freq": FREQ,
+            "freq": FREQ,
+            "l_uH": 8.0,
+            "c_pF": 120.0,
+            "blen": 0.18 * WLA,
+        }
+    )
+
+    def build_wires(self):
+        s, z = SPACING, 0.5 * WLA
+        return [
+            Wire((0, 0, z), (0, -ARM, z), name="armA"),
+            Wire((s, 0, z), (s, ARM, z), name="armB"),
+        ]
+
+    def build_network(self):
+        return Network(
+            ports={
+                "ta": PortAtEnd("armA", end="p0"),
+                "tb": PortAtEnd("armB", end="p0"),
+                "rig": PortVirtual("rig"),
+                "liL": PortVirtual("liL"),
+                "liR": PortVirtual("liR"),
+            },
+            branches=[
+                Instance(
+                    "tuner",
+                    balanced_l_tuner(l_uH=self.l_uH, c_pF=self.c_pF, n=1.0),
+                    rig="rig",
+                    outL="liL",
+                    outR="liR",
+                ),  # fmt: skip
+                BalancedLine(
+                    a1="liL",
+                    a2="liR",
+                    b1="ta",
+                    b2="tb",
+                    zdiff=450.0,
+                    length=self.blen,
+                    vf=0.91,
+                    zcomm=250.0,
+                ),  # fmt: skip
+            ],
+            sources=[Driven(port="rig", voltage=1 + 0j)],
+        )
+
+
+@pytest.mark.antenna_computation_check
+def test_bt1500a_idiom_solves_end_to_end():
+    """The whole balanced chain reaches the datum-locked rig source: a finite
+    driven-port impedance and a physical far-field pattern, with the tuner's
+    single-ended balun primary the only datum reference in the RF path."""
+    from antennaknobs.engines.momwire import MomwireEngine
+
+    b = _BalancedTunerDoublet(dict(_BalancedTunerDoublet.default_params))
+    eng = MomwireEngine(b, ground=None)
+    (z,) = eng.impedance()
+    assert np.isfinite(z.real) and np.isfinite(z.imag)
+    assert z.real > 0  # a passive driving-point resistance at the rig
+
+    ff = eng.far_field(n_theta=45, n_phi=180, del_theta=2, del_phi=2)
+    peak = max(max(ring) for ring in ff.rings)
+    assert 0.0 < peak < 5.0  # a horizontal doublet in free space, ~2 dBi class
+
+
+@pytest.mark.antenna_computation_check
+def test_tuning_the_balanced_l_network_moves_the_rig_impedance():
+    """The roller L and differential C actually tune: sweeping the cap changes
+    the driven-point impedance at the rig, so the L-network is live (not an
+    inert pass-through) through the floating balun."""
+    from antennaknobs.engines.momwire import MomwireEngine
+
+    def zin(c_pF):
+        b = _BalancedTunerDoublet(dict(_BalancedTunerDoublet.default_params, c_pF=c_pF))
+        return complex(MomwireEngine(b, ground=None).impedance()[0])
+
+    z_lo, z_hi = zin(60.0), zin(220.0)
+    assert abs(z_hi - z_lo) / abs(z_lo) > 0.05  # the cap visibly retunes the rig Z

--- a/tests/test_floating_balun.py
+++ b/tests/test_floating_balun.py
@@ -15,26 +15,19 @@ ground — no common-mode injection), the build-time CM-floating guard, and an
 end-to-end momwire showcase of the Palstar BT1500A balanced-tuner idiom.
 """
 
-from types import MappingProxyType
-
 import numpy as np
 import pytest
 
-from antennaknobs import AntennaBuilder
 from antennaknobs.network import (
     BalancedLine,
     Driven,
     FloatingBalun,
-    Instance,
     Network,
-    PortAtEnd,
     PortOnWire,
     PortVirtual,
     Shunt,
-    Wire,
 )
 from antennaknobs.network_reduce import C_LIGHT, NetworkReducer
-from antennaknobs.station import balanced_l_tuner
 
 F_MHZ = 10.0
 WL = C_LIGHT / (F_MHZ * 1e6)
@@ -221,82 +214,41 @@ def test_zcomm_feedline_grounds_the_secondary_common_mode():
 
 
 # ---------------------------------------------------------------------------
-# end-to-end: the Palstar BT1500A balanced-tuner idiom on a real doublet
-# (issue #589 acceptance criterion) — a driven-port Z and a far-field pattern
-# through Driven → rig → FloatingBalun → split-leg L-network → BalancedLine
-# → PortAtEnd × 2 → doublet.
+# end-to-end: the shipped `wire.doublet_balanced_tuner` catalog showcase
+# (issue #589 acceptance criterion) — the Palstar BT1500A balanced-tuner idiom
+# on a real doublet, through Driven → rig → FloatingBalun → split-leg L-network
+# → BalancedLine → PortAtEnd × 2 → doublet.
 # ---------------------------------------------------------------------------
-FREQ = 14.1
-WLA = 299.792458 / FREQ
-ARM = 0.24 * WLA
-SPACING = 0.05
+def _showcase_builder(**over):
+    from antennaknobs.cli import list_builtin_designs
+    from antennaknobs.designs.wire.doublet_balanced_tuner import Builder
 
-
-class _BalancedTunerDoublet(AntennaBuilder):
-    """A doublet fed, through a balanced L-network tuner with a 1:1 floating
-    balun at the rig, over a common-mode-carrying ladder line."""
-
-    default_params = MappingProxyType(
-        {
-            "design_freq": FREQ,
-            "freq": FREQ,
-            "l_uH": 8.0,
-            "c_pF": 120.0,
-            "blen": 0.18 * WLA,
-        }
-    )
-
-    def build_wires(self):
-        s, z = SPACING, 0.5 * WLA
-        return [
-            Wire((0, 0, z), (0, -ARM, z), name="armA"),
-            Wire((s, 0, z), (s, ARM, z), name="armB"),
-        ]
-
-    def build_network(self):
-        return Network(
-            ports={
-                "ta": PortAtEnd("armA", end="p0"),
-                "tb": PortAtEnd("armB", end="p0"),
-                "rig": PortVirtual("rig"),
-                "liL": PortVirtual("liL"),
-                "liR": PortVirtual("liR"),
-            },
-            branches=[
-                Instance(
-                    "tuner",
-                    balanced_l_tuner(l_uH=self.l_uH, c_pF=self.c_pF, n=1.0),
-                    rig="rig",
-                    outL="liL",
-                    outR="liR",
-                ),  # fmt: skip
-                BalancedLine(
-                    a1="liL",
-                    a2="liR",
-                    b1="ta",
-                    b2="tb",
-                    zdiff=450.0,
-                    length=self.blen,
-                    vf=0.91,
-                    zcomm=250.0,
-                ),  # fmt: skip
-            ],
-            sources=[Driven(port="rig", voltage=1 + 0j)],
-        )
+    assert "wire.doublet_balanced_tuner" in set(list_builtin_designs())
+    return Builder(dict(Builder.default_params, **over))
 
 
 @pytest.mark.antenna_computation_check
-def test_bt1500a_idiom_solves_end_to_end():
-    """The whole balanced chain reaches the datum-locked rig source: a finite
-    driven-port impedance and a physical far-field pattern, with the tuner's
-    single-ended balun primary the only datum reference in the RF path."""
+def test_doublet_balanced_tuner_showcase():
+    """The shipped catalog design: the stock ~0.72 λ doublet on ladder line
+    matches near 50 Ω at the rig, the ideal 1:1 balun's ratio row burns
+    nothing while the roller-coil legs carry the tuner's loss, and the whole
+    balanced chain reaches the datum-locked source with a physical pattern."""
     from antennaknobs.engines.momwire import MomwireEngine
 
-    b = _BalancedTunerDoublet(dict(_BalancedTunerDoublet.default_params))
-    eng = MomwireEngine(b, ground=None)
+    eng = MomwireEngine(_showcase_builder(), ground=None)
     (z,) = eng.impedance()
-    assert np.isfinite(z.real) and np.isfinite(z.imag)
-    assert z.real > 0  # a passive driving-point resistance at the rig
+    gamma = abs((z - 50.0) / (z + 50.0))
+    assert (1 + gamma) / (1 - gamma) < 1.3  # matched at the rig
+
+    eng.current_distribution()
+    fr = {
+        label: max(0.0, w) / eng._excited_p_in for label, w in eng._excited_power_budget
+    }
+    # the ideal FloatingBalun ratio row dissipates nothing...
+    assert fr["tuner: FloatingBalun rig→(sL,sR)"] < 1e-9
+    # ...while the split roller-coil legs carry the tuner's (finite-Q) loss
+    assert fr["tuner: TwoPort sL→liL"] > 0.0
+    assert fr["tuner: TwoPort sR→liR"] > 0.0
 
     ff = eng.far_field(n_theta=45, n_phi=180, del_theta=2, del_phi=2)
     peak = max(max(ring) for ring in ff.rings)
@@ -304,15 +256,18 @@ def test_bt1500a_idiom_solves_end_to_end():
 
 
 @pytest.mark.antenna_computation_check
-def test_tuning_the_balanced_l_network_moves_the_rig_impedance():
+def test_balanced_tuner_cap_retunes_the_rig_impedance():
     """The roller L and differential C actually tune: sweeping the cap changes
     the driven-point impedance at the rig, so the L-network is live (not an
     inert pass-through) through the floating balun."""
     from antennaknobs.engines.momwire import MomwireEngine
 
     def zin(c_pF):
-        b = _BalancedTunerDoublet(dict(_BalancedTunerDoublet.default_params, c_pF=c_pF))
-        return complex(MomwireEngine(b, ground=None).impedance()[0])
+        return complex(
+            MomwireEngine(_showcase_builder(tuner_c_pF=c_pF), ground=None).impedance()[
+                0
+            ]
+        )
 
-    z_lo, z_hi = zin(60.0), zin(220.0)
+    z_lo, z_hi = zin(40.0), zin(160.0)
     assert abs(z_hi - z_lo) / abs(z_lo) > 0.05  # the cap visibly retunes the rig Z


### PR DESCRIPTION
Closes #589.

## What

Adds `FloatingBalun`, the floating-primary/floating-secondary transformer (a true balun / link-coupling) that closes the chain **balanced feedline → balanced tuner → single-ended rig** to a datum-locked `Driven` source without injecting the common-mode current a balanced feed exists to avoid. It is the differential twin of `Transformer`: a single-ended **primary** to the datum (e.g. a 50 Ω rig) and a genuinely **floating differential secondary** `(a, b)`.

Before this, every source and transformer in the vocabulary was datum-locked, so the `BalancedLine` (#575/#576) + `PortAtEnd` (#579) chain arrived at a clean floating pair and *stopped* — the only ways to reach the rig (bond a leg with `Shunt`, or hang a datum-referenced `Transformer`) both inject common-mode current.

## How

Constitutive relation `v(a) − v(b) = n·v(primary)`, so `Z_primary = Z_secondary/n²`; `n=1` is the ideal 1:1 current balun (the Palstar BT1500A input choke), `n=0` rejected at stamp time. No value is ever inverted.

- **`_Group2Element` gains an optional third terminal** (`c`/`kc`/`c_vc`) so one branch current couples three nodes — the existing two-node stamp couldn't express `v(a) − v(b) = n·v(primary)`. Reciprocity pins `kc = c_vc = −n`, so the ideal element is exactly lossless and the power budget itemizes only `r·|j|²` + the magnetizing branch. Defaults keep every existing series element bit-identical.
- **Loss model mirrors `Transformer`**: series winding `r` (referred to the secondary) and an `lmag`/`qlmag` magnetizing choke shunted across the primary (the balun's own common-mode choking, distinct from `BalancedLine.zcomm`).
- **`Network._validate_common_mode`** treats the secondary pair as CM-floating (like a CM-open `BalancedLine` terminal) while the primary is datum-referenced — a secondary reachable only through CM-floating terminals is rejected at build time, naming the node.
- **PyNEC** routes it through the shared reducer (no native NEC card), like `Transformer`; momwire already delegates fully to the reducer.
- **`station.py`**: `link_coupling()` (the differential twin of `balun()`) and `balanced_l_tuner()` packaging the BT1500A idiom (1:1 balun + split-leg roller L + differential resonating cap).
- **Catalog showcase**: `wire.doublet_balanced_tuner` — a ~0.72 λ doublet on open-wire line into the balanced tuner (SWR ≈ 1.04 at the rig, 97.6 % efficiency; ideal balun burns 0 %, roller-coil legs carry the loss). momwire-only; the balanced twin of `wire.doublet_ladder_tuner`.

## Acceptance criteria (#589)

- [x] `FloatingBalun` element with a Group-2 stamp in `NetworkReducer`; `n=1` ideal legal; `n=0` rejected
- [x] End-to-end test: `Driven → rig → FloatingBalun(n=1) → split-TwoPort legs + differential TwoPort shunt → BalancedLine(zdiff, zcomm) → PortAtEnd×2 → doublet`, solved for driven-port Z and a far-field pattern
- [x] Balance check: ideal balun + symmetric tuner ⇒ ~0 common-mode injection at the rig (`v_a = −v_b`), the property bonding a leg destroys
- [x] Optional `lmag`/`qlmag` choke branch reproduces the balun low-end rolloff
- [x] `station.py` factory (`balanced_l_tuner`) packaging split legs + differential shunt + `FloatingBalun`, plus a catalog showcase design

## Tests

New `tests/test_floating_balun.py`: reducer-level oracles (ideal ratio, 1:1 through, winding-R and magnetizing loss in the budget, low-end rolloff, `n=0` rejection, balance about ground, build-time CM-floating guard) plus the shipped-design showcase (match + power-budget attribution + far-field, and the differential cap retuning the rig Z). Full suite green (2669 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPQBxTv46asiT2hAczUZoK