### PR TITLE
BalancedLine: broaden the physics evidence, scope the docs, and add PortOnWireFloating

### DIFF
--- a/site/src/content/docs/concepts/station-modelling.md
+++ b/site/src/content/docs/concepts/station-modelling.md
@@ -72,7 +72,7 @@ honest model:
 | branch | what it is |
 |---|---|
 | `TL` / `TL.from_cable` | transmission line — ideal, or a real cable from the `CABLES` catalog (RG-58, RG-8X, window line…) with frequency-dependent matched loss; SWR-multiplied loss *emerges* from the circuit solution rather than a formula |
-| `BalancedLine` | balanced / differential two-conductor line — the pair sibling of `TL`, carrying ±I with the return riding the partner wire (open-wire feeder, the Sterba curtain's offset-pair risers). Set by a single differential impedance `zdiff`; add an optional common-mode path `zcomm` for a pair that also carries end-to-end conductor continuity |
+| `BalancedLine` | balanced / differential two-conductor line — the pair sibling of `TL`, carrying ±I with the return riding the partner wire (open-wire feeder, the Sterba curtain's offset-pair risers). Set by a single differential impedance `zdiff`; add an optional common-mode path `zcomm` for a pair that also carries end-to-end conductor continuity. Narrower scope than the rest of this table — see [what `BalancedLine` is good for](#what-balancedline-is-good-for) |
 | `Load` | series R/L/C in a wire's current path — a trap, a terminating resistor |
 | `TwoPort` | series R/L/C between two ports — a tuner's series capacitor |
 | `Shunt` | R/L/C from a port to the common return — a tuner's shunt coil |
@@ -82,6 +82,44 @@ Reactive elements accept a finite **Q** (`ql`, `qc`, `qlmag`), and that
 is where real matchboxes and transformers burn power. Degenerate values
 are physics, not errors: a 0 H series arm is an ideal short, a 0 F
 shunt is an open — sliders can sweep straight through them.
+
+### What `BalancedLine` is good for
+
+`BalancedLine` is newer and more narrowly validated than the other
+branches, so it is worth being explicit about where it earns its keep.
+
+**It models a *tightly coupled* pair.** The differential stamp assumes the
+two conductors are close enough to behave as one TEM line. Measured
+against physical MoM wires, a pair at 0.004 λ spacing (the Sterba
+offset-pair scale) matches the analytic
+`(η₀/π)·acosh(D/2a)` within 3 %; by 0.06 λ the TEM model is visibly wrong
+and degrades monotonically in between. A widely-spaced pair is not a
+transmission line, and modelling it as one will quietly mislead you.
+
+**It is differential-only by construction.** The stamp carries ±I and
+cannot represent common-mode radiation. That is a deliberate contract, and
+it is why the element suits structures whose pairs measurably *are*
+balanced — `wire.sterba`'s risers run a common-mode residual of 0.05–0.15
+of the differential current. It is not the tool for asking "how much does
+my feedline radiate"; for feedline common-mode see `FloatingBalun`.
+
+**`zcomm` is a switch, not a knob.** The optional common-mode path exists
+because a real pair also provides end-to-end *conductor continuity*, which
+a purely differential stamp drops. In the Sterba curtain that continuity is
+load-bearing: without it the three-bay array loses 5 dB and its beam swings
+35° off broadside. But the *value* barely matters — sweeping `zcomm` across
+25 Ω to 3200 Ω moves the gain by 0.05 dB, because at the risers' λ/2 length
+the common-mode line is a repeater. Turn it on when the pair is physically
+continuous; don't try to tune it.
+
+**It is momwire-only.** Practical `BalancedLine` designs attach through
+`PortAtEnd`, which NEC-2 has no equivalent for, so the PyNEC backend
+rejects them (see [Ports](#ports-where-the-circuit-meets-the-wire)). You
+lose cross-engine validation on these designs — the available cross-check
+is between B-spline basis degrees rather than between engines.
+
+Three catalog designs use it today: `wire.sterba_bl`,
+`arrays.bowtie1x2_bl`, and `wire.doublet_balanced_tuner`.
 
 ## Boxes: reusable station components
 

--- a/site/src/content/docs/concepts/station-modelling.md
+++ b/site/src/content/docs/concepts/station-modelling.md
@@ -20,7 +20,7 @@ This page introduces the vocabulary. The worked examples put it to use:
 ## Ports: where the circuit meets the wire
 
 A design's `build_network()` returns a `Network` — ports, branches,
-sources. Ports come in three kinds:
+sources. Ports come in four kinds:
 
 - **`PortOnWire("feed")`** — a real port at a named wire of the
   geometry. This is the seam between the circuit world and the field
@@ -36,6 +36,19 @@ sources. Ports come in three kinds:
   multi-terminal element (a `BalancedLine`) hangs off a conductor's
   end. momwire-only: NEC-2 has no junction-node port, so the PyNEC
   backend rejects designs that use it (a declared engine-parity break).
+- **`PortOnWireFloating("feed")`** — a gap port with **both** terminals
+  exposed, addressed as `feed.p` and `feed.n`. An ordinary `PortOnWire` is
+  stamped node-to-datum: its second terminal is bonded to the common return,
+  so a branch can only reach one side of the gap. That is a stamping
+  convention, not physics — the field solver only ever knows gap voltage and
+  gap current. Use this when the two sides must go to *different* branches,
+  which is what a balanced feed actually needs. Unlike `PortAtEnd` it asks
+  nothing of the solver, so it works on every engine.
+
+  A single floating gap is a one-port, so its stamp is purely differential and
+  provides **no** common-mode path — give the network a CM return, or model
+  the common-mode path as its own gap port and let the two-port coupling carry
+  that physics.
 
 The source (`Driven(port="rig")`) goes wherever your measurement plane
 is. Put it at the antenna feed and you're modelling the antenna; put it

--- a/site/src/content/docs/concepts/station-modelling.md
+++ b/site/src/content/docs/concepts/station-modelling.md
@@ -103,14 +103,26 @@ balanced — `wire.sterba`'s risers run a common-mode residual of 0.05–0.15
 of the differential current. It is not the tool for asking "how much does
 my feedline radiate"; for feedline common-mode see `FloatingBalun`.
 
-**`zcomm` is a switch, not a knob.** The optional common-mode path exists
-because a real pair also provides end-to-end *conductor continuity*, which
-a purely differential stamp drops. In the Sterba curtain that continuity is
-load-bearing: without it the three-bay array loses 5 dB and its beam swings
-35° off broadside. But the *value* barely matters — sweeping `zcomm` across
-25 Ω to 3200 Ω moves the gain by 0.05 dB, because at the risers' λ/2 length
-the common-mode line is a repeater. Turn it on when the pair is physically
-continuous; don't try to tune it.
+**Whether `zcomm` matters depends on the topology it sits in.** The optional
+common-mode path exists because a real pair also provides end-to-end
+*conductor continuity*, which a purely differential stamp drops. Two regimes,
+and it is worth knowing which one you are in:
+
+- *Closed loop, λ/2 pairs* — the Sterba curtain. Continuity is load-bearing:
+  omit it and the three-bay array loses 5 dB with its beam swung 35° off
+  broadside. But the **value** carries no information: sweeping `zcomm` from
+  25 Ω to 3200 Ω moves the gain by 0.05 dB, because at λ/2 the common-mode
+  line is a repeater. Turn it on; don't try to tune it.
+- *Open feed tree* — `arrays.bowtie1x2_bl`'s corporate feed. There is no
+  common-mode return, so a CM path is a genuine extra shunt admittance and
+  its value matters a great deal: `zcomm = 100 Ω` drags the driving-point
+  resistance from 50 Ω to 5 Ω. The correct model is CM-**open** (leave
+  `zcomm` unset), which is what that design defaults to; large finite values
+  converge back to it.
+
+The rule of thumb: set `zcomm` when the pair's two conductors are part of a
+closed conduction path that the differential stamp would otherwise break.
+Leave it open when the pair simply ends.
 
 **It is momwire-only.** Practical `BalancedLine` designs attach through
 `PortAtEnd`, which NEC-2 has no equivalent for, so the PyNEC backend

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -32,8 +32,8 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
   riser as what it is — a differential two-conductor line — and its optional
   **common-mode path** (`zcomm`) restores the conduction path a purely
   differential stamp drops, so a **`build_network()`** TL Sterba now matches the
-  all-wire reference to a few tenths of a dB (**+15.4 dBi** at n=3), on both the
-  momwire and PyNEC backends. The result ships as the new **`wire.sterba_bl`**
+  all-wire reference to a few tenths of a dB (**+15.4 dBi** vs +15.2, at n=3
+  over average ground). The result ships as the new **`wire.sterba_bl`**
   catalog design. Also landing: **`PortAtEnd`** ports that attach a floating
   element at a conductor's very end (not just a mid-wire gap), stricter
   **network-authoring checks** that reject silent open-gap traps, and **one feed

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -71,6 +71,39 @@ class PortVirtual:
     name: str
 
 
+@dataclass(frozen=True)
+class PortOnWireFloating(PortOnWire):
+    """A `PortOnWire` whose BOTH terminals are exposed as circuit nodes.
+
+    An ordinary gap port is stamped node-to-datum: its second terminal is
+    bonded to the common return, so a branch can only connect to one side of
+    the gap. That is a *stamping convention*, not physics — the MoM only ever
+    knows gap voltage and gap current, so every delta gap is inherently a
+    floating two-terminal object. This port type stops imposing the bond.
+
+    The two terminals are addressed as dotted sub-nodes — ``"feed.p"`` and
+    ``"feed.n"`` for a port named ``feed`` — the same way `Instance` exposes a
+    composite's interior nodes (``"tuner.m"``). Branches reference those names;
+    the bare port name is not a node.
+
+    Use it to hang a genuinely balanced element off the structure: the two
+    terminals may go to *different* branches, which a node-to-datum port
+    cannot express. SimNEC models NEC feeds this way as a matter of course —
+    its `NECSource({w1,w2}, wire, percent)` takes two arbitrary circuit nets,
+    and its Ruthroff/Guanella balun sample runs the two sides of one antenna
+    gap into two different choke inductors.
+
+    Unlike `PortAtEnd` this needs nothing new from the solver — it changes only
+    how the shared reducer stamps the antenna's multiport Y — so it works on
+    every engine, PyNEC included.
+
+    NOTE a single floating gap is a 1-port: its Y has one degree of freedom, so
+    the stamp is purely differential and supplies NO common-mode path. Either
+    give the network a CM return, or model the CM path as its own gap port —
+    a 2-port Y couples the two gaps and carries that physics itself.
+    """
+
+
 # Deprecated alias — the pre-rename class name ("edge" meant a wire-graph
 # edge, i.e. one build_wires() tuple, but read as "wire end"). Kept so any
 # externally-authored design importing it keeps working.
@@ -108,7 +141,7 @@ class PortAtEnd:
             raise ValueError(f"PortAtEnd end must be 'p0' or 'p1', got {self.end!r}")
 
 
-Port = Union[PortOnWire, PortAtEnd, PortVirtual]
+Port = Union[PortOnWire, PortOnWireFloating, PortAtEnd, PortVirtual]
 
 
 @dataclass(frozen=True)
@@ -1063,11 +1096,25 @@ class Network:
                     f"port dict key {name!r} doesn't match Port.name {port.name!r}"
                 )
         port_names = set(self.ports)
+        # A floating gap port is addressed by its two terminals, never by the
+        # bare name: branches reference "<name>.p" / "<name>.n" (the dotted
+        # sub-node convention Instance already uses for composite interiors).
+        for name, port in self.ports.items():
+            if isinstance(port, PortOnWireFloating):
+                port_names.discard(name)
+                port_names.update((f"{name}.p", f"{name}.n"))
         for br in self.branches:
             for ref in _branch_port_refs(br):
                 if ref not in port_names:
                     raise ValueError(f"branch {br!r} references unknown port {ref!r}")
         for src in self.sources:
+            if isinstance(self.ports.get(src.port), PortOnWireFloating):
+                raise ValueError(
+                    f"source {src!r} drives floating gap port {src.port!r}: a "
+                    "floating gap is an attachment point, not a drive point "
+                    "(which terminal would be the reference?). Drive through "
+                    "the network instead, or use a plain PortOnWire."
+                )
             if src.port not in port_names:
                 raise ValueError(f"source {src!r} references unknown port")
         if not self.sources:

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -40,6 +40,7 @@ from .network import (
     FloatingBalun,
     Load,
     PortOnWire,
+    PortOnWireFloating,
     Shunt,
     Transformer,
     TwoPort,
@@ -340,8 +341,31 @@ class NetworkReducer:
 
     def __init__(self, network, port_to_idx, n_total_ports):
         self.network = network
-        self.port_to_idx = port_to_idx
+        self.port_to_idx = dict(port_to_idx)
         self.n_total_ports = n_total_ports
+
+        # Floating gap ports: the antenna Y row still lives at the port's
+        # existing index (that node becomes the "+" terminal), and the "-"
+        # terminal gets a freshly appended node instead of being bonded to the
+        # datum. Both are exposed as dotted sub-nodes, so every branch keeps
+        # resolving through port_to_idx unchanged.
+        self._floating = {}
+        next_node = n_total_ports
+        for name, port in network.ports.items():
+            if isinstance(port, PortOnWireFloating):
+                p_idx = self.port_to_idx[name]
+                self._floating[name] = (p_idx, next_node)
+                self.port_to_idx[f"{name}.p"] = p_idx
+                self.port_to_idx[f"{name}.n"] = next_node
+                next_node += 1
+        self.n_nodes = next_node
+        for src in network.sources:
+            if src.port in self._floating:
+                raise NotImplementedError(
+                    f"source on floating gap port {src.port!r}: drive it through "
+                    f"the network instead (a branch across {src.port}.p / "
+                    f"{src.port}.n), or use a plain PortOnWire"
+                )
 
         # 0-based driven port indices, with per-source kind: "v" for a
         # Driven voltage source (value = EMF), "i" for a DrivenCurrent
@@ -396,10 +420,23 @@ class NetworkReducer:
         plain KCL with zero injection (the floating I_ext = 0 condition).
         """
         omega = 2.0 * np.pi * C_LIGHT / wavelength
-        n = self.n_total_ports
+        n = self.n_nodes
         G = np.zeros((n, n), dtype=np.complex128)
         n_real = Y_real.shape[0]
-        G[:n_real, :n_real] = Y_real
+        if self._floating:
+            # Port incidence: gap row i drives node i positively, and a
+            # floating port also drives its "-" node negatively. The stamp is
+            # the congruence AᵀYA — the same [[1,-1],[-1,1]] structure
+            # BalancedLine uses, generalized over the whole multiport. With no
+            # floating ports A is the identity block and this reduces exactly
+            # to the historical G[:n_real, :n_real] = Y_real.
+            A = np.zeros((n_real, n), dtype=np.complex128)
+            A[np.arange(n_real), np.arange(n_real)] = 1.0
+            for p_idx, n_idx in self._floating.values():
+                A[p_idx, n_idx] = -1.0
+            G += A.T @ Y_real @ A
+        else:
+            G[:n_real, :n_real] = Y_real
 
         elements = []
         loads_by_node = {}

--- a/tests/test_balanced_line_physics.py
+++ b/tests/test_balanced_line_physics.py
@@ -51,6 +51,15 @@ to model*, against full-wave MoM solves:
    agrees to 2.4–4.3 % across feeder lengths spanning 83 − j118 to
    1158 + j1616 Ω. Covers the NON-λ/2 regime section 5's repeater argument
    does not, which is where ``wire.doublet_balanced_tuner`` operates.
+
+7. The counter-case that keeps 5 and 6 from being over-generalized: in an
+   OPEN feed tree (``arrays.bowtie1x2_bl``'s corporate feed) there is no
+   common-mode return, so a CM path is a real extra shunt admittance and its
+   VALUE matters — ``zcomm = 100 Ω`` drags the driving-point R from 50 Ω to
+   5 Ω. CM-open is the physical model there, and large ``zcomm`` converges
+   back to it monotonically. So the rule is topological, not universal: set
+   ``zcomm`` when the pair closes a conduction loop the differential stamp
+   would break; leave it open when the pair simply ends.
 """
 
 import importlib
@@ -519,3 +528,51 @@ def test_zcomm_value_is_immaterial_behind_a_floating_balun():
         for zc in (150.0, 300.0, 600.0, 1200.0, 2400.0)
     ]
     assert max(abs(z - zs[0]) for z in zs) < 1e-6, zs
+
+
+# ---------------------------------------------------------------------------
+# 7. The other topology: an OPEN feed tree, where zcomm's value does matter
+# ---------------------------------------------------------------------------
+#
+# Sections 5 and 6 both found zcomm's value immaterial — but both live in
+# topologies that make it so (a closed λ/2 loop; a floating-balun secondary
+# with no CM path at all). `arrays.bowtie1x2_bl` is the counter-case and the
+# reason the element ships zcomm as an explicit opt-in rather than a default:
+# its corporate feed is an open tree, so a common-mode path is a real extra
+# shunt admittance rather than a repeater, and the physical model is CM-OPEN.
+
+
+@pytest.mark.antenna_computation_check
+def test_zcomm_value_is_load_bearing_in_an_open_feed_tree():
+    """`arrays.bowtie1x2_bl` (zcomm off by default): adding a common-mode
+    path to a feed that has no common-mode return is not a refinement, it is
+    a modelling error, and the element does not hide it. Measured 2026-07-28,
+    driving-point Z:
+
+        zcomm off (open)   49.8 - 0.3j      <- the physical model
+        zcomm =  100       5.4 + 9.0j       <- 10x error in R
+        zcomm =  250      31.7 +16.7j
+        zcomm =  600      47.4 + 4.9j
+        zcomm = 1500      49.5 + 0.6j       <- converging back to open
+
+    The monotone return to the CM-open answer as zcomm grows is the
+    consistency check: `zcomm=None` really is the zcomm→∞ limit, not a
+    separate code path. Guards the docs' claim that the choice is topological
+    (closed conduction loop vs. a pair that simply ends), NOT a universal
+    "always turn it on"."""
+    from antennaknobs.designs.arrays.bowtie1x2_bl import Builder
+
+    def zin(zc):
+        b = Builder(dict(Builder.default_params, zcomm=zc))
+        return complex(MomwireEngine(b, ground=None).impedance()[0])
+
+    z_open = zin(0.0)  # the design default: CM path absent
+    assert abs(z_open.real - 50.0) < 5.0 and abs(z_open.imag) < 5.0
+
+    # a low-impedance CM shunt is a gross, visible error — not a nudge
+    assert abs(zin(100.0) - z_open) / abs(z_open) > 0.5
+
+    # ...and large zcomm converges monotonically back to the open case
+    devs = [abs(zin(zc) - z_open) / abs(z_open) for zc in (250.0, 600.0, 1500.0)]
+    assert devs[0] > devs[1] > devs[2]
+    assert devs[2] < 0.05

--- a/tests/test_balanced_line_physics.py
+++ b/tests/test_balanced_line_physics.py
@@ -35,8 +35,25 @@ to model*, against full-wave MoM solves:
    insensitive to the ``zcomm`` value, which the test also asserts.
    (History: #576 first found the attachment blocker, solved by #579's end
    ports; then the differential-only residual, solved by ``zcomm``.)
+
+5. The same end-to-end claim at the *catalog* configuration, n_cells=3,
+   where it is far sharper than at one bay: omitting the CM path costs 5 dB
+   and swings the beam 35° off broadside (vs −0.9 dB and still broadside at
+   n=1). Pins both published gain figures over average ground (+15.2 dBi
+   all-wire, +15.4 dBi BL-riser), and establishes that ``zcomm`` is a
+   *topological switch* rather than a tuning knob: a 128× sweep of its value
+   (25 Ω → 3200 Ω) moves the gain by 0.05 dB, while removing it costs 5 dB.
+
+6. Element SUBSTITUTION as a two-port — #576's original acceptance criterion,
+   stated directly. One antenna built twice, once with a physical open-wire
+   feeder and once with that feeder replaced by the element (``zdiff`` from
+   the analytic geometry, not fitted): the complex driving-point impedance
+   agrees to 2.4–4.3 % across feeder lengths spanning 83 − j118 to
+   1158 + j1616 Ω. Covers the NON-λ/2 regime section 5's repeater argument
+   does not, which is where ``wire.doublet_balanced_tuner`` operates.
 """
 
+import importlib
 import math
 from types import MappingProxyType
 
@@ -44,7 +61,16 @@ import numpy as np
 import pytest
 
 from antennaknobs import AntennaBuilder
-from antennaknobs.network import Driven, Network, PortOnWire, Wire
+from antennaknobs.network import (
+    BalancedLine,
+    Driven,
+    FloatingBalun,
+    Network,
+    PortAtEnd,
+    PortOnWire,
+    PortVirtual,
+    Wire,
+)
 from antennaknobs.engines.momwire import MomwireEngine
 
 C_LIGHT = 299.792458  # m·MHz
@@ -250,8 +276,6 @@ def test_bl_riser_curtain_reproduces_wire_sterba_with_zcomm():
     it. At the risers' λ/2 length the CM line is a repeater, so the result
     must be insensitive to the zcomm value — the reason no zdiff/zcomm
     tuning is needed or possible."""
-    import importlib
-
     ster = importlib.import_module("antennaknobs.designs.wire.sterba").Builder
     bp = ster(dict(ster.default_params, n_cells=1))
     gain_phys, az_phys = _peak(MomwireEngine(bp, ground=None))
@@ -265,3 +289,233 @@ def test_bl_riser_curtain_reproduces_wire_sterba_with_zcomm():
     b400 = _catalog_curtain(1, zcomm=400.0)
     gain_400, _az = _peak(MomwireEngine(b400, ground=None))
     assert abs(gain_400 - gain_100) < 0.1  # λ/2 repeater: zcomm-insensitive
+
+
+# ---------------------------------------------------------------------------
+# 5. The catalog configuration: n_cells=3, where the CM path is load-bearing
+# ---------------------------------------------------------------------------
+#
+# Section 4 validates one bay, which is the *weakest* form of the claim: at
+# n=1 the differential-only curtain is only −0.9 dB and still broadside, so
+# the CM path looks like a refinement. The catalog default is n_cells=3, and
+# there the same omission costs −5 dB AND swings the beam 35° off broadside.
+# These tests pin the shipped configuration and the documented gain figures.
+
+
+def _peak_over(builder, ground):
+    return _peak(MomwireEngine(builder, ground=ground))
+
+
+AVG_GROUND = ("finite-fast", 13.0, 0.005)
+
+
+@pytest.mark.antenna_computation_check
+def test_bl_riser_curtain_matches_wire_sterba_at_catalog_n_cells():
+    """Free space, n_cells=3 (the catalog default): the BL-riser curtain
+    tracks the all-wire wire.sterba to within 0.5 dB and fires broadside.
+
+    This is the load-bearing end-to-end case. Unlike the one-bay test, the
+    differential-only build fails here *unmistakably* — the per-boundary
+    span-phase fanout accumulates over three bays into a beam that is both
+    ~5 dB down and pointed 35° off broadside. Measured 2026-07-28:
+
+        wire.sterba (all wire)   10.47 dBi  az 180
+        sterba_bl  (zcomm on)    10.61 dBi  az 180   (+0.14)
+        sterba_bl  (zcomm off)    5.52 dBi  az  35   (-4.95)
+    """
+    ster = importlib.import_module("antennaknobs.designs.wire.sterba").Builder
+    bp = ster(dict(ster.default_params, n_cells=3))
+    gain_phys, az_phys = _peak_over(bp, None)
+    assert min(az_phys % 180.0, 180.0 - az_phys % 180.0) <= 10.0
+
+    gain_bl, az_bl = _peak_over(_catalog_curtain(3), None)
+    assert min(az_bl % 180.0, 180.0 - az_bl % 180.0) <= 10.0
+    assert abs(gain_bl - gain_phys) < 0.5
+
+    # differential-only: the failure is large and directional, not marginal
+    gain_dm, az_dm = _peak_over(_catalog_curtain(3, zcomm=0.0), None)
+    assert gain_phys - gain_dm > 3.0
+    assert min(az_dm % 180.0, 180.0 - az_dm % 180.0) > 20.0
+
+
+@pytest.mark.antenna_computation_check
+def test_catalog_curtain_gain_over_average_ground():
+    """Over average ground (eps_r 13, sigma 0.005) at n_cells=3 — the
+    configuration the documentation quotes. Pins both published figures:
+    wire.sterba at +15.2 dBi (issue #576's acceptance target) and
+    wire.sterba_bl at +15.4 dBi, both broadside. Measured 2026-07-28:
+    15.22 and 15.39 dBi."""
+    ster = importlib.import_module("antennaknobs.designs.wire.sterba").Builder
+    gain_phys, az_phys = _peak_over(
+        ster(dict(ster.default_params, n_cells=3)), AVG_GROUND
+    )
+    gain_bl, az_bl = _peak_over(_catalog_curtain(3), AVG_GROUND)
+
+    assert abs(gain_phys - 15.2) < 0.3, gain_phys
+    assert abs(gain_bl - 15.4) < 0.3, gain_bl
+    assert abs(gain_bl - gain_phys) < 0.5
+    for az in (az_phys, az_bl):
+        assert min(az % 180.0, 180.0 - az % 180.0) <= 10.0
+
+
+@pytest.mark.antenna_computation_check
+def test_zcomm_is_a_topological_switch_not_a_tuning_knob():
+    """The CM path's *presence* is load-bearing; its *value* is not.
+
+    At the risers' λ/2 length the common-mode line is a repeater, so the
+    curtain is insensitive to zcomm across a 128× range — 25 Ω to 3200 Ω
+    spans 0.05 dB (measured 2026-07-28: 10.62 / 10.61 / 10.61 / 10.61 /
+    10.61 / 10.62 / 10.63 / 10.66 dBi, all broadside). Removing it entirely
+    costs 5 dB (previous test).
+
+    This is why `zcomm` needs no calibration and cannot be fitted: it is a
+    switch for conductor continuity, not a characteristic impedance the user
+    is expected to get right. A future geometry-derived zcomm (#596) must
+    reproduce this insensitivity, not a particular number."""
+    gains = []
+    for zc in (25.0, 100.0, 400.0, 1600.0, 3200.0):
+        g, az = _peak_over(_catalog_curtain(3, zcomm=zc), None)
+        assert min(az % 180.0, 180.0 - az % 180.0) <= 10.0
+        gains.append(g)
+    assert max(gains) - min(gains) < 0.25, gains
+
+
+# ---------------------------------------------------------------------------
+# 6. Element substitution: a real feeder replaced by the element, as a 2-port
+# ---------------------------------------------------------------------------
+#
+# Sections 1-2 characterize the pair as a line (Z0, electrical length) and
+# sections 4-5 check an end-to-end pattern. This is the direct statement of
+# #576's original criterion in between: build one antenna twice — once with
+# the feeder as PHYSICAL MoM wires, once with that same feeder replaced by a
+# `BalancedLine` element — and compare the complex driving-point impedance.
+#
+# It generalizes past the Sterba: the feeder here is a plain open-wire drop
+# at lengths that are NOT λ/2, which is the regime `wire.doublet_balanced_
+# tuner` lives in and the one section 5's repeater argument does not cover.
+
+_ARM_FACTOR = 0.25
+_SUBST_BASE = {
+    "design_freq": FREQ,
+    "freq": FREQ,
+    "spacing": 0.004 * WL,
+    "arm_factor": _ARM_FACTOR,
+    "feed_len_wl": 0.30,
+}
+
+
+class _PhysFedDoublet(AntennaBuilder):
+    """Doublet + open-wire drop, all as physical wires, driven at a bridge
+    gap across the bottom of the pair (a genuinely floating differential
+    drive: the source loop closes through real metal)."""
+
+    default_params = MappingProxyType(_SUBST_BASE)
+
+    def build_wires(self):
+        s, arm, L = self.spacing, self.arm_factor * WL, self.feed_len_wl * WL
+        n = min(max(self.segs_for(L, 0.25 * WL), round(L / s)), 151)
+        xa, xb = -0.2 * s, 0.2 * s
+        return [
+            Wire((0.0, -s / 2, L), (-arm, -s / 2, L)),
+            Wire((0.0, +s / 2, L), (+arm, +s / 2, L)),
+            Wire((0.0, -s / 2, L), (0.0, -s / 2, 0.0), n_seg=n),
+            Wire((0.0, +s / 2, L), (0.0, +s / 2, 0.0), n_seg=n),
+            Wire((0.0, -s / 2, 0.0), (0.0, xa, 0.0)),
+            Wire((0.0, xa, 0.0), (0.0, xb, 0.0), name="feed"),
+            Wire((0.0, xb, 0.0), (0.0, +s / 2, 0.0)),
+        ]
+
+    def build_network(self):
+        return Network(
+            ports={"feed": PortOnWire("feed", distributed=True)},
+            branches=[],
+            sources=[Driven(port="feed")],
+        )
+
+
+class _ElementFedDoublet(AntennaBuilder):
+    """The SAME doublet, feeder deleted from the geometry and replaced by a
+    `BalancedLine` on `PortAtEnd` ports. Driven through an ideal 1:1
+    `FloatingBalun`, the circuit equivalent of the physical build's floating
+    bridge-gap drive."""
+
+    default_params = MappingProxyType(dict(_SUBST_BASE, zcomm=600.0))
+
+    def build_wires(self):
+        s, arm, L = self.spacing, self.arm_factor * WL, self.feed_len_wl * WL
+        return [
+            Wire((0.0, -s / 2, L), (-arm, -s / 2, L), name="armL"),
+            Wire((0.0, +s / 2, L), (+arm, +s / 2, L), name="armR"),
+        ]
+
+    def build_network(self):
+        s, L = self.spacing, self.feed_len_wl * WL
+        return Network(
+            ports={
+                "ta": PortAtEnd("armL", end="p0"),
+                "tb": PortAtEnd("armR", end="p0"),
+                "rig": PortVirtual("rig"),
+                "bL": PortVirtual("bL"),
+                "bR": PortVirtual("bR"),
+            },
+            branches=[
+                FloatingBalun(primary="rig", a="bL", b="bR", n=1.0),
+                BalancedLine(
+                    a1="bL",
+                    a2="bR",
+                    b1="ta",
+                    b2="tb",
+                    zdiff=analytic_zdiff(s),
+                    length=L,
+                    vf=1.0,
+                    zcomm=self.zcomm or None,
+                ),
+            ],
+            sources=[Driven(port="rig")],
+        )
+
+
+def _subst_zin(cls, **over):
+    b = cls(dict(cls.default_params, **over))
+    return complex(MomwireEngine(b, ground=None).impedance()[0])
+
+
+@pytest.mark.antenna_computation_check
+def test_element_reproduces_a_physical_feeder_as_a_two_port():
+    """Replacing a physical open-wire feeder with the element reproduces the
+    complex driving-point impedance to within 6 %, at feeder lengths chosen
+    to span wildly different impedance regimes — the element is not being
+    checked at one convenient operating point. `zdiff` is the ANALYTIC
+    value from the geometry, not a fitted one. Measured 2026-07-28:
+
+        len     physical            element           deviation
+        0.20 λ  1158.2 +1615.8j     1079.0 +1583.4j     4.3 %
+        0.30 λ   445.2 -1075.6j      467.2 -1100.5j     2.9 %
+        0.45 λ    82.6  -118.4j       83.1  -121.9j     2.4 %
+
+    The residual is the physical pair's own radiation and end effects, which
+    a differential-only element cannot represent by construction — i.e. this
+    bounds the element's achievable fidelity, it is not a bug to drive out.
+    """
+    for flw, tol in ((0.20, 0.06), (0.30, 0.06), (0.45, 0.06)):
+        zp = _subst_zin(_PhysFedDoublet, feed_len_wl=flw)
+        ze = _subst_zin(_ElementFedDoublet, feed_len_wl=flw)
+        assert abs(ze - zp) / abs(zp) < tol, (flw, zp, ze)
+
+
+@pytest.mark.antenna_computation_check
+def test_zcomm_value_is_immaterial_behind_a_floating_balun():
+    """Third independent confirmation that `zcomm` carries no information
+    (after section 5's λ/2-repeater sweep): behind a floating balun secondary
+    there is no common-mode circuit path at all, so the CM line carries no
+    current whatever its impedance — a 16× sweep is bit-identical.
+
+    `zcomm` is required here only for MNA determinacy: `Network` rejects a
+    CM-open BalancedLine feeding a floating-balun secondary as structurally
+    singular. That is the whole reason `wire.doublet_balanced_tuner` sets a
+    `line_zcomm` at all, and why its particular value needs no defending."""
+    zs = [
+        _subst_zin(_ElementFedDoublet, zcomm=zc)
+        for zc in (150.0, 300.0, 600.0, 1200.0, 2400.0)
+    ]
+    assert max(abs(z - zs[0]) for z in zs) < 1e-6, zs

--- a/tests/test_balanced_line_physics.py
+++ b/tests/test_balanced_line_physics.py
@@ -60,6 +60,17 @@ to model*, against full-wave MoM solves:
    back to it monotonically. So the rule is topological, not universal: set
    ``zcomm`` when the pair closes a conduction loop the differential stamp
    would break; leave it open when the pair simply ends.
+
+8. Why ``PortAtEnd`` exists at all — the negative result. The obvious
+   engine-portable substitute (hang a short stub off the conductor end and
+   centre-tap it with an ordinary gap port, then shrink it) does NOT converge
+   to a junction-node port: it converges to an OPEN, R collapsing to ~0.01 Ω.
+   The stub beyond the gap is a dead end, so the port can only drive
+   displacement current into a capacitance that vanishes with the stub. The
+   contrast with momwire's own ``_bridged_z`` oracle — where the same limit
+   converges to 1.5 % — is where the SECOND terminal lands: a live conductor
+   converges, a dead stub opens. A gap always needs metal on both sides,
+   which is exactly what a conductor end does not have.
 """
 
 import importlib
@@ -576,3 +587,95 @@ def test_zcomm_value_is_load_bearing_in_an_open_feed_tree():
     devs = [abs(zin(zc) - z_open) / abs(z_open) for zc in (250.0, 600.0, 1500.0)]
     assert devs[0] > devs[1] > devs[2]
     assert devs[2] < 0.05
+
+
+# ---------------------------------------------------------------------------
+# 8. Why PortAtEnd exists: the shrinking-nub construction does NOT converge
+# ---------------------------------------------------------------------------
+#
+# The natural objection to a momwire-only junction-node port is: "attach a
+# tiny wire at the conductor end, centre-tap it, and shrink it — in the limit
+# that IS an end port, and it works on every engine." It is a good objection,
+# and it is wrong, for a reason worth recording rather than rediscovering.
+
+
+class _NubFedDoublet(_ElementFedDoublet):
+    """`_ElementFedDoublet` with each `PortAtEnd` replaced by a short stub at
+    the arm end, centre-tapped by an ordinary `PortOnWire` gap."""
+
+    default_params = MappingProxyType(dict(_SUBST_BASE, zcomm=600.0, nub=0.1))
+
+    def build_wires(self):
+        s, arm, L = self.spacing, self.arm_factor * WL, self.feed_len_wl * WL
+        nub = self.nub
+        return [
+            # arms unnamed: the ports now live on the stubs, not the arm ends
+            Wire((0.0, -s / 2, L), (-arm, -s / 2, L)),
+            Wire((0.0, +s / 2, L), (+arm, +s / 2, L)),
+            Wire((0.0, -s / 2, L), (nub, -s / 2, L), name="nubL", n_seg=3),
+            Wire((0.0, +s / 2, L), (nub, +s / 2, L), name="nubR", n_seg=3),
+        ]
+
+    def build_network(self):
+        s, L = self.spacing, self.feed_len_wl * WL
+        return Network(
+            ports={
+                "nubL": PortOnWire("nubL"),
+                "nubR": PortOnWire("nubR"),
+                "rig": PortVirtual("rig"),
+                "bL": PortVirtual("bL"),
+                "bR": PortVirtual("bR"),
+            },
+            branches=[
+                FloatingBalun(primary="rig", a="bL", b="bR", n=1.0),
+                BalancedLine(
+                    a1="bL",
+                    a2="bR",
+                    b1="nubL",
+                    b2="nubR",
+                    zdiff=analytic_zdiff(s),
+                    length=L,
+                    vf=1.0,
+                    zcomm=self.zcomm,
+                ),
+            ],
+            sources=[Driven(port="rig")],
+        )
+
+
+@pytest.mark.antenna_computation_check
+def test_shrinking_nub_does_not_converge_to_an_end_port():
+    """A centre-tapped stub at a conductor end converges to an OPEN, not to
+    a junction-node port — so `PortAtEnd` cannot be replaced by it.
+
+    The stub beyond the gap is a dead end: current must vanish at its tip, so
+    the only current the port can drive is displacement current charging the
+    stub, whose capacitance shrinks with its length. The port series
+    impedance runs to -j*infinity. Measured 2026-07-29 (reference
+    PortAtEnd: 467.2 - 1100.5j):
+
+        nub = 1.00 m   13.32 + 470.7j
+        nub = 0.30 m    0.56 + 175.7j
+        nub = 0.10 m    0.06 + 193.5j
+        nub = 0.03 m    0.01 + 180.2j
+        nub = 0.01 m    0.01 + 173.8j
+
+    R collapses toward zero: no power reaches the antenna at all. Contrast
+    momwire's own `_bridged_z` oracle, where the same shrinking limit DOES
+    converge (<1.5%) — there both terminals land on conductors that carry
+    current away. The discriminator is where the second terminal lands: a
+    live conductor (converges) or a dead stub (opens). A gap construction
+    always needs metal on both sides, which is precisely what a conductor
+    END does not have."""
+    z_ref = _subst_zin(_ElementFedDoublet)
+    assert z_ref.real > 100.0  # the end port genuinely couples
+
+    r_vals = []
+    for nub in (1.0, 0.3, 0.1, 0.03, 0.01):
+        z = _subst_zin(_NubFedDoublet, nub=nub)
+        r_vals.append(z.real)
+        # never approaches the end-port answer, at any stub size
+        assert abs(z - z_ref) / abs(z_ref) > 0.5, (nub, z, z_ref)
+    # ...and the coupling collapses as the stub shrinks: the port opens
+    assert r_vals[0] > 1.0
+    assert r_vals[-1] < 0.1

--- a/tests/test_port_floating.py
+++ b/tests/test_port_floating.py
@@ -1,0 +1,152 @@
+"""`PortOnWireFloating` — a gap port with BOTH terminals exposed as nodes.
+
+An ordinary `PortOnWire` is stamped node-to-datum: its second terminal is
+bonded to the common return (`network_reduce`'s "every port's second terminal
+is bonded to it"). That is a stamping convention, not physics — the MoM only
+ever knows gap voltage and gap current. This port type drops the bond and
+exposes both sides as dotted sub-nodes `"<name>.p"` / `"<name>.n"`.
+
+The load-bearing property is that it needs nothing from the SOLVER — only the
+shared reducer's stamp changes, from `G[:n,:n] = Y` to the congruence `AᵀYA`.
+So unlike `PortAtEnd` it works on every engine, which the equivalence test
+below checks on momwire and PyNEC alike.
+
+Prior art: SimNEC's `NECSource({w1,w2}, wire, percent)` takes two arbitrary
+circuit nets; its Ruthroff/Guanella balun sample runs the two sides of one
+antenna gap into two *different* choke inductors — the case a node-to-datum
+port cannot express at all.
+"""
+
+from types import MappingProxyType
+
+import pytest
+
+from antennaknobs import AntennaBuilder
+from antennaknobs.engines.momwire import MomwireEngine
+from antennaknobs.engines.pynec import PyNECEngine
+from antennaknobs.network import (
+    TL,
+    Driven,
+    Network,
+    PortOnWire,
+    PortOnWireFloating,
+    PortVirtual,
+    Shunt,
+    Wire,
+)
+
+WL = 299.792458 / 14.0
+
+
+class _Doublet(AntennaBuilder):
+    """Half-wave doublet fed through 7 m of 450 Ω line. ``floating`` swaps the
+    gap port between the two kinds; the floating build additionally shorts its
+    "-" terminal to the datum, which must make the two IDENTICAL."""
+
+    default_params = MappingProxyType(
+        {"design_freq": 14.0, "freq": 14.0, "floating": 0}
+    )
+
+    def build_wires(self):
+        a = 0.25 * WL
+        return [
+            Wire((0, -a, 10), (0, -0.05, 10)),
+            Wire((0, -0.05, 10), (0, 0.05, 10), name="feed"),
+            Wire((0, 0.05, 10), (0, a, 10)),
+        ]
+
+    def build_network(self):
+        fl = bool(self.floating)
+        cls = PortOnWireFloating if fl else PortOnWire
+        branches = [TL(a="rig", b="feed.p" if fl else "feed", z0=450.0, length=7.0)]
+        if fl:
+            branches.append(Shunt(port="feed.n", l=0.0))  # ideal short to datum
+        return Network(
+            ports={"feed": cls("feed"), "rig": PortVirtual("rig")},
+            branches=branches,
+            sources=[Driven(port="rig")],
+        )
+
+
+def _z(engine_cls, floating):
+    b = _Doublet(dict(_Doublet.default_params, floating=int(floating)))
+    return complex(engine_cls(b, ground=None).impedance()[0])
+
+
+@pytest.mark.parametrize(
+    "engine_cls", [MomwireEngine, PyNECEngine], ids=["momwire", "pynec"]
+)
+def test_floating_port_with_shorted_return_equals_grounded_port(engine_cls):
+    """The reducer's correctness oracle: bonding the floating port's "-"
+    terminal to the datum reproduces the node-to-datum stamp EXACTLY, because
+    the congruence AᵀYA degenerates to the historical `G[:n,:n] = Y` when the
+    "-" node is the datum. Measured 2026-07-29 to ~1e-13 on both engines
+    (momwire 239.147 - 617.142j, PyNEC 229.745 - 632.761j).
+
+    Running on PyNEC is the point: this port type asks nothing of the solver,
+    so it carries none of `PortAtEnd`'s engine-parity break."""
+    z_grounded = _z(engine_cls, False)
+    z_floating = _z(engine_cls, True)
+    assert abs(z_floating - z_grounded) < 1e-9 * abs(z_grounded)
+
+
+class _SplitTerminals(_Doublet):
+    """The case a node-to-datum port cannot express at all: the gap's two
+    terminals go to two DIFFERENT branches (SimNEC's Guanella sample runs them
+    into two separate choke inductors). Here each side gets its own line back
+    to a common rig node, which is what makes the network CM-determinate."""
+
+    def build_network(self):
+        return Network(
+            ports={
+                "feed": PortOnWireFloating("feed"),
+                "rig": PortVirtual("rig"),
+            },
+            branches=[
+                TL(a="rig", b="feed.p", z0=450.0, length=7.0),
+                TL(a="rig", b="feed.n", z0=450.0, length=7.2),
+            ],
+            sources=[Driven(port="rig")],
+        )
+
+
+def test_two_terminals_may_drive_different_branches():
+    z = complex(MomwireEngine(_SplitTerminals(), ground=None).impedance()[0])
+    assert abs(z) > 0 and z.real == z.real  # solved, finite, not NaN
+
+
+def test_bare_port_name_is_not_a_node():
+    """Addressing a floating port by its bare name is an authoring error — it
+    has two terminals and no single node."""
+
+    class Bad(_Doublet):
+        def build_network(self):
+            return Network(
+                ports={
+                    "feed": PortOnWireFloating("feed"),
+                    "rig": PortVirtual("rig"),
+                },
+                branches=[TL(a="rig", b="feed", z0=450.0, length=7.0)],
+                sources=[Driven(port="rig")],
+            )
+
+    with pytest.raises(ValueError, match="unknown port"):
+        Bad().build_network()
+
+
+def test_driving_a_floating_port_is_rejected():
+    """v1 scope: a floating gap is an attachment point, not a drive point —
+    driving it is ambiguous (which terminal is the reference?). Drive through
+    the network instead, as SimNEC's samples do. Caught at authoring time by
+    `Network`, so it never reaches an engine."""
+
+    class Bad(_Doublet):
+        def build_network(self):
+            return Network(
+                ports={"feed": PortOnWireFloating("feed")},
+                branches=[],
+                sources=[Driven(port="feed")],
+            )
+
+    with pytest.raises(ValueError, match="attachment point, not a drive point"):
+        Bad().build_network()


### PR DESCRIPTION
## Summary

Started as "broaden the BalancedLine physics evidence and stop the docs
overselling it", and ended up adding a new port primitive after the evidence
showed the current one is narrower than advertised.

- **Physics evidence** (`tests/test_balanced_line_physics.py`, 7 → 11 tests,
  sections 5–8). The end-to-end claim was validated at `n_cells=1` only, while
  the docs quoted `n_cells=3` figures. Adds: the catalog configuration in free
  space (omitting the CM path costs **4.95 dB** *and* swings the beam 35° off
  broadside, vs −0.9 dB and still broadside at one bay); over average ground,
  pinning both published gains (+15.22 / +15.39 dBi) that were asserted
  nowhere; a 128× `zcomm` sweep (25→3200 Ω moves gain 0.05 dB); and **element
  substitution as a two-port** — #576's original acceptance criterion, which
  had only ever been discharged as a 1-port Z0 characterization. One antenna
  built twice, feeder as physical MoM wires vs as the element with `zdiff`
  from analytic geometry (not fitted): complex Zin agrees to **2.4–4.3 %**
  across lengths spanning 83 − j118 to 1158 + j1616 Ω.

- **`zcomm` is topological, not universal.** `arrays.bowtie1x2_bl` — the third
  BalancedLine design and the only one with no physics coverage — is the
  counter-case: its corporate feed is an open tree with no common-mode return,
  so a CM path is a real shunt and its *value* matters (`zcomm=100` drags R
  from 50 Ω to 5 Ω), converging back to CM-open as `zcomm→∞`. This corrects
  guidance added earlier in this same branch.

- **Why `PortAtEnd` exists** — the negative result, recorded so it isn't
  rediscovered. The obvious engine-portable substitute (stub at the conductor
  end, centre-tapped, shrunk) converges to an **OPEN**, R collapsing to
  ~0.01 Ω. The discriminator against momwire's `_bridged_z` oracle (which
  *does* converge, to 1.5 %) is where the second terminal lands: a live
  conductor, or a dead stub.

- **New: `PortOnWireFloating`** — a gap port with both terminals exposed as
  `feed.p` / `feed.n`. An ordinary `PortOnWire` is stamped node-to-datum, which
  is a *stamping convention, not physics* — the MoM only knows gap voltage and
  gap current. Small because it subclasses `PortOnWire` (no engine changes) and
  registers both terminals in `port_to_idx` (no per-branch changes); the stamp
  becomes the congruence `AᵀYA`, the same `[[1,-1],[-1,1]]` structure
  `BalancedLine` already used. **Works on PyNEC**, so unlike `PortAtEnd` it
  carries no engine-parity break. Prior art is SimNEC, whose
  `NECSource({w1,w2}, wire, percent)` takes two arbitrary circuit nets — its
  Ruthroff/Guanella sample runs the two sides of one antenna gap into two
  *different* choke inductors.

- **Docs**: `station-modelling.md` gains a "What `BalancedLine` is good for"
  section (tight-coupling envelope, differential-only contract, the two `zcomm`
  regimes, momwire-only restriction) and the new port type. `index.mdx`: the
  release box claimed the TL Sterba matches "on both the momwire and PyNEC
  backends" — **that is false**, `wire.sterba_bl` uses `PortAtEnd` and
  `PyNECEngine` rejects it at construction. Removed, and the +15.4 dBi figure
  now says what it is measured over.

## Notes for review

- All measured values are recorded in test docstrings with their date.
- The new physics tests are `antenna_computation_check` (main-only lane); the
  whole file runs in ~9 s.
- Scope call: a floating gap is an attachment point, not a drive point
  (rejected at authoring time). A *single* floating gap is a one-port, so its
  stamp is purely differential and supplies no common-mode path — the
  multi-gap case, where the Y coupling carries that physics, is future work.

## Test plan

- [x] `pytest tests/ -m "not heavy_mesh"` → **2862 passed, 2 skipped**
- [x] `tests/test_balanced_line_physics.py` → 11 passed (~9 s)
- [x] `tests/test_port_floating.py` → 5 passed, incl. the floating-vs-grounded
      equivalence oracle on **both** momwire and PyNEC (~1e-13)
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
