### PR TITLE
feat: measured VNA .s1p overlay — CLI charts and web workbench (#595)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,10 @@ python -m antennaknobs draw --builder beams.moxon --fn moxon.png
 python -m antennaknobs sweep --builder beams.moxon --param freq \
     --use_smithchart --npoints 21 --fn moxon_smith.png
 
+# Overlay a measured NanoVNA .s1p sweep on the modeled SWR curve
+python -m antennaknobs sweep --builder dipoles.invvee --swr \
+    --range 28.0 29.0 --npoints 21 --measured bench_10m.s1p
+
 # Far-field pattern of a Yagi, solved with momwire
 python -m antennaknobs pattern --builder beams.yagi --engine momwire:triangular
 

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -61,6 +61,47 @@ Note that knob sweeps in **free space** can be perfectly flat by design —
 translation-invariant knobs like a height `base` only matter over a ground
 (`--ground finite`).
 
+### Overlaying a VNA measurement
+
+`--measured <file.s1p>` draws a **measured** sweep alongside the modeled one —
+the "did my model match reality?" chart. A NanoVNA (or any VNA) exports the
+one-port Touchstone `.s1p` this reads; files written as R+jX instead of S11
+work too.
+
+```bash
+# the antenna on the bench, against the model of it
+python -m antennaknobs sweep --builder dipoles.invvee --swr \
+    --range 28.0 29.0 --npoints 21 --measured bench_10m.s1p --fn compare.png
+# same comparison on the Smith chart, or as R and X
+python -m antennaknobs sweep --builder dipoles.invvee --use_smithchart \
+    --measured bench_10m.s1p
+```
+
+The overlay works on all three impedance chart forms (SWR, Smith, R/X); the
+measured trace is dashed with `×` markers against the modeled solid line. Some
+details worth knowing:
+
+- **Reference impedance.** The file declares its own (a NanoVNA writes 50 Ω);
+  the trace is renormalized through its impedance to whatever `--z0` the chart
+  uses, so a 75 Ω calibration overlays correctly on a 50 Ω chart.
+- **Bands.** The measurement is interpolated onto the sweep grid and drawn only
+  where the two bands overlap — a single-band measurement against a wide sweep
+  renders over its own band, and nothing is extrapolated. Disjoint bands are an
+  error, not an empty chart.
+- **Frequency only.** Measured data is indexed by frequency, so `--measured`
+  needs `--param freq` (the default).
+- **Measurement plane.** The comparison happens at whatever plane the chart
+  already plots — normally the antenna feedpoint, so calibrate the VNA at the
+  feedpoint. A design whose `build_network()` includes a
+  [station chain](/concepts/station-modelling/) plots the station plane
+  instead, which is what a shack-end measurement sees.
+
+Expect some irreducible disagreement: common-mode current on a real feedline
+perturbs a measurement in ways a differential model does not reproduce. A
+*structured* residual — the two curves offset the same way across the band — is
+usually pointing at something physical (line length, ground, a connector),
+which is the diagnostic value of drawing them together.
+
 ## Choosing an engine
 
 The `--engine` flag selects the solver:

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -357,6 +357,36 @@ impedance, so you can see where the curve flattens out. Basics:
 method (ladders, cross-basis validation with a second solver slot, and what a
 non-settling curve is telling you): [How many segments?](/advanced/convergence/).
 
+## Measured overlay — your VNA on the Smith chart
+
+Under the Smith chart, **measured .s1p…** loads a one-port Touchstone file — a
+NanoVNA export, or any VNA's — and draws the antenna you actually measured as a
+dashed violet locus against the modeled one. It is the "did my model match
+reality?" view, and the same overlay the CLI draws with
+[`--measured`](/reference/cli/#overlaying-a-vna-measurement).
+
+- **Your file stays on your machine.** The browser reads it and posts the text
+  to be parsed; nothing is stored server-side. That also means it works
+  unchanged when the backend runs somewhere else while the VNA is plugged in
+  here.
+- **Reference impedance is handled.** The measurement travels as impedance and
+  is converted at the chart's own reference, so a 75 Ω calibration lands
+  correctly on a 50 Ω chart.
+- **Bands are clipped to the frequency sweep** so both loci cover the same
+  frequencies; the label under the chart reports the span actually drawn, and
+  says `(clipped)` when the measurement reaches past the swept band. A
+  measurement with no overlap at all says so rather than silently drawing
+  nothing — turn the [freq sweep](#convergence-sweep) onto that band, or move
+  the measurement frequency there.
+- **Calibrate at the plane you're comparing.** The chart shows the feedpoint,
+  so a measurement taken at the feedpoint is the like-for-like one; a
+  shack-end sweep includes feedline the model may not have.
+
+Expect some irreducible disagreement — common-mode current on a real feedline
+perturbs a measurement in ways a differential model doesn't reproduce. A
+*structured* gap (the same offset across the band) usually points at something
+physical: line length, ground, a connector.
+
 ## Design sessions (tabs)
 
 The sidebar is a **notebook**: the tabs across its top (**D1**, **D2**, …) are

--- a/src/antennaknobs/__init__.py
+++ b/src/antennaknobs/__init__.py
@@ -16,6 +16,8 @@ __all__ = [
     "read_json",
     "read_nec",
     "read_touchstone",
+    "read_measured",
+    "MeasuredTrace",
     "WireSpec",
     "Wire",
     "as_wire",
@@ -62,6 +64,7 @@ from .builder import (
 from .design_data import read_data, read_json
 from .nec_import import read_nec
 from .touchstone import read_touchstone
+from .measured import MeasuredTrace, read_measured
 from .network import Composite, Instance, Wire, WireSpec, as_wire
 from .transform import Transform, TransformStack
 from .cell import Cell, Placement, flatten_placements

--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -13,6 +13,7 @@ from . import (
 )
 from .engines import PyNECEngine, MomwireEngine
 from .serialize import builder_params_source
+from .measured import read_measured
 from .user_designs import USER_NS, iter_design_files, resolve_user_design
 
 from momwire import (
@@ -489,6 +490,12 @@ def cli(arguments=None):
     )
     p.add_argument("--z0", default=50, type=float, help="Reference impedance.")
     p.add_argument(
+        "--measured",
+        default=None,
+        help="Overlay a measured one-port Touchstone (.s1p, e.g. a NanoVNA "
+        "sweep) on the chart, renormalized to --z0. Frequency sweeps only.",
+    )
+    p.add_argument(
         "--markers",
         default=[],
         nargs="+",
@@ -506,6 +513,12 @@ def cli(arguments=None):
     def f(args):
         builder = get_builder(args.builder)
         engine = engine_factory_from_args(args)
+        measured = read_measured(args.measured, z0=args.z0) if args.measured else None
+        if measured is not None and (args.patterns or args.gain):
+            # Measured S11 has nothing to say about a pattern or gain chart.
+            raise SystemExit(
+                "--measured overlays an impedance/SWR chart; drop --patterns/--gain"
+            )
         if args.patterns:
             sweep_patterns(
                 builder(),
@@ -531,6 +544,7 @@ def cli(arguments=None):
                 fraction=args.fraction,
                 fn=args.fn,
                 engine=engine,
+                measured=measured,
             )
         elif args.gain:
             sweep_gain(
@@ -556,6 +570,7 @@ def cli(arguments=None):
                 z0=args.z0,
                 markers=args.markers,
                 engine=engine,
+                measured=measured,
             )
 
     p.set_defaults(func=f)

--- a/src/antennaknobs/measured.py
+++ b/src/antennaknobs/measured.py
@@ -1,0 +1,178 @@
+"""Measured antenna data as a *reference trace* for the sweep plots (issue #595).
+
+A NanoVNA (or any VNA) exports a one-port Touchstone ``.s1p``: S11 versus
+frequency for the antenna as it actually stands in the yard. This module turns
+such a file into a :class:`MeasuredTrace` — a frequency-indexed complex
+reflection coefficient that the CLI sweeps draw *alongside* the simulated
+curve, closing the loop between a design and the bench.
+
+The distinction from ``touchstone.py``'s consumers is one of *use*, not format:
+``network.TouchstoneLoad`` makes an ``.s1p`` a **circuit element** inside
+``build_network()``; here the same parsed file is **reference data** on the
+chart. One parser, two subsystems.
+
+Two pieces of arithmetic carry the feature:
+
+- **Reference renormalization.** The file declares its own ``R <z0>`` (a
+  NanoVNA writes 50 Ω, but a 75 Ω or 200 Ω calibration is legal). The plot has
+  its own ``--z0``. Comparing raw Γ across differing references is a silent
+  error, so a trace is always renormalized through the impedance it represents:
+  ``Z = z0_file·(1+Γ)/(1−Γ)`` then ``Γ' = (Z−z0)/(Z+z0)``.
+- **Grid alignment.** The measured grid is the VNA's (often hundreds of
+  points); the model grid is the sweep's (often ~21). :meth:`MeasuredTrace.align`
+  interpolates the measurement onto the sweep grid *restricted to the overlap*,
+  so a measurement covering only part of the swept span renders over its own
+  band and nothing is extrapolated. No overlap at all is an error, not an empty
+  chart.
+
+Comparison happens at whatever plane the chart already plots — normally the
+antenna feedpoint, so the VNA should be calibrated at the feedpoint too (a
+design whose ``build_network()`` includes a station chain plots the station
+plane instead, and a shack-end measurement matches that). Issue #639 makes the
+plane an explicit choice.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from .touchstone import Touchstone, _nports_from_name, parse_touchstone
+
+__all__ = ["MeasuredTrace", "read_measured", "BandOverlapError"]
+
+logger = logging.getLogger(__name__)
+
+
+class BandOverlapError(ValueError):
+    """The measured band and the swept band do not overlap at all."""
+
+
+@dataclass(frozen=True, eq=False)
+class MeasuredTrace:
+    """A measured one-port response on its own frequency grid.
+
+    ``freqs`` is MHz ascending (the unit the builders and sweep charts use, not
+    the Hz of the Touchstone file); ``gamma`` is the complex reflection
+    coefficient referenced to ``z0``; ``label`` names the trace in legends.
+    ``eq=False`` for the same reason as :class:`~antennaknobs.touchstone.Touchstone`
+    — array fields make value-equality meaningless.
+    """
+
+    freqs: np.ndarray
+    gamma: np.ndarray
+    z0: float
+    label: str = "measured"
+
+    @classmethod
+    def from_touchstone(
+        cls, ts: Touchstone, *, label: str = "measured"
+    ) -> "MeasuredTrace":
+        """Build from a parsed 1-port :class:`Touchstone`.
+
+        Y- and Z-parameter files convert through ``s_at`` (evaluated at the
+        file's own grid points, where the interpolation is exact), so an
+        ``.s1p`` written as R+jX overlays just like one written as S11.
+        """
+        if ts.nports != 1:
+            raise ValueError(
+                f"a measured overlay needs a 1-port (.s1p) file; got {ts.nports} ports"
+            )
+        if ts.ptype == "S":
+            gamma = ts.params[:, 0, 0].copy()
+        else:
+            gamma = np.array([ts.s_at(float(f))[0, 0] for f in ts.freqs])
+        return cls(freqs=ts.freqs / 1e6, gamma=gamma, z0=float(ts.z0), label=label)
+
+    # -- derived views ------------------------------------------------------
+    @property
+    def impedance(self) -> np.ndarray:
+        """Measured impedance (Ω) — ``z0·(1+Γ)/(1−Γ)``."""
+        return self.z0 * (1.0 + self.gamma) / (1.0 - self.gamma)
+
+    @property
+    def swr(self) -> np.ndarray:
+        rho = np.abs(self.gamma)
+        # A measurement with |Γ| ≥ 1 (noise, or a bad calibration on a
+        # near-open) would divide by zero or go negative; clamp just below 1 so
+        # the trace pins at a large SWR instead of exploding the axis.
+        rho = np.minimum(rho, 1.0 - 1e-9)
+        return (1.0 + rho) / (1.0 - rho)
+
+    def renormalized(self, z0: float) -> "MeasuredTrace":
+        """This trace re-referenced to ``z0`` (identity when already there)."""
+        if abs(z0 - self.z0) < 1e-12:
+            return self
+        z = self.impedance
+        return MeasuredTrace(
+            freqs=self.freqs,
+            gamma=(z - z0) / (z + z0),
+            z0=float(z0),
+            label=self.label,
+        )
+
+    # -- alignment onto a sweep grid ---------------------------------------
+    def align(self, freqs: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Interpolate onto sweep grid ``freqs`` (MHz), clipped to the overlap.
+
+        Returns ``(xs, gamma)`` over the sweep points that fall inside the
+        measured span. Raises :class:`BandOverlapError` when the bands are
+        disjoint; logs an informational message when the measurement covers the
+        swept band only partly (a legitimate and common case — a single-band
+        measurement against a multi-band sweep).
+        """
+        freqs = np.asarray(freqs, dtype=float)
+        f0, f1 = float(self.freqs[0]), float(self.freqs[-1])
+        tol = 1e-9 * max(abs(f1), 1.0)
+        inside = (freqs >= f0 - tol) & (freqs <= f1 + tol)
+        if not inside.any():
+            raise BandOverlapError(
+                f"measured band [{f0:.6g}, {f1:.6g}] MHz does not overlap the "
+                f"swept band [{freqs.min():.6g}, {freqs.max():.6g}] MHz — "
+                "sweep the measured band, or measure the swept one"
+            )
+        if not inside.all():
+            logger.info(
+                "measured trace %r covers %d of %d sweep points "
+                "([%.6g, %.6g] MHz of [%.6g, %.6g] MHz); drawing the overlap",
+                self.label,
+                int(inside.sum()),
+                freqs.size,
+                f0,
+                f1,
+                freqs.min(),
+                freqs.max(),
+            )
+        xs = freqs[inside]
+        gamma = np.interp(xs, self.freqs, self.gamma.real) + 1j * np.interp(
+            xs, self.freqs, self.gamma.imag
+        )
+        return xs, gamma
+
+
+def read_measured(
+    path, *, z0: float | None = None, label: str | None = None
+) -> MeasuredTrace:
+    """Read a measured ``.s1p`` from an arbitrary filesystem path.
+
+    This is the CLI/operator entry point: unlike
+    :func:`~antennaknobs.touchstone.read_touchstone` — which is confined to a
+    *design's* own folder because designs are untrusted code — a measured
+    overlay is a file the person at the keyboard names on the command line, so
+    an ordinary path is right. ``z0`` renormalizes the trace to the chart's
+    reference; ``label`` defaults to the file's stem.
+    """
+    p = Path(path)
+    nports = _nports_from_name(p.name)  # validate the extension before reading
+    if nports != 1:
+        raise ValueError(
+            f"{p.name}: a measured overlay needs a 1-port .s1p file "
+            "(a .s2p is a two-port block — see TouchstoneTwoPort)"
+        )
+    trace = MeasuredTrace.from_touchstone(
+        parse_touchstone(p.read_text(), nports=1), label=label or p.stem
+    )
+    return trace if z0 is None else trace.renormalized(z0)

--- a/src/antennaknobs/measured.py
+++ b/src/antennaknobs/measured.py
@@ -42,9 +42,20 @@ import numpy as np
 
 from .touchstone import Touchstone, _nports_from_name, parse_touchstone
 
-__all__ = ["MeasuredTrace", "read_measured", "BandOverlapError"]
+__all__ = [
+    "MeasuredTrace",
+    "parse_measured",
+    "read_measured",
+    "BandOverlapError",
+    "RHO_MAX",
+]
 
 logger = logging.getLogger(__name__)
+
+# Largest |Γ| the derived impedance/SWR views will evaluate at — see
+# MeasuredTrace.impedance. 1 − 1e-9 puts a measured open at ~1e11 Ω: off the
+# top of any chart, but finite.
+RHO_MAX = 1.0 - 1e-9
 
 
 class BandOverlapError(ValueError):
@@ -90,16 +101,27 @@ class MeasuredTrace:
     # -- derived views ------------------------------------------------------
     @property
     def impedance(self) -> np.ndarray:
-        """Measured impedance (Ω) — ``z0·(1+Γ)/(1−Γ)``."""
-        return self.z0 * (1.0 + self.gamma) / (1.0 - self.gamma)
+        """Measured impedance (Ω) — ``z0·(1+Γ)/(1−Γ)``.
+
+        A real measurement can land at or just outside |Γ| = 1 (noise on a
+        near-open, an imperfect calibration), where that expression divides by
+        zero. The magnitude is clamped a hair inside the unit circle so the
+        result stays finite — huge, which is the honest reading of a measured
+        open, and JSON-safe for the web overlay, where a bare ``inf`` would
+        produce a body the browser refuses to parse.
+        """
+        g = self.gamma
+        rho = np.abs(g)
+        over = rho > RHO_MAX
+        if over.any():
+            g = np.where(over, g * (RHO_MAX / np.maximum(rho, 1e-300)), g)
+        return self.z0 * (1.0 + g) / (1.0 - g)
 
     @property
     def swr(self) -> np.ndarray:
-        rho = np.abs(self.gamma)
-        # A measurement with |Γ| ≥ 1 (noise, or a bad calibration on a
-        # near-open) would divide by zero or go negative; clamp just below 1 so
-        # the trace pins at a large SWR instead of exploding the axis.
-        rho = np.minimum(rho, 1.0 - 1e-9)
+        # Same clamp as `impedance`, for the same reason: |Γ| ≥ 1 would divide
+        # by zero or go negative. The trace pins at a large SWR instead.
+        rho = np.minimum(np.abs(self.gamma), RHO_MAX)
         return (1.0 + rho) / (1.0 - rho)
 
     def renormalized(self, z0: float) -> "MeasuredTrace":
@@ -153,6 +175,21 @@ class MeasuredTrace:
         return xs, gamma
 
 
+def parse_measured(
+    text: str, *, z0: float | None = None, label: str = "measured"
+) -> MeasuredTrace:
+    """Parse Touchstone ``text`` into a measured overlay trace.
+
+    The port count is *inferred from the data* rather than taken on trust, so a
+    two-port file that reached here under a one-port name gets the "needs a
+    1-port" error instead of being silently read as three times as many
+    frequency points. This is the shared entry point for the web upload
+    (``/measured``) and :func:`read_measured`.
+    """
+    trace = MeasuredTrace.from_touchstone(parse_touchstone(text), label=label)
+    return trace if z0 is None else trace.renormalized(z0)
+
+
 def read_measured(
     path, *, z0: float | None = None, label: str | None = None
 ) -> MeasuredTrace:
@@ -166,13 +203,9 @@ def read_measured(
     reference; ``label`` defaults to the file's stem.
     """
     p = Path(path)
-    nports = _nports_from_name(p.name)  # validate the extension before reading
-    if nports != 1:
+    if _nports_from_name(p.name) != 1:  # validate the extension before reading
         raise ValueError(
             f"{p.name}: a measured overlay needs a 1-port .s1p file "
             "(a .s2p is a two-port block — see TouchstoneTwoPort)"
         )
-    trace = MeasuredTrace.from_touchstone(
-        parse_touchstone(p.read_text(), nports=1), label=label or p.stem
-    )
-    return trace if z0 is None else trace.renormalized(z0)
+    return parse_measured(p.read_text(), z0=z0, label=label or p.stem)

--- a/src/antennaknobs/sweep.py
+++ b/src/antennaknobs/sweep.py
@@ -37,6 +37,36 @@ def _polish_axes(ax, title=None):
         ax.set_title(title, fontsize=11)
 
 
+# A measured trace (issue #595) is drawn dashed with 'x' markers, against the
+# solid 'o' of the modeled curve, in whatever colour the axis already uses —
+# so the eye reads "same quantity, other source" rather than "another port".
+_MEASURED_KW = dict(linestyle="--", marker="x", ms=4, linewidth=1.3, alpha=0.75)
+
+
+def _align_measured(measured, nm, xs, z0):
+    """``(xs, gamma)`` of a measured overlay on the sweep grid, or ``None``.
+
+    Measured data is indexed by frequency, so it can only be overlaid on a
+    frequency sweep; any other knob gets a clear error rather than a chart
+    whose two traces share an axis by accident.
+    """
+    if measured is None:
+        return None
+    if nm != "freq":
+        raise ValueError(
+            f"a measured overlay is frequency data — it cannot be drawn against "
+            f"a {nm!r} sweep; sweep --param freq to compare against it"
+        )
+    return measured.renormalized(z0).align(xs)
+
+
+def _measured_legend(ax, label):
+    """Legend keying the solid/dashed convention, drawn in neutral grey."""
+    ax.plot([], [], color="0.35", linestyle="-", marker="o", ms=3, label="modeled")
+    ax.plot([], [], color="0.35", label=label, **_MEASURED_KW)
+    ax.legend(loc="best", frameon=False, fontsize=8)
+
+
 def build_and_get_elevation(antenna_builder, *, engine=Antenna):
     a = engine(antenna_builder)
     return get_elevation(a)
@@ -75,16 +105,23 @@ def sweep_swr(
     npoints=21,
     fn=None,
     engine=Antenna,
+    measured=None,
 ):
     """SWR + reflection magnitude against any swept knob.
 
     Sweeping `freq` uses the engine's vectorized impedance_sweep (one build,
     one matrix per frequency); any other knob changes the geometry, so the
     engine is rebuilt per point like the other parameter sweeps.
+
+    `measured` is an optional `MeasuredTrace` (a VNA `.s1p`, issue #595) drawn
+    as a second, dashed trace on both axes over the band it covers.
     """
     import matplotlib.pyplot as plt
 
     xs = gen_xs(getattr(antenna_builder, nm), rng, center, fraction, npoints)
+    # Align before solving: a disjoint measured band should fail immediately,
+    # not after a full sweep's worth of matrix solves.
+    meas = _align_measured(measured, nm, xs, z0)
 
     if nm == "freq":
         a = engine(antenna_builder)
@@ -112,6 +149,10 @@ def sweep_swr(
         ax0.plot(
             xs, rho_db[:, i], color=color, linestyle=_port_style(i), marker="o", ms=3
         )
+    if meas is not None:
+        mxs, mgamma = meas
+        mrho = np.abs(mgamma)
+        ax0.plot(mxs, np.log10(mrho) * 10.0, color=color, **_MEASURED_KW)
 
     color = "tab:blue"
     ax1 = ax0.twinx()
@@ -119,6 +160,10 @@ def sweep_swr(
     ax1.tick_params(axis="y", labelcolor=color)
     for i in range(swr.shape[1]):
         ax1.plot(xs, swr[:, i], color=color, linestyle=_port_style(i), marker="o", ms=3)
+    if meas is not None:
+        mrho_c = np.minimum(mrho, 1.0 - 1e-9)  # see MeasuredTrace.swr
+        ax1.plot(mxs, (1.0 + mrho_c) / (1.0 - mrho_c), color=color, **_MEASURED_KW)
+        _measured_legend(ax0, measured.label)
 
     _polish_axes(ax0, title=f"SWR vs {nm} (z0 = {z0:g} Ω)")
     ax1.spines["top"].set_visible(False)
@@ -219,10 +264,13 @@ def sweep(
     markers=[],
     fn=None,
     engine=Antenna,
+    measured=None,
 ):
     import matplotlib.pyplot as plt
 
     xs = gen_xs(getattr(antenna_builder, nm), rng, center, fraction, npoints)
+    # Align first so a disjoint measured band errors before any solving.
+    meas = _align_measured(measured, nm, xs, z0)
 
     zs = []
     for x in xs:
@@ -257,7 +305,10 @@ def sweep(
         draw_smith_chart(ax0, z0=z0)
         for i in range(nwidth):
             color = f"C{i}"
-            label = f"port {i + 1}" if nwidth > 1 else None
+            if nwidth > 1:
+                label = f"port {i + 1}"
+            else:
+                label = "modeled" if meas is not None else None
             if zs.shape[0] > 0:
                 gamma = (zs[:, i] - z0) / (zs[:, i] + z0)
                 plot_reflection(ax0, gamma, color=color, linewidth=1.8, label=label)
@@ -273,7 +324,15 @@ def sweep(
                     linestyle="None",
                     label=label,
                 )
-        if nwidth > 1:
+        if meas is not None:
+            plot_reflection(
+                ax0,
+                meas[1],
+                color="0.25",
+                label=measured.label,
+                **_MEASURED_KW,
+            )
+        if nwidth > 1 or meas is not None:
             # Upper left keeps clear of the z0 note in the lower-left corner.
             ax0.legend(loc="upper left", frameon=False, fontsize=8)
         # Same title as the rectangular branch — the chart form says "Smith".
@@ -304,6 +363,9 @@ def sweep(
                     marker="s",
                     linestyle="None",
                 )
+        if meas is not None:
+            mxs, mz = meas[0], z0 * (1.0 + meas[1]) / (1.0 - meas[1])
+            ax0.plot(mxs, np.real(mz), color=color, **_MEASURED_KW)
 
         color = "tab:blue"
         ax1 = ax0.twinx()
@@ -327,6 +389,9 @@ def sweep(
                     marker="s",
                     linestyle="None",
                 )
+        if meas is not None:
+            ax1.plot(mxs, np.imag(mz), color=color, **_MEASURED_KW)
+            _measured_legend(ax0, measured.label)
 
         _polish_axes(ax0, title=f"feedpoint impedance vs {nm}")
         ax1.spines["top"].set_visible(False)

--- a/src/antennaknobs/sweep.py
+++ b/src/antennaknobs/sweep.py
@@ -161,7 +161,9 @@ def sweep_swr(
     for i in range(swr.shape[1]):
         ax1.plot(xs, swr[:, i], color=color, linestyle=_port_style(i), marker="o", ms=3)
     if meas is not None:
-        mrho_c = np.minimum(mrho, 1.0 - 1e-9)  # see MeasuredTrace.swr
+        from .measured import RHO_MAX
+
+        mrho_c = np.minimum(mrho, RHO_MAX)  # see MeasuredTrace.swr
         ax1.plot(mxs, (1.0 + mrho_c) / (1.0 - mrho_c), color=color, **_MEASURED_KW)
         _measured_legend(ax0, measured.label)
 

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -1942,6 +1942,20 @@ type SweepData = {
   feeds_z_im?: number[][];
 };
 
+/** A measured VNA sweep uploaded for the measured-vs-modeled overlay
+ *  (issue #595). Parsed server-side by /measured — the browser never reads
+ *  Touchstone itself, so there is exactly one parser to disagree with.
+ *  Carried as impedance (like every other Z on this chart) so the chart
+ *  re-references it to its own z0; `z0_file` is kept only to report the
+ *  calibration the file declared. */
+type MeasuredData = {
+  label: string;
+  z0_file: number;
+  freqs_mhz: number[];
+  z_re: number[];
+  z_im: number[];
+};
+
 type ConvergeData = {
   n_values: number[];
   z_re: number[];
@@ -3120,6 +3134,11 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
   // convergence on slow geometries) without leaving the Smith view.
   const [sweepEnabled, setSweepEnabled] = useState(true);
   const [convergeEnabled, setConvergeEnabled] = useState(false);
+  // Measured overlay (issue #595): a VNA .s1p the user picks from their own
+  // machine, drawn against the modeled locus. Deliberately client-side state —
+  // the file is posted once to be parsed and is never stored server-side, which
+  // also means the overlay survives nothing but this tab, by design.
+  const [measured, setMeasured] = useState<MeasuredData | null>(null);
   const [converge, setConverge] = useState<ConvergeData | null>(null);
   const [convergeRunning, setConvergeRunning] = useState(false);
   // Far-field norm consistency check: on dwell, recompute the gain norm from
@@ -3615,6 +3634,36 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
       URL.revokeObjectURL(url);
     } catch (e) {
       window.alert(`NEC export failed: ${e}`);
+    }
+  }
+
+  // Load a measured VNA sweep (.s1p) for the measured-vs-modeled overlay.
+  // The file is read in the browser and posted as text: the server owns the
+  // Touchstone parsing (one reader, shared with the CLI), and because the
+  // *file* stays local, this works the same whether the backend is on this
+  // machine or across a tunnel.
+  async function loadMeasured(file: File) {
+    setGearMenuOpen(false);
+    try {
+      const text = await file.text();
+      const resp = await fetch("/measured", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: file.name, text }),
+      });
+      if (!resp.ok) {
+        let detail = `Could not read ${file.name} (${resp.status}).`;
+        try {
+          detail = (await resp.json()).detail ?? detail;
+        } catch {
+          /* non-JSON error body — keep the status-based message */
+        }
+        window.alert(detail);
+        return;
+      }
+      setMeasured(await resp.json());
+    } catch (e) {
+      window.alert(`Could not read ${file.name}: ${e}`);
     }
   }
 
@@ -4807,6 +4856,30 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                       />
                       converge sweep
                     </label>
+                    <label
+                      className="gear-menu-check gear-menu-file"
+                      title="Overlay a measured VNA sweep (one-port Touchstone .s1p, e.g. from a NanoVNA) against the modeled locus"
+                    >
+                      <input
+                        type="file"
+                        accept=".s1p,.S1P"
+                        onChange={(e) => {
+                          const f = e.target.files?.[0];
+                          e.target.value = "";
+                          if (f) loadMeasured(f);
+                        }}
+                      />
+                      {measured ? `measured: ${measured.label}` : "measured .s1p\u2026"}
+                    </label>
+                    {measured && (
+                      <button
+                        type="button"
+                        className="gear-menu-check gear-menu-button"
+                        onClick={() => setMeasured(null)}
+                      >
+                        clear measured
+                      </button>
+                    )}
                     <div className="gear-menu-section">azimuth / elevation</div>
                     <label
                       className="gear-menu-check"
@@ -5666,6 +5739,33 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                 />
                 converge sweep
               </label>
+              <label
+                className="overlay-file"
+                title="Overlay a measured VNA sweep (one-port Touchstone .s1p, e.g. from a NanoVNA) against the modeled locus"
+              >
+                <input
+                  type="file"
+                  accept=".s1p,.S1P"
+                  onChange={(e) => {
+                    const f = e.target.files?.[0];
+                    // Reset the input so re-picking the same file (after a
+                    // re-measure) fires onChange again.
+                    e.target.value = "";
+                    if (f) loadMeasured(f);
+                  }}
+                />
+                {measured ? `measured: ${measured.label}` : "measured .s1p…"}
+              </label>
+              {measured && (
+                <button
+                  type="button"
+                  className="overlay-clear"
+                  title="Remove the measured overlay"
+                  onClick={() => setMeasured(null)}
+                >
+                  clear
+                </button>
+              )}
             </div>
           )}
           {/* On mobile only the Δ readout survives (it's output, not a
@@ -5853,6 +5953,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
             preview={preview}
             sweep={sweep}
             converge={converge}
+            measured={measured}
             pattern={pattern}
             pinnedPatterns={pinnedPatterns}
             measFreqMhz={measFreq}
@@ -5966,6 +6067,7 @@ function DesignSession({ id, active }: { id: number; active: boolean }) {
                   preview={preview}
                   sweep={sweep}
                   converge={converge}
+                  measured={measured}
                   pattern={pattern}
                   pinnedPatterns={[]}
                   measFreqMhz={measFreq}
@@ -6859,6 +6961,7 @@ function ViewPanel({
   preview,
   sweep,
   converge,
+  measured,
   pattern,
   pinnedPatterns,
   measFreqMhz,
@@ -6881,6 +6984,7 @@ function ViewPanel({
   preview: SolveResponse | null;
   sweep: SweepData | null;
   converge: ConvergeData | null;
+  measured: MeasuredData | null;
   pattern: PatternData | null;
   pinnedPatterns: PinnedPattern[];
   measFreqMhz: number;
@@ -6952,6 +7056,7 @@ function ViewPanel({
       size={size}
       sweep={sweep}
       converge={converge}
+      measured={measured}
       measFreqMhz={measFreqMhz}
       running={sweepRunning}
       convergeRunning={convergeRunning}
@@ -7810,6 +7915,7 @@ function SmithChart({
   size,
   sweep,
   converge,
+  measured,
   measFreqMhz,
   running,
   convergeRunning,
@@ -7822,6 +7928,8 @@ function SmithChart({
   size: number;
   sweep: SweepData | null;
   converge: ConvergeData | null;
+  /** Uploaded VNA measurement drawn against the modeled locus (issue #595). */
+  measured: MeasuredData | null;
   measFreqMhz: number;
   running: boolean;
   convergeRunning: boolean;
@@ -7995,6 +8103,79 @@ function SmithChart({
       const txt = `${fLoTxt} → ${fHiTxt} MHz`;
       ctx.fillText(txt, size - 6 - ctx.measureText(txt).width, size - 6);
 
+    }
+
+    // Measured overlay (issue #595): the locus a VNA actually saw, against the
+    // one the model predicts. The measurement arrives as impedance and goes
+    // through the same reflectionCoefficient() as the solved Z, so the file's
+    // own calibration reference is absorbed by the conversion — a 75 Ω
+    // measurement lands correctly on a 50 Ω chart with no special case.
+    if (measured && measured.freqs_mhz.length > 0) {
+      // Clip to the swept band so both loci span the same frequencies (the CLI
+      // overlay applies the same rule). With no sweep on screen there is
+      // nothing to clip against, so the whole measurement is drawn.
+      const mf = measured.freqs_mhz;
+      const swept = sweep && sweep.freqs_mhz.length > 1;
+      const fLo = swept ? sweep!.freqs_mhz[0] : -Infinity;
+      const fHi = swept ? sweep!.freqs_mhz[sweep!.freqs_mhz.length - 1] : Infinity;
+      const idx: number[] = [];
+      for (let i = 0; i < mf.length; i++) {
+        if (mf[i] >= fLo && mf[i] <= fHi) idx.push(i);
+      }
+      const mGamma = (i: number) =>
+        reflectionCoefficient(measured.z_re[i], measured.z_im[i], z0);
+      ctx.font = "10px ui-monospace, monospace";
+      ctx.fillStyle = PC.measured;
+      if (idx.length === 0) {
+        // Disjoint bands. Say so — the user picked a file and would otherwise
+        // see the chart not change at all.
+        const txt = `measured ${mf[0].toFixed(2)}–${mf[mf.length - 1].toFixed(2)} MHz: outside the sweep`;
+        ctx.fillText(txt, size - 6 - ctx.measureText(txt).width, size - 20);
+      } else {
+        ctx.save();
+        ctx.beginPath();
+        ctx.arc(cx, cy, R, 0, 2 * Math.PI);
+        ctx.clip();
+        // Dashed, to read as "other source" next to the solid convergence
+        // trail and the scattered sweep dots.
+        ctx.setLineDash([4, 3]);
+        ctx.strokeStyle = PC.measured;
+        ctx.lineWidth = 1.4;
+        ctx.beginPath();
+        for (let k = 0; k < idx.length; k++) {
+          const g = mGamma(idx[k]);
+          const px = cx + g.gRe * R;
+          const py = cy - g.gIm * R;
+          if (k === 0) ctx.moveTo(px, py);
+          else ctx.lineTo(px, py);
+        }
+        ctx.stroke();
+        ctx.setLineDash([]);
+        ctx.restore();
+
+        // Endpoint markers matching the sweep trail's grammar: low-frequency
+        // end filled, high-frequency end hollow, so the locus has a direction.
+        for (const [k, filled] of [[0, true], [idx.length - 1, false]] as const) {
+          const g = mGamma(idx[k]);
+          ctx.lineWidth = 1.2;
+          ctx.strokeStyle = PC.measured;
+          ctx.fillStyle = filled ? PC.measured : `rgba(${PC.bgRgb}, 0.95)`;
+          ctx.beginPath();
+          ctx.arc(cx + g.gRe * R, cy - g.gIm * R, 3, 0, 2 * Math.PI);
+          ctx.fill();
+          ctx.stroke();
+        }
+
+        // Label above the sweep's freq-range line, with the span actually
+        // drawn — which is the measurement's own band when it is narrower than
+        // the sweep, and says as much when the file reaches past it.
+        ctx.fillStyle = PC.measured;
+        const dLo = mf[idx[0]].toFixed(2);
+        const dHi = mf[idx[idx.length - 1]].toFixed(2);
+        const partial = idx.length < mf.length ? " (clipped)" : "";
+        const txt = `measured: ${measured.label}  ${dLo} → ${dHi} MHz${partial}`;
+        ctx.fillText(txt, size - 6 - ctx.measureText(txt).width, size - 20);
+      }
     }
 
     if (running) {
@@ -8242,7 +8423,7 @@ function SmithChart({
     // initial false to the real /examples value (true for bowtie /
     // hexbeam_5band) — the user saw only one Z* annotation in the
     // legend because the closure stayed wedged on the single-feed branch.
-  }, [r, x, z0, size, sweep, converge, measFreqMhz, running, convergeRunning, feeds, multiFeed, theme]);
+  }, [r, x, z0, size, sweep, converge, measured, measFreqMhz, running, convergeRunning, feeds, multiFeed, theme]);
 
   return <canvas ref={canvasRef} className="smith" />;
 }
@@ -8941,6 +9122,9 @@ function plotColors() {
     groundRgb: v("--plot-ground-rgb", "140, 110, 70"),
     envelopeRgb: v("--plot-envelope-rgb", "118, 208, 255"),
     feed: v("--plot-feed", "#ffd166"),
+    // Measured-overlay locus (issue #595). Violet: unused elsewhere on the
+    // Smith chart, so it never reads as another feed.
+    measured: v("--plot-measured", "#b48cfa"),
   };
 }
 

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -83,6 +83,7 @@
   --plot-center-mark: #b6c5d6;
   --plot-spoke: rgba(120, 90, 200, 0.6);
   --plot-feed: #cf7a22;
+  --plot-measured: #7855cd;   /* measured VNA overlay (violet) */
   --plot-lobe-rgb: 207, 122, 34;     /* far-field radiation lobe (orange) */
   --plot-nec-rgb: 47, 95, 176;        /* NEC overlay (blueprint blue) */
   --plot-ground-rgb: 150, 116, 70;    /* ground line (brown) */
@@ -157,6 +158,7 @@
   --plot-center-mark: #5a6170;
   --plot-spoke: rgba(180, 140, 250, 0.7);
   --plot-feed: #ffd166;
+  --plot-measured: #b48cfa;
   --plot-lobe-rgb: 255, 209, 102;
   --plot-nec-rgb: 110, 220, 255;
   --plot-ground-rgb: 140, 110, 70;
@@ -2053,6 +2055,67 @@ input[type=checkbox] {
 .overlay-checkbox input {
   margin: 0;
   cursor: pointer;
+}
+
+/* Measured-overlay file picker + clear (issue #595). Same chip shell as the
+   Smith overlay's checkboxes; the native file input is hidden because its
+   default "Choose file / no file selected" chrome is unstyleable and far too
+   wide for the overlay strip — the label text carries the state instead. */
+.overlay-file {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  max-width: 15rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: var(--space-3) var(--space-5);
+  font: var(--text-xs) var(--font-mono);
+  color: var(--muted);
+  cursor: pointer;
+  user-select: none;
+  box-shadow: 0 2px 10px var(--shadow);
+}
+
+.overlay-file:hover {
+  color: var(--fg);
+  border-color: var(--accent);
+}
+
+.overlay-file input[type="file"] {
+  display: none;
+}
+
+.overlay-clear {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: var(--space-3) var(--space-5);
+  font: var(--text-xs) var(--font-mono);
+  color: var(--muted);
+  cursor: pointer;
+  box-shadow: 0 2px 10px var(--shadow);
+}
+
+.overlay-clear:hover {
+  color: var(--fg);
+  border-color: var(--accent);
+}
+
+/* Gear-menu twin (the mobile home for the same control). */
+.gear-menu-file input[type="file"] {
+  display: none;
+}
+
+.gear-menu-button {
+  background: none;
+  border: none;
+  width: 100%;
+  text-align: left;
+  font-family: inherit;
 }
 
 .projection-toggle button {

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -1606,6 +1606,68 @@ async def export_nec_endpoint(req: dict):
     )
 
 
+# Upload ceilings for the measured overlay (issue #595). A NanoVNA writes
+# 101–1001 points (a few tens of kB); nanovna-saver's segmented sweeps reach a
+# few thousand. The caps are generous multiples of that — they exist so a
+# mis-picked file (a NEC deck, a CSV log, a binary) is refused by size before
+# it is parsed, not to constrain real measurements.
+_MEASURED_MAX_CHARS = 4_000_000
+_MEASURED_MAX_POINTS = 100_000
+
+
+@app.post("/measured")
+async def measured_endpoint(req: dict):
+    """Parse an uploaded one-port Touchstone into a measured overlay trace.
+
+    The file is read *in the browser* and posted here as text: parsing happens
+    server-side so there is exactly one Touchstone reader (issue #593's), not a
+    second one transliterated into TypeScript that could disagree with the CLI
+    about the same file.
+
+    Returns the measurement as impedance versus frequency — the same shape the
+    solve and ``/sweep`` responses carry — so the chart converts it to Γ at
+    whatever reference the chart is showing, and a file calibrated at 75 Ω
+    lands correctly on a 50 Ω chart with no special case.
+
+    Nothing is stored: the trace lives in the client's state, so no
+    user-uploaded file is retained server-side (this endpoint is also the one
+    the hosted instance exposes to arbitrary visitors).
+    """
+    from antennaknobs.measured import parse_measured
+
+    text = req.get("text") or ""
+    name = str(req.get("name") or "measured.s1p")
+    if not isinstance(text, str) or not text.strip():
+        raise HTTPException(status_code=422, detail="empty measurement file")
+    if len(text) > _MEASURED_MAX_CHARS:
+        raise HTTPException(
+            status_code=413,
+            detail=f"measurement file is too large "
+            f"({len(text) // 1024} kB; limit {_MEASURED_MAX_CHARS // 1024} kB)",
+        )
+    label = Path(name).stem or "measured"
+    try:
+        trace = await run_in_threadpool(parse_measured, text, label=label)
+    except ValueError as e:
+        # Bad header, wrong port count, ragged records — the parser's messages
+        # already name the problem; surface them verbatim as a 422.
+        raise HTTPException(status_code=422, detail=str(e)) from e
+    if trace.freqs.size > _MEASURED_MAX_POINTS:
+        raise HTTPException(
+            status_code=413,
+            detail=f"measurement has {trace.freqs.size} points "
+            f"(limit {_MEASURED_MAX_POINTS})",
+        )
+    z = trace.impedance
+    return {
+        "label": trace.label,
+        "z0_file": trace.z0,
+        "freqs_mhz": [float(f) for f in trace.freqs],
+        "z_re": [float(v) for v in z.real],
+        "z_im": [float(v) for v in z.imag],
+    }
+
+
 @app.post("/params_source")
 async def params_source_endpoint(req: dict):
     """Serialise the current knob values to a paste-ready Python params block.

--- a/tests/test_measured.py
+++ b/tests/test_measured.py
@@ -1,0 +1,171 @@
+"""Measured-data overlay: the VNA `.s1p` as a reference trace (issue #595).
+
+Three layers: the trace itself (parsing, reference renormalization, derived
+R/X/SWR), grid alignment against a sweep band (interpolation, partial overlap,
+disjoint bands), and the CLI wiring that draws it on each chart form.
+"""
+
+import numpy as np
+import pytest
+
+import antennaknobs as ant
+from antennaknobs.measured import BandOverlapError, MeasuredTrace, read_measured
+from antennaknobs.sweep import _align_measured
+from antennaknobs.touchstone import parse_touchstone
+
+
+def gamma_of(z, z0=50.0):
+    return (z - z0) / (z + z0)
+
+
+def write_s1p(tmp_path, freqs_mhz, zs, *, z0=50.0, name="meas.s1p"):
+    """A synthetic RI-format .s1p for impedances ``zs`` at ``freqs_mhz``."""
+    g = gamma_of(np.asarray(zs, dtype=complex), z0)
+    lines = [f"# MHZ S RI R {z0:g}"]
+    lines += [f"{f:.6f} {v.real:.9f} {v.imag:.9f}" for f, v in zip(freqs_mhz, g)]
+    p = tmp_path / name
+    p.write_text("\n".join(lines) + "\n")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# the trace
+# ---------------------------------------------------------------------------
+def test_reads_s1p_into_mhz_grid_and_impedance(tmp_path):
+    freqs = [14.0, 14.1, 14.2]
+    zs = [40 - 30j, 50 + 0j, 60 + 25j]
+    trace = read_measured(write_s1p(tmp_path, freqs, zs))
+
+    assert trace.label == "meas"  # file stem
+    assert trace.z0 == 50.0
+    np.testing.assert_allclose(trace.freqs, freqs)  # Hz in the file → MHz here
+    np.testing.assert_allclose(trace.impedance, zs, atol=1e-7)
+
+
+def test_z_parameter_file_converts_to_reflection(tmp_path):
+    """An .s1p written as R+jX overlays exactly like one written as S11."""
+    freqs, zs = [14.0, 14.2], [40 - 30j, 60 + 25j]
+    text = "# MHZ Z RI R 50\n" + "\n".join(
+        f"{f} {z.real} {z.imag}" for f, z in zip(freqs, zs)
+    )
+    trace = MeasuredTrace.from_touchstone(parse_touchstone(text, nports=1))
+    np.testing.assert_allclose(trace.gamma, gamma_of(np.array(zs)), atol=1e-12)
+
+
+def test_renormalizing_preserves_impedance(tmp_path):
+    """Γ is reference-dependent; the impedance it stands for is not."""
+    zs = [40 - 30j, 60 + 25j]
+    trace = read_measured(write_s1p(tmp_path, [14.0, 14.2], zs, z0=75.0), z0=50.0)
+
+    assert trace.z0 == 50.0
+    np.testing.assert_allclose(trace.gamma, gamma_of(np.array(zs), 50.0), atol=1e-7)
+    np.testing.assert_allclose(trace.impedance, zs, atol=1e-6)
+    # A 75 Ω file drawn against a 50 Ω chart is a different curve — the
+    # renormalization is not cosmetic.
+    raw = read_measured(write_s1p(tmp_path, [14.0, 14.2], zs, z0=75.0))
+    assert not np.allclose(raw.gamma, trace.gamma)
+
+
+def test_renormalizing_to_the_same_reference_is_identity(tmp_path):
+    trace = read_measured(write_s1p(tmp_path, [14.0, 14.2], [40 - 30j, 60 + 25j]))
+    assert trace.renormalized(50.0) is trace
+
+
+def test_swr_clamps_a_unit_magnitude_measurement():
+    """|Γ| ≥ 1 happens on noisy near-open measurements; it must not divide by 0."""
+    trace = MeasuredTrace(
+        freqs=np.array([14.0, 14.1]), gamma=np.array([1.0 + 0j, 1.02 + 0j]), z0=50.0
+    )
+    swr = trace.swr
+    assert np.all(np.isfinite(swr)) and np.all(swr > 1e6)
+
+
+def test_s2p_is_rejected_as_an_overlay(tmp_path):
+    p = tmp_path / "balun.s2p"
+    p.write_text("# MHZ S RI R 50\n14.0 0 0 1 0 1 0 0 0\n")
+    with pytest.raises(ValueError, match="1-port"):
+        read_measured(p)
+
+
+def test_unknown_extension_is_rejected(tmp_path):
+    p = tmp_path / "sweep.csv"
+    p.write_text("14.0 0 0\n")
+    with pytest.raises(ValueError, match="s1p"):
+        read_measured(p)
+
+
+# ---------------------------------------------------------------------------
+# alignment onto the sweep grid
+# ---------------------------------------------------------------------------
+def test_align_interpolates_onto_the_sweep_grid(tmp_path):
+    trace = read_measured(write_s1p(tmp_path, [14.0, 14.2], [50 + 0j, 50 + 20j]))
+    xs, gamma = trace.align(np.array([14.0, 14.1, 14.2]))
+
+    np.testing.assert_allclose(xs, [14.0, 14.1, 14.2])
+    # Linear in the complex plane between the two measured points.
+    np.testing.assert_allclose(gamma[1], 0.5 * (trace.gamma[0] + trace.gamma[1]))
+
+
+def test_align_clips_to_the_overlap(tmp_path):
+    """A single-band measurement against a wide sweep draws over its own band."""
+    trace = read_measured(write_s1p(tmp_path, [14.0, 14.35], [50 + 0j, 50 + 20j]))
+    xs, gamma = trace.align(np.linspace(10.0, 30.0, 21))  # 1 MHz steps
+
+    np.testing.assert_allclose(xs, [14.0])
+    assert gamma.shape == (1,)
+
+
+def test_align_errors_on_disjoint_bands(tmp_path):
+    trace = read_measured(write_s1p(tmp_path, [14.0, 14.35], [50 + 0j, 50 + 20j]))
+    with pytest.raises(BandOverlapError, match="does not overlap"):
+        trace.align(np.linspace(28.0, 29.0, 11))
+
+
+def test_measured_needs_a_frequency_sweep(tmp_path):
+    trace = read_measured(write_s1p(tmp_path, [14.0, 14.2], [50 + 0j, 50 + 20j]))
+    with pytest.raises(ValueError, match="frequency data"):
+        _align_measured(trace, "length_top", np.linspace(1.0, 2.0, 5), 50.0)
+    # ...and is a no-op when absent, whatever the swept knob.
+    assert _align_measured(None, "length_top", np.linspace(1.0, 2.0, 5), 50.0) is None
+
+
+def test_align_renormalizes_through_the_chart_reference(tmp_path):
+    """The chart's z0, not the file's, decides the Γ that gets drawn."""
+    zs = [40 - 30j, 60 + 25j]
+    trace = read_measured(write_s1p(tmp_path, [14.0, 14.2], zs, z0=75.0))
+    _, gamma = _align_measured(trace, "freq", np.array([14.0, 14.2]), 50.0)
+    np.testing.assert_allclose(gamma, gamma_of(np.array(zs), 50.0), atol=1e-7)
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring — one smoke run per chart form
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def measured_10m(tmp_path):
+    """A plausible 10 m measured sweep spanning part of the default band."""
+    freqs = np.linspace(28.0, 29.0, 11)
+    zs = 45.0 + 1j * np.linspace(-40.0, 40.0, 11)
+    return str(write_s1p(tmp_path, freqs, zs, name="bench_10m.s1p"))
+
+
+@pytest.mark.parametrize("chart", ["--swr", "--use_smithchart", ""])
+def test_cli_sweep_draws_the_overlay(measured_10m, chart):
+    args = f"sweep --param freq --range 28.2 28.8 --npoints 3 --z0 50 {chart}"
+    ant.cli(f"{args} --measured {measured_10m} --fn /dev/null".split())
+
+
+def test_cli_sweep_measured_rejects_gain_and_patterns(measured_10m):
+    for flag in ("--gain", "--patterns"):
+        with pytest.raises(SystemExit, match="impedance/SWR"):
+            ant.cli(
+                f"sweep {flag} --npoints 2 --measured {measured_10m} "
+                "--fn /dev/null".split()
+            )
+
+
+def test_cli_sweep_measured_disjoint_band_is_a_clear_error(measured_10m):
+    with pytest.raises(BandOverlapError, match="does not overlap"):
+        ant.cli(
+            f"sweep --swr --param freq --range 14.0 14.3 --npoints 3 "
+            f"--measured {measured_10m} --fn /dev/null".split()
+        )

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -368,6 +368,69 @@ def test_trust_refused_when_hosted(client, monkeypatch):
     assert client.post("/untrust", json={"stem": "whatever"}).status_code == 403
 
 
+# ---------------------------------------------------------------------------
+# /measured — the VNA overlay upload (issue #595)
+# ---------------------------------------------------------------------------
+_S1P_75OHM = """! a two-point measurement calibrated at 75 ohms
+# MHZ S RI R 75
+14.000 0.0 0.0
+14.200 0.2 -0.1
+"""
+
+
+def test_measured_returns_impedance_not_reflection(client: TestClient):
+    """The overlay travels as Z so the chart re-references it to its own z0.
+
+    The first point is Gamma = 0 against a 75 ohm calibration, i.e. 75 ohms —
+    which is emphatically not the 50 ohms a naive read of the raw S11 would put
+    at chart centre.
+    """
+    r = client.post("/measured", json={"name": "bench_20m.s1p", "text": _S1P_75OHM})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["label"] == "bench_20m"  # file stem, for the chart legend
+    assert body["z0_file"] == 75.0
+    assert body["freqs_mhz"] == [14.0, 14.2]  # Hz in the file, MHz on the wire
+    assert body["z_re"][0] == pytest.approx(75.0)
+    assert body["z_im"][0] == pytest.approx(0.0)
+
+
+def test_measured_rejects_a_two_port_file(client: TestClient):
+    """A .s2p is a two-port block, not an overlay — and the port count is read
+    from the data, so a mislabelled upload can't be read as 3x the points."""
+    r = client.post(
+        "/measured",
+        json={"name": "balun.s1p", "text": "# MHZ S RI R 50\n14.0 0 0 1 0 1 0 0 0\n"},
+    )
+    assert r.status_code == 422 and "1-port" in r.json()["detail"]
+
+
+def test_measured_rejects_junk_and_empty_uploads(client: TestClient):
+    assert (
+        client.post("/measured", json={"name": "x.s1p", "text": ""}).status_code == 422
+    )
+    r = client.post("/measured", json={"name": "deck.nec", "text": "GW 1 9 0 0 0\n"})
+    assert r.status_code == 422
+
+
+def test_measured_refuses_an_oversized_upload(client: TestClient):
+    big = "! pad\n" * (server._MEASURED_MAX_CHARS // 6 + 1)
+    r = client.post("/measured", json={"name": "huge.s1p", "text": big})
+    assert r.status_code == 413
+
+
+def test_measured_open_circuit_stays_json_parseable(client: TestClient):
+    """|Gamma| = 1 is a measured open; the body must not carry Infinity, which
+    the browser's JSON.parse rejects outright."""
+    r = client.post(
+        "/measured",
+        json={"name": "open.s1p", "text": "# MHZ S RI R 50\n14.0 1.0 0.0\n"},
+    )
+    assert r.status_code == 200
+    json.loads(r.content)  # strict parse: no Infinity/NaN tokens
+    assert np.isfinite(r.json()["z_re"][0])
+
+
 def test_examples_serialize_param_groups_with_kind_group(client: TestClient):
     # fandipole is the canonical group-bearing geometry — its `bands`
     # ParamGroupSpec must round-trip with kind="group" so the frontend's


### PR DESCRIPTION
Closes #595 — measured-vs-modeled overlay, both halves.

## CLI

`--measured <file.s1p>` draws a measured VNA sweep alongside the modeled one, on all three impedance chart forms (SWR, Smith, R/X):

```bash
python -m antennaknobs sweep --builder dipoles.invvee --swr \
    --range 28.0 29.0 --npoints 21 --measured bench_10m.s1p
```

## Web workbench

**measured .s1p…** under the Smith chart loads a file from the operator's machine and draws it as a dashed violet locus against the modeled one, live as the knobs turn.

## Design notes

**One parser.** `measured.py` builds on the #593 Touchstone reader; the web upload posts the file *text* to `POST /measured` rather than reimplementing Touchstone in TypeScript, where a second reader could disagree with the CLI about the same file. Nothing is stored server-side — and since only the text travels, the overlay works with the backend across a tunnel while the VNA is plugged in locally (the topology #597 has to solve for).

**Reference impedance.** The file declares its own `R <z0>`; the chart has its own. Comparing raw Γ across differing references is a silent error, so the CLI renormalizes through the impedance, and the endpoint answers *in* impedance — the same shape the solve/`/sweep` responses carry — so the chart converts at its own reference and a 75 Ω calibration lands correctly on a 50 Ω chart with no special case.

**Bands.** The measurement is aligned to the sweep grid and drawn only over the overlap: partial coverage renders over its own band (labelled `(clipped)` in the web chart), nothing is extrapolated, and disjoint bands produce a clear message rather than an empty chart. On the CLI the alignment runs *before* any solving, so that error arrives immediately instead of after a full sweep of matrix solves.

**Port count is read from the data, not the name** — a two-port file arriving under a one-port name is refused rather than silently read as 3× the frequency points.

**`|Γ| ≥ 1` is real** (noise on a near-open, imperfect calibration). The derived impedance/SWR views clamp a hair inside the unit circle: finite and off-chart rather than a division by zero — and, for the web path, no bare `Infinity` in a JSON body the browser refuses to parse.

## Acceptance criteria (#595)

- [x] `.s1p` measured trace overlaid on CLI SWR/Smith sweeps
- [x] Web workbench measured-overlay upload + render against the live simulated curve
- [x] Interpolation onto the sweep grid; partial-band handling; clear message when bands don't overlap
- [x] Shares the s1p parser with #593 (no duplicate Touchstone reader)

## Testing

22 new tests: 17 in `tests/test_measured.py` (parsing incl. Z-parameter files, renormalization, SWR/impedance clamping, `.s2p` and extension rejection, interpolation exactness, partial-overlap clipping, disjoint-band error, one CLI smoke run per chart form) and 5 in `tests/test_web_server.py` (impedance-not-Γ response shape against a 75 Ω file, two-port rejection, junk/empty/oversized uploads, and a strict `json.loads` on a measured open). Full fast lane green: 2879 passed.

The three CLI chart forms were verified visually. The **web canvas rendering was not** — no browser automation is available in this environment (the endpoint round-trip, TypeScript typecheck, and production build all pass, but the drawn locus itself wants an eyeball).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g