### PR TITLE
refactor(web): DesignSession behavior hooks — every file now under the 1,500-line bar (#642 seam 5b-3)

### DIFF
--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -29,7 +29,6 @@ import {
   type GroundType,
   type TerrainParams,
 } from "../../lib/ground";
-import { feedwiseRichardson, richardsonExtrap } from "../../lib/math";
 import {
   findLinkedDesignFreq,
   groupExamplesForPicker,
@@ -44,7 +43,6 @@ import {
   type SchemaItem,
   type SchemaParamSpec,
 } from "../../lib/params";
-import { planSweepFreqs } from "../../lib/sweep";
 import {
   MOBILE_SCREENS,
   VIEWS,
@@ -52,16 +50,13 @@ import {
   type View,
 } from "../../lib/view";
 import type {
-  ConvergeData,
   MeasuredData,
-  NormCheckData,
   SolveRequest,
   SolveResponse,
-  SweepData,
 } from "../../lib/api";
 import { BackendConfigModal } from "../backend/BackendConfigModal";
 import { ParamForm } from "../params/ParamForm";
-import type { PatternData, PatternMetrics } from "../charts/types";
+import type { PatternMetrics } from "../charts/types";
 import {
   ThemeContext,
   useFullscreen,
@@ -87,18 +82,15 @@ import { copyParams, downloadNec, loadMeasured } from "./sessionActions";
 import { SessionGearMenu } from "./SessionGearMenu";
 import { SolveOverlays } from "./SolveOverlays";
 import { SolverSlotTabs } from "./SolverSlotTabs";
+import {
+  CONVERGE_N_VALUES,
+  useAnalysisRunners,
+} from "./useAnalysisRunners";
 import { useDesignCatalog } from "./useDesignCatalog";
 import { useMobileCarousel } from "./useMobileCarousel";
 import { useOptimizer } from "./useOptimizer";
 import { useSolveChannel } from "./useSolveChannel";
 import { VfoPanel } from "./VfoPanel";
-
-// Log-spaced segments-per-wire ladder for the convergence sweep. Hentenna's
-// 8N+2 total segments at N=68 puts the dense LU at a ~550-cell matrix —
-// still snappy at this N range on all backends, but enough span to see
-// O(1/N) trajectories clearly. Same ladder across backends so the curves
-// are directly comparable when the user switches slots.
-const CONVERGE_N_VALUES: number[] = [8, 12, 17, 24, 34, 48, 68];
 
 // One antenna design session: the entire left sidebar + right stage plus all
 // the state, effects, and the WebSocket that drive them. The shell (`App`,
@@ -550,8 +542,6 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
     preview?.multi_feed ??
     currentExample?.multi_feed ??
     false;
-  const [sweep, setSweep] = useState<SweepData | null>(null);
-  const [sweepRunning, setSweepRunning] = useState(false);
   // Smith-chart overlay toggles. Both are debounced sweeps that re-fire
   // whenever any antenna/backend parameter changes; gating them with these
   // checkboxes lets the user pause an expensive sweep (e.g. BSpline d=2
@@ -563,8 +553,6 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // the file is posted once to be parsed and is never stored server-side, which
   // also means the overlay survives nothing but this tab, by design.
   const [measured, setMeasured] = useState<MeasuredData | null>(null);
-  const [converge, setConverge] = useState<ConvergeData | null>(null);
-  const [convergeRunning, setConvergeRunning] = useState(false);
   // Far-field norm consistency check: on dwell, recompute the gain norm from
   // the pattern integral (field side) and overlay the resulting pattern
   // (dotted) against the live input-power norm (circuit side). The gap is the
@@ -575,10 +563,6 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // forced off (and the switch greyed) over a terrain ground, where NEC's
   // flat-ground rp pattern would silently disagree with the facet traces.
   const [necOverlayEnabled, setNecOverlayEnabled] = useState(true);
-  const [normCheck, setNormCheck] = useState<NormCheckData | null>(null);
-  // NEC's rp_card pattern, fetched on a debounce so we don't fire one per
-  // slider tick. Overlaid on the cuts as a comparison line.
-  const [pattern, setPattern] = useState<PatternData | null>(null);
   // Pinned far-field overlays for cross-antenna pattern comparison — shared
   // across all sessions through the shell (see PinsContext), so a pattern
   // pinned in one tab can be compared against in any other. The live
@@ -709,14 +693,6 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
     return () => window.removeEventListener("keydown", onKey);
   }, [view, active]);
 
-  const sweepTimerRef = useRef<number | null>(null);
-  const sweepAbortRef = useRef<AbortController | null>(null);
-  const patternTimerRef = useRef<number | null>(null);
-  const patternAbortRef = useRef<AbortController | null>(null);
-  const convergeTimerRef = useRef<number | null>(null);
-  const convergeAbortRef = useRef<AbortController | null>(null);
-  const normCheckTimerRef = useRef<number | null>(null);
-  const normCheckAbortRef = useRef<AbortController | null>(null);
   const previewAbortRef = useRef<AbortController | null>(null);
   // JSON of the request the currently-displayed preview wireframe was built
   // from. When Live is off no solve redraws the geometry, so the solve effect
@@ -1157,464 +1133,39 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [geometry]);
 
-  // Debounced sweep across measurement freq. Re-runs whenever any antenna
-  // parameter changes. Single-band geometries sweep around designFreq, so
-  // moving the measFreq slider doesn't re-sweep (the existing data already
-  // covers the new slider position). Fan dipole sweeps around measFreq,
-  // so measFreq is part of the deps there to re-anchor.
-  useEffect(() => {
-    // Cancel any in-flight sweep fetch immediately. Without this the
-    // previous sweep keeps streaming for hundreds of ms (PyNEC ground at
-    // 100 ms/point × 41 points = ~4 s) and starves the live /ws solve of
-    // CPU — the user moves a slider but the next impedance update is
-    // delayed behind the now-stale sweep finishing.
-    sweepAbortRef.current?.abort();
-    if (sweepTimerRef.current) {
-      window.clearTimeout(sweepTimerRef.current);
-    }
-    setSweep(null);
-    setSweepRunning(false);
-    // Paused (Live off) holds the engine (issue #612): an enabled sweep must
-    // not keep solving while the user edits. Clearing above + returning here
-    // blanks the overlay while paused; resuming Live re-runs this effect
-    // (autoSim is a dep) and restarts the sweep from the current design.
-    if (!autoSim || !sweepEnabled || !active) {
-      return;
-    }
-    // The 500 ms dwell only debounces network churn; ordering against the
-    // live solve is the server lane's job now (live outranks sweeps).
-    sweepTimerRef.current = window.setTimeout(runSweep, 500);
-    return () => {
-      if (sweepTimerRef.current) window.clearTimeout(sweepTimerRef.current);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    geometry, backend, backendOptsKey,
-    currentValuesKey,
-    designFreq,
-    groundEnabled, groundModel,
-    sweepEnabled,
-    autoSim,
-    active,
-    // measFreq/measLocked drive the anchor now (meas_freq policy, or any
-    // unlocked design — incl. fixed-geometry designs whose lock is inert),
-    // so a meas-band change or dial turn re-runs the sweep.
-    measFreq, measLocked,
-    // A variant can override sweep_policy (variant_ui) without changing any
-    // param — e.g. a band-locked variant. currentValuesKey wouldn't move then,
-    // so depend on currentVariant directly to re-run the sweep on switch.
-    currentVariant,
-    // The poor-match gate: while it withholds, runSweep declines to issue the
-    // batch; approving ("Solve anyway") or a new recommendation re-fires this
-    // effect (issue #382 — replaces the old 200 ms re-poll loop).
-    comboApproved, recommendedBackend,
-  ]);
-
-  // Debounced convergence sweep over segments-per-wire. Independent of the
-  // freq sweep above: re-runs on any antenna/backend change, gated by its
-  // own overlay checkbox. The active slot's `nPerWire` is *overridden* by
-  // the ladder values for the duration of the sweep — the per-slot opts
-  // stay untouched, so the live /ws solve keeps using the user's setting.
-  useEffect(() => {
-    convergeAbortRef.current?.abort();
-    if (convergeTimerRef.current) {
-      window.clearTimeout(convergeTimerRef.current);
-    }
-    setConverge(null);
-    setConvergeRunning(false);
-    // Held when Paused (issue #612) — see the sweep effect. autoSim is a dep so
-    // resuming Live restarts the convergence sweep.
-    if (!autoSim || !convergeEnabled || !active) {
-      return;
-    }
-    // Debounce only; the server lane orders it behind the live solve.
-    convergeTimerRef.current = window.setTimeout(runConverge, 500);
-    return () => {
-      if (convergeTimerRef.current) window.clearTimeout(convergeTimerRef.current);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    geometry, backend, backendOptsKey,
-    currentValuesKey,
-    designFreq, measFreq,
-    groundEnabled, groundModel,
-    convergeEnabled,
-    autoSim,
-    active,
-    // Poor-match gate (see the sweep effect).
-    comboApproved, recommendedBackend,
-  ]);
-
-  // Debounced far-field norm consistency check. Same shape as the converge
-  // sweep: re-runs on any antenna/param change (which invalidates the norm),
-  // gated by its own overlay checkbox. The server lane runs it after the
-  // live solve (priority ordering), so it lands on that solve's cached
-  // currents rather than forcing a re-solve.
-  useEffect(() => {
-    normCheckAbortRef.current?.abort();
-    if (normCheckTimerRef.current) {
-      window.clearTimeout(normCheckTimerRef.current);
-    }
-    setNormCheck(null);
-    // Held when Paused (issue #612): the norm check re-solves, so it must not
-    // run while the engine is held. autoSim is a dep — resuming Live re-runs it.
-    if (!autoSim || !normCheckEnabled || !active) {
-      return;
-    }
-    normCheckTimerRef.current = window.setTimeout(runNormCheck, 500);
-    return () => {
-      if (normCheckTimerRef.current) window.clearTimeout(normCheckTimerRef.current);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    geometry, backend, backendOptsKey,
-    currentValuesKey,
-    designFreq, measFreq,
-    groundEnabled, groundModel,
-    // The pattern integral runs over the facets, so terrain knob changes
-    // invalidate it (unlike the impedance-only sweep/converge effects,
-    // which are legitimately terrain-param-independent — every preset
-    // shares the crest medium the impedance solve uses).
-    terrainKey,
-    normCheckEnabled,
-    autoSim,
-    active,
-    // Poor-match gate (see the sweep effect).
-    comboApproved, recommendedBackend,
-  ]);
-
-  // Debounced NEC pattern fetch. PyNEC only — for momwire there's no rp_card
-  // equivalent. Tracks measurement freq too (unlike the impedance sweep).
-  // Held off entirely over terrain (the rp pattern is flat-ground only) and
-  // when the user switches the overlay off.
-  useEffect(() => {
-    if (patternTimerRef.current) window.clearTimeout(patternTimerRef.current);
-    setPattern(null);
-    if (
-      !autoSim || // Paused holds the engine (issue #612) — no NEC re-solve.
-      backend !== "pynec" ||
-      !active ||
-      !necOverlayEnabled ||
-      groundModel === "terrain"
-    ) {
-      return;
-    }
-    patternTimerRef.current = window.setTimeout(() => {
-      runPattern();
-      patternTimerRef.current = null;
-    }, 500);
-    return () => {
-      if (patternTimerRef.current) window.clearTimeout(patternTimerRef.current);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    geometry, backend, backendOptsKey,
-    currentValuesKey,
-    designFreq, measFreq,
-    groundEnabled, groundModel,
-    necOverlayEnabled,
-    autoSim,
-    active,
-  ]);
-
-  async function runSweep() {
-    // No competition with the live solve to time around anymore: the server's
-    // per-session solve lane (issue #382) runs everything one-at-a-time with
-    // the live solve first, so this just sends. While the poor-match gate is
-    // withholding, don't issue batches of the very solves it's blocking — the
-    // effect re-fires on approval (comboApproved is a dependency).
-    if (solveWithheld()) return;
-    sweepTimerRef.current = null;
-    sweepAbortRef.current?.abort();
-    const controller = new AbortController();
-    sweepAbortRef.current = controller;
-
-    // Sweep range, log-spaced — see planSweepFreqs for the resolution,
-    // anchor, and band-lock policy this applies.
-    const freqs = planSweepFreqs({
+  // The four background analyses (#642 seam 5b-3): freq sweep, convergence
+  // sweep, far-field norm check and the NEC rp_card pattern. Called here, at
+  // the debounce effects' old position, so all four keep their global order
+  // behind the solve and preview effects above.
+  const { sweep, sweepRunning, converge, convergeRunning, normCheck, pattern } =
+    useAnalysisRunners({
+      geometry,
       backend,
-      groundEnabled,
-      groundModel,
-      currentExample,
+      backendOptsKey,
+      currentValuesKey,
       currentVariant,
-      measLocked,
-      measFreq,
-      designFreq,
+      currentExample,
       currentBands,
       freqWindowCeiling,
+      designFreq,
+      measFreq,
+      measLocked,
+      groundEnabled,
+      groundModel,
+      terrainKey,
+      sweepEnabled,
+      convergeEnabled,
+      normCheckEnabled,
+      necOverlayEnabled,
+      autoSim,
+      active,
+      comboApproved,
+      recommendedBackend,
+      buildRequest,
+      solveWithheld,
+      seqRef,
+      approvedComboRef,
     });
-
-    const body = {
-      ...buildRequest(),
-      freqs_mhz: freqs,
-      // Lane metadata (issue #382): issued-at generation (a newer knob drag
-      // supersedes this batch server-side) + the gate's approval, which the
-      // server requires for a warned batch (poor-match combo backstop).
-      _gen: seqRef.current,
-      _approved: approvedComboRef.current,
-    };
-    setSweepRunning(true);
-    const acc: SweepData = {
-      freqs_mhz: [],
-      z_re: [],
-      z_im: [],
-      feeds_z_re: undefined,
-      feeds_z_im: undefined,
-    };
-    try {
-      const resp = await fetch("/sweep", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-        signal: controller.signal,
-      });
-      if (!resp.ok || !resp.body) throw new Error(`sweep failed: ${resp.status}`);
-      const reader = resp.body.getReader();
-      const decoder = new TextDecoder();
-      let buf = "";
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buf += decoder.decode(value, { stream: true });
-        let nl;
-        while ((nl = buf.indexOf("\n")) >= 0) {
-          const line = buf.slice(0, nl).trim();
-          buf = buf.slice(nl + 1);
-          if (!line) continue;
-          const pt = JSON.parse(line);
-          if (pt.done) continue;
-          // A failed point/chunk ends the stream with {error} instead of
-          // tearing the connection down (e.g. an approved poor-match combo
-          // whose dense fill can't allocate). Keep whatever points landed.
-          if (pt.error) {
-            console.error("sweep error", pt.error);
-            continue;
-          }
-          acc.freqs_mhz.push(pt.freq_mhz);
-          acc.z_re.push(pt.z_re);
-          acc.z_im.push(pt.z_im);
-          // Multi-feed sweep records (bowtie) ship per-feed Z alongside
-          // the primary. Allocate the per-feed buffers lazily on first
-          // sight so single-feed sweeps stay on the original code path.
-          if (Array.isArray(pt.feeds_z_re) && Array.isArray(pt.feeds_z_im)) {
-            if (!acc.feeds_z_re) acc.feeds_z_re = [];
-            if (!acc.feeds_z_im) acc.feeds_z_im = [];
-            acc.feeds_z_re.push(pt.feeds_z_re);
-            acc.feeds_z_im.push(pt.feeds_z_im);
-          }
-          if (!controller.signal.aborted) {
-            // New object so React re-renders the Smith chart per point.
-            setSweep({
-              freqs_mhz: acc.freqs_mhz.slice(),
-              z_re: acc.z_re.slice(),
-              z_im: acc.z_im.slice(),
-              feeds_z_re: acc.feeds_z_re
-                ? acc.feeds_z_re.map((row) => row.slice())
-                : undefined,
-              feeds_z_im: acc.feeds_z_im
-                ? acc.feeds_z_im.map((row) => row.slice())
-                : undefined,
-            });
-          }
-        }
-      }
-    } catch (e: unknown) {
-      if (e instanceof DOMException && e.name === "AbortError") return;
-      console.error("sweep error", e);
-    } finally {
-      if (sweepAbortRef.current === controller) {
-        sweepAbortRef.current = null;
-        setSweepRunning(false);
-      }
-    }
-  }
-
-  async function runConverge() {
-    // Same as runSweep: the server lane serializes and prioritizes; only the
-    // poor-match gate holds this back (effect re-fires on approval).
-    if (solveWithheld()) return;
-    convergeTimerRef.current = null;
-    convergeAbortRef.current?.abort();
-    const controller = new AbortController();
-    convergeAbortRef.current = controller;
-
-    // The active slot's nPerWire is irrelevant during a converge sweep —
-    // n_values overrides it on the server. We strip `n_per_wire` from the
-    // request anyway to make that explicit.
-    const body = {
-      ...buildRequest(),
-      n_values: CONVERGE_N_VALUES,
-      _gen: seqRef.current,
-      _approved: approvedComboRef.current,
-    };
-    setConvergeRunning(true);
-    const acc: ConvergeData = {
-      n_values: [],
-      z_re: [],
-      z_im: [],
-      z_re_extrap: null,
-      z_im_extrap: null,
-      feeds_z_re: undefined,
-      feeds_z_im: undefined,
-      feeds_z_re_extrap: undefined,
-      feeds_z_im_extrap: undefined,
-    };
-    try {
-      const resp = await fetch("/converge", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-        signal: controller.signal,
-      });
-      if (!resp.ok || !resp.body) throw new Error(`converge failed: ${resp.status}`);
-      const reader = resp.body.getReader();
-      const decoder = new TextDecoder();
-      let buf = "";
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buf += decoder.decode(value, { stream: true });
-        let nl;
-        while ((nl = buf.indexOf("\n")) >= 0) {
-          const line = buf.slice(0, nl).trim();
-          buf = buf.slice(nl + 1);
-          if (!line) continue;
-          const pt = JSON.parse(line);
-          if (pt.done) continue;
-          // A solver failure for one N (rare — degenerate small-N geometry)
-          // is reported by the backend as {n_per_wire, error}; skip rather
-          // than poisoning the trajectory.
-          if (pt.error) continue;
-          acc.n_values.push(pt.n_per_wire);
-          acc.z_re.push(pt.z_re);
-          acc.z_im.push(pt.z_im);
-          // Multi-feed convergence records ship per-feed Z alongside the
-          // primary; allocate the buffers lazily on first sight.
-          if (Array.isArray(pt.feeds_z_re) && Array.isArray(pt.feeds_z_im)) {
-            if (!acc.feeds_z_re) acc.feeds_z_re = [];
-            if (!acc.feeds_z_im) acc.feeds_z_im = [];
-            acc.feeds_z_re.push(pt.feeds_z_re);
-            acc.feeds_z_im.push(pt.feeds_z_im);
-          }
-          const invN = acc.n_values.map((n) => 1 / n);
-          acc.z_re_extrap = richardsonExtrap(invN, acc.z_re);
-          acc.z_im_extrap = richardsonExtrap(invN, acc.z_im);
-          // Per-feed Richardson Z* — see feedwiseRichardson.
-          if (acc.feeds_z_re && acc.feeds_z_im) {
-            const { feedsRe, feedsIm } = feedwiseRichardson(
-              invN,
-              acc.feeds_z_re,
-              acc.feeds_z_im,
-            );
-            acc.feeds_z_re_extrap = feedsRe;
-            acc.feeds_z_im_extrap = feedsIm;
-          }
-          if (!controller.signal.aborted) {
-            setConverge({
-              n_values: acc.n_values.slice(),
-              z_re: acc.z_re.slice(),
-              z_im: acc.z_im.slice(),
-              z_re_extrap: acc.z_re_extrap,
-              z_im_extrap: acc.z_im_extrap,
-              feeds_z_re: acc.feeds_z_re
-                ? acc.feeds_z_re.map((row) => row.slice())
-                : undefined,
-              feeds_z_im: acc.feeds_z_im
-                ? acc.feeds_z_im.map((row) => row.slice())
-                : undefined,
-              feeds_z_re_extrap: acc.feeds_z_re_extrap
-                ? acc.feeds_z_re_extrap.slice()
-                : undefined,
-              feeds_z_im_extrap: acc.feeds_z_im_extrap
-                ? acc.feeds_z_im_extrap.slice()
-                : undefined,
-            });
-          }
-        }
-      }
-    } catch (e: unknown) {
-      if (e instanceof DOMException && e.name === "AbortError") return;
-      console.error("converge error", e);
-    } finally {
-      if (convergeAbortRef.current === controller) {
-        convergeAbortRef.current = null;
-        setConvergeRunning(false);
-      }
-    }
-  }
-
-  async function runNormCheck() {
-    // The pattern norm reuses the settled live solve (a server cache hit):
-    // the lane's live-first priority guarantees that ordering now, no
-    // client-side timing needed. Only the poor-match gate holds this back.
-    if (solveWithheld()) return;
-    normCheckTimerRef.current = null;
-    normCheckAbortRef.current?.abort();
-    const controller = new AbortController();
-    normCheckAbortRef.current = controller;
-    try {
-      const resp = await fetch("/norm_check", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          ...buildRequest(),
-          _gen: seqRef.current,
-          _approved: approvedComboRef.current,
-        }),
-        signal: controller.signal,
-      });
-      if (!resp.ok) throw new Error(`norm check failed: ${resp.status}`);
-      const data = await resp.json();
-      if (controller.signal.aborted) return;
-      if (!data.available) {
-        setNormCheck(null);
-        return;
-      }
-      const delta = 10 * Math.log10(data.pattern_norm / data.directivity_norm);
-      setNormCheck({
-        directivity_norm: data.directivity_norm,
-        pattern_norm: data.pattern_norm,
-        method: data.method,
-        delta_db: delta,
-        radiated_fraction: data.radiated_fraction ?? 0,
-        radiation_efficiency: data.radiation_efficiency ?? 1,
-      });
-    } catch (e: unknown) {
-      if (e instanceof DOMException && e.name === "AbortError") return;
-      console.error("norm check error", e);
-    } finally {
-      if (normCheckAbortRef.current === controller) {
-        normCheckAbortRef.current = null;
-      }
-    }
-  }
-
-  async function runPattern() {
-    patternAbortRef.current?.abort();
-    const controller = new AbortController();
-    patternAbortRef.current = controller;
-    try {
-      const resp = await fetch("/pattern", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...buildRequest(), _gen: seqRef.current }),
-        signal: controller.signal,
-      });
-      if (!resp.ok) throw new Error(`pattern failed: ${resp.status}`);
-      const data = await resp.json();
-      if (!data.available) {
-        setPattern(null);
-        return;
-      }
-      if (!controller.signal.aborted) setPattern(data as PatternData);
-    } catch (e: unknown) {
-      if (e instanceof DOMException && e.name === "AbortError") return;
-      console.error("pattern error", e);
-    } finally {
-      if (patternAbortRef.current === controller) patternAbortRef.current = null;
-    }
-  }
-
   // Hoisted JSX shared between the desktop tree below and the mobile tree
   // (Phase B). These close over the session's locals, so they are consts /
   // a closure rather than components — zero prop surface, identical DOM.

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -99,6 +99,7 @@ import { copyParams, downloadNec, loadMeasured } from "./sessionActions";
 import { SessionGearMenu } from "./SessionGearMenu";
 import { SolveOverlays } from "./SolveOverlays";
 import { SolverSlotTabs } from "./SolverSlotTabs";
+import { useMobileCarousel } from "./useMobileCarousel";
 import {
   type OptimizeResult,
   type OptObjective,
@@ -855,74 +856,19 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   const thumbStripRef = useRef<HTMLDivElement>(null);
   const thumbSize = useThumbColumnSize(thumbStripRef, 280, isMobile);
 
-  // Mobile output carousel (all hooks unconditional — desktop leaves them
-  // inert). mobileIndex is which of the 5 screens the snap carousel rests on;
-  // `view` stays the source of truth for the 4 chart screens and their data
-  // effects, kept in sync by the scroll handler / reverse-sync effect below.
-  const [mobileIndex, setMobileIndex] = useState(0);
-  const mobileCarouselRef = useRef<HTMLDivElement>(null);
-  const mobileScrollRafRef = useRef<number | null>(null);
-  const { ref: mobRef, size: mobChartSize } = useSlideSize(720, isMobile);
+  const {
+    mobileIndex,
+    mobileCarouselRef,
+    mobRef,
+    mobChartSize,
+    onMobileCarouselScroll,
+    goToMobileScreen,
+  } = useMobileCarousel({ isMobile, orientation, view, setView });
   // The pinned-pattern comparison table minimizes to a "{n} pinned" chip so
   // it can get off the chart — it grows a row per pin and swallows a phone
   // screen. Starts collapsed on mobile, expanded on desktop (the pre-existing
   // behavior); pinning always expands it so the new row is seen.
   const [compareCollapsed, setCompareCollapsed] = useState(isMobile);
-
-  // Track where a swipe/fling snaps and mirror it into state. rAF-throttled:
-  // scroll events arrive per frame during a fling, one rounding per frame is
-  // plenty. The rounded-index compare inside the setters keeps this from
-  // fighting the programmatic scrolls below.
-  const onMobileCarouselScroll = () => {
-    if (mobileScrollRafRef.current !== null) return;
-    mobileScrollRafRef.current = requestAnimationFrame(() => {
-      mobileScrollRafRef.current = null;
-      const el = mobileCarouselRef.current;
-      if (!el || el.clientWidth === 0) return;
-      const i = Math.round(el.scrollLeft / el.clientWidth);
-      setMobileIndex((prev) => (prev === i ? prev : i));
-      if (i < VIEWS.length) setView(VIEWS[i].id);
-    });
-  };
-
-  // Dot tap: jump to a screen. Info (the last index) is reachable only here
-  // and by swipe — it deliberately leaves `view` on the last chart screen.
-  const goToMobileScreen = (i: number) => {
-    setMobileIndex(i);
-    if (i < VIEWS.length) setView(VIEWS[i].id);
-    const el = mobileCarouselRef.current;
-    if (el) el.scrollTo({ left: i * el.clientWidth, behavior: "smooth" });
-  };
-
-  // Reverse sync: anything else that sets `view` (the arrow-key cycler) pages
-  // the carousel to match. The DOM scroll position is the ground truth for
-  // "where are we" — comparing rounded indices means we never fight an
-  // in-progress swipe, and parking on Info ignores view changes entirely.
-  useEffect(() => {
-    if (!isMobile) return;
-    const el = mobileCarouselRef.current;
-    if (!el || el.clientWidth === 0) return;
-    const target = VIEWS.findIndex((v) => v.id === view);
-    const current = Math.round(el.scrollLeft / el.clientWidth);
-    if (target < 0 || current >= VIEWS.length || current === target) return;
-    setMobileIndex(target);
-    el.scrollTo({ left: target * el.clientWidth, behavior: "smooth" });
-  }, [view, isMobile]);
-
-  // An orientation flip (or any pane resize) changes the screen width, so
-  // scrollLeft no longer sits on a snap point; re-center the active screen
-  // once the new layout lands (hence the rAF). Skipped when the rounded
-  // position already matches — never fights a drag.
-  useEffect(() => {
-    if (!isMobile) return;
-    const raf = requestAnimationFrame(() => {
-      const el = mobileCarouselRef.current;
-      if (!el || el.clientWidth === 0) return;
-      const i = Math.round(el.scrollLeft / el.clientWidth);
-      if (i !== mobileIndex) el.scrollTo({ left: mobileIndex * el.clientWidth });
-    });
-    return () => cancelAnimationFrame(raf);
-  }, [isMobile, orientation, mobChartSize, mobileIndex]);
 
   useEffect(() => {
     if (!active) return;

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -4,31 +4,16 @@ import {
   backendDisplayLabel,
   backendSupportsGround,
   comboInappropriate,
-  DEFAULT_BACKEND_OPTS,
-  DEFAULT_SLOTS,
   isBSplineFamily,
   modelOptionsForRequest,
   normalizeBackend,
   resolveBackend,
-  resolveSlotConfig,
   selectableBackends,
-  type Backend,
-  type BackendOptsMap,
-  type Slot,
-  type SlotConfig,
 } from "../../lib/backends";
 import {
   bandContaining as bandContainingIn,
   freqWindowCeiling as freqWindowCeilingFor,
 } from "../../lib/bands";
-import {
-  groundSummaryLabel,
-  resolveGroundModel,
-  type FiniteGroundMethod,
-  type GroundModel,
-  type GroundType,
-  type TerrainParams,
-} from "../../lib/ground";
 import {
   findLinkedDesignFreq,
   groupExamplesForPicker,
@@ -43,12 +28,7 @@ import {
   type SchemaItem,
   type SchemaParamSpec,
 } from "../../lib/params";
-import {
-  MOBILE_SCREENS,
-  VIEWS,
-  type Projection,
-  type View,
-} from "../../lib/view";
+import { MOBILE_SCREENS, VIEWS, type View } from "../../lib/view";
 import type {
   MeasuredData,
   SolveRequest,
@@ -87,9 +67,12 @@ import {
   useAnalysisRunners,
 } from "./useAnalysisRunners";
 import { useDesignCatalog } from "./useDesignCatalog";
+import { useGroundConfig } from "./useGroundConfig";
 import { useMobileCarousel } from "./useMobileCarousel";
 import { useOptimizer } from "./useOptimizer";
 import { useSolveChannel } from "./useSolveChannel";
+import { useSolverSlots } from "./useSolverSlots";
+import { useViewState } from "./useViewState";
 import { VfoPanel } from "./VfoPanel";
 
 // One antenna design session: the entire left sidebar + right stage plus all
@@ -287,14 +270,24 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // paramValues["fan_dipole"], seeded from the schema's defaults +
   // default_overrides. The deletion removed ~25 lines of state plus the
   // setFanBandSlot / setFanBandFreq / setFanHalfdriverFactor helpers.
-  // Solver slots A / B / C — each one holds its own backend + options so
-  // the user can switch between configured solvers with a single click
-  // and tune each one independently from its gear menu.
-  const [activeSlot, setActiveSlot] = useState<Slot>("A");
-  const [slots, setSlots] = useState<Record<Slot, SlotConfig>>(DEFAULT_SLOTS);
-  // Set once the user picks a backend by hand; after that we stop auto-seeding
-  // the per-antenna recommended solver so their choice sticks.
-  const backendTouchedRef = useRef(false);
+  // Solver slots A / B / C (#642 seam 5b-3). Called at the cluster's own
+  // position, so its PyNEC-remap effect keeps its global order.
+  const {
+    activeSlot,
+    setActiveSlot,
+    slots,
+    backendTouchedRef,
+    gearOpen,
+    setGearOpen,
+    backend,
+    currentOpts,
+    nPerWire,
+    wireRadius,
+    backendOptsKey,
+    updateSlotOpts,
+    setSlotBackend,
+    resetSlot,
+  } = useSolverSlots({ havePynec });
   // True once the user clicked "Solve anyway" for the current design+solver
   // combo, so re-solves (knob drags) don't re-warn. Reset whenever the design or
   // solver changes (see the reset effect below). Mirrored into state so the
@@ -308,68 +301,6 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // solve is withheld until the user clicks "Solve anyway" or changes the solver
   // themselves; the app never switches solvers on its own.
   const [solverWarning, setSolverWarning] = useState(false);
-  const [gearOpen, setGearOpen] = useState<Slot | null>(null);
-  const activeConfig = slots[activeSlot];
-  const backend = activeConfig.backend;
-  const currentOpts = activeConfig.opts;
-  const nPerWire = currentOpts.nPerWire;
-  const wireRadius = currentOpts.wireRadius;
-  // Stable hash of the active slot's config so useEffect can depend on it.
-  const backendOptsKey = JSON.stringify(activeConfig);
-  function updateSlotOpts(slot: Slot, patch: Partial<BackendOptsMap[Backend]>) {
-    setSlots((prev) => ({
-      ...prev,
-      [slot]: {
-        ...prev[slot],
-        opts: { ...prev[slot].opts, ...patch } as BackendOptsMap[Backend],
-      },
-    }));
-  }
-  function setSlotBackend(slot: Slot, newBackend: Backend) {
-    // Preserve segments-per-wire and wire-radius across the swap so the
-    // user keeps their geometry-sizing choices when comparing models;
-    // model-specific kwargs revert to that backend's defaults.
-    setSlots((prev) => {
-      const prevOpts = prev[slot].opts;
-      const defaults = DEFAULT_BACKEND_OPTS[newBackend];
-      return {
-        ...prev,
-        [slot]: {
-          backend: newBackend,
-          opts: {
-            ...defaults,
-            nPerWire: prevOpts.nPerWire,
-            wireRadius: prevOpts.wireRadius,
-          } as BackendOptsMap[Backend],
-        },
-      };
-    });
-  }
-  function resetSlot(slot: Slot) {
-    setSlots((prev) => ({
-      ...prev,
-      [slot]: resolveSlotConfig(DEFAULT_SLOTS[slot], havePynec),
-    }));
-  }
-  // When the server reports no pynec-accel (#429), remap any slot still on
-  // PyNEC — the default slot C, or a saved/URL slot — to the fallback backend,
-  // so the panel never holds a backend the picker no longer offers (which the
-  // /ws solve would silently run as momwire).
-  useEffect(() => {
-    if (havePynec) return;
-    setSlots((prev) => {
-      let changed = false;
-      const next = { ...prev };
-      for (const s of Object.keys(prev) as Slot[]) {
-        const resolved = resolveSlotConfig(prev[s], havePynec);
-        if (resolved !== prev[s]) {
-          next[s] = resolved;
-          changed = true;
-        }
-      }
-      return changed ? next : prev;
-    });
-  }, [havePynec]);
   // band/designFreq/measFreq seed to placeholders; the auto-select
   // effect below picks the first band of the active example and
   // overwrites them once /examples resolves.
@@ -394,65 +325,46 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // design_freq-scaled design.
   const measLockable = currentExample?.has_design_freq ?? true;
   const measLocked = linkMeas && measLockable;
-  // Ground plane at z = 0 (model per backend; see groundType). ON by
-  // default: this is an HF wire-antenna workbench, and the over-ground
-  // picture (takeoff angle, ground-lobed elevation pattern, shifted Z)
-  // is the decision-relevant one — free space is the idealization you
-  // opt into. The whole catalog solves grounded (75/75 audit, all
-  // designs above z=0) on the default B-spline refl-coef path.
-  const [groundEnabled, setGroundEnabled] = useState(true);
-  // Shared ground choice — one selector describing the GROUND (finite vs
-  // PEC); every backend solves it as best it can (see the GroundType note).
-  const [groundType, setGroundType] = useState<GroundType>("finite");
-  // Finite-ground method; hidden (and inert) on backends with a single
-  // finite model, but kept in state so it survives backend flips during
-  // engine comparison. Defaults to "fast" — Sommerfeld is opt-in (it costs
-  // seconds per solve on the B-spline backend).
-  const [finiteGroundMethod, setFiniteGroundMethod] =
-    useState<FiniteGroundMethod>("fast");
-  // Terrain preset + knobs (groundType === "terrain"; momwire only). One
-  // flat params object for both presets so values survive preset flips.
-  const [terrainPreset, setTerrainPreset] = useState<string>("levee");
-  const [terrainParams, setTerrainParams] = useState<TerrainParams>({});
-  // Wire value derived for the server protocol (see GroundModel). A
-  // terrain selection quietly degrades to the finite method on any future
-  // backend without terrain support (all current ground-capable backends
-  // have it — PyNEC via the #553 hybrid).
-  const groundModel: GroundModel = resolveGroundModel(
-    groundType,
-    backend,
-    finiteGroundMethod,
-  );
-
-  // Solve-effect dep for the terrain knobs: only bites while terrain is
-  // the active model, so parked levee state never re-solves a flat-ground
-  // setup (and vice versa).
-  const terrainKey =
-    groundModel === "terrain"
-      ? JSON.stringify([terrainPreset, terrainParams])
-      : "";
-
-  // One-line tab-hover summary: design · solver N=segs · ground model.
-  // Every backend honours the selected method (momwire >= 0.8.0), so the
-  // wording is uniform; "free space" when ground is off or unsupported.
-  const groundSummary = groundSummaryLabel(
+  // Ground / terrain selection and its derived protocol values (#642 seam
+  // 5b-3). Pure state + derivations, so it adds no effects here.
+  const {
     groundEnabled,
-    backend,
-    groundModel,
+    setGroundEnabled,
+    groundType,
+    setGroundType,
+    finiteGroundMethod,
+    setFiniteGroundMethod,
     terrainPreset,
-  );
+    setTerrainPreset,
+    terrainParams,
+    setTerrainParams,
+    groundModel,
+    terrainKey,
+    groundSummary,
+  } = useGroundConfig({ backend });
   const tabSummary = `${(currentExample?.label ?? geometry) || "new design"} · ${backendDisplayLabel(backend, currentOpts)} N=${nPerWire} · ${groundSummary}`;
   useEffect(() => {
     reportSummary(id, tabSummary);
   }, [id, tabSummary, reportSummary]);
-  // Far-field cut angles. The azimuth plot slices the pattern at elevation
-  // `azElevDeg`; the elevation plot slices the vertical plane at azimuth
-  // bearing `elevAzDeg` (0° = +x). Defaults give the conventional views.
-  const [azElevDeg, setAzElevDeg] = useState(15);
-  // Default elevation-cut azimuth is 0° (+x) for every geometry: Yagi,
-  // moxon, and hexbeam beam +x; the inverted V now runs its arms along
-  // ±y so its broadside lobe also peaks at ±x.
-  const [elevAzDeg, setElevAzDeg] = useState(0);
+  // Output view, camera and canvas display toggles (#642 seam 5b-3).
+  const {
+    azElevDeg,
+    setAzElevDeg,
+    elevAzDeg,
+    setElevAzDeg,
+    view,
+    setView,
+    cameraProjection,
+    setCameraProjection,
+    showHeatmap,
+    setShowHeatmap,
+    showEnvelope,
+    setShowEnvelope,
+    showWireLabels,
+    setShowWireLabels,
+    showFeedNames,
+    setShowFeedNames,
+  } = useViewState({ currentExample, active });
 
   // When linked, design and measurement freq move together.
   function updateDesignFreq(v: number) {
@@ -575,23 +487,6 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
     clearPins,
   } = useContext(PinsContext);
   const [liveMetrics, setLiveMetrics] = useState<PatternMetrics | null>(null);
-  const [view, setView] = useState<View>("antenna");
-  const [cameraProjection, setCameraProjection] = useState<Projection>("xy");
-  // When the user switches antennas, reset the camera to that example's
-  // natural starting view (declared on the backend via default_view).
-  // Explicit user override sticks until the next geometry change.
-  //
-  // A deferred (user) design reports default_view === null — its real view is
-  // auto-detected and arrives with the first geometry preview (handled where
-  // the preview lands, below). Holding the current camera until then avoids
-  // snapping to a wrong provisional view and flipping when the preview arrives.
-  useEffect(() => {
-    if (currentExample?.default_view) {
-      setCameraProjection(currentExample.default_view);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentExample?.name]);
-
   // The app never switches solvers on its own. When the current design+solver
   // combo is a poor match the solve is withheld and a warning is shown; these
   // handle its two buttons. (To change solver, the user uses the gear menu.)
@@ -635,17 +530,6 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [linkedDesignFreq, linkMeas]);
-  // Antenna-canvas current visualization is split into two independent
-  // toggles: the per-segment current-magnitude heatmap (wire color/width)
-  // and the |I| envelope curve overlay. Either or both can be turned off;
-  // the wires and feed marker are always drawn.
-  const [showHeatmap, setShowHeatmap] = useState(true);
-  const [showEnvelope, setShowEnvelope] = useState(false);
-  // Wire labels and feed names can crowd dense geometries (and PyNEC returns
-  // many more wires than the momwire engines), so let them be toggled. Wire
-  // labels default OFF — they're the noisiest, especially on PyNEC.
-  const [showWireLabels, setShowWireLabels] = useState(false);
-  const [showFeedNames, setShowFeedNames] = useState(true);
   // Layout branch. Desktop never reads isMobile except as the sizing hooks'
   // reattach key, so no desktop viewport is affected; the key makes both
   // hooks re-measure if the window is resized across the breakpoint.
@@ -667,31 +551,6 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // screen. Starts collapsed on mobile, expanded on desktop (the pre-existing
   // behavior); pinning always expands it so the new row is seen.
   const [compareCollapsed, setCompareCollapsed] = useState(isMobile);
-
-  useEffect(() => {
-    if (!active) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
-      // Don't hijack arrows while a knob (e.g. the cut-angle dials) or a real
-      // field is focused — those consume arrows to turn/edit their own value.
-      const t = e.target as HTMLElement | null;
-      if (
-        t &&
-        (t.tagName === "INPUT" ||
-          t.tagName === "TEXTAREA" ||
-          t.tagName === "SELECT" ||
-          t.isContentEditable ||
-          t.classList.contains("knob"))
-      ) {
-        return;
-      }
-      const idx = VIEWS.findIndex((v) => v.id === view);
-      const next = e.key === "ArrowDown" ? (idx + 1) % VIEWS.length : (idx - 1 + VIEWS.length) % VIEWS.length;
-      setView(VIEWS[next].id);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [view, active]);
 
   const previewAbortRef = useRef<AbortController | null>(null);
   // JSON of the request the currently-displayed preview wireframe was built

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -31,7 +31,6 @@ import {
 } from "../../lib/ground";
 import { feedwiseRichardson, richardsonExtrap } from "../../lib/math";
 import {
-  defaultKnobOpt,
   findLinkedDesignFreq,
   groupExamplesForPicker,
   isGroup,
@@ -41,7 +40,6 @@ import {
   setValueAtPath,
   snapForExample,
   type BandSpec,
-  type KnobOpt,
   type ParamValueBag,
   type SchemaItem,
   type SchemaParamSpec,
@@ -91,13 +89,9 @@ import { SolveOverlays } from "./SolveOverlays";
 import { SolverSlotTabs } from "./SolverSlotTabs";
 import { useDesignCatalog } from "./useDesignCatalog";
 import { useMobileCarousel } from "./useMobileCarousel";
+import { useOptimizer } from "./useOptimizer";
 import { useSolveChannel } from "./useSolveChannel";
-import {
-  type OptimizeResult,
-  type OptObjective,
-  type OptPause,
-  VfoPanel,
-} from "./VfoPanel";
+import { VfoPanel } from "./VfoPanel";
 
 // Log-spaced segments-per-wire ladder for the convergence sweep. Hentenna's
 // 8N+2 total segments at N=68 puts the dense LU at a ~550-cell matrix —
@@ -147,56 +141,12 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // it, otherwise whatever the example shipped first.
   const [variantByGeom, setVariantByGeom] = useState<Record<string, string>>({});
 
-  // --- Reactive knob optimiser (POST /optimize) ---
   // Live simulation: when on, knob/freq changes auto-solve (and the optimiser
   // runs). When off ("Paused"), edits update the geometry but the engine is held
   // — the user keeps changing the design, then clicks Live to resume and solve.
   // This replaces the old fire-and-forget "Cancel" on the solver-mismatch prompt,
   // which left the plots blank with no obvious way back. Defaults on.
   const [autoSim, setAutoSim] = useState(true);
-
-  // Master enable + objective live in the compact control by meas-freq; per-knob
-  // "vary" + extents + step live in each knob's right-click menu (knobOpt).
-  const [optEnabled, setOptEnabled] = useState(false);
-  const [optObjective, setOptObjective] = useState<OptObjective>("swr");
-  const [knobOpt, setKnobOpt] = useState<Record<string, Record<string, KnobOpt>>>({});
-  // Open knob context menu: which param + anchor position.
-  const [knobMenu, setKnobMenu] = useState<{ name: string; x: number; y: number } | null>(
-    null,
-  );
-  const [optRunning, setOptRunning] = useState(false);
-  const [optResult, setOptResult] = useState<OptimizeResult | null>(null);
-  const [optError, setOptError] = useState<string | null>(null);
-  // When something auto-pauses the optimizer, this holds *why* for a brief cue
-  // (cleared on re-enable / after a few seconds): grabbing a knob marked for
-  // optimization by hand ("changing X by hand"), or loading a new design/variant
-  // ("loaded a new design").
-  const [optPausedBy, setOptPausedBy] = useState<OptPause | null>(null);
-  const optAbortRef = useRef<AbortController | null>(null);
-  // Latest optEnabled mirrored into a ref so the design-load reset (effects keyed
-  // on geometry, and selectVariant) can tell whether the optimizer was actually
-  // running — to show the pause cue only then — without taking optEnabled as a
-  // dep (which would re-run the reset on every toggle).
-  const optEnabledRef = useRef(false);
-  optEnabledRef.current = optEnabled; // mirror latest for the design-load reset
-  // Per-knob settings persist per geometry (knobOpt is keyed by geometry); just
-  // close any open menu / clear the last result / abort any in-flight run when
-  // the antenna changes. The optimizer also *pauses* on a design switch — its
-  // objective and marks belong to the design you left — but this design's marks
-  // are kept (they're keyed by geometry), so returning restores them; only the
-  // running toggle is switched off. Show the cue only if it was actually on.
-  useEffect(() => {
-    optAbortRef.current?.abort();
-    setKnobMenu(null);
-    setOptResult(null);
-    setOptError(null);
-    if (optEnabledRef.current) {
-      setOptEnabled(false);
-      setOptPausedBy({ kind: "load" });
-    }
-    // optEnabledRef is read (not a dep) on purpose — see its declaration.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [geometry]);
 
   const {
     examples,
@@ -846,136 +796,40 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
     return base;
   }
 
-  // Run the optimiser once: POST the current solve request + the free knobs
-  // (from each knob's menu) and objective, then apply the returned params to the
-  // knobs (re-solving via the normal onChange path). Warm-started from the
-  // current values; a newer run aborts the previous so stale results are
-  // dropped. Always uses the momwire engine server-side.
-  async function runOptimize() {
-    const settings = knobOpt[geometry] ?? {};
-    const free = Object.entries(settings)
-      .filter(([, o]) => o.vary)
-      .map(([name, o]) => ({ name, min: o.optMin, max: o.optMax }));
-    if (free.length === 0) return;
-    optAbortRef.current?.abort();
-    const ctrl = new AbortController();
-    optAbortRef.current = ctrl;
-    setOptRunning(true);
-    setOptError(null);
-    try {
-      const resp = await fetch("/optimize", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        signal: ctrl.signal,
-        body: JSON.stringify({
-          ...buildRequest(),
-          // Reactive runs are warm-started, so a modest eval cap keeps them snappy.
-          optimize: { free, objective: optObjective, max_evals: 40 },
-        }),
-      });
-      const data = await resp.json();
-      if (ctrl.signal.aborted) return; // superseded by a newer run
-      if (data.error) {
-        setOptError(String(data.error));
-      } else {
-        setOptResult(data as OptimizeResult);
-        for (const [name, val] of Object.entries((data as OptimizeResult).params)) {
-          setParamAtPath([name], val);
-        }
-      }
-    } catch (e) {
-      if (!ctrl.signal.aborted) setOptError(String(e));
-    } finally {
-      if (optAbortRef.current === ctrl) {
-        optAbortRef.current = null;
-        setOptRunning(false);
-      }
-    }
-  }
-
-  // Reactive optimisation. When enabled with >=1 free knob, re-tune shortly
-  // after the user pauses on any *fixed* input. The trigger is a signature of
-  // everything the optimiser depends on EXCEPT the free knobs' values — the
-  // optimiser writes those, so including them would loop. Turning it on produces
-  // a fresh signature, so it also tunes immediately on enable.
-  const optFixedSig = useMemo(() => {
-    if (!optEnabled) return "";
-    const settings = knobOpt[geometry] ?? {};
-    const free = Object.entries(settings).filter(([, o]) => o.vary);
-    if (free.length === 0) return "";
-    const freeSet = new Set(free.map(([n]) => n));
-    const fixed: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(currentValues)) {
-      if (!freeSet.has(k)) fixed[k] = v;
-    }
-    return JSON.stringify({
-      geometry,
-      objective: optObjective,
-      backend,
-      designFreq,
-      measFreq,
-      bounds: free.map(([n, o]) => [n, o.optMin, o.optMax]),
-      fixed,
-    });
-    // currentValuesKey stands in for currentValues' contents in the deps.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
+  // Reactive knob optimiser (#642 seam 5b-3). Called here, at the fixed-input
+  // signature's old position, so the cluster's three trailing effects keep
+  // their global order; the design-load reset rides along with them.
+  const {
     optEnabled,
-    knobOpt,
-    geometry,
+    setOptEnabled,
     optObjective,
+    setOptObjective,
+    knobOpt,
+    setKnobOpt,
+    knobMenu,
+    setKnobMenu,
+    optRunning,
+    optResult,
+    optError,
+    optPausedBy,
+    setOptPausedBy,
+    optAbortRef,
+    optEnabledRef,
+    knobOptFor,
+    updateKnobOpt,
+  } = useOptimizer({
+    geometry,
+    currentValues,
+    currentValuesKey,
+    currentSchema,
     backend,
     designFreq,
     measFreq,
-    currentValuesKey,
-  ]);
-
-  useEffect(() => {
-    // Paused (Live off) holds the optimiser too — it drives engine solves, so it
-    // must respect the same gate as the main solve. Resuming re-runs this effect
-    // (autoSim is a dep) and re-tunes.
-    if (!optFixedSig || !autoSim || !active) return;
-    const t = setTimeout(() => {
-      runOptimize();
-    }, 400);
-    return () => clearTimeout(t);
-    // runOptimize captured here reflects the state at this signature; re-running
-    // only when the signature changes is intentional.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [optFixedSig, autoSim, active]);
-
-  // The "paused — changing X by hand" cue is a brief flash: clear it a few
-  // seconds after it appears so it doesn't linger while Optimize stays off.
-  useEffect(() => {
-    if (!optPausedBy) return;
-    const t = setTimeout(() => setOptPausedBy(null), 5000);
-    return () => clearTimeout(t);
-  }, [optPausedBy]);
-
-  // The effective per-knob optimiser settings: the stored entry, or seeded from
-  // the schema (extents = slider bounds, step = schema step, not varying).
-  function knobOptFor(name: string): KnobOpt {
-    const existing = knobOpt[geometry]?.[name];
-    if (existing) return existing;
-    return defaultKnobOpt(currentSchema, name);
-  }
-  function updateKnobOpt(name: string, patch: Partial<KnobOpt>) {
-    const base = knobOptFor(name);
-    setKnobOpt((prev) => ({
-      ...prev,
-      [geometry]: { ...(prev[geometry] ?? {}), [name]: { ...base, ...patch } },
-    }));
-  }
-
-  // Close the knob menu on Escape.
-  useEffect(() => {
-    if (!knobMenu || !active) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setKnobMenu(null);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [knobMenu, active]);
+    autoSim,
+    active,
+    buildRequest,
+    setParamAtPath,
+  });
 
   const currentBands: BandSpec[] = currentExample?.bands ?? [];
 

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -63,13 +63,6 @@ import type {
 } from "../../lib/api";
 import { BackendConfigModal } from "../backend/BackendConfigModal";
 import { ParamForm } from "../params/ParamForm";
-import {
-  cutsWsSend,
-  flushCutsWsPending,
-  resolveCutsWsMessage,
-  setCutsWsSend,
-  type CutsWsMessage,
-} from "../charts/cuts";
 import type { PatternData, PatternMetrics } from "../charts/types";
 import {
   ThemeContext,
@@ -98,6 +91,7 @@ import { SolveOverlays } from "./SolveOverlays";
 import { SolverSlotTabs } from "./SolverSlotTabs";
 import { useDesignCatalog } from "./useDesignCatalog";
 import { useMobileCarousel } from "./useMobileCarousel";
+import { useSolveChannel } from "./useSolveChannel";
 import {
   type OptimizeResult,
   type OptObjective,
@@ -111,11 +105,6 @@ import {
 // O(1/N) trajectories clearly. Same ladder across backends so the curves
 // are directly comparable when the user switches slots.
 const CONVERGE_N_VALUES: number[] = [8, 12, 17, 24, 34, 48, 68];
-
-// Match the page's scheme: a wss:// upgrade is required on HTTPS pages (e.g. the
-// deployed site behind Fly's force_https), where browsers block insecure ws://
-// as mixed content. Plain ws:// only works on http:// (local dev).
-const WS_URL = `${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.host}/ws`;
 
 // One antenna design session: the entire left sidebar + right stage plus all
 // the state, effects, and the WebSocket that drive them. The shell (`App`,
@@ -611,15 +600,6 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
     preview?.multi_feed ??
     currentExample?.multi_feed ??
     false;
-  const [status, setStatus] = useState<"connecting" | "open" | "closed">("connecting");
-  const [rttMs, setRttMs] = useState<number | null>(null);
-  // True whenever a main solve is outstanding (in flight or queued) — i.e. the
-  // displayed analysis isn't current yet. `showBusy` is the *debounced* view of
-  // it: the progress bar / panel dimming only appear once a solve outlasts
-  // ~300 ms, so fast updates (cache hits, small designs) snap in cleanly
-  // without a flash of busy chrome.
-  const [solving, setSolving] = useState(false);
-  const [showBusy, setShowBusy] = useState(false);
   const [sweep, setSweep] = useState<SweepData | null>(null);
   const [sweepRunning, setSweepRunning] = useState(false);
   // Smith-chart overlay toggles. Both are debounced sweeps that re-fire
@@ -699,17 +679,6 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
     setComboApproved(true);
     setSolverWarning(false);
     setAutoSim(false);
-  }
-  // Cancel an IN-FLIGHT solve: stop waiting and discard its result. The server
-  // keeps computing (its /ws loop is sequential and a running MoM solve can't be
-  // interrupted), so this cancels the wait, not the computation.
-  function cancelSolve() {
-    if (lastSentSeqRef.current <= lastReceivedSeqRef.current) return; // nothing in flight
-    // Mark every seq sent so far as cancelled: onmessage will advance the
-    // received watermark for these but drop their results. A newer knob change
-    // bumps lastSentSeq past this and solves again.
-    canceledThroughSeqRef.current = lastSentSeqRef.current;
-    syncSolving();
   }
 
   // Schema-driven design-freq link: when the active example has any
@@ -805,23 +774,12 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // this signature actually changed, so it skips the redundant refetch right
   // after an antenna switch (whose preview the switch effect already built).
   const previewSigRef = useRef<string | null>(null);
-  // Timestamp (performance.now) when the busy chrome last became visible, so
-  // the reveal effect can enforce a minimum-visible window. null = not shown.
-  const shownAtRef = useRef<number | null>(null);
   // Latest selected antenna, mirrored into a ref so the (mount-once) WebSocket
   // onmessage handler can drop responses for an antenna the user already
   // switched away from. Updated every render — cheap and always current.
   const geometryRef = useRef(geometry);
   geometryRef.current = geometry;
 
-  const wsRef = useRef<WebSocket | null>(null);
-  // Latest-wins /ws protocol counters. Every knob change is sent eagerly with a
-  // monotonic `_seq`; the server keeps only the freshest queued request and may
-  // skip-send superseded results, so the client orders and prunes by `_seq`. A
-  // solve is outstanding iff more has been sent than received. These live in
-  // refs so they survive StrictMode/HMR socket teardown — the counter must
-  // never rewind below what's already been received.
-  const seqRef = useRef(0); // last _seq assigned (monotonic, never reset)
   // Solve-lane session id (issue #382): one per workbench tab (A/B compare
   // tabs are separate App instances, hence separate sessions). The server
   // keys its single-lane scheduler on this — everything this tab asks for
@@ -831,11 +789,6 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
       ? crypto.randomUUID()
       : `s-${Math.random().toString(36).slice(2)}`,
   );
-  const lastSentSeqRef = useRef(0); // highest _seq put on the wire
-  const lastReceivedSeqRef = useRef(0); // highest _seq received or implicitly acked
-  const canceledThroughSeqRef = useRef(0); // drop rendering for _seq <= this
-  const sentAtRef = useRef<Map<number, number>>(new Map()); // _seq → send time (RTT)
-  const solveRafRef = useRef<number | null>(null); // trailing-edge rAF throttle handle
 
   function buildRequest(): SolveRequest {
     // ground_model is shared across backends (εr=10, σ=0.002 for the finite
@@ -1119,6 +1072,28 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // The latest control values, used to send a new request when the prior one
   // completes (drops intermediate values rather than queuing them all up).
   const controlsRef = useRef<SolveRequest>(buildRequest());
+
+  // The /ws solve channel (#642 seam 5b-3): the socket, the latest-wins `_seq`
+  // protocol and the busy-chrome dwell. Called right after controlsRef — the
+  // channel reads that ref on every send, and the solve effect below reaches
+  // for requestSolve.
+  const {
+    status,
+    rttMs,
+    solving,
+    showBusy,
+    stale,
+    requestSolve,
+    cancelSolve,
+    seqRef,
+  } = useSolveChannel({
+    active,
+    controlsRef,
+    geometryRef,
+    previewSigRef,
+    setResult,
+    setSolveError,
+  });
 
   // --- Pattern compare (pin / ghost overlay) --------------------------------
   // Pin the current pattern: snapshot the solve response (for the ghost trace)
@@ -1785,202 +1760,6 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
       if (patternAbortRef.current === controller) patternAbortRef.current = null;
     }
   }
-
-  // Mirror the seq counters into `solving` state so the UI can react. Called
-  // wherever the sent / received / cancel watermarks move. A solve reads as
-  // running when more has been sent than received — unless everything
-  // outstanding was cancelled (lastSentSeq hasn't advanced past the cancel
-  // watermark), in which case the wait is over even though a doomed response
-  // is still coming.
-  function syncSolving() {
-    setSolving(
-      lastSentSeqRef.current > lastReceivedSeqRef.current &&
-        lastSentSeqRef.current > canceledThroughSeqRef.current,
-    );
-  }
-
-  // Busy-chrome reveal with two guards:
-  //  - dwell: only show once a solve has been outstanding >BUSY_DWELL_MS. 1 s
-  //    is the classic "flow of thought" threshold — below it users tolerate the
-  //    wait without feedback; at/above it the bar reassures them it's working.
-  //    A solve that finishes sooner clears the timer in cleanup, so the bar
-  //    never flips on for quick updates.
-  //  - min-visible: once shown, keep it up at least BUSY_MIN_VISIBLE_MS so a
-  //    solve that lands just past the dwell can't make it sub-perceptibly
-  //    flash.
-  const BUSY_DWELL_MS = 1000;
-  const BUSY_MIN_VISIBLE_MS = 400;
-  useEffect(() => {
-    if (solving) {
-      const t = window.setTimeout(() => {
-        shownAtRef.current = performance.now();
-        setShowBusy(true);
-      }, BUSY_DWELL_MS);
-      return () => window.clearTimeout(t);
-    }
-    // Solve finished. If the bar never showed (fast solve), hide immediately;
-    // otherwise hold it for the remainder of the minimum-visible window.
-    if (shownAtRef.current === null) {
-      setShowBusy(false);
-      return;
-    }
-    const remaining =
-      BUSY_MIN_VISIBLE_MS - (performance.now() - shownAtRef.current);
-    if (remaining <= 0) {
-      shownAtRef.current = null;
-      setShowBusy(false);
-      return;
-    }
-    const t = window.setTimeout(() => {
-      shownAtRef.current = null;
-      setShowBusy(false);
-    }, remaining);
-    return () => window.clearTimeout(t);
-  }, [solving]);
-
-  // The progress bar (`showBusy`) honors the min-visible window so it can't
-  // flash, but the *dimming* and the "solving…" label mean "what you're
-  // looking at is stale" — so they must clear the instant the result lands,
-  // even while the bar lingers out its minimum. `solving` flips false
-  // immediately on result-land, so `showBusy && solving` is exactly that: dim
-  // only after the dwell (showBusy) AND while genuinely still solving.
-  const stale = showBusy && solving;
-
-  function requestSolve() {
-    const ws = wsRef.current;
-    if (!ws || ws.readyState !== WebSocket.OPEN) {
-      // Can't send now. onopen resends controlsRef.current on (re)connect, so
-      // the latest state is solved as soon as the socket comes up.
-      return;
-    }
-    // Trailing-edge rAF throttle: coalesce a burst of knob changes within one
-    // animation frame to a single send of the latest controls. Bounds upload to
-    // ≤~60 msg/s during a drag and keeps localhost message churn near what the
-    // old one-in-flight gate produced; the server's latest-wins mailbox squashes
-    // whatever still piles up. The freshest value always wins within the frame.
-    if (solveRafRef.current !== null) return;
-    solveRafRef.current = requestAnimationFrame(() => {
-      solveRafRef.current = null;
-      const sock = wsRef.current;
-      if (!sock || sock.readyState !== WebSocket.OPEN) return;
-      const seq = ++seqRef.current;
-      lastSentSeqRef.current = seq;
-      sentAtRef.current.set(seq, performance.now());
-      sock.send(JSON.stringify({ ...controlsRef.current, _seq: seq }));
-      // Keep the preview signature current so that toggling Live *off* right
-      // after a solve doesn't see a stale signature and needlessly refetch the
-      // wireframe / drop the just-solved result — the solved geometry already
-      // matches these controls.
-      previewSigRef.current = JSON.stringify(controlsRef.current);
-      syncSolving();
-    });
-  }
-
-  useEffect(() => {
-    if (!active) return;
-    const ws = new WebSocket(WS_URL);
-    wsRef.current = ws;
-    // This socket's cuts sender (issue #551). A stable identity per socket
-    // so the close/cleanup handlers only deregister their OWN sender — a
-    // stale socket's late onclose must not tear down the transport a newer
-    // socket just registered.
-    const cutsSender = (msg: string): boolean => {
-      if (ws.readyState !== WebSocket.OPEN) return false;
-      ws.send(msg);
-      return true;
-    };
-    const dropCutsSender = () => {
-      if (cutsWsSend === cutsSender) setCutsWsSend(null);
-      flushCutsWsPending();
-    };
-    ws.onopen = () => {
-      setStatus("open");
-      setCutsWsSend(cutsSender);
-      // A prior socket's in-flight responses can never arrive on this new one.
-      // Treat everything sent so far as received so `solving` can't stick true,
-      // drop stale RTT timers, then send fresh current state. StrictMode and HMR
-      // both tear the socket down + recreate it; the seq counters survive in
-      // refs, so they must never rewind below what's already been received.
-      lastReceivedSeqRef.current = lastSentSeqRef.current;
-      sentAtRef.current.clear();
-      requestSolve();
-    };
-    ws.onclose = () => {
-      setStatus("closed");
-      dropCutsSender();
-      // No solve can progress while disconnected — collapse the outstanding
-      // count so the busy bar can't spin under a "closed" status (reconnect
-      // re-arms it via onopen).
-      lastReceivedSeqRef.current = lastSentSeqRef.current;
-      setSolving(false);
-    };
-    ws.onerror = () => {
-      setStatus("closed");
-      dropCutsSender();
-      lastReceivedSeqRef.current = lastSentSeqRef.current;
-      setSolving(false);
-    };
-    ws.onmessage = (ev) => {
-      const data: SolveResponse & Partial<CutsWsMessage> = JSON.parse(ev.data);
-      if (data._kind === "cuts") {
-        // Cuts sidecar response (issue #551) — never a solve; route it
-        // before any _seq/solving bookkeeping.
-        resolveCutsWsMessage(data as CutsWsMessage);
-        return;
-      }
-      const seq = data._seq ?? 0;
-      // One socket delivers in order, and the server may skip-send superseded
-      // results — so a higher `_seq` implicitly acknowledges every lower one.
-      // Ignore a straggler/duplicate at or below the received watermark.
-      if (seq <= lastReceivedSeqRef.current) {
-        syncSolving();
-        return;
-      }
-      lastReceivedSeqRef.current = seq;
-      // RTT from this seq's send; prune every acked entry (≤ seq) from the map —
-      // seqs skipped server-side never get their own response, so a single
-      // higher-seq arrival clears the whole run of them.
-      const sentAt = sentAtRef.current;
-      const t0 = sentAt.get(seq);
-      if (t0 !== undefined) setRttMs(performance.now() - t0);
-      for (const k of sentAt.keys()) {
-        if (k <= seq) sentAt.delete(k);
-      }
-      // Cancelled through this seq: the user bailed on it (and everything
-      // before). The watermark advanced above so `solving` can clear; just drop
-      // the result rather than rendering it.
-      if (seq <= canceledThroughSeqRef.current) {
-        syncSolving();
-        return;
-      }
-      // Drop a response for an antenna the user already switched away from: a
-      // slow in-flight solve for the previous selection must not stomp the new
-      // antenna's geometry preview (and briefly show the wrong antenna).
-      const staleGeom = !!data.geometry && data.geometry !== geometryRef.current;
-      if (!staleGeom) {
-        if (data.error) {
-          // A solve that raised (e.g. a user design's build_wires) — show the
-          // message and clear stale plot data rather than rendering an empty
-          // result on top of the last antenna.
-          setSolveError(data.error);
-          setResult(null);
-        } else {
-          setSolveError(null);
-          setResult(data);
-        }
-      }
-      syncSolving();
-    };
-    return () => {
-      if (solveRafRef.current !== null) {
-        cancelAnimationFrame(solveRafRef.current);
-        solveRafRef.current = null;
-      }
-      dropCutsSender(); // ws.close() fires onclose async; don't leave a dead sender up
-      ws.close();
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [active]);
 
   // Hoisted JSX shared between the desktop tree below and the mobile tree
   // (Phase B). These close over the session's locals, so they are consts /

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import {
   backendAllowed,
   backendDisplayLabel,
@@ -28,7 +28,6 @@ import {
   type GroundModel,
   type GroundType,
   type TerrainParams,
-  type TerrainPresetSchema,
 } from "../../lib/ground";
 import { feedwiseRichardson, richardsonExtrap } from "../../lib/math";
 import {
@@ -42,7 +41,6 @@ import {
   setValueAtPath,
   snapForExample,
   type BandSpec,
-  type ExampleDescriptor,
   type KnobOpt,
   type ParamValueBag,
   type SchemaItem,
@@ -64,7 +62,6 @@ import type {
   SweepData,
 } from "../../lib/api";
 import { BackendConfigModal } from "../backend/BackendConfigModal";
-import { type DesignLoadError } from "../AwaitingTrustPanel";
 import { ParamForm } from "../params/ParamForm";
 import {
   cutsWsSend,
@@ -99,6 +96,7 @@ import { copyParams, downloadNec, loadMeasured } from "./sessionActions";
 import { SessionGearMenu } from "./SessionGearMenu";
 import { SolveOverlays } from "./SolveOverlays";
 import { SolverSlotTabs } from "./SolverSlotTabs";
+import { useDesignCatalog } from "./useDesignCatalog";
 import { useMobileCarousel } from "./useMobileCarousel";
 import {
   type OptimizeResult,
@@ -146,34 +144,13 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // nearest settings surface to reach it from.
   const fullscreen = useFullscreen();
 
-  // Schema-driven parameter controls. Each registered example bundles
-  // its parameter schema in web/examples/<name>.py; the backend serves
-  // them on GET /examples and we render generic sliders from the result.
-  //
+  // Free-text filter for the antenna selector — matches name / label /
+  // family / keywords so users can find a design without knowing its family.
+  const [geomFilter, setGeomFilter] = useState<string>("");
   // Multi-band antennas (fan_dipole) get a nested shape for groups —
   // `paramValues[name].bands` is an array of per-instance bags,
   // pre-allocated to ParamGroupSpec.max_repeats so dialing the
   // repeat-count down and back up preserves the values.
-  const [examples, setExamples] = useState<ExampleDescriptor[]>([]);
-  const [examplesError, setExamplesError] = useState<string | null>(null);
-  // Whether the server has the optional pynec-accel package (#429). Reported
-  // by /examples on mount; gates the PyNEC backend option. Defaults true so
-  // the common (installed) case never flashes the option off before the fetch
-  // resolves; a false reply then hides it and remaps any PyNEC slot.
-  const [havePynec, setHavePynec] = useState<boolean>(true);
-  // Terrain preset catalog (issue #560), reported by /capabilities on mount.
-  // Empty until it resolves (and on any older server without the field), which
-  // gates the terrain ground option off — the panel is rendered entirely from
-  // this schema, so there is nothing to show without it.
-  const [terrainPresets, setTerrainPresets] = useState<TerrainPresetSchema[]>(
-    [],
-  );
-  // User designs that failed to load (bad Python, no Builder, geometry error).
-  // Surfaced from /examples so the author / Claude can see and fix them.
-  const [loadErrors, setLoadErrors] = useState<DesignLoadError[]>([]);
-  // Free-text filter for the antenna selector — matches name / label /
-  // family / keywords so users can find a design without knowing its family.
-  const [geomFilter, setGeomFilter] = useState<string>("");
   const [paramValues, setParamValues] = useState<Record<string, ParamValueBag>>({});
   // Per-geometry variant selection (which `<name>_params` dict on the
   // Builder to seed from). Falls back to the example's variants[0]
@@ -232,97 +209,15 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [geometry]);
 
-  // Load (or reload) the design catalog. Extracted so a trust action can
-  // re-fetch it — trusting a design registers it server-side, and re-fetching
-  // moves it out of the "awaiting trust" list into the selector.
-  const loadExamples = useCallback(async () => {
-    try {
-      const j = await (await fetch("/examples")).json();
-      const list: ExampleDescriptor[] = j.examples ?? [];
-      setExamples(list);
-      setExamplesError(null);
-      setLoadErrors(Array.isArray(j.errors) ? j.errors : []);
-      // Walk each example's schema and pre-seed defaults — including
-      // pre-allocated group instance arrays — so the sliders have
-      // something to render against on first show.
-      setParamValues((prev) => {
-        const next = { ...prev };
-        for (const ex of list) {
-          if (next[ex.name]) continue;
-          next[ex.name] = seedDefaults(ex.param_schema);
-        }
-        return next;
-      });
-    } catch (e: unknown) {
-      setExamplesError(String((e as Error)?.message ?? e));
-    }
-  }, []);
-
-  useEffect(() => {
-    loadExamples();
-  }, [loadExamples]);
-
-  // Backend capabilities (#429), fetched once on mount — server-static, so
-  // unlike the design catalog it is not re-fetched on trust actions. A failed
-  // fetch or an older server without the route leaves havePynec at its `true`
-  // default (prior behavior). Gates the PyNEC backend option.
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const c = await (await fetch("/capabilities")).json();
-        if (!cancelled) {
-          setHavePynec(c.have_pynec !== false);
-          setTerrainPresets(
-            Array.isArray(c.terrain_presets) ? c.terrain_presets : [],
-          );
-        }
-      } catch {
-        /* keep the default; PyNEC stays offered */
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  // Trust a user design from the UI (local-only; the backend refuses when
-  // hosted). `stem` is the design name (e.g. "user.my_dipole"); `allowEdits`
-  // trusts future edits too (path-level, for a design you author).
-  const [trustBusy, setTrustBusy] = useState<string | null>(null);
-  const trustDesign = useCallback(
-    async (stem: string, allowEdits: boolean) => {
-      setTrustBusy(stem);
-      try {
-        const r = await fetch("/trust", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ stem, allow_edits: allowEdits }),
-        });
-        if (!r.ok) {
-          const j = await r.json().catch(() => ({}));
-          setExamplesError(`Trust failed: ${j.detail ?? r.status}`);
-          return;
-        }
-        await loadExamples();
-      } finally {
-        setTrustBusy(null);
-      }
-    },
-    [loadExamples],
-  );
-
-  // Auto-select a sensible default once /examples resolves, and recover if
-  // the current selection disappears (e.g. backend dropped an example).
-  // dipoles.invvee is the canonical simple antenna (also the CLI default);
-  // fall back to the first example if it isn't registered.
-  useEffect(() => {
-    if (examples.length === 0) return;
-    if (!examples.some((e) => e.name === geometry)) {
-      const preferred = examples.find((e) => e.name === "dipoles.invvee");
-      setGeometry((preferred ?? examples[0]).name);
-    }
-  }, [examples, geometry]);
+  const {
+    examples,
+    examplesError,
+    havePynec,
+    terrainPresets,
+    loadErrors,
+    trustBusy,
+    trustDesign,
+  } = useDesignCatalog({ geometry, setGeometry, setParamValues });
 
   const currentExample = examples.find((e) => e.name === geometry);
   const currentValues = paramValues[geometry] ?? {};

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -95,6 +95,7 @@ import { CatalogPanel } from "./CatalogPanel";
 import { DesignFreqRow } from "./DesignFreqRow";
 import { GroundPanel } from "./GroundPanel";
 import { KnobOptMenu } from "./KnobOptMenu";
+import { copyParams, downloadNec, loadMeasured } from "./sessionActions";
 import { SessionGearMenu } from "./SessionGearMenu";
 import { SolveOverlays } from "./SolveOverlays";
 import { SolverSlotTabs } from "./SolverSlotTabs";
@@ -1182,108 +1183,6 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
     return () => window.removeEventListener("keydown", onKey);
   }, [knobMenu, active]);
 
-  // Export the current design as a NEC2 .nec card deck and trigger a
-  // browser download. The backend reuses the same builder construction as
-  // the live solve, so the deck matches what's on screen. Designs with no
-  // faithful native-NEC form (TL/DiffTL networks) come back 422; surface
-  // the server's message rather than downloading an error page.
-  async function downloadNec() {
-    setGearMenuOpen(false);
-    try {
-      const resp = await fetch("/export_nec", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(buildRequest()),
-      });
-      if (!resp.ok) {
-        let detail = `NEC export failed (${resp.status}).`;
-        try {
-          detail = (await resp.json()).detail ?? detail;
-        } catch {
-          /* non-JSON error body — keep the status-based message */
-        }
-        window.alert(detail);
-        return;
-      }
-      const blob = await resp.blob();
-      const cd = resp.headers.get("Content-Disposition") ?? "";
-      const m = cd.match(/filename="([^"]+)"/);
-      const filename = m ? m[1] : `${geometry.replace(/\./g, "_") || "antenna"}.nec`;
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(url);
-    } catch (e) {
-      window.alert(`NEC export failed: ${e}`);
-    }
-  }
-
-  // Load a measured VNA sweep (.s1p) for the measured-vs-modeled overlay.
-  // The file is read in the browser and posted as text: the server owns the
-  // Touchstone parsing (one reader, shared with the CLI), and because the
-  // *file* stays local, this works the same whether the backend is on this
-  // machine or across a tunnel.
-  async function loadMeasured(file: File) {
-    setGearMenuOpen(false);
-    try {
-      const text = await file.text();
-      const resp = await fetch("/measured", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: file.name, text }),
-      });
-      if (!resp.ok) {
-        let detail = `Could not read ${file.name} (${resp.status}).`;
-        try {
-          detail = (await resp.json()).detail ?? detail;
-        } catch {
-          /* non-JSON error body — keep the status-based message */
-        }
-        window.alert(detail);
-        return;
-      }
-      setMeasured(await resp.json());
-    } catch (e) {
-      window.alert(`Could not read ${file.name}: ${e}`);
-    }
-  }
-
-  // Copy the current knob values as a paste-ready Python `default_params`
-  // (or `<variant>_params`) block. Replaces the old workflow of hand-copying
-  // the values printed on screen back into a design file. The backend reuses
-  // the same variant + live-knob overlay as the solve, so what you copy is
-  // exactly the antenna on screen.
-  async function copyParams() {
-    try {
-      const resp = await fetch("/params_source", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(buildRequest()),
-      });
-      const data = await resp.json();
-      if (!resp.ok || data.available === false || data.error) {
-        window.alert(data.error ?? "Copy params is unavailable for this design.");
-        return;
-      }
-      const src: string = data.source;
-      try {
-        await navigator.clipboard.writeText(src);
-        setCopiedParams(true);
-        window.setTimeout(() => setCopiedParams(false), 1500);
-      } catch {
-        // Clipboard API blocked (e.g. insecure context) — fall back to a
-        // prompt the user can copy from by hand.
-        window.prompt("Copy these params:", src);
-      }
-    } catch (e) {
-      window.alert(`Copy params failed: ${e}`);
-    }
-  }
-
   const currentBands: BandSpec[] = currentExample?.bands ?? [];
 
   // Anchor for the measurement-freq VFO window: the snap-freq of the *selected*
@@ -2253,8 +2152,10 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
           gearMenuOpen={gearMenuOpen}
           setGearMenuOpen={setGearMenuOpen}
           copiedParams={copiedParams}
-          onCopyParams={copyParams}
-          onDownloadNec={downloadNec}
+          onCopyParams={() => copyParams({ buildRequest, setCopiedParams })}
+          onDownloadNec={() =>
+            downloadNec({ setGearMenuOpen, buildRequest, geometry })
+          }
           isMobile={isMobile}
           fullscreen={fullscreen}
           showHeatmap={showHeatmap}
@@ -2271,7 +2172,9 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
           setConvergeEnabled={setConvergeEnabled}
           convergeNValues={CONVERGE_N_VALUES}
           measured={measured}
-          onLoadMeasured={loadMeasured}
+          onLoadMeasured={(f) =>
+            loadMeasured(f, { setGearMenuOpen, setMeasured })
+          }
           onClearMeasured={() => setMeasured(null)}
           normCheckEnabled={normCheckEnabled}
           setNormCheckEnabled={setNormCheckEnabled}
@@ -2478,7 +2381,9 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
               setConvergeEnabled={setConvergeEnabled}
               convergeNValues={CONVERGE_N_VALUES}
               measured={measured}
-              onLoadMeasured={loadMeasured}
+              onLoadMeasured={(f) =>
+                loadMeasured(f, { setGearMenuOpen, setMeasured })
+              }
               onClearMeasured={() => setMeasured(null)}
             />
           )}

--- a/src/antennaknobs/web/frontend/src/components/session/sessionActions.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/sessionActions.ts
@@ -1,0 +1,132 @@
+import type { MeasuredData, SolveRequest } from "../../lib/api";
+
+// Imperative one-shot session actions lifted out of DesignSession (#642 seam
+// 5b-3). Deliberately plain async functions, not hooks: each one runs entirely
+// on a user gesture and touches no React state of its own, so it takes the
+// handful of setters / builders it needs as arguments and the component keeps
+// owning them.
+
+// Export the current design as a NEC2 .nec card deck and trigger a
+// browser download. The backend reuses the same builder construction as
+// the live solve, so the deck matches what's on screen. Designs with no
+// faithful native-NEC form (TL/DiffTL networks) come back 422; surface
+// the server's message rather than downloading an error page.
+export async function downloadNec({
+  setGearMenuOpen,
+  buildRequest,
+  geometry,
+}: {
+  setGearMenuOpen: (open: boolean) => void;
+  buildRequest: () => SolveRequest;
+  geometry: string;
+}) {
+  setGearMenuOpen(false);
+  try {
+    const resp = await fetch("/export_nec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(buildRequest()),
+    });
+    if (!resp.ok) {
+      let detail = `NEC export failed (${resp.status}).`;
+      try {
+        detail = (await resp.json()).detail ?? detail;
+      } catch {
+        /* non-JSON error body — keep the status-based message */
+      }
+      window.alert(detail);
+      return;
+    }
+    const blob = await resp.blob();
+    const cd = resp.headers.get("Content-Disposition") ?? "";
+    const m = cd.match(/filename="([^"]+)"/);
+    const filename = m ? m[1] : `${geometry.replace(/\./g, "_") || "antenna"}.nec`;
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  } catch (e) {
+    window.alert(`NEC export failed: ${e}`);
+  }
+}
+
+// Load a measured VNA sweep (.s1p) for the measured-vs-modeled overlay.
+// The file is read in the browser and posted as text: the server owns the
+// Touchstone parsing (one reader, shared with the CLI), and because the
+// *file* stays local, this works the same whether the backend is on this
+// machine or across a tunnel.
+export async function loadMeasured(
+  file: File,
+  {
+    setGearMenuOpen,
+    setMeasured,
+  }: {
+    setGearMenuOpen: (open: boolean) => void;
+    setMeasured: (data: MeasuredData) => void;
+  },
+) {
+  setGearMenuOpen(false);
+  try {
+    const text = await file.text();
+    const resp = await fetch("/measured", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: file.name, text }),
+    });
+    if (!resp.ok) {
+      let detail = `Could not read ${file.name} (${resp.status}).`;
+      try {
+        detail = (await resp.json()).detail ?? detail;
+      } catch {
+        /* non-JSON error body — keep the status-based message */
+      }
+      window.alert(detail);
+      return;
+    }
+    setMeasured(await resp.json());
+  } catch (e) {
+    window.alert(`Could not read ${file.name}: ${e}`);
+  }
+}
+
+// Copy the current knob values as a paste-ready Python `default_params`
+// (or `<variant>_params`) block. Replaces the old workflow of hand-copying
+// the values printed on screen back into a design file. The backend reuses
+// the same variant + live-knob overlay as the solve, so what you copy is
+// exactly the antenna on screen.
+export async function copyParams({
+  buildRequest,
+  setCopiedParams,
+}: {
+  buildRequest: () => SolveRequest;
+  setCopiedParams: (copied: boolean) => void;
+}) {
+  try {
+    const resp = await fetch("/params_source", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(buildRequest()),
+    });
+    const data = await resp.json();
+    if (!resp.ok || data.available === false || data.error) {
+      window.alert(data.error ?? "Copy params is unavailable for this design.");
+      return;
+    }
+    const src: string = data.source;
+    try {
+      await navigator.clipboard.writeText(src);
+      setCopiedParams(true);
+      window.setTimeout(() => setCopiedParams(false), 1500);
+    } catch {
+      // Clipboard API blocked (e.g. insecure context) — fall back to a
+      // prompt the user can copy from by hand.
+      window.prompt("Copy these params:", src);
+    }
+  } catch (e) {
+    window.alert(`Copy params failed: ${e}`);
+  }
+}

--- a/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
@@ -1,0 +1,575 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type MutableRefObject,
+} from "react";
+import type {
+  ConvergeData,
+  NormCheckData,
+  SolveRequest,
+  SweepData,
+} from "../../lib/api";
+import { type Backend } from "../../lib/backends";
+import { type GroundModel } from "../../lib/ground";
+import { feedwiseRichardson, richardsonExtrap } from "../../lib/math";
+import { type BandSpec, type ExampleDescriptor } from "../../lib/params";
+import { planSweepFreqs } from "../../lib/sweep";
+import type { PatternData } from "../charts/types";
+
+// Log-spaced segments-per-wire ladder for the convergence sweep. Hentenna's
+// 8N+2 total segments at N=68 puts the dense LU at a ~550-cell matrix —
+// still snappy at this N range on all backends, but enough span to see
+// O(1/N) trajectories clearly. Same ladder across backends so the curves
+// are directly comparable when the user switches slots.
+export const CONVERGE_N_VALUES: number[] = [8, 12, 17, 24, 34, 48, 68];
+
+// The four background analyses that shadow the live solve — the freq sweep,
+// the segments-per-wire convergence sweep, the far-field norm check and the
+// NEC rp_card pattern — with their debounce effects, timer/abort refs and
+// streaming runners (#642 seam 5b-3). The cluster moves whole, so the four
+// literal dep arrays and the runners' fresh-per-render closures are unchanged.
+//
+// Every dep-array member arrives as a plain per-render value, and buildRequest
+// / solveWithheld as plain per-render functions: memoizing either would change
+// which closure a pending debounce timeout fires.
+export function useAnalysisRunners({
+  geometry,
+  backend,
+  backendOptsKey,
+  currentValuesKey,
+  currentVariant,
+  currentExample,
+  currentBands,
+  freqWindowCeiling,
+  designFreq,
+  measFreq,
+  measLocked,
+  groundEnabled,
+  groundModel,
+  terrainKey,
+  sweepEnabled,
+  convergeEnabled,
+  normCheckEnabled,
+  necOverlayEnabled,
+  autoSim,
+  active,
+  comboApproved,
+  recommendedBackend,
+  buildRequest,
+  solveWithheld,
+  seqRef,
+  approvedComboRef,
+}: {
+  geometry: string;
+  backend: Backend;
+  backendOptsKey: string;
+  currentValuesKey: string;
+  currentVariant: string;
+  currentExample: ExampleDescriptor | undefined;
+  currentBands: BandSpec[];
+  freqWindowCeiling: number;
+  designFreq: number;
+  measFreq: number;
+  measLocked: boolean;
+  groundEnabled: boolean;
+  groundModel: GroundModel;
+  terrainKey: string;
+  sweepEnabled: boolean;
+  convergeEnabled: boolean;
+  normCheckEnabled: boolean;
+  necOverlayEnabled: boolean;
+  autoSim: boolean;
+  active: boolean;
+  comboApproved: boolean;
+  recommendedBackend: Backend | null;
+  buildRequest: () => SolveRequest;
+  solveWithheld: () => boolean;
+  seqRef: MutableRefObject<number>;
+  approvedComboRef: MutableRefObject<boolean>;
+}) {
+  const [sweep, setSweep] = useState<SweepData | null>(null);
+  const [sweepRunning, setSweepRunning] = useState(false);
+  const [converge, setConverge] = useState<ConvergeData | null>(null);
+  const [convergeRunning, setConvergeRunning] = useState(false);
+  const [normCheck, setNormCheck] = useState<NormCheckData | null>(null);
+  // NEC's rp_card pattern, fetched on a debounce so we don't fire one per
+  // slider tick. Overlaid on the cuts as a comparison line.
+  const [pattern, setPattern] = useState<PatternData | null>(null);
+
+  const sweepTimerRef = useRef<number | null>(null);
+  const sweepAbortRef = useRef<AbortController | null>(null);
+  const patternTimerRef = useRef<number | null>(null);
+  const patternAbortRef = useRef<AbortController | null>(null);
+  const convergeTimerRef = useRef<number | null>(null);
+  const convergeAbortRef = useRef<AbortController | null>(null);
+  const normCheckTimerRef = useRef<number | null>(null);
+  const normCheckAbortRef = useRef<AbortController | null>(null);
+
+  // Debounced sweep across measurement freq. Re-runs whenever any antenna
+  // parameter changes. Single-band geometries sweep around designFreq, so
+  // moving the measFreq slider doesn't re-sweep (the existing data already
+  // covers the new slider position). Fan dipole sweeps around measFreq,
+  // so measFreq is part of the deps there to re-anchor.
+  useEffect(() => {
+    // Cancel any in-flight sweep fetch immediately. Without this the
+    // previous sweep keeps streaming for hundreds of ms (PyNEC ground at
+    // 100 ms/point × 41 points = ~4 s) and starves the live /ws solve of
+    // CPU — the user moves a slider but the next impedance update is
+    // delayed behind the now-stale sweep finishing.
+    sweepAbortRef.current?.abort();
+    if (sweepTimerRef.current) {
+      window.clearTimeout(sweepTimerRef.current);
+    }
+    setSweep(null);
+    setSweepRunning(false);
+    // Paused (Live off) holds the engine (issue #612): an enabled sweep must
+    // not keep solving while the user edits. Clearing above + returning here
+    // blanks the overlay while paused; resuming Live re-runs this effect
+    // (autoSim is a dep) and restarts the sweep from the current design.
+    if (!autoSim || !sweepEnabled || !active) {
+      return;
+    }
+    // The 500 ms dwell only debounces network churn; ordering against the
+    // live solve is the server lane's job now (live outranks sweeps).
+    sweepTimerRef.current = window.setTimeout(runSweep, 500);
+    return () => {
+      if (sweepTimerRef.current) window.clearTimeout(sweepTimerRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    geometry, backend, backendOptsKey,
+    currentValuesKey,
+    designFreq,
+    groundEnabled, groundModel,
+    sweepEnabled,
+    autoSim,
+    active,
+    // measFreq/measLocked drive the anchor now (meas_freq policy, or any
+    // unlocked design — incl. fixed-geometry designs whose lock is inert),
+    // so a meas-band change or dial turn re-runs the sweep.
+    measFreq, measLocked,
+    // A variant can override sweep_policy (variant_ui) without changing any
+    // param — e.g. a band-locked variant. currentValuesKey wouldn't move then,
+    // so depend on currentVariant directly to re-run the sweep on switch.
+    currentVariant,
+    // The poor-match gate: while it withholds, runSweep declines to issue the
+    // batch; approving ("Solve anyway") or a new recommendation re-fires this
+    // effect (issue #382 — replaces the old 200 ms re-poll loop).
+    comboApproved, recommendedBackend,
+  ]);
+
+  // Debounced convergence sweep over segments-per-wire. Independent of the
+  // freq sweep above: re-runs on any antenna/backend change, gated by its
+  // own overlay checkbox. The active slot's `nPerWire` is *overridden* by
+  // the ladder values for the duration of the sweep — the per-slot opts
+  // stay untouched, so the live /ws solve keeps using the user's setting.
+  useEffect(() => {
+    convergeAbortRef.current?.abort();
+    if (convergeTimerRef.current) {
+      window.clearTimeout(convergeTimerRef.current);
+    }
+    setConverge(null);
+    setConvergeRunning(false);
+    // Held when Paused (issue #612) — see the sweep effect. autoSim is a dep so
+    // resuming Live restarts the convergence sweep.
+    if (!autoSim || !convergeEnabled || !active) {
+      return;
+    }
+    // Debounce only; the server lane orders it behind the live solve.
+    convergeTimerRef.current = window.setTimeout(runConverge, 500);
+    return () => {
+      if (convergeTimerRef.current) window.clearTimeout(convergeTimerRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    geometry, backend, backendOptsKey,
+    currentValuesKey,
+    designFreq, measFreq,
+    groundEnabled, groundModel,
+    convergeEnabled,
+    autoSim,
+    active,
+    // Poor-match gate (see the sweep effect).
+    comboApproved, recommendedBackend,
+  ]);
+
+  // Debounced far-field norm consistency check. Same shape as the converge
+  // sweep: re-runs on any antenna/param change (which invalidates the norm),
+  // gated by its own overlay checkbox. The server lane runs it after the
+  // live solve (priority ordering), so it lands on that solve's cached
+  // currents rather than forcing a re-solve.
+  useEffect(() => {
+    normCheckAbortRef.current?.abort();
+    if (normCheckTimerRef.current) {
+      window.clearTimeout(normCheckTimerRef.current);
+    }
+    setNormCheck(null);
+    // Held when Paused (issue #612): the norm check re-solves, so it must not
+    // run while the engine is held. autoSim is a dep — resuming Live re-runs it.
+    if (!autoSim || !normCheckEnabled || !active) {
+      return;
+    }
+    normCheckTimerRef.current = window.setTimeout(runNormCheck, 500);
+    return () => {
+      if (normCheckTimerRef.current) window.clearTimeout(normCheckTimerRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    geometry, backend, backendOptsKey,
+    currentValuesKey,
+    designFreq, measFreq,
+    groundEnabled, groundModel,
+    // The pattern integral runs over the facets, so terrain knob changes
+    // invalidate it (unlike the impedance-only sweep/converge effects,
+    // which are legitimately terrain-param-independent — every preset
+    // shares the crest medium the impedance solve uses).
+    terrainKey,
+    normCheckEnabled,
+    autoSim,
+    active,
+    // Poor-match gate (see the sweep effect).
+    comboApproved, recommendedBackend,
+  ]);
+
+  // Debounced NEC pattern fetch. PyNEC only — for momwire there's no rp_card
+  // equivalent. Tracks measurement freq too (unlike the impedance sweep).
+  // Held off entirely over terrain (the rp pattern is flat-ground only) and
+  // when the user switches the overlay off.
+  useEffect(() => {
+    if (patternTimerRef.current) window.clearTimeout(patternTimerRef.current);
+    setPattern(null);
+    if (
+      !autoSim || // Paused holds the engine (issue #612) — no NEC re-solve.
+      backend !== "pynec" ||
+      !active ||
+      !necOverlayEnabled ||
+      groundModel === "terrain"
+    ) {
+      return;
+    }
+    patternTimerRef.current = window.setTimeout(() => {
+      runPattern();
+      patternTimerRef.current = null;
+    }, 500);
+    return () => {
+      if (patternTimerRef.current) window.clearTimeout(patternTimerRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    geometry, backend, backendOptsKey,
+    currentValuesKey,
+    designFreq, measFreq,
+    groundEnabled, groundModel,
+    necOverlayEnabled,
+    autoSim,
+    active,
+  ]);
+
+  async function runSweep() {
+    // No competition with the live solve to time around anymore: the server's
+    // per-session solve lane (issue #382) runs everything one-at-a-time with
+    // the live solve first, so this just sends. While the poor-match gate is
+    // withholding, don't issue batches of the very solves it's blocking — the
+    // effect re-fires on approval (comboApproved is a dependency).
+    if (solveWithheld()) return;
+    sweepTimerRef.current = null;
+    sweepAbortRef.current?.abort();
+    const controller = new AbortController();
+    sweepAbortRef.current = controller;
+
+    // Sweep range, log-spaced — see planSweepFreqs for the resolution,
+    // anchor, and band-lock policy this applies.
+    const freqs = planSweepFreqs({
+      backend,
+      groundEnabled,
+      groundModel,
+      currentExample,
+      currentVariant,
+      measLocked,
+      measFreq,
+      designFreq,
+      currentBands,
+      freqWindowCeiling,
+    });
+
+    const body = {
+      ...buildRequest(),
+      freqs_mhz: freqs,
+      // Lane metadata (issue #382): issued-at generation (a newer knob drag
+      // supersedes this batch server-side) + the gate's approval, which the
+      // server requires for a warned batch (poor-match combo backstop).
+      _gen: seqRef.current,
+      _approved: approvedComboRef.current,
+    };
+    setSweepRunning(true);
+    const acc: SweepData = {
+      freqs_mhz: [],
+      z_re: [],
+      z_im: [],
+      feeds_z_re: undefined,
+      feeds_z_im: undefined,
+    };
+    try {
+      const resp = await fetch("/sweep", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      if (!resp.ok || !resp.body) throw new Error(`sweep failed: ${resp.status}`);
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        let nl;
+        while ((nl = buf.indexOf("\n")) >= 0) {
+          const line = buf.slice(0, nl).trim();
+          buf = buf.slice(nl + 1);
+          if (!line) continue;
+          const pt = JSON.parse(line);
+          if (pt.done) continue;
+          // A failed point/chunk ends the stream with {error} instead of
+          // tearing the connection down (e.g. an approved poor-match combo
+          // whose dense fill can't allocate). Keep whatever points landed.
+          if (pt.error) {
+            console.error("sweep error", pt.error);
+            continue;
+          }
+          acc.freqs_mhz.push(pt.freq_mhz);
+          acc.z_re.push(pt.z_re);
+          acc.z_im.push(pt.z_im);
+          // Multi-feed sweep records (bowtie) ship per-feed Z alongside
+          // the primary. Allocate the per-feed buffers lazily on first
+          // sight so single-feed sweeps stay on the original code path.
+          if (Array.isArray(pt.feeds_z_re) && Array.isArray(pt.feeds_z_im)) {
+            if (!acc.feeds_z_re) acc.feeds_z_re = [];
+            if (!acc.feeds_z_im) acc.feeds_z_im = [];
+            acc.feeds_z_re.push(pt.feeds_z_re);
+            acc.feeds_z_im.push(pt.feeds_z_im);
+          }
+          if (!controller.signal.aborted) {
+            // New object so React re-renders the Smith chart per point.
+            setSweep({
+              freqs_mhz: acc.freqs_mhz.slice(),
+              z_re: acc.z_re.slice(),
+              z_im: acc.z_im.slice(),
+              feeds_z_re: acc.feeds_z_re
+                ? acc.feeds_z_re.map((row) => row.slice())
+                : undefined,
+              feeds_z_im: acc.feeds_z_im
+                ? acc.feeds_z_im.map((row) => row.slice())
+                : undefined,
+            });
+          }
+        }
+      }
+    } catch (e: unknown) {
+      if (e instanceof DOMException && e.name === "AbortError") return;
+      console.error("sweep error", e);
+    } finally {
+      if (sweepAbortRef.current === controller) {
+        sweepAbortRef.current = null;
+        setSweepRunning(false);
+      }
+    }
+  }
+
+  async function runConverge() {
+    // Same as runSweep: the server lane serializes and prioritizes; only the
+    // poor-match gate holds this back (effect re-fires on approval).
+    if (solveWithheld()) return;
+    convergeTimerRef.current = null;
+    convergeAbortRef.current?.abort();
+    const controller = new AbortController();
+    convergeAbortRef.current = controller;
+
+    // The active slot's nPerWire is irrelevant during a converge sweep —
+    // n_values overrides it on the server. We strip `n_per_wire` from the
+    // request anyway to make that explicit.
+    const body = {
+      ...buildRequest(),
+      n_values: CONVERGE_N_VALUES,
+      _gen: seqRef.current,
+      _approved: approvedComboRef.current,
+    };
+    setConvergeRunning(true);
+    const acc: ConvergeData = {
+      n_values: [],
+      z_re: [],
+      z_im: [],
+      z_re_extrap: null,
+      z_im_extrap: null,
+      feeds_z_re: undefined,
+      feeds_z_im: undefined,
+      feeds_z_re_extrap: undefined,
+      feeds_z_im_extrap: undefined,
+    };
+    try {
+      const resp = await fetch("/converge", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      if (!resp.ok || !resp.body) throw new Error(`converge failed: ${resp.status}`);
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        let nl;
+        while ((nl = buf.indexOf("\n")) >= 0) {
+          const line = buf.slice(0, nl).trim();
+          buf = buf.slice(nl + 1);
+          if (!line) continue;
+          const pt = JSON.parse(line);
+          if (pt.done) continue;
+          // A solver failure for one N (rare — degenerate small-N geometry)
+          // is reported by the backend as {n_per_wire, error}; skip rather
+          // than poisoning the trajectory.
+          if (pt.error) continue;
+          acc.n_values.push(pt.n_per_wire);
+          acc.z_re.push(pt.z_re);
+          acc.z_im.push(pt.z_im);
+          // Multi-feed convergence records ship per-feed Z alongside the
+          // primary; allocate the buffers lazily on first sight.
+          if (Array.isArray(pt.feeds_z_re) && Array.isArray(pt.feeds_z_im)) {
+            if (!acc.feeds_z_re) acc.feeds_z_re = [];
+            if (!acc.feeds_z_im) acc.feeds_z_im = [];
+            acc.feeds_z_re.push(pt.feeds_z_re);
+            acc.feeds_z_im.push(pt.feeds_z_im);
+          }
+          const invN = acc.n_values.map((n) => 1 / n);
+          acc.z_re_extrap = richardsonExtrap(invN, acc.z_re);
+          acc.z_im_extrap = richardsonExtrap(invN, acc.z_im);
+          // Per-feed Richardson Z* — see feedwiseRichardson.
+          if (acc.feeds_z_re && acc.feeds_z_im) {
+            const { feedsRe, feedsIm } = feedwiseRichardson(
+              invN,
+              acc.feeds_z_re,
+              acc.feeds_z_im,
+            );
+            acc.feeds_z_re_extrap = feedsRe;
+            acc.feeds_z_im_extrap = feedsIm;
+          }
+          if (!controller.signal.aborted) {
+            setConverge({
+              n_values: acc.n_values.slice(),
+              z_re: acc.z_re.slice(),
+              z_im: acc.z_im.slice(),
+              z_re_extrap: acc.z_re_extrap,
+              z_im_extrap: acc.z_im_extrap,
+              feeds_z_re: acc.feeds_z_re
+                ? acc.feeds_z_re.map((row) => row.slice())
+                : undefined,
+              feeds_z_im: acc.feeds_z_im
+                ? acc.feeds_z_im.map((row) => row.slice())
+                : undefined,
+              feeds_z_re_extrap: acc.feeds_z_re_extrap
+                ? acc.feeds_z_re_extrap.slice()
+                : undefined,
+              feeds_z_im_extrap: acc.feeds_z_im_extrap
+                ? acc.feeds_z_im_extrap.slice()
+                : undefined,
+            });
+          }
+        }
+      }
+    } catch (e: unknown) {
+      if (e instanceof DOMException && e.name === "AbortError") return;
+      console.error("converge error", e);
+    } finally {
+      if (convergeAbortRef.current === controller) {
+        convergeAbortRef.current = null;
+        setConvergeRunning(false);
+      }
+    }
+  }
+
+  async function runNormCheck() {
+    // The pattern norm reuses the settled live solve (a server cache hit):
+    // the lane's live-first priority guarantees that ordering now, no
+    // client-side timing needed. Only the poor-match gate holds this back.
+    if (solveWithheld()) return;
+    normCheckTimerRef.current = null;
+    normCheckAbortRef.current?.abort();
+    const controller = new AbortController();
+    normCheckAbortRef.current = controller;
+    try {
+      const resp = await fetch("/norm_check", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...buildRequest(),
+          _gen: seqRef.current,
+          _approved: approvedComboRef.current,
+        }),
+        signal: controller.signal,
+      });
+      if (!resp.ok) throw new Error(`norm check failed: ${resp.status}`);
+      const data = await resp.json();
+      if (controller.signal.aborted) return;
+      if (!data.available) {
+        setNormCheck(null);
+        return;
+      }
+      const delta = 10 * Math.log10(data.pattern_norm / data.directivity_norm);
+      setNormCheck({
+        directivity_norm: data.directivity_norm,
+        pattern_norm: data.pattern_norm,
+        method: data.method,
+        delta_db: delta,
+        radiated_fraction: data.radiated_fraction ?? 0,
+        radiation_efficiency: data.radiation_efficiency ?? 1,
+      });
+    } catch (e: unknown) {
+      if (e instanceof DOMException && e.name === "AbortError") return;
+      console.error("norm check error", e);
+    } finally {
+      if (normCheckAbortRef.current === controller) {
+        normCheckAbortRef.current = null;
+      }
+    }
+  }
+
+  async function runPattern() {
+    patternAbortRef.current?.abort();
+    const controller = new AbortController();
+    patternAbortRef.current = controller;
+    try {
+      const resp = await fetch("/pattern", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...buildRequest(), _gen: seqRef.current }),
+        signal: controller.signal,
+      });
+      if (!resp.ok) throw new Error(`pattern failed: ${resp.status}`);
+      const data = await resp.json();
+      if (!data.available) {
+        setPattern(null);
+        return;
+      }
+      if (!controller.signal.aborted) setPattern(data as PatternData);
+    } catch (e: unknown) {
+      if (e instanceof DOMException && e.name === "AbortError") return;
+      console.error("pattern error", e);
+    } finally {
+      if (patternAbortRef.current === controller) patternAbortRef.current = null;
+    }
+  }
+
+  return {
+    sweep,
+    sweepRunning,
+    converge,
+    convergeRunning,
+    normCheck,
+    pattern,
+  };
+}

--- a/src/antennaknobs/web/frontend/src/components/session/useDesignCatalog.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useDesignCatalog.ts
@@ -1,0 +1,160 @@
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+import { type TerrainPresetSchema } from "../../lib/ground";
+import {
+  seedDefaults,
+  type ExampleDescriptor,
+  type ParamValueBag,
+} from "../../lib/params";
+import { type DesignLoadError } from "../AwaitingTrustPanel";
+
+// The design catalog: everything DesignSession learns from the server about
+// which antennas exist and what this backend can run (#642 seam 5b-3). The
+// cluster moves whole — the two mount fetches, the trust action that re-fetches
+// the catalog, and the auto-select effect that keeps `geometry` pointing at a
+// design that still exists — so its internal hook order and every literal dep
+// array are unchanged.
+//
+// Schema-driven parameter controls. Each registered example bundles
+// its parameter schema in web/examples/<name>.py; the backend serves
+// them on GET /examples and we render generic sliders from the result.
+export function useDesignCatalog({
+  geometry,
+  setGeometry,
+  setParamValues,
+}: {
+  geometry: string;
+  setGeometry: (name: string) => void;
+  setParamValues: Dispatch<SetStateAction<Record<string, ParamValueBag>>>;
+}) {
+  const [examples, setExamples] = useState<ExampleDescriptor[]>([]);
+  const [examplesError, setExamplesError] = useState<string | null>(null);
+  // Whether the server has the optional pynec-accel package (#429). Reported
+  // by /examples on mount; gates the PyNEC backend option. Defaults true so
+  // the common (installed) case never flashes the option off before the fetch
+  // resolves; a false reply then hides it and remaps any PyNEC slot.
+  const [havePynec, setHavePynec] = useState<boolean>(true);
+  // Terrain preset catalog (issue #560), reported by /capabilities on mount.
+  // Empty until it resolves (and on any older server without the field), which
+  // gates the terrain ground option off — the panel is rendered entirely from
+  // this schema, so there is nothing to show without it.
+  const [terrainPresets, setTerrainPresets] = useState<TerrainPresetSchema[]>(
+    [],
+  );
+  // User designs that failed to load (bad Python, no Builder, geometry error).
+  // Surfaced from /examples so the author / Claude can see and fix them.
+  const [loadErrors, setLoadErrors] = useState<DesignLoadError[]>([]);
+
+  // Load (or reload) the design catalog. Extracted so a trust action can
+  // re-fetch it — trusting a design registers it server-side, and re-fetching
+  // moves it out of the "awaiting trust" list into the selector.
+  const loadExamples = useCallback(async () => {
+    try {
+      const j = await (await fetch("/examples")).json();
+      const list: ExampleDescriptor[] = j.examples ?? [];
+      setExamples(list);
+      setExamplesError(null);
+      setLoadErrors(Array.isArray(j.errors) ? j.errors : []);
+      // Walk each example's schema and pre-seed defaults — including
+      // pre-allocated group instance arrays — so the sliders have
+      // something to render against on first show.
+      setParamValues((prev) => {
+        const next = { ...prev };
+        for (const ex of list) {
+          if (next[ex.name]) continue;
+          next[ex.name] = seedDefaults(ex.param_schema);
+        }
+        return next;
+      });
+    } catch (e: unknown) {
+      setExamplesError(String((e as Error)?.message ?? e));
+    }
+    // setParamValues is the caller's useState setter — stable for the life of
+    // the component, so the empty dep array is unchanged from before the move.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    loadExamples();
+  }, [loadExamples]);
+
+  // Backend capabilities (#429), fetched once on mount — server-static, so
+  // unlike the design catalog it is not re-fetched on trust actions. A failed
+  // fetch or an older server without the route leaves havePynec at its `true`
+  // default (prior behavior). Gates the PyNEC backend option.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const c = await (await fetch("/capabilities")).json();
+        if (!cancelled) {
+          setHavePynec(c.have_pynec !== false);
+          setTerrainPresets(
+            Array.isArray(c.terrain_presets) ? c.terrain_presets : [],
+          );
+        }
+      } catch {
+        /* keep the default; PyNEC stays offered */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Trust a user design from the UI (local-only; the backend refuses when
+  // hosted). `stem` is the design name (e.g. "user.my_dipole"); `allowEdits`
+  // trusts future edits too (path-level, for a design you author).
+  const [trustBusy, setTrustBusy] = useState<string | null>(null);
+  const trustDesign = useCallback(
+    async (stem: string, allowEdits: boolean) => {
+      setTrustBusy(stem);
+      try {
+        const r = await fetch("/trust", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ stem, allow_edits: allowEdits }),
+        });
+        if (!r.ok) {
+          const j = await r.json().catch(() => ({}));
+          setExamplesError(`Trust failed: ${j.detail ?? r.status}`);
+          return;
+        }
+        await loadExamples();
+      } finally {
+        setTrustBusy(null);
+      }
+    },
+    [loadExamples],
+  );
+
+  // Auto-select a sensible default once /examples resolves, and recover if
+  // the current selection disappears (e.g. backend dropped an example).
+  // dipoles.invvee is the canonical simple antenna (also the CLI default);
+  // fall back to the first example if it isn't registered.
+  useEffect(() => {
+    if (examples.length === 0) return;
+    if (!examples.some((e) => e.name === geometry)) {
+      const preferred = examples.find((e) => e.name === "dipoles.invvee");
+      setGeometry((preferred ?? examples[0]).name);
+    }
+    // setGeometry is a stable useState setter; the literal deps are unchanged
+    // from the pre-extraction effect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [examples, geometry]);
+
+  return {
+    examples,
+    examplesError,
+    havePynec,
+    terrainPresets,
+    loadErrors,
+    trustBusy,
+    trustDesign,
+  };
+}

--- a/src/antennaknobs/web/frontend/src/components/session/useGroundConfig.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useGroundConfig.ts
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import { type Backend } from "../../lib/backends";
+import {
+  groundSummaryLabel,
+  resolveGroundModel,
+  type FiniteGroundMethod,
+  type GroundModel,
+  type GroundType,
+  type TerrainParams,
+} from "../../lib/ground";
+
+// The ground/terrain selection and everything derived from it: the wire
+// `ground_model` value the server protocol takes, the terrain change-detector
+// string the solve and norm-check effects depend on, and the one-line summary
+// the tab hover shows (#642 seam 5b-3). No effects here — the cluster is state
+// plus derivations, so the component's global effect order is untouched.
+export function useGroundConfig({ backend }: { backend: Backend }) {
+  // Ground plane at z = 0 (model per backend; see groundType). ON by
+  // default: this is an HF wire-antenna workbench, and the over-ground
+  // picture (takeoff angle, ground-lobed elevation pattern, shifted Z)
+  // is the decision-relevant one — free space is the idealization you
+  // opt into. The whole catalog solves grounded (75/75 audit, all
+  // designs above z=0) on the default B-spline refl-coef path.
+  const [groundEnabled, setGroundEnabled] = useState(true);
+  // Shared ground choice — one selector describing the GROUND (finite vs
+  // PEC); every backend solves it as best it can (see the GroundType note).
+  const [groundType, setGroundType] = useState<GroundType>("finite");
+  // Finite-ground method; hidden (and inert) on backends with a single
+  // finite model, but kept in state so it survives backend flips during
+  // engine comparison. Defaults to "fast" — Sommerfeld is opt-in (it costs
+  // seconds per solve on the B-spline backend).
+  const [finiteGroundMethod, setFiniteGroundMethod] =
+    useState<FiniteGroundMethod>("fast");
+  // Terrain preset + knobs (groundType === "terrain"; momwire only). One
+  // flat params object for both presets so values survive preset flips.
+  const [terrainPreset, setTerrainPreset] = useState<string>("levee");
+  const [terrainParams, setTerrainParams] = useState<TerrainParams>({});
+  // Wire value derived for the server protocol (see GroundModel). A
+  // terrain selection quietly degrades to the finite method on any future
+  // backend without terrain support (all current ground-capable backends
+  // have it — PyNEC via the #553 hybrid).
+  const groundModel: GroundModel = resolveGroundModel(
+    groundType,
+    backend,
+    finiteGroundMethod,
+  );
+
+  // Solve-effect dep for the terrain knobs: only bites while terrain is
+  // the active model, so parked levee state never re-solves a flat-ground
+  // setup (and vice versa).
+  const terrainKey =
+    groundModel === "terrain"
+      ? JSON.stringify([terrainPreset, terrainParams])
+      : "";
+
+  // One-line tab-hover summary: design · solver N=segs · ground model.
+  // Every backend honours the selected method (momwire >= 0.8.0), so the
+  // wording is uniform; "free space" when ground is off or unsupported.
+  const groundSummary = groundSummaryLabel(
+    groundEnabled,
+    backend,
+    groundModel,
+    terrainPreset,
+  );
+
+  return {
+    groundEnabled,
+    setGroundEnabled,
+    groundType,
+    setGroundType,
+    finiteGroundMethod,
+    setFiniteGroundMethod,
+    terrainPreset,
+    setTerrainPreset,
+    terrainParams,
+    setTerrainParams,
+    groundModel,
+    terrainKey,
+    groundSummary,
+  };
+}

--- a/src/antennaknobs/web/frontend/src/components/session/useMobileCarousel.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useMobileCarousel.ts
@@ -1,0 +1,96 @@
+import { useEffect, useRef, useState } from "react";
+import { VIEWS, type View } from "../../lib/view";
+import { useSlideSize } from "../hooks";
+
+// The mobile output carousel's state, refs and the two effects that keep the
+// DOM scroll position and `view` in agreement (#642 seam 5b-3). Lifted whole
+// out of DesignSession so the cluster's internal hook order is preserved
+// exactly; the caller keeps `view`/`setView` because the desktop tree and the
+// arrow-key cycler share them.
+//
+// `compareCollapsed` deliberately stays behind in DesignSession: its
+// `useState(isMobile)` initializer has to run after `useIsMobile()` there.
+export function useMobileCarousel({
+  isMobile,
+  orientation,
+  view,
+  setView,
+}: {
+  isMobile: boolean;
+  orientation: "portrait" | "landscape";
+  view: View;
+  setView: (v: View) => void;
+}) {
+  // Mobile output carousel (all hooks unconditional — desktop leaves them
+  // inert). mobileIndex is which of the 5 screens the snap carousel rests on;
+  // `view` stays the source of truth for the 4 chart screens and their data
+  // effects, kept in sync by the scroll handler / reverse-sync effect below.
+  const [mobileIndex, setMobileIndex] = useState(0);
+  const mobileCarouselRef = useRef<HTMLDivElement>(null);
+  const mobileScrollRafRef = useRef<number | null>(null);
+  const { ref: mobRef, size: mobChartSize } = useSlideSize(720, isMobile);
+
+  // Track where a swipe/fling snaps and mirror it into state. rAF-throttled:
+  // scroll events arrive per frame during a fling, one rounding per frame is
+  // plenty. The rounded-index compare inside the setters keeps this from
+  // fighting the programmatic scrolls below.
+  const onMobileCarouselScroll = () => {
+    if (mobileScrollRafRef.current !== null) return;
+    mobileScrollRafRef.current = requestAnimationFrame(() => {
+      mobileScrollRafRef.current = null;
+      const el = mobileCarouselRef.current;
+      if (!el || el.clientWidth === 0) return;
+      const i = Math.round(el.scrollLeft / el.clientWidth);
+      setMobileIndex((prev) => (prev === i ? prev : i));
+      if (i < VIEWS.length) setView(VIEWS[i].id);
+    });
+  };
+
+  // Dot tap: jump to a screen. Info (the last index) is reachable only here
+  // and by swipe — it deliberately leaves `view` on the last chart screen.
+  const goToMobileScreen = (i: number) => {
+    setMobileIndex(i);
+    if (i < VIEWS.length) setView(VIEWS[i].id);
+    const el = mobileCarouselRef.current;
+    if (el) el.scrollTo({ left: i * el.clientWidth, behavior: "smooth" });
+  };
+
+  // Reverse sync: anything else that sets `view` (the arrow-key cycler) pages
+  // the carousel to match. The DOM scroll position is the ground truth for
+  // "where are we" — comparing rounded indices means we never fight an
+  // in-progress swipe, and parking on Info ignores view changes entirely.
+  useEffect(() => {
+    if (!isMobile) return;
+    const el = mobileCarouselRef.current;
+    if (!el || el.clientWidth === 0) return;
+    const target = VIEWS.findIndex((v) => v.id === view);
+    const current = Math.round(el.scrollLeft / el.clientWidth);
+    if (target < 0 || current >= VIEWS.length || current === target) return;
+    setMobileIndex(target);
+    el.scrollTo({ left: target * el.clientWidth, behavior: "smooth" });
+  }, [view, isMobile]);
+
+  // An orientation flip (or any pane resize) changes the screen width, so
+  // scrollLeft no longer sits on a snap point; re-center the active screen
+  // once the new layout lands (hence the rAF). Skipped when the rounded
+  // position already matches — never fights a drag.
+  useEffect(() => {
+    if (!isMobile) return;
+    const raf = requestAnimationFrame(() => {
+      const el = mobileCarouselRef.current;
+      if (!el || el.clientWidth === 0) return;
+      const i = Math.round(el.scrollLeft / el.clientWidth);
+      if (i !== mobileIndex) el.scrollTo({ left: mobileIndex * el.clientWidth });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [isMobile, orientation, mobChartSize, mobileIndex]);
+
+  return {
+    mobileIndex,
+    mobileCarouselRef,
+    mobRef,
+    mobChartSize,
+    onMobileCarouselScroll,
+    goToMobileScreen,
+  };
+}

--- a/src/antennaknobs/web/frontend/src/components/session/useOptimizer.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useOptimizer.ts
@@ -1,0 +1,250 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { SolveRequest } from "../../lib/api";
+import { type Backend } from "../../lib/backends";
+import {
+  defaultKnobOpt,
+  type KnobOpt,
+  type ParamValueBag,
+  type SchemaItem,
+} from "../../lib/params";
+import {
+  type OptimizeResult,
+  type OptObjective,
+  type OptPause,
+} from "./VfoPanel";
+
+// --- Reactive knob optimiser (POST /optimize) ---
+//
+// The reactive knob optimiser's whole behavior cluster (#642 seam 5b-3):
+// state, the render-time optEnabledRef mirror, the design-load reset, the
+// POST /optimize runner, the fixed-input signature that triggers a re-tune,
+// the pause cue, the per-knob settings helpers and the knob-menu Escape
+// listener. The cluster moves whole so its internal hook order and every
+// literal dep array are unchanged.
+//
+// optAbortRef and optEnabledRef come back raw: selectVariant and
+// handleUserParamChange stay in DesignSession and mutate them directly, which
+// is exactly the "the human took over" path, so wrapping them in helpers would
+// change what those call sites can express.
+export function useOptimizer({
+  geometry,
+  currentValues,
+  currentValuesKey,
+  currentSchema,
+  backend,
+  designFreq,
+  measFreq,
+  autoSim,
+  active,
+  buildRequest,
+  setParamAtPath,
+}: {
+  geometry: string;
+  currentValues: ParamValueBag;
+  currentValuesKey: string;
+  currentSchema: SchemaItem[];
+  backend: Backend;
+  designFreq: number;
+  measFreq: number;
+  autoSim: boolean;
+  active: boolean;
+  buildRequest: () => SolveRequest;
+  setParamAtPath: (
+    path: (string | number)[],
+    value: number | string | boolean,
+  ) => void;
+}) {
+  // Master enable + objective live in the compact control by meas-freq; per-knob
+  // "vary" + extents + step live in each knob's right-click menu (knobOpt).
+  const [optEnabled, setOptEnabled] = useState(false);
+  const [optObjective, setOptObjective] = useState<OptObjective>("swr");
+  const [knobOpt, setKnobOpt] = useState<Record<string, Record<string, KnobOpt>>>({});
+  // Open knob context menu: which param + anchor position.
+  const [knobMenu, setKnobMenu] = useState<{ name: string; x: number; y: number } | null>(
+    null,
+  );
+  const [optRunning, setOptRunning] = useState(false);
+  const [optResult, setOptResult] = useState<OptimizeResult | null>(null);
+  const [optError, setOptError] = useState<string | null>(null);
+  // When something auto-pauses the optimizer, this holds *why* for a brief cue
+  // (cleared on re-enable / after a few seconds): grabbing a knob marked for
+  // optimization by hand ("changing X by hand"), or loading a new design/variant
+  // ("loaded a new design").
+  const [optPausedBy, setOptPausedBy] = useState<OptPause | null>(null);
+  const optAbortRef = useRef<AbortController | null>(null);
+  // Latest optEnabled mirrored into a ref so the design-load reset (effects keyed
+  // on geometry, and selectVariant) can tell whether the optimizer was actually
+  // running — to show the pause cue only then — without taking optEnabled as a
+  // dep (which would re-run the reset on every toggle).
+  const optEnabledRef = useRef(false);
+  optEnabledRef.current = optEnabled; // mirror latest for the design-load reset
+  // Per-knob settings persist per geometry (knobOpt is keyed by geometry); just
+  // close any open menu / clear the last result / abort any in-flight run when
+  // the antenna changes. The optimizer also *pauses* on a design switch — its
+  // objective and marks belong to the design you left — but this design's marks
+  // are kept (they're keyed by geometry), so returning restores them; only the
+  // running toggle is switched off. Show the cue only if it was actually on.
+  useEffect(() => {
+    optAbortRef.current?.abort();
+    setKnobMenu(null);
+    setOptResult(null);
+    setOptError(null);
+    if (optEnabledRef.current) {
+      setOptEnabled(false);
+      setOptPausedBy({ kind: "load" });
+    }
+    // optEnabledRef is read (not a dep) on purpose — see its declaration.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [geometry]);
+
+  // Run the optimiser once: POST the current solve request + the free knobs
+  // (from each knob's menu) and objective, then apply the returned params to the
+  // knobs (re-solving via the normal onChange path). Warm-started from the
+  // current values; a newer run aborts the previous so stale results are
+  // dropped. Always uses the momwire engine server-side.
+  async function runOptimize() {
+    const settings = knobOpt[geometry] ?? {};
+    const free = Object.entries(settings)
+      .filter(([, o]) => o.vary)
+      .map(([name, o]) => ({ name, min: o.optMin, max: o.optMax }));
+    if (free.length === 0) return;
+    optAbortRef.current?.abort();
+    const ctrl = new AbortController();
+    optAbortRef.current = ctrl;
+    setOptRunning(true);
+    setOptError(null);
+    try {
+      const resp = await fetch("/optimize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        signal: ctrl.signal,
+        body: JSON.stringify({
+          ...buildRequest(),
+          // Reactive runs are warm-started, so a modest eval cap keeps them snappy.
+          optimize: { free, objective: optObjective, max_evals: 40 },
+        }),
+      });
+      const data = await resp.json();
+      if (ctrl.signal.aborted) return; // superseded by a newer run
+      if (data.error) {
+        setOptError(String(data.error));
+      } else {
+        setOptResult(data as OptimizeResult);
+        for (const [name, val] of Object.entries((data as OptimizeResult).params)) {
+          setParamAtPath([name], val);
+        }
+      }
+    } catch (e) {
+      if (!ctrl.signal.aborted) setOptError(String(e));
+    } finally {
+      if (optAbortRef.current === ctrl) {
+        optAbortRef.current = null;
+        setOptRunning(false);
+      }
+    }
+  }
+
+  // Reactive optimisation. When enabled with >=1 free knob, re-tune shortly
+  // after the user pauses on any *fixed* input. The trigger is a signature of
+  // everything the optimiser depends on EXCEPT the free knobs' values — the
+  // optimiser writes those, so including them would loop. Turning it on produces
+  // a fresh signature, so it also tunes immediately on enable.
+  const optFixedSig = useMemo(() => {
+    if (!optEnabled) return "";
+    const settings = knobOpt[geometry] ?? {};
+    const free = Object.entries(settings).filter(([, o]) => o.vary);
+    if (free.length === 0) return "";
+    const freeSet = new Set(free.map(([n]) => n));
+    const fixed: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(currentValues)) {
+      if (!freeSet.has(k)) fixed[k] = v;
+    }
+    return JSON.stringify({
+      geometry,
+      objective: optObjective,
+      backend,
+      designFreq,
+      measFreq,
+      bounds: free.map(([n, o]) => [n, o.optMin, o.optMax]),
+      fixed,
+    });
+    // currentValuesKey stands in for currentValues' contents in the deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    optEnabled,
+    knobOpt,
+    geometry,
+    optObjective,
+    backend,
+    designFreq,
+    measFreq,
+    currentValuesKey,
+  ]);
+
+  useEffect(() => {
+    // Paused (Live off) holds the optimiser too — it drives engine solves, so it
+    // must respect the same gate as the main solve. Resuming re-runs this effect
+    // (autoSim is a dep) and re-tunes.
+    if (!optFixedSig || !autoSim || !active) return;
+    const t = setTimeout(() => {
+      runOptimize();
+    }, 400);
+    return () => clearTimeout(t);
+    // runOptimize captured here reflects the state at this signature; re-running
+    // only when the signature changes is intentional.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [optFixedSig, autoSim, active]);
+
+  // The "paused — changing X by hand" cue is a brief flash: clear it a few
+  // seconds after it appears so it doesn't linger while Optimize stays off.
+  useEffect(() => {
+    if (!optPausedBy) return;
+    const t = setTimeout(() => setOptPausedBy(null), 5000);
+    return () => clearTimeout(t);
+  }, [optPausedBy]);
+
+  // The effective per-knob optimiser settings: the stored entry, or seeded from
+  // the schema (extents = slider bounds, step = schema step, not varying).
+  function knobOptFor(name: string): KnobOpt {
+    const existing = knobOpt[geometry]?.[name];
+    if (existing) return existing;
+    return defaultKnobOpt(currentSchema, name);
+  }
+  function updateKnobOpt(name: string, patch: Partial<KnobOpt>) {
+    const base = knobOptFor(name);
+    setKnobOpt((prev) => ({
+      ...prev,
+      [geometry]: { ...(prev[geometry] ?? {}), [name]: { ...base, ...patch } },
+    }));
+  }
+
+  // Close the knob menu on Escape.
+  useEffect(() => {
+    if (!knobMenu || !active) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setKnobMenu(null);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [knobMenu, active]);
+
+  return {
+    optEnabled,
+    setOptEnabled,
+    optObjective,
+    setOptObjective,
+    knobOpt,
+    setKnobOpt,
+    knobMenu,
+    setKnobMenu,
+    optRunning,
+    optResult,
+    optError,
+    optPausedBy,
+    setOptPausedBy,
+    optAbortRef,
+    optEnabledRef,
+    knobOptFor,
+    updateKnobOpt,
+  };
+}

--- a/src/antennaknobs/web/frontend/src/components/session/useSolveChannel.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useSolveChannel.ts
@@ -1,0 +1,291 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type MutableRefObject,
+} from "react";
+import type { SolveRequest, SolveResponse } from "../../lib/api";
+import {
+  cutsWsSend,
+  flushCutsWsPending,
+  resolveCutsWsMessage,
+  setCutsWsSend,
+  type CutsWsMessage,
+} from "../charts/cuts";
+
+// Match the page's scheme: a wss:// upgrade is required on HTTPS pages (e.g. the
+// deployed site behind Fly's force_https), where browsers block insecure ws://
+// as mixed content. Plain ws:// only works on http:// (local dev).
+const WS_URL = `${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.host}/ws`;
+
+// The /ws solve channel: the socket itself, the latest-wins `_seq` protocol,
+// the busy-chrome dwell, and the two imperative entry points the component
+// drives it with (#642 seam 5b-3). Lifted whole out of DesignSession so the
+// per-socket `cutsSender` identity guard, the seq watermarks that must survive
+// StrictMode/HMR teardown, and the literal `[active]` / `[solving]` dep arrays
+// all move unchanged.
+//
+// `controlsRef` stays owned by the component: the solve effect writes the
+// latest request into it and this hook only ever reads `.current`, so a
+// reconnect resends whatever the component last decided to solve.
+export function useSolveChannel({
+  active,
+  controlsRef,
+  geometryRef,
+  previewSigRef,
+  setResult,
+  setSolveError,
+}: {
+  active: boolean;
+  controlsRef: MutableRefObject<SolveRequest>;
+  geometryRef: MutableRefObject<string>;
+  previewSigRef: MutableRefObject<string | null>;
+  setResult: (r: SolveResponse | null) => void;
+  setSolveError: (e: string | null) => void;
+}) {
+  const [status, setStatus] = useState<"connecting" | "open" | "closed">("connecting");
+  const [rttMs, setRttMs] = useState<number | null>(null);
+  // True whenever a main solve is outstanding (in flight or queued) — i.e. the
+  // displayed analysis isn't current yet. `showBusy` is the *debounced* view of
+  // it: the progress bar / panel dimming only appear once a solve outlasts
+  // ~300 ms, so fast updates (cache hits, small designs) snap in cleanly
+  // without a flash of busy chrome.
+  const [solving, setSolving] = useState(false);
+  const [showBusy, setShowBusy] = useState(false);
+
+  // Timestamp (performance.now) when the busy chrome last became visible, so
+  // the reveal effect can enforce a minimum-visible window. null = not shown.
+  const shownAtRef = useRef<number | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  // Latest-wins /ws protocol counters. Every knob change is sent eagerly with a
+  // monotonic `_seq`; the server keeps only the freshest queued request and may
+  // skip-send superseded results, so the client orders and prunes by `_seq`. A
+  // solve is outstanding iff more has been sent than received. These live in
+  // refs so they survive StrictMode/HMR socket teardown — the counter must
+  // never rewind below what's already been received.
+  const seqRef = useRef(0); // last _seq assigned (monotonic, never reset)
+  const lastSentSeqRef = useRef(0); // highest _seq put on the wire
+  const lastReceivedSeqRef = useRef(0); // highest _seq received or implicitly acked
+  const canceledThroughSeqRef = useRef(0); // drop rendering for _seq <= this
+  const sentAtRef = useRef<Map<number, number>>(new Map()); // _seq → send time (RTT)
+  const solveRafRef = useRef<number | null>(null); // trailing-edge rAF throttle handle
+
+  // Cancel an IN-FLIGHT solve: stop waiting and discard its result. The server
+  // keeps computing (its /ws loop is sequential and a running MoM solve can't be
+  // interrupted), so this cancels the wait, not the computation.
+  function cancelSolve() {
+    if (lastSentSeqRef.current <= lastReceivedSeqRef.current) return; // nothing in flight
+    // Mark every seq sent so far as cancelled: onmessage will advance the
+    // received watermark for these but drop their results. A newer knob change
+    // bumps lastSentSeq past this and solves again.
+    canceledThroughSeqRef.current = lastSentSeqRef.current;
+    syncSolving();
+  }
+
+  // Mirror the seq counters into `solving` state so the UI can react. Called
+  // wherever the sent / received / cancel watermarks move. A solve reads as
+  // running when more has been sent than received — unless everything
+  // outstanding was cancelled (lastSentSeq hasn't advanced past the cancel
+  // watermark), in which case the wait is over even though a doomed response
+  // is still coming.
+  function syncSolving() {
+    setSolving(
+      lastSentSeqRef.current > lastReceivedSeqRef.current &&
+        lastSentSeqRef.current > canceledThroughSeqRef.current,
+    );
+  }
+
+  // Busy-chrome reveal with two guards:
+  //  - dwell: only show once a solve has been outstanding >BUSY_DWELL_MS. 1 s
+  //    is the classic "flow of thought" threshold — below it users tolerate the
+  //    wait without feedback; at/above it the bar reassures them it's working.
+  //    A solve that finishes sooner clears the timer in cleanup, so the bar
+  //    never flips on for quick updates.
+  //  - min-visible: once shown, keep it up at least BUSY_MIN_VISIBLE_MS so a
+  //    solve that lands just past the dwell can't make it sub-perceptibly
+  //    flash.
+  const BUSY_DWELL_MS = 1000;
+  const BUSY_MIN_VISIBLE_MS = 400;
+  useEffect(() => {
+    if (solving) {
+      const t = window.setTimeout(() => {
+        shownAtRef.current = performance.now();
+        setShowBusy(true);
+      }, BUSY_DWELL_MS);
+      return () => window.clearTimeout(t);
+    }
+    // Solve finished. If the bar never showed (fast solve), hide immediately;
+    // otherwise hold it for the remainder of the minimum-visible window.
+    if (shownAtRef.current === null) {
+      setShowBusy(false);
+      return;
+    }
+    const remaining =
+      BUSY_MIN_VISIBLE_MS - (performance.now() - shownAtRef.current);
+    if (remaining <= 0) {
+      shownAtRef.current = null;
+      setShowBusy(false);
+      return;
+    }
+    const t = window.setTimeout(() => {
+      shownAtRef.current = null;
+      setShowBusy(false);
+    }, remaining);
+    return () => window.clearTimeout(t);
+  }, [solving]);
+
+  // The progress bar (`showBusy`) honors the min-visible window so it can't
+  // flash, but the *dimming* and the "solving…" label mean "what you're
+  // looking at is stale" — so they must clear the instant the result lands,
+  // even while the bar lingers out its minimum. `solving` flips false
+  // immediately on result-land, so `showBusy && solving` is exactly that: dim
+  // only after the dwell (showBusy) AND while genuinely still solving.
+  const stale = showBusy && solving;
+
+  function requestSolve() {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      // Can't send now. onopen resends controlsRef.current on (re)connect, so
+      // the latest state is solved as soon as the socket comes up.
+      return;
+    }
+    // Trailing-edge rAF throttle: coalesce a burst of knob changes within one
+    // animation frame to a single send of the latest controls. Bounds upload to
+    // ≤~60 msg/s during a drag and keeps localhost message churn near what the
+    // old one-in-flight gate produced; the server's latest-wins mailbox squashes
+    // whatever still piles up. The freshest value always wins within the frame.
+    if (solveRafRef.current !== null) return;
+    solveRafRef.current = requestAnimationFrame(() => {
+      solveRafRef.current = null;
+      const sock = wsRef.current;
+      if (!sock || sock.readyState !== WebSocket.OPEN) return;
+      const seq = ++seqRef.current;
+      lastSentSeqRef.current = seq;
+      sentAtRef.current.set(seq, performance.now());
+      sock.send(JSON.stringify({ ...controlsRef.current, _seq: seq }));
+      // Keep the preview signature current so that toggling Live *off* right
+      // after a solve doesn't see a stale signature and needlessly refetch the
+      // wireframe / drop the just-solved result — the solved geometry already
+      // matches these controls.
+      previewSigRef.current = JSON.stringify(controlsRef.current);
+      syncSolving();
+    });
+  }
+
+  useEffect(() => {
+    if (!active) return;
+    const ws = new WebSocket(WS_URL);
+    wsRef.current = ws;
+    // This socket's cuts sender (issue #551). A stable identity per socket
+    // so the close/cleanup handlers only deregister their OWN sender — a
+    // stale socket's late onclose must not tear down the transport a newer
+    // socket just registered.
+    const cutsSender = (msg: string): boolean => {
+      if (ws.readyState !== WebSocket.OPEN) return false;
+      ws.send(msg);
+      return true;
+    };
+    const dropCutsSender = () => {
+      if (cutsWsSend === cutsSender) setCutsWsSend(null);
+      flushCutsWsPending();
+    };
+    ws.onopen = () => {
+      setStatus("open");
+      setCutsWsSend(cutsSender);
+      // A prior socket's in-flight responses can never arrive on this new one.
+      // Treat everything sent so far as received so `solving` can't stick true,
+      // drop stale RTT timers, then send fresh current state. StrictMode and HMR
+      // both tear the socket down + recreate it; the seq counters survive in
+      // refs, so they must never rewind below what's already been received.
+      lastReceivedSeqRef.current = lastSentSeqRef.current;
+      sentAtRef.current.clear();
+      requestSolve();
+    };
+    ws.onclose = () => {
+      setStatus("closed");
+      dropCutsSender();
+      // No solve can progress while disconnected — collapse the outstanding
+      // count so the busy bar can't spin under a "closed" status (reconnect
+      // re-arms it via onopen).
+      lastReceivedSeqRef.current = lastSentSeqRef.current;
+      setSolving(false);
+    };
+    ws.onerror = () => {
+      setStatus("closed");
+      dropCutsSender();
+      lastReceivedSeqRef.current = lastSentSeqRef.current;
+      setSolving(false);
+    };
+    ws.onmessage = (ev) => {
+      const data: SolveResponse & Partial<CutsWsMessage> = JSON.parse(ev.data);
+      if (data._kind === "cuts") {
+        // Cuts sidecar response (issue #551) — never a solve; route it
+        // before any _seq/solving bookkeeping.
+        resolveCutsWsMessage(data as CutsWsMessage);
+        return;
+      }
+      const seq = data._seq ?? 0;
+      // One socket delivers in order, and the server may skip-send superseded
+      // results — so a higher `_seq` implicitly acknowledges every lower one.
+      // Ignore a straggler/duplicate at or below the received watermark.
+      if (seq <= lastReceivedSeqRef.current) {
+        syncSolving();
+        return;
+      }
+      lastReceivedSeqRef.current = seq;
+      // RTT from this seq's send; prune every acked entry (≤ seq) from the map —
+      // seqs skipped server-side never get their own response, so a single
+      // higher-seq arrival clears the whole run of them.
+      const sentAt = sentAtRef.current;
+      const t0 = sentAt.get(seq);
+      if (t0 !== undefined) setRttMs(performance.now() - t0);
+      for (const k of sentAt.keys()) {
+        if (k <= seq) sentAt.delete(k);
+      }
+      // Cancelled through this seq: the user bailed on it (and everything
+      // before). The watermark advanced above so `solving` can clear; just drop
+      // the result rather than rendering it.
+      if (seq <= canceledThroughSeqRef.current) {
+        syncSolving();
+        return;
+      }
+      // Drop a response for an antenna the user already switched away from: a
+      // slow in-flight solve for the previous selection must not stomp the new
+      // antenna's geometry preview (and briefly show the wrong antenna).
+      const staleGeom = !!data.geometry && data.geometry !== geometryRef.current;
+      if (!staleGeom) {
+        if (data.error) {
+          // A solve that raised (e.g. a user design's build_wires) — show the
+          // message and clear stale plot data rather than rendering an empty
+          // result on top of the last antenna.
+          setSolveError(data.error);
+          setResult(null);
+        } else {
+          setSolveError(null);
+          setResult(data);
+        }
+      }
+      syncSolving();
+    };
+    return () => {
+      if (solveRafRef.current !== null) {
+        cancelAnimationFrame(solveRafRef.current);
+        solveRafRef.current = null;
+      }
+      dropCutsSender(); // ws.close() fires onclose async; don't leave a dead sender up
+      ws.close();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active]);
+
+  return {
+    status,
+    rttMs,
+    solving,
+    showBusy,
+    stale,
+    requestSolve,
+    cancelSolve,
+    seqRef,
+  };
+}

--- a/src/antennaknobs/web/frontend/src/components/session/useSolverSlots.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useSolverSlots.ts
@@ -1,0 +1,108 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  DEFAULT_BACKEND_OPTS,
+  DEFAULT_SLOTS,
+  resolveSlotConfig,
+  type Backend,
+  type BackendOptsMap,
+  type Slot,
+  type SlotConfig,
+} from "../../lib/backends";
+
+// The A/B/C solver slots: each slot's backend + per-backend options, the
+// derived view of the active one, the three mutators the gear modal drives,
+// and the effect that remaps a PyNEC slot when the server reports no
+// pynec-accel (#642 seam 5b-3). The cluster moves whole, so its one literal
+// dep array and its global effect position are unchanged.
+//
+// backendTouchedRef comes back raw: the two "the user picked a backend by
+// hand" call sites stay in the component's JSX and set it directly.
+export function useSolverSlots({ havePynec }: { havePynec: boolean }) {
+  // Solver slots A / B / C — each one holds its own backend + options so
+  // the user can switch between configured solvers with a single click
+  // and tune each one independently from its gear menu.
+  const [activeSlot, setActiveSlot] = useState<Slot>("A");
+  const [slots, setSlots] = useState<Record<Slot, SlotConfig>>(DEFAULT_SLOTS);
+  // Set once the user picks a backend by hand; after that we stop auto-seeding
+  // the per-antenna recommended solver so their choice sticks.
+  const backendTouchedRef = useRef(false);
+  const [gearOpen, setGearOpen] = useState<Slot | null>(null);
+  const activeConfig = slots[activeSlot];
+  const backend = activeConfig.backend;
+  const currentOpts = activeConfig.opts;
+  const nPerWire = currentOpts.nPerWire;
+  const wireRadius = currentOpts.wireRadius;
+  // Stable hash of the active slot's config so useEffect can depend on it.
+  const backendOptsKey = JSON.stringify(activeConfig);
+  function updateSlotOpts(slot: Slot, patch: Partial<BackendOptsMap[Backend]>) {
+    setSlots((prev) => ({
+      ...prev,
+      [slot]: {
+        ...prev[slot],
+        opts: { ...prev[slot].opts, ...patch } as BackendOptsMap[Backend],
+      },
+    }));
+  }
+  function setSlotBackend(slot: Slot, newBackend: Backend) {
+    // Preserve segments-per-wire and wire-radius across the swap so the
+    // user keeps their geometry-sizing choices when comparing models;
+    // model-specific kwargs revert to that backend's defaults.
+    setSlots((prev) => {
+      const prevOpts = prev[slot].opts;
+      const defaults = DEFAULT_BACKEND_OPTS[newBackend];
+      return {
+        ...prev,
+        [slot]: {
+          backend: newBackend,
+          opts: {
+            ...defaults,
+            nPerWire: prevOpts.nPerWire,
+            wireRadius: prevOpts.wireRadius,
+          } as BackendOptsMap[Backend],
+        },
+      };
+    });
+  }
+  function resetSlot(slot: Slot) {
+    setSlots((prev) => ({
+      ...prev,
+      [slot]: resolveSlotConfig(DEFAULT_SLOTS[slot], havePynec),
+    }));
+  }
+  // When the server reports no pynec-accel (#429), remap any slot still on
+  // PyNEC — the default slot C, or a saved/URL slot — to the fallback backend,
+  // so the panel never holds a backend the picker no longer offers (which the
+  // /ws solve would silently run as momwire).
+  useEffect(() => {
+    if (havePynec) return;
+    setSlots((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      for (const s of Object.keys(prev) as Slot[]) {
+        const resolved = resolveSlotConfig(prev[s], havePynec);
+        if (resolved !== prev[s]) {
+          next[s] = resolved;
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [havePynec]);
+
+  return {
+    activeSlot,
+    setActiveSlot,
+    slots,
+    backendTouchedRef,
+    gearOpen,
+    setGearOpen,
+    backend,
+    currentOpts,
+    nPerWire,
+    wireRadius,
+    backendOptsKey,
+    updateSlotOpts,
+    setSlotBackend,
+    resetSlot,
+  };
+}

--- a/src/antennaknobs/web/frontend/src/components/session/useViewState.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useViewState.ts
@@ -1,0 +1,100 @@
+import { useEffect, useState } from "react";
+import { type ExampleDescriptor } from "../../lib/params";
+import { VIEWS, type Projection, type View } from "../../lib/view";
+
+// Which output view is on screen and how it is drawn: the two far-field cut
+// angles, the selected view + camera projection, the antenna-canvas display
+// toggles, the per-example camera reset and the arrow-key view cycler (#642
+// seam 5b-3). Called from the component at the cut-angle states' old position,
+// which keeps the camera-reset effect exactly where it was; the arrow-key
+// listener moves up with it, ahead of the linked-design-freq and mobile
+// carousel effects it shares no state with.
+export function useViewState({
+  currentExample,
+  active,
+}: {
+  currentExample: ExampleDescriptor | undefined;
+  active: boolean;
+}) {
+  // Far-field cut angles. The azimuth plot slices the pattern at elevation
+  // `azElevDeg`; the elevation plot slices the vertical plane at azimuth
+  // bearing `elevAzDeg` (0° = +x). Defaults give the conventional views.
+  const [azElevDeg, setAzElevDeg] = useState(15);
+  // Default elevation-cut azimuth is 0° (+x) for every geometry: Yagi,
+  // moxon, and hexbeam beam +x; the inverted V now runs its arms along
+  // ±y so its broadside lobe also peaks at ±x.
+  const [elevAzDeg, setElevAzDeg] = useState(0);
+
+  const [view, setView] = useState<View>("antenna");
+  const [cameraProjection, setCameraProjection] = useState<Projection>("xy");
+  // When the user switches antennas, reset the camera to that example's
+  // natural starting view (declared on the backend via default_view).
+  // Explicit user override sticks until the next geometry change.
+  //
+  // A deferred (user) design reports default_view === null — its real view is
+  // auto-detected and arrives with the first geometry preview (handled where
+  // the preview lands, below). Holding the current camera until then avoids
+  // snapping to a wrong provisional view and flipping when the preview arrives.
+  useEffect(() => {
+    if (currentExample?.default_view) {
+      setCameraProjection(currentExample.default_view);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentExample?.name]);
+
+  // Antenna-canvas current visualization is split into two independent
+  // toggles: the per-segment current-magnitude heatmap (wire color/width)
+  // and the |I| envelope curve overlay. Either or both can be turned off;
+  // the wires and feed marker are always drawn.
+  const [showHeatmap, setShowHeatmap] = useState(true);
+  const [showEnvelope, setShowEnvelope] = useState(false);
+  // Wire labels and feed names can crowd dense geometries (and PyNEC returns
+  // many more wires than the momwire engines), so let them be toggled. Wire
+  // labels default OFF — they're the noisiest, especially on PyNEC.
+  const [showWireLabels, setShowWireLabels] = useState(false);
+  const [showFeedNames, setShowFeedNames] = useState(true);
+
+  useEffect(() => {
+    if (!active) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
+      // Don't hijack arrows while a knob (e.g. the cut-angle dials) or a real
+      // field is focused — those consume arrows to turn/edit their own value.
+      const t = e.target as HTMLElement | null;
+      if (
+        t &&
+        (t.tagName === "INPUT" ||
+          t.tagName === "TEXTAREA" ||
+          t.tagName === "SELECT" ||
+          t.isContentEditable ||
+          t.classList.contains("knob"))
+      ) {
+        return;
+      }
+      const idx = VIEWS.findIndex((v) => v.id === view);
+      const next = e.key === "ArrowDown" ? (idx + 1) % VIEWS.length : (idx - 1 + VIEWS.length) % VIEWS.length;
+      setView(VIEWS[next].id);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [view, active]);
+
+  return {
+    azElevDeg,
+    setAzElevDeg,
+    elevAzDeg,
+    setElevAzDeg,
+    view,
+    setView,
+    cameraProjection,
+    setCameraProjection,
+    showHeatmap,
+    setShowHeatmap,
+    showEnvelope,
+    setShowEnvelope,
+    showWireLabels,
+    setShowWireLabels,
+    showFeedNames,
+    setShowFeedNames,
+  };
+}


### PR DESCRIPTION
Seam 5b-3 — the final rung of the #642 arc (design: https://github.com/stevenmburns/antennaknobs/issues/642#issuecomment-5160699838): DesignSession's behavior clusters become custom hooks. **Every frontend file is now ≤ 1,478 lines**, meeting the arc's acceptance bar, with the ordering-critical core (combo-reset → main solve → preview effects, `buildRequest`, `controlsRef`) deliberately left in DesignSession.

## The hooks

`components/session/`: `useSolveChannel` (ws + seq/gen protocol, requestSolve/cancel, busy-dwell), `useOptimizer`, `useAnalysisRunners` (four debounce effects + sweep/converge/norm-check/pattern runners), `useDesignCatalog`, `useMobileCarousel`, `sessionActions.ts` (plain functions), plus three zero/inert-effect-motion extras the builder added to actually reach the bar: `useSolverSlots`, `useGroundConfig`, `useViewState`.

`DesignSession.tsx`: **2,689 → 1,478 lines**.

## Hazard compliance (each independently verified by the reviewer)

- **Dep arrays byte-identical** — builder diffed all 32; reviewer independently re-diffed the single-line subset (21/21 identical). `active` appears in exactly the same arrays.
- **No new memoization** — the `useCallback`/`useMemo` in the new files (`loadExamples`, `trustDesign`, `optFixedSig`) are pre-existing, verified against the pre-move file.
- **Render-time ref mirrors** (`optEnabledRef`, `geometryRef`) remain unconditional render writes.
- **Seq protocol + per-socket `cutsSender` identity guard** moved verbatim inside the ws effect; `flushCutsWsPending()` on every teardown path.
- **Effect-order audit** in the builder report: combo-reset → solve → preview untouched and adjacent; the two order-sensitive freq effects unchanged; the ws effect's move ahead of the solve effect analyzed as inert (cleanups-before-setups on `active` flips; `requestSolve` early-returns on a non-OPEN socket either way).
- **Sanctioned deviation**: `sessionIdRef` stays in DesignSession instead of moving (hazard g's two requirements were circular via `controlsRef`'s render-time `buildRequest()` call); this keeps `buildRequest` 100% verbatim.
- **Deliberately NOT extracted**: the design/meas frequency cluster — moving it would reorder the band-snap vs linked-design-freq effects, a real behavior change.

## Gates

- `npm test` 182/182 and `npm run build` green **on each of the seven commits independently**.
- Extra gate beyond the recipe: a throwaway jsdom harness mounted the pre-extraction component (from `8b6de6820`) and this one side-by-side through mount → active=false → active=true → unmount with stubbed fetch/WebSocket — **`innerHTML` identical, including under StrictMode; WebSocket construction counts match**.
- Roster contract 2/2; repo-wide `ruff format --check` clean.

## ⚠️ Not run: the manual browser smoke

The design's verification recipe calls for a StrictMode dev-server smoke (knob drag, combo-gate → solve-anyway, tab-switch socket handoff, mobile carousel) and a throttled-network seq-protocol check. Neither reviewer nor builder has a browser in this environment; the jsdom DOM-identity harness is the closest automated substitute. **Recommend a 2-minute manual smoke on the deployed/dev app after merge** — the seq protocol and socket handoff are the spots to poke.

## Review notes

Implemented by an **opus** subagent (chosen per the delegated-build model rule: this seam's failure mode is subtle closure/dep-array drift that no gate pins down); reviewed by the session model as above.

Closes the decomposition arc of #642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g
