### PR TITLE
Key the background-analysis effects on a solve-request signature

### DIFF
--- a/src/antennaknobs/web/frontend/src/__tests__/solveSignature.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/solveSignature.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { solveSignature } from "../lib/solveSignature";
+import type { SolveRequest } from "../lib/api";
+
+// The tests build partial requests; the helper only walks the object.
+const req = (r: Record<string, unknown>) => r as unknown as SolveRequest;
+
+describe("solveSignature", () => {
+  it("is stable under key construction order", () => {
+    expect(solveSignature(req({ a: 1, b: { c: 2, d: 3 } }))).toBe(
+      solveSignature(req({ b: { d: 3, c: 2 }, a: 1 })),
+    );
+  });
+
+  it("exempts the metadata fields, mirroring the server blocklist", () => {
+    const base = req({ geometry: "g", n_per_wire: 8 });
+    const noisy = req({
+      geometry: "g",
+      n_per_wire: 8,
+      _session: "tab-1",
+      _seq: 42,
+      _gen: 42,
+      _approved: true,
+      _request_id: "r",
+      _client_ts: 1,
+    });
+    expect(solveSignature(noisy)).toBe(solveSignature(base));
+  });
+
+  it("drops caller-exempted keys but nothing else", () => {
+    const a = req({ geometry: "g", az_elev_deg: 30 });
+    const b = req({ geometry: "g", az_elev_deg: 45 });
+    expect(solveSignature(a, { exempt: ["az_elev_deg"] })).toBe(
+      solveSignature(b, { exempt: ["az_elev_deg"] }),
+    );
+    expect(solveSignature(a)).not.toBe(solveSignature(b));
+  });
+
+  it("treats any new field as load-bearing", () => {
+    expect(solveSignature(req({ geometry: "g" }))).not.toBe(
+      solveSignature(req({ geometry: "g", future_knob: 1 })),
+    );
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/useAnalysisRunners.plane.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useAnalysisRunners.plane.test.tsx
@@ -66,10 +66,7 @@ function renderRunners() {
   return renderHook(
     (p: Props) =>
       useAnalysisRunners({
-        geometry: "dipoles.invvee_coax_station",
         backend: BACKEND,
-        backendOptsKey: "k",
-        currentValuesKey: "v1",
         currentVariant: "default",
         currentExample: undefined,
         currentBands: [],
@@ -77,10 +74,8 @@ function renderRunners() {
         designFreq: 28.47,
         measFreq: 28.47,
         measLocked: false,
-        plane: p.plane,
         groundEnabled: false,
         groundModel: "fast",
-        terrainKey: "",
         sweepEnabled: true,
         convergeEnabled: true,
         normCheckEnabled: false,

--- a/src/antennaknobs/web/frontend/src/__tests__/useAnalysisRunners.signature.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useAnalysisRunners.signature.test.tsx
@@ -1,0 +1,206 @@
+// The background analyses key their physics invalidation on a request
+// signature (issue #692), not hand-listed deps. These tests pin the two
+// halves of that contract:
+//  - the deliberate exemptions hold: a cut-angle drag re-runs nothing, a
+//    terrain knob skips the impedance-only sweep/converge but DOES re-run
+//    the norm check (its pattern integral runs over the facets);
+//  - the safe default holds: a brand-new SolveRequest field — one no dep
+//    array ever heard of — invalidates all four analyses.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useAnalysisRunners } from "../components/session/useAnalysisRunners";
+import type { BackendEntry } from "../lib/backends";
+import type { GroundModel } from "../lib/ground";
+import type { SolveRequest } from "../lib/api";
+
+const PYNEC: BackendEntry = {
+  name: "pynec",
+  label: "PyNEC",
+  kind: "pynec",
+  supports_ground: true,
+  options_schema: [],
+  panel: null,
+  default_n_per_wire: 8,
+  accelerator: false,
+  dense_family: false,
+};
+
+// A one-line NDJSON stream, enough for the accumulator loops to complete.
+function streamResponse(line: string) {
+  let sent = false;
+  return Promise.resolve({
+    ok: true,
+    body: {
+      getReader: () => ({
+        read: () =>
+          sent
+            ? Promise.resolve({ done: true, value: undefined })
+            : ((sent = true),
+              Promise.resolve({
+                done: false,
+                value: new TextEncoder().encode(line + "\n"),
+              })),
+      }),
+    },
+  });
+}
+
+function jsonResponse(data: Record<string, unknown>) {
+  return Promise.resolve({ ok: true, json: () => Promise.resolve(data) });
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  fetchMock = vi.fn((url: string) => {
+    if (url === "/sweep")
+      return streamResponse(JSON.stringify({ freq_mhz: 28.47, z_re: 44, z_im: -4 }));
+    if (url === "/converge")
+      return streamResponse(JSON.stringify({ n_per_wire: 8, z_re: 44, z_im: -4 }));
+    if (url === "/norm_check")
+      return jsonResponse({
+        available: true,
+        directivity_norm: 1,
+        pattern_norm: 1,
+        method: "grid",
+        radiated_fraction: 1,
+        radiation_efficiency: 1,
+      });
+    // /pattern
+    return jsonResponse({ available: true, az_deg: [], gains_db: [] });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+type Props = { req: Record<string, unknown> };
+
+function renderRunners(opts: {
+  initialReq: Record<string, unknown>;
+  groundModel?: GroundModel;
+  necOverlayEnabled?: boolean;
+}) {
+  return renderHook(
+    (p: Props) =>
+      useAnalysisRunners({
+        backend: PYNEC,
+        currentVariant: "default",
+        currentExample: undefined,
+        currentBands: [],
+        freqWindowCeiling: 60,
+        designFreq: 28.47,
+        measFreq: 28.47,
+        measLocked: false,
+        groundEnabled: false,
+        groundModel: opts.groundModel ?? "fast",
+        sweepEnabled: true,
+        convergeEnabled: true,
+        normCheckEnabled: true,
+        necOverlayEnabled: opts.necOverlayEnabled ?? false,
+        autoSim: true,
+        active: true,
+        comboApproved: false,
+        recommendedBackend: null,
+        buildRequest: () => ({ ...p.req }) as SolveRequest,
+        solveWithheld: () => false,
+        seqRef: { current: 0 },
+        approvedComboRef: { current: false },
+      }),
+    { initialProps: { req: opts.initialReq } as Props },
+  );
+}
+
+// Run the 500 ms debounce out and let the stream/json promises settle.
+async function settle() {
+  await act(async () => {
+    vi.advanceTimersByTime(500);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function countFor(url: string) {
+  return fetchMock.mock.calls.filter((c) => c[0] === url).length;
+}
+
+describe("request-signature invalidation (issue #692)", () => {
+  it("dragging a cut angle re-runs nothing and keeps the overlays", async () => {
+    const req = { geometry: "g", az_elev_deg: 30, elev_az_deg: 60 };
+    const { result, rerender } = renderRunners({
+      initialReq: req,
+      necOverlayEnabled: true,
+    });
+    await settle();
+    expect(countFor("/sweep")).toBe(1);
+    expect(countFor("/converge")).toBe(1);
+    expect(countFor("/norm_check")).toBe(1);
+    expect(countFor("/pattern")).toBe(1);
+
+    rerender({ req: { ...req, az_elev_deg: 45, elev_az_deg: 15 } });
+    await settle();
+    expect(countFor("/sweep")).toBe(1);
+    expect(countFor("/converge")).toBe(1);
+    expect(countFor("/norm_check")).toBe(1);
+    expect(countFor("/pattern")).toBe(1);
+    // The overlays were never cleared — the effects did not re-fire.
+    expect(result.current.sweep).not.toBeNull();
+    expect(result.current.converge).not.toBeNull();
+    expect(result.current.normCheck).not.toBeNull();
+    expect(result.current.pattern).not.toBeNull();
+  });
+
+  it("a terrain knob skips the sweep/converge but re-runs the norm check", async () => {
+    const req = {
+      geometry: "g",
+      ground: true,
+      ground_model: "terrain",
+      terrain: { preset: "levee", slope_deg: 10 },
+    };
+    const { result, rerender } = renderRunners({
+      initialReq: req,
+      groundModel: "terrain",
+    });
+    await settle();
+    expect(countFor("/sweep")).toBe(1);
+    expect(countFor("/converge")).toBe(1);
+    expect(countFor("/norm_check")).toBe(1);
+
+    rerender({ req: { ...req, terrain: { preset: "levee", slope_deg: 12 } } });
+    await settle();
+    // Impedance-only analyses: every preset shares the crest medium, so the
+    // curves are terrain-param-independent and must not clear or refetch.
+    expect(countFor("/sweep")).toBe(1);
+    expect(countFor("/converge")).toBe(1);
+    expect(result.current.sweep).not.toBeNull();
+    expect(result.current.converge).not.toBeNull();
+    // The norm check integrates over the facets: it must refetch.
+    expect(countFor("/norm_check")).toBe(2);
+  });
+
+  it("a brand-new request field invalidates all four analyses by default", async () => {
+    const req = { geometry: "g" };
+    const { rerender } = renderRunners({
+      initialReq: req,
+      necOverlayEnabled: true,
+    });
+    await settle();
+    expect(countFor("/sweep")).toBe(1);
+    expect(countFor("/converge")).toBe(1);
+    expect(countFor("/norm_check")).toBe(1);
+    expect(countFor("/pattern")).toBe(1);
+
+    // A field no dep array has ever heard of — the #652-c plane bug shape.
+    rerender({ req: { ...req, future_physics_knob: 1 } });
+    await settle();
+    expect(countFor("/sweep")).toBe(2);
+    expect(countFor("/converge")).toBe(2);
+    expect(countFor("/norm_check")).toBe(2);
+    expect(countFor("/pattern")).toBe(2);
+  });
+});

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -1086,10 +1086,7 @@ function DesignSessionBody({
   // behind the solve and preview effects above.
   const { sweep, sweepRunning, converge, convergeRunning, normCheck, pattern } =
     useAnalysisRunners({
-      geometry,
       backend,
-      backendOptsKey,
-      currentValuesKey,
       currentVariant,
       currentExample,
       currentBands,
@@ -1097,10 +1094,8 @@ function DesignSessionBody({
       designFreq,
       measFreq,
       measLocked,
-      plane,
       groundEnabled,
       groundModel,
-      terrainKey,
       sweepEnabled,
       convergeEnabled,
       normCheckEnabled,

--- a/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
@@ -14,6 +14,7 @@ import { type BackendEntry } from "../../lib/backends";
 import { type GroundModel } from "../../lib/ground";
 import { feedwiseRichardson, richardsonExtrap } from "../../lib/math";
 import { type BandSpec, type ExampleDescriptor } from "../../lib/params";
+import { solveSignature } from "../../lib/solveSignature";
 import { planSweepFreqs } from "../../lib/sweep";
 import type { PatternData } from "../charts/types";
 
@@ -24,20 +25,35 @@ import type { PatternData } from "../charts/types";
 // are directly comparable when the user switches slots.
 export const CONVERGE_N_VALUES: number[] = [8, 12, 17, 24, 34, 48, 68];
 
+// Deliberate physics non-deps (issue #692), mirroring the server's
+// _CACHE_KEY_BLOCKLIST (web/server.py) — the same idea at the other end of
+// the wire. Cut angles are attached per-request AFTER the solve (POST /cuts,
+// issue #547), so dragging a cut dial changes no analysis result: every
+// analysis exempts them, exactly as the server cache does.
+const CUT_ANGLE_EXEMPT = ["az_elev_deg", "elev_az_deg"] as const;
+
+// The freq sweep and convergence sweep are impedance-only, and every terrain
+// preset shares the crest medium the impedance solve uses — so the terrain
+// knobs are additionally exempt for those two. NOT for the norm check, whose
+// pattern integral runs over the facets.
+const IMPEDANCE_ANALYSIS_EXEMPT = [...CUT_ANGLE_EXEMPT, "terrain"] as const;
+
 // The four background analyses that shadow the live solve — the freq sweep,
 // the segments-per-wire convergence sweep, the far-field norm check and the
 // NEC rp_card pattern — with their debounce effects, timer/abort refs and
-// streaming runners (#642 seam 5b-3). The cluster moves whole, so the four
-// literal dep arrays and the runners' fresh-per-render closures are unchanged.
+// streaming runners (#642 seam 5b-3).
+//
+// Each effect's physics invalidation is one request-signature dependency
+// (issue #692): solveSignature(buildRequest()) minus the exemption lists
+// above. Only gating/UI state that is not a request field stays hand-listed.
 //
 // Every dep-array member arrives as a plain per-render value, and buildRequest
 // / solveWithheld as plain per-render functions: memoizing either would change
-// which closure a pending debounce timeout fires.
+// which closure a pending debounce timeout fires. The signatures are fresh
+// strings per render for the same reason — the string VALUE is what the dep
+// arrays compare, so an unchanged request still skips the effect.
 export function useAnalysisRunners({
-  geometry,
   backend,
-  backendOptsKey,
-  currentValuesKey,
   currentVariant,
   currentExample,
   currentBands,
@@ -45,10 +61,8 @@ export function useAnalysisRunners({
   designFreq,
   measFreq,
   measLocked,
-  plane,
   groundEnabled,
   groundModel,
-  terrainKey,
   sweepEnabled,
   convergeEnabled,
   normCheckEnabled,
@@ -62,10 +76,7 @@ export function useAnalysisRunners({
   seqRef,
   approvedComboRef,
 }: {
-  geometry: string;
   backend: BackendEntry;
-  backendOptsKey: string;
-  currentValuesKey: string;
   currentVariant: string;
   currentExample: ExampleDescriptor | undefined;
   currentBands: BandSpec[];
@@ -73,14 +84,8 @@ export function useAnalysisRunners({
   designFreq: number;
   measFreq: number;
   measLocked: boolean;
-  /** The picked measurement plane (issue #652 c; null = natural). Every
-   *  analysis here reads the driving-point solve, so a plane flip
-   *  invalidates all four — without it in the dep arrays the previous
-   *  plane's sweep/convergence curves stay on screen as wrong data. */
-  plane: string | null;
   groundEnabled: boolean;
   groundModel: GroundModel;
-  terrainKey: string;
   sweepEnabled: boolean;
   convergeEnabled: boolean;
   normCheckEnabled: boolean;
@@ -94,6 +99,15 @@ export function useAnalysisRunners({
   seqRef: MutableRefObject<number>;
   approvedComboRef: MutableRefObject<boolean>;
 }) {
+  // The physics dependency of each effect below (issue #692): a fresh
+  // buildRequest() per render, hashed down to a stable string. Anything that
+  // changes the request — a knob, the variant, the measurement plane, a
+  // NEW field someone adds next month — invalidates by default; the
+  // exemption lists at the top of this module are the only opt-outs.
+  const req = buildRequest();
+  const impedanceSig = solveSignature(req, { exempt: IMPEDANCE_ANALYSIS_EXEMPT });
+  const solveSig = solveSignature(req, { exempt: CUT_ANGLE_EXEMPT });
+
   const [sweep, setSweep] = useState<SweepData | null>(null);
   const [sweepRunning, setSweepRunning] = useState(false);
   const [converge, setConverge] = useState<ConvergeData | null>(null);
@@ -112,11 +126,8 @@ export function useAnalysisRunners({
   const normCheckTimerRef = useRef<number | null>(null);
   const normCheckAbortRef = useRef<AbortController | null>(null);
 
-  // Debounced sweep across measurement freq. Re-runs whenever any antenna
-  // parameter changes. Single-band geometries sweep around designFreq, so
-  // moving the measFreq slider doesn't re-sweep (the existing data already
-  // covers the new slider position). Fan dipole sweeps around measFreq,
-  // so measFreq is part of the deps there to re-anchor.
+  // Debounced sweep across measurement freq. Re-runs whenever the solve
+  // request changes (impedanceSig) or the freq planning inputs move.
   useEffect(() => {
     // Cancel any in-flight sweep fetch immediately. Without this the
     // previous sweep keeps streaming for hundreds of ms (PyNEC ground at
@@ -144,24 +155,16 @@ export function useAnalysisRunners({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    geometry, backend.name, backendOptsKey,
-    currentValuesKey,
-    designFreq,
-    groundEnabled, groundModel,
+    // Everything physics — knobs, freqs, ground, backend, variant, the
+    // measurement plane (#652 c / #691) — arrives through the signature.
+    impedanceSig,
+    // Not a request field: measLocked steers planSweepFreqs' anchor policy
+    // (band-locked sweeps stay put; unlocked re-anchor on measFreq), so a
+    // lock toggle must re-plan the freqs even though the solve is unchanged.
+    measLocked,
     sweepEnabled,
     autoSim,
     active,
-    // measFreq/measLocked drive the anchor now (meas_freq policy, or any
-    // unlocked design — incl. fixed-geometry designs whose lock is inert),
-    // so a meas-band change or dial turn re-runs the sweep.
-    measFreq, measLocked,
-    // The measurement plane (issue #652 c): the sweep is the driving-point
-    // impedance vs freq, which a plane flip changes wholesale.
-    plane,
-    // A variant can override sweep_policy (variant_ui) without changing any
-    // param — e.g. a band-locked variant. currentValuesKey wouldn't move then,
-    // so depend on currentVariant directly to re-run the sweep on switch.
-    currentVariant,
     // The poor-match gate: while it withholds, runSweep declines to issue the
     // batch; approving ("Solve anyway") or a new recommendation re-fires this
     // effect (issue #382 — replaces the old 200 ms re-poll loop).
@@ -192,10 +195,7 @@ export function useAnalysisRunners({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    geometry, backend.name, backendOptsKey,
-    currentValuesKey,
-    designFreq, measFreq, plane,
-    groundEnabled, groundModel,
+    impedanceSig,
     convergeEnabled,
     autoSim,
     active,
@@ -225,15 +225,10 @@ export function useAnalysisRunners({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    geometry, backend.name, backendOptsKey,
-    currentValuesKey,
-    designFreq, measFreq, plane,
-    groundEnabled, groundModel,
-    // The pattern integral runs over the facets, so terrain knob changes
-    // invalidate it (unlike the impedance-only sweep/converge effects,
-    // which are legitimately terrain-param-independent — every preset
-    // shares the crest medium the impedance solve uses).
-    terrainKey,
+    // solveSig, not impedanceSig: the pattern integral runs over the facets,
+    // so terrain knob changes invalidate the norm check (unlike the
+    // impedance-only sweep/converge effects above).
+    solveSig,
     normCheckEnabled,
     autoSim,
     active,
@@ -266,10 +261,9 @@ export function useAnalysisRunners({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    geometry, backend.name, backendOptsKey,
-    currentValuesKey,
-    designFreq, measFreq, plane,
-    groundEnabled, groundModel,
+    // The backend/terrain gates above re-evaluate on the signature too:
+    // solver, momwire_model and ground_model are all request fields.
+    solveSig,
     necOverlayEnabled,
     autoSim,
     active,

--- a/src/antennaknobs/web/frontend/src/lib/solveSignature.ts
+++ b/src/antennaknobs/web/frontend/src/lib/solveSignature.ts
@@ -1,0 +1,48 @@
+import type { SolveRequest } from "./api";
+
+// Client-side twin of the server's cache key (web/server.py::
+// _CACHE_KEY_BLOCKLIST) — the same idea at the other end of the wire:
+// every request field is load-bearing unless explicitly exempted. Keying
+// the background-analysis effects on this signature flips the invalidation
+// polarity (issue #692): a new SolveRequest field invalidates every
+// analysis by default, and opting *out* takes an exemption entry — the
+// safe failure mode. (The old polarity — nothing invalidates unless
+// hand-listed — is how the measurement plane was forgotten in #652 c.)
+//
+// These are the pure-metadata fields: scheduling identity, zero physics.
+// Kept in lockstep with the server blocklist's metadata entries.
+const METADATA_EXEMPT = [
+  "_request_id",
+  "_client_ts",
+  "_seq",
+  "_session",
+  "_gen",
+  "_approved",
+] as const;
+
+/** Stable stringification of a solve request minus the metadata fields and
+ *  a per-caller exemption list — the one physics dependency an analysis
+ *  effect needs. Keys are sorted recursively so the signature doesn't
+ *  depend on construction order (the server hashes with sort_keys=True for
+ *  the same reason), and exempt keys are dropped at every nesting level,
+ *  matching the server's quantise() walk. */
+export function solveSignature(
+  req: SolveRequest,
+  opts: { exempt?: readonly string[] } = {},
+): string {
+  const drop = new Set<string>([...METADATA_EXEMPT, ...(opts.exempt ?? [])]);
+  const strip = (x: unknown): unknown => {
+    if (Array.isArray(x)) return x.map(strip);
+    if (x !== null && typeof x === "object") {
+      const rec = x as Record<string, unknown>;
+      return Object.fromEntries(
+        Object.keys(rec)
+          .filter((k) => !drop.has(k))
+          .sort()
+          .map((k) => [k, strip(rec[k])]),
+      );
+    }
+    return x;
+  };
+  return JSON.stringify(strip(req));
+}

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -957,7 +957,9 @@ def _refuse_or_withhold(adm, req: dict) -> None:
 # Request fields that are pure metadata and never change the physics. Pop
 # them before hashing so noisy frontend additions (timestamps, request ids)
 # don't shred the hit rate. Anything else in `req` is treated as load-
-# bearing — preferring "extra miss" over "wrong hit".
+# bearing — preferring "extra miss" over "wrong hit". The client keys its
+# background-analysis effects the same way (frontend/src/lib/
+# solveSignature.ts, issue #692) — keep the metadata entries in lockstep.
 _CACHE_KEY_BLOCKLIST = frozenset(
     {
         "_request_id",


### PR DESCRIPTION
## Summary
- Adds a shared `solveSignature(buildRequest(), { exempt })` helper (`lib/solveSignature.ts`): stable stringification of the solve request minus metadata and a per-analysis exemption list — the client-side twin of the server's `_CACHE_KEY_BLOCKLIST`.
- The four background analyses in `useAnalysisRunners.ts` (freq sweep, convergence sweep, norm check, NEC pattern overlay) now take that signature as their one physics dependency; the hand-listed per-field deps (`currentValuesKey`, `designFreq`, `measFreq`, `plane`, ground/backend fields, `terrainKey`, …) are gone, along with the five props that only existed to feed them. Gating/UI deps (enable flags, `autoSim`, `active`, the poor-match gate, `measLocked` for sweep planning) stay listed.
- Flips the invalidation polarity that caused the #652-c plane bug (fixed point-wise in #691): a new `SolveRequest` field now invalidates all four analyses by default, and opting out requires an explicit exemption entry. Preserved exemptions: cut angles for all four (cuts attach post-solve via `POST /cuts`), terrain params for the impedance-only sweep/converge but **not** the norm check (its pattern integral runs over the facets).
- `buildRequest` stays a fresh-per-render closure (not memoized) so pending debounce timeouts keep firing the current closure; the signature string is what the dep arrays compare.

Closes #692

## Test plan
- [x] New `useAnalysisRunners.signature.test.tsx`: cut-angle drags re-run nothing and keep the overlays; a terrain knob skips sweep/converge but re-runs the norm check; a synthetic never-heard-of request field invalidates all four analyses.
- [x] New `solveSignature.test.ts`: key-order stability, metadata exemptions in lockstep with the server blocklist, caller exemptions, new-field sensitivity.
- [x] The #691 plane-flip regression test passes with assertions unchanged (only the deleted hook props were trimmed from its harness).
- [x] `tsc --noEmit` + full frontend suite: 394 passed. Python suite: 3267 passed. `ruff check` / `format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g