### PR TITLE
fix(params): resolve the three pinned param-schema quirks (#674)

### DIFF
--- a/src/antennaknobs/web/frontend/src/__tests__/params.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/params.test.ts
@@ -173,19 +173,20 @@ describe("seedDefaults", () => {
     }
   });
 
-  it("applies default_overrides per group instance, bypassing kind coercion", () => {
+  it("applies default_overrides per group instance through the same kind coercion as defaults (decided in issue #674)", () => {
     const group = makeGroup({
       name: "bands",
       max_repeats: 2,
       params: [makeParam({ name: "freq", kind: "float", default: 14.1 })],
-      // Instance 0 overridden to a *string* — seedDefaults passes an
-      // override through untouched (no Number()/String()/Boolean() applied),
-      // unlike the plain-default path. Instance 1 has no override.
+      // Instance 0 overridden with a *stringified* number — #674 routed
+      // overrides through the same per-kind coercion as plain defaults, so
+      // it lands as the number 14.2, not the string. (Server-side types
+      // agree by construction today; this guards a heterogeneous instance.)
       default_overrides: [{ freq: "14.200" }, {}],
     });
     const out = seedDefaults([group]);
     const instances = out.bands as ParamValueBag[];
-    expect(instances[0]).toEqual({ freq: "14.200" });
+    expect(instances[0]).toEqual({ freq: 14.2 });
     expect(instances[1]).toEqual({ freq: 14.1 });
   });
 
@@ -203,7 +204,9 @@ describe("seedDefaults", () => {
       // The outer group's default_overrides is keyed by the outer's own
       // param names (here just "inner", the nested group) — but overrides
       // only apply to scalar leaves, never to a nested group, which always
-      // self-seeds from its own default_overrides regardless.
+      // self-seeds from its own default_overrides regardless. Promoted to a
+      // documented CONTRACT in issue #674 (the adapter cannot emit nested
+      // groups; this pins the fail-soft behavior if one ever appears).
       default_overrides: [{}, {}],
     });
     const out = seedDefaults([outer]);
@@ -355,12 +358,12 @@ describe("matchesQuery", () => {
     expect(matchesQuery(ex, "helix")).toBe(false);
   });
 
-  it("lowercases the haystack but NOT the query — an uppercase query misses (caller must lowercase first)", () => {
+  it("is case-insensitive on both sides (decided in issue #674)", () => {
     const ex = makeExample({ name: "beams.yagi", label: "Yagi-Uda Beam" });
-    // Surprising: matchesQuery does `hay.toLowerCase().includes(q)`, so a
-    // query that isn't already lowercase will not match even an
-    // otherwise-identical substring.
-    expect(matchesQuery(ex, "YAGI")).toBe(false);
+    // Originally only the haystack was lowercased and callers had to
+    // pre-lower the query; #674 promoted both-sides insensitivity to the
+    // contract so a new call site can't silently miss.
+    expect(matchesQuery(ex, "YAGI")).toBe(true);
     expect(matchesQuery(ex, "yagi")).toBe(true);
   });
 });

--- a/src/antennaknobs/web/frontend/src/lib/params.ts
+++ b/src/antennaknobs/web/frontend/src/lib/params.ts
@@ -229,7 +229,10 @@ export function matchesQuery(ex: ExampleDescriptor, q: string): boolean {
   const hay = `${ex.name} ${ex.label} ${familyOf(ex.name)} ${
     SEARCH_KEYWORDS[ex.name] ?? ""
   }`.toLowerCase();
-  return hay.includes(q);
+  // Case-insensitive on both sides (issue #674): callers used to have to
+  // pre-lowercase the query, which was a silent-miss footgun for any new
+  // call site.
+  return hay.includes(q.toLowerCase());
 }
 
 export function applyVisibility(spec: SchemaParamSpec, values: ParamValueBag): boolean {
@@ -262,21 +265,31 @@ export function seedDefaults(
   const out: ParamValueBag = {};
   for (const item of schema) {
     if (isGroup(item)) {
+      // CONTRACT (issue #674): a nested group always self-seeds from its own
+      // default_overrides; a parent override bag never reaches it. Overrides
+      // are per-scalar-leaf by design, and the adapter cannot emit nested
+      // groups at all today (audited: 0 across all 100 designs) — this
+      // branch exists only so a future nested schema fails soft, not wrong.
       const arr: ParamValueBag[] = [];
       for (let i = 0; i < item.max_repeats; i++) {
         arr.push(seedDefaults(item.params, item.default_overrides[i]));
       }
       out[item.name] = arr;
     } else {
+      // An override wins over the leaf default, but both go through the same
+      // per-kind coercion (issue #674): the server builds default_overrides
+      // from the Builder's own instance dicts, so types agree by
+      // construction today — coercing here keeps a heterogeneously-typed
+      // instance (e.g. an int where instance 0 had a float, or a stringified
+      // number) from leaking a wrong-typed value into the ParamValueBag.
       const ov = overrides?.[item.name];
-      if (ov !== undefined) {
-        out[item.name] = ov as number | string | boolean;
-      } else if (item.kind === "enum") {
-        out[item.name] = String(item.default);
+      const raw = ov !== undefined ? ov : item.default;
+      if (item.kind === "enum") {
+        out[item.name] = String(raw);
       } else if (item.kind === "bool") {
-        out[item.name] = Boolean(item.default);
+        out[item.name] = Boolean(raw);
       } else {
-        out[item.name] = Number(item.default);
+        out[item.name] = Number(raw);
       }
     }
   }


### PR DESCRIPTION
Resolves #674 with the decisions the issue asked for, informed by two audits of the live `/examples` payload (all 100 designs):

- **`matchesQuery`** — **fixed**: now lowercases the query too. The only call site pre-lowered already (no live bug); the contract is no longer a footgun for the next caller.
- **`seedDefaults` override coercion** — **fixed**: overrides route through the same per-kind coercion as plain defaults. Audit result: **0 type mismatches** between override values and leaf kinds across all designs (types agree by construction — the adapter derives both from the same Builder instance dicts), so this is robustness, not a behavior change for any shipped schema.
- **Nested-group override propagation** — **contract**: documented in `seedDefaults` and the pinning test. Audit result: **0 nested groups** exist in any design and `_group_spec_from_default` cannot emit one; the branch pins fail-soft behavior for a hypothetical future schema.

Pinning tests updated to assert the decided behavior, each citing #674. Gates: `npm test` 182/182, `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g