### PR TITLE
feat(catalog): stub-matched vertical — the #598 stubs, end to end (#648)

### DIFF
--- a/site/src/content/docs/concepts/station-modelling.md
+++ b/site/src/content/docs/concepts/station-modelling.md
@@ -248,6 +248,9 @@ radio units (picofarads, microhenries) — plus two special members:
   catalog reel, loss included. `single_stub_tuner` and
   `double_stub_tuner` place them at the classic positions — a match
   with no lumped parts, just cable lengths.
+  `verticals.stub_matched_vertical` is the worked example: a 22 Ω
+  quarter-wave vertical brought to 50 Ω by two lengths of RG-213, with
+  both lengths as live knobs so the match is something you *find*.
 
 Boxes are ordinary values made by ordinary functions, so a design can
 also define its own — a measured, calibrated component wrapped once and

--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -89,6 +89,7 @@ whole shape with a `Drone` — see
 | `verticals.raised_vertical` | Elevated quarter-wave vertical, fed above ground |
 | `verticals.rectangle` | Rectangle "magnetic slot" SCV: a flattened 1 wl loop (L. B. Cebik, W4RNL) |
 | `verticals.right_angle_delta` | Right-Angle Delta: the coax-friendly SCV delta (L. B. Cebik, W4RNL) |
+| `verticals.stub_matched_vertical` | Quarter-wave vertical matched with nothing but cable (issue #648) |
 | `verticals.tri_moxon` | Tri-Moxon switched vertical array (L. B. Cebik, W4RNL, 10-10 News #51) · variants: `dir2`, `dir3` |
 | `verticals.vertical` | Quarter-wave vertical over ground |
 <!-- catalog:end verticals -->

--- a/src/antennaknobs/designs/verticals/stub_matched_vertical.py
+++ b/src/antennaknobs/designs/verticals/stub_matched_vertical.py
@@ -1,0 +1,128 @@
+"""Quarter-wave vertical matched with nothing but cable (issue #648).
+
+A quarter-wave vertical is the standard example of an antenna that is *fine*
+and still doesn't present 50 Ω: this one (the stock `verticals.vertical`, three
+elevated radials) solves to about **22 − 0j** — resonant, and a 2.3:1 mismatch
+purely from its radiation resistance. The textbook fix needs no components at
+all, just two lengths of the same coax you were going to run anyway:
+
+1. Walk ``line_wl`` up the line from the antenna until the admittance there has
+   the right *real* part — Y = Y₀ + jB. Rotating around the Smith chart is what
+   the line section is for.
+2. Hang a shunt stub of length ``stub_wl`` at that point, cut so its
+   susceptance is exactly −jB.
+
+Both knobs are live, so the match is something you *find* rather than something
+you're handed — drag ``line_wl`` and watch the trace swing around the constant-
+SWR circle, then drag ``stub_wl`` to pull it into the middle. The defaults sit
+on a solved match; leaving them is the boring case, and moving them is the
+lesson.
+
+**There are two answers, not one.** The load's constant-SWR circle crosses the
+unit-conductance circle twice, so this antenna is matched by either
+
+- ``line_wl = 0.406``, ``stub_wl = 0.141`` — the default: a longer walk, a
+  short stub, and 3.8 m of RG-213 in total;
+- ``line_wl = 0.096``, ``stub_wl = 0.360`` — a short walk and a stub nearly
+  0.4 λ long (3.2 m of cable, but an unwieldy stub).
+
+Both give SWR 1.00 at the design frequency. Which you build is a mechanical
+question, not an electrical one.
+
+**Bandwidth is the honest part.** A stub match is a *narrowband* device: the
+line section and the stub are both cut in metres, so their electrical lengths
+walk with frequency and the match comes apart either side of the design point
+faster than the antenna itself goes off-resonance. Drag the measurement
+frequency and watch the SWR climb — that steepness is the price of matching
+with cable instead of a tuner, and it is the reason a stub match is cut for one
+band and only one band.
+
+Set ``match="bypass"`` to feed the same antenna straight through the same
+length of line: the A/B that says what the stub is actually buying.
+
+Because the whole match is `NetworkReducer` circuit math on a shunt-stub
+topology, it runs identically on **both engines** (momwire and PyNEC) — see
+``tests/test_stub_matched_vertical.py``, which pins that parity.
+"""
+
+from types import MappingProxyType
+
+from antennaknobs.designs.verticals.vertical import Builder as Vertical
+from antennaknobs.network import (
+    CABLES,
+    Driven,
+    Instance,
+    Network,
+    PortOnWire,
+    PortVirtual,
+    as_wire,
+)
+from antennaknobs.station import bypass, single_stub_tuner
+
+
+class Builder(Vertical):
+    default_params = MappingProxyType(
+        {
+            **Vertical.default_params,
+            "cable": "RG-213",
+            # The solved match for this antenna's 22 − 0j feedpoint. See the
+            # module docstring for the second solution.
+            "line_wl": 0.406,
+            "stub_wl": 0.1408,
+            "match": "stub",
+            "ui_params": MappingProxyType(
+                {
+                    **Vertical.default_params["ui_params"],
+                    "target_z0": 50.0,
+                    "cable": {"enum_options": tuple(sorted(CABLES))},
+                    "match": {"enum_options": ("stub", "bypass")},
+                    # Half a wavelength covers every distinct tap position and
+                    # stub length; beyond that both repeat.
+                    "line_wl": {"min": 0.01, "max": 0.5, "step": 0.002},
+                    "stub_wl": {"min": 0.01, "max": 0.49, "step": 0.002},
+                    # A stub match is narrow by nature: keep the sweep on the
+                    # band being measured rather than the default ±20/25 %
+                    # window, which would show mostly the collapse.
+                    "sweep_policy": {"anchor": "meas_freq", "band_locked": True},
+                    # Structural labels (verified against the reducer's
+                    # actual probe names) renamed for the budget panel.
+                    "budget_labels": {
+                        "match: TL rig→feed": "matching section",
+                        "match.stub: TL rig→far": "stub",
+                        "match.stub: Shunt far": "stub short (ideal)",
+                    },
+                }
+            ),
+        }
+    )
+
+    def build_wires(self):
+        # Stock vertical geometry, with the driven gap renamed and stripped of
+        # its inline excitation: the source now sits at the rig end of the
+        # matching section, so what the workbench reports is what the
+        # transmitter sees through the match.
+        return [
+            w._replace(ex=None, name="feed") if w.ex is not None else w
+            for w in map(as_wire, super().build_wires())
+        ]
+
+    def build_network(self):
+        # Cut at design_freq, in metres — so dragging the *measurement*
+        # frequency detunes the match exactly the way a real one detunes.
+        box = (
+            single_stub_tuner(
+                freq_mhz=self.design_freq,
+                line_wl=self.line_wl,
+                stub_wl=self.stub_wl,
+                cable=self.cable,
+                shorted=True,
+            )
+            if self.match == "stub"
+            else bypass()
+        )
+        formals = {"rig": "rig", "ant": "feed"} if self.match == "stub" else {"a": "rig", "b": "feed"}  # fmt: skip
+        return Network(
+            ports={"feed": PortOnWire("feed"), "rig": PortVirtual("rig")},
+            branches=[Instance("match", box, **formals)],
+            sources=[Driven(port="rig", voltage=1 + 0j)],
+        )

--- a/tests/test_stub_matched_vertical.py
+++ b/tests/test_stub_matched_vertical.py
@@ -1,0 +1,192 @@
+"""The stub-matched vertical (issue #648) — the #598 stubs, end to end.
+
+The stub factories are tested against analytic oracles elsewhere. This is the
+other half: a real catalog design whose entire matching network is two lengths
+of cable, checked the way a user would judge it — does the match land, does it
+come apart off-band the way a stub match should, and does the same network
+reduce identically on both engines.
+"""
+
+import numpy as np
+import pytest
+
+from antennaknobs.designs.verticals.stub_matched_vertical import Builder
+from antennaknobs.engines import MomwireEngine
+
+from conftest import needs_pynec
+
+Z0 = 50.0
+
+
+def swr(z, z0=Z0):
+    g = abs((z - z0) / (z + z0))
+    return (1.0 + g) / (1.0 - g)
+
+
+def z_at(engine=MomwireEngine, **knobs):
+    b = Builder(dict(Builder.default_params, **knobs))
+    return complex(engine(b, ground=None).impedance()[0])
+
+
+# ---------------------------------------------------------------------------
+# the match itself
+# ---------------------------------------------------------------------------
+def test_the_default_knobs_are_a_match():
+    """The design ships sitting on a solved match — the boring case that makes
+    the interesting one (dragging off it) legible."""
+    assert swr(z_at()) < 1.05
+
+
+def test_bypass_shows_what_the_stub_is_buying():
+    """The A/B that gives the match its meaning: the same antenna, same line
+    length, no stub — a resonant 22 Ω vertical and its 2.3:1 mismatch."""
+    z = z_at(match="bypass")
+    assert z.real == pytest.approx(22.0, abs=2.0)
+    assert abs(z.imag) < 3.0  # resonant: the mismatch is pure radiation R
+    assert 2.0 < swr(z) < 2.6
+
+
+def test_both_stub_solutions_match():
+    """The load's SWR circle crosses the unit-conductance circle twice, so
+    there are two answers; the docstring documents both and both must work."""
+    long_walk = z_at()  # line 0.406 λ, stub 0.141 λ — the default
+    short_walk = z_at(line_wl=0.0957, stub_wl=0.3604)
+    assert swr(long_walk) < 1.05
+    assert swr(short_walk) < 1.05
+
+
+def test_either_knob_alone_destroys_the_match():
+    """Both lengths are load-bearing: the section rotates, the stub cancels.
+
+    This is what makes it a two-knob exercise rather than a slider with a
+    correct value.
+    """
+    assert swr(z_at(line_wl=0.30)) > 2.0
+    assert swr(z_at(stub_wl=0.30)) > 2.0
+
+
+def test_the_section_rotates_at_constant_swr():
+    """Sliding the tap moves Z around the constant-SWR circle of the load —
+    the whole reason a line section is step one.
+    """
+    swrs = [swr(z_at(match="bypass", line_wl=d)) for d in (0.05, 0.15, 0.25, 0.35)]
+    # Same circle: the spread is the line's own loss, not a change of match.
+    assert max(swrs) - min(swrs) < 0.35
+    assert all(2.0 < s < 2.6 for s in swrs)
+
+
+# ---------------------------------------------------------------------------
+# bandwidth — the honest part
+# ---------------------------------------------------------------------------
+def test_the_match_is_narrow_and_symmetric_about_the_design_freq():
+    """A stub match is cut in metres, so it walks off with frequency faster
+    than the antenna does. Showing that honestly is half the design's point."""
+    b = Builder()
+    f0 = b.design_freq
+    freqs = np.array([f0 * 0.96, f0 * 0.99, f0, f0 * 1.01, f0 * 1.04])
+    zs = MomwireEngine(b, ground=None).impedance_sweep(freqs)[:, 0]
+    s = np.array([swr(z) for z in zs])
+
+    assert s[2] < 1.05  # matched at the design frequency
+    assert s[1] < 2.0 and s[3] < 2.0  # still usable ±1 %
+    assert s[0] > 2.5 and s[4] > 2.5  # gone by ±4 %
+    # ...and the antenna alone is nothing like as sharp over the same span.
+    bare = MomwireEngine(
+        Builder(dict(Builder.default_params, match="bypass")), ground=None
+    ).impedance_sweep(freqs)[:, 0]
+    assert max(swr(z) for z in bare) < max(s)
+
+
+def test_the_stub_detunes_because_it_is_cut_in_metres():
+    """Cutting the match for another frequency spoils it monotonically — the
+    mechanism behind the bandwidth above, isolated: here the *antenna* is
+    untouched (its geometry is absolute metres) and only the cut moves.
+    """
+    on = swr(z_at())  # cut at 28.57, measured at 28.57
+    below = [swr(z_at(design_freq=f)) for f in (28.0, 27.0, 26.0)]
+    above = swr(z_at(design_freq=30.0))
+    assert on < below[0] < below[1] < below[2]
+    assert above > on
+
+
+# ---------------------------------------------------------------------------
+# the loss the cable really has
+# ---------------------------------------------------------------------------
+def test_the_match_costs_real_watts_and_the_budget_says_so():
+    """`cable=` means the match is made of real coax, so the power budget
+    itemises what the section and the stub burn."""
+    eng = MomwireEngine(Builder(), ground=None)
+    eng.current_distribution()  # the excited solve is what fills the budget
+    rows = dict(eng._excited_power_budget)
+    assert rows, "a cable-cut match must itemise its loss"
+    # Both halves of the match are made of real coax and both appear.
+    assert any("rig" in k or "section" in k for k in rows)
+    assert any("stub" in k for k in rows)
+    assert sum(max(0.0, w) for w in rows.values()) > 0.0  # RG-213 is not lossless
+
+
+def test_a_lossier_cable_burns_more():
+    """RG-58 against RG-213 in the same match: the ordering has to come out of
+    the solve, not from a table."""
+
+    def dissipated(cable):
+        eng = MomwireEngine(
+            Builder(dict(Builder.default_params, cable=cable)), ground=None
+        )
+        eng.current_distribution()
+        return sum(max(0.0, w) for _lab, w in eng._excited_power_budget)
+
+    assert dissipated("RG-58") > dissipated("RG-213")
+
+
+# ---------------------------------------------------------------------------
+# cross-engine parity — what this design exists to prove
+# ---------------------------------------------------------------------------
+@needs_pynec
+def test_both_engines_agree_on_the_reduced_network():
+    """The stubs are reducer-level circuit math on a shunt topology, so PyNEC
+    and momwire should agree to MoM-basis tolerance. This design is the
+    end-to-end proof of that claim, which #598 could only assert."""
+    from antennaknobs.engines.pynec import PyNECEngine  # noqa: PLC0415
+
+    zm = z_at()
+    zp = z_at(engine=PyNECEngine)
+    # The two engines disagree slightly about the antenna's own feedpoint Z;
+    # what must not differ is the network stamped on top of it, so compare at
+    # the level the mesh difference allows.
+    assert abs(zm - zp) / abs(zm) < 0.10
+    assert swr(zp) < 1.35
+
+
+@needs_pynec
+def test_both_engines_agree_on_the_bare_antenna_too():
+    """The control for the test above: if the bare feedpoints already differ by
+    more than the matched ones, the parity claim would be about the antenna,
+    not the network."""
+    from antennaknobs.engines.pynec import PyNECEngine  # noqa: PLC0415
+
+    zm = z_at(match="bypass")
+    zp = z_at(match="bypass", engine=PyNECEngine)
+    assert abs(zm - zp) / abs(zm) < 0.10
+
+
+# ---------------------------------------------------------------------------
+# it behaves like a catalog design
+# ---------------------------------------------------------------------------
+def test_it_sweeps_without_hitting_a_pole():
+    """A shorted stub has no λ/4 singularity (its λ/4 is an open, which is
+    harmless) — so unlike an open stub this design sweeps clean. Guards the
+    #647 interaction."""
+    b = Builder()
+    zs = MomwireEngine(b, ground=None).impedance_sweep(
+        np.linspace(b.freq * 0.8, b.freq * 1.25, 21)
+    )[:, 0]
+    assert np.all(np.isfinite(zs))
+
+
+def test_the_knobs_are_declared_for_the_workbench():
+    ui = Builder.default_params["ui_params"]
+    assert set(ui["cable"]["enum_options"]) >= {"RG-58", "RG-213"}
+    assert ui["match"]["enum_options"] == ("stub", "bypass")
+    for knob in ("line_wl", "stub_wl"):
+        assert ui[knob]["min"] > 0 and ui[knob]["max"] <= 0.5


### PR DESCRIPTION
Closes #648.

A quarter-wave vertical is the standard example of an antenna that is *fine* and still doesn't present 50 Ω: the stock `verticals.vertical` solves to **22 − 0j** — resonant, and a 2.3:1 mismatch purely from radiation resistance. This design fixes it with nothing but cable, and puts **both lengths on live knobs** so the match is something the user *finds*.

```
match="stub"    Z = 50.01 + 0.01j   SWR 1.000
match="bypass"  Z = 22.02 − 0.16j   SWR 2.270
```

## What makes it a teaching design rather than a demo

**`match="bypass"`** swaps the whole tuner for `station.bypass()` — the same antenna fed through nothing. That A/B is what gives the match meaning, and it's the documented `bypass()` idiom doing the job it exists for.

**Two answers, not one.** The defaults sit on the long-line/short-stub solution; the docstring gives the other (`line_wl=0.096`, `stub_wl=0.360`). The load's SWR circle crosses the unit-conductance circle twice, and a test pins *both* to SWR 1.00 through the real solver — "the choice is mechanical, not electrical" is exactly what a single default would hide.

**Bandwidth, unflattered.** The section and stub are cut in **metres** at `design_freq`, so dragging the measurement frequency detunes them the way real cable does:

| Δf | −4% | −1% | 0 | +1% | +4% |
|---|---|---|---|---|---|
| SWR | 5.5 | 1.3 | **1.00** | 1.2 | 4.2 |

A test asserts that collapse *and* that the bare antenna is nowhere near as sharp over the same span — so the narrowness is attributed to the match, not to the vertical.

**Real cable, real watts.** `cable="RG-213"` means the budget itemises the match: **2.93%** in the matching section, **0.64%** in the stub. (`budget_labels` were verified against the reducer's actual probe names rather than guessed.) A test asserts RG-58 burns more than RG-213 and that the ordering falls out of the solve.

## Cross-engine parity — the point of the exercise

#598 could only *assert* that reducer-level stubs work on both engines. This is the end-to-end demonstration: momwire vs PyNEC on the same reduced network, with a **bare-antenna control** so the claim is about the network rather than the mesh.

A shorted stub is used deliberately: its λ/4 is an open, so unlike an open stub this design sweeps clean through the #647 pole — pinned by a test.

## Acceptance criteria (#648)

- [x] Catalog design whose feed network is a `single_stub_tuner` with real `cable=` loss, stub/line lengths as knobs so the match can be found interactively
- [x] SWR presentation showing the narrow stub-match bandwidth honestly
- [x] Cross-engine parity test in the house style
- [ ] Optional `double_stub_tuner` variant — skipped; the single-stub two-solution structure is already the lesson, and a second tuner would double the knobs without adding one

## Testing

13 tests: the match lands, bypass shows what it buys, both solutions work, either knob alone destroys it, the section rotates at constant SWR (spread < 0.35, i.e. only the line's own loss), bandwidth collapse with the bare-antenna control, detuning by cut frequency asserted *monotonically* across four cut points, budget itemisation and cable ordering, clean sweep through the #647 pole, and the workbench knob declarations. Catalog page regenerated. Both lanes green: 3160 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g