### PR TITLE
SimNEC Track 2 stage-3: center-fed apples-to-apples + captured SimNEC value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ scripts/sterba_center_driven_pattern.png
 bench_out/
 # Claude Code scratchpad — session-local working files, never shipped
 scratchpad/
+# Dev-server logs (e.g. `.backend.log` / `.frontend.log` from local runs)
+*.log

--- a/docs/status/2026-07-28-simnec-comparison-handoff.md
+++ b/docs/status/2026-07-28-simnec-comparison-handoff.md
@@ -19,7 +19,7 @@ agree and where they diverge (common-mode).
   - Scenario 1 (antenna): SimNEC `nec2c` == PyNEC to <0.1 Ω on an identical mesh.
   - Scenario 2 (coupled rig): **SimNEC 40 − j5.7 (SWR 1.29) vs AntennaKNoBs 41.9 − j5.8 (SWR 1.24)** — ~2 Ω, identical reactance.
 - **Track 2 — divergence (`wire.doublet_balanced_tuner`, 14.1 MHz): DONE.** The common-mode "money shot". Compared with a matched (center-fed) feed: AntennaKNoBs symmetric **28.75 + j27.03 (SWR 2.41)** vs SimNEC **28.95 + j25.18 (SWR 2.31)** — agree to ~2 Ω; break symmetry and AntennaKNoBs fans SWR 5.0→5.7 across `line_zcomm` while SimNEC (no zcomm knob) holds one value.
-- **Bonus delivered:** a validated AntennaKNoBs → SimNEC `.ssn` exporter prototype (issue #600).
+- **Bonus delivered:** the AntennaKNoBs → SimNEC `.ssn` exporter — prototype validated, now shipped as `antennaknobs.simnec_export` (issue #600, PR #602); full-station export tracked in #604.
 - Reproduce everything: `scratch/simnec/*.py` (see [Reproducing](#reproducing)).
 
 ---
@@ -180,11 +180,15 @@ Validated: a generated `.ssn` loaded in SimNEC 5.1a1 and tracked the
 AntennaKNoBs/PyNEC convergence curve exactly (segPerWl 40 → 181+j573, 120 →
 188+j583). A `.ssn` is XML with LOAD / NETWORK / GENERATOR `<element>`s; the
 antenna lives in the NETWORK element's escape-hatch `<equ>` script between `NEC2`
-and `NECEND`. Recipe + prototype: `scratch/simnec/export_ssn.py`. #600 promotes
-it to `antennaknobs.simnec_export` with a **clean bundled template** (the
-prototype currently reuses a SimNEC-saved `.ssn` as its template — not in the
-repo) and a CLI. Phase-2 (full networked export) needs the `SERIES_CAP`/
-`SHUNT_CAP` element schemas confirmed (`SERIES_TLINE`, `SHUNT_IND` already known).
+and `NECEND`. Recipe + prototype: `scratch/simnec/export_ssn.py`. **#600 step 1
+is now shipped** as `antennaknobs.simnec_export` (PR #602): a clean-room minimal
+template (no dependency on a user's saved `.ssn`), a CLI, an optional Generator
+sweep, and Windows-confirmed load/solve/sweep. **Phase-2** (full networked /
+station export) is tracked in **#604** — the `SERIES_TLINE` / `SHUNT_CAP` /
+`SERIES_IND` / `TRANSFORMER2` element schemas are now in hand from a saved
+`lastCircuit.ssn`; the open work is mapping the reducer branches and **rejecting
+common-mode designs** (SimNEC's TLine has no `zcomm` knob, so `BalancedLine` /
+`FloatingBalun` can't be faithfully represented — this is Track 2's finding).
 
 ---
 
@@ -212,7 +216,7 @@ with **no** class default, and set `b._asym` on the instance.
 - [ ] Table 2 over real ground (variant): AntennaKNoBs 49.7 − j0.1 computed; SimNEC TODO.
 - [x] Table 3 (common-mode sweep): AntennaKNoBs center-fed + arm-end columns done; SimNEC single value captured (28.95 + j25.18, SWR 2.31) and matches the center-fed symmetric baseline to ~2 Ω.
 - [x] SimNEC gotchas documented.
-- [x] `.ssn` bridge (#600 filed).
+- [x] `.ssn` bridge (#600): antenna-only exporter shipped + SimNEC-validated (PR #602); full-station export tracked in #604.
 - [ ] SimNEC `.ssn` files + screenshots for the writeup.
 
 Related issues: #593 (s1p/s2p import), #594 (auto-transformer), #595 (VNA

--- a/docs/status/2026-07-28-simnec-comparison-handoff.md
+++ b/docs/status/2026-07-28-simnec-comparison-handoff.md
@@ -18,7 +18,7 @@ agree and where they diverge (common-mode).
 - **Track 1 — agreement (`wire.doublet_ladder_tuner`, 7.1 MHz): DONE, tools agree.**
   - Scenario 1 (antenna): SimNEC `nec2c` == PyNEC to <0.1 Ω on an identical mesh.
   - Scenario 2 (coupled rig): **SimNEC 40 − j5.7 (SWR 1.29) vs AntennaKNoBs 41.9 − j5.8 (SWR 1.24)** — ~2 Ω, identical reactance.
-- **Track 2 — divergence (`wire.doublet_balanced_tuner`, 14.1 MHz): TODO.** The common-mode "money shot". AntennaKNoBs numbers computed; SimNEC side is one differential cascade to build.
+- **Track 2 — divergence (`wire.doublet_balanced_tuner`, 14.1 MHz): DONE.** The common-mode "money shot". Compared with a matched (center-fed) feed: AntennaKNoBs symmetric **28.75 + j27.03 (SWR 2.41)** vs SimNEC **28.95 + j25.18 (SWR 2.31)** — agree to ~2 Ω; break symmetry and AntennaKNoBs fans SWR 5.0→5.7 across `line_zcomm` while SimNEC (no zcomm knob) holds one value.
 - **Bonus delivered:** a validated AntennaKNoBs → SimNEC `.ssn` exporter prototype (issue #600).
 - Reproduce everything: `scratch/simnec/*.py` (see [Reproducing](#reproducing)).
 
@@ -106,7 +106,27 @@ gives ~49.7 − j0.1, SWR 1.01 — a documented variant, not yet built in SimNEC
 Design: `wire.doublet_balanced_tuner` — 0.72 λ doublet on 450 Ω line → balanced
 L-tuner → 1:1 balun → 50 Ω rig, **14.1 MHz**, momwire/**BSpline** (PortAtEnd).
 
-**AntennaKNoBs (computed, `scratch/simnec/track2_commonmode.py`):**
+**Feed definition drives the baseline — compare tools with the SAME feed.**
+SimNEC's NEC can only **center-feed** (a delta-gap on the middle segment). The
+stock design's 0.04 λ **arm-end** `PortAtEnd` gap is a *different* feedpoint
+(51.8 / SWR 1.04 — momwire-only, and **not** what SimNEC solves). Shrinking the
+AntennaKNoBs feed gap toward 0 converges the symmetric rig answer onto SimNEC's
+(the residual is the delta-gap convergence caveat, correction 3):
+
+**Center-fed (0.004 λ gap ≈ SimNEC delta-gap) — the apples-to-apples column:**
+
+| `line_zcomm` | symmetric | asymmetric (R arm +15%) |
+|---|---|---|
+| 25  | 28.75 + j27.03 (SWR 2.407) | 18.06 + j43.27 (SWR 5.004) |
+| 100 | 28.75 + j27.03 (SWR 2.407) | 17.43 + j44.81 (SWR 5.333) |
+| 250 | 28.75 + j27.03 (SWR 2.407) | 17.03 + j46.06 (SWR 5.591) |
+| 400 | 28.75 + j27.03 (SWR 2.407) | 16.88 + j46.61 (SWR 5.699) |
+
+SimNEC (center-fed, tuned 14.1 MHz cascade): **28.95 + j25.18 (SWR 2.31)** —
+**captured** (rig readout of the cascade below, lossless line, coil Q=200) —
+matches the center-fed symmetric row to ~2 Ω (same order as Tracks 1–2).
+
+**Arm-end (0.04 λ `PortAtEnd`, momwire-only) — for reference, not SimNEC-matched:**
 
 | `line_zcomm` | symmetric | asymmetric (R arm +15%) |
 |---|---|---|
@@ -115,13 +135,15 @@ L-tuner → 1:1 balun → 50 Ω rig, **14.1 MHz**, momwire/**BSpline** (PortAtEn
 | 250 | 51.80 + j0.01 (SWR 1.036) | 24.23 + j31.38 (SWR 3.031) |
 | 400 | 51.80 + j0.01 (SWR 1.036) | 23.93 + j32.17 (SWR 3.112) |
 
-**SimNEC side (to do):** build the differential cascade **once** —
-`Generator(50Ω) ← Transformer(1:1 ideal) ← series L 2.8 µH (Q=200) ← shunt C
-74 pF ← TLine(450Ω, vf 0.91, 0.40λ=8.5048 m) ← NEC(doublet)` at 14.1 MHz — and
-record the single value. SimNEC's TLine is purely differential ("no common-mode
-conduction"), so it has **no `zcomm` knob**: one fixed number vs the AntennaKNoBs
-spread above. That spread-vs-point contrast **is** the result. (Symmetric row is
-the honest "both tools agree" null case; asymmetric is the divergence.)
+**SimNEC side (captured):** the differential cascade — `Generator(50Ω) ←
+Transformer(1:1 ideal) ← series L 2.8 µH (Q=200) ← shunt C 74 pF ← TLine(450Ω,
+vf 0.91, 0.40λ=8.5048 m=27.90 ft, `0/100f` lossless) ← NEC(center-fed doublet)`
+at 14.1 MHz — reads **28.95 + j25.18 (SWR 2.31)** at the rig. SimNEC's TLine is purely differential
+("no common-mode conduction"), so it has **no `zcomm` knob**: one fixed number vs
+the AntennaKNoBs spread above. In **either** feed definition the symmetric row is
+flat across `zcomm` (no common mode excited — the honest "both tools agree" null
+case); only the asymmetric case diverges, and that spread-vs-point contrast **is**
+the result. Both columns reproducible via `GAP_CENTER` / `GAP_ARMEND` in the script.
 
 Doublet deck for SimNEC's N block (14.1 MHz, free space), and the anchor
 feedpoint ≈ 342 + j962 (center-fed; note the arm-end vs center-fed caveat from
@@ -188,7 +210,7 @@ with **no** class default, and set `b._asym` on the instance.
 - [x] Table 1 (antenna): PyNEC/Sin/nec2c agree; converged 192.9 + j589.8.
 - [x] Table 2 (coupled rig, free space): SimNEC 40 − j5.7 vs AntennaKNoBs 41.9 − j5.8.
 - [ ] Table 2 over real ground (variant): AntennaKNoBs 49.7 − j0.1 computed; SimNEC TODO.
-- [ ] Table 3 (common-mode sweep): AntennaKNoBs done (above); SimNEC single value TODO.
+- [x] Table 3 (common-mode sweep): AntennaKNoBs center-fed + arm-end columns done; SimNEC single value captured (28.95 + j25.18, SWR 2.31) and matches the center-fed symmetric baseline to ~2 Ω.
 - [x] SimNEC gotchas documented.
 - [x] `.ssn` bridge (#600 filed).
 - [ ] SimNEC `.ssn` files + screenshots for the writeup.

--- a/scratch/simnec/track2_commonmode.py
+++ b/scratch/simnec/track2_commonmode.py
@@ -3,11 +3,27 @@
 Uses the BALANCED design wire.doublet_balanced_tuner (14.1 MHz, momwire/BSpline
 only -- PortAtEnd arm-end feed is not supported on Sinusoidal yet).
 
-Key finding: under a SYMMETRIC doublet the rig answer is BIT-IDENTICAL across
-line_zcomm (no common mode is excited) -- so the handoff doc's headline
-Scenario 3 must break symmetry. With one arm ~15% longer, the rig answer MOVES
-with zcomm; SimNEC's single-ended differential cascade cannot follow it (one
-fixed number, no zcomm knob). That spread-vs-point contrast IS the result.
+Two findings, in two feed definitions:
+
+1. FEED DEFINITION matters for the absolute baseline. The stock design feeds the
+   doublet across a 0.04 lambda arm-end gap (PortAtEnd); SimNEC's NEC can only
+   center-feed (a delta-gap on the middle segment). Shrinking the AntennaKNoBs
+   feed gap toward zero converges the symmetric rig answer onto SimNEC's:
+
+       center-fed AntennaKNoBs (0.004 lambda gap): 28.75 + j27.03  (SWR 2.41)
+       center-fed SimNEC        (delta-gap):        28.95 + j25.18  (SWR 2.31)
+
+   ~2 ohm apart -- the same agreement order as Track 1 (the residual is the
+   delta-gap convergence caveat, handoff correction 3). Compare tools with the
+   SAME feed definition; the arm-end 51.8 ohm / SWR 1.04 figure is a different
+   (momwire-only) feedpoint and is NOT what SimNEC solves.
+
+2. COMMON MODE is the divergence. Under a SYMMETRIC doublet the rig answer is
+   BIT-IDENTICAL across line_zcomm (no common mode is excited) in EITHER feed
+   definition -- so Scenario 3 must break symmetry. With one arm ~15% longer the
+   rig answer MOVES with zcomm; SimNEC's single-ended differential cascade cannot
+   follow it (one fixed number, no zcomm knob). That spread-vs-point contrast IS
+   the result.
 
 Run:  python scratch/simnec/track2_commonmode.py
 """
@@ -16,24 +32,34 @@ from antennaknobs.designs.wire.doublet_balanced_tuner import Builder
 from antennaknobs.engines.momwire import MomwireEngine
 from antennaknobs.network import Wire
 
+# Feed-gap half-width as a wavelength factor. The stock design uses 0.02 (a
+# 0.04 lambda arm-end gap); shrinking it toward 0 approaches a center-fed
+# delta-gap. 0.002 (0.004 lambda) lands on SimNEC's center-fed value.
+GAP_ARMEND = 0.02
+GAP_CENTER = 0.002
+
 
 def swr(z):
     g = abs((z - 50) / (z + 50))
     return (1 + g) / (1 - g)
 
 
-class AsymBuilder(Builder):
-    """Same design; right arm scaled by an ``_asym`` instance attribute to break
-    symmetry. NB: do NOT give ``_asym`` a class-attribute default — AntennaBuilder
-    routes instance assignments through a custom __setattr__/__getattr__, and a
-    class attribute shadows that routing (normal lookup succeeds, so the routed
-    instance value is never seen). Set ``b._asym = ...`` and read it with getattr."""
+class Doublet(Builder):
+    """Same design with two instance knobs: ``_gap_factor`` (feed-gap half-width
+    as a wavelength factor, default the stock 0.02 arm-end gap) and ``_asym``
+    (right-arm length scale, to break symmetry).
+
+    NB: do NOT give either knob a class-attribute default -- AntennaBuilder routes
+    instance assignments through a custom __setattr__/__getattr__, and a class
+    attribute shadows that routing (normal lookup succeeds, so the routed instance
+    value is never seen). Set ``b._asym = ...`` / ``b._gap_factor = ...`` on the
+    instance and read them with getattr and a literal default here."""
 
     def build_wires(self):
         wl = self.design_wavelength
         arm = 0.5 * self.length_factor * wl
         z = self.height_factor * wl
-        gap = 0.02 * wl
+        gap = getattr(self, "_gap_factor", GAP_ARMEND) * wl
         asym = getattr(self, "_asym", 1.0)
         return [
             Wire((0.0, -gap, z), (0.0, -arm, z), name="armL"),
@@ -41,27 +67,33 @@ class AsymBuilder(Builder):
         ]
 
 
-def rig(asym, zcomm):
-    b = AsymBuilder(dict(Builder.default_params, line_zcomm=zcomm))
+def rig(asym, zcomm, gap_factor):
+    b = Doublet(dict(Builder.default_params, line_zcomm=zcomm))
     b._asym = asym
+    b._gap_factor = gap_factor
     z = complex(MomwireEngine(b, ground=None).impedance()[0])
     return z, swr(z)
 
 
 if __name__ == "__main__":
-    for asym, tag in (
-        (1.0, "SYMMETRIC (null case: SimNEC and AntennaKNoBs agree)"),
-        (1.15, "ASYMMETRIC R+15% (the divergence SimNEC cannot follow)"),
+    for gap_factor, feed in (
+        (GAP_ARMEND, "ARM-END feed (0.04 lambda gap, PortAtEnd — momwire-only)"),
+        (GAP_CENTER, "CENTER-FED (0.004 lambda gap ≈ SimNEC delta-gap)"),
     ):
-        print(f"=== {tag} ===")
-        for zc in (25.0, 100.0, 250.0, 400.0):
-            z, s = rig(asym, zc)
-            print(
-                f"   line_zcomm={zc:5.0f}:  Z_rig = {z.real:7.2f} {z.imag:+7.2f} j   SWR = {s:6.3f}"
-            )
+        print(f"##### {feed} #####")
+        for asym, tag in (
+            (1.0, "SYMMETRIC (null case: flat across zcomm; tools agree)"),
+            (1.15, "ASYMMETRIC R+15% (the divergence SimNEC cannot follow)"),
+        ):
+            print(f"  --- {tag} ---")
+            for zc in (25.0, 100.0, 250.0, 400.0):
+                z, s = rig(asym, zc, gap_factor)
+                print(
+                    f"    line_zcomm={zc:5.0f}:  Z_rig = {z.real:7.2f} {z.imag:+7.2f} j   SWR = {s:6.3f}"
+                )
         print()
     print("SimNEC side: build the differential cascade ONCE (450ohm line, balanced")
     print("L-tuner as one series 2.8uH + one shunt 74pF, 1:1 balun, 50ohm gen) and")
-    print(
-        "record the single value. It has no zcomm knob -> one number vs the spread above."
-    )
+    print("record the single value (center-fed doublet -> ~28.95 + j25.18, SWR 2.31,")
+    print("matching the CENTER-FED symmetric row above). It has no zcomm knob -> one")
+    print("number vs the asymmetric spread above.")


### PR DESCRIPTION
## Summary
- **Track 2 (common-mode divergence) is done.** Adds a center-fed feed variant to `track2_commonmode.py` (`GAP_CENTER` vs the stock `GAP_ARMEND`): shrinking the doublet feed gap toward a delta-gap converges the symmetric rig answer onto SimNEC — AntennaKNoBs 28.75 + j27.03 (SWR 2.41) vs SimNEC 28.95 + j25.18 (SWR 2.31), ~2 Ω apart, the same agreement order as Tracks 1–2.
- The arm-end (0.04 λ `PortAtEnd`, momwire-only) columns are kept for reference — that 51.8 / SWR 1.04 feedpoint is *not* what SimNEC solves, so it's no longer the headline comparison.
- Under symmetry the rig answer is flat across `line_zcomm` in either feed (no common mode excited); breaking symmetry (R arm +15%) fans the center-fed answer SWR 5.0→5.7 across zcomm while SimNEC has no zcomm knob — the spread-vs-point divergence.
- **Handoff doc updated:** both feed columns in Table 3, the captured SimNEC single value (28.95 + j25.18, from the tuned 14.1 MHz cascade rig readout), and TL;DR + deliverables checklist flipped to done.
- Chore: gitignore the `.backend.log` / `.frontend.log` dev-server logs.

## Test plan
- [ ] `python scratch/simnec/track2_commonmode.py` reproduces both feed columns (center-fed symmetric 28.75 + j27.03; asymmetric fans SWR 5.0→5.7)
- [ ] `ruff check` / `ruff format --check` clean (verified locally)
- [ ] Handoff doc Table 3 reads correctly (center-fed = apples-to-apples, arm-end = reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)