### PR TITLE
Patch postcss for the source-map path-traversal advisory (GHSA-r28c-9q8g-f849)

### DIFF
--- a/src/antennaknobs/web/frontend/package-lock.json
+++ b/src/antennaknobs/web/frontend/package-lock.json
@@ -1279,9 +1279,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -1359,9 +1359,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -1379,7 +1379,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary

`npm audit` in `src/antennaknobs/web/frontend` reported one high-severity finding: **postcss <= 8.5.17**, [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) — path traversal in previous-source-map auto-loading via `sourceMappingURL`, disclosing arbitrary `.map` files. postcss is a transitive dev dependency of vite; nothing in this repo imports it directly.

- `npm audit fix` resolves it **entirely within the existing semver ranges**: postcss 8.5.15 → 8.5.25, and its own dependency nanoid 3.3.12 → 3.3.17. Both patch-level, no vite bump required.
- **Only `package-lock.json` moves** — `package.json` is untouched (7 insertions, 7 deletions: two `version`/`resolved`/`integrity` triples).
- `npm audit` now reports **0 vulnerabilities**.
- **The emitted bundle is unchanged, provably**: `npm run build` produces the same content hashes as before the bump (`index-D6hpa_fZ.css`, `index-BnOgc60L.js`). This is a supply-chain patch with no product surface.

Found while correcting a stale local `node_modules` (installed vite was 5.4.21 against a lockfile pinning 8.1.0 — that was an install-side problem only, no repo change needed).

## Test plan
- [x] `npm audit` — 0 vulnerabilities (was 1 high)
- [x] `npm test` — 182/182 across 8 files
- [x] `npm run build` — `tsc --noEmit` clean, identical output hashes
- [x] Dev server restarted and driven in the browser: live solve over `/ws` (SWR 1.20, rtt 12.5 ms, `ws: open`), no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PTs3n5Yv7pwpcxQdgMBfn