### PR TITLE
feat(schematic): draw the feed network, CLI first (#652)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,13 @@ web = ["fastapi", "uvicorn[standard]", "websockets", "psutil", "threadpoolctl"]
 # message covers both causes.
 vna = ["pyserial"]
 
+# Network schematics (`antennaknobs schematic`, issue #652): schemdraw supplies
+# the circuit symbols and an SVG writer. Optional because drawing is not on any
+# solve path — and cheap when wanted: schemdraw is MIT with NO required
+# dependencies of its own (its matplotlib backend is itself an extra, and we
+# use the built-in SVG one).
+schematic = ["schemdraw>=0.19"]
+
 # Test suite: `pip install -e ".[test]"` makes `pytest` reproducible from a
 # clean clone (the runtime deps in [project] cover the numpy/scipy/matplotlib
 # that the solver tests need).
@@ -87,7 +94,10 @@ vna = ["pyserial"]
 #     tests error at collection.
 #   - PyNEC is deliberately NOT included (GPL, installed separately per README);
 #     the pynec-backed tests skip when it's absent.
-test = ["antennaknobs[web]", "pytest", "coverage", "httpx2"]
+#   - the schematic extra is included so the renderer is actually exercised
+#     rather than skipped: schemdraw is MIT with no dependencies of its own, so
+#     it costs the test environment nothing.
+test = ["antennaknobs[web]", "antennaknobs[schematic]", "pytest", "coverage", "httpx2"]
 
 # Local developer tooling — install with `pip install -e ".[dev]"`.
 #   - ruff is the linter/formatter, configured under [tool.ruff] below. It is a

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -61,6 +61,49 @@ Note that knob sweeps in **free space** can be perfectly flat by design —
 translation-invariant knobs like a height `base` only matter over a ground
 (`--ground finite`).
 
+## Drawing the feed network
+
+`schematic` renders a design's `build_network()` — feedline, tuner, balun, and
+the port the source sits on — as an SVG:
+
+```bash
+python -m antennaknobs schematic --builder wire.doublet_ladder_tuner --out tuner.svg
+# annotate each box with the watts it burns
+python -m antennaknobs schematic --builder verticals.stub_matched_vertical --power --out m.svg
+```
+
+Needs the optional extra: `pip install 'antennaknobs[schematic]'` (schemdraw —
+MIT, and with no dependencies of its own).
+
+The circuit half of a design is otherwise visible only as
+[power-budget](/reference/web/#power-budget) rows, which means an element that
+burns nothing — an ideal `TL`, a `bypass()` — appears **nowhere**. This draws
+every branch whether it dissipates or not, groups them under the box they came
+from, and marks where the source sits, which is the design's reference plane.
+
+Boxes may carry their own drawing. `station.t_network_tuner` declares one, so
+it renders as the tee it is, with the coil between the capacitors — an ordering
+the branch list cannot express, because "the coil goes in the middle" lives in
+the head of whoever wrote the factory. A box without a fragment still draws,
+from per-branch default symbols; it is simply more anonymous. Fragments are
+written with `schematic.series` / `shunt`, which are plain data, so declaring
+one costs `station.py` no drawing-library import:
+
+```python
+Composite(
+    ports=("rig", "out"),
+    branches=(...),
+    schematic=(
+        series("capacitor", "81 pF"),
+        shunt("inductor", "4.2 µH"),
+        series("capacitor", "500 pF"),
+    ),
+)
+```
+
+Designs with no feed circuit are refused with a message rather than an empty
+picture, and a multi-feed antenna (16 driven ports, no chain) says so.
+
 ### Capturing from a VNA
 
 `capture` sweeps a USB-attached NanoVNA and writes the `.s1p` the overlay and

--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -894,6 +894,47 @@ def cli(arguments=None):
 
     p.set_defaults(func=f)
 
+    p = subparsers.add_parser(
+        "schematic",
+        help="Draw the design's feed network as a circuit schematic",
+        description="Render a design's build_network() — feedline, tuner, "
+        "balun, and the port the source sits on — as an SVG schematic. The "
+        "circuit half of a design is otherwise visible only as power-budget "
+        "rows, so an element that burns nothing appears nowhere.",
+    )
+    add_common(p)
+    add_engine_args(p)
+    p.add_argument("--out", default=None, help="Write the SVG here (default: stdout).")
+    p.add_argument(
+        "--power",
+        default=False,
+        action="store_true",
+        help="Solve first and annotate each block with the watts it burns.",
+    )
+
+    def f(args):
+        from .schematic import lower, render_svg
+
+        builder = get_builder(args.builder)()
+        net = builder.build_network() if hasattr(builder, "build_network") else None
+        if net is None:
+            raise SystemExit(
+                f"{args.builder} has no build_network() — it is an antenna with "
+                "no feed circuit, so there is no schematic to draw"
+            )
+        budget = None
+        if args.power:
+            eng = engine_factory_from_args(args)(builder)
+            eng.current_distribution()
+            budget = getattr(eng, "_excited_power_budget", None)
+        svg = render_svg(lower(net, title=args.builder, budget=budget), args.out)
+        if args.out:
+            print(f"wrote {args.out}")
+        else:
+            print(svg, end="")
+
+    p.set_defaults(func=f)
+
     p = subparsers.add_parser("pattern", help="Display far field of antenna")
     add_common(p)
     add_engine_args(p)

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -1108,6 +1108,12 @@ class Composite:
     ports: tuple[str, ...]
     branches: tuple = ()
     aliases: tuple[tuple[str, str], ...] = ()
+    #: How this box DRAWS (issue #652): a tuple of `schematic.Element`, or a
+    #: zero-argument callable returning one. Optional — a box without it falls
+    #: back to per-branch default symbols, which is a picture but an anonymous
+    #: one. Written with `schematic.series` / `shunt`, which are plain data, so
+    #: declaring one costs this module no drawing-library import.
+    schematic: object = None
 
     def __post_init__(self):
         if len(set(self.ports)) != len(self.ports):
@@ -1153,7 +1159,9 @@ class Instance:
         self.portmap = dict(portmap)
 
 
-def _expand_instance(inst, formal_to_final, prefix, flat, paths, aliases, internals):
+def _expand_instance(
+    inst, formal_to_final, prefix, flat, paths, aliases, internals, composites=None
+):
     """Recursively flatten ``inst`` into ``flat``/``paths``, collecting alias
     pairs and auto-created internal node names. ``formal_to_final`` maps the
     composite's formals to FINAL (fully resolved) names; ``prefix`` is the
@@ -1166,12 +1174,18 @@ def _expand_instance(inst, formal_to_final, prefix, flat, paths, aliases, intern
         internals.add(final)
         return final
 
+    if composites is not None:
+        # Keep the Composite that produced these branches, keyed by the same
+        # path `branch_paths` uses. Flattening otherwise erases every trace of
+        # the box, which is exactly what a schematic (issue #652) needs: the
+        # author's fragment lives on the Composite, not on its branches.
+        composites[prefix] = inst.of
     for item in inst.of.branches:
         if isinstance(item, Instance):
             child_map = {f: resolve(a) for f, a in item.portmap.items()}
             _expand_instance(
                 item, child_map, prefix + item.name + ".",
-                flat, paths, aliases, internals,
+                flat, paths, aliases, internals, composites,
             )  # fmt: skip
         else:
             flat.append(_rewrite_branch(item, resolve))
@@ -1391,6 +1405,9 @@ class Network:
     branches: list[Branch] = field(default_factory=list)
     sources: list[Source] = field(default_factory=list)
     branch_paths: list[str] = field(default_factory=list)
+    #: Instance path → the `Composite` it came from, filled by flattening
+    #: (issue #652). Derived, like ``branch_paths``.
+    composites: dict = field(default_factory=dict)
 
     def __post_init__(self):
         if self.branch_paths:
@@ -1481,6 +1498,7 @@ class Network:
         """Flatten `Instance` items (issue #489): namespace internals,
         resolve aliases, stamp per-branch instance paths."""
         flat, paths, alias_pairs, internals = [], [], [], set()
+        composites: dict[str, Composite] = {}
         for item in self.branches:
             if isinstance(item, Instance):
                 for actual in item.portmap.values():
@@ -1492,13 +1510,14 @@ class Network:
                         )
                 _expand_instance(
                     item, dict(item.portmap), item.name + ".",
-                    flat, paths, alias_pairs, internals,
+                    flat, paths, alias_pairs, internals, composites,
                 )  # fmt: skip
             else:
                 flat.append(item)
                 paths.append("")
         self.branches = flat
         self.branch_paths = paths
+        self.composites = composites
         for n in sorted(internals):
             if n in self.ports:
                 raise ValueError(f"internal node {n!r} collides with a port")

--- a/src/antennaknobs/schematic.py
+++ b/src/antennaknobs/schematic.py
@@ -1,0 +1,471 @@
+"""Draw a design's network as a schematic (issue #652).
+
+The circuit half of a design — feedline, tuner, balun, the port the source
+sits on — has until now been visible only as a power-budget loss ledger, so an
+element that burns nothing (an ideal `TL`, a `bypass()`) appeared *nowhere*.
+This module turns a `Network` into a picture.
+
+## Why authors draw their own boxes
+
+Auto-derivation cannot produce a good schematic. `wire.doublet_ladder_tuner`'s
+L-network lowers to `TwoPort → Shunt → TwoPort`: three anonymous boxes, because
+"this is an L-network" is not in the branch list — it is in the head of
+whoever wrote `l_network_tuner`. So a component may carry its own **fragment**,
+this module places the fragments along the chain, and anything without one
+falls back to a per-type default symbol. There is always a picture; a fragment
+only makes it a *good* picture.
+
+## The vocabulary is deliberately not schemdraw
+
+Fragments are written with :func:`series` / :func:`shunt` / :func:`ground`,
+which produce plain data. Rendering happens later, through schemdraw (an
+optional extra). That keeps `station.py` free of any drawing library, keeps
+the renderer swappable, and means a fragment can be inspected and tested
+without drawing anything.
+
+    def l_network_schematic(l_uH, c_pF):
+        return (
+            series("inductor", f"{l_uH:g} µH"),
+            shunt("capacitor", f"{c_pF:g} pF"),
+        )
+
+## Layout
+
+Every catalog network is small (≤ 9 branches, node degree ≤ 3), so the layout
+is a **spine with ribs**: the path from the source to the antenna runs left to
+right, and anything hanging off a spine node drops to ground beneath it. No
+graph-layout engine, and none needed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+
+from .network import (
+    TL,
+    Admittance,
+    Autotransformer,
+    BalancedLine,
+    FloatingBalun,
+    Load,
+    PortOnWire,
+    PortOnWireFloating,
+    Shunt,
+    TouchstoneLoad,
+    TouchstoneTwoPort,
+    Transformer,
+    TwoPort,
+)
+
+__all__ = [
+    "Element",
+    "Schematic",
+    "Block",
+    "series",
+    "shunt",
+    "ground",
+    "lower",
+    "fragment_of",
+    "terminals_of",
+]
+
+#: Symbol kinds the renderer knows. Anything else falls back to a labelled box,
+#: so a fragment referencing an unknown kind degrades instead of failing.
+KINDS = (
+    "inductor",
+    "capacitor",
+    "resistor",
+    "coax",
+    "line",
+    "transformer",
+    "box",
+    "short",
+    "open",
+    "antenna",
+    "source",
+)
+
+
+@dataclass(frozen=True)
+class Element:
+    """One drawn symbol. ``orient`` is ``"series"`` (along the spine) or
+    ``"shunt"`` (down to the datum)."""
+
+    kind: str
+    label: str = ""
+    orient: str = "series"
+    sublabel: str = ""
+
+
+def series(kind: str, label: str = "", sublabel: str = "") -> Element:
+    """A symbol in the signal path."""
+    return Element(kind=kind, label=label, orient="series", sublabel=sublabel)
+
+
+def shunt(kind: str, label: str = "", sublabel: str = "") -> Element:
+    """A symbol from the spine down to the common datum."""
+    return Element(kind=kind, label=label, orient="shunt", sublabel=sublabel)
+
+
+def ground(label: str = "") -> Element:
+    """An explicit connection to the datum (a shorted stub's far end)."""
+    return Element(kind="short", label=label, orient="shunt")
+
+
+@dataclass
+class Block:
+    """One box on the spine: its label and the elements that draw it."""
+
+    label: str
+    elements: tuple[Element, ...]
+    path: str = ""
+    watts: float | None = None
+
+
+@dataclass
+class Schematic:
+    """A whole drawing: the source, the chain, and what it ends in."""
+
+    source: str
+    blocks: list[Block] = field(default_factory=list)
+    ends_in_antenna: bool = True
+    title: str = ""
+    notes: list[str] = field(default_factory=list)
+
+
+# --- terminals -------------------------------------------------------------
+# Each branch class names its terminals differently (Shunt/Load use `port`,
+# FloatingBalun has a third `primary`), so the lowering needs an explicit map
+# rather than a guess-by-field-name. Keep in step with network.py.
+TERMINALS = {
+    "TL": ("a", "b"),
+    "BalancedLine": ("a1", "a2", "b1", "b2"),
+    "Shunt": ("port",),
+    "Load": ("port",),
+    "TwoPort": ("a", "b"),
+    "Transformer": ("a", "b"),
+    "Autotransformer": ("a", "b"),
+    "FloatingBalun": ("primary", "a", "b"),
+    "TouchstoneLoad": ("port",),
+    "TouchstoneTwoPort": ("a", "b"),
+}
+
+
+def terminals_of(branch) -> tuple[str, ...]:
+    """Node names a branch touches, in wiring order."""
+    if isinstance(branch, Admittance):
+        return tuple(branch.ports)
+    names = TERMINALS.get(type(branch).__name__, ())
+    return tuple(
+        v for v in (getattr(branch, f, None) for f in names) if isinstance(v, str)
+    )
+
+
+# --- default symbols for bare branches -------------------------------------
+def _fmt_len(m):
+    return f"{m:.2f} m" if m >= 1.0 else f"{m * 100:.0f} cm"
+
+
+def default_elements(branch) -> tuple[Element, ...]:
+    """The fallback picture for a branch with no author-supplied fragment.
+
+    Deliberately plain: enough to see that the element is there and what type
+    it is. A box that wants to look like what it *is* supplies a fragment.
+    """
+    if isinstance(branch, TL):
+        return (series("coax", f"{branch.z0:g} Ω", _fmt_len(branch.length)),)
+    if isinstance(branch, BalancedLine):
+        return (series("line", f"{branch.zdiff:g} Ω pair", _fmt_len(branch.length)),)
+    if isinstance(branch, Transformer):
+        return (series("transformer", f"1:{branch.n:g}"),)
+    if isinstance(branch, Autotransformer):
+        return (series("transformer", "autotransformer"),)
+    if isinstance(branch, FloatingBalun):
+        return (series("transformer", f"balun 1:{branch.n:g}"),)
+    if isinstance(branch, Shunt):
+        return (shunt(_rlc_kind(branch), _rlc_label(branch)),)
+    if isinstance(branch, Load):
+        return (shunt(_rlc_kind(branch), _rlc_label(branch)),)
+    if isinstance(branch, TwoPort):
+        return (series(_rlc_kind(branch), _rlc_label(branch)),)
+    if isinstance(branch, TouchstoneLoad):
+        return (shunt("box", "measured 1-port"),)
+    if isinstance(branch, TouchstoneTwoPort):
+        return (series("box", "measured 2-port"),)
+    if isinstance(branch, Admittance):
+        return (series("box", "admittance"),)
+    return (series("box", type(branch).__name__),)
+
+
+def _rlc_kind(br):
+    """The dominant symbol for an R/L/C branch — whichever one it actually is."""
+    has = [
+        k for k, v in (("resistor", br.r), ("inductor", br.l), ("capacitor", br.c)) if v
+    ]
+    return has[0] if len(has) == 1 else ("box" if has else "short")
+
+
+def _rlc_label(br):
+    bits = []
+    if getattr(br, "r", None):
+        bits.append(f"{br.r:g} Ω")
+    if getattr(br, "l", None):
+        bits.append(f"{br.l * 1e6:g} µH")
+    if getattr(br, "c", None):
+        bits.append(f"{br.c * 1e12:g} pF")
+    return " ".join(bits) if bits else "short"
+
+
+# --- lowering --------------------------------------------------------------
+def _real_ports(net):
+    return {
+        name
+        for name, p in net.ports.items()
+        if isinstance(p, (PortOnWire, PortOnWireFloating))
+    }
+
+
+def fragment_of(net, path):
+    """The author-supplied fragment for the instance at ``path``, or None.
+
+    Flattening erases `Instance` objects, so the `Composite` is recovered from
+    ``net.composites`` — which exists precisely so the author's drawing
+    survives the flattening that the solver needs.
+    """
+    comp = (getattr(net, "composites", None) or {}).get(path)
+    frag = getattr(comp, "schematic", None) if comp is not None else None
+    if frag is None:
+        return None
+    return tuple(frag() if callable(frag) else frag)
+
+
+def lower(net, *, title: str = "", budget=None) -> Schematic:
+    """`Network` → :class:`Schematic`.
+
+    Walks source → antenna to find the spine, groups consecutive spine
+    branches by the composite instance they came from (so a box draws as a
+    box), hangs everything else beneath the node it attaches to, and lets an
+    author-supplied fragment replace the default symbols for its box.
+
+    ``budget`` (the reducer's ``(label, watts)`` list) annotates each block
+    with what it burns — which is what puts the power budget *in* the topology
+    instead of beside it.
+    """
+    sch = Schematic(source=net.sources[0].port if net.sources else "", title=title)
+    if not net.sources:
+        sch.notes.append("no source: nothing to draw a chain from")
+        return sch
+    if len(net.sources) > 1:
+        sch.notes.append(
+            f"{len(net.sources)} driven ports — a multi-feed antenna rather "
+            "than a chain, so there is no single line to draw"
+        )
+        return sch
+
+    real = _real_ports(net)
+    branches = list(net.branches)
+    paths = list(net.branch_paths or [""] * len(branches))
+
+    adj: dict[str, list] = {}
+    for idx, br in enumerate(branches):
+        ts = terminals_of(br)
+        if len(ts) >= 2:
+            adj.setdefault(ts[0], []).append((ts[-1], idx))
+            adj.setdefault(ts[-1], []).append((ts[0], idx))
+
+    from collections import deque
+
+    prev, q, target = {sch.source: None}, deque([sch.source]), None
+    while q:
+        node = q.popleft()
+        if node in real:
+            target = node
+            break
+        for nxt, idx in adj.get(node, []):
+            if nxt not in prev:
+                prev[nxt] = (node, idx)
+                q.append(nxt)
+
+    spine = []  # [(branch_index, from_node, to_node)]
+    if target is None:
+        sch.ends_in_antenna = False
+        sch.notes.append("no path from the source to an antenna port")
+    else:
+        cur = target
+        while prev.get(cur):
+            node, idx = prev[cur]
+            spine.append((idx, node, cur))
+            cur = node
+        spine.reverse()
+    on_spine = {idx for idx, _a, _b in spine}
+
+    # Ribs: every non-spine branch, filed under the spine node it touches.
+    ribs: dict[str, list[int]] = {}
+    for idx, br in enumerate(branches):
+        if idx in on_spine:
+            continue
+        for t in terminals_of(br):
+            ribs.setdefault(t, []).append(idx)
+            break
+
+    watts = dict(budget or [])
+
+    def burned(path):
+        """Watts this block burns, children included.
+
+        Budget labels are "<path>: <branch>" with the trailing dot stripped
+        ("match: TL rig→feed"), and a nested box appears as "match.stub: ...",
+        so a block owns both its own rows and its descendants'.
+        """
+        if not path:
+            return None
+        base = path[:-1]
+        total = sum(
+            w
+            for k, w in watts.items()
+            if k.startswith(f"{base}: ") or k.startswith(f"{base}.")
+        )
+        return total or None
+
+    def elements_for(idxs, path):
+        frag = fragment_of(net, path) if path else None
+        if frag is not None:
+            return frag
+        out = []
+        for i in idxs:
+            out.extend(default_elements(branches[i]))
+        return tuple(out)
+
+    # Group consecutive spine branches sharing an instance path.
+    i = 0
+    while i < len(spine):
+        idx, a_node, b_node = spine[i]
+        path = paths[idx]
+        group, nodes = [idx], {a_node, b_node}
+        while i + 1 < len(spine) and path and paths[spine[i + 1][0]] == path:
+            i += 1
+            group.append(spine[i][0])
+            nodes |= {spine[i][1], spine[i][2]}
+        els = list(elements_for(group, path))
+        if fragment_of(net, path) is None:
+            # Ribs are already inside an author's fragment; only the default
+            # rendering needs them appended.
+            for node in nodes:
+                for rib in ribs.get(node, []):
+                    # A rib belongs to this block if it came from the same
+                    # instance or from one nested inside it — a stub tuner's
+                    # stub sits at "match.stub." under the section's "match.".
+                    if not path or paths[rib].startswith(path):
+                        # A rib hangs off the spine whatever the branch's own
+                        # default orientation says: a stub is a length of line
+                        # (drawn in series on its own) used as a shunt here.
+                        els.extend(
+                            replace(e, orient="shunt")
+                            for e in default_elements(branches[rib])
+                        )
+        sch.blocks.append(
+            Block(
+                label=path[:-1] if path else type(branches[idx]).__name__,
+                elements=tuple(els),
+                path=path,
+                watts=burned(path),
+            )
+        )
+        i += 1
+
+    if not spine:
+        for idx, br in enumerate(branches):
+            sch.blocks.append(
+                Block(
+                    label=paths[idx][:-1] or type(br).__name__,
+                    elements=default_elements(br),
+                    path=paths[idx],
+                    watts=burned(paths[idx]),
+                )
+            )
+    return sch
+
+
+# --- rendering -------------------------------------------------------------
+# schemdraw supplies the symbols and the SVG; the layout above is ours,
+# because schemdraw's API is a cursor, not a layout engine. Kept in one place
+# so the renderer stays swappable — nothing above this line imports it.
+_SCHEMDRAW_SYMBOLS = {
+    "inductor": "Inductor2",
+    "capacitor": "Capacitor",
+    "resistor": "Resistor",
+    "coax": "Coax",
+    "line": "Coax",
+    "transformer": "Transformer",
+    "short": "Line",
+    "open": "Gap",
+    "box": "RBox",
+}
+
+DX, DY = 3.2, 2.2  # spine step and rib drop, in schemdraw units
+
+
+def render_svg(sch: Schematic, path=None) -> str:
+    """Draw a :class:`Schematic` and return SVG (also written to ``path``).
+
+    Needs the optional extra: ``pip install 'antennaknobs[schematic]'``.
+    """
+    try:
+        import schemdraw
+        import schemdraw.elements as elm
+    except ImportError as e:  # pragma: no cover — depends on the install
+        raise ImportError(
+            "drawing a schematic needs schemdraw: pip install 'antennaknobs[schematic]'"
+        ) from e
+
+    schemdraw.use("svg")
+    d = schemdraw.Drawing(show=False)
+    d.config(unit=DX, fontsize=10)
+
+    def symbol(kind):
+        return getattr(elm, _SCHEMDRAW_SYMBOLS.get(kind, "RBox"))
+
+    x, y = 0.0, 0.0
+    d += elm.SourceSin().at((x, y - 2.0)).up().label(sch.source or "source", loc="left")
+    d += elm.Ground().at((x, y - 2.0))
+    d += elm.Line().at((x, y)).to((x + 0.7, y))
+    x += 0.7
+
+    for block in sch.blocks:
+        x0 = x
+        for el in block.elements:
+            if el.orient == "shunt":
+                d += (
+                    symbol(el.kind)()
+                    .at((x, y))
+                    .down()
+                    .label(el.label, loc="right", fontsize=8)
+                )
+                d += elm.Ground().at((x, y - DY))
+            else:
+                e = symbol(el.kind)().at((x, y)).right().label(el.label, fontsize=8)
+                if el.sublabel:
+                    e = e.label(el.sublabel, loc="bottom", fontsize=7)
+                d += e
+                x += DX
+        if x == x0:  # a block of pure shunts still needs a step
+            d += elm.Line().at((x, y)).to((x + DX, y))
+            x += DX
+        note = block.label
+        if block.watts:
+            note = f"{note}  ({block.watts * 1e3:.2f} mW)"
+        if note:
+            d += elm.Label().at(((x0 + x) / 2.0, y + 1.1)).label(note, fontsize=8)
+
+    if sch.ends_in_antenna:
+        d += elm.Line().at((x, y)).to((x + 0.7, y))
+        d += elm.Antenna().at((x + 0.7, y)).up().label("antenna", loc="right")
+    for i, note in enumerate(sch.notes):
+        d += elm.Label().at((0.0, y - 4.0 - i * 0.9)).label(note, fontsize=8)
+
+    d.draw()
+    svg = d.get_imagedata("svg").decode("utf-8")
+    if path is not None:
+        with open(path, "w") as fh:
+            fh.write(svg)
+    return svg

--- a/src/antennaknobs/station.py
+++ b/src/antennaknobs/station.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import math
 
 from .builder import C_LIGHT_MHZ_M
+from .schematic import series, shunt
 from .network_reduce import SingularNetworkError
 from .network import (
     Autotransformer,
@@ -68,6 +69,14 @@ def t_network_tuner(
             Shunt(port="m", l=l_uH * 1e-6, ql=ql),
             TwoPort(a="m", b="out", c=c2_pF * 1e-12),
         ),
+        # Draws as the tee it is (issue #652). Without this the shunt coil
+        # lands after both capacitors, because "the coil goes in the middle"
+        # is not recoverable from the branch list.
+        schematic=(
+            series("capacitor", f"{c1_pF:g} pF"),
+            shunt("inductor", f"{l_uH:g} µH"),
+            series("capacitor", f"{c2_pF:g} pF"),
+        ),
     )
 
 
@@ -85,6 +94,10 @@ def l_network_tuner(
         branches=(
             TwoPort(a="rig", b="out", l=series_l_uH * 1e-6, ql=ql),
             Shunt(port="out", c=shunt_c_pF * 1e-12),
+        ),
+        schematic=(
+            series("inductor", f"{series_l_uH:g} µH"),
+            shunt("capacitor", f"{shunt_c_pF:g} pF"),
         ),
     )
 
@@ -515,6 +528,10 @@ def single_stub_tuner(
         branches=(
             TL(a="rig", b="ant", z0=lz0, length=length, vf=lvf, k1=lk1, k2=lk2),
             Instance("stub", stub, port="rig"),
+        ),
+        schematic=(
+            shunt("coax", f"stub {stub_wl:g} λ", "shorted" if shorted else "open"),
+            series("coax", f"{lz0:g} Ω", f"{line_wl:g} λ"),
         ),
     )
 

--- a/tests/test_schematic.py
+++ b/tests/test_schematic.py
@@ -1,0 +1,191 @@
+"""Network → schematic (issue #652).
+
+The lowering is the part with judgement in it — which branches form the spine,
+what hangs beneath it, and when an author's fragment replaces the defaults — so
+that is where the tests are. Rendering is checked for "it produced an SVG";
+schemdraw owns the pixels.
+"""
+
+import importlib
+
+import pytest
+
+import antennaknobs as ant
+from antennaknobs.network import (
+    Composite,
+    Driven,
+    Instance,
+    Network,
+    PortVirtual,
+    Shunt,
+    TL,
+)
+from antennaknobs.schematic import (
+    Element,
+    lower,
+    render_svg,
+    series,
+    shunt,
+    terminals_of,
+)
+
+has_schemdraw = pytest.importorskip
+
+
+def build(name):
+    return importlib.import_module(f"antennaknobs.designs.{name}").Builder()
+
+
+def kinds(sch):
+    return [(b.label, [(e.kind, e.orient) for e in b.elements]) for b in sch.blocks]
+
+
+# ---------------------------------------------------------------------------
+# lowering
+# ---------------------------------------------------------------------------
+def test_a_station_chain_lowers_source_to_antenna():
+    sch = lower(build("dipoles.invvee_coax_station").build_network())
+    assert sch.source == "rig"
+    assert sch.ends_in_antenna
+    assert kinds(sch) == [("TL", [("coax", "series")])]
+
+
+def test_a_shunt_branch_hangs_beneath_the_spine():
+    sch = lower(build("wire.efhw_sloper").build_network())
+    orients = [e.orient for b in sch.blocks for e in b.elements]
+    assert "series" in orients and "shunt" in orients
+
+
+def test_a_stub_is_drawn_as_a_shunt_even_though_it_is_a_line():
+    """A stub is a length of line used as a shunt; the rib's orientation comes
+    from the topology, not from the branch type's own default."""
+    sch = lower(build("verticals.stub_matched_vertical").build_network())
+    (block,) = sch.blocks
+    assert [e.orient for e in block.elements] == ["shunt", "series"]
+    assert all(e.kind == "coax" for e in block.elements)
+
+
+def test_branches_group_under_the_instance_they_came_from():
+    sch = lower(build("wire.doublet_ladder_tuner").build_network())
+    labels = [b.label for b in sch.blocks]
+    assert "tuner" in labels  # the composite draws as one box, not three
+
+
+def test_an_author_fragment_replaces_the_default_symbols():
+    """The T-network's coil belongs BETWEEN its capacitors — an ordering the
+    branch list cannot express and the author can."""
+    sch = lower(build("wire.doublet_ladder_tuner").build_network())
+    tuner = next(b for b in sch.blocks if b.label == "tuner")
+    assert [e.kind for e in tuner.elements] == ["capacitor", "inductor", "capacitor"]
+    assert [e.orient for e in tuner.elements] == ["series", "shunt", "series"]
+
+
+def test_a_box_without_a_fragment_still_draws():
+    """The fallback is the whole reason there is always a picture."""
+    body = Composite(
+        ports=("a", "b"), branches=(TL(a="a", b="b", z0=75.0, length=3.0),)
+    )
+    assert body.schematic is None
+    net = Network(
+        ports={"rig": PortVirtual("rig"), "far": PortVirtual("far")},
+        branches=[Instance("mystery", body, a="rig", b="far")],
+        sources=[Driven(port="rig")],
+    )
+    sch = lower(net)
+    assert sch.blocks and sch.blocks[0].elements[0].kind == "coax"
+
+
+def test_a_multi_feed_antenna_says_so_instead_of_drawing_a_chain():
+    sch = lower(build("arrays.bowtie4x4").build_network())
+    assert sch.blocks == []
+    assert any("multi-feed" in n for n in sch.notes)
+
+
+def test_one_terminal_loads_still_appear():
+    """`multiband.trap_dipole` is all traps on the feed — no chain at all, but
+    emphatically not nothing to draw."""
+    sch = lower(build("multiband.trap_dipole").build_network())
+    assert len(sch.blocks) == 2
+    assert all(e.orient == "shunt" for b in sch.blocks for e in b.elements)
+
+
+def test_a_long_chain_keeps_its_order():
+    sch = lower(build("broadband.lpda").build_network())
+    assert len(sch.blocks) >= 5
+    assert all(e.kind == "coax" for b in sch.blocks for e in b.elements)
+
+
+def test_labels_carry_the_values():
+    sch = lower(build("wire.doublet_ladder_tuner").build_network())
+    text = " ".join(e.label for b in sch.blocks for e in b.elements)
+    assert "pF" in text and "µH" in text and "Ω" in text
+
+
+def test_power_annotates_the_blocks_that_burn():
+    net = build("verticals.stub_matched_vertical").build_network()
+    budget = [("match: TL rig→feed", 0.004), ("match.stub: TL rig→far", 0.001)]
+    sch = lower(net, budget=budget)
+    assert sch.blocks[0].watts == pytest.approx(0.005)
+    # ...and without a budget nothing is claimed.
+    assert lower(net).blocks[0].watts is None
+
+
+# ---------------------------------------------------------------------------
+# the wrapper vocabulary
+# ---------------------------------------------------------------------------
+def test_the_fragment_api_is_plain_data():
+    """`station.py` must be able to declare a drawing without importing any
+    drawing library."""
+    el = series("inductor", "2.5 µH")
+    assert isinstance(el, Element) and el.orient == "series"
+    assert shunt("capacitor", "180 pF").orient == "shunt"
+    import antennaknobs.station as station_mod
+
+    assert "schemdraw" not in str(vars(station_mod).keys())
+
+
+def test_terminals_are_read_per_class_not_guessed():
+    """Shunt/Load name their node `port`; a field-name guess would miss them."""
+    assert terminals_of(TL(a="x", b="y", z0=50, length=1.0)) == ("x", "y")
+    assert terminals_of(Shunt(port="z", c=1e-12)) == ("z",)
+
+
+# ---------------------------------------------------------------------------
+# rendering + CLI
+# ---------------------------------------------------------------------------
+def test_render_produces_an_svg(tmp_path):
+    pytest.importorskip("schemdraw")
+    out = tmp_path / "s.svg"
+    svg = render_svg(lower(build("wire.doublet_ladder_tuner").build_network()), out)
+    assert svg.lstrip().startswith("<?xml") or "<svg" in svg
+    assert out.read_text() == svg
+
+
+@pytest.mark.parametrize(
+    "design",
+    [
+        "verticals.stub_matched_vertical",
+        "wire.efhw_sloper",
+        "dipoles.invvee_coax_station",
+        "multiband.trap_dipole",
+        "broadband.lpda",
+        "arrays.bowtie4x4",
+    ],
+)
+def test_every_shape_in_the_corpus_renders(design, tmp_path):
+    """Including the awkward ones: no chain, one-terminal loads, 16 sources."""
+    pytest.importorskip("schemdraw")
+    svg = render_svg(lower(build(design).build_network()), tmp_path / "s.svg")
+    assert "<svg" in svg
+
+
+def test_cli_writes_a_file(tmp_path):
+    pytest.importorskip("schemdraw")
+    out = tmp_path / "cli.svg"
+    ant.cli(f"schematic --builder wire.doublet_ladder_tuner --out {out}".split())
+    assert "<svg" in out.read_text()
+
+
+def test_cli_refuses_an_antenna_with_no_network():
+    with pytest.raises(SystemExit, match="no build_network"):
+        ant.cli("schematic --builder dipoles.invvee".split())


### PR DESCRIPTION
First increment on #652. **The issue stays open** — the web panel and the measurement-plane rider are still to come.

```bash
python -m antennaknobs schematic --builder wire.doublet_ladder_tuner --out tuner.svg
python -m antennaknobs schematic --builder verticals.stub_matched_vertical --power --out m.svg
```

The circuit half of a design has been visible only as a power-budget loss ledger, so an element that burns nothing — an ideal `TL`, a `bypass()` — appeared **nowhere**, and neither did the port the source sits on.

## The three decisions from scoping, implemented

**Macro authors draw their own boxes.** `doublet_ladder_tuner`'s tuner lowers to `TwoPort → Shunt → TwoPort`, and *"the coil goes between the capacitors"* is not in the branch list — it's in the head of whoever wrote `t_network_tuner`. Composites may carry a `schematic` fragment; three station boxes now do. Anything without one falls back to per-type default symbols: **always a picture**, and a fragment only makes it a good one.

**A thin declarative wrapper**, not raw schemdraw. `series()`/`shunt()` produce plain data, so `station.py` declares drawings without importing a drawing library (asserted by a test) and the renderer stays swappable. schemdraw is an optional extra — MIT, no dependencies of its own — and it also goes in the `test` extra so CI exercises the renderer instead of skipping it.

**CLI first.** Pure Python, no frontend work.

## The load-bearing discovery

**Flattening erases `Instance`s.** By the time anyone holds a `Network`, the `Composite`s — and hence the authors' fragments — are gone. `Network` now records `composites` (path → Composite) alongside `branch_paths`: derived state the flattening already had and threw away.

## Layout

Ours, because schemdraw's API is a cursor, not a layout engine — the spike in the issue showed ribs landing wherever the pen happened to be. The survey says it can be small: every catalog network is ≤ 9 branches with degree ≤ 3, so a **spine with ribs** covers the corpus. The three awkward shapes are handled explicitly and tested:

- one-terminal `Load`s with no chain at all (`trap_dipole`)
- **16 sources, zero branches** (`bowtie4x4`) — says so rather than drawing an empty box
- a **stub**: a length of *line* used as a shunt, so a rib's orientation comes from the topology, not from the branch type's default

`--power` folds the budget into the topology, which is the point of the exercise: 2.9% shown *at* the matching section rather than in a table with no picture beside it.

## What's left on #652

- Web panel (server-rendered SVG + IR coordinates for hotspots)
- The measurement-plane rider — the source marker is drawn, but it isn't yet selectable, and `sweep.py` still hardcodes "feedpoint impedance" in its chart titles
- Fragments for the remaining station boxes (~8; the mechanism is proven by the three that have them)

## Testing

22 tests, all on the lowering (where the judgement is): spine/rib assignment, instance grouping, fragment override vs default fallback, the stub-orientation rule, multi-feed and no-chain shapes, value labels, budget attribution including nested boxes, and the "no drawing library in station.py" invariant. Rendering is checked as "produced an SVG" across six corpus shapes — schemdraw owns the pixels. Fast lane green: 3029 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g