### PR TITLE
refactor(web): extract DesignSession pure logic to lib, with 62 new tests (#642 seam 5b-1)

### DIFF
--- a/src/antennaknobs/web/frontend/src/__tests__/bands.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/bands.test.ts
@@ -1,0 +1,59 @@
+// Pins the pure band-window logic in src/lib/bands.ts (issue #642 PR 5b-1),
+// extracted verbatim from DesignSession's inline `freqWindowCeiling` const
+// and `bandContaining` closure.
+import { describe, it, expect } from "vitest";
+import { bandContaining, freqWindowCeiling } from "../lib/bands";
+import type { BandSpec } from "../lib/params";
+
+const BAND_2M: BandSpec = { key: "2m", label: "2 m", freq_mhz: 146, min_mhz: 144, max_mhz: 148 };
+const BAND_10M: BandSpec = { key: "10m", label: "10 m", freq_mhz: 28.5, min_mhz: 28.0, max_mhz: 29.7 };
+const BAND_20M: BandSpec = { key: "20m", label: "20 m", freq_mhz: 14.15, min_mhz: 14.0, max_mhz: 14.35 };
+
+describe("freqWindowCeiling", () => {
+  it("floors at 60 MHz for a bandless design", () => {
+    expect(freqWindowCeiling([])).toBe(60);
+  });
+
+  it("floors at 60 MHz for an HF-only design (1.25x max stays under the floor)", () => {
+    // 10 m's max_mhz * 1.25 = 37.125, well under the 60 MHz floor.
+    expect(freqWindowCeiling([BAND_10M])).toBe(60);
+  });
+
+  it("uses 1.25x the highest band's max_mhz on VHF (the #497 inverted-VFO regression)", () => {
+    // Before the fix this was hardcoded to 60, which INVERTED the VFO
+    // window for a 146 MHz anchor (min 116.8 > max 60).
+    expect(freqWindowCeiling([BAND_2M])).toBeCloseTo(148 * 1.25, 9);
+  });
+
+  it("takes the max across all bands, not just the last one", () => {
+    expect(freqWindowCeiling([BAND_2M, BAND_10M, BAND_20M])).toBeCloseTo(148 * 1.25, 9);
+    expect(freqWindowCeiling([BAND_10M, BAND_2M, BAND_20M])).toBeCloseTo(148 * 1.25, 9);
+  });
+});
+
+describe("bandContaining", () => {
+  const bands = [BAND_20M, BAND_10M];
+
+  it("finds the band containing an in-band frequency", () => {
+    expect(bandContaining(bands, 14.2)).toBe("20m");
+    expect(bandContaining(bands, 28.4)).toBe("10m");
+  });
+
+  it("includes both boundaries (min_mhz and max_mhz are inclusive)", () => {
+    expect(bandContaining(bands, 14.0)).toBe("20m");
+    expect(bandContaining(bands, 14.35)).toBe("20m");
+  });
+
+  it("returns null just outside a boundary", () => {
+    expect(bandContaining(bands, 13.999)).toBeNull();
+    expect(bandContaining(bands, 14.351)).toBeNull();
+  });
+
+  it("returns null for a frequency outside every band", () => {
+    expect(bandContaining(bands, 50.0)).toBeNull();
+  });
+
+  it("returns null for an empty band list", () => {
+    expect(bandContaining([], 14.2)).toBeNull();
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/ground.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/ground.test.ts
@@ -1,0 +1,63 @@
+// Pins the pure ground-model derivations in src/lib/ground.ts (issue #642
+// PR 5b-1), extracted verbatim from DesignSession's inline `groundModel` /
+// `groundSummary` consts.
+import { describe, it, expect } from "vitest";
+import type { Backend } from "../lib/backends";
+import { groundSummaryLabel, resolveGroundModel } from "../lib/ground";
+
+// Every Backend variant today supports ground/terrain (see
+// backendSupportsGround); the "unsupported" branches only matter for a
+// hypothetical future backend, so we exercise them with a cast past the
+// closed union — exactly the case the code's own comments call out.
+const UNSUPPORTED = "future-backend" as Backend;
+
+describe("resolveGroundModel", () => {
+  it("is 'pec' for groundType 'pec' regardless of backend", () => {
+    expect(resolveGroundModel("pec", "bspline", "fast")).toBe("pec");
+    expect(resolveGroundModel("pec", UNSUPPORTED, "sommerfeld")).toBe("pec");
+  });
+
+  it("is 'terrain' for groundType 'terrain' on a terrain-capable backend", () => {
+    expect(resolveGroundModel("terrain", "pynec", "fast")).toBe("terrain");
+    expect(resolveGroundModel("terrain", "sinusoidal-galerkin", "fast")).toBe("terrain");
+  });
+
+  it("degrades 'terrain' to 'fast' on a backend without terrain (and ground) support", () => {
+    expect(resolveGroundModel("terrain", UNSUPPORTED, "sommerfeld")).toBe("fast");
+  });
+
+  it("mirrors finiteGroundMethod for groundType 'finite' on a ground-capable backend", () => {
+    expect(resolveGroundModel("finite", "bspline", "fast")).toBe("fast");
+    expect(resolveGroundModel("finite", "bspline", "sommerfeld")).toBe("sommerfeld");
+  });
+
+  it("falls back to 'fast' for groundType 'finite' on a backend without ground support", () => {
+    expect(resolveGroundModel("finite", UNSUPPORTED, "sommerfeld")).toBe("fast");
+  });
+});
+
+describe("groundSummaryLabel", () => {
+  it("is 'free space' when ground is disabled, regardless of model", () => {
+    expect(groundSummaryLabel(false, "bspline", "pec", "levee")).toBe("free space");
+  });
+
+  it("is 'free space' when the backend doesn't support ground even if enabled", () => {
+    expect(groundSummaryLabel(true, UNSUPPORTED, "fast", "levee")).toBe("free space");
+  });
+
+  it("labels 'PEC ground'", () => {
+    expect(groundSummaryLabel(true, "bspline", "pec", "levee")).toBe("PEC ground");
+  });
+
+  it("labels 'terrain (<preset>)'", () => {
+    expect(groundSummaryLabel(true, "bspline", "terrain", "cliff")).toBe("terrain (cliff)");
+  });
+
+  it("labels 'reflection-coef ground' for the fast finite method", () => {
+    expect(groundSummaryLabel(true, "bspline", "fast", "levee")).toBe("reflection-coef ground");
+  });
+
+  it("labels 'Sommerfeld ground' for the sommerfeld finite method", () => {
+    expect(groundSummaryLabel(true, "bspline", "sommerfeld", "levee")).toBe("Sommerfeld ground");
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/math.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/math.test.ts
@@ -3,7 +3,7 @@
 // convergence sweep and the SWR/Smith-chart readouts.
 import { describe, it, expect } from "vitest";
 import { reflectionCoefficient } from "../lib/format";
-import { richardsonExtrap } from "../lib/math";
+import { feedwiseRichardson, richardsonExtrap } from "../lib/math";
 
 describe("richardsonExtrap", () => {
   it("returns null for fewer than 3 points", () => {
@@ -53,6 +53,52 @@ describe("richardsonExtrap", () => {
     const got = richardsonExtrap(invN, vals, 3);
     expect(got).not.toBeNull();
     expect(Math.abs((got as number) - a0)).toBeLessThan(1e-9);
+  });
+});
+
+// --- feedwiseRichardson -----------------------------------------------------
+// Extracted verbatim from runConverge's per-feed extrapolation block (issue
+// #642 PR 5b-1): richardsonExtrap applied per feed-index column of the
+// accumulated feeds_z_re / feeds_z_im rows.
+
+describe("feedwiseRichardson", () => {
+  it("returns null per feed until >= 3 points have accumulated", () => {
+    // 2 feeds, 2 rows (points) so far — richardsonExtrap needs >= 3.
+    const invN = [1 / 8, 1 / 12];
+    const feedsZRe = [
+      [10, 20],
+      [11, 21],
+    ];
+    const feedsZIm = [
+      [1, 2],
+      [1.1, 2.1],
+    ];
+    const { feedsRe, feedsIm } = feedwiseRichardson(invN, feedsZRe, feedsZIm);
+    expect(feedsRe).toEqual([null, null]);
+    expect(feedsIm).toEqual([null, null]);
+  });
+
+  it("agrees per-column with richardsonExtrap once >= 3 points are in", () => {
+    const N = [8, 12, 17, 24];
+    const invN = N.map((n) => 1 / n);
+    // Two independent feeds, each Z = a0 + a1*h + a2*h^2 with its own coeffs.
+    const feed0 = { a0: 50, a1: 12, a2: -3 };
+    const feed1 = { a0: 30, a1: -8, a2: 5 };
+    const zOf = (c: { a0: number; a1: number; a2: number }, h: number) =>
+      c.a0 + c.a1 * h + c.a2 * h * h;
+    const feedsZRe = invN.map((h) => [zOf(feed0, h), zOf(feed1, h)]);
+    const feedsZIm = invN.map((h) => [zOf(feed0, h) / 2, zOf(feed1, h) / 2]);
+
+    const { feedsRe, feedsIm } = feedwiseRichardson(invN, feedsZRe, feedsZIm);
+
+    const col = (rows: number[][], fi: number) => rows.map((row) => row[fi]);
+    expect(feedsRe[0]).toBeCloseTo(richardsonExtrap(invN, col(feedsZRe, 0))!, 9);
+    expect(feedsRe[1]).toBeCloseTo(richardsonExtrap(invN, col(feedsZRe, 1))!, 9);
+    expect(feedsIm[0]).toBeCloseTo(richardsonExtrap(invN, col(feedsZIm, 0))!, 9);
+    expect(feedsIm[1]).toBeCloseTo(richardsonExtrap(invN, col(feedsZIm, 1))!, 9);
+    // And, being generated from known quadratics, recovers a0 exactly.
+    expect(feedsRe[0]).toBeCloseTo(feed0.a0, 9);
+    expect(feedsRe[1]).toBeCloseTo(feed1.a0, 9);
   });
 });
 

--- a/src/antennaknobs/web/frontend/src/__tests__/params.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/params.test.ts
@@ -6,13 +6,19 @@
 import { describe, it, expect } from "vitest";
 import {
   applyVisibility,
+  defaultKnobOpt,
   familyOf,
   familyRank,
+  FAMILY_LABELS,
   FAMILY_ORDER,
   findLinkedDesignFreq,
+  groupExamplesForPicker,
   isGroup,
+  linkedMeasFreqFor,
   matchesQuery,
+  overlaySchemaForVariant,
   seedDefaults,
+  setValueAtPath,
   snapForExample,
   type BandSpec,
   type ExampleDescriptor,
@@ -384,5 +390,280 @@ describe("familyRank", () => {
   it("sorts an unknown family after every known one", () => {
     expect(familyRank("mystery")).toBe(FAMILY_ORDER.length);
     expect(familyRank("mystery")).toBeGreaterThan(familyRank(FAMILY_ORDER[FAMILY_ORDER.length - 1]));
+  });
+});
+
+// --- setValueAtPath -----------------------------------------------------
+// Issue #642 PR 5b-1: extracted verbatim from DesignSession's setParamAtPath
+// local `setIn` closure.
+
+describe("setValueAtPath", () => {
+  it("sets a top-level scalar path immutably", () => {
+    const node = { a: 1, b: 2 };
+    const out = setValueAtPath(node, ["a"], 5) as Record<string, unknown>;
+    expect(out).toEqual({ a: 5, b: 2 });
+    expect(node).toEqual({ a: 1, b: 2 }); // original untouched
+    expect(out).not.toBe(node);
+  });
+
+  it("returns `value` directly for an empty path", () => {
+    expect(setValueAtPath({ a: 1 }, [], 42)).toBe(42);
+  });
+
+  it("sets a nested group-array leaf (['bands', 2, 'freq']) immutably at every level", () => {
+    const inst0 = { freq: 1 };
+    const inst1 = { freq: 2 };
+    const inst2 = { freq: 3 };
+    const node = { bands: [inst0, inst1, inst2] };
+    const out = setValueAtPath(node, ["bands", 2, "freq"], 99) as {
+      bands: { freq: number }[];
+    };
+    expect(out.bands[2]).toEqual({ freq: 99 });
+    // Untouched sibling instances keep their original object identity —
+    // only the path actually walked gets cloned.
+    expect(out.bands[0]).toBe(inst0);
+    expect(out.bands[1]).toBe(inst1);
+    // Original tree is fully unmutated at every level (array + object).
+    expect(node.bands[2]).toEqual({ freq: 3 });
+    expect(node.bands).not.toBe(out.bands);
+    expect(node).not.toBe(out);
+  });
+
+  it("clones the array via slice when indexing into it (no in-place mutation)", () => {
+    const arr = [1, 2, 3];
+    const node = { xs: arr };
+    const out = setValueAtPath(node, ["xs", 1], 20) as { xs: number[] };
+    expect(out.xs).toEqual([1, 20, 3]);
+    expect(arr).toEqual([1, 2, 3]); // original array untouched
+    expect(out.xs).not.toBe(arr);
+  });
+
+  it("builds a fresh array from an undefined node when the path starts with a numeric index", () => {
+    const out = setValueAtPath(undefined, [0, "freq"], 14.1) as { freq: number }[];
+    expect(out).toEqual([{ freq: 14.1 }]);
+  });
+});
+
+// --- linkedMeasFreqFor -----------------------------------------------------
+
+describe("linkedMeasFreqFor", () => {
+  const groupSchema = makeGroup({
+    name: "bands",
+    max_repeats: 2,
+    params: [makeParam({ name: "freq", kind: "float", default: 14.1 })],
+    default_overrides: [{}, {}],
+    link_meas_freq_to_param: "freq",
+  });
+  const flatSchema = makeParam({
+    name: "freq_02",
+    kind: "float",
+    link_meas_freq_to_param: "freq_02",
+  });
+
+  it("returns null when the example is undefined", () => {
+    expect(linkedMeasFreqFor(undefined, ["freq_02"], {})).toBeNull();
+  });
+
+  it("resolves a flat-scalar link (path length 1)", () => {
+    const ex = makeExample({ param_schema: [flatSchema] });
+    const newRoot: ParamValueBag = { freq_02: 21.2 };
+    expect(linkedMeasFreqFor(ex, ["freq_02"], newRoot)).toBe(21.2);
+  });
+
+  it("returns null for a flat scalar with no link_meas_freq_to_param declared", () => {
+    const unlinked = makeParam({ name: "angle_deg" });
+    const ex = makeExample({ param_schema: [unlinked] });
+    expect(linkedMeasFreqFor(ex, ["angle_deg"], { angle_deg: 30 })).toBeNull();
+  });
+
+  it("returns null when the flat-scalar linked value is non-numeric", () => {
+    const ex = makeExample({ param_schema: [flatSchema] });
+    const newRoot: ParamValueBag = { freq_02: "n/a" };
+    expect(linkedMeasFreqFor(ex, ["freq_02"], newRoot)).toBeNull();
+  });
+
+  it("resolves a group-leaf link (path = [groupName, instanceIdx, leafName])", () => {
+    const ex = makeExample({ param_schema: [groupSchema] });
+    const newRoot: ParamValueBag = {
+      bands: [{ freq: 7.1 }, { freq: 21.2 }],
+    };
+    expect(linkedMeasFreqFor(ex, ["bands", 1, "freq"], newRoot)).toBe(21.2);
+  });
+
+  it("returns null when the group-leaf linked value is non-numeric", () => {
+    const ex = makeExample({ param_schema: [groupSchema] });
+    const newRoot: ParamValueBag = { bands: [{ freq: "n/a" }] };
+    expect(linkedMeasFreqFor(ex, ["bands", 0, "freq"], newRoot)).toBeNull();
+  });
+
+  it("returns null for a group with no link_meas_freq_to_param declared", () => {
+    const unlinkedGroup = makeGroup({
+      name: "bands",
+      params: [makeParam({ name: "freq" })],
+    });
+    const ex = makeExample({ param_schema: [unlinkedGroup] });
+    const newRoot: ParamValueBag = { bands: [{ freq: 7.1 }] };
+    expect(linkedMeasFreqFor(ex, ["bands", 0, "freq"], newRoot)).toBeNull();
+  });
+
+  it("returns null when path.length is 2 (too short for the group-leaf shape)", () => {
+    const ex = makeExample({ param_schema: [groupSchema] });
+    expect(linkedMeasFreqFor(ex, ["bands", 0], { bands: [{ freq: 1 }] })).toBeNull();
+  });
+
+  it("returns null when the group instance index is out of range", () => {
+    const ex = makeExample({ param_schema: [groupSchema] });
+    const newRoot: ParamValueBag = { bands: [{ freq: 7.1 }] };
+    expect(linkedMeasFreqFor(ex, ["bands", 5, "freq"], newRoot)).toBeNull();
+  });
+
+  it("returns null when the group's current value isn't an array", () => {
+    const ex = makeExample({ param_schema: [groupSchema] });
+    const newRoot: ParamValueBag = { bands: "oops" };
+    expect(linkedMeasFreqFor(ex, ["bands", 0, "freq"], newRoot)).toBeNull();
+  });
+});
+
+// --- overlaySchemaForVariant -----------------------------------------------------
+
+describe("overlaySchemaForVariant", () => {
+  it("returns [] when the example is undefined", () => {
+    expect(overlaySchemaForVariant(undefined, "default")).toEqual([]);
+  });
+
+  it("passes the schema through unchanged (same reference) when the variant has no variant_ui entry", () => {
+    const schema: SchemaItem[] = [makeParam({ name: "angle_deg" })];
+    const ex = makeExample({ param_schema: schema });
+    expect(overlaySchemaForVariant(ex, "default")).toBe(schema);
+  });
+
+  it("overlays a per-param override onto the matching scalar", () => {
+    const schema: SchemaItem[] = [
+      makeParam({ name: "length_factor", min: 0.5, max: 1.5 }),
+    ];
+    const ex = makeExample({
+      param_schema: schema,
+      variant_ui: {
+        longwire: { params: { length_factor: { min: 1, max: 4 } } },
+      },
+    });
+    const out = overlaySchemaForVariant(ex, "longwire");
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ name: "length_factor", min: 1, max: 4 });
+  });
+
+  it("hides a param the variant marks hidden, but leaves groups untouched (same reference)", () => {
+    const group = makeGroup({ name: "bands" });
+    const schema: SchemaItem[] = [makeParam({ name: "angle_deg" }), group];
+    const ex = makeExample({
+      param_schema: schema,
+      variant_ui: {
+        dipole: { params: { angle_deg: { hidden: true } } },
+      },
+    });
+    const out = overlaySchemaForVariant(ex, "dipole");
+    expect(out).toHaveLength(1);
+    expect(out[0]).toBe(group);
+  });
+
+  it("falls back to the base schema (same reference) for a variant absent from variant_ui", () => {
+    const schema: SchemaItem[] = [makeParam({ name: "angle_deg" })];
+    const ex = makeExample({
+      param_schema: schema,
+      variant_ui: { longwire: { params: {} } },
+    });
+    expect(overlaySchemaForVariant(ex, "default")).toBe(schema);
+  });
+});
+
+// --- groupExamplesForPicker -----------------------------------------------------
+
+describe("groupExamplesForPicker", () => {
+  const dipole = makeExample({ name: "dipoles.invvee", label: "Inverted Vee" });
+  const yagi = makeExample({ name: "beams.yagi", label: "Yagi-Uda Beam" });
+  const quad = makeExample({ name: "loops.quad", label: "Cubical Quad" });
+  const examples = [dipole, yagi, quad];
+
+  it("keeps the selected example visible even when the query matches nothing else", () => {
+    const groups = groupExamplesForPicker(examples, "dipoles.invvee", "zzzznomatch");
+    const names = groups.flatMap((g) => g.items.map((i) => i.name));
+    expect(names).toEqual(["dipoles.invvee"]);
+  });
+
+  it("groups by family and orders groups by familyRank (dipoles, then loops, then beams)", () => {
+    const groups = groupExamplesForPicker(examples, "", "");
+    expect(groups.map((g) => g.fam)).toEqual(["dipoles", "loops", "beams"]);
+    expect(groups.map((g) => g.label)).toEqual([
+      FAMILY_LABELS.dipoles,
+      FAMILY_LABELS.loops,
+      FAMILY_LABELS.beams,
+    ]);
+  });
+
+  it("sorts items within a family by label", () => {
+    const dipoleZ = makeExample({ name: "dipoles.zepp", label: "AAA Zepp" });
+    const groups = groupExamplesForPicker([dipole, dipoleZ], "", "");
+    expect(groups[0].items.map((i) => i.label)).toEqual(["AAA Zepp", "Inverted Vee"]);
+  });
+
+  it("filters non-selected examples by matchesQuery", () => {
+    const groups = groupExamplesForPicker(examples, "dipoles.invvee", "yagi");
+    const names = groups.flatMap((g) => g.items.map((i) => i.name)).sort();
+    expect(names).toEqual(["beams.yagi", "dipoles.invvee"]);
+  });
+});
+
+// --- defaultKnobOpt -----------------------------------------------------
+
+describe("defaultKnobOpt", () => {
+  it("seeds vary:false and mirrors the schema's min/max/step", () => {
+    const schema: SchemaItem[] = [
+      makeParam({ name: "length_factor", min: 0.5, max: 2, step: 0.01 }),
+    ];
+    expect(defaultKnobOpt(schema, "length_factor")).toEqual({
+      vary: false,
+      optMin: 0.5,
+      optMax: 2,
+      dispMin: 0.5,
+      dispMax: 2,
+      step: 0.01,
+    });
+  });
+
+  it("falls back to 0/1/0.001 when the param name isn't in the schema", () => {
+    expect(defaultKnobOpt([], "missing")).toEqual({
+      vary: false,
+      optMin: 0,
+      optMax: 1,
+      dispMin: 0,
+      dispMax: 1,
+      step: 0.001,
+    });
+  });
+
+  it("falls back to 0/1/0.001 when the matched param's min/max/step are null", () => {
+    const schema: SchemaItem[] = [
+      makeParam({ name: "n_directors", min: null, max: null, step: null }),
+    ];
+    expect(defaultKnobOpt(schema, "n_directors")).toEqual({
+      vary: false,
+      optMin: 0,
+      optMax: 1,
+      dispMin: 0,
+      dispMax: 1,
+      step: 0.001,
+    });
+  });
+
+  it("does not match a group with the same name (only scalar leaves are eligible)", () => {
+    const group = makeGroup({ name: "length_factor" });
+    expect(defaultKnobOpt([group], "length_factor")).toEqual({
+      vary: false,
+      optMin: 0,
+      optMax: 1,
+      dispMin: 0,
+      dispMax: 1,
+      step: 0.001,
+    });
   });
 });

--- a/src/antennaknobs/web/frontend/src/__tests__/sweep.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/sweep.test.ts
@@ -1,0 +1,211 @@
+// Pins the pure sweep-frequency plan in src/lib/sweep.ts (issue #642 PR
+// 5b-1), extracted verbatim from DesignSession's runSweep.
+import { describe, it, expect } from "vitest";
+import { planSweepFreqs } from "../lib/sweep";
+import type { BandSpec, ExampleDescriptor } from "../lib/params";
+
+function makeExample(overrides: Partial<ExampleDescriptor> = {}): ExampleDescriptor {
+  return {
+    name: "dipoles.test",
+    label: "Test Dipole",
+    multi_feed: false,
+    param_schema: [],
+    result_schema: [],
+    bands: [],
+    meas_freq_range_mhz: null,
+    default_view: null,
+    default_freq: null,
+    default_design_freq: null,
+    default_backend: null,
+    requires_backends: null,
+    has_design_freq: true,
+    variants: ["default"],
+    variant_values: {},
+    sweep_policy: { anchor: "design_freq", lo_factor: 0.8, hi_factor: 1.25 },
+    ...overrides,
+  };
+}
+
+const BAND_20M: BandSpec = { key: "20m", label: "20 m", freq_mhz: 14.15, min_mhz: 14.0, max_mhz: 14.35 };
+
+// Base params for a "plain HF, not band-locked, plenty of ceiling" sweep;
+// individual tests override just the fields under study.
+function baseParams(overrides: Partial<Parameters<typeof planSweepFreqs>[0]> = {}) {
+  return {
+    backend: "bspline" as const,
+    groundEnabled: false,
+    groundModel: "fast" as const,
+    currentExample: makeExample(),
+    currentVariant: "default",
+    measLocked: true,
+    measFreq: 7.1,
+    designFreq: 14.1,
+    currentBands: [] as BandSpec[],
+    freqWindowCeiling: 200,
+    ...overrides,
+  };
+}
+
+describe("planSweepFreqs", () => {
+  it("uses 41 points when ground is off or the model isn't Sommerfeld", () => {
+    expect(planSweepFreqs(baseParams())).toHaveLength(41);
+    expect(
+      planSweepFreqs(baseParams({ groundEnabled: true, groundModel: "fast" })),
+    ).toHaveLength(41);
+  });
+
+  it("halves to 21 points for a ground-capable backend on Sommerfeld ground", () => {
+    expect(
+      planSweepFreqs(
+        baseParams({ backend: "bspline", groundEnabled: true, groundModel: "sommerfeld" }),
+      ),
+    ).toHaveLength(21);
+  });
+
+  it("stays at 41 points on Sommerfeld ground if the backend doesn't support ground", () => {
+    // Every current Backend does support ground; cast past the closed union
+    // to exercise the (currently hypothetical) unsupported-backend branch.
+    const freqs = planSweepFreqs(
+      baseParams({
+        backend: "future-backend" as never,
+        groundEnabled: true,
+        groundModel: "sommerfeld",
+      }),
+    );
+    expect(freqs).toHaveLength(41);
+  });
+
+  it("anchors on designFreq when locked and the policy anchor is 'design_freq' (the default)", () => {
+    const freqs = planSweepFreqs(
+      baseParams({
+        currentExample: makeExample({
+          sweep_policy: { anchor: "design_freq", lo_factor: 0.8, hi_factor: 1.25 },
+        }),
+        measLocked: true,
+        measFreq: 7.1,
+        designFreq: 14.1,
+      }),
+    );
+    expect(freqs[0]).toBeCloseTo(14.1 * 0.8, 9);
+    expect(freqs[freqs.length - 1]).toBeCloseTo(14.1 * 1.25, 9);
+  });
+
+  it("anchors on measFreq when the policy declares anchor 'meas_freq', even while locked", () => {
+    const freqs = planSweepFreqs(
+      baseParams({
+        currentExample: makeExample({
+          sweep_policy: { anchor: "meas_freq", lo_factor: 0.8, hi_factor: 1.25 },
+        }),
+        measLocked: true,
+        measFreq: 7.1,
+        designFreq: 14.1,
+      }),
+    );
+    expect(freqs[0]).toBeCloseTo(7.1 * 0.8, 9);
+    expect(freqs[freqs.length - 1]).toBeCloseTo(7.1 * 1.25, 9);
+  });
+
+  it("anchors on measFreq when unlocked, overriding an anchor:'design_freq' policy", () => {
+    const freqs = planSweepFreqs(
+      baseParams({
+        currentExample: makeExample({
+          sweep_policy: { anchor: "design_freq", lo_factor: 0.8, hi_factor: 1.25 },
+        }),
+        measLocked: false,
+        measFreq: 7.1,
+        designFreq: 14.1,
+      }),
+    );
+    expect(freqs[0]).toBeCloseTo(7.1 * 0.8, 9);
+    expect(freqs[freqs.length - 1]).toBeCloseTo(7.1 * 1.25, 9);
+  });
+
+  it("prefers the active variant's sweep_policy over the design-level one", () => {
+    const ex = makeExample({
+      sweep_policy: { anchor: "design_freq", lo_factor: 0.8, hi_factor: 1.25 },
+      variant_ui: {
+        longwire: { sweep_policy: { anchor: "design_freq", lo_factor: 0.5, hi_factor: 2 } },
+      },
+    });
+    const freqs = planSweepFreqs(
+      baseParams({ currentExample: ex, currentVariant: "longwire", designFreq: 10 }),
+    );
+    expect(freqs[0]).toBeCloseTo(10 * 0.5, 9);
+    expect(freqs[freqs.length - 1]).toBeCloseTo(10 * 2, 9);
+  });
+
+  it("snaps to the containing band's [min_mhz, max_mhz] when band_locked and the anchor is in-band", () => {
+    const freqs = planSweepFreqs(
+      baseParams({
+        currentExample: makeExample({
+          sweep_policy: { anchor: "design_freq", lo_factor: 0.8, hi_factor: 1.25, band_locked: true },
+        }),
+        designFreq: 14.1,
+        currentBands: [BAND_20M],
+      }),
+    );
+    expect(freqs[0]).toBeCloseTo(14.0, 9);
+    expect(freqs[freqs.length - 1]).toBeCloseTo(14.35, 9);
+  });
+
+  it("falls through to the multiplicative window when band_locked but the anchor is outside every band", () => {
+    const freqs = planSweepFreqs(
+      baseParams({
+        currentExample: makeExample({
+          sweep_policy: { anchor: "design_freq", lo_factor: 0.8, hi_factor: 1.25, band_locked: true },
+        }),
+        designFreq: 50,
+        currentBands: [BAND_20M],
+        freqWindowCeiling: 200,
+      }),
+    );
+    expect(freqs[0]).toBeCloseTo(50 * 0.8, 9);
+    expect(freqs[freqs.length - 1]).toBeCloseTo(50 * 1.25, 9);
+  });
+
+  it("clamps the low end to a 0.5 MHz floor", () => {
+    const freqs = planSweepFreqs(
+      baseParams({
+        currentExample: makeExample({
+          sweep_policy: { anchor: "design_freq", lo_factor: 0.8, hi_factor: 1.25 },
+        }),
+        designFreq: 0.4, // 0.4 * 0.8 = 0.32, below the 0.5 floor
+      }),
+    );
+    expect(freqs[0]).toBeCloseTo(0.5, 9);
+  });
+
+  it("clamps the high end to freqWindowCeiling", () => {
+    const freqs = planSweepFreqs(
+      baseParams({
+        currentExample: makeExample({
+          sweep_policy: { anchor: "design_freq", lo_factor: 0.8, hi_factor: 1.25 },
+        }),
+        designFreq: 100, // 100 * 1.25 = 125, above a 60 MHz ceiling
+        freqWindowCeiling: 60,
+      }),
+    );
+    expect(freqs[freqs.length - 1]).toBeCloseTo(60, 9);
+  });
+
+  it("log-spaces the interior points between fLo and fHi", () => {
+    const freqs = planSweepFreqs(
+      baseParams({
+        currentExample: makeExample({
+          sweep_policy: { anchor: "design_freq", lo_factor: 0.8, hi_factor: 1.25 },
+        }),
+        designFreq: 14.1,
+      }),
+    );
+    const fLo = 14.1 * 0.8;
+    const fHi = 14.1 * 1.25;
+    expect(freqs[0]).toBeCloseTo(fLo, 9);
+    expect(freqs[freqs.length - 1]).toBeCloseTo(fHi, 9);
+    // Consecutive ratios are constant under log-spacing.
+    const ratio = freqs[1] / freqs[0];
+    for (let i = 1; i < freqs.length; i++) {
+      expect(freqs[i] / freqs[i - 1]).toBeCloseTo(ratio, 9);
+    }
+    expect(ratio).toBeCloseTo(Math.pow(fHi / fLo, 1 / (freqs.length - 1)), 9);
+  });
+});

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -21,31 +21,38 @@ import {
   type Slot,
   type SlotConfig,
 } from "../../lib/backends";
-import type {
-  FiniteGroundMethod,
-  GroundModel,
-  GroundType,
-  TerrainParams,
-  TerrainPresetSchema,
-} from "../../lib/ground";
-import { richardsonExtrap } from "../../lib/math";
 import {
-  familyOf,
-  familyRank,
-  FAMILY_LABELS,
+  bandContaining as bandContainingIn,
+  freqWindowCeiling as freqWindowCeilingFor,
+} from "../../lib/bands";
+import {
+  groundSummaryLabel,
+  resolveGroundModel,
+  type FiniteGroundMethod,
+  type GroundModel,
+  type GroundType,
+  type TerrainParams,
+  type TerrainPresetSchema,
+} from "../../lib/ground";
+import { feedwiseRichardson, richardsonExtrap } from "../../lib/math";
+import {
+  defaultKnobOpt,
   findLinkedDesignFreq,
+  groupExamplesForPicker,
   isGroup,
-  matchesQuery,
+  linkedMeasFreqFor,
+  overlaySchemaForVariant,
   seedDefaults,
+  setValueAtPath,
   snapForExample,
   type BandSpec,
   type ExampleDescriptor,
   type KnobOpt,
   type ParamValueBag,
   type SchemaItem,
-  type SchemaParamGroupSpec,
   type SchemaParamSpec,
 } from "../../lib/params";
+import { planSweepFreqs } from "../../lib/sweep";
 import {
   MOBILE_SCREENS,
   PROJECTIONS,
@@ -345,23 +352,7 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // selection visible so the <select> value stays valid), then group by
   // family in FAMILY_ORDER.
   const geomQuery = geomFilter.trim().toLowerCase();
-  const geomGroups = (() => {
-    const visible = examples.filter(
-      (ex) => ex.name === geometry || matchesQuery(ex, geomQuery),
-    );
-    const byFam = new Map<string, ExampleDescriptor[]>();
-    for (const ex of visible) {
-      const fam = familyOf(ex.name);
-      (byFam.get(fam) ?? byFam.set(fam, []).get(fam)!).push(ex);
-    }
-    return [...byFam.entries()]
-      .map(([fam, items]) => ({
-        fam,
-        label: FAMILY_LABELS[fam] ?? fam,
-        items: items.sort((a, b) => a.label.localeCompare(b.label)),
-      }))
-      .sort((a, b) => familyRank(a.fam) - familyRank(b.fam));
-  })();
+  const geomGroups = groupExamplesForPicker(examples, geometry, geomQuery);
   const currentVariant =
     variantByGeom[geometry] ?? currentExample?.variants?.[0] ?? "default";
 
@@ -371,23 +362,10 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // range. Feeds the knob rail and the per-knob optimiser menu so both
   // see variant-correct bounds; value seeding stays on the raw schema
   // (defaults/values are variant_values' job).
-  const currentSchema = useMemo<SchemaItem[]>(() => {
-    if (!currentExample) return [];
-    const over = currentExample.variant_ui?.[currentVariant]?.params;
-    if (!over) return currentExample.param_schema;
-    return currentExample.param_schema
-      .map((item) =>
-        !isGroup(item) && over[item.name]
-          ? { ...item, ...over[item.name] }
-          : item,
-      )
-      .filter(
-        // A variant can hide a base-visible knob (e.g. invvee:dipole's
-        // angle_deg — flat by definition, value pinned at 0 by the
-        // variant). Display-only: the value still rides variant_values.
-        (item) => isGroup(item) || !(item as { hidden?: boolean }).hidden,
-      );
-  }, [currentExample, currentVariant]);
+  const currentSchema = useMemo<SchemaItem[]>(
+    () => overlaySchemaForVariant(currentExample, currentVariant),
+    [currentExample, currentVariant],
+  );
 
   // Switch to a different variant: overlay the variant's per-param
   // values onto the existing slider state for this geometry (keeping
@@ -456,18 +434,6 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
     path: (string | number)[],
     value: number | string | boolean,
   ) {
-    const setIn = (node: unknown, ps: (string | number)[]): unknown => {
-      if (ps.length === 0) return value;
-      const [head, ...rest] = ps;
-      if (typeof head === "number") {
-        const arr = ((node as unknown[]) ?? []).slice();
-        arr[head] = setIn(arr[head], rest);
-        return arr;
-      }
-      const obj = { ...((node as Record<string, unknown>) ?? {}) };
-      obj[head] = setIn(obj[head], rest);
-      return obj;
-    };
     // Compute the new geometry bag eagerly (outside the setter) so the
     // meas-freq follow logic below can read newRoot reliably. React's
     // useState eager-bailout optimization runs the updater synchronously
@@ -475,49 +441,17 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
     // multiple updates, so a `newRoot` captured inside the updater
     // closure is null on the fast path — which manifests as the linked
     // measFreq snap working on slow drags but not on fast ones.
-    const newRoot = setIn(paramValues[geometry] ?? {}, path) as ParamValueBag;
+    const newRoot = setValueAtPath(paramValues[geometry] ?? {}, path, value) as ParamValueBag;
     setParamValues((prev) => ({
       ...prev,
-      [geometry]: setIn(prev[geometry] ?? {}, path) as ParamValueBag,
+      [geometry]: setValueAtPath(prev[geometry] ?? {}, path, value) as ParamValueBag,
     }));
 
-    // Schema-driven meas-freq follow. Two variants:
-    //   * group leaf: `path = [groupName, instanceIdx, leafName]` and
-    //     the group declares `link_meas_freq_to_param` — push that
-    //     instance's value of the named sibling into measFreq.
-    //   * flat scalar: `path = [paramName]` and the ParamSpec declares
-    //     `link_meas_freq_to_param` — push the current value of the
-    //     named sibling (possibly itself) into measFreq. Used by
-    //     multi-band antennas with parallel length_NN / freq_NN flat
-    //     sliders (antennaknobs's fandipole).
+    // Schema-driven meas-freq follow — see linkedMeasFreqFor for the two
+    // variants (group leaf vs. flat scalar `link_meas_freq_to_param`).
     if (!linkMeas) return;
-    const ex = currentExample;
-    if (!ex) return;
-    if (path.length === 1 && typeof path[0] === "string") {
-      const paramName = path[0];
-      const spec = ex.param_schema.find(
-        (s) => !isGroup(s) && s.name === paramName,
-      ) as SchemaParamSpec | undefined;
-      const linked = spec?.link_meas_freq_to_param;
-      if (!linked) return;
-      const freqValue = newRoot[linked];
-      if (typeof freqValue === "number") setMeasFreq(freqValue);
-      return;
-    }
-    if (path.length < 3) return;
-    const groupName = path[0];
-    const instanceIdx = path[1];
-    if (typeof groupName !== "string" || typeof instanceIdx !== "number") return;
-    const group = ex.param_schema.find(
-      (s) => isGroup(s) && s.name === groupName,
-    ) as SchemaParamGroupSpec | undefined;
-    if (!group || !group.link_meas_freq_to_param) return;
-    const instances = newRoot[groupName];
-    if (!Array.isArray(instances)) return;
-    const inst = instances[instanceIdx];
-    if (!inst) return;
-    const freqValue = inst[group.link_meas_freq_to_param];
-    if (typeof freqValue === "number") setMeasFreq(freqValue);
+    const freqValue = linkedMeasFreqFor(currentExample, path, newRoot);
+    if (freqValue != null) setMeasFreq(freqValue);
   }
 
   // A user-originated knob change (drag / arrow key) — the optimizer's own
@@ -679,14 +613,11 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // terrain selection quietly degrades to the finite method on any future
   // backend without terrain support (all current ground-capable backends
   // have it — PyNEC via the #553 hybrid).
-  const groundModel: GroundModel =
-    groundType === "pec"
-      ? "pec"
-      : groundType === "terrain" && backendSupportsTerrain(backend)
-        ? "terrain"
-        : backendSupportsGround(backend)
-          ? finiteGroundMethod
-          : "fast";
+  const groundModel: GroundModel = resolveGroundModel(
+    groundType,
+    backend,
+    finiteGroundMethod,
+  );
 
   // Solve-effect dep for the terrain knobs: only bites while terrain is
   // the active model, so parked levee state never re-solves a flat-ground
@@ -699,16 +630,12 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // One-line tab-hover summary: design · solver N=segs · ground model.
   // Every backend honours the selected method (momwire >= 0.8.0), so the
   // wording is uniform; "free space" when ground is off or unsupported.
-  const groundActiveForSummary = groundEnabled && backendSupportsGround(backend);
-  const groundSummary = !groundActiveForSummary
-    ? "free space"
-    : groundModel === "pec"
-      ? "PEC ground"
-      : groundModel === "terrain"
-        ? `terrain (${terrainPreset})`
-        : groundModel === "fast"
-          ? "reflection-coef ground"
-          : "Sommerfeld ground";
+  const groundSummary = groundSummaryLabel(
+    groundEnabled,
+    backend,
+    groundModel,
+    terrainPreset,
+  );
   const tabSummary = `${(currentExample?.label ?? geometry) || "new design"} · ${backendDisplayLabel(backend, currentOpts)} N=${nPerWire} · ${groundSummary}`;
   useEffect(() => {
     reportSummary(id, tabSummary);
@@ -1258,19 +1185,7 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   function knobOptFor(name: string): KnobOpt {
     const existing = knobOpt[geometry]?.[name];
     if (existing) return existing;
-    const s = currentSchema.find(
-      (x): x is SchemaParamSpec => !isGroup(x) && x.name === name,
-    );
-    const min = s?.min ?? 0;
-    const max = s?.max ?? 1;
-    return {
-      vary: false,
-      optMin: min,
-      optMax: max,
-      dispMin: min,
-      dispMax: max,
-      step: s?.step ?? 0.001,
-    };
+    return defaultKnobOpt(currentSchema, name);
   }
   function updateKnobOpt(name: string, patch: Partial<KnobOpt>) {
     const base = knobOptFor(name);
@@ -1410,10 +1325,7 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // max 60, so touching the knob clamped it to 60 MHz). Derive it from
   // the design's own band table instead, keeping 60 as the floor so
   // bandless/HF-only designs behave exactly as before.
-  const freqWindowCeiling = Math.max(
-    60,
-    ...currentBands.map((b) => b.max_mhz * 1.25),
-  );
+  const freqWindowCeiling = freqWindowCeilingFor(currentBands);
 
   // When the active example changes (or first loads), snap band /
   // designFreq / measFreq to the band whose [min, max] window contains
@@ -1484,10 +1396,7 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // the active-tab highlight on the meas-band selector. Falls outside any
   // band → no tab highlighted.
   function bandContaining(f: number): string | null {
-    for (const b of currentBands) {
-      if (f >= b.min_mhz && f <= b.max_mhz) return b.key;
-    }
-    return null;
+    return bandContainingIn(currentBands, f);
   }
 
   // The latest control values, used to send a new request when the prior one
@@ -1874,58 +1783,20 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
     const controller = new AbortController();
     sweepAbortRef.current = controller;
 
-    // Sweep range, log-spaced. Sommerfeld ground stays at half resolution:
-    // momwire 0.7.0's C++ fill + grid cache made warm sweeps fast (~30 ms
-    // per point once the per-frequency grids are cached; measured 0.6 s for
-    // 21 points at 2 threads), but the FIRST sweep after enabling it still
-    // fills one grid per point (measured 4.3 s for 21 points at 2 threads;
-    // 41 would be ~9 s) — half resolution halves that cold hit. Fast
-    // (reflection-coefficient) ground and momwire PEC ground are cheap
-    // enough for full resolution.
-    //
-    // Anchor + span come from the active example's sweep_policy. See
-    // SweepPolicy in web/examples/_base.py for the meaning of the fields.
-    // A variant can override the policy (e.g. a band-locked variant): prefer
-    // the active variant's entry in variant_ui, falling back to the
-    // design-level sweep_policy.
-    const slowGround =
-      backendSupportsGround(backend) &&
-      groundEnabled &&
-      groundModel === "sommerfeld";
-    const N = slowGround ? 21 : 41;
-    const policy =
-      currentExample?.variant_ui?.[currentVariant]?.sweep_policy ??
-      currentExample?.sweep_policy;
-    // Anchor on the measurement frequency whenever the sweep should follow what
-    // the user is *viewing*: multiband designs declare anchor="meas_freq", and
-    // any design that's been unlocked from its design freq (to check the pattern
-    // on another band) should sweep that band too — not stay pinned to the
-    // design band. Locked single-resonance designs keep sweeping design_freq
-    // (where measFreq == designFreq anyway).
-    const sweepAnchor =
-      !measLocked || policy?.anchor === "meas_freq" ? measFreq : designFreq;
-    // Band-locked sweep: when the active band contains the anchor,
-    // snap the sweep range to that band's [min_mhz, max_mhz] so the
-    // trace stays inside the band the user is tuning instead of
-    // bleeding into adjacent ones. Falls through to the multiplicative
-    // window if the anchor sits outside every band.
-    let fLo: number;
-    let fHi: number;
-    const bandLocked = policy?.band_locked
-      ? currentBands.find(
-          (b) => sweepAnchor >= b.min_mhz && sweepAnchor <= b.max_mhz,
-        )
-      : undefined;
-    if (bandLocked) {
-      fLo = bandLocked.min_mhz;
-      fHi = bandLocked.max_mhz;
-    } else {
-      fLo = Math.max(0.5, sweepAnchor * (policy?.lo_factor ?? 0.8));
-      fHi = Math.min(freqWindowCeiling, sweepAnchor * (policy?.hi_factor ?? 1.25));
-    }
-    const freqs = Array.from({ length: N }, (_, i) =>
-      Math.exp(Math.log(fLo) + (i / (N - 1)) * (Math.log(fHi) - Math.log(fLo))),
-    );
+    // Sweep range, log-spaced — see planSweepFreqs for the resolution,
+    // anchor, and band-lock policy this applies.
+    const freqs = planSweepFreqs({
+      backend,
+      groundEnabled,
+      groundModel,
+      currentExample,
+      currentVariant,
+      measLocked,
+      measFreq,
+      designFreq,
+      currentBands,
+      freqWindowCeiling,
+    });
 
     const body = {
       ...buildRequest(),
@@ -2082,21 +1953,13 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
           const invN = acc.n_values.map((n) => 1 / n);
           acc.z_re_extrap = richardsonExtrap(invN, acc.z_re);
           acc.z_im_extrap = richardsonExtrap(invN, acc.z_im);
-          // Per-feed Richardson Z*. Each feed's series is the column of
-          // feeds_z_re / feeds_z_im at that feed index across all sampled
-          // N values; richardsonExtrap returns null until ≥3 points are
-          // in, so the diamonds light up the same time the primary one
-          // does.
+          // Per-feed Richardson Z* — see feedwiseRichardson.
           if (acc.feeds_z_re && acc.feeds_z_im) {
-            const nFeeds = acc.feeds_z_re[0].length;
-            const feedsRe: (number | null)[] = [];
-            const feedsIm: (number | null)[] = [];
-            for (let fi = 0; fi < nFeeds; fi++) {
-              const re = acc.feeds_z_re.map((row) => row[fi]);
-              const im = acc.feeds_z_im.map((row) => row[fi]);
-              feedsRe.push(richardsonExtrap(invN, re));
-              feedsIm.push(richardsonExtrap(invN, im));
-            }
+            const { feedsRe, feedsIm } = feedwiseRichardson(
+              invN,
+              acc.feeds_z_re,
+              acc.feeds_z_im,
+            );
             acc.feeds_z_re_extrap = feedsRe;
             acc.feeds_z_im_extrap = feedsIm;
           }

--- a/src/antennaknobs/web/frontend/src/lib/bands.ts
+++ b/src/antennaknobs/web/frontend/src/lib/bands.ts
@@ -1,0 +1,22 @@
+import type { BandSpec } from "./params";
+
+// Ceiling for anchor-derived frequency windows (the unlocked meas-freq
+// VFO and un-band-locked sweeps). Historically a hardcoded 60 MHz — an
+// HF-era bound that survived the 2m/70cm band additions (#497) and
+// then INVERTED the VFO range on VHF designs (anchor 146: min 116.8 >
+// max 60, so touching the knob clamped it to 60 MHz). Derive it from
+// the design's own band table instead, keeping 60 as the floor so
+// bandless/HF-only designs behave exactly as before.
+export function freqWindowCeiling(bands: BandSpec[]): number {
+  return Math.max(60, ...bands.map((b) => b.max_mhz * 1.25));
+}
+
+// Which band (if any) contains frequency `f` — drives the active-tab
+// highlight on the meas-band selector. Falls outside any band → no tab
+// highlighted.
+export function bandContaining(bands: BandSpec[], f: number): string | null {
+  for (const b of bands) {
+    if (f >= b.min_mhz && f <= b.max_mhz) return b.key;
+  }
+  return null;
+}

--- a/src/antennaknobs/web/frontend/src/lib/ground.ts
+++ b/src/antennaknobs/web/frontend/src/lib/ground.ts
@@ -1,3 +1,6 @@
+import type { Backend } from "./backends";
+import { backendSupportsGround, backendSupportsTerrain } from "./backends";
+
 // The UI separates WHAT the ground is from HOW it's solved. GroundType is
 // the shared, backend-agnostic choice: a finite ground (εr=10, σ=0.002), a
 // perfectly conducting one, or a faceted terrain (levee/cliff presets).
@@ -50,3 +53,44 @@ export type TerrainPresetSchema = {
 // presets so edits survive preset flips; an unset key falls back to the
 // schema default and the server clamps every number.
 export type TerrainParams = Record<string, number>;
+
+// The wire value (`ground_model` on SolveRequest), derived from groundType
+// (+ the finite-ground method wherever the active backend supports it). A
+// terrain selection quietly degrades to the finite method on any backend
+// without terrain support (all current ground-capable backends have it —
+// PyNEC via the #553 hybrid).
+export function resolveGroundModel(
+  groundType: GroundType,
+  backend: Backend,
+  finiteGroundMethod: FiniteGroundMethod,
+): GroundModel {
+  return groundType === "pec"
+    ? "pec"
+    : groundType === "terrain" && backendSupportsTerrain(backend)
+      ? "terrain"
+      : backendSupportsGround(backend)
+        ? finiteGroundMethod
+        : "fast";
+}
+
+// One-line tab-hover ground summary: "free space", "PEC ground", "terrain
+// (<preset>)", "reflection-coef ground", or "Sommerfeld ground". Every
+// backend honours the selected method (momwire >= 0.8.0), so the wording is
+// uniform; "free space" when ground is off or unsupported.
+export function groundSummaryLabel(
+  groundEnabled: boolean,
+  backend: Backend,
+  groundModel: GroundModel,
+  terrainPreset: string,
+): string {
+  const groundActiveForSummary = groundEnabled && backendSupportsGround(backend);
+  return !groundActiveForSummary
+    ? "free space"
+    : groundModel === "pec"
+      ? "PEC ground"
+      : groundModel === "terrain"
+        ? `terrain (${terrainPreset})`
+        : groundModel === "fast"
+          ? "reflection-coef ground"
+          : "Sommerfeld ground";
+}

--- a/src/antennaknobs/web/frontend/src/lib/math.ts
+++ b/src/antennaknobs/web/frontend/src/lib/math.ts
@@ -44,6 +44,27 @@ export function richardsonExtrap(
   return a0;
 }
 
+// Per-feed Richardson Z*. Each feed's series is the column of feedsZRe /
+// feedsZIm (one row per sampled N value) at that feed index across all
+// sampled N values; richardsonExtrap returns null until ≥3 points are in,
+// so the diamonds light up the same time the primary one does.
+export function feedwiseRichardson(
+  invN: number[],
+  feedsZRe: number[][],
+  feedsZIm: number[][],
+): { feedsRe: (number | null)[]; feedsIm: (number | null)[] } {
+  const nFeeds = feedsZRe[0].length;
+  const feedsRe: (number | null)[] = [];
+  const feedsIm: (number | null)[] = [];
+  for (let fi = 0; fi < nFeeds; fi++) {
+    const re = feedsZRe.map((row) => row[fi]);
+    const im = feedsZIm.map((row) => row[fi]);
+    feedsRe.push(richardsonExtrap(invN, re));
+    feedsIm.push(richardsonExtrap(invN, im));
+  }
+  return { feedsRe, feedsIm };
+}
+
 // Blend two #rrggbb colors; t=0 -> a, t=1 -> b. Used to warm the knob's value
 // arc from --accent toward --hot as it nears max (an "energizing" cue).
 export function mixHex(a: string, b: string, t: number): string {

--- a/src/antennaknobs/web/frontend/src/lib/params.ts
+++ b/src/antennaknobs/web/frontend/src/lib/params.ts
@@ -367,3 +367,146 @@ export function findLinkedDesignFreq(
   }
   return null;
 }
+
+// Deep-immutable path setter. ParamForm calls with paths like
+// ["bands", 2, "freq"] for nested groups, or ["angle_deg"] for
+// scalars. Recursive clone along the path so React sees a new
+// reference at every level it watches.
+export function setValueAtPath(
+  node: unknown,
+  path: (string | number)[],
+  value: number | string | boolean,
+): unknown {
+  if (path.length === 0) return value;
+  const [head, ...rest] = path;
+  if (typeof head === "number") {
+    const arr = ((node as unknown[]) ?? []).slice();
+    arr[head] = setValueAtPath(arr[head], rest, value);
+    return arr;
+  }
+  const obj = { ...((node as Record<string, unknown>) ?? {}) };
+  obj[head] = setValueAtPath(obj[head], rest, value);
+  return obj;
+}
+
+// Schema-driven meas-freq follow, as a pure resolution over the just-set
+// value tree. Two variants:
+//   * group leaf: `path = [groupName, instanceIdx, leafName]` and the
+//     group declares `link_meas_freq_to_param` — resolve to that
+//     instance's value of the named sibling.
+//   * flat scalar: `path = [paramName]` and the ParamSpec declares
+//     `link_meas_freq_to_param` — resolve to the current value of the
+//     named sibling (possibly itself). Used by multi-band antennas with
+//     parallel length_NN / freq_NN flat sliders (antennaknobs's
+//     fandipole).
+// Returns null when nothing should follow (no link declared, or the
+// linked value isn't numeric); the caller decides whether/how to apply it
+// (e.g. gating on the linkMeas toggle and calling setMeasFreq).
+export function linkedMeasFreqFor(
+  ex: ExampleDescriptor | undefined,
+  path: (string | number)[],
+  newRoot: ParamValueBag,
+): number | null {
+  if (!ex) return null;
+  if (path.length === 1 && typeof path[0] === "string") {
+    const paramName = path[0];
+    const spec = ex.param_schema.find(
+      (s) => !isGroup(s) && s.name === paramName,
+    ) as SchemaParamSpec | undefined;
+    const linked = spec?.link_meas_freq_to_param;
+    if (!linked) return null;
+    const freqValue = newRoot[linked];
+    return typeof freqValue === "number" ? freqValue : null;
+  }
+  if (path.length < 3) return null;
+  const groupName = path[0];
+  const instanceIdx = path[1];
+  if (typeof groupName !== "string" || typeof instanceIdx !== "number") return null;
+  const group = ex.param_schema.find(
+    (s) => isGroup(s) && s.name === groupName,
+  ) as SchemaParamGroupSpec | undefined;
+  if (!group || !group.link_meas_freq_to_param) return null;
+  const instances = newRoot[groupName];
+  if (!Array.isArray(instances)) return null;
+  const inst = instances[instanceIdx];
+  if (!inst) return null;
+  const freqValue = inst[group.link_meas_freq_to_param];
+  return typeof freqValue === "number" ? freqValue : null;
+}
+
+// param_schema with a variant's explicit presentation overrides
+// (variant_ui[variant].params) overlaid per param — e.g. invvee's
+// long-wire variants carry their own length_factor slider range. Feeds
+// the knob rail and the per-knob optimiser menu so both see
+// variant-correct bounds; value seeding stays on the raw schema
+// (defaults/values are variant_values' job).
+export function overlaySchemaForVariant(
+  example: ExampleDescriptor | undefined,
+  variant: string,
+): SchemaItem[] {
+  if (!example) return [];
+  const over = example.variant_ui?.[variant]?.params;
+  if (!over) return example.param_schema;
+  return example.param_schema
+    .map((item) =>
+      !isGroup(item) && over[item.name]
+        ? { ...item, ...over[item.name] }
+        : item,
+    )
+    .filter(
+      // A variant can hide a base-visible knob (e.g. invvee:dipole's
+      // angle_deg — flat by definition, value pinned at 0 by the
+      // variant). Display-only: the value still rides variant_values.
+      (item) => isGroup(item) || !(item as { hidden?: boolean }).hidden,
+    );
+}
+
+// Picker contents: filter `examples` by `query` (always keeping `selected`
+// visible so the <select> value stays valid), then group by family in
+// FAMILY_ORDER.
+export type ExampleGroup = {
+  fam: string;
+  label: string;
+  items: ExampleDescriptor[];
+};
+
+export function groupExamplesForPicker(
+  examples: ExampleDescriptor[],
+  selected: string,
+  query: string,
+): ExampleGroup[] {
+  const visible = examples.filter(
+    (ex) => ex.name === selected || matchesQuery(ex, query),
+  );
+  const byFam = new Map<string, ExampleDescriptor[]>();
+  for (const ex of visible) {
+    const fam = familyOf(ex.name);
+    (byFam.get(fam) ?? byFam.set(fam, []).get(fam)!).push(ex);
+  }
+  return [...byFam.entries()]
+    .map(([fam, items]) => ({
+      fam,
+      label: FAMILY_LABELS[fam] ?? fam,
+      items: items.sort((a, b) => a.label.localeCompare(b.label)),
+    }))
+    .sort((a, b) => familyRank(a.fam) - familyRank(b.fam));
+}
+
+// The effective per-knob optimiser settings, seeded from the schema: opt
+// extents = slider bounds, step = schema step, not varying. The caller
+// overlays any explicitly stored KnobOpt entry on top of this default.
+export function defaultKnobOpt(schema: SchemaItem[], name: string): KnobOpt {
+  const s = schema.find(
+    (x): x is SchemaParamSpec => !isGroup(x) && x.name === name,
+  );
+  const min = s?.min ?? 0;
+  const max = s?.max ?? 1;
+  return {
+    vary: false,
+    optMin: min,
+    optMax: max,
+    dispMin: min,
+    dispMax: max,
+    step: s?.step ?? 0.001,
+  };
+}

--- a/src/antennaknobs/web/frontend/src/lib/sweep.ts
+++ b/src/antennaknobs/web/frontend/src/lib/sweep.ts
@@ -1,0 +1,79 @@
+import { backendSupportsGround, type Backend } from "./backends";
+import type { GroundModel } from "./ground";
+import type { BandSpec, ExampleDescriptor } from "./params";
+
+// Sweep frequency plan: the log-spaced freq list `runSweep` requests.
+// Sommerfeld ground stays at half resolution: momwire 0.7.0's C++ fill +
+// grid cache made warm sweeps fast (~30 ms per point once the
+// per-frequency grids are cached; measured 0.6 s for 21 points at 2
+// threads), but the FIRST sweep after enabling it still fills one grid per
+// point (measured 4.3 s for 21 points at 2 threads; 41 would be ~9 s) —
+// half resolution halves that cold hit. Fast (reflection-coefficient)
+// ground and momwire PEC ground are cheap enough for full resolution.
+//
+// Anchor + span come from the active example's sweep_policy (a variant can
+// override it — see SweepPolicy in web/examples/_base.py). Anchor on the
+// measurement frequency whenever the sweep should follow what the user is
+// *viewing*: multiband designs declare anchor="meas_freq", and any design
+// that's been unlocked from its design freq (to check the pattern on
+// another band) should sweep that band too — not stay pinned to the
+// design band. Locked single-resonance designs keep sweeping design_freq
+// (where measFreq == designFreq anyway).
+//
+// Band-locked sweep: when the active band contains the anchor, snap the
+// sweep range to that band's [min_mhz, max_mhz] so the trace stays inside
+// the band the user is tuning instead of bleeding into adjacent ones.
+// Falls through to the multiplicative window if the anchor sits outside
+// every band.
+export function planSweepFreqs(params: {
+  backend: Backend;
+  groundEnabled: boolean;
+  groundModel: GroundModel;
+  currentExample: ExampleDescriptor | undefined;
+  currentVariant: string;
+  measLocked: boolean;
+  measFreq: number;
+  designFreq: number;
+  currentBands: BandSpec[];
+  freqWindowCeiling: number;
+}): number[] {
+  const {
+    backend,
+    groundEnabled,
+    groundModel,
+    currentExample,
+    currentVariant,
+    measLocked,
+    measFreq,
+    designFreq,
+    currentBands,
+    freqWindowCeiling,
+  } = params;
+  const slowGround =
+    backendSupportsGround(backend) &&
+    groundEnabled &&
+    groundModel === "sommerfeld";
+  const N = slowGround ? 21 : 41;
+  const policy =
+    currentExample?.variant_ui?.[currentVariant]?.sweep_policy ??
+    currentExample?.sweep_policy;
+  const sweepAnchor =
+    !measLocked || policy?.anchor === "meas_freq" ? measFreq : designFreq;
+  let fLo: number;
+  let fHi: number;
+  const bandLocked = policy?.band_locked
+    ? currentBands.find(
+        (b) => sweepAnchor >= b.min_mhz && sweepAnchor <= b.max_mhz,
+      )
+    : undefined;
+  if (bandLocked) {
+    fLo = bandLocked.min_mhz;
+    fHi = bandLocked.max_mhz;
+  } else {
+    fLo = Math.max(0.5, sweepAnchor * (policy?.lo_factor ?? 0.8));
+    fHi = Math.min(freqWindowCeiling, sweepAnchor * (policy?.hi_factor ?? 1.25));
+  }
+  return Array.from({ length: N }, (_, i) =>
+    Math.exp(Math.log(fLo) + (i / (N - 1)) * (Math.log(fHi) - Math.log(fLo))),
+  );
+}


### PR DESCRIPTION
Seam 5b-1 of the #642 arc (design: https://github.com/stevenmburns/antennaknobs/issues/642#issuecomment-5160699838): the pure logic still buried in `DesignSession.tsx` moves to `src/lib/`, each block replaced by a one-line call, **with 62 new unit tests pinning current behavior before the structural seams (5b-2/5b-3) touch the component**.

## The extractions

| Function | New home | Pins |
|---|---|---|
| `setValueAtPath` | `lib/params.ts` | nested-path immutability, array cloning |
| `linkedMeasFreqFor` | `lib/params.ts` | group-leaf vs flat-scalar meas-freq follow, fall-throughs |
| `overlaySchemaForVariant` | `lib/params.ts` | variant param overrides, `hidden` filtering |
| `groupExamplesForPicker` | `lib/params.ts` | selected-stays-visible, family grouping/order |
| `defaultKnobOpt` | `lib/params.ts` | schema seeding + 0/1/0.001 fallbacks |
| `freqWindowCeiling`, `bandContaining` | `lib/bands.ts` (new) | 60 MHz floor, 1.25×max VHF ceiling (the #497 regression), band boundaries |
| `resolveGroundModel`, `groundSummaryLabel` | `lib/ground.ts` | pec/terrain/finite/fast per backend, all five summary wordings |
| `planSweepFreqs` | `lib/sweep.ts` (new) | Sommerfeld half-resolution (21 vs 41), anchor policy incl. unlocked-VFO rule, band-locked snap, log-spacing, floor/ceiling clamps |
| `feedwiseRichardson` | `lib/math.ts` | null until ≥3 points, per-column agreement with `richardsonExtrap` |

`DesignSession.tsx`: 3,808 → 3,671 lines. Suite: **120 → 182 tests**.

## Gates (re-run independently by the reviewer)

- `npm test`: **182/182 green** (existing 120 untouched).
- `npm run build`: green. Roster contract 2/2; repo-wide `ruff format --check` clean.
- Extraction fidelity: every call site is a one-line replacement; bodies verbatim modulo signature lines. The reviewer read every DesignSession hunk and the two subtlest extracted bodies line-by-line: `linkedMeasFreqFor` maps each original early-`return;` to `return null` with identical branch termination (the flat-scalar branch still stops before the group branch), and `setValueAtPath` threads `value` as a parameter exactly as the old closure captured it.

## Notable

- `bandContaining`/`freqWindowCeiling` are imported under aliases (`bandContainingIn`/`freqWindowCeilingFor`) because the component keeps local consts/wrappers of the original names — avoids a TDZ self-reference while leaving all downstream call sites untouched.
- Two pinned quirks: the log-spaced sweep endpoints aren't bit-exact to fLo/fHi (exp∘log round-trip; tests use closeTo), and every *current* backend supports ground/terrain, so the "unsupported backend" branches are pinned via a cast future-backend fixture, matching the code's own defensive comments.

## Review notes

Implemented by a sonnet subagent from the Plan-agent design (posted on the issue); reviewed by the session model as above. Next: 5b-2 (presentational components, props-only) then 5b-3 (behavior hooks) to reach the ≤1,500-line bar.

Part of #642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g
