### PR TITLE
refactor(web): DesignSession sidebar/overlay JSX becomes prop-driven components (#642 seam 5b-2)

### DIFF
--- a/src/antennaknobs/web/frontend/src/components/results/StageOverlays.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/StageOverlays.tsx
@@ -1,0 +1,425 @@
+import type { Backend } from "../../lib/backends";
+import type { MeasuredData, NormCheckData, SolveResponse } from "../../lib/api";
+import type { GroundModel } from "../../lib/ground";
+import type { ExampleDescriptor } from "../../lib/params";
+import type { Projection, View } from "../../lib/view";
+import { PROJECTIONS } from "../../lib/view";
+import type { PatternMetrics, PinnedPattern } from "../charts/types";
+import { Knob } from "../params/Knob";
+import { PatternCompareTable } from "./PatternCompareTable";
+
+export function AntennaOverlayControls({
+  cameraProjection,
+  setCameraProjection,
+  isMobile,
+  showHeatmap,
+  setShowHeatmap,
+  showEnvelope,
+  setShowEnvelope,
+  showWireLabels,
+  setShowWireLabels,
+  showFeedNames,
+  setShowFeedNames,
+}: {
+  cameraProjection: Projection;
+  setCameraProjection: (p: Projection) => void;
+  isMobile: boolean;
+  showHeatmap: boolean;
+  setShowHeatmap: (v: boolean) => void;
+  showEnvelope: boolean;
+  setShowEnvelope: (v: boolean) => void;
+  showWireLabels: boolean;
+  setShowWireLabels: (v: boolean) => void;
+  showFeedNames: boolean;
+  setShowFeedNames: (v: boolean) => void;
+}) {
+  return (
+    <div className="antenna-overlay">
+      <div className="projection-toggle">
+        {PROJECTIONS.map((p) => (
+          <button
+            key={p.id}
+            className={p.id === cameraProjection ? "active" : ""}
+            onClick={() => setCameraProjection(p.id)}
+            title={`Project onto the ${p.id} plane`}
+          >
+            {p.label}
+          </button>
+        ))}
+      </div>
+      {/* Mobile drops the checkbox column — it doesn't scale with the
+          chart and covers it on a phone. The same toggles live in the
+          sidebar gear menu (shared state). The projection toggle above
+          stays: it's compact and it's how you turn the view. */}
+      {!isMobile && (
+        <>
+          <label
+            className="overlay-checkbox"
+            title="Color wire segments by current magnitude; modulate wire width"
+          >
+            <input
+              type="checkbox"
+              checked={showHeatmap}
+              onChange={(e) => setShowHeatmap(e.target.checked)}
+            />
+            heatmapped currents
+          </label>
+          <label
+            className="overlay-checkbox"
+            title="Draw the |I| envelope curve along each wire"
+          >
+            <input
+              type="checkbox"
+              checked={showEnvelope}
+              onChange={(e) => setShowEnvelope(e.target.checked)}
+            />
+            current waveforms
+          </label>
+          <label
+            className="overlay-checkbox"
+            title="Draw the per-wire labels (off to declutter dense geometries)"
+          >
+            <input
+              type="checkbox"
+              checked={showWireLabels}
+              onChange={(e) => setShowWireLabels(e.target.checked)}
+            />
+            wire labels
+          </label>
+          <label
+            className="overlay-checkbox"
+            title="Draw the 'feed' name beside each feedpoint marker"
+          >
+            <input
+              type="checkbox"
+              checked={showFeedNames}
+              onChange={(e) => setShowFeedNames(e.target.checked)}
+            />
+            feed labels
+          </label>
+        </>
+      )}
+    </div>
+  );
+}
+
+// Both smith-overlay children are checkboxes — nothing to keep on mobile
+// (the toggles live in the gear menu there).
+export function SmithOverlayControls({
+  sweepEnabled,
+  setSweepEnabled,
+  convergeEnabled,
+  setConvergeEnabled,
+  convergeNValues,
+  measured,
+  onLoadMeasured,
+  onClearMeasured,
+}: {
+  sweepEnabled: boolean;
+  setSweepEnabled: (v: boolean) => void;
+  convergeEnabled: boolean;
+  setConvergeEnabled: (v: boolean) => void;
+  convergeNValues: number[];
+  measured: MeasuredData | null;
+  onLoadMeasured: (f: File) => void;
+  onClearMeasured: () => void;
+}) {
+  return (
+    <div className="smith-overlay">
+      <label
+        className="overlay-checkbox"
+        title="Sweep Z across measurement freq and plot the locus on the Smith chart"
+      >
+        <input
+          type="checkbox"
+          checked={sweepEnabled}
+          onChange={(e) => setSweepEnabled(e.target.checked)}
+        />
+        freq sweep
+      </label>
+      <label
+        className="overlay-checkbox"
+        title={`Re-solve at N = ${convergeNValues.join(", ")} segments/wire and Richardson-extrapolate Z to N→∞`}
+      >
+        <input
+          type="checkbox"
+          checked={convergeEnabled}
+          onChange={(e) => setConvergeEnabled(e.target.checked)}
+        />
+        converge sweep
+      </label>
+      <label
+        className="overlay-file"
+        title="Overlay a measured VNA sweep (one-port Touchstone .s1p, e.g. from a NanoVNA) against the modeled locus"
+      >
+        <input
+          type="file"
+          accept=".s1p,.S1P"
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            // Reset the input so re-picking the same file (after a
+            // re-measure) fires onChange again.
+            e.target.value = "";
+            if (f) onLoadMeasured(f);
+          }}
+        />
+        {measured ? `measured: ${measured.label}` : "measured .s1p…"}
+      </label>
+      {measured && (
+        <button
+          type="button"
+          className="overlay-clear"
+          title="Remove the measured overlay"
+          onClick={onClearMeasured}
+        >
+          clear
+        </button>
+      )}
+    </div>
+  );
+}
+
+// On mobile only the Δ readout survives (it's output, not a control, and
+// it's one short span); the norm-check toggle lives in the gear menu. The
+// caller skips this entirely when it would be empty (see the `!isMobile ||
+// (normCheckEnabled && normCheck)` gate at the call site).
+export function FarFieldOverlayControls({
+  isMobile,
+  normCheckEnabled,
+  setNormCheckEnabled,
+  normCheck,
+  backend,
+  groundModel,
+  necOverlayEnabled,
+  setNecOverlayEnabled,
+}: {
+  isMobile: boolean;
+  normCheckEnabled: boolean;
+  setNormCheckEnabled: (v: boolean) => void;
+  normCheck: NormCheckData | null;
+  backend: Backend;
+  groundModel: GroundModel;
+  necOverlayEnabled: boolean;
+  setNecOverlayEnabled: (v: boolean) => void;
+}) {
+  return (
+    <div className="farfield-overlay">
+      {!isMobile && (
+        <label
+          className="overlay-checkbox"
+          title="On dwell, renormalise the pattern by its own integrated radiated power (dotted) instead of the input power the solid line uses. Overlap ⇒ the solve conserves power; a visible gap is the solver's discretisation error (NEC's 'average gain' check)."
+        >
+          <input
+            type="checkbox"
+            checked={normCheckEnabled}
+            onChange={(e) => setNormCheckEnabled(e.target.checked)}
+          />
+          norm check
+        </label>
+      )}
+      {!isMobile && backend === "pynec" && (
+        <label
+          className="overlay-checkbox"
+          style={
+            groundModel === "terrain" ? { opacity: 0.45 } : undefined
+          }
+          title={
+            groundModel === "terrain"
+              ? "NEC's rp_card pattern is flat-ground only (no facet model), so the exact-pattern overlay is unavailable over terrain — the terrain traces come from the server's facet physics instead."
+              : "Overlay NEC's own rp_card far-field pattern (dashed cyan) as an exact reference for this engine's ground model."
+          }
+        >
+          <input
+            type="checkbox"
+            checked={necOverlayEnabled && groundModel !== "terrain"}
+            disabled={groundModel === "terrain"}
+            onChange={(e) => setNecOverlayEnabled(e.target.checked)}
+          />
+          NEC rp
+        </label>
+      )}
+      {/* Over a finite ground the norm gap IS physics (structural
+          loss + real ground absorption), so show it in its honest
+          form — the radiated fraction, same number as the Info-pane
+          row. Free space / PEC keeps the raw Δ dB, where it is a
+          pure solver power-balance diagnostic. Over faceted TERRAIN
+          the fraction is PEC-facet-referenced (the server integrates
+          the same facet geometry with lossless media as the
+          denominator, cancelling the hybrid ledger gap); the ledger
+          Δ itself lives in the tooltip and the dotted overlay. */}
+      {normCheckEnabled && normCheck && (
+        <span
+          className="overlay-readout"
+          title={
+            normCheck.method.startsWith("grid_terrain")
+              ? `Share of accepted power leaving as sky wave over the faceted terrain (${normCheck.method}): the same facet geometry integrated with perfect-reflector media is the reference, so the ratio isolates real ground-media absorption. The dotted overlay shows the separate hybrid-model ledger gap (Δ ${normCheck.delta_db >= 0 ? "+" : ""}${normCheck.delta_db.toFixed(2)} dB — the facet far field vs the crest-referenced input power; either sign is normal, and absolute gains stay anchored to the input-power norm, the convention validated against NEC-2's cliff).`
+              : normCheck.method.startsWith("grid_")
+                ? `P_radiated/P_input from the pattern-integral norm (${normCheck.method}): the gap between the solid and dotted lobes as a fraction — structural loss plus real ground absorption (Δ ${normCheck.delta_db >= 0 ? "+" : ""}${normCheck.delta_db.toFixed(3)} dB, NEC average-gain style)`
+                : `input-power norm vs pattern-integral norm (${normCheck.method}); 0 dB = perfect power balance`
+          }
+        >
+          {normCheck.method.startsWith("grid_") ? (
+            <>radiated {(normCheck.radiated_fraction * 100).toFixed(0)}%</>
+          ) : (
+            <>
+              Δ {normCheck.delta_db >= 0 ? "+" : ""}
+              {normCheck.delta_db.toFixed(3)} dB
+            </>
+          )}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// The cut-angle knob lives on the plot it drives: the azimuth (xy) cut is
+// taken at elevation azElevDeg; the elevation (yz) cut is taken at azimuth
+// bearing elevAzDeg. CCW dials from 3 o'clock.
+export function CutAngleOverlay({
+  v,
+  azElevDeg,
+  setAzElevDeg,
+  elevAzDeg,
+  setElevAzDeg,
+}: {
+  v: View;
+  azElevDeg: number;
+  setAzElevDeg: (v: number) => void;
+  elevAzDeg: number;
+  setElevAzDeg: (v: number) => void;
+}) {
+  return (
+    <>
+      {v === "azimuth" && (
+        <div
+          className="cut-overlay"
+          title="elevation at which this azimuth cut is taken"
+        >
+          <span className="cut-overlay-label">elevation</span>
+          <Knob
+            knobId="ff_cut_elevation"
+            value={azElevDeg}
+            min={0}
+            max={89}
+            step={1}
+            precision={0}
+            unit="°"
+            label="cut elevation"
+            onChange={setAzElevDeg}
+            startDeg={90}
+            sweepDeg={-89}
+          />
+          <span className="cut-overlay-value">{azElevDeg}°</span>
+        </div>
+      )}
+      {v === "elevation" && (
+        <div
+          className="cut-overlay"
+          title="azimuth bearing at which this elevation cut is taken"
+        >
+          <span className="cut-overlay-label">azimuth</span>
+          <Knob
+            knobId="ff_cut_azimuth"
+            value={elevAzDeg}
+            min={0}
+            max={359}
+            step={1}
+            precision={0}
+            unit="°"
+            label="cut azimuth"
+            onChange={setElevAzDeg}
+            startDeg={90}
+            sweepDeg={-359}
+          />
+          <span className="cut-overlay-value">{elevAzDeg}°</span>
+        </div>
+      )}
+    </>
+  );
+}
+
+export function CompareOverlay({
+  pinCurrentPattern,
+  setCompareCollapsed,
+  result,
+  pinnedPatterns,
+  compareCollapsed,
+  clearPins,
+  liveMetrics,
+  currentExample,
+  geometry,
+  measFreq,
+  removePin,
+  togglePin,
+}: {
+  pinCurrentPattern: () => void;
+  setCompareCollapsed: (v: boolean) => void;
+  result: SolveResponse | null;
+  pinnedPatterns: PinnedPattern[];
+  compareCollapsed: boolean;
+  clearPins: () => void;
+  liveMetrics: PatternMetrics | null;
+  currentExample: ExampleDescriptor | undefined;
+  geometry: string;
+  measFreq: number;
+  removePin: (id: string) => void;
+  togglePin: (id: string) => void;
+}) {
+  return (
+    <div className="compare-overlay">
+      <button
+        type="button"
+        className="pin-btn"
+        onClick={() => {
+          pinCurrentPattern();
+          // Pinning always reveals the table so the new row is seen;
+          // it stays open until minimized (no auto-collapse timer).
+          setCompareCollapsed(false);
+        }}
+        disabled={!result}
+        title="Pin the current pattern as a ghost overlay, to compare another antenna or tuning against it"
+      >
+        📌 Pin pattern
+      </button>
+      {pinnedPatterns.length > 0 &&
+        (compareCollapsed ? (
+          <button
+            type="button"
+            className="pin-btn pin-chip"
+            onClick={() => setCompareCollapsed(false)}
+            title="Show the pinned-pattern comparison table"
+          >
+            {pinnedPatterns.length} pinned ▾
+          </button>
+        ) : (
+          <>
+            <div className="pin-table-actions">
+              <button
+                type="button"
+                className="pin-clear"
+                onClick={clearPins}
+                title="Remove all pinned patterns"
+              >
+                clear
+              </button>
+              <button
+                type="button"
+                className="pin-clear"
+                onClick={() => setCompareCollapsed(true)}
+                title="Minimize the comparison table (pins and ghost overlays are kept)"
+              >
+                –
+              </button>
+            </div>
+            <PatternCompareTable
+              live={liveMetrics}
+              liveLabel={`${currentExample?.label ?? geometry} @ ${measFreq.toFixed(2)} MHz`}
+              pinned={pinnedPatterns}
+              onRemove={removePin}
+              onToggle={togglePin}
+            />
+          </>
+        ))}
+    </div>
+  );
+}

--- a/src/antennaknobs/web/frontend/src/components/session/CatalogPanel.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/CatalogPanel.tsx
@@ -1,0 +1,109 @@
+import {
+  AwaitingTrustPanel,
+  type DesignLoadError,
+} from "../AwaitingTrustPanel";
+import { GeometryCombobox } from "../params/GeometryCombobox";
+import type { ExampleDescriptor, ExampleGroup } from "../../lib/params";
+
+export function CatalogPanel({
+  geomGroups,
+  geometry,
+  currentExample,
+  geomFilter,
+  setGeomFilter,
+  setGeometry,
+  currentVariant,
+  selectVariant,
+  examplesError,
+  loadErrors,
+  trustBusy,
+  trustDesign,
+}: {
+  geomGroups: ExampleGroup[];
+  geometry: string;
+  currentExample: ExampleDescriptor | undefined;
+  geomFilter: string;
+  setGeomFilter: (v: string) => void;
+  setGeometry: (v: string) => void;
+  currentVariant: string;
+  selectVariant: (v: string) => void;
+  examplesError: string | null;
+  loadErrors: DesignLoadError[];
+  trustBusy: string | null;
+  trustDesign: (stem: string, allowEdits: boolean) => void;
+}) {
+  return (
+    <>
+      <div className="antenna-row">
+        <GeometryCombobox
+          groups={geomGroups}
+          selected={geometry}
+          currentLabel={currentExample?.label ?? ""}
+          filter={geomFilter}
+          setFilter={setGeomFilter}
+          onSelect={setGeometry}
+        />
+        {currentExample && currentExample.variants.length > 1 && (
+          <select
+            id="variant-select"
+            className="geometry-select variant-select"
+            value={currentVariant}
+            onChange={(e) => selectVariant(e.target.value)}
+            aria-label="variant"
+            title="variant"
+          >
+            {currentExample.variants.map((v) => (
+              <option key={v} value={v}>
+                {v}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+      {currentExample?.notes && (
+        <div className="design-note">{currentExample.notes}</div>
+      )}
+      {examplesError && (
+        <div className="examples-error">
+          Failed to load /examples: {examplesError}
+        </div>
+      )}
+      {loadErrors.some((e) => e.trust_required) && (
+        <AwaitingTrustPanel
+          designs={loadErrors.filter((e) => e.trust_required)}
+          busy={trustBusy}
+          onTrust={trustDesign}
+        />
+      )}
+      {loadErrors.some((e) => !e.trust_required) && (
+        <div className="design-load-errors" role="alert">
+          {(() => {
+            const errs = loadErrors.filter((e) => !e.trust_required);
+            return (
+              <>
+                <div className="design-load-errors-title">
+                  {errs.length} design{errs.length === 1 ? "" : "s"} failed to
+                  load
+                </div>
+                <ul>
+                  {errs.map((err) => (
+                    <li key={err.name}>
+                      <code>{err.name}</code> — {err.message}
+                      <span className="design-load-errors-file">
+                        {err.file}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+                <div className="design-load-errors-hint">
+                  Fix the file and refresh. See CLAUDE.md in your designs
+                  folder.
+                </div>
+              </>
+            );
+          })()}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/antennaknobs/web/frontend/src/components/session/DesignFreqRow.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignFreqRow.tsx
@@ -1,0 +1,49 @@
+import { BandDropdown } from "../params/BandDropdown";
+import type { BandSpec } from "../../lib/params";
+
+// Highlight the band whose window contains the current designFreq — same
+// behaviour as the meas-freq row. The slider min/max also tracks that band,
+// so sliding past its edge auto-re-anchors to the neighbouring band. The
+// caller gates this on has_design_freq so the row is hidden for hand-tuned
+// absolute designs where the slider would do nothing.
+export function DesignFreqRow({
+  bands,
+  designFreq,
+  activeKey,
+  onSelectBand,
+  onSetFreq,
+}: {
+  bands: BandSpec[];
+  designFreq: number;
+  activeKey: string | null;
+  onSelectBand: (key: string) => void;
+  onSetFreq: (v: number) => void;
+}) {
+  const active = bands.find((b) => b.key === activeKey) ?? bands[0];
+  return (
+    <div className="field">
+      <label>
+        <span>design freq</span>
+        <span>{designFreq.toFixed(3)} MHz</span>
+      </label>
+      <div className="band-row">
+        <BandDropdown
+          bands={bands}
+          value={active.key}
+          onSelect={onSelectBand}
+          ariaLabel="band"
+        />
+        <input
+          type="range"
+          min={active.min_mhz}
+          max={active.max_mhz}
+          step={0.005}
+          value={designFreq}
+          onInput={(e) =>
+            onSetFreq(Number((e.target as HTMLInputElement).value))
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -2245,8 +2245,8 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // Hoisted JSX shared between the desktop tree below and the mobile tree
   // (Phase B). These close over the session's locals, so they are consts /
   // a closure rather than components — zero prop surface, identical DOM.
-  // The moved blocks keep their original indentation so the refactor diff
-  // shows them as pure moves.
+  // (The former inline sub-blocks now live as prop-driven components in
+  // components/session/ and results/StageOverlays.tsx — #642 seam 5b-2.)
   const controls = (
     <>
         <SessionGearMenu

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -4,7 +4,6 @@ import {
   BACKEND_LABEL,
   backendDisplayLabel,
   backendSupportsGround,
-  backendSupportsTerrain,
   comboInappropriate,
   DEFAULT_BACKEND_OPTS,
   DEFAULT_SLOTS,
@@ -15,7 +14,6 @@ import {
   RESTRICTED_BACKEND_REASON,
   resolveSlotConfig,
   selectableBackends,
-  SLOT_ORDER,
   type Backend,
   type BackendOptsMap,
   type Slot,
@@ -69,13 +67,8 @@ import type {
   SweepData,
 } from "../../lib/api";
 import { BackendConfigModal } from "../backend/BackendConfigModal";
-import { KnobMenuNumber, NumberField } from "../backend/fields";
-import {
-  AwaitingTrustPanel,
-  type DesignLoadError,
-} from "../AwaitingTrustPanel";
+import { type DesignLoadError } from "../AwaitingTrustPanel";
 import { BandDropdown } from "../params/BandDropdown";
-import { GeometryCombobox } from "../params/GeometryCombobox";
 import { Knob } from "../params/Knob";
 import { ParamForm } from "../params/ParamForm";
 import {
@@ -97,7 +90,12 @@ import { PatternCompareTable } from "../results/PatternCompareTable";
 import { SolveReadout } from "../results/SolveReadout";
 import { ViewPanel } from "../results/ViewPanel";
 import { fetchMetrics, PinsContext, SessionsContext, ThemeControlContext } from "./contexts";
-import { TabStrip } from "./TabStrip";
+import { CatalogPanel } from "./CatalogPanel";
+import { DesignFreqRow } from "./DesignFreqRow";
+import { GroundPanel } from "./GroundPanel";
+import { KnobOptMenu } from "./KnobOptMenu";
+import { SessionGearMenu } from "./SessionGearMenu";
+import { SolverSlotTabs } from "./SolverSlotTabs";
 
 // Log-spaced segments-per-wire ladder for the convergence sweep. Hentenna's
 // 8N+2 total segments at N=68 puts the dense LU at a ~550-cell matrix —
@@ -2272,269 +2270,50 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // shows them as pure moves.
   const controls = (
     <>
-        <TabStrip />
-        <div className="sidebar-header">
-          <div className="brand">
-            <h1>AntennaKNoBs</h1>
-            <span className="byline">by KK7KNB</span>
-          </div>
-          <div className="header-actions">
-            <div className="gear-menu-wrap">
-              <button
-                type="button"
-                className="header-icon-btn"
-                onClick={() => setGearMenuOpen((o) => !o)}
-                title="Tools"
-                aria-label="Tools menu"
-                aria-haspopup="menu"
-                aria-expanded={gearMenuOpen}
-              >
-                ⚙
-              </button>
-              {gearMenuOpen && (
-                <>
-                  <div
-                    className="gear-menu-backdrop"
-                    onClick={() => setGearMenuOpen(false)}
-                  />
-                  <div className="gear-menu" role="menu">
-                    <button
-                      type="button"
-                      className="gear-menu-item"
-                      role="menuitem"
-                      onClick={copyParams}
-                      title="Copy the current knob values as a paste-ready Python default_params block"
-                    >
-                      {copiedParams ? "Copied ✓" : "Copy params (Python)"}
-                    </button>
-                    <button
-                      type="button"
-                      className="gear-menu-item"
-                      role="menuitem"
-                      onClick={downloadNec}
-                      title="Download this design as a NEC2 .nec card deck (for xnec2c, 4nec2, EZNEC, …)"
-                    >
-                      Download .nec deck
-                    </button>
-                    {/* Reactive copies of the chart-overlay toggles (same state
-                        the overlays use, so the two locations can never
-                        disagree). On mobile the checkbox overlays are not
-                        rendered on the chart screens — small screens can't
-                        spare the chart area — so this menu is the only place
-                        to reach them there; on desktop it's a convenience
-                        duplicate. */}
-                    <div className="gear-menu-divider" />
-                    {/* Mobile-layout only: it exists to reclaim the phone's
-                        status/nav bars; on desktop F11 already does this and
-                        the menu entry would be clutter. Also needs element
-                        fullscreen (missing on iPhone Safari). */}
-                    {isMobile && fullscreen.supported && (
-                      <>
-                        <div className="gear-menu-section">display</div>
-                        <label
-                          className="gear-menu-check"
-                          title="Take over the whole screen — hides the system status and navigation bars. Uncheck (or use the back gesture) to exit."
-                        >
-                          <input
-                            type="checkbox"
-                            checked={fullscreen.active}
-                            onChange={fullscreen.toggle}
-                          />
-                          full screen
-                        </label>
-                      </>
-                    )}
-                    <div className="gear-menu-section">antenna chart</div>
-                    <label
-                      className="gear-menu-check"
-                      title="Color wire segments by current magnitude; modulate wire width"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={showHeatmap}
-                        onChange={(e) => setShowHeatmap(e.target.checked)}
-                      />
-                      heatmapped currents
-                    </label>
-                    <label
-                      className="gear-menu-check"
-                      title="Draw the |I| envelope curve along each wire"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={showEnvelope}
-                        onChange={(e) => setShowEnvelope(e.target.checked)}
-                      />
-                      current waveforms
-                    </label>
-                    <label
-                      className="gear-menu-check"
-                      title="Draw the per-wire labels (off to declutter dense geometries)"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={showWireLabels}
-                        onChange={(e) => setShowWireLabels(e.target.checked)}
-                      />
-                      wire labels
-                    </label>
-                    <label
-                      className="gear-menu-check"
-                      title="Draw the 'feed' name beside each feedpoint marker"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={showFeedNames}
-                        onChange={(e) => setShowFeedNames(e.target.checked)}
-                      />
-                      feed labels
-                    </label>
-                    <div className="gear-menu-section">smith chart</div>
-                    <label
-                      className="gear-menu-check"
-                      title="Sweep Z across measurement freq and plot the locus on the Smith chart"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={sweepEnabled}
-                        onChange={(e) => setSweepEnabled(e.target.checked)}
-                      />
-                      freq sweep
-                    </label>
-                    <label
-                      className="gear-menu-check"
-                      title={`Re-solve at N = ${CONVERGE_N_VALUES.join(", ")} segments/wire and Richardson-extrapolate Z to N→∞`}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={convergeEnabled}
-                        onChange={(e) => setConvergeEnabled(e.target.checked)}
-                      />
-                      converge sweep
-                    </label>
-                    <label
-                      className="gear-menu-check gear-menu-file"
-                      title="Overlay a measured VNA sweep (one-port Touchstone .s1p, e.g. from a NanoVNA) against the modeled locus"
-                    >
-                      <input
-                        type="file"
-                        accept=".s1p,.S1P"
-                        onChange={(e) => {
-                          const f = e.target.files?.[0];
-                          e.target.value = "";
-                          if (f) loadMeasured(f);
-                        }}
-                      />
-                      {measured ? `measured: ${measured.label}` : "measured .s1p\u2026"}
-                    </label>
-                    {measured && (
-                      <button
-                        type="button"
-                        className="gear-menu-check gear-menu-button"
-                        onClick={() => setMeasured(null)}
-                      >
-                        clear measured
-                      </button>
-                    )}
-                    <div className="gear-menu-section">azimuth / elevation</div>
-                    <label
-                      className="gear-menu-check"
-                      title="On dwell, renormalise the pattern by its own integrated radiated power (dotted) instead of the input power the solid line uses. Overlap ⇒ the solve conserves power; a visible gap is the solver's discretisation error (NEC's 'average gain' check)."
-                    >
-                      <input
-                        type="checkbox"
-                        checked={normCheckEnabled}
-                        onChange={(e) => setNormCheckEnabled(e.target.checked)}
-                      />
-                      norm check
-                    </label>
-                  </div>
-                </>
-              )}
-            </div>
-            <button
-              type="button"
-              className="theme-toggle"
-              onClick={() => applyTheme(theme === "dark" ? "light" : "dark")}
-              title="Toggle light / dark theme"
-              aria-label="Toggle light / dark theme"
-            >
-              {theme === "dark" ? "☀" : "☾"}
-            </button>
-          </div>
-        </div>
+        <SessionGearMenu
+          gearMenuOpen={gearMenuOpen}
+          setGearMenuOpen={setGearMenuOpen}
+          copiedParams={copiedParams}
+          onCopyParams={copyParams}
+          onDownloadNec={downloadNec}
+          isMobile={isMobile}
+          fullscreen={fullscreen}
+          showHeatmap={showHeatmap}
+          setShowHeatmap={setShowHeatmap}
+          showEnvelope={showEnvelope}
+          setShowEnvelope={setShowEnvelope}
+          showWireLabels={showWireLabels}
+          setShowWireLabels={setShowWireLabels}
+          showFeedNames={showFeedNames}
+          setShowFeedNames={setShowFeedNames}
+          sweepEnabled={sweepEnabled}
+          setSweepEnabled={setSweepEnabled}
+          convergeEnabled={convergeEnabled}
+          setConvergeEnabled={setConvergeEnabled}
+          convergeNValues={CONVERGE_N_VALUES}
+          measured={measured}
+          onLoadMeasured={loadMeasured}
+          onClearMeasured={() => setMeasured(null)}
+          normCheckEnabled={normCheckEnabled}
+          setNormCheckEnabled={setNormCheckEnabled}
+          theme={theme}
+          applyTheme={applyTheme}
+        />
 
-        <div className="antenna-row">
-          <GeometryCombobox
-            groups={geomGroups}
-            selected={geometry}
-            currentLabel={currentExample?.label ?? ""}
-            filter={geomFilter}
-            setFilter={setGeomFilter}
-            onSelect={setGeometry}
-          />
-          {currentExample && currentExample.variants.length > 1 && (
-            <select
-              id="variant-select"
-              className="geometry-select variant-select"
-              value={currentVariant}
-              onChange={(e) => selectVariant(e.target.value)}
-              aria-label="variant"
-              title="variant"
-            >
-              {currentExample.variants.map((v) => (
-                <option key={v} value={v}>
-                  {v}
-                </option>
-              ))}
-            </select>
-          )}
-        </div>
-        {currentExample?.notes && (
-          <div className="design-note">{currentExample.notes}</div>
-        )}
-        {examplesError && (
-          <div className="examples-error">
-            Failed to load /examples: {examplesError}
-          </div>
-        )}
-        {loadErrors.some((e) => e.trust_required) && (
-          <AwaitingTrustPanel
-            designs={loadErrors.filter((e) => e.trust_required)}
-            busy={trustBusy}
-            onTrust={trustDesign}
-          />
-        )}
-        {loadErrors.some((e) => !e.trust_required) && (
-          <div className="design-load-errors" role="alert">
-            {(() => {
-              const errs = loadErrors.filter((e) => !e.trust_required);
-              return (
-                <>
-                  <div className="design-load-errors-title">
-                    {errs.length} design{errs.length === 1 ? "" : "s"} failed to
-                    load
-                  </div>
-                  <ul>
-                    {errs.map((err) => (
-                      <li key={err.name}>
-                        <code>{err.name}</code> — {err.message}
-                        <span className="design-load-errors-file">
-                          {err.file}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                  <div className="design-load-errors-hint">
-                    Fix the file and refresh. See CLAUDE.md in your designs
-                    folder.
-                  </div>
-                </>
-              );
-            })()}
-          </div>
-        )}
-
+        <CatalogPanel
+          geomGroups={geomGroups}
+          geometry={geometry}
+          currentExample={currentExample}
+          geomFilter={geomFilter}
+          setGeomFilter={setGeomFilter}
+          setGeometry={setGeometry}
+          currentVariant={currentVariant}
+          selectVariant={selectVariant}
+          examplesError={examplesError}
+          loadErrors={loadErrors}
+          trustBusy={trustBusy}
+          trustDesign={trustDesign}
+        />
 
         {currentExample && (
           <div
@@ -2565,119 +2344,29 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
           </div>
         )}
 
-        {currentBands.length > 0 && currentExample?.has_design_freq && (() => {
-          // Highlight the band whose window contains the current
-          // designFreq — same behaviour as the meas-freq row below.
-          // The slider min/max also tracks that band, so sliding past
-          // its edge auto-re-anchors to the neighbouring band.
-          // Gated on has_design_freq so the row is hidden for
-          // hand-tuned absolute designs where the slider would do
-          // nothing.
-          const activeKey = bandContaining(designFreq);
-          const active = currentBands.find((b) => b.key === activeKey) ?? currentBands[0];
-          return (
-            <div className="field">
-              <label>
-                <span>design freq</span>
-                <span>{designFreq.toFixed(3)} MHz</span>
-              </label>
-              <div className="band-row">
-                <BandDropdown
-                  bands={currentBands}
-                  value={active.key}
-                  onSelect={selectBand}
-                  ariaLabel="band"
-                />
-                <input
-                  type="range"
-                  min={active.min_mhz}
-                  max={active.max_mhz}
-                  step={0.005}
-                  value={designFreq}
-                  onInput={(e) =>
-                    updateDesignFreq(Number((e.target as HTMLInputElement).value))
-                  }
-                />
-              </div>
-            </div>
-          );
-        })()}
+        {currentBands.length > 0 && currentExample?.has_design_freq && (
+          <DesignFreqRow
+            bands={currentBands}
+            designFreq={designFreq}
+            activeKey={bandContaining(designFreq)}
+            onSelectBand={selectBand}
+            onSetFreq={updateDesignFreq}
+          />
+        )}
 
         {/* Per-knob optimiser menu (right-click a knob): vary toggle + extents +
             turn step. Position-fixed at the click point. */}
-        {knobMenu &&
-          currentExample &&
-          (() => {
-            const name = knobMenu.name;
-            const ko = knobOptFor(name);
-            const s = currentSchema.find(
-              (x): x is SchemaParamSpec => !isGroup(x) && x.name === name,
-            );
-            const num = (v: number) => (Number.isFinite(v) ? v : 0);
-            const set = (patch: Partial<KnobOpt>) => updateKnobOpt(name, patch);
-            return (
-              <>
-                <div
-                  className="knob-menu-backdrop"
-                  onClick={() => setKnobMenu(null)}
-                  onContextMenu={(e) => {
-                    e.preventDefault();
-                    setKnobMenu(null);
-                  }}
-                />
-                <div
-                  className="knob-menu"
-                  style={{ left: knobMenu.x, top: knobMenu.y }}
-                  onContextMenu={(e) => e.preventDefault()}
-                >
-                  <div className="knob-menu-title">{s?.label ?? name}</div>
-                  <label className="knob-menu-vary">
-                    <input
-                      type="checkbox"
-                      checked={ko.vary}
-                      onChange={(e) => set({ vary: e.target.checked })}
-                    />
-                    Optimize this knob
-                    <kbd
-                      className="knob-menu-kbd"
-                      title="Focus a knob and press O to toggle"
-                    >
-                      O
-                    </kbd>
-                  </label>
-                  <div className="knob-menu-row">
-                    <span>Optimize range</span>
-                    <KnobMenuNumber
-                      value={num(ko.optMin)}
-                      onChange={(v) => set({ optMin: v })}
-                    />
-                    <KnobMenuNumber
-                      value={num(ko.optMax)}
-                      onChange={(v) => set({ optMax: v })}
-                    />
-                  </div>
-                  <div className="knob-menu-row">
-                    <span>Display range</span>
-                    <KnobMenuNumber
-                      value={num(ko.dispMin)}
-                      onChange={(v) => set({ dispMin: v })}
-                    />
-                    <KnobMenuNumber
-                      value={num(ko.dispMax)}
-                      onChange={(v) => set({ dispMax: v })}
-                    />
-                  </div>
-                  <div className="knob-menu-row">
-                    <span>Turn step</span>
-                    <KnobMenuNumber
-                      value={num(ko.step)}
-                      onChange={(v) => set({ step: v })}
-                    />
-                  </div>
-                </div>
-              </>
-            );
-          })()}
+        {knobMenu && currentExample && (
+          <KnobOptMenu
+            menu={knobMenu}
+            spec={currentSchema.find(
+              (x): x is SchemaParamSpec => !isGroup(x) && x.name === knobMenu.name,
+            )}
+            ko={knobOptFor(knobMenu.name)}
+            onPatch={(patch) => updateKnobOpt(knobMenu.name, patch)}
+            onClose={() => setKnobMenu(null)}
+          />
+        )}
 
         {/* Measurement freq = the rig's tuning control: a weighted VFO dial +
             frequency-counter readout. Top line: band select + the LCD. Below:
@@ -2874,193 +2563,30 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
 
         <h2 className="group-label">simulation</h2>
 
-        <div className="field">
-          <label>
-            <span>solver slot</span>
-            <span>{backendDisplayLabel(backend, currentOpts)} · N={nPerWire}</span>
-          </label>
-          <div className="backend-tabs" role="tablist">
-            {SLOT_ORDER.map((s) => {
-              const cfg = slots[s];
-              return (
-                <div key={s} className="backend-tab-cell">
-                  <button
-                    role="tab"
-                    aria-selected={activeSlot === s}
-                    aria-label={`Solver slot ${s}: ${backendDisplayLabel(cfg.backend, cfg.opts)}, N=${cfg.opts.nPerWire}`}
-                    className={`backend-tab-btn ${activeSlot === s ? "active" : ""}`}
-                    title={`${backendDisplayLabel(cfg.backend, cfg.opts)}, N=${cfg.opts.nPerWire}`}
-                    onClick={() => setActiveSlot(s)}
-                  >
-                    <span className="slot-letter">{s}</span>
-                    <span className="slot-sub">{backendDisplayLabel(cfg.backend, cfg.opts)}</span>
-                  </button>
-                  <button
-                    className="backend-gear-btn"
-                    title={`Slot ${s} options`}
-                    aria-label={`Slot ${s} options`}
-                    onClick={() => setGearOpen(s)}
-                  >
-                    ⚙
-                  </button>
-                </div>
-              );
-            })}
-          </div>
-        </div>
+        <SolverSlotTabs
+          slots={slots}
+          activeSlot={activeSlot}
+          onSelect={setActiveSlot}
+          onOpenGear={setGearOpen}
+          backend={backend}
+          currentOpts={currentOpts}
+          nPerWire={nPerWire}
+        />
 
-        {!backendSupportsGround(backend) && groundEnabled && (
-          <div className="field" title="This backend doesn't model ground; ignored until you switch to one that does.">
-            <em style={{ color: "var(--muted)", fontSize: "var(--text-sm)" }}>
-              ground plane ignored for {BACKEND_LABEL[backend]}
-            </em>
-          </div>
-        )}
-
-        <div className="field">
-          <label
-            className="link-toggle"
-            title="Ground plane at z=0; pick the ground model below"
-          >
-            <input
-              type="checkbox"
-              checked={groundEnabled}
-              disabled={!backendSupportsGround(backend)}
-              onChange={(e) => setGroundEnabled(e.target.checked)}
-            />
-            ground plane
-          </label>
-          {backendSupportsGround(backend) && groundEnabled && (
-            <>
-              <div role="radiogroup" aria-label="Ground type">
-                {(
-                  [
-                    [
-                      "finite",
-                      "finite (εr=10, σ=0.002 S/m)",
-                      "Finite ground — pick the solve method below (Sommerfeld-Norton or the reflection-coefficient approximation).",
-                    ],
-                    [
-                      "pec",
-                      "PEC",
-                      backend === "pynec"
-                        ? "Perfectly conducting ground (image method, NEC ITYPE=1) — matches every backend's model='PEC' for apples-to-apples engine comparison."
-                        : "Perfectly conducting ground (image method) — matches PyNEC's PEC model for apples-to-apples engine comparison.",
-                    ],
-                    ...(backendSupportsTerrain(backend) &&
-                    terrainPresets.length > 0
-                      ? [
-                          [
-                            "terrain",
-                            "terrain",
-                            "Faceted terrain (levee or cliff preset): impedance solves Sommerfeld on the crest medium; the far field reflects off the facet each ray's specular point lands on — tilted incidence, per-facet media, full effective height below the drops.",
-                          ] as [GroundType, string, string],
-                        ]
-                      : []),
-                  ] as [GroundType, string, string][]
-                ).map(([value, label, title]) => (
-                  <label key={value} className="link-toggle" title={title}>
-                    <input
-                      type="radio"
-                      name="ground-type"
-                      checked={groundType === value}
-                      onChange={() => setGroundType(value)}
-                    />
-                    {label}
-                  </label>
-                ))}
-              </div>
-              {groundType === "finite" && (
-                  <div
-                    role="radiogroup"
-                    aria-label="Finite-ground solve method"
-                    style={{ marginLeft: "1.2em" }}
-                  >
-                    {(
-                      [
-                        [
-                          "fast",
-                          "refl-coef (fast)",
-                          backend === "pynec"
-                            ? "Reflection-coefficient approximation (NEC ITYPE=0), the default. ~2x faster per solve; impedance degrades below ~0.1λ height."
-                            : "Reflection-coefficient model, the default. Fast; matches Sommerfeld above ~0.1λ heights.",
-                        ],
-                        [
-                          "sommerfeld",
-                          "Sommerfeld",
-                          backend === "pynec"
-                            ? "Sommerfeld-Norton (NEC ITYPE=2) — most accurate, slowest; the impedance sweep drops to half resolution to compensate."
-                            : "True Sommerfeld ground — accurate at any height, on every momwire solver including the fast array paths (momwire ≥ 0.8.0). First solve at each frequency builds a grid (seconds); repeats are fast. The impedance sweep runs at half resolution.",
-                        ],
-                      ] as [FiniteGroundMethod, string, string][]
-                    ).map(([value, label, title]) => (
-                      <label key={value} className="link-toggle" title={title}>
-                        <input
-                          type="radio"
-                          name="ground-method"
-                          checked={finiteGroundMethod === value}
-                          onChange={() => setFiniteGroundMethod(value)}
-                        />
-                        {label}
-                      </label>
-                    ))}
-                  </div>
-                )}
-              {groundType === "terrain" &&
-                backendSupportsTerrain(backend) &&
-                terrainPresets.length > 0 &&
-                (() => {
-                  // Whole panel driven by the /capabilities schema (issue
-                  // #560): radio list, per-preset knobs and media note all
-                  // come from terrainPresets. Fall back to the first preset if
-                  // the parked name is absent (a server-side rename).
-                  const activePreset =
-                    terrainPresets.find((p) => p.name === terrainPreset) ??
-                    terrainPresets[0];
-                  return (
-                    <div style={{ marginLeft: "1.2em" }}>
-                      <div role="radiogroup" aria-label="Terrain preset">
-                        {terrainPresets.map((p) => (
-                          <label
-                            key={p.name}
-                            className="link-toggle"
-                            title={p.tooltip}
-                          >
-                            <input
-                              type="radio"
-                              name="terrain-preset"
-                              checked={activePreset.name === p.name}
-                              onChange={() => setTerrainPreset(p.name)}
-                            />
-                            {p.label}
-                          </label>
-                        ))}
-                      </div>
-                      {activePreset.fields.map((f) => (
-                        <NumberField
-                          key={f.key}
-                          label={f.unit ? `${f.label} (${f.unit})` : f.label}
-                          value={terrainParams[f.key] ?? f.default}
-                          min={f.min}
-                          max={f.max}
-                          step={f.step}
-                          onChange={(v) =>
-                            setTerrainParams((p) => ({ ...p, [f.key]: v }))
-                          }
-                        />
-                      ))}
-                      <div
-                        style={{ fontSize: "0.85em", opacity: 0.65 }}
-                        title="Media are fixed in this version; the geometry knobs above are the live parameters."
-                      >
-                        {activePreset.media_note}
-                      </div>
-                    </div>
-                  );
-                })()}
-            </>
-          )}
-        </div>
+        <GroundPanel
+          backend={backend}
+          groundEnabled={groundEnabled}
+          setGroundEnabled={setGroundEnabled}
+          groundType={groundType}
+          setGroundType={setGroundType}
+          finiteGroundMethod={finiteGroundMethod}
+          setFiniteGroundMethod={setFiniteGroundMethod}
+          terrainPresets={terrainPresets}
+          terrainPreset={terrainPreset}
+          setTerrainPreset={setTerrainPreset}
+          terrainParams={terrainParams}
+          setTerrainParams={setTerrainParams}
+        />
 
         {gearOpen && (
           <BackendConfigModal

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import {
   backendAllowed,
-  BACKEND_LABEL,
   backendDisplayLabel,
   backendSupportsGround,
   comboInappropriate,
@@ -11,7 +10,6 @@ import {
   modelOptionsForRequest,
   normalizeBackend,
   resolveBackend,
-  RESTRICTED_BACKEND_REASON,
   resolveSlotConfig,
   selectableBackends,
   type Backend,
@@ -94,6 +92,7 @@ import { DesignFreqRow } from "./DesignFreqRow";
 import { GroundPanel } from "./GroundPanel";
 import { KnobOptMenu } from "./KnobOptMenu";
 import { SessionGearMenu } from "./SessionGearMenu";
+import { SolveOverlays } from "./SolveOverlays";
 import { SolverSlotTabs } from "./SolverSlotTabs";
 import {
   type OptimizeResult,
@@ -2427,114 +2426,23 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   );
 
   const solveOverlays = (
-    <>
-        {/* Indeterminate progress bar: appears once a solve outlasts the dwell
-            and lingers out its min-visible window (showBusy), so it never
-            flashes — the dim/label (stale) clear earlier, when the result lands. */}
-        <div className={`solve-bar${showBusy ? " active" : ""}`} aria-hidden />
-        {showBusy && solving && (
-          <button
-            type="button"
-            className="solve-cancel"
-            onClick={cancelSolve}
-            title="Stop waiting for this solve (the server still finishes it)"
-          >
-            Cancel solve
-          </button>
-        )}
-        {solverWarning && backendDisallowed && (
-          <div
-            className="solver-suggest"
-            role="alertdialog"
-            aria-label="Solver unavailable for this design"
-          >
-            <span className="solver-suggest-title">
-              {BACKEND_LABEL[backend]} can't run this design
-            </span>
-            <span className="solver-suggest-sub">
-              {RESTRICTED_BACKEND_REASON} Switch to{" "}
-              {(requiredBackends ?? [])
-                .map((r) => normalizeBackend(r))
-                .filter((r): r is Backend => r !== null)
-                .map((r) => BACKEND_LABEL[r])
-                .join(" / ") || "a supported solver"}{" "}
-              to solve it, or pause to keep editing.
-            </span>
-            <div className="solver-suggest-actions">
-              {(() => {
-                const target = normalizeBackend(requiredBackends?.[0]);
-                return target ? (
-                  <button
-                    type="button"
-                    className="solver-suggest-primary"
-                    onClick={() => {
-                      backendTouchedRef.current = true;
-                      setSlotBackend(activeSlot, target);
-                    }}
-                  >
-                    Switch to {BACKEND_LABEL[target]}
-                  </button>
-                ) : null;
-              })()}
-              <button
-                type="button"
-                className="solver-suggest-secondary"
-                onClick={pauseSimulation}
-                title="Stop auto-solving so you can keep editing; click Live to resume."
-              >
-                Pause simulation
-              </button>
-            </div>
-          </div>
-        )}
-        {solverWarning && !backendDisallowed && (
-          <div
-            className="solver-suggest"
-            role="alertdialog"
-            aria-label="Solver mismatch"
-          >
-            <span className="solver-suggest-title">
-              {BACKEND_LABEL[backend]} is a poor match for this design
-            </span>
-            <span className="solver-suggest-sub">
-              {recommendedBackend === "sinusoidal"
-                ? "This mesh is benchmark-sized — B-spline-family solvers take minutes per solve here (and concurrent solves can exhaust memory). The sinusoidal solver or PyNEC answers in seconds. "
-                : backend === "arrayblock" || backend === "hmatrix"
-                  ? "This accelerator is overkill on a single-element design — a dense solver (e.g. B-spline) is faster here. "
-                  : "This is a large array — a dense solver can be very slow. Array-block is far faster. "}
-              Change the solver in the gear menu, solve anyway, or pause to keep
-              editing.
-            </span>
-            <div className="solver-suggest-actions">
-              <button
-                type="button"
-                className="solver-suggest-primary"
-                onClick={solveAnyway}
-              >
-                Solve anyway
-              </button>
-              <button
-                type="button"
-                className="solver-suggest-secondary"
-                onClick={pauseSimulation}
-                title="Stop auto-solving so you can keep editing; click Live to resume."
-              >
-                Pause simulation
-              </button>
-            </div>
-          </div>
-        )}
-        {solveError && (
-          <div className="solve-error" role="alert">
-            <span className="solve-error-title">This design failed to solve</span>
-            <code className="solve-error-message">{solveError}</code>
-            <span className="solve-error-hint">
-              Fix the design and adjust a control to retry. For user designs see
-              CLAUDE.md in your designs folder.
-            </span>
-          </div>
-        )}
-    </>
+    <SolveOverlays
+      showBusy={showBusy}
+      solving={solving}
+      onCancelSolve={cancelSolve}
+      solverWarning={solverWarning}
+      backendDisallowed={backendDisallowed}
+      backend={backend}
+      requiredBackends={requiredBackends}
+      onSwitchBackend={(target) => {
+        backendTouchedRef.current = true;
+        setSlotBackend(activeSlot, target);
+      }}
+      onPause={pauseSimulation}
+      recommendedBackend={recommendedBackend}
+      onSolveAnyway={solveAnyway}
+      solveError={solveError}
+    />
   );
 
   // One output view: the per-view overlays plus the main <ViewPanel>. A

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -51,7 +51,6 @@ import {
 import { planSweepFreqs } from "../../lib/sweep";
 import {
   MOBILE_SCREENS,
-  PROJECTIONS,
   VIEWS,
   type Projection,
   type View,
@@ -66,7 +65,6 @@ import type {
 } from "../../lib/api";
 import { BackendConfigModal } from "../backend/BackendConfigModal";
 import { type DesignLoadError } from "../AwaitingTrustPanel";
-import { Knob } from "../params/Knob";
 import { ParamForm } from "../params/ParamForm";
 import {
   cutsWsSend,
@@ -83,8 +81,14 @@ import {
   useSlideSize,
   useThumbColumnSize,
 } from "../hooks";
-import { PatternCompareTable } from "../results/PatternCompareTable";
 import { SolveReadout } from "../results/SolveReadout";
+import {
+  AntennaOverlayControls,
+  CompareOverlay,
+  CutAngleOverlay,
+  FarFieldOverlayControls,
+  SmithOverlayControls,
+} from "../results/StageOverlays";
 import { ViewPanel } from "../results/ViewPanel";
 import { fetchMetrics, PinsContext, SessionsContext, ThemeControlContext } from "./contexts";
 import { CatalogPanel } from "./CatalogPanel";
@@ -2452,304 +2456,68 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   const renderOutput = (v: View, size: number, fill: boolean) => (
     <>
           {v === "antenna" && (
-            <div className="antenna-overlay">
-              <div className="projection-toggle">
-                {PROJECTIONS.map((p) => (
-                  <button
-                    key={p.id}
-                    className={p.id === cameraProjection ? "active" : ""}
-                    onClick={() => setCameraProjection(p.id)}
-                    title={`Project onto the ${p.id} plane`}
-                  >
-                    {p.label}
-                  </button>
-                ))}
-              </div>
-              {/* Mobile drops the checkbox column — it doesn't scale with the
-                  chart and covers it on a phone. The same toggles live in the
-                  sidebar gear menu (shared state). The projection toggle above
-                  stays: it's compact and it's how you turn the view. */}
-              {!isMobile && (
-                <>
-                  <label
-                    className="overlay-checkbox"
-                    title="Color wire segments by current magnitude; modulate wire width"
-                  >
-                    <input
-                      type="checkbox"
-                      checked={showHeatmap}
-                      onChange={(e) => setShowHeatmap(e.target.checked)}
-                    />
-                    heatmapped currents
-                  </label>
-                  <label
-                    className="overlay-checkbox"
-                    title="Draw the |I| envelope curve along each wire"
-                  >
-                    <input
-                      type="checkbox"
-                      checked={showEnvelope}
-                      onChange={(e) => setShowEnvelope(e.target.checked)}
-                    />
-                    current waveforms
-                  </label>
-                  <label
-                    className="overlay-checkbox"
-                    title="Draw the per-wire labels (off to declutter dense geometries)"
-                  >
-                    <input
-                      type="checkbox"
-                      checked={showWireLabels}
-                      onChange={(e) => setShowWireLabels(e.target.checked)}
-                    />
-                    wire labels
-                  </label>
-                  <label
-                    className="overlay-checkbox"
-                    title="Draw the 'feed' name beside each feedpoint marker"
-                  >
-                    <input
-                      type="checkbox"
-                      checked={showFeedNames}
-                      onChange={(e) => setShowFeedNames(e.target.checked)}
-                    />
-                    feed labels
-                  </label>
-                </>
-              )}
-            </div>
+            <AntennaOverlayControls
+              cameraProjection={cameraProjection}
+              setCameraProjection={setCameraProjection}
+              isMobile={isMobile}
+              showHeatmap={showHeatmap}
+              setShowHeatmap={setShowHeatmap}
+              showEnvelope={showEnvelope}
+              setShowEnvelope={setShowEnvelope}
+              showWireLabels={showWireLabels}
+              setShowWireLabels={setShowWireLabels}
+              showFeedNames={showFeedNames}
+              setShowFeedNames={setShowFeedNames}
+            />
           )}
-          {/* Both smith-overlay children are checkboxes — nothing to keep on
-              mobile (the toggles live in the gear menu there). */}
           {v === "smith" && !isMobile && (
-            <div className="smith-overlay">
-              <label
-                className="overlay-checkbox"
-                title="Sweep Z across measurement freq and plot the locus on the Smith chart"
-              >
-                <input
-                  type="checkbox"
-                  checked={sweepEnabled}
-                  onChange={(e) => setSweepEnabled(e.target.checked)}
-                />
-                freq sweep
-              </label>
-              <label
-                className="overlay-checkbox"
-                title={`Re-solve at N = ${CONVERGE_N_VALUES.join(", ")} segments/wire and Richardson-extrapolate Z to N→∞`}
-              >
-                <input
-                  type="checkbox"
-                  checked={convergeEnabled}
-                  onChange={(e) => setConvergeEnabled(e.target.checked)}
-                />
-                converge sweep
-              </label>
-              <label
-                className="overlay-file"
-                title="Overlay a measured VNA sweep (one-port Touchstone .s1p, e.g. from a NanoVNA) against the modeled locus"
-              >
-                <input
-                  type="file"
-                  accept=".s1p,.S1P"
-                  onChange={(e) => {
-                    const f = e.target.files?.[0];
-                    // Reset the input so re-picking the same file (after a
-                    // re-measure) fires onChange again.
-                    e.target.value = "";
-                    if (f) loadMeasured(f);
-                  }}
-                />
-                {measured ? `measured: ${measured.label}` : "measured .s1p…"}
-              </label>
-              {measured && (
-                <button
-                  type="button"
-                  className="overlay-clear"
-                  title="Remove the measured overlay"
-                  onClick={() => setMeasured(null)}
-                >
-                  clear
-                </button>
-              )}
-            </div>
+            <SmithOverlayControls
+              sweepEnabled={sweepEnabled}
+              setSweepEnabled={setSweepEnabled}
+              convergeEnabled={convergeEnabled}
+              setConvergeEnabled={setConvergeEnabled}
+              convergeNValues={CONVERGE_N_VALUES}
+              measured={measured}
+              onLoadMeasured={loadMeasured}
+              onClearMeasured={() => setMeasured(null)}
+            />
           )}
-          {/* On mobile only the Δ readout survives (it's output, not a
-              control, and it's one short span); the norm-check toggle lives in
-              the gear menu. The container is skipped entirely when it would
-              be empty. */}
+          {/* The container is skipped entirely when it would be empty. */}
           {(v === "azimuth" || v === "elevation") &&
             (!isMobile || (normCheckEnabled && normCheck)) && (
-            <div className="farfield-overlay">
-              {!isMobile && (
-                <label
-                  className="overlay-checkbox"
-                  title="On dwell, renormalise the pattern by its own integrated radiated power (dotted) instead of the input power the solid line uses. Overlap ⇒ the solve conserves power; a visible gap is the solver's discretisation error (NEC's 'average gain' check)."
-                >
-                  <input
-                    type="checkbox"
-                    checked={normCheckEnabled}
-                    onChange={(e) => setNormCheckEnabled(e.target.checked)}
-                  />
-                  norm check
-                </label>
-              )}
-              {!isMobile && backend === "pynec" && (
-                <label
-                  className="overlay-checkbox"
-                  style={
-                    groundModel === "terrain" ? { opacity: 0.45 } : undefined
-                  }
-                  title={
-                    groundModel === "terrain"
-                      ? "NEC's rp_card pattern is flat-ground only (no facet model), so the exact-pattern overlay is unavailable over terrain — the terrain traces come from the server's facet physics instead."
-                      : "Overlay NEC's own rp_card far-field pattern (dashed cyan) as an exact reference for this engine's ground model."
-                  }
-                >
-                  <input
-                    type="checkbox"
-                    checked={necOverlayEnabled && groundModel !== "terrain"}
-                    disabled={groundModel === "terrain"}
-                    onChange={(e) => setNecOverlayEnabled(e.target.checked)}
-                  />
-                  NEC rp
-                </label>
-              )}
-              {/* Over a finite ground the norm gap IS physics (structural
-                  loss + real ground absorption), so show it in its honest
-                  form — the radiated fraction, same number as the Info-pane
-                  row. Free space / PEC keeps the raw Δ dB, where it is a
-                  pure solver power-balance diagnostic. Over faceted TERRAIN
-                  the fraction is PEC-facet-referenced (the server integrates
-                  the same facet geometry with lossless media as the
-                  denominator, cancelling the hybrid ledger gap); the ledger
-                  Δ itself lives in the tooltip and the dotted overlay. */}
-              {normCheckEnabled && normCheck && (
-                <span
-                  className="overlay-readout"
-                  title={
-                    normCheck.method.startsWith("grid_terrain")
-                      ? `Share of accepted power leaving as sky wave over the faceted terrain (${normCheck.method}): the same facet geometry integrated with perfect-reflector media is the reference, so the ratio isolates real ground-media absorption. The dotted overlay shows the separate hybrid-model ledger gap (Δ ${normCheck.delta_db >= 0 ? "+" : ""}${normCheck.delta_db.toFixed(2)} dB — the facet far field vs the crest-referenced input power; either sign is normal, and absolute gains stay anchored to the input-power norm, the convention validated against NEC-2's cliff).`
-                      : normCheck.method.startsWith("grid_")
-                        ? `P_radiated/P_input from the pattern-integral norm (${normCheck.method}): the gap between the solid and dotted lobes as a fraction — structural loss plus real ground absorption (Δ ${normCheck.delta_db >= 0 ? "+" : ""}${normCheck.delta_db.toFixed(3)} dB, NEC average-gain style)`
-                        : `input-power norm vs pattern-integral norm (${normCheck.method}); 0 dB = perfect power balance`
-                  }
-                >
-                  {normCheck.method.startsWith("grid_") ? (
-                    <>radiated {(normCheck.radiated_fraction * 100).toFixed(0)}%</>
-                  ) : (
-                    <>
-                      Δ {normCheck.delta_db >= 0 ? "+" : ""}
-                      {normCheck.delta_db.toFixed(3)} dB
-                    </>
-                  )}
-                </span>
-              )}
-            </div>
+            <FarFieldOverlayControls
+              isMobile={isMobile}
+              normCheckEnabled={normCheckEnabled}
+              setNormCheckEnabled={setNormCheckEnabled}
+              normCheck={normCheck}
+              backend={backend}
+              groundModel={groundModel}
+              necOverlayEnabled={necOverlayEnabled}
+              setNecOverlayEnabled={setNecOverlayEnabled}
+            />
           )}
-          {/* The cut-angle knob lives on the plot it drives: the azimuth
-              (xy) cut is taken at elevation azElevDeg; the elevation (yz) cut
-              is taken at azimuth bearing elevAzDeg. CCW dials from 3 o'clock. */}
-          {v === "azimuth" && (
-            <div
-              className="cut-overlay"
-              title="elevation at which this azimuth cut is taken"
-            >
-              <span className="cut-overlay-label">elevation</span>
-              <Knob
-                knobId="ff_cut_elevation"
-                value={azElevDeg}
-                min={0}
-                max={89}
-                step={1}
-                precision={0}
-                unit="°"
-                label="cut elevation"
-                onChange={setAzElevDeg}
-                startDeg={90}
-                sweepDeg={-89}
-              />
-              <span className="cut-overlay-value">{azElevDeg}°</span>
-            </div>
-          )}
-          {v === "elevation" && (
-            <div
-              className="cut-overlay"
-              title="azimuth bearing at which this elevation cut is taken"
-            >
-              <span className="cut-overlay-label">azimuth</span>
-              <Knob
-                knobId="ff_cut_azimuth"
-                value={elevAzDeg}
-                min={0}
-                max={359}
-                step={1}
-                precision={0}
-                unit="°"
-                label="cut azimuth"
-                onChange={setElevAzDeg}
-                startDeg={90}
-                sweepDeg={-359}
-              />
-              <span className="cut-overlay-value">{elevAzDeg}°</span>
-            </div>
-          )}
+          <CutAngleOverlay
+            v={v}
+            azElevDeg={azElevDeg}
+            setAzElevDeg={setAzElevDeg}
+            elevAzDeg={elevAzDeg}
+            setElevAzDeg={setElevAzDeg}
+          />
           {(v === "azimuth" || v === "elevation") && (
-            <div className="compare-overlay">
-              <button
-                type="button"
-                className="pin-btn"
-                onClick={() => {
-                  pinCurrentPattern();
-                  // Pinning always reveals the table so the new row is seen;
-                  // it stays open until minimized (no auto-collapse timer).
-                  setCompareCollapsed(false);
-                }}
-                disabled={!result}
-                title="Pin the current pattern as a ghost overlay, to compare another antenna or tuning against it"
-              >
-                📌 Pin pattern
-              </button>
-              {pinnedPatterns.length > 0 &&
-                (compareCollapsed ? (
-                  <button
-                    type="button"
-                    className="pin-btn pin-chip"
-                    onClick={() => setCompareCollapsed(false)}
-                    title="Show the pinned-pattern comparison table"
-                  >
-                    {pinnedPatterns.length} pinned ▾
-                  </button>
-                ) : (
-                  <>
-                    <div className="pin-table-actions">
-                      <button
-                        type="button"
-                        className="pin-clear"
-                        onClick={clearPins}
-                        title="Remove all pinned patterns"
-                      >
-                        clear
-                      </button>
-                      <button
-                        type="button"
-                        className="pin-clear"
-                        onClick={() => setCompareCollapsed(true)}
-                        title="Minimize the comparison table (pins and ghost overlays are kept)"
-                      >
-                        –
-                      </button>
-                    </div>
-                    <PatternCompareTable
-                      live={liveMetrics}
-                      liveLabel={`${currentExample?.label ?? geometry} @ ${measFreq.toFixed(2)} MHz`}
-                      pinned={pinnedPatterns}
-                      onRemove={removePin}
-                      onToggle={togglePin}
-                    />
-                  </>
-                ))}
-            </div>
+            <CompareOverlay
+              pinCurrentPattern={pinCurrentPattern}
+              setCompareCollapsed={setCompareCollapsed}
+              result={result}
+              pinnedPatterns={pinnedPatterns}
+              compareCollapsed={compareCollapsed}
+              clearPins={clearPins}
+              liveMetrics={liveMetrics}
+              currentExample={currentExample}
+              geometry={geometry}
+              measFreq={measFreq}
+              removePin={removePin}
+              togglePin={togglePin}
+            />
           )}
           <ViewPanel
             view={v}

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -68,7 +68,6 @@ import type {
 } from "../../lib/api";
 import { BackendConfigModal } from "../backend/BackendConfigModal";
 import { type DesignLoadError } from "../AwaitingTrustPanel";
-import { BandDropdown } from "../params/BandDropdown";
 import { Knob } from "../params/Knob";
 import { ParamForm } from "../params/ParamForm";
 import {
@@ -96,6 +95,12 @@ import { GroundPanel } from "./GroundPanel";
 import { KnobOptMenu } from "./KnobOptMenu";
 import { SessionGearMenu } from "./SessionGearMenu";
 import { SolverSlotTabs } from "./SolverSlotTabs";
+import {
+  type OptimizeResult,
+  type OptObjective,
+  type OptPause,
+  VfoPanel,
+} from "./VfoPanel";
 
 // Log-spaced segments-per-wire ladder for the convergence sweep. Hentenna's
 // 8N+2 total segments at N=68 puts the dense LU at a ~550-cell matrix —
@@ -108,32 +113,6 @@ const CONVERGE_N_VALUES: number[] = [8, 12, 17, 24, 34, 48, 68];
 // deployed site behind Fly's force_https), where browsers block insecure ws://
 // as mixed content. Plain ws:// only works on http:// (local dev).
 const WS_URL = `${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.host}/ws`;
-
-// Response from POST /optimize.
-type OptMetrics = { z_in_re: number; z_in_im: number; z0_ohms: number; swr: number };
-type OptimizeResult = {
-  objective: string;
-  params: Record<string, number>;
-  objective_before: number;
-  objective_after: number;
-  metrics_before: OptMetrics;
-  metrics_after: OptMetrics;
-  n_evals: number;
-  improved: boolean;
-};
-type OptObjective = "swr" | "resonance" | "match_z0";
-const OPT_OBJECTIVE_LABELS: Record<OptObjective, string> = {
-  swr: "SWR",
-  resonance: "Resonance",
-  match_z0: "Match Z₀",
-};
-// The two objectives offered in the compact control next to meas-freq.
-const OPT_OBJECTIVES: OptObjective[] = ["swr", "resonance"];
-
-// Why the optimizer auto-paused, for the transient cue. `knob` = the user grabbed
-// a marked knob by hand; `load` = a new design/variant was loaded (its marks and
-// ranges no longer apply).
-type OptPause = { kind: "knob"; name: string } | { kind: "load" };
 
 // One antenna design session: the entire left sidebar + right stage plus all
 // the state, effects, and the WebSocket that drive them. The shell (`App`,
@@ -209,9 +188,6 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // "vary" + extents + step live in each knob's right-click menu (knobOpt).
   const [optEnabled, setOptEnabled] = useState(false);
   const [optObjective, setOptObjective] = useState<OptObjective>("swr");
-  // The objective ("optimise for") picker lives in a small gear popover next to
-  // the Optimize button, mirroring the solver-slot gear.
-  const [optMenuOpen, setOptMenuOpen] = useState(false);
   const [knobOpt, setKnobOpt] = useState<Record<string, Record<string, KnobOpt>>>({});
   // Open knob context menu: which param + anchor position.
   const [knobMenu, setKnobMenu] = useState<{ name: string; x: number; y: number } | null>(
@@ -2373,193 +2349,33 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
             the Live/Optimize toggles stacked at the left of the dial, with the
             lock pinned to the dial's lower-right corner ("lock to design freq"
             disables the dial). */}
-        <h2 className="group-label">measurement freq</h2>
-        <div className={`field vfo-field${measLocked ? " is-locked" : ""}`}>
-          <div className="vfo-top">
-            {currentBands.length > 0 && (
-              <BandDropdown
-                bands={currentBands}
-                // Locked: mirror the design band (measFreq tracks designFreq).
-                // Unlocked: the persistent selection, stable as the dial roams.
-                value={
-                  measLocked
-                    ? bandContaining(measFreq) ?? currentBands[0].key
-                    : measBand || currentBands[0].key
-                }
-                onSelect={selectMeasBand}
-                disabled={measLocked}
-                ariaLabel="measurement band"
-              />
-            )}
-            <div className="freq-lcd" title={`${measFreq.toFixed(3)} MHz`}>
-              <span className="lcd-digits">
-                <span className="lcd-ghost">
-                  {measFreq.toFixed(3).replace(/\d/g, "8")}
-                </span>
-                <span className="lcd-live">{measFreq.toFixed(3)}</span>
-              </span>
-              <span className="lcd-unit">MHz</span>
-            </div>
-          </div>
+        <VfoPanel
+          currentBands={currentBands}
+          measLocked={measLocked}
+          measFreq={measFreq}
+          bandContaining={bandContaining}
+          measBand={measBand}
+          selectMeasBand={selectMeasBand}
+          currentExample={currentExample}
+          measBandAnchor={measBandAnchor}
+          freqWindowCeiling={freqWindowCeiling}
+          setMeasFreq={setMeasFreq}
+          measLockable={measLockable}
+          linkMeas={linkMeas}
+          toggleLink={toggleLink}
+          autoSim={autoSim}
+          setAutoSim={setAutoSim}
+          optEnabled={optEnabled}
+          setOptEnabled={setOptEnabled}
+          setOptPausedBy={setOptPausedBy}
+          optRunning={optRunning}
+          optObjective={optObjective}
+          setOptObjective={setOptObjective}
+          optResult={optResult}
+          optError={optError}
+          optPausedBy={optPausedBy}
+        />
 
-          <div className="vfo-body">
-            {/* Live / Optimize: two matching push-button toggles (depressed =
-                on), stacked at the left of the dial. Live gates auto-solving on
-                knob turns; Optimize gates the reactive tuner. The objective
-                ("optimise for") picker is the gear next to Optimize. */}
-            <div className="sim-controls">
-              <button
-                type="button"
-                className={`toggle-btn${autoSim ? " is-on" : ""}`}
-                aria-pressed={autoSim}
-                onClick={() => setAutoSim((v) => !v)}
-                title={
-                  autoSim
-                    ? "Live: knob changes re-solve automatically. Click to pause and edit without solving."
-                    : "Paused: edit the design freely; the engine is held. Click to resume and solve."
-                }
-              >
-                <span className="toggle-led" aria-hidden="true" />
-                {autoSim ? "Live" : "Paused"}
-              </button>
-              <div className="opt-cell">
-                <button
-                  type="button"
-                  className={`toggle-btn opt-toggle${optEnabled ? " is-on" : ""}`}
-                  aria-pressed={optEnabled}
-                  onClick={() => {
-                    setOptEnabled((v) => !v);
-                    setOptPausedBy(null);
-                  }}
-                  title="Reactive optimiser: vary the knobs you mark (right-click a knob) to hit the objective whenever a fixed knob changes. Changing a marked knob by hand pauses it — turn it back on to resume."
-                >
-                  <span className="toggle-led" aria-hidden="true" />
-                  Optimize
-                  {optRunning ? <span className="opt-pip">●</span> : null}
-                </button>
-                <button
-                  type="button"
-                  className="opt-gear-btn"
-                  aria-label="Optimisation method"
-                  aria-haspopup="menu"
-                  aria-expanded={optMenuOpen}
-                  title={`Optimise for: ${OPT_OBJECTIVE_LABELS[optObjective]}`}
-                  onClick={() => setOptMenuOpen((o) => !o)}
-                >
-                  ⚙
-                </button>
-                {optMenuOpen && (
-                  <>
-                    <div
-                      className="gear-menu-backdrop"
-                      onClick={() => setOptMenuOpen(false)}
-                    />
-                    <div className="opt-menu" role="menu">
-                      <div className="opt-menu-title">Optimise for</div>
-                      {OPT_OBJECTIVES.map((k) => (
-                        <button
-                          key={k}
-                          type="button"
-                          role="menuitemradio"
-                          aria-checked={optObjective === k}
-                          className={`gear-menu-item${optObjective === k ? " is-active" : ""}`}
-                          onClick={() => {
-                            setOptObjective(k);
-                            setOptMenuOpen(false);
-                          }}
-                        >
-                          {OPT_OBJECTIVE_LABELS[k]}
-                        </button>
-                      ))}
-                    </div>
-                  </>
-                )}
-              </div>
-              {optEnabled && optResult && (
-                <span className="opt-readout" title="SWR after optimisation">
-                  SWR {optResult.metrics_after.swr.toFixed(2)}
-                </span>
-              )}
-              {optEnabled && optError && (
-                <span
-                  className="opt-readout opt-readout-err"
-                  title={optError}
-                >
-                  {optError}
-                </span>
-              )}
-              {!optEnabled && optPausedBy && (
-                <span
-                  className="opt-readout opt-paused"
-                  title={
-                    optPausedBy.kind === "knob"
-                      ? "You changed a knob marked for optimization, so Optimize paused. Turn it back on to resume."
-                      : "Loading a design clears its optimize marks and pauses Optimize. Re-mark knobs and turn it back on to resume."
-                  }
-                >
-                  {optPausedBy.kind === "knob"
-                    ? `Paused — changing ${optPausedBy.name} by hand`
-                    : "Paused — loaded a new design"}
-                </span>
-              )}
-            </div>
-
-            <div className="vfo-dial">
-              <Knob
-                knobId="meas_freq"
-                variant="vfo"
-                value={measFreq}
-                min={
-                  currentExample?.meas_freq_range_mhz
-                    ? currentExample.meas_freq_range_mhz[0]
-                    : Math.max(0.5, measBandAnchor * 0.8)
-                }
-                max={
-                  currentExample?.meas_freq_range_mhz
-                    ? currentExample.meas_freq_range_mhz[1]
-                    : Math.min(freqWindowCeiling, measBandAnchor * 1.25)
-                }
-                step={0.005}
-                precision={3}
-                unit=" MHz"
-                label="measurement frequency"
-                onChange={setMeasFreq}
-                disabled={measLocked}
-              />
-              {/* No design frequency → nothing to lock to; the button would
-                  only re-disable the one meaningful control (issue #390). */}
-              {measLockable && (
-                <button
-                  type="button"
-                  className="vfo-lock"
-                  aria-pressed={linkMeas}
-                  aria-label="Lock measurement frequency to the design frequency"
-                  title={
-                    linkMeas
-                      ? "Locked to the design frequency — the dial is fixed. Click to unlock and tune freely."
-                      : "Lock the measurement frequency to the design frequency."
-                  }
-                  onClick={() => toggleLink(!linkMeas)}
-                >
-                  <svg className="lock-glyph" viewBox="0 0 16 16" aria-hidden="true">
-                    <rect x="3.5" y="7.2" width="9" height="6.3" rx="1.3" />
-                    {/* Shackle opens when unlocked (right leg lifts clear of
-                        the body) so the state reads from shape, not just the
-                        muted-vs-accent color. */}
-                    <path
-                      className="shackle"
-                      d={
-                        linkMeas
-                          ? "M5.3 7.2V5a2.7 2.7 0 0 1 5.4 0v2.2"
-                          : "M5.3 7.2V5a2.7 2.7 0 0 1 5.4 0v0.6"
-                      }
-                    />
-                  </svg>
-                </button>
-              )}
-            </div>
-          </div>
-        </div>
 
         <h2 className="group-label">simulation</h2>
 

--- a/src/antennaknobs/web/frontend/src/components/session/GroundPanel.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/GroundPanel.tsx
@@ -1,0 +1,194 @@
+import { BACKEND_LABEL, backendSupportsGround, backendSupportsTerrain } from "../../lib/backends";
+import type { Backend } from "../../lib/backends";
+import type {
+  FiniteGroundMethod,
+  GroundType,
+  TerrainParams,
+  TerrainPresetSchema,
+} from "../../lib/ground";
+import { NumberField } from "../backend/fields";
+
+export function GroundPanel({
+  backend,
+  groundEnabled,
+  setGroundEnabled,
+  groundType,
+  setGroundType,
+  finiteGroundMethod,
+  setFiniteGroundMethod,
+  terrainPresets,
+  terrainPreset,
+  setTerrainPreset,
+  terrainParams,
+  setTerrainParams,
+}: {
+  backend: Backend;
+  groundEnabled: boolean;
+  setGroundEnabled: (v: boolean) => void;
+  groundType: GroundType;
+  setGroundType: (v: GroundType) => void;
+  finiteGroundMethod: FiniteGroundMethod;
+  setFiniteGroundMethod: (v: FiniteGroundMethod) => void;
+  terrainPresets: TerrainPresetSchema[];
+  terrainPreset: string;
+  setTerrainPreset: (v: string) => void;
+  terrainParams: TerrainParams;
+  setTerrainParams: (fn: (p: TerrainParams) => TerrainParams) => void;
+}) {
+  return (
+    <>
+      {!backendSupportsGround(backend) && groundEnabled && (
+        <div className="field" title="This backend doesn't model ground; ignored until you switch to one that does.">
+          <em style={{ color: "var(--muted)", fontSize: "var(--text-sm)" }}>
+            ground plane ignored for {BACKEND_LABEL[backend]}
+          </em>
+        </div>
+      )}
+
+      <div className="field">
+        <label
+          className="link-toggle"
+          title="Ground plane at z=0; pick the ground model below"
+        >
+          <input
+            type="checkbox"
+            checked={groundEnabled}
+            disabled={!backendSupportsGround(backend)}
+            onChange={(e) => setGroundEnabled(e.target.checked)}
+          />
+          ground plane
+        </label>
+        {backendSupportsGround(backend) && groundEnabled && (
+          <>
+            <div role="radiogroup" aria-label="Ground type">
+              {(
+                [
+                  [
+                    "finite",
+                    "finite (εr=10, σ=0.002 S/m)",
+                    "Finite ground — pick the solve method below (Sommerfeld-Norton or the reflection-coefficient approximation).",
+                  ],
+                  [
+                    "pec",
+                    "PEC",
+                    backend === "pynec"
+                      ? "Perfectly conducting ground (image method, NEC ITYPE=1) — matches every backend's model='PEC' for apples-to-apples engine comparison."
+                      : "Perfectly conducting ground (image method) — matches PyNEC's PEC model for apples-to-apples engine comparison.",
+                  ],
+                  ...(backendSupportsTerrain(backend) &&
+                  terrainPresets.length > 0
+                    ? [
+                        [
+                          "terrain",
+                          "terrain",
+                          "Faceted terrain (levee or cliff preset): impedance solves Sommerfeld on the crest medium; the far field reflects off the facet each ray's specular point lands on — tilted incidence, per-facet media, full effective height below the drops.",
+                        ] as [GroundType, string, string],
+                      ]
+                    : []),
+                ] as [GroundType, string, string][]
+              ).map(([value, label, title]) => (
+                <label key={value} className="link-toggle" title={title}>
+                  <input
+                    type="radio"
+                    name="ground-type"
+                    checked={groundType === value}
+                    onChange={() => setGroundType(value)}
+                  />
+                  {label}
+                </label>
+              ))}
+            </div>
+            {groundType === "finite" && (
+                <div
+                  role="radiogroup"
+                  aria-label="Finite-ground solve method"
+                  style={{ marginLeft: "1.2em" }}
+                >
+                  {(
+                    [
+                      [
+                        "fast",
+                        "refl-coef (fast)",
+                        backend === "pynec"
+                          ? "Reflection-coefficient approximation (NEC ITYPE=0), the default. ~2x faster per solve; impedance degrades below ~0.1λ height."
+                          : "Reflection-coefficient model, the default. Fast; matches Sommerfeld above ~0.1λ heights.",
+                      ],
+                      [
+                        "sommerfeld",
+                        "Sommerfeld",
+                        backend === "pynec"
+                          ? "Sommerfeld-Norton (NEC ITYPE=2) — most accurate, slowest; the impedance sweep drops to half resolution to compensate."
+                          : "True Sommerfeld ground — accurate at any height, on every momwire solver including the fast array paths (momwire ≥ 0.8.0). First solve at each frequency builds a grid (seconds); repeats are fast. The impedance sweep runs at half resolution.",
+                      ],
+                    ] as [FiniteGroundMethod, string, string][]
+                  ).map(([value, label, title]) => (
+                    <label key={value} className="link-toggle" title={title}>
+                      <input
+                        type="radio"
+                        name="ground-method"
+                        checked={finiteGroundMethod === value}
+                        onChange={() => setFiniteGroundMethod(value)}
+                      />
+                      {label}
+                    </label>
+                  ))}
+                </div>
+              )}
+            {groundType === "terrain" &&
+              backendSupportsTerrain(backend) &&
+              terrainPresets.length > 0 &&
+              (() => {
+                // Whole panel driven by the /capabilities schema (issue
+                // #560): radio list, per-preset knobs and media note all
+                // come from terrainPresets. Fall back to the first preset if
+                // the parked name is absent (a server-side rename).
+                const activePreset =
+                  terrainPresets.find((p) => p.name === terrainPreset) ??
+                  terrainPresets[0];
+                return (
+                  <div style={{ marginLeft: "1.2em" }}>
+                    <div role="radiogroup" aria-label="Terrain preset">
+                      {terrainPresets.map((p) => (
+                        <label
+                          key={p.name}
+                          className="link-toggle"
+                          title={p.tooltip}
+                        >
+                          <input
+                            type="radio"
+                            name="terrain-preset"
+                            checked={activePreset.name === p.name}
+                            onChange={() => setTerrainPreset(p.name)}
+                          />
+                          {p.label}
+                        </label>
+                      ))}
+                    </div>
+                    {activePreset.fields.map((f) => (
+                      <NumberField
+                        key={f.key}
+                        label={f.unit ? `${f.label} (${f.unit})` : f.label}
+                        value={terrainParams[f.key] ?? f.default}
+                        min={f.min}
+                        max={f.max}
+                        step={f.step}
+                        onChange={(v) =>
+                          setTerrainParams((p) => ({ ...p, [f.key]: v }))
+                        }
+                      />
+                    ))}
+                    <div
+                      style={{ fontSize: "0.85em", opacity: 0.65 }}
+                      title="Media are fixed in this version; the geometry knobs above are the live parameters."
+                    >
+                      {activePreset.media_note}
+                    </div>
+                  </div>
+                );
+              })()}
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/antennaknobs/web/frontend/src/components/session/KnobOptMenu.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/KnobOptMenu.tsx
@@ -1,0 +1,85 @@
+import { KnobMenuNumber } from "../backend/fields";
+import type { KnobOpt, SchemaParamSpec } from "../../lib/params";
+
+// Per-knob optimiser menu (right-click a knob): vary toggle + extents + turn
+// step. Position-fixed at the click point.
+export function KnobOptMenu({
+  menu,
+  spec,
+  ko,
+  onPatch,
+  onClose,
+}: {
+  menu: { name: string; x: number; y: number };
+  spec: SchemaParamSpec | undefined;
+  ko: KnobOpt;
+  onPatch: (patch: Partial<KnobOpt>) => void;
+  onClose: () => void;
+}) {
+  const name = menu.name;
+  const s = spec;
+  const num = (v: number) => (Number.isFinite(v) ? v : 0);
+  const set = (patch: Partial<KnobOpt>) => onPatch(patch);
+  return (
+    <>
+      <div
+        className="knob-menu-backdrop"
+        onClick={onClose}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          onClose();
+        }}
+      />
+      <div
+        className="knob-menu"
+        style={{ left: menu.x, top: menu.y }}
+        onContextMenu={(e) => e.preventDefault()}
+      >
+        <div className="knob-menu-title">{s?.label ?? name}</div>
+        <label className="knob-menu-vary">
+          <input
+            type="checkbox"
+            checked={ko.vary}
+            onChange={(e) => set({ vary: e.target.checked })}
+          />
+          Optimize this knob
+          <kbd
+            className="knob-menu-kbd"
+            title="Focus a knob and press O to toggle"
+          >
+            O
+          </kbd>
+        </label>
+        <div className="knob-menu-row">
+          <span>Optimize range</span>
+          <KnobMenuNumber
+            value={num(ko.optMin)}
+            onChange={(v) => set({ optMin: v })}
+          />
+          <KnobMenuNumber
+            value={num(ko.optMax)}
+            onChange={(v) => set({ optMax: v })}
+          />
+        </div>
+        <div className="knob-menu-row">
+          <span>Display range</span>
+          <KnobMenuNumber
+            value={num(ko.dispMin)}
+            onChange={(v) => set({ dispMin: v })}
+          />
+          <KnobMenuNumber
+            value={num(ko.dispMax)}
+            onChange={(v) => set({ dispMax: v })}
+          />
+        </div>
+        <div className="knob-menu-row">
+          <span>Turn step</span>
+          <KnobMenuNumber
+            value={num(ko.step)}
+            onChange={(v) => set({ step: v })}
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/antennaknobs/web/frontend/src/components/session/SessionGearMenu.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/SessionGearMenu.tsx
@@ -1,0 +1,261 @@
+import type { MeasuredData } from "../../lib/api";
+import type { useFullscreen } from "../hooks";
+import type { Theme } from "../hooks";
+import { TabStrip } from "./TabStrip";
+
+// Sidebar header: brand + the tools (gear) dropdown, incl. the reactive
+// copies of the chart-overlay toggles (same state the overlays use, so the
+// two locations can never disagree), and the theme toggle.
+export function SessionGearMenu({
+  gearMenuOpen,
+  setGearMenuOpen,
+  copiedParams,
+  onCopyParams,
+  onDownloadNec,
+  isMobile,
+  fullscreen,
+  showHeatmap,
+  setShowHeatmap,
+  showEnvelope,
+  setShowEnvelope,
+  showWireLabels,
+  setShowWireLabels,
+  showFeedNames,
+  setShowFeedNames,
+  sweepEnabled,
+  setSweepEnabled,
+  convergeEnabled,
+  setConvergeEnabled,
+  convergeNValues,
+  measured,
+  onLoadMeasured,
+  onClearMeasured,
+  normCheckEnabled,
+  setNormCheckEnabled,
+  theme,
+  applyTheme,
+}: {
+  gearMenuOpen: boolean;
+  setGearMenuOpen: (v: boolean | ((o: boolean) => boolean)) => void;
+  copiedParams: boolean;
+  onCopyParams: () => void;
+  onDownloadNec: () => void;
+  isMobile: boolean;
+  fullscreen: ReturnType<typeof useFullscreen>;
+  showHeatmap: boolean;
+  setShowHeatmap: (v: boolean) => void;
+  showEnvelope: boolean;
+  setShowEnvelope: (v: boolean) => void;
+  showWireLabels: boolean;
+  setShowWireLabels: (v: boolean) => void;
+  showFeedNames: boolean;
+  setShowFeedNames: (v: boolean) => void;
+  sweepEnabled: boolean;
+  setSweepEnabled: (v: boolean) => void;
+  convergeEnabled: boolean;
+  setConvergeEnabled: (v: boolean) => void;
+  convergeNValues: number[];
+  measured: MeasuredData | null;
+  onLoadMeasured: (f: File) => void;
+  onClearMeasured: () => void;
+  normCheckEnabled: boolean;
+  setNormCheckEnabled: (v: boolean) => void;
+  theme: Theme;
+  applyTheme: (t: Theme) => void;
+}) {
+  return (
+    <>
+      <TabStrip />
+      <div className="sidebar-header">
+        <div className="brand">
+          <h1>AntennaKNoBs</h1>
+          <span className="byline">by KK7KNB</span>
+        </div>
+        <div className="header-actions">
+          <div className="gear-menu-wrap">
+            <button
+              type="button"
+              className="header-icon-btn"
+              onClick={() => setGearMenuOpen((o) => !o)}
+              title="Tools"
+              aria-label="Tools menu"
+              aria-haspopup="menu"
+              aria-expanded={gearMenuOpen}
+            >
+              ⚙
+            </button>
+            {gearMenuOpen && (
+              <>
+                <div
+                  className="gear-menu-backdrop"
+                  onClick={() => setGearMenuOpen(false)}
+                />
+                <div className="gear-menu" role="menu">
+                  <button
+                    type="button"
+                    className="gear-menu-item"
+                    role="menuitem"
+                    onClick={onCopyParams}
+                    title="Copy the current knob values as a paste-ready Python default_params block"
+                  >
+                    {copiedParams ? "Copied ✓" : "Copy params (Python)"}
+                  </button>
+                  <button
+                    type="button"
+                    className="gear-menu-item"
+                    role="menuitem"
+                    onClick={onDownloadNec}
+                    title="Download this design as a NEC2 .nec card deck (for xnec2c, 4nec2, EZNEC, …)"
+                  >
+                    Download .nec deck
+                  </button>
+                  {/* Reactive copies of the chart-overlay toggles (same state
+                      the overlays use, so the two locations can never
+                      disagree). On mobile the checkbox overlays are not
+                      rendered on the chart screens — small screens can't
+                      spare the chart area — so this menu is the only place
+                      to reach them there; on desktop it's a convenience
+                      duplicate. */}
+                  <div className="gear-menu-divider" />
+                  {/* Mobile-layout only: it exists to reclaim the phone's
+                      status/nav bars; on desktop F11 already does this and
+                      the menu entry would be clutter. Also needs element
+                      fullscreen (missing on iPhone Safari). */}
+                  {isMobile && fullscreen.supported && (
+                    <>
+                      <div className="gear-menu-section">display</div>
+                      <label
+                        className="gear-menu-check"
+                        title="Take over the whole screen — hides the system status and navigation bars. Uncheck (or use the back gesture) to exit."
+                      >
+                        <input
+                          type="checkbox"
+                          checked={fullscreen.active}
+                          onChange={fullscreen.toggle}
+                        />
+                        full screen
+                      </label>
+                    </>
+                  )}
+                  <div className="gear-menu-section">antenna chart</div>
+                  <label
+                    className="gear-menu-check"
+                    title="Color wire segments by current magnitude; modulate wire width"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={showHeatmap}
+                      onChange={(e) => setShowHeatmap(e.target.checked)}
+                    />
+                    heatmapped currents
+                  </label>
+                  <label
+                    className="gear-menu-check"
+                    title="Draw the |I| envelope curve along each wire"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={showEnvelope}
+                      onChange={(e) => setShowEnvelope(e.target.checked)}
+                    />
+                    current waveforms
+                  </label>
+                  <label
+                    className="gear-menu-check"
+                    title="Draw the per-wire labels (off to declutter dense geometries)"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={showWireLabels}
+                      onChange={(e) => setShowWireLabels(e.target.checked)}
+                    />
+                    wire labels
+                  </label>
+                  <label
+                    className="gear-menu-check"
+                    title="Draw the 'feed' name beside each feedpoint marker"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={showFeedNames}
+                      onChange={(e) => setShowFeedNames(e.target.checked)}
+                    />
+                    feed labels
+                  </label>
+                  <div className="gear-menu-section">smith chart</div>
+                  <label
+                    className="gear-menu-check"
+                    title="Sweep Z across measurement freq and plot the locus on the Smith chart"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={sweepEnabled}
+                      onChange={(e) => setSweepEnabled(e.target.checked)}
+                    />
+                    freq sweep
+                  </label>
+                  <label
+                    className="gear-menu-check"
+                    title={`Re-solve at N = ${convergeNValues.join(", ")} segments/wire and Richardson-extrapolate Z to N→∞`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={convergeEnabled}
+                      onChange={(e) => setConvergeEnabled(e.target.checked)}
+                    />
+                    converge sweep
+                  </label>
+                  <label
+                    className="gear-menu-check gear-menu-file"
+                    title="Overlay a measured VNA sweep (one-port Touchstone .s1p, e.g. from a NanoVNA) against the modeled locus"
+                  >
+                    <input
+                      type="file"
+                      accept=".s1p,.S1P"
+                      onChange={(e) => {
+                        const f = e.target.files?.[0];
+                        e.target.value = "";
+                        if (f) onLoadMeasured(f);
+                      }}
+                    />
+                    {measured ? `measured: ${measured.label}` : "measured .s1p\u2026"}
+                  </label>
+                  {measured && (
+                    <button
+                      type="button"
+                      className="gear-menu-check gear-menu-button"
+                      onClick={onClearMeasured}
+                    >
+                      clear measured
+                    </button>
+                  )}
+                  <div className="gear-menu-section">azimuth / elevation</div>
+                  <label
+                    className="gear-menu-check"
+                    title="On dwell, renormalise the pattern by its own integrated radiated power (dotted) instead of the input power the solid line uses. Overlap ⇒ the solve conserves power; a visible gap is the solver's discretisation error (NEC's 'average gain' check)."
+                  >
+                    <input
+                      type="checkbox"
+                      checked={normCheckEnabled}
+                      onChange={(e) => setNormCheckEnabled(e.target.checked)}
+                    />
+                    norm check
+                  </label>
+                </div>
+              </>
+            )}
+          </div>
+          <button
+            type="button"
+            className="theme-toggle"
+            onClick={() => applyTheme(theme === "dark" ? "light" : "dark")}
+            title="Toggle light / dark theme"
+            aria-label="Toggle light / dark theme"
+          >
+            {theme === "dark" ? "☀" : "☾"}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/antennaknobs/web/frontend/src/components/session/SolveOverlays.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/SolveOverlays.tsx
@@ -1,0 +1,144 @@
+import {
+  BACKEND_LABEL,
+  normalizeBackend,
+  RESTRICTED_BACKEND_REASON,
+  type Backend,
+} from "../../lib/backends";
+
+export function SolveOverlays({
+  showBusy,
+  solving,
+  onCancelSolve,
+  solverWarning,
+  backendDisallowed,
+  backend,
+  requiredBackends,
+  onSwitchBackend,
+  onPause,
+  recommendedBackend,
+  onSolveAnyway,
+  solveError,
+}: {
+  showBusy: boolean;
+  solving: boolean;
+  onCancelSolve: () => void;
+  solverWarning: boolean;
+  backendDisallowed: boolean;
+  backend: Backend;
+  requiredBackends: string[] | null;
+  onSwitchBackend: (target: Backend) => void;
+  onPause: () => void;
+  recommendedBackend: Backend | null;
+  onSolveAnyway: () => void;
+  solveError: string | null;
+}) {
+  return (
+    <>
+        {/* Indeterminate progress bar: appears once a solve outlasts the dwell
+            and lingers out its min-visible window (showBusy), so it never
+            flashes — the dim/label (stale) clear earlier, when the result lands. */}
+        <div className={`solve-bar${showBusy ? " active" : ""}`} aria-hidden />
+        {showBusy && solving && (
+          <button
+            type="button"
+            className="solve-cancel"
+            onClick={onCancelSolve}
+            title="Stop waiting for this solve (the server still finishes it)"
+          >
+            Cancel solve
+          </button>
+        )}
+        {solverWarning && backendDisallowed && (
+          <div
+            className="solver-suggest"
+            role="alertdialog"
+            aria-label="Solver unavailable for this design"
+          >
+            <span className="solver-suggest-title">
+              {BACKEND_LABEL[backend]} can't run this design
+            </span>
+            <span className="solver-suggest-sub">
+              {RESTRICTED_BACKEND_REASON} Switch to{" "}
+              {(requiredBackends ?? [])
+                .map((r) => normalizeBackend(r))
+                .filter((r): r is Backend => r !== null)
+                .map((r) => BACKEND_LABEL[r])
+                .join(" / ") || "a supported solver"}{" "}
+              to solve it, or pause to keep editing.
+            </span>
+            <div className="solver-suggest-actions">
+              {(() => {
+                const target = normalizeBackend(requiredBackends?.[0]);
+                return target ? (
+                  <button
+                    type="button"
+                    className="solver-suggest-primary"
+                    onClick={() => {
+                      onSwitchBackend(target);
+                    }}
+                  >
+                    Switch to {BACKEND_LABEL[target]}
+                  </button>
+                ) : null;
+              })()}
+              <button
+                type="button"
+                className="solver-suggest-secondary"
+                onClick={onPause}
+                title="Stop auto-solving so you can keep editing; click Live to resume."
+              >
+                Pause simulation
+              </button>
+            </div>
+          </div>
+        )}
+        {solverWarning && !backendDisallowed && (
+          <div
+            className="solver-suggest"
+            role="alertdialog"
+            aria-label="Solver mismatch"
+          >
+            <span className="solver-suggest-title">
+              {BACKEND_LABEL[backend]} is a poor match for this design
+            </span>
+            <span className="solver-suggest-sub">
+              {recommendedBackend === "sinusoidal"
+                ? "This mesh is benchmark-sized — B-spline-family solvers take minutes per solve here (and concurrent solves can exhaust memory). The sinusoidal solver or PyNEC answers in seconds. "
+                : backend === "arrayblock" || backend === "hmatrix"
+                  ? "This accelerator is overkill on a single-element design — a dense solver (e.g. B-spline) is faster here. "
+                  : "This is a large array — a dense solver can be very slow. Array-block is far faster. "}
+              Change the solver in the gear menu, solve anyway, or pause to keep
+              editing.
+            </span>
+            <div className="solver-suggest-actions">
+              <button
+                type="button"
+                className="solver-suggest-primary"
+                onClick={onSolveAnyway}
+              >
+                Solve anyway
+              </button>
+              <button
+                type="button"
+                className="solver-suggest-secondary"
+                onClick={onPause}
+                title="Stop auto-solving so you can keep editing; click Live to resume."
+              >
+                Pause simulation
+              </button>
+            </div>
+          </div>
+        )}
+        {solveError && (
+          <div className="solve-error" role="alert">
+            <span className="solve-error-title">This design failed to solve</span>
+            <code className="solve-error-message">{solveError}</code>
+            <span className="solve-error-hint">
+              Fix the design and adjust a control to retry. For user designs see
+              CLAUDE.md in your designs folder.
+            </span>
+          </div>
+        )}
+    </>
+  );
+}

--- a/src/antennaknobs/web/frontend/src/components/session/SolverSlotTabs.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/SolverSlotTabs.tsx
@@ -1,0 +1,57 @@
+import { backendDisplayLabel, SLOT_ORDER } from "../../lib/backends";
+import type { Backend, BackendOptsMap, Slot, SlotConfig } from "../../lib/backends";
+
+export function SolverSlotTabs({
+  slots,
+  activeSlot,
+  onSelect,
+  onOpenGear,
+  backend,
+  currentOpts,
+  nPerWire,
+}: {
+  slots: Record<Slot, SlotConfig>;
+  activeSlot: Slot;
+  onSelect: (s: Slot) => void;
+  onOpenGear: (s: Slot) => void;
+  backend: Backend;
+  currentOpts: BackendOptsMap[Backend];
+  nPerWire: number;
+}) {
+  return (
+    <div className="field">
+      <label>
+        <span>solver slot</span>
+        <span>{backendDisplayLabel(backend, currentOpts)} · N={nPerWire}</span>
+      </label>
+      <div className="backend-tabs" role="tablist">
+        {SLOT_ORDER.map((s) => {
+          const cfg = slots[s];
+          return (
+            <div key={s} className="backend-tab-cell">
+              <button
+                role="tab"
+                aria-selected={activeSlot === s}
+                aria-label={`Solver slot ${s}: ${backendDisplayLabel(cfg.backend, cfg.opts)}, N=${cfg.opts.nPerWire}`}
+                className={`backend-tab-btn ${activeSlot === s ? "active" : ""}`}
+                title={`${backendDisplayLabel(cfg.backend, cfg.opts)}, N=${cfg.opts.nPerWire}`}
+                onClick={() => onSelect(s)}
+              >
+                <span className="slot-letter">{s}</span>
+                <span className="slot-sub">{backendDisplayLabel(cfg.backend, cfg.opts)}</span>
+              </button>
+              <button
+                className="backend-gear-btn"
+                title={`Slot ${s} options`}
+                aria-label={`Slot ${s} options`}
+                onClick={() => onOpenGear(s)}
+              >
+                ⚙
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/antennaknobs/web/frontend/src/components/session/VfoPanel.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/VfoPanel.tsx
@@ -1,0 +1,327 @@
+import { BandDropdown } from "../params/BandDropdown";
+import { Knob } from "../params/Knob";
+import { useState } from "react";
+import type { BandSpec, ExampleDescriptor } from "../../lib/params";
+
+// Response from POST /optimize.
+type OptMetrics = { z_in_re: number; z_in_im: number; z0_ohms: number; swr: number };
+export type OptimizeResult = {
+  objective: string;
+  params: Record<string, number>;
+  objective_before: number;
+  objective_after: number;
+  metrics_before: OptMetrics;
+  metrics_after: OptMetrics;
+  n_evals: number;
+  improved: boolean;
+};
+export type OptObjective = "swr" | "resonance" | "match_z0";
+const OPT_OBJECTIVE_LABELS: Record<OptObjective, string> = {
+  swr: "SWR",
+  resonance: "Resonance",
+  match_z0: "Match Z₀",
+};
+// The two objectives offered in the compact control next to meas-freq.
+const OPT_OBJECTIVES: OptObjective[] = ["swr", "resonance"];
+
+// Why the optimizer auto-paused, for the transient cue. `knob` = the user grabbed
+// a marked knob by hand; `load` = a new design/variant was loaded (its marks and
+// ranges no longer apply).
+export type OptPause = { kind: "knob"; name: string } | { kind: "load" };
+
+// Live / Optimize: two matching push-button toggles (depressed = on), stacked
+// at the left of the dial. Live gates auto-solving on knob turns; Optimize
+// gates the reactive tuner. The objective ("optimise for") picker is the gear
+// next to Optimize. optMenuOpen is local — nothing outside this subtree reads
+// or writes it.
+function SimControls({
+  autoSim,
+  setAutoSim,
+  optEnabled,
+  setOptEnabled,
+  setOptPausedBy,
+  optRunning,
+  optObjective,
+  setOptObjective,
+  optResult,
+  optError,
+  optPausedBy,
+}: {
+  autoSim: boolean;
+  setAutoSim: (fn: (v: boolean) => boolean) => void;
+  optEnabled: boolean;
+  setOptEnabled: (fn: (v: boolean) => boolean) => void;
+  setOptPausedBy: (v: OptPause | null) => void;
+  optRunning: boolean;
+  optObjective: OptObjective;
+  setOptObjective: (v: OptObjective) => void;
+  optResult: OptimizeResult | null;
+  optError: string | null;
+  optPausedBy: OptPause | null;
+}) {
+  const [optMenuOpen, setOptMenuOpen] = useState(false);
+  return (
+    <div className="sim-controls">
+      <button
+        type="button"
+        className={`toggle-btn${autoSim ? " is-on" : ""}`}
+        aria-pressed={autoSim}
+        onClick={() => setAutoSim((v) => !v)}
+        title={
+          autoSim
+            ? "Live: knob changes re-solve automatically. Click to pause and edit without solving."
+            : "Paused: edit the design freely; the engine is held. Click to resume and solve."
+        }
+      >
+        <span className="toggle-led" aria-hidden="true" />
+        {autoSim ? "Live" : "Paused"}
+      </button>
+      <div className="opt-cell">
+        <button
+          type="button"
+          className={`toggle-btn opt-toggle${optEnabled ? " is-on" : ""}`}
+          aria-pressed={optEnabled}
+          onClick={() => {
+            setOptEnabled((v) => !v);
+            setOptPausedBy(null);
+          }}
+          title="Reactive optimiser: vary the knobs you mark (right-click a knob) to hit the objective whenever a fixed knob changes. Changing a marked knob by hand pauses it — turn it back on to resume."
+        >
+          <span className="toggle-led" aria-hidden="true" />
+          Optimize
+          {optRunning ? <span className="opt-pip">●</span> : null}
+        </button>
+        <button
+          type="button"
+          className="opt-gear-btn"
+          aria-label="Optimisation method"
+          aria-haspopup="menu"
+          aria-expanded={optMenuOpen}
+          title={`Optimise for: ${OPT_OBJECTIVE_LABELS[optObjective]}`}
+          onClick={() => setOptMenuOpen((o) => !o)}
+        >
+          ⚙
+        </button>
+        {optMenuOpen && (
+          <>
+            <div
+              className="gear-menu-backdrop"
+              onClick={() => setOptMenuOpen(false)}
+            />
+            <div className="opt-menu" role="menu">
+              <div className="opt-menu-title">Optimise for</div>
+              {OPT_OBJECTIVES.map((k) => (
+                <button
+                  key={k}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={optObjective === k}
+                  className={`gear-menu-item${optObjective === k ? " is-active" : ""}`}
+                  onClick={() => {
+                    setOptObjective(k);
+                    setOptMenuOpen(false);
+                  }}
+                >
+                  {OPT_OBJECTIVE_LABELS[k]}
+                </button>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+      {optEnabled && optResult && (
+        <span className="opt-readout" title="SWR after optimisation">
+          SWR {optResult.metrics_after.swr.toFixed(2)}
+        </span>
+      )}
+      {optEnabled && optError && (
+        <span
+          className="opt-readout opt-readout-err"
+          title={optError}
+        >
+          {optError}
+        </span>
+      )}
+      {!optEnabled && optPausedBy && (
+        <span
+          className="opt-readout opt-paused"
+          title={
+            optPausedBy.kind === "knob"
+              ? "You changed a knob marked for optimization, so Optimize paused. Turn it back on to resume."
+              : "Loading a design clears its optimize marks and pauses Optimize. Re-mark knobs and turn it back on to resume."
+          }
+        >
+          {optPausedBy.kind === "knob"
+            ? `Paused — changing ${optPausedBy.name} by hand`
+            : "Paused — loaded a new design"}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// Measurement freq = the rig's tuning control: a weighted VFO dial +
+// frequency-counter readout. Top line: band select + the LCD. Below: the
+// Live/Optimize toggles stacked at the left of the dial, with the lock
+// pinned to the dial's lower-right corner ("lock to design freq" disables
+// the dial).
+export function VfoPanel({
+  currentBands,
+  measLocked,
+  measFreq,
+  bandContaining,
+  measBand,
+  selectMeasBand,
+  currentExample,
+  measBandAnchor,
+  freqWindowCeiling,
+  setMeasFreq,
+  measLockable,
+  linkMeas,
+  toggleLink,
+  autoSim,
+  setAutoSim,
+  optEnabled,
+  setOptEnabled,
+  setOptPausedBy,
+  optRunning,
+  optObjective,
+  setOptObjective,
+  optResult,
+  optError,
+  optPausedBy,
+}: {
+  currentBands: BandSpec[];
+  measLocked: boolean;
+  measFreq: number;
+  bandContaining: (f: number) => string | null;
+  measBand: string;
+  selectMeasBand: (key: string) => void;
+  currentExample: ExampleDescriptor | undefined;
+  measBandAnchor: number;
+  freqWindowCeiling: number;
+  setMeasFreq: (v: number) => void;
+  measLockable: boolean;
+  linkMeas: boolean;
+  toggleLink: (next: boolean) => void;
+  autoSim: boolean;
+  setAutoSim: (fn: (v: boolean) => boolean) => void;
+  optEnabled: boolean;
+  setOptEnabled: (fn: (v: boolean) => boolean) => void;
+  setOptPausedBy: (v: OptPause | null) => void;
+  optRunning: boolean;
+  optObjective: OptObjective;
+  setOptObjective: (v: OptObjective) => void;
+  optResult: OptimizeResult | null;
+  optError: string | null;
+  optPausedBy: OptPause | null;
+}) {
+  return (
+    <>
+      <h2 className="group-label">measurement freq</h2>
+      <div className={`field vfo-field${measLocked ? " is-locked" : ""}`}>
+        <div className="vfo-top">
+          {currentBands.length > 0 && (
+            <BandDropdown
+              bands={currentBands}
+              // Locked: mirror the design band (measFreq tracks designFreq).
+              // Unlocked: the persistent selection, stable as the dial roams.
+              value={
+                measLocked
+                  ? bandContaining(measFreq) ?? currentBands[0].key
+                  : measBand || currentBands[0].key
+              }
+              onSelect={selectMeasBand}
+              disabled={measLocked}
+              ariaLabel="measurement band"
+            />
+          )}
+          <div className="freq-lcd" title={`${measFreq.toFixed(3)} MHz`}>
+            <span className="lcd-digits">
+              <span className="lcd-ghost">
+                {measFreq.toFixed(3).replace(/\d/g, "8")}
+              </span>
+              <span className="lcd-live">{measFreq.toFixed(3)}</span>
+            </span>
+            <span className="lcd-unit">MHz</span>
+          </div>
+        </div>
+
+        <div className="vfo-body">
+          {/* Live / Optimize: two matching push-button toggles (depressed =
+              on), stacked at the left of the dial. Live gates auto-solving on
+              knob turns; Optimize gates the reactive tuner. The objective
+              ("optimise for") picker is the gear next to Optimize. */}
+          <SimControls
+            autoSim={autoSim}
+            setAutoSim={setAutoSim}
+            optEnabled={optEnabled}
+            setOptEnabled={setOptEnabled}
+            setOptPausedBy={setOptPausedBy}
+            optRunning={optRunning}
+            optObjective={optObjective}
+            setOptObjective={setOptObjective}
+            optResult={optResult}
+            optError={optError}
+            optPausedBy={optPausedBy}
+          />
+
+          <div className="vfo-dial">
+            <Knob
+              knobId="meas_freq"
+              variant="vfo"
+              value={measFreq}
+              min={
+                currentExample?.meas_freq_range_mhz
+                  ? currentExample.meas_freq_range_mhz[0]
+                  : Math.max(0.5, measBandAnchor * 0.8)
+              }
+              max={
+                currentExample?.meas_freq_range_mhz
+                  ? currentExample.meas_freq_range_mhz[1]
+                  : Math.min(freqWindowCeiling, measBandAnchor * 1.25)
+              }
+              step={0.005}
+              precision={3}
+              unit=" MHz"
+              label="measurement frequency"
+              onChange={setMeasFreq}
+              disabled={measLocked}
+            />
+            {/* No design frequency → nothing to lock to; the button would
+                only re-disable the one meaningful control (issue #390). */}
+            {measLockable && (
+              <button
+                type="button"
+                className="vfo-lock"
+                aria-pressed={linkMeas}
+                aria-label="Lock measurement frequency to the design frequency"
+                title={
+                  linkMeas
+                    ? "Locked to the design frequency — the dial is fixed. Click to unlock and tune freely."
+                    : "Lock the measurement frequency to the design frequency."
+                }
+                onClick={() => toggleLink(!linkMeas)}
+              >
+                <svg className="lock-glyph" viewBox="0 0 16 16" aria-hidden="true">
+                  <rect x="3.5" y="7.2" width="9" height="6.3" rx="1.3" />
+                  {/* Shackle opens when unlocked (right leg lifts clear of
+                      the body) so the state reads from shape, not just the
+                      muted-vs-accent color. */}
+                  <path
+                    className="shackle"
+                    d={
+                      linkMeas
+                        ? "M5.3 7.2V5a2.7 2.7 0 0 1 5.4 0v2.2"
+                        : "M5.3 7.2V5a2.7 2.7 0 0 1 5.4 0v0.6"
+                    }
+                  />
+                </svg>
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
Seam 5b-2 of the #642 arc (design: https://github.com/stevenmburns/antennaknobs/issues/642#issuecomment-5160699838): the render-only JSX sub-blocks of `DesignSession.tsx` become module-level presentational components with explicit props. JSX bodies move verbatim (re-indented); the only new code is prop types, signatures, and call-site elements. No new context — props everywhere, per the design's risk analysis.

## The components

`components/session/`: `GroundPanel`, `SolverSlotTabs`, `DesignFreqRow`, `KnobOptMenu`, `SessionGearMenu`, `CatalogPanel`, `VfoPanel` (+`SimControls`), `SolveOverlays`. `components/results/StageOverlays.tsx`: `AntennaOverlayControls`, `SmithOverlayControls`, `FarFieldOverlayControls`, `CutAngleOverlay`, `CompareOverlay`.

`DesignSession.tsx`: **3,671 → 2,689 lines**. The `controls`/`solveOverlays`/`renderOutput` closures remain, now composed of these elements.

## Gates (re-run independently by the reviewer)

- `npm test`: **182/182 green**, test files untouched. `npm run build`: green. Roster contract 2/2; `ruff format --check` clean.
- Fidelity: with `--color-moved-ws=allow-indentation-change`, ~2,193 of ~2,836 added lines register as moves; the reviewer additionally ran a whitespace-insensitive bidirectional set-comparison — forward residue is exactly the documented capture renames (e.g. `cancelSolve`→`onCancelSolve`, `selectBand`→`onSelectBand`, `CONVERGE_N_VALUES`→prop) plus relocated opt types; reverse residue is re-wrapped JSX punctuation only.
- Component-identity check: no component definitions remain inside DesignSession.tsx (grep-verified) — everything extracted is module-level, so element identity is stable across renders (no remount/focus-loss hazard).

## Behavior notes (reviewed individually)

- `SolveOverlays.onSwitchBackend` folds `backendTouchedRef.current = true; setSlotBackend(...)` into the parent-side callback — ref write stays in DesignSession scope.
- `CutAngleOverlay` folds the two view-gated blocks into one always-mounted component gated internally; it returns a fragment, so the DOM is identical in every view.
- `optMenuOpen` became `SimControls`-local state (nothing else read it). Only observable difference: the objective popover no longer survives a full VfoPanel remount (e.g. mobile↔desktop layout flip) — closing a popover on layout flip is the conventional behavior.
- `gearMenuOpen` deliberately stayed lifted: `downloadNec`/`loadMeasured` auto-close the menu from outside.

## Deviation from an in-repo note

A pre-existing comment said moved blocks would keep their unusual 8-space indentation so the diff shows pure moves; the builder re-indented to normal depth instead (better long-term readability, move-detection still clean with the indentation-tolerant flag). The now-stale comment sentence was updated in a follow-up commit.

## Review notes

Implemented by a sonnet subagent from the Plan-agent design; reviewed by the session model as above. Next and last: 5b-3 (behavior hooks — `useSolveChannel`, `useOptimizer`, `useAnalysisRunners`, `useMobileCarousel`, `useDesignCatalog`) to reach the ≤1,500-line bar; that build goes to an opus builder given the closure/dep-array hazard register.

Part of #642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g
