### PR TITLE
test(frontend): Testing Library infra + BackendConfigModal matrix (#673 unit 1)

### DIFF
--- a/src/antennaknobs/web/frontend/package-lock.json
+++ b/src/antennaknobs/web/frontend/package-lock.json
@@ -12,6 +12,9 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^6.0.0",
@@ -33,6 +36,41 @@
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
         "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -491,6 +529,68 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -501,6 +601,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -704,6 +811,39 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -791,6 +931,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -800,6 +950,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -1261,6 +1418,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1387,6 +1554,21 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1421,6 +1603,13 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.1.3",

--- a/src/antennaknobs/web/frontend/package.json
+++ b/src/antennaknobs/web/frontend/package.json
@@ -14,6 +14,9 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^6.0.0",

--- a/src/antennaknobs/web/frontend/src/__tests__/BackendConfigModal.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/BackendConfigModal.test.tsx
@@ -1,0 +1,411 @@
+// Pins the conditional-rendering matrix of the slot gear menu
+// (src/components/backend/BackendConfigModal.tsx, issue #673): which knobs each
+// backend shows, the per-design backend allowlist gating, and the dismissal
+// paths. Every visibility assertion is paired with an absence assertion on a
+// backend/flag that must NOT show the field — a presence-only test still passes
+// if the conditional is deleted.
+//
+// BSplineFields has no separate export; it is exercised through the modal with
+// a B-spline-family backend, which is also the only way it ships.
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  BackendConfigModal,
+  type BackendConfigProps,
+} from "../components/backend/BackendConfigModal";
+import {
+  BACKEND_LABEL,
+  BACKEND_ORDER,
+  BSPLINE_DEFAULT_OPTS,
+  BSPLINE_FAMILY,
+  DEFAULT_BACKEND_OPTS,
+  RESTRICTED_BACKEND_REASON,
+  type BSplineOpts,
+  type SinGalerkinOpts,
+} from "../lib/backends";
+
+// --- fixtures --------------------------------------------------------------
+// Backend labels, option shapes and defaults all come from lib/backends so the
+// tests follow a rename or a default change instead of pinning a stale copy.
+
+function bsplineOpts(over: Partial<BSplineOpts> = {}): BSplineOpts {
+  return { ...BSPLINE_DEFAULT_OPTS, ...over };
+}
+
+function sinGalerkinOpts(over: Partial<SinGalerkinOpts> = {}): SinGalerkinOpts {
+  return { ...DEFAULT_BACKEND_OPTS["sinusoidal-galerkin"], ...over };
+}
+
+// Callbacks are supplied by the harness (and returned as spies) rather than
+// overridable, so an assertion can never target a spy the component never got.
+type ModalOverrides = Partial<
+  Omit<BackendConfigProps, "onChangeBackend" | "onPatch" | "onReset" | "onClose">
+>;
+
+function renderModal(overrides: ModalOverrides = {}) {
+  const backend = overrides.backend ?? "bspline";
+  const spies = {
+    onChangeBackend: vi.fn(),
+    onPatch: vi.fn(),
+    onReset: vi.fn(),
+    onClose: vi.fn(),
+  };
+  const view = render(
+    <BackendConfigModal
+      slot="A"
+      backend={backend}
+      backends={BACKEND_ORDER}
+      requiredBackends={null}
+      suggestConvergedFeed={false}
+      opts={DEFAULT_BACKEND_OPTS[backend]}
+      {...overrides}
+      {...spies}
+    />,
+  );
+  return { ...view, ...spies, user: userEvent.setup() };
+}
+
+// NumberField's <label> wraps only the caption/value spans, not the input, so
+// there is no label→control association for getByLabelText to follow: locate
+// the field by its caption text and step out to the sibling input.
+function numberField(label: string): HTMLInputElement {
+  const field = screen.getByText(label).closest(".field");
+  if (!field) throw new Error(`no .field wrapper for "${label}"`);
+  return within(field as HTMLElement).getByRole("spinbutton") as HTMLInputElement;
+}
+
+const N_QP_CONST = "n_qp_const (GL pts)";
+const N_QP_PAIR = "n_qp_pair (GL pts/axis)";
+const FEED_SMOOTHING_ALPHA = "α (bump width / h_feed)";
+const N_QP_SOURCE = "n_qp_source";
+const N_QP_SING = "n_qp_sing (GL pts/axis)";
+const ENRICHMENT_MIN_K = "enrichment_min_k";
+const TIKHONOV_LAMBDA = "tikhonov_lambda (λ)";
+const AUTO_TAP_THRESHOLD = "auto_tap_ratio_threshold";
+
+describe("BackendConfigModal — backend tab list", () => {
+  it("offers every backend, marking the current one selected", () => {
+    renderModal({ backend: "bspline" });
+    for (const b of BACKEND_ORDER) {
+      const tab = screen.getByRole("tab", { name: BACKEND_LABEL[b] });
+      expect(tab).toHaveProperty("disabled", false);
+      expect(tab.getAttribute("title")).toBeNull();
+      expect(tab.getAttribute("aria-selected")).toBe(String(b === "bspline"));
+    }
+  });
+
+  it("fires onChangeBackend with the clicked backend", async () => {
+    const { user, onChangeBackend } = renderModal({ backend: "bspline" });
+    await user.click(screen.getByRole("tab", { name: BACKEND_LABEL.pynec }));
+    expect(onChangeBackend).toHaveBeenCalledWith("pynec");
+    expect(onChangeBackend).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the backends a restricted design excludes, with the reason as tooltip", () => {
+    renderModal({
+      backend: "bspline",
+      requiredBackends: ["bspline", "sinusoidal-galerkin"],
+    });
+    for (const b of BACKEND_ORDER) {
+      const tab = screen.getByRole("tab", { name: BACKEND_LABEL[b] });
+      const allowed = b === "bspline" || b === "sinusoidal-galerkin";
+      expect(tab).toHaveProperty("disabled", !allowed);
+      expect(tab.getAttribute("title")).toBe(
+        allowed ? null : RESTRICTED_BACKEND_REASON,
+      );
+    }
+  });
+
+  it("does not fire onChangeBackend when a disallowed tab is clicked", async () => {
+    const { user, onChangeBackend } = renderModal({
+      backend: "bspline",
+      requiredBackends: ["bspline"],
+    });
+    await user.click(screen.getByRole("tab", { name: BACKEND_LABEL.pynec }));
+    expect(onChangeBackend).not.toHaveBeenCalled();
+  });
+});
+
+describe("BackendConfigModal — per-backend knob visibility", () => {
+  it("shows the shared mesh knobs for every backend", () => {
+    for (const b of BACKEND_ORDER) {
+      const { unmount } = renderModal({ backend: b });
+      expect(numberField("segments / wire (N)").value).toBe(
+        String(DEFAULT_BACKEND_OPTS[b].nPerWire),
+      );
+      expect(numberField("wire radius (m)")).toBeTruthy();
+      unmount();
+    }
+  });
+
+  it.each(["sinusoidal", "sinusoidal-galerkin"] as const)(
+    "shows n_qp_const for %s",
+    (backend) => {
+      renderModal({ backend });
+      expect(screen.queryByText(N_QP_CONST)).not.toBeNull();
+    },
+  );
+
+  it.each(["bspline", "hmatrix", "arrayblock", "pynec"] as const)(
+    "hides n_qp_const for %s",
+    (backend) => {
+      renderModal({ backend });
+      expect(screen.queryByText(N_QP_CONST)).toBeNull();
+    },
+  );
+
+  it.each(BSPLINE_FAMILY)("shows the B-spline knobs for %s", (backend) => {
+    renderModal({ backend });
+    expect(screen.queryByRole("tab", { name: "d=2" })).not.toBeNull();
+    expect(screen.queryByText(N_QP_PAIR)).not.toBeNull();
+  });
+
+  it.each(["sinusoidal", "sinusoidal-galerkin", "pynec"] as const)(
+    "hides the B-spline knobs for %s",
+    (backend) => {
+      renderModal({ backend });
+      expect(screen.queryByRole("tab", { name: "d=2" })).toBeNull();
+      expect(screen.queryByText(N_QP_PAIR)).toBeNull();
+    },
+  );
+
+  it("shows the no-extra-knobs note for pynec only", () => {
+    const { unmount } = renderModal({ backend: "pynec" });
+    expect(screen.queryByText(/no extra solver knobs/)).not.toBeNull();
+    unmount();
+    renderModal({ backend: "bspline" });
+    expect(screen.queryByText(/no extra solver knobs/)).toBeNull();
+  });
+});
+
+describe("BackendConfigModal — Sin-Galerkin feed model", () => {
+  it("offers the feed-model tabs only for sinusoidal-galerkin", () => {
+    const { unmount } = renderModal({
+      backend: "sinusoidal-galerkin",
+      opts: sinGalerkinOpts(),
+    });
+    expect(screen.queryByRole("tab", { name: "Converged" })).not.toBeNull();
+    expect(screen.queryByRole("tab", { name: "NEC-compatible" })).not.toBeNull();
+    unmount();
+    // Plain sinusoidal has no point-gap RHS, so it must not present the choice.
+    renderModal({ backend: "sinusoidal" });
+    expect(screen.queryByRole("tab", { name: "Converged" })).toBeNull();
+  });
+
+  it("patches feedModel to point when Converged is clicked", async () => {
+    const { user, onPatch } = renderModal({
+      backend: "sinusoidal-galerkin",
+      opts: sinGalerkinOpts({ feedModel: "segment" }),
+    });
+    await user.click(screen.getByRole("tab", { name: "Converged" }));
+    expect(onPatch).toHaveBeenCalledWith({ feedModel: "point" });
+    expect(onPatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("patches feedModel to segment when NEC-compatible is clicked", async () => {
+    const { user, onPatch } = renderModal({
+      backend: "sinusoidal-galerkin",
+      opts: sinGalerkinOpts({ feedModel: "point" }),
+    });
+    await user.click(screen.getByRole("tab", { name: "NEC-compatible" }));
+    expect(onPatch).toHaveBeenCalledWith({ feedModel: "segment" });
+  });
+
+  it("shows the Converged hint only when recommended and still on segment", () => {
+    const hint = /near-open \/ high-Q/;
+    const cases: Array<[boolean, "segment" | "point", boolean]> = [
+      [true, "segment", true],
+      [true, "point", false],
+      [false, "segment", false],
+      [false, "point", false],
+    ];
+    for (const [suggestConvergedFeed, feedModel, shown] of cases) {
+      const { unmount } = renderModal({
+        backend: "sinusoidal-galerkin",
+        suggestConvergedFeed,
+        opts: sinGalerkinOpts({ feedModel }),
+      });
+      expect(screen.queryByText(hint) !== null).toBe(shown);
+      unmount();
+    }
+  });
+});
+
+describe("BSplineFields — degree and feed smoothing", () => {
+  it("patches the degree of the clicked tab", async () => {
+    const { user, onPatch } = renderModal({
+      backend: "bspline",
+      opts: bsplineOpts({ degree: 2 }),
+    });
+    expect(screen.getByRole("tab", { name: "d=2" }).getAttribute("aria-selected")).toBe("true");
+    await user.click(screen.getByRole("tab", { name: "d=1" }));
+    expect(onPatch).toHaveBeenCalledWith({ degree: 1 });
+    expect(onPatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("commits an edited number field as a patch on that key alone", async () => {
+    const { user, onPatch } = renderModal({
+      backend: "bspline",
+      opts: bsplineOpts({ nQpPair: 4 }),
+    });
+    await user.type(numberField(N_QP_PAIR), "2"); // "4" -> "42"
+    expect(onPatch).toHaveBeenCalledWith({ nQpPair: 42 });
+  });
+
+  it("hides the smoothing sub-fields while the delta-gap is sharp", () => {
+    renderModal({
+      backend: "bspline",
+      opts: bsplineOpts({ feedSmoothingFactor: null }),
+    });
+    const box = screen.getByRole("checkbox", { name: /feed source smoothing/ });
+    expect(box).toHaveProperty("checked", false);
+    expect(screen.queryByText(FEED_SMOOTHING_ALPHA)).toBeNull();
+    expect(screen.queryByText(N_QP_SOURCE)).toBeNull();
+  });
+
+  it("shows the smoothing sub-fields once a factor is set", () => {
+    renderModal({
+      backend: "bspline",
+      opts: bsplineOpts({ feedSmoothingFactor: 3 }),
+    });
+    expect(
+      screen.getByRole("checkbox", { name: /feed source smoothing/ }),
+    ).toHaveProperty("checked", true);
+    expect(screen.queryByText(FEED_SMOOTHING_ALPHA)).not.toBeNull();
+    expect(screen.queryByText(N_QP_SOURCE)).not.toBeNull();
+  });
+
+  it("toggles feedSmoothingFactor between the default 3 and null", async () => {
+    const off = renderModal({
+      backend: "bspline",
+      opts: bsplineOpts({ feedSmoothingFactor: null }),
+    });
+    await off.user.click(
+      screen.getByRole("checkbox", { name: /feed source smoothing/ }),
+    );
+    expect(off.onPatch).toHaveBeenCalledWith({ feedSmoothingFactor: 3 });
+    off.unmount();
+
+    const on = renderModal({
+      backend: "bspline",
+      opts: bsplineOpts({ feedSmoothingFactor: 3 }),
+    });
+    await on.user.click(
+      screen.getByRole("checkbox", { name: /feed source smoothing/ }),
+    );
+    expect(on.onPatch).toHaveBeenCalledWith({ feedSmoothingFactor: null });
+  });
+});
+
+describe("BSplineFields — singular enrichment", () => {
+  it("hides every enrichment sub-field while enrichment is off", () => {
+    renderModal({
+      backend: "bspline",
+      opts: bsplineOpts({ useSingularEnrichment: false }),
+    });
+    expect(
+      screen.getByRole("checkbox", { name: /junction singular enrichment/ }),
+    ).toHaveProperty("checked", false);
+    expect(screen.queryByText(N_QP_SING)).toBeNull();
+    expect(screen.queryByText(ENRICHMENT_MIN_K)).toBeNull();
+    expect(screen.queryByRole("combobox")).toBeNull();
+  });
+
+  it("reveals the enrichment sub-fields when it is on", () => {
+    renderModal({
+      backend: "bspline",
+      opts: bsplineOpts({ useSingularEnrichment: true }),
+    });
+    expect(screen.queryByText(N_QP_SING)).not.toBeNull();
+    expect(screen.queryByText(ENRICHMENT_MIN_K)).not.toBeNull();
+    expect(screen.getByRole("combobox")).toHaveProperty("value", "raw");
+  });
+
+  it("patches useSingularEnrichment on toggle", async () => {
+    const { user, onPatch } = renderModal({
+      backend: "bspline",
+      opts: bsplineOpts({ useSingularEnrichment: false }),
+    });
+    await user.click(
+      screen.getByRole("checkbox", { name: /junction singular enrichment/ }),
+    );
+    expect(onPatch).toHaveBeenCalledWith({ useSingularEnrichment: true });
+  });
+
+  it("patches enrichmentVariant from the select", async () => {
+    const { user, onPatch } = renderModal({
+      backend: "bspline",
+      opts: bsplineOpts({ useSingularEnrichment: true }),
+    });
+    await user.selectOptions(screen.getByRole("combobox"), "auto");
+    expect(onPatch).toHaveBeenCalledWith({ enrichmentVariant: "auto" });
+  });
+
+  // Each variant owns exactly one extra knob; the other must stay hidden.
+  it.each([
+    ["raw", false, false],
+    ["stable", false, false],
+    ["tikhonov", true, false],
+    ["auto", false, true],
+  ] as const)(
+    "variant %s shows tikhonov_lambda=%s / auto_tap_ratio_threshold=%s",
+    (enrichmentVariant, lambdaShown, thresholdShown) => {
+      renderModal({
+        backend: "bspline",
+        opts: bsplineOpts({ useSingularEnrichment: true, enrichmentVariant }),
+      });
+      expect(screen.queryByText(TIKHONOV_LAMBDA) !== null).toBe(lambdaShown);
+      expect(screen.queryByText(AUTO_TAP_THRESHOLD) !== null).toBe(thresholdShown);
+    },
+  );
+
+  it("keeps the variant knobs hidden when enrichment itself is off", () => {
+    renderModal({
+      backend: "bspline",
+      opts: bsplineOpts({
+        useSingularEnrichment: false,
+        enrichmentVariant: "tikhonov",
+      }),
+    });
+    expect(screen.queryByText(TIKHONOV_LAMBDA)).toBeNull();
+  });
+});
+
+describe("BackendConfigModal — dismissal and footer", () => {
+  it("closes on Escape", async () => {
+    const { user, onClose } = renderModal();
+    await user.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores other keys", async () => {
+    const { user, onClose } = renderModal();
+    await user.keyboard("{Enter}");
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes on an overlay click but not on a click inside the modal", async () => {
+    const { user, onClose, container } = renderModal();
+    await user.click(screen.getByRole("dialog", { name: "Slot A options" }));
+    expect(onClose).not.toHaveBeenCalled();
+
+    const overlay = container.querySelector(".backend-config-overlay");
+    expect(overlay).not.toBeNull();
+    await user.click(overlay as HTMLElement);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on the × button", async () => {
+    const { user, onClose } = renderModal();
+    await user.click(screen.getByRole("button", { name: "Close" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onReset from the footer without touching onPatch", async () => {
+    const { user, onReset, onPatch } = renderModal();
+    await user.click(screen.getByRole("button", { name: /reset to defaults/ }));
+    expect(onReset).toHaveBeenCalledTimes(1);
+    expect(onPatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/setup.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/setup.ts
@@ -1,0 +1,13 @@
+// Vitest setup for the component tests (see vitest.config.ts `setupFiles`).
+//
+// Testing Library normally unmounts between tests by registering its own
+// afterEach at import time, but it looks for that hook on globalThis and this
+// suite runs without `globals: true`. Verified empirically: without the hook
+// below a component mounted in one test is still in document.body during the
+// next, so getBy* queries throw on duplicate matches. Registering it here
+// rather than per test file keeps the guarantee unconditional — a new
+// component test cannot forget it.
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+afterEach(cleanup);

--- a/src/antennaknobs/web/frontend/vitest.config.ts
+++ b/src/antennaknobs/web/frontend/vitest.config.ts
@@ -10,9 +10,16 @@ export default defineConfig({
     // #642), so importing it from a Node environment throws before any test
     // runs. jsdom supplies window/document without starting a real browser.
     environment: "jsdom",
-    include: ["src/__tests__/**/*.test.ts"],
+    include: ["src/__tests__/**/*.test.ts", "src/__tests__/**/*.test.tsx"],
     // No `globals: true` — tests import describe/it/expect explicitly so
     // they typecheck under tsc without adding vitest's ambient types to
     // tsconfig (npm run build's tsc --noEmit covers all of src/).
+    //
+    // That choice costs Testing Library its auto-cleanup: RTL only registers
+    // its own afterEach when it finds one on globalThis at import time, which
+    // without `globals` is never. setup.ts registers it explicitly instead —
+    // without it, mounted components from earlier tests stay in document.body
+    // and getBy* queries hit duplicate matches.
+    setupFiles: ["src/__tests__/setup.ts"],
   },
 });


### PR DESCRIPTION
First unit of the #673 component-test arc, stacked into the `issue-673-component-tests` integration branch.

## What
- `@testing-library/react` + `@testing-library/user-event` (+ `@testing-library/dom` peer, per RTL v16's documented install) as devDeps.
- `vitest.config.ts`: `include` extended to `.test.tsx`; `setupFiles` registering `afterEach(cleanup)` explicitly — RTL's auto-cleanup needs `globals: true`, which this suite deliberately doesn't use (verified empirically: without it, mounts leak across tests).
- `BackendConfigModal.test.tsx`: 41 tests pinning the conditional-rendering matrix — tab allowlist gating with `RESTRICTED_BACKEND_REASON` tooltip, per-backend knob visibility (adversarial: absence asserted for backends that must NOT show each field), Sin-Galerkin feed-model tabs + Converged-hint 4-cell truth table, BSplineFields smoothing/enrichment/variant gating, Escape/overlay/× dismissal, callbacks asserted with concrete arguments.

## Gates (re-run independently by the reviewer)
- `npm test`: 223 passed (was 182), 2.24 s wall — well under the 10 s budget.
- `npm run build` (tsc --noEmit + vite): green.
- `npm test` invocation and `.github/` untouched.
- Mutation checks: builder ran 9 (each conditional ungated one at a time → red); reviewer independently re-ran 2 (BSplineFields ungated → suite exit 1; `disabled={!allowed}` dropped → 1 failed).

## Review notes
Implemented by an opus subagent; reviewed by the session model (Fable). I read the full diff, re-ran all gates, and re-verified two mutations myself. Fixture factories draw from `lib/backends` exports rather than pinned copies; the render harness owns the callback spies so tests can't assert against unwired spies. Known cosmetic follow-up for the end of the arc: the CI step name "Unit-test the pure frontend logic" is now stale (deliberately out of scope — `.github/` frozen for this arc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g