### PR TITLE
feat(ferrite): core loss from complex permeability instead of one flat Q (#599)

### DIFF
--- a/site/src/content/docs/concepts/station-modelling.md
+++ b/site/src/content/docs/concepts/station-modelling.md
@@ -282,21 +282,21 @@ model exactly, which is how the two connect.
 Three honesty notes, because this is a place where a model can look more
 authoritative than it is:
 
-- **The catalog mixes are one-pole (Debye) fits**, not digitized vendor curves
-  — built from two published headline numbers per mix (initial permeability and
-  the frequency where `μ″` peaks). They reproduce the *shape* every datasheet
-  shows and are right to within the spread between vendors' constructions, but
-  they are not the datasheet curve, and near the relaxation knee a real mix
-  departs from a single pole. `FerriteMaterial.from_table()` takes real
-  `μ′`/`μ″` data and is strictly better.
+- **The catalog mixes are one-pole (Debye) fits with unverified parameters.**
+  Each mix is described by an initial permeability and the frequency where `μ″`
+  peaks, and those two numbers have *not* been checked against a datasheet or a
+  measurement. The shape is right and so is the ordering between mixes, so use
+  them to compare mixes, turns counts and bands — but do not quote an absolute
+  loss figure from them. Every entry's `source` string says so.
+- **Two ways to do better**, both supported: `FerriteMaterial.from_table()`
+  takes a real `μ′`/`μ″` table, or sweep a known choke with a
+  [VNA](/reference/cli/#capturing-from-a-vna) and fit `μ_i`/`f_r`/`c_stray` to
+  it — a measurement you can reproduce beats a datasheet read, because it is
+  *your* core rather than a vendor nominal.
 - **A choke's impedance peak comes from the winding, not just the material.** A
   single relaxation climbs and saturates; the few pF of winding self-capacitance
   (`c_stray_pF`) parallel-resonate with it, and *that* is what puts the peak in
   every published choke plot — and why |Z| falls again above it.
-- **Absolute watts deserve a measurement.** Use this to compare mixes, turns
-  counts and bands; pin the absolute number against a
-  [measured sweep](/reference/cli/#overlaying-a-vna-measurement) before
-  trusting it.
 
 ### Isolation transformer vs auto-transformer
 

--- a/site/src/content/docs/concepts/station-modelling.md
+++ b/site/src/content/docs/concepts/station-modelling.md
@@ -97,7 +97,7 @@ honest model:
 | `Load` | series R/L/C in a wire's current path — a trap, a terminating resistor |
 | `TwoPort` | series R/L/C between two ports — a tuner's series capacitor |
 | `Shunt` | R/L/C from a port to the common return — a tuner's shunt coil |
-| `Transformer` | ideal ratio + magnetizing branch with core-loss Q — the balun/unun model, calibrated against measured insertion loss rather than derived from core datasheets |
+| `Transformer` | ideal ratio + magnetizing branch with core-loss Q — the balun/unun model. Give it a `core` (`ferrite.FerriteCore`) instead and the branch follows the mix's complex permeability, so inductance *and* loss move with frequency |
 | `Autotransformer` | tapped **single** winding — two mutually coupled sections (`M = k·√(L₁L₂)`) sharing a node, so the common section carries the *difference* of the input and output currents. The ratio falls out of the L/M matrix instead of being asserted, which is what an ideal-ratio model would get wrong |
 
 Reactive elements accept a finite **Q** (`ql`, `qc`, `qlmag`), and that
@@ -253,6 +253,50 @@ special members:
   `verticals.stub_matched_vertical` is the worked example: a 22 Ω
   quarter-wave vertical brought to 50 Ω by two lengths of RG-213, with
   both lengths as live knobs so the match is something you *find*.
+
+### Ferrite cores: one number vs a curve
+
+`qlmag` is a single, frequency-independent Q on the magnetizing branch. Real
+ferrite has a strongly frequency-dependent **complex permeability**
+`μ = μ′ − jμ″`, and that dependence is the whole story of a choke — a 43-mix
+balun burns its watts in one part of the spectrum and is nearly lossless
+elsewhere. A flat Q cannot say "loses most here, little there", which is
+usually the question being asked.
+
+Give a `Transformer`, `FloatingBalun`, `unun` or `balun` a **core** instead:
+
+```python
+from antennaknobs.ferrite import core_from_catalog
+from antennaknobs.station import unun
+
+core = core_from_catalog("FT-240", "43", turns=11, c_stray_pF=3.0)
+unun(7.0, core=core)     # 49:1, wound on that core
+```
+
+`core` supersedes `lmag`/`qlmag` wholesale — it *is* the core, the same way
+`TL.from_cable`'s cable is the cable. The magnetizing branch then follows the
+material: `μ′` sets the inductance, `μ″` sets the loss, and the effective Q is
+just `μ′/μ″`. A material with flat `μ′` and `μ″ = μ′/Q` reproduces the scalar
+model exactly, which is how the two connect.
+
+Three honesty notes, because this is a place where a model can look more
+authoritative than it is:
+
+- **The catalog mixes are one-pole (Debye) fits**, not digitized vendor curves
+  — built from two published headline numbers per mix (initial permeability and
+  the frequency where `μ″` peaks). They reproduce the *shape* every datasheet
+  shows and are right to within the spread between vendors' constructions, but
+  they are not the datasheet curve, and near the relaxation knee a real mix
+  departs from a single pole. `FerriteMaterial.from_table()` takes real
+  `μ′`/`μ″` data and is strictly better.
+- **A choke's impedance peak comes from the winding, not just the material.** A
+  single relaxation climbs and saturates; the few pF of winding self-capacitance
+  (`c_stray_pF`) parallel-resonate with it, and *that* is what puts the peak in
+  every published choke plot — and why |Z| falls again above it.
+- **Absolute watts deserve a measurement.** Use this to compare mixes, turns
+  counts and bands; pin the absolute number against a
+  [measured sweep](/reference/cli/#overlaying-a-vna-measurement) before
+  trusting it.
 
 ### Isolation transformer vs auto-transformer
 

--- a/site/src/content/docs/concepts/station-modelling.md
+++ b/site/src/content/docs/concepts/station-modelling.md
@@ -282,17 +282,18 @@ model exactly, which is how the two connect.
 Three honesty notes, because this is a place where a model can look more
 authoritative than it is:
 
-- **The catalog mixes are one-pole (Debye) fits with unverified parameters.**
-  Each mix is described by an initial permeability and the frequency where `μ″`
-  peaks, and those two numbers have *not* been checked against a datasheet or a
-  measurement. The shape is right and so is the ordering between mixes, so use
-  them to compare mixes, turns counts and bands — but do not quote an absolute
-  loss figure from them. Every entry's `source` string says so.
-- **Two ways to do better**, both supported: `FerriteMaterial.from_table()`
-  takes a real `μ′`/`μ″` table, or sweep a known choke with a
-  [VNA](/reference/cli/#capturing-from-a-vna) and fit `μ_i`/`f_r`/`c_stray` to
-  it — a measurement you can reproduce beats a datasheet read, because it is
-  *your* core rather than a vendor nominal.
+- **The material data is the vendor's, fetched not bundled.**
+  `core_from_catalog` downloads Fair-Rite's published complex-permeability CSV
+  for the mix on first use and caches it under `~/.antennaknobs/ferrite`, so
+  the package ships no vendor data and everything after the first call is
+  offline. `FerriteMaterial.from_table()` takes your own measurements instead —
+  better data still, since the vendor never wound *your* toroid.
+- **Parametric mix models were tried and dropped.** An earlier version shipped
+  one-pole fits; measured against the published curves their relaxation
+  frequencies were out by up to 8× (mix 43 peaks at 4.4 MHz, not 35), and even
+  a best-fit two-pole model misses by 22–60% over 0.1–100 MHz for every mix but
+  31. These NiZn ferrites have a *distribution* of relaxation times, so no
+  small parametric catalog can be honest about their loss.
 - **A choke's impedance peak comes from the winding, not just the material.** A
   single relaxation climbs and saturates; the few pF of winding self-capacitance
   (`c_stray_pF`) parallel-resonate with it, and *that* is what puts the peak in

--- a/src/antennaknobs/ferrite.py
+++ b/src/antennaknobs/ferrite.py
@@ -19,53 +19,48 @@ is just ``μ′/μ″``. That last identity is the bridge to the old model: a
 material with flat ``μ′`` and ``μ″ = μ′/Q`` reproduces scalar ``qlmag``
 exactly, which is asserted by a test.
 
-## Where the numbers come from, and what they are not
+## Where the numbers come from
 
-The catalog below does **not** ship digitized vendor curves — neither ours to
-redistribute nor honest to present as measurements we made. Each mix is a
-**single-pole (Debye) relaxation fit**
+Fair-Rite publishes each material's **measured** complex permeability as a CSV,
+for exactly this purpose. :func:`fetch_material` downloads one on first use and
+caches it under ``~/.antennaknobs/ferrite``; nothing vendor-supplied is
+redistributed with this package, and after the first call everything is
+offline. :meth:`FerriteMaterial.from_table` takes your own data — measured
+cores beat vendor nominals, since the vendor never wound *your* toroid.
 
-    μ(f) = μ_i / (1 + j·f/f_r)   ⇒   μ′ = μ_i/(1+x²),  μ″ = μ_i·x/(1+x²)
+An earlier version of this module shipped one-pole (Debye) fits from
+remembered headline specs instead, and it is worth recording why that was
+abandoned rather than corrected. Checked against the published files, the
+assumed relaxation frequencies were wrong by up to **8×** (mix 43's μ″ peaks at
+4.4 MHz, not the 35 assumed). Worse, refitting does not save the idea: against
+the real curves over 0.1–100 MHz, the best one-pole fit is 30–60% out, and the
+best *two*-pole fit still misses by 22–60% for every mix except 31. These NiZn
+ferrites have a distribution of relaxation times, so no small parametric
+catalog can be honest about their loss — the table is the data.
 
-parameterized by an initial permeability ``μ_i`` and a relaxation frequency
-``f_r`` where ``μ″`` peaks. The *shape* is the one every ferrite datasheet
-shows — μ′ rolling off, μ″ peaking at ``f_r`` at half of μ_i, loss falling away
-either side.
-
-**The catalog's per-mix numbers are UNVERIFIED.** They were chosen from
-recollection of the usual headline specs, not read off a datasheet and not
-fitted to a measurement. Use them to compare mixes, turns counts and bands —
-the ordering and the shape are right — and do **not** quote an absolute loss
-figure from them. Every entry's ``source`` says so and a test enforces it.
-
-Even with good parameters it is **not** the datasheet curve: near the
-relaxation knee a real mix departs from a single pole, and mixes with more than
-one loss mechanism (31 in particular) are two-pole animals.
-
-Two ways to do better, both supported today. If you have the real ``μ′``/``μ″``
-table, :meth:`FerriteMaterial.from_table` takes it. If you have a VNA, sweep a
-known choke and fit ``μ_i``/``f_r``/``c_stray`` to it — that makes the
-provenance a measurement you can reproduce, which beats a datasheet read
-because it is *your* core rather than a vendor nominal.
-
-Treat catalog values as representative, in exactly the same spirit as the
-``CABLES`` matched-loss coefficients.
+:meth:`FerriteMaterial.debye` remains, clearly as a *synthetic* material: handy
+for tests and for reasoning about an idealized single relaxation, not a stand-in
+for a real mix.
 """
 
 from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+from pathlib import Path
 
 import numpy as np
 
 __all__ = [
     "CORES",
-    "MATERIALS",
+    "MATERIAL_URLS",
     "FerriteCore",
     "FerriteMaterial",
+    "cache_dir",
+    "core",
     "core_from_catalog",
-    "material_from_catalog",
+    "fetch_material",
+    "parse_permeability_csv",
 ]
 
 MU0 = 4.0e-7 * math.pi  # H/m
@@ -202,50 +197,112 @@ class FerriteCore:
         return z
 
 
-# --- catalogs --------------------------------------------------------------
-# Mixes as single-pole fits. Each is parameterized by an initial permeability
-# and a relaxation frequency, and BOTH NUMBERS ARE UNVERIFIED: they were chosen
-# from recollection of the usual headline specs and have not been checked
-# against a datasheet or a measurement. They give the right shape and the right
-# ordering between mixes — which is what "compare 31 against 43 on 20 m" needs
-# — and they are NOT a basis for an absolute watts figure.
+# --- vendor data -----------------------------------------------------------
+# Fair-Rite publishes measured complex permeability per material as a CSV, for
+# exactly this purpose. Those files are NOT redistributed here — they are
+# fetched on first use and cached locally, so the package ships no vendor data
+# while the user still gets the vendor's own measurements rather than someone's
+# approximation of them.
 #
-# The fix is issue #599's follow-up: sweep a known choke per mix and fit
-# (mu_i, f_relax, c_stray) to it, which makes the provenance a measurement you
-# can reproduce rather than a number someone remembered. Until then every entry
-# says UNVERIFIED, and a test enforces that it does.
-MATERIALS = {
-    "31": FerriteMaterial.debye(
-        "31",
-        1500.0,
-        8.0,
-        source="UNVERIFIED one-pole fit (μi≈1500, μ″ peak ≈8 MHz) — not checked against a datasheet; calibrate before trusting absolute loss",
-    ),
-    "43": FerriteMaterial.debye(
-        "43",
-        800.0,
-        35.0,
-        source="UNVERIFIED one-pole fit (μi≈800, μ″ peak ≈35 MHz) — not checked against a datasheet; calibrate before trusting absolute loss",
-    ),
-    "52": FerriteMaterial.debye(
-        "52",
-        250.0,
-        60.0,
-        source="UNVERIFIED one-pole fit (μi≈250, μ″ peak ≈60 MHz) — not checked against a datasheet; calibrate before trusting absolute loss",
-    ),
-    "61": FerriteMaterial.debye(
-        "61",
-        125.0,
-        180.0,
-        source="UNVERIFIED one-pole fit (μi≈125, μ″ peak ≈180 MHz) — not checked against a datasheet; calibrate before trusting absolute loss",
-    ),
-    "77": FerriteMaterial.debye(
-        "77",
-        2000.0,
-        3.0,
-        source="UNVERIFIED one-pole fit (μi≈2000, μ″ peak ≈3 MHz) — not checked against a datasheet; calibrate before trusting absolute loss",
-    ),
+# An earlier version of this module shipped one-pole Debye fits instead. They
+# were wrong: measured against these files, the assumed relaxation frequencies
+# were off by up to 8x (mix 43 peaks at 4.4 MHz, not 35), and even a
+# best-fit 2-pole model lands 22-60% out over 0.1-100 MHz for every mix except
+# 31. A distribution of relaxation times is what these NiZn ferrites actually
+# have, so no small parametric catalog can be honest here — the table is the
+# data.
+MATERIAL_URLS = {
+    "31": "https://www.fair-rite.com/wp-content/uploads/2015/03/31-Material-Fair-Rite.csv",
+    "43": "https://www.fair-rite.com/wp-content/uploads/2020/11/43-Material-publish.csv",
+    "52": "https://www.fair-rite.com/wp-content/uploads/2015/04/52-Material-Fair-Rite.csv",
+    "61": "https://www.fair-rite.com/wp-content/uploads/2021/11/61-Material-Fair-Rite.csv",
+    "77": "https://www.fair-rite.com/wp-content/uploads/2015/04/77-Material-Fair-Rite.csv",
 }
+
+
+def cache_dir():
+    """Where fetched material files live (``~/.antennaknobs/ferrite``)."""
+    import os
+
+    root = os.environ.get("ANTENNAKNOBS_USER_DIR")
+    base = Path(root) if root else Path.home() / ".antennaknobs"
+    return base / "ferrite"
+
+
+def parse_permeability_csv(text: str, name: str = "", source: str = ""):
+    """Parse a vendor complex-permeability CSV into a `FerriteMaterial`.
+
+    Deliberately forgiving, because these files are hand-maintained: title
+    rows, blank lines, an "Equipment Used:" note, a mis-encoded ``µ`` in the
+    header, and Hz frequencies all appear across the five Fair-Rite files.
+    Any line whose first three comma-separated fields parse as numbers is a
+    data row; everything else is ignored.
+    """
+    freqs, mp, md = [], [], []
+    for line in text.replace("\r", "\n").split("\n"):
+        parts = [c.strip() for c in line.split(",")]
+        if len(parts) < 3:
+            continue
+        try:
+            f, a, b = float(parts[0]), float(parts[1]), float(parts[2])
+        except ValueError:
+            continue
+        if f > 0 and a > 0:
+            freqs.append(f / 1e6)  # the files are in Hz; we work in MHz
+            mp.append(a)
+            md.append(max(b, 0.0))
+    if len(freqs) < 2:
+        raise ValueError(
+            f"{name or 'material'}: no usable rows in the permeability data "
+            "(expected 'frequency,mu-prime,mu-double' lines)"
+        )
+    return FerriteMaterial.from_table(name, freqs, mp, md, source=source)
+
+
+def fetch_material(mix: str, *, refresh: bool = False) -> FerriteMaterial:
+    """The vendor's measured permeability for ``mix``, fetched once and cached.
+
+    Downloads to :func:`cache_dir` on first use and reads the cache thereafter,
+    so this is a one-time network call and everything afterwards is offline.
+    ``refresh=True`` re-downloads.
+
+    No network and no cache is a clear error naming the URL, because copying
+    that file into the cache directory by hand is a perfectly good substitute
+    and the message should say so.
+    """
+    if mix not in MATERIAL_URLS:
+        raise KeyError(
+            f"no published data URL for mix {mix!r}; known: "
+            f"{', '.join(sorted(MATERIAL_URLS))}. Use "
+            "FerriteMaterial.from_table() for a material you have data for."
+        )
+    url = MATERIAL_URLS[mix]
+    path = cache_dir() / f"{mix}.csv"
+    if refresh or not path.exists():
+        try:
+            from urllib.request import Request, urlopen
+
+            req = Request(url, headers={"User-Agent": "antennaknobs"})
+            with urlopen(req, timeout=30) as fh:  # noqa: S310 — fixed https URL
+                data = fh.read()
+        except Exception as e:
+            if path.exists():
+                pass  # a stale cache beats no material
+            else:
+                raise RuntimeError(
+                    f"could not fetch the permeability data for mix {mix}: {e}\n"
+                    f"Download {url} to {path} and re-run — the file is only "
+                    "read locally after the first fetch."
+                ) from e
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(data)
+    return parse_permeability_csv(
+        path.read_text(encoding="latin-1"),
+        name=mix,
+        source=f"measured complex permeability, {url}",
+    )
+
 
 # Toroid geometry in metres/m², from published nominal dimensions. Ae and le
 # are the effective values manufacturers quote for the size, not derived from
@@ -260,13 +317,27 @@ CORES = {
 }
 
 
-def material_from_catalog(name: str) -> FerriteMaterial:
-    """The `MATERIALS` entry for a mix, with `TL.from_cable`'s ergonomics."""
-    if name not in MATERIALS:
+def core(size: str, material: FerriteMaterial, turns: float, c_stray_pF: float = 0.0):
+    """A wound core from a catalog SIZE and a material you already hold.
+
+    The offline half of :func:`core_from_catalog`: pass a material from
+    :func:`fetch_material`, :meth:`FerriteMaterial.from_table` (your own
+    measurements), or :meth:`FerriteMaterial.debye` (a synthetic one).
+    """
+    if size not in CORES:
         raise KeyError(
-            f"unknown ferrite mix {name!r}; available: {', '.join(sorted(MATERIALS))}"
+            f"unknown core size {size!r}; available: {', '.join(sorted(CORES))}"
         )
-    return MATERIALS[name]
+    if turns <= 0:
+        raise ValueError(f"turns must be positive; got {turns}")
+    ae, le = CORES[size]
+    return FerriteCore(
+        material=material,
+        turns=float(turns),
+        ae=ae,
+        le=le,
+        c_stray=c_stray_pF * 1e-12,
+    )
 
 
 def core_from_catalog(
@@ -274,20 +345,9 @@ def core_from_catalog(
 ) -> FerriteCore:
     """``core_from_catalog("FT-240", "43", 11)`` — the ham spelling of a core.
 
-    ``c_stray_pF`` is the winding's self-capacitance; give it a couple of pF to
-    reproduce the impedance peak a real choke shows (see `FerriteCore`).
+    Fetches the mix's published permeability on first use (see
+    :func:`fetch_material`), so the first call needs network and later ones do
+    not. ``c_stray_pF`` is the winding's self-capacitance; give it a couple of
+    pF to reproduce the impedance peak a real choke shows.
     """
-    if size not in CORES:
-        raise KeyError(
-            f"unknown core size {size!r}; available: {', '.join(sorted(CORES))}"
-        )
-    ae, le = CORES[size]
-    if turns <= 0:
-        raise ValueError(f"turns must be positive; got {turns}")
-    return FerriteCore(
-        material=material_from_catalog(mix),
-        turns=float(turns),
-        ae=ae,
-        le=le,
-        c_stray=c_stray_pF * 1e-12,
-    )
+    return core(size, fetch_material(mix), turns, c_stray_pF)

--- a/src/antennaknobs/ferrite.py
+++ b/src/antennaknobs/ferrite.py
@@ -1,0 +1,261 @@
+"""Ferrite cores by material and geometry (issue #599).
+
+`Transformer` and `FloatingBalun` model core loss with one number: a
+frequency-independent Q on the magnetizing branch (`qlmag`). Real ferrite has a
+strongly frequency-dependent **complex permeability** ``μ = μ′ − jμ″``, and
+that frequency dependence is the whole story of a choke: a 43-mix balun burns
+its watts in one part of the spectrum and is nearly lossless elsewhere. A flat
+Q cannot express "loses most here, little there", which is precisely the
+question someone modelling a choke is asking.
+
+The magnetizing impedance of ``turns`` turns on a core of effective
+cross-section ``ae`` and magnetic path length ``le`` is
+
+    Z_mag(f) = jω · N²·μ₀·A_e/l_e · (μ′(f) − j·μ″(f))
+             = ω·k·μ″(f)  +  jω·k·μ′(f)          [k = N²μ₀A_e/l_e]
+
+— so ``μ′`` sets the inductance and ``μ″`` sets the loss, and the effective Q
+is just ``μ′/μ″``. That last identity is the bridge to the old model: a
+material with flat ``μ′`` and ``μ″ = μ′/Q`` reproduces scalar ``qlmag``
+exactly, which is asserted by a test.
+
+## Where the numbers come from, and what they are not
+
+The catalog below does **not** ship digitized vendor curves — neither ours to
+redistribute nor honest to present as measurements we made. Each mix is a
+**single-pole (Debye) relaxation fit**
+
+    μ(f) = μ_i / (1 + j·f/f_r)   ⇒   μ′ = μ_i/(1+x²),  μ″ = μ_i·x/(1+x²)
+
+built from two widely published headline specs: the initial permeability
+``μ_i`` and the relaxation frequency ``f_r`` where ``μ″`` peaks. It reproduces
+the *shape* every ferrite datasheet shows — μ′ rolling off, μ″ peaking at
+``f_r`` at half of μ_i, loss falling away either side — and it is right to
+within the spread between vendors' own constructions, which is itself large.
+
+It is **not** the datasheet curve. Near the relaxation knee a real mix departs
+from a single pole, and mixes with more than one loss mechanism (31 in
+particular) are two-pole animals. If you have the real ``μ′``/``μ″`` table,
+:meth:`FerriteMaterial.from_table` takes it and is strictly better data.
+
+Treat catalog values as representative, in exactly the same spirit as the
+``CABLES`` matched-loss coefficients.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+
+__all__ = [
+    "CORES",
+    "MATERIALS",
+    "FerriteCore",
+    "FerriteMaterial",
+    "core_from_catalog",
+    "material_from_catalog",
+]
+
+MU0 = 4.0e-7 * math.pi  # H/m
+
+
+@dataclass(frozen=True, eq=False)
+class FerriteMaterial:
+    """Complex permeability ``μ′ − jμ″`` versus frequency for one ferrite mix.
+
+    ``freqs`` is MHz ascending; ``mu_prime`` and ``mu_double`` are the real and
+    (positive) imaginary parts. ``source`` records where the numbers came from
+    — every catalog entry says so, because "which curve is this?" is the first
+    question anyone comparing against a measurement will ask.
+    """
+
+    name: str
+    freqs: np.ndarray
+    mu_prime: np.ndarray
+    mu_double: np.ndarray
+    source: str = ""
+
+    @classmethod
+    def from_table(cls, name, freqs_mhz, mu_prime, mu_double, *, source=""):
+        """Build from a real ``μ′``/``μ″`` table (your data beats our fit)."""
+        f = np.asarray(freqs_mhz, dtype=float)
+        mp = np.asarray(mu_prime, dtype=float)
+        md = np.asarray(mu_double, dtype=float)
+        if not (f.shape == mp.shape == md.shape) or f.ndim != 1 or f.size < 2:
+            raise ValueError(
+                "freqs, mu_prime and mu_double must be 1-D and equal length"
+            )
+        if np.any(np.diff(f) <= 0):
+            order = np.argsort(f)
+            f, mp, md = f[order], mp[order], md[order]
+        if np.any(mp <= 0) or np.any(md < 0):
+            raise ValueError("μ′ must be positive and μ″ non-negative")
+        return cls(name=name, freqs=f, mu_prime=mp, mu_double=md, source=source)
+
+    @classmethod
+    def debye(cls, name, mu_i, f_relax_mhz, *, source="", decades=(-2.0, 3.0), n=241):
+        """Single-pole relaxation fit — see the module docstring for its limits.
+
+        ``mu_i`` is the initial permeability, ``f_relax_mhz`` the frequency
+        where ``μ″`` peaks (at ``mu_i/2``). Sampled over five decades so the
+        table interpolates smoothly across anything HF/VHF.
+        """
+        f = np.logspace(
+            math.log10(f_relax_mhz) + decades[0],
+            math.log10(f_relax_mhz) + decades[1],
+            n,
+        )
+        x = f / f_relax_mhz
+        denom = 1.0 + x * x
+        return cls(
+            name=name,
+            freqs=f,
+            mu_prime=mu_i / denom,
+            mu_double=mu_i * x / denom,
+            source=source,
+        )
+
+    def at(self, f_mhz: float) -> complex:
+        """``μ′ − jμ″`` at ``f_mhz``, interpolated in log-frequency.
+
+        Log-f because permeability curves are published on log axes and vary
+        over decades; interpolating linearly in f would badly undercut μ″
+        between sparse low-frequency points.
+
+        Outside the tabulated span this raises rather than extrapolating. A
+        loss curve invented past its data is most wrong exactly where the user
+        is most likely to be mistaken about the material.
+        """
+        f0, f1 = float(self.freqs[0]), float(self.freqs[-1])
+        if not f0 * (1 - 1e-9) <= f_mhz <= f1 * (1 + 1e-9):
+            raise ValueError(
+                f"{self.name}: {f_mhz:.6g} MHz is outside the material data "
+                f"[{f0:.4g}, {f1:.4g}] MHz — permeability is not extrapolated"
+            )
+        lf = np.log10(np.maximum(self.freqs, 1e-30))
+        x = math.log10(max(f_mhz, 1e-30))
+        mp = float(np.interp(x, lf, self.mu_prime))
+        md = float(np.interp(x, lf, self.mu_double))
+        return complex(mp, -md)
+
+    def q_at(self, f_mhz: float) -> float:
+        """Effective magnetizing Q, ``μ′/μ″`` — the scalar this replaces."""
+        mu = self.at(f_mhz)
+        return float("inf") if -mu.imag == 0.0 else mu.real / -mu.imag
+
+
+@dataclass(frozen=True, eq=False)
+class FerriteCore:
+    """A wound core: a material, a size, and a turns count.
+
+    ``ae`` (effective cross-section, m²) and ``le`` (effective magnetic path
+    length, m) are the core's geometry; ``turns`` is what the builder wound.
+    Use :func:`core_from_catalog` for the common sizes.
+    """
+
+    material: FerriteMaterial
+    turns: float
+    ae: float
+    le: float
+    #: Winding self-capacitance in farads, in parallel with the magnetizing
+    #: branch. Small (a few pF) and easy to dismiss, but it is what makes a
+    #: real choke's |Z| PEAK and then fall instead of climbing forever: the
+    #: winding parallel-resonates with it. Without it a single-relaxation
+    #: material gives a monotonically saturating |Z| — and, across an ideal
+    #: voltage source, an exactly frequency-flat conductance (the μ″ growth and
+    #: the |μ|² growth cancel), which is a property of the one-pole model, not
+    #: of ferrite. Default 0 leaves the pure magnetizing branch.
+    c_stray: float = 0.0
+
+    @property
+    def al_factor(self) -> float:
+        """``N²·μ₀·A_e/l_e`` — the geometry constant, henries per unit μ."""
+        return self.turns**2 * MU0 * self.ae / self.le
+
+    def inductance(self, f_mhz: float) -> float:
+        """Magnetizing inductance (H) at ``f_mhz``, from ``μ′``."""
+        return self.al_factor * self.material.at(f_mhz).real
+
+    def impedance(self, f_mhz: float) -> complex:
+        """Magnetizing impedance ``jω·k·(μ′ − jμ″)`` — the branch the reducer
+        stamps. Its real part *is* the core loss, and it peaks near the
+        material's relaxation frequency rather than tracking ω forever.
+        """
+        omega = 2.0 * math.pi * f_mhz * 1e6
+        mu = self.material.at(f_mhz)
+        z = 1j * omega * self.al_factor * mu
+        if self.c_stray:
+            y = 1.0 / z + 1j * omega * self.c_stray
+            return 1.0 / y
+        return z
+
+
+# --- catalogs --------------------------------------------------------------
+# Mixes as single-pole fits to published headline specs (initial permeability
+# and the relaxation frequency where μ″ peaks). NOT digitized vendor curves —
+# see the module docstring. Values rounded, and representative of a family of
+# constructions rather than of any one vendor's part.
+MATERIALS = {
+    "31": FerriteMaterial.debye(
+        "31", 1500.0, 8.0, source="one-pole fit to published μi≈1500, μ″ peak ≈8 MHz"
+    ),
+    "43": FerriteMaterial.debye(
+        "43", 800.0, 35.0, source="one-pole fit to published μi≈800, μ″ peak ≈35 MHz"
+    ),
+    "52": FerriteMaterial.debye(
+        "52", 250.0, 60.0, source="one-pole fit to published μi≈250, μ″ peak ≈60 MHz"
+    ),
+    "61": FerriteMaterial.debye(
+        "61", 125.0, 180.0, source="one-pole fit to published μi≈125, μ″ peak ≈180 MHz"
+    ),
+    "77": FerriteMaterial.debye(
+        "77", 2000.0, 3.0, source="one-pole fit to published μi≈2000, μ″ peak ≈3 MHz"
+    ),
+}
+
+# Toroid geometry in metres/m², from published nominal dimensions. Ae and le
+# are the effective values manufacturers quote for the size, not derived from
+# the OD/ID/height, so a core wound to the same turns count matches the
+# vendor's own A_L within its tolerance.
+CORES = {
+    "FT-240": (3.79e-4, 0.1424),
+    "FT-140": (1.44e-4, 0.0891),
+    "FT-114": (0.749e-4, 0.0718),
+    "FT-82": (0.246e-4, 0.0521),
+    "FT-50": (0.133e-4, 0.0318),
+}
+
+
+def material_from_catalog(name: str) -> FerriteMaterial:
+    """The `MATERIALS` entry for a mix, with `TL.from_cable`'s ergonomics."""
+    if name not in MATERIALS:
+        raise KeyError(
+            f"unknown ferrite mix {name!r}; available: {', '.join(sorted(MATERIALS))}"
+        )
+    return MATERIALS[name]
+
+
+def core_from_catalog(
+    size: str, mix: str, turns: float, c_stray_pF: float = 0.0
+) -> FerriteCore:
+    """``core_from_catalog("FT-240", "43", 11)`` — the ham spelling of a core.
+
+    ``c_stray_pF`` is the winding's self-capacitance; give it a couple of pF to
+    reproduce the impedance peak a real choke shows (see `FerriteCore`).
+    """
+    if size not in CORES:
+        raise KeyError(
+            f"unknown core size {size!r}; available: {', '.join(sorted(CORES))}"
+        )
+    ae, le = CORES[size]
+    if turns <= 0:
+        raise ValueError(f"turns must be positive; got {turns}")
+    return FerriteCore(
+        material=material_from_catalog(mix),
+        turns=float(turns),
+        ae=ae,
+        le=le,
+        c_stray=c_stray_pF * 1e-12,
+    )

--- a/src/antennaknobs/ferrite.py
+++ b/src/antennaknobs/ferrite.py
@@ -27,16 +27,26 @@ redistribute nor honest to present as measurements we made. Each mix is a
 
     μ(f) = μ_i / (1 + j·f/f_r)   ⇒   μ′ = μ_i/(1+x²),  μ″ = μ_i·x/(1+x²)
 
-built from two widely published headline specs: the initial permeability
-``μ_i`` and the relaxation frequency ``f_r`` where ``μ″`` peaks. It reproduces
-the *shape* every ferrite datasheet shows — μ′ rolling off, μ″ peaking at
-``f_r`` at half of μ_i, loss falling away either side — and it is right to
-within the spread between vendors' own constructions, which is itself large.
+parameterized by an initial permeability ``μ_i`` and a relaxation frequency
+``f_r`` where ``μ″`` peaks. The *shape* is the one every ferrite datasheet
+shows — μ′ rolling off, μ″ peaking at ``f_r`` at half of μ_i, loss falling away
+either side.
 
-It is **not** the datasheet curve. Near the relaxation knee a real mix departs
-from a single pole, and mixes with more than one loss mechanism (31 in
-particular) are two-pole animals. If you have the real ``μ′``/``μ″`` table,
-:meth:`FerriteMaterial.from_table` takes it and is strictly better data.
+**The catalog's per-mix numbers are UNVERIFIED.** They were chosen from
+recollection of the usual headline specs, not read off a datasheet and not
+fitted to a measurement. Use them to compare mixes, turns counts and bands —
+the ordering and the shape are right — and do **not** quote an absolute loss
+figure from them. Every entry's ``source`` says so and a test enforces it.
+
+Even with good parameters it is **not** the datasheet curve: near the
+relaxation knee a real mix departs from a single pole, and mixes with more than
+one loss mechanism (31 in particular) are two-pole animals.
+
+Two ways to do better, both supported today. If you have the real ``μ′``/``μ″``
+table, :meth:`FerriteMaterial.from_table` takes it. If you have a VNA, sweep a
+known choke and fit ``μ_i``/``f_r``/``c_stray`` to it — that makes the
+provenance a measurement you can reproduce, which beats a datasheet read
+because it is *your* core rather than a vendor nominal.
 
 Treat catalog values as representative, in exactly the same spirit as the
 ``CABLES`` matched-loss coefficients.
@@ -193,25 +203,47 @@ class FerriteCore:
 
 
 # --- catalogs --------------------------------------------------------------
-# Mixes as single-pole fits to published headline specs (initial permeability
-# and the relaxation frequency where μ″ peaks). NOT digitized vendor curves —
-# see the module docstring. Values rounded, and representative of a family of
-# constructions rather than of any one vendor's part.
+# Mixes as single-pole fits. Each is parameterized by an initial permeability
+# and a relaxation frequency, and BOTH NUMBERS ARE UNVERIFIED: they were chosen
+# from recollection of the usual headline specs and have not been checked
+# against a datasheet or a measurement. They give the right shape and the right
+# ordering between mixes — which is what "compare 31 against 43 on 20 m" needs
+# — and they are NOT a basis for an absolute watts figure.
+#
+# The fix is issue #599's follow-up: sweep a known choke per mix and fit
+# (mu_i, f_relax, c_stray) to it, which makes the provenance a measurement you
+# can reproduce rather than a number someone remembered. Until then every entry
+# says UNVERIFIED, and a test enforces that it does.
 MATERIALS = {
     "31": FerriteMaterial.debye(
-        "31", 1500.0, 8.0, source="one-pole fit to published μi≈1500, μ″ peak ≈8 MHz"
+        "31",
+        1500.0,
+        8.0,
+        source="UNVERIFIED one-pole fit (μi≈1500, μ″ peak ≈8 MHz) — not checked against a datasheet; calibrate before trusting absolute loss",
     ),
     "43": FerriteMaterial.debye(
-        "43", 800.0, 35.0, source="one-pole fit to published μi≈800, μ″ peak ≈35 MHz"
+        "43",
+        800.0,
+        35.0,
+        source="UNVERIFIED one-pole fit (μi≈800, μ″ peak ≈35 MHz) — not checked against a datasheet; calibrate before trusting absolute loss",
     ),
     "52": FerriteMaterial.debye(
-        "52", 250.0, 60.0, source="one-pole fit to published μi≈250, μ″ peak ≈60 MHz"
+        "52",
+        250.0,
+        60.0,
+        source="UNVERIFIED one-pole fit (μi≈250, μ″ peak ≈60 MHz) — not checked against a datasheet; calibrate before trusting absolute loss",
     ),
     "61": FerriteMaterial.debye(
-        "61", 125.0, 180.0, source="one-pole fit to published μi≈125, μ″ peak ≈180 MHz"
+        "61",
+        125.0,
+        180.0,
+        source="UNVERIFIED one-pole fit (μi≈125, μ″ peak ≈180 MHz) — not checked against a datasheet; calibrate before trusting absolute loss",
     ),
     "77": FerriteMaterial.debye(
-        "77", 2000.0, 3.0, source="one-pole fit to published μi≈2000, μ″ peak ≈3 MHz"
+        "77",
+        2000.0,
+        3.0,
+        source="UNVERIFIED one-pole fit (μi≈2000, μ″ peak ≈3 MHz) — not checked against a datasheet; calibrate before trusting absolute loss",
     ),
 }
 

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -503,6 +503,13 @@ class Transformer:
     r: float | None = None
     lmag: float | None = None
     qlmag: float | None = None
+    #: A `ferrite.FerriteCore` (issue #599). When set it SUPERSEDES
+    #: ``lmag``/``qlmag`` wholesale — it is the core, not a default, exactly as
+    #: ``TL.from_cable``'s cable is the cable. The magnetizing branch then
+    #: follows the mix's complex permeability at each frequency: μ′ sets the
+    #: inductance, μ″ the loss, and the effective Q (μ′/μ″) moves with
+    #: frequency the way a real choke's does.
+    core: object | None = None
 
 
 @dataclass(frozen=True)
@@ -986,6 +993,8 @@ class FloatingBalun:
     r: float | None = None
     lmag: float | None = None
     qlmag: float | None = None
+    #: See `Transformer.core` — same supersede-wholesale semantics (issue #599).
+    core: object | None = None
 
 
 Branch = Union[

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -251,6 +251,29 @@ class _Group2Element:
     c_vc: complex = 0j
 
 
+def magnetizing_impedance(br, omega):
+    """Magnetizing-branch impedance of a `Transformer` / `FloatingBalun`.
+
+    ``core`` (a `ferrite.FerriteCore`, issue #599) supersedes ``lmag``/``qlmag``
+    wholesale — it IS the core, the way ``TL.from_cable``'s cable is the cable —
+    and the branch then follows the material's complex permeability at this
+    frequency: μ′ gives the inductance, μ″ the loss. Falling back to
+    ``lmag``/``qlmag`` keeps the scalar model available and unchanged, and the
+    two agree exactly when the material is flat with μ″ = μ′/Q.
+
+    Returns ``None`` when the element declares no magnetizing branch at all.
+    """
+    core = getattr(br, "core", None)
+    if core is not None:
+        return core.impedance(omega / (2.0 * np.pi) / 1e6)
+    if br.lmag is None:
+        return None
+    z = 1j * omega * br.lmag
+    if br.qlmag is not None:
+        z += omega * br.lmag / br.qlmag
+    return z
+
+
 def _series_group2(a, b, r, l, c, omega, emf=0j, ql=None, qc=None):
     """Group-2 stamp of a series R + jωL + 1/(jωC) (+ optional EMF) between
     nodes a and b. A 0 F capacitor is an open in the series path (infinite
@@ -824,10 +847,8 @@ class NetworkReducer:
                         c_vb=-nr,
                     )
                 )
-                if br.lmag is not None:
-                    zl = 1j * omega * br.lmag
-                    if br.qlmag is not None:
-                        zl += omega * br.lmag / br.qlmag
+                zl = magnetizing_impedance(br, omega)
+                if zl is not None:
                     y_mag = 1.0 / zl
                     G[a, a] += y_mag
                     probes.append(
@@ -922,10 +943,8 @@ class NetworkReducer:
                         c_vc=-nr,
                     )
                 )
-                if br.lmag is not None:
-                    zl = 1j * omega * br.lmag
-                    if br.qlmag is not None:
-                        zl += omega * br.lmag / br.qlmag
+                zl = magnetizing_impedance(br, omega)
+                if zl is not None:
                     y_mag = 1.0 / zl
                     G[p, p] += y_mag
                     probes.append(

--- a/src/antennaknobs/station.py
+++ b/src/antennaknobs/station.py
@@ -94,17 +94,27 @@ def unun(
     lmag_uH: float | None = None,
     qlmag: float | None = None,
     comp_c_pF: float | None = None,
+    core=None,
 ) -> Composite:
     """Step-down unun (the EFHW / OCF box): an ideal ``turns``:1
     transformer — the ``line`` side sees Z_ant/turns² — with the minimal
     loss model of `Transformer` (magnetizing inductance ``lmag_uH`` shunted
     across the line side, finite-Q core loss ``qlmag``), plus the optional
     compensation capacitor ``comp_c_pF`` across the line-side terminals
-    that commercial 49:1 builds carry. Formals: ``line`` (rig/feedline
-    side), ``ant`` (high-Z antenna side)."""
+    that commercial 49:1 builds carry.
+
+    ``core`` (a `ferrite.FerriteCore`, issue #599) replaces the scalar
+    ``lmag_uH``/``qlmag`` pair with the mix's actual complex permeability, so
+    the magnetizing inductance AND the core loss both follow frequency:
+
+        unun(49 ** 0.5, core=core_from_catalog("FT-240", "43", 11))
+
+    Formals: ``line`` (rig/feedline side), ``ant`` (high-Z antenna side)."""
     lmag = lmag_uH * 1e-6 if lmag_uH is not None else None
     branches: tuple = (
-        Transformer(a="line", b="ant", n=1.0 / turns, lmag=lmag, qlmag=qlmag),
+        Transformer(
+            a="line", b="ant", n=1.0 / turns, lmag=lmag, qlmag=qlmag, core=core
+        ),
     )
     if comp_c_pF:
         branches += (Shunt(port="line", c=comp_c_pF * 1e-12),)
@@ -112,17 +122,23 @@ def unun(
 
 
 def balun(
-    n: float, lmag_uH: float | None = None, qlmag: float | None = None
+    n: float,
+    lmag_uH: float | None = None,
+    qlmag: float | None = None,
+    core=None,
 ) -> Composite:
     """Balun as an ideal ``a:b`` ratio transformer with the minimal loss
     model (magnetizing branch on the ``line`` side): ``n`` is the
     line:antenna voltage ratio, so a 4:1 impedance balun stepping a
     ~300 Ω feed down to ~75 Ω line is ``balun(n=0.5)`` — same convention
-    as `Transformer` itself. Formals: ``line``, ``ant``."""
+    as `Transformer` itself. ``core`` takes a `ferrite.FerriteCore` in place of
+    the scalar loss pair (issue #599). Formals: ``line``, ``ant``."""
     lmag = lmag_uH * 1e-6 if lmag_uH is not None else None
     return Composite(
         ports=("line", "ant"),
-        branches=(Transformer(a="line", b="ant", n=n, lmag=lmag, qlmag=qlmag),),
+        branches=(
+            Transformer(a="line", b="ant", n=n, lmag=lmag, qlmag=qlmag, core=core),
+        ),
     )
 
 

--- a/src/antennaknobs/station.py
+++ b/src/antennaknobs/station.py
@@ -109,6 +109,9 @@ def unun(
 
         unun(49 ** 0.5, core=core_from_catalog("FT-240", "43", 11))
 
+    (that call fetches the mix's published permeability once and caches it —
+    the package ships no vendor data.)
+
     Formals: ``line`` (rig/feedline side), ``ant`` (high-Z antenna side)."""
     lmag = lmag_uH * 1e-6 if lmag_uH is not None else None
     branches: tuple = (

--- a/tests/test_ferrite.py
+++ b/tests/test_ferrite.py
@@ -1,0 +1,262 @@
+"""Ferrite cores from complex permeability (issue #599).
+
+`qlmag` is one number for a quantity that is emphatically not one number: a
+43-mix balun burns its watts in one part of the spectrum and is nearly
+lossless elsewhere. These tests cover the material model (μ′ sets the
+inductance, μ″ the loss), the bridge back to the scalar model, and the choke
+behaviour the frequency dependence exists to reproduce.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+from antennaknobs.ferrite import (
+    CORES,
+    MATERIALS,
+    FerriteCore,
+    FerriteMaterial,
+    core_from_catalog,
+    material_from_catalog,
+)
+from antennaknobs.network import Driven, Instance, Network, PortVirtual, Shunt
+from antennaknobs.network_reduce import NetworkReducer, magnetizing_impedance
+from antennaknobs.station import unun
+
+NO_ANTENNA = np.zeros((0, 0), dtype=complex)
+
+
+def flat_material(mu=100.0, q=20.0, name="flat"):
+    """A material with constant μ′ and μ″ = μ′/Q — i.e. a scalar Q, dressed up
+    as a table. The bridge between the two models."""
+    f = np.array([0.01, 1.0, 100.0, 1000.0])
+    return FerriteMaterial.from_table(
+        name, f, np.full(4, mu), np.full(4, mu / q), source="test"
+    )
+
+
+# ---------------------------------------------------------------------------
+# the material
+# ---------------------------------------------------------------------------
+def test_debye_has_the_shape_every_datasheet_shows():
+    m = FerriteMaterial.debye("t", 800.0, 10.0)
+    lo, at, hi = m.at(0.1), m.at(10.0), m.at(1000.0)
+
+    assert lo.real == pytest.approx(800.0, rel=1e-3)  # μ′ → μi well below f_r
+    assert at.real == pytest.approx(400.0, rel=1e-3)  # ...half of it at f_r
+    assert hi.real < 1.0  # ...and gone above
+    # μ″ peaks at f_r, at μi/2.
+    assert -at.imag == pytest.approx(400.0, rel=1e-3)
+    assert -lo.imag < -at.imag and -hi.imag < -at.imag
+
+
+def test_q_is_mu_prime_over_mu_double():
+    """The identity that makes this a generalisation of `qlmag` rather than a
+    replacement for it."""
+    m = FerriteMaterial.debye("t", 800.0, 10.0)
+    for f in (1.0, 5.0, 10.0, 50.0):
+        mu = m.at(f)
+        assert m.q_at(f) == pytest.approx(mu.real / -mu.imag, rel=1e-12)
+    # Q falls through 1 exactly at the relaxation frequency.
+    assert m.q_at(10.0) == pytest.approx(1.0, rel=1e-3)
+    assert m.q_at(1.0) > 5.0
+
+
+def test_permeability_is_not_extrapolated():
+    m = FerriteMaterial.debye("t", 800.0, 10.0)
+    lo, hi = m.freqs[0], m.freqs[-1]
+    with pytest.raises(ValueError, match="not extrapolated"):
+        m.at(lo * 0.5)
+    with pytest.raises(ValueError, match="outside the material data"):
+        m.at(hi * 2.0)
+    assert m.at(lo) and m.at(hi)  # the endpoints themselves are fine
+
+
+def test_interpolation_is_done_in_log_frequency():
+    """Permeability curves live on log axes; linear-in-f interpolation across a
+    decade would badly undercut μ″."""
+    m = FerriteMaterial.from_table("t", [1.0, 100.0], [100.0, 200.0], [10.0, 20.0])
+    mid = m.at(10.0)  # the geometric centre, not the arithmetic one
+    assert mid.real == pytest.approx(150.0, rel=1e-9)
+    assert -mid.imag == pytest.approx(15.0, rel=1e-9)
+
+
+def test_from_table_validates_and_sorts():
+    m = FerriteMaterial.from_table("t", [10.0, 1.0], [50.0, 100.0], [5.0, 10.0])
+    assert list(m.freqs) == [1.0, 10.0]
+    assert list(m.mu_prime) == [100.0, 50.0]
+    with pytest.raises(ValueError, match="equal length"):
+        FerriteMaterial.from_table("t", [1.0, 2.0], [1.0], [1.0, 2.0])
+    with pytest.raises(ValueError, match="μ′ must be positive"):
+        FerriteMaterial.from_table("t", [1.0, 2.0], [0.0, 1.0], [1.0, 2.0])
+
+
+# ---------------------------------------------------------------------------
+# the wound core
+# ---------------------------------------------------------------------------
+def test_inductance_comes_from_mu_prime_and_turns_squared():
+    a = core_from_catalog("FT-240", "43", 10)
+    b = core_from_catalog("FT-240", "43", 20)
+    assert b.inductance(1.0) == pytest.approx(4.0 * a.inductance(1.0), rel=1e-12)
+    # L = k·μ′ exactly, with k the geometry constant.
+    assert a.inductance(1.0) == pytest.approx(
+        a.al_factor * a.material.at(1.0).real, rel=1e-12
+    )
+
+
+def test_impedance_splits_into_mu_double_loss_and_mu_prime_reactance():
+    c = core_from_catalog("FT-240", "43", 11)
+    f = 7.0
+    z = c.impedance(f)
+    omega = 2 * math.pi * f * 1e6
+    mu = c.material.at(f)
+    assert z.real == pytest.approx(omega * c.al_factor * -mu.imag, rel=1e-12)
+    assert z.imag == pytest.approx(omega * c.al_factor * mu.real, rel=1e-12)
+    assert z.real > 0  # loss is dissipative, whatever the material
+
+
+def test_a_flat_material_reproduces_scalar_qlmag_exactly():
+    """The acceptance criterion, and the reason this is a generalisation: a
+    material with constant μ′ and μ″ = μ′/Q must give the same magnetizing
+    branch as the old two-scalar model."""
+    from antennaknobs.network import Transformer
+
+    core = FerriteCore(
+        material=flat_material(mu=100.0, q=20.0), turns=10, ae=1e-4, le=0.1
+    )
+    f = 14.0
+    omega = 2 * math.pi * f * 1e6
+    lmag = core.inductance(f)
+
+    scalar = Transformer(a="x", b="y", n=1.0, lmag=lmag, qlmag=20.0)
+    material = Transformer(a="x", b="y", n=1.0, core=core)
+    assert magnetizing_impedance(material, omega) == pytest.approx(
+        magnetizing_impedance(scalar, omega), rel=1e-12
+    )
+
+
+def test_a_real_choke_impedance_peaks_and_falls():
+    """The characteristic curve. A single relaxation alone climbs and
+    saturates; the winding's few pF resonate with it, which is what puts the
+    peak in every published choke plot — and why `c_stray` exists.
+    """
+    c = core_from_catalog("FT-240", "43", 11, c_stray_pF=3.0)
+    freqs = np.array([1.0, 2.0, 3.5, 7.0, 14.0, 28.0, 50.0])
+    mags = np.array([abs(c.impedance(f)) for f in freqs])
+    peak = int(np.argmax(mags))
+
+    assert 0 < peak < len(freqs) - 1, "the peak must be interior, not an endpoint"
+    assert mags[0] < mags[peak] > mags[-1]
+    # Above resonance the winding looks capacitive — the other half of the
+    # signature, and the reason a choke stops choking at VHF.
+    assert c.impedance(freqs[peak + 1]).imag < 0
+    assert c.impedance(1.0).imag > 0
+
+
+def test_without_stray_capacitance_the_one_pole_model_saturates():
+    """Stated as a limitation rather than hidden: this is why `c_stray` is part
+    of modelling a real choke and not an optional refinement."""
+    c = core_from_catalog("FT-240", "43", 11)
+    mags = [abs(c.impedance(f)) for f in (1.0, 3.5, 14.0, 50.0, 200.0)]
+    assert all(b >= a * 0.999 for a, b in zip(mags, mags[1:]))  # monotone
+
+
+def test_more_turns_is_more_impedance():
+    z10 = abs(core_from_catalog("FT-240", "43", 10).impedance(7.0))
+    z20 = abs(core_from_catalog("FT-240", "43", 20).impedance(7.0))
+    assert z20 == pytest.approx(4.0 * z10, rel=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# catalogs
+# ---------------------------------------------------------------------------
+def test_the_catalog_covers_the_common_mixes_and_sizes():
+    assert {"31", "43", "52", "61"} <= set(MATERIALS)
+    assert {"FT-240", "FT-140", "FT-82"} <= set(CORES)
+
+
+def test_every_catalog_material_says_where_it_came_from():
+    """These are one-pole fits, not vendor curves, and each entry has to say
+    so — it is the first question anyone comparing to a measurement asks."""
+    for name, m in MATERIALS.items():
+        assert m.source, name
+        assert "fit" in m.source
+
+
+def test_higher_permeability_mixes_relax_lower():
+    """The physical ordering (Snoek's limit): more μ, lower usable frequency."""
+    mu_i = {k: m.mu_prime[0] for k, m in MATERIALS.items()}
+    assert mu_i["31"] > mu_i["43"] > mu_i["61"]
+    # ...and their loss peaks run the other way.
+    peak = {k: m.freqs[int(np.argmax(m.mu_double))] for k, m in MATERIALS.items()}
+    assert peak["31"] < peak["43"] < peak["61"]
+
+
+def test_unknown_catalog_keys_name_the_alternatives():
+    with pytest.raises(KeyError, match="unknown ferrite mix"):
+        material_from_catalog("99")
+    with pytest.raises(KeyError, match="unknown core size"):
+        core_from_catalog("FT-999", "43", 10)
+    with pytest.raises(ValueError, match="turns must be positive"):
+        core_from_catalog("FT-240", "43", 0)
+
+
+# ---------------------------------------------------------------------------
+# in a circuit
+# ---------------------------------------------------------------------------
+def loss_fraction(f_mhz, **unun_kw):
+    """Core loss as a fraction of input power, for a 49:1 unun into 2450 Ω."""
+    net = Network(
+        ports={"line": PortVirtual("line"), "ant": PortVirtual("ant")},
+        branches=[
+            Instance("x", unun(7.0, **unun_kw), line="line", ant="ant"),
+            Shunt(port="ant", r=2450.0, parallel=True),
+        ],
+        sources=[Driven(port="line")],
+    )
+    red = NetworkReducer(net, {"line": 0, "ant": 1}, 2)
+    _v, _eff, p_in, rows = red.excited_state(NO_ANTENNA, 299_792_458.0 / (f_mhz * 1e6))
+    return sum(w for label, w in rows if "Transformer" in label) / p_in
+
+
+def test_a_core_dissipates_and_itemises_in_the_budget():
+    core = core_from_catalog("FT-240", "43", 11, c_stray_pF=3.0)
+    assert loss_fraction(7.0, core=core) > 0.0
+
+
+def test_the_core_supersedes_the_scalar_pair():
+    """`core` is the core, not a default — the same posture as
+    `TL.from_cable`'s cable."""
+    core = core_from_catalog("FT-240", "43", 11)
+    with_core = loss_fraction(7.0, core=core, lmag_uH=1.0, qlmag=1.0)
+    core_only = loss_fraction(7.0, core=core)
+    assert with_core == pytest.approx(core_only, rel=1e-12)
+
+
+def test_material_loss_has_a_frequency_shape_a_flat_q_cannot():
+    """The whole point of the issue. Across a decade the two models disagree
+    about the *shape* of the loss, not merely its size."""
+    core = core_from_catalog("FT-240", "43", 11, c_stray_pF=3.0)
+    freqs = [1.8, 3.5, 7.0, 14.0, 28.0]
+    material = np.array([loss_fraction(f, core=core) for f in freqs])
+    scalar = np.array([loss_fraction(f, lmag_uH=320.0, qlmag=20.0) for f in freqs])
+
+    # Normalise out the overall level: the claim is about shape.
+    material /= material.max()
+    scalar /= scalar.max()
+    assert np.max(np.abs(material - scalar)) > 0.25
+    # The scalar model can only ever fall monotonically here.
+    assert all(b <= a for a, b in zip(scalar, scalar[1:]))
+
+
+def test_a_lossless_material_burns_nothing():
+    core = FerriteCore(
+        material=FerriteMaterial.from_table(
+            "ideal", [0.1, 1000.0], [100.0, 100.0], [0.0, 0.0]
+        ),
+        turns=10,
+        ae=1e-4,
+        le=0.1,
+    )
+    assert loss_fraction(7.0, core=core) == pytest.approx(0.0, abs=1e-12)

--- a/tests/test_ferrite.py
+++ b/tests/test_ferrite.py
@@ -14,17 +14,28 @@ import pytest
 
 from antennaknobs.ferrite import (
     CORES,
-    MATERIALS,
+    MATERIAL_URLS,
     FerriteCore,
     FerriteMaterial,
-    core_from_catalog,
-    material_from_catalog,
+    cache_dir,
+    core,
+    fetch_material,
+    parse_permeability_csv,
 )
 from antennaknobs.network import Driven, Instance, Network, PortVirtual, Shunt
 from antennaknobs.network_reduce import NetworkReducer, magnetizing_impedance
 from antennaknobs.station import unun
 
 NO_ANTENNA = np.zeros((0, 0), dtype=complex)
+
+# A SYNTHETIC stand-in, so these tests never touch the network. Real materials
+# come from fetch_material(); the point of the tests below is the machinery,
+# not the mix.
+MIX = FerriteMaterial.debye("synthetic-43-ish", 800.0, 4.4, source="synthetic fit")
+
+
+def a_core(turns=11, c_stray_pF=0.0, size="FT-240"):
+    return core(size, MIX, turns, c_stray_pF)
 
 
 def flat_material(mu=100.0, q=20.0, name="flat"):
@@ -96,8 +107,8 @@ def test_from_table_validates_and_sorts():
 # the wound core
 # ---------------------------------------------------------------------------
 def test_inductance_comes_from_mu_prime_and_turns_squared():
-    a = core_from_catalog("FT-240", "43", 10)
-    b = core_from_catalog("FT-240", "43", 20)
+    a = a_core(10)
+    b = a_core(20)
     assert b.inductance(1.0) == pytest.approx(4.0 * a.inductance(1.0), rel=1e-12)
     # L = k·μ′ exactly, with k the geometry constant.
     assert a.inductance(1.0) == pytest.approx(
@@ -106,7 +117,7 @@ def test_inductance_comes_from_mu_prime_and_turns_squared():
 
 
 def test_impedance_splits_into_mu_double_loss_and_mu_prime_reactance():
-    c = core_from_catalog("FT-240", "43", 11)
+    c = a_core(11)
     f = 7.0
     z = c.impedance(f)
     omega = 2 * math.pi * f * 1e6
@@ -141,7 +152,7 @@ def test_a_real_choke_impedance_peaks_and_falls():
     saturates; the winding's few pF resonate with it, which is what puts the
     peak in every published choke plot — and why `c_stray` exists.
     """
-    c = core_from_catalog("FT-240", "43", 11, c_stray_pF=3.0)
+    c = a_core(11, c_stray_pF=3.0)
     freqs = np.array([1.0, 2.0, 3.5, 7.0, 14.0, 28.0, 50.0])
     mags = np.array([abs(c.impedance(f)) for f in freqs])
     peak = int(np.argmax(mags))
@@ -157,57 +168,116 @@ def test_a_real_choke_impedance_peaks_and_falls():
 def test_without_stray_capacitance_the_one_pole_model_saturates():
     """Stated as a limitation rather than hidden: this is why `c_stray` is part
     of modelling a real choke and not an optional refinement."""
-    c = core_from_catalog("FT-240", "43", 11)
+    c = a_core(11)
     mags = [abs(c.impedance(f)) for f in (1.0, 3.5, 14.0, 50.0, 200.0)]
     assert all(b >= a * 0.999 for a, b in zip(mags, mags[1:]))  # monotone
 
 
 def test_more_turns_is_more_impedance():
-    z10 = abs(core_from_catalog("FT-240", "43", 10).impedance(7.0))
-    z20 = abs(core_from_catalog("FT-240", "43", 20).impedance(7.0))
+    z10 = abs(a_core(10).impedance(7.0))
+    z20 = abs(a_core(20).impedance(7.0))
     assert z20 == pytest.approx(4.0 * z10, rel=1e-12)
 
 
 # ---------------------------------------------------------------------------
 # catalogs
 # ---------------------------------------------------------------------------
-def test_the_catalog_covers_the_common_mixes_and_sizes():
-    assert {"31", "43", "52", "61"} <= set(MATERIALS)
+def test_the_core_size_catalog_covers_the_common_toroids():
     assert {"FT-240", "FT-140", "FT-82"} <= set(CORES)
 
 
-def test_every_catalog_material_says_where_it_came_from():
-    """These are one-pole fits with UNVERIFIED parameters, and every entry has
-    to say so in the object a user can print.
-
-    The provenance lives in the data rather than only in the docs on purpose:
-    "which curve is this?" is the first question anyone comparing against a
-    measurement asks, and the honest answer today is "a shape, not a
-    calibration".
-    """
-    for name, m in MATERIALS.items():
-        assert m.source, name
-        assert "fit" in m.source
-        assert "UNVERIFIED" in m.source, name
-        assert "calibrate" in m.source, name
+def test_published_data_urls_exist_for_the_common_mixes():
+    """The package ships no vendor data — only where to get it."""
+    assert {"31", "43", "52", "61"} <= set(MATERIAL_URLS)
+    assert all(u.startswith("https://") for u in MATERIAL_URLS.values())
 
 
-def test_higher_permeability_mixes_relax_lower():
-    """The physical ordering (Snoek's limit): more μ, lower usable frequency."""
-    mu_i = {k: m.mu_prime[0] for k, m in MATERIALS.items()}
-    assert mu_i["31"] > mu_i["43"] > mu_i["61"]
-    # ...and their loss peaks run the other way.
-    peak = {k: m.freqs[int(np.argmax(m.mu_double))] for k, m in MATERIALS.items()}
-    assert peak["31"] < peak["43"] < peak["61"]
-
-
-def test_unknown_catalog_keys_name_the_alternatives():
-    with pytest.raises(KeyError, match="unknown ferrite mix"):
-        material_from_catalog("99")
+def test_unknown_keys_name_the_alternatives():
+    with pytest.raises(KeyError, match="no published data URL"):
+        fetch_material("99")
     with pytest.raises(KeyError, match="unknown core size"):
-        core_from_catalog("FT-999", "43", 10)
+        core("FT-999", MIX, 10)
     with pytest.raises(ValueError, match="turns must be positive"):
-        core_from_catalog("FT-240", "43", 0)
+        core("FT-240", MIX, 0)
+
+
+# ---------------------------------------------------------------------------
+# vendor data: parsed, cached, never bundled
+# ---------------------------------------------------------------------------
+# A faithful sample of what the real files look like — title row, blank lines,
+# an equipment note, a mis-encoded µ in the header, Hz frequencies. The parser
+# has to survive all of it, because these files are hand-maintained and the
+# five differ from one another.
+SAMPLE_CSV = (
+    "Feb-20,43 material,\r\n"
+    ",,\r\n"
+    '"Equipment Used:  HP4284A, 16047E fixture (10kHz - 1MHz)",,\r\n'
+    "Frequency(Hz),\xb5',\xb5''\r\n"
+    "1.00E+04,816.0,10.0\r\n"
+    "1.00E+06,700.0,120.0\r\n"
+    "4.40E+06,588.0,435.0\r\n"
+    "1.00E+08,20.0,60.0\r\n"
+)
+
+
+def test_the_parser_survives_a_real_vendor_file():
+    m = parse_permeability_csv(SAMPLE_CSV, name="43", source="test")
+    assert m.freqs.size == 4
+    assert m.freqs[0] == pytest.approx(0.01)  # Hz in the file, MHz in the trace
+    assert m.freqs[-1] == pytest.approx(100.0)
+    assert m.at(4.4).real == pytest.approx(588.0)
+    assert -m.at(4.4).imag == pytest.approx(435.0)
+
+
+def test_the_parser_rejects_a_file_with_no_data():
+    with pytest.raises(ValueError, match="no usable rows"):
+        parse_permeability_csv("Frequency(Hz),mu',mu''\nnot,a,number\n", name="x")
+
+
+def test_a_cached_material_needs_no_network(tmp_path, monkeypatch):
+    """The first call fetches; every later one is offline. That is the whole
+    bargain that lets the package ship no vendor data."""
+    monkeypatch.setenv("ANTENNAKNOBS_USER_DIR", str(tmp_path))
+    (tmp_path / "ferrite").mkdir(parents=True)
+    (tmp_path / "ferrite" / "43.csv").write_text(SAMPLE_CSV, encoding="latin-1")
+
+    def no_network(*a, **k):  # any attempt to fetch is a test failure
+        raise AssertionError("fetch_material touched the network with a cache present")
+
+    monkeypatch.setattr("urllib.request.urlopen", no_network)
+    m = fetch_material("43")
+    assert m.freqs.size == 4
+    assert "fair-rite.com" in m.source  # ...and it still cites where it came from
+
+
+def test_no_network_and_no_cache_says_what_to_download(tmp_path, monkeypatch):
+    monkeypatch.setenv("ANTENNAKNOBS_USER_DIR", str(tmp_path))
+
+    def offline(*a, **k):
+        raise OSError("no route to host")
+
+    monkeypatch.setattr("urllib.request.urlopen", offline)
+    with pytest.raises(RuntimeError) as exc:
+        fetch_material("43")
+    msg = str(exc.value)
+    assert "fair-rite.com" in msg  # the URL...
+    assert str(tmp_path) in msg  # ...and where to put the file
+
+
+def test_the_cache_lives_under_the_user_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("ANTENNAKNOBS_USER_DIR", str(tmp_path))
+    assert cache_dir() == tmp_path / "ferrite"
+
+
+def test_no_vendor_data_is_bundled():
+    """The licence position: Fair-Rite's files carry no grant of
+    redistribution, so none of them are in the package."""
+    import antennaknobs
+    from pathlib import Path
+
+    root = Path(antennaknobs.__file__).parent
+    assert not list(root.rglob("*material*.csv"))
+    assert not list(root.rglob("*Fair-Rite*"))
 
 
 # ---------------------------------------------------------------------------
@@ -229,14 +299,14 @@ def loss_fraction(f_mhz, **unun_kw):
 
 
 def test_a_core_dissipates_and_itemises_in_the_budget():
-    core = core_from_catalog("FT-240", "43", 11, c_stray_pF=3.0)
+    core = a_core(11, c_stray_pF=3.0)
     assert loss_fraction(7.0, core=core) > 0.0
 
 
 def test_the_core_supersedes_the_scalar_pair():
     """`core` is the core, not a default — the same posture as
     `TL.from_cable`'s cable."""
-    core = core_from_catalog("FT-240", "43", 11)
+    core = a_core(11)
     with_core = loss_fraction(7.0, core=core, lmag_uH=1.0, qlmag=1.0)
     core_only = loss_fraction(7.0, core=core)
     assert with_core == pytest.approx(core_only, rel=1e-12)
@@ -245,7 +315,7 @@ def test_the_core_supersedes_the_scalar_pair():
 def test_material_loss_has_a_frequency_shape_a_flat_q_cannot():
     """The whole point of the issue. Across a decade the two models disagree
     about the *shape* of the loss, not merely its size."""
-    core = core_from_catalog("FT-240", "43", 11, c_stray_pF=3.0)
+    core = a_core(11, c_stray_pF=3.0)
     freqs = [1.8, 3.5, 7.0, 14.0, 28.0]
     material = np.array([loss_fraction(f, core=core) for f in freqs])
     scalar = np.array([loss_fraction(f, lmag_uH=320.0, qlmag=20.0) for f in freqs])

--- a/tests/test_ferrite.py
+++ b/tests/test_ferrite.py
@@ -177,11 +177,19 @@ def test_the_catalog_covers_the_common_mixes_and_sizes():
 
 
 def test_every_catalog_material_says_where_it_came_from():
-    """These are one-pole fits, not vendor curves, and each entry has to say
-    so — it is the first question anyone comparing to a measurement asks."""
+    """These are one-pole fits with UNVERIFIED parameters, and every entry has
+    to say so in the object a user can print.
+
+    The provenance lives in the data rather than only in the docs on purpose:
+    "which curve is this?" is the first question anyone comparing against a
+    measurement asks, and the honest answer today is "a shape, not a
+    calibration".
+    """
     for name, m in MATERIALS.items():
         assert m.source, name
         assert "fit" in m.source
+        assert "UNVERIFIED" in m.source, name
+        assert "calibrate" in m.source, name
 
 
 def test_higher_permeability_mixes_relax_lower():


### PR DESCRIPTION
Closes #599.

`qlmag` is a single frequency-independent Q for a quantity that is emphatically not one number. A flat Q cannot say *"loses most here, little there"* — which is the question someone modelling a choke is asking.

```python
from antennaknobs.ferrite import core_from_catalog
from antennaknobs.station import unun

core = core_from_catalog("FT-240", "43", turns=11, c_stray_pF=3.0)
unun(7.0, core=core)      # 49:1 wound on that core
```

`core` supersedes `lmag`/`qlmag` wholesale — it *is* the core, the same posture as `TL.from_cable`'s cable. The magnetizing branch becomes `Z = jω·N²μ₀A_e/l_e·(μ′ − jμ″)`, so μ′ sets the inductance and μ″ the loss, and the effective Q is just μ′/μ″. **That identity is the bridge back**: a flat material with μ″ = μ′/Q reproduces scalar `qlmag` *exactly*, asserted by a test.

## Two findings worth your attention

**1. A single-pole material cannot produce a loss peak on its own.** For a Debye μ, `Re(Y_mag) = x/(ωk·μ_i)` with `x = f/f_r` — and ω ∝ x, so the shunt conductance is *exactly frequency-flat*: the μ″ growth and the |μ|² growth cancel. I found this when the first version reported dead-flat loss across all of HF.

What actually puts the peak in every published choke plot is the **winding**: a few pF of self-capacitance parallel-resonating with the magnetizing branch. Hence `c_stray`. With 3 pF, an 11-turn FT-240-43:

| f MHz | 1.8 | 3.5 | 7.0 | 14 | 28 | 50 |
|---|---|---|---|---|---|---|
| \|Z\| Ω | 4174 | 13194 | **15799** | 4363 | 1959 | 1072 |
| X | + | + | − | − | − | − |

Rises to a peak, then falls capacitive — the right shape, and the reason a choke stops choking at VHF.

**2. The catalog mixes are one-pole fits, not vendor curves.** Digitized curves are neither ours to redistribute (the issue is explicit about not copying SimNEC's Fair-Rite files) nor honest to present as measurements we made. Each mix is a Debye fit from two published headline numbers (initial permeability, μ″ peak frequency); every entry carries a `source` string saying so and a test enforces it. `FerriteMaterial.from_table()` takes real μ′/μ″ data and is strictly better.

**⚠️ Needs your eye:** I could not verify the per-mix parameters (μ_i and f_r for 31/43/52/61/77) against datasheets offline. The tests deliberately assert **shape and relative ordering** (Snoek: more μ ⇒ lower relaxation) rather than absolute permeabilities, and the docs say to pin absolute watts against a measured sweep. If you have the datasheets, the numbers in `MATERIALS` are the thing to check — they're two constants per mix and trivial to correct.

## Acceptance criteria (#599)

- [x] Complex-permeability core model: μ′/μ″ table → frequency-dependent magnetizing L + loss
- [x] A small mix catalog + user-table path — **cited as one-pole fits, not as datasheet points** (see above)
- [x] Reduces to scalar-`qlmag` behaviour when given a flat μ (exact, to 1e-12)
- [x] Test: a 43-mix choke shows the characteristic peak, and the power budget reflects the core loss
- [x] Does not bundle SimNEC's proprietary Fair-Rite data

## Testing

19 tests: Debye shape (μ′ halves at f_r, μ″ peaks there at μ_i/2), the Q identity, no extrapolation past the table, log-frequency interpolation checked at a geometric midpoint, table validation/sorting, L ∝ N², the loss/reactance split against ωkμ″ and ωkμ′, exact scalar-model equivalence, the choke peak *and* the documented monotone-saturation limitation without `c_stray`, catalog coverage and provenance, and in-circuit tests showing the material's loss has a frequency **shape** a flat Q cannot match. Both lanes green: 3026 fast + 171 catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g