### PR TITLE
chore: release v0.40.0 (accelerated Galerkin + the helix split)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/sta
 # install below sees its requirement already satisfied, then the package with the
 # web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install "momwire==0.20.0" \
+ && pip install "momwire==0.21.0" \
  && pip install -e ".[web]"
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.39.0"
+version = "0.40.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]
@@ -41,7 +41,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire==0.20.0",
+    "momwire==0.21.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,22 +25,19 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.39.0" icon="star">
-  **A second opinion for every port-fed design — and a verdict on a
-  years-old question.** The new **`sinusoidal-galerkin`** backend keeps
-  NEC's three-term sinusoidal current basis but tests it by integration
-  (Galerkin), the way the B-spline solver does. That fourth basis × testing
-  cell turned solver disagreement into *attribution*: the junction-heavy
-  sin↔B-spline gaps in the catalog census were the **point matching, not the
-  basis** (1–23 % collapsing to 0.01–0.33 %), and the near-open residual is
-  the **feed model**. Practically: exactly reciprocal Z, B-spline-class
-  convergence on junction geometry, and **junction-node ports** — so
-  **`PortAtEnd`** designs like `wire.sterba_bl` (previously B-spline-only)
-  now solve on two independent bases agreeing to 0.28 % / 0.001 dB. Also:
-  **Touchstone (.s1p/.s2p) import** as network elements, the
-  **`bowtie1x2_bl`** corporate-feed design, and a frontend↔backend roster
-  contract test. Built on **momwire 0.20.0**; the full story is
-  [momwire chapter 15](https://momwire.antennaknobs.dev/act-5/the-fourth-cell/).
+<Card title="New in v0.40.0" icon="star">
+  **The Galerkin backend grows up, and the helix splits in two.** The
+  `sinusoidal-galerkin` backend now runs on **momwire 0.21.0**, whose far
+  fill is a fused C++ kernel — **7–12× faster end-to-end**, and the memory
+  ceiling that capped it near 2 000 segments is gone (a 4 000-segment solve
+  fits in under 4 GiB), so census-scale meshes are interactive. In the
+  catalog, the helix is now **two designs with one refinement axis each**:
+  **`faceted_helix`** (the winding's polygon is the geometry; the mesh
+  subdivides along it) and **`continuous_helix`** (the chord count follows
+  the mesh density, converging to the true circular winding) — both
+  arc-length-normalized so they wind identical wire at every mesh, closing
+  the catalog's last unmeshable convergence story (the old builder solved
+  one frozen 53-segment mesh at every density).
   [All release notes →](/reference/releases/)
 </Card>
 


### PR DESCRIPTION
Release PR per the ritual (precedent: #265, #269).

- **Adopt momwire 0.21.0** — the #194 arc: profiler, blocked numpy far fill (memory ceiling removed), fused C++ far-fill kernel (7–12× end-to-end, matrix agreement 1e-14). All three pin sites updated in one commit: `pyproject.toml`, `Dockerfile`, submodule pointer (at momwire's bump commit `9e119d4`). PyPI is already serving 0.21.0, so wheel-smoke won't race the publish.
- **Version 0.39.0 → 0.40.0**; what's-new card refreshed (Galerkin speed/memory + the `faceted_helix`/`continuous_helix` split from #636).
- De-stale sweep of `site/`: no stale solver/CLI/web pages found — the Galerkin backend docs never claimed the old cost, and the catalog page regenerated in #636. Site builds clean (25 pages).
- Full suite locally: 2986 passed, 2 skipped.

No solver-behavior change on unqualified request paths (the accelerated fill is gated on matrix agreement with the reference; defaults unchanged).

After merge: tag v0.40.0 → four pipelines (PyPI, simulator, docs, Docker) + fleet-convergence verification, then the Discussions announcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)