### PR TITLE
Make the measurement-plane picker clickable inside the passive HUD

### DIFF
--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -2105,6 +2105,15 @@ input[type=checkbox] {
   pointer-events: none; /* a passive HUD — never intercept drags on the view */
 }
 
+/* The one interactive thing in the HUD: the measurement-plane picker
+   (issue #652 c). Children can restore pointer-events under a none parent,
+   so the select is clickable while every other pixel of the card still
+   lets canvas drags through. */
+.stage-readout .plane-select {
+  pointer-events: auto;
+  cursor: pointer;
+}
+
 .projection-toggle {
   display: flex;
   gap: var(--space-2);


### PR DESCRIPTION
## Summary
- The desktop solve readout is a passive HUD (`pointer-events: none`) so canvas drags pass through it — which also made the new plane select (#652 c, PR #689) unclickable; the canvas zoom cursor showed over it. One CSS rule restores pointer-events on exactly the select, keeping every other pixel of the card drag-transparent.

## Test plan
- [ ] Live check on localhost:8137: the dropdown takes clicks; dragging elsewhere on the readout still rotates/zooms the canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxcDWKRbc18jY2m49vDfhc