### PR TITLE
docs(simnec): SimNEC↔AntennaKNoBs comparison handoff + repro scripts

### DIFF
--- a/docs/status/2026-07-28-simnec-comparison-handoff.md
+++ b/docs/status/2026-07-28-simnec-comparison-handoff.md
@@ -1,0 +1,200 @@
+# Handoff: SimNEC ↔ AntennaKNoBs full-tool comparison — status + next steps
+
+**Date:** 2026-07-28
+**Predecessor:** the original "SimNEC ↔ AntennaKNoBs full-tool comparison experiment"
+handoff (a doc that lived in the requester's Downloads, not the repo). This
+supersedes it with (a) verified results, (b) three corrections to its plan, and
+(c) a clean two-track structure. Read this instead.
+
+**One-line goal:** compare the *whole* SimNEC tool (NEC2 antenna + its MNA
+circuit solver) against AntennaKNoBs (momwire/PyNEC antenna + network reducer)
+on a coupled antenna + feedline + tuner → rig system, and locate where they
+agree and where they diverge (common-mode).
+
+---
+
+## TL;DR status
+
+- **Track 1 — agreement (`wire.doublet_ladder_tuner`, 7.1 MHz): DONE, tools agree.**
+  - Scenario 1 (antenna): SimNEC `nec2c` == PyNEC to <0.1 Ω on an identical mesh.
+  - Scenario 2 (coupled rig): **SimNEC 40 − j5.7 (SWR 1.29) vs AntennaKNoBs 41.9 − j5.8 (SWR 1.24)** — ~2 Ω, identical reactance.
+- **Track 2 — divergence (`wire.doublet_balanced_tuner`, 14.1 MHz): TODO.** The common-mode "money shot". AntennaKNoBs numbers computed; SimNEC side is one differential cascade to build.
+- **Bonus delivered:** a validated AntennaKNoBs → SimNEC `.ssn` exporter prototype (issue #600).
+- Reproduce everything: `scratch/simnec/*.py` (see [Reproducing](#reproducing)).
+
+---
+
+## Three corrections to the original plan (important)
+
+1. **The original showcase design is a bad choice for the *agreement* scenarios.**
+   `wire.doublet_balanced_tuner` feeds the doublet at its **arm-ends** across a
+   0.04 λ gap (`PortAtEnd`), which (a) is **momwire/BSpline-only** — `PortAtEnd`
+   is not supported on the Sinusoidal basis (the closest-to-NEC one) yet — and
+   (b) presents a feedpoint ~100 Ω off the center-fed NEC value, which the stiff
+   reactive point amplifies into a large rig-level disagreement. Built exactly
+   per the original doc (center-fed 342+j962 → single-ended L-net) the rig lands
+   ~28 − j25 / SWR 2.34, **not** the promised 51.8 / 1.04. → **Use a center-fed,
+   single-ended design for agreement.** We switched to `wire.doublet_ladder_tuner`.
+
+2. **Scenario 3's headline test as written produces a NULL result.** Sweeping
+   `line_zcomm` on the *symmetric* balanced doublet gives a **bit-identical** rig
+   answer (no common mode is excited under symmetry). You **must break symmetry**
+   (one arm longer, or one side lowered) for AntennaKNoBs to move and the
+   SimNEC-can't-follow contrast to appear. The original doc buried this in an
+   optional parenthetical.
+
+3. **The antenna feedpoint is delta-gap mesh-sensitive and converges slowly.**
+   Both tools *under-converge* at default mesh (SimNEC ~76 seg → 188+j583) — the
+   Richardson-extrapolated truth is **192.9 + j589.8**. Both tools sit on the
+   same convergence curve, so they agree with *each other* at matched mesh; just
+   don't call any single default-mesh feedpoint "the answer".
+
+---
+
+## Environment (fresh clone)
+
+```bash
+python -m venv .venv && . .venv/Scripts/activate   # (Windows: .venv/Scripts/python.exe)
+pip install -e .            # antennaknobs + momwire submodule + PyNEC
+```
+Sanity: `python -c "import antennaknobs, PyNEC, momwire; print('ok')"`.
+Windows console + non-ASCII: prefix runs with `PYTHONIOENCODING=utf-8`.
+
+**SimNEC** (proprietary freeware, Windows/Java): download "windows64 with JRE"
+from https://www.ae6ty.com/smith_charts/. Version used here: **5.1a1**. It stores
+working files under `~/.SimNEC/<maj>/<min>/` — notably `lastConstructedNEC.nec`
+(the deck it actually solved, post re-mesh) and `lastCircuit.ssn` (the live
+circuit, XML). Reading those two files is the fastest way to see what SimNEC did.
+
+---
+
+## Track 1 — agreement (DONE)
+
+Design: `wire.doublet_ladder_tuner` — 88 ft center-fed doublet → 100 ft of 600 Ω
+open-wire line → T-network tuner → 50 Ω rig, at **7.1 MHz**, free space. Runs on
+**Sinusoidal** (≡ PyNEC ≡ SimNEC `nec2c`). Single-ended, maps 1:1 to SimNEC.
+
+### Scenario 1 — antenna only
+Paste into SimNEC's N block, and **set `NECOptions.segmentsPerWavelength` high**
+(the deck's segment counts are ignored — see gotcha 1):
+```
+NEC2
+GW 1 55 0 -13.40030 10 0 13.40030 10 0.0005
+FR 0 1 0 0 7.1 0
+EX 0 1 28 0 1 0
+NECEND
+```
+Target (matched mesh): ~**189 + j579** at ~76 seg; converged **192.9 + j589.8**.
+Verified: PyNEC on SimNEC's *own* constructed mesh reproduced SimNEC's reading to
+**0.07 Ω** → same engine, mesh-only differences.
+
+### Scenario 2 — coupled cascade (SimNEC, right→left)
+`GENERATOR(50Ω,7.1MHz)` ← `series C 81.2 pF` ← `shunt L 4.218 µH (Q=200)` ←
+`series C 500 pF` ← `SERIES_TLINE(Zo=600, vf=0.95, 100 ft)` ← `N block (antenna)`.
+
+Checkpoints (looking toward antenna, from Za=188+j583):
+`line-in 162 − j496` → `+500pF 162 − j541` → `+shuntL 40 + j270` → `+81.2pF ≈ 40 − j6`.
+
+**Result: SimNEC 40 − j5.7 (SWR 1.29) == AntennaKNoBs momwire/Sin 41.9 − j5.8
+(SWR 1.24).** Agree to ~2 Ω. (Over finite ground εr=10 σ=0.002, AntennaKNoBs
+gives ~49.7 − j0.1, SWR 1.01 — a documented variant, not yet built in SimNEC.)
+
+---
+
+## Track 2 — common-mode divergence (TODO — the money shot)
+
+Design: `wire.doublet_balanced_tuner` — 0.72 λ doublet on 450 Ω line → balanced
+L-tuner → 1:1 balun → 50 Ω rig, **14.1 MHz**, momwire/**BSpline** (PortAtEnd).
+
+**AntennaKNoBs (computed, `scratch/simnec/track2_commonmode.py`):**
+
+| `line_zcomm` | symmetric | asymmetric (R arm +15%) |
+|---|---|---|
+| 25  | 51.80 + j0.01 (SWR 1.036) | 26.50 + j26.77 (SWR 2.568) |
+| 100 | 51.80 + j0.01 (SWR 1.036) | 25.09 + j29.43 (SWR 2.832) |
+| 250 | 51.80 + j0.01 (SWR 1.036) | 24.23 + j31.38 (SWR 3.031) |
+| 400 | 51.80 + j0.01 (SWR 1.036) | 23.93 + j32.17 (SWR 3.112) |
+
+**SimNEC side (to do):** build the differential cascade **once** —
+`Generator(50Ω) ← Transformer(1:1 ideal) ← series L 2.8 µH (Q=200) ← shunt C
+74 pF ← TLine(450Ω, vf 0.91, 0.40λ=8.5048 m) ← NEC(doublet)` at 14.1 MHz — and
+record the single value. SimNEC's TLine is purely differential ("no common-mode
+conduction"), so it has **no `zcomm` knob**: one fixed number vs the AntennaKNoBs
+spread above. That spread-vs-point contrast **is** the result. (Symmetric row is
+the honest "both tools agree" null case; asymmetric is the divergence.)
+
+Doublet deck for SimNEC's N block (14.1 MHz, free space), and the anchor
+feedpoint ≈ 342 + j962 (center-fed; note the arm-end vs center-fed caveat from
+correction 1):
+```
+NEC2
+GW 1 31 0 -7.65430 0 0 7.65430 0 0.0005
+FR 0 1 0 0 14.1 0
+EX 0 1 16 0 1 0
+NECEND
+```
+
+---
+
+## SimNEC gotchas (all "it silently changed your model" — good writeup material)
+
+1. **Silent re-meshing.** SimNEC ignores the `GW` segment counts and applies its
+   own graded taper toward the feed (+ adds the `EK` extended kernel). Control it
+   with `NECOptions.segmentsPerWavelength = N` in the N-block script. (Diagnosed
+   by reading `~/.SimNEC/5/1/lastConstructedNEC.nec`.)
+2. **`VFnom` ≠ effective vf.** The `SERIES_TLINE` "simplified" model *displays*
+   `VFnom=0.95` but computes an effective vf (~0.911 here) from its dielectric
+   params, making the line 11.6° too long — this threw the rig to 52.8 instead of
+   ~40. Check the reported `~deg`, not the label. (Diagnosed by reading
+   `lastCircuit.ssn`.)
+3. **Everything is lossy by default** — `SERIES_TLINE` `/100f` line loss, finite
+   coil `Q`. Match or zero it deliberately per element.
+
+---
+
+## The AntennaKNoBs → SimNEC `.ssn` bridge (issue #600)
+
+Validated: a generated `.ssn` loaded in SimNEC 5.1a1 and tracked the
+AntennaKNoBs/PyNEC convergence curve exactly (segPerWl 40 → 181+j573, 120 →
+188+j583). A `.ssn` is XML with LOAD / NETWORK / GENERATOR `<element>`s; the
+antenna lives in the NETWORK element's escape-hatch `<equ>` script between `NEC2`
+and `NECEND`. Recipe + prototype: `scratch/simnec/export_ssn.py`. #600 promotes
+it to `antennaknobs.simnec_export` with a **clean bundled template** (the
+prototype currently reuses a SimNEC-saved `.ssn` as its template — not in the
+repo) and a CLI. Phase-2 (full networked export) needs the `SERIES_CAP`/
+`SHUNT_CAP` element schemas confirmed (`SERIES_TLINE`, `SHUNT_IND` already known).
+
+---
+
+## Reproducing
+
+```bash
+python scratch/simnec/track1_agreement.py   # antenna deck, feedpoint, rig (both bases/grounds), checkpoints
+python scratch/simnec/convergence.py         # Richardson mutual-limit -> 192.9 + j589.8
+python scratch/simnec/track2_commonmode.py   # symmetric (flat) vs asymmetric (moves) zcomm sweep
+python scratch/simnec/export_ssn.py          # .ssn exporter prototype (needs a template .ssn; see #600)
+```
+
+**Footgun in the Track-2 script:** `AntennaBuilder` routes instance attribute
+assignment through a custom `__setattr__`/`__getattr__`. A **class-attribute**
+default (`_asym = 1.0`) shadows that routing so `b._asym = 1.15` is silently
+ignored (you get the symmetric geometry back). Use `getattr(self, "_asym", 1.0)`
+with **no** class default, and set `b._asym` on the instance.
+
+---
+
+## Deliverables checklist (original doc's §11, updated)
+
+- [x] Table 1 (antenna): PyNEC/Sin/nec2c agree; converged 192.9 + j589.8.
+- [x] Table 2 (coupled rig, free space): SimNEC 40 − j5.7 vs AntennaKNoBs 41.9 − j5.8.
+- [ ] Table 2 over real ground (variant): AntennaKNoBs 49.7 − j0.1 computed; SimNEC TODO.
+- [ ] Table 3 (common-mode sweep): AntennaKNoBs done (above); SimNEC single value TODO.
+- [x] SimNEC gotchas documented.
+- [x] `.ssn` bridge (#600 filed).
+- [ ] SimNEC `.ssn` files + screenshots for the writeup.
+
+Related issues: #593 (s1p/s2p import), #594 (auto-transformer), #595 (VNA
+overlay), #596 (ladder-line-from-geometry), #599 (ferrite loss), **#600
+(simnec_export)**. Memory files (auto-recalled by a Claude Code agent on this
+repo): `simnec-comparison-positioning`, `simnec-comparison-scenario3-needs-asymmetry`,
+`simnec-comparison-results`.

--- a/scratch/simnec/convergence.py
+++ b/scratch/simnec/convergence.py
@@ -1,0 +1,65 @@
+"""Mutual-limit / Richardson convergence of the single-wire center-fed doublet
+feedpoint (free space, 7.1 MHz), on BSpline d=2 and Sinusoidal.
+
+The delta-gap feedpoint is mesh-sensitive: both bases climb monotonically with
+nominal_nsegs and Richardson/Neville-extrapolate to the SAME value (<0.05 ohm
+apart) -> that mutual limit is the "correct" converged feedpoint.
+
+Result:  Z_converged ~= 192.9 + j589.8 ohm.
+(SimNEC/momwire at default meshes undershoot: ~28 seg -> 181+j573,
+ ~76 seg -> 188+j583. That is why a single default-mesh solve is not the truth.)
+
+Run:  python scratch/simnec/convergence.py
+"""
+from antennaknobs.designs.wire.doublet_ladder_tuner import Builder
+from antennaknobs.engines.momwire import MomwireEngine
+from antennaknobs.network import Driven, Network, PortOnWire, Wire
+from momwire import BSplineSolver, SinusoidalSolver
+
+YT = 13.400300629701409
+
+
+class DipoleOnly(Builder):
+    def build_wires(self):
+        return [Wire((0, -YT, 10.0), (0, YT, 10.0), n_seg=None, name="feed")]
+
+    def build_network(self):
+        return Network(ports={"feed": PortOnWire("feed")}, branches=[],
+                       sources=[Driven(port="feed")])
+
+
+def zfeed(solver, kw, nominal):
+    b = DipoleOnly(dict(Builder.default_params))
+    b.nominal_nsegs = nominal
+    return complex(MomwireEngine(b, solver=solver, ground=None, solver_kwargs=kw).impedance()[0])
+
+
+def neville(hs, ys):
+    """Polynomial extrapolation of ys(hs) to h=0."""
+    T = list(ys)
+    n = len(ys)
+    for k in range(1, n):
+        T = [((0 - hs[i + k]) * T[i] - (0 - hs[i]) * T[i + 1]) / (hs[i] - hs[i + k])
+             for i in range(n - k)]
+    return T[0]
+
+
+if __name__ == "__main__":
+    ladder = [21, 61, 161, 321, 641]
+    finest = {}
+    for name, solver, kw in (("bs2", BSplineSolver, {"degree": 2}),
+                             ("sin", SinusoidalSolver, None)):
+        print(f"=== {name} ===")
+        zs = []
+        for nseg in ladder:
+            z = zfeed(solver, kw, nseg)
+            zs.append(z)
+            print(f"   nominal_nsegs={nseg:4d}   Z = {z.real:8.3f} {z.imag:+8.3f} j")
+        hs = [1.0 / n for n in ladder]
+        zr = neville(hs[-4:], [z.real for z in zs[-4:]])
+        zx = neville(hs[-4:], [z.imag for z in zs[-4:]])
+        finest[name] = (zs[-1], complex(zr, zx))
+        print(f"   Neville -> h=0 : {zr:8.3f} {zx:+8.3f} j\n")
+    a, b = finest["bs2"][1], finest["sin"][1]
+    print(f"CONVERGED (both bases agree to {abs(a - b):.3f} ohm): "
+          f"{(a.real + b.real) / 2:.1f} {(a.imag + b.imag) / 2:+.1f} j")

--- a/scratch/simnec/convergence.py
+++ b/scratch/simnec/convergence.py
@@ -11,6 +11,7 @@ Result:  Z_converged ~= 192.9 + j589.8 ohm.
 
 Run:  python scratch/simnec/convergence.py
 """
+
 from antennaknobs.designs.wire.doublet_ladder_tuner import Builder
 from antennaknobs.engines.momwire import MomwireEngine
 from antennaknobs.network import Driven, Network, PortOnWire, Wire
@@ -24,14 +25,19 @@ class DipoleOnly(Builder):
         return [Wire((0, -YT, 10.0), (0, YT, 10.0), n_seg=None, name="feed")]
 
     def build_network(self):
-        return Network(ports={"feed": PortOnWire("feed")}, branches=[],
-                       sources=[Driven(port="feed")])
+        return Network(
+            ports={"feed": PortOnWire("feed")},
+            branches=[],
+            sources=[Driven(port="feed")],
+        )
 
 
 def zfeed(solver, kw, nominal):
     b = DipoleOnly(dict(Builder.default_params))
     b.nominal_nsegs = nominal
-    return complex(MomwireEngine(b, solver=solver, ground=None, solver_kwargs=kw).impedance()[0])
+    return complex(
+        MomwireEngine(b, solver=solver, ground=None, solver_kwargs=kw).impedance()[0]
+    )
 
 
 def neville(hs, ys):
@@ -39,16 +45,20 @@ def neville(hs, ys):
     T = list(ys)
     n = len(ys)
     for k in range(1, n):
-        T = [((0 - hs[i + k]) * T[i] - (0 - hs[i]) * T[i + 1]) / (hs[i] - hs[i + k])
-             for i in range(n - k)]
+        T = [
+            ((0 - hs[i + k]) * T[i] - (0 - hs[i]) * T[i + 1]) / (hs[i] - hs[i + k])
+            for i in range(n - k)
+        ]
     return T[0]
 
 
 if __name__ == "__main__":
     ladder = [21, 61, 161, 321, 641]
     finest = {}
-    for name, solver, kw in (("bs2", BSplineSolver, {"degree": 2}),
-                             ("sin", SinusoidalSolver, None)):
+    for name, solver, kw in (
+        ("bs2", BSplineSolver, {"degree": 2}),
+        ("sin", SinusoidalSolver, None),
+    ):
         print(f"=== {name} ===")
         zs = []
         for nseg in ladder:
@@ -61,5 +71,7 @@ if __name__ == "__main__":
         finest[name] = (zs[-1], complex(zr, zx))
         print(f"   Neville -> h=0 : {zr:8.3f} {zx:+8.3f} j\n")
     a, b = finest["bs2"][1], finest["sin"][1]
-    print(f"CONVERGED (both bases agree to {abs(a - b):.3f} ohm): "
-          f"{(a.real + b.real) / 2:.1f} {(a.imag + b.imag) / 2:+.1f} j")
+    print(
+        f"CONVERGED (both bases agree to {abs(a - b):.3f} ohm): "
+        f"{(a.real + b.real) / 2:.1f} {(a.imag + b.imag) / 2:+.1f} j"
+    )

--- a/scratch/simnec/export_ssn.py
+++ b/scratch/simnec/export_ssn.py
@@ -1,0 +1,86 @@
+"""PROTOTYPE: AntennaKNoBs antenna-only design -> SimNEC .ssn (issue #600).
+
+Validated: SimNEC 5.1a1 loaded a generated .ssn and solved it, tracking the
+AntennaKNoBs/PyNEC segment-convergence curve exactly (segPerWl 40 -> 181+j573,
+120 -> 188+j583).
+
+HOW IT WORKS
+  A .ssn is XML with three circuit <element>s (LOAD / NETWORK / GENERATOR); the
+  antenna lives inside the NETWORK element's escape-hatch <equ> script, as a NEC
+  deck between `NEC2` and `NECEND`. Recipe:
+    1. export_nec(builder)  -> pull GW*/GN?/FR/EX lines
+    2. splice them between NEC2/NECEND in a template .ssn
+    3. set generator MHz
+    4. uncomment SommerfeldGround(sigma, eps_r)   for finite ground
+    5. uncomment NECOptions.segmentsPerWavelength = N  to control the auto-mesh
+
+TEMPLATE DEPENDENCY (fresh environment!)
+  This prototype reuses a SimNEC-saved .ssn as the template (originally
+  ~/.SimNEC/5/1/lastCircuit.ssn). That file is NOT in the repo. To run this you
+  need ANY antenna-only .ssn saved from SimNEC to point TEMPLATE at. Issue #600
+  is to promote this into antennaknobs.simnec_export with a clean BUNDLED
+  minimal template (no dependency on a user's saved file) + a CLI.
+
+  Network element XML types already reverse-engineered for a phase-2 (full
+  networked export): SERIES_TLINE (Zo/VFnom/ft/~deg/k0..k2/'/100f' loss),
+  SERIES_CAP (F/Q/@MHz), SHUNT_IND (H/Q/@MHz).
+"""
+import re
+
+from antennaknobs.nec_export import export_nec
+
+TEMPLATE = None  # set to a SimNEC-saved antenna-only .ssn path before running
+
+
+def _cards(builder, ground):
+    """GW*/GN?/FR/EX lines SimNEC honors, in deck order, from export_nec."""
+    buckets = {"GW": [], "GN": [], "FR": [], "EX": []}
+    for ln in export_nec(builder, ground=ground, include_rp=False).splitlines():
+        s = ln.strip()
+        for key in buckets:
+            if s.startswith(key):
+                buckets[key].append(s)
+    return "\n".join(buckets["GW"] + buckets["GN"] + buckets["FR"] + buckets["EX"])
+
+
+def export_ssn(builder, out_path, *, freq_mhz, ground="free",
+               seg_per_wl=None, template=None):
+    template = template or TEMPLATE
+    if not template:
+        raise ValueError("Set TEMPLATE to a SimNEC-saved antenna-only .ssn (see #600).")
+    xml = open(template, encoding="utf-8").read()
+    cards = _cards(builder, ground)
+    xml = re.sub(r"(NEC2\n).*?(\nNECEND)", lambda m: m.group(1) + cards + m.group(2),
+                 xml, count=1, flags=re.S)
+    if isinstance(ground, tuple) and len(ground) == 3:
+        _, eps_r, sigma = ground
+        xml = xml.replace("//SommerfeldGround(0.005, 13);",
+                          f"SommerfeldGround({sigma}, {eps_r});")
+    if seg_per_wl is not None:
+        xml = xml.replace("//NECOptions.segmentsPerWavelength = 20;",
+                          f"NECOptions.segmentsPerWavelength = {seg_per_wl};")
+    xml = re.sub(r"(<n>MHz</n><v>)[^<]*(</v>)", rf"\g<1>{freq_mhz}\g<2>", xml, count=1)
+    open(out_path, "w", encoding="utf-8").write(xml)
+    return cards
+
+
+if __name__ == "__main__":
+    from antennaknobs.designs.wire.doublet_ladder_tuner import Builder
+    from antennaknobs.network import Driven, Network, PortOnWire, Wire
+    YT = 13.400300629701409
+
+    class DipoleOnly(Builder):
+        def build_wires(self):
+            return [Wire((0, -YT, 10.0), (0, YT, 10.0), n_seg=None, name="feed")]
+
+        def build_network(self):
+            return Network(ports={"feed": PortOnWire("feed")}, branches=[],
+                           sources=[Driven(port="feed")])
+
+    if not TEMPLATE:
+        print("Set TEMPLATE to a SimNEC-saved .ssn first (see module docstring / #600).")
+    else:
+        b = DipoleOnly(dict(Builder.default_params))
+        b.nominal_nsegs = 120
+        cards = export_ssn(b, "out.ssn", freq_mhz=7.1, ground="free", seg_per_wl=120)
+        print("wrote out.ssn with NEC cards:\n" + cards)

--- a/scratch/simnec/export_ssn.py
+++ b/scratch/simnec/export_ssn.py
@@ -25,6 +25,7 @@ TEMPLATE DEPENDENCY (fresh environment!)
   networked export): SERIES_TLINE (Zo/VFnom/ft/~deg/k0..k2/'/100f' loss),
   SERIES_CAP (F/Q/@MHz), SHUNT_IND (H/Q/@MHz).
 """
+
 import re
 
 from antennaknobs.nec_export import export_nec
@@ -43,22 +44,31 @@ def _cards(builder, ground):
     return "\n".join(buckets["GW"] + buckets["GN"] + buckets["FR"] + buckets["EX"])
 
 
-def export_ssn(builder, out_path, *, freq_mhz, ground="free",
-               seg_per_wl=None, template=None):
+def export_ssn(
+    builder, out_path, *, freq_mhz, ground="free", seg_per_wl=None, template=None
+):
     template = template or TEMPLATE
     if not template:
         raise ValueError("Set TEMPLATE to a SimNEC-saved antenna-only .ssn (see #600).")
     xml = open(template, encoding="utf-8").read()
     cards = _cards(builder, ground)
-    xml = re.sub(r"(NEC2\n).*?(\nNECEND)", lambda m: m.group(1) + cards + m.group(2),
-                 xml, count=1, flags=re.S)
+    xml = re.sub(
+        r"(NEC2\n).*?(\nNECEND)",
+        lambda m: m.group(1) + cards + m.group(2),
+        xml,
+        count=1,
+        flags=re.S,
+    )
     if isinstance(ground, tuple) and len(ground) == 3:
         _, eps_r, sigma = ground
-        xml = xml.replace("//SommerfeldGround(0.005, 13);",
-                          f"SommerfeldGround({sigma}, {eps_r});")
+        xml = xml.replace(
+            "//SommerfeldGround(0.005, 13);", f"SommerfeldGround({sigma}, {eps_r});"
+        )
     if seg_per_wl is not None:
-        xml = xml.replace("//NECOptions.segmentsPerWavelength = 20;",
-                          f"NECOptions.segmentsPerWavelength = {seg_per_wl};")
+        xml = xml.replace(
+            "//NECOptions.segmentsPerWavelength = 20;",
+            f"NECOptions.segmentsPerWavelength = {seg_per_wl};",
+        )
     xml = re.sub(r"(<n>MHz</n><v>)[^<]*(</v>)", rf"\g<1>{freq_mhz}\g<2>", xml, count=1)
     open(out_path, "w", encoding="utf-8").write(xml)
     return cards
@@ -67,6 +77,7 @@ def export_ssn(builder, out_path, *, freq_mhz, ground="free",
 if __name__ == "__main__":
     from antennaknobs.designs.wire.doublet_ladder_tuner import Builder
     from antennaknobs.network import Driven, Network, PortOnWire, Wire
+
     YT = 13.400300629701409
 
     class DipoleOnly(Builder):
@@ -74,11 +85,16 @@ if __name__ == "__main__":
             return [Wire((0, -YT, 10.0), (0, YT, 10.0), n_seg=None, name="feed")]
 
         def build_network(self):
-            return Network(ports={"feed": PortOnWire("feed")}, branches=[],
-                           sources=[Driven(port="feed")])
+            return Network(
+                ports={"feed": PortOnWire("feed")},
+                branches=[],
+                sources=[Driven(port="feed")],
+            )
 
     if not TEMPLATE:
-        print("Set TEMPLATE to a SimNEC-saved .ssn first (see module docstring / #600).")
+        print(
+            "Set TEMPLATE to a SimNEC-saved .ssn first (see module docstring / #600)."
+        )
     else:
         b = DipoleOnly(dict(Builder.default_params))
         b.nominal_nsegs = 120

--- a/scratch/simnec/track1_agreement.py
+++ b/scratch/simnec/track1_agreement.py
@@ -9,6 +9,7 @@ and runs on the Sinusoidal basis (== PyNEC == SimNEC's nec2c). Prints:
 
 Run:  python scratch/simnec/track1_agreement.py
 """
+
 import cmath
 import math
 
@@ -18,7 +19,7 @@ from antennaknobs.network import Driven, Network, PortOnWire, Wire
 from momwire import BSplineSolver, SinusoidalSolver
 
 YT = 13.400300629701409  # half-length of the 88 ft doublet, metres
-Z10 = 10.0               # height (free space => irrelevant, kept for parity)
+Z10 = 10.0  # height (free space => irrelevant, kept for parity)
 
 
 def swr(z):
@@ -95,19 +96,32 @@ def analytic_cascade(Za, vf, label):
 if __name__ == "__main__":
     print("=== antenna-only feedpoint (free space, momwire/Sin, nominal=120) ===")
     za = antenna_feedpoint()
-    print(f"  {za.real:.2f} {za.imag:+.2f} j   (SimNEC nec2c reproduces this at matched mesh)\n")
+    print(
+        f"  {za.real:.2f} {za.imag:+.2f} j   (SimNEC nec2c reproduces this at matched mesh)\n"
+    )
 
     print("=== NEC deck for SimNEC's N block ===")
     print(NEC_DECK, "\n")
 
     print("=== full-chain rig Z ===")
-    for gname, ground in (("free space", None),
-                          ("finite (eps10 sig0.002)", ("finite-fast", 10.0, 0.002))):
-        for sname, solver in (("BSpline", BSplineSolver), ("Sinusoidal", SinusoidalSolver)):
+    for gname, ground in (
+        ("free space", None),
+        ("finite (eps10 sig0.002)", ("finite-fast", 10.0, 0.002)),
+    ):
+        for sname, solver in (
+            ("BSpline", BSplineSolver),
+            ("Sinusoidal", SinusoidalSolver),
+        ):
             z = full_chain(solver, ground)
-            print(f"  {gname:24s} {sname:10s}: {z.real:7.2f} {z.imag:+7.2f} j  SWR={swr(z):.3f}")
+            print(
+                f"  {gname:24s} {sname:10s}: {z.real:7.2f} {z.imag:+7.2f} j  SWR={swr(z):.3f}"
+            )
     print()
 
     print("=== analytic cascade checkpoints (Za=188+583j, the SimNEC-mesh antenna) ===")
-    analytic_cascade(complex(188, 583), 0.95, "vf 0.95 -> SimNEC read 40-j5.7; momwire/Sin 41.9-j5.8")
-    print("\n  VERDICT: SimNEC 40-j5.7 (SWR 1.29) == AntennaKNoBs 41.9-j5.8 (SWR 1.24). Agree.")
+    analytic_cascade(
+        complex(188, 583), 0.95, "vf 0.95 -> SimNEC read 40-j5.7; momwire/Sin 41.9-j5.8"
+    )
+    print(
+        "\n  VERDICT: SimNEC 40-j5.7 (SWR 1.29) == AntennaKNoBs 41.9-j5.8 (SWR 1.24). Agree."
+    )

--- a/scratch/simnec/track1_agreement.py
+++ b/scratch/simnec/track1_agreement.py
@@ -1,0 +1,113 @@
+"""SimNEC comparison, Track 1 (agreement): wire.doublet_ladder_tuner.
+
+Center-fed, single-ended station at 7.1 MHz that maps 1:1 onto SimNEC blocks
+and runs on the Sinusoidal basis (== PyNEC == SimNEC's nec2c). Prints:
+  - the antenna-only feedpoint (single-wire, the geometry SimNEC solves)
+  - the NEC deck to paste into SimNEC's N block
+  - the full-chain rig Z on BSpline / Sinusoidal / PyNEC, free space + ground
+  - the analytic cascade checkpoints (antenna -> line -> T-net -> rig)
+
+Run:  python scratch/simnec/track1_agreement.py
+"""
+import cmath
+import math
+
+from antennaknobs.designs.wire.doublet_ladder_tuner import Builder
+from antennaknobs.engines.momwire import MomwireEngine
+from antennaknobs.network import Driven, Network, PortOnWire, Wire
+from momwire import BSplineSolver, SinusoidalSolver
+
+YT = 13.400300629701409  # half-length of the 88 ft doublet, metres
+Z10 = 10.0               # height (free space => irrelevant, kept for parity)
+
+
+def swr(z):
+    g = abs((z - 50) / (z + 50))
+    return (1 + g) / (1 - g)
+
+
+class SingleWire(Builder):
+    """doublet_ladder_tuner but the antenna is ONE center-fed wire (no feed
+    bridge), matching a plain NEC center feed in SimNEC. n_seg=None => the wire
+    density-meshes at nominal_nsegs (the framework's convergence knob)."""
+
+    def build_wires(self):
+        return [Wire((0, -YT, Z10), (0, YT, Z10), n_seg=None, name="feed")]
+
+
+class DipoleOnly(SingleWire):
+    """Antenna only — no station network, for the feedpoint number."""
+
+    def build_network(self):
+        return Network(
+            ports={"feed": PortOnWire("feed")},
+            branches=[],
+            sources=[Driven(port="feed")],
+        )
+
+
+def full_chain(solver, ground, nominal=120):
+    b = SingleWire(dict(Builder.default_params))
+    b.nominal_nsegs = nominal
+    eng = MomwireEngine(b, solver=solver, ground=ground)
+    return complex(eng.impedance()[0])
+
+
+def antenna_feedpoint(nominal=120):
+    b = DipoleOnly(dict(Builder.default_params))
+    b.nominal_nsegs = nominal
+    eng = MomwireEngine(b, solver=SinusoidalSolver, ground=None)
+    return complex(eng.impedance()[0])
+
+
+NEC_DECK = """\
+NEC2
+GW 1 55 0 -13.40030 10 0 13.40030 10 0.0005
+FR 0 1 0 0 7.1 0
+EX 0 1 28 0 1 0
+NECEND
+(SimNEC: set NECOptions.segmentsPerWavelength high; ~120 => ~76 seg => 188+j583.
+ The delta-gap feed converges slowly; Richardson truth is 192.9+j589.8, see
+ convergence.py.)"""
+
+
+def analytic_cascade(Za, vf, label):
+    """Antenna Z -> 600 ohm line (vf) -> series C2 500pF -> shunt L 4.218uH Q200
+    -> series C1 81.2pF -> 50 ohm rig. Lossless line (openwire-600 is low-loss)."""
+    f = 7.1e6
+    w = 2 * math.pi * f
+    lam0 = 299.792458e6 / f
+    Z0, Lline = 600.0, 30.48  # 100 ft
+    t = cmath.tan(2 * math.pi * Lline / (vf * lam0))
+    B = Z0 * (Za + 1j * Z0 * t) / (Z0 + 1j * Za * t)
+    C = B + 1 / (1j * w * 500e-12)
+    zl = 1j * w * 4.218e-6 + (w * 4.218e-6 / 200)
+    D = 1 / (1 / C + 1 / zl)
+    E = D + 1 / (1j * w * 81.2e-12)
+    print(f"  [{label}] vf={vf}")
+    print(f"    A antenna     {Za.real:8.2f} {Za.imag:+8.2f} j")
+    print(f"    B +600ohm line {B.real:8.2f} {B.imag:+8.2f} j")
+    print(f"    C +C2 500pF   {C.real:8.2f} {C.imag:+8.2f} j")
+    print(f"    D +L 4.218uH  {D.real:8.2f} {D.imag:+8.2f} j")
+    print(f"    E +C1 81.2pF  {E.real:8.2f} {E.imag:+8.2f} j   SWR={swr(E):.3f}")
+
+
+if __name__ == "__main__":
+    print("=== antenna-only feedpoint (free space, momwire/Sin, nominal=120) ===")
+    za = antenna_feedpoint()
+    print(f"  {za.real:.2f} {za.imag:+.2f} j   (SimNEC nec2c reproduces this at matched mesh)\n")
+
+    print("=== NEC deck for SimNEC's N block ===")
+    print(NEC_DECK, "\n")
+
+    print("=== full-chain rig Z ===")
+    for gname, ground in (("free space", None),
+                          ("finite (eps10 sig0.002)", ("finite-fast", 10.0, 0.002))):
+        for sname, solver in (("BSpline", BSplineSolver), ("Sinusoidal", SinusoidalSolver)):
+            z = full_chain(solver, ground)
+            print(f"  {gname:24s} {sname:10s}: {z.real:7.2f} {z.imag:+7.2f} j  SWR={swr(z):.3f}")
+    print()
+
+    print("=== analytic cascade checkpoints (Za=188+583j, the SimNEC-mesh antenna) ===")
+    analytic_cascade(complex(188, 583), 0.95, "vf 0.95 -> SimNEC read 40-j5.7; momwire/Sin 41.9-j5.8")
+    print("\n  VERDICT: SimNEC 40-j5.7 (SWR 1.29) == AntennaKNoBs 41.9-j5.8 (SWR 1.24). Agree.")

--- a/scratch/simnec/track2_commonmode.py
+++ b/scratch/simnec/track2_commonmode.py
@@ -11,6 +11,7 @@ fixed number, no zcomm knob). That spread-vs-point contrast IS the result.
 
 Run:  python scratch/simnec/track2_commonmode.py
 """
+
 from antennaknobs.designs.wire.doublet_balanced_tuner import Builder
 from antennaknobs.engines.momwire import MomwireEngine
 from antennaknobs.network import Wire
@@ -48,13 +49,19 @@ def rig(asym, zcomm):
 
 
 if __name__ == "__main__":
-    for asym, tag in ((1.0, "SYMMETRIC (null case: SimNEC and AntennaKNoBs agree)"),
-                      (1.15, "ASYMMETRIC R+15% (the divergence SimNEC cannot follow)")):
+    for asym, tag in (
+        (1.0, "SYMMETRIC (null case: SimNEC and AntennaKNoBs agree)"),
+        (1.15, "ASYMMETRIC R+15% (the divergence SimNEC cannot follow)"),
+    ):
         print(f"=== {tag} ===")
         for zc in (25.0, 100.0, 250.0, 400.0):
             z, s = rig(asym, zc)
-            print(f"   line_zcomm={zc:5.0f}:  Z_rig = {z.real:7.2f} {z.imag:+7.2f} j   SWR = {s:6.3f}")
+            print(
+                f"   line_zcomm={zc:5.0f}:  Z_rig = {z.real:7.2f} {z.imag:+7.2f} j   SWR = {s:6.3f}"
+            )
         print()
     print("SimNEC side: build the differential cascade ONCE (450ohm line, balanced")
     print("L-tuner as one series 2.8uH + one shunt 74pF, 1:1 balun, 50ohm gen) and")
-    print("record the single value. It has no zcomm knob -> one number vs the spread above.")
+    print(
+        "record the single value. It has no zcomm knob -> one number vs the spread above."
+    )

--- a/scratch/simnec/track2_commonmode.py
+++ b/scratch/simnec/track2_commonmode.py
@@ -1,0 +1,60 @@
+"""SimNEC comparison, Track 2 (divergence): the common-mode "money shot".
+
+Uses the BALANCED design wire.doublet_balanced_tuner (14.1 MHz, momwire/BSpline
+only -- PortAtEnd arm-end feed is not supported on Sinusoidal yet).
+
+Key finding: under a SYMMETRIC doublet the rig answer is BIT-IDENTICAL across
+line_zcomm (no common mode is excited) -- so the handoff doc's headline
+Scenario 3 must break symmetry. With one arm ~15% longer, the rig answer MOVES
+with zcomm; SimNEC's single-ended differential cascade cannot follow it (one
+fixed number, no zcomm knob). That spread-vs-point contrast IS the result.
+
+Run:  python scratch/simnec/track2_commonmode.py
+"""
+from antennaknobs.designs.wire.doublet_balanced_tuner import Builder
+from antennaknobs.engines.momwire import MomwireEngine
+from antennaknobs.network import Wire
+
+
+def swr(z):
+    g = abs((z - 50) / (z + 50))
+    return (1 + g) / (1 - g)
+
+
+class AsymBuilder(Builder):
+    """Same design; right arm scaled by an ``_asym`` instance attribute to break
+    symmetry. NB: do NOT give ``_asym`` a class-attribute default — AntennaBuilder
+    routes instance assignments through a custom __setattr__/__getattr__, and a
+    class attribute shadows that routing (normal lookup succeeds, so the routed
+    instance value is never seen). Set ``b._asym = ...`` and read it with getattr."""
+
+    def build_wires(self):
+        wl = self.design_wavelength
+        arm = 0.5 * self.length_factor * wl
+        z = self.height_factor * wl
+        gap = 0.02 * wl
+        asym = getattr(self, "_asym", 1.0)
+        return [
+            Wire((0.0, -gap, z), (0.0, -arm, z), name="armL"),
+            Wire((0.0, gap, z), (0.0, arm * asym, z), name="armR"),
+        ]
+
+
+def rig(asym, zcomm):
+    b = AsymBuilder(dict(Builder.default_params, line_zcomm=zcomm))
+    b._asym = asym
+    z = complex(MomwireEngine(b, ground=None).impedance()[0])
+    return z, swr(z)
+
+
+if __name__ == "__main__":
+    for asym, tag in ((1.0, "SYMMETRIC (null case: SimNEC and AntennaKNoBs agree)"),
+                      (1.15, "ASYMMETRIC R+15% (the divergence SimNEC cannot follow)")):
+        print(f"=== {tag} ===")
+        for zc in (25.0, 100.0, 250.0, 400.0):
+            z, s = rig(asym, zc)
+            print(f"   line_zcomm={zc:5.0f}:  Z_rig = {z.real:7.2f} {z.imag:+7.2f} j   SWR = {s:6.3f}")
+        print()
+    print("SimNEC side: build the differential cascade ONCE (450ohm line, balanced")
+    print("L-tuner as one series 2.8uH + one shunt 74pF, 1:1 balun, 50ohm gen) and")
+    print("record the single value. It has no zcomm knob -> one number vs the spread above.")


### PR DESCRIPTION
Hands off the SimNEC ↔ AntennaKNoBs full-tool comparison to another agent.

## What's here
- **`docs/status/2026-07-28-simnec-comparison-handoff.md`** — self-contained handoff (fresh-environment ready): status, three corrections to the original plan, env + SimNEC setup, both tracks, verified result tables, the SimNEC gotchas, and the `.ssn` bridge.
- **`scratch/simnec/*.py`** — runnable repro: `track1_agreement.py`, `convergence.py` (Richardson mutual-limit → feedpoint 192.9+j589.8), `track2_commonmode.py`, `export_ssn.py` (the #600 prototype).

## Status
- **Track 1 (agreement, `doublet_ladder_tuner`, 7.1 MHz): verified.** Scenario 1 antenna: SimNEC `nec2c` == PyNEC to <0.1 Ω on identical mesh. Scenario 2 rig: **SimNEC 40 − j5.7 (SWR 1.29) vs AntennaKNoBs 41.9 − j5.8 (SWR 1.24)**.
- **Track 2 (common-mode divergence, asymmetric `doublet_balanced_tuner`): set up.** AntennaKNoBs sweep computed (SWR 2.57→3.11 across `zcomm`); SimNEC side is one differential cascade to build.

## Notes
- Docs + scratch only; no product code changed. The `momwire` submodule bump and `.backend/.frontend.log` in the working tree are pre-existing and intentionally excluded.
- Companion to the `.ssn` exporter feature #600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)