### PR TITLE
bowtie1x2_bl: retune to keep the corporate line at 100 Ω

### DIFF
--- a/src/antennaknobs/designs/arrays/bowtie1x2_bl.py
+++ b/src/antennaknobs/designs/arrays/bowtie1x2_bl.py
@@ -19,9 +19,10 @@ current ratio the balanced network sets differs from an isolated or delta-gap
 drive), so there is no feed-independent "100 Ω element" — the tuned
 element-plus-line network as a whole realizes the 50 Ω tap. The tune is also
 feed-MODEL-dependent: the pre-#608 `PortAtEnd` authoring of this same design
-tuned to (44.0°, 0.560, 100 Ω); the floating-gap authoring below retunes to
-(46.5°, 0.555, 97 Ω) for the same SWR ~1.01 — the restored bridge metal and
-gap drive shift each element's driving-point by a few percent.
+tuned to (44.0°, 0.560); the floating-gap authoring below retunes to
+(45.0°, 0.5525) for the same match with the line kept at the round 100 Ω —
+the restored bridge metal and gap drive shift each element's driving-point
+by a few percent, absorbed entirely in the geometry knobs.
 
 Against ideal equal-current feeding of the same geometry the balanced feed is
 pattern-identical (within ~0.2 dB everywhere): it is lossless and matched, so
@@ -58,7 +59,7 @@ Construction (issues #575/#576/#605; re-authored engine-portable per #608):
 Engine support: **all engines.** The floating gap is stamped entirely in the
 shared reducer (#605/#607), so momwire (every basis) and PyNEC both run this
 design; measured 2026-07-30 at the retuned point: momwire 5.70 dBi broadside,
-tap 49.80−0.39j (SWR 1.009); PyNEC 5.70 dBi, 49.74−1.26j (SWR 1.026) —
+tap 50.00−0.21j (SWR 1.004); PyNEC 5.71 dBi, 49.98−0.94j (SWR 1.019) —
 0.01 dB and ~1 Ω apart, both mesh-stable nsegs 21→41. This closed the
 bowtie half of issue #608 (the sterba half measured "no"; see that design).
 """
@@ -85,14 +86,15 @@ class Builder(AntennaBuilder):
             # design_freq scales the geometry AND anchors auto_mesh; hidden.
             "design_freq": 28.47,
             # Bowtie flare half-angle and length (as a wavelength factor),
-            # tuned so the center TAP presents 50 Ohm to the coax (SWR ~1.01)
-            # under the floating-gap feed model (#608 re-authoring).
-            "angle_deg": 46.5,
-            "length_factor": 0.555,
+            # tuned so the center TAP presents 50 Ohm to the coax (SWR 1.004)
+            # under the floating-gap feed model (#608 re-authoring) with the
+            # line held at the round 100 Ohm.
+            "angle_deg": 45.0,
+            "length_factor": 0.5525,
             # Element stacking distance / wavelength (sets the half-line length).
             "del_z_factor": 0.5,
             # Corporate-feed line impedance (matched to the element).
-            "zdiff": 97.0,
+            "zdiff": 100.0,
             # Feeders are common-mode-open (0 -> None): the physical model.
             # Exposed for the modelling study only — see the docstring note
             # on why zcomm must NOT be used as the CM level pin here.

--- a/tests/test_balanced_line_physics.py
+++ b/tests/test_balanced_line_physics.py
@@ -605,8 +605,9 @@ def test_bowtie_corporate_feed_runs_on_both_engines():
     """The #608 bowtie-half payoff: the floating-gap corporate feed is
     engine-portable. PyNEC accepts the design (impossible with the previous
     PortAtEnd authoring — NEC-2 has no junction-node card) and agrees with
-    momwire on the matched tap. Measured 2026-07-30 at the retuned point:
-    momwire 49.80−0.39j, PyNEC 49.74−1.26j, gains 5.70/5.70 dBi broadside."""
+    momwire on the matched tap. Measured 2026-07-30 at the retuned point
+    (45.0°, 0.5525, 100 Ω): momwire 50.00−0.21j, PyNEC 49.86−1.19j, gains
+    5.70/5.70 dBi broadside."""
     from antennaknobs.designs.arrays.bowtie1x2_bl import Builder
     from antennaknobs.engines.pynec import PyNECEngine
 


### PR DESCRIPTION
## Summary
- Follow-up to #624: absorb the floating-gap feed-model shift entirely in the geometry knobs instead of the line impedance — `zdiff` back to the round 100 Ω, `angle_deg` 46.5→45.0, `length_factor` 0.555→0.5525.
- The match improves: tap 50.00−0.21j (**SWR 1.004**) momwire / 49.98−0.94j (SWR 1.019) PyNEC at nsegs 41; gains unchanged (5.70/5.71 dBi broadside), mesh-stable 21→41 on both engines.

## Test plan
- [x] `tests/test_balanced_line_physics.py` — 13 passed (cross-engine + zcomm tests bound the tap at ±3/±5 Ω, comfortably met)
- [x] ruff check / format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPQBxTv46asiT2hAczUZoK