### PR TITLE
feat(engines): register SinusoidalGalerkinSolver as a momwire backend (momwire#182 M6)

### DIFF
--- a/scripts/bench_catalog.py
+++ b/scripts/bench_catalog.py
@@ -68,7 +68,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import bench_converge as cvg  # noqa: E402
 import bench_nec_corpus as bnc  # noqa: E402
 
-ENGINE_KEYS = cvg.ENGINE_KEYS  # ("pynec", "sin", "bs1", "bs2")
+ENGINE_KEYS = cvg.ENGINE_KEYS  # ("pynec", "sin", "sing", "bs1", "bs2")
+DEFAULT_ENGINE_KEYS = cvg.DEFAULT_ENGINE_KEYS
 ENGINE_LABEL = cvg.ENGINE_LABEL
 
 # Ground specs by CLI label — identical to profile_ground_models.py, so the
@@ -333,7 +334,10 @@ def main(argv=None):
     )
     ap.add_argument("--designs", nargs="+", default=None)
     ap.add_argument(
-        "--engines", nargs="+", default=list(ENGINE_KEYS), choices=ENGINE_KEYS
+        "--engines",
+        nargs="+",
+        default=list(DEFAULT_ENGINE_KEYS),
+        choices=ENGINE_KEYS,
     )
     ap.add_argument(
         "--grounds",

--- a/scripts/bench_converge.py
+++ b/scripts/bench_converge.py
@@ -64,7 +64,8 @@ DEFAULT_DESIGNS = (
     "beams.yagi",
 )
 DEFAULT_LADDER = (7, 11, 15, 21, 31, 45, 61, 85)
-ENGINE_KEYS = bnc.ENGINE_KEYS  # ("pynec", "sin", "bs1", "bs2")
+ENGINE_KEYS = bnc.ENGINE_KEYS  # ("pynec", "sin", "sing", "bs1", "bs2")
+DEFAULT_ENGINE_KEYS = bnc.DEFAULT_ENGINE_KEYS
 ENGINE_LABEL = bnc.ENGINE_LABEL
 
 
@@ -164,6 +165,11 @@ def solve_design(builder_cls, nseg: int, engine: str, ground):
         eng = PyNECEngine(b, ground=ground)
     elif engine == "sin":
         eng = MomwireEngine(b, solver=SinusoidalSolver, ground=ground)
+    elif engine == "sing":
+        # Same basis as "sin", Galerkin-tested (momwire#182).
+        from momwire import SinusoidalGalerkinSolver
+
+        eng = MomwireEngine(b, solver=SinusoidalGalerkinSolver, ground=ground)
     elif engine == "bs1":
         eng = MomwireEngine(
             b, solver=BSplineSolver, solver_kwargs={"degree": 1}, ground=ground
@@ -334,7 +340,10 @@ def main(argv=None):
     )
     ap.add_argument("--designs", nargs="+", default=list(DEFAULT_DESIGNS))
     ap.add_argument(
-        "--engines", nargs="+", default=list(ENGINE_KEYS), choices=ENGINE_KEYS
+        "--engines",
+        nargs="+",
+        default=list(DEFAULT_ENGINE_KEYS),
+        choices=ENGINE_KEYS,
     )
     ap.add_argument(
         "--nseg-ladder",

--- a/scripts/bench_nec_corpus.py
+++ b/scripts/bench_nec_corpus.py
@@ -85,13 +85,23 @@ import numpy as np  # noqa: E402
 
 XNEC2C_EXAMPLES = Path.home() / "antennas" / "xnec2c" / "examples"
 Z0 = 50.0  # system impedance for the reflection-coefficient metric (issue #407)
-ENGINE_KEYS = ("pynec", "sin", "bs1", "bs2")
+# Every engine key the benchmark scripts can dispatch. "sing" (momwire#182)
+# is the SAME three-term basis as "sin" tested variationally instead of
+# point-matched, so the pair isolates the TESTING scheme with the basis held
+# fixed — that is what it is here for.
+ENGINE_KEYS = ("pynec", "sin", "sing", "bs1", "bs2")
 ENGINE_LABEL = {
     "pynec": "PyNEC",
     "sin": "Sinusoidal",
+    "sing": "Sinusoidal-Gal",
     "bs1": "BSpline d=1",
     "bs2": "BSpline d=2",
 }
+# What `--engines` defaults to. Deliberately NOT all of ENGINE_KEYS: the
+# corpus/catalog sweeps are long-running, and silently adding a fifth column
+# to every historical benchmark would change what those runs cost and mean.
+# Ask for "sing" explicitly.
+DEFAULT_ENGINE_KEYS = ("pynec", "sin", "bs1", "bs2")
 
 
 # --------------------------------------------------------------------------
@@ -387,6 +397,10 @@ def worker_main(engine: str, deck_path: str, freq: float, ground_json: str):
             )
         elif engine == "sin":
             eng = MomwireEngine(builder, solver=SinusoidalSolver, ground=ground)
+        elif engine == "sing":
+            from momwire import SinusoidalGalerkinSolver
+
+            eng = MomwireEngine(builder, solver=SinusoidalGalerkinSolver, ground=ground)
         elif engine == "bs1":
             eng = MomwireEngine(
                 builder,
@@ -1644,7 +1658,10 @@ def main(argv=None):
     )
     ap.add_argument("--corpus", type=Path, default=XNEC2C_EXAMPLES)
     ap.add_argument(
-        "--engines", nargs="+", default=list(ENGINE_KEYS), choices=ENGINE_KEYS
+        "--engines",
+        nargs="+",
+        default=list(DEFAULT_ENGINE_KEYS),
+        choices=ENGINE_KEYS,
     )
     ap.add_argument(
         "--decks",

--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -22,6 +22,11 @@ from momwire import (
     ArrayBlockSolver,
 )
 
+try:
+    from momwire import SinusoidalGalerkinSolver
+except ImportError:  # momwire older than the #182 Galerkin solver
+    SinusoidalGalerkinSolver = None
+
 import argparse
 import logging
 from importlib import import_module
@@ -41,6 +46,12 @@ MOMWIRE_BASES = {
     "hmatrix": HMatrixSolver,
     "arrayblock": ArrayBlockSolver,
 }
+if SinusoidalGalerkinSolver is not None:
+    # Same three-term basis as `sinusoidal`, tested variationally instead of
+    # point-matched (momwire#182). Registered conditionally only because the
+    # `momwire==` pin in pyproject.toml still admits a release that predates
+    # the class; make it unconditional at the next momwire bump.
+    MOMWIRE_BASES["sinusoidal-galerkin"] = SinusoidalGalerkinSolver
 
 
 def resolve_class(s):
@@ -276,7 +287,8 @@ def broadcast_pairs(builders, engines):
 def parse_engine_spec(spec):
     """Parse an engine spec into (engine_name, kwargs_to_bind).
 
-    Forms: "pynec", "momwire", "momwire:sinusoidal|bspline|hmatrix|arrayblock".
+    Forms: "pynec", "momwire",
+    "momwire:sinusoidal|sinusoidal-galerkin|bspline|hmatrix|arrayblock".
     """
     name, _, basis = spec.partition(":")
     if name not in ENGINE_CLASSES:
@@ -357,7 +369,8 @@ def cli(arguments=None):
                 nargs="+",
                 default=["momwire"],
                 help="One or more simulation backends. Each spec is "
-                '"momwire[:sinusoidal|bspline|hmatrix|arrayblock]" or "pynec". '
+                '"momwire[:sinusoidal|sinusoidal-galerkin|bspline|'
+                'hmatrix|arrayblock]" or "pynec". '
                 "Cross-products with --builders.",
             )
         else:
@@ -366,7 +379,8 @@ def cli(arguments=None):
                 type=str,
                 default="momwire",
                 help="Simulation backend: momwire | "
-                "momwire:sinusoidal | momwire:bspline | momwire:hmatrix | "
+                "momwire:sinusoidal | momwire:sinusoidal-galerkin | "
+                "momwire:bspline | momwire:hmatrix | "
                 "momwire:arrayblock | pynec (default: momwire). pynec needs "
                 "the optional pynec-accel package; momwire is always "
                 "available.",

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -30,9 +30,16 @@ def _parity_for_solver(solver, solver_kwargs):
       - BSplineSolver degree=1 → tent basis, even (feed straddles 2 segs)
       - BSplineSolver degree=2 → quadratic → odd
       - SinusoidalSolver → odd
+      - SinusoidalGalerkinSolver → odd (same basis, Galerkin testing)
     Anything else falls through as "any" (no coercion)."""
     name = getattr(solver, "__name__", "")
-    if name == "SinusoidalSolver":
+    if name in ("SinusoidalSolver", "SinusoidalGalerkinSolver"):
+        # SinusoidalGalerkinSolver subclasses SinusoidalSolver — same three-term
+        # basis and the same delta-gap feed, so it inherits the odd-segment
+        # rule. Load-bearing for the whole point of the class: the basis ×
+        # testing instrument (momwire#182) only reads cleanly when the two
+        # sinusoidal cells differ in exactly ONE thing (the testing), and a
+        # parity fall-through to "any" would have them differ in the mesh too.
         return "odd"
     if name in ("BSplineSolver", "HMatrixSolver", "ArrayBlockSolver"):
         # HMatrixSolver and ArrayBlockSolver are BSplineSolver subclasses (same
@@ -106,6 +113,14 @@ _GROUND_EPS_SOLVERS = (
     "HMatrixSolver",
     "ArrayBlockSolver",
     "SinusoidalSolver",
+    # SinusoidalGalerkinSolver wires all three grounds (momwire#182 M4) by
+    # reusing each ground's existing source-field evaluator under the Galerkin
+    # test quadrature — no new field kernels, so it inherits the point-matched
+    # sibling's NEC gn 0 / gn 2 agreement. Caveat, inherited and shared with
+    # SinusoidalSolver: a wire END LYING IN the ground plane is only sound
+    # under the PEC image (the #151 ground-connected basis completes the end
+    # current with an exact mirror, which a Fresnel/Sommerfeld image is not).
+    "SinusoidalGalerkinSolver",
 )
 
 
@@ -123,6 +138,10 @@ _WIRE_LOADING_SOLVERS = (
     "HMatrixSolver",
     "ArrayBlockSolver",
     "SinusoidalSolver",
+    # SinusoidalGalerkinSolver is DELIBERATELY absent: momwire#182 left wire
+    # loading unwired on it (it raises where reached), so it takes the
+    # warn-and-drop branch below rather than crashing a loaded design. Add it
+    # here when momwire wires loading into the Galerkin testing.
 )
 
 
@@ -147,9 +166,16 @@ class MomwireEngine(SimulationEngine):
         """
         solver:
           A momwire solver class — BSplineSolver (default), SinusoidalSolver,
-          or the fast BSpline subclasses (HMatrixSolver, ArrayBlockSolver).
+          SinusoidalGalerkinSolver, or the fast BSpline subclasses
+          (HMatrixSolver, ArrayBlockSolver).
           Different bases trade speed vs impedance fidelity; on the hentenna
           sinusoidal is typically closer to PyNEC at modest segmentation.
+          SinusoidalGalerkinSolver is the same three-term basis as
+          SinusoidalSolver tested variationally instead of point-matched
+          (momwire#182): it costs more per fill and buys coarse-mesh
+          reactance accuracy, and it closes most of the sin↔bs2 gaps this
+          repo tracked as basis effects — see momwire
+          docs/sinusoidal-galerkin-instrument-report.md.
         solver_kwargs:
           Dict of solver-specific kwargs passed straight to the constructor
           (e.g. `{"degree": 1}` for BSplineSolver, or `{"n_qp_const": 16}`

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -91,6 +91,11 @@ from momwire import (
     SinusoidalSolver,
 )
 
+try:
+    from momwire import SinusoidalGalerkinSolver
+except ImportError:  # momwire older than the #182 Galerkin solver
+    SinusoidalGalerkinSolver = None
+
 from .examples import register
 from .examples._base import (
     DEFAULT_AMATEUR_BANDS,
@@ -158,6 +163,20 @@ _MOMWIRE_MODELS = {
     # structure it degrades to one element and matches the dense bspline solve.
     "arrayblock": ArrayBlockSolver,
 }
+if SinusoidalGalerkinSolver is not None:
+    # The same three-term basis as "sinusoidal", tested variationally rather
+    # than point-matched (momwire#182). It is the instrument column, not an
+    # interactive default: no C++ accelerator and no distributed wire loading,
+    # and the fill costs several times the point-matched one. Exposed on the
+    # wire protocol so the CLI/API and the engine-parity tests can select it by
+    # name; the frontend's own `Backend` union deliberately does NOT list it,
+    # so no solver tab appears until it earns one.
+    #
+    # Conditional only because the `momwire==` pin in pyproject.toml still
+    # admits a release predating the class (the wheel-smoke CI job installs
+    # momwire from PyPI, not the submodule). Make it unconditional at the
+    # next momwire release bump.
+    _MOMWIRE_MODELS["sinusoidal-galerkin"] = SinusoidalGalerkinSolver
 
 
 # ---------------------------------------------------------------------------
@@ -1605,6 +1624,20 @@ def _auto_default_view(cls) -> str:
 # already past interactive; the whip benchmark sits at ~12,700.
 _SINUSOIDAL_RECOMMEND_MIN_BASIS = 3000
 
+# Backends that implement junction-node ports, in preference order — the
+# allowlist a `PortAtEnd` design is restricted to. `bspline` stays FIRST
+# because `_required_backends()[0]` becomes the design's default backend and
+# the dense mixed-potential solver is the reference implementation for these
+# ports. `sinusoidal-galerkin` joined in momwire#182 M5b: it holds the node's
+# lumped charge outside the reaction integral and reproduces the B-spline port
+# network entrywise to 3.4e-5 / 3.9e-6, which is what "widening this tuple"
+# was waiting for. Caveat carried by the solver's own hard error, not by this
+# list: its junction ports are FREE SPACE only (the node-charge image is not
+# removed yet) and reject mixed per-wire radii.
+_JUNCTION_PORT_BACKENDS = ("bspline",) + (
+    ("sinusoidal-galerkin",) if SinusoidalGalerkinSolver is not None else ()
+)
+
 
 @lru_cache(maxsize=None)
 def _required_backends(cls) -> tuple[str, ...] | None:
@@ -1612,24 +1645,24 @@ def _required_backends(cls) -> tuple[str, ...] | None:
 
     Today's only restriction: a design whose network has any `PortAtEnd`
     resolves to junction-node ports, which only the dense B-spline solver
-    implements (momwire#172 — the sinusoidal and iterative HMatrix/
-    ArrayBlock solvers raise NotImplementedError, and NEC-2 has no
-    equivalent card at all, so `PyNECEngine` rejects the design at
-    construction, issue #579). DERIVED from the flattened network spec
-    rather than declared per design, so the capability cannot drift from
-    what the design actually does. The frontend disables the other backend
-    tabs (with an explanatory tooltip) and coerces an active disallowed
-    selection to the first allowed entry on design switch; the solvers'
-    hard errors remain the enforcement. Any failure to build the network
-    falls back to None — the design's real error surfaces through the
-    normal solve path. A future momwire release that widens junction-port
-    support only needs to widen this tuple."""
+    and the sinusoidal-Galerkin solver implement (momwire#172 / momwire#182 —
+    the point-matched sinusoidal and iterative HMatrix/ArrayBlock solvers
+    raise NotImplementedError, and NEC-2 has no equivalent card at all, so
+    `PyNECEngine` rejects the design at construction, issue #579). DERIVED
+    from the flattened network spec rather than declared per design, so the
+    capability cannot drift from what the design actually does. The frontend
+    disables the other backend tabs (with an explanatory tooltip) and coerces
+    an active disallowed selection to the first allowed entry on design
+    switch; the solvers' hard errors remain the enforcement. Any failure to
+    build the network falls back to None — the design's real error surfaces
+    through the normal solve path. A future momwire release that widens
+    junction-port support only needs to widen `_JUNCTION_PORT_BACKENDS`."""
     try:
         net = _build_builder(cls, {}).build_network()
     except Exception:
         return None
     if net is not None and any(isinstance(p, PortAtEnd) for p in net.ports.values()):
-        return ("bspline",)
+        return _JUNCTION_PORT_BACKENDS
     return None
 
 

--- a/tests/test_balanced_line_physics.py
+++ b/tests/test_balanced_line_physics.py
@@ -780,3 +780,108 @@ def test_centre_port_construction_tracks_a_physical_feeder():
         zp = _subst_zin(_PhysFedDoublet, feed_len_wl=flw)
         dev = abs(_subst_zin(_CentrePortDoublet, feed_len_wl=flw) - zp) / abs(zp)
         assert dev < 0.05, (flw, dev)
+
+
+# ---------------------------------------------------------------------------
+# 8. The junction-port network on a second formulation (momwire#182 M5b)
+# ---------------------------------------------------------------------------
+#
+# Everything above rides `PortAtEnd` -> momwire junction ports, which until
+# momwire#182 only `BSplineSolver` implemented. A single implementation of a
+# port model is a single point of failure for the whole `sterba_bl` result:
+# the design's physics rests on 16 one-terminal node ports whose only oracle
+# is the all-wire `wire.sterba`, and a shared bug in the port algebra would
+# reproduce itself in every test in this file.
+#
+# `SinusoidalGalerkinSolver` is now an independent second implementation --
+# different basis (NEC's three-term vs quadratic B-spline), different testing
+# quadrature, and a completely different port derivation (the node's lumped
+# charge removed from a FIELD-based reaction integral, vs a Lagrange
+# multiplier on a KCL row in a MIXED-POTENTIAL formulation). Agreement
+# between them is therefore evidence about the port MODEL, not about one
+# implementation's self-consistency.
+#
+# FREE SPACE ONLY, stated openly: momwire#182 M5b scoped junction ports over
+# any ground out (the node-charge IMAGE is not removed yet, so part of the M5
+# blocker would survive), and the solver refuses rather than approximating.
+# Section 5's average-ground test therefore has no sinusoidal-Galerkin column;
+# `test_catalog_curtain_on_sin_galerkin_refuses_a_ground` pins the refusal so
+# the omission cannot be mistaken for an oversight.
+
+
+def _sin_galerkin_curtain(n_cells, **overrides):
+    from momwire import SinusoidalGalerkinSolver
+
+    return MomwireEngine(
+        _catalog_curtain(n_cells, **overrides),
+        solver=SinusoidalGalerkinSolver,
+        ground=None,
+    )
+
+
+@pytest.mark.antenna_computation_check
+def test_catalog_curtain_matches_on_the_sinusoidal_galerkin_basis():
+    """wire.sterba_bl's 16-port junction-port network, solved twice on two
+    formulations that share no basis, no testing and no port algebra.
+
+    Both the driving-point impedance and the radiated pattern must agree --
+    Z is the port network's own readout, gain is what the resulting current
+    distribution does, and a port-model error that cancelled in one would
+    still show in the other.
+
+    Measured 2026-07-30, free space, catalog default n_cells=3:
+
+        bspline d=2           Z = 673.293 + 385.592j   10.606 dBi  az 180
+        sinusoidal-Galerkin   Z = 672.055 + 387.371j   10.605 dBi  az 180
+
+    i.e. 0.28 % in |Z| and 0.001 dB in peak gain. The bounds below are set an
+    order of magnitude looser than the measurement (2 % / 0.15 dB) because
+    this is a cross-FORMULATION check, not a pin: the two schemes' ordinary
+    discretization error does not have to agree to three digits, and only a
+    port-model discrepancy would be large enough to trip these.
+    """
+    # One engine per formulation, reused for both readouts (the far field
+    # rides the same cached solve, so this costs one solve each).
+    e_ref = MomwireEngine(_catalog_curtain(3), ground=None)  # BSplineSolver
+    e_sg = _sin_galerkin_curtain(3)
+    z_ref, z_sg = e_ref.impedance()[0], e_sg.impedance()[0]
+    assert abs(z_sg - z_ref) / abs(z_ref) < 0.02, (z_ref, z_sg)
+
+    gain_ref, az_ref = _peak(e_ref)
+    gain_sg, az_sg = _peak(e_sg)
+    assert abs(gain_sg - gain_ref) < 0.15, (gain_ref, gain_sg)
+    for az in (az_ref, az_sg):
+        assert min(az % 180.0, 180.0 - az % 180.0) <= 10.0
+
+
+@pytest.mark.antenna_computation_check
+def test_sin_galerkin_curtain_still_needs_the_common_mode_path():
+    """The section-5 finding, re-derived on the independent formulation.
+
+    `zcomm` is the file's most load-bearing claim -- the CM path is what
+    makes a 4-terminal element stand in for a pair of conductors that closes
+    a conduction loop -- and it is a claim about the PORT boundary condition,
+    exactly what a second port implementation is able to falsify. Removing
+    the CM path must cost several dB and swing the beam off broadside here
+    too. Measured 2026-07-30: 10.61 dBi az 180 with, 5.53 dBi az 35 without.
+    """
+    gain_on, az_on = _peak(_sin_galerkin_curtain(3))
+    gain_off, az_off = _peak(_sin_galerkin_curtain(3, zcomm=0.0))
+    assert min(az_on % 180.0, 180.0 - az_on % 180.0) <= 10.0
+    assert gain_on - gain_off > 3.0, (gain_on, gain_off)
+    assert min(az_off % 180.0, 180.0 - az_off % 180.0) > 20.0
+
+
+def test_catalog_curtain_on_sin_galerkin_refuses_a_ground():
+    """Junction ports over a ground are REFUSED on the sinusoidal-Galerkin
+    solver, not approximated (momwire#182 M5b scoped them out: the node
+    charge's ground IMAGE is still in the kernel). Pinned so that section 5's
+    missing sinusoidal-Galerkin column reads as a scope boundary rather than
+    an untested path -- and so a future momwire that lifts the restriction
+    fails here loudly instead of silently changing what this file covers."""
+    with pytest.raises(NotImplementedError, match="junction_ports over a ground"):
+        MomwireEngine(
+            _catalog_curtain(1),
+            solver=__import__("momwire").SinusoidalGalerkinSolver,
+            ground=AVG_GROUND,
+        ).impedance()

--- a/tests/test_balanced_line_physics.py
+++ b/tests/test_balanced_line_physics.py
@@ -863,7 +863,9 @@ def test_sin_galerkin_curtain_still_needs_the_common_mode_path():
     a conduction loop -- and it is a claim about the PORT boundary condition,
     exactly what a second port implementation is able to falsify. Removing
     the CM path must cost several dB and swing the beam off broadside here
-    too. Measured 2026-07-30: 10.61 dBi az 180 with, 5.53 dBi az 35 without.
+    too. Measured 2026-07-30: 10.605 dBi az 180 with, 5.518 dBi az 35
+    without -- against the B-spline solver's own 10.606 / 5.519 on the same
+    pair of builds.
     """
     gain_on, az_on = _peak(_sin_galerkin_curtain(3))
     gain_off, az_off = _peak(_sin_galerkin_curtain(3, zcomm=0.0))

--- a/tests/test_bench_catalog.py
+++ b/tests/test_bench_catalog.py
@@ -112,6 +112,17 @@ def test_bench_one_guard_skips_finite_grounds_for_oversized_meshes():
             assert "skipped" in cell["error"]
 
 
-def test_engine_keys_cover_all_four_solvers():
-    assert set(bc.ENGINE_KEYS) == {"pynec", "sin", "bs1", "bs2"}
+def test_engine_keys_cover_every_dispatchable_solver():
+    # "sing" (momwire#182) is the sinusoidal basis tested variationally — the
+    # same basis as "sin", so the pair isolates the testing scheme.
+    assert set(bc.ENGINE_KEYS) == {"pynec", "sin", "sing", "bs1", "bs2"}
     assert all(k in bc.ENGINE_LABEL for k in bc.ENGINE_KEYS)
+
+
+def test_default_engine_keys_stay_the_historical_four():
+    """`--engines` defaults must NOT silently grow: the corpus/catalog sweeps
+    are long-running, and adding a column to every historical benchmark would
+    change what those runs cost and what they can be compared against. "sing"
+    is dispatchable but opt-in."""
+    assert set(bc.DEFAULT_ENGINE_KEYS) == {"pynec", "sin", "bs1", "bs2"}
+    assert set(bc.DEFAULT_ENGINE_KEYS) <= set(bc.ENGINE_KEYS)

--- a/tests/test_engine_spec.py
+++ b/tests/test_engine_spec.py
@@ -74,10 +74,22 @@ def test_make_factory_binds_ground_and_solver():
 def test_momwire_bases_keys():
     assert set(MOMWIRE_BASES) == {
         "sinusoidal",
+        "sinusoidal-galerkin",
         "bspline",
         "hmatrix",
         "arrayblock",
     }
+
+
+def test_make_factory_binds_sinusoidal_galerkin():
+    """The Galerkin-tested sinusoidal basis is selectable by name
+    (momwire#182). Same basis as `momwire:sinusoidal`, variational testing —
+    the pair is the instrument, so both must be addressable."""
+    from momwire import SinusoidalGalerkinSolver
+
+    factory = make_engine_factory("momwire:sinusoidal-galerkin", _GROUND_UNSET)
+    assert factory.func is MomwireEngine
+    assert factory.keywords == {"solver": SinusoidalGalerkinSolver}
 
 
 O = " --fn /dev/null"

--- a/tests/test_momwire_engine.py
+++ b/tests/test_momwire_engine.py
@@ -1264,6 +1264,96 @@ def test_momwire_arrayblock_parity_matches_bspline():
 
 
 # --------------------------------------------------------------------------
+# SinusoidalGalerkinSolver wiring — momwire#182.
+#
+# The same three-term basis as SinusoidalSolver, tested variationally instead
+# of point-matched. It is a MEASURING instrument first: with the basis and the
+# mesh held fixed, the sin/sin-Galerkin pair reads the testing scheme's
+# contribution to a discrepancy directly, which is what antennaknobs#521's
+# residue cluster needed. Full write-up: momwire
+# docs/sinusoidal-galerkin-instrument-report.md.
+# --------------------------------------------------------------------------
+
+
+def test_momwire_sinusoidal_galerkin_parity_matches_sinusoidal():
+    """The Galerkin solver shares the point-matched one's odd-segment parity
+    (a regression guard for the _parity_for_solver wiring).
+
+    Load-bearing rather than cosmetic: the whole point of running the two
+    sinusoidal cells side by side is that they differ in exactly ONE thing
+    (the testing). A parity fall-through to "any" would build a different
+    mesh and quietly make every comparison a comparison of two problems."""
+    from momwire import SinusoidalSolver, SinusoidalGalerkinSolver
+    from antennaknobs.engines.momwire import _parity_for_solver
+
+    assert _parity_for_solver(SinusoidalGalerkinSolver, {}) == "odd"
+    assert _parity_for_solver(SinusoidalGalerkinSolver, {}) == _parity_for_solver(
+        SinusoidalSolver, {}
+    )
+
+
+def test_momwire_sinusoidal_galerkin_capability_gates():
+    """The name-keyed capability tuples, both directions.
+
+    Grounds: momwire#182 M4 wired all three ground models onto the Galerkin
+    testing, so ground_eps must NOT be silently dropped. Wire loading: M6
+    left it unwired (the solver raises where reached), so the engine must
+    take the warn-and-drop branch instead — deliberately absent, not
+    forgotten."""
+    from momwire import SinusoidalGalerkinSolver
+    from antennaknobs.engines.momwire import (
+        _solver_supports_ground_eps,
+        _solver_supports_wire_loading,
+    )
+
+    assert _solver_supports_ground_eps(SinusoidalGalerkinSolver)
+    assert not _solver_supports_wire_loading(SinusoidalGalerkinSolver)
+
+
+def test_momwire_sinusoidal_galerkin_reads_the_hentenna_residue():
+    """The instrument's headline reading, as a regression guard.
+
+    antennaknobs#521 filed specialty.hentenna at the top of the "no-mutual
+    residue cluster": at the catalog mesh the point-matched sinusoidal solver
+    and the B-spline Galerkin solver disagree by tens of percent, concentrated
+    in reactance, and the census could not say whether that was the basis or
+    the testing. Swapping ONLY the testing answers it — sin-Galerkin lands on
+    the B-spline value at the same mesh, so the gap is a testing effect, not a
+    basis effect.
+
+    Measured 2026-07-30 at the catalog default (nominal_nsegs=21, 119 segs,
+    free space):
+
+        sin (collocation)   42.44 + 29.23j
+        sin-Galerkin        43.01 + 38.90j
+        bspline d=2         43.05 + 38.59j
+
+    The bounds are loose on purpose — this pins the VERDICT (collocation far,
+    the two Galerkin schemes together), not the third digit."""
+    from importlib import import_module
+    from momwire import BSplineSolver, SinusoidalSolver, SinusoidalGalerkinSolver
+
+    mod = "antennaknobs.designs.specialty.hentenna"
+    z = {}
+    for key, cls in (
+        ("coll", SinusoidalSolver),
+        ("gal", SinusoidalGalerkinSolver),
+        ("bs2", BSplineSolver),
+    ):
+        b = import_module(mod).Builder()
+        z[key] = MomwireEngine(b, solver=cls, ground=None).impedance()[0]
+
+    def rel(a, b):
+        return abs(a - b) / abs(b)
+
+    assert rel(z["coll"], z["bs2"]) > 0.10, z
+    assert rel(z["gal"], z["bs2"]) < 0.02, z
+    # ...and the win is in the reactance, which is where #521 filed the gap.
+    assert abs(z["coll"].imag - z["bs2"].imag) > 5.0, z
+    assert abs(z["gal"].imag - z["bs2"].imag) < 1.0, z
+
+
+# --------------------------------------------------------------------------
 # TwoPort branch — issue #65 piece (B).
 #
 # A lumped series R+jωL+1/(jωC) bridging two distinct feed segments. The

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1186,7 +1186,13 @@ def test_examples_carry_requires_backends(client: TestClient):
     by_name = {e["name"]: e for e in payload["examples"]}
     for e in payload["examples"]:
         assert "requires_backends" in e
-    assert by_name["wire.sterba_bl"]["requires_backends"] == ["bspline"]
+    # momwire#182 M5b widened junction-port support to the sinusoidal-Galerkin
+    # solver, so the allowlist is a PAIR now. bspline stays first — it is the
+    # reference implementation and `default_backend` is `requires_backends[0]`.
+    assert by_name["wire.sterba_bl"]["requires_backends"] == [
+        "bspline",
+        "sinusoidal-galerkin",
+    ]
     assert by_name["wire.sterba_bl"]["default_backend"] == "bspline"
     # The unrestricted Sterba siblings stay unrestricted — including the
     # network-TL one (TL/BalancedLine on PortOnWire gaps run everywhere).


### PR DESCRIPTION
The antennaknobs half of momwire#182's final milestone. The momwire half — **the instrument report** — is stevenmburns/momwire#190; this PR is what lets that report's column be selected here, plus the `wire.sterba_bl` end-to-end it made possible.

## Why this matters, not just what it wires

momwire#182 built a fourth cell of the basis × testing matrix: the **same** three-term sinusoidal basis as `SinusoidalSolver`, tested variationally instead of point-matched. That turns a `sin`↔`bs2` disagreement from a guess into a measurement, because the pair now differs in exactly one thing.

Run across this repo's own open discrepancy issues (momwire#190, full write-up):

- **#521's T/X-junction residue cluster is the TESTING scheme.** On `specialty.hentenna` at the catalog mesh: `sin` 42.44 + 29.23j, `sin-Galerkin` 43.01 + **38.90j**, `bspline` 43.05 + **38.59j**. The Galerkin testing of the sinusoidal basis has at 119 segments the answer collocation has not reached at 1835. Same at 9.9–23 % across hourglass, hentenna_array, hourglass_array and discone.
- **#478's near-open class is the FEED MODEL** — testing buys ~0, matching the source model collapses `lazy_h`/`vbeam` from 1.25 %/0.78 % to 0.022 %/0.010 %.
- **#521's helix control cannot be scored at all yet, and this PR does not pretend otherwise.** `specialty.helix`'s builder emits one segment per winding chord, so it ignores `nominal_nsegs`: the census's N = 21…641 ladder re-solved one identical 53-segment mesh at every rung. (momwire#190 reproduces #521's 30.6 % figure exactly, at that mesh, and refuses to attribute it.) That is a meshing bug in this repo's design, filed back to #521.

## The wiring

| where | change |
|---|---|
| `engines/momwire.py` | odd-segment parity + the `ground_eps` capability |
| `cli.py`, `web/adapter.py` | the `sinusoidal-galerkin` backend name |
| `web/adapter.py` | `_required_backends` widened via `_JUNCTION_PORT_BACKENDS` |
| `scripts/bench_*.py` | dispatchable engine key `sing` |
| `momwire` | submodule pointer → momwire main (b3c8d22, M5b) |

Three of those are load-bearing rather than bookkeeping:

**Parity is not cosmetic.** `_parity_for_solver` fell through to `"any"` for an unregistered solver, which would build a *different mesh* — and the entire value of the sin/sin-Galerkin pair is that they differ in exactly one thing. A parity miss would silently turn every reading above into a comparison of two problems. Pinned by a regression test.

**Wire loading is deliberately NOT claimed.** momwire leaves it unwired on this solver (it raises where reached), so the engine takes its existing warn-and-drop branch instead of crashing a loaded design. The omission is asserted, not assumed.

**`_required_backends` widening.** That docstring has said "a future momwire release that widens junction-port support only needs to widen this tuple" since #579. momwire#182 M5b is that release: it implements one-terminal junction ports on a completely different derivation (the node's lumped charge held outside a *field-based* reaction integral, vs a Lagrange multiplier on a KCL row in a *mixed-potential* one) and reproduces `BSplineSolver`'s port network **entrywise to 3.4e-5**. `bspline` stays first in the tuple — it is the reference implementation and `default_backend` is `requires_backends[0]`. The frontend's own `Backend` union deliberately does not list the new name, so no solver tab appears until it earns one; this is registered as an instrument column (no C++ accelerator, several times the fill cost), not as an interactive backend.

The `momwire` imports are behind `try/except ImportError` because the `momwire==` pin still admits a PyPI release predating the class, and the `wheel-smoke` job installs from PyPI rather than the submodule. Unconditional at the next momwire release bump.

## `wire.sterba_bl` end-to-end — a second port implementation

`test_balanced_line_physics.py` gains a section 8. Until now this design's entire physics story — 16 one-terminal `PortAtEnd` junction ports, whose only oracle is the all-wire `wire.sterba` — rested on a **single** port implementation, so a shared bug in the port algebra would have reproduced itself in every test in the file.

Free space, catalog default `n_cells=3`:

| | Z | peak gain | az |
|---|---|--:|--:|
| `BSplineSolver` | 673.293 + 385.592j | 10.6064 dBi | 180° |
| `SinusoidalGalerkinSolver` | 672.055 + 387.371j | 10.6054 dBi | 180° |
| **difference** | **0.28 %** | **0.001 dB** | — |

At one bay: 315.518 + 138.156j vs 315.338 + 138.840j (0.20 %). Both readouts are asserted on purpose — Z is the port network's own output, gain is what the resulting current distribution *does*, and a port-model error that cancelled in one would still show in the other. The file's most load-bearing claim, that `zcomm` is a **topological switch** rather than a tuning knob, re-derives on the independent formulation too: removing the CM path costs 10.605 → 5.518 dBi and swings the beam 180° → 35°, against the B-spline solver's own 10.606 → 5.519.

Stated above the visibility floor: the fill's 8.3e-12 reciprocity floor amplifies to ~1e-8 through a port solve, so 0.28 % is five and a half orders above anything the floor could explain.

**Free space only, and the omission is pinned rather than left silent.** momwire#182 M5b scoped junction ports over any ground out (the node charge's *image* is not removed yet), and the solver refuses rather than approximating. So `test_catalog_curtain_gain_over_average_ground` has no sinusoidal-Galerkin column, and `test_catalog_curtain_on_sin_galerkin_refuses_a_ground` asserts the refusal — a future momwire that lifts the restriction fails there loudly instead of quietly changing what this file covers.

## Bench-script defaults deliberately unchanged

`sing` joins `ENGINE_KEYS` (dispatchable) but **not** `DEFAULT_ENGINE_KEYS`. Silently adding a fifth column to every corpus/catalog sweep would change what those long-running benchmarks cost and what historical runs can be compared against. Ask for it explicitly. Both invariants are now asserted.

## Verification

- `ruff check` + `ruff format --check` clean (0.15.21, the CI pin).
- Fast lane: **2796 passed**, 2 skipped, 168 deselected (72 s).
- New `antenna_computation_check` tests (main lane) run green locally: 43 s for the three sterba_bl additions.
- New fast-lane tests: parity, capability gates, the CLI factory binding, `MOMWIRE_BASES`/`ENGINE_KEYS` shapes, and the hentenna reading itself (0.5 s).

## Follow-ups

1. **#521** — the T/X cluster closes as a testing effect; hentenna/hourglass fine-mesh reference values are scoreable again, with the `sinusoidal` column read as under-resolved rather than as a competing answer.
2. **#521, helix** — needs a real mesh knob before it can be scored at all.
3. **#478** — the *inter-basis* part of the near-open residual is the feed model and is now explained; the shared whole-structure part stands as filed.