### PR TITLE
test(frontend): cover GroundPanel's no-ground-support branches (mocked predicate)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,11 +196,11 @@ jobs:
       run: |
         npm ci
         npm run build
-    - name: Unit-test the pure frontend logic
-      # Vitest (issue #642): the backend-selection/model-options/format free
-      # functions in App.tsx, run headless under jsdom (module-scope WS_URL
-      # reads window.location, so a Node environment can't import App.tsx at
-      # all). A separate step, not folded into the run block above, so a
+    - name: Unit-test the frontend (lib logic + mounted components)
+      # Vitest: the pure lib/ functions (issue #642) plus Testing Library
+      # component tests (issue #673), run headless under jsdom (module-scope
+      # WS_URL reads window.location, so a Node environment can't import the
+      # app modules at all). A separate step, not folded into the run block above, so a
       # failure here is named distinctly from a build failure in the log.
       working-directory: src/antennaknobs/web/frontend
       run: npm test

--- a/src/antennaknobs/web/frontend/src/__tests__/GroundPanel.noGround.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/GroundPanel.noGround.test.tsx
@@ -1,0 +1,98 @@
+// Pins GroundPanel's no-ground-support branches (issue #673 follow-up):
+// the "ground plane ignored for <backend>" note, the disabled checkbox, and
+// the withheld ground-type sub-panel. Every current Backend supports ground,
+// so these branches are unreachable with real predicates — but issue #628
+// moves `supports_ground` into the server-supplied backend roster, where a
+// future solver can genuinely carry `false`. This file mocks the predicate
+// (rather than casting a fake Backend string, which would render an
+// undefined label) to pin the UI contract that server data will exercise.
+//
+// A separate file from GroundPanel.test.tsx because vi.mock is file-scoped
+// and hoisted: the main matrix must keep testing the real predicates.
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GroundPanel } from "../components/session/GroundPanel";
+import { BACKEND_LABEL, type Backend } from "../lib/backends";
+
+// Pretend PyNEC is the ground-less solver. Both predicates are mocked in
+// step: the real backendSupportsTerrain calls backendSupportsGround through
+// a module-internal reference the mock cannot intercept, so overriding only
+// one would leave the pair inconsistent.
+vi.mock("../lib/backends", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/backends")>();
+  const supports = (b: Backend) => b !== "pynec";
+  return {
+    ...actual,
+    backendSupportsGround: supports,
+    backendSupportsTerrain: supports,
+  };
+});
+
+// Callbacks are supplied by the harness (and returned as spies) rather than
+// overridable, so an assertion can never target a spy the component never got.
+function renderGroundPanel(overrides: Partial<{
+  backend: Backend;
+  groundEnabled: boolean;
+}> = {}) {
+  const spies = {
+    setGroundEnabled: vi.fn(),
+    setGroundType: vi.fn(),
+    setFiniteGroundMethod: vi.fn(),
+    setTerrainPreset: vi.fn(),
+    setTerrainParams: vi.fn(),
+  };
+  const view = render(
+    <GroundPanel
+      backend="pynec"
+      groundEnabled={true}
+      groundType="finite"
+      finiteGroundMethod="fast"
+      terrainPresets={[]}
+      terrainPreset=""
+      terrainParams={{}}
+      {...overrides}
+      {...spies}
+    />,
+  );
+  return { ...view, ...spies, user: userEvent.setup() };
+}
+
+const IGNORED_NOTE = `ground plane ignored for ${BACKEND_LABEL.pynec}`;
+
+describe("GroundPanel — backend without ground support (mocked predicate)", () => {
+  it("shows the ignored note only while ground is enabled", () => {
+    const on = renderGroundPanel({ groundEnabled: true });
+    expect(screen.queryByText(IGNORED_NOTE)).not.toBeNull();
+    on.unmount();
+
+    renderGroundPanel({ groundEnabled: false });
+    expect(screen.queryByText(IGNORED_NOTE)).toBeNull();
+  });
+
+  it("shows no note for a backend that supports ground", () => {
+    renderGroundPanel({ backend: "bspline", groundEnabled: true });
+    expect(screen.queryByText(/ground plane ignored/)).toBeNull();
+  });
+
+  it("disables the checkbox, and clicking it fires nothing", async () => {
+    const { user, setGroundEnabled } = renderGroundPanel({ groundEnabled: true });
+    const box = screen.getByRole("checkbox", { name: /ground plane/ });
+    expect(box).toHaveProperty("disabled", true);
+    await user.click(box);
+    expect(setGroundEnabled).not.toHaveBeenCalled();
+  });
+
+  it("keeps the checkbox enabled for a supporting backend", () => {
+    renderGroundPanel({ backend: "bspline", groundEnabled: true });
+    expect(screen.getByRole("checkbox", { name: /ground plane/ })).toHaveProperty(
+      "disabled",
+      false,
+    );
+  });
+
+  it("withholds the ground-type sub-panel even though groundEnabled is true", () => {
+    renderGroundPanel({ groundEnabled: true });
+    expect(screen.queryByRole("radiogroup", { name: "Ground type" })).toBeNull();
+  });
+});


### PR DESCRIPTION
Follow-up to the #673 arc, which flagged GroundPanel's unsupported-backend branches as unreachable dead code (every current `Backend` supports ground). #628 will make `supports_ground` server-supplied roster data, where a future solver can genuinely carry `false` — so instead of deleting the branches, this pins their UI contract now.

## What
`GroundPanel.noGround.test.tsx` (5 tests): mocks `backendSupportsGround`/`backendSupportsTerrain` in step (the real terrain predicate calls the ground one via a module-internal reference, so mocking only one would leave the pair inconsistent), pretending PyNEC is ground-less. Pins: the "ground plane ignored for PyNEC" note (present only while groundEnabled; absent for a supporting backend), the disabled checkbox (click fires nothing; enabled for a supporting backend), and the withheld ground-type sub-panel despite groundEnabled. A separate file from the main GroundPanel matrix because `vi.mock` is file-scoped and hoisted — the main matrix keeps testing the real predicates.

Also rides along: the frontend CI step rename ("Unit-test the pure frontend logic" → "Unit-test the frontend (lib logic + mounted components)") — the other #673 follow-up, deferred while `.github/` was frozen during the arc. Job name is unchanged, so branch-protection required-check matching is unaffected.

## Gates
- `npm test`: 358 passed (was 353), 16 files, ~4 s.
- `npm run build`: green.
- Mutations (each restored after): ungate the note → 1 failed; drop `disabled={!backendSupportsGround(backend)}` → 1 failed.

## Review notes
Implemented and reviewed by the session model directly (single small file — no delegation). When #628 lands, this file's mock should be replaced by a roster fixture carrying `supports_ground: false`, at which point the mock indirection disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g