### PR TITLE
fix(reduce): name the branch when a network goes singular mid-sweep (#647)

### DIFF
--- a/site/src/content/docs/concepts/station-modelling.md
+++ b/site/src/content/docs/concepts/station-modelling.md
@@ -253,6 +253,44 @@ Boxes are ordinary values made by ordinary functions, so a design can
 also define its own — a measured, calibrated component wrapped once and
 reused across variants.
 
+### When a lossless line has no answer
+
+An *ideal* line has frequencies where the circuit genuinely has no finite
+solution. A lossless half-wave line has no finite admittance at all; a lossless
+quarter-wave **open** stub is a dead short across the port it hangs on. These
+are not numerical accidents — they are what the idealisation says, and the fix
+is physical: give the line the loss it really has (`k1`/`k2`, or `cable="..."`).
+Any real attenuation moves the pole off the real axis.
+
+Two places this shows up:
+
+- **At construction**, when the length and design frequency make it decidable —
+  `shunt_open_stub` at exactly λ/4 refuses to be built.
+- **Mid-sweep**, when a length that was innocuous at its design frequency
+  becomes λ/4 or λ/2 somewhere else in the swept band. Nothing is decidable in
+  advance there, and no individual element is singular — each stamp is finite
+  and the *assembled system* is not. The reducer detects it, names the branch
+  and its electrical length, and repeats the remedy:
+
+  ```
+  SingularNetworkError: the network has no finite solution at this frequency
+  (reciprocal condition 7.6e-16 after equilibration). Every branch stamped fine
+  on its own — the singularity is in the assembled system.
+  Suspect:
+    stub: open-ended line feed→stub.far is 0.2500 λ at 35.0000 MHz — an odd
+    multiple of λ/4, where an open stub's Z_in = 0 shorts the port it hangs on
+  ```
+
+A **sweep** loses only that sample: the frequency in question comes back as
+NaN (the workbench renders it as an open) with the reason logged, and every
+other frequency answers normally. A single-point solve raises, because someone
+who asked about one frequency should get the sentence, not a silent NaN.
+
+The near-miss is the sneaky case and gets the same treatment: a sample a few
+kHz off the pole is not singular, merely dominated by it, and produces
+enormous numbers whose leading digits are noise. That logs a warning rather
+than refusing — the answer exists, it just should not be believed.
+
 ## The power budget: where the watts go
 
 Because every branch current is an explicit unknown in the circuit

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -20,7 +20,11 @@ from ..network import (
     validate_named_wires_referenced,
 )
 from ..terrain import Terrain, specular_cut
-from ..network_reduce import NetworkReducer, tl_admittance_2x2
+from ..network_reduce import (
+    NetworkReducer,
+    poison_singular_sample,
+    tl_admittance_2x2,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -751,6 +755,12 @@ class MomwireEngine(SimulationEngine):
         z_arr = np.atleast_1d(z)
         return [complex(zi) for zi in z_arr]
 
+    def _reduce_at(self, y_real, wavelength):
+        """One frequency's branch stamp + driven-port reduction."""
+        return self._reducer.impedance_from_y(
+            self._reducer.apply_branches(y_real, wavelength)
+        )
+
     def impedance_sweep(self, freqs):
         freqs = np.asarray(freqs, dtype=float)
         if freqs.ndim != 1 or freqs.size == 0:
@@ -763,10 +773,15 @@ class MomwireEngine(SimulationEngine):
             )  # (n_k, n_real, n_real) at port granularity
             zs = np.empty((freqs.size, self._reducer.n_driven), dtype=np.complex128)
             for ki, freq in enumerate(freqs):
-                Y_total = self._reducer.apply_branches(
-                    Y_swept[ki], self._wavelength_for(freq)
+                # A lossless line can sit on its pole at ONE sample of a sweep
+                # (issue #647); poison that sample rather than the sweep.
+                z = poison_singular_sample(
+                    self._reduce_at,
+                    Y_swept[ki],
+                    self._wavelength_for(freq),
+                    where=f" at {freq:.6g} MHz",
                 )
-                zs[ki] = self._reducer.impedance_from_y(Y_total)
+                zs[ki] = np.nan if z is None else z
             return zs
         if self._tls:
             # Batched Y at every frequency, then per-k TL stamping (βL is

--- a/src/antennaknobs/engines/pynec.py
+++ b/src/antennaknobs/engines/pynec.py
@@ -28,7 +28,7 @@ from ..network import (
     load_impedance,
     validate_named_wires_referenced,
 )
-from ..network_reduce import C_LIGHT, NetworkReducer
+from ..network_reduce import C_LIGHT, NetworkReducer, poison_singular_sample
 
 _logger = logging.getLogger(__name__)
 
@@ -972,7 +972,14 @@ class PyNECEngine(SimulationEngine):
             zs = np.empty((freqs.size, self._reducer.n_driven), dtype=np.complex128)
             for k, f in enumerate(freqs):
                 wl = C_LIGHT / (float(f) * 1e6)
-                zs[k] = self._reducer.driven_impedance(self._compute_y_matrix(wl), wl)
+                # One singular sample must not cost the sweep (issue #647).
+                z = poison_singular_sample(
+                    self._reducer.driven_impedance,
+                    self._compute_y_matrix(wl),
+                    wl,
+                    where=f" at {f:.6g} MHz",
+                )
+                zs[k] = np.nan if z is None else z
             return zs
         if freqs.size == 1:
             del_freq = 0.0

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -27,6 +27,8 @@ constitutive row, so no element value is ever inverted.
 
 from __future__ import annotations
 
+import logging
+import warnings
 from dataclasses import dataclass
 
 import numpy as np
@@ -59,6 +61,32 @@ FEET_PER_M = 1.0 / 0.3048
 NEPER_PER_DB = 1.0 / (20.0 / np.log(10.0))  # 1/8.6859: dB → nepers
 
 
+class SingularNetworkError(ValueError):
+    """The network has no finite solution at this frequency (issue #647).
+
+    Raised by the construction-time guards (a lossless k·λ/2 line, whose
+    admittance itself is infinite) and by the solve (a network the branches
+    made singular *as a system* — the classic case being a lossless quarter-
+    wave open stub, whose Z_in = 0 shorts the port it hangs on, with every
+    individual stamp perfectly finite).
+
+    A `ValueError` subclass so the guards that predate it keep their contract;
+    a distinct type so `impedance_sweep` can poison one sample and carry on
+    instead of losing the whole sweep.
+    """
+
+
+# Reciprocal condition number below which the MNA solve is called singular.
+# 1e-12 is the same threshold the stamp-time guards use for |sinh γl| — one
+# policy for "this is a pole, not a stiff problem".
+_logger = logging.getLogger(__name__)
+
+RCOND_SINGULAR = 1e-12
+# Between the two, the answer exists but its leading digits are being eaten by
+# the pole; worth saying so, not worth refusing.
+RCOND_SUSPECT = 1e-9
+
+
 def tl_admittance_2x2(z0, length, wavelength, transposed=False, vf=1.0, k1=0.0, k2=0.0):
     """Ideal-TL nodal admittance between its two terminals — lossless or
     lossy (issue #297).
@@ -88,9 +116,10 @@ def tl_admittance_2x2(z0, length, wavelength, transposed=False, vf=1.0, k1=0.0, 
     gl = (alpha + 1j * beta) * length
     sh, ch = np.sinh(gl), np.cosh(gl)
     if abs(sh) < 1e-12:
-        raise ValueError(
+        raise SingularNetworkError(
             f"lossless TL length {length} is ~k·vf·λ/2 at "
-            f"f={f_mhz:.4f} MHz (sinh γl ≈ 0); admittance is singular"
+            f"f={f_mhz:.4f} MHz (sinh γl ≈ 0); admittance is singular — give "
+            "the line the loss it really has (k1/k2, or cable=...)"
         )
     scale = 1.0 / (z0 * sh)
     off = 1.0 if transposed else -1.0
@@ -250,7 +279,7 @@ class MNASystem:
     impedance is ``v_k / j[column] + z_chain``.
     """
 
-    def __init__(self, G, elements, terminations, probes=None):
+    def __init__(self, G, elements, terminations, probes=None, diagnose=None):
         n = G.shape[0]
         m = len(elements)
         A = np.zeros((n + m, n + m), dtype=np.complex128)
@@ -279,6 +308,10 @@ class MNASystem:
         # kind "group2" → payload element index; kind "termination" →
         # payload node index (dissipation = the Load part of the branch).
         self.probes = probes or []
+        # Called only when the solve goes singular, to name the branch that
+        # did it (issue #647). A closure rather than stored state: the walk
+        # costs nothing on the happy path, which is every path but one.
+        self.diagnose = diagnose
         self._solution = None
 
     def branch_power(self, label_kind_payload):
@@ -322,11 +355,75 @@ class MNASystem:
         return 0.5 * float(np.real((e - v[payload]) * np.conj(j[col])))
 
     def solve(self):
-        """Solve once (cached); returns ``(v, j)``."""
+        """Solve once (cached); returns ``(v, j)``.
+
+        Uses LAPACK's expert driver rather than a bare ``np.linalg.solve``,
+        because the failure this guards against is usually not an exception
+        (issue #647). A lossless quarter-wave open stub puts a dead short
+        across its port: exactly on the pole the system is singular, but a few
+        kHz off it is merely *nearly* singular, and a plain solve answers with
+        enormous, meaningless numbers and no complaint at all.
+
+        The subtlety is that a raw condition number is useless here. An MNA
+        matrix mixes admittance rows with unit-valued constitutive rows, so a
+        perfectly healthy network routinely spans twenty-plus orders of
+        magnitude and "looks" singular to any unscaled estimate — the shipping
+        `arrays.bowtie1x2_bl` reports 1e-16 that way while solving fine.
+        ``zgesvx`` equilibrates first (``fact="E"``) and reports the condition
+        of the *scaled* system, which is the number that means rank-deficient
+        rather than badly-scaled: across every catalog design with a network,
+        the worst healthy value measured is 2.4e-7, five orders above the
+        threshold below.
+        """
         if self._solution is None:
-            x = np.linalg.solve(self.A, self.rhs)
+            from scipy.linalg.lapack import zgesvx
+
+            with warnings.catch_warnings():
+                # An exactly-singular factorization warns; we are about to
+                # raise a message that actually explains it.
+                warnings.simplefilter("ignore")
+                out = zgesvx(self.A, self.rhs.reshape(-1, 1))
+            x, rcond, info = out[7], float(out[8]), int(out[11])
+            n = self.A.shape[0]
+            if (0 < info <= n) or not np.isfinite(rcond) or rcond < RCOND_SINGULAR:
+                detail = self.diagnose() if self.diagnose is not None else ""
+                raise SingularNetworkError(
+                    "the network has no finite solution at this frequency "
+                    f"(reciprocal condition {rcond:.2e} after equilibration). "
+                    "Every branch stamped fine on its own — the singularity is "
+                    "in the assembled system." + (f"\n{detail}" if detail else "")
+                )
+            if rcond < RCOND_SUSPECT:
+                _logger.warning(
+                    "MNA solve is nearly singular (reciprocal condition %.2e): "
+                    "the impedance is dominated by proximity to a pole and its "
+                    "leading digits are unreliable.%s",
+                    rcond,
+                    ("\n" + self.diagnose()) if self.diagnose is not None else "",
+                )
+            x = np.asarray(x).reshape(-1)
             self._solution = (x[: self.n_nodes], x[self.n_nodes :])
         return self._solution
+
+
+def poison_singular_sample(fn, *args, where="", **kwargs):
+    """Run a per-frequency reduction, returning NaNs if it is singular (#647).
+
+    A sweep is a series of independent questions, and one of them landing
+    exactly on a lossless line's pole is no reason to lose the answers to the
+    other forty. The bad sample becomes NaN — which the web adapter already
+    converts to its ``Z_OPEN_OHMS`` JSON sentinel, and which every plotting
+    path already skips — and the reason is logged once, with the same
+    attribution a single-point solve would have raised.
+
+    Deliberately NOT applied to a single-point ``impedance()``: someone who
+    asked about one frequency should get the message, not a silent NaN.
+    """
+    try:
+        return fn(*args, **kwargs)
+    except SingularNetworkError as e:
+        _logger.warning("singular network%s — this sample is NaN.\n%s", where, e)
+        return None
 
 
 class NetworkReducer:
@@ -391,6 +488,107 @@ class NetworkReducer:
     @property
     def n_driven(self):
         return len(self.driven_port_idx)
+
+    def _open_ended_nodes(self):
+        """Node indices that only one branch terminal touches.
+
+        An open stub is spelled as the *absence* of a termination — a `TL`
+        into a private node nothing else uses (see ``station.shunt_open_stub``)
+        — so "TL with a dangling far end" is how an open stub is recognised
+        here, and the same walk finds any accidentally-unterminated line.
+        """
+        degree = {}
+        for br in self.network.branches:
+            for name in getattr(br, "__dataclass_fields__", {}):
+                if name in ("a", "b", "c", "a1", "a2", "b1", "b2", "port", "line"):
+                    node = getattr(br, name, None)
+                    if isinstance(node, str) and node in self.port_to_idx:
+                        idx = self.port_to_idx[node]
+                        degree[idx] = degree.get(idx, 0) + 1
+        # A real feed node is never "open" however few branches touch it: the
+        # antenna's own dense Y ties it to every other feed. Only a virtual
+        # node can dangle, so real ports and driven ports are excluded.
+        real = {
+            self.port_to_idx[name]
+            for name, port in self.network.ports.items()
+            if isinstance(port, PortOnWire) and name in self.port_to_idx
+        }
+        driven = set(self.driven_port_idx)
+        return {
+            idx
+            for idx, deg in degree.items()
+            if deg == 1 and idx not in driven and idx not in real
+        }
+
+    def _singularity_report(self, wavelength):
+        """Which branch drove the system singular at this wavelength (#647).
+
+        Attribution rather than a bare "matrix is singular": a lossless line
+        is singular at a *specific* electrical length, so the walk asks each
+        lossless line how close it sits to its own pole — k·λ/2 for a line
+        between two live nodes (no finite admittance), odd λ/4 for one hanging
+        open (Z_in = 0, a dead short across the port it hangs on). Anything
+        with real loss is skipped, because loss is exactly what regularises
+        both, and that is also the remedy the message recommends.
+        """
+        f_mhz = C_LIGHT / wavelength / 1e6
+        open_nodes = self._open_ended_nodes()
+        suspects = []
+        for br, path in zip(
+            self.network.branches,
+            self.network.branch_paths or [""] * len(self.network.branches),
+        ):
+            if isinstance(br, TL):
+                z0, vf, k1, k2 = br.z0, br.vf, br.k1, br.k2
+                ends = (br.a, br.b)
+            elif isinstance(br, BalancedLine):
+                z0, vf, k1, k2 = br.zdiff, br.vf, br.k1, br.k2
+                ends = (br.a1, br.b1)
+            else:
+                continue
+            if k1 or k2:
+                continue  # a lossy line has no pole to sit on
+            wl_line = wavelength * vf
+            n_half = br.length / (0.5 * wl_line)  # length in half-wavelengths
+            hanging = any(
+                self.port_to_idx.get(e) in open_nodes
+                for e in ends
+                if isinstance(e, str)
+            )
+            name = f"{path[:-1]}: " if path else ""
+            if hanging:
+                # Odd quarter-waves: n_half at an odd multiple of 0.5.
+                off = abs(n_half % 1.0 - 0.5)
+                if off < 0.02:
+                    suspects.append(
+                        f"  {name}open-ended line {'→'.join(str(e) for e in ends)} "
+                        f"is {n_half / 2:.4f} λ at {f_mhz:.4f} MHz — an odd "
+                        "multiple of λ/4, where an open stub's Z_in = 0 shorts "
+                        f"the port it hangs on (z0 = {z0:g} Ω)"
+                    )
+            else:
+                off = min(n_half % 1.0, 1.0 - n_half % 1.0)
+                if off < 0.02:
+                    suspects.append(
+                        f"  {name}line {'→'.join(str(e) for e in ends)} is "
+                        f"{n_half / 2:.4f} λ at {f_mhz:.4f} MHz — a multiple of "
+                        f"λ/2, where a lossless line has no finite admittance "
+                        f"(z0 = {z0:g} Ω)"
+                    )
+        if not suspects:
+            return (
+                "No lossless line sits on a pole at this frequency, so the "
+                "cause is elsewhere in the topology — a node reachable only "
+                "through open-circuited branches, or two ideal sources in "
+                "contradiction."
+            )
+        return (
+            "Suspect:\n"
+            + "\n".join(suspects)
+            + "\nGive the line the loss it really has (k1/k2, or cable=...): "
+            "any real attenuation moves the pole off the real axis and the "
+            "solve becomes well-posed."
+        )
 
     def apply_branches(self, Y_real, wavelength):
         """Stamp the antenna Y and every network branch into one MNA system.
@@ -752,7 +950,13 @@ class NetworkReducer:
                 names = [br.port for br in loads]
                 probes.append((f"Load {'+'.join(names)}", "termination", k))
 
-        return MNASystem(G, elements, terminations, probes=probes)
+        return MNASystem(
+            G,
+            elements,
+            terminations,
+            probes=probes,
+            diagnose=lambda wl=wavelength: self._singularity_report(wl),
+        )
 
     def _physical_port_voltages(self, v):
         """Node voltages -> PHYSICAL port voltages. They differ only for a

--- a/src/antennaknobs/station.py
+++ b/src/antennaknobs/station.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import math
 
 from .builder import C_LIGHT_MHZ_M
+from .network_reduce import SingularNetworkError
 from .network import (
     TL,
     BalancedLine,
@@ -242,7 +243,7 @@ def _guard_open_stub(freq_mhz, length_wl, k1, k2):
     if k1 or k2:
         return
     if abs(math.cos(2.0 * math.pi * length_wl)) < 1e-12:
-        raise ValueError(
+        raise SingularNetworkError(
             f"lossless open stub of {length_wl} λ is an odd multiple of λ/4 at "
             f"f={freq_mhz:.4f} MHz (cos βl ≈ 0); Z_in = 0 shorts the port and "
             "the admittance is singular — pick a different length, or give the "

--- a/src/antennaknobs/web/pynec_backend.py
+++ b/src/antennaknobs/web/pynec_backend.py
@@ -21,6 +21,7 @@ except ImportError:
     HAVE_PYNEC = False
     nec = None
 
+from ..network_reduce import SingularNetworkError
 from .examples import REGISTRY as EXAMPLES
 
 
@@ -172,7 +173,16 @@ def _sweep_at(req: dict, freq_mhz: float) -> complex:
     """
     req2 = dict(req)
     req2["measurement_freq_mhz"] = freq_mhz
-    res = solve(req2)
+    try:
+        res = solve(req2)
+    except SingularNetworkError:
+        # One frequency landing on a lossless line's pole (issue #647) must
+        # not break the stream; the sentinel is what the momwire path's
+        # non-finite samples already clamp to. Imported here, not at module
+        # scope: adapter imports the examples registry, which imports this.
+        from .adapter import Z_OPEN_OHMS
+
+        return complex(Z_OPEN_OHMS, 0.0)
     return complex(res["z_in_re"], res["z_in_im"])
 
 
@@ -186,7 +196,12 @@ def _sweep_at_multifeed(req: dict, freq_mhz: float):
     """
     req2 = dict(req)
     req2["measurement_freq_mhz"] = freq_mhz
-    res = solve(req2)
+    try:
+        res = solve(req2)
+    except SingularNetworkError:  # see _sweep_at
+        from .adapter import Z_OPEN_OHMS
+
+        return complex(Z_OPEN_OHMS, 0.0), []
     primary = complex(res["z_in_re"], res["z_in_im"])
     feeds_z = [complex(f["z_re"], f["z_im"]) for f in res.get("feeds", [])]
     return primary, feeds_z

--- a/tests/test_singular_network.py
+++ b/tests/test_singular_network.py
@@ -1,0 +1,196 @@
+"""Singular networks reached mid-sweep (issue #647).
+
+The stub factories guard their own singularity at *construction*, where
+`freq_mhz` and `length_wl` make it decidable. A frequency sweep can walk the
+same stub onto its pole anyway, at a frequency the construction guard never
+saw — and there the failure is not in any one stamp (each is perfectly finite)
+but in the assembled system. These tests cover the two halves of the fix:
+detecting that with attribution, and losing one sweep sample instead of the
+whole sweep.
+"""
+
+from types import MappingProxyType
+
+import numpy as np
+import pytest
+
+from antennaknobs import AntennaBuilder
+from antennaknobs.engines import MomwireEngine
+from antennaknobs.network import Driven, Instance, Network, PortOnWire, Wire
+from antennaknobs.network_reduce import (
+    RCOND_SINGULAR,
+    RCOND_SUSPECT,
+    SingularNetworkError,
+)
+from antennaknobs.station import shunt_open_stub
+
+# The stub is 0.20 λ at 28 MHz — a perfectly ordinary length there, and an odd
+# quarter-wave at 35 MHz, which is where the sweep below walks it.
+STUB_DESIGN_MHZ, STUB_WL = 28.0, 0.20
+POLE_MHZ = STUB_DESIGN_MHZ * 0.25 / STUB_WL  # 35.0
+
+
+class StubbedDipole(AntennaBuilder):
+    """A dipole with a lossless open stub across the feed."""
+
+    default_params = MappingProxyType(
+        {"freq": 30.0, "base": 0.0, "length_factor": 1.0, "stub_k1": 0.0}
+    )
+
+    def build_wires(self):
+        y = 0.25 * (300.0 / self.freq) * self.length_factor
+        return [
+            Wire((0, -y, 0), (0, -0.05, 0), 21, None),
+            Wire((0, 0.05, 0), (0, y, 0), 21, None),
+            Wire((0, -0.05, 0), (0, 0.05, 0), 3, 1 + 0j, "feed"),
+        ]
+
+    def build_network(self):
+        stub = shunt_open_stub(
+            freq_mhz=STUB_DESIGN_MHZ, length_wl=STUB_WL, z0=50.0, k1=self.stub_k1
+        )
+        return Network(
+            ports={"feed": PortOnWire("feed")},
+            branches=[Instance("stub", stub, port="feed")],
+            sources=[Driven(port="feed")],
+        )
+
+
+def engine(**knobs):
+    return MomwireEngine(StubbedDipole(dict(StubbedDipole.default_params, **knobs)),
+                         ground=None)  # fmt: skip
+
+
+# ---------------------------------------------------------------------------
+# detection + attribution
+# ---------------------------------------------------------------------------
+def test_a_single_point_on_the_pole_raises_with_the_element_named():
+    """The whole value of the guard is the sentence it prints."""
+    with pytest.raises(SingularNetworkError) as exc:
+        engine(freq=POLE_MHZ).impedance()
+    msg = str(exc.value)
+    assert "stub" in msg  # the instance path, so you know WHICH element
+    assert "λ/4" in msg and f"{POLE_MHZ:.4f}" in msg
+    assert "k1/k2" in msg or "cable=" in msg  # ...and what to do about it
+
+
+def test_the_message_says_the_stamps_were_individually_fine():
+    """This is the distinguishing feature of the reducer-level case: no single
+    branch is singular, so the user should not go looking for one."""
+    with pytest.raises(SingularNetworkError) as exc:
+        engine(freq=POLE_MHZ).impedance()
+    assert "assembled system" in str(exc.value)
+
+
+def test_real_loss_dissolves_the_singularity():
+    """The remedy the message recommends has to actually work."""
+    z = engine(freq=POLE_MHZ, stub_k1=0.2).impedance()[0]
+    assert np.isfinite(z)
+    assert abs(z) < 1e6
+
+
+def test_off_the_pole_solves_normally():
+    z = engine(freq=POLE_MHZ * 0.9).impedance()[0]
+    assert np.isfinite(z)
+
+
+# ---------------------------------------------------------------------------
+# a sweep loses one sample, not the sweep
+# ---------------------------------------------------------------------------
+def test_sweep_across_the_pole_poisons_only_that_sample():
+    """The acceptance criterion: a lossless open stub swept across its λ/4."""
+    freqs = np.array([33.0, 34.0, POLE_MHZ, 36.0, 37.0])
+    zs = engine().impedance_sweep(freqs)[:, 0]
+
+    assert not np.isfinite(zs[2])  # the pole
+    assert np.all(np.isfinite(np.delete(zs, 2)))  # everything either side
+    # ...and the surviving samples are the real answer, not garbage: an open
+    # stub is capacitive below λ/4 and inductive above.
+    assert zs[1].imag < 0 < zs[3].imag
+
+
+def test_the_poisoned_sample_is_logged_with_its_reason(caplog):
+    """NaN with no explanation would be its own kind of silent failure."""
+    with caplog.at_level("WARNING"):
+        engine().impedance_sweep(np.array([34.0, POLE_MHZ, 36.0]))
+    text = caplog.text
+    assert "singular network" in text and f"{POLE_MHZ:g}" in text
+    assert "stub" in text
+
+
+def test_a_lossless_half_wave_line_mid_sweep_also_degrades():
+    """The other pole: a plain TL at k·λ/2, caught by the stamp-time guard.
+
+    That guard raises from inside the stamp, so before this change it aborted
+    the entire sweep rather than one sample of it. `wire.doublet_balanced_tuner`
+    walks its lossless line through exactly this.
+    """
+    from antennaknobs.designs.wire.doublet_balanced_tuner import Builder
+
+    b = Builder()
+    zs = MomwireEngine(b, ground=None).impedance_sweep(
+        np.linspace(b.freq * 0.8, b.freq * 1.25, 9)
+    )[:, 0]
+    finite = np.isfinite(zs)
+    assert finite.sum() >= zs.size - 2  # at most the pole samples are lost
+    assert finite.sum() >= 1  # ...and the sweep is not a total loss
+
+
+# ---------------------------------------------------------------------------
+# the thresholds — the part that could silently break healthy designs
+# ---------------------------------------------------------------------------
+def test_thresholds_are_ordered_and_far_below_healthy_designs():
+    assert RCOND_SINGULAR < RCOND_SUSPECT
+    # Measured worst case across every catalog design carrying a network is
+    # 2.4e-7 (arrays.bowtie1x2_bl); the suspect threshold must sit well under
+    # it or healthy designs would warn on every solve.
+    assert RCOND_SUSPECT < 2.4e-7
+
+
+@pytest.mark.parametrize(
+    "design",
+    [
+        "dipoles.invvee_coax_station",
+        "dipoles.folded_invvee_balun",
+        "verticals.dominator",
+        "wire.doublet_ladder_tuner",
+        "wire.efhw_sloper",
+        "arrays.bowtie1x2_bl",
+    ],
+)
+def test_shipping_network_designs_still_solve(design, caplog):
+    """The regression this guard could plausibly cause.
+
+    An MNA matrix mixes admittance rows with unit-valued constitutive rows, so
+    a healthy network spans twenty-plus orders of magnitude and an *unscaled*
+    condition estimate calls it singular — `arrays.bowtie1x2_bl` reports 1e-16
+    that way. Equilibration is what makes the threshold mean rank-deficient
+    rather than badly-scaled, and this test is what keeps it honest.
+    """
+    from importlib import import_module
+
+    Builder = import_module(f"antennaknobs.designs.{design}").Builder
+    with caplog.at_level("WARNING"):
+        z = MomwireEngine(Builder(), ground=None).impedance()[0]
+    assert np.isfinite(z)
+    assert "nearly singular" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# the web contract: a singular sample must not produce un-parseable JSON
+# ---------------------------------------------------------------------------
+def test_web_sweep_stays_json_clean_through_a_singular_sample():
+    import json
+
+    # `web.examples` first: importing `web.adapter` cold trips the adapter ⇄
+    # examples import cycle (the same reason pynec_backend imports the
+    # sentinel lazily).
+    import antennaknobs.web.examples  # noqa: F401
+    from antennaknobs.web.adapter import Z_OPEN_OHMS
+
+    zs = engine().impedance_sweep(np.array([34.0, POLE_MHZ, 36.0]))
+    # This is the clamp the /sweep adapter applies before serialising.
+    clamped = np.where(np.isfinite(zs), zs, complex(Z_OPEN_OHMS, 0.0))
+    body = json.dumps({"z_re": clamped[:, 0].real.tolist()})
+    assert "NaN" not in body and "Infinity" not in body
+    assert json.loads(body)["z_re"][1] == Z_OPEN_OHMS


### PR DESCRIPTION
Closes #647.

The stub factories guard their own singularity at *construction*. A sweep walks the same stub onto its pole at a frequency that guard never saw — and there **no individual stamp is singular**: each is finite and the assembled system is not. That reached `np.linalg.solve` as a bare `LinAlgError`, or — a few kHz off the pole — as enormous meaningless numbers with no complaint at all.

## The part that nearly went wrong

A raw condition estimate **cannot** be used here, and the first cut that used one flagged two shipping designs as broken.

An MNA matrix mixes admittance rows with unit-valued constitutive rows, so a perfectly healthy network spans twenty-plus orders of magnitude. `arrays.bowtie1x2_bl` reports `rcond = 1e-16` while solving fine at 50.00−0.21j — that number is *scaling*, not rank deficiency.

LAPACK's `zgesvx` equilibrates first (`fact="E"`) and reports the condition of the **scaled** system, which is the number that distinguishes rank-deficient from badly-scaled. Measured across every catalog design carrying a network:

| design | worst equilibrated rcond |
|---|---|
| `verticals.challenger` | 1.3e-01 |
| `dipoles.invvee_coax_station` | 6.6e-02 |
| `wire.sterba_bl` | 2.4e-04 |
| `wire.doublet_ladder_tuner` | 1.0e-04 |
| **`arrays.bowtie1x2_bl`** | **2.4e-07** ← worst healthy |
| singular | 0.0 |

Threshold is 1e-12 — five orders below the worst healthy design. Both thresholds and that measurement are pinned by tests, and the full per-design catalog lane (171 solves) passes.

## Attribution

Rather than "matrix is singular", the reducer walks the lossless lines and asks each how close it sits to its own pole — `k·λ/2` for a line between live nodes, odd `λ/4` for one hanging open. The open case is recognised *structurally*: an open stub is spelled as a `TL` into a private node nothing else touches, so "dangling far end" **is** the open.

```
SingularNetworkError: the network has no finite solution at this frequency
(reciprocal condition 7.6e-16 after equilibration). Every branch stamped fine on
its own — the singularity is in the assembled system.
Suspect:
  stub: open-ended line feed→stub.far is 0.2500 λ at 35.0000 MHz — an odd multiple
  of λ/4, where an open stub's Z_in = 0 shorts the port it hangs on (z0 = 50 Ω)
Give the line the loss it really has (k1/k2, or cable=...): any real attenuation
moves the pole off the real axis and the solve becomes well-posed.
```

## Sweeps lose a sample, not the sweep

`poison_singular_sample()` maps a singular reduction to NaN with the reason logged, on both engines. The web adapter's existing `Z_OPEN_OHMS` clamp already turns that into clean JSON; the PyNEC web path (which sweeps via single-point solves) catches the same error. `wire.doublet_balanced_tuner` crosses a lossless half-wave mid-sweep and now returns **8 of 9 samples instead of aborting**.

Deliberately **not** applied to `impedance()`: someone who asked about one frequency should get the sentence, not a silent NaN.

The near-miss keeps its answer and gets a warning rather than a refusal — it exists, it just shouldn't be believed.

## Acceptance criteria (#647)

- [x] A lossless `shunt_open_stub` swept across its λ/4 produces a clean per-sample sentinel with an actionable message, not a raw `LinAlgError`
- [x] The half-wave TL case gets the same treatment where the stamp-time guard can't see it
- [x] Web sweep responses stay JSON-clean through a singular sample

`SingularNetworkError` subclasses `ValueError`, so the pre-existing guards keep their contract while becoming individually catchable.

## Testing

15 new tests: attribution content (names the instance, the electrical length, the remedy), the remedy actually working, one-sample poisoning with the surviving samples still *correct* (capacitive below λ/4, inductive above), the logged reason, the half-wave mid-sweep case through a real catalog design, threshold ordering pinned against the measured healthy worst case, six shipping designs asserted to solve without even a warning, and the JSON-cleanliness contract. Fast lane 2960 passed; catalog lane 171 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g