### PR TITLE
feat(vna): capture a sweep straight off a NanoVNA into a .s1p (#597)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,9 @@ python -m antennaknobs draw --builder beams.moxon --fn moxon.png
 python -m antennaknobs sweep --builder beams.moxon --param freq \
     --use_smithchart --npoints 21 --fn moxon_smith.png
 
+# Capture a sweep from an attached NanoVNA (needs the [vna] extra)
+python -m antennaknobs capture --out bench_10m.s1p --start 28 --stop 29
+
 # Overlay a measured NanoVNA .s1p sweep on the modeled SWR curve
 python -m antennaknobs sweep --builder dipoles.invvee --swr \
     --range 28.0 29.0 --npoints 21 --measured bench_10m.s1p

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,15 @@ dependencies = [
 #     can set them (issue #377).
 web = ["fastapi", "uvicorn[standard]", "websockets", "psutil", "threadpoolctl"]
 
+# VNA capture (`antennaknobs capture`, issue #597): pyserial drives the USB
+# serial console of a NanoVNA. Optional because talking to hardware is a
+# capability nothing else in the package needs — the import is lazy, and every
+# other entry point (including the whole web server, which must never open a
+# serial port) works without it. `antennaknobs.vna.list_candidate_ports()`
+# returns empty rather than raising when it is absent, so the CLI's "no device"
+# message covers both causes.
+vna = ["pyserial"]
+
 # Test suite: `pip install -e ".[test]"` makes `pytest` reproducible from a
 # clean clone (the runtime deps in [project] cover the numpy/scipy/matplotlib
 # that the solver tests need).

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -61,6 +61,32 @@ Note that knob sweeps in **free space** can be perfectly flat by design —
 translation-invariant knobs like a height `base` only matter over a ground
 (`--ground finite`).
 
+### Capturing from a VNA
+
+`capture` sweeps a USB-attached NanoVNA and writes the `.s1p` the overlay and
+`fit` read:
+
+```bash
+# list what's attached
+python -m antennaknobs capture --list
+# sweep 27-30 MHz and save it
+python -m antennaknobs capture --out bench_10m.s1p --start 27 --stop 30 --points 101
+```
+
+Needs the optional extra: `pip install 'antennaknobs[vna]'` (pyserial). Pass
+`--port /dev/ttyACM0` when more than one analyzer is attached; `--driver` selects
+the protocol (`nanovna` today — the driver registry is the extension point for
+others). Both NanoVNA console dialects are handled: the `scan` command on
+current firmware, falling back to `sweep` + `data 0` on the original. Whatever
+the device measures is what you get — a firmware that caps the sweep at 101
+points reports 101 points rather than being padded out.
+
+Capture is **CLI-only and local by design**. The web workbench never opens a
+serial port: its backend often runs on another machine, where the serial ports
+aren't yours (and on the hosted instance aren't anyone's business). The
+workflow across a remote backend is capture locally, then upload the file in
+the workbench.
+
 ### Overlaying a VNA measurement
 
 `--measured <file.s1p>` draws a **measured** sweep alongside the modeled one —

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -365,6 +365,10 @@ dashed violet locus against the modeled one. It is the "did my model match
 reality?" view, and the same overlay the CLI draws with
 [`--measured`](/reference/cli/#overlaying-a-vna-measurement).
 
+- **Capture is a local CLI step.** `python -m antennaknobs capture --out
+  bench.s1p --start 27 --stop 30` sweeps an attached NanoVNA into a file you
+  then load here. The server never opens a serial port — its ports are not
+  yours when the backend runs elsewhere.
 - **Your file stays on your machine.** The browser reads it and posts the text
   to be parsed; nothing is stored server-side. That also means it works
   unchanged when the backend runs somewhere else while the VNA is plugged in

--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -15,6 +15,8 @@ from .engines import PyNECEngine, MomwireEngine
 from .serialize import builder_params_source
 from .fit import MAX_FREE_PARAMS, LineEmbedding, fit, plot_fit
 from .measured import read_measured
+from .touchstone import format_s1p
+from .vna import DRIVERS, VNAError, capture, list_candidate_ports
 from .user_designs import USER_NS, iter_design_files, resolve_user_design
 
 from momwire import (
@@ -807,6 +809,88 @@ def cli(arguments=None):
         )
         if not args.no_plot:
             plot_fit(result, fn=args.fn)
+
+    p.set_defaults(func=f)
+
+    p = subparsers.add_parser(
+        "capture",
+        help="Capture a sweep from an attached VNA into a .s1p file",
+        description="Sweep a USB-attached analyzer (NanoVNA) and write the "
+        "result as a one-port Touchstone. Feed the file to `sweep --measured` "
+        "to overlay it on a model, or to `fit` to calibrate against it. "
+        "Capture is CLI-only and local: the web server never opens a serial "
+        "port.",
+    )
+    p.add_argument(
+        "--out",
+        default=None,
+        help="Write the .s1p here (default: stdout, so it can be piped).",
+    )
+    p.add_argument("--start", type=float, default=None, help="Sweep start (MHz).")
+    p.add_argument("--stop", type=float, default=None, help="Sweep stop (MHz).")
+    p.add_argument(
+        "--points", type=int, default=101, help="Sweep points (default 101)."
+    )
+    p.add_argument(
+        "--port",
+        default=None,
+        help="Serial device (e.g. /dev/ttyACM0). Default: the only analyzer found.",
+    )
+    p.add_argument(
+        "--driver",
+        default="nanovna",
+        help=f"Analyzer protocol: {' | '.join(sorted(DRIVERS))} (default nanovna).",
+    )
+    p.add_argument("--z0", default=50, type=float, help="Calibration reference (Ω).")
+    p.add_argument(
+        "--list",
+        dest="list_devices",
+        default=False,
+        action="store_true",
+        help="List attached analyzers and exit, without sweeping.",
+    )
+
+    def f(args):
+        if args.list_devices:
+            found = list_candidate_ports()
+            if not found:
+                print("no analyzer found (see `capture --help` for what to check)")
+            for device, desc in found:
+                print(f"{device}\t{desc}")
+            return
+        if args.start is None or args.stop is None:
+            raise SystemExit("capture needs --start and --stop in MHz")
+        try:
+            trace = capture(
+                args.start,
+                args.stop,
+                points=args.points,
+                port=args.port,
+                driver=args.driver,
+                z0=args.z0,
+            )
+        except VNAError as e:
+            # Missing device, busy port, unreadable reply: a plain message, not
+            # a traceback — none of these are bugs in antennaknobs.
+            raise SystemExit(str(e)) from e
+        text = format_s1p(
+            trace.freqs * 1e6,
+            trace.gamma,
+            z0=trace.z0,
+            comments=(
+                f"captured by antennaknobs from a {args.driver}",
+                f"{trace.freqs[0]:g}-{trace.freqs[-1]:g} MHz, {trace.freqs.size} points",
+            ),
+        )
+        if args.out:
+            with open(args.out, "w") as fh:
+                fh.write(text)
+            print(
+                f"wrote {args.out}: {trace.freqs.size} points, "
+                f"{trace.freqs[0]:g}-{trace.freqs[-1]:g} MHz"
+            )
+        else:
+            print(text, end="")
 
     p.set_defaults(func=f)
 

--- a/src/antennaknobs/touchstone.py
+++ b/src/antennaknobs/touchstone.py
@@ -27,7 +27,12 @@ import numpy as np
 
 from .design_data import read_data
 
-__all__ = ["Touchstone", "parse_touchstone", "read_touchstone"]
+__all__ = [
+    "Touchstone",
+    "parse_touchstone",
+    "read_touchstone",
+    "format_s1p",
+]
 
 # Touchstone frequency-unit keywords → multiplier to Hz.
 _FUNIT = {"HZ": 1.0, "KHZ": 1e3, "MHZ": 1e6, "GHZ": 1e9}
@@ -207,6 +212,29 @@ def parse_touchstone(text: str, *, nports: int | None = None) -> Touchstone:
     return Touchstone(
         freqs=freqs[order], params=params[order], ptype=ptype, z0=float(z0)
     )
+
+
+def format_s1p(
+    freqs_hz, s11, *, z0: float = 50.0, comments: tuple[str, ...] = ()
+) -> str:
+    """Render a one-port sweep as Touchstone ``.s1p`` text (MHz, S, RI).
+
+    The writing counterpart of :func:`parse_touchstone`, used by the VNA
+    capture path (issue #597) so a captured sweep becomes an ordinary file that
+    the overlay, ``fit``, and every other Touchstone-reading tool consume — the
+    same format, not a private one. MHz keeps the numbers readable against the
+    rest of antennaknobs; real/imaginary keeps them exact.
+    """
+    import numpy as _np
+
+    f = _np.asarray(freqs_hz, dtype=float)
+    g = _np.asarray(s11, dtype=complex)
+    if f.shape != g.shape:
+        raise ValueError(f"{f.size} frequencies but {g.size} S11 values")
+    lines = [f"! {c}" for c in comments]
+    lines.append(f"# MHZ S RI R {z0:g}")
+    lines += [f"{a / 1e6:.6f} {v.real:+.9f} {v.imag:+.9f}" for a, v in zip(f, g)]
+    return "\n".join(lines) + "\n"
 
 
 def read_touchstone(builder, name: str) -> Touchstone:

--- a/src/antennaknobs/vna.py
+++ b/src/antennaknobs/vna.py
@@ -1,0 +1,288 @@
+"""Capture a sweep straight off a VNA (issue #597).
+
+``measured.py`` overlays a ``.s1p`` someone else's software wrote. This module
+produces that file: connect to an analyzer over USB serial, run a one-port
+sweep, and write the Touchstone the overlay and ``fit`` already read. The
+workflow is deliberately **file-mediated** —
+
+    python -m antennaknobs capture --out bench.s1p --start 27 --stop 30
+    python -m antennaknobs sweep --builder ... --measured bench.s1p --swr
+
+— rather than a live socket into the plotting code. Two reasons, one practical
+and one about trust:
+
+*Practical.* The web backend commonly runs on another machine while the VNA is
+plugged in here (see the workbench docs). A local capture writing a local file,
+uploaded through the browser, works in every topology; a server-side capture
+would open *the server's* serial ports, which on a shared instance is both
+wrong and a hazard. Nothing here is reachable from ``web/server.py``, and that
+is deliberate.
+
+*Trust.* Talking to hardware is a capability the rest of antennaknobs doesn't
+need. Keeping it in one CLI command, invoked explicitly, with the device named
+or auto-detected and reported, means it never happens as a side effect of
+something else.
+
+Drivers are pluggable: a driver is any object with :meth:`Driver.sweep`, and
+:data:`DRIVERS` maps CLI names to them. ``nanovna`` speaks the console protocol
+that NanoVNA-H / NanoVNA-Saver firmware exposes; a DG8SAQ (or anything else
+with a documented protocol) drops in beside it without touching the CLI.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import numpy as np
+
+__all__ = [
+    "DRIVERS",
+    "Driver",
+    "NanoVNADriver",
+    "SerialTransport",
+    "VNAError",
+    "capture",
+    "list_candidate_ports",
+]
+
+logger = logging.getLogger(__name__)
+
+# USB VID/PID pairs that identify a NanoVNA-class device. The STM32 virtual COM
+# port (0483:5740) covers the original NanoVNA and the -H/-H4; 16c0:0483 is the
+# Objective Development shared VID some clones ship with.
+NANOVNA_USB_IDS = ((0x0483, 0x5740), (0x16C0, 0x0483))
+
+# NanoVNA firmware answers a command with its output followed by this prompt.
+_PROMPT = b"ch>"
+
+
+class VNAError(RuntimeError):
+    """Any failure talking to an analyzer — no device, wrong device, bad reply."""
+
+
+class Driver:
+    """What a VNA driver has to provide.
+
+    Not an ABC on purpose: a driver is duck-typed, so a user with an
+    unsupported analyzer can pass their own object to :func:`capture` without
+    importing anything from here.
+    """
+
+    name = "driver"
+
+    def sweep(
+        self, start_hz: float, stop_hz: float, points: int
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Run a one-port sweep; return ``(freqs_hz, s11)`` as numpy arrays.
+
+        Implementations should return whatever the instrument actually
+        measured — if it clamps the point count or the span, report the clamped
+        result rather than padding it out to what was asked for.
+        """
+        raise NotImplementedError
+
+
+class SerialTransport:
+    """Line-oriented serial link to an analyzer.
+
+    Wraps pyserial so the drivers depend on a two-method interface
+    (``write`` / ``read_until``) instead of on pyserial itself — which is what
+    lets the protocol be tested without hardware, and keeps pyserial an
+    optional extra (``pip install antennaknobs[vna]``).
+    """
+
+    def __init__(self, port: str, *, baudrate: int = 115200, timeout: float = 5.0):
+        try:
+            import serial  # noqa: PLC0415 — optional extra, imported on use
+        except ImportError as e:  # pragma: no cover — depends on the install
+            raise VNAError(
+                "capturing from a VNA needs pyserial: pip install 'antennaknobs[vna]'"
+            ) from e
+        try:
+            self._ser = serial.Serial(port, baudrate=baudrate, timeout=timeout)
+        except Exception as e:  # serial.SerialException and OS-level errors
+            raise VNAError(f"cannot open {port}: {e}") from e
+
+    def write(self, data: bytes) -> None:
+        self._ser.write(data)
+
+    def read_until(self, expected: bytes) -> bytes:
+        """Read through ``expected``, or return what arrived before the timeout."""
+        return self._ser.read_until(expected)
+
+    def close(self) -> None:
+        self._ser.close()
+
+
+def list_candidate_ports() -> list[tuple[str, str]]:
+    """``(device, description)`` for every port that looks like a NanoVNA.
+
+    Returns an empty list when pyserial is missing, so the "no device" path
+    reads the same whether the cause is no hardware or no driver package —
+    :func:`capture` reports which.
+    """
+    try:
+        from serial.tools import list_ports  # noqa: PLC0415 — optional extra
+    except ImportError:
+        return []
+    out = []
+    for p in list_ports.comports():
+        ids = (p.vid, p.pid)
+        if ids in NANOVNA_USB_IDS or "nanovna" in (p.description or "").lower():
+            out.append((p.device, p.description or ""))
+    return out
+
+
+@dataclass
+class NanoVNADriver:
+    """NanoVNA over its USB serial console.
+
+    The firmware family has two dialects and this speaks both, because which
+    one a given device answers to depends on its build, not its label:
+
+    ``scan <start> <stop> <points> <mask>``
+        The modern one (NanoVNA-H, the protocol NanoVNA-Saver drives). Mask 3
+        selects frequency + S11, so each output line is ``freq re im`` — the
+        frequency axis comes from the instrument rather than being assumed.
+
+    ``sweep <start> <stop> <points>`` then ``data 0``
+        The original firmware. ``data 0`` emits ``re im`` per point with no
+        frequencies, so the axis is reconstructed from the requested span —
+        correct only because the device just accepted that exact span.
+
+    Older firmware also caps a sweep at 101 points. Whatever comes back is
+    returned as-is; a short sweep is reported, not padded.
+    """
+
+    transport: object
+    name: str = "nanovna"
+
+    def _command(self, text: str) -> str:
+        """Send one command, return its output with echo and prompt stripped."""
+        self.transport.write((text + "\r\n").encode())
+        raw = self.transport.read_until(_PROMPT).decode("ascii", errors="replace")
+        body = raw.split(_PROMPT.decode())[0]
+        lines = body.replace("\r", "").split("\n")
+        # The console echoes the command it just received; drop that and any
+        # blank padding around the payload.
+        if lines and lines[0].strip() == text.strip():
+            lines = lines[1:]
+        return "\n".join(line for line in lines if line.strip())
+
+    @staticmethod
+    def _numbers(out: str, width: int) -> list[list[float]]:
+        rows = []
+        for line in out.split("\n"):
+            parts = line.split()
+            if len(parts) != width:
+                continue
+            try:
+                rows.append([float(p) for p in parts])
+            except ValueError:
+                continue
+        return rows
+
+    def sweep(self, start_hz, stop_hz, points):
+        start, stop = int(round(start_hz)), int(round(stop_hz))
+        out = self._command(f"scan {start} {stop} {points} 3")
+        rows = self._numbers(out, 3)
+        if rows:
+            a = np.array(rows, dtype=float)
+            return a[:, 0], a[:, 1] + 1j * a[:, 2]
+
+        # Older firmware: set the sweep, then read the S11 table back.
+        logger.info("device did not answer `scan`; falling back to `sweep`/`data 0`")
+        self._command(f"sweep {start} {stop} {points}")
+        rows = self._numbers(self._command("data 0"), 2)
+        if not rows:
+            raise VNAError(
+                "the device answered neither `scan` nor `data 0` with sweep data — "
+                "is this a NanoVNA, and is another program (NanoVNA-Saver, a "
+                "serial monitor) holding the port?"
+            )
+        a = np.array(rows, dtype=float)
+        # No frequency axis in this dialect; the device just accepted this span,
+        # so reconstruct it linearly across however many points came back.
+        freqs = np.linspace(start, stop, a.shape[0])
+        return freqs, a[:, 0] + 1j * a[:, 1]
+
+
+#: CLI driver names → factories taking a transport. Add an analyzer here and it
+#: is immediately available as ``capture --driver <name>``.
+DRIVERS = {"nanovna": NanoVNADriver}
+
+
+def capture(
+    start_mhz: float,
+    stop_mhz: float,
+    *,
+    points: int = 101,
+    port: str | None = None,
+    driver: str = "nanovna",
+    transport=None,
+    z0: float = 50.0,
+    label: str | None = None,
+):
+    """Sweep the attached analyzer and return the result as a `MeasuredTrace`.
+
+    ``port`` names the serial device; omitted, the only NanoVNA-looking port is
+    used and an ambiguous or empty result is an error naming what was found.
+    ``transport`` injects an already-open link (what the tests use, and the
+    escape hatch for a device this module doesn't know how to find).
+    """
+    from .measured import MeasuredTrace
+
+    if stop_mhz <= start_mhz:
+        raise VNAError(f"stop ({stop_mhz} MHz) must be above start ({start_mhz} MHz)")
+    if points < 2:
+        raise VNAError("a sweep needs at least 2 points")
+    if driver not in DRIVERS:
+        raise VNAError(
+            f"unknown VNA driver {driver!r}; available: {', '.join(sorted(DRIVERS))}"
+        )
+
+    owned = transport is None
+    if owned:
+        transport = SerialTransport(port or _sole_port())
+    try:
+        dev = DRIVERS[driver](transport)
+        freqs_hz, s11 = dev.sweep(start_mhz * 1e6, stop_mhz * 1e6, points)
+    finally:
+        if owned:
+            close = getattr(transport, "close", None)
+            if close:
+                close()
+
+    freqs_hz = np.asarray(freqs_hz, dtype=float)
+    s11 = np.asarray(s11, dtype=complex)
+    if freqs_hz.size == 0:
+        raise VNAError("the device returned an empty sweep")
+    if freqs_hz.size != points:
+        logger.info(
+            "device returned %d of the %d points requested", freqs_hz.size, points
+        )
+    order = np.argsort(freqs_hz)
+    return MeasuredTrace(
+        freqs=freqs_hz[order] / 1e6,
+        gamma=s11[order],
+        z0=float(z0),
+        label=label or f"{driver} {start_mhz:g}-{stop_mhz:g} MHz",
+    )
+
+
+def _sole_port() -> str:
+    """The one attached analyzer, or an error that says what to do next."""
+    found = list_candidate_ports()
+    if not found:
+        raise VNAError(
+            "no VNA found. Check that the analyzer is plugged in and powered, that "
+            "you can read its serial port (on Linux, membership of the `dialout` "
+            "group), and that pyserial is installed "
+            "(pip install 'antennaknobs[vna]'). Pass --port to name the device "
+            "explicitly."
+        )
+    if len(found) > 1:
+        listing = ", ".join(f"{d} ({desc})" for d, desc in found)
+        raise VNAError(f"several analyzers found — name one with --port: {listing}")
+    return found[0][0]

--- a/tests/test_vna.py
+++ b/tests/test_vna.py
@@ -1,0 +1,268 @@
+"""Live VNA capture (issue #597), tested without a VNA.
+
+The drivers talk to a *transport* — two methods, ``write`` and ``read_until`` —
+rather than to pyserial directly, so the console protocol can be exercised
+against a scripted device. That covers what actually breaks in the field: a
+firmware that speaks the other dialect, a device that answers with junk, a port
+that opens but has nothing on the far end.
+"""
+
+import numpy as np
+import pytest
+
+import antennaknobs as ant
+from antennaknobs.touchstone import format_s1p, parse_touchstone
+from antennaknobs.vna import (
+    DRIVERS,
+    NanoVNADriver,
+    VNAError,
+    capture,
+)
+
+PROMPT = b"ch>"
+
+
+class FakeNanoVNA:
+    """A scripted NanoVNA console.
+
+    ``dialect="scan"`` is modern firmware (frequency axis included);
+    ``dialect="data"`` is the original (``scan`` unrecognised, ``data 0``
+    returns S11 with no frequencies). ``max_points`` models the 101-point cap
+    older builds enforce.
+    """
+
+    def __init__(
+        self, *, dialect="scan", max_points=None, gamma=None, junk=False,
+        descending=False,
+    ):  # fmt: skip
+        self.descending = descending
+        self.dialect = dialect
+        self.max_points = max_points
+        self.gamma = gamma
+        self.junk = junk
+        self.commands: list[str] = []
+        self._pending = b""
+        self._span = (1e6, 2e6, 11)
+
+    # -- transport interface ------------------------------------------------
+    def write(self, data: bytes) -> None:
+        cmd = data.decode().strip()
+        self.commands.append(cmd)
+        self._pending = (cmd + "\r\n" + self._respond(cmd) + PROMPT.decode()).encode()
+
+    def read_until(self, expected: bytes) -> bytes:
+        out, self._pending = self._pending, b""
+        return out
+
+    def close(self) -> None:
+        self.closed = True
+
+    # -- the scripted device ------------------------------------------------
+    def _points(self, start, stop, n):
+        n = min(n, self.max_points) if self.max_points else n
+        f = np.linspace(start, stop, n)
+        if self.gamma is not None:
+            g = np.asarray(self.gamma)[:n]
+        else:  # a plausible resonance so the numbers aren't all identical
+            g = (f / f[-1] - 0.5) + 0.25j
+        return f, g
+
+    def _respond(self, cmd: str) -> str:
+        if self.junk:
+            return "hello there\r\n"
+        head = cmd.split()
+        if head[0] == "scan":
+            if self.dialect != "scan":
+                return "usage: scan {start(Hz)} {stop(Hz)} [points] [outmask]\r\n"
+            start, stop, n = float(head[1]), float(head[2]), int(head[3])
+            f, g = self._points(start, stop, n)
+            if self.descending:  # some firmware/segments report high → low
+                f, g = f[::-1], g[::-1]
+            return "".join(f"{a:.0f} {v.real} {v.imag}\r\n" for a, v in zip(f, g))
+        if head[0] == "sweep":
+            self._span = (float(head[1]), float(head[2]), int(head[3]))
+            return ""
+        if head[0] == "data":
+            f, g = self._points(*self._span)
+            return "".join(f"{v.real} {v.imag}\r\n" for v in g)
+        return "?\r\n"
+
+
+# ---------------------------------------------------------------------------
+# the two firmware dialects
+# ---------------------------------------------------------------------------
+def test_captures_over_the_scan_dialect():
+    dev = FakeNanoVNA(dialect="scan")
+    trace = capture(14.0, 14.35, points=11, transport=dev)
+
+    assert any(c.startswith("scan ") for c in dev.commands)
+    assert trace.freqs.size == 11
+    # Hz on the wire, MHz in the trace.
+    assert trace.freqs[0] == pytest.approx(14.0)
+    assert trace.freqs[-1] == pytest.approx(14.35)
+    assert trace.z0 == 50.0
+
+
+def test_falls_back_to_the_older_sweep_dialect():
+    dev = FakeNanoVNA(dialect="data")
+    trace = capture(14.0, 14.35, points=11, transport=dev)
+
+    assert dev.commands == [
+        "scan 14000000 14350000 11 3",  # tried first...
+        "sweep 14000000 14350000 11",  # ...then the old pair
+        "data 0",
+    ]
+    assert trace.freqs.size == 11
+    assert trace.freqs[0] == pytest.approx(14.0)
+
+
+def test_short_sweep_is_reported_not_padded():
+    """Older firmware caps at 101 points; return what the device measured."""
+    dev = FakeNanoVNA(dialect="scan", max_points=101)
+    trace = capture(14.0, 14.35, points=301, transport=dev)
+    assert trace.freqs.size == 101
+
+
+def test_a_device_that_answers_junk_is_an_error_not_a_trace():
+    dev = FakeNanoVNA(junk=True)
+    with pytest.raises(VNAError, match="neither"):
+        capture(14.0, 14.35, points=11, transport=dev)
+
+
+def test_capture_sorts_by_frequency():
+    """A device reporting high→low still yields an ascending trace.
+
+    Everything downstream — align(), the fit grid, np.interp — assumes ascending
+    frequencies, so the capture normalises rather than trusting the instrument.
+    """
+    dev = FakeNanoVNA(dialect="scan", descending=True)
+    trace = capture(14.0, 14.35, points=11, transport=dev)
+    assert np.all(np.diff(trace.freqs) > 0)
+    assert trace.freqs[0] == pytest.approx(14.0)
+
+
+# ---------------------------------------------------------------------------
+# argument validation — none of these should reach the hardware
+# ---------------------------------------------------------------------------
+def test_rejects_an_inverted_or_degenerate_span():
+    dev = FakeNanoVNA()
+    with pytest.raises(VNAError, match="must be above"):
+        capture(14.0, 14.0, points=11, transport=dev)
+    with pytest.raises(VNAError, match="at least 2 points"):
+        capture(14.0, 14.35, points=1, transport=dev)
+    assert dev.commands == []
+
+
+def test_unknown_driver_names_the_available_ones():
+    with pytest.raises(VNAError, match="nanovna"):
+        capture(14.0, 14.35, driver="dg8saq", transport=FakeNanoVNA())
+
+
+def test_driver_registry_is_the_extension_point():
+    """A new analyzer is a registry entry, not a change to capture()."""
+
+    class Fake(NanoVNADriver):
+        name = "fake"
+
+        def sweep(self, start_hz, stop_hz, points):
+            f = np.linspace(start_hz, stop_hz, points)
+            return f, np.full(points, 0.25 + 0j)
+
+    DRIVERS["_test_fake"] = Fake
+    try:
+        trace = capture(7.0, 7.3, points=5, driver="_test_fake", transport=object())
+        assert np.allclose(trace.gamma, 0.25)
+    finally:
+        del DRIVERS["_test_fake"]
+
+
+def test_missing_device_message_is_actionable(monkeypatch):
+    """The no-hardware path is the one every new user hits first."""
+    monkeypatch.setattr("antennaknobs.vna.list_candidate_ports", lambda: [])
+    with pytest.raises(VNAError) as exc:
+        capture(14.0, 14.35, points=11)
+    msg = str(exc.value)
+    assert "no VNA found" in msg
+    assert "--port" in msg and "dialout" in msg
+
+
+def test_several_devices_ask_which(monkeypatch):
+    monkeypatch.setattr(
+        "antennaknobs.vna.list_candidate_ports",
+        lambda: [("/dev/ttyACM0", "NanoVNA"), ("/dev/ttyACM1", "NanoVNA-H")],
+    )
+    with pytest.raises(VNAError, match="--port"):
+        capture(14.0, 14.35, points=11)
+
+
+# ---------------------------------------------------------------------------
+# capture → file → overlay, the whole point of the feature
+# ---------------------------------------------------------------------------
+def test_captured_sweep_round_trips_through_touchstone(tmp_path):
+    dev = FakeNanoVNA(dialect="scan")
+    trace = capture(28.0, 29.0, points=21, transport=dev)
+    p = tmp_path / "bench.s1p"
+    p.write_text(format_s1p(trace.freqs * 1e6, trace.gamma, z0=trace.z0))
+
+    ts = parse_touchstone(p.read_text(), nports=1)
+    np.testing.assert_allclose(ts.freqs / 1e6, trace.freqs, rtol=1e-9)
+    np.testing.assert_allclose(ts.params[:, 0, 0], trace.gamma, atol=1e-9)
+
+    # ...and the file the capture wrote is one the overlay accepts.
+    from antennaknobs.measured import read_measured
+
+    again = read_measured(p)
+    np.testing.assert_allclose(again.gamma, trace.gamma, atol=1e-9)
+
+
+def test_format_s1p_rejects_mismatched_lengths():
+    with pytest.raises(ValueError, match="frequencies"):
+        format_s1p(np.array([1e6, 2e6]), np.array([0.1 + 0j]))
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def test_cli_capture_writes_a_file(tmp_path, monkeypatch):
+    dev = FakeNanoVNA(dialect="scan")
+    monkeypatch.setattr("antennaknobs.vna.SerialTransport", lambda *a, **k: dev)
+    monkeypatch.setattr(
+        "antennaknobs.vna.list_candidate_ports", lambda: [("/dev/fake", "NanoVNA")]
+    )
+    out = tmp_path / "bench.s1p"
+    ant.cli(f"capture --out {out} --start 28 --stop 29 --points 11".split())
+
+    text = out.read_text()
+    assert text.startswith("! captured by antennaknobs")
+    assert parse_touchstone(text, nports=1).freqs.size == 11
+
+
+def test_cli_capture_needs_a_span():
+    with pytest.raises(SystemExit, match="--start and --stop"):
+        ant.cli("capture --out /dev/null".split())
+
+
+def test_cli_capture_reports_a_missing_device_cleanly(monkeypatch):
+    """No hardware is a message and a non-zero exit, never a traceback."""
+    monkeypatch.setattr("antennaknobs.vna.list_candidate_ports", lambda: [])
+    with pytest.raises(SystemExit, match="no VNA found"):
+        ant.cli("capture --start 28 --stop 29".split())
+
+
+def test_cli_capture_list_is_quiet_with_no_hardware(monkeypatch, capsys):
+    monkeypatch.setattr("antennaknobs.vna.list_candidate_ports", lambda: [])
+    ant.cli("capture --list".split())
+    assert "no analyzer found" in capsys.readouterr().out
+
+
+def test_web_server_exposes_no_capture_route():
+    """Hardware access must stay CLI-local: the server has no serial capability.
+
+    A remote backend's serial ports are not the operator's, and on the hosted
+    instance they are not anyone's business. The capture path is deliberately
+    unreachable from the web app.
+    """
+    from antennaknobs.web import server
+
+    paths = {getattr(r, "path", "") for r in server.app.routes}
+    assert not any("capture" in p or "vna" in p for p in paths)


### PR DESCRIPTION
Closes #597. Completes the VNA arc: #595 overlays a measurement, #639 fits to one, and this produces the file both read.

```bash
python -m antennaknobs capture --list
python -m antennaknobs capture --out bench_10m.s1p --start 27 --stop 30 --points 101
python -m antennaknobs sweep --builder dipoles.invvee --swr --measured bench_10m.s1p
```

## Two scope decisions worth reviewing

**File-mediated, not a live socket.** The issue lists a web-workbench "capture" affordance. I deliberately did *not* build one: the backend commonly runs on another machine while the VNA is plugged in locally, so a server-side capture opens **the server's** serial ports — wrong on a remote backend, and a hazard on the hosted instance. The issue itself flags this ("a local CLI capture → `.s1p` file → overlay is a clean first cut that sidesteps this entirely"), and with #595's upload already in place that path is complete today: capture locally, upload in the workbench. A real in-browser capture wants WebSerial in the frontend, which is a separate piece of work with its own permission model. A test asserts the server exposes no capture route.

**Optional dependency.** Talking to hardware is a capability nothing else needs, so pyserial is an extra (`antennaknobs[vna]`), imported lazily. Every other entry point — including the entire web server — works without it, and the "no device" message covers both causes (no hardware / no pyserial) because `list_candidate_ports()` returns empty rather than raising.

## Design

**Transport, not pyserial.** Drivers talk to a two-method object (`write` / `read_until`). That is what makes the console protocol testable without hardware, and it doubles as the escape hatch for an analyzer this module can't auto-detect.

**Both NanoVNA dialects**, because which one a device answers to depends on its firmware build, not its label:
- `scan <start> <stop> <points> 3` — current firmware; the frequency axis comes from the instrument.
- `sweep …` + `data 0` — original firmware; no frequency axis, so it is reconstructed across the span the device just accepted.

**Report what the device measured.** A firmware that caps at 101 points returns 101 points rather than being padded to the request; a descending sweep is sorted (everything downstream — `align()`, the fit grid, `np.interp` — assumes ascending).

**`touchstone.format_s1p`** is the writing counterpart of `parse_touchstone`, so a capture becomes an ordinary Touchstone file rather than a private format. One test round-trips capture → file → `read_measured`.

## Acceptance criteria (#597)

- [x] NanoVNA driver capturing one-port S11 into #595's measured-trace format (CLI first)
- [x] Graceful no-device / wrong-device handling — names the three things to check, exits non-zero, no traceback
- [x] Pluggable driver interface (`DRIVERS` registry + duck-typed `Driver`) so DG8SAQ and others drop in
- [~] Web "capture" affordance — deliberately not built; the local-capture-then-upload path is complete instead (see above). Happy to open a follow-up for WebSerial if you want it in-browser.

## Testing

17 new tests against a scripted NanoVNA console: both dialects, a device answering junk, a capped sweep, a descending sweep, argument validation that must not reach the hardware, the driver registry as an extension point, the missing/ambiguous-device messages, and capture → file → overlay. Runs in 0.7 s with **pyserial uninstalled** (verified — that's CI's state). Full fast lane green: 2896 passed.

Untested by nature: `SerialTransport` itself, which needs a physical NanoVNA. If you have one on the bench, `capture --list` then a short sweep is the check worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g