### PR TITLE
Invalidate frequency/convergence sweeps when the measurement plane changes

### DIFF
--- a/src/antennaknobs/web/frontend/src/__tests__/useAnalysisRunners.plane.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useAnalysisRunners.plane.test.tsx
@@ -1,0 +1,144 @@
+// A measurement-plane flip (issue #652 c) must invalidate every background
+// analysis: the freq sweep and convergence sweep read the driving-point
+// impedance, so the previous plane's curves on screen are wrong data, not
+// stale decoration. Pins that changing `plane` (alone — same knobs, same
+// freqs) clears the overlays and refetches with the plane in the body.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useAnalysisRunners } from "../components/session/useAnalysisRunners";
+import type { BackendEntry } from "../lib/backends";
+import type { SolveRequest } from "../lib/api";
+
+const BACKEND: BackendEntry = {
+  name: "bspline",
+  label: "B-spline",
+  kind: "momwire",
+  supports_ground: true,
+  options_schema: [],
+  panel: null,
+  default_n_per_wire: 8,
+  accelerator: false,
+  dense_family: false,
+};
+
+// A one-line NDJSON stream, enough for the accumulator loops to complete.
+function streamResponse(line: string) {
+  let sent = false;
+  return Promise.resolve({
+    ok: true,
+    body: {
+      getReader: () => ({
+        read: () =>
+          sent
+            ? Promise.resolve({ done: true, value: undefined })
+            : ((sent = true),
+              Promise.resolve({
+                done: false,
+                value: new TextEncoder().encode(line + "\n"),
+              })),
+      }),
+    },
+  });
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  fetchMock = vi.fn((url: string) =>
+    streamResponse(
+      url === "/converge"
+        ? JSON.stringify({ n: 8, z_re: 44, z_im: -4 })
+        : JSON.stringify({ freq_mhz: 28.47, z_re: 44, z_im: -4 }),
+    ),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+type Props = { plane: string | null };
+
+function renderRunners() {
+  return renderHook(
+    (p: Props) =>
+      useAnalysisRunners({
+        geometry: "dipoles.invvee_coax_station",
+        backend: BACKEND,
+        backendOptsKey: "k",
+        currentValuesKey: "v1",
+        currentVariant: "default",
+        currentExample: undefined,
+        currentBands: [],
+        freqWindowCeiling: 60,
+        designFreq: 28.47,
+        measFreq: 28.47,
+        measLocked: false,
+        plane: p.plane,
+        groundEnabled: false,
+        groundModel: "fast",
+        terrainKey: "",
+        sweepEnabled: true,
+        convergeEnabled: true,
+        normCheckEnabled: false,
+        necOverlayEnabled: false,
+        autoSim: true,
+        active: true,
+        comboApproved: false,
+        recommendedBackend: null,
+        buildRequest: () =>
+          ({
+            geometry: "dipoles.invvee_coax_station",
+            ...(p.plane ? { plane: p.plane } : {}),
+          }) as SolveRequest,
+        solveWithheld: () => false,
+        seqRef: { current: 0 },
+        approvedComboRef: { current: false },
+      }),
+    { initialProps: { plane: null } as Props },
+  );
+}
+
+// Run the 500 ms debounce out and let the stream promises settle.
+async function settle() {
+  await act(async () => {
+    vi.advanceTimersByTime(500);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function bodiesFor(url: string) {
+  return fetchMock.mock.calls
+    .filter((c) => c[0] === url)
+    .map((c) => JSON.parse((c[1] as { body: string }).body));
+}
+
+describe("plane flip invalidates the background analyses", () => {
+  it("clears and refetches the freq sweep and convergence sweep", async () => {
+    const { result, rerender } = renderRunners();
+    await settle();
+    expect(bodiesFor("/sweep")).toHaveLength(1);
+    expect(bodiesFor("/converge")).toHaveLength(1);
+    expect(result.current.sweep).not.toBeNull();
+    expect(result.current.converge).not.toBeNull();
+    // No plane picked: the field is absent.
+    expect("plane" in bodiesFor("/sweep")[0]).toBe(false);
+
+    rerender({ plane: "feed" });
+    // The previous plane's curves must not linger while the refetch runs —
+    // they are wrong for the new plane, not merely stale.
+    expect(result.current.sweep).toBeNull();
+    expect(result.current.converge).toBeNull();
+
+    await settle();
+    expect(bodiesFor("/sweep")).toHaveLength(2);
+    expect(bodiesFor("/converge")).toHaveLength(2);
+    expect(bodiesFor("/sweep")[1].plane).toBe("feed");
+    expect(bodiesFor("/converge")[1].plane).toBe("feed");
+  });
+});

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -1097,6 +1097,7 @@ function DesignSessionBody({
       designFreq,
       measFreq,
       measLocked,
+      plane,
       groundEnabled,
       groundModel,
       terrainKey,

--- a/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
@@ -45,6 +45,7 @@ export function useAnalysisRunners({
   designFreq,
   measFreq,
   measLocked,
+  plane,
   groundEnabled,
   groundModel,
   terrainKey,
@@ -72,6 +73,11 @@ export function useAnalysisRunners({
   designFreq: number;
   measFreq: number;
   measLocked: boolean;
+  /** The picked measurement plane (issue #652 c; null = natural). Every
+   *  analysis here reads the driving-point solve, so a plane flip
+   *  invalidates all four — without it in the dep arrays the previous
+   *  plane's sweep/convergence curves stay on screen as wrong data. */
+  plane: string | null;
   groundEnabled: boolean;
   groundModel: GroundModel;
   terrainKey: string;
@@ -149,6 +155,9 @@ export function useAnalysisRunners({
     // unlocked design — incl. fixed-geometry designs whose lock is inert),
     // so a meas-band change or dial turn re-runs the sweep.
     measFreq, measLocked,
+    // The measurement plane (issue #652 c): the sweep is the driving-point
+    // impedance vs freq, which a plane flip changes wholesale.
+    plane,
     // A variant can override sweep_policy (variant_ui) without changing any
     // param — e.g. a band-locked variant. currentValuesKey wouldn't move then,
     // so depend on currentVariant directly to re-run the sweep on switch.
@@ -185,7 +194,7 @@ export function useAnalysisRunners({
   }, [
     geometry, backend.name, backendOptsKey,
     currentValuesKey,
-    designFreq, measFreq,
+    designFreq, measFreq, plane,
     groundEnabled, groundModel,
     convergeEnabled,
     autoSim,
@@ -218,7 +227,7 @@ export function useAnalysisRunners({
   }, [
     geometry, backend.name, backendOptsKey,
     currentValuesKey,
-    designFreq, measFreq,
+    designFreq, measFreq, plane,
     groundEnabled, groundModel,
     // The pattern integral runs over the facets, so terrain knob changes
     // invalidate it (unlike the impedance-only sweep/converge effects,
@@ -259,7 +268,7 @@ export function useAnalysisRunners({
   }, [
     geometry, backend.name, backendOptsKey,
     currentValuesKey,
-    designFreq, measFreq,
+    designFreq, measFreq, plane,
     groundEnabled, groundModel,
     necOverlayEnabled,
     autoSim,


### PR DESCRIPTION
## Summary
- Flipping the measurement plane (#652 c) updated the live impedance but left the previous plane's frequency-sweep and convergence curves on screen — wrong values rendered against the new plane's chart. The four background analyses (freq sweep, convergence sweep, norm check, NEC pattern overlay) now take `plane` as a dependency: a flip clears the overlays immediately and refetches at the new plane.
- Caches audited: the server's `_SOLVE_CACHE` keys on the full request minus a metadata blocklist, and `plane` is not blocklisted — so it was already load-bearing in the key; the cuts cache is keyed per solve_id (new solve → new id). The gap was purely client-side invalidation.
- New regression test pins the behavior: same knobs, plane flip alone → overlays cleared synchronously, one refetch each with `plane` in the body.

## Test plan
- [x] `useAnalysisRunners.plane.test.tsx` (new) — clear + refetch with plane in the body for /sweep and /converge
- [x] 387 vitest + `tsc --noEmit` clean; bundle rebuilt for the local server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxcDWKRbc18jY2m49vDfhc