### PR TITLE
fix(docs): momwire.dev does not exist — the momwire site is momwire.antennaknobs.dev

### DIFF
--- a/site/src/content/docs/advanced/convergence.md
+++ b/site/src/content/docs/advanced/convergence.md
@@ -70,7 +70,7 @@ mostly the **point matching**, not the basis — swap only the testing
 scheme (the `sinusoidal-galerkin` backend) and the junction-heavy gaps
 collapse ~100×, with the residual on clean geometry down at the
 feed-model level. The mechanism write-up is
-[momwire chapter 15](https://momwire.dev/act-5/the-fourth-cell/).
+[momwire chapter 15](https://momwire.antennaknobs.dev/act-5/the-fourth-cell/).
 
 ## The four ways a curve refuses to settle
 

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -40,7 +40,7 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
   **Touchstone (.s1p/.s2p) import** as network elements, the
   **`bowtie1x2_bl`** corporate-feed design, and a frontend↔backend roster
   contract test. Built on **momwire 0.20.0**; the full story is
-  [momwire chapter 15](https://momwire.dev/act-5/the-fourth-cell/).
+  [momwire chapter 15](https://momwire.antennaknobs.dev/act-5/the-fourth-cell/).
   [All release notes →](/reference/releases/)
 </Card>
 

--- a/site/src/content/docs/reference/solver.mdx
+++ b/site/src/content/docs/reference/solver.mdx
@@ -29,7 +29,7 @@ among free tools, where basis quality is usually a paid feature:
   faster reactance convergence on junction-heavy geometry, and junction-node
   ports (free space). It exists so basis effects and testing effects can be
   told apart — the full story is
-  [momwire's chapter 15](https://momwire.dev/act-5/the-fourth-cell/).
+  [momwire's chapter 15](https://momwire.antennaknobs.dev/act-5/the-fourth-cell/).
 
 Plus two **accelerated** solvers for large problems:
 


### PR DESCRIPTION
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L74dw56F7DCjG3u7RhMHEp
