### PR TITLE
feat(network): BalancedLine.from_geometry — zdiff/vf from the physical line (#596)

### DIFF
--- a/site/src/content/docs/concepts/station-modelling.md
+++ b/site/src/content/docs/concepts/station-modelling.md
@@ -157,6 +157,49 @@ grounds are still refused). So a `PortAtEnd` design can be checked against a
 different basis *and* a different testing scheme, not merely a second B-spline
 degree. A design that attaches through `PortOnWireFloating` keeps both engines.
 
+### Naming a line by its geometry instead of its spool
+
+`zdiff` is the number off the spool — 300 / 450 / 600 Ω. When you know the
+*line* instead (conductor size, spacing, jacket), `BalancedLine.from_geometry`
+computes `zdiff` and `vf` for you:
+
+```python
+# #12 bare wire on six-inch spreaders — the classic 600 Ω open-wire line
+BalancedLine.from_geometry(
+    "t1", "t2", "a1", "a2",
+    spacing=0.1524, length=20.0, conductor=0.001024,
+)
+# a jacketed catalog wire brings its own insulation along
+BalancedLine.from_geometry(
+    "t1", "t2", "a1", "a2",
+    spacing=0.0254, length=20.0, conductor="18-awg-pvc",
+)
+```
+
+`conductor` is a radius in metres, a `WireSpec`, or a `WIRES` catalog key; pass
+`conductor2` for an unequal pair. `two_wire_params()` is the same calculation
+standalone, if you want the numbers without the element.
+
+How much to trust it depends on the construction:
+
+- **Bare conductors are exact** — the general unequal-radius
+  `Z = (η₀/2π)·acosh((D² − a₁² − a₂²)/2a₁a₂)`, which collapses to the textbook
+  `(η₀/π)·acosh(D/d)` for a matched pair. #12 at six inches comes out at
+  599.9 Ω.
+- **Jacketed round conductors** use a coaxial-shell model: the potential splits
+  into a dielectric part near each wire and an air part across the gap. Right
+  for insulated open-wire and for window line, and refused outright when the
+  jackets touch — there is no air path then, and the model would be quietly
+  wrong rather than loudly absent.
+- **Solid-web twinlead** has no air path at all, so it takes the mixing rule
+  `ε_eff = 1 + fill·(εᵣ − 1)` with an explicit `fill` (≈0.5 for a solid web,
+  ≈0.15–0.25 for windowed). That is a *fitted* fraction, not a derived one.
+
+A manufacturer's "450 Ω" is a round number covering a range of real
+constructions, so expect geometry to land within a few percent of a nameplate
+rather than on it — and when you know the nameplate `vf`, that is better data
+than either estimator here.
+
 Three catalog designs use `BalancedLine` today:
 `wire.doublet_balanced_tuner` (floating centre port — runs on every engine),
 plus `wire.sterba_bl` and `arrays.bowtie1x2_bl` (both `PortAtEnd`, so

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -21,6 +21,7 @@ as tiny stub wires at sensible locations.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field, replace
 from typing import NamedTuple, Optional, Union
 
@@ -677,6 +678,197 @@ class BalancedLine:
     k1: float = 0.0
     k2: float = 0.0
     zcomm: Optional[float] = None
+
+    @classmethod
+    def from_geometry(
+        cls,
+        a1,
+        a2,
+        b1,
+        b2,
+        *,
+        spacing,
+        length,
+        conductor,
+        conductor2=None,
+        eps_r=None,
+        fill=None,
+        k1=0.0,
+        k2=0.0,
+        zcomm=None,
+    ):
+        """A `BalancedLine` whose ``zdiff``/``vf`` come from the line's physical
+        dimensions instead of a spool label (issue #596).
+
+        ``conductor`` (and ``conductor2`` for an unequal pair) is a radius in
+        metres, a `WireSpec`, or a `WIRES` catalog key — so a jacketed catalog
+        wire brings its own insulation along::
+
+            BalancedLine.from_geometry(
+                "t1", "t2", "a1", "a2",
+                spacing=0.0254, length=20.0, conductor="18-awg-pvc",
+            )
+
+        ``spacing`` is centre-to-centre in metres. See :func:`two_wire_params`
+        for the electrical model and, importantly, for what the insulation
+        estimators can and cannot claim. ``k1``/``k2``/``zcomm`` pass straight
+        through — geometry says nothing about matched loss or the common-mode
+        path, which stay explicit.
+        """
+        r1, ins1, er1 = _conductor_geometry(conductor)
+        r2, ins2, er2 = (
+            (None, None, None)
+            if conductor2 is None
+            else _conductor_geometry(conductor2)
+        )
+        if ins1 is not None and ins2 is not None and ins1 != ins2:
+            raise ValueError(
+                "the two conductors declare different insulation radii "
+                f"({ins1} vs {ins2} m); the shell model assumes one jacket "
+                "thickness — pass `fill` (with eps_r) instead"
+            )
+        insulation_radius = ins1 if ins1 is not None else ins2
+        eps_r = eps_r if eps_r is not None else (er1 if er1 is not None else er2)
+        zdiff, vf = two_wire_params(
+            spacing,
+            r1,
+            r2,
+            insulation_radius=insulation_radius,
+            eps_r=eps_r,
+            fill=fill,
+        )
+        return cls(
+            a1=a1, a2=a2, b1=b1, b2=b2, zdiff=zdiff, length=length,
+            vf=vf, k1=k1, k2=k2, zcomm=zcomm,
+        )  # fmt: skip
+
+
+# Free-space wave impedance, √(μ₀/ε₀). The two-wire line formula below is
+# η₀/π ≈ 119.917 Ω per unit of acosh — the familiar "276·log₁₀(2D/d)" of the
+# handbooks is this same constant in base-10 clothing.
+ETA0 = 376.730313668
+
+
+def _conductor_geometry(spec):
+    """``(radius, insulation_radius, eps_r)`` from a radius, `WireSpec`, or
+    `WIRES` key — the three ways a caller can name a conductor."""
+    if isinstance(spec, str):
+        spec = wire_from_catalog(spec)
+    if isinstance(spec, WireSpec):
+        return spec.radius, spec.insulation_radius, spec.insulation_eps_r
+    return float(spec), None, None
+
+
+def two_wire_params(
+    spacing: float,
+    radius: float,
+    radius2: float | None = None,
+    *,
+    insulation_radius: float | None = None,
+    eps_r: float | None = None,
+    fill: float | None = None,
+) -> tuple[float, float]:
+    """``(zdiff, vf)`` of a two-conductor line from its physical dimensions
+    (issue #596).
+
+    ``spacing`` is centre-to-centre, ``radius``/``radius2`` are the conductor
+    radii (``radius2=None`` → equal conductors); all lengths in metres, to
+    match the rest of ``network.py``. Use it when you know the *line* — "#14
+    wire, six inches apart" — rather than the number off a spool:
+
+        zdiff, vf = two_wire_params(0.1524, 0.000815)   # ≈ 627 Ω, 1.0
+
+    **Bare conductors** are exact, from the general unequal-radius form
+
+        Z = (η₀/2π)·acosh((D² − a₁² − a₂²) / (2·a₁·a₂))
+
+    which collapses to the textbook ``(η₀/π)·acosh(D/d)`` for equal radii
+    (evaluated in that direct form when the radii match, which is both exactly
+    the identity ``acosh(2x²−1) = 2·acosh(x)`` and better conditioned for
+    closely-spaced wires).
+
+    **Insulation** is where the honesty caveats live, because a real balanced
+    line is a *partial* dielectric fill — some of the field is in the plastic,
+    most is in the air — and no closed form covers every construction. Two
+    documented estimators, both reducing the result by ``√ε_eff`` (the
+    inductance is unchanged: the jacket is not magnetic), so
+    ``vf = 1/√ε_eff``:
+
+    - ``insulation_radius`` + ``eps_r`` — the **coaxial-shell** model: each
+      conductor wears a jacket of outer radius ``b``, and the potential
+      integral splits into a dielectric part ``(1/εᵣ)·ln(b/a)`` and an air part
+      ``ln(D/b)``. Right for jacketed wire and for window line, where the
+      conductors are round, jacketed, and separated by mostly air. It uses the
+      wide-spacing (``D ≫ b``) logarithmic form for the *correction only* — the
+      bare value it corrects stays exact — and it is refused outright when the
+      jackets touch (``b₁ + b₂ ≥ D``), where the assumption of air between them
+      is simply false.
+    - ``fill`` + ``eps_r`` — the **mixing rule** ``ε_eff = 1 + fill·(εᵣ − 1)``
+      for the constructions the shell model can't describe: solid-web twinlead,
+      or windowed line whose webbing you want to account for empirically.
+      ``fill`` is the fraction of the field energy sitting in dielectric, and
+      it is a fitted number, not a derived one (≈0.5 for solid twinlead,
+      ≈0.15–0.25 for windowed line). Supply it when you have a nameplate ``vf``
+      to match; prefer the shell model when you don't.
+
+    Manufacturers' "450 Ω" and "300 Ω" are round numbers over a range of real
+    constructions, so expect geometry-derived values to land within a few
+    percent of a nameplate, not on it. When you know the nameplate ``vf``,
+    it is better data than either estimator here.
+    """
+    a1 = float(radius)
+    a2 = float(radius if radius2 is None else radius2)
+    d = float(spacing)
+    if a1 <= 0 or a2 <= 0:
+        raise ValueError("conductor radii must be positive")
+    if d <= a1 + a2:
+        raise ValueError(
+            f"centre spacing {d} m must exceed the sum of the radii "
+            f"({a1 + a2} m) — these conductors overlap"
+        )
+
+    if a1 == a2:
+        z_bare = (ETA0 / math.pi) * math.acosh(d / (2.0 * a1))
+    else:
+        z_bare = (ETA0 / (2.0 * math.pi)) * math.acosh(
+            (d * d - a1 * a1 - a2 * a2) / (2.0 * a1 * a2)
+        )
+
+    eps_eff = 1.0
+    if fill is not None:
+        if eps_r is None:
+            raise ValueError("fill needs eps_r (the insulation's permittivity)")
+        if not 0.0 <= fill <= 1.0:
+            raise ValueError(f"fill must be a fraction in [0, 1]; got {fill}")
+        eps_eff = 1.0 + fill * (float(eps_r) - 1.0)
+    elif insulation_radius is not None:
+        if eps_r is None:
+            raise ValueError("insulation_radius needs eps_r")
+        b = float(insulation_radius)
+        b1 = b2 = b
+        if b1 <= a1 or b2 <= a2:
+            raise ValueError(
+                f"insulation radius {b} m must exceed the conductor radius"
+            )
+        if b1 + b2 >= d:
+            raise ValueError(
+                f"the jackets touch at this spacing ({b1 + b2} m of insulation "
+                f"across a {d} m gap): there is no air path between the "
+                "conductors, so the coaxial-shell model does not apply. Give "
+                "`fill` (with eps_r) for a solid-web line, or pass the "
+                "nameplate zdiff/vf directly."
+            )
+        er = float(eps_r)
+        bare_terms = math.log(d / a1) + math.log(d / a2)
+        clad_terms = (
+            math.log(b1 / a1) / er
+            + math.log(d / b1)
+            + math.log(b2 / a2) / er
+            + math.log(d / b2)
+        )
+        eps_eff = bare_terms / clad_terms
+
+    return z_bare / math.sqrt(eps_eff), 1.0 / math.sqrt(eps_eff)
 
 
 @dataclass(frozen=True)

--- a/tests/test_two_wire_geometry.py
+++ b/tests/test_two_wire_geometry.py
@@ -1,0 +1,237 @@
+"""Two-wire line parameters from physical geometry (issue #596).
+
+`two_wire_params` turns "#14 wire, six inches apart" into the ``zdiff``/``vf``
+a `BalancedLine` wants. The bare-conductor case has a closed form, so most of
+these are exact-identity tests; the insulated cases are approximations, and the
+tests say which claims are exact and which are engineering tolerances.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+from antennaknobs.network import (
+    ETA0,
+    BalancedLine,
+    WireSpec,
+    two_wire_params,
+)
+
+# Handy conductors: bare #12, #14 and #18 copper (radii in metres).
+AWG12, AWG14, AWG18 = 1.024e-3, 0.815e-3, 0.512e-3
+INCH = 0.0254
+
+
+# ---------------------------------------------------------------------------
+# bare conductors — the exact part
+# ---------------------------------------------------------------------------
+def test_matches_the_textbook_acosh_form():
+    d, a = 6 * INCH, AWG14
+    z, vf = two_wire_params(d, a)
+    assert z == pytest.approx((ETA0 / math.pi) * math.acosh(d / (2 * a)), rel=1e-15)
+    assert vf == 1.0  # no dielectric, no slowing — exactly
+
+
+def test_equal_radii_agree_with_the_general_unequal_form():
+    """The two branches are the identity acosh(2x²−1) = 2·acosh(x).
+
+    The equal-radius path exists for conditioning, not for a different answer.
+    """
+    d, a = 3 * INCH, AWG18
+    general = (ETA0 / (2 * math.pi)) * math.acosh((d * d - 2 * a * a) / (2 * a * a))
+    assert two_wire_params(d, a)[0] == pytest.approx(general, rel=1e-12)
+
+
+def test_matches_the_handbook_log10_approximation_when_widely_spaced():
+    """276·log₁₀(2D/d) is the same constant in base-10 clothing."""
+    d, a = 12 * INCH, AWG14
+    handbook = 276.0 * math.log10(d / a)  # = 276·log10(2D/diameter)
+    assert two_wire_params(d, a)[0] == pytest.approx(handbook, rel=2e-3)
+
+
+def test_unequal_conductors_sit_between_their_equal_pair_cases():
+    z_thin = two_wire_params(6 * INCH, AWG18)[0]
+    z_fat = two_wire_params(6 * INCH, AWG12)[0]
+    z_mixed = two_wire_params(6 * INCH, AWG18, AWG12)[0]
+    assert z_fat < z_mixed < z_thin
+
+
+def test_wider_spacing_raises_impedance():
+    zs = [two_wire_params(s * INCH, AWG14)[0] for s in (1, 3, 6, 12)]
+    assert np.all(np.diff(zs) > 0)
+
+
+# ---------------------------------------------------------------------------
+# insulation — the approximate part
+# ---------------------------------------------------------------------------
+def test_shell_model_reduces_to_bare_at_unit_permittivity():
+    bare = two_wire_params(INCH, AWG18)
+    clad = two_wire_params(INCH, AWG18, insulation_radius=1.0e-3, eps_r=1.0)
+    assert clad[0] == pytest.approx(bare[0], rel=1e-12)
+    assert clad[1] == pytest.approx(1.0, rel=1e-12)
+
+
+def test_insulation_slows_and_lowers_by_the_same_factor():
+    """Z and vf both scale by 1/√ε_eff — the jacket adds C, not L."""
+    bare_z = two_wire_params(INCH, AWG18)[0]
+    z, vf = two_wire_params(INCH, AWG18, insulation_radius=1.0e-3, eps_r=2.3)
+    assert vf < 1.0
+    assert z == pytest.approx(bare_z * vf, rel=1e-12)
+
+
+def test_a_thicker_jacket_slows_the_line_further():
+    vfs = [
+        two_wire_params(INCH, AWG18, insulation_radius=b, eps_r=2.3)[1]
+        for b in (0.6e-3, 0.8e-3, 1.2e-3, 2.0e-3)
+    ]
+    assert np.all(np.diff(vfs) < 0)
+
+
+def test_fill_rule_spans_air_to_solid():
+    bare_z, _ = two_wire_params(INCH, AWG18)
+    z0, vf0 = two_wire_params(INCH, AWG18, eps_r=2.25, fill=0.0)
+    z1, vf1 = two_wire_params(INCH, AWG18, eps_r=2.25, fill=1.0)
+    assert (z0, vf0) == pytest.approx((bare_z, 1.0), rel=1e-12)
+    # Fully immersed: the classic vf = 1/√εᵣ.
+    assert vf1 == pytest.approx(1.0 / math.sqrt(2.25), rel=1e-12)
+    assert z1 == pytest.approx(bare_z / math.sqrt(2.25), rel=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# real spools — engineering tolerances, stated as such
+# ---------------------------------------------------------------------------
+def test_600_ohm_open_wire_lands_on_its_nameplate():
+    """#12 bare at 6 inches is the textbook 600 Ω line — and this one is exact
+    physics, so it earns a tight tolerance."""
+    z, vf = two_wire_params(6 * INCH, AWG12)
+    assert z == pytest.approx(600.0, rel=0.01)
+    assert vf == 1.0
+
+
+def test_450_ohm_window_line_is_within_a_few_percent():
+    """#18 jacketed at ~1 inch. The nameplate is a round number over a range of
+    real constructions, so a few percent is the honest claim."""
+    z, vf = two_wire_params(INCH, AWG18, insulation_radius=1.05e-3, eps_r=3.5)
+    assert z == pytest.approx(450.0, rel=0.05)
+    assert 0.88 < vf < 0.97
+
+
+def test_300_ohm_twinlead_needs_the_fill_rule():
+    """Solid-web twinlead has no air path, so the shell model refuses it and
+    the mixing rule (fill ≈ 0.5 for a solid web) is the available estimator."""
+    z, vf = two_wire_params(0.3 * INCH, 0.406e-3, eps_r=2.25, fill=0.5)
+    assert z == pytest.approx(300.0, rel=0.10)
+    assert 0.75 < vf < 0.85
+
+
+# ---------------------------------------------------------------------------
+# refusals — each one is a case the model genuinely cannot describe
+# ---------------------------------------------------------------------------
+def test_overlapping_conductors_are_refused():
+    with pytest.raises(ValueError, match="overlap"):
+        two_wire_params(1.0e-3, 0.6e-3)
+
+
+def test_touching_jackets_are_refused_with_the_way_out():
+    """The shell model's whole premise is air between the conductors."""
+    with pytest.raises(ValueError, match="jackets touch") as exc:
+        two_wire_params(2.0e-3, 0.4e-3, insulation_radius=1.05e-3, eps_r=2.25)
+    assert "fill" in str(exc.value)  # names the estimator that does apply
+
+
+def test_insulation_inside_the_conductor_is_refused():
+    with pytest.raises(ValueError, match="must exceed the conductor radius"):
+        two_wire_params(INCH, AWG18, insulation_radius=0.2e-3, eps_r=2.25)
+
+
+def test_permittivity_is_required_with_either_estimator():
+    with pytest.raises(ValueError, match="eps_r"):
+        two_wire_params(INCH, AWG18, insulation_radius=1.0e-3)
+    with pytest.raises(ValueError, match="eps_r"):
+        two_wire_params(INCH, AWG18, fill=0.3)
+
+
+def test_fill_must_be_a_fraction():
+    with pytest.raises(ValueError, match="fraction"):
+        two_wire_params(INCH, AWG18, eps_r=2.25, fill=1.4)
+
+
+def test_nonpositive_radius_is_refused():
+    with pytest.raises(ValueError, match="radii must be positive"):
+        two_wire_params(INCH, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# the BalancedLine constructor
+# ---------------------------------------------------------------------------
+def test_from_geometry_is_exactly_the_element_it_computes():
+    """It's a constructor, not a new element: same fields, same stamp."""
+    z, vf = two_wire_params(6 * INCH, AWG12)
+    made = BalancedLine.from_geometry(
+        "t1", "t2", "a1", "a2", spacing=6 * INCH, length=20.0, conductor=AWG12
+    )
+    hand = BalancedLine("t1", "t2", "a1", "a2", zdiff=z, length=20.0, vf=vf)
+    assert made == hand
+
+
+def test_from_geometry_takes_a_catalog_wire_with_its_jacket():
+    made = BalancedLine.from_geometry(
+        "t1", "t2", "a1", "a2", spacing=INCH, length=20.0, conductor="18-awg-pvc"
+    )
+    bare = BalancedLine.from_geometry(
+        "t1", "t2", "a1", "a2", spacing=INCH, length=20.0, conductor=0.512e-3
+    )
+    # The catalog entry carries insulation_radius + eps_r, so the constructed
+    # line is slower and lower-Z than the same bare conductor.
+    assert bare.vf == 1.0
+    assert made.vf < 1.0
+    assert made.zdiff < bare.zdiff
+
+
+def test_from_geometry_takes_a_wire_spec():
+    spec = WireSpec(radius=AWG14)
+    made = BalancedLine.from_geometry(
+        "t1", "t2", "a1", "a2", spacing=6 * INCH, length=10.0, conductor=spec
+    )
+    assert made.zdiff == pytest.approx(two_wire_params(6 * INCH, AWG14)[0])
+
+
+def test_from_geometry_supports_an_unequal_pair():
+    made = BalancedLine.from_geometry(
+        "t1", "t2", "a1", "a2", spacing=6 * INCH, length=10.0,
+        conductor=AWG18, conductor2=AWG12,
+    )  # fmt: skip
+    assert made.zdiff == pytest.approx(two_wire_params(6 * INCH, AWG18, AWG12)[0])
+
+
+def test_from_geometry_refuses_two_different_jackets():
+    with pytest.raises(ValueError, match="different insulation radii"):
+        BalancedLine.from_geometry(
+            "t1", "t2", "a1", "a2", spacing=INCH, length=10.0,
+            conductor="18-awg-pvc", conductor2="22-awg-pvc",
+        )  # fmt: skip
+
+
+def test_from_geometry_passes_loss_and_common_mode_through():
+    """Geometry says nothing about matched loss or the CM path — those stay
+    the caller's explicit choice."""
+    made = BalancedLine.from_geometry(
+        "t1", "t2", "a1", "a2", spacing=6 * INCH, length=12.5,
+        conductor=AWG12, k1=0.02, k2=0.0001, zcomm=300.0,
+    )  # fmt: skip
+    assert (made.k1, made.k2, made.zcomm, made.length) == (0.02, 0.0001, 300.0, 12.5)
+    assert (made.a1, made.a2, made.b1, made.b2) == ("t1", "t2", "a1", "a2")
+
+
+def test_from_geometry_line_stamps_like_any_other():
+    """End to end: the constructed line reduces through the shared reducer."""
+    from antennaknobs.network_reduce import balanced_admittance_4x4
+
+    made = BalancedLine.from_geometry(
+        "t1", "t2", "a1", "a2", spacing=6 * INCH, length=5.0, conductor=AWG12
+    )
+    y = balanced_admittance_4x4(made.zdiff, made.length, 20.0, vf=made.vf)
+    assert y.shape == (4, 4)
+    # Differential stamp: rank 2, common mode structurally open.
+    assert np.linalg.matrix_rank(y) == 2


### PR DESCRIPTION
Closes #596. `zdiff` is the number off the spool; this is for the user who knows the *line* instead.

```python
# #12 bare wire on six-inch spreaders — the classic 600 Ω open-wire line
BalancedLine.from_geometry("t1", "t2", "a1", "a2",
                           spacing=0.1524, length=20.0, conductor=0.001024)
# a jacketed catalog wire brings its own insulation along
BalancedLine.from_geometry("t1", "t2", "a1", "a2",
                           spacing=0.0254, length=20.0, conductor="18-awg-pvc")
```

`conductor` accepts a radius in metres, a `WireSpec`, or a `WIRES` catalog key; `conductor2` gives an unequal pair. `two_wire_params()` is the same calculation standalone.

## Three tiers of confidence, made explicit

The interesting part of this issue isn't the acosh — it's that "insulated balanced line" covers constructions with genuinely different physics, and the honest thing is to say which one you're in rather than return a number for all of them.

1. **Bare conductors — exact.** The general unequal-radius form, evaluated through the direct `(η₀/π)·acosh(D/d)` when the radii match (the identity `acosh(2x²−1) = 2·acosh(x)`, better conditioned for close spacing). #12 at six inches lands on **599.9 Ω**.
2. **Jacketed round conductors — coaxial-shell model.** The potential integral splits into a dielectric part near each wire and an air part across the gap. Right for insulated open-wire and window line. **Refused when the jackets touch**: the premise is air between the conductors, a solid web has none, and the model would be quietly wrong rather than loudly absent. The error names the estimator that does apply.
3. **Solid-web twinlead — mixing rule.** `ε_eff = 1 + fill·(εᵣ − 1)` with an explicit `fill`, documented as a *fitted* fraction (≈0.5 solid, ≈0.15–0.25 windowed), not a derived one.

The issue asks for nameplate table tests "within a few %". Bare open-wire earns 1%; the insulated cases get 5–10%, because a manufacturer's "450 Ω" is a round number over a range of real constructions. The docstring, the docs, and the tests all say so — and note that a known nameplate `vf` is better data than either estimator.

## Acceptance criteria (#596)

- [x] `BalancedLine.from_geometry(...)` computing `zdiff` + `vf` from radius, spacing, optional insulation
- [x] Unequal-diameter support (general unequal-radius acosh)
- [x] Bare-wire limit matches `acosh(D/d)` to machine precision (`rel=1e-15`), and the two branches agree to `1e-12`
- [x] Table test: 600 Ω open-wire (1%), 450 Ω window line (5%), 300 Ω twinlead via the fill rule (10%)
- [x] Docstring documents the effective-εᵣ approximation and its limits — plus the docs page

## Testing

25 tests: exact-identity checks against the textbook acosh and the handbook `276·log₁₀(2D/d)`, monotonicity in spacing and jacket thickness, the shell model reducing to bare at εᵣ=1, `fill` spanning air → `1/√εᵣ`, the nameplate table, six refusal paths (overlapping conductors, touching jackets, insulation inside the conductor, missing `eps_r`, out-of-range `fill`, non-positive radius), and the constructor asserting it produces exactly the hand-built element. Pure helper — no reducer change. Full fast lane green: 2945 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g