### PR TITLE
Measurement-plane picker: solve at any named port on the chain (#652 option c)

### DIFF
--- a/src/antennaknobs/plane.py
+++ b/src/antennaknobs/plane.py
@@ -1,0 +1,164 @@
+"""The measurement plane as a thing you can pick (issue #652, option c).
+
+A station design declares both ends of its chain — ``Driven(port="rig")`` and
+the antenna's ``feed`` — and the whole chart is drawn at whichever port the
+source sits on. That plane used to be a convention to remember; with the
+schematic on screen it becomes a thing to point at, and this module makes
+pointing at it *mean* something: solve the design as a VNA clipped on at that
+port would see it.
+
+## Why picking a plane prunes, rather than just moving the source
+
+The issue sketches "re-solve with ``Driven(port='feed')``" — but moving the
+source alone leaves the feed chain wired to the node, now ending at an
+undriven, unterminated ``rig``: a length of open-ended coax hanging in
+parallel with the antenna. That is "VNA at the feedpoint with the coax still
+dangling on it", and it is not what anyone means by measuring at the
+feedpoint. What they mean is the upstream *unscrewed*: so ``driven_at``
+cuts the chain at the picked port, drops everything on the source side of the
+cut, and drives what remains. Attachments — traps, stubs wired into the
+structure — are not upstream of anything and always stay.
+
+The cut is found with the same (signal, return) pair-walk the schematic uses,
+because "which side of this node is upstream" is exactly the question the
+chain drawing already answers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from .network import Network, PortOnWireFloating, PortVirtual
+from .schematic import DATUM, _antenna_nodes, _datum_nodes, _walk, terminals_of
+
+__all__ = ["driven_at", "planes_of"]
+
+
+def _chain(net: Network):
+    """The design's feed chain, walked from its natural source."""
+    src = net.sources[0]
+    return _walk(
+        list(net.branches),
+        src.port,
+        _antenna_nodes(net),
+        _datum_nodes(net),
+    )
+
+
+def _cut_at(chain, node: str):
+    """Index of the first chain step the plane node sits in front of.
+
+    ``k`` means: steps ``0..k-1`` are upstream (source side) of the plane;
+    ``len(chain)`` means the plane is the chain's end. None: not on the chain.
+    """
+    for k, st in enumerate(chain):
+        if node in st.pair_in:
+            return k
+    if chain and node in chain[-1].pair_out:
+        return len(chain)
+    return None
+
+
+def driven_at(net: Network, plane: str) -> Network:
+    """Re-source ``net`` at the named port, upstream disconnected.
+
+    Returns ``net`` itself when ``plane`` is already the driven port.
+    Everything on the source side of the cut is dropped — the chain branches
+    before the plane, any branch hanging entirely on their internal nodes,
+    and any `PortVirtual` nothing references anymore (an orphaned virtual
+    node would be a floating MNA row). The original source's drive value is
+    kept; only its port moves.
+    """
+    if len(net.sources) != 1:
+        raise ValueError(
+            f"{len(net.sources)} sources — a multi-feed drive has no single "
+            "plane to move"
+        )
+    src = net.sources[0]
+    if plane == src.port:
+        return net
+    port = net.ports.get(plane)
+    if port is None:
+        raise ValueError(f"no port named {plane!r} to measure at")
+    if isinstance(port, PortOnWireFloating):
+        raise ValueError(
+            f"{plane!r} is a floating gap — it has no reference terminal to "
+            "drive against"
+        )
+
+    chain = _chain(net)
+    cut = _cut_at(chain, plane)
+    if cut is None:
+        raise ValueError(f"{plane!r} is not on the feed chain from {src.port!r}")
+
+    upstream = {st.idx for st in chain[:cut]}
+    # Nodes that exist only on the source side: everything the upstream steps
+    # touch, minus the pair the cut leaves live. A rib AT the plane node stays
+    # — the wiring cannot say whether it unscrews with the upstream, and
+    # keeping it is the claim the drawing already makes.
+    live = set(chain[cut].pair_in if cut < len(chain) else chain[-1].pair_out)
+    gone = set()
+    for st in chain[:cut]:
+        gone |= set(st.pair_in) | set(st.pair_out)
+    gone -= live
+    gone.discard(DATUM)
+
+    is_datum = _datum_nodes(net)
+    branches, paths = [], []
+    all_paths = net.branch_paths or [""] * len(net.branches)
+    for i, br in enumerate(net.branches):
+        if i in upstream:
+            continue
+        ts = [t for t in terminals_of(br) if t not in is_datum]
+        if ts and all(t in gone for t in ts):
+            continue
+        branches.append(br)
+        paths.append(all_paths[i])
+
+    # An orphaned PortVirtual is a floating matrix row; wire ports are
+    # geometry and keep their antenna-Y grounding regardless.
+    referenced = set()
+    for br in branches:
+        referenced |= set(terminals_of(br))
+    ports = {
+        name: p
+        for name, p in net.ports.items()
+        if name == plane or not isinstance(p, PortVirtual) or name in referenced
+    }
+
+    out = Network(ports=ports, branches=branches, sources=[replace(src, port=plane)])
+    # branch_paths is derived-only in __post_init__ (and these branches are
+    # already flat), so the surviving instance attribution is restored here —
+    # the power budget and the schematic group by it.
+    out.branch_paths = paths
+    out.composites = dict(net.composites or {})
+    return out
+
+
+def planes_of(net: Network) -> list[str]:
+    """The ports a VNA could be clipped to, natural plane first.
+
+    Chain order after that, so a picker reads source → antenna. Only named,
+    drivable, top-level ports count: a floating pair has no reference to
+    drive against, and a flattening-invented interior ("tuner.o") is an
+    implementation detail nobody calibrates to. Each candidate is proven by
+    actually building its pruned network — a plane the solve would reject is
+    not offered.
+    """
+    if len(net.sources) != 1:
+        return []
+    natural = net.sources[0].port
+    out = [natural]
+    for st in _chain(net):
+        for node in (st.pair_in[0], st.pair_out[0]):
+            if node in out or node == DATUM or "." in node:
+                continue
+            p = net.ports.get(node)
+            if p is None or isinstance(p, PortOnWireFloating):
+                continue
+            try:
+                driven_at(net, node)
+            except ValueError:
+                continue
+            out.append(node)
+    return out

--- a/src/antennaknobs/schematic.py
+++ b/src/antennaknobs/schematic.py
@@ -230,6 +230,12 @@ class Schematic:
     # value-identical parallel lines; without naming its end, the chain and
     # the feed1 attachment read as the same components listed twice.
     antenna_name: str = ""
+    # The picked measurement plane (issue #652 c), when it is NOT the natural
+    # source. ``plane_cut`` is the block index the marker draws in front of
+    # (len(blocks) = at the antenna); everything left of it is disconnected
+    # for the solve being displayed and renders de-emphasised.
+    plane: str = ""
+    plane_cut: int | None = None
     title: str = ""
     notes: list[str] = field(default_factory=list)
     attachments: list[Block] = field(default_factory=list)
@@ -545,7 +551,7 @@ def _walk(branches, start, targets, is_datum):
     return best
 
 
-def lower(net, *, title: str = "", budget=None, p_in=None) -> Schematic:
+def lower(net, *, title: str = "", budget=None, p_in=None, plane=None) -> Schematic:
     """`Network` → :class:`Schematic`.
 
     Walks source → antenna to find the chain, groups consecutive chain
@@ -557,6 +563,12 @@ def lower(net, *, title: str = "", budget=None, p_in=None) -> Schematic:
     with what it burns — which is what puts the power budget *in* the topology
     instead of beside it. ``p_in`` is the same solve's input power; with it
     the annotation renders as the fraction the budget table already shows.
+
+    ``plane`` marks a picked measurement plane (issue #652 c): the FULL chain
+    still draws — the picker needs the whole thing on screen to point at —
+    with a marker at the cut and the disconnected upstream de-emphasised. A
+    plane the chain does not visit is quietly ignored: the drawing must never
+    crash, and the solve path (`plane.driven_at`) is the validating gate.
     """
     sch = Schematic(
         source=net.sources[0].port if net.sources else "",
@@ -758,8 +770,10 @@ def lower(net, *, title: str = "", budget=None, p_in=None) -> Schematic:
 
     # Group consecutive chain steps sharing an instance path.
     groups = []  # [(steps, path, nodes)]
+    starts = []  # each group's first chain-step index, for the plane cut
     i = 0
     while i < len(chain):
+        starts.append(i)
         path = paths[chain[i].idx]
         group, nodes = [chain[i]], set(chain[i].pair_in)
         while i + 1 < len(chain) and path and paths[chain[i + 1].idx] == path:
@@ -770,6 +784,18 @@ def lower(net, *, title: str = "", budget=None, p_in=None) -> Schematic:
         nodes.discard(DATUM)
         groups.append((group, path, nodes))
         i += 1
+
+    if plane and plane != sch.source and chain:
+        # Where the picked plane sits: in front of the first step whose
+        # entry pair carries it, or at the chain's end. Blocks wholly before
+        # that step are the upstream the solve disconnected.
+        cut = next(
+            (k for k, st in enumerate(chain) if plane in st.pair_in),
+            len(chain) if plane in chain[-1].pair_out else None,
+        )
+        if cut is not None:
+            sch.plane = plane
+            sch.plane_cut = sum(1 for s in starts if s < cut)
 
     # Assign each rib to EXACTLY ONE block. A node the chain passes through
     # can belong to two consecutive blocks, so keying a rib by node alone drew
@@ -947,8 +973,17 @@ def render_svg(sch: Schematic, path=None, color: str | None = None) -> str:
     schemdraw.use("svg")
     d = schemdraw.Drawing(show=False)
     d.config(unit=DX, fontsize=FONTSIZE)
+    base_color = color or "black"
     if color is not None:
         d.config(color=color)
+    # De-emphasis for the section a picked measurement plane disconnects
+    # (issue #652 c). The upstream still DRAWS — the picker needs the whole
+    # chain on screen to point at — but it is not part of the solve being
+    # displayed, and the page must not pretend it is.
+    DIM = "gray"
+
+    def upstream(n: int) -> bool:
+        return sch.plane_cut is not None and n < sch.plane_cut
 
     def symbol(kind):
         return getattr(elm, _SCHEMDRAW_SYMBOLS.get(kind, "RBox"))
@@ -986,6 +1021,27 @@ def render_svg(sch: Schematic, path=None, color: str | None = None) -> str:
                     drawn.append(line)
         x = xc = at
 
+    def plane_marker(px):
+        """The picked measurement plane: a dash-dot line crossing the chain.
+
+        Inherits the drawing colour from the config state on purpose — both
+        call sites have just restored the full colour, and an explicit
+        ``.color()`` would trip schemdraw's name validation on
+        "currentColor", which only ``config`` passes through verbatim.
+        `d.add`, not `d +=` — see `sync` for why.
+        """
+        top, bot = y + 0.9, gnd_y() + 0.3
+        d.add(elm.Line().at((px, top)).to((px, bot)).linestyle("-."))
+        d.add(
+            elm.Label()
+            .at((px, top + 0.1))
+            .label(f"plane: {sch.plane}", valign="bottom")
+        )
+
+    # A picked plane makes everything from the source to the cut a
+    # disconnected stub of the drawing — the source glyph included.
+    if sch.plane_cut is not None:
+        d.config(color=DIM)
     # `.to()` rather than `.up()`: an element's default length is one unit
     # (DX), so `.up()` from the datum overshoots the spine and leaves a bare
     # wire sticking out of the top of the source.
@@ -1008,12 +1064,18 @@ def render_svg(sch: Schematic, path=None, color: str | None = None) -> str:
     x += leadin
 
     for n, block in enumerate(sch.blocks):
+        if sch.plane_cut is not None:
+            d.config(color=DIM if upstream(n) else base_color)
         if n:
             d += elm.Line().at((x, y)).to((x + GAP, y))
             x += GAP
             if balanced:
                 d += elm.Line().at((xc, yr)).to((xc + GAP, yr))
                 xc += GAP
+        if sch.plane_cut == n:
+            # The cut sits at the node this block starts from — mid-gap
+            # between blocks, or on the lead-in for a cut at the first one.
+            plane_marker(x - (GAP if n else leadin) / 2.0)
         x0 = x
         drawn = []  # what the block's enclosure has to contain
         tall = False  # the last symbol drawn reaches below the spine
@@ -1282,8 +1344,10 @@ def render_svg(sch: Schematic, path=None, color: str | None = None) -> str:
             )
             if note:
                 # The box's own colour is the de-emphasis gray; the label
-                # re-asserts the drawing colour so it reads as content.
-                box.label(note, loc="top", color=color or "black")
+                # re-asserts the drawing colour so it reads as content —
+                # unless the block is upstream of a picked plane, in which
+                # case dim is exactly what it should read as.
+                box.label(note, loc="top", color=DIM if upstream(n) else base_color)
             d += box
         elif block.watts:
             # A bare branch has no enclosure to caption, but its burn still
@@ -1298,6 +1362,14 @@ def render_svg(sch: Schematic, path=None, color: str | None = None) -> str:
                     valign="top",
                 )
             )
+
+    if sch.plane_cut is not None:
+        # Everything from here on — the antenna, attachments, notes — is on
+        # the live side of any cut; restore the drawing colour. A cut at the
+        # chain's very end marks the antenna terminals themselves.
+        d.config(color=base_color)
+        if sch.plane_cut == len(sch.blocks):
+            plane_marker(x + LEADOUT / 2.0)
 
     # "antenna (feed0)" when the chain's end carries a name — it only does
     # when the network has other antenna ports to confuse it with.

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -629,6 +629,42 @@ def _req_budget(req):
     return out or None, (float(p_in) if ok else None)
 
 
+def _apply_plane(builder, req):
+    """Move the solve to the request's measurement plane (issue #652 c).
+
+    Returns ``(plane, planes)`` for the response — the plane actually solved
+    at (the natural source port when none was asked for) and every pickable
+    one. Asking for a non-natural plane shadows the built builder's
+    ``build_network`` with the pruned, re-sourced network from
+    `plane.driven_at`: engines read the network exactly once, so the
+    instance attribute is a sufficient seam. ``(None, None)`` when there is
+    nothing to pick — no network, or a multi-feed drive with no single plane
+    to move. An unknown plane raises ValueError like any bad request field.
+    """
+    from antennaknobs.plane import driven_at, planes_of
+
+    build = getattr(builder, "build_network", None)
+    net = build() if callable(build) else None
+    if net is None or len(net.sources) != 1:
+        return None, None
+    natural = net.sources[0].port
+    planes = planes_of(net)
+    plane = req.get("plane")
+    if not plane or plane == natural:
+        return natural, planes
+    if plane not in planes:
+        raise ValueError(
+            f"unknown measurement plane {plane!r}; this design offers {planes}"
+        )
+    pruned = driven_at(net, plane)
+    # object.__setattr__, NOT plain assignment: Builder.__setattr__ files
+    # every write into _params, where a normal read never finds it (the
+    # class method wins the lookup) — the shadow would be silently absorbed
+    # and every plane would quietly solve at the natural port.
+    object.__setattr__(builder, "build_network", lambda: pruned)
+    return plane, planes
+
+
 def _derive_schema(default_params: dict) -> tuple:
     ui = dict(default_params.get("ui_params") or {})
     specs: list[ParamSpec] = []
@@ -2010,6 +2046,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         # into _params and never read — guard on has_design_freq.
         if has_design_freq:
             builder.design_freq = design_freq
+        plane, planes = _apply_plane(builder, req)
         eng = _make_momwire_engine(req, builder, cancel=cancel)
         t0 = time.perf_counter()
         zs = [_json_safe_z(z) for z in eng.impedance()]
@@ -2055,6 +2092,11 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             "input_power_w": float(eng.input_power()),
             **_wire_material_results(builder),
         }
+        if planes is not None:
+            # Measurement plane (issue #652 c): which port this solve is
+            # referenced to, and which the picker may offer.
+            out["plane"] = plane
+            out["planes"] = planes
         # Array Block coupling-path diagnostics (issue #613): absent for
         # every other engine/model (eng.solver_diag() only returns a dict
         # for an ArrayBlockSolver-backed solve).
@@ -2144,6 +2186,9 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         builder.freq = meas_freq
         if has_design_freq:
             builder.design_freq = design_freq
+        # The pattern must be the same solve the impedance readout shows —
+        # a picked plane (issue #652 c) moves both together.
+        _apply_plane(builder, req)
         eng = _make_pynec_engine(req, builder)
         # Find the first excited wire to fill the feed_seg / feed_tag
         # parity fields. PyNECEngine.excitation_pairs is (tag, sub_seg,
@@ -2179,6 +2224,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         builder.freq = meas_freq
         if has_design_freq:
             builder.design_freq = design_freq
+        plane, planes = _apply_plane(builder, req)
         eng = _make_pynec_engine(req, builder)
         t0 = time.perf_counter()
         zs = [_json_safe_z(z) for z in eng.impedance()]
@@ -2226,6 +2272,10 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             "input_power_w": float(getattr(eng, "_excited_p_in", None) or 0.0),
             **_wire_material_results(builder),
         }
+        if planes is not None:
+            # Same plane fields as the momwire path (issue #652 c).
+            out["plane"] = plane
+            out["planes"] = planes
         if _requested_ground_model(req) == "terrain":
             # PyNEC terrain hybrid (issue #553): the engine solved over the
             # crest-medium Sommerfeld spec (so ground_eps_r/sigma above are
@@ -2316,6 +2366,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         builder.freq = meas_freq
         if has_design_freq:
             builder.design_freq = design_freq
+        _apply_plane(builder, req)
         eng = _make_momwire_engine(req, builder, cancel=cancel)
         ff = eng.far_field(n_theta=90, n_phi=360, del_theta=1, del_phi=1)
         metrics = pattern_metrics(ff)
@@ -2366,10 +2417,16 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         # echoes the latest solve's structural (key, watts) rows and input
         # power, and each block gets its burn drawn where it happens.
         budget, p_in = _req_budget(req)
+        # A picked plane (issue #652 c) draws as a marker on the FULL chain
+        # with the disconnected upstream dimmed — lower() quietly ignores a
+        # name the chain doesn't visit, so no validation needed here.
+        plane = req.get("plane")
+        plane = plane if isinstance(plane, str) else None
         # "currentColor": the frontend inlines the SVG, so strokes/text
         # inherit the app theme's CSS colour (see render_svg's docstring).
         return render_svg(
-            lower(net, title=name, budget=budget, p_in=p_in), color="currentColor"
+            lower(net, title=name, budget=budget, p_in=p_in, plane=plane),
+            color="currentColor",
         )
 
     def momwire_sweep(req: dict, freqs_mhz: list[float], cancel=None):
@@ -2382,6 +2439,9 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         # solve sees. See momwire_solve for the rationale.
         if has_design_freq:
             builder.design_freq = _req_freqs(req)[0]
+        # A sweep at a picked plane sweeps THAT plane's impedance — the
+        # curve the measured overlay lands on (issue #652 c).
+        _apply_plane(builder, req)
         eng = _make_momwire_engine(req, builder, cancel=cancel)
         zs = np.asarray(eng.impedance_sweep(list(freqs_mhz)))
         # Open-circuited points sweep through as inf; clamp for JSON.

--- a/src/antennaknobs/web/frontend/src/__tests__/SolveReadout.plane.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/SolveReadout.plane.test.tsx
@@ -1,0 +1,88 @@
+// The measurement-plane picker (issue #652 c) in the solve readout: shown
+// exactly when the solve offers >1 plane AND the session wired a handler;
+// paired presence/absence pins in the repo's matrix style.
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SolveReadout } from "../components/results/SolveReadout";
+import type { SolveResponse } from "../lib/api";
+
+function fakeResult(extra: Partial<SolveResponse> = {}): SolveResponse {
+  return {
+    geometry: "dipoles.invvee_coax_station",
+    wires: [
+      {
+        label: "w",
+        knot_positions: [[0, 0, 0]],
+        knot_currents_re: [0],
+        knot_currents_im: [0],
+      },
+    ],
+    feed_wire_index: 0,
+    feed_knot_index: 0,
+    z_in_re: 44,
+    z_in_im: -4,
+    design_freq_mhz: 28.47,
+    measurement_freq_mhz: 28.47,
+    solve_ms: 1.0,
+    z0_ohms: 50,
+    ...extra,
+  } as SolveResponse;
+}
+
+function renderReadout(
+  result: SolveResponse | null,
+  onPlaneChange?: (p: string) => void,
+) {
+  return render(
+    <SolveReadout
+      result={result}
+      rttMs={null}
+      currentExample={undefined}
+      effectiveMultiFeed={false}
+      normCheck={null}
+      normCheckEnabled={false}
+      onPlaneChange={onPlaneChange}
+    />,
+  );
+}
+
+describe("measurement-plane picker", () => {
+  it("offers the solve's planes and reports a pick", () => {
+    const onPlaneChange = vi.fn();
+    renderReadout(
+      fakeResult({ plane: "rig", planes: ["rig", "feed"] }),
+      onPlaneChange,
+    );
+    const select = screen.getByLabelText(
+      "measurement plane",
+    ) as HTMLSelectElement;
+    expect(select.value).toBe("rig");
+    fireEvent.change(select, { target: { value: "feed" } });
+    expect(onPlaneChange).toHaveBeenCalledWith("feed");
+  });
+
+  it("reflects the plane the solve actually ran at", () => {
+    renderReadout(
+      fakeResult({ plane: "feed", planes: ["rig", "feed"] }),
+      vi.fn(),
+    );
+    expect(
+      (screen.getByLabelText("measurement plane") as HTMLSelectElement).value,
+    ).toBe("feed");
+  });
+
+  it("is absent when the design has no planes to offer", () => {
+    renderReadout(fakeResult(), vi.fn());
+    expect(screen.queryByLabelText("measurement plane")).toBeNull();
+  });
+
+  it("is absent when there is only the natural plane", () => {
+    renderReadout(fakeResult({ plane: "feed", planes: ["feed"] }), vi.fn());
+    expect(screen.queryByLabelText("measurement plane")).toBeNull();
+  });
+
+  it("is absent when no handler is wired, whatever the solve offers", () => {
+    renderReadout(fakeResult({ plane: "rig", planes: ["rig", "feed"] }));
+    expect(screen.queryByLabelText("measurement plane")).toBeNull();
+  });
+});

--- a/src/antennaknobs/web/frontend/src/components/results/SolveReadout.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/SolveReadout.tsx
@@ -35,6 +35,7 @@ export function SolveReadout({
   effectiveMultiFeed,
   normCheck,
   normCheckEnabled,
+  onPlaneChange,
   className = "",
 }: {
   result: SolveResponse | null;
@@ -43,10 +44,33 @@ export function SolveReadout({
   effectiveMultiFeed: boolean;
   normCheck: NormCheckData | null;
   normCheckEnabled: boolean;
+  /** Measurement-plane pick (issue #652 c). Absent = picker never shown. */
+  onPlaneChange?: (plane: string) => void;
   className?: string;
 }) {
+  const planes = result?.planes;
   return (
     <div className={`readout${className ? " " + className : ""}`}>
+      {onPlaneChange && planes && planes.length > 1 && (
+        <div
+          className="row"
+          title="Measurement plane: the port every number and chart here is referenced to. Picking another port re-solves as a VNA clipped on there — the chain upstream of it disconnected."
+        >
+          <span>plane</span>
+          <select
+            className="val plane-select"
+            aria-label="measurement plane"
+            value={result?.plane ?? planes[0]}
+            onChange={(e) => onPlaneChange(e.target.value)}
+          >
+            {planes.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
       <div className="row">
         <span>R</span>
         <span className="val">{result ? formatOhms(result.z_in_re) : "—"}</span>

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -394,6 +394,11 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // measFreq still follows designFreq via the linkMeas useEffect below.
 
   const [result, setResult] = useState<SolveResponse | null>(null);
+  // Measurement plane (issue #652 c): null = the design's natural source
+  // port (the field is then omitted from requests). A picked plane
+  // re-solves everything — readout, charts, sweeps, pattern — with the
+  // chain upstream of it disconnected, and the schematic marks the cut.
+  const [plane, setPlane] = useState<string | null>(null);
   // Geometry-only snapshot of the just-selected antenna (wires + feed marker,
   // no currents), fetched fast so a large design's shape renders immediately
   // instead of waiting tens of seconds for the full solve. Superseded by
@@ -621,6 +626,10 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
       }
       base.model_options = opts;
     }
+    // Measurement plane (issue #652 c): only ever sent when picked — the
+    // natural plane is the absence of the field, so designs with no
+    // network never see it.
+    if (plane) base.plane = plane;
     // Schema-driven antennas (all of them now): merge the active
     // paramValues straight in. For fan_dipole this includes a nested
     // `bands: [{band_id, freq, length_factor}, ...]` array; the backend
@@ -692,6 +701,7 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
       currentVariant,
       designFreq,
       measFreq,
+      plane, // the picked plane draws as a marker + dimmed upstream
     ]),
     buildRequest,
     budget: schematicBudget,
@@ -820,6 +830,13 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
   // Pin the current pattern: snapshot the solve response (for the ghost trace)
   // into the shared cross-session pin list. The snapshot is frozen — it won't
   // change as the live knobs move, which is the whole point of comparing.
+  // Measurement-plane pick (issue #652 c). Choosing the natural (first)
+  // plane clears the override entirely, so the request field disappears
+  // rather than pinning the default by name.
+  function pickPlane(p: string) {
+    setPlane(p === result?.planes?.[0] ? null : p);
+  }
+
   function pinCurrentPattern() {
     if (!result) return;
     const label = `${currentExample?.label ?? geometry} @ ${measFreq.toFixed(2)} MHz`;
@@ -938,7 +955,7 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
     autoSim,
     geometry, previewReady, backend, backendOptsKey,
     currentValuesKey,
-    designFreq, measFreq,
+    designFreq, measFreq, plane,
     groundEnabled, groundModel, terrainKey,
   ]);
 
@@ -961,6 +978,7 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
     setResult(null);
     setPreview(null);
     setSolveError(null);
+    setPlane(null); // plane names belong to a design; never carry one over
     setPreviewReady(null); // close the solve gate until this antenna's preview lands
     setSolverWarning(false); // drop any combo warning from the prior design
     previewAbortRef.current?.abort();
@@ -1403,6 +1421,7 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
                       effectiveMultiFeed={effectiveMultiFeed}
                       normCheck={normCheck}
                       normCheckEnabled={normCheckEnabled}
+                      onPlaneChange={pickPlane}
                     />
                     {/* The ws status lives HERE, not floating over the
                         carousel — on a phone the desktop-style absolute
@@ -1517,6 +1536,7 @@ export function DesignSession({ id, active }: { id: number; active: boolean }) {
             effectiveMultiFeed={effectiveMultiFeed}
             normCheck={normCheck}
             normCheckEnabled={normCheckEnabled}
+            onPlaneChange={pickPlane}
           />
         </div>
         <div className="status">

--- a/src/antennaknobs/web/frontend/src/lib/api.ts
+++ b/src/antennaknobs/web/frontend/src/lib/api.ts
@@ -120,6 +120,11 @@ export type SolveResponse = {
    *  (issue #652). */
   power_budget?: { label: string; watts: number; path?: string; key?: string }[];
   input_power_w?: number;
+  /** Measurement plane (issue #652 c): the port this solve's Z/SWR/chart are
+   *  referenced to, and every port the picker may offer (natural plane
+   *  first). Absent for designs with no network or a multi-feed drive. */
+  plane?: string;
+  planes?: string[];
   k_meas_m_inv?: number;
   // V-specific
   arm_len_m?: number;
@@ -200,6 +205,10 @@ export type SolveRequest = {
   /** Cut angles for the server-attached polar traces (issue #547). */
   az_elev_deg?: number;
   elev_az_deg?: number;
+  /** Measurement plane to solve at (issue #652 c). Omitted = the design's
+   *  natural source port. A non-natural plane re-solves with the upstream
+   *  chain disconnected — a VNA clipped on at that port. */
+  plane?: string;
   // V
   angle_deg?: number;
   halfdriver_factor?: number;

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1746,6 +1746,19 @@ input[type=checkbox] {
   color: var(--muted);
 }
 
+/* Measurement-plane picker (issue #652 c): a select that reads like the
+   value it replaces — mono, accent, right-aligned — not a form control. */
+.readout .plane-select {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--accent);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 0 var(--space-1);
+  text-align: right;
+}
+
 .feeds-table {
   margin-top: var(--space-3);
   padding-top: var(--space-3);

--- a/tests/test_plane.py
+++ b/tests/test_plane.py
@@ -1,0 +1,165 @@
+"""Measurement-plane picking (issue #652, option c).
+
+`driven_at` is a graph surgery with judgement in it — what counts as
+"upstream of the plane", what survives the cut — so that is where the tests
+are, plus one engine oracle pinning the semantics the module exists for:
+plane = feed measures the BARE antenna, not the antenna with a dangling
+open-ended coax on it.
+"""
+
+import importlib
+
+import pytest
+
+from antennaknobs.network import (
+    TL,
+    Driven,
+    Network,
+    PortOnWire,
+    PortVirtual,
+    Shunt,
+    TwoPort,
+)
+from antennaknobs.plane import driven_at, planes_of
+
+
+def build(name):
+    return importlib.import_module(f"antennaknobs.designs.{name}").Builder()
+
+
+def _ports(**kinds):
+    return {
+        name: (PortOnWire(name) if kind == "real" else PortVirtual(name))
+        for name, kind in kinds.items()
+    }
+
+
+def _tuner_line_net():
+    """rig → [tuner: series C, shunt L, series C] → li → 600 Ω line → feed.
+
+    "li" is a NAMED mid-chain port, so all three planes are pickable.
+    """
+    return Network(
+        ports=_ports(feed="real", li="virt", m="virt", rig="virt"),
+        branches=[
+            TwoPort(a="rig", b="m", c=30e-12),
+            Shunt(port="m", l=2.5e-6),
+            TwoPort(a="m", b="li", c=500e-12),
+            TL(a="li", b="feed", z0=600, length=20.0),
+        ],
+        sources=[Driven(port="rig", voltage=2 + 0j)],
+    )
+
+
+# ---------------------------------------------------------------------------
+# the cut
+# ---------------------------------------------------------------------------
+def test_the_natural_plane_is_the_network_itself():
+    net = _tuner_line_net()
+    assert driven_at(net, "rig") is net
+
+
+def test_planes_read_source_to_antenna():
+    # Every named top-level port on the chain is a legitimate readout point,
+    # in source → antenna order — including "m", the tuner's own tee node,
+    # because this fixture NAMES it at top level. (A composite's interior
+    # gets a dotted auto-name instead and is deliberately not offered.)
+    assert planes_of(_tuner_line_net()) == ["rig", "m", "li", "feed"]
+
+
+def test_a_mid_chain_plane_keeps_only_the_antenna_side():
+    net = driven_at(_tuner_line_net(), "li")
+    assert [type(b).__name__ for b in net.branches] == ["TL"]
+    assert net.sources == [Driven(port="li", voltage=2 + 0j)]  # drive kept
+    # The tuner's nodes are gone with it; the plane and the antenna stay.
+    assert set(net.ports) == {"li", "feed"}
+
+
+def test_the_feed_plane_is_the_bare_antenna():
+    net = driven_at(_tuner_line_net(), "feed")
+    assert net.branches == []
+    assert set(net.ports) == {"feed"}
+    assert net.sources == [Driven(port="feed", voltage=2 + 0j)]
+
+
+def test_instance_paths_survive_the_cut():
+    """branch_paths is derived-only on Network, so the surgery restores it —
+    the power budget and the schematic group by it."""
+    sta = build("verticals.stub_matched_vertical").build_network()
+    assert any(p for p in sta.branch_paths)  # the design uses a composite
+    cut = driven_at(sta, "feed")
+    assert len(cut.branch_paths) == len(cut.branches)
+
+
+def test_attachments_are_not_upstream_of_anything():
+    """A trap is wired into the structure; no plane disconnects it."""
+    net = build("multiband.trap_dipole").build_network()
+    assert planes_of(net) == [net.sources[0].port]
+    assert driven_at(net, net.sources[0].port) is net
+
+
+# ---------------------------------------------------------------------------
+# refusals
+# ---------------------------------------------------------------------------
+def test_an_unknown_port_is_refused():
+    with pytest.raises(ValueError, match="no port named"):
+        driven_at(_tuner_line_net(), "vna")
+
+
+def test_a_floating_gap_is_not_a_plane():
+    """`wire.doublet_balanced_tuner`'s feed is a floating pair — there is no
+    reference terminal for a single-ended VNA to drive against."""
+    net = build("wire.doublet_balanced_tuner").build_network()
+    with pytest.raises(ValueError, match="floating gap"):
+        driven_at(net, "feed")
+    assert "feed" not in planes_of(net)
+
+
+def test_a_multi_feed_drive_has_no_plane_to_move():
+    net = build("arrays.bowtie4x4").build_network()
+    assert planes_of(net) == []
+    with pytest.raises(ValueError, match="multi-feed"):
+        driven_at(net, "feed0")
+
+
+# ---------------------------------------------------------------------------
+# the physics the module exists for
+# ---------------------------------------------------------------------------
+def test_plane_feed_measures_the_bare_antenna_not_a_dangling_stub():
+    """The issue sketched "just re-solve with Driven(port='feed')" — but
+    moving the source alone leaves the coax as an open-ended stub hanging on
+    the feedpoint, which is a different (and wrong) measurement. The prune
+    is the difference between "VNA at the feedpoint, coax unscrewed" and
+    "VNA at the feedpoint, coax dangling"."""
+    from antennaknobs.engines.momwire import MomwireEngine
+    from antennaknobs.designs.dipoles.invvee_coax_station import Builder
+
+    class AtFeed(Builder):
+        def build_network(self):
+            return driven_at(super().build_network(), "feed")
+
+    class Dangling(Builder):
+        def build_network(self):
+            net = super().build_network()
+            return Network(
+                ports=dict(net.ports),
+                branches=list(net.branches),
+                sources=[Driven(port="feed", voltage=1 + 0j)],
+            )
+
+    class Bare(Builder):
+        def build_network(self):
+            net = super().build_network()
+            return Network(
+                ports={"feed": net.ports["feed"]},
+                branches=[],
+                sources=[Driven(port="feed", voltage=1 + 0j)],
+            )
+
+    z_plane = MomwireEngine(AtFeed()).impedance()[0]
+    z_bare = MomwireEngine(Bare()).impedance()[0]
+    z_dangling = MomwireEngine(Dangling()).impedance()[0]
+    z_rig = MomwireEngine(Builder()).impedance()[0]
+    assert z_plane == pytest.approx(z_bare, rel=1e-12)
+    assert abs(z_plane - z_dangling) > 1.0  # the stub loads the feedpoint
+    assert abs(z_plane - z_rig) > 1.0  # and the rig plane is a third thing

--- a/tests/test_schematic.py
+++ b/tests/test_schematic.py
@@ -369,6 +369,31 @@ def test_every_shape_in_the_corpus_renders(design, tmp_path):
     assert "<svg" in svg
 
 
+def test_a_picked_plane_marks_the_cut_but_keeps_the_whole_chain():
+    """Plane UX (issue #652 c): the drawing is the picker, so the FULL chain
+    stays on screen — the cut index says where the marker goes and which
+    blocks are the disconnected upstream."""
+    net = build("wire.doublet_ladder_tuner").build_network()
+    sch = lower(net, plane="li")
+    assert (sch.plane, sch.plane_cut) == ("li", 1)
+    assert len(sch.blocks) == 2  # tuner (upstream) + line, both still drawn
+    # A cut at the chain's end marks the antenna terminals themselves.
+    assert lower(net, plane="feed").plane_cut == 2
+    # The natural plane and an unknown one mark nothing — the drawing never
+    # crashes; plane.driven_at is the validating gate.
+    assert lower(net, plane="rig").plane_cut is None
+    assert lower(net, plane="bogus").plane_cut is None
+
+
+def test_render_draws_the_plane_marker():
+    pytest.importorskip("schemdraw")
+    net = build("dipoles.invvee_coax_station").build_network()
+    svg = render_svg(lower(net, plane="feed"))
+    assert "plane: feed" in svg
+    # without a picked plane, no marker
+    assert "plane:" not in render_svg(lower(net))
+
+
 def test_render_burn_is_a_fraction_of_input_when_p_in_is_known(tmp_path):
     """With p_in the annotation is the same percent the power-budget table
     shows, placed where it burns; without a reference it falls back to the

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -561,6 +561,38 @@ def test_solve_dispatches_to_momwire_for_dipole():
     assert out["z_in_re"] > 0
 
 
+def test_solve_at_a_picked_plane_measures_the_bare_antenna():
+    """Measurement-plane picking (issue #652 c): plane="feed" re-solves with
+    the upstream disconnected — the VNA-at-the-feedpoint measurement — and
+    the response says which plane it is referenced to and which are on
+    offer."""
+    base = {
+        "geometry": "dipoles.invvee_coax_station",
+        "measurement_freq_mhz": 28.47,
+        "design_freq_mhz": 28.47,
+        "momwire_model": "bspline",
+    }
+    at_rig = server.solve(base)
+    assert at_rig["plane"] == "rig"
+    assert at_rig["planes"] == ["rig", "feed"]
+    at_feed = server.solve({**base, "plane": "feed"})
+    assert at_feed["plane"] == "feed"
+    z_rig = complex(at_rig["z_in_re"], at_rig["z_in_im"])
+    z_feed = complex(at_feed["z_in_re"], at_feed["z_in_im"])
+    # 100 ft of RG-8X transforms the impedance; the planes must differ.
+    assert abs(z_rig - z_feed) > 1.0
+    # With the coax unscrewed nothing is left to burn.
+    assert at_rig["power_budget"] and not at_feed["power_budget"]
+
+    # A plain build_wires antenna has no plane to speak of — no fields.
+    bare = server.solve({**base, "geometry": "dipoles.invvee"})
+    assert "plane" not in bare and "planes" not in bare
+
+    # An unknown plane is a bad request field, same as a bad freq.
+    with pytest.raises(ValueError, match="measurement plane"):
+        server.solve({**base, "plane": "vna"})
+
+
 def _design_builder(dotted):
     import importlib
 
@@ -2926,6 +2958,14 @@ def test_schematic_folds_in_the_echoed_power_budget(client: TestClient):
     assert "(25.0%)" in svg
     # Without the budget nothing is claimed.
     assert "%" not in client.post("/schematic", json=base).json()["svg"]
+
+
+def test_schematic_marks_a_picked_plane(client: TestClient):
+    svg = client.post(
+        "/schematic",
+        json={"geometry": "dipoles.invvee_coax_station", "plane": "feed"},
+    ).json()["svg"]
+    assert "plane: feed" in svg
 
 
 def test_schematic_ignores_a_malformed_budget(client: TestClient):


### PR DESCRIPTION
## Summary
- **`plane.py`** — `driven_at(net, plane)` re-sources the network at a named port **with the upstream disconnected**: chain branches on the source side of the cut are dropped (located with the schematic's pair-walk), plus branches stranded on their internal nodes and orphaned `PortVirtual`s (a floating MNA row). `planes_of(net)` enumerates what a picker may offer — single-source designs' named, drivable, top-level ports on the chain, each proven by building its pruned network.
- **Physics note — this deliberately diverges from the issue's sketched mechanism.** "Re-solve with `Driven(port='feed')`" alone leaves the coax as an open-ended stub dangling on the feedpoint, which is a different measurement from "VNA at the feedpoint with the coax disconnected". The engine-oracle test pins all three values apart: plane=feed ≡ bare antenna ≠ dangling-stub ≠ rig.
- **Web plumbing** — `_apply_plane()` shadows the built builder's `build_network` with the pruned net (via `object.__setattr__`: `Builder.__setattr__` files plain writes into `_params` where reads never find them, so a normal assignment made every plane silently solve at the natural port — the exact trap the `design_freq` comment warns about). Applied across solve/sweep/pattern/metrics so every chart moves together; responses carry `plane` + `planes`, making the plane machine-readable as the issue asked.
- **Schematic** — a picked plane draws as a dash-dot marker on the **full** chain (the drawing is the picker; nothing vanishes) with the disconnected upstream dimmed, source glyph included. Two schemdraw traps: per-element `.color()` validates names and rejects `currentColor` (only `config` passes it through), and `d.add` vs `d +=` in nested helpers.
- **Frontend** — a `plane` select in the solve readout (both call sites), shown only when the solve offers more than one plane; session state resets on design switch, rides every request, and re-triggers solve + schematic refetch. The measured overlay (#595) needs nothing extra — it lands on whatever curve the solve now produces.

## Test plan
- [x] `tests/test_plane.py` (10 new) — cut semantics, path survival, refusals (floating gap, multi-feed, unknown), and the bare-vs-dangling-vs-rig engine oracle
- [x] `tests/test_schematic.py` (+2) — cut index recorded, full chain kept, marker rendered, natural/bogus planes ignored
- [x] `tests/test_web_server.py` (+2) — solve at plane=feed differs from rig, carries `plane`/`planes`, empty budget when the chain is unscrewed; `/schematic` marks the plane
- [x] frontend: 380 vitest (5 new picker pins) + `tsc --noEmit` clean
- [x] 262 Python tests across the affected suites; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxcDWKRbc18jY2m49vDfhc