### PR TITLE
Fold the power budget into the schematic chain, and title impedance charts at the real plane (#652)

### DIFF
--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -922,12 +922,17 @@ def cli(arguments=None):
                 f"{args.builder} has no build_network() — it is an antenna with "
                 "no feed circuit, so there is no schematic to draw"
             )
-        budget = None
+        budget = p_in = None
         if args.power:
             eng = engine_factory_from_args(args)(builder)
             eng.current_distribution()
             budget = getattr(eng, "_excited_power_budget", None)
-        svg = render_svg(lower(net, title=args.builder, budget=budget), args.out)
+            # With p_in the annotation reads as the budget table's percent
+            # instead of the canonical drive's meaningless milliwatts.
+            p_in = getattr(eng, "_excited_p_in", None)
+        svg = render_svg(
+            lower(net, title=args.builder, budget=budget, p_in=p_in), args.out
+        )
         if args.out:
             print(f"wrote {args.out}")
         else:

--- a/src/antennaknobs/schematic.py
+++ b/src/antennaknobs/schematic.py
@@ -218,6 +218,11 @@ class Schematic:
 
     source: str
     blocks: list[Block] = field(default_factory=list)
+    # Input power for the same solve the block watts came from. Watts alone
+    # are meaningless on the page — the canonical drive is 1 V, so a real
+    # loss is fractions of a milliwatt — but watts/p_in is the same "12.3%"
+    # the power-budget table shows, at the point in the chain where it burns.
+    p_in: float | None = None
     ends_in_antenna: bool = True
     balanced_end: bool = False  # the chain reaches the antenna as a pair
     # The port the chain actually landed on, set only when the network has
@@ -540,7 +545,7 @@ def _walk(branches, start, targets, is_datum):
     return best
 
 
-def lower(net, *, title: str = "", budget=None) -> Schematic:
+def lower(net, *, title: str = "", budget=None, p_in=None) -> Schematic:
     """`Network` → :class:`Schematic`.
 
     Walks source → antenna to find the chain, groups consecutive chain
@@ -550,9 +555,14 @@ def lower(net, *, title: str = "", budget=None) -> Schematic:
 
     ``budget`` (the reducer's ``(label, watts)`` list) annotates each block
     with what it burns — which is what puts the power budget *in* the topology
-    instead of beside it.
+    instead of beside it. ``p_in`` is the same solve's input power; with it
+    the annotation renders as the fraction the budget table already shows.
     """
-    sch = Schematic(source=net.sources[0].port if net.sources else "", title=title)
+    sch = Schematic(
+        source=net.sources[0].port if net.sources else "",
+        title=title,
+        p_in=p_in,
+    )
     if not net.sources:
         sch.notes.append("no source: nothing to draw a chain from")
         return sch
@@ -567,6 +577,65 @@ def lower(net, *, title: str = "", budget=None) -> Schematic:
     paths = list(net.branch_paths or [""] * len(branches))
     is_datum = _datum_nodes(net)
     targets = _antenna_nodes(net)
+
+    # Accumulated, not dict(budget): two probes can share one label (a
+    # parallel Shunt stamps group-1 and a series one group-2 under the same
+    # "Shunt <port>"), and a plain dict would keep only the last row's watts.
+    watts: dict[str, float] = {}
+    for k, w in budget or []:
+        watts[k] = watts.get(k, 0.0) + w
+
+    def burned(path):
+        """Watts this block burns, children included.
+
+        Budget labels are "<path>: <branch>" with the trailing dot stripped
+        ("match: TL rig→feed", "match.stub: ..."), so a block owns both its
+        own rows and its descendants'.
+        """
+        if not path:
+            return None
+        base = path[:-1]
+        total = sum(
+            w
+            for k, w in watts.items()
+            if k.startswith(f"{base}: ") or k.startswith(f"{base}.")
+        )
+        return total or None
+
+    #: Qualifiers the reducer appends to a branch's label for its sub-rows —
+    #: "Transformer a→b (mag)", "Autotransformer a→b (lower)"/"(upper)".
+    _QUALS = {"mag", "lower", "upper"}
+
+    def burned_bare(idx):
+        """Watts for a PATHLESS branch, matched by its own budget label.
+
+        A bare branch has no "<path>: " prefix to own rows by; its rows are
+        labelled "<Type> <terminals>" ("TL rig→feed", "Load trap_l").
+        Reconstructing each exact format here would duplicate
+        network_reduce's strings and drift, so the match is on what
+        identifies the branch — the type-name prefix and the set of node
+        names — letting the punctuation and any "(mag)" qualifier fall away.
+        `invvee_coax_station`, the design the issue opens with, is one bare
+        TL; without this its 30 m of coax showed no loss at all. Two bare
+        same-type branches on identical nodes would each claim both rows,
+        the same ambiguity the label scheme itself has.
+        """
+        br = branches[idx]
+        prefix = f"{type(br).__name__} "
+        want = set(terminals_of(br))
+        if not want:
+            return None
+        total = 0.0
+        for k, w in watts.items():
+            if not k.startswith(prefix):
+                continue
+            rest = k[len(prefix) :]
+            for sep in ("→", "(", ")", ","):
+                rest = rest.replace(sep, " ")
+            tokens = set(rest.split())
+            if want <= tokens and tokens - want <= _QUALS:
+                total += w
+        return total or None
 
     chain = _walk(branches, sch.source, targets, is_datum)
     on_chain = {st.idx for st in chain}
@@ -622,6 +691,7 @@ def lower(net, *, title: str = "", budget=None) -> Schematic:
                     label=paths[idx][:-1] or type(br).__name__,
                     elements=default_elements(br),
                     path=paths[idx],
+                    watts=burned(paths[idx]) if paths[idx] else burned_bare(idx),
                     nodes=tuple(ts),
                 )
             )
@@ -655,25 +725,6 @@ def lower(net, *, title: str = "", budget=None) -> Schematic:
             )
         else:
             sch.notes.append("no run of branches carries the source to an antenna")
-
-    watts = dict(budget or [])
-
-    def burned(path):
-        """Watts this block burns, children included.
-
-        Budget labels are "<path>: <branch>" with the trailing dot stripped
-        ("match: TL rig→feed"), and a nested box appears as "match.stub: ...",
-        so a block owns both its own rows and its descendants'.
-        """
-        if not path:
-            return None
-        base = path[:-1]
-        total = sum(
-            w
-            for k, w in watts.items()
-            if k.startswith(f"{base}: ") or k.startswith(f"{base}.")
-        )
-        return total or None
 
     def stamped(frag, balanced_in):
         """An author's fragment, with the local reference stamped onto it.
@@ -774,7 +825,7 @@ def lower(net, *, title: str = "", budget=None) -> Schematic:
                 label=path[:-1] if path else type(branches[group[0].idx]).__name__,
                 elements=tuple(els),
                 path=path,
-                watts=burned(path),
+                watts=burned(path) if path else burned_bare(group[0].idx),
             )
         )
 
@@ -787,7 +838,7 @@ def lower(net, *, title: str = "", budget=None) -> Schematic:
                         label=paths[idx][:-1] or type(branches[idx]).__name__,
                         elements=default_elements(branches[idx]),
                         path=paths[idx],
-                        watts=burned(paths[idx]),
+                        watts=burned(paths[idx]) if paths[idx] else burned_bare(idx),
                     )
                 )
     return sch
@@ -822,6 +873,20 @@ SRC_R = 0.5  # radius of the source circle, for label clearance
 SHUNT_STEP = 0.9  # past a drop, so two in a row do not land on the same x
 PAIR_LEN = 4.6  # a two-conductor line, long enough to read as a line
 ATTACH_ROW = 1.9  # between attachment rows, which carry two lines of text each
+
+
+def _burn_text(watts: float, p_in: float | None) -> str:
+    """How a block's dissipation reads on the page.
+
+    As the fraction of input power when the solve's ``p_in`` is known — the
+    same number the power-budget table shows, placed where it burns — and as
+    raw milliwatts otherwise: the canonical 1 V drive gives watts no
+    meaningful absolute scale, but with no reference there is nothing truer
+    to print.
+    """
+    if p_in:
+        return f"{watts / p_in:.1%}"
+    return f"{watts * 1e3:.2f} mW"
 
 
 def _text_width(s: str, fontsize: float = FONTSIZE) -> float:
@@ -1207,7 +1272,7 @@ def render_svg(sch: Schematic, path=None, color: str | None = None) -> str:
         if block.path:
             note = block.label
             if block.watts:
-                note = f"{note}  ({block.watts * 1e3:.2f} mW)"
+                note = f"{note}  ({_burn_text(block.watts, sch.p_in)})"
             # A dashed enclosure, not a floating caption: the label names a
             # box in the design, so the drawing shows where that box stops.
             box = (
@@ -1220,6 +1285,19 @@ def render_svg(sch: Schematic, path=None, color: str | None = None) -> str:
                 # re-asserts the drawing colour so it reads as content.
                 box.label(note, loc="top", color=color or "black")
             d += box
+        elif block.watts:
+            # A bare branch has no enclosure to caption, but its burn still
+            # belongs on the page — the issue's opening design is one bare
+            # TL. Centered under the block, below the symbol's own sublabel.
+            d += (
+                elm.Label()
+                .at(((x0 + x) / 2.0, y - 1.15))
+                .label(
+                    f"({_burn_text(block.watts, sch.p_in)})",
+                    fontsize=SUBFONT,
+                    valign="top",
+                )
+            )
 
     # "antenna (feed0)" when the chain's end carries a name — it only does
     # when the network has other antenna ports to confuse it with.
@@ -1267,8 +1345,14 @@ def render_svg(sch: Schematic, path=None, color: str | None = None) -> str:
                 .label(", ".join(block.nodes[:half]), halign="right", fontsize=SUBFONT)
             )
             e = symbol(el.kind if el else "box")().at((2.5, ay)).right().length(1.6)
-            if el is not None and el.label:
-                e.label(el.label, loc="top", fontsize=SUBFONT)
+            # A trap in a dipole leg burns power too; an attachment carries
+            # its burn on the symbol since it has no enclosure to caption.
+            top = el.label if el is not None else ""
+            if block.watts:
+                burn = f"({_burn_text(block.watts, sch.p_in)})"
+                top = f"{top}  {burn}" if top else burn
+            if top:
+                e.label(top, loc="top", fontsize=SUBFONT)
             if el is not None and el.sublabel:
                 e.label(el.sublabel, loc="bottom", ofst=0.4, fontsize=SUBFONT)
             d += e

--- a/src/antennaknobs/sweep.py
+++ b/src/antennaknobs/sweep.py
@@ -28,6 +28,22 @@ def _param_label(nm):
     return "freq (MHz)" if nm == "freq" else nm
 
 
+def _z_title(antenna_builder, nm):
+    """Title for an impedance sweep, naming the plane it is drawn at.
+
+    "feedpoint" is only true for a bare antenna. A station design is solved
+    at the port its source sits on — ``Driven(port="rig")`` — and with a
+    measured trace on the same axes (#595) calling that the feedpoint
+    actively invites comparing a VNA calibrated at the wrong plane (#652).
+    """
+    build = getattr(antenna_builder, "build_network", None)
+    net = build() if callable(build) else None
+    sources = getattr(net, "sources", None) if net is not None else None
+    if sources:
+        return f"impedance at {sources[0].port} vs {nm}"
+    return f"feedpoint impedance vs {nm}"
+
+
 def _polish_axes(ax, title=None):
     """Shared look-and-feel for the rectangular CLI charts."""
     ax.grid(True, alpha=0.3, linewidth=0.6)
@@ -338,7 +354,7 @@ def sweep(
             # Upper left keeps clear of the z0 note in the lower-left corner.
             ax0.legend(loc="upper left", frameon=False, fontsize=8)
         # Same title as the rectangular branch — the chart form says "Smith".
-        ax0.set_title(f"feedpoint impedance vs {nm}", fontsize=11)
+        ax0.set_title(_z_title(antenna_builder, nm), fontsize=11)
         fig.tight_layout()
 
     else:
@@ -395,7 +411,7 @@ def sweep(
             ax1.plot(mxs, np.imag(mz), color=color, **_MEASURED_KW)
             _measured_legend(ax0, measured.label)
 
-        _polish_axes(ax0, title=f"feedpoint impedance vs {nm}")
+        _polish_axes(ax0, title=_z_title(antenna_builder, nm))
         ax1.spines["top"].set_visible(False)
         fig.tight_layout()
 

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -594,8 +594,39 @@ def _budget_rows(eng, builder):
             display = label[len(path) + 2 :]
         else:
             display = label
-        rows.append({"label": display, "watts": max(0.0, float(w)), "path": path})
+        # `key` keeps the raw structural label alongside the display rename:
+        # the schematic fold-in (issue #652) matches blocks by "<path>: ..."
+        # prefixes, which the relabelled/stripped display label no longer
+        # carries. The frontend echoes (key, watts) back to /schematic.
+        rows.append(
+            {"label": display, "watts": max(0.0, float(w)), "path": path, "key": label}
+        )
     return rows
+
+
+def _req_budget(req):
+    """The solve's power budget, read back out of a /schematic request.
+
+    The schematic endpoint deliberately never solves — it stays cheap enough
+    to refetch per knob change — so the frontend passes the budget it already
+    holds from the latest solve: structural ``(key, watts)`` pairs (the `key`
+    field `_budget_rows` carries) plus that solve's ``input_power_w``.
+    Malformed entries are dropped rather than erroring: the budget is an
+    annotation, and a drawing without watts beats a 422 for the whole panel.
+    """
+    out = []
+    for row in req.get("budget") or ():
+        if (
+            isinstance(row, (list, tuple))
+            and len(row) == 2
+            and isinstance(row[0], str)
+            and isinstance(row[1], (int, float))
+            and math.isfinite(row[1])
+        ):
+            out.append((row[0], float(row[1])))
+    p_in = req.get("input_power_w")
+    ok = isinstance(p_in, (int, float)) and math.isfinite(p_in) and p_in > 0
+    return out or None, (float(p_in) if ok else None)
 
 
 def _derive_schema(default_params: dict) -> tuple:
@@ -2331,9 +2362,15 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         net = builder.build_network()
         if net is None:
             return None
+        # Budget fold-in (issue #652): still no solve here — the frontend
+        # echoes the latest solve's structural (key, watts) rows and input
+        # power, and each block gets its burn drawn where it happens.
+        budget, p_in = _req_budget(req)
         # "currentColor": the frontend inlines the SVG, so strokes/text
         # inherit the app theme's CSS colour (see render_svg's docstring).
-        return render_svg(lower(net, title=name), color="currentColor")
+        return render_svg(
+            lower(net, title=name, budget=budget, p_in=p_in), color="currentColor"
+        )
 
     def momwire_sweep(req: dict, freqs_mhz: list[float], cancel=None):
         builder = _build_builder(cls, req)

--- a/src/antennaknobs/web/frontend/src/__tests__/useSchematic.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useSchematic.test.tsx
@@ -29,7 +29,13 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-type HookProps = { active: boolean; geometry: string; requestKey: string };
+type HookProps = {
+  active: boolean;
+  geometry: string;
+  requestKey: string;
+  budget?: [string, number][] | null;
+  inputPowerW?: number | null;
+};
 
 function renderSchematic(initial: Partial<HookProps> = {}) {
   return renderHook(
@@ -135,7 +141,54 @@ describe("stale-display policy", () => {
   });
 });
 
-// --- 4. inactive gate --------------------------------------------------------
+// --- 4. power-budget echo (issue #652) ---------------------------------------
+// /schematic never solves; the hook echoes the latest solve's structural
+// (key, watts) rows and input power so blocks draw their burn.
+
+describe("power-budget echo", () => {
+  const BUDGET: [string, number][] = [["TL rig→feed", 0.004]];
+
+  function lastBody() {
+    const call = fetchMock.mock.calls.at(-1) as unknown as [
+      string,
+      { body: string },
+    ];
+    return JSON.parse(call[1].body);
+  }
+
+  it("includes budget and input power in the POST when a solve has landed", async () => {
+    renderSchematic({ budget: BUDGET, inputPowerW: 0.016 });
+    await settle();
+    expect(lastBody().budget).toEqual(BUDGET);
+    expect(lastBody().input_power_w).toBe(0.016);
+  });
+
+  it("omits the fields entirely before a solve lands", async () => {
+    renderSchematic({ budget: null, inputPowerW: null });
+    await settle();
+    expect("budget" in lastBody()).toBe(false);
+    expect("input_power_w" in lastBody()).toBe(false);
+  });
+
+  it("a landed solve refetches the drawing with the fresh watts", async () => {
+    const { rerender } = renderSchematic({ budget: null, inputPowerW: null });
+    await settle();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Same knobs (requestKey unchanged) — only the solve result arrived.
+    rerender({
+      active: true,
+      geometry: "dipoles.invvee_coax_station",
+      requestKey: "k1",
+      budget: BUDGET,
+      inputPowerW: 0.016,
+    });
+    await settle();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(lastBody().budget).toEqual(BUDGET);
+  });
+});
+
+// --- 5. inactive gate --------------------------------------------------------
 
 describe("inactive sessions", () => {
   it("does not fetch while the session tab is inactive", async () => {

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -670,6 +670,20 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // The feed-network schematic (issue #652): fifth view in the carousel.
   // Keyed on what can change the drawing — knobs, variant, freqs — not on
   // solver/backend state: the network is the design's, not the solver's.
+  // The one piece of solver output that DOES ride along is the power budget,
+  // echoed as structural (key, watts) rows so each block draws its burn.
+  // Gated on the result being THIS design's: two station designs share
+  // instance paths ("sta."), so a stale budget from the previous design
+  // would annotate the new chain with the old antenna's watts.
+  const schematicBudget = useMemo(
+    () =>
+      result?.geometry === geometry && result.power_budget
+        ? result.power_budget
+            .filter((b) => b.key !== undefined)
+            .map((b) => [b.key as string, b.watts] as [string, number])
+        : null,
+    [result, geometry],
+  );
   const { schematicSvg, schematicUnavailable } = useSchematic({
     active,
     geometry,
@@ -680,6 +694,8 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
       measFreq,
     ]),
     buildRequest,
+    budget: schematicBudget,
+    inputPowerW: result?.input_power_w ?? null,
   });
 
   const currentBands: BandSpec[] = currentExample?.bands ?? [];

--- a/src/antennaknobs/web/frontend/src/components/session/useSchematic.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useSchematic.ts
@@ -12,6 +12,8 @@ export function useSchematic({
   geometry,
   requestKey,
   buildRequest,
+  budget,
+  inputPowerW,
 }: {
   active: boolean;
   geometry: string;
@@ -20,6 +22,14 @@ export function useSchematic({
   // absent: the network is the design's, not the solver's.
   requestKey: string;
   buildRequest: () => SolveRequest;
+  // The latest solve's power budget (issue #652): structural (key, watts)
+  // pairs plus that solve's input power, echoed in the POST so each block
+  // draws its burn as the same percent the budget table shows. Null before
+  // a solve lands — the drawing then simply carries no watts. This IS
+  // solver output on a design-only endpoint, deliberately: /schematic never
+  // solves, so the watts ride along from the solve the session already ran.
+  budget?: [string, number][] | null;
+  inputPowerW?: number | null;
 }) {
   const [svg, setSvg] = useState<string | null>(null);
   // True once the server answered "no feed circuit" — the panel's empty
@@ -42,10 +52,18 @@ export function useSchematic({
     const controller = new AbortController();
     abortRef.current = controller;
     const t = setTimeout(() => {
+      const body: SolveRequest & {
+        budget?: [string, number][];
+        input_power_w?: number;
+      } = { ...buildRequest() };
+      if (budget && budget.length) {
+        body.budget = budget;
+        if (inputPowerW) body.input_power_w = inputPowerW;
+      }
       fetch("/schematic", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(buildRequest()),
+        body: JSON.stringify(body),
         signal: controller.signal,
       })
         .then((r) => (r.ok ? r.json() : null))
@@ -66,9 +84,12 @@ export function useSchematic({
       controller.abort();
     };
     // buildRequest is a plain closure over the session's live state (not
-    // memoized); requestKey is the real dependency signature.
+    // memoized); requestKey is the real dependency signature. The budget is
+    // a dependency of its own: a knob change refetches immediately (labels
+    // update, watts briefly stale), then the solve lands and this refetches
+    // once more with the fresh watts.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [active, geometry, requestKey]);
+  }, [active, geometry, requestKey, JSON.stringify([budget, inputPowerW])]);
 
   return { schematicSvg: svg, schematicUnavailable: unavailable };
 }

--- a/src/antennaknobs/web/frontend/src/lib/api.ts
+++ b/src/antennaknobs/web/frontend/src/lib/api.ts
@@ -114,7 +114,11 @@ export type SolveResponse = {
    *  one entry per TL / TwoPort / Shunt / Load branch, in watts for the
    *  canonical 1 V drive. Absent or all-~0 for plain and lossless
    *  designs; input_power_w is the 100% reference. */
-  power_budget?: { label: string; watts: number; path?: string }[];
+  /** `label` is the display name (after ui_params["budget_labels"] renames);
+   *  `key` is the raw structural label, echoed back to /schematic so the
+   *  chain drawing can place each row's burn by its "<path>: ..." prefix
+   *  (issue #652). */
+  power_budget?: { label: string; watts: number; path?: string; key?: string }[];
   input_power_w?: number;
   k_meas_m_inv?: number;
   // V-specific

--- a/tests/test_composite_network.py
+++ b/tests/test_composite_network.py
@@ -430,12 +430,24 @@ def test_budget_rows_apply_display_renames():
     class Bare:
         pass
 
+    # `key` keeps the raw structural label alongside every rename/strip:
+    # the schematic fold-in (issue #652) joins on it.
     assert _budget_rows(Eng(), WithLabels()) == [
         # renamed: the design's display name wins verbatim
-        {"label": "unun comp cap", "watts": 0.25, "path": "unun"},
+        {
+            "label": "unun comp cap",
+            "watts": 0.25,
+            "path": "unun",
+            "key": "unun: Shunt pri",
+        },
         # unrenamed instance row: prefix stripped, path carries the group
-        {"label": "Transformer pri→ant", "watts": 0.05, "path": "unun"},
-        {"label": "TL rig→pri", "watts": 0.0, "path": ""},
+        {
+            "label": "Transformer pri→ant",
+            "watts": 0.05,
+            "path": "unun",
+            "key": "unun: Transformer pri→ant",
+        },
+        {"label": "TL rig→pri", "watts": 0.0, "path": "", "key": "TL rig→pri"},
     ]
     assert [r["label"] for r in _budget_rows(Eng(), Bare())] == [
         "Shunt pri",
@@ -449,7 +461,12 @@ def test_budget_rows_apply_display_renames():
         _excited_power_budget = [("unun: Shunt pri", 0.25)]
 
     assert _budget_rows(EngNoNet(), Bare()) == [
-        {"label": "unun: Shunt pri", "watts": 0.25, "path": ""}
+        {
+            "label": "unun: Shunt pri",
+            "watts": 0.25,
+            "path": "",
+            "key": "unun: Shunt pri",
+        }
     ]
 
     # The server's _build_builder STRIPS ui_params from the instance's

--- a/tests/test_schematic.py
+++ b/tests/test_schematic.py
@@ -141,6 +141,35 @@ def test_power_annotates_the_blocks_that_burn():
     assert lower(net).blocks[0].watts is None
 
 
+def test_power_reaches_a_bare_branch_by_its_own_label():
+    """`dipoles.invvee_coax_station` — the design the issue opens with — is
+    ONE bare TL, no composite: there is no "<path>: " prefix to own budget
+    rows by. The block matches its branch's own "TL rig→feed" row instead,
+    or the design that exists to model feedline loss shows none at all."""
+    net = build("dipoles.invvee_coax_station").build_network()
+    sch = lower(net, budget=[("TL rig→feed", 0.004)])
+    assert sch.blocks[0].watts == pytest.approx(0.004)
+
+
+def test_power_reaches_an_attachment():
+    """A trap in a dipole leg burns power where it hangs, not on a chain."""
+    net = build("multiband.trap_dipole").build_network()
+    sch = lower(net, budget=[("Load trap_l", 0.002), ("Load trap_r", 0.001)])
+    assert [a.watts for a in sch.attachments] == [
+        pytest.approx(0.002),
+        pytest.approx(0.001),
+    ]
+
+
+def test_duplicate_budget_labels_accumulate():
+    """Two probes can share one label (a parallel Shunt stamps group-1 and a
+    series one group-2 under the same "Shunt <port>"); a plain dict(budget)
+    kept only the last row's watts."""
+    net = build("verticals.stub_matched_vertical").build_network()
+    budget = [("match: TL rig→feed", 0.004), ("match: TL rig→feed", 0.001)]
+    assert lower(net, budget=budget).blocks[0].watts == pytest.approx(0.005)
+
+
 # ---------------------------------------------------------------------------
 # the return conductor
 #
@@ -338,6 +367,19 @@ def test_every_shape_in_the_corpus_renders(design, tmp_path):
     pytest.importorskip("schemdraw")
     svg = render_svg(lower(build(design).build_network()), tmp_path / "s.svg")
     assert "<svg" in svg
+
+
+def test_render_burn_is_a_fraction_of_input_when_p_in_is_known(tmp_path):
+    """With p_in the annotation is the same percent the power-budget table
+    shows, placed where it burns; without a reference it falls back to the
+    canonical drive's raw milliwatts."""
+    pytest.importorskip("schemdraw")
+    net = build("dipoles.invvee_coax_station").build_network()
+    budget = [("TL rig→feed", 0.004)]
+    with_pin = render_svg(lower(net, budget=budget, p_in=0.016))
+    assert "(25.0%)" in with_pin
+    without = render_svg(lower(net, budget=budget))
+    assert "mW" in without and "%" not in without
 
 
 def test_cli_writes_a_file(tmp_path):

--- a/tests/test_sweep_freq.py
+++ b/tests/test_sweep_freq.py
@@ -1,5 +1,9 @@
 import antennaknobs as ant
 from antennaknobs.designs.dipoles.invvee import Builder
+from antennaknobs.designs.dipoles.invvee_coax_station import (
+    Builder as StationBuilder,
+)
+from antennaknobs.sweep import _z_title
 
 from conftest import needs_pynec
 
@@ -7,3 +11,11 @@ from conftest import needs_pynec
 @needs_pynec
 def test_fandipole_sweep_freq():
     ant.sweep_freq(Builder(), z0=50, rng=(10, 30), npoints=2, fn="/dev/null")
+
+
+def test_impedance_title_names_the_driven_plane():
+    """ "feedpoint" is only true for a bare antenna (issue #652): a station
+    design is solved at the port its source sits on, and titling that chart
+    "feedpoint" invites comparing a VNA calibrated at the wrong plane."""
+    assert _z_title(Builder(), "freq") == "feedpoint impedance vs freq"
+    assert _z_title(StationBuilder(), "freq") == "impedance at rig vs freq"

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2911,3 +2911,33 @@ def test_schematic_labels_track_the_request_params(client: TestClient):
     a = client.post("/schematic", json=base).json()["svg"]
     b = client.post("/schematic", json={**base, "line_len_m": 10.0}).json()["svg"]
     assert a != b
+
+
+def test_schematic_folds_in_the_echoed_power_budget(client: TestClient):
+    """The endpoint still never solves; the frontend echoes the latest
+    solve's structural (key, watts) rows — the `key` field _budget_rows now
+    carries — plus its input power, and the burn draws as the budget table's
+    percent at the point in the chain it happens (issue #652)."""
+    base = {"geometry": "dipoles.invvee_coax_station"}
+    svg = client.post(
+        "/schematic",
+        json={**base, "budget": [["TL rig→feed", 0.004]], "input_power_w": 0.016},
+    ).json()["svg"]
+    assert "(25.0%)" in svg
+    # Without the budget nothing is claimed.
+    assert "%" not in client.post("/schematic", json=base).json()["svg"]
+
+
+def test_schematic_ignores_a_malformed_budget(client: TestClient):
+    # The budget is an annotation: junk entries drop, the drawing survives.
+    resp = client.post(
+        "/schematic",
+        json={
+            "geometry": "dipoles.invvee_coax_station",
+            "budget": ["nonsense", [1, 2], ["TL rig→feed", "NaN"], {"a": 1}],
+            "input_power_w": "lots",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["available"] is True and "%" not in data["svg"]


### PR DESCRIPTION
## Summary
- **Per-branch loss on the chain** (the remaining #652 acceptance item): each schematic block now draws its burn as the same percent the power-budget table shows — placed at the point in the chain it happens. `lower()` takes `p_in` beside `budget`; without a reference it falls back to the old milliwatt text.
- **Web fold-in without solving**: `/schematic` stays a no-solve endpoint. `_budget_rows` keeps the raw structural label as `key` beside the display rename, the frontend echoes the latest solve's `(key, watts)` rows plus `input_power_w` in the POST, and the hook refetches when a solve lands. The echo is gated on the result belonging to the current design (station designs share instance paths, so a stale budget would annotate the new chain with the old antenna's watts), and malformed entries drop instead of erroring.
- **Three reach gaps closed while placing the burn**: a pathless branch now matches its own budget rows by type prefix + terminal-name set (`invvee_coax_station` — the design the issue opens with — is one bare TL and previously showed no loss at all); attachments carry their burn too (a trap burns where it hangs); duplicate budget labels accumulate instead of dict-collapsing.
- **`sweep.py` titles name the actual plane**: networked designs title `impedance at <port> vs <param>` instead of the hardcoded (and, for a station, false) "feedpoint" — the last live-defect item on #652.

## Test plan
- [x] `pytest tests/test_schematic.py tests/test_web_server.py tests/test_composite_network.py tests/test_sweep_freq.py tests/test_power_budget.py` — 250 passed (new: bare-branch/attachment/duplicate-label matching, percent-vs-mW rendering, `/schematic` budget echo + malformed-budget, `_budget_rows` `key`, `_z_title`)
- [x] frontend `tsc --noEmit` + `vitest run` — 375 passed (new: budget echoed in POST body, omitted before a solve, landed solve refetches)
- [x] CLI smoke: `schematic --builder dipoles.invvee_coax_station --power` now annotates the coax with `(31.2%)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxcDWKRbc18jY2m49vDfhc