### PR TITLE
feat(simnec): antennaknobs.simnec_export — emit SimNEC .ssn for antenna-only designs (#600)

### DIFF
--- a/src/antennaknobs/simnec_export.py
+++ b/src/antennaknobs/simnec_export.py
@@ -208,10 +208,18 @@ _SSN_TEMPLATE = """\
                 <p><n>MHz</n><v>{mhz}</v>{gen_sweep}</p>
                 <p><n>Zo</n><v>50</v></p>
             </element>
-        </CIRCUIT>
+        </CIRCUIT>{sweep_state}
     </SmithChartCircuit>
 </SimNEC1p0>
 """
+
+# When a sweep is requested, arm it: SCATTERGUN names the swept parameter (without
+# it, doSweep=y on the param does nothing) and ROUNDCHART puts the chart in
+# swept-trace mode. Confirmed against a SimNEC 5.1a1-saved, actively-sweeping file.
+_SWEEP_STATE = (
+    "\n        <SCATTERGUN><n>G.MHz</n></SCATTERGUN>"
+    "\n        <ROUNDCHART><displayMode>Sweep</displayMode></ROUNDCHART>"
+)
 
 
 def _gen_sweep_block(lo: float, hi: float) -> str:
@@ -266,8 +274,12 @@ def export_ssn(
     gen_sweep = (
         "" if sweep is None else _gen_sweep_block(float(sweep[0]), float(sweep[1]))
     )
+    sweep_state = "" if sweep is None else _SWEEP_STATE
     return _SSN_TEMPLATE.format(
-        equ=_xml_escape(script), mhz=_fmt(freq_mhz), gen_sweep=gen_sweep
+        equ=_xml_escape(script),
+        mhz=_fmt(freq_mhz),
+        gen_sweep=gen_sweep,
+        sweep_state=sweep_state,
     )
 
 

--- a/src/antennaknobs/simnec_export.py
+++ b/src/antennaknobs/simnec_export.py
@@ -53,7 +53,9 @@ the documented NEC-portal API. The surrounding XML scaffold in
    impedance tag, and the retained ``FR`` card all match SimNEC's own output.
    The scaffold here is deliberately *minimal* (it omits SimNEC's display state
    — ``SPREADSHEET`` / charts / band menus — which SimNEC regenerates on load);
-   a Windows load-test confirms SimNEC accepts that minimal subset.
+   a Windows load-test confirms SimNEC accepts that minimal subset. The Generator
+   frequency sweep is off by default (SimNEC supplies its own range); pass
+   ``sweep=(lo, hi)`` / ``--sweep`` to emit an enabled band.
 """
 
 from __future__ import annotations
@@ -147,7 +149,12 @@ def build_nec_portal_script(
     deck = export_nec(builder, ground=ground, freq=freq_mhz, include_rp=False)
     cards = _nec_cards_for_portal(deck)
 
-    name = name or f"{type(builder).__module__}.{type(builder).__qualname__}"
+    if name is None:
+        mod = type(builder).__module__
+        qual = type(builder).__qualname__
+        # Keep the dotted path for real designs (e.g. antennaknobs.designs...),
+        # but drop the noisy "__main__." prefix for builders defined in a script.
+        name = qual if mod == "__main__" else f"{mod}.{qual}"
     ground_call, mhos = _ground_directive(ground)
 
     lines = [
@@ -168,10 +175,11 @@ def build_nec_portal_script(
     return "\n".join(lines)
 
 
-# --- provisional .ssn XML scaffold (see module warning) ---------------------
-# Minimal three-element cascade: LOAD (open, right end) — NETWORK (the antenna,
-# in the escape-hatch script) — GENERATOR (50 Ohm source, left end). Authored
-# here from the observed format; confirm it loads in SimNEC before relying on it.
+# --- minimal .ssn XML scaffold (see module note) ----------------------------
+# Three-element cascade: LOAD (open, right end) — NETWORK (the antenna, in the
+# escape-hatch script) — GENERATOR (50 Ohm source, left end). Deliberately minimal
+# — SimNEC regenerates the display state (SPREADSHEET / charts / band menus) it
+# omits. The Generator's MHz carries an optional {gen_sweep} <sweepParam>.
 _SSN_TEMPLATE = """\
 <?xml version="1.0" encoding="utf-8"?>
 <SimNEC1p0>
@@ -192,7 +200,7 @@ _SSN_TEMPLATE = """\
             <element>
                 <type>GENERATOR</type>
                 <sweeperLabel>G</sweeperLabel>
-                <p><n>MHz</n><v>{mhz}</v></p>
+                <p><n>MHz</n><v>{mhz}</v>{gen_sweep}</p>
                 <p><n>Zo</n><v>50</v></p>
             </element>
         </CIRCUIT>
@@ -201,12 +209,31 @@ _SSN_TEMPLATE = """\
 """
 
 
+def _gen_sweep_block(lo: float, hi: float) -> str:
+    """SimNEC ``<sweepParam>`` for the Generator's ``MHz``, enabled (``doSweep
+    y``). Mirrors the structure of a SimNEC 5.1a1-saved file (confirmed to load);
+    without it SimNEC falls back to its default (disabled) sweep range."""
+    return (
+        "<sweepParam><name>G.MHz</name><listed>true</listed>"
+        "<p><n>points</n><v>100</v></p>"
+        f"<p><n>from</n><v>{_fmt(lo)}</v></p>"
+        f"<p><n>to</n><v>{_fmt(hi)}</v></p>"
+        "<p><n>log</n><v>lin</v></p>"
+        "<p><n>doSweep</n><v>y</v></p>"
+        "<p><n>expr</n><v>Vary</v><fontScale>1</fontScale><w>640</w><h>360</h>"
+        "<relx>0</relx><rely>360</rely><ProgrammingDialog><ThreeSplitPane>"
+        "<errDiv>0.3</errDiv><outDiv>0.7</outDiv></ThreeSplitPane>"
+        "</ProgrammingDialog></p></sweepParam>"
+    )
+
+
 def export_ssn(
     builder,
     *,
     freq_mhz: float | None = None,
     ground=DEFAULT_GROUND,
     seg_per_wl: int | None = None,
+    sweep: tuple[float, float] | None = None,
 ) -> str:
     """Return a SimNEC ``.ssn`` (str) for an antenna-only ``builder``.
 
@@ -216,6 +243,10 @@ def export_ssn(
     seg_per_wl : SimNEC auto-mesh density (segments per wavelength). None leaves
                  SimNEC's default; set it to pin SimNEC's mesh for a convergence
                  comparison (SimNEC re-segments regardless of the deck).
+    sweep      : ``(lo_mhz, hi_mhz)`` to enable the Generator's frequency sweep
+                 over that band. ``None`` (default) leaves it minimal, so SimNEC
+                 uses its own default (disabled) range — the single-point solve
+                 at ``freq_mhz`` is still correct.
 
     Raises ``NotImplementedError`` (via ``export_nec``) for networked designs.
     """
@@ -223,7 +254,12 @@ def export_ssn(
     script = build_nec_portal_script(
         builder, freq_mhz=freq_mhz, ground=ground, seg_per_wl=seg_per_wl
     )
-    return _SSN_TEMPLATE.format(equ=_xml_escape(script), mhz=_fmt(freq_mhz))
+    gen_sweep = (
+        "" if sweep is None else _gen_sweep_block(float(sweep[0]), float(sweep[1]))
+    )
+    return _SSN_TEMPLATE.format(
+        equ=_xml_escape(script), mhz=_fmt(freq_mhz), gen_sweep=gen_sweep
+    )
 
 
 def main(argv=None):
@@ -251,15 +287,35 @@ def main(argv=None):
         default=None,
         help="SimNEC auto-mesh density (segments/wavelength)",
     )
+    ap.add_argument(
+        "--sweep",
+        nargs="?",
+        const="auto",
+        default=None,
+        metavar="LO,HI",
+        help="Enable the Generator frequency sweep: bare '--sweep' for an auto "
+        "band (+/-10%% around --freq), or '--sweep LO,HI' for an explicit MHz range.",
+    )
     ap.add_argument("--out", default=None, help="Write here (default: stdout)")
     args = ap.parse_args(argv)
 
     builder = get_builder(args.builder)()
+    freq = builder.freq if args.freq is None else args.freq
+    sweep = None
+    if args.sweep is not None:
+        if args.sweep == "auto":
+            sweep = (round(freq * 0.9, 6), round(freq * 1.1, 6))
+        else:
+            parts = args.sweep.split(",")
+            if len(parts) != 2:
+                ap.error("--sweep expects LO,HI (two MHz values), or bare for auto")
+            sweep = (float(parts[0]), float(parts[1]))
     ssn = export_ssn(
         builder,
         freq_mhz=args.freq,
         ground=parse_ground(args.ground),
         seg_per_wl=args.seg_per_wl,
+        sweep=sweep,
     )
     if args.out:
         with open(args.out, "w") as fh:

--- a/src/antennaknobs/simnec_export.py
+++ b/src/antennaknobs/simnec_export.py
@@ -24,10 +24,13 @@ script, expressed in SimNEC's NEC-portal daemon language:
     NECEND
 
 We reuse :func:`antennaknobs.nec_export.export_nec` for the geometry, then keep
-only the ``GW`` / ``EX`` / lumped-``LD`` cards and translate the rest into
-daemon directives: ``FR`` → the Generator's ``MHz``; ``GN`` → the ground call;
-the deck's segment counts are *advisory only* — SimNEC re-meshes at
-``NECOptions.segmentsPerWavelength``, which is why that knob is exposed.
+the ``GW`` / ``FR`` / ``EX`` / lumped-``LD`` cards and translate the rest into
+daemon directives: the Generator's ``MHz`` carries the (sweepable) solve
+frequency; ``GN`` → the ground call; the deck's segment counts are *advisory
+only* — SimNEC re-meshes at ``NECOptions.segmentsPerWavelength``, which is why
+that knob is exposed. ``FR`` is left in the deck too: a SimNEC 5.1a1-saved
+``.ssn`` carries ``FR`` alongside a live ``G.MHz`` sweep, so it is harmless
+(advisory) and matches SimNEC's own output.
 
 Scope
 -----
@@ -44,12 +47,13 @@ for interoperability (like emitting a NEC deck or a Touchstone file); it does
 the documented NEC-portal API. The surrounding XML scaffold in
 :data:`_SSN_TEMPLATE` is authored here (clean-room) from the format's structure.
 
-.. warning::
-   The XML scaffold is **provisional** until confirmed to load in SimNEC on a
-   Windows box — this environment has no Java runtime to test against. The
-   generated *daemon script* (the substantive part) is unit-tested here; the
-   wrapper's exact required tags may need reconciliation with a known-good
-   SimNEC-saved ``.ssn``.
+.. note::
+   Reconciled against a SimNEC 5.1a1-saved ``.ssn``: the root ``SimNEC1p0``,
+   the ``SimNEC:<version>`` ``XMLVersionControl`` string, the Generator's ``Zo``
+   impedance tag, and the retained ``FR`` card all match SimNEC's own output.
+   The scaffold here is deliberately *minimal* (it omits SimNEC's display state
+   — ``SPREADSHEET`` / charts / band menus — which SimNEC regenerates on load);
+   a Windows load-test confirms SimNEC accepts that minimal subset.
 """
 
 from __future__ import annotations
@@ -93,27 +97,40 @@ def _ground_directive(ground) -> tuple[str | None, float]:
 
 
 def _nec_cards_for_portal(deck: str) -> list[str]:
-    """Keep only the cards SimNEC's NEC block wants: geometry (``GW``),
-    excitation (``EX``), and lumped loads (``LD 0`` / ``LD 1``).
+    """Keep the cards SimNEC's NEC block wants: geometry (``GW``), frequency
+    (``FR``), excitation (``EX``), and lumped loads (``LD 0`` / ``LD 1``).
 
-    Dropped: ``CM``/``CE``/``GE``/``FR``/``RP``/``XQ``/``EN`` (structural or
-    handled by daemon directives), ``GN`` (→ ground call), ``LD 5`` global
-    conductivity (→ ``NECOptions.mhosPerMeter``) and ``LD 2`` insulation
-    (not representable in the NEC block — see the warning below).
+    ``FR`` is kept because SimNEC's own NEC-portal decks carry it — even while
+    the Generator sweeps ``G.MHz`` (the deck's ``FR`` is advisory; the solve
+    frequency comes from the Generator). Confirmed against a SimNEC 5.1a1-saved
+    ``.ssn`` (``FR 0 1 0 0 <f> 0`` present alongside a live G.MHz sweep).
+
+    Dropped: ``CM``/``CE``/``GE``/``RP``/``XQ``/``EN`` (structural), ``GN`` (→
+    ground call), ``LD 5`` global conductivity (→ ``NECOptions.mhosPerMeter``)
+    and ``LD 2`` insulation (not representable in the NEC block).
     """
-    kept: list[str] = []
+    # Group into canonical NEC order — geometry+loads, then FR, then EX — to
+    # match a SimNEC 5.1a1-saved deck (GW … FR … EX) rather than export_nec's
+    # emission order, which puts EX before FR.
+    geom: list[str] = []
+    fr: list[str] = []
+    ex: list[str] = []
     for raw in deck.splitlines():
         s = raw.strip()
-        if s.startswith("GW ") or s.startswith("EX "):
-            kept.append(s)
+        if s.startswith("GW "):
+            geom.append(s)
+        elif s.startswith("FR "):
+            fr.append(s)
+        elif s.startswith("EX "):
+            ex.append(s)
         elif s.startswith("LD "):
             parts = s.split()
             ldtyp = parts[1] if len(parts) > 1 else ""
             if ldtyp in ("0", "1"):  # series / parallel lumped RLC load
-                kept.append(s)
+                geom.append(s)
             # LD 5 (conductivity) and LD 2 (insulation) are handled elsewhere
             # or unsupported; skip here.
-    return kept
+    return geom + fr + ex
 
 
 def build_nec_portal_script(
@@ -159,7 +176,7 @@ _SSN_TEMPLATE = """\
 <?xml version="1.0" encoding="utf-8"?>
 <SimNEC1p0>
     <SmithChartCircuit>
-        <XMLVersionControl>SimNEC:antennaknobs.simnec_export</XMLVersionControl>
+        <XMLVersionControl>SimNEC:5.1a1</XMLVersionControl>
         <CIRCUIT>
             <element>
                 <type>LOAD</type>
@@ -176,7 +193,7 @@ _SSN_TEMPLATE = """\
                 <type>GENERATOR</type>
                 <sweeperLabel>G</sweeperLabel>
                 <p><n>MHz</n><v>{mhz}</v></p>
-                <p><n>ohms</n><v>50</v></p>
+                <p><n>Zo</n><v>50</v></p>
             </element>
         </CIRCUIT>
     </SmithChartCircuit>

--- a/src/antennaknobs/simnec_export.py
+++ b/src/antennaknobs/simnec_export.py
@@ -205,6 +205,7 @@ _SSN_TEMPLATE = """\
             <element>
                 <type>GENERATOR</type>
                 <sweeperLabel>G</sweeperLabel>
+                <showInSmith>true</showInSmith>
                 <p><n>MHz</n><v>{mhz}</v>{gen_sweep}</p>
                 <p><n>Zo</n><v>50</v></p>
             </element>

--- a/src/antennaknobs/simnec_export.py
+++ b/src/antennaknobs/simnec_export.py
@@ -152,9 +152,14 @@ def build_nec_portal_script(
     if name is None:
         mod = type(builder).__module__
         qual = type(builder).__qualname__
-        # Keep the dotted path for real designs (e.g. antennaknobs.designs...),
-        # but drop the noisy "__main__." prefix for builders defined in a script.
-        name = qual if mod == "__main__" else f"{mod}.{qual}"
+        # SimNEC shows this first //comment as the block's display name, which
+        # only fits ~12 chars before the font shrinks to unreadable. So use the
+        # SHORT leaf name: the design's module leaf (e.g. "invvee") for a real
+        # design, or the class qualname for a script-defined (__main__) builder.
+        if mod != "__main__" and qual == "Builder":
+            name = mod.rsplit(".", 1)[-1]
+        else:
+            name = qual
     ground_call, mhos = _ground_directive(ground)
 
     lines = [
@@ -234,6 +239,7 @@ def export_ssn(
     ground=DEFAULT_GROUND,
     seg_per_wl: int | None = None,
     sweep: tuple[float, float] | None = None,
+    name: str | None = None,
 ) -> str:
     """Return a SimNEC ``.ssn`` (str) for an antenna-only ``builder``.
 
@@ -247,12 +253,15 @@ def export_ssn(
                  over that band. ``None`` (default) leaves it minimal, so SimNEC
                  uses its own default (disabled) range — the single-point solve
                  at ``freq_mhz`` is still correct.
+    name       : block display name (SimNEC's first ``//`` comment). Defaults to
+                 the design's short leaf name; keep it ≤ ~12 chars — SimNEC
+                 shrinks the font for longer names.
 
     Raises ``NotImplementedError`` (via ``export_nec``) for networked designs.
     """
     freq_mhz = builder.freq if freq_mhz is None else float(freq_mhz)
     script = build_nec_portal_script(
-        builder, freq_mhz=freq_mhz, ground=ground, seg_per_wl=seg_per_wl
+        builder, freq_mhz=freq_mhz, ground=ground, seg_per_wl=seg_per_wl, name=name
     )
     gen_sweep = (
         "" if sweep is None else _gen_sweep_block(float(sweep[0]), float(sweep[1]))
@@ -296,6 +305,12 @@ def main(argv=None):
         help="Enable the Generator frequency sweep: bare '--sweep' for an auto "
         "band (+/-10%% around --freq), or '--sweep LO,HI' for an explicit MHz range.",
     )
+    ap.add_argument(
+        "--name",
+        default=None,
+        help="Block display name (default: design's short leaf name). SimNEC "
+        "shrinks the font past ~12 chars, so keep it short.",
+    )
     ap.add_argument("--out", default=None, help="Write here (default: stdout)")
     args = ap.parse_args(argv)
 
@@ -316,6 +331,7 @@ def main(argv=None):
         ground=parse_ground(args.ground),
         seg_per_wl=args.seg_per_wl,
         sweep=sweep,
+        name=args.name,
     )
     if args.out:
         with open(args.out, "w") as fh:

--- a/src/antennaknobs/simnec_export.py
+++ b/src/antennaknobs/simnec_export.py
@@ -1,0 +1,256 @@
+"""Emit a SimNEC (``.ssn``) circuit for an antenna-only design (issue #600).
+
+SimNEC (AE6TY) is a Java Smith-chart / station tool that embeds NEC2 behind an
+in-house MNA solver. Its native circuit file is ``.ssn`` (XML). This module
+lets any *antenna-only* antennaknobs design be round-tripped into SimNEC for
+cross-validation, without the fiddly UI step of hand-entering geometry.
+
+How it works — the escape-hatch route
+-------------------------------------
+A SimNEC ``.ssn`` is a list of circuit ``<element>``s. For an antenna model the
+canonical shape is three elements — ``LOAD`` / ``NETWORK`` / ``GENERATOR`` —
+where the antenna lives inside the ``NETWORK`` element's escape-hatch ``<equ>``
+script, expressed in SimNEC's NEC-portal daemon language:
+
+    P1 w1 gnd;                         // the two circuit ports; EX drives P2
+    P2 w2 gnd;
+    NECUnits meters, meters;
+    SommerfeldGround(0.0303, 20);      // (mhos, dielectric) == (sigma, eps_r)
+    NECOptions.mhosPerMeter = 0;       // 0 = PEC
+    NECOptions.segmentsPerWavelength = 120;
+    NEC2                               // NEC cards go between NEC2 and NECEND
+    GW 1 ...
+    EX 0 1 6 0 1. 0.
+    NECEND
+
+We reuse :func:`antennaknobs.nec_export.export_nec` for the geometry, then keep
+only the ``GW`` / ``EX`` / lumped-``LD`` cards and translate the rest into
+daemon directives: ``FR`` → the Generator's ``MHz``; ``GN`` → the ground call;
+the deck's segment counts are *advisory only* — SimNEC re-meshes at
+``NECOptions.segmentsPerWavelength``, which is why that knob is exposed.
+
+Scope
+-----
+**Antenna-only** designs (no ``build_network`` TL/virtual-driver station), matching
+issue #600. ``export_nec`` already raises ``NotImplementedError`` for reducer
+networks, and this module surfaces that. Emitting the *station network* too
+(via SimNEC's ``N`` / RUSE blocks) is a possible phase 2.
+
+Licensing
+---------
+SimNEC is proprietary freeware. This module emits SimNEC's *open file format*
+for interoperability (like emitting a NEC deck or a Touchstone file); it does
+**not** copy SimNEC's bundled circuit files or assets. The daemon directives are
+the documented NEC-portal API. The surrounding XML scaffold in
+:data:`_SSN_TEMPLATE` is authored here (clean-room) from the format's structure.
+
+.. warning::
+   The XML scaffold is **provisional** until confirmed to load in SimNEC on a
+   Windows box — this environment has no Java runtime to test against. The
+   generated *daemon script* (the substantive part) is unit-tested here; the
+   wrapper's exact required tags may need reconciliation with a known-good
+   SimNEC-saved ``.ssn``.
+"""
+
+from __future__ import annotations
+
+from xml.sax.saxutils import escape as _xml_escape
+
+from .engines.pynec import DEFAULT_GROUND
+from .nec_export import export_nec
+
+__all__ = ["export_ssn", "build_nec_portal_script"]
+
+
+def _fmt(x: float) -> str:
+    """Compact real for daemon directives (trim trailing zeros)."""
+    return f"{float(x):g}"
+
+
+def _ground_directive(ground) -> tuple[str | None, float]:
+    """Map an antennaknobs ground spec to a SimNEC daemon ground call and the
+    wire conductivity (mhos/m) to set on ``NECOptions.mhosPerMeter``.
+
+    Returns ``(call_or_None, mhos_per_meter)``. Free space → no ground call.
+    Note SimNEC's ``SommerfeldGround(mhos, dielectric)`` takes (sigma, eps_r) —
+    the reverse of our ``("finite", eps_r, sigma)`` tuple.
+    """
+    if ground is None or ground == "free":
+        return None, 0.0
+    if ground == "pec":
+        return "PerfectGround();", 0.0
+    if (
+        isinstance(ground, tuple)
+        and len(ground) == 3
+        and ground[0] in ("finite", "finite-fast")
+    ):
+        _, eps_r, sigma = ground
+        # SimNEC has no distinct reflection-coefficient ("finite-fast") ground;
+        # both map to its Sommerfeld solve — the accurate model — which is also
+        # what a validation run should compare against.
+        return f"SommerfeldGround({_fmt(sigma)}, {_fmt(eps_r)});", 0.0
+    raise ValueError(f"unrecognised ground spec: {ground!r}")
+
+
+def _nec_cards_for_portal(deck: str) -> list[str]:
+    """Keep only the cards SimNEC's NEC block wants: geometry (``GW``),
+    excitation (``EX``), and lumped loads (``LD 0`` / ``LD 1``).
+
+    Dropped: ``CM``/``CE``/``GE``/``FR``/``RP``/``XQ``/``EN`` (structural or
+    handled by daemon directives), ``GN`` (→ ground call), ``LD 5`` global
+    conductivity (→ ``NECOptions.mhosPerMeter``) and ``LD 2`` insulation
+    (not representable in the NEC block — see the warning below).
+    """
+    kept: list[str] = []
+    for raw in deck.splitlines():
+        s = raw.strip()
+        if s.startswith("GW ") or s.startswith("EX "):
+            kept.append(s)
+        elif s.startswith("LD "):
+            parts = s.split()
+            ldtyp = parts[1] if len(parts) > 1 else ""
+            if ldtyp in ("0", "1"):  # series / parallel lumped RLC load
+                kept.append(s)
+            # LD 5 (conductivity) and LD 2 (insulation) are handled elsewhere
+            # or unsupported; skip here.
+    return kept
+
+
+def build_nec_portal_script(
+    builder,
+    *,
+    freq_mhz: float,
+    ground=DEFAULT_GROUND,
+    seg_per_wl: int | None = None,
+    name: str | None = None,
+) -> str:
+    """Build the SimNEC NEC-portal daemon script (the ``<equ>`` body) for an
+    antenna-only ``builder``. Reuses :func:`export_nec` for the geometry.
+    """
+    deck = export_nec(builder, ground=ground, freq=freq_mhz, include_rp=False)
+    cards = _nec_cards_for_portal(deck)
+
+    name = name or f"{type(builder).__module__}.{type(builder).__qualname__}"
+    ground_call, mhos = _ground_directive(ground)
+
+    lines = [
+        f"//{name}",
+        "// generated by antennaknobs.simnec_export",
+        "P1 w1 gnd;",
+        "P2 w2 gnd;",
+        "NECUnits meters, meters;",
+    ]
+    if ground_call:
+        lines.append(ground_call)
+    lines.append(f"NECOptions.mhosPerMeter = {_fmt(mhos)};")
+    if seg_per_wl is not None:
+        lines.append(f"NECOptions.segmentsPerWavelength = {int(seg_per_wl)};")
+    lines.append("NEC2")
+    lines.extend(cards)
+    lines.append("NECEND")
+    return "\n".join(lines)
+
+
+# --- provisional .ssn XML scaffold (see module warning) ---------------------
+# Minimal three-element cascade: LOAD (open, right end) — NETWORK (the antenna,
+# in the escape-hatch script) — GENERATOR (50 Ohm source, left end). Authored
+# here from the observed format; confirm it loads in SimNEC before relying on it.
+_SSN_TEMPLATE = """\
+<?xml version="1.0" encoding="utf-8"?>
+<SimNEC1p0>
+    <SmithChartCircuit>
+        <XMLVersionControl>SimNEC:antennaknobs.simnec_export</XMLVersionControl>
+        <CIRCUIT>
+            <element>
+                <type>LOAD</type>
+                <sweeperLabel>L</sweeperLabel>
+                <p><n>ohms</n><v>1000000000</v></p>
+            </element>
+            <element>
+                <type>NETWORK</type>
+                <sweeperLabel>A</sweeperLabel>
+                <escapeHatch/>
+                <p><n>equ</n><v>{equ}</v></p>
+            </element>
+            <element>
+                <type>GENERATOR</type>
+                <sweeperLabel>G</sweeperLabel>
+                <p><n>MHz</n><v>{mhz}</v></p>
+                <p><n>ohms</n><v>50</v></p>
+            </element>
+        </CIRCUIT>
+    </SmithChartCircuit>
+</SimNEC1p0>
+"""
+
+
+def export_ssn(
+    builder,
+    *,
+    freq_mhz: float | None = None,
+    ground=DEFAULT_GROUND,
+    seg_per_wl: int | None = None,
+) -> str:
+    """Return a SimNEC ``.ssn`` (str) for an antenna-only ``builder``.
+
+    freq_mhz   : Generator frequency in MHz; defaults to ``builder.freq``.
+    ground     : same spec as ``export_nec`` / PyNECEngine — None/"free",
+                 "pec", ("finite", eps_r, sigma), ("finite-fast", eps_r, sigma).
+    seg_per_wl : SimNEC auto-mesh density (segments per wavelength). None leaves
+                 SimNEC's default; set it to pin SimNEC's mesh for a convergence
+                 comparison (SimNEC re-segments regardless of the deck).
+
+    Raises ``NotImplementedError`` (via ``export_nec``) for networked designs.
+    """
+    freq_mhz = builder.freq if freq_mhz is None else float(freq_mhz)
+    script = build_nec_portal_script(
+        builder, freq_mhz=freq_mhz, ground=ground, seg_per_wl=seg_per_wl
+    )
+    return _SSN_TEMPLATE.format(equ=_xml_escape(script), mhz=_fmt(freq_mhz))
+
+
+def main(argv=None):
+    """CLI: ``python -m antennaknobs.simnec_export <design> [opts]``."""
+    import argparse
+
+    from .cli import get_builder, parse_ground
+
+    ap = argparse.ArgumentParser(
+        prog="antennaknobs.simnec_export",
+        description="Emit a SimNEC (.ssn) circuit for an antenna-only design.",
+    )
+    ap.add_argument("builder", help="Design name, e.g. dipoles.invvee[:variant]")
+    ap.add_argument(
+        "--freq", type=float, default=None, help="MHz (default: builder.freq)"
+    )
+    ap.add_argument(
+        "--ground",
+        default="free",
+        help="free | pec | finite | finite:<eps_r>,<sigma> (default: free)",
+    )
+    ap.add_argument(
+        "--seg-per-wl",
+        type=int,
+        default=None,
+        help="SimNEC auto-mesh density (segments/wavelength)",
+    )
+    ap.add_argument("--out", default=None, help="Write here (default: stdout)")
+    args = ap.parse_args(argv)
+
+    builder = get_builder(args.builder)()
+    ssn = export_ssn(
+        builder,
+        freq_mhz=args.freq,
+        ground=parse_ground(args.ground),
+        seg_per_wl=args.seg_per_wl,
+    )
+    if args.out:
+        with open(args.out, "w") as fh:
+            fh.write(ssn)
+        print(f"wrote {args.out}")
+    else:
+        print(ssn, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_simnec_export.py
+++ b/tests/test_simnec_export.py
@@ -148,6 +148,56 @@ def test_version_control_string_is_simnec_shaped():
     assert vc.startswith("SimNEC:")
 
 
+def test_name_comment_strips_main_prefix():
+    """Builders defined in a script live in module __main__; the leading
+    '__main__.' is noise, so the name comment is just the qualname."""
+    # simulate a script-defined builder (__module__ == "__main__")
+    Script = type("FlatDoublet", (_Dipole,), {})
+    Script.__module__ = "__main__"
+    line0 = build_nec_portal_script(Script(), freq_mhz=14.0).splitlines()[0]
+    assert line0 == "//FlatDoublet"
+    # a real design keeps its full dotted path
+    from antennaknobs.designs.dipoles.invvee import Builder as InvVee
+
+    line0 = build_nec_portal_script(InvVee(), freq_mhz=14.1).splitlines()[0]
+    assert line0 == "//antennaknobs.designs.dipoles.invvee.Builder"
+
+
+def test_no_generator_sweep_by_default():
+    """Minimal by default: no <sweepParam> on the Generator (SimNEC supplies its
+    own default, disabled range)."""
+    ssn = export_ssn(_Dipole(), freq_mhz=14.1, ground=None)
+    assert "<sweepParam>" not in ssn
+    assert "doSweep" not in ssn
+
+
+def test_sweep_enabled_when_requested():
+    ssn = export_ssn(_Dipole(), freq_mhz=14.1, ground=None, sweep=(13.0, 15.0))
+    root = ET.fromstring(ssn)  # well-formed
+    gen_mhz = None
+    for el in root.iter("element"):
+        if el.findtext("type") == "GENERATOR":
+            for p in el.findall("p"):
+                if p.findtext("n") == "MHz":
+                    gen_mhz = p
+    sp = gen_mhz.find("sweepParam")
+    assert sp is not None and sp.findtext("name") == "G.MHz"
+    got = {p.findtext("n"): p.findtext("v") for p in sp.findall("p")}
+    assert got["from"] == "13" and got["to"] == "15"
+    assert got["doSweep"] == "y"
+
+
+def test_cli_sweep_auto_band(capsys):
+    """Bare --sweep enables an auto +/-10% band around the design frequency."""
+    from antennaknobs.simnec_export import main
+
+    main(["dipoles.invvee", "--freq", "10", "--sweep"])
+    out = capsys.readouterr().out
+    sp = ET.fromstring(out).find(".//sweepParam")
+    got = {p.findtext("n"): p.findtext("v") for p in sp.findall("p")}
+    assert got["from"] == "9" and got["to"] == "11" and got["doSweep"] == "y"
+
+
 def test_networked_design_raises():
     from antennaknobs.designs.wire.zepp import Builder as Zepp
 

--- a/tests/test_simnec_export.py
+++ b/tests/test_simnec_export.py
@@ -148,19 +148,26 @@ def test_version_control_string_is_simnec_shaped():
     assert vc.startswith("SimNEC:")
 
 
-def test_name_comment_strips_main_prefix():
-    """Builders defined in a script live in module __main__; the leading
-    '__main__.' is noise, so the name comment is just the qualname."""
-    # simulate a script-defined builder (__module__ == "__main__")
-    Script = type("FlatDoublet", (_Dipole,), {})
-    Script.__module__ = "__main__"
-    line0 = build_nec_portal_script(Script(), freq_mhz=14.0).splitlines()[0]
-    assert line0 == "//FlatDoublet"
-    # a real design keeps its full dotted path
+def test_name_comment_is_short_leaf_name():
+    """SimNEC shows the first //comment as the block name (~12-char budget), so
+    the default is the design's short leaf name — not the full dotted path."""
+    # a real design → its module leaf, e.g. "invvee"
     from antennaknobs.designs.dipoles.invvee import Builder as InvVee
 
-    line0 = build_nec_portal_script(InvVee(), freq_mhz=14.1).splitlines()[0]
-    assert line0 == "//antennaknobs.designs.dipoles.invvee.Builder"
+    assert (
+        build_nec_portal_script(InvVee(), freq_mhz=14.1).splitlines()[0] == "//invvee"
+    )
+    # a script-defined builder (__module__ == "__main__") → the class qualname
+    Script = type("FlatDoublet", (_Dipole,), {})
+    Script.__module__ = "__main__"
+    assert build_nec_portal_script(Script(), freq_mhz=14.0).splitlines()[0] == (
+        "//FlatDoublet"
+    )
+
+
+def test_name_override():
+    ssn = export_ssn(_Dipole(), freq_mhz=14.1, ground=None, name="dip20")
+    assert "//dip20" in ssn
 
 
 def test_no_generator_sweep_by_default():

--- a/tests/test_simnec_export.py
+++ b/tests/test_simnec_export.py
@@ -170,6 +170,15 @@ def test_name_override():
     assert "//dip20" in ssn
 
 
+def test_generator_is_measured_block():
+    """The GENERATOR carries showInSmith so its impedance is measured/displayed
+    (and plotted during a sweep) without the user turning a block on."""
+    ssn = export_ssn(_Dipole(), freq_mhz=14.1, ground=None)
+    root = ET.fromstring(ssn)
+    gen = next(el for el in root.iter("element") if el.findtext("type") == "GENERATOR")
+    assert gen.findtext("showInSmith") == "true"
+
+
 def test_no_generator_sweep_by_default():
     """Minimal by default: no <sweepParam> on the Generator (SimNEC supplies its
     own default, disabled range), and no SCATTERGUN arming."""

--- a/tests/test_simnec_export.py
+++ b/tests/test_simnec_export.py
@@ -31,24 +31,48 @@ def _script(**kw):
 
 
 def test_geometry_cards_match_export_nec():
-    """The GW/EX cards in the portal script are exactly export_nec's."""
+    """The portal script carries exactly export_nec's GW/FR/EX cards (as a set),
+    regrouped into canonical GW → FR → EX order (see test_card_order_gw_fr_ex)."""
     deck = export_nec(_Dipole(), ground=None, freq=14.0, include_rp=False)
-    deck_cards = [
-        s.strip() for s in deck.splitlines() if s.strip().startswith(("GW ", "EX "))
-    ]
+    deck_cards = {
+        s.strip()
+        for s in deck.splitlines()
+        if s.strip().startswith(("GW ", "FR ", "EX "))
+    }
     script = _script(ground=None)
     body = script.split("NEC2", 1)[1].split("NECEND", 1)[0]
-    script_cards = [
-        ln.strip() for ln in body.splitlines() if ln.strip().startswith(("GW ", "EX "))
-    ]
+    script_cards = {
+        ln.strip()
+        for ln in body.splitlines()
+        if ln.strip().startswith(("GW ", "FR ", "EX "))
+    }
     assert script_cards == deck_cards
     assert deck_cards, "expected at least one GW and one EX card"
+
+
+def test_card_order_gw_fr_ex():
+    """SimNEC-saved decks order GW … FR … EX; export_nec emits EX before FR, so
+    the portal regroups. Guard the order the module guarantees."""
+    body = _script(ground=None).split("NEC2", 1)[1].split("NECEND", 1)[0]
+    kinds = [
+        ln.strip()[:2]
+        for ln in body.splitlines()
+        if ln.strip().startswith(("GW ", "FR ", "EX "))
+    ]
+    assert kinds.index("GW") < kinds.index("FR") < kinds.index("EX")
+
+
+def test_fr_card_is_kept():
+    """FR stays in the deck — SimNEC's own .ssn carries it alongside a G.MHz
+    sweep (advisory; the solve frequency comes from the Generator)."""
+    body = _script(ground=None).split("NEC2", 1)[1].split("NECEND", 1)[0]
+    assert "FR " in body
 
 
 def test_structural_cards_are_dropped():
     script = _script(ground=None)
     body = script.split("NEC2", 1)[1].split("NECEND", 1)[0]
-    for card in ("FR ", "RP ", "XQ", "GE ", "GN ", "EN"):
+    for card in ("RP ", "XQ", "GE ", "GN ", "EN"):
         assert card not in body, f"{card!r} should not be inside NEC2..NECEND"
     assert "NEC2" in script and "NECEND" in script
 
@@ -101,6 +125,27 @@ def test_export_ssn_is_wellformed_xml_carrying_the_script():
                 mhz = p.findtext("v")
     assert equ is not None and "NEC2" in equ and "GW " in equ  # ET unescapes text
     assert mhz == "14.1"
+
+
+def test_generator_impedance_uses_zo_tag():
+    """SimNEC's GENERATOR impedance param is <n>Zo</n> (the LOAD uses <n>ohms</n>).
+    Reconciled against a SimNEC 5.1a1-saved .ssn."""
+    ssn = export_ssn(_Dipole(), freq_mhz=14.1, ground=None)
+    root = ET.fromstring(ssn)
+    zo = None
+    for el in root.iter("element"):
+        if el.findtext("type") == "GENERATOR":
+            for p in el.findall("p"):
+                if p.findtext("n") == "Zo":
+                    zo = p.findtext("v")
+            assert all(p.findtext("n") != "ohms" for p in el.findall("p"))
+    assert zo == "50"
+
+
+def test_version_control_string_is_simnec_shaped():
+    ssn = export_ssn(_Dipole(), freq_mhz=14.1, ground=None)
+    vc = ET.fromstring(ssn).find(".//XMLVersionControl").text
+    assert vc.startswith("SimNEC:")
 
 
 def test_networked_design_raises():

--- a/tests/test_simnec_export.py
+++ b/tests/test_simnec_export.py
@@ -1,0 +1,119 @@
+"""SimNEC .ssn export for antenna-only designs (issue #600).
+
+Covers the parts that are verifiable without a SimNEC/Java runtime: the
+NEC-portal daemon script (geometry cards reused verbatim from ``export_nec``,
+ground/units/segmentation directives) and the ``.ssn`` XML wrapper (well-formed,
+carries the escaped script, frequency on the Generator). The XML scaffold's
+acceptance *by SimNEC* is a separate Windows validation step.
+"""
+
+import xml.etree.ElementTree as ET
+from types import MappingProxyType
+
+import pytest
+
+from antennaknobs.builder import AntennaBuilder
+from antennaknobs.nec_export import export_nec
+from antennaknobs.network import Wire
+from antennaknobs.simnec_export import build_nec_portal_script, export_ssn
+
+
+class _Dipole(AntennaBuilder):
+    default_params = MappingProxyType({"freq": 14.0, "design_freq": 14.0})
+
+    def build_wires(self):
+        # up at z=10 m so the ground-plane cases (pec/finite) are valid geometry
+        return [Wire((0.0, -5.0, 10.0), (0.0, 5.0, 10.0), n_seg=11, ex=1 + 0j)]
+
+
+def _script(**kw):
+    return build_nec_portal_script(_Dipole(), freq_mhz=14.0, **kw)
+
+
+def test_geometry_cards_match_export_nec():
+    """The GW/EX cards in the portal script are exactly export_nec's."""
+    deck = export_nec(_Dipole(), ground=None, freq=14.0, include_rp=False)
+    deck_cards = [
+        s.strip() for s in deck.splitlines() if s.strip().startswith(("GW ", "EX "))
+    ]
+    script = _script(ground=None)
+    body = script.split("NEC2", 1)[1].split("NECEND", 1)[0]
+    script_cards = [
+        ln.strip() for ln in body.splitlines() if ln.strip().startswith(("GW ", "EX "))
+    ]
+    assert script_cards == deck_cards
+    assert deck_cards, "expected at least one GW and one EX card"
+
+
+def test_structural_cards_are_dropped():
+    script = _script(ground=None)
+    body = script.split("NEC2", 1)[1].split("NECEND", 1)[0]
+    for card in ("FR ", "RP ", "XQ", "GE ", "GN ", "EN"):
+        assert card not in body, f"{card!r} should not be inside NEC2..NECEND"
+    assert "NEC2" in script and "NECEND" in script
+
+
+def test_free_space_has_no_ground_call():
+    script = _script(ground=None)
+    assert "SommerfeldGround" not in script
+    assert "PerfectGround" not in script
+    assert "NECOptions.mhosPerMeter = 0;" in script
+
+
+def test_pec_ground_is_perfectground():
+    assert "PerfectGround();" in _script(ground="pec")
+
+
+def test_finite_ground_maps_sigma_then_epsr():
+    """SimNEC's SommerfeldGround(mhos, dielectric) == (sigma, eps_r) — the
+    reverse of our ('finite', eps_r, sigma) tuple. Order matters."""
+    script = _script(ground=("finite", 20.0, 0.0303))
+    assert "SommerfeldGround(0.0303, 20);" in script
+
+
+def test_seg_per_wl_directive():
+    assert "NECOptions.segmentsPerWavelength = 120;" in _script(
+        ground=None, seg_per_wl=120
+    )
+    # absent when not requested
+    assert "segmentsPerWavelength" not in _script(ground=None)
+
+
+def test_ports_and_units_boilerplate():
+    script = _script(ground=None)
+    assert "P1 w1 gnd;" in script
+    assert "P2 w2 gnd;" in script
+    assert "NECUnits meters, meters;" in script
+
+
+def test_export_ssn_is_wellformed_xml_carrying_the_script():
+    ssn = export_ssn(_Dipole(), freq_mhz=14.1, ground=None)
+    root = ET.fromstring(ssn)  # raises if malformed
+    # find the NETWORK element's equ param and the GENERATOR MHz
+    equ = None
+    mhz = None
+    for el in root.iter("element"):
+        typ = el.findtext("type")
+        for p in el.findall("p"):
+            if p.findtext("n") == "equ":
+                equ = p.findtext("v")
+            if typ == "GENERATOR" and p.findtext("n") == "MHz":
+                mhz = p.findtext("v")
+    assert equ is not None and "NEC2" in equ and "GW " in equ  # ET unescapes text
+    assert mhz == "14.1"
+
+
+def test_networked_design_raises():
+    from antennaknobs.designs.wire.zepp import Builder as Zepp
+
+    with pytest.raises(NotImplementedError):
+        export_ssn(Zepp(), freq_mhz=14.1, ground=None)
+
+
+def test_smoke_real_builtin_antenna_only():
+    from antennaknobs.designs.dipoles.invvee import Builder as InvVee
+
+    ssn = export_ssn(InvVee(), ground=("finite", 13.0, 0.005), seg_per_wl=80)
+    ET.fromstring(ssn)  # well-formed
+    assert "SommerfeldGround(0.005, 13);" in ssn
+    assert "segmentsPerWavelength = 80;" in ssn

--- a/tests/test_simnec_export.py
+++ b/tests/test_simnec_export.py
@@ -172,10 +172,20 @@ def test_name_override():
 
 def test_no_generator_sweep_by_default():
     """Minimal by default: no <sweepParam> on the Generator (SimNEC supplies its
-    own default, disabled range)."""
+    own default, disabled range), and no SCATTERGUN arming."""
     ssn = export_ssn(_Dipole(), freq_mhz=14.1, ground=None)
     assert "<sweepParam>" not in ssn
     assert "doSweep" not in ssn
+    assert "SCATTERGUN" not in ssn
+
+
+def test_sweep_arms_scattergun_and_chart():
+    """A requested sweep also arms it: SCATTERGUN names G.MHz (without it doSweep
+    does nothing) and the chart goes to Sweep mode. ET-parseable."""
+    ssn = export_ssn(_Dipole(), freq_mhz=14.1, ground=None, sweep=(13.0, 15.0))
+    ET.fromstring(ssn)  # well-formed
+    assert "<SCATTERGUN><n>G.MHz</n></SCATTERGUN>" in ssn
+    assert "<displayMode>Sweep</displayMode>" in ssn
 
 
 def test_sweep_enabled_when_requested():


### PR DESCRIPTION
## Summary
Step 1 of #600: promote the `.ssn` export prototype into a real, packaged module — `antennaknobs.simnec_export`.

- **`export_ssn(builder, *, freq_mhz, ground, seg_per_wl, sweep, name) -> str`** + `build_nec_portal_script()` for the `NETWORK` escape-hatch `<equ>` body.
- Reuses `export_nec` for geometry; keeps `GW`/`FR`/`EX`/lumped-`LD` cards (canonical GW→FR→EX order) and translates the rest into SimNEC NEC-portal daemon directives: `GN → SommerfeldGround(σ, εr)` / `PerfectGround()`, `NECOptions.segmentsPerWavelength`, Generator `MHz`.
- **Optional Generator sweep** (`sweep=(lo,hi)` / `--sweep`): emits the `sweepParam`, arms it (`SCATTERGUN` + `ROUNDCHART` Sweep mode), and marks the Generator as the measured block (`showInSmith`) so it runs on load. Off by default (single-point solve stays correct).
- **Short block name** (SimNEC's ~12-char display budget): the design's leaf name by default, `--name` to override.
- **CLI**: `python -m antennaknobs.simnec_export dipoles.invvee --freq 14.1 --ground finite:13,0.005 --seg-per-wl 100 --sweep --out inv.ssn`
- **21 tests** covering the daemon script, card set/order, ground/units/seg directives, GENERATOR `Zo`, version string, name, sweep on/off + arming, and well-formed XML.

## ✅ SimNEC 5.1a1 validation (was the draft blocker)

Reconciled the generated `.ssn` against a **known-good SimNEC 5.1a1-saved** antenna-only `.ssn`, then confirmed on Windows:

- **The minimal wrapper loads in SimNEC 5.1a1** and solves — SimNEC regenerates the display state (`SPREADSHEET`/charts/band menus) the scaffold omits.
- Returns the **correct feedpoint** (~181 + j573 at segPerWl 40), matching the reference `.ssn` on the same deck.
- **Sweep runs on load** — a generated sweep-enabled `.ssn` re-saved by SimNEC is byte-identical (bar the stored filename) to a hand-enabled one.

Discrepancies found in reconciliation and fixed: keep `FR` (SimNEC's own deck carries it alongside a live `G.MHz` sweep); GENERATOR impedance is `<n>Zo</n>` not `<n>ohms</n>`; `XMLVersionControl` is a `SimNEC:<version>` string; canonical `GW→FR→EX` card order.

## Follow-ups (out of scope here)
- Wire conductivity/insulation → `NECOptions.mhosPerMeter` (PEC designs fine today).
- **Phase 2 (#604): networked / full-station export.** The `SERIES_TLINE`/`SHUNT_CAP`/`SERIES_IND`/`TRANSFORMER2` element schemas are now in hand from a saved `lastCircuit.ssn`; the open work is mapping reducer branches to SimNEC elements and **rejecting common-mode designs** (SimNEC's TLine has no `zcomm` knob, so `BalancedLine`/`FloatingBalun` can't be faithfully represented — see #604).

## Licensing
Emits SimNEC's open file format for interoperability (like a NEC deck or Touchstone); does **not** copy SimNEC's bundled files/assets; XML scaffold authored clean-room from the format's structure.

## Test plan
- [x] `tests/test_simnec_export.py` (21 tests) green
- [x] `ruff check` + `ruff format --check` clean
- [x] CLI smoke on `dipoles.invvee`
- [x] **SimNEC 5.1a1 loads + solves a generated `.ssn` (Windows)** — correct feedpoint
- [x] **Generated sweep runs on load in SimNEC (Windows)**
- [x] Reconcile scaffold + `FR` handling against a real saved `.ssn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
