### PR TITLE
docs: document the sinusoidal-galerkin backend (solver reference, convergence, README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ What you get:
 - **A ground plane, on by default** — real antennas hang over real ground, so
   the workbench starts there (free space is one click away). The ground is
   described by what it *is* — finite (εr=10, σ=0.002) or PEC — independent of
-  solver; both backends offer the true Sommerfeld-Norton solve and the faster
-  reflection-coefficient method, and the solve readout reports the model that
-  actually ran.
+  solver; every momwire backend (and PyNEC) offers the true Sommerfeld-Norton
+  solve and the faster reflection-coefficient method, and the solve readout
+  reports the model that actually ran.
 
 Live updates stay responsive because rapid knob drags are coalesced into one
 solve per round-trip, so the solver is never buried under stale requests.

--- a/site/src/content/docs/advanced/convergence.md
+++ b/site/src/content/docs/advanced/convergence.md
@@ -64,6 +64,14 @@ N=21 on 53 — the sinusoidal basis on 36 — with conv@N advantages up to
 N=15: on the scorable catalog it is converged out of the box, at ~35 %
 less cost per solve than N=21.
 
+Why the sinusoidal basis lags has since been *attributed*, not just
+measured: momwire's basis × testing instrument showed the census gap is
+mostly the **point matching**, not the basis — swap only the testing
+scheme (the `sinusoidal-galerkin` backend) and the junction-heavy gaps
+collapse ~100×, with the residual on clean geometry down at the
+feed-model level. The mechanism write-up is
+[momwire chapter 15](https://momwire.dev/act-5/the-fourth-cell/).
+
 ## The four ways a curve refuses to settle
 
 When the sweep does *not* flatten, resist the reflex to just raise N.

--- a/site/src/content/docs/reference/solver.mdx
+++ b/site/src/content/docs/reference/solver.mdx
@@ -21,7 +21,15 @@ momwire offers two current-expansion basis families in one engine — uncommon
 among free tools, where basis quality is usually a paid feature:
 
 - **B-spline** — a degree-1/2 Galerkin basis, the default (degree 2),
-- **sinusoidal** — a NEC-2-style three-term basis, useful as a cross-validator.
+- **sinusoidal** — a NEC-2-style three-term basis, point-matched like NEC-2;
+  useful as a cross-validator (it tracks PyNEC closely because it shares both
+  the basis and the point matching),
+- **sinusoidal-galerkin** — the same three-term basis with Galerkin
+  (integrated) test rows: exactly reciprocal Z by construction, markedly
+  faster reactance convergence on junction-heavy geometry, and junction-node
+  ports (free space). It exists so basis effects and testing effects can be
+  told apart — the full story is
+  [momwire's chapter 15](https://momwire.dev/act-5/the-fourth-cell/).
 
 Plus two **accelerated** solvers for large problems:
 
@@ -100,6 +108,16 @@ threading; see the benchmark docs for full tables.
   loops converge on d=2 as coarse as N=7 — ~2–3× below the sinusoidal
   basis; details and how to
   check your own design: [How many segments?](/advanced/convergence/)
+- **That census gap is mostly the *point matching*, not the basis.** The
+  momwire#182 instrument (the `sinusoidal-galerkin` backend) re-ran the
+  residue cluster varying only the testing scheme: the junction-heavy
+  sin↔bspline gaps of 1–23 % collapse to 0.01–0.33 %, and with a matched
+  feed model the remaining basis gap on clean geometry is ~4×10⁻⁸. So
+  `sinusoidal-galerkin` converges at B-spline-class meshes while keeping
+  the sinusoidal basis — use it as the second opinion on **junction-port
+  (`PortAtEnd`) designs**, which historically were B-spline-only and now
+  accept either (`bspline` remains the default; the sin-Galerkin junction
+  ports are free-space only for now).
 
 ## Segments & convergence
 


### PR DESCRIPTION
Backend bullet + census-attribution guidance in reference/solver.mdx,
the point-matching attribution cross-ref in advanced/convergence.md
(links momwire chapter 15), and the stale 'both backends' ground wording
in the README.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L74dw56F7DCjG3u7RhMHEp
