### PR TITLE
Document why sterba_bl keeps PortAtEnd (#608 sterba verdict)

### DIFF
--- a/src/antennaknobs/designs/wire/sterba_bl.py
+++ b/src/antennaknobs/designs/wire/sterba_bl.py
@@ -37,6 +37,19 @@ offers only momwire backends for it.
 Known model residual: the CM stamp neither radiates nor dissipates the real
 pair's small antenna-mode current, so the model runs progressively hot at
 high n (+0.2 dB at n=3 → +0.8 dB at n=7 vs the all-wire curtain).
+
+Why not the engine-portable `PortOnWireFloating` (issue #608, measured
+2026-07-30): a floating gap is a single-DOF series EMF on CONTINUOUS metal,
+so through-current continuity is forced at every gap — but the weave needs
+the rail current to reverse across each boundary (the span ends there; its
+current leaves down the riser). That per-boundary four-terminal exchange is
+exactly what `PortAtEnd` provides and no across-gap element can express;
+the #576 zcomm rescue is also unavailable (a gap passes zero CM current
+structurally). Measured on a rectangle-with-gap-risers re-authoring: one
+bay converges cleanly at 7.22 dBi broadside (its own forced-co-phase
+ceiling), but the mechanism does not scale — 5.28 dBi steered az 145 at
+n=3, 5.17 az 50 at n=5 — the #576 phase-fanout failure class with no CM
+lever. Full record on the issue.
 """
 
 import math


### PR DESCRIPTION
## Summary
- Records the measured #608 verdict for `wire.sterba_bl` in the design's own docstring, per the issue's instruction to document *why* at each site if re-authoring fails: a `PortOnWireFloating` gap is a single-DOF series EMF on continuous metal (through-current continuity forced; zero CM current structurally), while the Sterba weave needs a four-terminal current exchange at every bay boundary — which is exactly what `PortAtEnd` provides.
- Experimental record (rectangle + BL gap-risers: one-bay converges at its own co-phase ceiling, multi-bay fans out 30–150° off broadside at ~5 dB down; stub, ladder, trim-sweep and two-feed controls) is on the issue: https://github.com/stevenmburns/antennaknobs/issues/608#issuecomment-5125483052
- Docs-only change; `arrays.bowtie1x2_bl` remains the open half of #608.

## Test plan
- [x] module imports; ruff check/format clean (docstring-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPQBxTv46asiT2hAczUZoK