### PR TITLE
feat(station): transmission-line stub matching elements (#598)

### DIFF
--- a/site/src/content/docs/concepts/station-modelling.md
+++ b/site/src/content/docs/concepts/station-modelling.md
@@ -184,13 +184,24 @@ A box (`Composite`) has a formal port interface and a private inside:
 the tuner's tee midpoint exists as `tuner.m`, invisible to the rest of
 the design. The stdlib today: `t_network_tuner`, `l_network_tuner`,
 `unun` (with the compensation capacitor real 49:1 builds carry),
-`balun` — all parameterized in radio units (picofarads, microhenries)
-— plus one special member:
+`balun`, `link_coupling`, `balanced_l_tuner` — all parameterized in
+radio units (picofarads, microhenries) — plus two special members:
 
 - **`bypass()`** — a box-shaped nothing: it wires its input straight to
   its output. Swap any tuner or balun for `bypass()` and you get the
   same station *without* that box, in a one-line change — the honest
   way to answer "what is this component actually buying me?"
+
+- **stubs** — `shunt_shorted_stub`, `shunt_open_stub`, and their
+  `series_*` twins are matching elements made of nothing but cable: a
+  length of line terminated in a short or an open, presenting
+  `+jZ₀·tan(βl)` or `−jZ₀·cot(βl)` at its port. Lengths are given in
+  wavelengths *on the line* at a design frequency (the velocity factor
+  is applied for you; the composite bakes metres, so it detunes across
+  a sweep like the real thing), and `cable="RG-213"` cuts it from a
+  catalog reel, loss included. `single_stub_tuner` and
+  `double_stub_tuner` place them at the classic positions — a match
+  with no lumped parts, just cable lengths.
 
 Boxes are ordinary values made by ordinary functions, so a design can
 also define its own — a measured, calibrated component wrapped once and

--- a/src/antennaknobs/station.py
+++ b/src/antennaknobs/station.py
@@ -26,7 +26,19 @@ branch classes' SI at construction. Ohms and Q are dimensionless-as-usual.
 
 from __future__ import annotations
 
-from .network import Composite, FloatingBalun, Shunt, Transformer, TwoPort
+import math
+
+from .builder import C_LIGHT_MHZ_M
+from .network import (
+    TL,
+    BalancedLine,
+    Composite,
+    FloatingBalun,
+    Instance,
+    Shunt,
+    Transformer,
+    TwoPort,
+)
 
 
 def bypass() -> Composite:
@@ -166,6 +178,305 @@ def balanced_l_tuner(
             TwoPort(a="sR", b="outR", l=0.5 * l_uH * 1e-6, ql=ql),
             # differential resonating cap across the balanced output legs
             TwoPort(a="outL", b="outR", c=c_pF * 1e-12),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Transmission-line stubs (issue #598) — composition sugar over `TL` /
+# `BalancedLine`, no new reducer math.
+#
+# LENGTH CONVENTION, once, for everything below: ``length_wl`` is the stub's
+# ELECTRICAL length in wavelengths ON THE LINE at ``freq_mhz`` — i.e. βl =
+# 2π·length_wl at the design frequency, the number you read off a Smith chart
+# ("a 0.125 λ shorted stub"). The physical line that gets cut is
+#
+#     length_m = length_wl · vf · (C_LIGHT_MHZ_M / freq_mhz)
+#
+# so the velocity factor is applied FOR you and a 0.125 λ stub is 0.125 λ
+# electrically whatever it is made of. That physical length is what lands in
+# the `TL`, so a frequency sweep re-derives βl from the solve wavelength the
+# usual way: away from ``freq_mhz`` the stub is exactly as detuned as the real
+# piece of coax would be. (Contrast the raw `TL`, whose ``length`` is metres
+# and whose ``vf`` you must apply yourself.)
+#
+# LOSS: ``k1``/``k2`` are the cable-table matched-loss coefficients of `TL`
+# (dB per 100 ft = k1·√f_MHz + k2·f_MHz); ``cable="RG-213"`` fills z0/vf/k1/k2
+# from the `CABLES` catalog in one word — the honest spelling for a stub cut
+# from real coax, and the escape hatch from the lossless singularities below.
+# ---------------------------------------------------------------------------
+def _stub_line(freq_mhz, length_wl, z0, vf, k1, k2, cable):
+    """Resolve a stub's line parameters to ``(z0, length_m, vf, k1, k2)``.
+
+    ``cable`` (a `CABLES` key) supersedes z0/vf/k1/k2 wholesale — it is the
+    cable, not a default — and reuses `TL.from_cable`'s unknown-name
+    ergonomics by probing it with a zero length. Then the one length
+    conversion of the module section header, in one place."""
+    if cable is not None:
+        probe = TL.from_cable(cable, a="_", b="_", length=0.0)
+        z0, vf, k1, k2 = probe.z0, probe.vf, probe.k1, probe.k2
+    if freq_mhz <= 0.0:
+        raise ValueError(f"stub freq_mhz must be positive, got {freq_mhz!r}")
+    return z0, length_wl * vf * C_LIGHT_MHZ_M / freq_mhz, vf, k1, k2
+
+
+def _guard_open_stub(freq_mhz, length_wl, k1, k2):
+    """The open stub's odd-quarter-wave singularity, guarded with the SAME
+    policy (and the same 1e-12 threshold) as the half-wave guard in
+    ``network_reduce.tl_admittance_2x2`` — raise rather than hand the solver
+    a singular matrix, and let any real loss regularize it.
+
+    Same coin, other face: that guard trips when ``sinh γl`` → 0 (a lossless
+    k·λ/2 line has no finite admittance); an open stub goes singular when
+    ``cosh γl`` → 0, i.e. at an odd multiple of λ/4, where Z_in = 0 puts a
+    dead short across the port and no ideal source can drive it. Lossless is
+    the precondition for both (with α > 0 neither function reaches zero), so
+    a lossy ``k1``/``k2`` — or ``cable=`` — buys the exact λ/4 open stub.
+    The shorted flavors need nothing here: their λ/4 is Z_in = ∞, a
+    perfectly well-behaved zero admittance.
+
+    Checked at construction, not at stamp time, because ``freq_mhz`` and
+    ``length_wl`` are exactly the pair that makes it decidable; a sweep can
+    still walk a lossless stub onto a λ/4 point elsewhere, where the TL guard
+    (half-wave) or a singular solve reports it."""
+    if k1 or k2:
+        return
+    if abs(math.cos(2.0 * math.pi * length_wl)) < 1e-12:
+        raise ValueError(
+            f"lossless open stub of {length_wl} λ is an odd multiple of λ/4 at "
+            f"f={freq_mhz:.4f} MHz (cos βl ≈ 0); Z_in = 0 shorts the port and "
+            "the admittance is singular — pick a different length, or give the "
+            "stub the loss it really has (k1/k2, or cable=...)"
+        )
+
+
+def shunt_open_stub(
+    freq_mhz: float,
+    length_wl: float,
+    z0: float = 50.0,
+    vf: float = 1.0,
+    k1: float = 0.0,
+    k2: float = 0.0,
+    cable: str | None = None,
+) -> Composite:
+    """Open-circuited stub hung ACROSS the line (issue #598): a `TL` from the
+    formal port into a private internal node that nothing else touches — an
+    open is the *absence* of a termination, so it is spelled as one, with no
+    element to stand for it. The port sees the classic
+
+        Z_in = −j·Z₀·cot(βl)      (lossless; Z₀·coth(γl) in general)
+
+    — capacitive below λ/4, inductive between λ/4 and λ/2, and repeating: the
+    quarter-wave open stub is a short (the harmonic-notch trap), the half-wave
+    open stub an open. Lengths in wavelengths at ``freq_mhz``; see this
+    section's header for the convention and `_guard_open_stub` for why an
+    exactly-λ/4 LOSSLESS open stub raises. Formal: ``port``."""
+    z0, length, vf, k1, k2 = _stub_line(freq_mhz, length_wl, z0, vf, k1, k2, cable)
+    _guard_open_stub(freq_mhz, length_wl, k1, k2)
+    return Composite(
+        ports=("port",),
+        branches=(TL(a="port", b="far", z0=z0, length=length, vf=vf, k1=k1, k2=k2),),
+    )
+
+
+def shunt_shorted_stub(
+    freq_mhz: float,
+    length_wl: float,
+    z0: float = 50.0,
+    vf: float = 1.0,
+    k1: float = 0.0,
+    k2: float = 0.0,
+    cable: str | None = None,
+) -> Composite:
+    """Short-circuited stub hung ACROSS the line (issue #598): a `TL` from the
+    formal port into a private node bonded to the datum by a 0 Ω `Shunt` —
+    the reducer's exact ideal short (issue #285), not a small resistor. The
+    port sees
+
+        Z_in = +j·Z₀·tan(βl)      (lossless; Z₀·tanh(γl) in general)
+
+    — inductive below λ/4, capacitive between λ/4 and λ/2: the dual of
+    `shunt_open_stub`, and the flavor real installations prefer (DC-grounded,
+    weatherable, adjustable with a shorting bar). The quarter-wave shorted
+    stub is an open — the "metal insulator" / RF choke — and needs no guard,
+    being a plain zero admittance; the half-wave one is a dead short and
+    trips `TL`'s own half-wave singularity guard at stamp time. Lengths in
+    wavelengths at ``freq_mhz`` (section header). Formal: ``port``."""
+    z0, length, vf, k1, k2 = _stub_line(freq_mhz, length_wl, z0, vf, k1, k2, cable)
+    return Composite(
+        ports=("port",),
+        branches=(
+            TL(a="port", b="far", z0=z0, length=length, vf=vf, k1=k1, k2=k2),
+            Shunt(port="far", r=0.0),  # the shorting strap, as an ideal short
+        ),
+    )
+
+
+def series_open_stub(
+    freq_mhz: float,
+    length_wl: float,
+    z0: float = 50.0,
+    vf: float = 1.0,
+    k1: float = 0.0,
+    k2: float = 0.0,
+    cable: str | None = None,
+) -> Composite:
+    """Open-circuited stub inserted IN SERIES with the line (issue #598) —
+    the line is broken and the stub's ``Z_in = −j·Z₀·cot(βl)`` appears
+    between ``a`` and ``b``.
+
+    Built on `BalancedLine`, not `TL`, and that is forced: a `TL`'s two
+    terminals are each referenced to the network datum, so a `TL` stub's
+    input impedance is unavoidably a node-to-DATUM (shunt) quantity. A
+    series element must float between two nodes, which is precisely what
+    `BalancedLine`'s differential stamp gives — it forces I(a1) = −I(a2)
+    with no datum path (``zcomm=None``), so the pair IS a floating
+    two-terminal impedance of value ``zdiff·coth(γl)``. ``z0`` is therefore
+    the stub's differential Z₀ (`BalancedLine.zdiff`).
+
+    The far end: ``far1`` open (a 0 F `Shunt` — the reducer's exact open,
+    here spelling out "nothing is attached" so the node is not rejected as
+    common-mode floating), ``far2`` bonded to the datum. That bond carries
+    ZERO current — the differential stamp forces I(far2) = −I(far1) and
+    ``far1`` is open — so it is a common-mode reference pin, not a
+    termination, and the element stays genuinely floating at ``a``/``b``.
+    Same lossless-λ/4 guard as `shunt_open_stub` (there it shorts the port;
+    here it shorts the line's two halves together). Formals: ``a``, ``b``."""
+    z0, length, vf, k1, k2 = _stub_line(freq_mhz, length_wl, z0, vf, k1, k2, cable)
+    _guard_open_stub(freq_mhz, length_wl, k1, k2)
+    return Composite(
+        ports=("a", "b"),
+        branches=(
+            BalancedLine(
+                a1="a",
+                a2="b",
+                b1="far1",
+                b2="far2",
+                zdiff=z0,
+                length=length,
+                vf=vf,
+                k1=k1,
+                k2=k2,
+            ),
+            Shunt(port="far1", c=0.0),  # open end: 0 F = no element
+            Shunt(port="far2", r=0.0),  # common-mode reference pin (0 A)
+        ),
+    )
+
+
+def series_shorted_stub(
+    freq_mhz: float,
+    length_wl: float,
+    z0: float = 50.0,
+    vf: float = 1.0,
+    k1: float = 0.0,
+    k2: float = 0.0,
+    cable: str | None = None,
+) -> Composite:
+    """Short-circuited stub inserted IN SERIES with the line (issue #598) —
+    the line is broken and the stub's ``Z_in = +j·Z₀·tan(βl)`` appears
+    between ``a`` and ``b``. The floating-element argument, the ``zdiff``
+    reading of ``z0``, and the zero-current reference pin are all as in
+    `series_open_stub`; the difference is the far end, where a 0 Ω `TwoPort`
+    straps ``far1`` to ``far2`` — the shorting strap itself, exactly where
+    the physical one goes. Formals: ``a``, ``b``."""
+    z0, length, vf, k1, k2 = _stub_line(freq_mhz, length_wl, z0, vf, k1, k2, cable)
+    return Composite(
+        ports=("a", "b"),
+        branches=(
+            BalancedLine(
+                a1="a",
+                a2="b",
+                b1="far1",
+                b2="far2",
+                zdiff=z0,
+                length=length,
+                vf=vf,
+                k1=k1,
+                k2=k2,
+            ),
+            TwoPort(a="far1", b="far2", r=0.0),  # the shorting strap
+            Shunt(port="far2", r=0.0),  # common-mode reference pin (0 A)
+        ),
+    )
+
+
+def single_stub_tuner(
+    freq_mhz: float,
+    line_wl: float,
+    stub_wl: float,
+    z0: float = 50.0,
+    shorted: bool = True,
+    vf: float = 1.0,
+    k1: float = 0.0,
+    k2: float = 0.0,
+    cable: str | None = None,
+) -> Composite:
+    """The classic single-stub match (issue #598): a section of line of
+    length ``line_wl`` from the load up to a tap, and a shunt stub of length
+    ``stub_wl`` hung at that tap. Walk ``line_wl`` from the load until the
+    admittance there has the right real part (Y = Y₀ + jB), then pick
+    ``stub_wl`` so the stub's susceptance cancels the jB — a match with no
+    lumped parts, just two lengths of the same cable.
+
+    ``shorted`` picks the stub flavor (`shunt_shorted_stub` by default,
+    `shunt_open_stub` when False); the section and the stub share one set of
+    line parameters, which is what cutting both from the same reel means. For
+    a stub of a *different* cable, compose the pieces by hand — that is all
+    this factory does. Both lengths are in wavelengths at ``freq_mhz``
+    (section header). Formals: ``rig`` (source side — this IS the tap), ``ant``
+    (load side)."""
+    lz0, length, lvf, lk1, lk2 = _stub_line(freq_mhz, line_wl, z0, vf, k1, k2, cable)
+    make = shunt_shorted_stub if shorted else shunt_open_stub
+    stub = make(freq_mhz, stub_wl, z0=z0, vf=vf, k1=k1, k2=k2, cable=cable)
+    return Composite(
+        ports=("rig", "ant"),
+        branches=(
+            TL(a="rig", b="ant", z0=lz0, length=length, vf=lvf, k1=lk1, k2=lk2),
+            Instance("stub", stub, port="rig"),
+        ),
+    )
+
+
+def double_stub_tuner(
+    freq_mhz: float,
+    spacing_wl: float,
+    stub1_wl: float,
+    stub2_wl: float,
+    z0: float = 50.0,
+    shorted: bool = True,
+    vf: float = 1.0,
+    k1: float = 0.0,
+    k2: float = 0.0,
+    cable: str | None = None,
+) -> Composite:
+    """The double-stub tuner (issue #598): stubs at two FIXED positions —
+    ``stub1`` at the load end, ``stub2`` a fixed ``spacing_wl`` up the line at
+    the rig end — matched by adjusting the two lengths instead of sliding a
+    tap. The trombone-free tuner of the real world (both stubs can be
+    telescoping sections at fixed tees), at the price of a forbidden region:
+    loads whose admittance lands inside the spacing's dead circle cannot be
+    matched at all, and that is the tuner's fault, not the solver's. λ/8 and
+    3λ/8 spacings are the usual choices.
+
+    Same parameter conventions as `single_stub_tuner`, one stub length per
+    stub. Formals: ``rig`` (stub2 side), ``ant`` (stub1/load side)."""
+    lz0, length, lvf, lk1, lk2 = _stub_line(freq_mhz, spacing_wl, z0, vf, k1, k2, cable)
+    make = shunt_shorted_stub if shorted else shunt_open_stub
+    return Composite(
+        ports=("rig", "ant"),
+        branches=(
+            Instance(
+                "stub1",
+                make(freq_mhz, stub1_wl, z0=z0, vf=vf, k1=k1, k2=k2, cable=cable),
+                port="ant",
+            ),
+            TL(a="rig", b="ant", z0=lz0, length=length, vf=lvf, k1=lk1, k2=lk2),
+            Instance(
+                "stub2",
+                make(freq_mhz, stub2_wl, z0=z0, vf=vf, k1=k1, k2=k2, cable=cable),
+                port="rig",
+            ),
         ),
     )
 

--- a/tests/test_station_stubs.py
+++ b/tests/test_station_stubs.py
@@ -1,0 +1,416 @@
+"""Transmission-line stub matching elements (issue #598).
+
+The four stub flavors are composition sugar over `TL` (shunt) and
+`BalancedLine` (series) — no new reducer math — so the tests are analytic
+oracles on the reduced network: a shorted stub must present jZ₀·tan(βl) and
+an open one −jZ₀·cot(βl) at its port, with the sign flipping past λ/4, and
+the lossless singularities must behave exactly as the TL guard says they do.
+
+No MoM here: the "antenna" is a synthetic 1×1 Y (or nothing at all), so the
+whole file is arithmetic.
+"""
+
+import numpy as np
+import pytest
+
+from antennaknobs.network import (
+    TL,
+    BalancedLine,
+    Driven,
+    Instance,
+    Network,
+    PortOnWire,
+    PortVirtual,
+    Shunt,
+)
+from antennaknobs.network_reduce import C_LIGHT, NetworkReducer
+from antennaknobs.station import (
+    double_stub_tuner,
+    series_open_stub,
+    series_shorted_stub,
+    shunt_open_stub,
+    shunt_shorted_stub,
+    single_stub_tuner,
+)
+
+F_MHZ = 14.0
+WL = C_LIGHT / (F_MHZ * 1e6)
+Z0 = 50.0
+NO_ANTENNA = np.zeros((0, 0), dtype=np.complex128)
+
+
+def reducer(net):
+    """Standard port indexing: real PortOnWire ports first, virtual after."""
+    real = [n for n, p in net.ports.items() if isinstance(p, PortOnWire)]
+    virt = [n for n, p in net.ports.items() if isinstance(p, PortVirtual)]
+    idx = {n: i for i, n in enumerate(real + virt)}
+    return NetworkReducer(net, idx, len(idx))
+
+
+def z_shunt(stub):
+    """Driving-point impedance of a one-port stub hung on a bare virtual
+    port: nothing else is attached, so this IS the stub's input impedance."""
+    net = Network(
+        ports={"rig": PortVirtual("rig")},
+        branches=[Instance("stub", stub, port="rig")],
+        sources=[Driven(port="rig")],
+    )
+    return reducer(net).driven_impedance(NO_ANTENNA, WL)[0]
+
+
+def z_series(stub, z_load=Z0):
+    """Driving-point impedance of a series stub inserted between the driven
+    virtual port and a synthetic `z_load` antenna. A series element adds, so
+    the answer must be exactly ``z_stub + z_load`` — which is also the proof
+    that the element floats (any datum leakage would break the sum)."""
+    net = Network(
+        ports={"ant": PortOnWire("ant"), "rig": PortVirtual("rig")},
+        branches=[Instance("stub", stub, a="rig", b="ant")],
+        sources=[Driven(port="rig")],
+    )
+    y = np.array([[1.0 / z_load]], dtype=np.complex128)
+    return reducer(net).driven_impedance(y, WL)[0]
+
+
+def z_shorted(length_wl, z0=Z0):
+    """The closed form: Z_in = +j·Z₀·tan(βl), βl = 2π·length_wl."""
+    return 1j * z0 * np.tan(2.0 * np.pi * length_wl)
+
+
+def z_open(length_wl, z0=Z0):
+    """The closed form: Z_in = −j·Z₀·cot(βl), βl = 2π·length_wl."""
+    return -1j * z0 / np.tan(2.0 * np.pi * length_wl)
+
+
+# ---------------------------------------------------------------------------
+# the closed forms
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("length_wl", [0.02, 0.05, 0.125, 0.2, 0.24])
+def test_shunt_shorted_stub_is_j_z0_tan(length_wl):
+    """Below λ/4 a shorted stub is a pure inductive reactance +jZ₀·tan(βl)."""
+    z = z_shunt(shunt_shorted_stub(F_MHZ, length_wl, z0=Z0))
+    assert z == pytest.approx(z_shorted(length_wl), rel=1e-9)
+    assert z.imag > 0.0  # inductive below λ/4
+
+
+@pytest.mark.parametrize("length_wl", [0.02, 0.05, 0.125, 0.2, 0.24])
+def test_shunt_open_stub_is_minus_j_z0_cot(length_wl):
+    """Below λ/4 an open stub is a pure capacitive reactance −jZ₀·cot(βl)."""
+    z = z_shunt(shunt_open_stub(F_MHZ, length_wl, z0=Z0))
+    assert z == pytest.approx(z_open(length_wl), rel=1e-9)
+    assert z.imag < 0.0  # capacitive below λ/4
+
+
+@pytest.mark.parametrize("length_wl", [0.26, 0.3, 0.375, 0.45])
+def test_stub_reactance_sign_flips_past_quarter_wave(length_wl):
+    """Past λ/4 both flavors swap character — the same closed forms keep
+    holding, tan/cot having gone through their pole."""
+    z_sh = z_shunt(shunt_shorted_stub(F_MHZ, length_wl, z0=Z0))
+    z_op = z_shunt(shunt_open_stub(F_MHZ, length_wl, z0=Z0))
+    assert z_sh == pytest.approx(z_shorted(length_wl), rel=1e-9)
+    assert z_op == pytest.approx(z_open(length_wl), rel=1e-9)
+    assert z_sh.imag < 0.0 and z_op.imag > 0.0  # capacitive / inductive now
+
+
+def test_stub_impedance_scales_with_z0():
+    """Z₀ is a plain multiplier on the reactance — a 450 Ω ladder-line stub
+    of the same electrical length is 9× the 50 Ω one."""
+    z50 = z_shunt(shunt_shorted_stub(F_MHZ, 0.1, z0=50.0))
+    z450 = z_shunt(shunt_shorted_stub(F_MHZ, 0.1, z0=450.0))
+    assert z450 == pytest.approx(9.0 * z50, rel=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# the length convention: wavelengths ON THE LINE at the design frequency
+# ---------------------------------------------------------------------------
+def test_length_is_electrical_and_vf_is_applied_for_you():
+    """``length_wl`` is electrical length in wavelengths on the line, so vf
+    changes the METRES cut, never the reactance presented at ``freq_mhz``."""
+    lossless = shunt_shorted_stub(F_MHZ, 0.125, z0=Z0, vf=1.0)
+    coax = shunt_shorted_stub(F_MHZ, 0.125, z0=Z0, vf=0.66)
+    assert z_shunt(coax) == pytest.approx(z_shunt(lossless), rel=1e-12)
+    (tl_l, _short_l) = lossless.branches
+    (tl_c, _short_c) = coax.branches
+    assert tl_l.length == pytest.approx(0.125 * WL, rel=1e-12)
+    assert tl_c.length == pytest.approx(0.66 * 0.125 * WL, rel=1e-12)
+
+
+def test_stub_detunes_off_the_design_frequency_like_real_coax():
+    """The composite bakes METRES, so a sweep re-derives βl: at 2× the
+    design frequency a 0.1 λ stub is a 0.2 λ stub."""
+    stub = shunt_shorted_stub(F_MHZ, 0.1, z0=Z0)
+    net = Network(
+        ports={"rig": PortVirtual("rig")},
+        branches=[Instance("stub", stub, port="rig")],
+        sources=[Driven(port="rig")],
+    )
+    z = reducer(net).driven_impedance(NO_ANTENNA, WL / 2.0)[0]
+    assert z == pytest.approx(z_shorted(0.2), rel=1e-9)
+
+
+def test_cable_keyword_takes_z0_vf_and_loss_from_the_catalog():
+    """``cable=`` is the one-word spelling of "cut it from this reel"."""
+    from antennaknobs.network import CABLES
+
+    c = CABLES["RG-213"]
+    (tl, _short) = shunt_shorted_stub(F_MHZ, 0.125, cable="RG-213").branches
+    assert (tl.z0, tl.vf, tl.k1, tl.k2) == (c.z0, c.vf, c.k1, c.k2)
+    assert tl.length == pytest.approx(0.125 * c.vf * WL, rel=1e-12)
+
+
+def test_unknown_cable_reuses_from_cable_ergonomics():
+    with pytest.raises(KeyError, match="unknown cable"):
+        shunt_open_stub(F_MHZ, 0.125, cable="RG-8XX")
+
+
+# ---------------------------------------------------------------------------
+# the lossless singularities — same policy as the TL guard
+# ---------------------------------------------------------------------------
+def test_quarter_wave_shorted_stub_is_an_open_and_needs_no_guard():
+    """λ/4 shorted = the metal insulator: Z_in → ∞, which is a plain zero
+    admittance the stamp handles without complaint."""
+    z = z_shunt(shunt_shorted_stub(F_MHZ, 0.25, z0=Z0))
+    assert abs(z) > 1e12
+
+
+def test_lossless_quarter_wave_open_stub_raises_like_the_tl_guard():
+    """λ/4 open = a dead short across the port: singular, and refused at
+    construction with the TL guard's message shape and escape hatch."""
+    with pytest.raises(ValueError, match=r"odd multiple of λ/4"):
+        shunt_open_stub(F_MHZ, 0.25, z0=Z0)
+    with pytest.raises(ValueError, match=r"odd multiple of λ/4"):
+        series_open_stub(F_MHZ, 0.75, z0=Z0)  # every odd multiple, not just λ/4
+
+
+def test_loss_is_the_escape_hatch_for_the_quarter_wave_open_stub():
+    """With real cable loss the λ/4 open stub is finite and REAL: coth of
+    (αl + jπ/2) is tanh(αl), so Z_in ≈ Z₀·αl — the stub's own copper."""
+    from antennaknobs.network import CABLES
+    from antennaknobs.network_reduce import FEET_PER_M, NEPER_PER_DB
+
+    c = CABLES["RG-213"]
+    z = z_shunt(shunt_open_stub(F_MHZ, 0.25, cable="RG-213"))
+    alpha = (
+        (c.k1 * np.sqrt(F_MHZ) + c.k2 * F_MHZ) * NEPER_PER_DB * FEET_PER_M / 100.0
+    )  # fmt: skip
+    length = 0.25 * c.vf * WL
+    assert z == pytest.approx(c.z0 * np.tanh(alpha * length), rel=1e-9)
+    assert z.real > 0.0 and abs(z.imag) < 1e-9
+
+
+def test_half_wave_shorted_stub_trips_the_tl_guard_at_stamp_time():
+    """The other face of the same coin is TL's own: a lossless k·λ/2 line has
+    no finite admittance, so the reducer raises when it stamps."""
+    with pytest.raises(ValueError, match="sinh γl"):
+        z_shunt(shunt_shorted_stub(F_MHZ, 0.5, z0=Z0))
+
+
+# ---------------------------------------------------------------------------
+# series stubs — floating, via BalancedLine
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("length_wl", [0.05, 0.125, 0.375])
+def test_series_shorted_stub_adds_j_z0_tan_in_series(length_wl):
+    z = z_series(series_shorted_stub(F_MHZ, length_wl, z0=Z0))
+    assert z == pytest.approx(Z0 + z_shorted(length_wl), rel=1e-9)
+
+
+@pytest.mark.parametrize("length_wl", [0.05, 0.125, 0.375])
+def test_series_open_stub_adds_minus_j_z0_cot_in_series(length_wl):
+    z = z_series(series_open_stub(F_MHZ, length_wl, z0=Z0))
+    assert z == pytest.approx(Z0 + z_open(length_wl), rel=1e-9)
+
+
+def test_series_stub_is_floating_not_a_shunt():
+    """The whole point of the BalancedLine spelling: the same electrical
+    length in series and in shunt give different answers, and only the series
+    one adds to the load. (A datum-referenced TL could not do this.)"""
+    z_ser = z_series(series_shorted_stub(F_MHZ, 0.125, z0=Z0), z_load=100.0)
+    assert z_ser == pytest.approx(100.0 + z_shorted(0.125), rel=1e-9)
+    # the shunt twin on the same load is the parallel combination instead
+    net = Network(
+        ports={"ant": PortOnWire("ant"), "rig": PortVirtual("rig")},
+        branches=[
+            Instance("stub", shunt_shorted_stub(F_MHZ, 0.125, z0=Z0), port="rig"),
+            TL(a="rig", b="ant", z0=Z0, length=1e-9),  # a nominal wire, not a line
+        ],
+        sources=[Driven(port="rig")],
+    )
+    y = np.array([[1.0 / 100.0]], dtype=np.complex128)
+    z_sh = reducer(net).driven_impedance(y, WL)[0]
+    assert z_sh == pytest.approx(1.0 / (1.0 / 100.0 + 1.0 / z_shorted(0.125)), rel=1e-6)
+
+
+def test_series_stub_far_end_reference_pin_carries_no_current():
+    """The datum bond at ``far2`` is a common-mode reference, not a return:
+    it must dissipate nothing and leave the element's power budget to the
+    line itself."""
+    stub = series_shorted_stub(F_MHZ, 0.125, z0=Z0, k1=0.2)
+    net = Network(
+        ports={"ant": PortOnWire("ant"), "rig": PortVirtual("rig")},
+        branches=[Instance("stub", stub, a="rig", b="ant")],
+        sources=[Driven(port="rig")],
+    )
+    y = np.array([[1.0 / Z0]], dtype=np.complex128)
+    _v, _eff, _p_in, budget = reducer(net).excited_state(y, WL)
+    watts = dict(budget)
+    assert watts["stub: Shunt far2"] == pytest.approx(0.0, abs=1e-18)
+    assert watts["stub: TwoPort far1→far2"] == pytest.approx(0.0, abs=1e-18)
+    assert watts["stub: BalancedLine rig,ant→far1,far2"] > 0.0
+
+
+def test_series_stubs_are_balancedline_shaped():
+    """Structure, so the "why not TL" decision stays visible: the series
+    flavors are a differential (CM-open) line with its far end terminated."""
+    line, strap, pin = series_shorted_stub(F_MHZ, 0.1, z0=300.0).branches
+    assert isinstance(line, BalancedLine) and line.zcomm is None
+    assert (line.a1, line.a2, line.b1, line.b2) == ("a", "b", "far1", "far2")
+    assert line.zdiff == 300.0
+    assert (strap.a, strap.b, strap.r) == ("far1", "far2", 0.0)
+    assert (pin.port, pin.r) == ("far2", 0.0)
+    _line, open_end, pin = series_open_stub(F_MHZ, 0.1, z0=300.0).branches
+    assert (open_end.port, open_end.c) == ("far1", 0.0)  # 0 F = no element
+    assert (pin.port, pin.r) == ("far2", 0.0)
+
+
+# ---------------------------------------------------------------------------
+# the tuners
+# ---------------------------------------------------------------------------
+def test_single_stub_tuner_matches_a_real_load_to_z0():
+    """The textbook worked case: for a purely real load n = R_L/Z₀ the tap
+    is at tan(βd) = √n and the shorted stub at cot(βl) = (n−1)/√n. With
+    n = 2 both angles collapse to atan(√2) — one length, cut twice — and the
+    tuner must land on exactly Z₀."""
+    n = 2.0
+    d = np.arctan(np.sqrt(n)) / (2.0 * np.pi)
+    stub_wl = np.arctan(np.sqrt(n) / (n - 1.0)) / (2.0 * np.pi)
+    assert stub_wl == pytest.approx(d, rel=1e-12)  # the n = 2 coincidence
+    net = Network(
+        ports={"ant": PortOnWire("ant"), "rig": PortVirtual("rig")},
+        branches=[
+            Instance(
+                "t", single_stub_tuner(F_MHZ, d, stub_wl, z0=Z0), rig="rig", ant="ant"
+            )  # fmt: skip
+        ],
+        sources=[Driven(port="rig")],
+    )
+    y = np.array([[1.0 / (n * Z0)]], dtype=np.complex128)
+    z = reducer(net).driven_impedance(y, WL)[0]
+    assert z == pytest.approx(Z0 + 0j, rel=1e-9, abs=1e-9)
+
+
+def test_single_stub_tuner_open_flavor_matches_the_same_load():
+    """Same match with an open stub: the susceptance to cancel is the same,
+    so the open stub is a quarter wave shorter (mod λ/2)."""
+    n = 2.0
+    d = np.arctan(np.sqrt(n)) / (2.0 * np.pi)
+    stub_wl = d + 0.25  # open stub = shorted stub + λ/4
+    net = Network(
+        ports={"ant": PortOnWire("ant"), "rig": PortVirtual("rig")},
+        branches=[
+            Instance(
+                "t",
+                single_stub_tuner(F_MHZ, d, stub_wl, z0=Z0, shorted=False),
+                rig="rig",
+                ant="ant",
+            )  # fmt: skip
+        ],
+        sources=[Driven(port="rig")],
+    )
+    y = np.array([[1.0 / (n * Z0)]], dtype=np.complex128)
+    z = reducer(net).driven_impedance(y, WL)[0]
+    assert z == pytest.approx(Z0 + 0j, rel=1e-9, abs=1e-9)
+
+
+def test_single_stub_tuner_is_the_hand_composition():
+    """Sugar, not math: the tuner is exactly a line section plus a stub at
+    the tap, and must reduce identically to that hand-built network."""
+    d, stub_wl = 0.15, 0.2
+    sugar = Network(
+        ports={"ant": PortOnWire("ant"), "rig": PortVirtual("rig")},
+        branches=[
+            Instance(
+                "t", single_stub_tuner(F_MHZ, d, stub_wl, z0=Z0), rig="rig", ant="ant"
+            )  # fmt: skip
+        ],
+        sources=[Driven(port="rig")],
+    )
+    hand = Network(
+        ports={
+            "ant": PortOnWire("ant"),
+            "rig": PortVirtual("rig"),
+            "far": PortVirtual("far"),
+        },
+        branches=[
+            TL(a="rig", b="ant", z0=Z0, length=d * WL),
+            TL(a="rig", b="far", z0=Z0, length=stub_wl * WL),
+            Shunt(port="far", r=0.0),
+        ],
+        sources=[Driven(port="rig")],
+    )
+    y = np.array([[1.0 / (30.0 + 40.0j)]], dtype=np.complex128)
+    z_sugar = reducer(sugar).driven_impedance(y, WL)[0]
+    z_hand = reducer(hand).driven_impedance(y, WL)[0]
+    assert z_sugar == pytest.approx(z_hand, rel=1e-12)
+
+
+def test_double_stub_tuner_places_both_stubs_across_the_spacing():
+    """Two stubs, one fixed spacing — again pure composition, checked
+    against the hand-built three-branch network."""
+    spacing, l1, l2 = 0.125, 0.1, 0.3
+    sugar = Network(
+        ports={"ant": PortOnWire("ant"), "rig": PortVirtual("rig")},
+        branches=[
+            Instance(
+                "t",
+                double_stub_tuner(F_MHZ, spacing, l1, l2, z0=Z0),
+                rig="rig",
+                ant="ant",
+            )  # fmt: skip
+        ],
+        sources=[Driven(port="rig")],
+    )
+    hand = Network(
+        ports={
+            "ant": PortOnWire("ant"),
+            "rig": PortVirtual("rig"),
+            "f1": PortVirtual("f1"),
+            "f2": PortVirtual("f2"),
+        },
+        branches=[
+            TL(a="ant", b="f1", z0=Z0, length=l1 * WL),
+            Shunt(port="f1", r=0.0),
+            TL(a="rig", b="ant", z0=Z0, length=spacing * WL),
+            TL(a="rig", b="f2", z0=Z0, length=l2 * WL),
+            Shunt(port="f2", r=0.0),
+        ],
+        sources=[Driven(port="rig")],
+    )
+    y = np.array([[1.0 / (80.0 - 25.0j)]], dtype=np.complex128)
+    assert reducer(sugar).driven_impedance(y, WL)[0] == pytest.approx(
+        reducer(hand).driven_impedance(y, WL)[0], rel=1e-12
+    )
+
+
+def test_lossy_stub_itemizes_under_its_instance_in_the_power_budget():
+    """A stub cut from real coax burns real watts, attributed to its
+    instance path like every other composite (issue #299/#489)."""
+    net = Network(
+        ports={"ant": PortOnWire("ant"), "rig": PortVirtual("rig")},
+        branches=[
+            Instance(
+                "tuner",
+                single_stub_tuner(F_MHZ, 0.15, 0.2, cable="RG-58"),
+                rig="rig",
+                ant="ant",
+            )  # fmt: skip
+        ],
+        sources=[Driven(port="rig")],
+    )
+    y = np.array([[1.0 / (30.0 + 40.0j)]], dtype=np.complex128)
+    _v, eff, p_in, budget = reducer(net).excited_state(y, WL)
+    watts = dict(budget)
+    assert set(watts) == {"tuner: TL rig→ant", "tuner.stub: TL rig→far",
+                          "tuner.stub: Shunt far"}  # fmt: skip
+    assert watts["tuner.stub: TL rig→far"] > 0.0  # the stub's own copper
+    assert watts["tuner.stub: Shunt far"] == pytest.approx(0.0, abs=1e-18)
+    assert 0.0 < 1.0 - eff < 1.0 and p_in > 0.0


### PR DESCRIPTION
Closes #598. The four stub flavors (shunt/series × open/shorted) plus `single_stub_tuner` / `double_stub_tuner`, as pure composition over existing branch elements — zero reducer change.

## Design

- **Shunt stubs are `TL`**, per the issue: open = TL into a private untouched node (an open is the absence of a termination); shorted = TL into `Shunt(r=0)`, the reducer's exact ideal short.
- **Series stubs are `BalancedLine`, not `TL` — a forced deviation from the issue text.** A TL's terminals are datum-referenced, so its input impedance is unavoidably a shunt quantity; a series element must float between two nodes, which is exactly BalancedLine's differential stamp (`I(a1)=−I(a2)`, `zcomm=None`). The far end is strapped (shorted) or open, with one leg bonded to datum as a common-mode reference pin that provably carries zero current (KCL: `I_datum = I_line(far2) + I_strap = +I_loop − I_loop = 0`; also asserted via the power budget in-test).
- **Length convention**: `length_wl` is electrical length on the line at `freq_mhz`; vf is applied for you and the composite bakes metres, so sweeps detune like real coax. `cable="RG-213"` pulls z0/vf/k1/k2 from the CABLES catalog.
- **Singularity policy mirrors TL's own**: the lossless open stub at odd λ/4 (Z_in=0, singular admittance) raises at construction with the same 1e-12 threshold and same escape (real loss) as `tl_admittance_2x2`'s half-wave guard; shorted λ/4 is a well-behaved open and needs nothing.

## Verification (agent's + reviewer's own)

- 37 new analytic-oracle tests; 59 passed across the station/balanced-line files re-run by the reviewer from the worktree (with a worktree-import proof).
- **Reviewer's independent probe with parameters no test pins** (21 MHz, 75/93 Ω, vf 0.66): shorted/open shunt at 0.08 λ and 0.31 λ, and a series open 0.13 λ into 42 Ω — all five agree with jZ₀tan(βl) / −jZ₀cot(βl) / z_load+z_stub to ≤1.3e-15 relative.
- ruff check + format clean; station-modelling.md gains the stub entry (and un-stales the stdlib list with `link_coupling`/`balanced_l_tuner`).

## Review notes

Implemented by an Opus agent in an isolated worktree; reviewed by the session model — full diff read, the floating-series KCL argument re-derived, tests re-run, and the independent oracle probe above. Follow-up candidates from the agent, endorsed: a reducer-level guard for a lossless stub *swept* onto λ/4 (currently a bare singular solve away from the design frequency), and a stub-matched catalog design to exercise these end-to-end on both engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g