### PR TITLE
Design doc: pinned set + overflow for the output-view rail (#684)

### DIFF
--- a/docs/mock-view-rail.html
+++ b/docs/mock-view-rail.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Mock: view rail scaling (issue #684)</title>
+<style>
+  :root {
+    --bg: #14171c; --panel: #1d2129; --panel2: #232833; --line: #3a4150;
+    --text: #d7dce5; --dim: #8b93a3; --accent: #4da3ff; --pin: #ffb454;
+    --new: #46c98b;
+  }
+  * { box-sizing: border-box; }
+  body { background: var(--bg); color: var(--text); font: 13px/1.45 system-ui, sans-serif; margin: 0; padding: 24px; }
+  h1 { font-size: 18px; margin: 0 0 4px; }
+  h2 { font-size: 14px; margin: 28px 0 8px; color: var(--accent); }
+  p.note { color: var(--dim); max-width: 72em; margin: 4px 0 12px; }
+  .mock { display: inline-block; vertical-align: top; margin: 0 24px 24px 0; }
+  .caption { color: var(--dim); font-size: 12px; margin-top: 6px; max-width: 46em; }
+
+  /* ---- stage scaffolding ---- */
+  .stage { display: flex; gap: 10px; background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 12px; }
+  .rail { display: flex; flex-direction: column; gap: 8px; width: 132px; }
+  .thumb { background: var(--panel2); border: 1px solid var(--line); border-radius: 8px; padding: 6px 6px 4px; text-align: center; }
+  .thumb .cv { background: #10131a; border-radius: 5px; height: 88px; display: flex; align-items: center; justify-content: center; }
+  .thumb .lbl { font-size: 11px; color: var(--dim); margin-top: 4px; }
+  .primary { background: var(--panel2); border: 1px solid var(--line); border-radius: 8px; width: 430px; height: 430px; display: flex; align-items: center; justify-content: center; position: relative; }
+  .hud { position: absolute; left: 10px; bottom: 10px; background: #10131add; border: 1px solid var(--line); border-radius: 6px; padding: 5px 9px; font-size: 11px; color: var(--dim); }
+  .hud b { color: var(--text); font-weight: 600; }
+  .modes { position: absolute; right: 10px; top: 10px; display: flex; border: 1px solid var(--line); border-radius: 6px; overflow: hidden; font-size: 12px; }
+  .modes span { padding: 3px 9px; background: var(--panel2); color: var(--dim); }
+  .modes span.on { background: var(--accent); color: #08111d; }
+
+  /* picker button */
+  .allviews { border: 1px dashed var(--line); border-radius: 8px; color: var(--dim); font-size: 12px; padding: 7px 6px; text-align: center; }
+  .allviews b { color: var(--text); font-weight: 600; }
+
+  /* ---- picker popover ---- */
+  .picker { width: 210px; background: var(--panel2); border: 1px solid var(--line); border-radius: 10px; padding: 6px; box-shadow: 0 8px 28px #0009; }
+  .prow { display: flex; align-items: center; gap: 8px; padding: 6px 8px; border-radius: 6px; }
+  .prow:hover { background: #2c3342; }
+  .prow .name { flex: 1; }
+  .prow.unpinned .name { color: var(--dim); }
+  .prow .dot { width: 12px; height: 12px; border-radius: 50%; border: 2px solid var(--pin); }
+  .prow.pinned .dot { background: var(--pin); }
+  .prow .badge { font-size: 9px; font-weight: 700; color: #08110c; background: var(--new); border-radius: 4px; padding: 1px 4px; letter-spacing: .04em; }
+  .prow.capped { opacity: .95; }
+  .cap-note { color: var(--dim); font-size: 10px; padding: 4px 8px 2px; border-top: 1px solid var(--line); margin-top: 4px; }
+
+  /* ---- grid mode ---- */
+  .gridstage { position: relative; background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 12px; width: 586px; }
+  .grid { display: grid; grid-template-columns: 1fr 1fr; grid-template-rows: 1fr 1fr; gap: 10px; height: 430px; }
+  .cell { background: var(--panel2); border: 1px solid var(--line); border-radius: 8px; position: relative; display: flex; align-items: center; justify-content: center; }
+  .cell.focused { outline: 2px solid var(--accent); outline-offset: -2px; }
+  .cell .max { position: absolute; right: 6px; top: 6px; color: var(--dim); font-size: 11px; border: 1px solid var(--line); border-radius: 4px; padding: 0 4px; background: #10131a; }
+  .cell .clbl { position: absolute; left: 8px; top: 6px; font-size: 10px; color: var(--dim); }
+
+  /* ---- mobile ---- */
+  .phone { width: 200px; background: var(--panel); border: 1px solid var(--line); border-radius: 16px; padding: 10px; }
+  .phone .screen { background: var(--panel2); border: 1px solid var(--line); border-radius: 8px; height: 190px; display: flex; align-items: center; justify-content: center; }
+  .dots { display: flex; justify-content: center; gap: 8px; margin-top: 10px; align-items: center; }
+  .dots i { width: 7px; height: 7px; border-radius: 50%; background: var(--line); font-style: normal; }
+  .dots i.on { background: var(--accent); }
+  .dots .more { width: auto; height: auto; background: none; color: var(--dim); font-size: 13px; line-height: 7px; letter-spacing: 1px; }
+
+  svg text { fill: var(--dim); font: 9px system-ui, sans-serif; }
+</style>
+</head>
+<body>
+
+<h1>Mock — output-view rail at a 9-view roster (issue #684)</h1>
+<p class="note">Pinned set (max 6, default 4) + overflow picker; two layout modes as presets over
+the same pinned set. Thumb heights use the real <code>useThumbColumnSize</code> overhead model at a
+720&nbsp;px column: 4&nbsp;pins&nbsp;→&nbsp;3 rail thumbs ≈ 131&nbsp;px (shown to scale below at ~⅔).</p>
+
+<h2>A — Rail mode (default): primary + pinned thumbs + the “All views” button</h2>
+<div class="mock">
+  <div class="stage">
+    <div class="rail">
+      <div class="thumb"><div class="cv">
+        <svg width="80" height="80" viewBox="0 0 80 80"><circle cx="40" cy="40" r="34" fill="none" stroke="#3a4150"/><circle cx="40" cy="40" r="22" fill="none" stroke="#2c3342"/><path d="M40 40 C 55 10, 72 30, 40 6 C 30 26, 20 20, 40 40" fill="none" stroke="#4da3ff" stroke-width="1.5"/></svg>
+      </div><div class="lbl">Azimuth (xy)</div></div>
+      <div class="thumb"><div class="cv">
+        <svg width="80" height="80" viewBox="0 0 80 80"><circle cx="40" cy="40" r="34" fill="none" stroke="#3a4150"/><path d="M8 40 A 32 32 0 0 1 72 40" fill="none" stroke="#2c3342"/><path d="M40 40 C 20 25, 25 8, 40 8 C 55 8, 60 25, 40 40" fill="none" stroke="#4da3ff" stroke-width="1.5"/></svg>
+      </div><div class="lbl">Elevation (yz)</div></div>
+      <div class="thumb"><div class="cv">
+        <svg width="80" height="80" viewBox="0 0 80 80"><circle cx="40" cy="40" r="34" fill="none" stroke="#3a4150"/><circle cx="52" cy="40" r="22" fill="none" stroke="#2c3342"/><circle cx="58" cy="40" r="15" fill="none" stroke="#2c3342"/><path d="M20 44 C 34 28, 52 30, 66 40" fill="none" stroke="#4da3ff" stroke-width="1.5"/><circle cx="47" cy="34" r="2.5" fill="#ffb454"/></svg>
+      </div><div class="lbl">Smith</div></div>
+      <div class="allviews">All views ⌄ <b>+5</b></div>
+    </div>
+    <div class="primary">
+      <svg width="300" height="300" viewBox="0 0 300 300">
+        <path d="M40 150 L130 150 M170 150 L260 150" stroke="#d7dce5" stroke-width="2"/>
+        <path d="M130 150 L150 150 M150 150 L170 150" stroke="#4da3ff" stroke-width="3"/>
+        <circle cx="150" cy="150" r="4" fill="#ffb454"/>
+        <path d="M40 150 Q 95 120 150 148 Q 205 120 260 150" fill="none" stroke="#46c98b" stroke-dasharray="3 3"/>
+        <text x="150" y="175" text-anchor="middle">Antenna — active (primary)</text>
+      </svg>
+      <div class="modes"><span class="on">▤ rail</span><span>⊞ grid</span></div>
+      <div class="hud"><b>Z</b> 71.8 −j1.2 · <b>SWR</b> 1.44 · 9 ms</div>
+    </div>
+  </div>
+  <div class="caption">Pinned = Antenna, Azimuth, Elevation, Smith (defaults). Rail shows pinned
+  minus active, exactly today's behavior. The dashed “All views” button is a fixed-height slot —
+  thumbs stay ≥ ~96&nbsp;px even at the 6-pin cap.</div>
+</div>
+
+<h2>B — The picker (overflow affordance, channel-enable idiom)</h2>
+<div class="mock">
+  <div class="picker">
+    <div class="prow pinned"><span class="name">Antenna</span><span class="dot"></span></div>
+    <div class="prow pinned"><span class="name">Azimuth (xy)</span><span class="dot"></span></div>
+    <div class="prow pinned"><span class="name">Elevation (yz)</span><span class="dot"></span></div>
+    <div class="prow pinned"><span class="name">Smith</span><span class="dot"></span></div>
+    <div class="prow unpinned"><span class="name">Schematic</span><span class="dot"></span></div>
+    <div class="prow unpinned"><span class="name">|Γ| vs freq</span><span class="badge">NEW</span><span class="dot"></span></div>
+    <div class="prow unpinned"><span class="name">VSWR vs freq</span><span class="badge">NEW</span><span class="dot"></span></div>
+    <div class="prow unpinned"><span class="name">Optimization</span><span class="dot"></span></div>
+    <div class="prow unpinned"><span class="name">Convergence</span><span class="dot"></span></div>
+    <div class="cap-note">Row click = show (peek) · pin dot = keep in rail · max 6 pinned</div>
+  </div>
+  <div class="caption">Whole roster in registry order. Filled amber dot = pinned. Clicking a row
+  shows that view (a transient “peek” that costs no pin slot); clicking the dot pins/unpins.
+  “NEW” marks views added since the picker was last opened.</div>
+</div>
+
+<h2>C — Grid mode: equal 2×2 over the first four pins, no primary</h2>
+<div class="mock">
+  <div class="gridstage">
+    <div class="grid">
+      <div class="cell focused"><span class="clbl">Antenna</span><span class="max">⤢</span>
+        <svg width="150" height="150" viewBox="0 0 300 300"><path d="M40 150 L130 150 M170 150 L260 150" stroke="#d7dce5" stroke-width="4"/><circle cx="150" cy="150" r="7" fill="#ffb454"/></svg>
+      </div>
+      <div class="cell"><span class="clbl">Azimuth (xy)</span><span class="max">⤢</span>
+        <svg width="140" height="140" viewBox="0 0 80 80"><circle cx="40" cy="40" r="34" fill="none" stroke="#3a4150"/><path d="M40 40 C 55 10, 72 30, 40 6 C 30 26, 20 20, 40 40" fill="none" stroke="#4da3ff"/></svg>
+      </div>
+      <div class="cell"><span class="clbl">Elevation (yz)</span><span class="max">⤢</span>
+        <svg width="140" height="140" viewBox="0 0 80 80"><circle cx="40" cy="40" r="34" fill="none" stroke="#3a4150"/><path d="M40 40 C 20 25, 25 8, 40 8 C 55 8, 60 25, 40 40" fill="none" stroke="#4da3ff"/></svg>
+      </div>
+      <div class="cell"><span class="clbl">Smith</span><span class="max">⤢</span>
+        <svg width="140" height="140" viewBox="0 0 80 80"><circle cx="40" cy="40" r="34" fill="none" stroke="#3a4150"/><circle cx="52" cy="40" r="22" fill="none" stroke="#2c3342"/><path d="M20 44 C 34 28, 52 30, 66 40" fill="none" stroke="#4da3ff"/><circle cx="47" cy="34" r="2.5" fill="#ffb454"/></svg>
+      </div>
+    </div>
+    <div class="modes" style="position:absolute; right:10px; top:-14px;"><span>▤ rail</span><span class="on">⊞ grid</span></div>
+    <div class="hud" style="position:absolute; left:18px; bottom:18px;"><b>Z</b> 71.8 −j1.2 · <b>SWR</b> 1.44 · 9 ms</div>
+  </div>
+  <div class="caption">Cells are full live views (no thumbnail scaling). The focus ring is the
+  “active” view — ArrowUp/Down moves it. ⤢ (or double-click) maximizes: jump to rail mode with
+  that view primary, Blender-style. 3 pins → the 4th cell shows a “pin a 4th view” hint;
+  pins 5–6 stay rail-only.</div>
+</div>
+
+<h2>D — Mobile: carousel = pinned + Info, picker behind the “⋯” dot</h2>
+<div class="mock">
+  <div class="phone">
+    <div class="screen">
+      <svg width="130" height="130" viewBox="0 0 80 80"><circle cx="40" cy="40" r="34" fill="none" stroke="#3a4150"/><path d="M40 40 C 55 10, 72 30, 40 6 C 30 26, 20 20, 40 40" fill="none" stroke="#4da3ff"/></svg>
+    </div>
+    <div class="dots">
+      <i></i><i class="on"></i><i></i><i></i><i title="Info"></i><i class="more">⋯</i>
+    </div>
+  </div>
+  <div class="caption">Pages = pinned views + Info (5 dots at the default pin set — same as
+  today). The trailing “⋯” opens the picker as a bottom sheet; on mobile a row tap pins
+  (no transient peek), keeping the carousel ↔ pinned mapping simple.</div>
+</div>
+
+</body>
+</html>

--- a/docs/plan-view-rail-scaling.md
+++ b/docs/plan-view-rail-scaling.md
@@ -1,0 +1,345 @@
+# Plan: scale the output-view rail beyond 4 views (pinned set + overflow)
+
+Status: **design for review** (issue #684). This is the design-exploration
+deliverable — the pattern survey, the chosen direction, and the follow-up
+implementation issues to file once the direction is accepted. No code changes
+land with this doc. Mock: `docs/mock-view-rail.html` (open in a browser; shows
+both layout modes and the picker at a 9-view roster).
+
+## Context
+
+The output-view roster is growing. #686 shipped the schematic as view five,
+putting four thumbnails in the desktop rail, and the next views are imminent
+rather than hypothetical (sweep data already reaches the Smith chart, so an
+RC-vs-frequency chart is mostly presentation). The current layout divides the
+thumbstrip column equally among all non-active views
+(`useThumbColumnSize`, `components/hooks.ts`), so every added view shrinks
+every thumbnail.
+
+The numbers, using the hook's own overhead model on a ~720 px stage column
+(a 13" laptop):
+
+| rail thumbs | thumb height | verdict |
+|---|---|---|
+| 3 (pre-#686) | ~160 px | comfortable |
+| 4 (today) | ~131 px | noticeably smaller, still fine |
+| 6 | ~72 px | labels legible, charts marginal |
+| 8 (roster below, unbounded) | ~44 px | at the 40 px clamp floor — unusable |
+
+So the rail cannot stay "everything, always resident." The user needs to pick
+a small always-visible set; the rest must be reachable without being resident.
+
+### Constraints (scored against every surveyed pattern)
+
+- **C1 Live charts.** Every resident view re-renders on each solve (the rail
+  thumbs are real `ViewPanel`s, not snapshots). A pattern that keeps many
+  views resident multiplies render cost; a pattern that hides views must
+  bring them back current, not stale.
+- **C2 Thumbnail legibility floor.** Charts draw fixed-px text at the
+  3-thumb-era width and scale down uniformly (`thumb-scale`); below ~70 px of
+  height a polar chart is a smudge. The clamp floor is 40 px.
+- **C3 Keyboard cycling.** ArrowUp/Down cycles views (`useViewState`). Cycling
+  must stay fast — 9 stops to get back to the antenna view is a regression.
+- **C4 Mobile carousel.** Scroll-snap pages + dots (`useMobileCarousel`), with
+  the invariant that carousel index ↔ `VIEWS` order plus a trailing Info page.
+  Whatever the desktop does must project onto this cleanly.
+- **C5 Small-laptop column height.** The rail never scrolls
+  (`overflow: hidden` by design); everything resident must fit ~700–800 px.
+
+### The view roster this must be sized for
+
+| # | view | status |
+|---|---|---|
+| 1 | Antenna (3D geometry + currents) | shipped |
+| 2 | Azimuth cut | shipped |
+| 3 | Elevation cut | shipped |
+| 4 | Smith chart | shipped |
+| 5 | Schematic | shipped (#686) |
+| 6 | \|Γ\| / return loss vs. frequency | imminent (sweep data already flows) |
+| 7 | VSWR vs. frequency | imminent (same data, different axis) |
+| 8 | Optimization traces (objective vs. iteration, parameter trajectories) | planned |
+| 9 | Convergence view (metric vs. mesh density; today an overlay on Smith) | planned |
+
+Design target: **9 views**, of which a user actively watches 3–5 at a time.
+
+## Survey: how other UIs solve "many views, few slots"
+
+### P1. Pinned rail + overflow picker
+
+*Browser bookmarks bar + "other bookmarks" chevron; Chrome/Firefox pinned
+tabs; IDE pinned editor tabs; Grafana dashboard panels drawn from a panel
+library; Slack starred channels.*
+
+```
+┌──────┐ ┌──────────────────┐
+│ [az] │ │                  │
+│ [el] │ │   ACTIVE VIEW    │
+│ [sm] │ │                  │
+│ ⋯ +5 │ │                  │
+└──────┘ └──────────────────┘
+```
+
+The user curates a small "always visible" set; everything else lives behind
+one compact affordance. Pinning is an explicit, low-frequency act; switching
+among pinned items is the high-frequency act and stays one click.
+
+- **C1** ✅ resident set is bounded, so live re-render cost is bounded.
+- **C2** ✅ thumb size is a function of pin count, which is capped.
+- **C3** ✅ cycling over the pinned set is short by construction.
+- **C4** ✅ "carousel pages = pinned set" is a clean projection.
+- **C5** ✅ the cap is chosen *from* the column-height math.
+- **Cons:** unpinned views are out of sight (no ambient monitoring of view
+  #7); needs a picker affordance and sane defaults; new views ship invisible
+  unless the picker advertises them.
+
+### P2. Multi-chart grid presets
+
+*TradingView layouts: 1/2/4/6/8-up grid presets over the same loaded charts,
+saved as named workspaces; thinkorswim flexible grid.*
+
+```
+┌─────────┬─────────┐
+│  az     │  el     │
+├─────────┼─────────┤
+│  smith  │  vswr   │
+└─────────┴─────────┘
+```
+
+The key insight from TradingView: "1 big" and "N equal" are **presets of one
+system**, not separate features — the same chart set flows into whichever
+arrangement is selected. Users flip presets constantly; they curate the chart
+set rarely.
+
+- **C1** ✅ 4 live full-size charts is comparable to today's 1 full + 4 thumbs.
+- **C2** ✅✅ no thumbnails at all — every cell is above legibility.
+- **C3** ⚠️ "active view" needs a definition (a focus ring) for arrows to act on.
+- **C4** ➖ grids don't project to a phone; mobile keeps its carousel.
+- **C5** ✅ 2×2 uses the stage, not the column.
+- **Cons:** no primacy — the antenna canvas (the view you steer by) drops to
+  quarter size; slot-assignment UI (drag into cells) can balloon; at 9 views
+  a 3×3 makes everything small again, so a grid still needs a curated subset —
+  i.e. it needs P1 underneath it.
+
+### P3. Docking / tiling workspaces
+
+*JupyterLab drag-dock panels; VS Code editor groups; Golden Layout; CAD quad
+viewport (Blender `Ctrl-Alt-Q`, Fusion 360).*
+
+Fully free-form: any view any size anywhere, persisted workspaces. The CAD
+quad viewport is the disciplined version: a fixed 2×2 of standard projections
+with a **maximize toggle** flipping one cell ↔ full stage.
+
+- **C1** ⚠️ unbounded resident set — a user can dock all 9 live views.
+- **C2** ✅ user controls every size (and can make them illegible).
+- **C3** ❌ cycling over a free-form layout is ill-defined.
+- **C4** ❌ nothing about a dock layout projects to a phone.
+- **C5** ⚠️ user-managed; layouts rot as the roster changes.
+- **Cons:** by far the most implementation surface (drag targets, splitters,
+  serialization, migration of stale layouts) for a roster of only 9
+  fixed-aspect views. **Take from it:** the maximize toggle — grid cell ↔
+  primary is one gesture, both directions.
+
+### P4. Filmstrip / carousel with paging
+
+*Lightroom filmstrip; macOS Mission Control; our own mobile carousel.*
+
+A single strip of all views, scrolled/paged; the strip shows a window of N.
+
+- **C1** ✅ only the visible window renders (virtualization is natural).
+- **C2** ✅ fixed thumb size, count handled by scrolling.
+- **C3** ⚠️ cycling walks the *full* roster — 9 stops (the regression C3 fears).
+- **C4** ✅ it *is* the mobile pattern; already shipped.
+- **C5** ❌ contradicts the rail's deliberate never-scrolls invariant: a
+  scrolling rail means the view you glance at may be off-screen, killing
+  ambient monitoring (the rail's whole point).
+- **Verdict:** stays exactly where it already is — the mobile mode.
+
+### P5. Instrument idioms
+
+*Spectrum-analyzer multi-trace with soft-key trace enable; oscilloscope
+channel enable buttons (CH1–CH4 toggle lit/unlit); SDR panadapter split
+views.*
+
+The front panel has N channel buttons, each toggling that channel's
+visibility; enabled channels share the screen. State is visible at a glance
+— a lit button *is* the indicator.
+
+- **C1** ✅ enabled set bounded by channel count.
+- **C2/C5** ✅ bounded by construction.
+- **C3** ✅ scopes cycle among *enabled* channels only.
+- **C4** ➖ n/a.
+- **Cons:** scope channels are homogeneous overlaid traces; our views are
+  heterogeneous (3D canvas / polar / Smith / SVG) so they can't overlay —
+  they need slots. Soft-key menu trees are modal and dated. **Take from
+  it:** the picker should read as a channel-enable row — every view listed,
+  each with a visible on/off pin state, one tap to toggle.
+
+### P6. Ham/RF simulator prior art
+
+*xnec2c: an independent GTK top-level window per chart (geometry, pattern,
+charts each float free). EZNEC: modal window per output — open the pattern
+window, close it, open the SWR window. 4nec2: same, separate windows. SimNEC:
+everything on one fixed canvas, always. AntennaSim: single view + tabs.*
+
+- xnec2c's window-per-chart is the P3 endpoint: great on a 30" desk with a
+  window manager, untenable inside one browser tab and hostile to laptops.
+- EZNEC's modal windows break the live loop — you cannot watch SWR while
+  turning a knob, which is this workbench's entire reason to exist.
+- SimNEC's single canvas is the zero-navigation extreme and simply does not
+  scale in roster.
+- **Verdict:** none of the incumbents solve "live-updating + bounded space";
+  whatever we pick here is a differentiator, not table stakes.
+
+### Survey conclusion
+
+P4 is already correctly deployed (mobile). P3 and P6-windows are
+over-engineered for 9 fixed views. P2 alone still needs curation underneath.
+The composition that scores green across the constraint row is:
+
+> **P1 (pinned set + overflow picker) as the model, P5 (channel-enable row)
+> as the picker idiom, P2 (presets of one system) for layout modes, P3's
+> maximize toggle as the mode-switch gesture.**
+
+Precedent note the issue asked for: TradingView and the CAD quad viewport
+both treat "1 big + N small" and "N equal" as **presets over one selection**;
+Lightroom's Loupe/Grid similarly share one filmstrip selection. Nobody
+successful makes them separate features with separate state. We follow that:
+both layout modes render *the pinned set*; only the arrangement changes.
+
+## Chosen direction
+
+### The pin model
+
+- `pinned: View[]` — an **ordered** list, default
+  `["antenna", "azimuth", "elevation", "smith"]` (the founding four;
+  schematic and all future views default unpinned).
+- **Cap: 6 pinned.** From the column math: 6 pinned ⇒ 5 rail thumbs (active
+  excluded) ⇒ ~96 px thumbs on a 720 px column — above the legibility floor
+  with margin. The picker disables further pinning at the cap (tooltip: "Unpin
+  a view first").
+- Rail renders `pinned \ {active}` exactly as today. **Peek:** activating an
+  unpinned view (from the picker) makes it primary without pinning it; the
+  rail then shows all pinned views. Peek is transient — it costs no pin slot.
+
+### The overflow affordance: the view picker
+
+A fixed-height slot at the bottom of the thumbstrip — a compact button
+labeled **"All views ⌄"** with a count of unpinned views ("+5"). Clicking
+opens a popover listing the **entire roster in registry order**, channel-row
+style (P5):
+
+```
+┌──────────────────────────┐
+│ 📌 Antenna            ●  │   ● = pinned (click pin dot to toggle)
+│ 📌 Azimuth (xy)       ●  │   row click = show (peek or switch)
+│ 📌 Elevation (yz)     ●  │
+│ 📌 Smith              ●  │
+│    Schematic          ○  │
+│    |Γ| vs freq   NEW  ○  │
+│    VSWR vs freq  NEW  ○  │
+│    Optimization       ○  │
+│    Convergence        ○  │
+└──────────────────────────┘
+```
+
+- Row click → that view becomes active (peek if unpinned). Pin-dot click →
+  toggles pinned, capped at 6.
+- A **"NEW" badge** marks views added since the user last opened the picker
+  (roster version stamped into the persisted state) — this answers P1's
+  discoverability con: new views ship unpinned but announced.
+- The button occupies fixed height, so `useThumbColumnSize`'s overhead model
+  gains one constant term and nothing else changes shape.
+
+### Layout modes (presets of one system)
+
+Two modes, selectable via a two-icon segmented control in the stage's top-right
+corner (▤ rail / ⊞ grid):
+
+1. **Rail** (today): primary + pinned thumbs. Unchanged behavior, now over
+   the pinned set.
+2. **Grid**: equal cells over the **first 4 pinned views** in pin order, no
+   primary. 2 pinned → 1×2, 3–4 pinned → 2×2 (a 3-pin grid leaves cell 4
+   empty with a "pin a 4th view" hint). Pins beyond 4 stay rail-only —
+   the grid does not go 3×2; below ~⅓-stage cells the antenna canvas stops
+   being steerable, which defeats the mode. Each cell is a **full live
+   `ViewPanel`** (`fill` semantics, not a scaled thumb — no `thumb-scale`
+   trick), so C2 vanishes in this mode.
+3. **Active still exists in grid** — a focus ring on one cell. ArrowUp/Down
+   moves the ring (C3 keeps working, same key mnemonic); the HUD readout
+   anchors to the stage lower-left as today. Clicking a cell's body focuses
+   it; the maximize glyph in a cell's corner (or double-click, Blender-style)
+   jumps to rail mode with that view primary. The segmented control returns
+   to grid.
+
+### Keyboard
+
+ArrowUp/Down cycles **`pinned ∪ {active}`** — the active view joins the cycle
+transiently while peeked, so arrows never strand you. Full roster is
+reachable through the picker only. With the default 4 pins the cycle is
+exactly today's pre-#686 feel: short.
+
+### Mobile
+
+- Carousel pages = **pinned views + Info**, same scroll-snap and dots. Pin
+  order is the page order; the `mobileIndex ↔ VIEWS` mapping becomes
+  `mobileIndex ↔ pinned` (plus trailing Info).
+- The dots row gains a trailing **"⋯" dot** opening the same picker as a
+  bottom sheet. On mobile the picker's row-click **pins** (no transient peek
+  — a peeked page would break the "carousel = pinned + Info" invariant and
+  scroll-position bookkeeping for one gesture's worth of convenience).
+- Grid mode is desktop-only; the segmented control hides on mobile.
+
+### Persistence: global, not per-design
+
+Pinned set, pin order, layout mode, and picker roster-version persist in
+`localStorage` under one key (e.g. `akb.viewPrefs.v1`).
+
+Rationale: the roster is a property of the **workbench**, not of a design —
+every design has every view, and the user's watching habits ("I care about
+VSWR and the pattern") span designs. Per-design pin sets would reshuffle the
+workspace on every catalog switch and strand stale state across 100+
+designs. The counter-case (a multi-feed design where you'd pin the schematic)
+is served by peek — one picker click, no state to clean up later.
+Per-design overrides can be layered on later without migration (a per-design
+key shadowing the global one); starting global keeps door open, starting
+per-design doesn't.
+
+### What this deliberately does not do
+
+- **No drag-to-reorder** in v1 — pin order = order pinned. Reorder is cheap
+  to add later and drag machinery is the biggest cost in P2/P3 systems.
+- **No analysis gating** — unpinned views stop *rendering* but background
+  analyses (sweep, converge, schematic fetch) keep their current triggers;
+  gating analyses on residency is a real perf opportunity but couples data
+  flow to layout and deserves its own issue after this ships.
+- **No saved named workspaces** (TradingView's full feature) — one persisted
+  state is enough at 9 views.
+
+## Mock
+
+`docs/mock-view-rail.html` — static, self-contained. Shows, at the 9-view
+roster: (a) rail mode with 4 pins + the "All views" button, (b) the picker
+open with pin dots and NEW badges, (c) grid mode 2×2 with focus ring and
+maximize glyphs, (d) the mobile carousel dots with the "⋯" dot. Numbers in
+the mock use the real overhead model from `useThumbColumnSize`.
+
+## Follow-up implementation issues (file on acceptance)
+
+1. **View registry.** Replace `ViewPanel`'s flat conditional and the bare
+   `VIEWS` array with a registry: `{ id, label, defaultPinned, render(props) }`.
+   Pure refactor, no behavior change; netted by the #673 component tests.
+   Everything below depends on it.
+2. **Pin model + picker (desktop).** `pinned` state + localStorage
+   persistence + the "All views" button/popover + peek + cycling over
+   `pinned ∪ {active}` + NEW badges. Rail rendering itself barely changes
+   (`pinned` replaces `VIEWS` in the filter; `useThumbColumnSize` gains the
+   picker-button constant).
+3. **Grid layout mode.** The segmented control, 2×2 stage layout, focus
+   ring, maximize toggle, HUD anchoring.
+4. **Mobile: pinned carousel + picker sheet.** `useMobileCarousel` maps
+   pages onto `pinned`; "⋯" dot; sheet variant of the picker.
+5. **New views: |Γ| and VSWR vs. frequency.** First registry customers;
+   presentation over existing `SweepData`.
+
+(1) and (2) are the core; (3), (4), (5) are independent of each other once
+(1)+(2) land.


### PR DESCRIPTION
## Summary
- Adds `docs/plan-view-rail-scaling.md` — the design-exploration deliverable for #684: a six-pattern survey (pinned rail + overflow, TradingView grid presets, docking workspaces, filmstrip paging, instrument channel-enable idioms, xnec2c/EZNEC/SimNEC prior art) scored against the five constraints (live charts, thumbnail legibility floor, ArrowUp/Down cycling, mobile carousel, small-laptop column height).
- Chosen direction: an **ordered pinned set** (default = the founding four, hard cap 6 from the column-height math) + an **"All views" overflow picker** styled as an instrument channel-enable row, with transient *peek* for unpinned views and NEW badges for roster growth.
- **Two layout modes as presets over the same pinned set**: today's primary+rail, and an equal 2×2 grid over the first four pins with a focus ring and a Blender-style maximize toggle back to rail.
- Persistence decision: **global** (one localStorage key), with per-design overrides layerable later. Mobile: carousel pages = pinned + Info, picker as a bottom sheet behind a trailing "⋯" dot.
- Includes `docs/mock-view-rail.html` — a static mock at the full 9-view roster (rail, picker, grid, mobile), thumb sizes computed from the real `useThumbColumnSize` overhead model.
- Five follow-up implementation issues are enumerated in the doc, to be filed when the design is accepted (#684 closes on the accepted doc, not on code).

## Test plan
- [ ] Open `docs/mock-view-rail.html` in a browser and review the four mock sections
- [ ] Review the survey scoring and the chosen-direction rationale

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01522PMkNyJbRX772WV5DwaA