### PR TITLE
chore: bump momwire pin to 0.19.0 (Array Block solver diagnostics)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/sta
 # install below sees its requirement already satisfied, then the package with the
 # web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install "momwire==0.18.0" \
+ && pip install "momwire==0.19.0" \
  && pip install -e ".[web]"
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire==0.18.0",
+    "momwire==0.19.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",


### PR DESCRIPTION
## Summary
- Adopts [momwire v0.19.0](https://github.com/stevenmburns/momwire/releases/tag/v0.19.0): `ArrayBlockSolver.solver_diag()` (issue #613's backend) plus the lattice-FFT operator, both merged to momwire `main` after the 0.18.0 release tag.
- The exact pin (`pyproject.toml`, `Dockerfile`) had silently drifted behind what antennaknobs already ships and tests against (`arrays.bowtie4x4`/`bowtie16x1`, `solver_diag`). CI's editable submodule install (`--remote`, tracks momwire `main`) was masking this — the installed version *string* still happened to read `0.18.0` until momwire's release bump changed it, at which point `pip install -e ".[test]"`'s exact-pin resolution started silently swapping the newer editable install for the stale PyPI `0.18.0` wheel and breaking every solver_diag/lattice-FFT test (caught live on #618's CI).
- Bumps the `momwire` submodule pointer to the `v0.19.0` tag commit too, so a fresh editable dev install matches the pin from the start.
- Default engine path is unaffected (dense B-spline stays default; Array Block/lattice-FFT remain opt-in via `momwire_model`) — no latency-smoke needed on the unqualified request path.

## Test plan
- [x] `python -m pytest tests/` — 2935 passed, 2 skipped
- [x] `ruff check .` — clean
- [x] `curl pypi.org/pypi/momwire/json` confirms 0.19.0 is live with wheels for cp310–cp313 on linux/macOS/Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)