### PR TITLE
test(frontend): CatalogPanel/GeometryCombobox matrices (#673 unit 5)

### DIFF
--- a/src/antennaknobs/web/frontend/src/__tests__/CatalogPanel.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/CatalogPanel.test.tsx
@@ -1,0 +1,264 @@
+// Pins the conditional-rendering matrix of src/components/session/CatalogPanel.tsx
+// (issue #673): the variant-select visibility gate, the design-note and
+// examples-error banners, and — the load-bearing bit — the trust_required
+// split that routes a design-load error into either the AwaitingTrustPanel
+// (loaded fine, awaiting a trust decision) or the plain "failed to load"
+// alert, never both. Every conditional-presence assertion is paired with an
+// absence assertion so a deleted guard still fails the suite.
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CatalogPanel } from "../components/session/CatalogPanel";
+import type { DesignLoadError } from "../components/AwaitingTrustPanel";
+import type { ExampleDescriptor, ExampleGroup } from "../lib/params";
+
+// --- fixtures --------------------------------------------------------------
+// Real (fully-typed) minimal objects rather than `as` casts, so every field
+// the component might read is present and type-checked.
+
+function example(overrides: Partial<ExampleDescriptor> = {}): ExampleDescriptor {
+  return {
+    name: "dipole.test",
+    label: "Test Dipole",
+    multi_feed: false,
+    param_schema: [],
+    result_schema: [],
+    bands: [],
+    meas_freq_range_mhz: null,
+    default_view: null,
+    default_freq: null,
+    default_design_freq: null,
+    default_backend: null,
+    requires_backends: null,
+    has_design_freq: true,
+    variants: ["default"],
+    variant_values: {},
+    sweep_policy: { anchor: "design_freq", lo_factor: 0.5, hi_factor: 2 },
+    ...overrides,
+  };
+}
+
+function group(overrides: Partial<ExampleGroup> = {}): ExampleGroup {
+  return {
+    fam: "dipole",
+    label: "Dipoles",
+    items: [example()],
+    ...overrides,
+  };
+}
+
+function loadError(overrides: Partial<DesignLoadError> = {}): DesignLoadError {
+  return {
+    name: "some_design",
+    file: "some_design.py",
+    message: "boom",
+    ...overrides,
+  };
+}
+
+// Callbacks are supplied by the harness (and returned as spies) rather than
+// overridable, so an assertion can never target a spy the component never got.
+type PanelOverrides = Partial<{
+  geomGroups: ExampleGroup[];
+  geometry: string;
+  currentExample: ExampleDescriptor | undefined;
+  geomFilter: string;
+  currentVariant: string;
+  examplesError: string | null;
+  loadErrors: DesignLoadError[];
+  trustBusy: string | null;
+}>;
+
+function renderPanel(overrides: PanelOverrides = {}) {
+  const spies = {
+    setGeomFilter: vi.fn(),
+    setGeometry: vi.fn(),
+    selectVariant: vi.fn(),
+    trustDesign: vi.fn(),
+  };
+  const defaultExample = example();
+  const props = {
+    geomGroups: [group({ items: [defaultExample] })],
+    geometry: defaultExample.name,
+    currentExample: defaultExample,
+    geomFilter: "",
+    currentVariant: "default",
+    examplesError: null,
+    loadErrors: [],
+    trustBusy: null,
+    ...overrides,
+    ...spies,
+  };
+  const view = render(<CatalogPanel {...props} />);
+  return { ...view, ...spies, user: userEvent.setup() };
+}
+
+function variantSelect(): HTMLSelectElement | null {
+  return screen.queryByRole("combobox", { name: "variant" }) as HTMLSelectElement | null;
+}
+
+describe("CatalogPanel — variant select", () => {
+  it("shows the select when there is more than one variant", () => {
+    renderPanel({ currentExample: example({ variants: ["default", "opt"] }) });
+    expect(variantSelect()).not.toBeNull();
+  });
+
+  it("hides the select for exactly one variant", () => {
+    renderPanel({ currentExample: example({ variants: ["default"] }) });
+    expect(variantSelect()).toBeNull();
+  });
+
+  it("hides the select when currentExample is undefined", () => {
+    renderPanel({ currentExample: undefined });
+    expect(variantSelect()).toBeNull();
+  });
+
+  it("lists the variants as options and follows currentVariant", () => {
+    renderPanel({
+      currentExample: example({ variants: ["default", "opt"] }),
+      currentVariant: "opt",
+    });
+    const select = variantSelect()!;
+    expect(select.value).toBe("opt");
+    const optionValues = within(select)
+      .getAllByRole("option")
+      .map((o) => (o as HTMLOptionElement).value);
+    expect(optionValues).toEqual(["default", "opt"]);
+  });
+
+  it("fires selectVariant with the chosen value on change", async () => {
+    const { user, selectVariant } = renderPanel({
+      currentExample: example({ variants: ["default", "opt"] }),
+      currentVariant: "default",
+    });
+    await user.selectOptions(variantSelect()!, "opt");
+    expect(selectVariant).toHaveBeenCalledWith("opt");
+    expect(selectVariant).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("CatalogPanel — design note", () => {
+  it("renders currentExample.notes in .design-note", () => {
+    const { container } = renderPanel({
+      currentExample: example({ notes: "careful with the feed point" }),
+    });
+    const note = container.querySelector(".design-note");
+    expect(note).not.toBeNull();
+    expect(note?.textContent).toBe("careful with the feed point");
+  });
+
+  it.each([undefined, null, ""] as const)(
+    "hides .design-note when notes is %s",
+    (notes) => {
+      const { container } = renderPanel({ currentExample: example({ notes }) });
+      expect(container.querySelector(".design-note")).toBeNull();
+    },
+  );
+});
+
+describe("CatalogPanel — examplesError", () => {
+  it("shows the failed-to-load banner with the message", () => {
+    renderPanel({ examplesError: "network down" });
+    expect(screen.getByText("Failed to load /examples: network down")).not.toBeNull();
+  });
+
+  it("hides the banner when examplesError is null", () => {
+    renderPanel({ examplesError: null });
+    expect(screen.queryByText(/Failed to load \/examples/)).toBeNull();
+  });
+});
+
+describe("CatalogPanel — trust gate (AwaitingTrustPanel)", () => {
+  it("renders the trust summary with singular wording for one pending design", () => {
+    renderPanel({ loadErrors: [loadError({ name: "a", trust_required: true })] });
+    expect(
+      screen.getByRole("button", { name: "1 design needs your OK to run" }),
+    ).not.toBeNull();
+  });
+
+  it("renders the trust summary with plural wording for two pending designs", () => {
+    renderPanel({
+      loadErrors: [
+        loadError({ name: "a", trust_required: true }),
+        loadError({ name: "b", trust_required: true }),
+      ],
+    });
+    expect(
+      screen.getByRole("button", { name: "2 designs need your OK to run" }),
+    ).not.toBeNull();
+  });
+
+  it("hides the trust panel when no entry has trust_required", () => {
+    renderPanel({
+      loadErrors: [loadError({ name: "a", trust_required: false })],
+    });
+    expect(screen.queryByText(/need your OK to run/)).toBeNull();
+  });
+});
+
+describe("CatalogPanel — plain load errors", () => {
+  it("shows the alert with singular wording and the error's fields for one error", () => {
+    renderPanel({
+      loadErrors: [loadError({ name: "broke", message: "SyntaxError", file: "broke.py" })],
+    });
+    const alert = screen.getByRole("alert");
+    expect(within(alert).getByText("1 design failed to load")).not.toBeNull();
+    const item = within(alert).getByText("broke").closest("li");
+    expect(item).not.toBeNull();
+    expect(item?.textContent).toContain("SyntaxError");
+    expect(item?.textContent).toContain("broke.py");
+  });
+
+  it("shows the alert with plural wording and one <li> per error for two errors", () => {
+    renderPanel({
+      loadErrors: [
+        loadError({ name: "a", message: "m1", file: "a.py" }),
+        loadError({ name: "b", message: "m2", file: "b.py" }),
+      ],
+    });
+    const alert = screen.getByRole("alert");
+    expect(within(alert).getByText("2 designs failed to load")).not.toBeNull();
+    expect(within(alert).getAllByRole("listitem")).toHaveLength(2);
+  });
+
+  it("hides the alert when every entry has trust_required", () => {
+    renderPanel({ loadErrors: [loadError({ name: "a", trust_required: true })] });
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});
+
+describe("CatalogPanel — mixed loadErrors (the trust_required split)", () => {
+  it("routes each entry to exactly one panel: pending -> trust list, broken -> alert list", async () => {
+    const { user } = renderPanel({
+      loadErrors: [
+        loadError({ name: "pending_design", trust_required: true }),
+        loadError({
+          name: "broken_design",
+          message: "boom",
+          file: "broken_design.py",
+          trust_required: false,
+        }),
+      ],
+    });
+
+    const trustButton = screen.getByRole("button", {
+      name: "1 design needs your OK to run",
+    });
+    const trustPanel = trustButton.closest(".design-trust-panel") as HTMLElement;
+    await user.click(trustButton); // expand to reveal the per-design list
+    expect(within(trustPanel).getByText("pending_design")).not.toBeNull();
+    expect(within(trustPanel).queryByText("broken_design")).toBeNull();
+
+    const alert = screen.getByRole("alert");
+    expect(within(alert).getByText("broken_design")).not.toBeNull();
+    expect(within(alert).queryByText("pending_design")).toBeNull();
+  });
+});
+
+describe("CatalogPanel — adversarial", () => {
+  it("renders neither panel when loadErrors is empty", () => {
+    renderPanel({ loadErrors: [] });
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.queryByText(/need your OK to run/)).toBeNull();
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/GeometryCombobox.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/GeometryCombobox.test.tsx
@@ -1,0 +1,289 @@
+// Pins the controlled-filter combobox in src/components/params/GeometryCombobox.tsx
+// (issue #673): the component owns only open/active state — `filter` and
+// `setFilter` are props the parent normally reconciles, so any assertion that
+// depends on the displayed filter text rerenders with the new prop after
+// asserting the setFilter call, exactly as the real parent would. Keyboard
+// navigation is pinned across a group boundary so the flat-index math (not
+// per-group indices) is what's under test.
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GeometryCombobox } from "../components/params/GeometryCombobox";
+import type { ExampleDescriptor, ExampleGroup } from "../lib/params";
+
+// --- fixtures --------------------------------------------------------------
+// Real (fully-typed) minimal objects rather than `as` casts, so every field
+// the component might read is present and type-checked.
+
+function example(overrides: Partial<ExampleDescriptor> = {}): ExampleDescriptor {
+  return {
+    name: "dipole.test",
+    label: "Test Dipole",
+    multi_feed: false,
+    param_schema: [],
+    result_schema: [],
+    bands: [],
+    meas_freq_range_mhz: null,
+    default_view: null,
+    default_freq: null,
+    default_design_freq: null,
+    default_backend: null,
+    requires_backends: null,
+    has_design_freq: true,
+    variants: ["default"],
+    variant_values: {},
+    sweep_policy: { anchor: "design_freq", lo_factor: 0.5, hi_factor: 2 },
+    ...overrides,
+  };
+}
+
+function group(overrides: Partial<ExampleGroup> = {}): ExampleGroup {
+  return {
+    fam: "dipole",
+    label: "Dipoles",
+    items: [example()],
+    ...overrides,
+  };
+}
+
+// Callbacks are supplied by the harness (and returned as spies) rather than
+// overridable, so an assertion can never target a spy the component never got.
+type ComboboxOverrides = Partial<{
+  groups: ExampleGroup[];
+  selected: string;
+  currentLabel: string;
+  filter: string;
+}>;
+
+function renderCombobox(overrides: ComboboxOverrides = {}) {
+  const spies = { setFilter: vi.fn(), onSelect: vi.fn() };
+  const props = {
+    groups: [group()],
+    selected: "dipole.test",
+    currentLabel: "Test Dipole",
+    filter: "",
+    ...overrides,
+    ...spies,
+  };
+  const view = render(<GeometryCombobox {...props} />);
+  // Mirrors what the real parent does after a setFilter call: re-render with
+  // the new filter value, everything else unchanged.
+  const rerenderWithFilter = (filter: string) =>
+    view.rerender(<GeometryCombobox {...props} filter={filter} />);
+  return { ...view, ...spies, rerenderWithFilter, user: userEvent.setup() };
+}
+
+function input(): HTMLInputElement {
+  return screen.getByRole("combobox") as HTMLInputElement;
+}
+
+describe("GeometryCombobox — closed/open display", () => {
+  it("closed: aria-expanded false, value is currentLabel, no listbox", () => {
+    renderCombobox({ currentLabel: "Test Dipole", filter: "stale filter text" });
+    expect(input().getAttribute("aria-expanded")).toBe("false");
+    expect(input().value).toBe("Test Dipole");
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+
+  it("open (focused): aria-expanded true, value is the filter prop, listbox appears", async () => {
+    const { user } = renderCombobox({ currentLabel: "Test Dipole", filter: "di" });
+    await user.click(input());
+    expect(input().getAttribute("aria-expanded")).toBe("true");
+    expect(input().value).toBe("di");
+    expect(screen.queryByRole("listbox")).not.toBeNull();
+  });
+});
+
+describe("GeometryCombobox — typing", () => {
+  // A single keystroke: with setFilter mocked (a no-op), the filter prop
+  // never advances, so a second keystroke would type into a field the
+  // component has re-rendered back to "" — a real controlled-input effect,
+  // not a test bug. One character keeps the assertion about what onChange
+  // actually reports, not about the mock's inability to drive a rerender.
+  it("calls setFilter with the typed character and opens the list", async () => {
+    const { user, setFilter } = renderCombobox({ filter: "" });
+    await user.type(input(), "y");
+    expect(setFilter).toHaveBeenCalledWith("y");
+    expect(input().getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("shows the new text once the parent reconciles the filter prop", async () => {
+    const { user, setFilter, rerenderWithFilter } = renderCombobox({ filter: "" });
+    await user.type(input(), "y");
+    expect(setFilter).toHaveBeenCalledWith("y");
+    rerenderWithFilter("y");
+    expect(input().value).toBe("y");
+  });
+});
+
+describe("GeometryCombobox — list rendering", () => {
+  it("renders group labels and options; marks the selected and active items", async () => {
+    const g = group({
+      fam: "dipole",
+      label: "Dipoles",
+      items: [example({ name: "d1", label: "D1" }), example({ name: "d2", label: "D2" })],
+    });
+    const { user } = renderCombobox({ groups: [g], selected: "d2" });
+    await user.click(input());
+    expect(screen.getByText("Dipoles")).not.toBeNull();
+
+    const opt1 = screen.getByRole("option", { name: "D1" });
+    const opt2 = screen.getByRole("option", { name: "D2" });
+    expect(opt1.getAttribute("aria-selected")).toBe("false");
+    expect(opt2.getAttribute("aria-selected")).toBe("true");
+    // active starts at flat index 0 -> the first item, not the selected one.
+    expect(opt1.className).toContain("is-active");
+    expect(opt2.className).not.toContain("is-active");
+  });
+
+  it("shows 'no antennas match' and no options when every group is empty", async () => {
+    const { user } = renderCombobox({ groups: [group({ items: [] })] });
+    await user.click(input());
+    expect(screen.getByText("no antennas match")).not.toBeNull();
+    expect(screen.queryAllByRole("option")).toHaveLength(0);
+  });
+});
+
+describe("GeometryCombobox — keyboard", () => {
+  function twoGroups(): ExampleGroup[] {
+    return [
+      group({
+        fam: "g1",
+        label: "G1",
+        items: [example({ name: "a", label: "A" }), example({ name: "b", label: "B" })],
+      }),
+      group({
+        fam: "g2",
+        label: "G2",
+        items: [example({ name: "c", label: "C" }), example({ name: "d", label: "D" })],
+      }),
+    ];
+  }
+
+  it("ArrowDown moves the active option forward across a group boundary, clamped at the end", async () => {
+    const { user } = renderCombobox({ groups: twoGroups(), selected: "a" });
+    await user.click(input());
+    expect(screen.getByRole("option", { name: "A" }).className).toContain("is-active");
+
+    await user.keyboard("{ArrowDown}");
+    expect(screen.getByRole("option", { name: "B" }).className).toContain("is-active");
+    expect(screen.getByRole("option", { name: "A" }).className).not.toContain("is-active");
+
+    await user.keyboard("{ArrowDown}"); // crosses from group g1 into g2
+    expect(screen.getByRole("option", { name: "C" }).className).toContain("is-active");
+
+    await user.keyboard("{ArrowDown}");
+    expect(screen.getByRole("option", { name: "D" }).className).toContain("is-active");
+
+    await user.keyboard("{ArrowDown}"); // already at the last flat item
+    expect(screen.getByRole("option", { name: "D" }).className).toContain("is-active");
+  });
+
+  it("ArrowUp moves the active option back and stops at 0", async () => {
+    const { user } = renderCombobox({ groups: twoGroups(), selected: "a" });
+    await user.click(input());
+    await user.keyboard("{ArrowDown}{ArrowDown}"); // active -> "c" (flat index 2)
+    expect(screen.getByRole("option", { name: "C" }).className).toContain("is-active");
+
+    await user.keyboard("{ArrowUp}");
+    expect(screen.getByRole("option", { name: "B" }).className).toContain("is-active");
+
+    await user.keyboard("{ArrowUp}{ArrowUp}{ArrowUp}"); // overshoot below 0
+    expect(screen.getByRole("option", { name: "A" }).className).toContain("is-active");
+  });
+
+  it("Enter with the list open chooses the active item", async () => {
+    const g = group({
+      items: [example({ name: "a", label: "A" }), example({ name: "b", label: "B" })],
+    });
+    const { user, onSelect, setFilter } = renderCombobox({
+      groups: [g],
+      selected: "a",
+      filter: "x",
+    });
+    await user.click(input());
+    await user.keyboard("{ArrowDown}"); // active -> "b"
+    await user.keyboard("{Enter}");
+    expect(onSelect).toHaveBeenCalledWith("b");
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(setFilter).toHaveBeenCalledWith("");
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+
+  it("Escape closes and clears the filter WITHOUT selecting", async () => {
+    const { user, onSelect, setFilter } = renderCombobox({ filter: "x" });
+    await user.click(input());
+    expect(screen.queryByRole("listbox")).not.toBeNull();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("listbox")).toBeNull();
+    expect(setFilter).toHaveBeenCalledWith("");
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});
+
+describe("GeometryCombobox — mouse", () => {
+  it("mousedown on an option chooses it", async () => {
+    const g = group({
+      items: [example({ name: "a", label: "A" }), example({ name: "b", label: "B" })],
+    });
+    const { user, onSelect, setFilter } = renderCombobox({ groups: [g], selected: "a" });
+    await user.click(input());
+    await user.click(screen.getByRole("option", { name: "B" }));
+    expect(onSelect).toHaveBeenCalledWith("b");
+    expect(setFilter).toHaveBeenCalledWith("");
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+
+  it("mousedown outside the component closes the list and clears the filter", async () => {
+    const setFilter = vi.fn();
+    const onSelect = vi.fn();
+    render(
+      <div>
+        <GeometryCombobox
+          groups={[group()]}
+          selected="dipole.test"
+          currentLabel="Test Dipole"
+          filter="abc"
+          setFilter={setFilter}
+          onSelect={onSelect}
+        />
+        <button>outside target</button>
+      </div>,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.queryByRole("listbox")).not.toBeNull();
+
+    await user.click(screen.getByText("outside target"));
+    expect(screen.queryByRole("listbox")).toBeNull();
+    expect(setFilter).toHaveBeenCalledWith("");
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("mousedown on the caret toggles open/closed", async () => {
+    const { user, container } = renderCombobox();
+    const caret = container.querySelector(".combobox-caret");
+    expect(caret).not.toBeNull();
+
+    expect(screen.queryByRole("listbox")).toBeNull();
+    await user.click(caret as HTMLElement);
+    expect(screen.queryByRole("listbox")).not.toBeNull();
+
+    await user.click(caret as HTMLElement);
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+});
+
+describe("GeometryCombobox — adversarial", () => {
+  it("has no listbox in the DOM while closed", () => {
+    renderCombobox();
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+
+  it("Enter with the list closed fires no onSelect", () => {
+    const { onSelect } = renderCombobox();
+    fireEvent.keyDown(input(), { key: "Enter" });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Unit 5 of the #673 arc, stacked into `issue-673-component-tests` (top-level PR #678).

## What
- `GeometryCombobox.test.tsx` (17 tests): closed-vs-open value source (`currentLabel` vs `filter`), controlled-filter typing contract (single-keystroke assertion + parent-reconcile rerender — a mocked `setFilter` can't advance the prop, so multi-char accumulation would be fabricated), flat-index keyboard navigation pinned across a group boundary with end-clamping, Enter/Escape/mouse selection with concrete args, outside-mousedown close, caret toggle, empty-filter state.
- `CatalogPanel.test.tsx` (17 tests): variant-select `variants.length > 1` gate (absent for 1 variant and undefined example), design note, examples-error banner, trust-gate singular/plural wording, plain load-error alert fields, and the load-bearing mixed fixture: one trust-pending + one broken entry route to exactly one panel each.

## Gates (re-run independently by the reviewer)
- `npm test` in the unit worktree: 257 passed (its base was 223; +34).
- `npm run build`: green; fixtures fully typed, no `any` casts.
- Mutations: builder ran 6 (all red); reviewer re-ran the flipped trust_required filter — 1 failed, and it's precisely the mixed-split test (the all-trust case is separately guarded by the outer `some()` gate, so 1 is the right count).

## Review notes
Implemented by a sonnet subagent; reviewed by the session model (Fable) — both diffs read in full, gates re-run, one mutation re-verified. The single-keystroke deviation is correct controlled-component reasoning, documented in-file. Follow-up note from the builder: native `<select>` also maps to ARIA role `combobox`, harmless here (distinct accessible names) but worth remembering if a future test mixes both in one scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g