### PR TITLE
Catenary wire geometry: sagging inverted vee with tension/rope rigging (#698)

### DIFF
--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -18,6 +18,7 @@ after L. B. Cebik (W4RNL)'s articles.
 | `dipoles.folded_invvee` | Folded inverted-vee — the folded dipole's impedance step-up, with drooped arms |
 | `dipoles.folded_invvee_balun` | Folded inverted-V fed through a 4:1 balun and real coax — the `Transformer` showcase (issue #301) |
 | `dipoles.invvee` | Inverted-vee dipole — the default quickstart example · variants: `classic_edz`, `dipole`, `three_halves` |
+| `dipoles.invvee_catenary` | Inverted-vee dipole whose arms hang as real catenaries (issue #698, unit 2) |
 | `dipoles.invvee_coax_station` | Inverted-V fed through real coax — the classic "resonant antenna on 50 Ω line" station, modelled from the rig (issue #300) · variants: `classic_edz`, `dipole`, `three_halves` |
 | `dipoles.koch_dipole` | Koch fractal dipole (L. B. Cebik, W4RNL -- "fractal antennas") |
 | `dipoles.ocf_dipole` | Off-Center-Fed dipole (Windom): a half-wave fed away from the middle (L. B. Cebik, W4RNL) |

--- a/src/antennaknobs/catenary.py
+++ b/src/antennaknobs/catenary.py
@@ -1,0 +1,895 @@
+"""Hanging-chain equilibrium: the shape a real wire takes under its own weight.
+
+Every catalog wire in a design is a perfectly straight line, but a wire strung
+between an apex and a rigging point hangs in a catenary set by its weight per
+metre and how it is tensioned.  This module is the pure-geometry half of issue
+#698: given a serial chain of segments — each with a fixed arc length and a
+weight per metre — and one of two rig closures, it returns the chain's actual
+shape in its own vertical plane.
+
+Nothing here imports engines, the builder, the network spec, or the web layer:
+it is 2-D statics and closed forms only.  The design layer (a later unit)
+embeds the returned plane curve into 3-D at some azimuth and emits it as a
+chord polyline.
+
+Coordinates and sign conventions
+--------------------------------
+Work in the chain's own vertical plane: ``x`` runs horizontally in the
+direction the chain travels, ``z`` is up.  Gravity is ``-z``.
+
+The internal tension state at arc position ``s`` is the vector
+
+    t(s) = (H, V(s))
+
+meaning *the force the downstream material exerts on the upstream material* —
+it pulls forward, along increasing arc length.  Statics on an element gives
+``dt/ds = (0, +w)``, so
+
+  * ``H`` — the horizontal component — is **constant along the whole chain**,
+    and is the single scalar that sets the catenary's shape; and
+  * ``V(s) = V0 + w·s`` accumulates the weight hung below.
+
+``H > 0`` always, which also makes ``x`` strictly increasing along the chain
+(``dx/ds = H/T > 0``).  A chain hanging straight down has ``H = 0``: a real
+equilibrium, but a degenerate one this formulation cannot express, so the
+solvers reject it with an explicit error rather than limping toward it.
+
+The *support* forces reported on :class:`ChainSolution` follow from the same
+convention: the apex support must supply ``-t(0)`` and the far support ``+t(L)``
+so that
+
+    F_apex + F_end = (0, Σ Lᵢ·wᵢ)
+
+— horizontal components cancel exactly, verticals sum to the total weight.
+That identity is the module's cheapest global correctness check and is
+asserted in the tests.
+
+Closed forms
+------------
+With ``a = H/w`` the catenary parameter and ``v = V/H`` the local slope:
+
+    z(x) = a·cosh((x − x_v)/a) + c      s(x) = a·sinh((x − x_v)/a)
+    T(x) = H·cosh((x − x_v)/a) = w·(z(x) − c) = √(H² + V²)
+
+Marching a segment means: from the start position and ``(H, V0)`` advance the
+arc length ``L`` and read off the end position and ``V1 = V0 + w·L``.  The
+displacement over an arc length ``s`` is, exactly,
+
+    Δx = a·(asinh(v₁) − asinh(v₀))      Δz = (T₁ − T₀)/w
+
+Note that ``Δz`` never evaluates ``cosh`` — the naive ``a·cosh(x/a)`` form
+overflows long before a taut wire is taut enough to matter.  See "Numerics".
+
+Architecture: a swappable marching kernel
+-----------------------------------------
+The solve is split into
+
+  1. a **marching kernel** (:func:`march_continuous`) that turns
+     ``(start, (H, V0), segments)`` into per-segment polylines and end states,
+     and
+  2. a **2-unknown shooting wrapper** that hunts for the ``(H, V0)`` satisfying
+     the rig closure.
+
+Only the continuous closed-form kernel ships now.  Keeping it behind the
+:class:`MarchKernel` call signature is deliberate: a *discrete funicular*
+kernel (per-node force balance) slots in behind exactly the same interface
+when point masses — insulators, a hanging feedline — or per-segment wind/ice
+loads are wanted, and those break the closed forms but not the shooting
+wrapper.  The continuous kernel ships first because it makes the mechanical
+shape exact and independent of chord count: a convergence ladder then refines
+only the *electrical* discretization, never a moving geometric target (the
+#606 lesson — do not let a discretization parameter read as physics).
+
+Deliberately out of scope, stated honestly:
+
+  * **Wire elasticity.**  Copper stretch is second-order at these tensions and
+    an inextensible chain stays closed-form.  A stretching chain couples the
+    arc length to the tension and turns every march into an inner solve.
+  * **Wind and ice loading.**  This is the follow-up the kernel seam exists
+    for: a transverse distributed load is not a vertical-plane catenary.
+  * **Ground contact of a slack wire.**  A wire that touches the ground needs
+    a constrained energy minimization; the catenary simply cannot express the
+    unilateral contact condition, and pretending otherwise would silently
+    return a shape that passes below grade.
+  * **Non-serial topologies** — branches, sliding pulleys, multi-wire
+    halyards.  Those need the fully assembled per-node force-balance system,
+    which is not worth building until such a design actually appears.
+
+Numerics: the taut limit
+------------------------
+As a wire is pulled taut, ``a = H/w`` grows without bound and every naive form
+falls over.  The governing small parameter is
+
+    d = w·L/H = L/a
+
+— the segment's arc length measured in catenary parameters, i.e. how much the
+chain bends over the segment.  For ``d`` small the exact displacement formulas
+subtract two nearly equal numbers of size ``a``, so their *absolute* error is
+``eps·a``: at ``a = 10¹⁰ m`` that is microns of garbage in a millimetre-scale
+answer.  Below :data:`TAUT_D` the module therefore switches to a midpoint
+Taylor expansion in ``d`` (the small-sag / parabolic expansion, carried to
+``d⁴``), which is cancellation-free and reduces to a straight line at ``d = 0``
+— so massless segments (``w = 0``, a taut halyard) fall out of the same code
+path with no special case.  The threshold is chosen where the two branches
+agree to ~1e-13 relative; :func:`chord_sag` uses a second, tighter threshold
+because a perpendicular sag is a far more cancellation-sensitive quantity than
+a position.  Both are exercised by continuity tests that straddle them.
+
+Issue #698.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Callable, Sequence
+
+import numpy as np
+
+# Standard gravity, m/s².  Catalog wire weights are grams per metre; the chain
+# math wants newtons per metre.
+GRAVITY = 9.80665
+
+# Switch to the midpoint series when d = w·L/H falls below this.  Rationale:
+# at d = 1e-3 the exact form's cancellation error is ~eps/d ≈ 2e-13 relative
+# while the series truncates at O(d⁴/1920) ≈ 5e-16 relative, so the two agree
+# to ~2e-13 and the crossover is seamless.  Larger d and the series would
+# truncate visibly; smaller and the exact form would already be losing digits.
+TAUT_D = 1.0e-3
+
+# The same crossover for the chord-perpendicular sag, which is a *difference*
+# of O(L²) products divided by O(L) — its absolute error is ~eps·L against a
+# sag of ~L·d/8, i.e. a relative error of ~8·eps/d.  Matching that against the
+# transverse-string formula's O(d²) truncation puts the balance point two
+# decades lower than TAUT_D: at d = 1e-5 both branches carry ~1e-10 relative
+# error.  A single shared threshold would leave a visible 1e-6 step in the sag.
+TAUT_SAG_D = 1.0e-5
+
+# Newton's residuals are non-dimensionalised (positions by the chain's total
+# length, forces by whichever of the rope pull and the chain's own weight is
+# larger), so one tolerance covers both closures at any scale.
+_NEWTON_TOL = 1.0e-11
+_NEWTON_MAX_ITER = 80
+
+
+def weight_n_per_m(weight_g_per_m: float) -> float:
+    """Catalog wire weight (grams per metre) → chain load (newtons per metre)."""
+    return weight_g_per_m * 1.0e-3 * GRAVITY
+
+
+# --------------------------------------------------------------------------
+# Segment description and kernel outputs
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ChainSegment:
+    """One inextensible span of the serial chain.
+
+    ``length_m`` is the *arc* length — the cut length of wire or rope, which is
+    a fixed input and never a solver unknown (the electrical knob must not move
+    when the tension knob does).  ``weight_n_per_m`` is the distributed load;
+    ``0.0`` means a massless segment, which marches as a straight line.
+
+    A future discrete kernel will read extra fields here (a point mass at the
+    downstream junction, a transverse wind load); the continuous kernel needs
+    only these two.
+    """
+
+    length_m: float
+    weight_n_per_m: float
+    name: str = ""
+
+    def __post_init__(self) -> None:
+        if not (self.length_m > 0.0):
+            raise ValueError(
+                f"chain segment {self.name or '?'!r}: arc length must be "
+                f"positive, got {self.length_m!r} m"
+            )
+        if self.weight_n_per_m < 0.0:
+            raise ValueError(
+                f"chain segment {self.name or '?'!r}: weight per metre must be "
+                f"non-negative, got {self.weight_n_per_m!r} N/m"
+            )
+
+
+@dataclass(frozen=True, eq=False)
+class SegmentMarch:
+    """Raw kernel output for one segment: samples, end position, end tension.
+
+    ``points`` is ``(n, 2)`` of ``(x, z)`` sampled uniformly in *arc length*
+    from the segment's start to its end inclusive.  ``end_tension`` is the
+    forward internal tension ``(H, V1)`` handed to the next segment.
+
+    ``eq=False`` (as in :class:`~antennaknobs.touchstone.Touchstone`) because
+    the array makes value equality meaningless and unhashable.
+    """
+
+    points: np.ndarray
+    end_point: tuple[float, float]
+    end_tension: tuple[float, float]
+
+
+#: Signature every marching kernel must honour.  The continuous kernel is
+#: :func:`march_continuous`; a discrete funicular kernel will present the same
+#: call and return the same objects, so the shooting wrapper never changes.
+MarchKernel = Callable[
+    [tuple[float, float], tuple[float, float], Sequence[ChainSegment], int],
+    "tuple[SegmentMarch, ...]",
+]
+
+
+# --------------------------------------------------------------------------
+# Continuous catenary kernel
+# --------------------------------------------------------------------------
+
+
+def _offset(h: float, v0: float, w: float, s: float) -> tuple[float, float]:
+    """Displacement ``(Δx, Δz)`` after advancing arc length ``s``.
+
+    Exact catenary displacement, written to avoid the two ways the textbook
+    form dies in the taut limit: ``Δz`` is ``(T₁ − T₀)/w`` rather than a
+    difference of ``a·cosh`` (no overflow), and below :data:`TAUT_D` both
+    components come from a midpoint Taylor expansion in ``d = w·s/h`` (no
+    cancellation).  ``w = 0`` lands in the series branch with ``d = 0`` and
+    yields the straight-line result exactly.
+    """
+    if s == 0.0:
+        return 0.0, 0.0
+    slope0 = v0 / h
+    d = w * s / h
+    slope1 = slope0 + d
+    if abs(d) < TAUT_D:
+        # Midpoint expansion kills the even-order derivatives, so the leading
+        # correction is O(d²) and the next is O(d⁴):
+        #   Δx = s·[f'(m) + f'''(m)·d²/24 + f⁽⁵⁾(m)·d⁴/1920],  f = asinh
+        #   Δz = s·[g'(m) + g'''(m)·d²/24 + g⁽⁵⁾(m)·d⁴/1920],  g = √(1+v²)
+        m = 0.5 * (slope0 + slope1)
+        m2 = m * m
+        g = math.sqrt(1.0 + m2)
+        g5 = g**5
+        g9 = g**9
+        d2 = d * d
+        d4 = d2 * d2
+        fx = (
+            1.0 / g
+            + (2.0 * m2 - 1.0) / g5 * (d2 / 24.0)
+            + (9.0 - 72.0 * m2 + 24.0 * m2 * m2) / g9 * (d4 / 1920.0)
+        )
+        fz = (
+            m / g
+            + (-3.0 * m) / g5 * (d2 / 24.0)
+            + (45.0 * m - 60.0 * m2 * m) / g9 * (d4 / 1920.0)
+        )
+        return s * fx, s * fz
+    a = h / w
+    dx = a * (math.asinh(slope1) - math.asinh(slope0))
+    dz = (math.hypot(h, v0 + w * s) - math.hypot(h, v0)) / w
+    return dx, dz
+
+
+def chord_sag(h: float, v0: float, w: float, length_m: float) -> float:
+    """Max distance of a catenary segment from its own chord, measured ⟂.
+
+    A catenary is convex (``z'' = cosh(·)/a > 0``), so the arc lies entirely
+    below its chord and the maximum offset is unsigned and unambiguous.  It
+    occurs where the tangent is parallel to the chord, i.e. where the local
+    slope ``V/H`` equals the chord slope — the mean value theorem guarantees
+    such a point exists because ``x`` is monotone.
+
+    Below :data:`TAUT_SAG_D` the exact cross-product form has cancelled away
+    its significant digits, so the sag comes from the taut-string result
+    ``q·C²/(8·T)`` with the transverse load ``q = w·Δx/C``:
+
+        sag ≈ w·Δx·C/(8·T_mid)
+
+    which reduces to the familiar ``w·d²/(8H)`` for a level span.
+    """
+    if w == 0.0:
+        return 0.0
+    dx, dz = _offset(h, v0, w, length_m)
+    chord = math.hypot(dx, dz)
+    if chord == 0.0:
+        return 0.0
+    if w * length_m / h < TAUT_SAG_D:
+        t_mid = math.hypot(h, v0 + 0.5 * w * length_m)
+        return w * dx * chord / (8.0 * t_mid)
+    # Tangent parallel to the chord: V* = H·(Δz/Δx), reached at arc length
+    # s* = (V* − V0)/w.  Its perpendicular offset is the 2-D cross product
+    # with the unit chord.
+    v_star = h * (dz / dx)
+    s_star = (v_star - v0) / w
+    s_star = min(max(s_star, 0.0), length_m)
+    px, pz = _offset(h, v0, w, s_star)
+    return abs((dx * pz - dz * px) / chord)
+
+
+def march_continuous(
+    start: tuple[float, float],
+    tension: tuple[float, float],
+    segments: Sequence[ChainSegment],
+    samples_per_segment: int = 33,
+) -> tuple[SegmentMarch, ...]:
+    """March a serial chain with the continuous closed-form catenary.
+
+    Given the start point, the forward internal tension ``(H, V0)`` there, and
+    the segment list, walk segment by segment: each one is an exact catenary
+    arc of its own parameter ``a = H/wᵢ`` (a straight line where ``wᵢ = 0``),
+    joined to the next at the position and tension the previous one ended at.
+    ``H`` is shared by every segment — that is what makes the chain serial and
+    the whole problem two-unknown.
+
+    Raises :class:`ValueError` for ``H ≤ 0`` (a vertical hanging chain; see the
+    module docstring) or a sample count below 2.
+    """
+    h, v = tension
+    if not (h > 0.0):
+        raise ValueError(
+            f"horizontal tension must be positive, got H = {h!r} N; a chain "
+            "hanging straight down (H = 0) is a degenerate equilibrium this "
+            "catenary formulation cannot represent"
+        )
+    if not math.isfinite(h) or not math.isfinite(v):
+        raise ValueError(f"non-finite tension state (H, V0) = ({h!r}, {v!r})")
+    if samples_per_segment < 2:
+        raise ValueError(
+            f"samples_per_segment must be at least 2 (both endpoints), got "
+            f"{samples_per_segment}"
+        )
+    if not segments:
+        raise ValueError("a chain needs at least one segment")
+
+    x, z = start
+    out: list[SegmentMarch] = []
+    for seg in segments:
+        length = seg.length_m
+        w = seg.weight_n_per_m
+        pts = np.empty((samples_per_segment, 2), dtype=float)
+        for i in range(samples_per_segment):
+            s = length * i / (samples_per_segment - 1)
+            dx, dz = _offset(h, v, w, s)
+            pts[i, 0] = x + dx
+            pts[i, 1] = z + dz
+        # Recompute the endpoint from the closed form rather than trusting the
+        # last sample's rounding, then hand the exact state to the next span.
+        dx_end, dz_end = _offset(h, v, w, length)
+        x, z = x + dx_end, z + dz_end
+        pts[-1, 0] = x
+        pts[-1, 1] = z
+        v = v + w * length
+        out.append(SegmentMarch(points=pts, end_point=(x, z), end_tension=(h, v)))
+    return tuple(out)
+
+
+# --------------------------------------------------------------------------
+# Result object
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, eq=False)
+class SegmentShape:
+    """One solved segment: its sampled arc plus the per-segment diagnostics.
+
+    ``points`` is ``(n, 2)`` of ``(x, z)`` in the chain's vertical plane,
+    uniform in arc length.  ``polyline_length_m`` is the length of that
+    *sampled* polyline — always slightly short of ``arc_length_m``, by
+    ``O(1/n²)``, which is the internal consistency check the caller (and the
+    tests) use to size the sampling.  ``max_sag_m`` is measured perpendicular
+    to the segment's own chord, not vertically, and not from the whole chain's
+    chord.
+    """
+
+    name: str
+    points: np.ndarray
+    arc_length_m: float
+    polyline_length_m: float
+    max_sag_m: float
+    weight_n_per_m: float
+    start_tension_vector: tuple[float, float]
+    end_tension_vector: tuple[float, float]
+
+    @property
+    def chord_length_m(self) -> float:
+        return float(np.hypot(*(self.points[-1] - self.points[0])))
+
+
+@dataclass(frozen=True, eq=False)
+class ChainSolution:
+    """A solved hanging chain in its own vertical plane.
+
+    ``segments`` carries the sampled shape and per-segment diagnostics in chain
+    order; ``junctions`` are the interior joins between consecutive segments
+    (empty for a single-segment chain).
+
+    The two tension *vectors* are the forces the **supports exert on the
+    chain**, not the internal tension in a fixed direction — so they sum to the
+    chain's total weight pointing up and their horizontal parts cancel (see the
+    module docstring).  ``apex_tension`` / ``end_tension`` are their magnitudes,
+    which are also the internal line tensions at those points.
+    ``horizontal_tension_n`` is the shared ``H``, the one number that sets the
+    shape.
+    """
+
+    apex: tuple[float, float]
+    end_point: tuple[float, float]
+    segments: tuple[SegmentShape, ...]
+    junctions: tuple[tuple[float, float], ...]
+    apex_tension_vector: tuple[float, float]
+    end_tension_vector: tuple[float, float]
+    apex_tension: float
+    end_tension: float
+    horizontal_tension_n: float
+    total_weight_n: float
+    iterations: int
+    residual: float
+
+    @property
+    def polyline(self) -> np.ndarray:
+        """All segments concatenated, duplicate junction samples dropped."""
+        parts = [self.segments[0].points]
+        parts.extend(seg.points[1:] for seg in self.segments[1:])
+        return np.vstack(parts)
+
+    @property
+    def max_sag_m(self) -> float:
+        """Largest per-segment chord sag over the chain."""
+        return max(seg.max_sag_m for seg in self.segments)
+
+    @property
+    def total_arc_length_m(self) -> float:
+        return sum(seg.arc_length_m for seg in self.segments)
+
+
+def _assemble(
+    apex: tuple[float, float],
+    tension: tuple[float, float],
+    segments: Sequence[ChainSegment],
+    marched: Sequence[SegmentMarch],
+    iterations: int,
+    residual: float,
+) -> ChainSolution:
+    """Package a converged march into a :class:`ChainSolution`."""
+    h = tension[0]
+    v = tension[1]
+    shapes: list[SegmentShape] = []
+    for seg, march in zip(segments, marched):
+        steps = np.diff(march.points, axis=0)
+        polyline_length = float(np.hypot(steps[:, 0], steps[:, 1]).sum())
+        shapes.append(
+            SegmentShape(
+                name=seg.name,
+                points=march.points,
+                arc_length_m=seg.length_m,
+                polyline_length_m=polyline_length,
+                max_sag_m=chord_sag(h, v, seg.weight_n_per_m, seg.length_m),
+                weight_n_per_m=seg.weight_n_per_m,
+                start_tension_vector=(h, v),
+                end_tension_vector=march.end_tension,
+            )
+        )
+        v = march.end_tension[1]
+
+    total_weight = sum(s.length_m * s.weight_n_per_m for s in segments)
+    # Support forces: the apex holds the chain back (−t(0)); the far support
+    # pulls it on (+t(L)).  Their sum is the weight, pointing up.
+    apex_force = (-tension[0], -tension[1])
+    end_force = marched[-1].end_tension
+    return ChainSolution(
+        apex=apex,
+        end_point=marched[-1].end_point,
+        segments=tuple(shapes),
+        junctions=tuple(m.end_point for m in marched[:-1]),
+        apex_tension_vector=apex_force,
+        end_tension_vector=end_force,
+        apex_tension=math.hypot(*apex_force),
+        end_tension=math.hypot(*end_force),
+        horizontal_tension_n=h,
+        total_weight_n=total_weight,
+        iterations=iterations,
+        residual=residual,
+    )
+
+
+# --------------------------------------------------------------------------
+# Damped Newton on the 2-unknown shooting problem
+# --------------------------------------------------------------------------
+
+# The unknowns are non-dimensionalised as q = (ln H, V0/H):
+#   * ln H keeps H > 0 structurally — no barrier, no clamping — and makes the
+#     Jacobian scale-free across the ten decades of tension a knob scrub can
+#     visit (a taut chain's position depends on H only through ln H, so this
+#     is also the difference between a well- and an ill-conditioned solve);
+#   * V0/H is the chain's slope at the apex, an O(1) dimensionless number.
+_Q_STEP = 1.0e-6
+# Largest Newton step in q-space per iteration.  One unit of ln H is a factor
+# of e in tension; letting Newton leap further from a bad Jacobian is how the
+# solve ends up in the overflow weeds.
+_MAX_STEP = 2.0
+_H_FLOOR_REL = 1.0e-12
+
+
+class _Infeasible(Exception):
+    """Residual could not be evaluated at this trial point."""
+
+
+def _damped_newton(
+    residual: Callable[[np.ndarray], np.ndarray],
+    q0: np.ndarray,
+) -> tuple[np.ndarray, int, float]:
+    """Damped Newton with a finite-difference Jacobian on a 2-vector.
+
+    Two unknowns is far too small to be worth an analytic Jacobian or a scipy
+    dependency: three residual evaluations per iteration, a backtracking line
+    search on ‖r‖, and a step clamp make this robust enough to survive a knob
+    being scrubbed through configurations that briefly have no equilibrium.
+    """
+    q = np.array(q0, dtype=float)
+    try:
+        r = residual(q)
+    except _Infeasible as exc:
+        raise ValueError(f"initial guess is infeasible: {exc}") from exc
+    norm = float(np.linalg.norm(r))
+
+    for it in range(1, _NEWTON_MAX_ITER + 1):
+        if norm < _NEWTON_TOL:
+            return q, it - 1, norm
+        jac = np.empty((2, 2), dtype=float)
+        for k in range(2):
+            # Relative step: the apex slope V0/H is O(1) for a normal arm but
+            # runs to 1e3 or more for a nearly vertical one, where a fixed
+            # absolute step would be lost in the mantissa and hand Newton a
+            # column of pure noise.
+            step_k = _Q_STEP * max(1.0, abs(q[k]))
+            qk = q.copy()
+            qk[k] += step_k
+            try:
+                rk = residual(qk)
+            except _Infeasible:
+                qk[k] = q[k] - step_k
+                rk = residual(qk)
+                jac[:, k] = (r - rk) / step_k
+            else:
+                jac[:, k] = (rk - r) / step_k
+        try:
+            step = np.linalg.solve(jac, -r)
+        except np.linalg.LinAlgError:
+            step = -r
+        if not np.all(np.isfinite(step)):
+            step = -r
+        # Clamp componentwise against each unknown's own scale, so a steep arm
+        # (large |V0/H|) is not held to the same absolute leash as a shallow
+        # one while ln H stays capped at a couple of e-foldings per iteration.
+        limits = np.array([_MAX_STEP, _MAX_STEP * max(1.0, abs(q[1]))])
+        excess = float(np.max(np.abs(step) / limits))
+        if excess > 1.0:
+            step /= excess
+
+        lam = 1.0
+        for _ in range(40):
+            trial = q + lam * step
+            try:
+                r_trial = residual(trial)
+            except _Infeasible:
+                lam *= 0.5
+                continue
+            n_trial = float(np.linalg.norm(r_trial))
+            if math.isfinite(n_trial) and n_trial < (1.0 - 1.0e-4 * lam) * norm:
+                q, r, norm = trial, r_trial, n_trial
+                break
+            lam *= 0.5
+        else:
+            # No downhill step exists — either converged to round-off or stuck.
+            return q, it, norm
+    return q, _NEWTON_MAX_ITER, norm
+
+
+def _shoot(
+    residual: Callable[[np.ndarray], np.ndarray],
+    guesses: Sequence[tuple[float, float]],
+    what: str,
+    hint: str,
+) -> tuple[np.ndarray, int, float]:
+    """Run :func:`_damped_newton` from each guess in turn; first win returns.
+
+    Retrying from perturbed starts (a decade either side of the physical
+    estimate) costs a few milliseconds and turns most "no equilibrium" reports
+    that were really "bad initial guess" into solves.
+    """
+    best_norm = math.inf
+    for guess in guesses:
+        if not (guess[0] > 0.0) or not math.isfinite(guess[0]):
+            continue
+        q0 = np.array([math.log(guess[0]), guess[1] / guess[0]], dtype=float)
+        try:
+            q, iters, norm = _damped_newton(residual, q0)
+        except ValueError:
+            continue
+        if norm < _NEWTON_TOL:
+            return q, iters, norm
+        best_norm = min(best_norm, norm)
+    raise ValueError(
+        f"no equilibrium found for {what}: the shooting solve stalled at a "
+        f"residual of {best_norm:.3e} (target {_NEWTON_TOL:.0e}). {hint}"
+    )
+
+
+# --------------------------------------------------------------------------
+# Rig closure 1 — tensioned halyard (massless rope of specified tension)
+# --------------------------------------------------------------------------
+
+
+def solve_tensioned(
+    apex: tuple[float, float],
+    wire_length_m: float,
+    wire_weight_n_per_m: float,
+    stake: tuple[float, float],
+    rope_tension_n: float,
+    *,
+    samples_per_segment: int = 33,
+    kernel: MarchKernel = march_continuous,
+    name: str = "wire",
+) -> ChainSolution:
+    """Model 1: a wire of fixed cut length held by a rope of specified tension.
+
+    The wire hangs from ``apex``; its far end is held by a *massless* straight
+    rope running to ``stake`` and pulling with magnitude ``rope_tension_n``.
+    The wire's end position is **not** an input — equilibrium places it, which
+    is the whole point: ``rope_tension_n`` is the design knob and the arm's
+    droop is the answer.
+
+    The closure is that the end tension vector equals the rope pull:
+
+        t(L) = T_rope · (stake − end) / ‖stake − end‖
+
+    As ``T_rope → ∞`` the wire converges to the straight chord of length
+    ``wire_length_m`` from ``apex`` toward ``stake`` — the taut-limit oracle
+    against a straight inverted-vee arm.
+
+    Raises :class:`ValueError` when no equilibrium exists.  Two cases are
+    physical, not numerical: a stake that is not horizontally beyond the apex
+    (the rope would have to pull backwards, needing ``H ≤ 0``), and a stake
+    closer to the apex than the wire is long — the wire's end runs past the
+    stake, so again the rope reverses, and no tension rescues it.
+
+    The tension itself is otherwise unconstrained: the solve is exercised from
+    1e-6 N (a wire hanging all but vertically) to 1e12 N (a straight chord)
+    without special-casing, which is what a scrubbed UI knob demands.
+    """
+    if not (wire_length_m > 0.0):
+        raise ValueError(f"wire length must be positive, got {wire_length_m!r} m")
+    if not (wire_weight_n_per_m > 0.0):
+        raise ValueError(
+            "a weightless wire has no catenary: wire_weight_n_per_m must be "
+            f"positive, got {wire_weight_n_per_m!r} N/m (pick a WireSpec with a "
+            "real weight_g_per_m)"
+        )
+    if not (rope_tension_n > 0.0):
+        raise ValueError(
+            f"rope tension must be positive, got {rope_tension_n!r} N; a slack "
+            "rope holds nothing and leaves no equilibrium for the wire's end"
+        )
+
+    span_x = stake[0] - apex[0]
+    if span_x <= 0.0:
+        raise ValueError(
+            f"stake must be horizontally beyond the apex: apex x = {apex[0]!r} m, "
+            f"stake x = {stake[0]!r} m.  With the stake level with or behind the "
+            "apex the rope would pull the wire's end backwards, which needs a "
+            "non-positive horizontal tension (a vertical hanging chain)"
+        )
+
+    segments = (
+        ChainSegment(
+            length_m=wire_length_m, weight_n_per_m=wire_weight_n_per_m, name=name
+        ),
+    )
+    total_weight = wire_length_m * wire_weight_n_per_m
+    # Non-dimensionalise the force residual by whichever of the rope pull and
+    # the wire's own weight actually sets the scale.  Dividing by the rope
+    # tension alone looks natural but blows the residual up (and stalls Newton
+    # on round-off) when a knob scrub drives the tension far below the weight
+    # the wire is asking the rope to help carry.
+    force_scale = max(rope_tension_n, total_weight)
+    h_floor = _H_FLOOR_REL * force_scale
+
+    def residual(q: np.ndarray) -> np.ndarray:
+        h = math.exp(q[0])
+        if not math.isfinite(h) or h <= h_floor:
+            raise _Infeasible("horizontal tension collapsed to zero")
+        v0 = q[1] * h
+        marched = kernel(apex, (h, v0), segments, 2)
+        end = marched[-1].end_point
+        rx = stake[0] - end[0]
+        rz = stake[1] - end[1]
+        dist = math.hypot(rx, rz)
+        if dist == 0.0:
+            raise _Infeasible("wire end coincides with the stake")
+        pull = (rope_tension_n * rx / dist, rope_tension_n * rz / dist)
+        end_t = marched[-1].end_tension
+        return np.array(
+            [
+                (end_t[0] - pull[0]) / force_scale,
+                (end_t[1] - pull[1]) / force_scale,
+            ],
+            dtype=float,
+        )
+
+    # Physical first guess: pretend the wire is already straight from the apex
+    # toward the stake, then read the tension the rope would have to apply
+    # there.  That is exact in the taut limit and merely close otherwise.
+    ax, az = apex
+    sx, sz = stake
+    reach = math.hypot(sx - ax, sz - az)
+    ux, uz = (sx - ax) / reach, (sz - az) / reach
+    guess_h = rope_tension_n * ux
+    guess_v1 = rope_tension_n * uz
+    guess_v0 = guess_v1 - total_weight
+    guesses = [
+        (guess_h, guess_v0),
+        (max(guess_h, total_weight), guess_v0),
+        (0.1 * max(guess_h, total_weight), guess_v0),
+        (10.0 * max(guess_h, total_weight), guess_v0),
+        (total_weight, -total_weight),
+    ]
+    hint = (
+        f"With a rope tension of {rope_tension_n:g} N pulling a {wire_length_m:g} m "
+        f"wire toward a stake {reach:g} m away, check that the stake is farther "
+        "from the apex than the wire is long (otherwise the taut wire overshoots "
+        "it and the rope must pull backwards) and that the tension is large "
+        "enough to keep the wire off the vertical."
+    )
+    q, iters, norm = _shoot(
+        residual, guesses, "the tensioned-halyard rig (model 1)", hint
+    )
+
+    h = math.exp(q[0])
+    v0 = q[1] * h
+    marched = kernel(apex, (h, v0), segments, samples_per_segment)
+    return _assemble(apex, (h, v0), segments, marched, iters, norm)
+
+
+# --------------------------------------------------------------------------
+# Rig closure 2 — heavy rope of fixed length to a ground anchor
+# --------------------------------------------------------------------------
+
+
+def solve_anchored(
+    apex: tuple[float, float],
+    segments: Sequence[ChainSegment],
+    anchor: tuple[float, float],
+    *,
+    samples_per_segment: int = 33,
+    kernel: MarchKernel = march_continuous,
+) -> ChainSolution:
+    """Model 2: a multi-segment chain of fixed lengths landing on an anchor.
+
+    The chain — typically antenna wire then halyard, each with its own length
+    and weight per metre — hangs from ``apex`` and its far end must land on
+    ``anchor``.  Fixed endpoints plus inextensible fixed lengths leave **no
+    tension freedom**: tension is an *output* here, a readout, not a knob.  The
+    knob a winch actually turns is the rope's take-up, i.e. its ``length_m``.
+
+    The closure is simply ``end == anchor``; the two unknowns are again
+    ``(H, V0)``.
+
+    Raises :class:`ValueError` when the chain cannot reach — the straight-line
+    distance to the anchor exceeds the total arc length (a rope shorter than
+    the gap) — or when the anchor is not horizontally beyond the apex, which
+    would need a vertical hanging chain.
+    """
+    segments = tuple(segments)
+    if not segments:
+        raise ValueError("a chain needs at least one segment")
+
+    total_length = sum(s.length_m for s in segments)
+    total_weight = sum(s.length_m * s.weight_n_per_m for s in segments)
+    if total_weight <= 0.0:
+        raise ValueError(
+            "a weightless chain has no catenary: every segment has "
+            "weight_n_per_m = 0, so the shape is a straight line and no "
+            "tension can be recovered (pick a WireSpec with a real "
+            "weight_g_per_m)"
+        )
+
+    dx = anchor[0] - apex[0]
+    dz = anchor[1] - apex[1]
+    reach = math.hypot(dx, dz)
+    if reach >= total_length:
+        raise ValueError(
+            f"chain cannot reach the anchor: the straight-line distance is "
+            f"{reach:.6g} m but the segments total only {total_length:.6g} m of "
+            "arc.  Lengthen the rope (reduce the take-up) or move the anchor "
+            "closer; an inextensible chain has no equilibrium once it is pulled "
+            "straight."
+        )
+    if dx <= 0.0:
+        raise ValueError(
+            f"anchor must be horizontally beyond the apex: apex x = {apex[0]!r} m, "
+            f"anchor x = {anchor[0]!r} m.  A chain hanging straight down needs "
+            "zero horizontal tension, a degenerate equilibrium this catenary "
+            "formulation cannot represent"
+        )
+
+    h_floor = _H_FLOOR_REL * total_weight
+
+    def residual(q: np.ndarray) -> np.ndarray:
+        h = math.exp(q[0])
+        if not math.isfinite(h) or h <= h_floor:
+            raise _Infeasible("horizontal tension collapsed to zero")
+        v0 = q[1] * h
+        marched = kernel(apex, (h, v0), segments, 2)
+        end = marched[-1].end_point
+        return np.array(
+            [
+                (end[0] - anchor[0]) / total_length,
+                (end[1] - anchor[1]) / total_length,
+            ],
+            dtype=float,
+        )
+
+    # Straight-chord initialisation via the shallow-parabola relations: a
+    # parabola of sag f over a chord of length C carries an excess arc length
+    # of 8f²/(3C), and its sag is w·C²/(8·H).  Invert both to get an H that
+    # already has the right order of magnitude, then offset the apex slope by
+    # the parabola's end slope, 4f/C.
+    slack = total_length - reach
+    sag_guess = math.sqrt(max(3.0 * reach * slack / 8.0, 1e-30))
+    w_mean = total_weight / total_length
+    chord_slope = dz / dx
+    guess_h = max(w_mean * dx * reach / (8.0 * sag_guess), 1e-9 * total_weight)
+    guess_v0 = guess_h * (chord_slope - 4.0 * sag_guess / reach)
+    guesses = [
+        (guess_h, guess_v0),
+        (guess_h, guess_h * chord_slope),
+        (0.1 * guess_h, guess_v0),
+        (10.0 * guess_h, guess_v0),
+        (total_weight, -total_weight),
+    ]
+    hint = (
+        f"The chain totals {total_length:.6g} m of arc across a {reach:.6g} m gap "
+        f"(slack {slack:.6g} m); very small slack makes the tension diverge and "
+        "the solve ill-conditioned — lengthen the rope slightly."
+    )
+    q, iters, norm = _shoot(residual, guesses, "the anchored-chain rig (model 2)", hint)
+
+    h = math.exp(q[0])
+    v0 = q[1] * h
+    marched = kernel(apex, (h, v0), segments, samples_per_segment)
+    return _assemble(apex, (h, v0), segments, marched, iters, norm)
+
+
+def solve_chain(
+    apex: tuple[float, float],
+    tension: tuple[float, float],
+    segments: Sequence[ChainSegment],
+    *,
+    samples_per_segment: int = 33,
+    kernel: MarchKernel = march_continuous,
+) -> ChainSolution:
+    """Package a *known* ``(H, V0)`` state as a :class:`ChainSolution`.
+
+    No solve — this is the open-loop march, useful for oracles (a symmetric
+    span whose tension state is known analytically) and for a caller that has
+    already pinned the tension by other means.
+    """
+    segments = tuple(segments)
+    marched = kernel(apex, tension, segments, samples_per_segment)
+    return _assemble(apex, tension, segments, marched, 0, 0.0)
+
+
+__all__ = [
+    "GRAVITY",
+    "TAUT_D",
+    "TAUT_SAG_D",
+    "ChainSegment",
+    "ChainSolution",
+    "MarchKernel",
+    "SegmentMarch",
+    "SegmentShape",
+    "chord_sag",
+    "march_continuous",
+    "solve_anchored",
+    "solve_chain",
+    "solve_tensioned",
+    "weight_n_per_m",
+]

--- a/src/antennaknobs/designs/dipoles/invvee_catenary.py
+++ b/src/antennaknobs/designs/dipoles/invvee_catenary.py
@@ -1,0 +1,194 @@
+"""Inverted-vee dipole whose arms hang as real catenaries (issue #698, unit 2).
+
+Every other inv-vee in the catalog (`dipoles.invvee`) treats an arm as a
+straight chord at a fixed droop angle. A real wire does not do that: strung
+from the apex to a stake under some rope tension, it sags into the shape
+`antennaknobs.catenary` solves for — a hanging-chain equilibrium set by the
+wire's own weight per metre and how hard the halyard pulls. This design wires
+that solve into the geometry: `build_wires()` emits each arm as a chord
+polyline sampled uniformly along the solved catenary's arc length, following
+the `specialty.faceted_helix` curved-wire idiom (`Wire(p_i, p_{i+1},
+n_seg=None)`, `auto_mesh` owning the electrical density — issue #630's
+lesson: never hand-freeze `n_seg` on a chorded curve).
+
+The model: tensioned halyard (catenary's "model 1")
+----------------------------------------------------
+Each arm is `catenary.solve_tensioned`: a wire of *fixed cut length*
+`0.25 * design_wavelength * length_factor` — the same length law
+`dipoles.invvee` uses for its straight arm — hangs from the apex, and its far
+end is held by a massless rope of specified tension `tension_n` running to a
+fixed stake. The wire's end position is not an input; equilibrium places it,
+which is the whole point of the model: `tension_n` is the design knob and the
+arm's droop is the answer.
+
+This keeps the **electrical knob and the mechanical knob orthogonal by
+construction** — `length_factor` sets how much wire is up there;
+`tension_n` sets how it hangs. Scrubbing tension never changes the cut
+length, only the shape, exactly as issue #698 requires ("the electrical
+knob must not move when tension changes"). As `tension_n -> infinity` the
+arm's shape converges to the straight chord from the apex toward the stake,
+which is the design's own built-in regression oracle against a straight-arm
+inv-vee of the same geometry (see `tests/test_invvee_catenary.py`).
+
+Feasibility: the stake must be beyond the arm
+----------------------------------------------
+`solve_tensioned` requires the stake to be farther from the apex than the
+wire is long — a taut wire reaching for a stake it has already overshot has
+no equilibrium at any tension. With the apex at `(0, base)` and the stake at
+`(stake_dist, stake_height)` in the arm's own vertical plane, this needs
+
+    hypot(stake_dist, base - stake_height) > 0.25 * design_wavelength * length_factor
+
+The stock `stake_dist` (~1.15x the default arm length) and `stake_height`
+(1.0 m) satisfy this with a comfortable margin even at the top of the
+`length_factor` UI range, because most of the reach comes from the mast
+height (`base - stake_height`) rather than the horizontal offset — see the
+module tests for the numeric check. Push the knobs hard enough (a very long
+arm, a stake dragged close to directly under the apex) and the solver's own
+`ValueError` explains exactly why no rig exists; this design does not
+second-guess or clamp that error.
+
+Geometry
+--------
+The apex sits on the mast at `(0, 0, base)`. A short feed wire (the
+`doublet_ladder_tuner` / `invvee` idiom: `eps = 0.05` m either side of
+centre) carries the driven gap; each catenary arm starts from that feed
+wire's end and runs in the +y or -y azimuth (no azimuth knob in this unit —
+the two arms are always 180 deg apart). The catenary solve itself works in
+the arm's 2-D vertical plane (`horizontal`, `z`); the design maps
+`horizontal -> +-y` and holds `x = 0`.
+
+Requires a real `WireSpec`: a weightless wire has no catenary
+(`solve_tensioned` raises `ValueError` for `wire_weight_n_per_m <= 0`, and
+this module raises its own clear error first if `build_wire_material()`
+returns `None`). The stock wire is `18-awg-pvc` (via `wire_type`), which
+carries a real `weight_g_per_m` — swap the catalog entry and the antenna
+sags differently AND its loss/insulation electrical behaviour changes in one
+move (the same one-knob-two-effects story as `dipoles.pota_invvee`, issue
+#316).
+
+`chords_per_arm` (default 14) is the *geometric* fidelity knob, independent
+of the electrical mesh: it is passed straight through as
+`samples_per_segment = chords_per_arm + 1` to `solve_tensioned`, so the
+solver's own uniform-in-arc-length sampling IS the chord split.
+
+See also
+--------
+`antennaknobs.catenary` for the chain solver and its numerics/sign
+conventions; `dipoles.invvee` for the base design and param conventions;
+`specialty.faceted_helix` for the chord-polyline-as-geometry precedent.
+Issue #698.
+"""
+
+from types import MappingProxyType
+
+from antennaknobs import AntennaBuilder
+from antennaknobs.catenary import ChainSolution, solve_tensioned, weight_n_per_m
+from antennaknobs.network import WIRES, Wire
+
+# Half-gap either side of the mast centreline for the driven feed wire — the
+# same value `dipoles.invvee` and `wire.doublet_ladder_tuner` use.
+_EPS = 0.05
+
+
+class Builder(AntennaBuilder):
+    """A subclass of `AntennaBuilder` directly, not `dipoles.invvee`: the
+    variant-discovery convention (`web.adapter._discover_variants`) walks
+    `dir(cls)`, so subclassing `InvVee` would silently inherit its
+    `dipole_params` / `three_halves_params` / `classic_edz_params`
+    overlays — every one of which sets `angle_deg`, a knob this design does
+    not have (droop is physics here, not a param). Subclassing
+    `AntennaBuilder` sidesteps that entirely; the param *conventions* (name
+    the length knob `length_factor`, keep `design_freq`/`freq`/`base`) are
+    still reused, per the issue's brief.
+    """
+
+    default_params = MappingProxyType(
+        {
+            # Same band/height/length-law defaults as dipoles.invvee.
+            "design_freq": 28.47,
+            "freq": 28.47,
+            "base": 7.0,
+            "length_factor": 0.9719,
+            # Rope tension holding each arm's far end (issue #698 model 1).
+            # ~9 lbf: a realistic hand-tensioned dacron halyard pull.
+            "tension_n": 40.0,
+            # Stake position in the arm's vertical plane, horizontal
+            # distance from the mast and height above ground. Defaults
+            # chosen so hypot(stake_dist, base - stake_height) clears the
+            # longest arm the length_factor UI range can produce (see the
+            # module docstring and the feasibility test).
+            "stake_dist": 2.94,
+            "stake_height": 1.0,
+            # Chord count per arm: geometric fidelity, orthogonal to the
+            # electrical mesh density (nominal_nsegs / auto_mesh).
+            "chords_per_arm": 14,
+            # Real wire is mandatory (a weightless wire has no catenary);
+            # 18 AWG PVC is a common real-world halyard-fed hookup wire.
+            "wire_type": "18-awg-pvc",
+            "ui_params": MappingProxyType(
+                {
+                    "length_factor": {"min": 0.8, "max": 1.25},
+                    "tension_n": {"min": 2.0, "max": 400.0},
+                    "stake_dist": {"min": 1.0, "max": 6.0},
+                    "stake_height": {"min": 0.0, "max": 3.0},
+                    "chords_per_arm": {"min": 6, "max": 32, "step": 1},
+                    "wire_type": {"enum_options": tuple(sorted(WIRES))},
+                }
+            ),
+        }
+    )
+
+    def rig_solutions(self) -> ChainSolution:
+        """Solve one arm's catenary (both arms are mirror images in y, so
+        one solve in the shared vertical plane covers both).
+
+        `build_wires()` calls this same method for its geometry, so the
+        rigged shape and any diagnostics a caller reads off it (sag,
+        tension, arc length) can never drift apart.
+        """
+        spec = self.build_wire_material()
+        if spec is None or not spec.weight_g_per_m:
+            raise ValueError(
+                f"{type(self).__name__}: catenary sag needs a real WireSpec "
+                "with weight_g_per_m > 0 (a weightless wire has no "
+                f"catenary); got {spec!r} from build_wire_material() — set "
+                "wire_type to a catalog entry such as '18-awg-pvc'."
+            )
+
+        arm_length_m = 0.25 * self.design_wavelength * self.length_factor
+        wire_weight = weight_n_per_m(spec.weight_g_per_m)
+
+        return solve_tensioned(
+            apex=(_EPS, self.base),
+            wire_length_m=arm_length_m,
+            wire_weight_n_per_m=wire_weight,
+            stake=(self.stake_dist, self.stake_height),
+            rope_tension_n=self.tension_n,
+            samples_per_segment=int(self.chords_per_arm) + 1,
+            name="invvee_catenary_arm",
+        )
+
+    # build_wire_material() is intentionally NOT overridden: the inherited
+    # AntennaBuilder default already resolves a `wire_type` param via
+    # `wire_from_catalog` (the same mechanism `dipoles.pota_invvee` relies
+    # on), and the stock `wire_type` above already names a real WireSpec.
+
+    def build_wires(self):
+        b = self.base
+        solution = self.rig_solutions()
+        # (horizontal, z) samples, uniform in arc length, apex-first.
+        plane_points = solution.segments[0].points
+
+        wires = [
+            # Driven gap at the apex — the invvee/doublet_ladder_tuner
+            # idiom: a short wire from -eps to +eps carries the excitation,
+            # and each catenary arm starts from one of its ends.
+            Wire((0.0, -_EPS, b), (0.0, _EPS, b), ex=1 + 0j),
+        ]
+        for sign in (1.0, -1.0):
+            arm_points = [(0.0, sign * h, z) for h, z in plane_points]
+            wires.extend(
+                Wire(p0, p1) for p0, p1 in zip(arm_points[:-1], arm_points[1:])
+            )
+        return wires

--- a/src/antennaknobs/designs/dipoles/invvee_catenary.py
+++ b/src/antennaknobs/designs/dipoles/invvee_catenary.py
@@ -11,8 +11,13 @@ the `specialty.faceted_helix` curved-wire idiom (`Wire(p_i, p_{i+1},
 n_seg=None)`, `auto_mesh` owning the electrical density — issue #630's
 lesson: never hand-freeze `n_seg` on a chorded curve).
 
-The model: tensioned halyard (catenary's "model 1")
-----------------------------------------------------
+Two rig models share the same wire and geometry idiom, picked by `rig_model`;
+`rig_solutions()` is the single method that solves either one, and
+`rig_report()` (issue #698 unit 3) reports the tension/sag readout for
+whichever model is active.
+
+Model 1 — tensioned halyard (catenary's "model 1", the default)
+-----------------------------------------------------------------
 Each arm is `catenary.solve_tensioned`: a wire of *fixed cut length*
 `0.25 * design_wavelength * length_factor` — the same length law
 `dipoles.invvee` uses for its straight arm — hangs from the apex, and its far
@@ -48,6 +53,76 @@ arm, a stake dragged close to directly under the apex) and the solver's own
 `ValueError` explains exactly why no rig exists; this design does not
 second-guess or clamp that error.
 
+Model 2 — anchored heavy rope (catenary's "model 2")
+------------------------------------------------------
+Each arm is `catenary.solve_anchored`: the SAME fixed-cut-length antenna
+wire (same `WireSpec` weight as model 1), followed by a second chain segment
+— a rope of its own length and weight, `rope_weight_g_per_m` — whose far end
+must land exactly on a fixed **ground anchor**. That anchor reuses
+`stake_dist` / `stake_height`, the same rig-point params model 1 calls a
+"stake": for this model they name where the rope is staked to the ground,
+not a pull direction.
+
+Fixed endpoints plus two inextensible fixed lengths leave **no tension
+freedom** — `tension_n` is ignored entirely in this model. The knob a winch
+actually turns is the rope's take-up, which raises the apex tension and
+lowers the sag as an **output**, not an input; `rig_report()` is where that
+readout surfaces (issue #698's "tension readout in N and lbf; sag reported"
+acceptance criterion, plus the derived `rope_length_m` — what you'd actually
+cut).
+
+The knob is SLACK, not absolute rope length
+----------------------------------------------
+`rope_slack_mm` — not a rope length — is the UI knob, for a reason a first
+pass at this design got wrong (an absolute `rope_length_m` knob failed
+review): the rope's cut length is derived inside `rig_solutions()` from the
+CURRENT geometry, not stored as its own param —
+
+    reach = hypot(stake_dist - EPS, base - stake_height)   # apex -> anchor
+    rope_length_m = (reach - arm_length_m) + rope_slack_mm * 1.0e-3
+
+An absolute `rope_length_m` param cannot span the geometry knobs' own
+ranges: `reach - arm_length_m` (the shortest rope that can possibly reach)
+moves with `length_factor`, `stake_dist`, and `stake_height`, so any single
+fixed length is infeasible across large parts of their sliders — scrub
+`length_factor` to its 0.8 UI minimum, or `stake_dist` to its 6.0 UI
+maximum, and a `rope_length_m` picked for the stock geometry raises "chain
+cannot reach the anchor" for every value in a reasonably sized UI range.
+Slack is feasible **by construction** instead: the total chain arc is always
+`reach + rope_slack_mm * 1e-3`, strictly more than `reach`, for every
+positive slack and every combination of the geometry knobs — the one
+remaining way to fail is `reach <= arm_length_m` (the wire ALONE already
+reaches past the anchor, so no rope length, slack or otherwise, rescues it);
+`rig_solutions()` raises a `ValueError` naming that constraint rather than
+clamping it away. It does not occur anywhere in the tested UI cross-product
+(`length_factor` in `{0.8, 1.25}` x `stake_dist` in `{1.0, 6.0}` x
+`stake_height` in `{0, 3}`, all eight corners, at stock `base`) — see the
+module tests — but a knob combination well outside those ranges (a stake
+dragged nearly under the apex, or a very long arm) can still reach it.
+
+This also turns the taut-limit's hypersensitivity from a liability into the
+slider's whole point: at the stock geometry the shortest feasible rope is
+~4.101182 m of arc, and (per the shallow-catenary relation
+`H ~ w*L^2/(8*sag)`) apex tension is only a fraction of a newton until slack
+shrinks to millimetre scale — not a numerical artifact, the ordinary
+behaviour of any lightly loaded near-taut catenary (see `catenary.py`'s own
+numerics discussion). `rope_slack_mm`'s range (0.05-200.0 mm) puts that
+whole taut-to-slack transition inside one slider: its low end is a
+hand-tensioned halyard's tens-of-newtons regime, its high end a visibly
+saggy rope carrying almost nothing. The stock default, 0.5 mm of slack,
+lands the stock apex tension at ~5.18 N (see the module tests for the exact
+number) — inside a real halyard's range without sitting at either the
+reach floor or the slider's own edge.
+
+Neither `tension_n` nor `rope_slack_mm` / `rope_weight_g_per_m` is hidden
+from the UI even though only one set is "live" per `rig_model`: the
+`ui_params` `hidden` hint (see `dipoles.invvee`'s `angle_deg` or
+`wire.doublet_ladder_tuner`) is an unconditional, per-param override applied
+once at schema-derivation time — it cannot key off another param's value, so
+there is no way to hide `tension_n` only when `rig_model == "anchored_rope"`.
+Both knobs stay visible; this docstring (and each param's own comment below)
+says which one is live in which model.
+
 Geometry
 --------
 The apex sits on the mast at `(0, 0, base)`. A short feed wire (the
@@ -69,8 +144,15 @@ move (the same one-knob-two-effects story as `dipoles.pota_invvee`, issue
 
 `chords_per_arm` (default 14) is the *geometric* fidelity knob, independent
 of the electrical mesh: it is passed straight through as
-`samples_per_segment = chords_per_arm + 1` to `solve_tensioned`, so the
-solver's own uniform-in-arc-length sampling IS the chord split.
+`samples_per_segment = chords_per_arm + 1` to the active model's solve, so
+the solver's own uniform-in-arc-length sampling IS the chord split.
+
+`build_wires()` emits ONLY the wire segment's chords as antenna geometry —
+`ChainSolution.segments[0].points` is always the wire, in both models. Under
+`rig_model="anchored_rope"` the rope is a second chain segment, but it is
+rigging, not a conductor: its shape is `rig_report()` diagnostics only and
+never reaches `build_wires()`, so the wire count emitted is identical
+between the two models.
 
 See also
 --------
@@ -80,11 +162,21 @@ conventions; `dipoles.invvee` for the base design and param conventions;
 Issue #698.
 """
 
+import math
 from types import MappingProxyType
 
 from antennaknobs import AntennaBuilder
-from antennaknobs.catenary import ChainSolution, solve_tensioned, weight_n_per_m
+from antennaknobs.catenary import (
+    ChainSegment,
+    ChainSolution,
+    solve_anchored,
+    solve_tensioned,
+    weight_n_per_m,
+)
 from antennaknobs.network import WIRES, Wire
+
+# lbf per newton (exact: 1 lbf = 0.45359237 kg * 9.80665 m/s^2).
+_N_PER_LBF = 4.4482216152605
 
 # Half-gap either side of the mast centreline for the driven feed wire — the
 # same value `dipoles.invvee` and `wire.doublet_ladder_tuner` use.
@@ -110,16 +202,41 @@ class Builder(AntennaBuilder):
             "freq": 28.47,
             "base": 7.0,
             "length_factor": 0.9719,
-            # Rope tension holding each arm's far end (issue #698 model 1).
-            # ~9 lbf: a realistic hand-tensioned dacron halyard pull.
+            # Which rig closure solves each arm (issue #698 unit 3):
+            # "halyard" (model 1, tensioned massless rope, tension_n live) or
+            # "anchored_rope" (model 2, heavy rope to a ground anchor,
+            # rope_slack_mm/rope_weight_g_per_m live). See the module
+            # docstring for why both knob sets stay visible in both models.
+            "rig_model": "halyard",
+            # Rope tension holding each arm's far end. LIVE under
+            # rig_model="halyard" only; ignored entirely under
+            # "anchored_rope", where tension is a rig_report() readout, not
+            # an input. ~9 lbf: a realistic hand-tensioned dacron halyard
+            # pull.
             "tension_n": 40.0,
-            # Stake position in the arm's vertical plane, horizontal
-            # distance from the mast and height above ground. Defaults
-            # chosen so hypot(stake_dist, base - stake_height) clears the
-            # longest arm the length_factor UI range can produce (see the
-            # module docstring and the feasibility test).
+            # Stake / ground-anchor position in the arm's vertical plane,
+            # horizontal distance from the mast and height above ground.
+            # Shared by both models (see the module docstring): model 1
+            # calls it the stake the halyard runs to; model 2 calls it the
+            # ground anchor the rope's far end must land on. Defaults chosen
+            # so hypot(stake_dist, base - stake_height) clears the longest
+            # arm the length_factor UI range can produce (see the module
+            # docstring and the feasibility test).
             "stake_dist": 2.94,
             "stake_height": 1.0,
+            # Rope take-up (issue #698 model 2), in MILLIMETRES of slack
+            # above the shortest rope that can reach the anchor at all — the
+            # actual winch knob, and feasible by construction across the
+            # geometry knobs' full ranges (see the module docstring for why
+            # an absolute rope_length_m param cannot be). LIVE under
+            # rig_model="anchored_rope" only; unused under "halyard". 0.5 mm
+            # lands the stock apex tension at ~5.18 N, inside a real
+            # halyard's range (see the module docstring's derivation and the
+            # module tests for the exact number).
+            "rope_slack_mm": 0.5,
+            # Rope weight per metre (issue #698 model 2): typical 3 mm
+            # dacron. LIVE under rig_model="anchored_rope" only.
+            "rope_weight_g_per_m": 5.5,
             # Chord count per arm: geometric fidelity, orthogonal to the
             # electrical mesh density (nominal_nsegs / auto_mesh).
             "chords_per_arm": 14,
@@ -129,9 +246,19 @@ class Builder(AntennaBuilder):
             "ui_params": MappingProxyType(
                 {
                     "length_factor": {"min": 0.8, "max": 1.25},
+                    "rig_model": {
+                        "enum_options": ("halyard", "anchored_rope"),
+                    },
                     "tension_n": {"min": 2.0, "max": 400.0},
                     "stake_dist": {"min": 1.0, "max": 6.0},
                     "stake_height": {"min": 0.0, "max": 3.0},
+                    # 0.05 mm (near the taut/high-tension extreme a real
+                    # cleated halyard shows) to 200 mm (visibly saggy,
+                    # carrying almost nothing) — feasible for every value at
+                    # every combination of the geometry knobs above (see the
+                    # module docstring's feasibility derivation).
+                    "rope_slack_mm": {"min": 0.05, "max": 200.0},
+                    "rope_weight_g_per_m": {"min": 1.0, "max": 50.0},
                     "chords_per_arm": {"min": 6, "max": 32, "step": 1},
                     "wire_type": {"enum_options": tuple(sorted(WIRES))},
                 }
@@ -141,11 +268,12 @@ class Builder(AntennaBuilder):
 
     def rig_solutions(self) -> ChainSolution:
         """Solve one arm's catenary (both arms are mirror images in y, so
-        one solve in the shared vertical plane covers both).
-
-        `build_wires()` calls this same method for its geometry, so the
+        one solve in the shared vertical plane covers both) under whichever
+        `rig_model` is selected. Single source of truth for both models —
+        `build_wires()` and `rig_report()` both call this same method, so the
         rigged shape and any diagnostics a caller reads off it (sag,
-        tension, arc length) can never drift apart.
+        tension, arc length) can never drift apart, and the two models can
+        never disagree about the wire segment.
         """
         spec = self.build_wire_material()
         if spec is None or not spec.weight_g_per_m:
@@ -158,16 +286,100 @@ class Builder(AntennaBuilder):
 
         arm_length_m = 0.25 * self.design_wavelength * self.length_factor
         wire_weight = weight_n_per_m(spec.weight_g_per_m)
+        apex = (_EPS, self.base)
+        samples_per_segment = int(self.chords_per_arm) + 1
+
+        if self.rig_model == "anchored_rope":
+            anchor = (self.stake_dist, self.stake_height)
+            reach = math.hypot(anchor[0] - apex[0], anchor[1] - apex[1])
+            if reach <= arm_length_m:
+                raise ValueError(
+                    f"{type(self).__name__}: the wire alone (arc length "
+                    f"{arm_length_m:.6g} m) already reaches past the anchor "
+                    f"(straight-line distance {reach:.6g} m) -- no rope "
+                    "length, slack or otherwise, can rescue this; move the "
+                    "anchor farther out (larger stake_dist / lower "
+                    "stake_height) or shorten the arm (smaller "
+                    "length_factor)."
+                )
+            # SLACK is the knob, not the rope's cut length (issue #698 unit
+            # 3 review fix): the cut length is derived from the CURRENT
+            # geometry every solve, never stored as its own param, so it is
+            # feasible by construction for every combination of the
+            # geometry knobs above -- see the module docstring's "knob is
+            # slack" section.
+            rope_length_m = reach - arm_length_m + self.rope_slack_mm * 1.0e-3
+            rope_weight = weight_n_per_m(self.rope_weight_g_per_m)
+            segments = (
+                ChainSegment(
+                    length_m=arm_length_m,
+                    weight_n_per_m=wire_weight,
+                    name="invvee_catenary_arm",
+                ),
+                ChainSegment(
+                    length_m=rope_length_m,
+                    weight_n_per_m=rope_weight,
+                    name="rope",
+                ),
+            )
+            return solve_anchored(
+                apex=apex,
+                segments=segments,
+                anchor=anchor,
+                samples_per_segment=samples_per_segment,
+            )
+
+        if self.rig_model != "halyard":
+            raise ValueError(
+                f"{type(self).__name__}: unknown rig_model {self.rig_model!r}; "
+                "expected 'halyard' or 'anchored_rope'"
+            )
 
         return solve_tensioned(
-            apex=(_EPS, self.base),
+            apex=apex,
             wire_length_m=arm_length_m,
             wire_weight_n_per_m=wire_weight,
             stake=(self.stake_dist, self.stake_height),
             rope_tension_n=self.tension_n,
-            samples_per_segment=int(self.chords_per_arm) + 1,
+            samples_per_segment=samples_per_segment,
             name="invvee_catenary_arm",
         )
+
+    def rig_report(self) -> dict:
+        """Tension/sag readout for whichever `rig_model` is active (issue
+        #698's "tension readout in N and lbf; sag reported" acceptance
+        criterion) — the same shape for both models so a caller (the web
+        adapter's solve response, issue #318's `wire_length_m` precedent)
+        never has to branch on which model produced it.
+
+        `wire_end_height_m` is the z coordinate of the wire segment's own
+        far end — the wire/rope junction under "anchored_rope", or simply
+        the wire's end (there is nothing downstream of it) under "halyard".
+        `rope_sag_m` / `rope_length_m` are `None` under "halyard" (there is
+        no rope segment there — model 1's rope is massless and its length is
+        never solved for, only its direction). Under "anchored_rope",
+        `rope_length_m` is the CUT length `rig_solutions()` derived from
+        `rope_slack_mm` and the current geometry — what you would actually
+        cut and tie off, read back off the already-solved chain rather than
+        recomputed (so it can never drift from what was actually solved).
+        """
+        solution = self.rig_solutions()
+        wire_seg = solution.segments[0]
+        rope_seg = solution.segments[1] if len(solution.segments) > 1 else None
+        apex_tension_n = solution.apex_tension
+        end_tension_n = solution.end_tension
+        return {
+            "rig_model": self.rig_model,
+            "apex_tension_n": apex_tension_n,
+            "apex_tension_lbf": apex_tension_n / _N_PER_LBF,
+            "end_tension_n": end_tension_n,
+            "end_tension_lbf": end_tension_n / _N_PER_LBF,
+            "horizontal_tension_n": solution.horizontal_tension_n,
+            "wire_sag_m": wire_seg.max_sag_m,
+            "rope_sag_m": rope_seg.max_sag_m if rope_seg is not None else None,
+            "rope_length_m": rope_seg.arc_length_m if rope_seg is not None else None,
+            "wire_end_height_m": float(wire_seg.points[-1][1]),
+        }
 
     # build_wire_material() is intentionally NOT overridden: the inherited
     # AntennaBuilder default already resolves a `wire_type` param via

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -50,6 +50,7 @@ skipped (no UI yet — the request can still override via re/im dict).
 from __future__ import annotations
 
 import importlib
+import logging
 import math
 import os
 import pathlib
@@ -105,6 +106,8 @@ from .examples._base import (
 )
 
 C_LIGHT = 299_792_458.0
+
+_logger = logging.getLogger(__name__)
 
 # Sentinel impedance for an open-circuited feed on the wire protocol. The
 # network core reports a true open (e.g. a series matchbox capacitor slider
@@ -1313,6 +1316,35 @@ def _wire_material_results(builder) -> dict:
     }
 
 
+def _rig_report_results(builder) -> dict:
+    """Rigging tension/sag readout (issue #698 unit 3), surfaced under "rig"
+    in the same solve responses that carry `_wire_material_results`. {} for
+    every design without a `rig_report()` (nearly all of them) — the
+    per-design method, not a registry flag, is the discovery mechanism, same
+    idiom as `build_wire_material()` for `_wire_material_results`.
+
+    A mid-scrub rig can be geometrically infeasible (e.g. the
+    `dipoles.invvee_catenary` anchored-rope model with a rope too short to
+    reach its anchor) independently of whether the antenna solve itself
+    succeeded or failed — the readout is garnish on top of a solve that
+    already stands on its own, so a `rig_report()` failure must never fail
+    the response.
+    Debug-logged and omitted rather than surfaced as an "error" key: the
+    solve response already carries no other per-field error slots, and the
+    solve's own success/failure is the signal that matters to the caller.
+    """
+    rig_report = getattr(builder, "rig_report", None)
+    if not callable(rig_report):
+        return {}
+    try:
+        return {"rig": rig_report()}
+    except Exception:
+        _logger.debug(
+            "rig_report() failed for %r", type(builder).__name__, exc_info=True
+        )
+        return {}
+
+
 def _make_momwire_engine(req: dict, builder, cancel=None):
     # "bspline" is the default and the fallback for unknown/retired model
     # names (a stale client may still send "triangular").
@@ -2239,6 +2271,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             # ground losses live inside P_in, so no efficiency multiply).
             "input_power_w": float(eng.input_power()),
             **_wire_material_results(builder),
+            **_rig_report_results(builder),
         }
         if planes is not None:
             # Measurement plane (issue #652 c): which port this solve is
@@ -2419,6 +2452,7 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             "power_budget": _budget_rows(eng, builder),
             "input_power_w": float(getattr(eng, "_excited_p_in", None) or 0.0),
             **_wire_material_results(builder),
+            **_rig_report_results(builder),
         }
         if planes is not None:
             # Same plane fields as the momwire path (issue #652 c).

--- a/tests/test_catenary.py
+++ b/tests/test_catenary.py
@@ -1,0 +1,628 @@
+"""Tests for the hanging-chain equilibrium solver (``catenary.py``, issue #698).
+
+Every assertion here is checked against an *independently written* closed form
+— the textbook catenary relations spelled out fresh in the test — rather than
+against whatever the module happened to compute.  The oracles are:
+
+  * symmetric level span: sag ``a·(cosh(d/2a) − 1)``, arc ``2a·sinh(d/2a)``,
+    and the tension distribution ``T = w·(z − c)``;
+  * an asymmetric span built from hand-picked catenary parameters ``u₀, u₁``;
+  * global statics: the two support reactions sum to the chain's weight;
+  * the taut-string limit ``sag = w·d²/(8H)`` for the small-sag branch.
+
+One numerical caution worth stating up front: the *oracle* itself has to be
+written stably.  ``a·(cosh(u) − 1)`` cancels catastrophically once ``u`` is
+tiny (the taut regime), so the taut tests use the algebraically identical
+``2a·sinh(u/2)²``, which does not.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+import antennaknobs.catenary as catenary
+from antennaknobs.catenary import (
+    GRAVITY,
+    TAUT_D,
+    TAUT_SAG_D,
+    ChainSegment,
+    SegmentMarch,
+    chord_sag,
+    march_continuous,
+    solve_anchored,
+    solve_chain,
+    solve_tensioned,
+    weight_n_per_m,
+)
+
+# A 14-awg-ish wire and a heavier halyard, in newtons per metre.
+W_WIRE = weight_n_per_m(7.37)
+W_ROPE = weight_n_per_m(30.0)
+
+
+# --------------------------------------------------------------------------
+# Closed-form oracles for the marching kernel
+# --------------------------------------------------------------------------
+
+
+def _symmetric_state(a, w, span):
+    """Tension state at the LEFT end of a level span of horizontal width
+    ``span`` whose catenary parameter is ``a``.
+
+    The vertex sits at mid-span, so the left end is at ``u₀ = −span/2a`` and
+    ``V₀ = H·sinh(u₀)``.  Returns ``(H, V0, arc_length)``.
+    """
+    h = a * w
+    u0 = -span / (2.0 * a)
+    return h, h * math.sinh(u0), 2.0 * a * math.sinh(span / (2.0 * a))
+
+
+def test_symmetric_span_matches_textbook_sag_arc_and_tension():
+    """Level span: sag, arc length and T = w·(z − c) all reproduced."""
+    a, w, span = 40.0, 0.35, 30.0
+    h, v0, arc = _symmetric_state(a, w, span)
+
+    # Independent oracles.
+    assert arc == pytest.approx(2.0 * a * math.sinh(span / (2.0 * a)), rel=1e-15)
+    sag_oracle = a * (math.cosh(span / (2.0 * a)) - 1.0)
+
+    n = 201  # odd, so a sample lands exactly on the vertex
+    sol = solve_chain(
+        apex=(0.0, 0.0),
+        tension=(h, v0),
+        segments=(ChainSegment(arc, w, "span"),),
+        samples_per_segment=n,
+    )
+
+    # The far end is level with the start, one full span away.
+    assert sol.end_point[0] == pytest.approx(span, rel=1e-12)
+    assert sol.end_point[1] == pytest.approx(0.0, abs=1e-12 * span)
+
+    # Chord is level here, so the perpendicular sag IS the vertical sag.
+    assert sol.max_sag_m == pytest.approx(sag_oracle, rel=1e-12)
+
+    # Tension distribution: with z measured from the left end, the directrix
+    # sits at c = −a·cosh(u₀), so T(s) = w·(z(s) − c) must equal √(H² + V²).
+    c = -a * math.cosh(-span / (2.0 * a))
+    pts = sol.segments[0].points
+    for i, (_, z) in enumerate(pts):
+        s = arc * i / (n - 1)
+        assert w * (z - c) == pytest.approx(math.hypot(h, v0 + w * s), rel=1e-12)
+
+    # The vertex (deepest point) is at mid-span and mid-arc.
+    lowest = pts[np.argmin(pts[:, 1])]
+    assert lowest[0] == pytest.approx(span / 2.0, rel=1e-9)
+    assert lowest[1] == pytest.approx(-sag_oracle, rel=1e-9)
+
+
+def test_asymmetric_span_matches_hand_computed_catenary():
+    """Two points at different heights, built from chosen ``u₀``/``u₁``."""
+    a, w = 5.0, 0.3
+    h = a * w
+    u0, u1 = -0.8, 0.6
+
+    # Hand-computed from z = a·cosh(u) + c, s = a·sinh(u), x = a·u + const.
+    dx_oracle = a * (u1 - u0)
+    dz_oracle = a * (math.cosh(u1) - math.cosh(u0))
+    arc_oracle = a * (math.sinh(u1) - math.sinh(u0))
+    v0 = h * math.sinh(u0)
+
+    sol = solve_chain(
+        apex=(2.0, 9.0),
+        tension=(h, v0),
+        segments=(ChainSegment(arc_oracle, w, "span"),),
+        samples_per_segment=401,
+    )
+    assert sol.end_point[0] == pytest.approx(2.0 + dx_oracle, rel=1e-13)
+    assert sol.end_point[1] == pytest.approx(9.0 + dz_oracle, rel=1e-13)
+
+    # End tension vector (the far support's pull) is (H, V1) with V1 = H·sinh(u₁).
+    assert sol.end_tension_vector[0] == pytest.approx(h, rel=1e-13)
+    assert sol.end_tension_vector[1] == pytest.approx(h * math.sinh(u1), rel=1e-12)
+    assert sol.end_tension == pytest.approx(h * math.cosh(u1), rel=1e-12)
+    assert sol.apex_tension == pytest.approx(h * math.cosh(u0), rel=1e-12)
+
+    # Perpendicular sag, hand-derived: the chord has slope m = Δz/Δx; the
+    # tangent matches it at u* = asinh(m); the vertical gap there is
+    # a·[cosh u₀ − cosh u* + m·(u* − u₀)], and the perpendicular offset is that
+    # gap foreshortened by Δx/‖chord‖.
+    m = dz_oracle / dx_oracle
+    u_star = math.asinh(m)
+    vertical = a * (math.cosh(u0) - math.cosh(u_star) + m * (u_star - u0))
+    chord = math.hypot(dx_oracle, dz_oracle)
+    assert sol.max_sag_m == pytest.approx(vertical * dx_oracle / chord, rel=1e-11)
+
+
+def test_steeply_descending_arm_with_negative_v0():
+    """An arm that drops steeply (V0 strongly negative) marches correctly."""
+    a, w = 3.0, 0.5
+    h = a * w
+    u0, u1 = -2.5, -1.0
+    sol = solve_chain(
+        apex=(0.0, 0.0),
+        tension=(h, h * math.sinh(u0)),
+        segments=(ChainSegment(a * (math.sinh(u1) - math.sinh(u0)), w),),
+        samples_per_segment=51,
+    )
+    # Still descending at the end, so the whole arc is below the start.
+    assert sol.end_point[1] < 0.0
+    assert sol.end_point[0] == pytest.approx(a * (u1 - u0), rel=1e-13)
+    assert sol.end_point[1] == pytest.approx(
+        a * (math.cosh(u1) - math.cosh(u0)), rel=1e-13
+    )
+    # x is strictly increasing along the chain whenever H > 0.
+    assert np.all(np.diff(sol.segments[0].points[:, 0]) > 0.0)
+
+
+def test_massless_segment_marches_straight():
+    """``w = 0`` degenerates to a straight line along the tension direction."""
+    h, v0, length = 12.0, -5.0, 7.0
+    sol = solve_chain(
+        apex=(1.0, 4.0),
+        tension=(h, v0),
+        segments=(ChainSegment(length, 0.0, "halyard"),),
+        samples_per_segment=17,
+    )
+    t = math.hypot(h, v0)
+    assert sol.end_point[0] == pytest.approx(1.0 + length * h / t, rel=1e-14)
+    assert sol.end_point[1] == pytest.approx(4.0 + length * v0 / t, rel=1e-14)
+    assert sol.max_sag_m == 0.0
+    # Tension is unchanged along a weightless span.
+    assert sol.end_tension == pytest.approx(t, rel=1e-14)
+    # Sampled polyline length equals the arc length exactly for a line.
+    assert sol.segments[0].polyline_length_m == pytest.approx(length, rel=1e-13)
+
+
+def test_march_rejects_non_positive_horizontal_tension():
+    for bad in (0.0, -3.0):
+        with pytest.raises(ValueError, match="horizontal tension must be positive"):
+            march_continuous((0.0, 0.0), (bad, -1.0), (ChainSegment(5.0, W_WIRE),))
+
+
+def test_march_rejects_degenerate_sampling_and_empty_chain():
+    with pytest.raises(ValueError, match="samples_per_segment"):
+        march_continuous((0.0, 0.0), (5.0, -1.0), (ChainSegment(5.0, W_WIRE),), 1)
+    with pytest.raises(ValueError, match="at least one segment"):
+        march_continuous((0.0, 0.0), (5.0, -1.0), ())
+
+
+# --------------------------------------------------------------------------
+# Taut-limit numerics
+# --------------------------------------------------------------------------
+
+
+def test_taut_limit_solves_without_overflow_and_matches_parabola():
+    """H/w ≈ 1e9 × span: the regime where the naive cosh form dies."""
+    span, w = 20.0, W_WIRE
+    a = 1.0e9 * span
+    h, v0, arc = _symmetric_state(a, w, span)
+    assert h / w == pytest.approx(a, rel=1e-15)
+
+    sol = solve_chain(
+        apex=(0.0, 0.0),
+        tension=(h, v0),
+        segments=(ChainSegment(arc, w, "taut"),),
+        samples_per_segment=101,
+    )
+    assert np.all(np.isfinite(sol.segments[0].points))
+    assert sol.end_point[0] == pytest.approx(span, rel=1e-14)
+    assert sol.end_point[1] == pytest.approx(0.0, abs=1e-12)
+
+    # Stable form of a·(cosh(u) − 1); the naive one has already cancelled away
+    # every significant digit at u = 5e-10.
+    u = span / (2.0 * a)
+    sag_oracle = 2.0 * a * math.sinh(u / 2.0) ** 2
+    parabolic = w * span**2 / (8.0 * h)
+    assert sag_oracle == pytest.approx(parabolic, rel=1e-12)
+    assert sol.max_sag_m == pytest.approx(parabolic, rel=1e-9)
+
+
+def test_offset_branches_agree_across_the_taut_threshold(monkeypatch):
+    """The exact and series displacement branches meet seamlessly at TAUT_D."""
+    w, length = 0.4, 12.0
+    h = w * length / TAUT_D  # exactly on the threshold
+    for slope0 in (0.0, -0.7, 1.5, -3.0):
+        v0 = slope0 * h
+        monkeypatch.setattr(catenary, "TAUT_D", 0.0)  # force exact branch
+        exact = catenary._offset(h, v0, w, length)
+        monkeypatch.setattr(catenary, "TAUT_D", math.inf)  # force series branch
+        series = catenary._offset(h, v0, w, length)
+        assert exact[0] == pytest.approx(series[0], rel=1e-11)
+        assert exact[1] == pytest.approx(series[1], rel=1e-9, abs=1e-15 * length)
+
+
+def test_sag_branches_agree_across_the_taut_sag_threshold(monkeypatch):
+    """Same seamlessness check for the far touchier perpendicular sag."""
+    w, length = 0.4, 12.0
+    for d in (TAUT_SAG_D, 10.0 * TAUT_SAG_D, 0.1 * TAUT_SAG_D):
+        h = w * length / d
+        for slope0 in (0.0, -0.7, 1.5):
+            v0 = slope0 * h
+            monkeypatch.setattr(catenary, "TAUT_SAG_D", 0.0)
+            exact = chord_sag(h, v0, w, length)
+            monkeypatch.setattr(catenary, "TAUT_SAG_D", math.inf)
+            series = chord_sag(h, v0, w, length)
+            assert exact == pytest.approx(series, rel=1e-9)
+
+
+def test_sag_reduces_to_the_level_span_parabola():
+    """``w·d²/(8H)`` for a level span, checked well inside the taut branch."""
+    w, span = 0.4, 25.0
+    a = 5.0e7 * span
+    h, v0, arc = _symmetric_state(a, w, span)
+    assert chord_sag(h, v0, w, arc) == pytest.approx(w * span**2 / (8.0 * h), rel=1e-9)
+
+
+# --------------------------------------------------------------------------
+# Sampling consistency
+# --------------------------------------------------------------------------
+
+
+def test_sampled_polyline_length_converges_to_the_arc_length():
+    """Chord-sum length approaches L_i, and the error falls like 1/n²."""
+    a, w, span = 12.0, 0.6, 25.0  # deliberately saggy, so the error is visible
+    h, v0, arc = _symmetric_state(a, w, span)
+    errors = []
+    for n in (9, 17, 33, 65, 129):
+        sol = solve_chain(
+            apex=(0.0, 0.0),
+            tension=(h, v0),
+            segments=(ChainSegment(arc, w),),
+            samples_per_segment=n,
+        )
+        shape = sol.segments[0]
+        assert shape.arc_length_m == pytest.approx(arc, rel=1e-15)
+        assert shape.polyline_length_m < arc  # chords cut corners
+        errors.append(arc - shape.polyline_length_m)
+    for coarse, fine in zip(errors, errors[1:]):
+        assert fine < coarse / 3.5  # second-order: each halving gains ~4x
+    assert errors[-1] / arc < 1e-5
+
+
+def test_multi_segment_polyline_is_continuous_at_the_junction():
+    sol = solve_anchored(
+        apex=(0.0, 12.0),
+        segments=(
+            ChainSegment(12.0, W_WIRE, "wire"),
+            ChainSegment(14.0, W_ROPE, "rope"),
+        ),
+        anchor=(20.0, 0.0),
+        samples_per_segment=25,
+    )
+    assert len(sol.junctions) == 1
+    junction = np.array(sol.junctions[0])
+    assert sol.segments[0].points[-1] == pytest.approx(junction, rel=1e-12)
+    assert sol.segments[1].points[0] == pytest.approx(junction, rel=1e-12)
+    # ``polyline`` drops the duplicated junction sample.
+    assert sol.polyline.shape == (25 + 25 - 1, 2)
+    assert sol.total_arc_length_m == pytest.approx(26.0, rel=1e-15)
+
+
+# --------------------------------------------------------------------------
+# Model 2 — anchored chain
+# --------------------------------------------------------------------------
+
+
+def _anchored(rope_len, *, samples=101):
+    return solve_anchored(
+        apex=(0.0, 12.0),
+        segments=(
+            ChainSegment(12.0, W_WIRE, "wire"),
+            ChainSegment(rope_len, W_ROPE, "rope"),
+        ),
+        anchor=(20.0, 0.0),
+        samples_per_segment=samples,
+    )
+
+
+def test_anchored_lands_on_the_anchor():
+    sol = _anchored(14.0)
+    assert sol.end_point[0] == pytest.approx(20.0, abs=1e-9)
+    assert sol.end_point[1] == pytest.approx(0.0, abs=1e-9)
+    assert sol.polyline[0] == pytest.approx(np.array([0.0, 12.0]))
+    assert sol.polyline[-1] == pytest.approx(np.array([20.0, 0.0]), abs=1e-9)
+
+
+def test_anchored_support_reactions_sum_to_the_weight():
+    """Global statics: F_apex + F_end = (0, Σ Lᵢ·wᵢ), horizontals cancel."""
+    for rope_len in (13.0, 16.0, 22.0):
+        sol = _anchored(rope_len)
+        weight_oracle = 12.0 * W_WIRE + rope_len * W_ROPE
+        assert sol.total_weight_n == pytest.approx(weight_oracle, rel=1e-15)
+        fx = sol.apex_tension_vector[0] + sol.end_tension_vector[0]
+        fz = sol.apex_tension_vector[1] + sol.end_tension_vector[1]
+        assert fx == pytest.approx(0.0, abs=1e-12 * weight_oracle)
+        assert fz == pytest.approx(weight_oracle, rel=1e-12)
+        # Magnitudes agree with the vectors they came from.
+        assert sol.apex_tension == pytest.approx(math.hypot(*sol.apex_tension_vector))
+        assert sol.end_tension == pytest.approx(math.hypot(*sol.end_tension_vector))
+        # The shared H is what both reactions carry horizontally.
+        assert abs(sol.apex_tension_vector[0]) == pytest.approx(
+            sol.horizontal_tension_n, rel=1e-14
+        )
+
+
+def test_anchored_tension_is_continuous_across_the_junction():
+    """Tension is an output; the wire's end state is the rope's start state."""
+    sol = _anchored(14.0)
+    wire, rope = sol.segments
+    assert wire.end_tension_vector == pytest.approx(rope.start_tension_vector)
+    # Vertical tension accumulates exactly the weight hung below it.
+    assert rope.end_tension_vector[1] - rope.start_tension_vector[1] == pytest.approx(
+        14.0 * W_ROPE, rel=1e-12
+    )
+
+
+def test_anchored_rope_takeup_raises_tension_and_reduces_sag():
+    """Winching the rope in (shorter L_r) pulls the chain taut.
+
+    Sag is measured perpendicular to each segment's OWN chord, which is not
+    monotone over the whole slack range: a very slack chain swings its wire
+    chord toward the vertical, and a near-vertical chord has little
+    perpendicular offset no matter how loose the wire is.  The monotone claim
+    belongs to the taut half of the range, which is where any real rig lives.
+    """
+    lengths = [14.0, 13.0, 12.5, 12.0, 11.6, 11.4]
+    sols = [_anchored(length) for length in lengths]
+    tensions = [s.apex_tension for s in sols]
+    h_values = [s.horizontal_tension_n for s in sols]
+    wire_sags = [s.segments[0].max_sag_m for s in sols]
+    rope_sags = [s.segments[1].max_sag_m for s in sols]
+
+    for prev, nxt in zip(tensions, tensions[1:]):
+        assert nxt > prev
+    for prev, nxt in zip(h_values, h_values[1:]):
+        assert nxt > prev
+    for prev, nxt in zip(wire_sags, wire_sags[1:]):
+        assert nxt < prev
+    for prev, nxt in zip(rope_sags, rope_sags[1:]):
+        assert nxt < prev
+
+
+def test_anchored_rejects_a_rope_too_short_to_reach():
+    reach = math.hypot(20.0, 12.0)
+    with pytest.raises(ValueError, match="chain cannot reach the anchor"):
+        _anchored(reach - 12.0 - 0.5)
+    # Exactly straight is rejected too: no equilibrium for an inextensible chain.
+    with pytest.raises(ValueError, match="chain cannot reach the anchor"):
+        _anchored(reach - 12.0)
+
+
+def test_anchored_rejects_a_vertical_hanging_chain():
+    with pytest.raises(ValueError, match="horizontally beyond the apex"):
+        solve_anchored(
+            apex=(0.0, 12.0),
+            segments=(ChainSegment(14.0, W_WIRE),),
+            anchor=(0.0, 0.0),
+        )
+
+
+def test_anchored_rejects_a_weightless_chain():
+    with pytest.raises(ValueError, match="weightless chain has no catenary"):
+        solve_anchored(
+            apex=(0.0, 12.0),
+            segments=(ChainSegment(14.0, 0.0), ChainSegment(14.0, 0.0)),
+            anchor=(10.0, 0.0),
+        )
+
+
+def test_anchored_rejects_an_empty_chain():
+    with pytest.raises(ValueError, match="at least one segment"):
+        solve_anchored(apex=(0.0, 0.0), segments=(), anchor=(1.0, -1.0))
+
+
+# --------------------------------------------------------------------------
+# Model 1 — tensioned halyard
+# --------------------------------------------------------------------------
+
+APEX = (0.0, 10.0)
+STAKE = (9.0, 1.0)
+WIRE_LEN = 10.0
+
+
+def _tensioned(tension, *, stake=STAKE, samples=101):
+    return solve_tensioned(
+        apex=APEX,
+        wire_length_m=WIRE_LEN,
+        wire_weight_n_per_m=W_WIRE,
+        stake=stake,
+        rope_tension_n=tension,
+        samples_per_segment=samples,
+    )
+
+
+def test_tensioned_closure_is_satisfied():
+    """The end tension vector really is T_rope pointing at the stake."""
+    for tension in (2.0, 40.0, 900.0):
+        sol = _tensioned(tension)
+        ex, ez = sol.end_point
+        rx, rz = STAKE[0] - ex, STAKE[1] - ez
+        dist = math.hypot(rx, rz)
+        assert sol.end_tension_vector[0] == pytest.approx(
+            tension * rx / dist, rel=1e-9, abs=1e-9 * tension
+        )
+        assert sol.end_tension_vector[1] == pytest.approx(
+            tension * rz / dist, rel=1e-9, abs=1e-9 * tension
+        )
+        assert sol.end_tension == pytest.approx(tension, rel=1e-9)
+
+
+def test_tensioned_support_reactions_sum_to_the_weight():
+    sol = _tensioned(40.0)
+    weight_oracle = WIRE_LEN * W_WIRE
+    fx = sol.apex_tension_vector[0] + sol.end_tension_vector[0]
+    fz = sol.apex_tension_vector[1] + sol.end_tension_vector[1]
+    assert fx == pytest.approx(0.0, abs=1e-12 * weight_oracle)
+    assert fz == pytest.approx(weight_oracle, rel=1e-9)
+
+
+def test_tensioned_taut_limit_approaches_the_straight_chord():
+    """T_rope → ∞ converges to the straight arm — the invvee oracle."""
+    reach = math.hypot(STAKE[0] - APEX[0], STAKE[1] - APEX[1])
+    ux = (STAKE[0] - APEX[0]) / reach
+    uz = (STAKE[1] - APEX[1]) / reach
+    chord_end = (APEX[0] + WIRE_LEN * ux, APEX[1] + WIRE_LEN * uz)
+
+    previous_miss = math.inf
+    for tension in (5.0e2, 5.0e4, 5.0e6, 5.0e8):
+        sol = _tensioned(tension)
+        miss = math.hypot(
+            sol.end_point[0] - chord_end[0], sol.end_point[1] - chord_end[1]
+        )
+        assert miss < previous_miss / 50.0  # ~1/T convergence, two decades a step
+        previous_miss = miss
+        # Sag falls off like the taut-string result q·L²/(8·T), where the
+        # transverse load q is only the component of the weight perpendicular
+        # to this (45°-inclined) arm: q = w·cosθ = w·ux.
+        assert sol.max_sag_m == pytest.approx(
+            W_WIRE * ux * WIRE_LEN**2 / (8.0 * tension), rel=2e-2
+        )
+    assert previous_miss < 1e-7
+    # And the whole arc, not just its endpoint, has collapsed onto the chord.
+    assert _tensioned(5.0e8).max_sag_m < 1e-8
+
+
+def test_tensioned_more_tension_means_less_sag():
+    sags = [_tensioned(t).max_sag_m for t in (5.0, 20.0, 80.0, 320.0)]
+    for prev, nxt in zip(sags, sags[1:]):
+        assert nxt < prev
+
+
+def test_tensioned_solves_across_twenty_decades_of_tension():
+    """Knob-scrub robustness: nothing in the usable range may throw."""
+    for tension in (1e-6, 1e-3, 1e-1, 1e1, 1e3, 1e6, 1e9, 1e12):
+        sol = _tensioned(tension, samples=9)
+        assert sol.residual < 1e-9
+        assert math.isfinite(sol.horizontal_tension_n)
+        assert sol.horizontal_tension_n > 0.0
+
+
+def test_tensioned_rejects_a_stake_not_beyond_the_apex():
+    for stake in ((0.0, 1.0), (-4.0, 1.0)):
+        with pytest.raises(ValueError, match="horizontally beyond the apex"):
+            _tensioned(500.0, stake=stake)
+
+
+def test_tensioned_rejects_a_stake_the_wire_would_overshoot():
+    """A stake nearer than the wire is long has no equilibrium at any tension:
+    the taut wire runs past it and the rope would have to pull backwards."""
+    near = (4.5, 6.0)
+    assert math.hypot(near[0] - APEX[0], near[1] - APEX[1]) < WIRE_LEN
+    for tension in (5.0, 50.0, 5000.0):
+        with pytest.raises(ValueError, match="no equilibrium found"):
+            _tensioned(tension, stake=near)
+
+
+def test_tensioned_rejects_impossible_inputs():
+    with pytest.raises(ValueError, match="rope tension must be positive"):
+        _tensioned(0.0)
+    with pytest.raises(ValueError, match="rope tension must be positive"):
+        _tensioned(-5.0)
+    with pytest.raises(ValueError, match="weightless wire has no catenary"):
+        solve_tensioned(
+            apex=APEX,
+            wire_length_m=WIRE_LEN,
+            wire_weight_n_per_m=0.0,
+            stake=STAKE,
+            rope_tension_n=50.0,
+        )
+    with pytest.raises(ValueError, match="wire length must be positive"):
+        solve_tensioned(
+            apex=APEX,
+            wire_length_m=0.0,
+            wire_weight_n_per_m=W_WIRE,
+            stake=STAKE,
+            rope_tension_n=50.0,
+        )
+
+
+def test_tensioned_keeps_the_cut_length_fixed_as_tension_changes():
+    """The electrical knob must not move when the mechanical one does."""
+    for tension in (3.0, 300.0, 30000.0):
+        sol = _tensioned(tension, samples=401)
+        assert sol.segments[0].arc_length_m == WIRE_LEN
+        assert sol.segments[0].polyline_length_m == pytest.approx(WIRE_LEN, rel=1e-6)
+
+
+# --------------------------------------------------------------------------
+# Segment validation and the kernel seam
+# --------------------------------------------------------------------------
+
+
+def test_chain_segment_validates_its_inputs():
+    with pytest.raises(ValueError, match="arc length must be positive"):
+        ChainSegment(0.0, W_WIRE)
+    with pytest.raises(ValueError, match="arc length must be positive"):
+        ChainSegment(-2.0, W_WIRE)
+    with pytest.raises(ValueError, match="weight per metre must be non-negative"):
+        ChainSegment(5.0, -1.0, "rope")
+
+
+def test_weight_conversion_uses_standard_gravity():
+    assert weight_n_per_m(1000.0) == pytest.approx(GRAVITY)
+    assert weight_n_per_m(7.37) == pytest.approx(7.37e-3 * 9.80665)
+
+
+def test_solvers_accept_an_alternative_marching_kernel():
+    """The kernel is a seam: any callable with the signature can stand in.
+
+    This stands in for the discrete funicular kernel that will land later —
+    here a thin wrapper that just counts calls, proving the shooting wrappers
+    route every march through the injected kernel and nothing else.
+    """
+    calls = []
+
+    def counting_kernel(start, tension, segments, samples_per_segment=33):
+        calls.append(samples_per_segment)
+        return march_continuous(start, tension, segments, samples_per_segment)
+
+    sol = solve_tensioned(
+        apex=APEX,
+        wire_length_m=WIRE_LEN,
+        wire_weight_n_per_m=W_WIRE,
+        stake=STAKE,
+        rope_tension_n=100.0,
+        samples_per_segment=64,
+        kernel=counting_kernel,
+    )
+    assert calls  # every march went through the injected kernel
+    assert calls[-1] == 64  # the final, full-resolution march
+    assert set(calls[:-1]) == {2}  # residual evaluations sample only endpoints
+    assert sol.segments[0].points.shape == (64, 2)
+
+    calls.clear()
+    anchored = solve_anchored(
+        apex=(0.0, 12.0),
+        segments=(ChainSegment(12.0, W_WIRE), ChainSegment(14.0, W_ROPE)),
+        anchor=(20.0, 0.0),
+        samples_per_segment=48,
+        kernel=counting_kernel,
+    )
+    assert calls[-1] == 48
+    assert anchored.polyline.shape == (48 + 48 - 1, 2)
+
+
+def test_segment_march_carries_the_raw_kernel_contract():
+    marched = march_continuous(
+        (0.0, 0.0), (5.0, -2.0), (ChainSegment(4.0, 0.5), ChainSegment(3.0, 0.9)), 11
+    )
+    assert len(marched) == 2
+    for m in marched:
+        assert isinstance(m, SegmentMarch)
+        assert m.points.shape == (11, 2)
+        assert m.end_point == pytest.approx(tuple(m.points[-1]))
+    # H is shared; V accumulates the weight of each span in turn.
+    assert marched[0].end_tension[0] == 5.0
+    assert marched[1].end_tension[0] == 5.0
+    assert marched[0].end_tension[1] == pytest.approx(-2.0 + 4.0 * 0.5)
+    assert marched[1].end_tension[1] == pytest.approx(-2.0 + 4.0 * 0.5 + 3.0 * 0.9)
+    # Segment 2 starts where segment 1 ended.
+    assert marched[1].points[0] == pytest.approx(np.array(marched[0].end_point))
+
+
+def test_chain_solution_reports_the_worst_segment_sag():
+    sol = _anchored(20.0)
+    assert sol.max_sag_m == max(s.max_sag_m for s in sol.segments)
+    assert sol.segments[1].max_sag_m > sol.segments[0].max_sag_m
+    assert sol.segments[0].chord_length_m < sol.segments[0].arc_length_m

--- a/tests/test_invvee_catenary.py
+++ b/tests/test_invvee_catenary.py
@@ -1,0 +1,232 @@
+"""dipoles.invvee_catenary (issue #698, unit 2): the sagging inv-vee arm.
+
+Engine-agnostic impedance checks follow the `tests/test_pota_invvee.py`
+precedent — build a `MomwireEngine` directly over the default (finite)
+ground and read `.impedance()`.
+"""
+
+import math
+
+import pytest
+
+from antennaknobs.designs.dipoles.invvee_catenary import Builder
+from antennaknobs.engines.momwire import MomwireEngine
+from antennaknobs.engines.pynec import DEFAULT_GROUND
+from antennaknobs.network import Wire
+
+_EPS = 0.05
+
+
+def _builder(**params):
+    b = Builder()
+    for k, v in params.items():
+        setattr(b, k, v)
+    return b
+
+
+def _z(builder):
+    return MomwireEngine(builder, ground=DEFAULT_GROUND).impedance()[0]
+
+
+# ---------------------------------------------------------------------------
+# 1. Taut-limit regression vs a hand-built straight-arm oracle
+# ---------------------------------------------------------------------------
+
+
+def test_taut_limit_matches_straight_arm_oracle():
+    """As tension_n -> infinity, `solve_tensioned` converges to the straight
+    chord of the same arc length running from the apex toward the stake
+    (the module docstring's built-in regression oracle). Build that straight
+    chord BY HAND -- not by calling the catenary solver -- so the comparison
+    is independent of the solver's own numerics, then chord it into the same
+    number of straight segments (`chords_per_arm`) that `build_wires()` uses,
+    so both geometries get the identical auto_mesh segment counts per chord
+    and the comparison isolates the sag physics, not a mesh-density delta.
+    """
+    b = _builder(tension_n=1.0e5)
+    z_catenary = _z(b)
+
+    n = int(b.chords_per_arm)
+    apex_x, apex_z = _EPS, b.base
+    dx = b.stake_dist - apex_x
+    dz = b.stake_height - apex_z
+    reach = math.hypot(dx, dz)
+    ux, uz = dx / reach, dz / reach
+    arm_length_m = 0.25 * b.design_wavelength * b.length_factor
+
+    class StraightArmOracle(Builder):
+        """Same feed wire + chord count as invvee_catenary, but each arm is
+        the exact analytic straight chord of `arm_length_m` toward the
+        stake -- the T -> infinity limit, computed without touching
+        catenary.py at all."""
+
+        def build_wires(self):
+            plane_points = []
+            for i in range(n + 1):
+                s = arm_length_m * i / n
+                plane_points.append((apex_x + s * ux, apex_z + s * uz))
+            wires = [Wire((0.0, -_EPS, apex_z), (0.0, _EPS, apex_z), ex=1 + 0j)]
+            for sign in (1.0, -1.0):
+                arm_pts = [(0.0, sign * h, z) for h, z in plane_points]
+                wires.extend(Wire(p0, p1) for p0, p1 in zip(arm_pts[:-1], arm_pts[1:]))
+            return wires
+
+    z_oracle = _z(StraightArmOracle(dict(b._params)))
+
+    rel_err = abs(z_catenary - z_oracle) / abs(z_oracle)
+    assert rel_err < 0.01, (z_catenary, z_oracle, rel_err)
+
+
+# ---------------------------------------------------------------------------
+# 2. Chord-count convergence
+# ---------------------------------------------------------------------------
+
+
+def test_chord_count_convergence():
+    """More chords per arm means a finer polyline approximation of the same
+    smooth catenary curve, so impedance should settle down as chords_per_arm
+    grows, at a fixed electrical mesh density (nominal_nsegs untouched).
+
+    16/32/64 (doubling, well above the UI slider's 6-32 sticker range) are
+    used rather than the UI's own 8/16/24 window: at very low absolute
+    per-chord segment counts (1-3 segments, since auto_mesh rounds each
+    short chord's own count independently -- issue #630's per-wire auto_mesh
+    contract), integer rounding on individual chords aliases the *total*
+    electrical segment count non-monotonically with chords_per_arm (e.g.
+    8 chords can auto-mesh to MORE total segments than 16 chords, because
+    each of the 8 longer chords rounds up to 3 segments while each of the 16
+    shorter ones rounds down to 1). That is a mesh-density artifact, not the
+    curve-fidelity convergence this test is after, and it clears up once the
+    per-chord segment counts are comfortably above 1 -- doubling from 16
+    confirms strictly shrinking steps.
+    """
+    zs = {n: _z(_builder(chords_per_arm=n)) for n in (16, 32, 64)}
+    step1 = abs(zs[32] - zs[16])
+    step2 = abs(zs[64] - zs[32])
+    assert step2 < step1, (step1, step2)
+    assert step2 < 1.0, step2
+
+
+# ---------------------------------------------------------------------------
+# 3. Physics smoke: sag vs tension, reactance vs tension
+# ---------------------------------------------------------------------------
+
+
+def test_sag_decreases_monotonically_with_tension():
+    sags = [_builder(tension_n=t).rig_solutions().max_sag_m for t in (5.0, 40.0, 300.0)]
+    assert sags[0] > sags[1] > sags[2] > 0.0
+
+
+def test_reactance_moves_monotonically_with_tension():
+    """Direction, determined by actually running the solve (not assumed):
+    reactance INCREASES with tension. A slacker (lower-tension) arm sags
+    into a shape that folds more of its fixed wire length into a smaller
+    net horizontal reach from the feed -- the same total conductor length
+    packed into a physically shorter span, which behaves like *shortening*
+    the antenna (moving it away from the taut straight-arm's tuning) and
+    pulls the reactance down/capacitive. As tension climbs toward the taut
+    limit the arm straightens back out toward the full-reach straight-arm
+    geometry (see the taut-limit oracle test above, ~+20.36 ohm), and the
+    reactance climbs back up toward that value.
+    """
+    freqs = (5.0, 40.0, 300.0)
+    reactances = [_z(_builder(tension_n=t)).imag for t in freqs]
+    assert reactances[0] < reactances[1] < reactances[2]
+
+
+def test_emitted_arm_bows_off_its_chord_by_the_solved_sag():
+    """The EMITTED wires must carry the catenary's curve, not just its
+    endpoints. Geometry-level on purpose: at hand-tension scales the
+    curve-vs-chord impedance delta is fractions of an ohm, so no electrical
+    assertion in this file can tell a correctly sagged arm from its straight
+    chord (a straight-chord mutation of build_wires survived exactly that
+    way in review) — but a flattened plane->3D mapping is still a real bug
+    the moment anything reads the geometry. Pin the interior nodes' max
+    perpendicular deviation from the arm's own chord to the solver's
+    reported max_sag_m."""
+    b = _builder(tension_n=5.0)
+    sol = b.rig_solutions()
+    wires = b.build_wires()
+    # The +y arm's chords, in emission order (apex-first).
+    arm = [w for w in wires if w.ex is None and w.p0[1] > 0]
+    nodes = [(w.p0[1], w.p0[2]) for w in arm] + [(arm[-1].p1[1], arm[-1].p1[2])]
+    (y0, z0), (y1, z1) = nodes[0], nodes[-1]
+    cy, cz = y1 - y0, z1 - z0
+    chord = math.hypot(cy, cz)
+    devs = [abs((cy * (z - z0) - cz * (y - y0)) / chord) for y, z in nodes[1:-1]]
+    # Discrete nodes sample near, not exactly at, the continuous maximum.
+    assert max(devs) == pytest.approx(sol.max_sag_m, rel=0.05)
+    assert max(devs) > 1.0e-3  # and the bow is real, not round-off
+
+
+# ---------------------------------------------------------------------------
+# 4. Cut-length invariance
+# ---------------------------------------------------------------------------
+
+
+def test_cut_length_invariant_under_tension():
+    b = _builder()
+    expected_arm_length = 0.25 * b.design_wavelength * b.length_factor
+
+    for t in (5.0, 40.0, 300.0, 1.0e4):
+        solution = _builder(tension_n=t).rig_solutions()
+        assert solution.segments[0].arc_length_m == pytest.approx(
+            expected_arm_length, rel=1e-12
+        )
+
+    # Total emitted polyline length ~= 2 arms + the short feed wire.
+    wires = b.build_wires()
+    total = sum(math.dist(w.p0, w.p1) for w in wires)
+    expected_total = 2.0 * expected_arm_length + 2.0 * _EPS
+    assert total == pytest.approx(expected_total, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# 5. Weightless wire rejected
+# ---------------------------------------------------------------------------
+
+
+def test_weightless_wire_raises():
+    class WeightlessVariant(Builder):
+        def build_wire_material(self):
+            return None
+
+    b = WeightlessVariant()
+    with pytest.raises(ValueError, match="WireSpec"):
+        b.rig_solutions()
+    with pytest.raises(ValueError, match="WireSpec"):
+        b.build_wires()
+
+
+# ---------------------------------------------------------------------------
+# 6. Wires stay above ground
+# ---------------------------------------------------------------------------
+
+
+def test_wires_stay_above_ground_at_defaults():
+    wires = Builder().build_wires()
+    zs = [w.p0[2] for w in wires] + [w.p1[2] for w in wires]
+    assert min(zs) > 0.0
+
+
+# ---------------------------------------------------------------------------
+# 7. Catalog smoke
+# ---------------------------------------------------------------------------
+
+
+def test_builds_meshes_and_solves_at_defaults():
+    b = Builder()
+    wires = b.build_wires()
+    assert len(wires) == 1 + 2 * int(b.chords_per_arm)
+
+    feed = [w for w in wires if w.ex is not None]
+    assert len(feed) == 1
+    assert feed[0].ex == 1 + 0j
+
+    for w in wires:
+        assert isinstance(w, Wire)
+        assert w.n_seg is not None and w.n_seg >= 1
+
+    z = _z(b)
+    assert math.isfinite(z.real) and math.isfinite(z.imag)
+    assert z.real > 0.0

--- a/tests/test_invvee_catenary.py
+++ b/tests/test_invvee_catenary.py
@@ -230,3 +230,180 @@ def test_builds_meshes_and_solves_at_defaults():
     z = _z(b)
     assert math.isfinite(z.real) and math.isfinite(z.imag)
     assert z.real > 0.0
+
+
+# ---------------------------------------------------------------------------
+# 8. Model 2 (anchored heavy rope): solves at defaults, rig_report() shape
+# ---------------------------------------------------------------------------
+
+_N_PER_LBF = 4.4482216152605
+
+
+def test_anchored_model_solves_with_full_report_at_defaults():
+    b = _builder(rig_model="anchored_rope")
+    report = b.rig_report()
+
+    assert set(report) == {
+        "rig_model",
+        "apex_tension_n",
+        "apex_tension_lbf",
+        "end_tension_n",
+        "end_tension_lbf",
+        "horizontal_tension_n",
+        "wire_sag_m",
+        "rope_sag_m",
+        "rope_length_m",
+        "wire_end_height_m",
+    }
+    assert report["rig_model"] == "anchored_rope"
+    assert report["apex_tension_lbf"] == report["apex_tension_n"] / _N_PER_LBF
+    assert report["end_tension_lbf"] == report["end_tension_n"] / _N_PER_LBF
+    assert report["rope_sag_m"] is not None
+    assert report["rope_length_m"] is not None and report["rope_length_m"] > 0.0
+    # Sane band for a stock hand-rigged halyard-equivalent, not a knife-edge
+    # taut extreme or a slack line carrying nothing.
+    assert 5.0 < report["apex_tension_n"] < 500.0
+
+
+# ---------------------------------------------------------------------------
+# 9. Model 2 rope take-up: less slack raises tension, lowers sag
+# ---------------------------------------------------------------------------
+
+
+def test_rope_takeup_raises_tension_and_lowers_sag():
+    """Taking up slack (a smaller `rope_slack_mm`) pulls the chain tauter.
+    As in `tests/test_catenary.py`'s own anchored-chain monotonicity test,
+    the monotone claim belongs to the TAUT half of the feasible range — a
+    very slack chain swings toward vertical and stops responding to further
+    slack — so these three values (20mm -> 5mm -> 1mm) stay well under the
+    UI range's 200 mm ceiling, the taut side any real rig lives on."""
+    slack_values_mm = [20.0, 5.0, 1.0]
+    reports = [
+        _builder(rig_model="anchored_rope", rope_slack_mm=slack).rig_report()
+        for slack in slack_values_mm
+    ]
+    tensions = [r["apex_tension_n"] for r in reports]
+    sags = [r["wire_sag_m"] for r in reports]
+
+    for prev, nxt in zip(tensions, tensions[1:]):
+        assert nxt > prev
+    for prev, nxt in zip(sags, sags[1:]):
+        assert nxt < prev
+
+
+# ---------------------------------------------------------------------------
+# 10. Model 2 design-level equilibrium: apex + end reactions sum to weight
+# ---------------------------------------------------------------------------
+
+
+def test_anchored_model_equilibrium_at_design_level():
+    """Per arm, the apex and anchor support forces sum to (0, total weight of
+    wire + rope) — catenary.py's own cheapest correctness check, exercised
+    here at the design level (through rig_solutions(), not the bare solver),
+    which is the issue's "equilibrium check at design level" criterion."""
+    b = _builder(rig_model="anchored_rope")
+    sol = b.rig_solutions()
+
+    fx = sol.apex_tension_vector[0] + sol.end_tension_vector[0]
+    fz = sol.apex_tension_vector[1] + sol.end_tension_vector[1]
+    assert fx == pytest.approx(0.0, abs=1e-9)
+    assert fz == pytest.approx(sol.total_weight_n, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# 11. Model 2 geometry excludes the rope
+# ---------------------------------------------------------------------------
+
+
+def test_anchored_model_emits_only_the_wire_not_the_rope():
+    b = _builder(rig_model="anchored_rope")
+    expected_arm_length = 0.25 * b.design_wavelength * b.length_factor
+
+    wires = b.build_wires()
+    assert len(wires) == 1 + 2 * int(b.chords_per_arm)  # same count as model 1
+
+    total = sum(math.dist(w.p0, w.p1) for w in wires)
+    expected_total = 2.0 * expected_arm_length + 2.0 * _EPS
+    assert total == pytest.approx(expected_total, rel=1e-6)
+    # The derived rope (~4.1 m) dwarfs the arm length; if it leaked into the
+    # emitted geometry the total would be off by meters, not a rel=1e-6 hair.
+    derived_rope_length_m = b.rig_report()["rope_length_m"]
+    assert total < expected_total + derived_rope_length_m
+
+
+# ---------------------------------------------------------------------------
+# 12. The two models differ, but agree on wire count
+# ---------------------------------------------------------------------------
+
+
+def test_halyard_and_anchored_models_differ_but_agree_on_wire_count():
+    halyard = _builder(rig_model="halyard")
+    anchored = _builder(rig_model="anchored_rope")
+
+    halyard_report = halyard.rig_report()
+    anchored_report = anchored.rig_report()
+    assert (
+        abs(halyard_report["wire_end_height_m"] - anchored_report["wire_end_height_m"])
+        > 1.0e-3
+    )
+
+    assert len(halyard.build_wires()) == len(anchored.build_wires())
+
+
+# ---------------------------------------------------------------------------
+# 13. tension_n is inert under the anchored model
+# ---------------------------------------------------------------------------
+
+
+def test_tension_n_does_not_affect_the_anchored_model():
+    low = _builder(rig_model="anchored_rope", tension_n=5.0)
+    high = _builder(rig_model="anchored_rope", tension_n=300.0)
+
+    low_points = low.rig_solutions().segments[0].points
+    high_points = high.rig_solutions().segments[0].points
+    assert low_points == pytest.approx(high_points)
+
+
+# ---------------------------------------------------------------------------
+# 14. Model 2 slack knob is feasible across the geometry knobs' full ranges
+# ---------------------------------------------------------------------------
+
+
+def test_anchored_model_solves_at_every_geometry_corner():
+    """The whole point of switching from an absolute `rope_length_m` to
+    `rope_slack_mm` (issue #698 unit 3 review fix): a fixed rope length
+    can't span the geometry knobs' own UI ranges (the shortest rope that can
+    reach the anchor moves with length_factor/stake_dist/stake_height), but
+    slack is feasible BY CONSTRUCTION for every combination, since the
+    derived rope length is always (reach - arm_length) + slack, strictly
+    positive slack away from the reach floor.
+
+    Exercise the full cross-product of the three geometry knobs' UI extremes
+    at the DEFAULT rope_slack_mm — every one of the eight corners is
+    feasible (verified numerically; none of them trips the "wire alone
+    already reaches past the anchor" guard, see the next test for a case
+    that does)."""
+    for length_factor in (0.8, 1.25):  # ui_params range
+        for stake_dist in (1.0, 6.0):  # ui_params range
+            for stake_height in (0.0, 3.0):  # ui_params range
+                b = _builder(
+                    rig_model="anchored_rope",
+                    length_factor=length_factor,
+                    stake_dist=stake_dist,
+                    stake_height=stake_height,
+                )
+                report = b.rig_report()
+                assert report["apex_tension_n"] > 0.0
+                assert report["rope_length_m"] > 0.0
+
+
+def test_anchored_model_rejects_wire_that_already_overshoots_the_anchor():
+    """The one remaining infeasible corner (issue #698 unit 3 review fix):
+    no positive rope_slack_mm can rescue a wire whose own arc length already
+    reaches past the anchor. This does not happen anywhere in the geometry
+    knobs' UI cross-product (the previous test) at stock base/wire_type, but
+    an anchor dragged close enough to the mast still reaches it, and the
+    solver's own ValueError -- not a silent clamp -- explains why."""
+    b = _builder(rig_model="anchored_rope", stake_dist=0.1, stake_height=6.9)
+    with pytest.raises(ValueError, match="already reaches past the anchor"):
+        b.rig_report()

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -13,6 +13,7 @@ integration territory and want their own targeted tests.
 from __future__ import annotations
 
 import json
+import math
 import threading
 import time
 from copy import deepcopy
@@ -601,6 +602,61 @@ def test_solve_at_a_picked_plane_measures_the_bare_antenna():
     # An unknown plane is a bad request field, same as a bad freq.
     with pytest.raises(ValueError, match="measurement plane"):
         server.solve({**base, "plane": "vna"})
+
+
+def test_solve_carries_rig_report_only_for_designs_that_have_one():
+    """The rigging tension/sag readout (issue #698 unit 3) is surfaced under
+    "rig" for a design that defines `rig_report()` — dipoles.invvee_catenary,
+    stock rig_model="halyard" — and is entirely absent (no "rig" key) for a
+    design that doesn't, mirroring how `_wire_material_results` fields
+    (issue #318) only appear for wire-material designs."""
+    out = server.solve(
+        {
+            "geometry": "dipoles.invvee_catenary",
+            "measurement_freq_mhz": 28.47,
+            "design_freq_mhz": 28.47,
+            "momwire_model": "bspline",
+        }
+    )
+    assert out["rig"]["rig_model"] == "halyard"
+    assert math.isfinite(out["rig"]["apex_tension_n"])
+
+    bare = server.solve(
+        {
+            "geometry": "dipoles.invvee",
+            "measurement_freq_mhz": 28.47,
+            "design_freq_mhz": 28.47,
+            "momwire_model": "bspline",
+        }
+    )
+    assert "rig" not in bare
+
+
+def test_rig_report_failure_never_fails_the_solve(monkeypatch):
+    """The omit-on-error contract of `_rig_report_results` (issue #698 unit
+    3): the readout is garnish on a solve that stands on its own, so a
+    `rig_report()` that raises — a mid-scrub geometrically infeasible rig —
+    must yield a normal solve response with the "rig" key simply absent,
+    never a failed response or an error field."""
+    from antennaknobs.designs.dipoles.invvee_catenary import Builder
+
+    def boom(self):
+        raise ValueError("mid-scrub infeasible rig")
+
+    monkeypatch.setattr(Builder, "rig_report", boom)
+    out = server.solve(
+        {
+            "geometry": "dipoles.invvee_catenary",
+            # Deliberately NOT the request other tests in this file solve:
+            # _SOLVE_CACHE would otherwise serve their cached response —
+            # rig key and all — without ever calling the patched method.
+            "measurement_freq_mhz": 28.51,
+            "design_freq_mhz": 28.47,
+            "momwire_model": "bspline",
+        }
+    )
+    assert "rig" not in out
+    assert math.isfinite(out["z_in_re"])
 
 
 def _design_builder(dotted):


### PR DESCRIPTION
Integration PR for issue #698, landed as a stacked arc — each unit built by a delegated subagent on its own sub-PR into this branch, reviewed and re-gated by the session model (full diff read, gates re-run, adversarial probes) before merging. Rebase-merged, so these three commits land on main verbatim as one atomic batch.

## Units
- [x] **Unit 1** (#701, opus builder) — `catenary.py`: continuous closed-form catenary marching kernel behind a swappable `MarchKernel` seam, damped-Newton 2-unknown shooting in `(ln H, V0/H)`, both rig closures, taut-limit series fallback. **34 tests.** Review: independent statics-ODE cross-check (≤8e-14 agreement), two mutations caught by the suite.
- [x] **Unit 2** (#705, sonnet builder) — `designs/dipoles/invvee_catenary.py`: arms as chord polylines of the model-1 (tensioned halyard) solve, fixed cut length, `tension_n` knob, stock `18-awg-pvc` (one catalog entry sets sag weight AND loss/insulation). **9 tests** incl. a reviewer-added geometry-fidelity test after a straight-chord mutation survived the original suite. Taut-limit regression vs a hand-built straight-arm oracle: 2e-6/5e-6 relative.
- [x] **Unit 3** (#711, sonnet builder, one rework round) — `rig_model="anchored_rope"`: wire + heavy rope chain to a ground anchor, tension as a readout. **Slack (`rope_slack_mm`), not rope length, is the knob** — review probes showed an absolute length param was infeasible across the geometry knobs' own UI ranges; slack is feasible by construction (all 8 UI-corner extremes verified). `rig_report()` (N + lbf tensions, sag, derived cut length) surfaced in solve responses via a duck-typed adapter block with an omit-on-error contract (reviewer-tested). **+8 tests.**

## Acceptance criteria (#698)
- [x] Closed-form math oracles (sag, arc, tension distribution)
- [x] Equilibrium sum: support reactions = total chain weight (solver AND design level)
- [x] Taut-limit fallback tested in the cosh-overflow regime
- [x] Taut-limit regression vs a straight-arm inv-vee (< 1% gate; measured 5e-6)
- [x] Chord-count convergence independent of segments-per-wire (with the auto-mesh aliasing caveat documented in-test)
- [x] Physics smoke: tension ↓ sag, moves reactance monotonically toward the taut value (direction documented with the physics)
- [x] Tension readout in N and lbf; sag-from-chord reported (`rig_report()` + `rig` response field)

## Assembled-branch verification (post-rebase onto e32219b3e)
- Full Python suite: **3345 passed, 2 skipped**
- Frontend `npm run build` (tsc + vite): clean — zero TS changes in this arc; knobs render from the served param schema
- skip-ci contagion grep over all branch commits: clean

## Follow-ups
- #708 — elastic (bungee) rig closure `solve_sprung` (filed during the arc)
- Generic readouts display contract (to be filed): render `rig`-style diagnostics rows in the workbench via one server-driven table, so future construction features stay Python-only

Closes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g