### PR TITLE
Add C_LIGHT_MHZ_M constant + design_wavelength property; migrate catalog off bare literals

### DIFF
--- a/site/src/content/docs/concepts/authoring-with-claude.md
+++ b/site/src/content/docs/concepts/authoring-with-claude.md
@@ -83,7 +83,7 @@ class Builder(AntennaBuilder):
     }
 
     def build_wires(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength   # = C_LIGHT_MHZ_M / design_freq, in metres
         h = (wavelength / 4.0) * self.length_factor
         z, eps = self.height, 0.01
         return [
@@ -95,8 +95,10 @@ class Builder(AntennaBuilder):
 
 :::tip[The `design_freq` rule — resonate across bands]
 To put an antenna on a band *and keep it tunable there*, size every dimension as
-a fraction of `wavelength = 299.792458 / self.design_freq` (times a
-`length_factor` near 1.0). That scales the geometry with the band selector, so
+a fraction of `self.design_wavelength` (the free-space wavelength at
+`design_freq`, in metres — an `AntennaBuilder` property, so you never write the
+bare `299.792458` constant), times a `length_factor` near 1.0. That scales the
+geometry with the band selector, so
 one design resonates anywhere you point it. Skip it — freeze the dimensions in
 metres — and changing the band no longer resizes the antenna: the meas-freq
 slider still reaches any band you select, but a fixed-metre wire only *resonates*

--- a/site/src/content/docs/concepts/first-builder.mdx
+++ b/site/src/content/docs/concepts/first-builder.mdx
@@ -233,7 +233,7 @@ class Builder(AntennaBuilder):
     }
 
     def build_wires(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength   # free-space λ at design_freq, in metres
         quarter = wavelength / 4.0
         y = quarter * self.length_factor   # half-length ≈ a quarter wavelength
         z = self.base
@@ -255,8 +255,10 @@ Two things changed, and they're the whole point:
   leaving `design_freq` to do the coarse band placement.
 
 <Aside type="tip" title="The design_freq rule — resonate across bands, not just one">
-  Sizing dimensions as fractions of `wavelength = 299.792458 / self.design_freq`
-  is the house rule for tunable designs. Skip it — freeze the length in metres —
+  Sizing dimensions as fractions of `self.design_wavelength` — an
+  `AntennaBuilder` property that returns the free-space wavelength at
+  `design_freq`, so you never spell the `299.792458` constant yourself — is the
+  house rule for tunable designs. Skip it — freeze the length in metres —
   and the geometry won't resize when you pick a different band: you can still
   *measure* the antenna anywhere (the meas-freq slider reaches any band you
   select), but a fixed-metre wire only *resonates* on the one band its

--- a/src/antennaknobs/__init__.py
+++ b/src/antennaknobs/__init__.py
@@ -4,6 +4,7 @@ __all__ = [
     "Drone",
     "Antenna",
     "AntennaBuilder",
+    "C_LIGHT_MHZ_M",
     "Array2x2Builder",
     "Array2x4Builder",
     "Array1x4Builder",
@@ -40,6 +41,7 @@ __all__ = [
 
 from .builder import (
     AntennaBuilder,
+    C_LIGHT_MHZ_M,
     Array2x2Builder,
     Array2x4Builder,
     Array1x4Builder,

--- a/src/antennaknobs/builder.py
+++ b/src/antennaknobs/builder.py
@@ -9,6 +9,15 @@ import numpy as np
 # so keeping it off module import keeps `import antennaknobs` and web startup
 # (which never plots) lean.
 
+# Speed of light in the units radio work actually uses: a free-space
+# wavelength in metres is ``C_LIGHT_MHZ_M / freq_MHz``. It is the same physical
+# constant the engines carry as SI ``C_LIGHT = 299_792_458`` m/s, pre-scaled so
+# that dividing by a frequency in MHz yields metres with no 1e6 bookkeeping —
+# the form catalog designs (which work in MHz and metres throughout) want. One
+# canonical spelling of the number, exported from the package top level, so a
+# design never has to write the bare ``299.792458`` literal again.
+C_LIGHT_MHZ_M = 299.792458
+
 
 def merge_params(base, over):
     """Recursively overlay ``over`` onto a copy of ``base``.
@@ -139,6 +148,38 @@ class AntennaBuilder:
                 res.append(f"{k} = {v!r}")
         return ", ".join(res)
 
+    @property
+    def design_wavelength(self):
+        """Free-space wavelength in metres at ``design_freq`` (MHz).
+
+        The single named quantity for the ``299.792458 / self.design_freq``
+        idiom that every wavelength-scaled builder repeats — geometry held as
+        wavelength fractions (``half_frac * self.design_wavelength``) then reads
+        as what it is, and the constant lives in exactly one place. This is the
+        *design* wavelength (the frequency the geometry is dimensioned for), not
+        the *measurement* ``freq``: sweeping ``freq`` must never resize the
+        antenna, so wavelength-fraction specs scale against this, matching
+        :meth:`auto_mesh`'s density.
+
+        Raises ``ValueError`` if the design declares no ``design_freq`` — a
+        builder holding its geometry in wavelength fractions must say what
+        frequency those fractions are of, the same contract ``auto_mesh``
+        enforces for ``None`` segment counts. ``design_lambda`` is a spelling
+        alias for the same value."""
+        design_freq = getattr(self, "design_freq", None)
+        if not design_freq:
+            raise ValueError(
+                f"{type(self).__name__}: design_wavelength needs a design_freq "
+                "param (the frequency the geometry is designed for); declare "
+                "one in default_params."
+            )
+        return C_LIGHT_MHZ_M / float(design_freq)
+
+    @property
+    def design_lambda(self):
+        """Spelling alias for :attr:`design_wavelength`."""
+        return self.design_wavelength
+
     def build_tls(self):
         return []
 
@@ -239,7 +280,7 @@ class AntennaBuilder:
                 "per quarter-wavelength); declare one in default_params "
                 "or give every wire an explicit segment count."
             )
-        quarter_wave = 0.25 * 299.792458 / float(design_freq)
+        quarter_wave = 0.25 * C_LIGHT_MHZ_M / float(design_freq)
 
         def resolve(t):
             if t[2] is not None:

--- a/src/antennaknobs/designs/arrays/bowtie1x2_bl.py
+++ b/src/antennaknobs/designs/arrays/bowtie1x2_bl.py
@@ -61,8 +61,6 @@ from antennaknobs.network import (
     Wire,
 )
 
-C_LIGHT = 299.792458  # m·MHz
-
 
 class Builder(AntennaBuilder):
     default_params = MappingProxyType(
@@ -98,7 +96,7 @@ class Builder(AntennaBuilder):
     # ---- geometry -------------------------------------------------------
     def _element_geo(self):
         """(wavelength, half-width y, half-height z) of one bowtie."""
-        wl = C_LIGHT / self.design_freq
+        wl = self.design_wavelength
         length = self.length_factor * wl
         theta = math.radians(self.angle_deg)
         half = 0.5 * length / (1.0 + math.sin(theta))

--- a/src/antennaknobs/designs/arrays/delta_looparray_network.py
+++ b/src/antennaknobs/designs/arrays/delta_looparray_network.py
@@ -40,7 +40,7 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
         b = self.base
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         driver = wavelength * self.length_factor
         angle = math.radians(self.angle_deg)
         cos_t = math.cos(angle)
@@ -76,7 +76,7 @@ class Builder(AntennaBuilder):
         ]
 
     def build_network(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         tl_lengths = (
             self.del_y - wavelength * self.twist,
             self.del_y + wavelength * self.twist,

--- a/src/antennaknobs/designs/arrays/lumped_coupled_pair.py
+++ b/src/antennaknobs/designs/arrays/lumped_coupled_pair.py
@@ -45,7 +45,7 @@ class Builder(AntennaBuilder):
     )
 
     def build_wires(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         half_arm = 0.25 * wavelength * self.length_factor
         spacing = self.spacing_factor * wavelength
         z = self.base

--- a/src/antennaknobs/designs/beams/hb9cv.py
+++ b/src/antennaknobs/designs/beams/hb9cv.py
@@ -83,7 +83,7 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         quarter = 0.25 * wavelength
 
         spacing = self.spacing_frac * wavelength
@@ -108,7 +108,7 @@ class Builder(AntennaBuilder):
         return tups
 
     def build_network(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         length = self.phasing_frac * wavelength
         return Network(
             ports={"rear": PortOnWire("rear"), "front": PortOnWire("front")},

--- a/src/antennaknobs/designs/beams/moxon_turnstile.py
+++ b/src/antennaknobs/designs/beams/moxon_turnstile.py
@@ -154,7 +154,7 @@ class Builder(AntennaBuilder):
         return self._element("a") + self._element("b")
 
     def build_network(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         return Network(
             ports={
                 "feed_a": PortOnWire("feed_a"),

--- a/src/antennaknobs/designs/beams/owa_yagi.py
+++ b/src/antennaknobs/designs/beams/owa_yagi.py
@@ -91,12 +91,12 @@ class Builder(AntennaBuilder):
         # 1" aluminum tubing idealized as PEC, held as a wavelength fraction
         # (0.0127 m at 28.4 MHz) so the fat-element behaviour -- which the
         # OWA's bandwidth depends on -- survives rescaling to other bands.
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         return WireSpec(radius=0.001203 * wavelength)
 
     def build_wires(self):
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         b = self.base
 
         tups = []

--- a/src/antennaknobs/designs/beams/owa_yagi_6el.py
+++ b/src/antennaknobs/designs/beams/owa_yagi_6el.py
@@ -83,11 +83,11 @@ class Builder(AntennaBuilder):
         # 3/16" aluminum tube at 146 MHz, held as a wavelength fraction
         # (0.0023813 m / lambda) so the fat-element behaviour survives
         # rescaling; aluminum conductivity per the source deck's LD 5.
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         return WireSpec(radius=0.0011597 * wavelength, conductivity=2.5e7)
 
     def build_wires(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         eps = 0.025 * wavelength / 2.053373  # feed-gap half-width, scaled
         b = self.base
 

--- a/src/antennaknobs/designs/beams/phased_driver_yagi.py
+++ b/src/antennaknobs/designs/beams/phased_driver_yagi.py
@@ -101,7 +101,7 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         lf = self.length_factor
 
         tups = []
@@ -126,7 +126,7 @@ class Builder(AntennaBuilder):
         return tups
 
     def build_network(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         drivers_apart = (self.TABLE[self.FWD][1] - self.TABLE[self.REAR][1]) * (
             wavelength
         )

--- a/src/antennaknobs/designs/beams/yagi.py
+++ b/src/antennaknobs/designs/beams/yagi.py
@@ -26,7 +26,7 @@ class Builder(AntennaBuilder):
         eps = 0.05
         b = self.base
 
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         driver_y = 0.25 * wavelength * self.length_factor
         reflector_y = driver_y * self.reflector_factor

--- a/src/antennaknobs/designs/broadband/discone.py
+++ b/src/antennaknobs/designs/broadband/discone.py
@@ -79,7 +79,7 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         cone = self.cone_frac * wavelength
         ang = math.radians(self.cone_half_angle_deg)

--- a/src/antennaknobs/designs/broadband/g5rv.py
+++ b/src/antennaknobs/designs/broadband/g5rv.py
@@ -89,7 +89,7 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         top = self.top_frac * wavelength * self.length_factor
         half = top / 2.0
@@ -108,7 +108,7 @@ class Builder(AntennaBuilder):
         ]
 
     def build_network(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         match_len = self.match_len_frac * wavelength
         return Network(
             ports={

--- a/src/antennaknobs/designs/broadband/lpda.py
+++ b/src/antennaknobs/designs/broadband/lpda.py
@@ -44,7 +44,7 @@ Horizontally polarised.
    back (low freq)                              front (high freq), beam --> +x
 """
 
-from antennaknobs import AntennaBuilder
+from antennaknobs import AntennaBuilder, C_LIGHT_MHZ_M
 from antennaknobs.network import Driven, Network, PortOnWire, TL, Wire
 from types import MappingProxyType
 
@@ -93,7 +93,7 @@ class Builder(AntennaBuilder):
     def _layout(self):
         """Element half-lengths h[n] and boom positions x[n], longest (n=0)
         at the back. Shared by build_wires and build_network."""
-        c = 299.792458
+        c = C_LIGHT_MHZ_M
         n = int(self.n_elements)
         tau = self.tau
         sigma = self.sigma

--- a/src/antennaknobs/designs/broadband/t2fd.py
+++ b/src/antennaknobs/designs/broadband/t2fd.py
@@ -77,7 +77,7 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         D = self.length_frac * wavelength
         s = self.spacing_frac * wavelength

--- a/src/antennaknobs/designs/dipoles/dipole_turnstile.py
+++ b/src/antennaknobs/designs/dipoles/dipole_turnstile.py
@@ -24,7 +24,7 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
 
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         length = wavelength * self.length_factor
         x = 0.5 * length
 

--- a/src/antennaknobs/designs/dipoles/folded_invvee.py
+++ b/src/antennaknobs/designs/dipoles/folded_invvee.py
@@ -23,7 +23,7 @@ class Builder(AntennaBuilder):
         eps = 0.05
         b = self.base
 
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         driver_y = 0.25 * wavelength * self.length_factor
 

--- a/src/antennaknobs/designs/dipoles/invvee.py
+++ b/src/antennaknobs/designs/dipoles/invvee.py
@@ -95,7 +95,7 @@ class Builder(AntennaBuilder):
         eps = 0.05
         b = self.base
 
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         driver_y = 0.25 * wavelength * self.length_factor
 

--- a/src/antennaknobs/designs/dipoles/koch_dipole.py
+++ b/src/antennaknobs/designs/dipoles/koch_dipole.py
@@ -89,7 +89,7 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         span = self.span_frac * wavelength * self.length_factor
         half = span / 2.0

--- a/src/antennaknobs/designs/dipoles/ocf_dipole.py
+++ b/src/antennaknobs/designs/dipoles/ocf_dipole.py
@@ -63,7 +63,7 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         length = self.length_frac * wavelength
         z = self.base

--- a/src/antennaknobs/designs/dipoles/short_dipole_loaded.py
+++ b/src/antennaknobs/designs/dipoles/short_dipole_loaded.py
@@ -32,7 +32,7 @@ class Builder(AntennaBuilder):
     )
 
     def build_wires(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         half_arm = 0.25 * wavelength * self.length_factor
         # Single straight wire spanning the dipole, feed at the centre.
         # No `ex` — the Network supplies the source; `name` marks the

--- a/src/antennaknobs/designs/loops/bisquare.py
+++ b/src/antennaknobs/designs/loops/bisquare.py
@@ -71,7 +71,7 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         side = self.side_frac * wavelength * self.length_factor
         # Square standing on a corner: the half-diagonal is side / sqrt(2).

--- a/src/antennaknobs/designs/loops/delta_loop.py
+++ b/src/antennaknobs/designs/loops/delta_loop.py
@@ -28,7 +28,7 @@ class Builder(AntennaBuilder):
         eps = 0.05
         b = self.base
 
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         driver = wavelength * self.length_factor
 

--- a/src/antennaknobs/designs/loops/delta_loop_flyby.py
+++ b/src/antennaknobs/designs/loops/delta_loop_flyby.py
@@ -59,7 +59,7 @@ class Builder(AntennaBuilder):
         from scipy.optimize import brentq
 
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         target = self.length_factor * wavelength
 
         def geometry(side):

--- a/src/antennaknobs/designs/loops/delta_loop_reflected.py
+++ b/src/antennaknobs/designs/loops/delta_loop_reflected.py
@@ -63,7 +63,7 @@ class Builder(AntennaBuilder):
         from scipy.optimize import brentq
 
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         target = self.length_factor * wavelength
 
         def ry(p):

--- a/src/antennaknobs/designs/loops/delta_loop_slanted.py
+++ b/src/antennaknobs/designs/loops/delta_loop_slanted.py
@@ -38,7 +38,7 @@ class Builder(AntennaBuilder):
         eps = 0.05
         b = self.base
 
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         driver = wavelength * self.length_factor
 

--- a/src/antennaknobs/designs/loops/delta_loop_topdown.py
+++ b/src/antennaknobs/designs/loops/delta_loop_topdown.py
@@ -57,7 +57,7 @@ class Builder(AntennaBuilder):
         from scipy.optimize import brentq
 
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         target = self.length_factor * wavelength
 
         def ry(p):

--- a/src/antennaknobs/designs/loops/diamond_loop.py
+++ b/src/antennaknobs/designs/loops/diamond_loop.py
@@ -31,7 +31,7 @@ class Builder(AntennaBuilder):
         eps = 0.05
         b = self.base
 
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         driver = wavelength * self.length_factor
 

--- a/src/antennaknobs/designs/loops/diamond_loop_turnstile.py
+++ b/src/antennaknobs/designs/loops/diamond_loop_turnstile.py
@@ -22,7 +22,7 @@ class Builder(AntennaBuilder):
         eps = 0.05
         b = self.base
 
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         driver = wavelength * self.length_factor
 

--- a/src/antennaknobs/designs/loops/horizontal_loop.py
+++ b/src/antennaknobs/designs/loops/horizontal_loop.py
@@ -77,7 +77,7 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
 
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         side = self.side_frac * wavelength * self.length_factor
         h = side / 2.0

--- a/src/antennaknobs/designs/loops/horizontal_loop_drone.py
+++ b/src/antennaknobs/designs/loops/horizontal_loop_drone.py
@@ -54,7 +54,7 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         quarter = 0.25 * wavelength
 
         side = quarter * self.length_factor  # each side ~ a quarter wave

--- a/src/antennaknobs/designs/loops/inv_delta_loop.py
+++ b/src/antennaknobs/designs/loops/inv_delta_loop.py
@@ -28,7 +28,7 @@ class Builder(AntennaBuilder):
         eps = 0.05
         b = self.base
 
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         driver = wavelength * self.length_factor
 

--- a/src/antennaknobs/designs/loops/quad.py
+++ b/src/antennaknobs/designs/loops/quad.py
@@ -77,7 +77,7 @@ class Builder(AntennaBuilder):
     )
 
     def build_wires(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         side_d = self.driver_circ * wavelength / 4
         side_r = self.reflector_circ * wavelength / 4

--- a/src/antennaknobs/designs/loops/triangular_skyloop.py
+++ b/src/antennaknobs/designs/loops/triangular_skyloop.py
@@ -96,7 +96,7 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
 
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         # Equilateral triangle, so each side is a third of the perimeter; the
         # perimeter is length_factor wavelengths (length_factor = 1 -> a nominal

--- a/src/antennaknobs/designs/multiband/fandipole.py
+++ b/src/antennaknobs/designs/multiband/fandipole.py
@@ -4,13 +4,11 @@ import logging
 import math
 from types import MappingProxyType
 
-from antennaknobs import AntennaBuilder
+from antennaknobs import AntennaBuilder, C_LIGHT_MHZ_M
 from antennaknobs.network import Wire
 
 logger = logging.getLogger(__name__)
 
-
-C_LIGHT_MHZ_M = 299.792458
 
 # Max bands the cone geometry supports — fixes the spoke layout so
 # variants with fewer active bands can still share a single bands tuple

--- a/src/antennaknobs/designs/multiband/hexbeam_5band.py
+++ b/src/antennaknobs/designs/multiband/hexbeam_5band.py
@@ -27,10 +27,8 @@ daisy chain; momwire could not model the jumpers. That path is gone.)
 import math
 from types import MappingProxyType
 
-from antennaknobs import AntennaBuilder
+from antennaknobs import AntennaBuilder, C_LIGHT_MHZ_M
 from antennaknobs.network import Driven, Network, PortOnWire, TL, Wire
-
-C_LIGHT_MHZ_M = 299.792458
 
 _MAX_BANDS = 5
 
@@ -307,7 +305,7 @@ class Builder(AntennaBuilder):
         # 2*_FEED_GAP*sin30 = _FEED_GAP for every band, so one shared count
         # against the design_freq quarter-wave keeps all five feeds equal
         # (1 segment at the default mesh).
-        wavelength0 = C_LIGHT_MHZ_M / self.design_freq
+        wavelength0 = self.design_wavelength
         n_seg_feed = self.segs_for(_FEED_GAP, 0.25 * wavelength0)
 
         tups = []

--- a/src/antennaknobs/designs/multiband/trap_dipole.py
+++ b/src/antennaknobs/designs/multiband/trap_dipole.py
@@ -66,7 +66,7 @@ class Builder(AntennaBuilder):
     )
 
     def build_wires(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         inner_arm = 0.25 * wavelength * self.length_factor
         z = self.base
         trap_seg = self.trap_seg_m

--- a/src/antennaknobs/designs/multiband/trap_fan_dipole.py
+++ b/src/antennaknobs/designs/multiband/trap_fan_dipole.py
@@ -33,14 +33,11 @@ function carries the actual arm current and Load(parallel=True) acts
 exactly as NEC2's ld_card type-1 would.
 """
 
-from antennaknobs import AntennaBuilder
+from antennaknobs import AntennaBuilder, C_LIGHT_MHZ_M
 from antennaknobs.network import Driven, Load, Network, PortOnWire, Wire
 
 import math
 from types import MappingProxyType
-
-
-C_LIGHT_MHZ_M = 299.792458
 
 
 # Defaults: 5 µH traps, C chosen so each trap LC-resonates at its trap_freq.

--- a/src/antennaknobs/designs/specialty/helix.py
+++ b/src/antennaknobs/designs/specialty/helix.py
@@ -89,7 +89,7 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         quarter = 0.25 * wavelength
 
         radius = self.radius_frac * wavelength

--- a/src/antennaknobs/designs/specialty/hentenna.py
+++ b/src/antennaknobs/designs/specialty/hentenna.py
@@ -34,7 +34,7 @@ class Builder(AntennaBuilder):
         eps = 0.05
         b = self.base
 
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         def ry(p):
             return p[0], -p[1], p[2]

--- a/src/antennaknobs/designs/specialty/hentenna_slant.py
+++ b/src/antennaknobs/designs/specialty/hentenna_slant.py
@@ -119,7 +119,7 @@ class Builder(AntennaBuilder):
         eps = 0.05
         b = self.base
 
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         slant_radians = math.radians(self.slant_deg)
         slant_cos = math.cos(slant_radians)

--- a/src/antennaknobs/designs/specialty/hourglass.py
+++ b/src/antennaknobs/designs/specialty/hourglass.py
@@ -22,7 +22,7 @@ class Builder(AntennaBuilder):
         eps = 0.05
         b = self.base
 
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         third = wavelength / 3
 

--- a/src/antennaknobs/designs/specialty/hourglass_slant.py
+++ b/src/antennaknobs/designs/specialty/hourglass_slant.py
@@ -26,7 +26,7 @@ class Builder(AntennaBuilder):
         eps = 0.05
         b = self.base
 
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         third = wavelength / 3
 

--- a/src/antennaknobs/designs/verticals/bobtail.py
+++ b/src/antennaknobs/designs/verticals/bobtail.py
@@ -92,7 +92,7 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
 
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         vert = self.vert_frac * wavelength * self.length_factor
         span = self.span_frac * wavelength * self.length_factor

--- a/src/antennaknobs/designs/verticals/bruce.py
+++ b/src/antennaknobs/designs/verticals/bruce.py
@@ -98,7 +98,7 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         vert = self.vert_frac * wavelength * self.length_factor
         horiz = self.horiz_frac * wavelength * self.length_factor

--- a/src/antennaknobs/designs/verticals/four_square.py
+++ b/src/antennaknobs/designs/verticals/four_square.py
@@ -106,7 +106,7 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         elem = self.elem_frac * wavelength * self.length_factor
         spacing = self.spacing_frac * wavelength

--- a/src/antennaknobs/designs/verticals/half_square.py
+++ b/src/antennaknobs/designs/verticals/half_square.py
@@ -70,7 +70,7 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
 
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         vert = self.vert_frac * wavelength * self.length_factor
         horiz = self.horiz_frac * wavelength * self.length_factor

--- a/src/antennaknobs/designs/verticals/inverted_l.py
+++ b/src/antennaknobs/designs/verticals/inverted_l.py
@@ -66,7 +66,7 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         quarter = 0.25 * wavelength
 
         vert = self.vert_frac * wavelength * self.length_factor

--- a/src/antennaknobs/designs/verticals/jpole.py
+++ b/src/antennaknobs/designs/verticals/jpole.py
@@ -67,7 +67,7 @@ class Builder(AntennaBuilder):
     )
 
     def build_wires(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         radiator = self.radiator_frac * wavelength
         stub = self.stub_frac * wavelength

--- a/src/antennaknobs/designs/verticals/phased_verticals.py
+++ b/src/antennaknobs/designs/verticals/phased_verticals.py
@@ -80,7 +80,7 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         elem = self.elem_frac * wavelength
         spacing = self.spacing_frac * wavelength

--- a/src/antennaknobs/designs/verticals/rectangle.py
+++ b/src/antennaknobs/designs/verticals/rectangle.py
@@ -99,7 +99,7 @@ class Builder(AntennaBuilder):
     )
 
     def build_wires(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         lf = self.length_factor
 
         w = self.horiz_frac * wavelength * lf
@@ -130,7 +130,7 @@ class Builder(AntennaBuilder):
         ]
 
     def build_network(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         return Network(
             ports={
                 "feed": PortOnWire("feed"),  # centre of the left short side

--- a/src/antennaknobs/designs/verticals/right_angle_delta.py
+++ b/src/antennaknobs/designs/verticals/right_angle_delta.py
@@ -83,7 +83,7 @@ class Builder(AntennaBuilder):
     )
 
     def build_wires(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         lf = self.length_factor
 
         w = self.base_frac * wavelength * lf

--- a/src/antennaknobs/designs/verticals/tri_moxon.py
+++ b/src/antennaknobs/designs/verticals/tri_moxon.py
@@ -115,7 +115,7 @@ class Builder(AntennaBuilder):
     def _element(self, k):
         """Wire tuples for rectangle k (1-3), standing in the vertical
         plane at azimuth (k-1)*120 deg, reflector nearest the post."""
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         lf = self.length_factor
 
         a = self.a_frac * wavelength * lf
@@ -154,7 +154,7 @@ class Builder(AntennaBuilder):
         return [t for k in (1, 2, 3) for t in self._element(k)]
 
     def build_network(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         active = int(self.active)
         parked = [k for k in (1, 2, 3) if k != active]
 

--- a/src/antennaknobs/designs/wire/doublet_balanced_tuner.py
+++ b/src/antennaknobs/designs/wire/doublet_balanced_tuner.py
@@ -50,8 +50,6 @@ from antennaknobs.network import (
 )
 from antennaknobs.station import balanced_l_tuner
 
-C_LIGHT = 299.792458  # m·MHz
-
 
 class Builder(AntennaBuilder):
     default_params = MappingProxyType(
@@ -108,7 +106,7 @@ class Builder(AntennaBuilder):
 
     # ---- geometry -------------------------------------------------------
     def build_wires(self):
-        wl = C_LIGHT / self.design_freq
+        wl = self.design_wavelength
         arm = 0.5 * self.length_factor * wl
         z = self.height_factor * wl
         gap = 0.02 * wl  # feed-gap half-width, so the arm ends are free ENDS
@@ -123,7 +121,7 @@ class Builder(AntennaBuilder):
 
     # ---- feed network ---------------------------------------------------
     def build_network(self):
-        wl = C_LIGHT / self.design_freq
+        wl = self.design_wavelength
         line_len = self.line_len_factor * wl
         zc = self.line_zcomm or None
         return Network(

--- a/src/antennaknobs/designs/wire/edz.py
+++ b/src/antennaknobs/designs/wire/edz.py
@@ -94,7 +94,7 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         length = self.elem_frac * wavelength * self.length_factor
         half = length / 2.0
@@ -113,7 +113,7 @@ class Builder(AntennaBuilder):
         ]
 
     def build_network(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         match_len = self.match_len_frac * wavelength
         return Network(
             ports={

--- a/src/antennaknobs/designs/wire/efhw_sloper.py
+++ b/src/antennaknobs/designs/wire/efhw_sloper.py
@@ -170,7 +170,7 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         length = 0.5 * wavelength * self.length_factor
 
         # Fly it: face −x so the radiator climbs toward −x and the sloper's

--- a/src/antennaknobs/designs/wire/expanded_lazy_h.py
+++ b/src/antennaknobs/designs/wire/expanded_lazy_h.py
@@ -92,7 +92,7 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
 
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         elem = self.elem_frac * wavelength
         spacing = self.spacing_frac * wavelength
@@ -118,7 +118,7 @@ class Builder(AntennaBuilder):
         return tups
 
     def build_network(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         # Equal legs from each element centre to the mid-stack junction --
         # equal length is what makes the drive in-phase.
         leg = 0.5 * self.spacing_frac * wavelength

--- a/src/antennaknobs/designs/wire/lazy_h.py
+++ b/src/antennaknobs/designs/wire/lazy_h.py
@@ -67,7 +67,7 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
 
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         elem = self.elem_frac * wavelength
         spacing = self.spacing_frac * wavelength

--- a/src/antennaknobs/designs/wire/longwire.py
+++ b/src/antennaknobs/designs/wire/longwire.py
@@ -75,7 +75,7 @@ class Builder(AntennaBuilder):
     def build_wires(self):
         eps = 0.05
 
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         length = self.length_frac * wavelength * self.length_factor
         half = length / 2

--- a/src/antennaknobs/designs/wire/rhombic.py
+++ b/src/antennaknobs/designs/wire/rhombic.py
@@ -78,7 +78,7 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         eps = 0.05  # half-gap at the feed / termination apexes
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         L = self.leg_factor * wavelength
         tilt = math.radians(self.tilt_deg)

--- a/src/antennaknobs/designs/wire/sterba.py
+++ b/src/antennaknobs/designs/wire/sterba.py
@@ -86,7 +86,7 @@ class Builder(AntennaBuilder):
     )
 
     def build_wires(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         h = 0.5 * wavelength * self.length_factor  # half-wave unit
         q = 0.5 * h  # quarter-wave end section

--- a/src/antennaknobs/designs/wire/sterba_bl.py
+++ b/src/antennaknobs/designs/wire/sterba_bl.py
@@ -97,7 +97,7 @@ class Builder(AntennaBuilder):
 
     # ---- layout ---------------------------------------------------------
     def _layout(self):
-        wl = 299.792458 / self.design_freq
+        wl = self.design_wavelength
         h = 0.5 * wl * self.length_factor
         q = 0.5 * h
         n = int(self.n_cells)

--- a/src/antennaknobs/designs/wire/sterba_tl.py
+++ b/src/antennaknobs/designs/wire/sterba_tl.py
@@ -84,7 +84,7 @@ class Builder(AntennaBuilder):
     )
 
     def build_wires(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         h = 0.5 * wavelength * self.length_factor  # half-wave unit
         q = 0.5 * h  # quarter-wave end section
         bot = self.base

--- a/src/antennaknobs/designs/wire/terminated_longwire.py
+++ b/src/antennaknobs/designs/wire/terminated_longwire.py
@@ -86,7 +86,7 @@ class Builder(AntennaBuilder):
     )
 
     def build_wires(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         L = self.length_frac * wavelength
         h = self.height_frac * wavelength

--- a/src/antennaknobs/designs/wire/vbeam.py
+++ b/src/antennaknobs/designs/wire/vbeam.py
@@ -71,7 +71,7 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         leg = self.leg_frac * wavelength
         theta = math.radians(self.half_apex_deg)

--- a/src/antennaknobs/designs/wire/w8jk.py
+++ b/src/antennaknobs/designs/wire/w8jk.py
@@ -72,7 +72,7 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         elem = self.elem_frac * wavelength
         spacing = self.spacing_frac * wavelength

--- a/src/antennaknobs/designs/wire/zepp.py
+++ b/src/antennaknobs/designs/wire/zepp.py
@@ -90,7 +90,7 @@ class Builder(AntennaBuilder):
 
     def build_wires(self):
         eps = 0.05
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
 
         length = self.length_frac * wavelength * self.length_factor
         z = self.base
@@ -104,7 +104,7 @@ class Builder(AntennaBuilder):
         ]
 
     def build_network(self):
-        wavelength = 299.792458 / self.design_freq
+        wavelength = self.design_wavelength
         stub_len = self.stub_len_frac * wavelength
         return Network(
             ports={

--- a/src/antennaknobs/web/user_design_assets/CLAUDE.md
+++ b/src/antennaknobs/web/user_design_assets/CLAUDE.md
@@ -248,9 +248,11 @@ scale knobs and transforms move geometry, never specs.
 
 **Tuning on a band — use `design_freq` (strongly recommended).** To place an
 antenna on a band *and be able to tune it there*, add a `design_freq` param
-(MHz) plus a `length_factor` (a multiplier near 1.0), compute
-`wavelength = 299.792458 / self.design_freq`, and build every dimension as a
-fraction of `wavelength * self.length_factor`. This does two things at once:
+(MHz) plus a `length_factor` (a multiplier near 1.0), read
+`wavelength = self.design_wavelength` (an `AntennaBuilder` property giving the
+free-space wavelength at `design_freq` in metres — no need to spell the
+speed-of-light constant), and build every dimension as a fraction of
+`wavelength * self.length_factor`. This does two things at once:
 it scales the geometry to the chosen frequency, **and** it makes the app's band
 selector and the measurement-frequency slider follow `design_freq`. So a design
 with `design_freq = 7.1` lands on 40m and tunes on 40m. This is how the built-in

--- a/src/antennaknobs/web/user_design_assets/TEMPLATE.py
+++ b/src/antennaknobs/web/user_design_assets/TEMPLATE.py
@@ -83,7 +83,7 @@ class Builder(AntennaBuilder):
         # Size each arm from the design frequency: a half-wave dipole is about
         # lambda/2 tip-to-tip, so each arm is ~lambda/4. ``length_factor`` trims
         # it to resonance (real wire runs a few % short of the ideal).
-        wavelength = 299.792458 / self.design_freq  # metres
+        wavelength = self.design_wavelength  # free-space λ at design_freq, in metres
         h = (wavelength / 4.0) * self.length_factor  # each arm, metres
         z = self.height
         eps = 0.01  # tiny half-gap at the centre where the feed point sits

--- a/tests/test_design_wavelength.py
+++ b/tests/test_design_wavelength.py
@@ -1,0 +1,60 @@
+"""AntennaBuilder.design_wavelength — the wavelength-fraction scaling helper.
+
+The single named quantity for the ``299.792458 / self.design_freq`` idiom that
+wavelength-scaled builders repeat: a free-space wavelength in metres at the
+design frequency, sourced from the one exported ``C_LIGHT_MHZ_M`` constant.
+Anchored on ``design_freq`` (the frequency the geometry is dimensioned for),
+never the measurement ``freq``, so a frequency sweep can never resize the
+antenna — the same contract ``auto_mesh`` enforces.
+"""
+
+from types import MappingProxyType
+
+import pytest
+
+import antennaknobs
+from antennaknobs import AntennaBuilder, C_LIGHT_MHZ_M
+
+
+class _Design(AntennaBuilder):
+    default_params = MappingProxyType({"freq": 21.0, "design_freq": 28.4})
+
+
+class _NoDesignFreq(AntennaBuilder):
+    default_params = MappingProxyType({"freq": 21.0})
+
+
+def test_constant_is_exported_and_is_c_in_mhz_metres():
+    assert antennaknobs.C_LIGHT_MHZ_M == C_LIGHT_MHZ_M
+    assert C_LIGHT_MHZ_M == pytest.approx(299.792458)
+    # it is the SI speed of light scaled for MHz·metres work
+    assert C_LIGHT_MHZ_M * 1e6 == pytest.approx(299_792_458.0)
+
+
+def test_design_wavelength_is_c_over_design_freq():
+    b = _Design()
+    assert b.design_wavelength == pytest.approx(C_LIGHT_MHZ_M / 28.4)
+
+
+def test_design_lambda_is_an_alias():
+    b = _Design()
+    assert b.design_lambda == b.design_wavelength
+
+
+def test_scales_on_design_freq_not_measurement_freq():
+    """Sweeping the measurement ``freq`` must not move the wavelength the
+    geometry scales against — only ``design_freq`` does."""
+    b = _Design()
+    wl = b.design_wavelength
+    b.freq = 7.15  # retune the measurement point
+    assert b.design_wavelength == wl
+    b.design_freq = 14.2  # halve the design frequency -> double the wavelength
+    assert b.design_wavelength == pytest.approx(2.0 * wl)
+
+
+def test_missing_design_freq_raises():
+    b = _NoDesignFreq()
+    with pytest.raises(ValueError, match="design_freq"):
+        _ = b.design_wavelength
+    with pytest.raises(ValueError, match="design_freq"):
+        _ = b.design_lambda


### PR DESCRIPTION
## Summary
- **New tooling** in `AntennaBuilder`: exported `C_LIGHT_MHZ_M = 299.792458` (speed of light pre-scaled for MHz·m work) and a `design_wavelength` property (alias `design_lambda`) — the single named quantity for the `299.792458 / self.design_freq` idiom. It scales on `design_freq`, never the measurement `freq`, and raises if no `design_freq` is declared (same contract as `auto_mesh`).
- **Catalog migration**: replaced all 76 bare `299.792458` literals across 66 design files — 70 exact `/ self.design_freq` sites → `self.design_wavelength`; the three multiband builders that each defined their own `C_LIGHT_MHZ_M` → the shared constant; `lpda`/`bowtie1x2_bl`/`doublet_balanced_tuner`'s local constants likewise.
- `auto_mesh` now sources its quarter-wave from the constant.
- Pure refactor — `design_wavelength` returns exactly `299.792458 / design_freq`, so all geometry is bit-identical.

## Test plan
- [x] `tests/test_design_wavelength.py` — constant export, value, alias, scales-on-design-freq-not-freq, missing-design_freq raises
- [x] `tests/test_auto_mesh.py` green (constant swap)
- [x] All 94 builtin design modules import
- [x] `ruff check` + `ruff format --check` clean
- [x] Full suite: 2830 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)