### PR TITLE
Docs: lead with PortOnWireFloating, correct the momwire-only BalancedLine claim

### DIFF
--- a/site/src/content/docs/concepts/station-modelling.md
+++ b/site/src/content/docs/concepts/station-modelling.md
@@ -30,25 +30,33 @@ sources. Ports come in four kinds:
   transmitter end of a feedline is the classic one: it exists only in
   the network, and driving it makes every readout — impedance, SWR,
   gain, the power budget — **rig-referenced**.
-- **`PortAtEnd("riser", "p1")`** — a port at a wire's *endpoint*
-  rather than a mid-wire gap. It attaches to the shared junction node
-  at that point without cutting a gap — the way a floating
-  multi-terminal element (a `BalancedLine`) hangs off a conductor's
-  end. momwire-only: NEC-2 has no junction-node port, so the PyNEC
-  backend rejects designs that use it (a declared engine-parity break).
 - **`PortOnWireFloating("feed")`** — a gap port with **both** terminals
   exposed, addressed as `feed.p` and `feed.n`. An ordinary `PortOnWire` is
   stamped node-to-datum: its second terminal is bonded to the common return,
   so a branch can only reach one side of the gap. That is a stamping
   convention, not physics — the field solver only ever knows gap voltage and
   gap current. Use this when the two sides must go to *different* branches,
-  which is what a balanced feed actually needs. Unlike `PortAtEnd` it asks
-  nothing of the solver, so it works on every engine.
+  which is what a balanced feed actually needs. It asks nothing of the
+  solver, so it works on **every** engine — this is the construct to reach
+  for when you need to hang a floating element off an antenna.
 
   A single floating gap is a one-port, so its stamp is purely differential and
   provides **no** common-mode path — give the network a CM return, or model
   the common-mode path as its own gap port and let the two-port coupling carry
   that physics.
+- **`PortAtEnd("riser", "p1")`** — a port at a wire's *endpoint*
+  rather than a mid-wire gap. It attaches to the shared junction node
+  at that point without cutting a gap. momwire-only: NEC-2 has no
+  junction-node port, so the PyNEC backend rejects designs that use it
+  (a declared engine-parity break).
+
+  Prefer `PortOnWireFloating` where the attachment can be authored as a
+  mid-wire gap — it is portable and costs nothing. `PortAtEnd` earns its
+  parity break only where the attachment is genuinely at a bare conductor
+  *end*, because the obvious workarounds are measurably wrong there: a
+  vanishing centre-tapped stub converges to an **open** (its far face is a
+  dead end, not live conductor), and bridging across the two conductors
+  gives the wrong conduction graph.
 
 The source (`Driven(port="rig")`) goes wherever your measurement plane
 is. Put it at the antenna feed and you're modelling the antenna; put it
@@ -137,14 +145,19 @@ The rule of thumb: set `zcomm` when the pair's two conductors are part of a
 closed conduction path that the differential stamp would otherwise break.
 Leave it open when the pair simply ends.
 
-**It is momwire-only.** Practical `BalancedLine` designs attach through
-`PortAtEnd`, which NEC-2 has no equivalent for, so the PyNEC backend
-rejects them (see [Ports](#ports-where-the-circuit-meets-the-wire)). You
-lose cross-engine validation on these designs — the available cross-check
-is between B-spline basis degrees rather than between engines.
+**Engine support follows the port, not the element.** `BalancedLine` itself
+is a pure circuit stamp and runs anywhere. What can pin a design to momwire
+is how it *attaches*: a design that hangs the line off `PortAtEnd` is
+momwire-only, because NEC-2 has no junction-node port and the PyNEC backend
+rejects it (see [Ports](#ports-where-the-circuit-meets-the-wire)). Those
+designs lose cross-engine validation — the available cross-check is between
+B-spline basis degrees rather than between engines. A design that attaches
+through `PortOnWireFloating` keeps both engines.
 
-Three catalog designs use it today: `wire.sterba_bl`,
-`arrays.bowtie1x2_bl`, and `wire.doublet_balanced_tuner`.
+Three catalog designs use `BalancedLine` today:
+`wire.doublet_balanced_tuner` (floating centre port — runs on every engine),
+plus `wire.sterba_bl` and `arrays.bowtie1x2_bl` (both `PortAtEnd`, so
+momwire-only).
 
 ## Boxes: reusable station components
 

--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -107,7 +107,7 @@ whole shape with a `Drone` — see
 | `wire.longwire` | Resonant multi-wavelength long-wire (L. B. Cebik, W4RNL) |
 | `wire.rhombic` | Terminated rhombic: a traveling-wave directional long-wire (L. B. Cebik, W4RNL, "Long-Wire Antennas" / "The Terminated Vee-Beam and Rhombic") |
 | `wire.sterba` | Sterba curtain: a broadside, bidirectional, horizontally-polarised curtain array (E. J. Sterba, Bell Labs, 1930s) |
-| `wire.sterba_bl` | Sterba curtain with balanced-line risers — the faithful TL Sterba |
+| `wire.sterba_bl` | Sterba curtain whose interior risers are ideal balanced line, not wire (momwire-only) |
 | `wire.sterba_tl` | Sterba curtain, transmission-line sister design of `sterba.py` |
 | `wire.terminated_longwire` | Terminated end-fed long-wire: the directional single wire (L. B. Cebik, W4RNL, "Long-Wire Antennas", Part 2) |
 | `wire.vbeam` | Resonant V-beam: two long wires splayed into a V (L. B. Cebik, W4RNL) |

--- a/src/antennaknobs/designs/wire/sterba_bl.py
+++ b/src/antennaknobs/designs/wire/sterba_bl.py
@@ -1,4 +1,4 @@
-"""Sterba curtain with balanced-line risers — the faithful TL Sterba.
+"""Sterba curtain whose interior risers are ideal balanced line, not wire (momwire-only).
 
 The third member of the Sterba family: where `wire.sterba` models the whole
 curtain as wires (verticals as tightly-spaced offset pairs) and


### PR DESCRIPTION
## Summary

- `wire.doublet_balanced_tuner` was re-authored off `PortAtEnd` in #607, which made the station-modelling page's "practical `BalancedLine` designs attach through `PortAtEnd` ... **It is momwire-only**" claim false. Engine support follows the **port**, not the element — corrected, and the three designs are now split by which port they use.
- Reordered the port list so the portable `PortOnWireFloating` leads, and gave `PortAtEnd` an explicit narrow warrant (bare conductor *ends*), citing the two measured failure modes of the obvious workarounds.
- Retitled `wire.sterba_bl` off "the faithful TL Sterba" — it's faithful to a TL *idealisation* of the risers, which is a modelling choice rather than a fidelity claim. `catalog.md` regenerated from the docstring.

Follow-up filed as #608: can `wire.sterba_bl` / `arrays.bowtie1x2_bl` drop `PortAtEnd` too? Deliberately not attempted here — the risers attach at structural junctions, not feeds, so the doublet result may not transfer.

## Test plan

- [x] `ruff check` / `ruff format --check` clean
- [x] `test_catalog_generated::test_catalog_page_is_not_stale` passes (regenerated)
- [x] 20 doc/catalog tests pass
- [x] Docs-only + one docstring line; no behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)