### PR TITLE
Fix silent far-field bug in PortOnWireFloating; re-author doublet_balanced_tuner as one wire + a centre port

### DIFF
--- a/src/antennaknobs/designs/wire/doublet_balanced_tuner.py
+++ b/src/antennaknobs/designs/wire/doublet_balanced_tuner.py
@@ -15,26 +15,32 @@ close before #589 — a balanced feedline into a balanced tuner into a
 Signal path, the Palstar BT1500A "double roller balanced tuner" idiom:
 
     rig (50 Ω) → FloatingBalun 1:1 → [L/2 roller in each leg] → diff cap
-                → open-wire BalancedLine → doublet arm ends (PortAtEnd)
+                → open-wire BalancedLine → doublet centre port
 
-Only the balun's primary touches the datum. The doublet is authored WITHOUT a
-center feed-bridge, so its two inner arm ends are free conductor ENDS that
-`PortAtEnd` grabs (issue #579), and one `BalancedLine` carries the differential
-feed up to them. The line's ``line_zcomm`` (issue #576) is the common-mode
-return that lets the floating tuner section reference ground through the
-antenna — without it the MNA is singular, and the design says so at build time.
+Only the balun's primary touches the datum. The doublet is ONE wire carrying a
+`PortOnWireFloating` at its centre: an ordinary delta gap (a point
+discontinuity, no physical extent), but with BOTH its terminals exposed as
+circuit nodes, so the `BalancedLine`'s two conductors attach to the two sides
+of it. The line is an ideal element — its conductor spacing lives in
+``line_zdiff``, not in the geometry — so nothing here has a second length
+scale, and the whole antenna meshes at one uniform density. The line's
+``line_zcomm`` (issue #576) is the common-mode return that lets the floating
+tuner section reference ground through the antenna — without it the MNA is
+singular, and the design says so at build time.
 
 The roller inductance ``tuner_l_uH`` and differential capacitance
 ``tuner_c_pF`` are the two tuning knobs; ``tuner_ql`` is the roller-coil Q (the
 tuner's dominant loss, so the power budget shows where the watts go). The stock
-values land the ~0.72 λ doublet's ladder-line feedpoint on ~50 Ω at the rig
-(SWR ≈ 1.04) at 14.1 MHz — retune them (and the line length) for another band,
+values land the ~0.72 λ doublet's ladder-line feedpoint on 50 Ω at the rig
+(SWR ≈ 1.00 momwire, 1.03 PyNEC) at 14.1 MHz — retune them (and the line length) for another band,
 the way a real balanced tuner is worked.
 
-Engine support: **momwire only** — `PortAtEnd` resolves to a junction-node port
-(momwire#172) that NEC-2 has no card for, so `PyNECEngine` rejects the design.
-The balanced tuner itself is engine-agnostic; the end-port feed is the
-momwire-only piece, as in `wire.sterba_bl` / `arrays.bowtie1x2_bl`."""
+Engine support: **every engine**. A floating port changes only how the shared
+reducer stamps the antenna's multiport Y, never what the solver is asked for,
+so this runs on PyNEC as well as momwire. Both converge on refinement and agree
+to 0.2 % by N=641 (the delta gap is smeared over one segment, so the answer
+depends on segment length until refined — the usual delta-gap convergence, not
+a modelling choice)."""
 
 from types import MappingProxyType
 
@@ -44,7 +50,7 @@ from antennaknobs.network import (
     Driven,
     Instance,
     Network,
-    PortAtEnd,
+    PortOnWireFloating,
     PortVirtual,
     Wire,
 )
@@ -73,10 +79,10 @@ class Builder(AntennaBuilder):
             # be present (0 → None → a singular, rejected common mode).
             "line_zcomm": 250.0,
             # Balanced L-network tuner knobs (roller L split into both legs,
-            # differential resonating C), tuned to ~50 Ω at the rig (SWR ≈ 1.04
+            # differential resonating C), tuned to 50 Ω at the rig (SWR ≈ 1.00
             # at 14.1 MHz on the stock geometry).
-            "tuner_l_uH": 2.8,
-            "tuner_c_pF": 74.0,
+            "tuner_l_uH": 3.350,
+            "tuner_c_pF": 60.43,
             # Roller-coil Q (issue #298) — defaults high (near-ideal); the
             # power budget itemizes the coil loss so you can watch it grow as
             # you retune a shorter wire.
@@ -109,15 +115,11 @@ class Builder(AntennaBuilder):
         wl = self.design_wavelength
         arm = 0.5 * self.length_factor * wl
         z = self.height_factor * wl
-        gap = 0.02 * wl  # feed-gap half-width, so the arm ends are free ENDS
 
-        # Two collinear horizontal arms along y, center gap at y = 0. Name only
-        # the two inner arm ends (issue #578: a named wire must be referenced —
-        # both are, by PortAtEnd).
-        return [
-            Wire((0.0, -gap, z), (0.0, -arm, z), name="armL"),
-            Wire((0.0, gap, z), (0.0, arm, z), name="armR"),
-        ]
+        # One horizontal wire along y. The feed is a floating port at its
+        # centre — a delta gap has no physical extent, so there is no bridge
+        # and no second length scale to mesh around.
+        return self.auto_mesh([Wire((0.0, -arm, z), (0.0, arm, z), name="feed")])
 
     # ---- feed network ---------------------------------------------------
     def build_network(self):
@@ -126,9 +128,8 @@ class Builder(AntennaBuilder):
         zc = self.line_zcomm or None
         return Network(
             ports={
-                # doublet inner arm ends → the balanced line's top
-                "ta": PortAtEnd("armL", end="p0"),
-                "tb": PortAtEnd("armR", end="p0"),
+                # the doublet's centre port, BOTH terminals exposed
+                "feed": PortOnWireFloating("feed"),
                 "rig": PortVirtual("rig"),
                 "liL": PortVirtual("liL"),  # tuner output → line bottom
                 "liR": PortVirtual("liR"),
@@ -149,8 +150,8 @@ class Builder(AntennaBuilder):
                 BalancedLine(
                     a1="liL",
                     a2="liR",
-                    b1="ta",
-                    b2="tb",
+                    b1="feed.p",
+                    b2="feed.n",
                     zdiff=self.line_zdiff,
                     length=line_len,
                     vf=self.line_vf,

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -724,6 +724,21 @@ class NetworkReducer:
 
         return MNASystem(G, elements, terminations, probes=probes)
 
+    def _physical_port_voltages(self, v):
+        """Node voltages -> PHYSICAL port voltages. They differ only for a
+        floating gap port, whose voltage is the drop ACROSS the gap,
+        ``v[p] - v[n]``, not the "+" node's voltage against a datum it is
+        deliberately not bonded to. The excited far-field/current solve forces
+        these at the real feeds, so getting it wrong under-drives the antenna
+        (and silently: the driven-point impedance reads off the termination
+        branch and stays correct)."""
+        if not self._floating:
+            return v.copy()
+        out = v.copy()
+        for p_idx, n_idx in self._floating.values():
+            out[p_idx] = v[p_idx] - v[n_idx]
+        return out
+
     def resolve_voltages(self, system):
         """Return the (n_total,) physical port-voltage vector of the solved
         network: voltage-driven ports at their applied voltages, current-
@@ -734,7 +749,7 @@ class NetworkReducer:
         These are the voltages the excited far-field/current solver forces
         at the real feeds."""
         v, _j = system.solve()
-        return v.copy()
+        return self._physical_port_voltages(v)
 
     def excited_state(self, Y_real, wavelength):
         """Physical port voltages + radiation efficiency + per-branch power
@@ -793,7 +808,7 @@ class NetworkReducer:
         if p_in > 0.0 and abs(p_diss) <= 1e-9 * p_in:
             p_diss = 0.0
         efficiency = 1.0 if p_in <= 0.0 else max(0.0, min(1.0, 1.0 - p_diss / p_in))
-        return v.copy(), efficiency, p_in, budget
+        return self._physical_port_voltages(v), efficiency, p_in, budget
 
     def impedance_from_y(self, system):
         """Driven-point impedance per Driven source from an `apply_branches`

--- a/tests/test_balanced_line_physics.py
+++ b/tests/test_balanced_line_physics.py
@@ -71,6 +71,16 @@ to model*, against full-wave MoM solves:
    converges to 1.5 % — is where the SECOND terminal lands: a live conductor
    converges, a dead stub opens. A gap always needs metal on both sides,
    which is exactly what a conductor end does not have.
+
+9. The construction actually shipped (`wire.doublet_balanced_tuner`): one
+   wire, an ideal delta gap at its centre exposed as a `PortOnWireFloating`,
+   no bridge and no second length scale. Its idealization error against a
+   physical feeder is 3.2 / 2.1 / 1.3 % — a few percent being the expected gap
+   between an ideal delta-gap feed and a real two-wire attachment. Agreement
+   with physical wires BOUNDS that error; it is not the definition of
+   correctness, since the model is an idealization and the physical build is a
+   different model. The model's own criterion is convergence under refinement,
+   which both engines satisfy.
 """
 
 import importlib
@@ -88,6 +98,7 @@ from antennaknobs.network import (
     Network,
     PortAtEnd,
     PortOnWire,
+    PortOnWireFloating,
     PortVirtual,
     Wire,
 )
@@ -679,3 +690,75 @@ def test_shrinking_nub_does_not_converge_to_an_end_port():
     # ...and the coupling collapses as the stub shrinks: the port opens
     assert r_vals[0] > 1.0
     assert r_vals[-1] < 0.1
+
+
+# ---------------------------------------------------------------------------
+# 9. The shipped centre-port construction, on the same oracle
+# ---------------------------------------------------------------------------
+#
+# `wire.doublet_balanced_tuner` feeds a single wire through a
+# `PortOnWireFloating` at its centre: an ideal TL plus an ideal delta gap, with
+# no bridge and no second length scale. Section 6 bounded `PortAtEnd`'s
+# idealization error against a physical feeder; this does the same for the
+# construction actually shipped.
+#
+# NOTE on what this does and does not prove. Agreement with a physical-wire
+# feeder BOUNDS the idealization error — it is not the definition of
+# correctness, because the model is an idealization by construction and the
+# physical build is a different model. The model's own criterion is
+# convergence under refinement, which both engines satisfy (bare wire,
+# N = 21 -> 641: momwire 344.3 -> 383.4 + j1010.0, PyNEC 328.3 -> 382.1 +
+# j1008.6, steps halving per doubling, 0.4% apart at the end).
+
+
+class _CentrePortDoublet(_ElementFedDoublet):
+    """One wire, floating port at its centre — the shipped construction."""
+
+    def build_wires(self):
+        arm, L = self.arm_factor * WL, self.feed_len_wl * WL
+        return self.auto_mesh([Wire((-arm, 0.0, L), (arm, 0.0, L), name="feed")])
+
+    def build_network(self):
+        s, L = self.spacing, self.feed_len_wl * WL
+        return Network(
+            ports={
+                "feed": PortOnWireFloating("feed"),
+                "rig": PortVirtual("rig"),
+                "bL": PortVirtual("bL"),
+                "bR": PortVirtual("bR"),
+            },
+            branches=[
+                FloatingBalun(primary="rig", a="bL", b="bR", n=1.0),
+                BalancedLine(
+                    a1="bL",
+                    a2="bR",
+                    b1="feed.p",
+                    b2="feed.n",
+                    zdiff=analytic_zdiff(s),
+                    length=L,
+                    vf=1.0,
+                    zcomm=self.zcomm,
+                ),
+            ],
+            sources=[Driven(port="rig")],
+        )
+
+
+@pytest.mark.antenna_computation_check
+def test_centre_port_construction_tracks_a_physical_feeder():
+    """Idealization error of the shipped construction, measured 2026-07-29:
+
+        feeder   physical           centre port         dev    (PortAtEnd)
+        0.20 λ   1158.2 +1615.8j    1097.5 +1595.0j    3.2 %      4.3 %
+        0.30 λ    445.2 -1075.6j     460.5 -1094.0j    2.1 %      2.9 %
+        0.45 λ     82.6  -118.4j      82.8  -120.3j    1.3 %      2.4 %
+
+    A few percent is the expected gap between an ideal delta-gap feed and a
+    real two-wire attachment, and it is the bound worth pinning. It also beats
+    the `PortAtEnd` authoring at every length — but that is a secondary
+    observation, not the reason to prefer it; portability and the absence of a
+    second length scale are."""
+    for flw in (0.20, 0.30, 0.45):
+        zp = _subst_zin(_PhysFedDoublet, feed_len_wl=flw)
+        dev = abs(_subst_zin(_CentrePortDoublet, feed_len_wl=flw) - zp) / abs(zp)
+        assert dev < 0.05, (flw, dev)

--- a/tests/test_port_floating.py
+++ b/tests/test_port_floating.py
@@ -150,3 +150,26 @@ def test_driving_a_floating_port_is_rejected():
 
     with pytest.raises(ValueError, match="attachment point, not a drive point"):
         Bad().build_network()
+
+
+def test_physical_port_voltage_is_the_drop_across_the_gap():
+    """Regression: the excited far-field/current solve must be driven with the
+    gap voltage `v[p] - v[n]`, not the "+" node against a datum the port is
+    deliberately not bonded to.
+
+    Getting this wrong under-drives the antenna SILENTLY — the driven-point
+    impedance reads off the termination branch and stays correct, so SWR and
+    the power budget look fine while the radiated field is wrong. It surfaced
+    as `wire.doublet_balanced_tuner` reporting -3.46 dBi for a 0.72 lambda
+    free-space doublet (correct: +2.56 dBi).
+
+    Oracle: the floating build with its "-" terminal shorted to the datum must
+    match the grounded build's FAR FIELD, not merely its impedance."""
+    ff = {}
+    for floating in (False, True):
+        b = _Doublet(dict(_Doublet.default_params, floating=int(floating)))
+        eng = MomwireEngine(b, ground=None)
+        eng.impedance()
+        pat = eng.far_field(n_theta=45, n_phi=72, del_theta=2, del_phi=5)
+        ff[floating] = max(max(r) for r in pat.rings)
+    assert abs(ff[True] - ff[False]) < 1e-6, ff


### PR DESCRIPTION
## Summary

- **Fixes a silent correctness bug in `PortOnWireFloating`** (shipped in #605, live on `main`). The stamp was right, the readout wasn't: `resolve_voltages` / `excited_state` returned raw NODE voltages, so the excited far-field/current solve forced `v[p]` at a floating port instead of the physical gap drop `v[p] - v[n]`. It failed in the worst way — the driven-point impedance reads off the termination branch, so SWR and the power budget stayed correct while only the radiated field was wrong (`wire.doublet_balanced_tuner`: **-3.46 dBi** for a 0.72 λ free-space doublet, correct **+2.56 dBi**, while still matching 50 Ω to SWR 1.001). Nothing in the catalog used the port type yet, so nothing was actually broken — but this branch makes that design its first user, so fix and consumer land together.

- **Re-authors `wire.doublet_balanced_tuner` as one wire with a floating centre port**, replacing two `PortAtEnd` ports on free conductor ends. It now runs on **every engine** — it was momwire-only, since NEC-2 has no junction-node port. Retuned for the new geometry (L 2.8 → 3.350 µH, C 74.0 → 60.43 pF): SWR **1.001 momwire / 1.032 PyNEC**, +2.56 dBi.

- **The simplification is the point.** A delta gap is a point discontinuity with no physical extent, and `BalancedLine` is an ideal element whose conductor spacing lives in `line_zdiff`, not in the geometry. So there is nothing to bridge, no second length scale, and the whole antenna meshes at one uniform density:

  ```python
  return self.auto_mesh([Wire((0.0, -arm, z), (0.0, arm, z), name="feed")])
  ports = {"feed": PortOnWireFloating("feed"), ...}
  ```

- **Adds section 9** to the BalancedLine physics tests: bounds the idealization error of that construction against a physical two-wire feeder at 3.2 / 2.1 / 1.3 % across three feeder lengths — stated as a *bound*, not a definition of correctness. The model is an idealization and the physical build is a different model, so its own criterion is convergence under refinement, which both engines satisfy (bare wire, N = 21 → 641: momwire 344.3 → 383.4 + j1010.0, PyNEC 328.3 → 382.1 + j1008.6, steps halving per doubling, 0.4 % apart).

## Notes for review

- The regression test for the voltage bug compares the **far field** of a floating-with-shorted-return build against the grounded build. The pre-existing equivalence oracle compared impedance only — which is exactly the quantity that stayed correct while the bug was live, and why it went unnoticed.
- Issue #606 (feed-bridge meshing vs the uniform-density lint) is **closed as retracted**: its premise was that a floating port needs a bridge sized to the line's conductor spacing, making the geometry multi-scale. It does not. The uniform-density lint (#521/#522) is untouched and passes.

## Test plan

- [x] `pytest tests/ -m "not heavy_mesh"` → **2865 passed, 2 skipped**
- [x] `tests/test_port_floating.py` → 6 passed, incl. the far-field regression and the floating-vs-grounded equivalence oracle on both momwire and PyNEC
- [x] `tests/test_balanced_line_physics.py` → 12 passed
- [x] `tests/test_delta_a_lint.py` uniform-density check passes for the re-authored design
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
