### PR TITLE
FloatingBalun primary determinacy: state the mechanism that actually holds

### DIFF
--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -1460,7 +1460,17 @@ class Network:
         (an antenna-Y row grounds it), is driven by a source, is referenced by
         any non-BalancedLine branch or by a ``zcomm``-carrying BalancedLine
         (its CM block is itself a return), or is a `FloatingBalun` *primary*
-        (datum-referenced) — issues #575/#576/#589."""
+        — issues #575/#576/#589.
+
+        The primary is pinned by the element's CONSTITUTIVE ROW, not by any
+        path to the datum: ``v_a − v_b − n·v_p = r·j`` determines ``v_p`` once
+        the secondary pair is determinate (which the check above already
+        requires), and ``n = 0`` is rejected at stamp time so the coefficient
+        is never zero. The datum path one might reach for — the magnetizing
+        shunt ``G[p, p] += y_mag`` — is stamped only when the element declares
+        a magnetizing branch, and both `station.floating_balun` and
+        `station.balanced_l_tuner` default ``lmag_uH=None``, so for the common
+        ideal-balun case there is no such path at all (issue #660)."""
         cm_open = [
             b for b in self.branches if isinstance(b, BalancedLine) and b.zcomm is None
         ]
@@ -1475,7 +1485,9 @@ class Network:
             if isinstance(br, BalancedLine) and br.zcomm is None:
                 continue  # CM-open line is not itself a common-mode return
             if isinstance(br, FloatingBalun):
-                determinate.add(br.primary)  # only the datum-referenced primary
+                # Only the primary — pinned by the constitutive row, see the
+                # docstring. The secondary pair is what we are checking FOR.
+                determinate.add(br.primary)
                 continue
             determinate.update(_branch_port_refs(br))
         touched = set()

--- a/tests/test_floating_balun.py
+++ b/tests/test_floating_balun.py
@@ -183,6 +183,45 @@ def test_floating_secondary_needs_a_common_mode_return():
         )
 
 
+def test_the_primary_is_pinned_by_the_constitutive_row_not_a_datum_path():
+    """A `FloatingBalun` primary counts as common-mode determinate, and the
+    reason is the constitutive row ``v_a − v_b − n·v_p = r·j`` rather than any
+    path to the datum (issue #660).
+
+    The obvious-looking reason — the magnetizing shunt ``G[p, p] += y_mag`` —
+    is stamped only when the element declares a magnetizing branch, and the
+    ideal balun the catalog uses declares none. So an ideal balun has NO datum
+    path at its primary, and the network must still build.
+    """
+    from antennaknobs.network_reduce import magnetizing_impedance
+
+    ideal = _fb(1.0)
+    assert magnetizing_impedance(ideal, OMEGA) is None  # no shunt to the datum
+
+    def net(branches):
+        return Network(
+            ports={
+                "p": PortVirtual("p"),  # balun primary AND a CM-open terminal
+                "q": PortVirtual("q"),
+                "w1": PortOnWire("w1"),
+                "w2": PortOnWire("w2"),
+                "s1": PortOnWire("s1"),
+                "s2": PortOnWire("s2"),
+            },
+            branches=branches,
+            sources=[Driven("q", 1 + 0j)],
+        )
+
+    line = BalancedLine(a1="p", a2="q", b1="w1", b2="w2", zdiff=450.0, length=1.0)
+    # "p" is reachable only through the CM-open line and the balun primary, so
+    # the primary rule is the only thing making it determinate.
+    net([line, FloatingBalun(primary="p", a="s1", b="s2", n=1.0)])
+    # ...and without the balun, the same node is rejected — which is what
+    # makes this a test of the rule rather than of the rest of the network.
+    with pytest.raises(ValueError, match=r"'p'"):
+        net([line])
+
+
 def test_zcomm_feedline_grounds_the_secondary_common_mode():
     """The same chain with a zcomm-carrying feedline is a valid common-mode
     return, so the network builds and solves."""


### PR DESCRIPTION
## Summary

Closes #660. Comment accuracy only — `_validate_common_mode` reaches the right conclusion and the code is unchanged.

- The docstring justified treating a `FloatingBalun` **primary** as common-mode determinate by calling it *"datum-referenced"*. That implies the magnetizing shunt `G[p, p] += y_mag`, which `magnetizing_impedance` stamps only when the element declares a magnetizing branch — and `station.floating_balun` / `station.balanced_l_tuner` both default `lmag_uH=None`. For the ordinary ideal balun there is no datum path at the primary at all, so the stated reason was false exactly where it is most relied on.
- What pins it is the constitutive row `v_a − v_b − n·v_p = r·j`: once the secondary pair is determinate — which the same validator already requires, that being what it is checking for — `v_p` follows, and `n = 0` is rejected at stamp time so the coefficient is never zero.
- **Made executable, not just reworded.** The new test wires a balun primary onto a CM-open `BalancedLine` terminal so that node is determinate through the primary rule and nothing else: the network builds with the balun, and is rejected by name without it. Deleting `determinate.add(br.primary)` fails it (verified), which is what makes it a test of the rule rather than of the rest of the network. It also asserts `magnetizing_impedance` is `None` for the ideal balun — the absent datum path, stated where someone would otherwise re-derive the wrong reason.
- `station.py:257` keeps the phrase deliberately: there it describes the element's port convention (the primary is the single-ended side), which is true.

## Test plan
- [x] `pytest tests/test_floating_balun.py tests/test_balanced_line_physics.py` — 29 passed
- [x] Mutation check: removing `determinate.add(br.primary)` fails the new test
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PTs3n5Yv7pwpcxQdgMBfn