### PR TITLE
chore: release v0.41.0 (the feed-model release)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/sta
 # install below sees its requirement already satisfied, then the package with the
 # web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install "momwire==0.21.0" \
+ && pip install "momwire==0.22.0" \
  && pip install -e ".[web]"
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.40.0"
+version = "0.41.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]
@@ -41,7 +41,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire==0.21.0",
+    "momwire==0.22.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",

--- a/site/src/content/docs/concepts/station-modelling.md
+++ b/site/src/content/docs/concepts/station-modelling.md
@@ -150,9 +150,12 @@ is a pure circuit stamp and runs anywhere. What can pin a design to momwire
 is how it *attaches*: a design that hangs the line off `PortAtEnd` is
 momwire-only, because NEC-2 has no junction-node port and the PyNEC backend
 rejects it (see [Ports](#ports-where-the-circuit-meets-the-wire)). Those
-designs lose cross-engine validation — the available cross-check is between
-B-spline basis degrees rather than between engines. A design that attaches
-through `PortOnWireFloating` keeps both engines.
+designs lose cross-*engine* validation, but no longer cross-*basis*
+validation: the sinusoidal-Galerkin solver implements junction ports as well
+(momwire#182), in free space and over a **PEC** ground (momwire#191; finite
+grounds are still refused). So a `PortAtEnd` design can be checked against a
+different basis *and* a different testing scheme, not merely a second B-spline
+degree. A design that attaches through `PortOnWireFloating` keeps both engines.
 
 Three catalog designs use `BalancedLine` today:
 `wire.doublet_balanced_tuner` (floating centre port — runs on every engine),

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,19 +25,21 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.40.0" icon="star">
-  **The Galerkin backend grows up, and the helix splits in two.** The
-  `sinusoidal-galerkin` backend now runs on **momwire 0.21.0**, whose far
-  fill is a fused C++ kernel — **7–12× faster end-to-end**, and the memory
-  ceiling that capped it near 2 000 segments is gone (a 4 000-segment solve
-  fits in under 4 GiB), so census-scale meshes are interactive. In the
-  catalog, the helix is now **two designs with one refinement axis each**:
-  **`faceted_helix`** (the winding's polygon is the geometry; the mesh
-  subdivides along it) and **`continuous_helix`** (the chord count follows
-  the mesh density, converging to the true circular winding) — both
-  arc-length-normalized so they wind identical wire at every mesh, closing
-  the catalog's last unmeshable convergence story (the old builder solved
-  one frozen 53-segment mesh at every density).
+<Card title="New in v0.41.0" icon="star">
+  **The feed-model release: NEC-compatible or converged — your choice.** The
+  `sinusoidal-galerkin` backend (now on **momwire 0.22.0**) gains a
+  **feed-model control**: *NEC-compatible* reproduces NEC/EZNEC behaviour,
+  gap and all, while *Converged* drives a zero-width feed whose impedance
+  converges to the B-spline answer. On **near-open, high-Q designs**
+  (`lazy_h`, `vbeam`) the converged feed removes **two to three orders of
+  magnitude** of the apparent disagreement between solver bases — measured
+  out to 5 000+ segments — and the workbench now recommends it on the
+  designs that need it. Under the hood, an instrumented campaign settled
+  *why*: most of the historical "sinusoidal vs B-spline" gap was never the
+  basis — it was the feed. Also new: sin-Galerkin **junction ports over a
+  PEC ground**, and a sparse Galerkin assembly path. Details in
+  [Solvers & accuracy](/reference/solver/) and
+  [How many segments?](/advanced/convergence/).
   [All release notes →](/reference/releases/)
 </Card>
 

--- a/site/src/content/docs/reference/solver.mdx
+++ b/site/src/content/docs/reference/solver.mdx
@@ -131,7 +131,8 @@ threading; see the benchmark docs for full tables.
   the sinusoidal basis — use it as the second opinion on **junction-port
   (`PortAtEnd`) designs**, which historically were B-spline-only and now
   accept either (`bspline` remains the default; the sin-Galerkin junction
-  ports are free-space only for now).
+  ports run in free space and over a PEC ground — momwire#191 — with finite
+  grounds still refused).
 
 ## Segments & convergence
 

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -147,8 +147,8 @@ variant just replaced. Re-mark the knobs and turn Optimize back on to resume.
 A **solver selector** offers a few preset slots so you can flip between engines
 without re-entering options — e.g. a fast dense basis, an accelerated array
 engine, and the PyNEC reference. The available engines are the momwire bases
-(**sinusoidal**, **bspline**), the accelerators (**hmatrix**,
-**arrayblock**), and the optional **PyNEC** backend — see
+(**Sinusoidal**, **Sin-Galerkin**, **B-spline**), the accelerators
+(**H-matrix (ACA)**, **Array-block**), and the optional **PyNEC** backend — see
 [The solver & accuracy](/reference/solver/) for what each is good at.
 
 The solver's gear menu also exposes **segments / wire (N)** — how finely each
@@ -167,6 +167,31 @@ above anything the UI sends. This applies **only** to the shared hosted
 instance: a local install is **unlocked** (solve as big as your own machine
 allows, sweep as long as you like). See `docs/deploy.md`.
 :::
+
+### The feed model (Sin-Galerkin only)
+
+Pick **Sin-Galerkin** and its gear menu grows one more control, **feed
+model** — how the source gap itself is modelled:
+
+- **NEC-compatible** (the default) — NEC's segment-wide gap. The readout
+  reproduces NEC/EZNEC behaviour, including the familiar reactance drift as
+  the mesh refines. Use it when you're cross-checking against NEC results.
+- **Converged** — a zero-width (point) gap instead: the impedance converges
+  to the B-spline answer, and the port admittance is exactly reciprocal.
+
+On **near-open, high-Q feeds** the choice is worth a lot, and the gear menu
+says so: those designs (`wire.lazy_h`, `wire.vbeam` and their class) show a
+hint recommending *Converged*, which removes two to three orders of magnitude
+of the apparent disagreement between solver bases (momwire#213). What it does
+**not** do is reduce the mesh such a design needs — budget fine segments
+either way; see
+[the near-open feed](/advanced/convergence/#the-four-ways-a-curve-refuses-to-settle).
+A slot running the non-default setting is labelled **Sin-Galerkin
+(converged)**, so two Sin-Galerkin slots stay tellable apart at a glance.
+
+No other engine carries the control: the plain **Sinusoidal** solver cannot
+express a zero-width gap under point matching (momwire#212), and the B-spline
+family already uses the point gap.
 
 ### One solve at a time
 

--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -17,15 +17,11 @@ from .user_designs import USER_NS, iter_design_files, resolve_user_design
 
 from momwire import (
     SinusoidalSolver,
+    SinusoidalGalerkinSolver,
     BSplineSolver,
     HMatrixSolver,
     ArrayBlockSolver,
 )
-
-try:
-    from momwire import SinusoidalGalerkinSolver
-except ImportError:  # momwire older than the #182 Galerkin solver
-    SinusoidalGalerkinSolver = None
 
 import argparse
 import logging
@@ -42,16 +38,13 @@ if PyNECEngine is not None:
 
 MOMWIRE_BASES = {
     "sinusoidal": SinusoidalSolver,
+    # Same three-term basis as `sinusoidal`, tested variationally instead of
+    # point-matched (momwire#182).
+    "sinusoidal-galerkin": SinusoidalGalerkinSolver,
     "bspline": BSplineSolver,
     "hmatrix": HMatrixSolver,
     "arrayblock": ArrayBlockSolver,
 }
-if SinusoidalGalerkinSolver is not None:
-    # Same three-term basis as `sinusoidal`, tested variationally instead of
-    # point-matched (momwire#182). Registered conditionally only because the
-    # `momwire==` pin in pyproject.toml still admits a release that predates
-    # the class; make it unconditional at the next momwire bump.
-    MOMWIRE_BASES["sinusoidal-galerkin"] = SinusoidalGalerkinSolver
 
 # Roster variants: a basis name bound to solver kwargs. The one entry is the
 # feed-model axis (issue #640): the plain `sinusoidal-galerkin` keeps NEC's
@@ -63,12 +56,12 @@ if SinusoidalGalerkinSolver is not None:
 # variant exists for plain `sinusoidal`: the point gap has no collocation RHS
 # (momwire#212), and the solver refuses it rather than silently serving the
 # segment gap.
-MOMWIRE_BASIS_VARIANTS = {}
-if SinusoidalGalerkinSolver is not None:
-    MOMWIRE_BASIS_VARIANTS["sinusoidal-galerkin-converged"] = (
+MOMWIRE_BASIS_VARIANTS = {
+    "sinusoidal-galerkin-converged": (
         SinusoidalGalerkinSolver,
         {"feed_model": "point"},
-    )
+    ),
+}
 
 
 def resolve_class(s):

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -88,13 +88,9 @@ from momwire import (
     ArrayBlockSolver,
     BSplineSolver,
     HMatrixSolver,
+    SinusoidalGalerkinSolver,
     SinusoidalSolver,
 )
-
-try:
-    from momwire import SinusoidalGalerkinSolver
-except ImportError:  # momwire older than the #182 Galerkin solver
-    SinusoidalGalerkinSolver = None
 
 from .examples import register
 from .examples._base import (
@@ -163,20 +159,13 @@ _MOMWIRE_MODELS = {
     # structure it degrades to one element and matches the dense bspline solve.
     "arrayblock": ArrayBlockSolver,
 }
-if SinusoidalGalerkinSolver is not None:
-    # The same three-term basis as "sinusoidal", tested variationally rather
-    # than point-matched (momwire#182). It is the instrument column, not an
-    # interactive default: no C++ accelerator and no distributed wire loading,
-    # and the fill costs several times the point-matched one. Exposed on the
-    # wire protocol so the CLI/API and the engine-parity tests can select it by
-    # name; the frontend's own `Backend` union deliberately does NOT list it,
-    # so no solver tab appears until it earns one.
-    #
-    # Conditional only because the `momwire==` pin in pyproject.toml still
-    # admits a release predating the class (the wheel-smoke CI job installs
-    # momwire from PyPI, not the submodule). Make it unconditional at the
-    # next momwire release bump.
-    _MOMWIRE_MODELS["sinusoidal-galerkin"] = SinusoidalGalerkinSolver
+# The same three-term basis as "sinusoidal", tested variationally rather
+# than point-matched (momwire#182). Not the interactive default — no C++
+# accelerator and no distributed wire loading, and the fill costs several
+# times the point-matched one — but a first-class backend tab in the
+# frontend, and the one solver carrying the feed-model choice
+# ("NEC-compatible vs converged", issue #640).
+_MOMWIRE_MODELS["sinusoidal-galerkin"] = SinusoidalGalerkinSolver
 
 
 # ---------------------------------------------------------------------------
@@ -1638,11 +1627,11 @@ _SINUSOIDAL_RECOMMEND_MIN_BASIS = 3000
 # lumped charge outside the reaction integral and reproduces the B-spline port
 # network entrywise to 3.4e-5 / 3.9e-6, which is what "widening this tuple"
 # was waiting for. Caveat carried by the solver's own hard error, not by this
-# list: its junction ports are FREE SPACE only (the node-charge image is not
-# removed yet) and reject mixed per-wire radii.
-_JUNCTION_PORT_BACKENDS = ("bspline",) + (
-    ("sinusoidal-galerkin",) if SinusoidalGalerkinSolver is not None else ()
-)
+# list: its junction ports run in free space and over a PEC ground
+# (momwire#191 removed the node-charge PEC image) but refuse FINITE grounds —
+# the reflection-coefficient and Sommerfeld images of a point charge are not
+# point charges — and reject mixed per-wire radii.
+_JUNCTION_PORT_BACKENDS = ("bspline", "sinusoidal-galerkin")
 
 
 @lru_cache(maxsize=None)


### PR DESCRIPTION
Release PR per the ritual (precedent: #265, #269). Two commits:

1. **Adopt momwire 0.22.0** — the three-place pin bump (pyproject, Dockerfile, submodule pointer at the v0.22.0 bump commit `829aabc`), plus the promised de-conditionalization of the `SinusoidalGalerkinSolver` imports/roster entries and the momwire#191 ground-scope comment fixes. Default-path latency smoke: 4 ms (bspline d=2 invvee) — no regression.
2. **Release v0.41.0** — version bump, what's-new card refresh, and the de-stale docs sweep: `web.md` gains the feed-model control section, `station-modelling.md`'s junction-port cross-check claim updated (sin-Galerkin ports: free space + PEC, finite refused), `solver.mdx`'s last "free-space only for now" resolved. Site builds clean (25 pages).

Release theme: **the feed-model release** — the NEC-compatible-vs-converged choice on the Sin-Galerkin solver (#640/#641), built on momwire 0.22.0's feed-model axis (momwire#192–#217), near-open recommendations on `lazy_h`/`vbeam` (momwire#213), and sin-Galerkin junction ports over PEC (momwire#191).

PyPI serves momwire 0.22.0 as of this PR (verified), so wheel-smoke runs against the real wheel.

After merge: tag `v0.41.0` → four pipelines (publish, simulator deploy, docs deploy, Docker) → fleet-convergence verification → Discussions announcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g