### PR TITLE
feat: expose momwire feed_model as "NEC-compatible vs converged" (#640)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,21 @@ point — agreement between independent engines is your confidence check.
 --engine momwire:hmatrix         # B-spline + hierarchical-matrix (ACA) acceleration
 --engine momwire:arrayblock      # element-aware block solver for arrays
 --engine pynec                   # NEC2 via PyNEC (needs the optional pynec-accel)
+--engine momwire:sinusoidal-galerkin            # three-term basis, Galerkin testing
+--engine momwire:sinusoidal-galerkin-converged  # same, with the converged feed model
 ```
+
+**NEC-compatible vs converged feed** (sinusoidal-Galerkin only): the plain
+`sinusoidal-galerkin` drives NEC's segment-wide gap — it reproduces NEC/EZNEC
+behaviour, including the well-known reactance drift as the mesh refines, which
+is what you want when cross-checking against NEC results. The `-converged`
+variant (web: the "Converged" feed-model setting on the Sin-Galerkin solver)
+drives a zero-width gap instead: the impedance converges to the B-spline
+answer, and on near-open high-Q designs (`lazy_h`, `vbeam`) it removes two to
+three orders of magnitude of the apparent disagreement between solver bases
+(momwire#213). It does not reduce the mesh a near-open design needs — budget
+fine mesh either way. The plain `sinusoidal` solver offers no such choice: a
+zero-width gap cannot be expressed under point-matching (momwire#212).
 
 In Python, instantiate an engine directly:
 

--- a/site/src/content/docs/advanced/convergence.md
+++ b/site/src/content/docs/advanced/convergence.md
@@ -106,6 +106,17 @@ default fixes this class; expect a slow drift of a few percent, read the
 admittance if you need a well-conditioned number, and treat the last
 percent as physical uncertainty rather than solver error.
 
+One refinement since that was first written (momwire#213): on this class
+the *apparent disagreement between bases* — sin-Galerkin vs B-spline
+reading percent-level apart at the same mesh — turned out to be almost
+entirely the **feed model**, not the physics. The Sin-Galerkin solver's
+*Converged* feed-model setting (the gear-menu control; the workbench
+recommends it on the designs that need it) removes two to three orders
+of magnitude of that cross-basis gap, measured out to N=641. What it
+does **not** change is the paragraph above: each solver's own
+rung-to-rung drift is still percent-level, so the mesh budget and the
+"treat the last percent as physical" advice stand exactly as written.
+
 **4. A wire's segments approaching its own radius (Δ/a).** The oldest
 rule in thin-wire MoM is also the one that produced the census's most
 spectacular failure. The thin-wire kernel needs each segment to stay

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -68,11 +68,22 @@ The `--engine` flag selects the solver:
 ```bash
 --engine momwire                 # momwire (default), default (B-spline) basis
 --engine momwire:sinusoidal      # NEC-2-style three-term basis
+--engine momwire:sinusoidal-galerkin            # same basis, Galerkin testing
+--engine momwire:sinusoidal-galerkin-converged  # …with the converged feed model
 --engine momwire:bspline         # B-spline Galerkin basis
 --engine momwire:hmatrix         # B-spline + hierarchical-matrix (ACA) acceleration
 --engine momwire:arrayblock      # element-aware block solver for arrays
 --engine pynec                   # the NEC-2 reference backend (needs pynec-accel)
 ```
+
+The `-converged` variant swaps the sinusoidal-Galerkin solver's NEC-style
+segment-wide gap for a zero-width one: the impedance converges to the
+B-spline answer instead of reproducing NEC's mesh-dependent reactance
+drift. Use the plain form when cross-checking against NEC/EZNEC results;
+use `-converged` on near-open high-Q feeds (`wire.lazy_h`, `wire.vbeam`
+class), where it removes two to three orders of magnitude of the apparent
+disagreement between solver bases — see
+[Solvers & accuracy](/reference/solver/) for the details.
 
 `momwire` is the default so a plain install works without the optional
 `pynec-accel` package. See [The solver & accuracy](/reference/solver/) for which

--- a/site/src/content/docs/reference/solver.mdx
+++ b/site/src/content/docs/reference/solver.mdx
@@ -27,9 +27,23 @@ among free tools, where basis quality is usually a paid feature:
 - **sinusoidal-galerkin** — the same three-term basis with Galerkin
   (integrated) test rows: exactly reciprocal Z by construction, markedly
   faster reactance convergence on junction-heavy geometry, and junction-node
-  ports (free space). It exists so basis effects and testing effects can be
-  told apart — the full story is
+  ports (free space; PEC since momwire#191). It exists so basis effects and
+  testing effects can be told apart — the full story is
   [momwire's chapter 15](https://momwire.antennaknobs.dev/act-5/the-fourth-cell/).
+  It also carries the one user-facing **feed-model choice**:
+  *NEC-compatible* (the default segment-wide gap — reproduces NEC/EZNEC
+  behaviour, including the reactance drift as the mesh refines) or
+  *Converged* (a zero-width gap — converges to the B-spline answer, exactly
+  reciprocal Y). In the workbench it is the "feed model" control in the
+  Sin-Galerkin slot's gear menu; on the CLI,
+  `momwire:sinusoidal-galerkin-converged`. Pick *NEC-compatible* when
+  cross-checking against NEC results, *Converged* on near-open high-Q
+  feeds (the workbench recommends it on the designs that need it —
+  momwire#213 measured it removing 992×/374× of the cross-basis
+  disagreement on `lazy_h`/`vbeam`, without reducing the mesh those
+  designs genuinely need). The plain `sinusoidal` solver offers no such
+  choice: a zero-width gap cannot be expressed under point matching
+  (momwire#212).
 
 Plus two **accelerated** solvers for large problems:
 

--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -53,6 +53,23 @@ if SinusoidalGalerkinSolver is not None:
     # the class; make it unconditional at the next momwire bump.
     MOMWIRE_BASES["sinusoidal-galerkin"] = SinusoidalGalerkinSolver
 
+# Roster variants: a basis name bound to solver kwargs. The one entry is the
+# feed-model axis (issue #640): the plain `sinusoidal-galerkin` keeps NEC's
+# segment-wide gap (NEC-compatible — reproduces NEC/EZNEC behaviour, including
+# the reactance walk with mesh density), while `-converged` opts into the
+# zero-width point gap that converges to the B-spline answer (momwire#192) and
+# is the recommended setting for near-open high-Q designs — up to 992× tighter
+# cross-basis agreement on the antennaknobs#478 class (momwire#213). No such
+# variant exists for plain `sinusoidal`: the point gap has no collocation RHS
+# (momwire#212), and the solver refuses it rather than silently serving the
+# segment gap.
+MOMWIRE_BASIS_VARIANTS = {}
+if SinusoidalGalerkinSolver is not None:
+    MOMWIRE_BASIS_VARIANTS["sinusoidal-galerkin-converged"] = (
+        SinusoidalGalerkinSolver,
+        {"feed_model": "point"},
+    )
+
 
 def resolve_class(s):
     lst = s.split(".")
@@ -288,7 +305,9 @@ def parse_engine_spec(spec):
     """Parse an engine spec into (engine_name, kwargs_to_bind).
 
     Forms: "pynec", "momwire",
-    "momwire:sinusoidal|sinusoidal-galerkin|bspline|hmatrix|arrayblock".
+    "momwire:sinusoidal|sinusoidal-galerkin|sinusoidal-galerkin-converged|
+    bspline|hmatrix|arrayblock". The `-converged` variant is sinusoidal-galerkin
+    with the point-gap feed model (issue #640; see MOMWIRE_BASIS_VARIANTS).
     """
     name, _, basis = spec.partition(":")
     if name not in ENGINE_CLASSES:
@@ -301,9 +320,13 @@ def parse_engine_spec(spec):
         raise argparse.ArgumentTypeError(
             f"engine {name!r} does not accept a basis suffix (got {basis!r})"
         )
+    if basis in MOMWIRE_BASIS_VARIANTS:
+        solver, solver_kwargs = MOMWIRE_BASIS_VARIANTS[basis]
+        return name, {"solver": solver, "solver_kwargs": dict(solver_kwargs)}
     if basis not in MOMWIRE_BASES:
+        available = sorted(MOMWIRE_BASES) + sorted(MOMWIRE_BASIS_VARIANTS)
         raise argparse.ArgumentTypeError(
-            f"unknown momwire basis {basis!r}; available: {', '.join(sorted(MOMWIRE_BASES))}"
+            f"unknown momwire basis {basis!r}; available: {', '.join(available)}"
         )
     return name, {"solver": MOMWIRE_BASES[basis]}
 
@@ -369,9 +392,13 @@ def cli(arguments=None):
                 nargs="+",
                 default=["momwire"],
                 help="One or more simulation backends. Each spec is "
-                '"momwire[:sinusoidal|sinusoidal-galerkin|bspline|'
+                '"momwire[:sinusoidal|sinusoidal-galerkin|'
+                "sinusoidal-galerkin-converged|bspline|"
                 'hmatrix|arrayblock]" or "pynec". '
-                "Cross-products with --builders.",
+                "The -converged variant uses the point-gap feed model — "
+                "converges to the B-spline answer instead of reproducing "
+                "NEC's segment gap; recommended for near-open high-Q "
+                "designs. Cross-products with --builders.",
             )
         else:
             p.add_argument(
@@ -380,8 +407,12 @@ def cli(arguments=None):
                 default="momwire",
                 help="Simulation backend: momwire | "
                 "momwire:sinusoidal | momwire:sinusoidal-galerkin | "
+                "momwire:sinusoidal-galerkin-converged | "
                 "momwire:bspline | momwire:hmatrix | "
-                "momwire:arrayblock | pynec (default: momwire). pynec needs "
+                "momwire:arrayblock | pynec (default: momwire). The "
+                "-converged variant uses the point-gap feed model "
+                "(converges to the B-spline answer; recommended for "
+                "near-open high-Q designs). pynec needs "
                 "the optional pynec-accel package; momwire is always "
                 "available.",
             )

--- a/src/antennaknobs/designs/wire/lazy_h.py
+++ b/src/antennaknobs/designs/wire/lazy_h.py
@@ -51,6 +51,10 @@ class Builder(AntennaBuilder):
                     # High-Z junction fed via open-wire line + tuner.
                     "target_z0": 300.0,
                     "default_view": "yz",
+                    # Near-open high-Q feed (antennaknobs#478): the converged
+                    # (point-gap) feed model collapses the cross-basis residual
+                    # up to 992× on this design (momwire#213, report §18).
+                    "converged_feed_suggested": True,
                     "elem_frac": {
                         "min": 0.8,
                         "max": 1.3,

--- a/src/antennaknobs/designs/wire/vbeam.py
+++ b/src/antennaknobs/designs/wire/vbeam.py
@@ -54,6 +54,10 @@ class Builder(AntennaBuilder):
                     "target_z0": 300.0,
                     # Legs splay in x/y -> the xy view is face-on.
                     "default_view": "xy",
+                    # Near-open high-Q feed (antennaknobs#478): the converged
+                    # (point-gap) feed model collapses the cross-basis residual
+                    # up to 374× on this design (momwire#213, report §18).
+                    "converged_feed_suggested": True,
                     "leg_frac": {
                         "min": 0.75,
                         "max": 2.0,

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -247,6 +247,12 @@ _HOSTED_MODEL_OPTIONS = {
     "n_qp_source": _int_in(1, 64),
     "n_qp_sing": _int_in(1, 128),
     "feed_smoothing_factor": _float_in(0.0, 100.0, allow_none=True),
+    # Gap-source model on the solvers that offer it (momwire#192/#216):
+    # "segment" is NEC's segment-wide gap, "point" the zero-width (converged)
+    # gap. The UI words this "NEC-compatible vs converged" (issue #640). The
+    # point-matched SinusoidalSolver refuses "point" with its own instructive
+    # error (momwire#212), so no per-solver filtering is needed here.
+    "feed_model": _enum_opt("segment", "point"),
     "use_singular_enrichment": _bool_opt,
     "enrichment_variant": _enum_opt("raw", "stable", "tikhonov", "auto"),
     "tikhonov_lambda": _float_in(0.0, 1e3),
@@ -2374,6 +2380,11 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         count_basis=count_basis,
         default_backend=field_default_backend,
         requires_backends=field_requires_backends,
+        # Static ui_params pin, never derived — safe to read eagerly even for
+        # deferred (user) designs, unlike the geometry hints above.
+        converged_feed_suggested=bool(
+            _ui_scalar(dp, "converged_feed_suggested", False)
+        ),
         pynec_solve=pynec_solve,
         pynec_build=pynec_build,
         pynec_pattern_excite=pynec_pattern_excite,

--- a/src/antennaknobs/web/examples/_base.py
+++ b/src/antennaknobs/web/examples/_base.py
@@ -319,6 +319,13 @@ class AntennaExample:
     # tooltip) and coerces a disallowed active selection on switch; the
     # solvers' hard errors remain the enforcement.
     requires_backends: Optional[tuple[str, ...]] = None
+    # Near-open high-Q feed (antennaknobs#478): the design benefits from the
+    # sinusoidal-Galerkin solver's converged (point-gap) feed model, which
+    # collapses the cross-basis residual by 2-3 orders on this class
+    # (momwire#213). Declared statically in the design's ui_params — it is an
+    # empirical classification, not derivable from geometry. The frontend uses
+    # it to recommend "Converged" in the Sin-Galerkin feed-model control.
+    converged_feed_suggested: bool = False
     pynec_build: Optional[PynecBuildFn] = None
     pynec_solve: Optional[SolveFn] = None
     # Render the geometry as a NEC2 .nec card deck (str) for the current

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -157,6 +157,13 @@ type ExampleDescriptor = {
    *  "solve anyway") gate when the active backend is disallowed; the
    *  solvers' errors remain the enforcement. */
   requires_backends: string[] | null;
+  /** Near-open high-Q feed (antennaknobs#478): the Sin-Galerkin solver's
+   *  "Converged" (point-gap) feed model is recommended for this design —
+   *  it collapses the cross-basis residual by 2-3 orders on this class
+   *  (momwire#213). Drives the recommendation hint in the Sin-Galerkin
+   *  feed-model control; declared statically in the design's ui_params.
+   *  Absent/undefined on older servers → treat as false. */
+  converged_feed_suggested?: boolean;
   /** True when the Builder has a `design_freq` param that scales
    *  geometry (design_freq-sized designs). When false, the design-freq
    *  band-tab row is hidden because dragging it would be a no-op. */
@@ -1659,6 +1666,14 @@ function normalizeBackend(b: string | null | undefined): Backend | null {
 type CommonOpts = { nPerWire: number; wireRadius: number };
 
 type SinusoidalOpts = CommonOpts & { nQpConst: number };
+// Sin-Galerkin only: the feed-model axis (issue #640, momwire#192).
+// "segment" = NEC-compatible (NEC's segment-wide gap — reproduces NEC/EZNEC
+// behaviour, including the reactance walk with mesh density); "point" =
+// Converged (zero-width gap — converges to the B-spline answer; recommended
+// for near-open high-Q designs, momwire#213). Deliberately NOT on plain
+// sinusoidal: the point gap has no collocation RHS (momwire#212), so that
+// solver offers no choice to present.
+type SinGalerkinOpts = SinusoidalOpts & { feedModel: "segment" | "point" };
 type BSplineOpts = CommonOpts & {
   degree: 1 | 2;
   nQpPair: number;
@@ -1693,8 +1708,9 @@ type PyNECOpts = CommonOpts;
 type BackendOptsMap = {
   sinusoidal: SinusoidalOpts;
   // Same constructor surface as sinusoidal (momwire#182: same basis, Galerkin
-  // testing); the test-quadrature knobs keep their solver defaults.
-  "sinusoidal-galerkin": SinusoidalOpts;
+  // testing) plus the feed-model choice only the Galerkin testing can carry;
+  // the test-quadrature knobs keep their solver defaults.
+  "sinusoidal-galerkin": SinGalerkinOpts;
   bspline: BSplineOpts;
   hmatrix: BSplineOpts;
   arrayblock: BSplineOpts;
@@ -1718,7 +1734,14 @@ const BSPLINE_DEFAULT_OPTS: BSplineOpts = {
 
 const DEFAULT_BACKEND_OPTS: BackendOptsMap = {
   sinusoidal: { nPerWire: 30, wireRadius: 0.0005, nQpConst: 8 },
-  "sinusoidal-galerkin": { nPerWire: 30, wireRadius: 0.0005, nQpConst: 8 },
+  // feedModel "segment" (NEC-compatible) is the solver's own default; the
+  // gear menu recommends "point" (Converged) on near-open designs (#640).
+  "sinusoidal-galerkin": {
+    nPerWire: 30,
+    wireRadius: 0.0005,
+    nQpConst: 8,
+    feedModel: "segment",
+  },
   bspline: { ...BSPLINE_DEFAULT_OPTS },
   hmatrix: { ...BSPLINE_DEFAULT_OPTS },
   // Arrays auto-select this; 21 segs/wire is the converged, correct-parity
@@ -1745,9 +1768,13 @@ type SlotConfig = {
 // their spline degree so two b-spline slots (the default A d=2 / B d=1
 // pair) stay distinguishable at a glance.
 function backendDisplayLabel(b: Backend, opts: BackendOptsMap[Backend]): string {
-  return isBSplineFamily(b)
-    ? `${BACKEND_LABEL[b]} d=${(opts as BSplineOpts).degree}`
-    : BACKEND_LABEL[b];
+  if (isBSplineFamily(b))
+    return `${BACKEND_LABEL[b]} d=${(opts as BSplineOpts).degree}`;
+  // Surface the non-default feed model on the slot chip: two Sin-Galerkin
+  // slots differing only in feed model must be tellable apart at a glance.
+  if (b === "sinusoidal-galerkin" && (opts as SinGalerkinOpts).feedModel === "point")
+    return `${BACKEND_LABEL[b]} (converged)`;
+  return BACKEND_LABEL[b];
 }
 
 const DEFAULT_SLOTS: Record<Slot, SlotConfig> = {
@@ -1803,7 +1830,13 @@ function modelOptionsForRequest(
   backend: Backend,
   opts: BackendOptsMap[Backend],
 ): Record<string, unknown> {
-  if (backend === "sinusoidal" || backend === "sinusoidal-galerkin") {
+  if (backend === "sinusoidal-galerkin") {
+    const o = opts as SinGalerkinOpts;
+    // feed_model only here: plain sinusoidal cannot carry the point gap
+    // (momwire#212) and must not receive the key at all.
+    return { n_qp_const: o.nQpConst, feed_model: o.feedModel };
+  }
+  if (backend === "sinusoidal") {
     const o = opts as SinusoidalOpts;
     return { n_qp_const: o.nQpConst };
   }
@@ -5406,6 +5439,9 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
             backend={slots[gearOpen].backend}
             backends={selectableBackends(havePynec)}
             requiredBackends={requiredBackends}
+            suggestConvergedFeed={
+              currentExample?.converged_feed_suggested ?? false
+            }
             opts={slots[gearOpen].opts}
             onChangeBackend={(b) => {
               backendTouchedRef.current = true;
@@ -6135,6 +6171,10 @@ type BackendConfigProps = {
    *  explaining why, rather than disappearing — the picker stays stable
    *  across design switches and the restriction itself is the signal. */
   requiredBackends: string[] | null;
+  /** Current design recommends the Converged feed model (near-open high-Q,
+   *  antennaknobs#478) — shown as a hint on the Sin-Galerkin feed-model
+   *  control. */
+  suggestConvergedFeed: boolean;
   opts: BackendOptsMap[Backend];
   onChangeBackend: (b: Backend) => void;
   onPatch: (patch: Partial<BackendOptsMap[Backend]>) => void;
@@ -6147,6 +6187,7 @@ function BackendConfigModal({
   backend,
   backends,
   requiredBackends,
+  suggestConvergedFeed,
   opts,
   onChangeBackend,
   onPatch,
@@ -6224,6 +6265,63 @@ function BackendConfigModal({
               step={1}
               onChange={(v) => onPatch({ nQpConst: v } as never)}
             />
+          )}
+
+          {backend === "sinusoidal-galerkin" && (
+            <div className="field">
+              <label>
+                <span>feed model</span>
+              </label>
+              <div className="geometry-tabs" role="tablist">
+                {(
+                  [
+                    ["segment", "NEC-compatible"],
+                    ["point", "Converged"],
+                  ] as const
+                ).map(([value, label]) => (
+                  <button
+                    key={value}
+                    role="tab"
+                    aria-selected={
+                      (opts as SinGalerkinOpts).feedModel === value
+                    }
+                    className={
+                      (opts as SinGalerkinOpts).feedModel === value
+                        ? "active"
+                        : ""
+                    }
+                    title={
+                      value === "segment"
+                        ? "NEC's segment-wide gap: reproduces NEC/EZNEC " +
+                          "behaviour, including reactance drift with mesh " +
+                          "density. Use when cross-checking against NEC " +
+                          "results."
+                        : "Zero-width (point) gap: converges to the " +
+                          "B-spline answer and gives a reciprocal Y. " +
+                          "Recommended for near-open high-Q designs " +
+                          "(momwire#213)."
+                    }
+                    onClick={() => onPatch({ feedModel: value } as never)}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+              {suggestConvergedFeed &&
+                (opts as SinGalerkinOpts).feedModel === "segment" && (
+                  <em
+                    style={{
+                      color: "var(--muted)",
+                      fontSize: "var(--text-sm)",
+                    }}
+                  >
+                    This design's feed is near-open / high-Q: "Converged" is
+                    recommended — it removes up to ~1000× of the cross-basis
+                    disagreement here (momwire#213). "NEC-compatible" remains
+                    right for NEC cross-checks.
+                  </em>
+                )}
+            </div>
           )}
 
           {isBSplineFamily(backend) && (

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -1925,6 +1925,7 @@ def examples_endpoint():
                     if ex.requires_backends is not None
                     else None
                 ),
+                "converged_feed_suggested": ex.converged_feed_suggested,
                 "has_design_freq": ex.has_design_freq,
                 "variants": list(ex.variants),
                 "variant_values": dict(ex.variant_values),

--- a/tests/test_balanced_line_physics.py
+++ b/tests/test_balanced_line_physics.py
@@ -875,13 +875,18 @@ def test_sin_galerkin_curtain_still_needs_the_common_mode_path():
 
 
 def test_catalog_curtain_on_sin_galerkin_refuses_a_ground():
-    """Junction ports over a ground are REFUSED on the sinusoidal-Galerkin
-    solver, not approximated (momwire#182 M5b scoped them out: the node
-    charge's ground IMAGE is still in the kernel). Pinned so that section 5's
-    missing sinusoidal-Galerkin column reads as a scope boundary rather than
-    an untested path -- and so a future momwire that lifts the restriction
-    fails here loudly instead of silently changing what this file covers."""
-    with pytest.raises(NotImplementedError, match="junction_ports over a ground"):
+    """Junction ports over a FINITE ground are REFUSED on the
+    sinusoidal-Galerkin solver, not approximated. momwire#182 M5b scoped all
+    grounds out (the node charge's ground image was still in the kernel);
+    momwire#191 lifted exactly the PEC case (a point charge's PEC image is a
+    point charge), so the boundary this file pins moved once already -- this
+    test fired on that bump, as designed. Finite grounds remain out: the
+    reflection-coefficient and Sommerfeld images of a point charge are not
+    point charges. Pinned so section 5's missing sinusoidal-Galerkin column
+    reads as a scope boundary rather than an untested path -- and so the next
+    momwire that moves the boundary again fails here loudly instead of
+    silently changing what this file covers."""
+    with pytest.raises(NotImplementedError, match="junction_ports over a FINITE"):
         MomwireEngine(
             _catalog_curtain(1),
             solver=__import__("momwire").SinusoidalGalerkinSolver,

--- a/tests/test_engine_spec.py
+++ b/tests/test_engine_spec.py
@@ -92,6 +92,45 @@ def test_make_factory_binds_sinusoidal_galerkin():
     assert factory.keywords == {"solver": SinusoidalGalerkinSolver}
 
 
+def test_parse_converged_variant_binds_feed_model():
+    """`momwire:sinusoidal-galerkin-converged` is the point-gap feed model as
+    a roster variant (issue #640): same solver class, `feed_model="point"`
+    bound as solver kwargs. The kwargs are a fresh dict per parse so a caller
+    mutating them cannot poison the roster."""
+    from momwire import SinusoidalGalerkinSolver
+
+    name, kw = parse_engine_spec("momwire:sinusoidal-galerkin-converged")
+    assert name == "momwire"
+    assert kw == {
+        "solver": SinusoidalGalerkinSolver,
+        "solver_kwargs": {"feed_model": "point"},
+    }
+    kw["solver_kwargs"]["feed_model"] = "mutated"
+    assert parse_engine_spec("momwire:sinusoidal-galerkin-converged")[1][
+        "solver_kwargs"
+    ] == {"feed_model": "point"}
+
+
+def test_make_factory_binds_converged_variant():
+    from momwire import SinusoidalGalerkinSolver
+
+    factory = make_engine_factory(
+        "momwire:sinusoidal-galerkin-converged", _GROUND_UNSET
+    )
+    assert factory.func is MomwireEngine
+    assert factory.keywords == {
+        "solver": SinusoidalGalerkinSolver,
+        "solver_kwargs": {"feed_model": "point"},
+    }
+
+
+def test_no_converged_variant_for_plain_sinusoidal():
+    """The point gap has no collocation RHS (momwire#212), so the roster must
+    not offer a converged flavour of the point-matched solver."""
+    with pytest.raises(argparse.ArgumentTypeError):
+        parse_engine_spec("momwire:sinusoidal-converged")
+
+
 O = " --fn /dev/null"
 
 

--- a/tests/test_momwire_engine.py
+++ b/tests/test_momwire_engine.py
@@ -43,6 +43,26 @@ def test_momwire_impedance_in_realistic_range():
     assert abs(z.imag) < 200, f"unrealistic X: {z}"
 
 
+def test_converged_feed_model_reaches_the_solver():
+    """Issue #640: `solver_kwargs={"feed_model": "point"}` must reach the
+    sinusoidal-Galerkin constructor and change the answer. Both feed models
+    solve the same dipole to a realistic impedance; the point gap differs
+    from the segment gap by a measurable margin (the M3 feed-model axis,
+    momwire#192) — a plumbing regression that dropped the kwarg would read
+    identical impedances and fail the inequality."""
+    from momwire import SinusoidalGalerkinSolver
+
+    b = Builder(resolve_variant_params(Builder, "dipole"))
+    z = {}
+    for fm in ("segment", "point"):
+        (z[fm],) = MomwireEngine(
+            b, solver=SinusoidalGalerkinSolver, solver_kwargs={"feed_model": fm}
+        ).impedance()
+        assert 30 < z[fm].real < 150, (fm, z[fm])
+    rel = abs(z["point"] - z["segment"]) / abs(z["segment"])
+    assert 1e-6 < rel < 0.05, z
+
+
 def test_momwire_impedance_sweep_shape_and_monotone_resistance():
     freqs = np.linspace(28.0, 29.0, 5)
     zs = MomwireEngine(Builder()).impedance_sweep(freqs)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -239,6 +239,16 @@ def test_examples_are_sorted_by_label(client: TestClient):
     assert labels == sorted(labels)
 
 
+def test_examples_carry_the_converged_feed_suggestion(client: TestClient):
+    """Issue #640: the near-open high-Q designs (antennaknobs#478) declare
+    `converged_feed_suggested` in ui_params and the descriptor must carry it —
+    it drives the "Converged" recommendation hint in the frontend's
+    Sin-Galerkin feed-model control. Everything else defaults to False."""
+    by_name = {e["name"]: e for e in client.get("/examples").json()["examples"]}
+    flagged = {n for n, e in by_name.items() if e.get("converged_feed_suggested")}
+    assert flagged == {"wire.lazy_h", "wire.vbeam"}, flagged
+
+
 def test_capabilities_reports_pynec_availability(client: TestClient, monkeypatch):
     """The frontend gates the PyNEC backend option on this flag (#429): when
     pynec-accel is absent the UI must not offer PyNEC, so the /ws solve does
@@ -2443,6 +2453,22 @@ def test_local_model_options_forward_verbatim():
     }
     with pytest.raises(ValueError):  # non-dict is a clean error even locally
         adapter.sanitize_model_options({"model_options": "junk"})
+
+
+def test_hosted_feed_model_option_is_whitelisted(monkeypatch):
+    """Issue #640: the feed-model choice ("NEC-compatible vs converged" in
+    the UI) must survive the hosted whitelist — it is a physics selection,
+    not a compute-amplification lever — and bad values get the clean
+    enum error."""
+    from antennaknobs.web import adapter
+
+    monkeypatch.setattr(adapter, "_HOSTED", True)
+    out = adapter.sanitize_model_options({"model_options": {"feed_model": "point"}})
+    assert out == {"feed_model": "point"}
+    out = adapter.sanitize_model_options({"model_options": {"feed_model": "segment"}})
+    assert out == {"feed_model": "segment"}
+    with pytest.raises(ValueError, match="feed_model"):
+        adapter.sanitize_model_options({"model_options": {"feed_model": "delta"}})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #640. The momwire `feed_model` knob (momwire#192) becomes user-reachable from antennaknobs, worded on the user-meaningful axis — **NEC-compatible** (segment gap: reproduces NEC/EZNEC behaviour, right for NEC cross-checks) vs **Converged** (point gap: converges to the B-spline answer, recommended for near-open high-Q designs, momwire#213: 992×/374× residual collapse on lazy_h/vbeam).

## What's here

- **momwire submodule bump** to main (`d69d83d`) — the full #192–#217 feed-model arc.
- **CLI**: `momwire:sinusoidal-galerkin-converged` roster variant binding `{"feed_model": "point"}` through the existing `solver_kwargs` path. Deliberately no variant for plain `sinusoidal` — the point gap has no collocation RHS (momwire#212), and a silent alias would manufacture the two-feed-model confound the momwire report's §16 exists to prevent.
- **Web**: `feed_model` joins the hosted `model_options` whitelist (enum, a physics selection not a compute lever). Frontend gains a "feed model" control on the Sin-Galerkin slot only (`NEC-compatible` / `Converged`, with explanatory tooltips); the request includes `feed_model` only for that backend; the slot chip reads "Sin-Galerkin (converged)" when active so two slots differing only in feed model are tellable apart.
- **Per-design recommendation**: `wire.lazy_h` and `wire.vbeam` declare `converged_feed_suggested` in ui_params (static — the #478 classification is empirical, not geometry-derivable); the descriptor and `/examples` carry it; the frontend shows a recommendation hint while the control sits on the default.
- **Docs**: README paragraph + three site pages — the solver reference (the choice, on the one solver that carries it), the CLI page, and the convergence page's near-open section, whose "no basis and no default fixes this class" claim was stale after momwire#213 (the cross-basis part was the feed model; the physics-limited drift and mesh-budget advice stand as written).
- **Test re-pin**: `test_catalog_curtain_on_sin_galerkin_refuses_a_ground` fired on the submodule bump exactly as designed — momwire#191 moved the boundary (PEC lifted, finite grounds still refused); re-pinned on the new message.

## Verification

- Full suite: **2992 passed, 2 pre-existing skips** (pytest exit 0, verified directly — not through a pipe).
- Frontend: `tsc --noEmit` clean; site `npm run build` clean (25 pages).
- Live CLI smoke: `pattern --engine momwire:sinusoidal-galerkin-converged` end-to-end.
- New tests: engine-spec variant parsing (incl. roster-mutation guard and the no-sinusoidal-variant guard), engine-level kwarg plumbing (feed models must *differ* — a dropped kwarg fails the inequality), hosted whitelist enum, `/examples` flag coverage (exactly {wire.lazy_h, wire.vbeam}).

## Notes for release sequencing

Merging this is safe pre-momwire-release: CI's test job checks out momwire main (`--remote`), and the PyPI wheel-smoke job is protected by the existing conditional imports. An antennaknobs *release* exposing this needs momwire v0.22.0 on PyPI first, then the `momwire==0.21.0` pin bump (at which point the conditional imports become unconditional per their own comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g