### PR TITLE
feat(web): surface Array Block solver diagnostics in the solve response

### DIFF
--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -866,6 +866,23 @@ class MomwireEngine(SimulationEngine):
             return float(p_in)
         return self._p_in_from_excited(sim, z)
 
+    def solver_diag(self):
+        """Array Block solver diagnostics from the last solve (issue #613):
+        which coupling path engaged (lattice-FFT / per-pair / dense
+        H-matrix fallback) and, when the FFT path did not, why not.
+
+        Delegates to `ArrayBlockSolver.solver_diag()` on the cached excited
+        solver — the same instance `current_distribution()` reads currents
+        from — so this needs no re-solve. Returns None before any solve has
+        run, or when the configured model isn't Array Block (no
+        `solver_diag` attribute), so the adapter can omit the field."""
+        cached = getattr(self, "_solved_cache", None)
+        if cached is None:
+            return None
+        sim = cached[1][0]
+        diag = getattr(sim, "solver_diag", None)
+        return diag() if diag is not None else None
+
     def current_distribution(self):
         self._raise_if_cancelled()
         sim, coeffs, _z = self._solved_excited(self._wavelength_for(self.builder.freq))

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -1996,6 +1996,12 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             "input_power_w": float(eng.input_power()),
             **_wire_material_results(builder),
         }
+        # Array Block coupling-path diagnostics (issue #613): absent for
+        # every other engine/model (eng.solver_diag() only returns a dict
+        # for an ArrayBlockSolver-backed solve).
+        solver_diag = eng.solver_diag()
+        if solver_diag is not None:
+            out["solver_diag"] = solver_diag
         if hints()["multi_feed"] and len(zs) > 1:
             # Pull per-feed drive voltages off the engine so the frontend
             # can render each feed's phase indicator. MomwireEngine stores

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1398,6 +1398,21 @@ type SolveResponse = {
    *  readout's ground row shows this rather than re-deriving it from
    *  backend + groundType state. */
   ground_model_applied?: string;
+  /** Array Block solver diagnostics (issue #613): which coupling path the
+   *  last solve actually used. Only the Array Block engine populates this —
+   *  every other engine/model leaves it absent, and the Info panel omits
+   *  the row in that case. `reason` names the specific unmet FFT-gate
+   *  condition (e.g. a height split under ground, or fewer than 16
+   *  elements) and is null when `lattice_fft` is true. This never reflects
+   *  a refused solve — the engine always falls back to a slower-but-correct
+   *  path instead of erroring. */
+  solver_diag?: {
+    operator: "LatticeArrayBlock" | "ArrayBlock" | "HMatrix";
+    lattice_fft: boolean;
+    n_elem: number | null;
+    n_shapes: number | null;
+    reason: string | null;
+  };
   /** Per-branch network dissipation from the MNA solve (issue #299):
    *  one entry per TL / TwoPort / Shunt / Load branch, in watts for the
    *  canonical 1 V drive. Absent or all-~0 for plain and lossless
@@ -6686,6 +6701,25 @@ function SolveReadout({
           feeds-table wrapper is used only for its dashed separator rule —
           no header. */}
       <div className="feeds-table">
+        {result?.solver_diag && (
+          <div
+            className="row"
+            title={
+              result.solver_diag.reason
+                ? `Array Block solve did not use the fast lattice-FFT coupling path: ${result.solver_diag.reason}. Correctness is unaffected — only speed.`
+                : "Array Block solve used the fast lattice-FFT coupling path (a regular same-height lattice of 16+ identical elements)."
+            }
+          >
+            <span>array path</span>
+            <span className="val">
+              {result.solver_diag.lattice_fft
+                ? "FFT lattice"
+                : result.solver_diag.operator === "HMatrix"
+                  ? "H-matrix"
+                  : "per-pair"}
+            </span>
+          </div>
+        )}
         <div className="row">
           <span>solve</span>
           <span className="val">

--- a/tests/test_momwire_engine.py
+++ b/tests/test_momwire_engine.py
@@ -1851,3 +1851,68 @@ def test_lattice_fft_identical_feeds_give_symmetric_port_impedances():
     # And the array is genuinely inhomogeneous — edge and interior differ, so
     # the mirror check above isn't passing trivially on 16 equal numbers.
     assert abs(z[0] - z[5]) / abs(z[5]) > 1e-3
+
+
+# --------------------------------------------------------------------------
+# solver_diag() (issue #613): surfaces which coupling path the Array Block
+# engine actually used, so a surprising solve time is explainable instead of
+# opaque. The 4x4 bowtie panel is the issue's own worked example: it engages
+# the FFT lattice path in free space, but drops to per-pair under any ground
+# model because block-shape classes are refined by height above the plane
+# (4 rows -> 4 heights) — see array_block.py's build_array_blocks().
+# --------------------------------------------------------------------------
+
+
+def test_solver_diag_engine_fft_engaged_on_4x4_bowtie_array():
+    from momwire import ArrayBlockSolver
+
+    eng = MomwireEngine(
+        _bowtie_4x4(), solver=ArrayBlockSolver, solver_kwargs={"degree": 2}
+    )
+    assert eng.solver_diag() is None  # nothing solved yet
+    eng.current_distribution()
+    assert eng.solver_diag() == {
+        "operator": "LatticeArrayBlock",
+        "lattice_fft": True,
+        "n_elem": 16,
+        "n_shapes": 1,
+        "reason": None,
+    }
+
+
+def test_solver_diag_engine_height_split_under_pec_ground_on_4x4_bowtie_array():
+    """The headline case from the issue: same panel, same 16 elements, but
+    PEC ground refines the block-shape classes by height (4 rows -> 4
+    heights), dropping the FFT path — and the reason names that specifically,
+    not just `lattice_fft: false`."""
+    from momwire import ArrayBlockSolver
+
+    eng = MomwireEngine(
+        _bowtie_4x4(),
+        solver=ArrayBlockSolver,
+        solver_kwargs={"degree": 2},
+        ground="pec",
+    )
+    eng.current_distribution()
+    assert eng.solver_diag() == {
+        "operator": "ArrayBlock",
+        "lattice_fft": False,
+        "n_elem": 16,
+        "n_shapes": 4,
+        "reason": (
+            "shape classes split by height above ground (4 classes); "
+            "the FFT path needs 1"
+        ),
+    }
+
+
+def test_solver_diag_absent_for_dense_bspline_engine():
+    """Only the Array Block engine reports this (issue #613's scope) — the
+    default dense B-spline solver has no `solver_diag` method at all."""
+    from momwire import BSplineSolver
+
+    eng = MomwireEngine(
+        _bowtie_4x4(), solver=BSplineSolver, solver_kwargs={"degree": 2}
+    )
+    eng.current_distribution()
+    assert eng.solver_diag() is None

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2660,6 +2660,56 @@ def test_momwire_sommerfeld_applies_on_every_solver(model):
     assert abs(z_somm - z_ref) < 3.0  # cross-solver floor
 
 
+def test_solve_response_carries_solver_diag_for_array_block():
+    """Issue #613: the Array Block solve response reports which coupling
+    path engaged, sourced from the operator momwire already built (no
+    re-solve). `arrays.bowtie4x4` is the issue's own worked example: 16
+    identical elements engage the FFT lattice path in free space, but ANY
+    ground model splits the block-shape classes by height (4 rows -> 4
+    heights), dropping to the per-pair path with a reason that names the
+    split specifically — not just `lattice_fft: false`."""
+    base = {
+        "geometry": "arrays.bowtie4x4",
+        "solver": "momwire",
+        "momwire_model": "arrayblock",
+        "measurement_freq_mhz": 28.47,
+    }
+    free = server.solve(base)
+    assert free["solver_diag"] == {
+        "operator": "LatticeArrayBlock",
+        "lattice_fft": True,
+        "n_elem": 16,
+        "n_shapes": 1,
+        "reason": None,
+    }
+    grounded = server.solve({**base, "ground": True})
+    assert grounded["solver_diag"] == {
+        "operator": "ArrayBlock",
+        "lattice_fft": False,
+        "n_elem": 16,
+        "n_shapes": 4,
+        "reason": (
+            "shape classes split by height above ground (4 classes); "
+            "the FFT path needs 1"
+        ),
+    }
+
+
+def test_solve_response_omits_solver_diag_for_other_engines():
+    """Only the Array Block engine populates this field (issue #613's
+    scope) — every other momwire model, and PyNEC, leave it absent rather
+    than reporting a misleading empty/false diagnostic."""
+    base = {
+        "geometry": "dipoles.invvee",
+        "measurement_freq_mhz": 28.47,
+    }
+    for model in ("bspline", "sinusoidal", "hmatrix"):
+        resp = server.solve({**base, "solver": "momwire", "momwire_model": model})
+        assert "solver_diag" not in resp, model
+    resp = server.solve({**base, "solver": "pynec"})
+    assert "solver_diag" not in resp
+
+
 def test_retired_model_name_falls_back_to_bspline():
     """The triangular solver is retired: a stale client still naming it
     (or any unknown model) gets the default BSpline solve instead of a


### PR DESCRIPTION
## Summary
- Attaches `solver_diag` (operator type, `lattice_fft`, `n_elem`, `n_shapes`, and — when the FFT path did not engage — a `reason` naming the specific unmet gate condition) to momwire solve responses for the Array Block engine. Every other engine/model omits the field entirely; no solve is ever refused.
- `MomwireEngine.solver_diag()` (`src/antennaknobs/engines/momwire.py`) delegates to `ArrayBlockSolver.solver_diag()` (momwire, [stevenmburns/momwire#179](https://github.com/stevenmburns/momwire/pull/179), merged to momwire `main` — no release cut, both repos run as editable installs for now), reading it off the operator already built by the solve, so no re-solve is needed.
- The Info panel (`App.tsx`) renders an "array path" row next to `solve`, with a tooltip carrying the reason text.
- Bumps the `momwire` submodule pointer to the merged commit.

Resolves #613.

## Test plan
- [x] `pytest tests/test_web_server.py tests/test_momwire_engine.py` (257 passed) — includes new coverage: `test_solve_response_carries_solver_diag_for_array_block` / `test_solve_response_omits_solver_diag_for_other_engines` (server level, using `arrays.bowtie4x4` — the issue's own worked example: FFT engages in free space, drops to per-pair with the height-split reason under any ground model) and three `MomwireEngine.solver_diag()` tests (FFT engaged, height-split under PEC ground, absent for plain B-spline)
- [x] `npx tsc --noEmit` in the frontend — clean
- [x] momwire side: `pytest tests/` in the submodule (496 passed, including 8 new `solver_diag` unit tests) — done as part of momwire#179

🤖 Generated with [Claude Code](https://claude.com/claude-code)