### PR TITLE
Schematic in the workbench: fifth view in the carousel, served as themed SVG

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,18 @@ dependencies = [
 #     antennaknobs.web.server — env vars are snapshotted by each library at
 #     import time, which happens (via antennaknobs/__init__) before server.py
 #     can set them (issue #377).
-web = ["fastapi", "uvicorn[standard]", "websockets", "psutil", "threadpoolctl"]
+#   - schemdraw renders the /schematic panel (issue #652). It lives here as
+#     well as in the `schematic` extra because the Docker image installs
+#     ".[web]" only — without it the endpoint would 500 in production while
+#     the test extra (which includes schemdraw) kept CI green.
+web = [
+    "fastapi",
+    "uvicorn[standard]",
+    "websockets",
+    "psutil",
+    "threadpoolctl",
+    "schemdraw>=0.19",
+]
 
 # VNA capture (`antennaknobs capture`, issue #597): pyserial drives the USB
 # serial console of a NanoVNA. Optional because talking to hardware is a

--- a/src/antennaknobs/schematic.py
+++ b/src/antennaknobs/schematic.py
@@ -851,10 +851,15 @@ def _exit_y(e, fallback: float) -> float:
     return fallback
 
 
-def render_svg(sch: Schematic, path=None) -> str:
+def render_svg(sch: Schematic, path=None, color: str | None = None) -> str:
     """Draw a :class:`Schematic` and return SVG (also written to ``path``).
 
     Needs the optional extra: ``pip install 'antennaknobs[schematic]'``.
+
+    ``color`` sets the drawing's stroke/text colour. Schemdraw passes it
+    through to the SVG verbatim, so CSS's ``"currentColor"`` works: the web
+    panel inlines the SVG and the schematic follows the app theme with no
+    re-render (the default black would vanish on the dark theme).
     """
     try:
         import schemdraw
@@ -867,6 +872,8 @@ def render_svg(sch: Schematic, path=None) -> str:
     schemdraw.use("svg")
     d = schemdraw.Drawing(show=False)
     d.config(unit=DX, fontsize=FONTSIZE)
+    if color is not None:
+        d.config(color=color)
 
     def symbol(kind):
         return getattr(elm, _SCHEMDRAW_SYMBOLS.get(kind, "RBox"))
@@ -1199,7 +1206,9 @@ def render_svg(sch: Schematic, path=None) -> str:
                 .color("gray")
             )
             if note:
-                box.label(note, loc="top", color="black")
+                # The box's own colour is the de-emphasis gray; the label
+                # re-asserts the drawing colour so it reads as content.
+                box.label(note, loc="top", color=color or "black")
             d += box
 
     if sch.ends_in_antenna and sch.balanced_end:

--- a/src/antennaknobs/schematic.py
+++ b/src/antennaknobs/schematic.py
@@ -220,6 +220,11 @@ class Schematic:
     blocks: list[Block] = field(default_factory=list)
     ends_in_antenna: bool = True
     balanced_end: bool = False  # the chain reaches the antenna as a pair
+    # The port the chain actually landed on, set only when the network has
+    # more than one antenna port. A bowtie1x2_bl chain draws one of two
+    # value-identical parallel lines; without naming its end, the chain and
+    # the feed1 attachment read as the same components listed twice.
+    antenna_name: str = ""
     title: str = ""
     notes: list[str] = field(default_factory=list)
     attachments: list[Block] = field(default_factory=list)
@@ -566,6 +571,11 @@ def lower(net, *, title: str = "", budget=None) -> Schematic:
     chain = _walk(branches, sch.source, targets, is_datum)
     on_chain = {st.idx for st in chain}
     sch.balanced_end = bool(chain) and chain[-1].balanced
+    if chain and len(set(targets.values())) > 1:
+        # Several antenna ports: say which one this chain reached, so it can
+        # be told apart from a parallel feed drawn in the attachments.
+        end_names = {targets[t] for t in chain[-1].pair_out if t in targets}
+        sch.antenna_name = ", ".join(sorted(end_names))
 
     # Nodes the drawing reaches — what an off-chain branch can attach TO.
     reached = {sch.source}
@@ -1211,6 +1221,9 @@ def render_svg(sch: Schematic, path=None, color: str | None = None) -> str:
                 box.label(note, loc="top", color=color or "black")
             d += box
 
+    # "antenna (feed0)" when the chain's end carries a name — it only does
+    # when the network has other antenna ports to confuse it with.
+    antenna_text = f"antenna ({sch.antenna_name})" if sch.antenna_name else "antenna"
     if sch.ends_in_antenna and sch.balanced_end:
         # A pair does not arrive at a one-terminal antenna symbol. Both
         # conductors reach the structure — the two halves of a doublet — so
@@ -1225,13 +1238,13 @@ def render_svg(sch: Schematic, path=None, color: str | None = None) -> str:
         d += (
             elm.Label()
             .at((tip + arm + 0.2, (y + yr) / 2.0))
-            .label("antenna", halign="left")
+            .label(antenna_text, halign="left")
         )
     elif sch.ends_in_antenna:
         d += elm.Line().at((x, y)).to((x + LEADOUT, y))
         # No `.up()`: Antenna pins its own theta=0 and already draws its mast
         # upward, so rotating it lays the whole symbol on its side.
-        d += elm.Antenna().at((x + LEADOUT, y)).label("antenna", loc="right")
+        d += elm.Antenna().at((x + LEADOUT, y)).label(antenna_text, loc="right")
 
     # Attachments: branches wired into the antenna structure rather than into
     # the feed. They have no place on the chain, and inventing one for them is

--- a/src/antennaknobs/schematic.py
+++ b/src/antennaknobs/schematic.py
@@ -1270,7 +1270,10 @@ def render_svg(sch: Schematic, path=None, color: str | None = None) -> str:
     for i, note in enumerate(sch.notes):
         d += elm.Label().at((0.0, ay - 1.4 - i * 0.9)).label(note, halign="left")
 
-    d.draw()
+    # show=False here, not just on the Drawing constructor: draw() defaults
+    # to show=True, which writes a temp file and xdg-opens it in the desktop
+    # image viewer — one popup per render, i.e. per web knob tweak.
+    d.draw(show=False)
     svg = d.get_imagedata("svg").decode("utf-8")
     if path is not None:
         with open(path, "w") as fh:

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -2311,6 +2311,30 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             ground = ("finite",) + ground[1].crest_medium
         return _export_nec(builder, ground=ground, freq=meas_freq)
 
+    def schematic_svg(req: dict) -> str | None:
+        # Same builder construction as the live solve, so the schematic's
+        # component labels (lengths, C/L values, turns ratios) match the
+        # knobs on screen. No solve happens — build_network() plus the
+        # schemdraw render is milliseconds, cheap enough to refetch on
+        # every knob change like the geometry preview. None (not a raise)
+        # for a plain build_wires antenna: "no feed circuit" is an answer,
+        # not an error, and it can only be told by building the builder —
+        # the base class defines build_network() returning None, so the
+        # override cannot be detected statically on cls.
+        from antennaknobs.schematic import lower, render_svg
+
+        design_freq, meas_freq = _req_freqs(req)
+        builder = _build_builder(cls, req)
+        builder.freq = meas_freq
+        if has_design_freq:
+            builder.design_freq = design_freq
+        net = builder.build_network()
+        if net is None:
+            return None
+        # "currentColor": the frontend inlines the SVG, so strokes/text
+        # inherit the app theme's CSS colour (see render_svg's docstring).
+        return render_svg(lower(net, title=name), color="currentColor")
+
     def momwire_sweep(req: dict, freqs_mhz: list[float], cancel=None):
         builder = _build_builder(cls, req)
         # MomwireEngine reads builder.freq only for the initial wavelength
@@ -2378,6 +2402,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         pynec_build=pynec_build,
         pynec_pattern_excite=pynec_pattern_excite,
         nec_export=nec_export,
+        schematic_svg=schematic_svg,
         params_source=params_source,
         far_field_metrics=far_field_metrics,
         multi_feed=field_multi_feed,

--- a/src/antennaknobs/web/examples/_base.py
+++ b/src/antennaknobs/web/examples/_base.py
@@ -332,6 +332,14 @@ class AntennaExample:
     # request (params/variant/freq/ground). None when the design has no
     # faithful native-NEC representation (TL/virtual-driver networks).
     nec_export: Optional[Callable[[dict], str]] = None
+    # Render the design's build_network() — feedline, tuner, balun, and the
+    # port the source sits on — as an SVG circuit schematic for the current
+    # request (issue #652). The callable returns None when the design has no
+    # network (a plain build_wires antenna — only knowable by building the
+    # builder, since the base class defines build_network() returning None):
+    # the /schematic endpoint then answers "no feed circuit" instead of
+    # drawing an empty picture.
+    schematic_svg: Optional[Callable[[dict], Optional[str]]] = None
     # Serialise the request's current knob values back to a paste-ready
     # Python `default_params = {...}` (or named-variant) block, so the UI can
     # offer a "Copy Python" action that drops straight into a design file.

--- a/src/antennaknobs/web/frontend/src/__tests__/SchematicPanel.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/SchematicPanel.test.tsx
@@ -1,0 +1,86 @@
+// Pins the conditional-rendering matrix of the schematic view's panel
+// (src/components/results/SchematicPanel.tsx, issue #652): the three states
+// the useSchematic hook can hand it — loading gap (no svg, not yet declared
+// unavailable), the bare-antenna empty state, and an inlined server-rendered
+// drawing — plus the fill/thumb sizing split. Every presence assertion is
+// paired with an absence assertion on a state that must NOT show the element,
+// matching the SolveOverlays precedent.
+//
+// The SVG arrives as a markup string and is inlined via dangerouslySetInnerHTML
+// (so its currentColor strokes inherit the theme), which is why the drawing
+// assertions query the container's innerHTML/child rather than a React child.
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SchematicPanel } from "../components/results/SchematicPanel";
+
+const SVG = '<svg viewBox="0 0 10 10"><path d="M 0,0 L 10,10" /></svg>';
+const EMPTY_MSG = /no feed circuit/i;
+
+function renderPanel(
+  overrides: Partial<{
+    svg: string | null;
+    unavailable: boolean;
+    size: number;
+    fill: boolean;
+  }> = {},
+) {
+  return render(
+    <SchematicPanel
+      svg={null}
+      unavailable={false}
+      size={180}
+      fill={true}
+      {...overrides}
+    />,
+  );
+}
+
+// --- 1. The three data states ----------------------------------------------
+
+describe("data states", () => {
+  it("renders nothing but the container while loading (no svg, not unavailable)", () => {
+    const { container } = renderPanel();
+    expect(screen.queryByText(EMPTY_MSG)).toBeNull();
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("shows the bare-antenna message once the server said no feed circuit", () => {
+    renderPanel({ unavailable: true });
+    expect(screen.queryByText(EMPTY_MSG)).not.toBeNull();
+  });
+
+  it("inlines the drawing, and the empty message stays out", () => {
+    const { container } = renderPanel({ svg: SVG });
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg!.getAttribute("viewBox")).toBe("0 0 10 10");
+    expect(screen.queryByText(EMPTY_MSG)).toBeNull();
+  });
+
+  it("prefers the drawing when svg and unavailable are both set", () => {
+    // The hook never produces this pair (each response sets one and clears
+    // the other), but the panel's precedence should not depend on that.
+    const { container } = renderPanel({ svg: SVG, unavailable: true });
+    expect(container.querySelector("svg")).not.toBeNull();
+    expect(screen.queryByText(EMPTY_MSG)).toBeNull();
+  });
+});
+
+// --- 2. fill vs thumb sizing -------------------------------------------------
+
+describe("fill/thumb split", () => {
+  it("fill mode stretches (class), no fixed size", () => {
+    const { container } = renderPanel({ svg: SVG, fill: true });
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.className).toBe("schematic-fill");
+    expect(el.style.width).toBe("");
+  });
+
+  it("thumb mode pins the square from the size prop", () => {
+    const { container } = renderPanel({ svg: SVG, fill: false, size: 150 });
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.className).toBe("schematic-thumb");
+    expect(el.style.width).toBe("150px");
+    expect(el.style.height).toBe("150px");
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/useSchematic.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useSchematic.test.tsx
@@ -1,0 +1,152 @@
+// Pins the fetch discipline of the schematic hook
+// (src/components/session/useSchematic.ts, issue #652): the 250 ms debounce
+// that coalesces a knob drag into one POST, the stale-display policy (a knob
+// tweak keeps the previous drawing up until the refetch lands; a design
+// switch clears it immediately — another antenna's feed chain on screen is
+// misinformation), the available/unavailable state split, and the inactive-
+// session gate. fetch is stubbed per test; fake timers drive the debounce.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useSchematic } from "../components/session/useSchematic";
+import type { SolveRequest } from "../lib/api";
+
+const REQ = { geometry: "x" } as unknown as SolveRequest;
+
+function respond(body: unknown) {
+  return Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  fetchMock = vi.fn(() => respond({ available: true, svg: "<svg one/>" }));
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+type HookProps = { active: boolean; geometry: string; requestKey: string };
+
+function renderSchematic(initial: Partial<HookProps> = {}) {
+  return renderHook(
+    (p: HookProps) => useSchematic({ ...p, buildRequest: () => REQ }),
+    {
+      initialProps: {
+        active: true,
+        geometry: "dipoles.invvee_coax_station",
+        requestKey: "k1",
+        ...initial,
+      },
+    },
+  );
+}
+
+// Run the debounce out and let the stubbed response's promise chain settle.
+async function settle() {
+  await act(async () => {
+    vi.advanceTimersByTime(250);
+    await Promise.resolve();
+  });
+}
+
+// --- 1. debounce -------------------------------------------------------------
+
+describe("debounce", () => {
+  it("does not fetch before the debounce elapses", async () => {
+    renderSchematic();
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("coalesces rapid requestKey changes into one POST", async () => {
+    const { rerender } = renderSchematic();
+    rerender({
+      active: true,
+      geometry: "dipoles.invvee_coax_station",
+      requestKey: "k2",
+    });
+    rerender({
+      active: true,
+      geometry: "dipoles.invvee_coax_station",
+      requestKey: "k3",
+    });
+    await settle();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// --- 2. state split ----------------------------------------------------------
+
+describe("response handling", () => {
+  it("an available response lands the svg and stays not-unavailable", async () => {
+    const { result } = renderSchematic();
+    await settle();
+    expect(result.current.schematicSvg).toBe("<svg one/>");
+    expect(result.current.schematicUnavailable).toBe(false);
+  });
+
+  it("a no-network response clears the svg and flags unavailable", async () => {
+    fetchMock.mockImplementation(() => respond({ available: false }));
+    const { result } = renderSchematic();
+    await settle();
+    expect(result.current.schematicSvg).toBeNull();
+    expect(result.current.schematicUnavailable).toBe(true);
+  });
+});
+
+// --- 3. stale-display policy -------------------------------------------------
+
+describe("stale-display policy", () => {
+  it("a knob tweak keeps the old drawing up until the refetch lands", async () => {
+    const { result, rerender } = renderSchematic();
+    await settle();
+    expect(result.current.schematicSvg).toBe("<svg one/>");
+
+    fetchMock.mockImplementation(() =>
+      respond({ available: true, svg: "<svg two/>" }),
+    );
+    rerender({
+      active: true,
+      geometry: "dipoles.invvee_coax_station",
+      requestKey: "k2",
+    });
+    // Debounce still pending: the previous drawing must not flash away.
+    expect(result.current.schematicSvg).toBe("<svg one/>");
+    await settle();
+    expect(result.current.schematicSvg).toBe("<svg two/>");
+  });
+
+  it("a design switch clears the drawing immediately", async () => {
+    const { result, rerender } = renderSchematic();
+    await settle();
+    expect(result.current.schematicSvg).toBe("<svg one/>");
+
+    rerender({ active: true, geometry: "dipoles.invvee", requestKey: "k2" });
+    // Before any response: another design's chain must not stay on screen,
+    // and the empty state must not claim "no feed circuit" yet either.
+    expect(result.current.schematicSvg).toBeNull();
+    expect(result.current.schematicUnavailable).toBe(false);
+  });
+});
+
+// --- 4. inactive gate --------------------------------------------------------
+
+describe("inactive sessions", () => {
+  it("does not fetch while the session tab is inactive", async () => {
+    renderSchematic({ active: false });
+    await settle();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch before a design is selected (geometry \"\")", async () => {
+    renderSchematic({ geometry: "" });
+    await settle();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/antennaknobs/web/frontend/src/components/hooks.ts
+++ b/src/antennaknobs/web/frontend/src/components/hooks.ts
@@ -7,6 +7,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
+import { VIEWS } from "../lib/view";
 
 // Shared between App.tsx (which owns the Provider and the theme-toggle
 // control) and the chart components under components/charts/ (which read it
@@ -112,12 +113,15 @@ export function useThumbColumnSize(
   maxThumb = 280,
   reattachKey?: unknown, // see useSlideSize
 ) {
-  // Vertical thumbstrip: 3 thumbs scaled so they ALWAYS fit (the strip never
-  // scrolls — overflow:hidden in CSS). Fixed overhead:
-  //   strip padding (12+12) + 2 gaps (2*8) +
-  //   per-thumb (button padding 8+6 + label ~14 + gap 6 + border 2) * 3 ≈ 148.
-  // Bias slightly high (150) so they fit with a hair of slack rather than
-  // clip; floor low so a short window shrinks them instead of overflowing.
+  // Vertical thumbstrip: the non-active views scaled so they ALWAYS fit (the
+  // strip never scrolls — overflow:hidden in CSS). Fixed overhead per the CSS:
+  //   strip padding (12+12) + (n-1) gaps of 8 +
+  //   per-thumb (button padding 8+6 + label ~14 + gap 6 + border 2) ≈ 36 each,
+  // biased slightly high (26 base) so they fit with a hair of slack rather
+  // than clip; floor low so a short window shrinks them instead of
+  // overflowing. n tracks the view registry: every view but the active one.
+  const nThumbs = VIEWS.length - 1;
+  const overhead = 26 + (nThumbs - 1) * 8 + nThumbs * 36;
   const [size, setSize] = useState(180);
   useEffect(() => {
     const el = stripRef.current;
@@ -125,7 +129,7 @@ export function useThumbColumnSize(
     const update = () => {
       const h = el.clientHeight;
       if (h <= 0) return;
-      const perThumb = (h - 150) / 3;
+      const perThumb = (h - overhead) / nThumbs;
       setSize(Math.max(40, Math.min(maxThumb, Math.floor(perThumb))));
     };
     update();

--- a/src/antennaknobs/web/frontend/src/components/hooks.ts
+++ b/src/antennaknobs/web/frontend/src/components/hooks.ts
@@ -120,17 +120,29 @@ export function useThumbColumnSize(
   // biased slightly high (26 base) so they fit with a hair of slack rather
   // than clip; floor low so a short window shrinks them instead of
   // overflowing. n tracks the view registry: every view but the active one.
+  //
+  // Two dimensions since the schematic view made it 4 thumbs (issue #652):
+  // `width` stays what the column measured in its 3-thumb era — chart text
+  // is drawn at fixed pixel fonts, so squares small enough to stack 4 high
+  // collide their left/right labels. Each thumb is a width × height
+  // rectangle; the chart renders at width and scales down uniformly to
+  // height (a true miniature — text shrinks with it instead of colliding).
   const nThumbs = VIEWS.length - 1;
   const overhead = 26 + (nThumbs - 1) * 8 + nThumbs * 36;
-  const [size, setSize] = useState(180);
+  const widthOverhead = 26 + 2 * 8 + 3 * 36;
+  const [size, setSize] = useState({ width: 180, height: 180 });
   useEffect(() => {
     const el = stripRef.current;
     if (!el) return;
+    const clamp = (v: number) => Math.max(40, Math.min(maxThumb, Math.floor(v)));
     const update = () => {
       const h = el.clientHeight;
       if (h <= 0) return;
-      const perThumb = (h - overhead) / nThumbs;
-      setSize(Math.max(40, Math.min(maxThumb, Math.floor(perThumb))));
+      const width = clamp((h - widthOverhead) / 3);
+      const height = clamp((h - overhead) / nThumbs);
+      setSize((s) =>
+        s.width === width && s.height === height ? s : { width, height },
+      );
     };
     update();
     const ro = new ResizeObserver(update);

--- a/src/antennaknobs/web/frontend/src/components/results/SchematicPanel.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/SchematicPanel.tsx
@@ -1,0 +1,38 @@
+// The feed-network schematic view (issue #652): the circuit half of a
+// design — feedline, tuner, balun, and the port the source sits on — which
+// is otherwise invisible in every view. The SVG arrives server-rendered
+// (schemdraw is Python-only) drawn in currentColor, and is inlined rather
+// than <img>-embedded so it inherits the theme's text colour.
+export function SchematicPanel({
+  svg,
+  unavailable,
+  size,
+  fill,
+}: {
+  svg: string | null;
+  unavailable: boolean;
+  size: number;
+  fill: boolean;
+}) {
+  const cls = fill ? "schematic-fill" : "schematic-thumb";
+  const style = fill ? undefined : { width: size, height: size };
+  if (!svg) {
+    // One message at every scale (stage, phone screen, thumbnail — the
+    // thumb shrinks it via CSS): the design is a bare antenna, so there is
+    // no feedline, tuner, or balun to draw.
+    return (
+      <div className={cls} style={style}>
+        {unavailable && (
+          <div className="schematic-empty">
+            No feed circuit — this design is the bare antenna.
+          </div>
+        )}
+      </div>
+    );
+  }
+  // Server-generated markup from our own backend — the same trust boundary
+  // as every solve response this UI renders.
+  return (
+    <div className={cls} style={style} dangerouslySetInnerHTML={{ __html: svg }} />
+  );
+}

--- a/src/antennaknobs/web/frontend/src/components/results/ViewPanel.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/ViewPanel.tsx
@@ -4,6 +4,7 @@ import { CurrentCanvas } from "../charts/CurrentCanvas";
 import { FarFieldChart } from "../charts/FarFieldChart";
 import { SmithChart } from "../charts/SmithChart";
 import type { PatternData, PinnedPattern } from "../charts/types";
+import { SchematicPanel } from "./SchematicPanel";
 
 export function ViewPanel({
   view,
@@ -28,6 +29,8 @@ export function ViewPanel({
   showFeedNames = true,
   multiFeed,
   fineNorm,
+  schematicSvg = null,
+  schematicUnavailable = false,
 }: {
   view: View;
   size: number;
@@ -51,6 +54,8 @@ export function ViewPanel({
   showFeedNames?: boolean;
   multiFeed: boolean;
   fineNorm?: number | null;
+  schematicSvg?: string | null;
+  schematicUnavailable?: boolean;
 }) {
   if (view === "antenna") {
     // Fall back to the geometry-only preview while the real solve is in
@@ -97,6 +102,16 @@ export function ViewPanel({
         azElevDeg={azElevDeg}
         elevAzDeg={elevAzDeg}
         fineNorm={fineNorm}
+      />
+    );
+  }
+  if (view === "schematic") {
+    return (
+      <SchematicPanel
+        svg={schematicSvg}
+        unavailable={schematicUnavailable}
+        size={size}
+        fill={fill}
       />
     );
   }

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -70,6 +70,7 @@ import { useDesignCatalog } from "./useDesignCatalog";
 import { useGroundConfig } from "./useGroundConfig";
 import { useMobileCarousel } from "./useMobileCarousel";
 import { useOptimizer } from "./useOptimizer";
+import { useSchematic } from "./useSchematic";
 import { useSolveChannel } from "./useSolveChannel";
 import { useSolverSlots } from "./useSolverSlots";
 import { useViewState } from "./useViewState";
@@ -664,6 +665,21 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
     active,
     buildRequest,
     setParamAtPath,
+  });
+
+  // The feed-network schematic (issue #652): fifth view in the carousel.
+  // Keyed on what can change the drawing — knobs, variant, freqs — not on
+  // solver/backend state: the network is the design's, not the solver's.
+  const { schematicSvg, schematicUnavailable } = useSchematic({
+    active,
+    geometry,
+    requestKey: JSON.stringify([
+      currentValuesKey,
+      currentVariant,
+      designFreq,
+      measFreq,
+    ]),
+    buildRequest,
   });
 
   const currentBands: BandSpec[] = currentExample?.bands ?? [];
@@ -1331,6 +1347,8 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
             showFeedNames={showFeedNames}
             multiFeed={effectiveMultiFeed}
             fineNorm={normCheck?.pattern_norm ?? null}
+            schematicSvg={schematicSvg}
+            schematicUnavailable={schematicUnavailable}
           />
     </>
   );

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -1460,6 +1460,8 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
                   showHeatmap={showHeatmap}
                   showEnvelope={showEnvelope}
                   multiFeed={effectiveMultiFeed}
+                  schematicSvg={schematicSvg}
+                  schematicUnavailable={schematicUnavailable}
                 />
               </div>
               <div className="thumb-label">{v.label}</div>

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -1438,11 +1438,25 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
             >
               <div
                 className="thumb-canvas"
-                style={{ width: thumbSize, height: thumbSize }}
+                style={{ width: thumbSize.width, height: thumbSize.height }}
               >
+                {/* The chart draws at the column's full (3-thumb-era) width
+                    — where its fixed-px labels fit — and scales down
+                    uniformly into the shorter rectangle, a true miniature
+                    (issue #652; see useThumbColumnSize). */}
+                <div
+                  className="thumb-scale"
+                  style={{
+                    width: thumbSize.width,
+                    height: thumbSize.width,
+                    transform: `translate(-50%, -50%) scale(${
+                      thumbSize.height / thumbSize.width
+                    })`,
+                  }}
+                >
                 <ViewPanel
                   view={v.id}
-                  size={thumbSize}
+                  size={thumbSize.width}
                   fill={false}
                   result={result}
                   preview={preview}
@@ -1463,6 +1477,7 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
                   schematicSvg={schematicSvg}
                   schematicUnavailable={schematicUnavailable}
                 />
+                </div>
               </div>
               <div className="thumb-label">{v.label}</div>
             </button>

--- a/src/antennaknobs/web/frontend/src/components/session/useSchematic.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useSchematic.ts
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useState } from "react";
+import type { SolveRequest } from "../../lib/api";
+
+// The feed-network schematic (issue #652): server-rendered SVG from
+// POST /schematic. No solve happens server-side — build_network() plus the
+// schemdraw render is milliseconds — so this refetches on every knob/freq
+// change like the geometry preview, debounced so a knob drag coalesces.
+// The SVG is drawn in "currentColor", so the inlined markup follows the
+// app theme with no refetch on theme flips.
+export function useSchematic({
+  active,
+  geometry,
+  requestKey,
+  buildRequest,
+}: {
+  active: boolean;
+  geometry: string;
+  // Everything that can change the drawing (param values, variant, freqs),
+  // pre-stringified by the caller. Solver/backend knobs are deliberately
+  // absent: the network is the design's, not the solver's.
+  requestKey: string;
+  buildRequest: () => SolveRequest;
+}) {
+  const [svg, setSvg] = useState<string | null>(null);
+  // True once the server answered "no feed circuit" — the panel's empty
+  // state. Distinct from svg === null alone, which is also the loading gap.
+  const [unavailable, setUnavailable] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const forGeometryRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!active || !geometry) return;
+    // A knob tweak keeps the previous drawing up while the refetch is in
+    // flight (labels update when it lands, no flash). A design switch must
+    // not: another antenna's feed chain on screen is misinformation.
+    if (forGeometryRef.current !== geometry) {
+      forGeometryRef.current = geometry;
+      setSvg(null);
+      setUnavailable(false);
+    }
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    const t = setTimeout(() => {
+      fetch("/schematic", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildRequest()),
+        signal: controller.signal,
+      })
+        .then((r) => (r.ok ? r.json() : null))
+        .then((data) => {
+          if (controller.signal.aborted || !data) return;
+          if (data.available) {
+            setSvg(data.svg as string);
+            setUnavailable(false);
+          } else {
+            setSvg(null);
+            setUnavailable(true);
+          }
+        })
+        .catch(() => {});
+    }, 250);
+    return () => {
+      clearTimeout(t);
+      controller.abort();
+    };
+    // buildRequest is a plain closure over the session's live state (not
+    // memoized); requestKey is the real dependency signature.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, geometry, requestKey]);
+
+  return { schematicSvg: svg, schematicUnavailable: unavailable };
+}

--- a/src/antennaknobs/web/frontend/src/lib/view.ts
+++ b/src/antennaknobs/web/frontend/src/lib/view.ts
@@ -1,12 +1,13 @@
-export type View = "antenna" | "azimuth" | "elevation" | "smith";
+export type View = "antenna" | "azimuth" | "elevation" | "smith" | "schematic";
 export const VIEWS: { id: View; label: string }[] = [
   { id: "antenna", label: "Antenna" },
   { id: "azimuth", label: "Azimuth (xy)" },
   { id: "elevation", label: "Elevation (yz)" },
   { id: "smith", label: "Smith" },
+  { id: "schematic", label: "Schematic" },
 ];
 
-// The mobile output carousel's screens: the 4 chart views plus a dedicated
+// The mobile output carousel's screens: the 5 chart views plus a dedicated
 // Info screen for the solve readout (which floats as a HUD on desktop but
 // deserves its own page on a phone). "info" stays out of the `View` union on
 // purpose — `view` (and every data effect keyed on it) only ever holds a

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1810,6 +1810,18 @@ input[type=checkbox] {
   pointer-events: none;
   border-radius: var(--r-sm);
   overflow: hidden;
+  position: relative;
+}
+
+/* The rectangle thumb's inner square: the chart renders at the column's
+   full width (where its fixed-px labels fit) and is scaled down uniformly
+   to the rectangle height — a miniature, not a crop (issue #652). The
+   inline style carries the size and scale; centering lives here. */
+.thumb-scale {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform-origin: center;
 }
 
 .thumb-label {

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1836,6 +1836,47 @@ input[type=checkbox] {
   position: relative;
 }
 
+/* Feed-network schematic view (issue #652). The SVG arrives server-rendered
+   in currentColor, inlined — so `color` here is what paints the circuit,
+   and the drawing follows the theme with no refetch. Scale DOWN to fit
+   (max-*) but never up: a small station chain at its natural size stays
+   readable, a 9-branch LPDA shrinks into view. */
+.schematic-fill,
+.schematic-thumb {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--fg);
+  overflow: hidden;
+}
+
+.schematic-fill {
+  position: absolute;
+  inset: 0;
+  padding: var(--space-6, 16px);
+}
+
+.schematic-fill svg,
+.schematic-thumb svg {
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+}
+
+.schematic-empty {
+  color: var(--muted);
+  text-align: center;
+  max-width: 34em;
+  padding: 0 16px;
+  font-size: 0.9rem;
+}
+
+.schematic-thumb .schematic-empty {
+  font-size: 0.7rem;
+  padding: 0 6px;
+}
+
 .antenna-overlay,
 .smith-overlay,
 .farfield-overlay {

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -1606,6 +1606,37 @@ async def export_nec_endpoint(req: dict):
     )
 
 
+@app.post("/schematic")
+async def schematic_endpoint(req: dict):
+    """Render the design's feed network as an SVG circuit schematic (#652).
+
+    Same builder construction as the live solve, so component labels match
+    the knobs on screen. No solve happens — this is build_network() plus a
+    schemdraw render, cheap enough for the frontend to refetch per knob
+    change. JSON (not a raw SVG response) so "this antenna has no feed
+    circuit" is an answer rather than an error: the schematic view exists
+    for every design and shows an empty state for the ~2/3 without a
+    network.
+    """
+    geometry = req.get("geometry", next(iter(EXAMPLES)))
+    ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
+    if ex.schematic_svg is None:
+        return {"available": False}
+    try:
+        svg = await run_in_threadpool(ex.schematic_svg, req)
+    except ValueError as e:
+        # Request validation (bad freq / radius) — 422 like every endpoint.
+        raise HTTPException(status_code=422, detail=str(e)) from e
+    except ImportError as e:
+        # schemdraw missing: an install without the schematic extra. The
+        # message names the pip command; surfacing it beats a 500.
+        return {"available": False, "reason": str(e)}
+    if svg is None:
+        # build_network() returned None: a plain build_wires antenna.
+        return {"available": False}
+    return {"available": True, "svg": svg}
+
+
 # Upload ceilings for the measured overlay (issue #595). A NanoVNA writes
 # 101–1001 points (a few tens of kB); nanovna-saver's segmented sweeps reach a
 # few thousand. The caps are generous multiples of that — they exist so a

--- a/tests/test_schematic.py
+++ b/tests/test_schematic.py
@@ -235,6 +235,17 @@ def test_a_second_antenna_is_not_drawn_in_line():
     assert any("feed1.p" in a.nodes for a in sch.attachments)
 
 
+def test_a_chain_among_parallel_feeds_names_the_port_it_reached():
+    """`bowtie1x2_bl`'s two lines are value-identical, so the chain and the
+    feed1 attachment read as the same components listed twice unless the
+    chain says which feed it landed on. A single-antenna design stays
+    unnamed — there is nothing to confuse its chain with."""
+    sch = lower(build("arrays.bowtie1x2_bl").build_network())
+    assert sch.antenna_name == "feed0"
+    sch = lower(build("dipoles.invvee_coax_station").build_network())
+    assert sch.antenna_name == ""
+
+
 def test_a_structure_with_no_feed_chain_does_not_invent_one():
     """`wire.sterba_bl`'s four risers share no node with each other or with the
     source. The old walk wandered the graph and drew them as a plausible

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2881,3 +2881,33 @@ def test_momwire_ground_off_reports_free_model():
     )
     assert resp["ground_model_applied"] == "free"
     assert resp["ground_eps_r"] == pytest.approx(1.0e10)
+
+
+# ---------------------------------------------------------------------------
+# /schematic (issue #652)
+# ---------------------------------------------------------------------------
+
+
+def test_schematic_returns_themed_svg_for_a_networked_design(client: TestClient):
+    resp = client.post("/schematic", json={"geometry": "dipoles.invvee_coax_station"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["available"] is True
+    assert "<svg" in data["svg"]
+    # The frontend inlines the SVG, so the drawing must use currentColor
+    # (a hard-coded black would vanish on the dark theme).
+    assert "currentColor" in data["svg"]
+
+
+def test_schematic_says_no_feed_circuit_for_a_plain_antenna(client: TestClient):
+    resp = client.post("/schematic", json={"geometry": "dipoles.invvee"})
+    assert resp.status_code == 200
+    assert resp.json() == {"available": False}
+
+
+def test_schematic_labels_track_the_request_params(client: TestClient):
+    # Same design, different knob values → different component labels.
+    base = {"geometry": "dipoles.invvee_coax_station"}
+    a = client.post("/schematic", json=base).json()["svg"]
+    b = client.post("/schematic", json={**base, "line_len_m": 10.0}).json()["svg"]
+    assert a != b


### PR DESCRIPTION
## Summary

Part of #652 — the web face of the schematic renderer (PR #662). The feed network becomes a **fifth view** in the view registry: a peer of antenna/azimuth/elevation/smith rather than a mode inside the 3D canvas (the chain isn't geometry — a `PortVirtual` has no coordinates). One `VIEWS` entry propagates it to the desktop thumbstrip, the arrow-key cycler, and the mobile swipe carousel.

- **`POST /schematic`**: same builder construction as the live solve, so component labels track the knobs; JSON `{available, svg}` — "no feed circuit" is an answer, not an error, and the ~⅔ of the catalog without a network get a clean empty state. No solve happens; it's `build_network()` + schemdraw, cheap enough to refetch per knob change.
- **Theming for free**: the SVG is drawn in `currentColor` (schemdraw passes it through verbatim) and inlined, so it follows light/dark instantly with no refetch. `schemdraw` joins the `web` extra — the Docker image installs `[web]` only, and the test extra already carrying it would have kept CI green while production 500'd.
- **`useSchematic` fetch discipline**: debounced per knob/variant/freq change; a knob tweak keeps the previous drawing up until the refetch lands, a design switch clears it immediately.
- **Live-testing fixes**: schemdraw's `draw()` defaults to `show=True` and xdg-opened a viewer popup per render; the thumbstrip's own `ViewPanel` call site was missing the new props; and four stacked square thumbs collided their fixed-px chart labels — thumbs are now rectangles at the old 3-thumb width, with each chart rendered at that width and scaled down uniformly (a true miniature, nothing cropped).
- **`antenna (feed0)`**: when parallel feeds exist, the chain names the port it reached, so `bowtie1x2_bl`'s two value-identical lines stop reading as the same components listed twice. Follow-up multi-feed UX (junction visibility, distribution view) is filed as #685.

## Test plan
- [x] `pytest` full suite: 3239 passed, 2 skipped (endpoint tests: themed SVG for a networked design, `available: false` for a bare antenna, labels track request params)
- [x] `npm test`: 367 passed, incl. 14 new component tests in the #673 style (SchematicPanel state matrix; useSchematic debounce/stale-keep/clear-on-switch/inactive gates)
- [x] `ruff check` / `ruff format --check` clean; `tsc --noEmit` + vite build clean
- [x] Verified live in Chrome: station chain renders with source marked and grounded, labels refetch on knob change, theme flip recolors instantly, empty state on bare antennas, thumbnails legible at four-up
- [ ] Mobile swipe carousel (6th dot) — registry-driven, not visually verified; worth a phone glance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxcDWKRbc18jY2m49vDfhc