### PR TITLE
feat(fit): calibrate design parameters against a measured VNA sweep (#639)

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -95,6 +95,7 @@ export default defineConfig({
             { label: "Cut for one band, worked on another", slug: "advanced/off-band" },
             { label: "How many segments?", slug: "advanced/convergence" },
             { label: "Antennas on a levee", slug: "advanced/terrain" },
+            { label: "Calibrating against your VNA", slug: "advanced/calibrating" },
           ],
         },
         {

--- a/site/src/content/docs/advanced/calibrating.md
+++ b/site/src/content/docs/advanced/calibrating.md
@@ -1,0 +1,177 @@
+---
+title: Calibrating a model against your VNA
+description: fit mode — solve for the parameters a tape measure can't give you (ground constants, as-built length, feedline electrical length) by fitting a measured .s1p, and read the residual to know how far to trust the answer.
+---
+
+[Overlaying a measured sweep](/reference/cli/#overlaying-a-vna-measurement)
+answers *does the model match the bench?* The `fit` command inverts the
+question: **what would the model have to believe to reproduce this
+measurement?**
+
+That inversion is worth something because the parameters you'd most like to
+know are the ones you cannot measure with a tape:
+
+- the ground constants under *this* yard — not the "average soil" from a table,
+- the as-built length after sag, end effects, and insulated-wire velocity factor,
+- the electrical length and loss of the feedline that's actually buried,
+- stray reactance at the feedpoint from the connector and the balun.
+
+A VNA sweep constrains all of these. `fit` turns that constraint into numbers,
+and — just as importantly — tells you when the measurement *doesn't* constrain
+what you asked it to.
+
+## The basic run
+
+```bash
+python -m antennaknobs fit --builder dipoles.invvee \
+    --measured bench_10m.s1p \
+    --params length_factor angle_deg \
+    --npoints 15 --fractions 0.15 --fn fit.png
+```
+
+`--params` takes the same dotted paths `optimize` resolves, so builder knobs,
+per-band dicts, and terrain facets are all reachable
+(`length_top`, `bands.1.halfdriver_factor`, `terrain.facets.0.eps_r`).
+
+```
+fit against 'bench_10m': 15 points, 26–31 MHz, z0 = 50 Ω
+
+parameter                         nominal       fitted        shift
+length_factor                      0.9719     0.992629   +0.0207291  +2.13%
+angle_deg                         31.6846      34.6707     +2.98609   +9.42%
+
+RMS |ΔΓ|   nominal 0.1858  →  fitted 0.0044   (20 model evaluations)
+```
+
+The plot is two panels: the three SWR traces (measured, nominal model, fitted
+model) on top, and **the residual |ΔΓ| versus frequency** underneath, before and
+after. The bottom panel is the one to read carefully.
+
+## Reading the residual
+
+The fitted RMS is the honest bottom line — it says how much of the measurement
+the model can account for at all. Its *shape* says what's missing.
+
+Take the same measurement, fitted two ways:
+
+```bash
+# just the length
+--params length_factor            #  RMS 0.1869 → 0.0200
+# length and droop angle
+--params length_factor angle_deg  #  RMS 0.1858 → 0.0044
+```
+
+The one-parameter fit converges happily and reports a plausible +1.9% length
+correction. But its residual doesn't look like noise — it has structure across
+the band, because the antenna differs from the model in a way length alone
+can't express. Adding the droop angle drops the residual by 4.5×, and *that*
+residual is flat.
+
+So:
+
+- **Flat, small residual** → the model explains the measurement. The fitted
+  parameters mean what they say.
+- **Structured residual** (a tilt, a bump at one end, a peak at resonance) →
+  something physical is missing from the model. More often than not the
+  culprit is **common-mode current on the feedline**, which a differential
+  model cannot reproduce at all. Fitting harder will not remove it; it will
+  only push a parameter somewhere nonphysical to hide it.
+- **Large residual** (the report calls out anything over 0.05 RMS) → treat the
+  numbers as meaningless until you know why.
+
+This is why `fit` reports the residual instead of just the parameters. A fit
+with small residual is a much stronger statement about a model than an overlay
+is — and a fit with *structured* residual is a pointer at the physics you
+haven't modelled yet.
+
+## Identifiability is the hard part
+
+Length, ground, and feedline length all bend S11 in similar ways. Over one
+narrow band they are barely distinguishable, so a fit can be simultaneously
+well-converged and meaningless. `fit` caps you at **four** free parameters and
+reports the conditioning of what it solved:
+
+```
+WARNING: under-determined (Jacobian condition 789). These data barely constrain
+         the combination
+         +0.71·length_factor  +0.71·design_freq
+         — its fitted value is close to arbitrary. Fit fewer parameters, or
+         measure a wider / second band.
+```
+
+That is `fit` naming the degeneracy: `length_factor` and `design_freq` both
+scale the element, so moving them together changes nothing the measurement can
+see. The *identified* direction is still solid — it's the blind combination
+whose split between the two knobs is arbitrary.
+
+What actually fixes it is data, not settings: **a wider sweep, or a second
+band.** Two bands separate length from ground in a way one band never can.
+
+A related warning covers bounds:
+
+```
+WARNING: angle_deg ended at a bound — the fit wanted to go further than you
+         allowed.
+```
+
+Either the bound is too tight, or that knob is standing in for something the
+model is missing. Both are worth knowing before you paste the value into a
+design.
+
+Free parameters default to a ±10% window (`--fractions 0.15` for ±15%, one
+value or one per parameter; `--bounds lo hi lo hi` for explicit ones). The
+default is deliberately tighter than `optimize`'s: a calibration is a
+*correction* to a design you already believe, and a wide window invites the
+optimizer to explain a bad measurement with an absurd antenna.
+
+## Where was the VNA calibrated?
+
+The fit compares at the plane the model's port sits on — normally the antenna
+feedpoint. If you calibrated at the feedpoint, that's already like-for-like and
+there is nothing to do.
+
+For a sweep taken at the **shack end**, tell `fit` what's in between:
+
+```bash
+python -m antennaknobs fit --builder dipoles.invvee --measured shack_10m.s1p \
+    --params length_factor angle_deg --plane station --line RG-213:30.5
+```
+
+`--line <cable>:<length_m>` uses the same cable catalog and matched-loss model
+as the `TL` element, so the line embeds exactly as it would inside a network.
+Skipping it doesn't produce an obvious error — it produces a *plausible wrong
+answer*: the fit can still land the resonance about right while the feedpoint
+resistance it infers is badly off, because loss and rotation in the line are
+being blamed on the antenna.
+
+If your design already models its feedline in `build_network()` (see
+[station modelling](/concepts/station-modelling/)), its port **is** the station
+plane — keep `--plane feedpoint` and change nothing.
+
+## Saving the result
+
+The command prints a paste-ready variant block of the deltas from the design's
+defaults:
+
+```python
+measured_params = {
+    'length_factor': 0.992629,
+    'angle_deg': 34.670689,
+}
+```
+
+Drop that into the design class as a named variant and every later run can
+select the *calibrated* antenna with `--builder dipoles.invvee:measured` —
+your model of the antenna in your yard, rather than the antenna on paper.
+
+## Limits worth stating
+
+- **One port.** A VNA sweep is one-port data; multi-feed designs are fitted at
+  port 0.
+- **Ground fitting needs a ground.** `terrain.facets.0.eps_r` is only meaningful
+  with a real-ground solve (`--ground finite`), and ground is exactly the
+  parameter most likely to be degenerate with length over a single band.
+- **A fit is not a measurement of truth.** It's the parameter set that best
+  explains one sweep under one model. The residual is what tells you how much
+  of the antenna that model actually captured — which is why every run reports
+  it.

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -102,6 +102,26 @@ perturbs a measurement in ways a differential model does not reproduce. A
 usually pointing at something physical (line length, ground, a connector),
 which is the diagnostic value of drawing them together.
 
+### Fitting a model to a measurement
+
+`fit` goes the other way: instead of drawing the measurement next to the model,
+it solves for the model parameters that reproduce it — site ground constants,
+as-built length, feedline electrical length, stray feedpoint reactance.
+
+```bash
+python -m antennaknobs fit --builder dipoles.invvee --measured bench_10m.s1p \
+    --params length_factor angle_deg --npoints 15 --fractions 0.15 --fn fit.png
+```
+
+It prints the fitted values with their shifts, the RMS |ΔΓ| before and after, a
+paste-ready variant block, and warnings when the fit is under-determined or a
+parameter ended pinned at a bound. `--plane station --line RG-213:30.5` moves
+the comparison to the far end of a known feedline for a shack-end sweep.
+
+The full treatment — how to read the residual, why identifiability is the hard
+part, and what a fit does and doesn't prove — is in
+[Calibrating a model against your VNA](/advanced/calibrating/).
+
 ## Choosing an engine
 
 The `--engine` flag selects the solver:

--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -13,6 +13,7 @@ from . import (
 )
 from .engines import PyNECEngine, MomwireEngine
 from .serialize import builder_params_source
+from .fit import MAX_FREE_PARAMS, LineEmbedding, fit, plot_fit
 from .measured import read_measured
 from .user_designs import USER_NS, iter_design_files, resolve_user_design
 
@@ -676,6 +677,136 @@ def cli(arguments=None):
                 base=base,
             )
         )
+
+    p.set_defaults(func=f)
+
+    p = subparsers.add_parser(
+        "fit",
+        help="Calibrate design params against a measured .s1p sweep",
+        description="Fit selected design parameters so the model reproduces a "
+        "measured VNA sweep. Fit the things a tape measure can't give you — "
+        "site ground constants, as-built length after sag, feedline electrical "
+        "length, stray feedpoint reactance — and read the residual to see how "
+        "much of the measurement the model can actually account for.",
+    )
+    add_common(p)
+    add_engine_args(p)
+    p.add_argument(
+        "--measured",
+        required=True,
+        help="Measured one-port Touchstone (.s1p) to fit against.",
+    )
+    p.add_argument(
+        "--params",
+        nargs="+",
+        required=True,
+        help=f"Free parameters as dotted paths (at most {MAX_FREE_PARAMS}), e.g. "
+        "length_factor terrain.facets.0.eps_r",
+    )
+    p.add_argument("--z0", default=50, type=float, help="Reference impedance.")
+    p.add_argument(
+        "--npoints",
+        default=21,
+        type=int,
+        help="Frequencies compared per iteration, subsampled from the "
+        "measured grid (default 21).",
+    )
+    p.add_argument(
+        "--range",
+        nargs=2,
+        default=None,
+        type=float,
+        help="Restrict the fit to this band (MHz) of the measurement.",
+    )
+    p.add_argument(
+        "--bounds",
+        nargs="+",
+        default=None,
+        type=float,
+        help="Bounds as 'lo hi' per free parameter, in --params order.",
+    )
+    p.add_argument(
+        "--fractions",
+        nargs="+",
+        default=None,
+        type=float,
+        help="Multiplicative window per free parameter when --bounds is "
+        "absent (one value, or one per parameter; default 0.10 = +/-10%%).",
+    )
+    p.add_argument(
+        "--plane",
+        default="feedpoint",
+        choices=("feedpoint", "station"),
+        help="Where the VNA was calibrated. 'station' needs --line.",
+    )
+    p.add_argument(
+        "--line",
+        default=None,
+        help="Feedline between the model port and a --plane station "
+        "measurement, as '<cable>:<length_m>' (e.g. RG-213:30.5).",
+    )
+    p.add_argument(
+        "--no_plot",
+        default=False,
+        action="store_true",
+        help="Print the fit report without drawing the comparison plot.",
+    )
+
+    def f(args):
+        pairs = None
+        if args.bounds is not None:
+            if len(args.bounds) != 2 * len(args.params):
+                raise SystemExit(
+                    f"--bounds takes 'lo hi' per free parameter: "
+                    f"{2 * len(args.params)} numbers for {len(args.params)} params"
+                )
+            pairs = list(zip(args.bounds[0::2], args.bounds[1::2]))
+        line = None
+        if args.plane == "station":
+            if not args.line:
+                raise SystemExit(
+                    "--plane station needs --line '<cable>:<length_m>' — the line "
+                    "between the antenna and where the VNA was calibrated. (If the "
+                    "design already models its feedline in build_network(), its port "
+                    "IS the station plane: use --plane feedpoint.)"
+                )
+            line = LineEmbedding.parse(args.line)
+        elif args.line:
+            raise SystemExit("--line only applies with --plane station")
+
+        builder = get_builder(args.builder)()
+        try:
+            result = fit(
+                builder,
+                read_measured(args.measured),
+                args.params,
+                z0=args.z0,
+                engine=engine_factory_from_args(args),
+                bounds=pairs,
+                fractions=args.fractions,
+                npoints=args.npoints,
+                band=args.range,
+                line=line,
+            )
+        except (ValueError, KeyError) as e:
+            # Bad free-parameter list, disjoint bands, malformed bounds: the
+            # messages already name the problem, and a traceback would only
+            # bury it (same convention as the unknown-builder path).
+            raise SystemExit(str(e)) from e
+        print(result.report())
+        print()
+        print("# Calibrated knobs — paste into the design as a variant:")
+        print(
+            builder_params_source(
+                result.builder,
+                name="measured_params",
+                base=type(result.builder).default_params,
+                include_ui=False,
+                default_precision=6,
+            )
+        )
+        if not args.no_plot:
+            plot_fit(result, fn=args.fn)
 
     p.set_defaults(func=f)
 

--- a/src/antennaknobs/fit.py
+++ b/src/antennaknobs/fit.py
@@ -1,0 +1,527 @@
+"""Calibrate model parameters against a measured VNA sweep (issue #639).
+
+The measured overlay (``measured.py``, issue #595) answers "does the model
+match the bench?". This module inverts the question: given a measurement,
+**what would the model have to believe** to reproduce it? The free parameters
+worth fitting are the ones a tape measure can't give you — the ground constants
+under *this* yard, the as-built length after sag and end effects, the electrical
+length of a feedline, a stray feedpoint reactance. The output is a calibrated
+design plus a residual that says how much of the measurement the model can
+account for.
+
+Three deliberate choices shape the implementation:
+
+**Fit complex Γ, not SWR.** Phase is what separates causes: a length error and
+a ground error both widen |Γ|, but they rotate it differently. Fitting |Γ| (or
+SWR) throws away exactly the information that makes the parameters
+distinguishable.
+
+**Identifiability is the hard part, not the optimizer.** Length, ground, and
+line length all bend S11 in similar ways, so a fit over four free parameters
+and one narrow band is usually under-determined even when it converges
+beautifully. :func:`fit` caps the free-parameter count and reports the
+conditioning of the solution — the near-degenerate *combination* of parameters
+by name, not just a warning — so an under-determined fit announces itself
+instead of looking like an answer.
+
+**Report the residual honestly.** Common-mode current on a real feedline
+perturbs a measurement in ways a differential model cannot reproduce; so does
+anything the design omits. The final RMS misfit is part of the result, and
+structured residual (a systematic tilt or offset rather than noise) is a
+diagnostic pointer, not a number to optimize away by letting parameters wander
+somewhere nonphysical. Bounds keep them physical.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+import numpy as np
+from scipy.optimize import least_squares
+
+from . import Antenna
+from .measured import MeasuredTrace
+from .opt import _get_path, _set_path
+
+__all__ = ["fit", "FitResult", "LineEmbedding", "MAX_FREE_PARAMS", "plot_fit"]
+
+logger = logging.getLogger(__name__)
+
+# Upper bound on simultaneously fitted parameters. Not an optimizer limit — a
+# scientific one: past three or four knobs, a single-band S11 curve simply does
+# not carry enough independent information, and the fit starts trading one
+# physical explanation against another (see the module docstring).
+MAX_FREE_PARAMS = 4
+
+# Condition number of the Jacobian above which the fit is reported as
+# under-determined. The Jacobian is column-scaled first, so this is a pure
+# collinearity measure: 100 means the weakest parameter combination moves the
+# residual 100× less than the strongest.
+ILL_CONDITIONED = 100.0
+
+
+@dataclass(frozen=True)
+class LineEmbedding:
+    """A known feedline between the model's port and the measurement plane.
+
+    A VNA calibrated at the shack end sees the antenna *through* the feedline.
+    When the design itself models that line (a ``TL`` in ``build_network()``),
+    nothing is needed here — the model's port already is the station plane.
+    This is for the other case: an antenna-only model and a measurement taken
+    at the far end of a line whose type and length are known.
+
+    ``k1``/``k2`` are the cable-table matched-loss coefficients
+    (dB/100 ft = k1·√f_MHz + k2·f_MHz), the same model ``network.TL`` uses, so
+    a catalog cable embeds here exactly as it would inside the network.
+    """
+
+    z0: float
+    length_m: float
+    vf: float = 1.0
+    k1: float = 0.0
+    k2: float = 0.0
+
+    @classmethod
+    def from_cable(cls, cable: str, length_m: float) -> "LineEmbedding":
+        """Look ``cable`` up in ``network.CABLES`` (``"RG-213"``, …)."""
+        from .network import CABLES
+
+        if cable not in CABLES:
+            raise KeyError(
+                f"unknown cable {cable!r}; available: {', '.join(sorted(CABLES))}"
+            )
+        c = CABLES[cable]
+        return cls(z0=c.z0, length_m=length_m, vf=c.vf, k1=c.k1, k2=c.k2)
+
+    @classmethod
+    def parse(cls, spec: str) -> "LineEmbedding":
+        """``"RG-213:30.5"`` → 30.5 m of RG-213 (the CLI spelling)."""
+        cable, _, length = spec.partition(":")
+        if not length:
+            raise ValueError(
+                f"line spec {spec!r} should be '<cable>:<length_m>', e.g. 'RG-213:30.5'"
+            )
+        return cls.from_cable(cable.strip(), float(length))
+
+    def embed(self, z_load: np.ndarray, freqs_mhz: np.ndarray) -> np.ndarray:
+        """Impedance seen through the line, ``Z₀(Z+Z₀·tanh γl)/(Z₀+Z·tanh γl)``."""
+        from .network_reduce import C_LIGHT, FEET_PER_M, NEPER_PER_DB
+
+        f = np.asarray(freqs_mhz, dtype=float)
+        beta = 2.0 * np.pi * (f * 1e6) / (self.vf * C_LIGHT)
+        alpha = (self.k1 * np.sqrt(f) + self.k2 * f) * NEPER_PER_DB * FEET_PER_M / 100.0
+        t = np.tanh((alpha + 1j * beta) * self.length_m)
+        return self.z0 * (z_load + self.z0 * t) / (self.z0 + z_load * t)
+
+
+@dataclass
+class FitResult:
+    """Outcome of a fit: what moved, how far, and how much is left over."""
+
+    names: tuple[str, ...]
+    nominal: tuple[float, ...]
+    fitted: tuple[float, ...]
+    bounds: tuple[tuple[float, float], ...]
+    freqs: np.ndarray
+    gamma_measured: np.ndarray
+    gamma_nominal: np.ndarray
+    gamma_fitted: np.ndarray
+    z0: float
+    builder: object
+    label: str = "measured"
+    #: Column-scaled Jacobian condition number; ``inf`` when it is singular.
+    condition: float = float("nan")
+    #: Parameter weights of the least-identifiable combination (see `report`).
+    weakest: tuple[float, ...] = ()
+    nfev: int = 0
+    #: Set when the measured band sits far from what the design is cut for.
+    band_note: str = ""
+    message: str = ""
+    _rms: dict = field(default_factory=dict, repr=False)
+
+    @staticmethod
+    def _rms_of(delta: np.ndarray) -> float:
+        return float(np.sqrt(np.mean(np.abs(delta) ** 2)))
+
+    @property
+    def rms_nominal(self) -> float:
+        """RMS |ΔΓ| of the *starting* model against the measurement."""
+        return self._rms_of(self.gamma_nominal - self.gamma_measured)
+
+    @property
+    def rms_fitted(self) -> float:
+        """RMS |ΔΓ| left after fitting — the honest bottom line."""
+        return self._rms_of(self.gamma_fitted - self.gamma_measured)
+
+    @property
+    def at_bound(self) -> tuple[str, ...]:
+        """Parameters that ended pinned against a bound.
+
+        A pinned parameter means the fit wanted to go somewhere the bounds
+        forbade: either the bound is too tight, or the model is absorbing
+        something physical (common mode, a missing element) into the wrong
+        knob. Either way the value is not a measurement.
+        """
+        out = []
+        for nm, v, (lo, hi) in zip(self.names, self.fitted, self.bounds):
+            span = hi - lo
+            if span > 0 and (v - lo < 1e-6 * span or hi - v < 1e-6 * span):
+                out.append(nm)
+        return tuple(out)
+
+    def report(self) -> str:
+        """A human-readable summary — what the CLI prints."""
+        lines = [
+            f"fit against {self.label!r}: {self.freqs.size} points, "
+            f"{self.freqs[0]:.4g}–{self.freqs[-1]:.4g} MHz, z0 = {self.z0:g} Ω",
+            "",
+            f"{'parameter':<28} {'nominal':>12} {'fitted':>12} {'shift':>12}",
+        ]
+        for nm, a, b in zip(self.names, self.nominal, self.fitted):
+            pct = f"{100.0 * (b - a) / a:+.2f}%" if a else "—"
+            lines.append(f"{nm:<28} {a:>12.6g} {b:>12.6g} {b - a:>+12.6g}  {pct}")
+        lines += [
+            "",
+            f"RMS |ΔΓ|   nominal {self.rms_nominal:.4f}  →  fitted {self.rms_fitted:.4f}"
+            f"   ({self.nfev} model evaluations)",
+        ]
+        if pinned := self.at_bound:
+            lines.append(
+                f"WARNING: {', '.join(pinned)} ended at a bound — the fit wanted to "
+                "go further than you allowed. Widen the bound, or ask whether the "
+                "model is missing something this knob is standing in for."
+            )
+        if not np.isfinite(self.condition) or self.condition > ILL_CONDITIONED:
+            combo = "  ".join(
+                f"{w:+.2f}·{nm}" for w, nm in zip(self.weakest, self.names)
+            )
+            lines += [
+                f"WARNING: under-determined (Jacobian condition {self.condition:.3g}). "
+                "These data barely constrain the combination",
+                f"         {combo}",
+                "         — its fitted value is close to arbitrary. Fit fewer "
+                "parameters, or measure a wider / second band.",
+            ]
+        if self.band_note:
+            lines.append(self.band_note)
+        if self.rms_fitted > 0.05:
+            lines.append(
+                f"NOTE: {self.rms_fitted:.3f} RMS |ΔΓ| is a large residual. Look at "
+                "its shape before trusting the parameters: a systematic tilt or "
+                "offset means something physical is missing from the model "
+                "(commonly common-mode current on the feedline), not that the "
+                "knobs are wrong."
+            )
+        return "\n".join(lines)
+
+
+def _fit_grid(measured: MeasuredTrace, npoints: int, band=None) -> np.ndarray:
+    """Frequencies to compare on: the measured grid, thinned to ``npoints``.
+
+    Comparison points are *measured* frequencies, so neither side is
+    interpolated where it matters — the model is solved exactly there, and the
+    measurement is used as recorded. A VNA's few hundred points would make
+    every optimizer step a few hundred solves for information a couple of dozen
+    already carry.
+
+    The subsample takes every k-th point rather than ``npoints`` evenly spaced
+    ones: on the uniform grid every analyzer writes, a constant stride keeps the
+    result exactly evenly spaced (which ``PyNECEngine.impedance_sweep``
+    requires), at the cost of landing a little under ``npoints`` rather than
+    exactly on it.
+    """
+    freqs = measured.freqs
+    if band is not None:
+        lo, hi = float(band[0]), float(band[1])
+        inside = (freqs >= lo) & (freqs <= hi)
+        if not inside.any():
+            from .measured import BandOverlapError
+
+            raise BandOverlapError(
+                f"fit range [{lo:.6g}, {hi:.6g}] MHz does not overlap the measured "
+                f"band [{freqs[0]:.6g}, {freqs[-1]:.6g}] MHz"
+            )
+        freqs = freqs[inside]
+    if npoints < 2:
+        raise ValueError("a fit needs at least 2 comparison frequencies")
+    if freqs.size <= npoints:
+        return freqs
+    stride = int(np.ceil(freqs.size / npoints))
+    return freqs[::stride]
+
+
+def _resolve_bounds(x0, bounds, fractions):
+    """Bounds per parameter, in ``optimize()``'s conventions.
+
+    Explicit ``bounds`` win; otherwise each parameter gets a multiplicative
+    window from ``fractions`` (scalar or per-parameter), defaulting to ±10%
+    — a deliberately tighter default than ``optimize()``'s ±67%, because a
+    calibration is a *correction* to a known design, and a wide window invites
+    the optimizer to explain a bad measurement with an absurd antenna.
+    """
+    if bounds is not None:
+        if len(bounds) != len(x0):
+            raise ValueError(
+                f"got {len(bounds)} bound pairs for {len(x0)} free parameters"
+            )
+        return tuple((float(lo), float(hi)) for lo, hi in bounds)
+    if fractions is None:
+        fracs = [0.10] * len(x0)
+    elif np.isscalar(fractions):
+        fracs = [float(fractions)] * len(x0)
+    else:
+        fracs = [float(f) for f in fractions]
+        if len(fracs) == 1:
+            fracs *= len(x0)  # one value broadcasts to every parameter
+        elif len(fracs) != len(x0):
+            raise ValueError(
+                f"got {len(fracs)} fractions for {len(x0)} free parameters "
+                "(pass one value, or one per parameter)"
+            )
+    out = []
+    for x, f in zip(x0, fracs):
+        # A parameter nominally 0 (a stray reactance, a length correction) has
+        # no multiplicative window; give it an absolute one instead.
+        lo, hi = (-f, f) if x == 0 else sorted((x * (1 - f), x * (1 + f)))
+        out.append((float(lo), float(hi)))
+    return tuple(out)
+
+
+def _band_note(antenna_builder, freqs: np.ndarray) -> str:
+    """A note when the measurement sits nowhere near what the design is cut for.
+
+    Deliberately a note and not an error. The obvious gate — "refuse when the
+    measured band misses the design band" — would reject the legitimate case of
+    fitting a design on a *harmonic* band, which is ordinary practice (a 40 m
+    dipole worked on 15 m) and something this tool should support. Nor is a
+    remote band meaningless: an off-band measurement genuinely constrains
+    length and ground. What it usually means is that the wrong file got picked,
+    so say so and let the residual speak.
+    """
+    bands = getattr(antenna_builder, "bands", None)
+    if bands:
+        centers = [
+            float(b["freq"]) for b in bands if isinstance(b, dict) and "freq" in b
+        ]
+    else:
+        centers = []
+    if not centers:
+        f0 = getattr(antenna_builder, "design_freq", None) or getattr(
+            antenna_builder, "freq", None
+        )
+        if not f0:
+            return ""
+        centers = [float(f0)]
+    fc = float(np.sqrt(freqs[0] * freqs[-1]))  # geometric centre of the measurement
+    for c in centers:
+        ratio = fc / c
+        if 1 / 1.4 <= ratio <= 1.4:
+            return ""
+        # Harmonic operation is a real use of a design, not a mistake.
+        n = round(ratio)
+        if 2 <= n <= 9 and abs(ratio - n) / n < 0.1:
+            return (
+                f"NOTE: the measurement ({fc:.4g} MHz) is near the {n}th harmonic of "
+                f"the {c:.4g} MHz design — fitting off-band is fine, but remember "
+                "the model must be right there too."
+            )
+    near = min(centers, key=lambda c: abs(np.log(fc / c)))
+    return (
+        f"NOTE: the measurement is centred at {fc:.4g} MHz while the design is cut "
+        f"for {near:.4g} MHz. That is a long way off-band — if this is not the file "
+        "you meant to fit, the parameter values below are meaningless."
+    )
+
+
+def _conditioning(jac: np.ndarray) -> tuple[float, tuple[float, ...]]:
+    """Column-scaled condition number and the weakest parameter combination.
+
+    Scaling each column to unit norm first removes the units — otherwise a
+    parameter measured in metres and one in siemens/metre would look
+    "ill-conditioned" purely from their magnitudes. What is left is genuine
+    collinearity: how nearly two knobs bend Γ the same way over this band.
+    """
+    if jac.size == 0:
+        return float("nan"), ()
+    norms = np.linalg.norm(jac, axis=0)
+    if not np.all(norms > 0):
+        # A column of zeros: that parameter does not move the model at all here.
+        weakest = np.zeros(jac.shape[1])
+        weakest[int(np.argmin(norms))] = 1.0
+        return float("inf"), tuple(weakest)
+    scaled = jac / norms
+    _, sv, vt = np.linalg.svd(scaled, full_matrices=False)
+    cond = float(sv[0] / sv[-1]) if sv[-1] > 0 else float("inf")
+    return cond, tuple(float(v) for v in vt[-1])
+
+
+def fit(
+    antenna_builder,
+    measured: MeasuredTrace,
+    names,
+    *,
+    z0: float = 50.0,
+    engine=Antenna,
+    bounds=None,
+    fractions=None,
+    npoints: int = 21,
+    band=None,
+    port: int = 0,
+    line: LineEmbedding | None = None,
+    weights=None,
+) -> FitResult:
+    """Fit ``names`` (dotted paths) of ``antenna_builder`` to ``measured``.
+
+    Paths are resolved by the same ``opt.py`` machinery ``optimize()`` uses, so
+    builder attributes, the bands tuple, and per-band dicts are all reachable
+    (``length_top``, ``terrain.facets.0.eps_r``, ``bands.1.halfdriver_factor``).
+
+    The objective is the complex-Γ misfit at ``z0`` over a subsample of the
+    measured grid (see :func:`_fit_grid`); ``line`` moves the comparison to the
+    far end of a known feedline. Returns a :class:`FitResult` — the builder it
+    carries has been left at the fitted values.
+    """
+    names = tuple(names)
+    if not names:
+        raise ValueError("fit needs at least one free parameter")
+    if len(names) > MAX_FREE_PARAMS:
+        raise ValueError(
+            f"{len(names)} free parameters is more than a single measured sweep can "
+            f"identify; fit at most {MAX_FREE_PARAMS} at a time. Length, ground, and "
+            "line length all bend S11 in similar ways — fitting them together makes "
+            "the answer depend on the starting point rather than on the data. Fit "
+            "the ones you cannot measure, hold the rest at their as-built values, "
+            "and use a wider or a second band when you need more."
+        )
+
+    grid = _fit_grid(measured, npoints, band)
+    _, gamma_meas = measured.renormalized(z0).align(grid)
+    w = np.ones(grid.size) if weights is None else np.asarray(weights, dtype=float)
+    if w.shape != grid.shape:
+        raise ValueError(f"weights must have {grid.size} entries, one per fit point")
+    sw = np.sqrt(w)
+
+    x0 = np.array([float(_get_path(antenna_builder, nm)) for nm in names], dtype=float)
+    bnds = _resolve_bounds(x0, bounds, fractions)
+    lo = np.array([b[0] for b in bnds])
+    hi = np.array([b[1] for b in bnds])
+    if np.any(x0 < lo) or np.any(x0 > hi):
+        # least_squares rejects an out-of-bounds start outright; nudging in is
+        # friendlier than refusing, and says so.
+        logger.info("starting values clipped into the requested bounds")
+        x0 = np.clip(x0, lo, hi)
+
+    evals = {"n": 0}
+
+    def model_gamma(x) -> np.ndarray:
+        for v, nm in zip(x, names):
+            _set_path(antenna_builder, nm, float(v))
+        a = engine(antenna_builder)
+        zs = np.asarray(a.impedance_sweep(grid))
+        del a
+        zs = zs[:, port] if zs.ndim > 1 else zs
+        if line is not None:
+            zs = line.embed(zs, grid)
+        evals["n"] += 1
+        return (zs - z0) / (zs + z0)
+
+    def residual(x) -> np.ndarray:
+        d = (model_gamma(x) - gamma_meas) * sw
+        # least_squares wants a real vector: real and imaginary parts are two
+        # independent residuals, which is exactly the point of fitting complex Γ.
+        return np.concatenate([d.real, d.imag])
+
+    gamma_nominal = model_gamma(x0)
+    res = least_squares(
+        residual,
+        x0=x0,
+        bounds=(lo, hi),
+        # Jacobian columns scaled by their own sensitivity: without it a
+        # metres-scale knob and a conductivity-scale one get the same step.
+        x_scale="jac",
+        diff_step=1e-4,
+        xtol=1e-10,
+        ftol=1e-8,
+    )
+    gamma_fitted = model_gamma(res.x)  # also leaves the builder at the fit
+    cond, weakest = _conditioning(np.asarray(res.jac))
+
+    return FitResult(
+        names=names,
+        nominal=tuple(float(v) for v in x0),
+        fitted=tuple(float(v) for v in res.x),
+        bounds=bnds,
+        freqs=grid,
+        gamma_measured=gamma_meas,
+        gamma_nominal=gamma_nominal,
+        gamma_fitted=gamma_fitted,
+        z0=float(z0),
+        builder=antenna_builder,
+        label=measured.label,
+        condition=cond,
+        weakest=weakest,
+        nfev=evals["n"],
+        band_note=_band_note(antenna_builder, grid),
+        message=str(res.message),
+    )
+
+
+def plot_fit(result: FitResult, *, fn=None):
+    """Two-panel comparison: SWR of all three traces, and the residual.
+
+    The top panel is the familiar view (measured, nominal model, fitted model)
+    and answers "did it get closer?". The bottom panel is the one worth reading
+    carefully: |ΔΓ| versus frequency, before and after. Residual that is flat
+    and small is noise — the fit is done. Residual with *shape* — a tilt, a
+    bump at one end, a peak at resonance — is structure the model does not
+    contain, and no amount of parameter fitting will remove it honestly.
+    """
+    import matplotlib.pyplot as plt
+
+    from .core import save_or_show
+    from .measured import RHO_MAX
+    from .sweep import _polish_axes
+
+    def swr(g):
+        rho = np.minimum(np.abs(g), RHO_MAX)
+        return (1.0 + rho) / (1.0 - rho)
+
+    f = result.freqs
+    fig, (ax0, ax1) = plt.subplots(
+        2, 1, figsize=(7.5, 6.4), sharex=True, height_ratios=(2, 1)
+    )
+    ax0.plot(
+        f, swr(result.gamma_measured), color="0.25", linestyle="--", marker="x",
+        ms=4, linewidth=1.3, label=f"measured ({result.label})",
+    )  # fmt: skip
+    ax0.plot(
+        f, swr(result.gamma_nominal), color="tab:orange", linestyle=":",
+        marker="o", ms=3, label="model (nominal)",
+    )  # fmt: skip
+    ax0.plot(
+        f, swr(result.gamma_fitted), color="tab:blue", marker="o", ms=3,
+        label="model (fitted)",
+    )  # fmt: skip
+    ax0.set_ylabel(f"SWR (z0 = {result.z0:g} Ω)")
+    ax0.legend(loc="best", frameon=False, fontsize=8)
+    _polish_axes(ax0, title=f"fit to {result.label!r}")
+
+    ax1.plot(
+        f, np.abs(result.gamma_nominal - result.gamma_measured),
+        color="tab:orange", linestyle=":", marker="o", ms=3,
+        label=f"nominal (RMS {result.rms_nominal:.4f})",
+    )  # fmt: skip
+    ax1.plot(
+        f, np.abs(result.gamma_fitted - result.gamma_measured),
+        color="tab:blue", marker="o", ms=3,
+        label=f"fitted (RMS {result.rms_fitted:.4f})",
+    )  # fmt: skip
+    ax1.set_ylabel("residual |ΔΓ|")
+    ax1.set_xlabel("freq (MHz)")
+    ax1.set_ylim(bottom=0)
+    ax1.legend(loc="best", frameon=False, fontsize=8)
+    _polish_axes(ax1)
+
+    fig.tight_layout()
+    save_or_show(plt, fn)

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -1,0 +1,391 @@
+"""Fitting model parameters to a measured sweep (issue #639).
+
+Most of these run against an *analytic* stand-in engine — a series-RLC
+feedpoint whose resonance and loss follow the builder's knobs. That is on
+purpose: the machinery under test is the objective, the bounds, the
+identifiability diagnostics and the plane handling, and an engine with a closed
+form makes "did the fit recover the truth?" an exact question with no meshing
+noise and no seconds-long solves. One test at the bottom does the same round
+trip through the real momwire engine, so the wiring is covered too.
+"""
+
+from types import MappingProxyType
+
+import numpy as np
+import pytest
+
+import antennaknobs as ant
+from antennaknobs import AntennaBuilder
+from antennaknobs.fit import (
+    MAX_FREE_PARAMS,
+    FitResult,
+    LineEmbedding,
+    fit,
+    plot_fit,
+)
+from antennaknobs.measured import BandOverlapError, MeasuredTrace
+
+
+class Builder(AntennaBuilder):
+    """Knobs for the analytic engine below; never actually meshed."""
+
+    default_params = MappingProxyType(
+        {"freq": 14.1, "design_freq": 14.1, "length_factor": 1.0, "rs": 60.0}
+    )
+
+    def build_wires(self):  # pragma: no cover — the fake engine never calls it
+        raise NotImplementedError
+
+
+class RLCEngine:
+    """A series-RLC feedpoint: R = ``rs``, resonant where the element is 1/2 λ.
+
+    ``length_factor`` slides the resonance and ``rs`` sets the depth of the
+    match — two knobs that bend Γ in genuinely different ways, which is what
+    makes them jointly identifiable (unlike ``length_factor`` and
+    ``design_freq``, which do not, and which one test below relies on).
+    """
+
+    Q = 12.0
+
+    def __init__(self, builder):
+        self.b = builder
+
+    def impedance_sweep(self, freqs):
+        f = np.asarray(freqs, dtype=float)
+        f0 = self.b.design_freq / self.b.length_factor
+        x = self.b.rs * self.Q * (f / f0 - f0 / f)
+        return (self.b.rs + 1j * x)[:, None]
+
+
+def synth_measurement(
+    z0=50.0, label="synthetic", npoints=41, band=(13.6, 14.6), **knobs
+):
+    """A 'measurement' generated from the model itself at known knob values."""
+    b = Builder()
+    for k, v in knobs.items():
+        setattr(b, k, v)
+    freqs = np.linspace(band[0], band[1], npoints)
+    z = RLCEngine(b).impedance_sweep(freqs)[:, 0]
+    return MeasuredTrace(freqs=freqs, gamma=(z - z0) / (z + z0), z0=z0, label=label)
+
+
+# ---------------------------------------------------------------------------
+# the fit itself
+# ---------------------------------------------------------------------------
+def test_recovers_known_parameters():
+    """The headline claim: perturb the model, and the fit finds the perturbation."""
+    meas = synth_measurement(length_factor=1.035, rs=72.0)
+    res = fit(
+        Builder(), meas, ["length_factor", "rs"], engine=RLCEngine, npoints=15,
+        fractions=0.3,
+    )  # fmt: skip
+
+    assert res.fitted[0] == pytest.approx(1.035, rel=1e-3)
+    assert res.fitted[1] == pytest.approx(72.0, rel=1e-3)
+    assert res.rms_fitted < 1e-4 < res.rms_nominal
+    assert res.at_bound == ()
+    assert res.condition < 100  # these two knobs really are distinguishable
+
+
+def test_fitted_builder_carries_the_answer():
+    """The builder comes back *at* the fit, ready to serialise as a variant."""
+    meas = synth_measurement(length_factor=1.02)
+    b = Builder()
+    res = fit(b, meas, ["length_factor"], engine=RLCEngine, npoints=9)
+    assert res.builder is b
+    assert b.length_factor == pytest.approx(res.fitted[0])
+    assert "length_factor" in ant.builder_params_source(b, include_ui=False)
+
+
+def test_reports_a_degenerate_pair_by_name():
+    """length_factor and design_freq are the same knob wearing two hats.
+
+    The fit still converges — the *identified* direction is well determined —
+    so the only thing standing between the user and a confident nonsense value
+    is this diagnostic.
+    """
+    meas = synth_measurement(length_factor=1.03)
+    res = fit(
+        Builder(), meas, ["length_factor", "design_freq"], engine=RLCEngine,
+        npoints=11, fractions=0.15,
+    )  # fmt: skip
+
+    assert res.condition > 100
+    # Both knobs scale the element the same way, so the blind direction moves
+    # them together with equal weight.
+    w = np.abs(np.array(res.weakest))
+    assert w[0] == pytest.approx(w[1], rel=0.05)
+    assert "under-determined" in res.report()
+
+
+def test_bounds_are_respected_and_pinning_is_reported():
+    meas = synth_measurement(length_factor=1.20)  # far outside the bounds below
+    res = fit(
+        Builder(), meas, ["length_factor"], engine=RLCEngine, npoints=9,
+        bounds=[(0.98, 1.02)],
+    )  # fmt: skip
+
+    assert res.fitted[0] == pytest.approx(1.02, abs=1e-9)
+    assert res.at_bound == ("length_factor",)
+    assert "ended at a bound" in res.report()
+
+
+def test_a_scalar_fraction_covers_every_parameter():
+    meas = synth_measurement(length_factor=1.01, rs=63.0)
+    res = fit(
+        Builder(), meas, ["length_factor", "rs"], engine=RLCEngine, npoints=9,
+        fractions=[0.2],
+    )  # fmt: skip
+    assert res.bounds == ((0.8, 1.2), (48.0, 72.0))
+
+
+def test_too_many_free_parameters_is_refused():
+    meas = synth_measurement()
+    names = ["length_factor", "rs", "design_freq", "freq", "base"]
+    assert len(names) > MAX_FREE_PARAMS
+    with pytest.raises(ValueError, match="identify"):
+        fit(Builder(), meas, names, engine=RLCEngine)
+
+
+def test_disjoint_fit_range_is_a_clear_error():
+    meas = synth_measurement()
+    with pytest.raises(BandOverlapError, match="does not overlap"):
+        fit(Builder(), meas, ["length_factor"], engine=RLCEngine, band=(21.0, 21.5))
+
+
+def test_fit_range_restricts_the_comparison_band():
+    meas = synth_measurement(length_factor=1.02, npoints=101)
+    res = fit(
+        Builder(), meas, ["length_factor"], engine=RLCEngine, npoints=9,
+        band=(14.0, 14.3),
+    )  # fmt: skip
+    assert res.freqs.min() >= 14.0 and res.freqs.max() <= 14.3
+    assert 2 <= res.freqs.size <= 9
+    # Evenly spaced, which PyNECEngine.impedance_sweep requires.
+    assert np.allclose(np.diff(res.freqs), np.diff(res.freqs)[0])
+    assert res.fitted[0] == pytest.approx(1.02, rel=1e-3)
+
+
+def test_comparison_points_are_measured_frequencies():
+    """The grid is a subsample of the measurement — nothing is interpolated."""
+    meas = synth_measurement(npoints=41)
+    res = fit(Builder(), meas, ["length_factor"], engine=RLCEngine, npoints=11)
+    assert res.freqs.size == 11
+    assert np.all(np.isin(res.freqs, meas.freqs))
+
+
+def test_a_coarse_measurement_is_used_whole():
+    meas = synth_measurement(npoints=5)
+    res = fit(Builder(), meas, ["length_factor"], engine=RLCEngine, npoints=21)
+    np.testing.assert_allclose(res.freqs, meas.freqs)
+
+
+def test_off_band_measurement_is_flagged_not_refused():
+    """Fitting off-band is legitimate; picking the wrong file is not. Say so."""
+    meas = synth_measurement(band=(21.0, 21.5))  # 20 m design, a 15 m measurement
+    res = fit(Builder(), meas, ["length_factor"], engine=RLCEngine, npoints=7)
+    assert "long way off-band" in res.report()
+
+
+def test_harmonic_band_reads_as_harmonic_operation():
+    meas = synth_measurement(band=(42.0, 42.6))  # 3rd harmonic of 14.1
+    res = fit(Builder(), meas, ["length_factor"], engine=RLCEngine, npoints=7)
+    assert "3rd harmonic" in res.report() or "3th harmonic" in res.report()
+
+
+# ---------------------------------------------------------------------------
+# measurement plane
+# ---------------------------------------------------------------------------
+def test_line_embedding_matches_the_classic_transforms():
+    lam_vf = 299792458.0 / 14e6 * 0.66
+    quarter = LineEmbedding(z0=50.0, length_m=lam_vf / 4, vf=0.66)
+    half = LineEmbedding(z0=50.0, length_m=lam_vf / 2, vf=0.66)
+    f = np.array([14.0])
+    # Quarter-wave inverts about z0²; half-wave is the identity.
+    assert quarter.embed(np.array([100 + 0j]), f)[0] == pytest.approx(25.0, abs=1e-9)
+    assert half.embed(np.array([100 + 0j]), f)[0] == pytest.approx(100.0, abs=1e-9)
+
+
+def test_lossy_line_pulls_a_mismatch_toward_z0():
+    """Loss is why a long coax makes a bad antenna look good from the shack."""
+    line = LineEmbedding.from_cable("RG-58", 60.0)
+    f = np.array([28.0])
+    z = line.embed(np.array([500 + 0j]), f)[0]
+    g_in = abs((z - 50.0) / (z + 50.0))
+    g_load = abs((500 - 50.0) / (500 + 50.0))
+    assert g_in < g_load
+
+
+def test_station_plane_measurement_recovers_the_antenna():
+    """A sweep taken through 20 m of coax fits the same antenna it came from.
+
+    This is the whole point of --plane station: the parameters are properties
+    of the antenna, so moving the measurement plane must not move them.
+    """
+    line = LineEmbedding.from_cable("RG-213", 20.0)
+    truth = synth_measurement(length_factor=1.04, rs=70.0)
+    at_shack = MeasuredTrace(
+        freqs=truth.freqs,
+        gamma=(lambda z: (z - 50.0) / (z + 50.0))(
+            line.embed(truth.impedance, truth.freqs)
+        ),
+        z0=50.0,
+        label="shack",
+    )
+    res = fit(
+        Builder(), at_shack, ["length_factor", "rs"], engine=RLCEngine,
+        npoints=15, fractions=0.3, line=line,
+    )  # fmt: skip
+    assert res.fitted[0] == pytest.approx(1.04, rel=1e-3)
+    assert res.fitted[1] == pytest.approx(70.0, rel=1e-3)
+    assert res.rms_fitted < 1e-4
+
+
+def test_ignoring_the_line_gets_the_antenna_wrong():
+    """The counterexample that makes the previous test mean something.
+
+    Note *how* it goes wrong: the line rotates Γ, so the fit can still land the
+    resonance roughly right while the feedpoint resistance it infers is badly
+    off (here it runs into its bound). That is the shape of the mistake a
+    shack-end measurement fitted at the feedpoint plane actually makes.
+    """
+    line = LineEmbedding.from_cable("RG-213", 20.0)
+    truth = synth_measurement(length_factor=1.04, rs=70.0)
+    at_shack = MeasuredTrace(
+        freqs=truth.freqs,
+        gamma=(lambda z: (z - 50.0) / (z + 50.0))(
+            line.embed(truth.impedance, truth.freqs)
+        ),
+        z0=50.0,
+        label="shack",
+    )
+    res = fit(
+        Builder(), at_shack, ["length_factor", "rs"], engine=RLCEngine,
+        npoints=15, fractions=0.3,
+    )  # fmt: skip
+    assert res.fitted[1] != pytest.approx(70.0, rel=1e-2)
+    assert res.at_bound  # it hits a bound reaching for an explanation
+    assert res.rms_fitted > 0.05
+
+
+def test_line_spec_parsing():
+    assert LineEmbedding.parse("RG-8X:12.5").length_m == 12.5
+    assert LineEmbedding.parse("RG-8X:12.5").vf == 0.80
+    with pytest.raises(ValueError, match="cable"):
+        LineEmbedding.parse("RG-8X")
+    with pytest.raises(KeyError, match="unknown cable"):
+        LineEmbedding.parse("RG-999:10")
+
+
+# ---------------------------------------------------------------------------
+# reporting & plotting
+# ---------------------------------------------------------------------------
+def test_report_names_the_shift_and_the_residual():
+    meas = synth_measurement(length_factor=1.05)
+    res = fit(Builder(), meas, ["length_factor"], engine=RLCEngine, npoints=9,
+              fractions=0.2)  # fmt: skip
+    text = res.report()
+    assert "length_factor" in text
+    assert "RMS |ΔΓ|" in text
+    assert f"{res.rms_fitted:.4f}" in text
+
+
+def test_large_residual_is_called_out():
+    """A measurement the model can't reproduce must not read as a good fit."""
+    meas = synth_measurement()
+    # Nothing like the model: a flat 200 Ω load across the band.
+    meas = MeasuredTrace(
+        freqs=meas.freqs,
+        gamma=np.full(meas.freqs.shape, (200 - 50) / (200 + 50) + 0j),
+        z0=50.0,
+    )
+    res = fit(Builder(), meas, ["length_factor"], engine=RLCEngine, npoints=9)
+    assert res.rms_fitted > 0.05
+    assert "large residual" in res.report()
+
+
+def test_plot_fit_draws(tmp_path):
+    meas = synth_measurement(length_factor=1.02)
+    res = fit(Builder(), meas, ["length_factor"], engine=RLCEngine, npoints=9)
+    out = tmp_path / "fit.png"
+    plot_fit(res, fn=str(out))
+    assert out.stat().st_size > 0
+
+
+def test_fit_result_is_reusable_without_an_optimizer_run():
+    """FitResult's numbers are derived, so a hand-built one still reports."""
+    f = np.array([14.0, 14.1])
+    g = np.array([0.1 + 0j, 0.1 + 0j])
+    res = FitResult(
+        names=("x",), nominal=(1.0,), fitted=(1.1,), bounds=((0.9, 1.2),),
+        freqs=f, gamma_measured=g, gamma_nominal=g + 0.2, gamma_fitted=g + 0.01,
+        z0=50.0, builder=None,
+    )  # fmt: skip
+    assert res.rms_nominal == pytest.approx(0.2)
+    assert res.rms_fitted == pytest.approx(0.01)
+    assert res.at_bound == ()
+
+
+# ---------------------------------------------------------------------------
+# the real engine, end to end
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def invvee_s1p(tmp_path):
+    """A 'measurement' of an inverted-V built 2.5% longer than the design."""
+    from antennaknobs.designs.dipoles.invvee import Builder as InvVee
+    from antennaknobs.engines import MomwireEngine
+
+    b = InvVee()
+    b.length_factor = b.length_factor * 1.025
+    freqs = np.linspace(27.5, 29.5, 9)
+    z = MomwireEngine(b).impedance_sweep(freqs)[:, 0]
+    g = (z - 50.0) / (z + 50.0)
+    p = tmp_path / "asbuilt.s1p"
+    p.write_text(
+        "# MHZ S RI R 50\n"
+        + "\n".join(f"{f:.6f} {v.real:.9f} {v.imag:.9f}" for f, v in zip(freqs, g))
+        + "\n"
+    )
+    return p
+
+
+def test_momwire_fit_recovers_an_as_built_length(invvee_s1p):
+    from antennaknobs.designs.dipoles.invvee import Builder as InvVee
+    from antennaknobs.engines import MomwireEngine
+    from antennaknobs.measured import read_measured
+
+    nominal = InvVee().length_factor
+    res = fit(
+        InvVee(), read_measured(invvee_s1p), ["length_factor"], npoints=7,
+        fractions=0.1, engine=MomwireEngine,
+    )  # fmt: skip
+    assert res.fitted[0] == pytest.approx(nominal * 1.025, rel=2e-3)
+    assert res.rms_fitted < 1e-3
+
+
+def test_cli_fit(invvee_s1p, tmp_path):
+    out = tmp_path / "fit.png"
+    ant.cli(
+        f"fit --builder dipoles.invvee --measured {invvee_s1p} "
+        f"--params length_factor --npoints 5 --fn {out}".split()
+    )
+    assert out.stat().st_size > 0
+
+
+def test_cli_fit_rejects_a_bad_invocation(invvee_s1p):
+    with pytest.raises(SystemExit, match="--plane station needs --line"):
+        ant.cli(
+            f"fit --builder dipoles.invvee --measured {invvee_s1p} "
+            "--params length_factor --plane station --no_plot".split()
+        )
+    with pytest.raises(SystemExit, match="lo hi"):
+        ant.cli(
+            f"fit --builder dipoles.invvee --measured {invvee_s1p} "
+            "--params length_factor --bounds 0.9 --no_plot".split()
+        )
+    with pytest.raises(SystemExit, match="identify"):
+        ant.cli(
+            f"fit --builder dipoles.invvee --measured {invvee_s1p} "
+            "--params a b c d e --no_plot".split()
+        )


### PR DESCRIPTION
Closes #639. The inverse of #595's overlay: instead of drawing a measurement next to the model, solve for the model parameters that reproduce it.

```bash
python -m antennaknobs fit --builder dipoles.invvee --measured bench_10m.s1p \
    --params length_factor angle_deg --npoints 15 --fractions 0.15 --fn fit.png
```

```
fit against 'bench_10m': 15 points, 26–31 MHz, z0 = 50 Ω

parameter                         nominal       fitted        shift
length_factor                      0.9719     0.992629   +0.0207291  +2.13%
angle_deg                         31.6846      34.6707     +2.98609   +9.42%

RMS |ΔΓ|   nominal 0.1858  →  fitted 0.0044   (20 model evaluations)
```

(That run recovers a synthetic "as built" antenna made 2% long with 4° more droop and a stray 1.5 + j3 Ω at the feedpoint — the length comes back to within 0.13%, and the stray gets absorbed into the droop, which is exactly the kind of trade the residual is there to expose.)

## Design

**Complex Γ, not SWR.** Phase is what separates causes: a length error and a ground error both widen |Γ|, but they rotate it differently. Fitting magnitude throws away the information that makes parameters distinguishable.

**Comparison on measured frequencies.** The fit grid is a strided subsample of the measured grid, so the model is solved exactly where the measurement was taken and neither side is interpolated. Striding (rather than N evenly-spaced picks) also keeps the grid uniform, which `PyNECEngine.impedance_sweep` requires.

**Identifiability, reported by name.** `least_squares` hands back a Jacobian, so the fit reports its column-scaled condition number *and* the near-degenerate combination:

```
WARNING: under-determined (Jacobian condition 789). These data barely constrain the combination
         +0.71·length_factor  +0.71·design_freq
```

That is the fit saying precisely which knobs this measurement cannot separate — more actionable than a generic caution. Free parameters are capped at 4, and default to a ±10% window (tighter than `optimize()`'s ±67%: a calibration is a correction to a design you already believe).

**Honest residual.** RMS |ΔΓ| before/after is part of the result, with callouts for a large residual and for parameters pinned at a bound. The plot puts the residual panel under the three SWR traces because its *shape* is the diagnostic — structure means missing physics (commonly common-mode current), which fitting harder cannot fix honestly.

**Measurement plane.** `--plane station --line RG-213:30.5` embeds a known feedline using the same cable catalog and matched-loss model as `TL`. The issue asked to forward-embed through the station chain — but a design that models its own feedline already has its port *at* the station plane, so the genuinely missing case was the antenna-only model plus a shack-end sweep, which this covers. A test shows what skipping it costs: the resonance still lands roughly right while the inferred feedpoint resistance runs into its bound.

## One deliberate deviation from the issue

The issue asks for an error when the measured band and the design band don't overlap. I implemented a **note** instead: a hard gate would refuse the legitimate case of fitting a design on a harmonic band (a 40 m dipole worked on 15 m), and an off-band sweep does genuinely constrain length and ground. So an off-band measurement is flagged with both frequencies named — recognising harmonics as harmonics — and the residual is left to speak. A disjoint `--range` against the measurement is still a hard error (`BandOverlapError`).

## Acceptance criteria (#639)

- [x] CLI `fit`: design + measured `.s1p` + dotted-path free parameters → fitted values, RMS residual, 3-trace comparison plot
- [x] Complex-Γ objective on the measured frequency grid; clear error when the requested band doesn't overlap
- [x] `--plane station` embeds the line to the measurement plane (see note above)
- [x] Free-parameter count capped at 4 with an identifiability message; bounds/fractions supported
- [x] Fitted builder saveable as a design variant (paste-ready `measured_params` block of deltas)
- [x] Docs: [Calibrating a model against your VNA](site/src/content/docs/advanced/calibrating.md) — worked example, a case with visible structured residual and how to read it, and the identifiability discussion

## Testing

24 new tests. Most run against an analytic series-RLC stand-in engine, which makes "did the fit recover the truth?" an exact question with no meshing noise and no seconds-long solves: parameter recovery, bound pinning, degeneracy detection (asserting the *named* combination), grid subsampling and uniformity, off-band vs harmonic notes, and a station-plane round trip with its counterexample. One test does the same recovery through real momwire, plus CLI smoke and error paths. Whole file runs in 1.3 s. Full fast lane green: 2903 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g