### PR TITLE
feat(station): auto-transformer as two mutually coupled winding sections (#594)

### DIFF
--- a/site/src/content/docs/concepts/station-modelling.md
+++ b/site/src/content/docs/concepts/station-modelling.md
@@ -98,6 +98,7 @@ honest model:
 | `TwoPort` | series R/L/C between two ports — a tuner's series capacitor |
 | `Shunt` | R/L/C from a port to the common return — a tuner's shunt coil |
 | `Transformer` | ideal ratio + magnetizing branch with core-loss Q — the balun/unun model, calibrated against measured insertion loss rather than derived from core datasheets |
+| `Autotransformer` | tapped **single** winding — two mutually coupled sections (`M = k·√(L₁L₂)`) sharing a node, so the common section carries the *difference* of the input and output currents. The ratio falls out of the L/M matrix instead of being asserted, which is what an ideal-ratio model would get wrong |
 
 Reactive elements accept a finite **Q** (`ql`, `qc`, `qlmag`), and that
 is where real matchboxes and transformers burn power. Degenerate values
@@ -230,8 +231,9 @@ A box (`Composite`) has a formal port interface and a private inside:
 the tuner's tee midpoint exists as `tuner.m`, invisible to the rest of
 the design. The stdlib today: `t_network_tuner`, `l_network_tuner`,
 `unun` (with the compensation capacitor real 49:1 builds carry),
-`balun`, `link_coupling`, `balanced_l_tuner` — all parameterized in
-radio units (picofarads, microhenries) — plus two special members:
+`balun`, `autotransformer`, `link_coupling`, `balanced_l_tuner` — all
+parameterized in radio units (picofarads, microhenries) — plus two
+special members:
 
 - **`bypass()`** — a box-shaped nothing: it wires its input straight to
   its output. Swap any tuner or balun for `bypass()` and you get the
@@ -251,6 +253,38 @@ radio units (picofarads, microhenries) — plus two special members:
   `verticals.stub_matched_vertical` is the worked example: a 22 Ω
   quarter-wave vertical brought to 50 Ω by two lengths of RG-213, with
   both lengths as live knobs so the match is something you *find*.
+
+### Isolation transformer vs auto-transformer
+
+`unun` / `balun` model the **isolated** case: two windings, coupled only
+through the core, so the secondary current is a ratio-scaled copy of the
+primary's. `autotransformer` is the other one — a *single* coil with a tap, so
+the two sections are galvanically connected and the common section carries the
+**difference** of the input and output currents.
+
+That difference is constitutive, not cosmetic, which is why the element is two
+mutually coupled inductors rather than an ideal ratio:
+
+```python
+from antennaknobs.station import autotransformer, autotransformer_ratio
+
+# 4 µH from ground to the tap, 1.05 µH from the tap to the top
+Instance("xf", autotransformer(4.0, 1.05, k=0.99), tap="feed", top="rig")
+autotransformer_ratio(4.0, 1.05)   # 1.51 — impedance ratio n² ≈ 2.3
+```
+
+Turns go as √L on one core, so the ideal ratio is `n = 1 + √(upper/lower)` and
+the tap sees the top's load over `n²`. The model **reproduces** that in the
+`k` → 1 limit rather than assuming it — at realistic coupling (0.95–0.99) you
+get a little less, plus the series leakage reactance a real tapped coil has,
+which is the whole reason not to use an ideal ratio here.
+
+`k` must lie in [0, 1]. Above 1 the inductance matrix stops being positive
+semi-definite (`M² > L₁L₂`) and the pair would deliver more energy than it
+stores; SimSmith permits that and calls it non-physical, we refuse it, because
+the [power budget](#the-power-budget-where-the-watts-go) claims to balance.
+`ql` gives both sections a finite Q, and only the **resistive** part is
+itemised — never the reactive power the two sections trade back and forth.
 
 Boxes are ordinary values made by ordinary functions, so a design can
 also define its own — a measured, calibrated component wrapped once and

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -506,6 +506,58 @@ class Transformer:
 
 
 @dataclass(frozen=True)
+class Autotransformer:
+    """Tapped single winding — the auto-transformer (issue #594).
+
+    `Transformer` is an *isolation* transformer: two windings, coupled only by
+    the core. An autotransformer has **one** winding with a tap, so primary and
+    secondary are galvanically connected and share the common turns. That is
+    not a detail of construction — it changes the constitutive law, because the
+    current in the common section is the *difference* of the input and output
+    currents rather than a ratio-scaled copy.
+
+    So this is not modelled as an ideal ratio. It is two **mutually coupled
+    inductors** in series up one leg:
+
+        datum ──[ l_lower ]── a (tap) ──[ l_upper ]── b (top)
+
+    with mutual ``M = k·√(l_lower·l_upper)`` between them, stamped as two
+    Group-2 branch-current rows plus their off-diagonal coupling. The turns
+    ratio, the magnetizing behaviour, and the loss all fall *out* of that L/M
+    matrix instead of being asserted — which is the point: an ideal-ratio model
+    would get the common-section current wrong.
+
+    In the ideal limit (``k`` → 1, inductances ≫ the load reactance) it
+    reproduces the textbook tapped ratio
+
+        n = 1 + √(l_upper / l_lower)          (turns go as √L on one core)
+
+    so the impedance at the tap is the load at the top divided by n² —
+    :func:`~antennaknobs.station.autotransformer_ratio` computes it.
+
+    ``ql`` gives both sections the same finite Q (core + winding loss as a
+    series r = ωL/Q, the ``ql`` convention used elsewhere); it itemizes in the
+    power budget as *resistive* dissipation only, never the reactive power the
+    two windings exchange.
+
+    ``k`` must satisfy 0 ≤ k ≤ 1. Above 1 the inductance matrix stops being
+    positive semi-definite — M² > L₁L₂ means the pair can deliver more energy
+    than it stores — and the element would quietly generate power. SimSmith
+    permits it and calls it non-physical; we refuse it, because our power
+    budget claims to balance.
+
+    Reducer-only, like `Transformer`: no NEC card, both engines.
+    """
+
+    a: str  # the tap — the low-impedance side
+    b: str  # the top of the winding — the high-impedance side
+    l_lower: float  # henries, datum → tap (the common section)
+    l_upper: float  # henries, tap → top
+    k: float = 1.0
+    ql: float | None = None
+
+
+@dataclass(frozen=True)
 class Admittance:
     """A fixed, frequency-INDEPENDENT complex admittance branch (issue #416) —
     the general primitive a reactive NT card, a reactive TL end-shunt, and a
@@ -937,7 +989,15 @@ class FloatingBalun:
 
 
 Branch = Union[
-    TL, Load, TwoPort, Shunt, Transformer, Admittance, BalancedLine, FloatingBalun
+    TL,
+    Load,
+    TwoPort,
+    Shunt,
+    Transformer,
+    Autotransformer,
+    Admittance,
+    BalancedLine,
+    FloatingBalun,
 ]
 
 

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -28,6 +28,7 @@ constitutive row, so no element value is ever inverted.
 from __future__ import annotations
 
 import logging
+import math
 import warnings
 from dataclasses import dataclass
 
@@ -36,6 +37,7 @@ import numpy as np
 from .network import (
     TL,
     Admittance,
+    Autotransformer,
     BalancedLine,
     Driven,
     DrivenCurrent,
@@ -279,7 +281,9 @@ class MNASystem:
     impedance is ``v_k / j[column] + z_chain``.
     """
 
-    def __init__(self, G, elements, terminations, probes=None, diagnose=None):
+    def __init__(
+        self, G, elements, terminations, probes=None, diagnose=None, couplings=()
+    ):
         n = G.shape[0]
         m = len(elements)
         A = np.zeros((n + m, n + m), dtype=np.complex128)
@@ -298,6 +302,13 @@ class MNASystem:
                 A[col, el.c] += el.c_vc
             A[col, col] = el.c_j
             rhs[col] = el.e
+        # Mutual coupling between two Group-2 rows (issue #594): an
+        # autotransformer's two winding sections share flux, so one branch
+        # current appears in the OTHER's constitutive row. Every other element
+        # here is diagonal in the branch-current block; this is the only term
+        # that is not.
+        for i, k, z in couplings:
+            A[n + i, n + k] += z
         self.n_nodes = n
         self.A = A
         self.rhs = rhs
@@ -348,6 +359,15 @@ class MNASystem:
             if el.c is not None:
                 p += v[el.c] * np.conj(el.kc * j[payload])
             return 0.5 * float(np.real(p))
+        if kind == "group2r":
+            # Resistive dissipation ONLY (issue #594). The generic "group2"
+            # probe reads ½Re((v_a − v_b)·j*), which for a mutually-coupled
+            # winding also picks up the reactive power the two sections
+            # exchange — real-valued, sloshing back and forth, and emphatically
+            # not loss. Half of a lossless coupled pair would report positive
+            # dissipation and the other half negative.
+            idx, r = payload
+            return 0.5 * float(r) * float(abs(j[idx])) ** 2
         # termination: the Load part of the source/load branch at node k.
         col, e, tkind, z_chain = self.terminations[payload]
         if tkind == "i":
@@ -620,6 +640,7 @@ class NetworkReducer:
         plain KCL with zero injection (the floating I_ext = 0 condition).
         """
         omega = 2.0 * np.pi * C_LIGHT / wavelength
+        couplings: list[tuple[int, int, complex]] = []
         n = self.n_nodes
         G = np.zeros((n, n), dtype=np.complex128)
         n_real = Y_real.shape[0]
@@ -816,6 +837,47 @@ class NetworkReducer:
                             ([a], np.array([[y_mag]])),
                         )
                     )
+            elif isinstance(br, Autotransformer):
+                if not 0.0 <= br.k <= 1.0:
+                    raise ValueError(
+                        f"Autotransformer {br.a!r}→{br.b!r} has k = {br.k}; "
+                        "coupling must be 0 ≤ k ≤ 1. Above 1 the inductance "
+                        "matrix is not positive semi-definite (M² > L₁L₂) and "
+                        "the winding pair would deliver more energy than it "
+                        "stores — the power budget would stop balancing"
+                    )
+                if br.l_lower <= 0 or br.l_upper <= 0:
+                    raise ValueError(
+                        f"Autotransformer {br.a!r}→{br.b!r} needs positive "
+                        f"section inductances; got {br.l_lower} / {br.l_upper} H"
+                    )
+                a_i, b_i = self.port_to_idx[br.a], self.port_to_idx[br.b]
+                # Series r per section from the shared finite-Q convention.
+                r1 = omega * br.l_lower / br.ql if br.ql else 0.0
+                r2 = omega * br.l_upper / br.ql if br.ql else 0.0
+                z1 = r1 + 1j * omega * br.l_lower
+                z2 = r2 + 1j * omega * br.l_upper
+                zm = 1j * omega * br.k * math.sqrt(br.l_lower * br.l_upper)
+                # Both branch currents are referenced UP the winding: j1 runs
+                # datum → tap (its "a side" is the datum, absent from the node
+                # space), j2 runs tap → top. Each therefore enters its section
+                # at the lower terminal, so the passive-sign voltage is
+                #   (v_datum − v_tap) = z1·j1 + zm·j2
+                #   (v_tap   − v_top) = zm·j1 + z2·j2
+                # — the node potential is the NEGATIVE of the voltage across
+                # the element for j1, which is where a sign slip would hide.
+                # Same reference direction up the coil ⇒ flux adds ⇒ +zm.
+                i1, i2 = len(elements), len(elements) + 1
+                lo = lab(f"Autotransformer {_short(br.a)}→{_short(br.b)} (lower)")
+                hi = lab(f"Autotransformer {_short(br.a)}→{_short(br.b)} (upper)")
+                probes.append((lo, "group2r", (i1, r1)))
+                probes.append((hi, "group2r", (i2, r2)))
+                elements.append(_Group2Element(None, a_i, c_v=1.0 + 0j, c_j=z1, e=0j))
+                elements.append(_Group2Element(a_i, b_i, c_v=1.0 + 0j, c_j=z2, e=0j))
+                # v_a = z1·j1 + zm·j2 and v_b − v_a = zm·j1 + z2·j2: the
+                # off-diagonal pair that makes this one winding, not two.
+                couplings.append((i1, i2, zm))
+                couplings.append((i2, i1, zm))
             elif isinstance(br, FloatingBalun):
                 if br.n == 0:
                     raise ValueError(
@@ -956,6 +1018,7 @@ class NetworkReducer:
             terminations,
             probes=probes,
             diagnose=lambda wl=wavelength: self._singularity_report(wl),
+            couplings=couplings,
         )
 
     def _physical_port_voltages(self, v):

--- a/src/antennaknobs/station.py
+++ b/src/antennaknobs/station.py
@@ -31,6 +31,7 @@ import math
 from .builder import C_LIGHT_MHZ_M
 from .network_reduce import SingularNetworkError
 from .network import (
+    Autotransformer,
     TL,
     BalancedLine,
     Composite,
@@ -122,6 +123,66 @@ def balun(
     return Composite(
         ports=("line", "ant"),
         branches=(Transformer(a="line", b="ant", n=n, lmag=lmag, qlmag=qlmag),),
+    )
+
+
+def autotransformer_ratio(lower_uH: float, upper_uH: float) -> float:
+    """Ideal tapped-autotransformer voltage ratio ``n = 1 + √(upper/lower)``.
+
+    Turns go as √L on one core, so a tap at ``lower`` on a winding whose
+    remainder is ``upper`` steps the tap voltage up by ``n`` — and the
+    impedance at the tap is the load at the top over ``n²``. This is the ``k``
+    → 1 limit that the coupled-inductor model in
+    :class:`~antennaknobs.network.Autotransformer` reproduces rather than
+    assumes; at realistic coupling (0.95–0.99) the achieved ratio falls a
+    little short of it, which is exactly the difference the model exists to
+    show.
+
+    SimSmith surfaces the two section inductances as ``Lwr`` / ``Upr``; they
+    are the arguments here, so a design can label its readout with
+    ``autotransformer_ratio(lwr, upr)`` alongside them.
+    """
+    if lower_uH <= 0 or upper_uH <= 0:
+        raise ValueError(
+            f"section inductances must be positive; got {lower_uH} / {upper_uH} µH"
+        )
+    return 1.0 + math.sqrt(upper_uH / lower_uH)
+
+
+def autotransformer(
+    lower_uH: float,
+    upper_uH: float,
+    k: float = 0.98,
+    ql: float | None = None,
+) -> Composite:
+    """Tapped single winding — the auto-transformer (issue #594).
+
+    The matching element in many unun and L-network builds: *one* coil with a
+    tap, so the sections are galvanically connected and the common section
+    carries the difference of the input and output currents. `unun` / `balun`
+    model the *isolated* two-winding case; this is the other one, and the
+    difference is constitutive, not cosmetic.
+
+    ``lower_uH`` is the common section (datum to the tap), ``upper_uH`` the
+    remainder (tap to the top). Step-up: feed ``tap``, load ``top``, and the
+    tap sees roughly the load over ``autotransformer_ratio(lower, upper)²``.
+    ``k`` is the coupling coefficient — the default 0.98 is a realistic
+    close-wound air-core value, and 1.0 is the ideal limit; ``ql`` gives both
+    sections a finite Q whose *resistive* dissipation lands in the power
+    budget. Formals: ``tap`` (low-Z side), ``top`` (high-Z side).
+    """
+    return Composite(
+        ports=("tap", "top"),
+        branches=(
+            Autotransformer(
+                a="tap",
+                b="top",
+                l_lower=lower_uH * 1e-6,
+                l_upper=upper_uH * 1e-6,
+                k=k,
+                ql=ql,
+            ),
+        ),
     )
 
 

--- a/tests/test_autotransformer.py
+++ b/tests/test_autotransformer.py
@@ -1,0 +1,258 @@
+"""The tapped-winding auto-transformer (issue #594).
+
+`Transformer` is an *isolation* transformer — two windings coupled only by the
+core. An autotransformer has one winding with a tap, so the sections are
+galvanically connected and the common section carries the *difference* of the
+input and output currents. That difference is constitutive, so the element is
+modelled as two mutually coupled inductors rather than as an ideal ratio, and
+the ratio has to *fall out* of the L/M matrix. These tests check that it does,
+and that the coupled pair does not quietly break the power budget.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+from antennaknobs.network import (
+    Autotransformer,
+    Driven,
+    Instance,
+    Network,
+    PortVirtual,
+    Shunt,
+)
+from antennaknobs.network_reduce import NetworkReducer
+from antennaknobs.station import autotransformer, autotransformer_ratio
+
+FREQ = 14.0
+OMEGA = 2.0 * math.pi * FREQ * 1e6
+WAVELENGTH = 299_792_458.0 / (FREQ * 1e6)
+NO_ANTENNA = np.zeros((0, 0), dtype=complex)  # pure-circuit tests: no wires
+
+
+def build(lower_uH, upper_uH, k, *, rload=None, ql=None, drive="tap"):
+    branches = [
+        Instance(
+            "xf",
+            autotransformer(lower_uH, upper_uH, k=k, ql=ql),
+            tap="tap",
+            top="top",
+        )
+    ]
+    if rload is not None:
+        load_at = "top" if drive == "tap" else "tap"
+        branches.append(Shunt(port=load_at, r=rload, parallel=True))
+    net = Network(
+        ports={"tap": PortVirtual("tap"), "top": PortVirtual("top")},
+        branches=branches,
+        sources=[Driven(port=drive)],
+    )
+    return NetworkReducer(net, {"tap": 0, "top": 1}, 2)
+
+
+def z_in(*args, **kw):
+    red = build(*args, **kw)
+    return complex(red.impedance_from_y(red.apply_branches(NO_ANTENNA, WAVELENGTH))[0])
+
+
+def budget_of(*args, **kw):
+    """(efficiency, p_in, {label: watts}) — every probed branch."""
+    red = build(*args, **kw)
+    _v, eff, p_in, rows = red.excited_state(NO_ANTENNA, WAVELENGTH)
+    return eff, p_in, dict(rows)
+
+
+def winding_rows(rows):
+    """Just the two coupled sections — the load Shunt is a probed branch too."""
+    return {k: v for k, v in rows.items() if "Autotransformer" in k}
+
+
+# ---------------------------------------------------------------------------
+# the constitutive model, checked where it has a closed form
+# ---------------------------------------------------------------------------
+def test_uncoupled_open_winding_is_just_its_inductance():
+    """k = 0, top open: the tap sees the lower section alone. Exact."""
+    z = z_in(2.0, 8.0, 0.0)
+    assert z.real == pytest.approx(0.0, abs=1e-9)
+    assert z.imag == pytest.approx(OMEGA * 2.0e-6, rel=1e-12)
+
+
+def test_uncoupled_loaded_is_the_analytic_parallel_combination():
+    """k = 0 decouples the sections, leaving lower ∥ (upper + load) — a
+    two-element network with an exact answer, so any sign or factor error in
+    the stamp shows up here rather than as a plausible-looking number."""
+    z = z_in(2.0, 8.0, 0.0, rload=200.0)
+    z_lower = 1j * OMEGA * 2.0e-6
+    z_branch = 1j * OMEGA * 8.0e-6 + 200.0
+    expect = 1.0 / (1.0 / z_lower + 1.0 / z_branch)
+    assert z == pytest.approx(expect, rel=1e-12)
+
+
+def test_the_ideal_ratio_falls_out_of_the_coupled_pair():
+    """The acceptance criterion: at k → 1 with the magnetizing reactance far
+    above the load, the tap sees load / n² with n = 1 + √(upper/lower) —
+    reproduced, not asserted anywhere in the stamp."""
+    n = autotransformer_ratio(2.0, 8.0)
+    assert n == pytest.approx(3.0)  # 1 + √4
+    z = z_in(2.0 * 10_000, 8.0 * 10_000, 1.0, rload=200.0)
+    assert z.real == pytest.approx(200.0 / n**2, rel=1e-4)
+    assert abs(z.imag) < 1e-3 * z.real  # magnetizing reactance is out of the way
+
+
+@pytest.mark.parametrize(
+    "lower,upper,n", [(1.0, 1.0, 2.0), (2.0, 8.0, 3.0), (4.0, 4.0, 2.0)]
+)
+def test_several_taps_hit_their_analytic_ratios(lower, upper, n):
+    assert autotransformer_ratio(lower, upper) == pytest.approx(n)
+    z = z_in(lower * 10_000, upper * 10_000, 1.0, rload=100.0)
+    assert z.real == pytest.approx(100.0 / n**2, rel=1e-3)
+
+
+def test_driving_the_top_steps_the_other_way():
+    """An autotransformer is symmetric: feed the top, and the tap load looks
+    n² *larger* rather than smaller."""
+    n = autotransformer_ratio(2.0, 8.0)
+    z = z_in(2.0 * 10_000, 8.0 * 10_000, 1.0, rload=20.0, drive="top")
+    assert z.real == pytest.approx(20.0 * n**2, rel=1e-3)
+
+
+def test_imperfect_coupling_adds_series_leakage_reactance():
+    """Real coils are not perfectly coupled, and the leakage that produces is
+    the reason this is a coupled-inductor model instead of a ratio."""
+    ideal = z_in(2.0 * 100, 8.0 * 100, 1.0, rload=200.0)
+    loose = z_in(2.0 * 100, 8.0 * 100, 0.9, rload=200.0)
+    assert abs(ideal.imag) < 1.0
+    assert loose.imag > 100.0  # inductive, and large — leakage ∝ (1 − k²)·L
+    # Passive network, so the reactance must be inductive at every coupling.
+    for k in (0.5, 0.8, 0.95, 0.99):
+        assert z_in(2.0 * 100, 8.0 * 100, k, rload=200.0).imag > 0.0
+
+
+# ---------------------------------------------------------------------------
+# power — the part a coupled pair could silently break
+# ---------------------------------------------------------------------------
+def test_a_lossless_winding_dissipates_exactly_nothing():
+    """The subtle one. A generic branch probe reads ½Re((v_a − v_b)·j*), which
+    for coupled windings also picks up the *reactive* power the two sections
+    exchange — real-valued, sloshing back and forth, and not loss. One row
+    would read positive and the other negative. The resistive-only probe must
+    read exactly zero on both.
+    """
+    eff, p_in, rows = budget_of(2.0, 8.0, 0.98, rload=200.0)
+    windings = winding_rows(rows)
+    assert len(windings) == 2  # both sections itemised
+    for label, watts in windings.items():
+        assert watts == 0.0, (label, watts)
+    assert p_in > 0.0
+    # The only sink is the load, so efficiency is "not burned in the network".
+    assert eff < 1.0
+
+
+def test_finite_q_dissipates_and_itemises():
+    _eff, p_in, rows = budget_of(2.0, 8.0, 0.98, rload=200.0, ql=50.0)
+    windings = winding_rows(rows)
+    assert len(windings) == 2
+    assert all(w > 0.0 for w in windings.values())
+    # Less than the input, and less than the load gets — a matching coil that
+    # burned most of the power would be a broken model, not a lossy one.
+    assert sum(windings.values()) < 0.5 * p_in
+    # (`efficiency` is "fraction reaching the antenna", and this rig has no
+    # antenna — every watt lands in a probed branch — so it reads 0 here.)
+
+
+def test_power_balances_against_the_load():
+    """Input power = load dissipation + winding dissipation, to machine
+    precision. Coupled branch currents are exactly where that would go wrong.
+    """
+    for ql in (None, 30.0):
+        _eff, p_in, rows = budget_of(2.0, 8.0, 0.98, rload=200.0, ql=ql)
+        # No antenna in this circuit, so every watt in must be accounted for by
+        # a probed branch: the two windings plus the load.
+        assert p_in == pytest.approx(sum(rows.values()), rel=1e-9)
+
+
+def test_lower_q_burns_more():
+    _e1, _p1, rows_hi = budget_of(2.0, 8.0, 0.98, rload=200.0, ql=200.0)
+    _e2, _p2, rows_lo = budget_of(2.0, 8.0, 0.98, rload=200.0, ql=20.0)
+    assert sum(winding_rows(rows_lo).values()) > sum(winding_rows(rows_hi).values())
+
+
+def test_both_sections_are_named_in_the_budget():
+    _eff, _p, rows = budget_of(2.0, 8.0, 0.98, rload=200.0, ql=50.0)
+    labels = " ".join(winding_rows(rows))
+    assert "lower" in labels and "upper" in labels
+    assert "Autotransformer" in labels
+
+
+# ---------------------------------------------------------------------------
+# refusals
+# ---------------------------------------------------------------------------
+def test_overcoupling_is_refused():
+    """k > 1 means M² > L₁L₂: the inductance matrix stops being positive
+    semi-definite and the pair can deliver more energy than it stores. SimSmith
+    allows it and calls it non-physical; we refuse, because the power budget
+    claims to balance."""
+    with pytest.raises(ValueError, match="0 ≤ k ≤ 1") as exc:
+        z_in(2.0, 8.0, 1.5)
+    assert "power budget" in str(exc.value)
+
+
+def test_negative_coupling_is_refused():
+    with pytest.raises(ValueError, match="0 ≤ k ≤ 1"):
+        z_in(2.0, 8.0, -0.2)
+
+
+def test_nonpositive_inductances_are_refused():
+    with pytest.raises(ValueError, match="positive"):
+        z_in(0.0, 8.0, 0.98)
+    with pytest.raises(ValueError, match="positive"):
+        autotransformer_ratio(2.0, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# it composes like every other station box
+# ---------------------------------------------------------------------------
+def test_the_factory_declares_the_documented_formals():
+    box = autotransformer(2.0, 8.0)
+    assert box.ports == ("tap", "top")
+    (br,) = box.branches
+    assert isinstance(br, Autotransformer)
+    assert br.l_lower == pytest.approx(2e-6) and br.l_upper == pytest.approx(8e-6)
+
+
+def test_it_matches_a_real_antenna_on_both_engines():
+    """End to end: a 22 Ω vertical stepped up toward 50 Ω by a tapped coil."""
+    from antennaknobs.designs.verticals.vertical import Builder as V
+    from antennaknobs.engines import MomwireEngine
+    from antennaknobs.network import Driven as D
+    from antennaknobs.network import PortOnWire, as_wire
+
+    class Tapped(V):
+        def build_wires(self):
+            return [
+                w._replace(ex=None, name="feed") if w.ex is not None else w
+                for w in map(as_wire, super().build_wires())
+            ]
+
+        def build_network(self):
+            # The ANTENNA sits at the tap and the rig at the top, so the
+            # 22 Ω feedpoint is stepped UP by n² toward 50 Ω:
+            # n = 1 + √(1.05/4.0) ≈ 1.51, n² ≈ 2.3.
+            return Network(
+                ports={"feed": PortOnWire("feed"), "rig": PortVirtual("rig")},
+                branches=[
+                    Instance(
+                        "xf",
+                        autotransformer(4.0, 1.05, k=0.99),
+                        tap="feed",
+                        top="rig",
+                    )
+                ],
+                sources=[D(port="rig")],
+            )
+
+    z = complex(MomwireEngine(Tapped(), ground=None).impedance()[0])
+    assert np.isfinite(z)
+    # A step-up from the 22 Ω feedpoint: the rig side sees ~n² more.
+    assert 35.0 < z.real < 70.0


### PR DESCRIPTION
Closes #594.

`Transformer` is an **isolation** transformer — two windings coupled only through the core, the secondary current a ratio-scaled copy of the primary's. An autotransformer is *one* coil with a tap, so the sections are galvanically connected and the common section carries the **difference** of the input and output currents. Modelling that as an ideal ratio would get the common-section current wrong.

So it's two mutually coupled inductors:

```
datum ──[ l_lower ]── a (tap) ──[ l_upper ]── b (top),   M = k·√(L₁L₂)
```

stamped as two Group-2 rows **plus their off-diagonal coupling** — the first element here whose branch-current block isn't diagonal, so `MNASystem` gains a `couplings` list for it.

The ratio, the magnetizing behaviour and the leakage all *fall out* of the L/M matrix. At k→1 with the magnetizing reactance clear of the load, the tap sees load/n² with n = 1 + √(upper/lower) — **reproduced to 1e-4, asserted nowhere in the stamp**:

| k | L×1 | L×100 | L×10000 |
|---|---|---|---|
| 0.90 | 20.8 + j18 | 21.2 + j1555 | 21.2 + j155472 |
| 0.98 | 21.7 + j5.9 | 22.0 + j312 | 22.0 + j31241 |
| 1.00 | 21.9 + j2.8 | 22.2 + j0.03 | **22.222 + j0.000** |

(200 Ω load, 2 µH / 8 µH sections ⇒ n = 3, analytic 200/n² = 22.2222. Off-ideal k shows the series leakage reactance a real tapped coil has — the whole reason not to use an ideal ratio.)

## Two things that needed care

**Sign.** The lower section's branch current enters at the *datum* terminal, so the node potential is the **negative** of the passive-sign voltage across it. Getting that backwards gives a grounded inductor a *negative* reactance — impossible for a passive RL network. My first cut had it wrong; the `k=0` open-winding test (Z must be exactly +jωL) is what pins it, and a second test checks the uncoupled loaded case against the exact parallel combination so a sign or factor slip can't hide behind a plausible number.

**Power.** The generic Group-2 probe reads ½Re((v_a − v_b)·j\*), which for coupled windings also picks up the **reactive** power the two sections exchange — real-valued, sloshing back and forth, and not loss. One row would read positive and the other negative, and the adapter's negative-clamp would turn that into fictitious dissipation. A resistive-only probe kind reports ½·r·|j|², so a lossless pair reads **exactly 0.0** in both rows and p_in balances against the load to 1e-9.

## Deliberate deviation

The issue says `k > 1` is "non-physical, matching SimSmith's guard". **I refuse it** instead of allowing it: M² > L₁L₂ makes the inductance matrix indefinite and the pair would deliver more energy than it stores. SimSmith can permit that because it doesn't claim a balanced power budget; we do. The error message says exactly that.

## Acceptance criteria (#594)

- [x] `autotransformer()` factory + reducer stamp via coupled-inductor (mutual-M) Group-2 rows
- [x] Finite-Q core loss shows up in the power budget
- [x] Limit test: ideal ratio matches the analytic tapped-autotransformer ratio; lossless power balance to machine precision
- [x] Reports effective turns ratio + upper/lower inductance (`autotransformer_ratio()`; the section inductances are the arguments, SimSmith's `Lwr`/`Upr`)

## Testing

18 tests: exact closed-form checks (uncoupled open winding = jωL to 1e-12, uncoupled loaded = the analytic parallel combination), the ideal-ratio limit at three taps, the reverse step-up direction, leakage reactance inductive at every coupling, the lossless-probe-reads-exactly-zero case, energy balance with and without loss, Q ordering, budget labelling, three refusals, and an end-to-end step-up of a real 22 Ω vertical. Both lanes green: 3007 fast + 171 catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g