### PR TITLE
refactor(web): extract App.tsx pure logic into src/lib modules (#642 phase 2)

### DIFF
--- a/src/antennaknobs/web/cost.py
+++ b/src/antennaknobs/web/cost.py
@@ -3,7 +3,7 @@
 Admission used to be three parallel inventions: the hosted matrix caps
 (``_check_solve_size``), the hosted point-count caps (inline in ``/sweep``
 and ``/converge``), and the frontend's poor-match withhold gate
-(``comboInappropriate`` in App.tsx, keyed off the server's recommended
+(``comboInappropriate`` in frontend/src/lib/backends.ts, keyed off the server's recommended
 backend). This module is the single mapping they all consult:
 
     admit(req, kind=..., points=..., use_pynec=..., hosted=..., example=...)

--- a/src/antennaknobs/web/frontend/src/App.tsx
+++ b/src/antennaknobs/web/frontend/src/App.tsx
@@ -10,6 +10,46 @@ import {
   useSyncExternalStore,
 } from "react";
 import type { CSSProperties } from "react";
+import {
+  backendAllowed,
+  BACKEND_LABEL,
+  backendDisplayLabel,
+  backendSupportsGround,
+  backendSupportsTerrain,
+  comboInappropriate,
+  DEFAULT_BACKEND_OPTS,
+  DEFAULT_SLOTS,
+  isBSplineFamily,
+  modelOptionsForRequest,
+  normalizeBackend,
+  resolveBackend,
+  RESTRICTED_BACKEND_REASON,
+  resolveSlotConfig,
+  selectableBackends,
+  SLOT_ORDER,
+  type Backend,
+  type BackendOptsMap,
+  type BSplineOpts,
+  type SinGalerkinOpts,
+  type SinusoidalOpts,
+  type Slot,
+  type SlotConfig,
+} from "./lib/backends";
+import type {
+  FiniteGroundMethod,
+  GroundModel,
+  GroundType,
+  TerrainParams,
+  TerrainPresetSchema,
+} from "./lib/ground";
+import {
+  formatMetres,
+  formatOhms,
+  formatScalar,
+  formatSwr,
+  reflectionCoefficient,
+} from "./lib/format";
+import { mixHex, richardsonExtrap } from "./lib/math";
 
 type Wire = {
   label: string;
@@ -390,16 +430,6 @@ function findLinkedDesignFreq(
     }
   }
   return null;
-}
-
-// Blend two #rrggbb colors; t=0 -> a, t=1 -> b. Used to warm the knob's value
-// arc from --accent toward --hot as it nears max (an "energizing" cue).
-export function mixHex(a: string, b: string, t: number): string {
-  const ch = (s: string, i: number) => parseInt(s.slice(i, i + 2), 16);
-  const r = Math.round(ch(a, 1) + (ch(b, 1) - ch(a, 1)) * t);
-  const g = Math.round(ch(a, 3) + (ch(b, 3) - ch(a, 3)) * t);
-  const bl = Math.round(ch(a, 5) + (ch(b, 5) - ch(a, 5)) * t);
-  return `rgb(${r}, ${g}, ${bl})`;
 }
 
 // A dependency-free rotary knob — a drop-in alternative to the range
@@ -1253,10 +1283,6 @@ function ParamForm({
   );
 }
 
-export function formatScalar(raw: unknown, precision: number, unit: string | null): string {
-  return typeof raw === "number" ? `${raw.toFixed(precision)}${unit ?? ""}` : "—";
-}
-
 // label_template substitutions for ResultGroupItem:
 //   {i}            → 0-based index
 //   {i1}           → 1-based index
@@ -1480,386 +1506,6 @@ type SolveResponse = {
   error?: string;
 };
 
-// Backend selector — Momwire model variants + PyNEC. Per-backend
-// `model_options` are forwarded to server.py's _make_momwire_sim.
-// "triangular" is retired from the UI (the server still accepts it);
-// see normalizeBackend for how a stale recommendation is mapped.
-export type Backend =
-  | "sinusoidal"
-  | "sinusoidal-galerkin"
-  | "bspline"
-  | "hmatrix"
-  | "arrayblock"
-  | "pynec";
-
-const BACKEND_LABEL: Record<Backend, string> = {
-  sinusoidal: "Sinusoidal",
-  "sinusoidal-galerkin": "Sin-Galerkin",
-  bspline: "B-spline",
-  hmatrix: "H-matrix (ACA)",
-  arrayblock: "Array-block",
-  pynec: "PyNEC",
-};
-
-// A design/solver combo is "inappropriate" when the solver is a poor fit: a
-// dense solver (or PyNEC) on a large array is very slow, an accelerator
-// (array-block / H-matrix) on a single-element design is pure overhead, and
-// on a benchmark-class mesh (thousands of segments) every b-spline-family
-// solver is minutes per solve where sinusoidal (or PyNEC) is seconds. `rec`
-// is the server's recommended backend ("arrayblock" for grid arrays,
-// "sinusoidal" for huge meshes, else null).
-export function comboInappropriate(b: Backend, rec: Backend | null): boolean {
-  const accel = b === "arrayblock" || b === "hmatrix";
-  if (rec === "arrayblock") return !accel; // an array wants an accelerator
-  if (rec === "sinusoidal") return b !== "sinusoidal" && b !== "pynec";
-  return accel; // everything else doesn't need one
-}
-
-export const BACKEND_ORDER: Backend[] = [
-  "sinusoidal",
-  "sinusoidal-galerkin",
-  "bspline",
-  "hmatrix",
-  "arrayblock",
-  "pynec",
-];
-
-// PyNEC needs the optional pynec-accel package, so the server reports whether
-// it is installed (`have_pynec` in /examples). When it is not, the UI must not
-// offer it — otherwise the /ws solve silently falls back to momwire (#429).
-// `sinusoidal` is the fallback: it is the momwire basis closest to NEC (the
-// same sinusoidal current expansion), so a default panel or a coerced saved
-// slot still solves the same physics without PyNEC.
-const PYNEC_FALLBACK_BACKEND: Backend = "sinusoidal";
-
-// Backends selectable given the server's capabilities: drops PyNEC when
-// pynec-accel is absent.
-export function selectableBackends(havePynec: boolean): Backend[] {
-  return havePynec ? BACKEND_ORDER : BACKEND_ORDER.filter((b) => b !== "pynec");
-}
-
-// Map an unavailable PyNEC selection to the fallback; leave everything else
-// untouched. Applied wherever a backend can arrive from outside the gated
-// picker — default slots, a saved/URL slot, a server recommendation.
-export function resolveBackend(b: Backend, havePynec: boolean): Backend {
-  return b === "pynec" && !havePynec ? PYNEC_FALLBACK_BACKEND : b;
-}
-
-// Per-design backend allowlist (`requires_backends` on the descriptor —
-// e.g. ["bspline"] for designs with PortAtEnd junction ports, which only
-// the B-spline solver implements; NEC-2 has no equivalent card at all).
-// null/undefined = no restriction. Unlike the missing-pynec-accel case
-// (#429) this is per-design, and unlike comboInappropriate it is a HARD
-// incompatibility: the disallowed solvers raise, so the gate offers
-// "switch", never "solve anyway".
-export function backendAllowed(
-  b: Backend,
-  required: string[] | null | undefined,
-): boolean {
-  return !required || required.includes(b);
-}
-
-// One-line explanation for why a design is backend-restricted, used by the
-// disabled tabs' tooltip and the hard withhold gate. Today the only
-// restriction cause is junction ports, so the copy is specific; broaden it
-// if _required_backends ever grows another cause.
-const RESTRICTED_BACKEND_REASON =
-  "This design attaches network elements at conductor ends (junction-node " +
-  "ports) — only the B-spline and sinusoidal-Galerkin solvers implement " +
-  "them, and NEC-2 has no equivalent card.";
-
-// hmatrix (hierarchical H-matrix / ACA) and arrayblock (element-aware block
-// solver for arrays) are accelerators built on the same B-spline basis as
-// bspline; they share its options and request shape, and fall back to the
-// dense bspline path for ground/enrichment.
-const BSPLINE_FAMILY: Backend[] = ["bspline", "hmatrix", "arrayblock"];
-export function isBSplineFamily(b: Backend): boolean {
-  return BSPLINE_FAMILY.includes(b);
-}
-
-// The UI separates WHAT the ground is from HOW it's solved. GroundType is
-// the shared, backend-agnostic choice: a finite ground (εr=10, σ=0.002), a
-// perfectly conducting one, or a faceted terrain (levee/cliff presets).
-// It never promises more than the physics — each backend
-// solves it as best it can: PyNEC and the plain B-spline backend offer a
-// method sub-choice (Sommerfeld-Norton vs the reflection-coefficient
-// approximation) — since momwire 0.8.0 every momwire backend honours both,
-// so the choice is uniform across solvers; either way the finite constants
-// reach the far-field Fresnel cut. Terrain solves impedance on the crest
-// medium (Sommerfeld) and applies per-direction specular-facet reflection
-// in the far field (issue #534).
-type GroundType = "finite" | "pec" | "terrain";
-// Finite-ground solve method, shown for every finite-ground backend:
-// PyNEC (NEC ITYPE=2 vs ITYPE=0) and, since momwire 0.8.0, every momwire
-// solver (true Sommerfeld on bspline dense, sinusoidal field-based, and
-// the hmatrix/arrayblock fast paths). "fast" is the default everywhere;
-// Sommerfeld is opt-in because it is more expensive: the first solve at a
-// new frequency fills an interpolation grid (~0.2-0.5 s on a small box;
-// the first sweep pays that per point), and repeat solves at seen
-// frequencies reuse cached grids (tens of ms).
-type FiniteGroundMethod = "sommerfeld" | "fast";
-// The wire value (`ground_model` on SolveRequest): derived from groundType
-// (+ the method wherever finite ground is supported).
-type GroundModel = "sommerfeld" | "fast" | "pec" | "terrain";
-
-// Terrain preset schema, served by GET /capabilities (issue #560). The
-// frontend renders the whole terrain knob panel from this — the presets,
-// their field ranges/labels/units, and the read-only media note all live
-// server-side (adapter.terrain_presets_schema), so a Python-only preset needs
-// no TypeScript. Media are fixed server-side (water 80/0.005, land + crest
-// 13/0.005); each preset's media_note describes its own.
-type TerrainFieldSchema = {
-  key: string;
-  label: string; // omits the unit; the panel renders "{label} ({unit})"
-  unit: string | null;
-  default: number;
-  min: number;
-  max: number;
-  step: number;
-};
-type TerrainPresetSchema = {
-  name: string;
-  label: string; // radio label
-  tooltip: string; // radio hover text
-  media_note: string;
-  fields: TerrainFieldSchema[];
-};
-// Terrain knob values keyed by field key, sent (spread) as the request's
-// `terrain` object when ground_model === "terrain". One flat bag across all
-// presets so edits survive preset flips; an unset key falls back to the
-// schema default and the server clamps every number.
-type TerrainParams = Record<string, number>;
-
-export function backendSupportsGround(b: Backend): boolean {
-  // sinusoidal-galerkin: all three grounds since momwire#182 M4. (Junction-
-  // port designs OVER a ground refuse server-side — a per-design error the
-  // solve surfaces cleanly, not a backend capability gap.)
-  return (
-    b === "sinusoidal" ||
-    b === "sinusoidal-galerkin" ||
-    isBSplineFamily(b) ||
-    b === "pynec"
-  );
-}
-
-// Every ground-capable backend supports terrain. Momwire applies the
-// per-facet far field natively; PyNEC runs the hybrid (issue #553): NEC
-// solves the currents over crest-medium Sommerfeld — exactly what the
-// terrain recipe feeds the current solve anyway — and the server's cut
-// physics applies the facet reflection to those currents.
-export function backendSupportsTerrain(b: Backend): boolean {
-  return backendSupportsGround(b);
-}
-
-// Coerce a server-supplied backend name into something this UI knows.
-// "triangular" was retired from the frontend (the server still accepts
-// it and may still recommend it, e.g. from an older adapter or a saved
-// design hint): map it to "bspline", the default working solver on the
-// same dense path. Anything else unrecognised falls back to null ("no
-// recommendation") so a stale value never reaches state or the wire.
-export function normalizeBackend(b: string | null | undefined): Backend | null {
-  if (!b) return null;
-  if (b === "triangular") return "bspline";
-  return (BACKEND_ORDER as string[]).includes(b) ? (b as Backend) : null;
-}
-
-type CommonOpts = { nPerWire: number; wireRadius: number };
-
-type SinusoidalOpts = CommonOpts & { nQpConst: number };
-// Sin-Galerkin only: the feed-model axis (issue #640, momwire#192).
-// "segment" = NEC-compatible (NEC's segment-wide gap — reproduces NEC/EZNEC
-// behaviour, including the reactance walk with mesh density); "point" =
-// Converged (zero-width gap — converges to the B-spline answer; recommended
-// for near-open high-Q designs, momwire#213). Deliberately NOT on plain
-// sinusoidal: the point gap has no collocation RHS (momwire#212), so that
-// solver offers no choice to present.
-export type SinGalerkinOpts = SinusoidalOpts & { feedModel: "segment" | "point" };
-export type BSplineOpts = CommonOpts & {
-  degree: 1 | 2;
-  nQpPair: number;
-  feedSmoothingFactor: number | null; // null = sharp delta-gap
-  useSingularEnrichment: boolean;
-  // "raw"      → Φ_sing(t) = t·log(t), PR #45/#47 original shape.
-  // "stable"   → Φ_sing − bubble-subspace L²-projection: faster large-N
-  //              convergence on dominant-pair K=3 junctions; larger
-  //              small-N transient; loses Y-fixture cusp benefit. d=1
-  //              collapses to raw bit-exact.
-  // "tikhonov" → raw basis + λ·s·I penalty on Z_ee at solve time.
-  //              λ→0 is raw; λ→∞ kills enrichment. λ=0.1 preserves
-  //              Y-fixture cusp; λ=1.0 fully suppresses the small-N
-  //              transient on dominant-pair K=3 junctions but loses Y cusp.
-  // "auto"     → two-pass: solve once without enrichment, measure
-  //              tap_ratio at each K≥3 junction, apply raw enrichment
-  //              only where tap_ratio > autoTapRatioThreshold. Cleanly
-  //              separates dominant-pair K=3 (tap_ratio ≈ 0.16) from
-  //              balanced 3-way (Y ≈ 0.50). The selectivity that
-  //              raw/stable/tikhonov can't deliver algebraically.
-  enrichmentVariant: "raw" | "stable" | "tikhonov" | "auto";
-  tikhonovLambda: number;
-  autoTapRatioThreshold: number;
-  nQpSing: number;
-  enrichmentMinK: number;
-  nQpSource: number;
-};
-type PyNECOpts = CommonOpts;
-
-// hmatrix and arrayblock share BSplineOpts (same basis + knobs); the ACA
-// tolerances use the solver defaults.
-type BackendOptsMap = {
-  sinusoidal: SinusoidalOpts;
-  // Same constructor surface as sinusoidal (momwire#182: same basis, Galerkin
-  // testing) plus the feed-model choice only the Galerkin testing can carry;
-  // the test-quadrature knobs keep their solver defaults.
-  "sinusoidal-galerkin": SinGalerkinOpts;
-  bspline: BSplineOpts;
-  hmatrix: BSplineOpts;
-  arrayblock: BSplineOpts;
-  pynec: PyNECOpts;
-};
-
-const BSPLINE_DEFAULT_OPTS: BSplineOpts = {
-  nPerWire: 30,
-  wireRadius: 0.0005,
-  degree: 2,
-  nQpPair: 4,
-  feedSmoothingFactor: null,
-  useSingularEnrichment: false,
-  enrichmentVariant: "raw",
-  tikhonovLambda: 0.1,
-  autoTapRatioThreshold: 0.3,
-  nQpSing: 32,
-  enrichmentMinK: 3,
-  nQpSource: 16,
-};
-
-export const DEFAULT_BACKEND_OPTS: BackendOptsMap = {
-  sinusoidal: { nPerWire: 30, wireRadius: 0.0005, nQpConst: 8 },
-  // feedModel "segment" (NEC-compatible) is the solver's own default; the
-  // gear menu recommends "point" (Converged) on near-open designs (#640).
-  "sinusoidal-galerkin": {
-    nPerWire: 30,
-    wireRadius: 0.0005,
-    nQpConst: 8,
-    feedModel: "segment",
-  },
-  bspline: { ...BSPLINE_DEFAULT_OPTS },
-  hmatrix: { ...BSPLINE_DEFAULT_OPTS },
-  // Arrays auto-select this; 21 segs/wire is the converged, correct-parity
-  // choice for B-spline d=2 (odd → interior knot at the feed). The old
-  // inherited 40 was both too many and the wrong (even) parity.
-  arrayblock: { ...BSPLINE_DEFAULT_OPTS, nPerWire: 21 },
-  pynec: { nPerWire: 21, wireRadius: 0.0005 },
-};
-
-// Three abstract solver slots. Each holds one backend choice and its
-// options; the user picks A/B/C with the row of buttons, configures the
-// inhabitants from the per-slot gear menu. Lets the same UI compare
-// e.g. "B-spline d=2 @ N=15" against "B-spline d=1 @ N=20" without
-// losing either setup.
-type Slot = "A" | "B" | "C";
-const SLOT_ORDER: Slot[] = ["A", "B", "C"];
-
-export type SlotConfig = {
-  backend: Backend;
-  opts: BackendOptsMap[Backend];
-};
-
-// Display label for a configured backend: B-spline-family entries carry
-// their spline degree so two b-spline slots (the default A d=2 / B d=1
-// pair) stay distinguishable at a glance.
-export function backendDisplayLabel(b: Backend, opts: BackendOptsMap[Backend]): string {
-  if (isBSplineFamily(b))
-    return `${BACKEND_LABEL[b]} d=${(opts as BSplineOpts).degree}`;
-  // Surface the non-default feed model on the slot chip: two Sin-Galerkin
-  // slots differing only in feed model must be tellable apart at a glance.
-  if (b === "sinusoidal-galerkin" && (opts as SinGalerkinOpts).feedModel === "point")
-    return `${BACKEND_LABEL[b]} (converged)`;
-  return BACKEND_LABEL[b];
-}
-
-const DEFAULT_SLOTS: Record<Slot, SlotConfig> = {
-  // A is the default working solver: B-spline d=2 — most accurate per
-  // unknown, converged at a small odd N (interior knot at the feed), and
-  // its impedance solve honours finite grounds (Triangular, the old,
-  // now-retired default, folded them to the PEC image). N=15 per the
-  // basis-convergence census (docs/status/2026-07-20): within 2% of the
-  // basis-agreed limit on 50/66 scorable designs (N=21 buys only 3 more,
-  // all within 2.3%), patterns within 0.05 dB of the fine-mesh reference,
-  // ~35% faster ticks. Odd parity keeps the feed's interior knot.
-  A: {
-    backend: "bspline",
-    opts: { ...DEFAULT_BACKEND_OPTS.bspline, nPerWire: 15 },
-  },
-  // B is the cross-check basis: B-spline d=1 needs a larger N to reach
-  // the same answer (slower), which is what makes agreement with A a
-  // meaningful second opinion rather than the same solve twice. N=20
-  // trades cross-check tightness for speed (within 2% of the limit on
-  // 45/66 vs 55/66 at the old N=40 — disagreement with A beyond a couple
-  // of percent warrants raising N before suspecting the design).
-  B: {
-    backend: "bspline",
-    opts: { ...DEFAULT_BACKEND_OPTS.bspline, degree: 1, nPerWire: 20 },
-  },
-  C: {
-    backend: "pynec",
-    opts: { ...DEFAULT_BACKEND_OPTS.pynec },
-  },
-};
-
-// Resolve a slot config against server capabilities (#429): if it names PyNEC
-// and pynec-accel is absent, swap to the fallback backend with that backend's
-// default kwargs, preserving the geometry-sizing (segments/wire, radius) the
-// same way a manual backend swap does. Slot C defaults to PyNEC, so this is
-// what keeps the default panel sensible on a server without it.
-export function resolveSlotConfig(cfg: SlotConfig, havePynec: boolean): SlotConfig {
-  const backend = resolveBackend(cfg.backend, havePynec);
-  if (backend === cfg.backend) return cfg;
-  return {
-    backend,
-    opts: {
-      ...DEFAULT_BACKEND_OPTS[backend],
-      nPerWire: cfg.opts.nPerWire,
-      wireRadius: cfg.opts.wireRadius,
-    } as BackendOptsMap[Backend],
-  };
-}
-
-// Translates the camelCase frontend options into the snake_case kwargs the
-// server forwards to each Momwire model class constructor.
-export function modelOptionsForRequest(
-  backend: Backend,
-  opts: BackendOptsMap[Backend],
-): Record<string, unknown> {
-  if (backend === "sinusoidal-galerkin") {
-    const o = opts as SinGalerkinOpts;
-    // feed_model only here: plain sinusoidal cannot carry the point gap
-    // (momwire#212) and must not receive the key at all.
-    return { n_qp_const: o.nQpConst, feed_model: o.feedModel };
-  }
-  if (backend === "sinusoidal") {
-    const o = opts as SinusoidalOpts;
-    return { n_qp_const: o.nQpConst };
-  }
-  if (isBSplineFamily(backend)) {
-    // bspline, hmatrix, and arrayblock all take the B-spline kwargs; the
-    // accelerators read additional aca_tol/solve_tol from their own defaults.
-    const o = opts as BSplineOpts;
-    return {
-      degree: o.degree,
-      n_qp_pair: o.nQpPair,
-      n_qp_source: o.nQpSource,
-      feed_smoothing_factor: o.feedSmoothingFactor,
-      use_singular_enrichment: o.useSingularEnrichment,
-      enrichment_variant: o.enrichmentVariant,
-      tikhonov_lambda: o.tikhonovLambda,
-      auto_tap_ratio_threshold: o.autoTapRatioThreshold,
-      n_qp_sing: o.nQpSing,
-      enrichment_min_k: o.enrichmentMinK,
-    };
-  }
-  return {};
-}
-
 type SolveRequest = {
   geometry: string;
   /** Which `<name>_params` dict on the Builder to seed from. Omitted
@@ -1999,52 +1645,6 @@ type NormCheckData = {
 // O(1/N) trajectories clearly. Same ladder across backends so the curves
 // are directly comparable when the user switches slots.
 const CONVERGE_N_VALUES: number[] = [8, 12, 17, 24, 34, 48, 68];
-
-// Richardson-style extrapolation Z(1/N) → Z(N→∞). Fits Z = a₀ + a₁·h + a₂·h²
-// (h = 1/N) on the last `nLast` points via least squares and returns a₀.
-// Quadratic gives a sane answer for O(1/N) limit (BSpline without
-// enrichment) AND O(1/N^p) for p slightly above 1 — basis-cap, enrichment,
-// etc. With ≤2 points we can't fit; return null.
-export function richardsonExtrap(
-  invN: number[],
-  vals: number[],
-  nLast = 5,
-): number | null {
-  const m = Math.min(nLast, invN.length);
-  if (m < 3) return null;
-  const start = invN.length - m;
-  // Solve Ax = b for x = [a₀, a₁, a₂] using normal equations on the last m
-  // points. m × 3 → 3 × 3 — small, no need for an LAPACK call.
-  let s0 = 0, s1 = 0, s2 = 0, s3 = 0, s4 = 0;
-  let t0 = 0, t1 = 0, t2 = 0;
-  for (let i = start; i < invN.length; i++) {
-    const h = invN[i];
-    const y = vals[i];
-    s0 += 1;
-    s1 += h;
-    s2 += h * h;
-    s3 += h * h * h;
-    s4 += h * h * h * h;
-    t0 += y;
-    t1 += y * h;
-    t2 += y * h * h;
-  }
-  // 3x3 linear system: [[s0,s1,s2],[s1,s2,s3],[s2,s3,s4]] · [a0,a1,a2] = [t0,t1,t2]
-  const m00 = s0, m01 = s1, m02 = s2;
-  const m10 = s1, m11 = s2, m12 = s3;
-  const m20 = s2, m21 = s3, m22 = s4;
-  const det =
-    m00 * (m11 * m22 - m12 * m21) -
-    m01 * (m10 * m22 - m12 * m20) +
-    m02 * (m10 * m21 - m11 * m20);
-  if (Math.abs(det) < 1e-30) return null;
-  const a0 =
-    (t0 * (m11 * m22 - m12 * m21) -
-      m01 * (t1 * m22 - m12 * t2) +
-      m02 * (t1 * m21 - m11 * t2)) /
-    det;
-  return a0;
-}
 
 type PatternData = {
   theta_deg: number[];
@@ -6695,14 +6295,6 @@ function feedMag(r: SolveResponse): number {
   return Math.hypot(re, im);
 }
 
-export function reflectionCoefficient(r: number, x: number, z0: number) {
-  // Γ = (Z - Z0) / (Z + Z0), with Z = r + jx (Z0 real).
-  const denom = (r + z0) * (r + z0) + x * x;
-  const gRe = (r * r - z0 * z0 + x * x) / denom;
-  const gIm = (2 * x * z0) / denom;
-  return { gRe, gIm, gMag: Math.hypot(gRe, gIm) };
-}
-
 // Display labels for SolveResponse.ground_model_applied — what the
 // impedance solve actually ran, as reported by the server (see the type).
 const GROUND_APPLIED_LABEL: Record<string, string> = {
@@ -6714,22 +6306,6 @@ const GROUND_APPLIED_LABEL: Record<string, string> = {
   // reflects per-direction off the facets (issue #534).
   terrain: "terrain (crest Somm.)",
 };
-
-export function formatOhms(v: number): string {
-  // The server clamps an open-circuited feed (e.g. a series matchbox
-  // capacitor slider at 0 pF) to a 1e9 Ω sentinel — JSON has no Infinity.
-  // Anything that large is physically an open, not a number worth printing.
-  if (Math.abs(v) >= 1e8) return "∞ (open)";
-  return `${v.toFixed(2)} Ω`;
-}
-
-export function formatSwr(r: number, x: number, z0: number): string {
-  const { gMag } = reflectionCoefficient(r, x, z0);
-  if (gMag >= 0.9999) return "∞";
-  const swr = (1 + gMag) / (1 - gMag);
-  if (swr > 99) return swr.toFixed(0);
-  return swr.toFixed(2);
-}
 
 // The R/X/SWR/rtt solve readout. The desktop stage floats it over the canvas
 // as a HUD (className="stage-readout"); the mobile Info screen (Phase B)
@@ -9022,15 +8598,6 @@ function CurrentCanvas({
       )}
     </div>
   );
-}
-
-// Nice-number lengths for the zoomed scale bar: pick the readable unit and
-// trim float dust (5×10⁻³ m × 1000 → "5 mm", not "5.000000000000001 mm").
-function formatMetres(v: number): string {
-  const fmt = (x: number, unit: string) => `${parseFloat(x.toPrecision(2))} ${unit}`;
-  if (v >= 1) return fmt(v, "m");
-  if (v >= 0.01) return fmt(v * 100, "cm");
-  return fmt(v * 1000, "mm");
 }
 
 function drawArmEnvelope(

--- a/src/antennaknobs/web/frontend/src/__tests__/backends.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/backends.test.ts
@@ -1,7 +1,7 @@
-// Pins the backend-selection/config logic in App.tsx's backend-config block
-// (issue #642 step 2). These are pure functions with no DOM dependency; the
-// jsdom environment is only here because importing "../App" evaluates the
-// module's WS_URL, which reads window.location.
+// Pins the backend-selection/config logic in src/lib/backends.ts (issue #642
+// step 2). Pure functions with no DOM dependency — the suite-wide jsdom
+// environment exists for tests that import App.tsx (its module-scope WS_URL
+// reads window.location), not for these.
 import { describe, it, expect } from "vitest";
 import {
   BACKEND_ORDER,

--- a/src/antennaknobs/web/frontend/src/__tests__/backends.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/backends.test.ts
@@ -20,7 +20,7 @@ import {
   type BSplineOpts,
   type SinGalerkinOpts,
   type SlotConfig,
-} from "../App";
+} from "../lib/backends";
 
 describe("normalizeBackend", () => {
   it("maps the retired 'triangular' name to bspline", () => {

--- a/src/antennaknobs/web/frontend/src/__tests__/format.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/format.test.ts
@@ -3,7 +3,8 @@
 // formatSwr (impedance/SWR readouts, including the open-circuit sentinel and
 // the |Gamma| -> 1 asymptote).
 import { describe, it, expect } from "vitest";
-import { formatOhms, formatScalar, formatSwr, mixHex } from "../App";
+import { formatOhms, formatScalar, formatSwr } from "../lib/format";
+import { mixHex } from "../lib/math";
 
 describe("mixHex", () => {
   it("returns exactly a at t=0 and exactly b at t=1", () => {

--- a/src/antennaknobs/web/frontend/src/__tests__/format.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/format.test.ts
@@ -1,4 +1,4 @@
-// Pins the small display-formatting free functions in App.tsx: mixHex (knob
+// Pins the small display-formatting free functions in src/lib: mixHex (knob
 // arc color blend), formatScalar (generic numeric readout), formatOhms and
 // formatSwr (impedance/SWR readouts, including the open-circuit sentinel and
 // the |Gamma| -> 1 asymptote).

--- a/src/antennaknobs/web/frontend/src/__tests__/math.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/math.test.ts
@@ -2,7 +2,8 @@
 // reflectionCoefficient (Gamma from R/X/Z0), the numeric cores behind the
 // convergence sweep and the SWR/Smith-chart readouts.
 import { describe, it, expect } from "vitest";
-import { reflectionCoefficient, richardsonExtrap } from "../App";
+import { reflectionCoefficient } from "../lib/format";
+import { richardsonExtrap } from "../lib/math";
 
 describe("richardsonExtrap", () => {
   it("returns null for fewer than 3 points", () => {

--- a/src/antennaknobs/web/frontend/src/__tests__/modelOptions.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/modelOptions.test.ts
@@ -7,7 +7,7 @@ import {
   modelOptionsForRequest,
   type BSplineOpts,
   type SinGalerkinOpts,
-} from "../App";
+} from "../lib/backends";
 
 describe("modelOptionsForRequest", () => {
   it("sinusoidal-galerkin sends exactly n_qp_const and feed_model", () => {

--- a/src/antennaknobs/web/frontend/src/lib/backends.ts
+++ b/src/antennaknobs/web/frontend/src/lib/backends.ts
@@ -1,0 +1,326 @@
+// Backend selector — Momwire model variants + PyNEC. Per-backend
+// `model_options` are forwarded to server.py's _make_momwire_sim.
+// "triangular" is retired from the UI (the server still accepts it);
+// see normalizeBackend for how a stale recommendation is mapped.
+export type Backend =
+  | "sinusoidal"
+  | "sinusoidal-galerkin"
+  | "bspline"
+  | "hmatrix"
+  | "arrayblock"
+  | "pynec";
+
+export const BACKEND_LABEL: Record<Backend, string> = {
+  sinusoidal: "Sinusoidal",
+  "sinusoidal-galerkin": "Sin-Galerkin",
+  bspline: "B-spline",
+  hmatrix: "H-matrix (ACA)",
+  arrayblock: "Array-block",
+  pynec: "PyNEC",
+};
+
+// A design/solver combo is "inappropriate" when the solver is a poor fit: a
+// dense solver (or PyNEC) on a large array is very slow, an accelerator
+// (array-block / H-matrix) on a single-element design is pure overhead, and
+// on a benchmark-class mesh (thousands of segments) every b-spline-family
+// solver is minutes per solve where sinusoidal (or PyNEC) is seconds. `rec`
+// is the server's recommended backend ("arrayblock" for grid arrays,
+// "sinusoidal" for huge meshes, else null).
+export function comboInappropriate(b: Backend, rec: Backend | null): boolean {
+  const accel = b === "arrayblock" || b === "hmatrix";
+  if (rec === "arrayblock") return !accel; // an array wants an accelerator
+  if (rec === "sinusoidal") return b !== "sinusoidal" && b !== "pynec";
+  return accel; // everything else doesn't need one
+}
+
+export const BACKEND_ORDER: Backend[] = [
+  "sinusoidal",
+  "sinusoidal-galerkin",
+  "bspline",
+  "hmatrix",
+  "arrayblock",
+  "pynec",
+];
+
+// PyNEC needs the optional pynec-accel package, so the server reports whether
+// it is installed (`have_pynec` in /examples). When it is not, the UI must not
+// offer it — otherwise the /ws solve silently falls back to momwire (#429).
+// `sinusoidal` is the fallback: it is the momwire basis closest to NEC (the
+// same sinusoidal current expansion), so a default panel or a coerced saved
+// slot still solves the same physics without PyNEC.
+export const PYNEC_FALLBACK_BACKEND: Backend = "sinusoidal";
+
+// Backends selectable given the server's capabilities: drops PyNEC when
+// pynec-accel is absent.
+export function selectableBackends(havePynec: boolean): Backend[] {
+  return havePynec ? BACKEND_ORDER : BACKEND_ORDER.filter((b) => b !== "pynec");
+}
+
+// Map an unavailable PyNEC selection to the fallback; leave everything else
+// untouched. Applied wherever a backend can arrive from outside the gated
+// picker — default slots, a saved/URL slot, a server recommendation.
+export function resolveBackend(b: Backend, havePynec: boolean): Backend {
+  return b === "pynec" && !havePynec ? PYNEC_FALLBACK_BACKEND : b;
+}
+
+// Per-design backend allowlist (`requires_backends` on the descriptor —
+// e.g. ["bspline"] for designs with PortAtEnd junction ports, which only
+// the B-spline solver implements; NEC-2 has no equivalent card at all).
+// null/undefined = no restriction. Unlike the missing-pynec-accel case
+// (#429) this is per-design, and unlike comboInappropriate it is a HARD
+// incompatibility: the disallowed solvers raise, so the gate offers
+// "switch", never "solve anyway".
+export function backendAllowed(
+  b: Backend,
+  required: string[] | null | undefined,
+): boolean {
+  return !required || required.includes(b);
+}
+
+// One-line explanation for why a design is backend-restricted, used by the
+// disabled tabs' tooltip and the hard withhold gate. Today the only
+// restriction cause is junction ports, so the copy is specific; broaden it
+// if _required_backends ever grows another cause.
+export const RESTRICTED_BACKEND_REASON =
+  "This design attaches network elements at conductor ends (junction-node " +
+  "ports) — only the B-spline and sinusoidal-Galerkin solvers implement " +
+  "them, and NEC-2 has no equivalent card.";
+
+// hmatrix (hierarchical H-matrix / ACA) and arrayblock (element-aware block
+// solver for arrays) are accelerators built on the same B-spline basis as
+// bspline; they share its options and request shape, and fall back to the
+// dense bspline path for ground/enrichment.
+export const BSPLINE_FAMILY: Backend[] = ["bspline", "hmatrix", "arrayblock"];
+export function isBSplineFamily(b: Backend): boolean {
+  return BSPLINE_FAMILY.includes(b);
+}
+
+export function backendSupportsGround(b: Backend): boolean {
+  // sinusoidal-galerkin: all three grounds since momwire#182 M4. (Junction-
+  // port designs OVER a ground refuse server-side — a per-design error the
+  // solve surfaces cleanly, not a backend capability gap.)
+  return (
+    b === "sinusoidal" ||
+    b === "sinusoidal-galerkin" ||
+    isBSplineFamily(b) ||
+    b === "pynec"
+  );
+}
+
+// Every ground-capable backend supports terrain. Momwire applies the
+// per-facet far field natively; PyNEC runs the hybrid (issue #553): NEC
+// solves the currents over crest-medium Sommerfeld — exactly what the
+// terrain recipe feeds the current solve anyway — and the server's cut
+// physics applies the facet reflection to those currents.
+export function backendSupportsTerrain(b: Backend): boolean {
+  return backendSupportsGround(b);
+}
+
+// Coerce a server-supplied backend name into something this UI knows.
+// "triangular" was retired from the frontend (the server still accepts
+// it and may still recommend it, e.g. from an older adapter or a saved
+// design hint): map it to "bspline", the default working solver on the
+// same dense path. Anything else unrecognised falls back to null ("no
+// recommendation") so a stale value never reaches state or the wire.
+export function normalizeBackend(b: string | null | undefined): Backend | null {
+  if (!b) return null;
+  if (b === "triangular") return "bspline";
+  return (BACKEND_ORDER as string[]).includes(b) ? (b as Backend) : null;
+}
+
+export type CommonOpts = { nPerWire: number; wireRadius: number };
+
+export type SinusoidalOpts = CommonOpts & { nQpConst: number };
+// Sin-Galerkin only: the feed-model axis (issue #640, momwire#192).
+// "segment" = NEC-compatible (NEC's segment-wide gap — reproduces NEC/EZNEC
+// behaviour, including the reactance walk with mesh density); "point" =
+// Converged (zero-width gap — converges to the B-spline answer; recommended
+// for near-open high-Q designs, momwire#213). Deliberately NOT on plain
+// sinusoidal: the point gap has no collocation RHS (momwire#212), so that
+// solver offers no choice to present.
+export type SinGalerkinOpts = SinusoidalOpts & { feedModel: "segment" | "point" };
+export type BSplineOpts = CommonOpts & {
+  degree: 1 | 2;
+  nQpPair: number;
+  feedSmoothingFactor: number | null; // null = sharp delta-gap
+  useSingularEnrichment: boolean;
+  // "raw"      → Φ_sing(t) = t·log(t), PR #45/#47 original shape.
+  // "stable"   → Φ_sing − bubble-subspace L²-projection: faster large-N
+  //              convergence on dominant-pair K=3 junctions; larger
+  //              small-N transient; loses Y-fixture cusp benefit. d=1
+  //              collapses to raw bit-exact.
+  // "tikhonov" → raw basis + λ·s·I penalty on Z_ee at solve time.
+  //              λ→0 is raw; λ→∞ kills enrichment. λ=0.1 preserves
+  //              Y-fixture cusp; λ=1.0 fully suppresses the small-N
+  //              transient on dominant-pair K=3 junctions but loses Y cusp.
+  // "auto"     → two-pass: solve once without enrichment, measure
+  //              tap_ratio at each K≥3 junction, apply raw enrichment
+  //              only where tap_ratio > autoTapRatioThreshold. Cleanly
+  //              separates dominant-pair K=3 (tap_ratio ≈ 0.16) from
+  //              balanced 3-way (Y ≈ 0.50). The selectivity that
+  //              raw/stable/tikhonov can't deliver algebraically.
+  enrichmentVariant: "raw" | "stable" | "tikhonov" | "auto";
+  tikhonovLambda: number;
+  autoTapRatioThreshold: number;
+  nQpSing: number;
+  enrichmentMinK: number;
+  nQpSource: number;
+};
+export type PyNECOpts = CommonOpts;
+
+// hmatrix and arrayblock share BSplineOpts (same basis + knobs); the ACA
+// tolerances use the solver defaults.
+export type BackendOptsMap = {
+  sinusoidal: SinusoidalOpts;
+  // Same constructor surface as sinusoidal (momwire#182: same basis, Galerkin
+  // testing) plus the feed-model choice only the Galerkin testing can carry;
+  // the test-quadrature knobs keep their solver defaults.
+  "sinusoidal-galerkin": SinGalerkinOpts;
+  bspline: BSplineOpts;
+  hmatrix: BSplineOpts;
+  arrayblock: BSplineOpts;
+  pynec: PyNECOpts;
+};
+
+export const BSPLINE_DEFAULT_OPTS: BSplineOpts = {
+  nPerWire: 30,
+  wireRadius: 0.0005,
+  degree: 2,
+  nQpPair: 4,
+  feedSmoothingFactor: null,
+  useSingularEnrichment: false,
+  enrichmentVariant: "raw",
+  tikhonovLambda: 0.1,
+  autoTapRatioThreshold: 0.3,
+  nQpSing: 32,
+  enrichmentMinK: 3,
+  nQpSource: 16,
+};
+
+export const DEFAULT_BACKEND_OPTS: BackendOptsMap = {
+  sinusoidal: { nPerWire: 30, wireRadius: 0.0005, nQpConst: 8 },
+  // feedModel "segment" (NEC-compatible) is the solver's own default; the
+  // gear menu recommends "point" (Converged) on near-open designs (#640).
+  "sinusoidal-galerkin": {
+    nPerWire: 30,
+    wireRadius: 0.0005,
+    nQpConst: 8,
+    feedModel: "segment",
+  },
+  bspline: { ...BSPLINE_DEFAULT_OPTS },
+  hmatrix: { ...BSPLINE_DEFAULT_OPTS },
+  // Arrays auto-select this; 21 segs/wire is the converged, correct-parity
+  // choice for B-spline d=2 (odd → interior knot at the feed). The old
+  // inherited 40 was both too many and the wrong (even) parity.
+  arrayblock: { ...BSPLINE_DEFAULT_OPTS, nPerWire: 21 },
+  pynec: { nPerWire: 21, wireRadius: 0.0005 },
+};
+
+// Three abstract solver slots. Each holds one backend choice and its
+// options; the user picks A/B/C with the row of buttons, configures the
+// inhabitants from the per-slot gear menu. Lets the same UI compare
+// e.g. "B-spline d=2 @ N=15" against "B-spline d=1 @ N=20" without
+// losing either setup.
+export type Slot = "A" | "B" | "C";
+export const SLOT_ORDER: Slot[] = ["A", "B", "C"];
+
+export type SlotConfig = {
+  backend: Backend;
+  opts: BackendOptsMap[Backend];
+};
+
+// Display label for a configured backend: B-spline-family entries carry
+// their spline degree so two b-spline slots (the default A d=2 / B d=1
+// pair) stay distinguishable at a glance.
+export function backendDisplayLabel(b: Backend, opts: BackendOptsMap[Backend]): string {
+  if (isBSplineFamily(b))
+    return `${BACKEND_LABEL[b]} d=${(opts as BSplineOpts).degree}`;
+  // Surface the non-default feed model on the slot chip: two Sin-Galerkin
+  // slots differing only in feed model must be tellable apart at a glance.
+  if (b === "sinusoidal-galerkin" && (opts as SinGalerkinOpts).feedModel === "point")
+    return `${BACKEND_LABEL[b]} (converged)`;
+  return BACKEND_LABEL[b];
+}
+
+export const DEFAULT_SLOTS: Record<Slot, SlotConfig> = {
+  // A is the default working solver: B-spline d=2 — most accurate per
+  // unknown, converged at a small odd N (interior knot at the feed), and
+  // its impedance solve honours finite grounds (Triangular, the old,
+  // now-retired default, folded them to the PEC image). N=15 per the
+  // basis-convergence census (docs/status/2026-07-20): within 2% of the
+  // basis-agreed limit on 50/66 scorable designs (N=21 buys only 3 more,
+  // all within 2.3%), patterns within 0.05 dB of the fine-mesh reference,
+  // ~35% faster ticks. Odd parity keeps the feed's interior knot.
+  A: {
+    backend: "bspline",
+    opts: { ...DEFAULT_BACKEND_OPTS.bspline, nPerWire: 15 },
+  },
+  // B is the cross-check basis: B-spline d=1 needs a larger N to reach
+  // the same answer (slower), which is what makes agreement with A a
+  // meaningful second opinion rather than the same solve twice. N=20
+  // trades cross-check tightness for speed (within 2% of the limit on
+  // 45/66 vs 55/66 at the old N=40 — disagreement with A beyond a couple
+  // of percent warrants raising N before suspecting the design).
+  B: {
+    backend: "bspline",
+    opts: { ...DEFAULT_BACKEND_OPTS.bspline, degree: 1, nPerWire: 20 },
+  },
+  C: {
+    backend: "pynec",
+    opts: { ...DEFAULT_BACKEND_OPTS.pynec },
+  },
+};
+
+// Resolve a slot config against server capabilities (#429): if it names PyNEC
+// and pynec-accel is absent, swap to the fallback backend with that backend's
+// default kwargs, preserving the geometry-sizing (segments/wire, radius) the
+// same way a manual backend swap does. Slot C defaults to PyNEC, so this is
+// what keeps the default panel sensible on a server without it.
+export function resolveSlotConfig(cfg: SlotConfig, havePynec: boolean): SlotConfig {
+  const backend = resolveBackend(cfg.backend, havePynec);
+  if (backend === cfg.backend) return cfg;
+  return {
+    backend,
+    opts: {
+      ...DEFAULT_BACKEND_OPTS[backend],
+      nPerWire: cfg.opts.nPerWire,
+      wireRadius: cfg.opts.wireRadius,
+    } as BackendOptsMap[Backend],
+  };
+}
+
+// Translates the camelCase frontend options into the snake_case kwargs the
+// server forwards to each Momwire model class constructor.
+export function modelOptionsForRequest(
+  backend: Backend,
+  opts: BackendOptsMap[Backend],
+): Record<string, unknown> {
+  if (backend === "sinusoidal-galerkin") {
+    const o = opts as SinGalerkinOpts;
+    // feed_model only here: plain sinusoidal cannot carry the point gap
+    // (momwire#212) and must not receive the key at all.
+    return { n_qp_const: o.nQpConst, feed_model: o.feedModel };
+  }
+  if (backend === "sinusoidal") {
+    const o = opts as SinusoidalOpts;
+    return { n_qp_const: o.nQpConst };
+  }
+  if (isBSplineFamily(backend)) {
+    // bspline, hmatrix, and arrayblock all take the B-spline kwargs; the
+    // accelerators read additional aca_tol/solve_tol from their own defaults.
+    const o = opts as BSplineOpts;
+    return {
+      degree: o.degree,
+      n_qp_pair: o.nQpPair,
+      n_qp_source: o.nQpSource,
+      feed_smoothing_factor: o.feedSmoothingFactor,
+      use_singular_enrichment: o.useSingularEnrichment,
+      enrichment_variant: o.enrichmentVariant,
+      tikhonov_lambda: o.tikhonovLambda,
+      auto_tap_ratio_threshold: o.autoTapRatioThreshold,
+      n_qp_sing: o.nQpSing,
+      enrichment_min_k: o.enrichmentMinK,
+    };
+  }
+  return {};
+}

--- a/src/antennaknobs/web/frontend/src/lib/format.ts
+++ b/src/antennaknobs/web/frontend/src/lib/format.ts
@@ -1,0 +1,36 @@
+export function formatScalar(raw: unknown, precision: number, unit: string | null): string {
+  return typeof raw === "number" ? `${raw.toFixed(precision)}${unit ?? ""}` : "—";
+}
+
+export function reflectionCoefficient(r: number, x: number, z0: number) {
+  // Γ = (Z - Z0) / (Z + Z0), with Z = r + jx (Z0 real).
+  const denom = (r + z0) * (r + z0) + x * x;
+  const gRe = (r * r - z0 * z0 + x * x) / denom;
+  const gIm = (2 * x * z0) / denom;
+  return { gRe, gIm, gMag: Math.hypot(gRe, gIm) };
+}
+
+export function formatOhms(v: number): string {
+  // The server clamps an open-circuited feed (e.g. a series matchbox
+  // capacitor slider at 0 pF) to a 1e9 Ω sentinel — JSON has no Infinity.
+  // Anything that large is physically an open, not a number worth printing.
+  if (Math.abs(v) >= 1e8) return "∞ (open)";
+  return `${v.toFixed(2)} Ω`;
+}
+
+export function formatSwr(r: number, x: number, z0: number): string {
+  const { gMag } = reflectionCoefficient(r, x, z0);
+  if (gMag >= 0.9999) return "∞";
+  const swr = (1 + gMag) / (1 - gMag);
+  if (swr > 99) return swr.toFixed(0);
+  return swr.toFixed(2);
+}
+
+// Nice-number lengths for the zoomed scale bar: pick the readable unit and
+// trim float dust (5×10⁻³ m × 1000 → "5 mm", not "5.000000000000001 mm").
+export function formatMetres(v: number): string {
+  const fmt = (x: number, unit: string) => `${parseFloat(x.toPrecision(2))} ${unit}`;
+  if (v >= 1) return fmt(v, "m");
+  if (v >= 0.01) return fmt(v * 100, "cm");
+  return fmt(v * 1000, "mm");
+}

--- a/src/antennaknobs/web/frontend/src/lib/ground.ts
+++ b/src/antennaknobs/web/frontend/src/lib/ground.ts
@@ -1,0 +1,52 @@
+// The UI separates WHAT the ground is from HOW it's solved. GroundType is
+// the shared, backend-agnostic choice: a finite ground (εr=10, σ=0.002), a
+// perfectly conducting one, or a faceted terrain (levee/cliff presets).
+// It never promises more than the physics — each backend
+// solves it as best it can: PyNEC and the plain B-spline backend offer a
+// method sub-choice (Sommerfeld-Norton vs the reflection-coefficient
+// approximation) — since momwire 0.8.0 every momwire backend honours both,
+// so the choice is uniform across solvers; either way the finite constants
+// reach the far-field Fresnel cut. Terrain solves impedance on the crest
+// medium (Sommerfeld) and applies per-direction specular-facet reflection
+// in the far field (issue #534).
+export type GroundType = "finite" | "pec" | "terrain";
+// Finite-ground solve method, shown for every finite-ground backend:
+// PyNEC (NEC ITYPE=2 vs ITYPE=0) and, since momwire 0.8.0, every momwire
+// solver (true Sommerfeld on bspline dense, sinusoidal field-based, and
+// the hmatrix/arrayblock fast paths). "fast" is the default everywhere;
+// Sommerfeld is opt-in because it is more expensive: the first solve at a
+// new frequency fills an interpolation grid (~0.2-0.5 s on a small box;
+// the first sweep pays that per point), and repeat solves at seen
+// frequencies reuse cached grids (tens of ms).
+export type FiniteGroundMethod = "sommerfeld" | "fast";
+// The wire value (`ground_model` on SolveRequest): derived from groundType
+// (+ the method wherever finite ground is supported).
+export type GroundModel = "sommerfeld" | "fast" | "pec" | "terrain";
+
+// Terrain preset schema, served by GET /capabilities (issue #560). The
+// frontend renders the whole terrain knob panel from this — the presets,
+// their field ranges/labels/units, and the read-only media note all live
+// server-side (adapter.terrain_presets_schema), so a Python-only preset needs
+// no TypeScript. Media are fixed server-side (water 80/0.005, land + crest
+// 13/0.005); each preset's media_note describes its own.
+export type TerrainFieldSchema = {
+  key: string;
+  label: string; // omits the unit; the panel renders "{label} ({unit})"
+  unit: string | null;
+  default: number;
+  min: number;
+  max: number;
+  step: number;
+};
+export type TerrainPresetSchema = {
+  name: string;
+  label: string; // radio label
+  tooltip: string; // radio hover text
+  media_note: string;
+  fields: TerrainFieldSchema[];
+};
+// Terrain knob values keyed by field key, sent (spread) as the request's
+// `terrain` object when ground_model === "terrain". One flat bag across all
+// presets so edits survive preset flips; an unset key falls back to the
+// schema default and the server clamps every number.
+export type TerrainParams = Record<string, number>;

--- a/src/antennaknobs/web/frontend/src/lib/math.ts
+++ b/src/antennaknobs/web/frontend/src/lib/math.ts
@@ -1,0 +1,55 @@
+// Richardson-style extrapolation Z(1/N) → Z(N→∞). Fits Z = a₀ + a₁·h + a₂·h²
+// (h = 1/N) on the last `nLast` points via least squares and returns a₀.
+// Quadratic gives a sane answer for O(1/N) limit (BSpline without
+// enrichment) AND O(1/N^p) for p slightly above 1 — basis-cap, enrichment,
+// etc. With ≤2 points we can't fit; return null.
+export function richardsonExtrap(
+  invN: number[],
+  vals: number[],
+  nLast = 5,
+): number | null {
+  const m = Math.min(nLast, invN.length);
+  if (m < 3) return null;
+  const start = invN.length - m;
+  // Solve Ax = b for x = [a₀, a₁, a₂] using normal equations on the last m
+  // points. m × 3 → 3 × 3 — small, no need for an LAPACK call.
+  let s0 = 0, s1 = 0, s2 = 0, s3 = 0, s4 = 0;
+  let t0 = 0, t1 = 0, t2 = 0;
+  for (let i = start; i < invN.length; i++) {
+    const h = invN[i];
+    const y = vals[i];
+    s0 += 1;
+    s1 += h;
+    s2 += h * h;
+    s3 += h * h * h;
+    s4 += h * h * h * h;
+    t0 += y;
+    t1 += y * h;
+    t2 += y * h * h;
+  }
+  // 3x3 linear system: [[s0,s1,s2],[s1,s2,s3],[s2,s3,s4]] · [a0,a1,a2] = [t0,t1,t2]
+  const m00 = s0, m01 = s1, m02 = s2;
+  const m10 = s1, m11 = s2, m12 = s3;
+  const m20 = s2, m21 = s3, m22 = s4;
+  const det =
+    m00 * (m11 * m22 - m12 * m21) -
+    m01 * (m10 * m22 - m12 * m20) +
+    m02 * (m10 * m21 - m11 * m20);
+  if (Math.abs(det) < 1e-30) return null;
+  const a0 =
+    (t0 * (m11 * m22 - m12 * m21) -
+      m01 * (t1 * m22 - m12 * t2) +
+      m02 * (t1 * m21 - m11 * t2)) /
+    det;
+  return a0;
+}
+
+// Blend two #rrggbb colors; t=0 -> a, t=1 -> b. Used to warm the knob's value
+// arc from --accent toward --hot as it nears max (an "energizing" cue).
+export function mixHex(a: string, b: string, t: number): string {
+  const ch = (s: string, i: number) => parseInt(s.slice(i, i + 2), 16);
+  const r = Math.round(ch(a, 1) + (ch(b, 1) - ch(a, 1)) * t);
+  const g = Math.round(ch(a, 3) + (ch(b, 3) - ch(a, 3)) * t);
+  const bl = Math.round(ch(a, 5) + (ch(b, 5) - ch(a, 5)) * t);
+  return `rgb(${r}, ${g}, ${bl})`;
+}

--- a/tests/test_backend_roster_contract.py
+++ b/tests/test_backend_roster_contract.py
@@ -47,7 +47,9 @@ _NON_MOMWIRE_BACKENDS = {"pynec"}
 def _frontend_roster() -> set[str]:
     src = _BACKENDS_TS.read_text()
     m = re.search(r"const BACKEND_ORDER: Backend\[\] = \[(?P<body>[^\]]*)\]", src, re.S)
-    assert m, "BACKEND_ORDER literal not found in lib/backends.ts — update this contract test"
+    assert m, (
+        "BACKEND_ORDER literal not found in lib/backends.ts — update this contract test"
+    )
     entries = set(re.findall(r'"([a-z0-9-]+)"', m.group("body")))
     assert entries, "BACKEND_ORDER parsed empty — update this contract test"
     return entries

--- a/tests/test_backend_roster_contract.py
+++ b/tests/test_backend_roster_contract.py
@@ -3,7 +3,7 @@
 The two halves of the backend roster live in different languages in different
 places — ``_MOMWIRE_MODELS`` in ``web/adapter.py`` (the authority: what the
 server will actually construct) and ``BACKEND_ORDER`` in
-``web/frontend/src/App.tsx`` (what the UI offers). Nothing structural keeps
+``web/frontend/src/lib/backends.ts`` (what the UI offers). Nothing structural keeps
 them in sync, and the failure mode of drift is *silent absence*: when the
 sinusoidal-Galerkin backend landed server-side (momwire#182 M6, PR #626),
 every test in both repos stayed green while the UI simply had no tab to
@@ -28,14 +28,15 @@ from pathlib import Path
 from antennaknobs.web import server as _server  # noqa: F401
 from antennaknobs.web.adapter import _MOMWIRE_MODELS
 
-_APP_TSX = (
+_BACKENDS_TS = (
     Path(__file__).resolve().parents[1]
     / "src"
     / "antennaknobs"
     / "web"
     / "frontend"
     / "src"
-    / "App.tsx"
+    / "lib"
+    / "backends.ts"
 )
 
 # Frontend entries that are deliberately not momwire models. PyNEC rides the
@@ -44,9 +45,9 @@ _NON_MOMWIRE_BACKENDS = {"pynec"}
 
 
 def _frontend_roster() -> set[str]:
-    src = _APP_TSX.read_text()
+    src = _BACKENDS_TS.read_text()
     m = re.search(r"const BACKEND_ORDER: Backend\[\] = \[(?P<body>[^\]]*)\]", src, re.S)
-    assert m, "BACKEND_ORDER literal not found in App.tsx — update this contract test"
+    assert m, "BACKEND_ORDER literal not found in lib/backends.ts — update this contract test"
     entries = set(re.findall(r'"([a-z0-9-]+)"', m.group("body")))
     assert entries, "BACKEND_ORDER parsed empty — update this contract test"
     return entries
@@ -58,8 +59,8 @@ def test_every_server_backend_has_a_frontend_tab():
     missing = set(_MOMWIRE_MODELS) - _frontend_roster()
     assert not missing, (
         f"server backends with no frontend tab: {sorted(missing)} — add them to "
-        "BACKEND_ORDER / BACKEND_LABEL / BackendOptsMap in App.tsx (see PR #627 "
-        "for the full checklist of touch-points)"
+        "BACKEND_ORDER / BACKEND_LABEL / BackendOptsMap in lib/backends.ts (see "
+        "PR #627 for the full checklist of touch-points)"
     )
 
 


### PR DESCRIPTION
Phase 2 of the #642 arc (plan: https://github.com/stevenmburns/antennaknobs/issues/642#issuecomment-5160203979), on top of #661: move the pure free-function logic out of App.tsx into `src/lib/` modules. Verbatim code-move — zero logic edits; comments travel with their definitions.

## The move

| New module | Contents |
|---|---|
| `src/lib/backends.ts` (326 lines) | `Backend` type, labels/order/defaults, `comboInappropriate`, `selectableBackends`/`resolveBackend`/`backendAllowed`/`normalizeBackend`, opts types, slots + `resolveSlotConfig`, `backendDisplayLabel`, `modelOptionsForRequest` |
| `src/lib/ground.ts` (52 lines) | `GroundType`/`FiniteGroundMethod`/`GroundModel`, terrain preset/param types |
| `src/lib/format.ts` (36 lines) | `formatScalar`/`formatOhms`/`formatSwr`/`formatMetres`, `reflectionCoefficient` |
| `src/lib/math.ts` (55 lines) | `richardsonExtrap`, `mixHex` |

App.tsx: **9,169 → 8,736 lines**; its only additions are the four import blocks. The Phase-1 tests re-point their imports to the lib modules; every assertion line is byte-identical — that unchanged-assertion property is itself the proof the move changed no behavior.

`Vec3`/`dot3`/`cross3` deliberately stayed in App.tsx: `Vec3` is entangled with the component-side `Projection`/camera code, so they belong to the Phase-3 charts extraction, not this move.

## Gates (re-run independently by the reviewer)

- `npm test`: **81/81 green**, assertions untouched (import lines are the only test diffs — verified from the raw diff).
- `npm run build` (`tsc --noEmit && vite build`): green.
- Move fidelity, verified two ways: the builder diffed each lib file against the re-extracted original App.tsx line ranges (identical after normalizing the added `export ` keywords); the reviewer independently set-compared every line deleted from App.tsx against the union of lib-file lines with `comm` — **exact bijection both directions** (no lost code, no invented code) modulo `export ` and blank-line separators.

## Review notes

Implemented by a sonnet subagent from a move-map brief; reviewed by the session model as above. One reviewer fix-up commit: the test-file headers still said the functions live in App.tsx (and that jsdom exists for importing it from those files) — un-staled, 5 lines of comments only.

Part of #642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g
