### PR TITLE
Unit 1: view registry replaces ViewPanel's flat conditional (#700)

### DIFF
--- a/src/antennaknobs/web/frontend/src/__tests__/viewRegistry.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/viewRegistry.test.tsx
@@ -1,0 +1,154 @@
+// Pins the view registry (unit 1 of docs/plan-view-rail-scaling.md): the
+// metadata half in lib/view.ts and the render half in
+// components/results/viewRegistry.tsx are two records keyed by the same View
+// ids, and ViewPanel is nothing but the lookup between them. What this file
+// guards is that the two halves stay in step and that dispatch lands on the
+// right component — a wiring swap (schematic's id pointing at the Smith
+// renderer) typechecks fine, so only a mounted probe catches it.
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { VIEWS, type View } from "../lib/view";
+import { VIEW_RENDERERS, type ViewRenderProps } from "../components/results/viewRegistry";
+import { ViewPanel } from "../components/results/ViewPanel";
+
+// Azimuth and elevation are the same component differing only by its `cut`
+// prop, which drives canvas drawing and leaves no DOM trace. Stubbing that
+// one component surfaces `cut` as an attribute so an az↔el swap fails here;
+// every other view's component renders for real.
+vi.mock("../components/charts/FarFieldChart", () => ({
+  FarFieldChart: ({ cut }: { cut: string }) => (
+    <canvas className="farfield" data-cut={cut} />
+  ),
+}));
+
+// jsdom ships no 2-D context, and every chart mounted below already guards on
+// a null one and takes its no-draw path. Returning null directly keeps that
+// path while dropping jsdom's "not implemented" stack trace per mount.
+HTMLCanvasElement.prototype.getContext =
+  (() => null) as unknown as HTMLCanvasElement["getContext"];
+
+// Compile-time enumeration of the View union: a missing or misspelled member
+// fails tsc (npm run build), so the runtime lists below cannot drift from the
+// type.
+const EVERY_VIEW: Record<View, true> = {
+  antenna: true,
+  azimuth: true,
+  elevation: true,
+  smith: true,
+  schematic: true,
+};
+const ALL_VIEWS = Object.keys(EVERY_VIEW) as View[];
+
+// --- 1. The two halves cover the union, once each ---------------------------
+
+describe("registry coverage", () => {
+  it("has exactly one VIEWS entry per member of the View union", () => {
+    expect(VIEWS.map((v) => v.id).sort()).toEqual([...ALL_VIEWS].sort());
+    expect(new Set(VIEWS.map((v) => v.id)).size).toBe(VIEWS.length);
+  });
+
+  it("has exactly one render entry per member of the View union", () => {
+    expect(Object.keys(VIEW_RENDERERS).sort()).toEqual([...ALL_VIEWS].sort());
+    for (const id of ALL_VIEWS) {
+      expect(typeof VIEW_RENDERERS[id]).toBe("function");
+    }
+  });
+});
+
+// --- 2. Metadata values -----------------------------------------------------
+
+describe("view metadata", () => {
+  it("keeps the shipped labels and their rail order", () => {
+    expect(VIEWS.map((v) => [v.id, v.label])).toEqual([
+      ["antenna", "Antenna"],
+      ["azimuth", "Azimuth (xy)"],
+      ["elevation", "Elevation (yz)"],
+      ["smith", "Smith"],
+      ["schematic", "Schematic"],
+    ]);
+  });
+
+  // The founding four are pinned by default; schematic and every later view
+  // ship unpinned (docs/plan-view-rail-scaling.md, "The pin model").
+  it("defaults exactly the founding four to pinned", () => {
+    expect(VIEWS.filter((v) => v.defaultPinned).map((v) => v.id).sort()).toEqual(
+      ["antenna", "azimuth", "elevation", "smith"],
+    );
+  });
+});
+
+// --- 3. Dispatch lands on the right component -------------------------------
+
+const PROPS: Omit<ViewRenderProps, "showWireLabels" | "showFeedNames" | "schematicSvg" | "schematicUnavailable"> = {
+  size: 180,
+  fill: true,
+  result: null,
+  preview: null,
+  sweep: null,
+  converge: null,
+  measured: null,
+  pattern: null,
+  pinnedPatterns: [],
+  measFreqMhz: 14.1,
+  sweepRunning: false,
+  convergeRunning: false,
+  azElevDeg: 0,
+  elevAzDeg: 0,
+  cameraProjection: "xy",
+  showHeatmap: false,
+  showEnvelope: false,
+  multiFeed: false,
+  fineNorm: null,
+};
+
+function mount(view: View, overrides: Partial<React.ComponentProps<typeof ViewPanel>> = {}) {
+  return render(<ViewPanel view={view} {...PROPS} {...overrides} />).container;
+}
+
+// One selector per view's own component. Each probe asserts its own marker is
+// present AND that the neighbours it could be confused with are absent, so a
+// swapped pair fails on both sides.
+const MARKERS: Record<View, string> = {
+  antenna: ".canvas-viewport",
+  azimuth: 'canvas.farfield[data-cut="xy"]',
+  elevation: 'canvas.farfield[data-cut="yz"]',
+  smith: "canvas.smith",
+  schematic: ".schematic-fill",
+};
+
+describe("dispatch", () => {
+  for (const view of ALL_VIEWS) {
+    it(`renders only the ${view} view's component`, () => {
+      const container = mount(view);
+      expect(container.querySelector(MARKERS[view])).not.toBeNull();
+      for (const other of ALL_VIEWS) {
+        if (other === view) continue;
+        expect(container.querySelector(MARKERS[other])).toBeNull();
+      }
+    });
+  }
+
+  it("keeps the antenna view's preview fallback and thumb sizing", () => {
+    const preview = { z_in_re: 50, z_in_im: 0 } as ViewRenderProps["preview"];
+    const thumb = mount("antenna", { fill: false, size: 96, preview });
+    const wrapper = thumb.querySelector(".antenna-thumb") as HTMLElement;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper.style.width).toBe("96px");
+    expect(wrapper.style.height).toBe("96px");
+    expect(thumb.querySelector(".antenna-fill")).toBeNull();
+    // fill drives the canvas's interactive affordances, so the Fit button is
+    // the thumb/stage discriminator.
+    expect(thumb.querySelector(".viewport-fit")).toBeNull();
+    expect(mount("antenna").querySelector(".viewport-fit")).not.toBeNull();
+  });
+
+  it("passes the schematic view its own props", () => {
+    const svg = '<svg viewBox="0 0 10 10"><path d="M 0,0 L 10,10" /></svg>';
+    expect(mount("schematic", { schematicSvg: svg }).innerHTML).toContain("viewBox");
+    const empty = mount("schematic", { schematicUnavailable: true });
+    expect(empty.textContent).toMatch(/no feed circuit/i);
+    // Thumb sizing is the panel's, not the wrapper div's.
+    const thumb = mount("schematic", { fill: false, size: 96 });
+    expect(thumb.querySelector(".schematic-thumb")).not.toBeNull();
+  });
+});

--- a/src/antennaknobs/web/frontend/src/components/results/ViewPanel.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/ViewPanel.tsx
@@ -1,134 +1,33 @@
-import type { ConvergeData, MeasuredData, SolveResponse, SweepData } from "../../lib/api";
-import type { Projection, View } from "../../lib/view";
-import { CurrentCanvas } from "../charts/CurrentCanvas";
-import { FarFieldChart } from "../charts/FarFieldChart";
-import { SmithChart } from "../charts/SmithChart";
-import type { PatternData, PinnedPattern } from "../charts/types";
-import { SchematicPanel } from "./SchematicPanel";
+import type { View } from "../../lib/view";
+import { VIEW_RENDERERS, type ViewRenderProps } from "./viewRegistry";
 
+// Dispatch only: look the view's renderer up in the registry and invoke it.
+// The lookup is exact per id — there is no fallthrough view, so a missing
+// entry is a typecheck failure rather than a silently wrong chart.
 export function ViewPanel({
   view,
-  size,
-  fill,
-  result,
-  preview,
-  sweep,
-  converge,
-  measured,
-  pattern,
-  pinnedPatterns,
-  measFreqMhz,
-  sweepRunning,
-  convergeRunning,
-  azElevDeg,
-  elevAzDeg,
-  cameraProjection,
-  showHeatmap,
-  showEnvelope,
   showWireLabels = false,
   showFeedNames = true,
-  multiFeed,
-  fineNorm,
   schematicSvg = null,
   schematicUnavailable = false,
-}: {
+  ...rest
+}: Omit<
+  ViewRenderProps,
+  "showWireLabels" | "showFeedNames" | "schematicSvg" | "schematicUnavailable"
+> & {
   view: View;
-  size: number;
-  fill: boolean;
-  result: SolveResponse | null;
-  preview: SolveResponse | null;
-  sweep: SweepData | null;
-  converge: ConvergeData | null;
-  measured: MeasuredData | null;
-  pattern: PatternData | null;
-  pinnedPatterns: PinnedPattern[];
-  measFreqMhz: number;
-  sweepRunning: boolean;
-  convergeRunning: boolean;
-  azElevDeg: number;
-  elevAzDeg: number;
-  cameraProjection: Projection;
-  showHeatmap: boolean;
-  showEnvelope: boolean;
+  // Optional at the call sites (the thumbstrip omits them); resolved here so
+  // every registry entry sees a complete prop bag.
   showWireLabels?: boolean;
   showFeedNames?: boolean;
-  multiFeed: boolean;
-  fineNorm?: number | null;
   schematicSvg?: string | null;
   schematicUnavailable?: boolean;
 }) {
-  if (view === "antenna") {
-    // Fall back to the geometry-only preview while the real solve is in
-    // flight, but with the current heatmap/waveform overlays forced off —
-    // the preview has no currents, so only the bare wires + feed are drawn.
-    const showingPreview = !result && !!preview;
-    return (
-      <div className={fill ? "antenna-fill" : "antenna-thumb"}
-           style={fill ? undefined : { width: size, height: size }}>
-        <CurrentCanvas
-          result={result ?? preview}
-          projection={cameraProjection}
-          showHeatmap={showingPreview ? false : showHeatmap}
-          showEnvelope={showingPreview ? false : showEnvelope}
-          showWireLabels={showWireLabels}
-          showFeedNames={showFeedNames}
-          interactive={fill}
-        />
-      </div>
-    );
-  }
-  if (view === "azimuth") {
-    return (
-      <FarFieldChart
-        result={result}
-        pattern={pattern}
-        pinned={pinnedPatterns}
-        size={size}
-        cut="xy"
-        azElevDeg={azElevDeg}
-        elevAzDeg={elevAzDeg}
-        fineNorm={fineNorm}
-      />
-    );
-  }
-  if (view === "elevation") {
-    return (
-      <FarFieldChart
-        result={result}
-        pattern={pattern}
-        pinned={pinnedPatterns}
-        size={size}
-        cut="yz"
-        azElevDeg={azElevDeg}
-        elevAzDeg={elevAzDeg}
-        fineNorm={fineNorm}
-      />
-    );
-  }
-  if (view === "schematic") {
-    return (
-      <SchematicPanel
-        svg={schematicSvg}
-        unavailable={schematicUnavailable}
-        size={size}
-        fill={fill}
-      />
-    );
-  }
-  return (
-    <SmithChart
-      r={result?.z_in_re ?? 0}
-      x={result?.z_in_im ?? 0}
-      z0={result?.z0_ohms ?? 50}
-      size={size}
-      sweep={sweep}
-      converge={converge}
-      measured={measured}
-      measFreqMhz={measFreqMhz}
-      running={sweepRunning}
-      convergeRunning={convergeRunning}
-      feeds={result?.feeds}
-      multiFeed={multiFeed}
-    />
-  );
+  return VIEW_RENDERERS[view]({
+    ...rest,
+    showWireLabels,
+    showFeedNames,
+    schematicSvg,
+    schematicUnavailable,
+  });
 }

--- a/src/antennaknobs/web/frontend/src/components/results/viewRegistry.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/viewRegistry.tsx
@@ -1,0 +1,117 @@
+import type { ReactElement } from "react";
+import type { ConvergeData, MeasuredData, SolveResponse, SweepData } from "../../lib/api";
+import type { Projection, View } from "../../lib/view";
+import { CurrentCanvas } from "../charts/CurrentCanvas";
+import { FarFieldChart } from "../charts/FarFieldChart";
+import { SmithChart } from "../charts/SmithChart";
+import type { PatternData, PinnedPattern } from "../charts/types";
+import { SchematicPanel } from "./SchematicPanel";
+
+// The render half of the view registry (the metadata half — id, label,
+// defaultPinned — is VIEWS in lib/view.ts, which stays component-free).
+//
+// Every view receives the same prop bag: the stage hands out one set of
+// inputs and each view takes what it needs, so adding a view is one entry
+// here plus its component, with no plumbing at the call sites.
+export type ViewRenderProps = {
+  size: number;
+  fill: boolean;
+  result: SolveResponse | null;
+  preview: SolveResponse | null;
+  sweep: SweepData | null;
+  converge: ConvergeData | null;
+  measured: MeasuredData | null;
+  pattern: PatternData | null;
+  pinnedPatterns: PinnedPattern[];
+  measFreqMhz: number;
+  sweepRunning: boolean;
+  convergeRunning: boolean;
+  azElevDeg: number;
+  elevAzDeg: number;
+  cameraProjection: Projection;
+  showHeatmap: boolean;
+  showEnvelope: boolean;
+  showWireLabels: boolean;
+  showFeedNames: boolean;
+  multiFeed: boolean;
+  fineNorm?: number | null;
+  schematicSvg: string | null;
+  schematicUnavailable: boolean;
+};
+
+// Plain functions, not components: ViewPanel calls the entry rather than
+// mounting it, so the rendered tree has exactly the depth it had when this
+// was a conditional — no extra fiber between the panel and the chart.
+//
+// Record<View, …> is the exhaustiveness gate: a new member of the View union
+// fails to typecheck until it has an entry.
+export const VIEW_RENDERERS: Record<View, (p: ViewRenderProps) => ReactElement> = {
+  antenna: (p) => {
+    // Fall back to the geometry-only preview while the real solve is in
+    // flight, but with the current heatmap/waveform overlays forced off —
+    // the preview has no currents, so only the bare wires + feed are drawn.
+    const showingPreview = !p.result && !!p.preview;
+    return (
+      <div className={p.fill ? "antenna-fill" : "antenna-thumb"}
+           style={p.fill ? undefined : { width: p.size, height: p.size }}>
+        <CurrentCanvas
+          result={p.result ?? p.preview}
+          projection={p.cameraProjection}
+          showHeatmap={showingPreview ? false : p.showHeatmap}
+          showEnvelope={showingPreview ? false : p.showEnvelope}
+          showWireLabels={p.showWireLabels}
+          showFeedNames={p.showFeedNames}
+          interactive={p.fill}
+        />
+      </div>
+    );
+  },
+  azimuth: (p) => (
+    <FarFieldChart
+      result={p.result}
+      pattern={p.pattern}
+      pinned={p.pinnedPatterns}
+      size={p.size}
+      cut="xy"
+      azElevDeg={p.azElevDeg}
+      elevAzDeg={p.elevAzDeg}
+      fineNorm={p.fineNorm}
+    />
+  ),
+  elevation: (p) => (
+    <FarFieldChart
+      result={p.result}
+      pattern={p.pattern}
+      pinned={p.pinnedPatterns}
+      size={p.size}
+      cut="yz"
+      azElevDeg={p.azElevDeg}
+      elevAzDeg={p.elevAzDeg}
+      fineNorm={p.fineNorm}
+    />
+  ),
+  smith: (p) => (
+    <SmithChart
+      r={p.result?.z_in_re ?? 0}
+      x={p.result?.z_in_im ?? 0}
+      z0={p.result?.z0_ohms ?? 50}
+      size={p.size}
+      sweep={p.sweep}
+      converge={p.converge}
+      measured={p.measured}
+      measFreqMhz={p.measFreqMhz}
+      running={p.sweepRunning}
+      convergeRunning={p.convergeRunning}
+      feeds={p.result?.feeds}
+      multiFeed={p.multiFeed}
+    />
+  ),
+  schematic: (p) => (
+    <SchematicPanel
+      svg={p.schematicSvg}
+      unavailable={p.schematicUnavailable}
+      size={p.size}
+      fill={p.fill}
+    />
+  ),
+};

--- a/src/antennaknobs/web/frontend/src/lib/view.ts
+++ b/src/antennaknobs/web/frontend/src/lib/view.ts
@@ -1,10 +1,24 @@
 export type View = "antenna" | "azimuth" | "elevation" | "smith" | "schematic";
-export const VIEWS: { id: View; label: string }[] = [
-  { id: "antenna", label: "Antenna" },
-  { id: "azimuth", label: "Azimuth (xy)" },
-  { id: "elevation", label: "Elevation (yz)" },
-  { id: "smith", label: "Smith" },
-  { id: "schematic", label: "Schematic" },
+
+// The view registry's metadata half. The render half — one function per id —
+// lives in components/results/viewRegistry.tsx, keyed by these same ids:
+// lib/ stays component-free, so the two halves cannot be one object here.
+// Adding a view = one entry below + one render entry there (the render map is
+// a Record<View, …>, so the compiler names the gap).
+export type ViewMeta = {
+  id: View;
+  label: string;
+  // Whether the view starts in the user's pinned set. Dormant until the pin
+  // model lands — unit 2 of docs/plan-view-rail-scaling.md is the only
+  // consumer. Nothing reads it today.
+  defaultPinned: boolean;
+};
+export const VIEWS: ViewMeta[] = [
+  { id: "antenna", label: "Antenna", defaultPinned: true },
+  { id: "azimuth", label: "Azimuth (xy)", defaultPinned: true },
+  { id: "elevation", label: "Elevation (yz)", defaultPinned: true },
+  { id: "smith", label: "Smith", defaultPinned: true },
+  { id: "schematic", label: "Schematic", defaultPinned: false },
 ];
 
 // The mobile output carousel's screens: the 5 chart views plus a dedicated


### PR DESCRIPTION
First unit of the #700 stacked arc (docs/plan-view-rail-scaling.md). Stacked onto `issue-700-view-rail`.

## Summary
- `lib/view.ts`: `VIEWS` entries gain `defaultPinned` (`ViewMeta`) — founding four true, schematic false; dormant until unit 2.
- New `components/results/viewRegistry.tsx`: `ViewRenderProps` + `VIEW_RENDERERS: Record<View, (p) => ReactElement>` — the exhaustiveness gate; entries are plain functions so the tree keeps the conditional's exact depth.
- `ViewPanel` is now dispatch only; the Smith fallthrough became an exact entry.
- New `viewRegistry.test.tsx` (11 tests): union coverage both halves, labels/order, defaultPinned set, per-view mounted dispatch probes (FarFieldChart stubbed to surface `cut`, others render real).

## Gates (measured)
- Suite: 24 files / 405 tests green (baseline 23/394; zero edits to existing tests).
- `npm run build` green (tsc + vite).
- Mutation probes: schematic↔smith renderer swap → 3 failures; azimuth↔elevation `cut` swap → 2 failures. Both reverted.

## Review notes
- Built by an opus subagent (delegated-build); reviewed by the session model: full diff read, prop-for-prop compare against the old conditional, suite + build re-run (405 green, build clean), and the schematic↔smith dispatch mutation independently re-run (same 3 failures, reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01522PMkNyJbRX772WV5DwaA