### PR TITLE
Touchstone (.s1p/.s2p) import as build_network() elements (#593)

### DIFF
--- a/src/antennaknobs/__init__.py
+++ b/src/antennaknobs/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     "read_data",
     "read_json",
     "read_nec",
+    "read_touchstone",
     "WireSpec",
     "Wire",
     "as_wire",
@@ -60,6 +61,7 @@ from .builder import (
 )
 from .design_data import read_data, read_json
 from .nec_import import read_nec
+from .touchstone import read_touchstone
 from .network import Composite, Instance, Wire, WireSpec, as_wire
 from .transform import Transform, TransformStack
 from .cell import Cell, Placement, flatten_placements

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field, replace
 from typing import NamedTuple, Optional, Union
 
+from .touchstone import Touchstone
+
 
 @dataclass(frozen=True)
 class PortOnWire:
@@ -539,6 +541,52 @@ class Admittance:
             raise ValueError(
                 f"Admittance y must be {n}×{n} to match ports {self.ports}; "
                 f"got {len(self.y)}×{len(self.y[0]) if self.y else 0}"
+            )
+
+
+@dataclass(frozen=True)
+class TouchstoneLoad:
+    """A measured / vendor 1-port (``.s1p``) as a frequency-dependent load
+    (issue #593) — a node-to-datum admittance the reducer stamps at each solve
+    frequency by interpolating the Touchstone data. Use it to terminate the
+    model with a *measured* antenna feedpoint (NanoVNA/VNA) or a real load
+    instead of an ideal one. The admittance is ``y = 1/Z(f)`` from the file, so
+    it is the measured-data sibling of a 1-port ``Admittance`` / ``Shunt``.
+
+    ``data`` is a 1-port :class:`~antennaknobs.touchstone.Touchstone`
+    (see ``read_touchstone``). Works on both engines (post-MoM reducer math)."""
+
+    port: str
+    data: Touchstone
+
+    def __post_init__(self):
+        if self.data.nports != 1:
+            raise ValueError(
+                f"TouchstoneLoad on port {self.port!r} needs a 1-port (.s1p) "
+                f"file; got a {self.data.nports}-port"
+            )
+
+
+@dataclass(frozen=True)
+class TouchstoneTwoPort:
+    """A measured / vendor 2-port (``.s2p``) as an in-line branch between ports
+    ``a`` and ``b`` (issue #593) — the SimSmith "S block" analog. The file's
+    measured ``[S]`` is converted to ``[Y]`` and stamped as a 2×2 Group-1 block,
+    like ``TL``/``Admittance`` but from real data: a characterized balun, coax
+    section, filter, or tuner dropped in as a black box.
+
+    ``data`` is a 2-port :class:`~antennaknobs.touchstone.Touchstone`
+    (see ``read_touchstone``). Works on both engines (post-MoM reducer math)."""
+
+    a: str
+    b: str
+    data: Touchstone
+
+    def __post_init__(self):
+        if self.data.nports != 2:
+            raise ValueError(
+                f"TouchstoneTwoPort {self.a!r}→{self.b!r} needs a 2-port (.s2p) "
+                f"file; got a {self.data.nports}-port"
             )
 
 

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -42,6 +42,8 @@ from .network import (
     PortOnWire,
     PortOnWireFloating,
     Shunt,
+    TouchstoneLoad,
+    TouchstoneTwoPort,
     Transformer,
     TwoPort,
     _parallel_rlc_admittance,
@@ -505,6 +507,34 @@ class NetworkReducer:
                         lab(f"Admittance {'→'.join(map(_short, br.ports))}"),
                         "group1",
                         (idxs, yb),
+                    )
+                )
+            elif isinstance(br, TouchstoneLoad):
+                # Measured 1-port (.s2p→.s1p) as a node-to-datum admittance
+                # (issue #593): y = 1/Z(f) interpolated from the file, stamped
+                # verbatim like a 1-port Admittance / parallel Shunt.
+                k = self.port_to_idx[br.port]
+                yb = br.data.y_at(C_LIGHT / wavelength)
+                G[k, k] += yb[0, 0]
+                probes.append(
+                    (
+                        lab(f"Touchstone {_short(br.port)}"),
+                        "group1",
+                        ([k], np.array([[yb[0, 0]]])),
+                    )
+                )
+            elif isinstance(br, TouchstoneTwoPort):
+                # Measured 2-port (.s2p) as an in-line 2×2 admittance block
+                # (issue #593): [S](f)→[Y](f) interpolated from the file, stamped
+                # like TL's 2×2 — a characterized balun / coax / filter black box.
+                a, b = self.port_to_idx[br.a], self.port_to_idx[br.b]
+                yb = br.data.y_at(C_LIGHT / wavelength)
+                G[np.ix_([a, b], [a, b])] += yb
+                probes.append(
+                    (
+                        lab(f"Touchstone {_short(br.a)}→{_short(br.b)}"),
+                        "group1",
+                        ([a, b], yb),
                     )
                 )
             elif isinstance(br, TwoPort):

--- a/src/antennaknobs/touchstone.py
+++ b/src/antennaknobs/touchstone.py
@@ -1,0 +1,223 @@
+"""Touchstone (``.s1p`` / ``.s2p``) reader for measured / vendor-supplied
+S-parameters (issue #593).
+
+A Touchstone file describes an N-port's network parameters versus frequency:
+``.s1p`` a 1-port (a single ``S11`` — an antenna feedpoint, a load, a
+termination), ``.s2p`` a 2-port (``S11 S21 S12 S22`` — a balun, coax section,
+filter, or tuner as a black box). Both share one header::
+
+    # <HZ|KHZ|MHZ|GHZ> <S|Y|Z> <RI|MA|DB> R <z0>
+
+This module parses that format into a :class:`Touchstone`, which interpolates
+onto any solve frequency and converts to the admittance the network reducer
+stamps. The circuit *elements* that consume it live in ``network.py``
+(``TouchstoneLoad`` / ``TouchstoneTwoPort``); because they stamp into the
+``NetworkReducer`` — post-MoM circuit math — they work on **both** momwire and
+PyNEC, unlike a geometry-level feed such as ``PortAtEnd``.
+
+Only 1- and 2-port ``S`` / ``Y`` / ``Z`` files are supported (the VNA case);
+``G`` / ``H`` parameters and N > 2 raise a clear error.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .design_data import read_data
+
+__all__ = ["Touchstone", "parse_touchstone", "read_touchstone"]
+
+# Touchstone frequency-unit keywords → multiplier to Hz.
+_FUNIT = {"HZ": 1.0, "KHZ": 1e3, "MHZ": 1e6, "GHZ": 1e9}
+
+
+@dataclass(frozen=True, eq=False)
+class Touchstone:
+    """Parsed Touchstone data: complex network parameters on a frequency grid.
+
+    ``freqs`` is in Hz (ascending); ``params`` is ``(n_freq, nports, nports)``
+    complex in the declared parameter type (``ptype`` ∈ {S, Y, Z}); ``z0`` is
+    the real reference impedance from the header. ``eq=False`` so instances
+    hash/compare by identity (the arrays make value-equality meaningless and
+    unhashable), which keeps the frozen branch dataclasses that hold one usable.
+    """
+
+    freqs: np.ndarray
+    params: np.ndarray
+    ptype: str
+    z0: float
+
+    @property
+    def nports(self) -> int:
+        return self.params.shape[1]
+
+    def _interp(self, f_hz: float) -> np.ndarray:
+        """Linear-interpolate the parameter matrix onto ``f_hz`` (Hz).
+
+        Raises ``ValueError`` when ``f_hz`` falls outside the data's frequency
+        span — measured data must not be silently extrapolated.
+        """
+        f0, f1 = float(self.freqs[0]), float(self.freqs[-1])
+        tol = 1e-6 * max(abs(f1), 1.0)
+        if f_hz < f0 - tol or f_hz > f1 + tol:
+            raise ValueError(
+                f"solve frequency {f_hz / 1e6:.6g} MHz is outside the Touchstone "
+                f"data range [{f0 / 1e6:.6g}, {f1 / 1e6:.6g}] MHz — measured data "
+                "is not extrapolated; widen the sweep or the measurement"
+            )
+        n = self.nports
+        m = np.empty((n, n), dtype=np.complex128)
+        for i in range(n):
+            for j in range(n):
+                col = self.params[:, i, j]
+                m[i, j] = np.interp(f_hz, self.freqs, col.real) + 1j * np.interp(
+                    f_hz, self.freqs, col.imag
+                )
+        return m
+
+    def s_at(self, f_hz: float) -> np.ndarray:
+        """S-parameter matrix at ``f_hz`` (converting from Y/Z if needed)."""
+        m = self._interp(f_hz)
+        if self.ptype == "S":
+            return m
+        n = self.nports
+        eye = np.eye(n)
+        z = m if self.ptype == "Z" else np.linalg.inv(m)
+        return (z - self.z0 * eye) @ np.linalg.inv(z + self.z0 * eye)
+
+    def y_at(self, f_hz: float) -> np.ndarray:
+        """Admittance matrix (siemens) at ``f_hz`` — what the reducer stamps."""
+        m = self._interp(f_hz)
+        if self.ptype == "Y":
+            return m
+        if self.ptype == "Z":
+            return np.linalg.inv(m)
+        n = self.nports
+        eye = np.eye(n)
+        # real reference z0:  Y = (1/z0)·(I − S)·(I + S)⁻¹
+        return (1.0 / self.z0) * (eye - m) @ np.linalg.inv(eye + m)
+
+    def z_at(self, f_hz: float) -> np.ndarray:
+        """Impedance matrix (ohms) at ``f_hz``."""
+        m = self._interp(f_hz)
+        if self.ptype == "Z":
+            return m
+        if self.ptype == "Y":
+            return np.linalg.inv(m)
+        n = self.nports
+        eye = np.eye(n)
+        return self.z0 * (eye + m) @ np.linalg.inv(eye - m)
+
+
+def _nports_from_name(name: str) -> int:
+    low = name.lower()
+    if low.endswith(".s1p"):
+        return 1
+    if low.endswith(".s2p"):
+        return 2
+    raise ValueError(
+        f"{name!r}: expected a .s1p or .s2p Touchstone extension "
+        "(only 1- and 2-port files are supported)"
+    )
+
+
+def parse_touchstone(text: str, *, nports: int | None = None) -> Touchstone:
+    """Parse Touchstone ``text`` into a :class:`Touchstone`.
+
+    ``nports`` is taken from the file extension by :func:`read_touchstone`; when
+    omitted here it is inferred from the first data record's width
+    (``1 + 2·nports²`` numbers per frequency). Honors the header's frequency
+    unit (HZ/KHZ/MHZ/GHZ), parameter type (S/Y/Z), format (RI/MA/DB) and
+    reference impedance (``R <z0>``); Touchstone's own defaults (GHz, S, MA,
+    50 Ω) apply when the option line omits a field.
+    """
+    funit, ptype, fmt, z0 = _FUNIT["GHZ"], "S", "MA", 50.0
+    rows: list[list[str]] = []
+    for raw in text.splitlines():
+        line = raw.split("!", 1)[0].strip()  # drop ! comments
+        if not line:
+            continue
+        if line.startswith("#"):
+            toks = line[1:].upper().split()
+            i = 0
+            while i < len(toks):
+                t = toks[i]
+                if t in _FUNIT:
+                    funit = _FUNIT[t]
+                elif t in ("S", "Y", "Z", "G", "H"):
+                    ptype = t
+                elif t in ("RI", "MA", "DB"):
+                    fmt = t
+                elif t == "R" and i + 1 < len(toks):
+                    z0 = float(toks[i + 1])
+                    i += 1
+                i += 1
+            continue
+        rows.append(line.split())
+
+    if ptype in ("G", "H"):
+        raise ValueError(f"{ptype}-parameter Touchstone files are not supported")
+    if not rows:
+        raise ValueError("Touchstone file has no data rows")
+
+    if nports is None:
+        width = len(rows[0])  # 1 freq + 2·nports² values, one record per line
+        n2 = (width - 1) // 2
+        nports = int(round(n2**0.5))
+        if nports not in (1, 2) or 1 + 2 * nports * nports != width:
+            raise ValueError(
+                f"cannot infer port count from a {width}-column data row "
+                "(expected 3 for .s1p or 9 for .s2p)"
+            )
+    if nports not in (1, 2):
+        raise ValueError("only 1- and 2-port Touchstone files are supported")
+
+    rec = 1 + 2 * nports * nports
+    vals = np.array([float(x) for row in rows for x in row], dtype=float)
+    if vals.size % rec != 0:
+        raise ValueError(
+            f"Touchstone data length {vals.size} is not a multiple of the "
+            f"{rec}-number record for a {nports}-port file"
+        )
+    arr = vals.reshape(-1, rec)
+    freqs = arr[:, 0] * funit
+    pairs = arr[:, 1:].reshape(arr.shape[0], nports * nports, 2)
+
+    a, b = pairs[:, :, 0], pairs[:, :, 1]
+    if fmt == "RI":
+        comp = a + 1j * b
+    elif fmt == "MA":
+        comp = a * np.exp(1j * np.deg2rad(b))
+    else:  # DB
+        comp = (10.0 ** (a / 20.0)) * np.exp(1j * np.deg2rad(b))
+
+    nf = arr.shape[0]
+    params = np.empty((nf, nports, nports), dtype=np.complex128)
+    if nports == 1:
+        params[:, 0, 0] = comp[:, 0]
+    else:  # Touchstone 2-port column order is S11 S21 S12 S22
+        params[:, 0, 0] = comp[:, 0]
+        params[:, 1, 0] = comp[:, 1]
+        params[:, 0, 1] = comp[:, 2]
+        params[:, 1, 1] = comp[:, 3]
+
+    order = np.argsort(freqs)
+    return Touchstone(
+        freqs=freqs[order], params=params[order], ptype=ptype, z0=float(z0)
+    )
+
+
+def read_touchstone(builder, name: str) -> Touchstone:
+    """Read a Touchstone file from the calling design's own folder.
+
+    Confined exactly like :func:`antennaknobs.read_data` / ``read_json`` (no
+    ``..`` escape, no symlink-out); the port count comes from the ``.s1p`` /
+    ``.s2p`` extension. Use it in ``build_network()``::
+
+        s = read_touchstone(self, "measured_antenna.s1p")
+        return Network(..., branches=[TouchstoneLoad("ant", s), ...])
+    """
+    nports = _nports_from_name(name)  # validate extension before touching disk
+    return parse_touchstone(read_data(builder, name), nports=nports)

--- a/tests/fixtures/measured_dipole.s1p
+++ b/tests/fixtures/measured_dipole.s1p
@@ -1,0 +1,5 @@
+! Synthetic measured 1-port (a dipole feedpoint near 14 MHz), for tests.
+# MHZ S RI R 50
+13.5  -0.30  -0.25
+14.0  -0.10  -0.05
+14.5   0.05   0.10

--- a/tests/test_touchstone.py
+++ b/tests/test_touchstone.py
@@ -1,0 +1,257 @@
+"""Touchstone (.s1p/.s2p) import as build_network() elements (issue #593).
+
+Two layers, mirroring test_admittance_branch.py: the parser + parameter
+conversions (pure), then the reducer stamps on a synthetic antenna Y — since
+both Touchstone elements are group-1 verbatim-Y stamps, the exact oracle is the
+bare nodal solve of the augmented admittance, exactly as for Admittance.
+"""
+
+import math
+from types import MappingProxyType
+
+import numpy as np
+import pytest
+
+from antennaknobs import AntennaBuilder, read_touchstone
+from antennaknobs.network import (
+    Driven,
+    Network,
+    PortOnWire,
+    PortVirtual,
+    TL,
+    TouchstoneLoad,
+    TouchstoneTwoPort,
+    Wire,
+)
+from antennaknobs.network_reduce import C_LIGHT, NetworkReducer, tl_admittance_2x2
+from antennaknobs.touchstone import parse_touchstone
+
+FREQ_MHZ = 14.0
+WL = C_LIGHT / (FREQ_MHZ * 1e6)
+
+
+# ---------------------------------------------------------------------------
+# harness (shared with test_admittance_branch.py in spirit)
+# ---------------------------------------------------------------------------
+def synth_y(n, seed):
+    rng = np.random.default_rng(seed)
+    a = rng.normal(size=(n, n)) + 1j * rng.normal(size=(n, n))
+    y = 0.004 * (a + a.T) / 2.0
+    return y + np.eye(n) * (0.02 + 0.008j)
+
+
+def reducer(net, n_real):
+    real = [n for n, p in net.ports.items() if isinstance(p, PortOnWire)]
+    virt = [n for n, p in net.ports.items() if isinstance(p, PortVirtual)]
+    port_to_idx = {n: i for i, n in enumerate(real + virt)}
+    return NetworkReducer(net, port_to_idx, len(real) + len(virt))
+
+
+def nodal_reference(y_full, driven):
+    n = y_full.shape[0]
+    idx = sorted(driven)
+    other = [i for i in range(n) if i not in driven]
+    v = np.zeros(n, dtype=np.complex128)
+    for k, e in driven.items():
+        v[k] = e
+    if other:
+        rhs = -y_full[np.ix_(other, idx)] @ np.array([driven[k] for k in idx])
+        v[other] = np.linalg.solve(y_full[np.ix_(other, other)], rhs)
+    return v, y_full @ v
+
+
+def _s2p_from_matrix(freqs_hz, s_of_f):
+    """Build .s2p text (HZ, RI) from a function f→2×2 S."""
+    out = ["# HZ S RI R 50"]
+    for f in freqs_hz:
+        s = s_of_f(f)
+        vals = [s[0, 0], s[1, 0], s[0, 1], s[1, 1]]  # Touchstone order
+        out.append(f"{f} " + " ".join(f"{v.real} {v.imag}" for v in vals))
+    return "\n".join(out) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# 1. parser + conversions
+# ---------------------------------------------------------------------------
+def test_s1p_ri_impedance_and_admittance():
+    """S11 = 1/3 at z0=50 → Z = 100 Ω, Y = 0.01 S."""
+    t = parse_touchstone("# MHZ S RI R 50\n10 0.333333333333 0\n30 0.333333333333 0\n")
+    assert t.nports == 1 and t.z0 == 50.0
+    assert t.z_at(20e6)[0, 0] == pytest.approx(100.0, rel=1e-9)
+    assert t.y_at(20e6)[0, 0] == pytest.approx(0.01, rel=1e-9)
+
+
+def test_ri_ma_db_formats_agree():
+    val = 0.1 + 0.2j
+    mag, ang, db = (
+        abs(val),
+        math.degrees(math.atan2(0.2, 0.1)),
+        20 * math.log10(abs(val)),
+    )
+    ri = parse_touchstone("# HZ S RI R 50\n1e7 0.1 0.2\n2e7 0.1 0.2\n")
+    ma = parse_touchstone(f"# HZ S MA R 50\n1e7 {mag} {ang}\n2e7 {mag} {ang}\n")
+    dbf = parse_touchstone(f"# HZ S DB R 50\n1e7 {db} {ang}\n2e7 {db} {ang}\n")
+    assert np.allclose(ri.s_at(1.5e7), ma.s_at(1.5e7))
+    assert np.allclose(ri.s_at(1.5e7), dbf.s_at(1.5e7))
+
+
+@pytest.mark.parametrize(
+    "unit,scale", [("HZ", 1.0), ("KHZ", 1e3), ("MHZ", 1e6), ("GHZ", 1e9)]
+)
+def test_frequency_units(unit, scale):
+    t = parse_touchstone(f"# {unit} S RI R 50\n1 0 0\n2 0 0\n")
+    assert t.freqs[0] == pytest.approx(1 * scale) and t.freqs[1] == pytest.approx(
+        2 * scale
+    )
+
+
+def test_linear_interpolation_midpoint():
+    t = parse_touchstone("# HZ S RI R 50\n10 0 0\n20 0.4 0.2\n")
+    assert t.s_at(15)[0, 0] == pytest.approx(0.2 + 0.1j, rel=1e-12)
+
+
+def test_out_of_range_raises():
+    t = parse_touchstone("# MHZ S RI R 50\n10 0 0\n20 0 0\n")
+    with pytest.raises(ValueError, match="outside the Touchstone data range"):
+        t.y_at(5e6)
+    with pytest.raises(ValueError, match="outside the Touchstone data range"):
+        t.y_at(25e6)
+
+
+def test_z_and_y_parameter_files():
+    """Z- and Y-parameter Touchstone convert correctly (not just S)."""
+    tz = parse_touchstone("# HZ Z RI R 50\n1e7 100 0\n2e7 100 0\n")
+    assert tz.y_at(1.5e7)[0, 0] == pytest.approx(0.01, rel=1e-12)
+    ty = parse_touchstone("# HZ Y RI R 50\n1e7 0.01 0\n2e7 0.01 0\n")
+    assert ty.z_at(1.5e7)[0, 0] == pytest.approx(100.0, rel=1e-12)
+
+
+def test_infer_port_count_from_width():
+    assert parse_touchstone("# HZ S RI R 50\n1 0 0\n2 0 0\n").nports == 1
+    assert (
+        parse_touchstone(
+            "# HZ S RI R 50\n1 0 0 0.9 0 0.9 0 0 0\n2 0 0 0.9 0 0.9 0 0 0\n"
+        ).nports
+        == 2
+    )
+
+
+def test_gh_parameters_rejected():
+    with pytest.raises(ValueError, match="not supported"):
+        parse_touchstone("# HZ G RI R 50\n1 0 0\n")
+
+
+# ---------------------------------------------------------------------------
+# 2. reciprocity / element validation
+# ---------------------------------------------------------------------------
+def test_reciprocal_2port_gives_symmetric_y():
+    t = parse_touchstone(
+        "# MHZ S RI R 50\n14 0.2 0.0 0.9 0.0 0.9 0.0 0.2 0.0\n"
+        "15 0.2 0.0 0.9 0.0 0.9 0.0 0.2 0.0\n",
+        nports=2,
+    )
+    y = t.y_at(14.5e6)
+    assert np.allclose(y, y.T)  # S12 == S21 ⇒ Y12 == Y21
+
+
+def test_passive_1port_has_positive_resistance():
+    """|S11| < 1 ⇒ Re(Z) > 0 (a passive termination)."""
+    t = parse_touchstone("# HZ S MA R 50\n1e7 0.5 45\n2e7 0.5 45\n")
+    assert t.z_at(1.5e7)[0, 0].real > 0
+
+
+def test_element_port_count_validation():
+    one = parse_touchstone("# HZ S RI R 50\n1 0 0\n2 0 0\n")
+    two = parse_touchstone(
+        "# HZ S RI R 50\n1 0 0 0.9 0 0.9 0 0 0\n2 0 0 0.9 0 0.9 0 0 0\n", nports=2
+    )
+    with pytest.raises(ValueError, match="1-port"):
+        TouchstoneLoad("a", two)
+    with pytest.raises(ValueError, match="2-port"):
+        TouchstoneTwoPort("a", "b", one)
+
+
+# ---------------------------------------------------------------------------
+# 3. reducer stamps (synthetic antenna Y; nodal oracle)
+# ---------------------------------------------------------------------------
+def test_touchstone_load_is_shunt_to_common():
+    """A 1-port TouchstoneLoad at the driven port adds y = 1/Z(f): Z = 1/(Y₀₀+y)."""
+    y = synth_y(1, 3)
+    # S11 = 1/3 → Z = 100, y = 0.01 at z0 = 50
+    t = parse_touchstone("# MHZ S RI R 50\n10 0.333333333333 0\n30 0.333333333333 0\n")
+    net = Network(
+        ports={"a": PortOnWire("a")},
+        branches=[TouchstoneLoad("a", t)],
+        sources=[Driven(port="a")],
+    )
+    z = reducer(net, 1).driven_impedance(y, WL)[0]
+    assert z == pytest.approx(1.0 / (y[0, 0] + 0.01), rel=1e-9)
+
+
+def test_touchstone_twoport_matches_augmented_nodal_solve():
+    """A driven port + a measured 2-port to a floating port: the branch is a
+    pure group-1 stamp, so the reference is the nodal solve of (antenna Y + [Y])."""
+    y = synth_y(2, 11)
+    # a reciprocal, well-behaved synthetic 2-port, constant across the band
+    s = np.array([[0.2 + 0.05j, 0.7 - 0.1j], [0.7 - 0.1j, -0.15 + 0.02j]])
+    txt = _s2p_from_matrix([13e6, 15e6], lambda f: s)
+    t = parse_touchstone(txt, nports=2)
+    net = Network(
+        ports={"a": PortOnWire("a"), "b": PortOnWire("b")},
+        branches=[TouchstoneTwoPort("a", "b", t)],
+        sources=[Driven(port="a")],
+    )
+    z = reducer(net, 2).driven_impedance(y, WL)[0]
+    yblock = t.y_at(C_LIGHT / WL)
+    v, i = nodal_reference(y + yblock, {0: 1 + 0j})
+    assert z == pytest.approx(v[0] / i[0], rel=1e-9)
+
+
+def test_degenerate_s2p_of_ideal_tl_equals_TL_element():
+    """An .s2p of an ideal lossless line reproduces the TL element's stamp,
+    hence the identical driven-port impedance (acceptance criterion)."""
+    y = synth_y(2, 5)
+    zc, length = 75.0, 3.0
+    y_tl = tl_admittance_2x2(zc, length, WL)
+    eye = np.eye(2)
+    s_tl = (eye - 50.0 * y_tl) @ np.linalg.inv(eye + 50.0 * y_tl)  # Y→S at z0=50
+    t = parse_touchstone(_s2p_from_matrix([C_LIGHT / WL], lambda f: s_tl), nports=2)
+
+    def net_with(branch):
+        return Network(
+            ports={"a": PortOnWire("a"), "b": PortOnWire("b")},
+            branches=[branch],
+            sources=[Driven(port="a")],
+        )
+
+    z_tl = reducer(net_with(TL("a", "b", zc, length)), 2).driven_impedance(y, WL)[0]
+    z_ts = reducer(net_with(TouchstoneTwoPort("a", "b", t)), 2).driven_impedance(y, WL)[
+        0
+    ]
+    assert z_ts == pytest.approx(z_tl, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# 4. folder-confined read
+# ---------------------------------------------------------------------------
+class _B(AntennaBuilder):
+    default_params = MappingProxyType({"freq": 14.0, "design_freq": 14.0})
+
+    def build_wires(self):
+        return [Wire((0.0, -5.0, 10.0), (0.0, 5.0, 10.0), n_seg=11, ex=1 + 0j)]
+
+
+def test_read_touchstone_confined_read_of_fixture():
+    t = read_touchstone(_B(), "fixtures/measured_dipole.s1p")
+    assert t.nports == 1 and t.z0 == 50.0
+    assert t.freqs[0] == pytest.approx(13.5e6) and t.freqs[-1] == pytest.approx(14.5e6)
+
+
+def test_read_touchstone_rejects_escape():
+    with pytest.raises(ValueError, match="outside the design's folder"):
+        read_touchstone(_B(), "../secrets.s1p")
+
+
+def test_read_touchstone_requires_touchstone_extension():
+    with pytest.raises(ValueError, match="expected a .s1p or .s2p"):
+        read_touchstone(_B(), "fixtures/measured_dipole.txt")


### PR DESCRIPTION
## Summary
antennaknobs modeled every feedline/tuner/balun/antenna as an **ideal** element and could not ingest **measured** or **vendor** S-parameter data. This adds Touchstone import so a real, characterized component — or a *measured* antenna feedpoint — drops straight into `build_network()`. It's the SimNEC/SimSmith **S block** (s2p) and **load-file** (s1p) analog, the first step of the measured-data feature family (#593 → #595 overlay → #597 live VNA).

- **`touchstone.py`** — a folder-confined parser: s1p + s2p; `HZ/KHZ/MHZ/GHZ`; `RI/MA/DB`; arbitrary reference `z0`; `S/Y/Z` params. Returns a `Touchstone` that linearly interpolates onto the solve frequency and converts `S↔Y↔Z`. An out-of-range solve frequency **raises** rather than silently extrapolating measured data. `read_touchstone(builder, name)` mirrors `read_data`/`read_json` confinement and is exported at top level.
- **`network.py`** — two elements:
  - `TouchstoneLoad(port, data)` — a 1-port `.s1p` as a node-to-datum admittance `y = 1/Z(f)` (measured sibling of a 1-port `Admittance`/`Shunt`). Terminate the model with a *measured* feedpoint instead of a solved one.
  - `TouchstoneTwoPort(a, b, data)` — a 2-port `.s2p` as an in-line 2×2 `[S]→[Y]` block (sibling of `TL`/`Admittance`). A characterized balun / coax / filter / tuner as a black box.
- **`network_reduce.py`** — group-1 verbatim-Y stamps for both, itemized in the power budget. Because they stamp into the `NetworkReducer` (post-MoM circuit math), they work on **both momwire and PyNEC**, unlike `PortAtEnd`.

## s1p vs s2p
Same Touchstone header; port count differs. **s1p** = a boundary (`S11` → an antenna feedpoint / load / termination). **s2p** = a pass-through (`S11 S21 S12 S22` → a balun / coax / filter). A NanoVNA exports s1p directly; s2p needs a 2-port measurement.

## Test plan
- [x] `tests/test_touchstone.py` (20 tests): parser (formats, units, interpolation, out-of-range, Z/Y-param files, port inference), reciprocity + element port-count validation, reducer stamps vs the nodal oracle, the **degenerate `s2p` of an ideal `TL` == `TL` element** check (machine precision), folder-confined read + escape rejection.
- [x] Existing network/reducer tests unaffected (55 pass: admittance, balanced_line, network_mna).
- [x] `ruff check` + `ruff format --check` clean.

## Acceptance criteria (from #593)
- [x] Touchstone parser (s1p + s2p; units; RI/MA/DB; arbitrary z0) with interpolation + out-of-range error
- [x] `TouchstoneLoad` 1-port element + reducer stamp; power-budget itemized
- [x] `TouchstoneTwoPort` 2-port element + `[S]→[Y]` stamp; reciprocity sanity vs a synthetic 2-port
- [x] Degenerate: `s2p` of an ideal TL matches the `TL` element to tolerance
- [x] Folder-confined file read for user designs

## Follow-ups
Shares this parser with **#595** (measured-vs-modeled overlay) and **#597** (live NanoVNA capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)