### PR TITLE
Pinned view rail + overflow picker (closes #700)

### DIFF
--- a/src/antennaknobs/web/frontend/src/__tests__/DesignSession.mobile.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/DesignSession.mobile.test.tsx
@@ -1,0 +1,119 @@
+// The wiring MobileCarousel.test.tsx cannot see: that the REAL session's
+// mobile tree derives its carousel pages and its dots from the same pinned
+// list (#700 unit 4). One mount, three facts — page count, page identity, and
+// the "⋯" affordance's presence — because everything about how those pages
+// behave is already pinned at the hook and component level.
+//
+// The stub set is newBackend.test.tsx's, with matchMedia flipped to MATCH the
+// phone breakpoint so the session renders its mobile branch instead of the
+// stage.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { DesignSession } from "../components/session/DesignSession";
+import { VIEW_META, VIEWS, type View } from "../lib/view";
+import { VIEW_PREFS_KEY } from "../components/session/useViewPrefs";
+import type { ExampleDescriptor } from "../lib/params";
+import { SERVED_ROSTER } from "./backendFixtures";
+
+const PINNED: View[] = ["smith", "antenna", "gamma"];
+
+const EXAMPLE: ExampleDescriptor = {
+  name: "dipoles.probe",
+  label: "Probe dipole",
+  multi_feed: false,
+  param_schema: [],
+  result_schema: [],
+  bands: [],
+  meas_freq_range_mhz: null,
+  default_view: "xz",
+  default_freq: null,
+  default_design_freq: null,
+  default_backend: null,
+  requires_backends: null,
+  has_design_freq: true,
+  variants: ["default"],
+  variant_values: {},
+  sweep_policy: { anchor: "design_freq", lo_factor: 0.8, hi_factor: 1.25 },
+};
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  localStorage.setItem(
+    VIEW_PREFS_KEY,
+    JSON.stringify({ pinned: PINNED, seen: VIEWS.map((v) => v.id) }),
+  );
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+  // Every query matches: this session is on a phone, in portrait.
+  vi.stubGlobal("matchMedia", () => ({
+    matches: true,
+    addEventListener() {},
+    removeEventListener() {},
+  }));
+  vi.stubGlobal(
+    "WebSocket",
+    class {
+      static OPEN = 1;
+      readyState = 0;
+      close() {}
+      send() {}
+    },
+  );
+  vi.stubGlobal("fetch", async (url: string) => {
+    const path = String(url);
+    if (path.startsWith("/capabilities"))
+      return jsonResponse({
+        have_pynec: true,
+        backends: SERVED_ROSTER,
+        terrain_presets: [],
+      });
+    if (path.startsWith("/examples"))
+      return jsonResponse({ examples: [EXAMPLE], errors: [] });
+    if (path.startsWith("/geometry")) return jsonResponse({ wires: [] });
+    return jsonResponse({});
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("the session's mobile tree", () => {
+  it("carries one carousel page and one dot per pinned view, plus Info", async () => {
+    const { container } = render(<DesignSession id={1} active />);
+    await waitFor(() =>
+      expect(container.querySelector(".mobile-carousel")).not.toBeNull(),
+    );
+
+    // Pages: the pinned views in pin order, then the Info screen — NOT the
+    // registry, which is four views longer here.
+    const pages = container.querySelectorAll(".mobile-screen");
+    expect(pages).toHaveLength(PINNED.length + 1);
+    expect(pages[pages.length - 1].classList).toContain("mobile-screen-info");
+
+    // Dots: the same list, from the same derivation.
+    expect(
+      screen.getAllByRole("button", { name: /^Show / }).map((b) => b.getAttribute("title")),
+    ).toEqual([...PINNED.map((id) => VIEW_META[id].label), "Info"]);
+
+    // The roster the pages were drawn from is one tap away.
+    expect(screen.getByRole("button", { name: "All views" })).toBeTruthy();
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/LayoutModeToggle.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/LayoutModeToggle.test.tsx
@@ -1,0 +1,39 @@
+// The rail/grid segmented control (unit 3, docs/plan-view-rail-scaling.md).
+// Placement (desktop only, stage top-right) is DesignSession's job, not
+// this component's — see the placement check in
+// gridLayoutPlacement.test.ts for why that's tested structurally rather
+// than by mounting this component through DesignSession.
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LayoutModeToggle } from "../components/results/StageOverlays";
+
+describe("LayoutModeToggle", () => {
+  it("marks rail active when layout is rail", () => {
+    render(<LayoutModeToggle layout="rail" setLayout={vi.fn()} />);
+    expect(screen.getByTitle(/^Rail:/).className).toContain("active");
+    expect(screen.getByTitle(/^Grid:/).className).not.toContain("active");
+  });
+
+  it("marks grid active when layout is grid", () => {
+    render(<LayoutModeToggle layout="grid" setLayout={vi.fn()} />);
+    expect(screen.getByTitle(/^Grid:/).className).toContain("active");
+    expect(screen.getByTitle(/^Rail:/).className).not.toContain("active");
+  });
+
+  it("calls setLayout('grid') from rail", async () => {
+    const user = userEvent.setup();
+    const setLayout = vi.fn();
+    render(<LayoutModeToggle layout="rail" setLayout={setLayout} />);
+    await user.click(screen.getByTitle(/^Grid:/));
+    expect(setLayout).toHaveBeenCalledWith("grid");
+  });
+
+  it("calls setLayout('rail') from grid", async () => {
+    const user = userEvent.setup();
+    const setLayout = vi.fn();
+    render(<LayoutModeToggle layout="grid" setLayout={setLayout} />);
+    await user.click(screen.getByTitle(/^Rail:/));
+    expect(setLayout).toHaveBeenCalledWith("rail");
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/MobileCarousel.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/MobileCarousel.test.tsx
@@ -1,0 +1,414 @@
+// The phone carousel as DesignSession wires it (#700 unit 4): the real prefs
+// store, the real hook, the real dots row and the real picker sheet, over a
+// stubbed scroll geometry. What it pins is the one contract the unit is about
+// — carousel pages ARE the pinned set plus Info, in pin order — plus the four
+// ways that mapping can be walked off: a view with no page, unpinning the page
+// you are on, pinning a page while you stand somewhere, and Info's index
+// moving under both.
+//
+// jsdom has no layout: clientWidth is 0, scrollLeft never moves, and
+// Element.scrollTo does not exist, so scroll-snap cannot be exercised for
+// real. The stubs below supply exactly the three geometry facts the hook reads
+// (page width, scroll position, and a scrollTo that lands instantly), which
+// turns a swipe into "put scrollLeft on a snap point and fire scroll" — the
+// same event the browser delivers at the end of a fling.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { VIEW_META, VIEWS, mobileScreens, type View } from "../lib/view";
+import { MobileDots } from "../components/session/MobileDots";
+import { useMobileCarousel } from "../components/session/useMobileCarousel";
+import { PIN_CAP, VIEW_PREFS_KEY, useViewPrefs } from "../components/session/useViewPrefs";
+
+const W = 300; // one page wide; every snap point is a multiple of it
+const ROSTER = VIEWS.map((v) => v.id);
+const label = (id: View) => VIEW_META[id].label;
+
+let scrollPos = 0;
+let scrolls: number[] = [];
+let origClientWidth: PropertyDescriptor | undefined;
+let origScrollLeft: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  localStorage.clear();
+  scrollPos = 0;
+  scrolls = [];
+  origClientWidth = Object.getOwnPropertyDescriptor(Element.prototype, "clientWidth");
+  origScrollLeft = Object.getOwnPropertyDescriptor(Element.prototype, "scrollLeft");
+  Object.defineProperty(Element.prototype, "clientWidth", {
+    configurable: true,
+    get: () => W,
+  });
+  Object.defineProperty(Element.prototype, "scrollLeft", {
+    configurable: true,
+    get: () => scrollPos,
+    set: (v: number) => {
+      scrollPos = v;
+    },
+  });
+  // jsdom ships no Element.scrollTo at all. Landing instantly (rather than
+  // recording and ignoring) is what makes a programmatic page change visible
+  // to the next effect, exactly as a finished smooth scroll would be.
+  Object.defineProperty(Element.prototype, "scrollTo", {
+    configurable: true,
+    writable: true,
+    value: (o: ScrollToOptions) => {
+      scrolls.push(o.left ?? 0);
+      scrollPos = o.left ?? 0;
+    },
+  });
+});
+
+afterEach(() => {
+  if (origClientWidth) Object.defineProperty(Element.prototype, "clientWidth", origClientWidth);
+  if (origScrollLeft) Object.defineProperty(Element.prototype, "scrollLeft", origScrollLeft);
+  delete (Element.prototype as unknown as Record<string, unknown>).scrollTo;
+  vi.restoreAllMocks();
+});
+
+function seed(pinned: View[], seen: View[] = ROSTER) {
+  localStorage.setItem(VIEW_PREFS_KEY, JSON.stringify({ pinned, seen }));
+}
+
+// DesignSession's mobile branch, minus the charts: same hook call, same
+// derived screen list feeding both the pages and the dots, same sheet props.
+function Mobile({
+  isMobile = true,
+  initialView = "antenna" as View,
+}: {
+  isMobile?: boolean;
+  initialView?: View;
+}) {
+  const [view, setView] = useState<View>(initialView);
+  const prefs = useViewPrefs();
+  const car = useMobileCarousel({
+    isMobile,
+    orientation: "portrait",
+    pinned: prefs.pinned,
+    view,
+    setView,
+  });
+  const screens = mobileScreens(prefs.pinned);
+  return (
+    <>
+      <div data-testid="view">{view}</div>
+      <div data-testid="index">{car.mobileIndex}</div>
+      <div data-testid="pages">{screens.map((s) => s.id).join(",")}</div>
+      <div
+        data-testid="carousel"
+        ref={car.mobileCarouselRef}
+        onScroll={car.onMobileCarouselScroll}
+      />
+      <MobileDots
+        screens={screens}
+        index={car.mobileIndex}
+        goToScreen={car.goToMobileScreen}
+        view={view}
+        pinned={prefs.pinned}
+        newIds={prefs.newIds}
+        togglePin={prefs.togglePin}
+        markRosterSeen={prefs.markRosterSeen}
+      />
+    </>
+  );
+}
+
+const probe = (id: string) => screen.getByTestId(id).textContent;
+const frame = () => new Promise((r) => requestAnimationFrame(() => r(null)));
+
+// A finished swipe: the snap point becomes the scroll position and the browser
+// delivers one scroll event. The handler is rAF-throttled, hence the frames.
+//
+// The leading drain is not ceremony: the re-centre effect queues a frame every
+// time the index changes, and here scrollTo lands instantly, so an undrained
+// frame from the previous gesture would re-centre the OLD page on top of this
+// one. On a phone those frames run milliseconds after the commit, long before
+// the next swipe — draining is what makes the simulation match that.
+async function swipeTo(i: number) {
+  await act(async () => {
+    await frame();
+  });
+  scrollPos = i * W;
+  await act(async () => {
+    fireEvent.scroll(screen.getByTestId("carousel"));
+    await frame();
+  });
+}
+
+const dots = () =>
+  screen.getAllByRole("button", { name: /^Show / }).map((b) => b.getAttribute("title"));
+const openSheet = (user: ReturnType<typeof userEvent.setup>) =>
+  user.click(screen.getByRole("button", { name: "All views" }));
+const sheetRow = (id: View) => screen.getByRole("menuitem", { name: label(id) });
+const dot = (name: string) => screen.getByRole("button", { name }) as HTMLButtonElement;
+
+const TWO: View[] = ["smith", "antenna"];
+const FOUR: View[] = ["smith", "antenna", "vswr", "azimuth"];
+const SIX: View[] = ["smith", "antenna", "vswr", "azimuth", "schematic", "gamma"];
+
+// --- 1. Pages and dots ------------------------------------------------------
+
+describe("the carousel's pages", () => {
+  it.each([
+    ["2 pins", TWO],
+    ["4 pins", FOUR],
+    ["6 pins", SIX],
+  ])("are the pinned views plus Info, one dot each, at %s", (_n, pinned) => {
+    seed(pinned);
+    render(<Mobile initialView={pinned[0]} />);
+    expect(probe("pages")).toBe([...pinned, "info"].join(","));
+    // One dot per page and nothing else — an unpinned view has neither.
+    expect(dots()).toEqual([...pinned.map(label), "Info"]);
+    // The overflow affordance rides the row but is not a dot.
+    expect(screen.getByRole("button", { name: "All views" })).toBeTruthy();
+  });
+
+  it("gives an unpinned view no page at all", () => {
+    seed(TWO);
+    render(<Mobile initialView="smith" />);
+    for (const id of ROSTER.filter((v) => !TWO.includes(v))) {
+      expect(screen.queryByRole("button", { name: `Show ${label(id)}` })).toBeNull();
+    }
+  });
+});
+
+// --- 2. Index ↔ view mapping ------------------------------------------------
+
+describe("a swipe", () => {
+  it.each([
+    ["2 pins", TWO],
+    ["4 pins", FOUR],
+    ["6 pins", SIX],
+  ])("maps every page index onto the pin at that index, at %s", async (_n, pinned) => {
+    seed(pinned);
+    render(<Mobile initialView={pinned[0]} />);
+    for (let i = 0; i < pinned.length; i++) {
+      await swipeTo(i);
+      expect(probe("index")).toBe(String(i));
+      expect(probe("view")).toBe(pinned[i]);
+    }
+  });
+
+  it.each([
+    ["2 pins", TWO],
+    ["4 pins", FOUR],
+    ["6 pins", SIX],
+  ])("onto Info leaves `view` parked on the last chart page, at %s", async (_n, pinned) => {
+    seed(pinned);
+    render(<Mobile initialView={pinned[0]} />);
+    await swipeTo(pinned.length - 1);
+    await swipeTo(pinned.length); // Info
+    expect(probe("index")).toBe(String(pinned.length));
+    expect(probe("view")).toBe(pinned[pinned.length - 1]);
+  });
+});
+
+describe("a dot tap", () => {
+  it("pages to that pin and scrolls there", async () => {
+    const user = userEvent.setup();
+    seed(FOUR);
+    render(<Mobile initialView="smith" />);
+    await user.click(screen.getByRole("button", { name: `Show ${label("vswr")}` }));
+    expect(probe("view")).toBe("vswr");
+    expect(probe("index")).toBe("2");
+    expect(scrolls.at(-1)).toBe(2 * W);
+  });
+
+  it("reaches Info without moving `view` off the last chart", async () => {
+    const user = userEvent.setup();
+    seed(FOUR);
+    render(<Mobile initialView="smith" />);
+    await user.click(screen.getByRole("button", { name: `Show ${label("azimuth")}` }));
+    await user.click(screen.getByRole("button", { name: "Show Info" }));
+    expect(probe("index")).toBe("4");
+    expect(probe("view")).toBe("azimuth");
+    expect(scrolls.at(-1)).toBe(4 * W);
+  });
+});
+
+// --- 3. The sheet -----------------------------------------------------------
+
+describe("the ⋯ affordance", () => {
+  it("opens the whole roster as a sheet, in registry order", async () => {
+    const user = userEvent.setup();
+    seed(TWO);
+    render(<Mobile initialView="smith" />);
+    expect(screen.queryByRole("menu")).toBeNull();
+    await openSheet(user);
+    expect(screen.getByRole("menu")).toBeTruthy();
+    expect(
+      screen.getAllByRole("menuitem").map((el) => el.textContent?.replace(/NEW$/, "")),
+    ).toEqual(ROSTER.map(label));
+  });
+
+  it("closes on a backdrop click", async () => {
+    const user = userEvent.setup();
+    seed(TWO);
+    const { container } = render(<Mobile initialView="smith" />);
+    await openSheet(user);
+    await user.click(container.querySelector(".view-sheet-backdrop") as Element);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+});
+
+describe("a sheet row tap", () => {
+  // Hard case 3. A peek would have made `view` schematic with no page behind
+  // it; on mobile the row is the pin, and the new page lands at the end.
+  it("pins the view — it does NOT peek it — and appends its page", async () => {
+    const user = userEvent.setup();
+    seed(TWO);
+    render(<Mobile initialView="smith" />);
+    await swipeTo(1);
+    scrolls = [];
+    await openSheet(user);
+    await user.click(sheetRow("schematic"));
+    expect(probe("pages")).toBe("smith,antenna,schematic,info");
+    // The page under the thumb neither moves nor is scrolled away from.
+    expect(probe("view")).toBe("antenna");
+    expect(probe("index")).toBe("1");
+    expect(scrolls).toEqual([]);
+    // Curating is a run of gestures: the sheet stays up.
+    expect(screen.getByRole("menu")).toBeTruthy();
+    expect(dots()).toEqual([label("smith"), label("antenna"), label("schematic"), "Info"]);
+  });
+
+  // Hard case 2.
+  it("unpins the page you are on, landing on its successor with the sheet still open", async () => {
+    const user = userEvent.setup();
+    seed(FOUR);
+    render(<Mobile initialView="smith" />);
+    await swipeTo(1); // antenna
+    await openSheet(user);
+    await user.click(sheetRow("antenna"));
+    expect(probe("pages")).toBe("smith,vswr,azimuth,info");
+    // Same slot, new occupant — the page that slid into it.
+    expect(probe("index")).toBe("1");
+    expect(probe("view")).toBe("vswr");
+    expect(screen.getByRole("menu")).toBeTruthy();
+  });
+
+  it("clamps onto the new last page when the unpinned one was last", async () => {
+    const user = userEvent.setup();
+    seed(FOUR);
+    render(<Mobile initialView="smith" />);
+    await swipeTo(3); // azimuth, the last chart page
+    await openSheet(user);
+    await user.click(sheetRow("azimuth"));
+    expect(probe("index")).toBe("2");
+    expect(probe("view")).toBe("vswr");
+    expect(scrolls.at(-1)).toBe(2 * W);
+  });
+
+  // Hard case 4: Info's index is pinned.length, so both gestures move it.
+  it("moves Info under a user parked on it, without unparking them", async () => {
+    const user = userEvent.setup();
+    seed(TWO);
+    render(<Mobile initialView="smith" />);
+    await swipeTo(1); // antenna
+    await swipeTo(2); // Info, parked on antenna
+    await openSheet(user);
+    await user.click(sheetRow("schematic"));
+    expect(probe("index")).toBe("3");
+    expect(probe("view")).toBe("antenna"); // still parked where Info found it
+    await user.click(sheetRow("schematic")); // and back
+    expect(probe("index")).toBe("2");
+    expect(probe("view")).toBe("antenna");
+  });
+
+  it("re-parks `view` when the page Info parked it on is unpinned", async () => {
+    const user = userEvent.setup();
+    seed(FOUR);
+    render(<Mobile initialView="smith" />);
+    await swipeTo(3); // azimuth
+    await swipeTo(4); // Info, parked on azimuth
+    await openSheet(user);
+    await user.click(sheetRow("azimuth"));
+    expect(probe("index")).toBe("3"); // Info, one page earlier
+    expect(probe("view")).toBe("vswr"); // the new last chart page
+  });
+});
+
+// --- 4. Cap and floor (the sheet reuses togglePin, so it inherits both) ------
+
+describe("the sheet's disabled states", () => {
+  it(`refuses a ${PIN_CAP + 1}th page, on the row as well as the dot`, async () => {
+    const user = userEvent.setup();
+    seed(SIX);
+    render(<Mobile initialView="smith" />);
+    await openSheet(user);
+    const spare = ROSTER.filter((id) => !SIX.includes(id));
+    expect(spare.length).toBeGreaterThan(0); // the roster can overrun the cap
+    for (const id of spare) {
+      expect((sheetRow(id) as HTMLButtonElement).disabled).toBe(true);
+      expect(sheetRow(id).getAttribute("title")).toBe("Unpin a view first");
+      expect(dot(`Pin ${label(id)}`).disabled).toBe(true);
+      await user.click(sheetRow(id));
+    }
+    expect(probe("pages")).toBe([...SIX, "info"].join(","));
+  });
+
+  it("refuses to drop the last page", async () => {
+    const user = userEvent.setup();
+    seed(["gamma"]);
+    render(<Mobile initialView="gamma" />);
+    await openSheet(user);
+    expect((sheetRow("gamma") as HTMLButtonElement).disabled).toBe(true);
+    expect(sheetRow("gamma").getAttribute("title")).toBe("Keep at least one view pinned");
+    expect(dot(`Unpin ${label("gamma")}`).disabled).toBe(true);
+    await user.click(sheetRow("gamma"));
+    expect(probe("pages")).toBe("gamma,info");
+  });
+});
+
+// --- 5. NEW badges ----------------------------------------------------------
+
+describe("the sheet's NEW badges", () => {
+  it("announces unseen views and marks the roster seen on open", async () => {
+    const user = userEvent.setup();
+    const unseen: View[] = ["gamma", "vswr"];
+    seed(
+      TWO,
+      ROSTER.filter((id) => !unseen.includes(id)),
+    );
+    render(<Mobile initialView="smith" />);
+    await openSheet(user);
+    expect(screen.getAllByText("NEW").map((el) => el.parentElement?.textContent)).toEqual(
+      unseen.map((id) => `${label(id)}NEW`),
+    );
+    // Opening IS "you have now been shown the roster" — but the badges must
+    // survive the open that revealed them.
+    expect(JSON.parse(localStorage.getItem(VIEW_PREFS_KEY) ?? "{}").seen).toEqual(
+      expect.arrayContaining(ROSTER),
+    );
+    await openSheet(user); // close
+    await openSheet(user); // and back
+    expect(screen.queryByText("NEW")).toBeNull();
+  });
+});
+
+// --- 6. A view with no page (hard case 1) -----------------------------------
+
+describe("a `view` that is not pinned", () => {
+  it("snaps onto the first page rather than stranding on a pageless view", () => {
+    seed(FOUR);
+    // Stored prefs that do not include the view the session starts on — the
+    // carousel would otherwise sit on a page that has no dot.
+    render(<Mobile initialView="elevation" />);
+    expect(probe("view")).toBe("smith");
+    expect(probe("index")).toBe("0");
+  });
+
+  it("rescues a peek carried across the desktop → mobile breakpoint", async () => {
+    seed(FOUR);
+    // Desktop peek: `schematic` is active but unpinned, which is legal there
+    // (the rail shows every pin and the peek costs no slot).
+    const { rerender } = render(<Mobile isMobile={false} initialView="schematic" />);
+    expect(probe("view")).toBe("schematic");
+    await act(async () => {
+      rerender(<Mobile isMobile initialView="schematic" />);
+    });
+    expect(probe("view")).toBe("smith");
+    expect(probe("index")).toBe("0");
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/SweepChart.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/SweepChart.test.tsx
@@ -17,8 +17,9 @@ HTMLCanvasElement.prototype.getContext =
   (() => null) as unknown as HTMLCanvasElement["getContext"];
 
 // Three points chosen from the closed-form oracle pairs pinned in
-// math.test.ts: Z=50+0j -> matched (|Γ|=0, VSWR=1); Z=100+0j and Z=25+0j ->
-// the 2:1 real mismatch (|Γ|=1/3, VSWR=2) from either side of Z0=50.
+// math.test.ts: Z=50+0j -> matched (S11 floored at -60 dB, VSWR=1);
+// Z=100+0j and Z=25+0j -> the 2:1 real mismatch (|Γ|=1/3 ⇒ S11 -9.5424 dB,
+// VSWR=2) from either side of Z0=50.
 const SWEEP: SweepData = {
   freqs_mhz: [10, 14, 18],
   z_re: [50, 100, 25],
@@ -79,15 +80,15 @@ describe("empty/loading state", () => {
 });
 
 describe("a synthetic 3-point sweep produces a trace", () => {
-  it("gamma mode: y-values are |Γ|, not VSWR, per sample", () => {
+  it("gamma mode: y-values are S11 in dB, not VSWR, per sample", () => {
     const { container } = renderChart("gamma", { sweep: SWEEP });
     const canvas = container.querySelector("canvas.sweep") as HTMLCanvasElement;
     expect(canvas.dataset.points).toBe("3");
     expect(canvas.dataset.feeds).toBe("1");
-    expect(canvas.dataset.yValues).toBe("0.0000,0.3333,0.3333");
+    expect(canvas.dataset.yValues).toBe("-60.0000,-9.5424,-9.5424");
   });
 
-  it("vswr mode: y-values are VSWR, not |Γ|, per sample", () => {
+  it("vswr mode: y-values are VSWR, not S11 dB, per sample", () => {
     const { container } = renderChart("vswr", { sweep: SWEEP });
     const canvas = container.querySelector("canvas.sweep") as HTMLCanvasElement;
     expect(canvas.dataset.points).toBe("3");
@@ -105,7 +106,7 @@ describe("a synthetic 3-point sweep produces a trace", () => {
   it("current-Z marker reflects the live result, converted by the chart's own mode", () => {
     const gamma = renderChart("gamma", { sweep: SWEEP, r: 100, x: 0, z0: 50 });
     const gCanvas = gamma.container.querySelector("canvas.sweep") as HTMLCanvasElement;
-    expect(gCanvas.dataset.current).toBe("0.3333");
+    expect(gCanvas.dataset.current).toBe("-9.5424");
 
     const vswr = renderChart("vswr", { sweep: SWEEP, r: 100, x: 0, z0: 50 });
     const vCanvas = vswr.container.querySelector("canvas.sweep") as HTMLCanvasElement;
@@ -136,7 +137,7 @@ describe("multi-feed sweeps (mirrors SmithChart's feeds_z_re/feeds_z_im policy)"
     // Feed-0's trace is what data-y-values reports (the legacy single-trace
     // convention), and it must come from feeds_z_re[*][0], not the
     // top-level z_re — same fallback order as SmithChart's zAt().
-    expect(canvas.dataset.yValues).toBe("0.0000,0.3333,0.3333");
+    expect(canvas.dataset.yValues).toBe("-60.0000,-9.5424,-9.5424");
   });
 
   it("falls back to the legacy single trace when feeds_z_re is absent or too short", () => {

--- a/src/antennaknobs/web/frontend/src/__tests__/SweepChart.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/SweepChart.test.tsx
@@ -1,0 +1,147 @@
+// Pins SweepChart (src/components/charts/SweepChart.tsx, issue #700 unit 5):
+// the shared |Γ|/VSWR-vs-frequency component behind the "gamma" and "vswr"
+// views. jsdom ships no 2-D canvas context, so — like every other chart —
+// the draw effect's ctx-null guard takes the no-draw path; what's asserted
+// here is the pure-derivation data-* attributes computed at render time
+// (data-mode/data-points/data-feeds/data-y-values/data-current), which are
+// available regardless of whether a real context exists. data-y-values in
+// particular is the mutation catcher: it carries the actual per-mode
+// numbers, so a conversion swap (gamma math running under the vswr label,
+// or vice versa) changes the string even though data-mode stays correct.
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { SweepChart } from "../components/charts/SweepChart";
+import type { SweepData } from "../lib/api";
+
+HTMLCanvasElement.prototype.getContext =
+  (() => null) as unknown as HTMLCanvasElement["getContext"];
+
+// Three points chosen from the closed-form oracle pairs pinned in
+// math.test.ts: Z=50+0j -> matched (|Γ|=0, VSWR=1); Z=100+0j and Z=25+0j ->
+// the 2:1 real mismatch (|Γ|=1/3, VSWR=2) from either side of Z0=50.
+const SWEEP: SweepData = {
+  freqs_mhz: [10, 14, 18],
+  z_re: [50, 100, 25],
+  z_im: [0, 0, 0],
+};
+
+function renderChart(
+  mode: "gamma" | "vswr",
+  overrides: Partial<React.ComponentProps<typeof SweepChart>> = {},
+) {
+  return render(
+    <SweepChart
+      mode={mode}
+      r={0}
+      x={0}
+      z0={50}
+      size={180}
+      sweep={null}
+      measFreqMhz={14}
+      running={false}
+      multiFeed={false}
+      {...overrides}
+    />,
+  );
+}
+
+describe("mode dispatch", () => {
+  it("renders the gamma canvas with its own marker", () => {
+    const { container } = renderChart("gamma");
+    const canvas = container.querySelector('canvas.sweep[data-mode="gamma"]');
+    expect(canvas).not.toBeNull();
+    expect(container.querySelector('canvas.sweep[data-mode="vswr"]')).toBeNull();
+  });
+
+  it("renders the vswr canvas with its own marker", () => {
+    const { container } = renderChart("vswr");
+    const canvas = container.querySelector('canvas.sweep[data-mode="vswr"]');
+    expect(canvas).not.toBeNull();
+    expect(container.querySelector('canvas.sweep[data-mode="gamma"]')).toBeNull();
+  });
+});
+
+describe("empty/loading state", () => {
+  it("renders the frame with no trace and does not crash when sweep is null", () => {
+    const { container } = renderChart("gamma", { sweep: null });
+    const canvas = container.querySelector("canvas.sweep") as HTMLCanvasElement;
+    expect(canvas).not.toBeNull();
+    expect(canvas.dataset.points).toBe("0");
+    expect(canvas.dataset.feeds).toBe("0");
+    expect(canvas.dataset.yValues).toBe("");
+  });
+
+  it("shows no current marker before any solve (r=x=0, no feeds)", () => {
+    const { container } = renderChart("vswr", { sweep: null, r: 0, x: 0 });
+    const canvas = container.querySelector("canvas.sweep") as HTMLCanvasElement;
+    expect(canvas.dataset.current).toBe("");
+  });
+});
+
+describe("a synthetic 3-point sweep produces a trace", () => {
+  it("gamma mode: y-values are |Γ|, not VSWR, per sample", () => {
+    const { container } = renderChart("gamma", { sweep: SWEEP });
+    const canvas = container.querySelector("canvas.sweep") as HTMLCanvasElement;
+    expect(canvas.dataset.points).toBe("3");
+    expect(canvas.dataset.feeds).toBe("1");
+    expect(canvas.dataset.yValues).toBe("0.0000,0.3333,0.3333");
+  });
+
+  it("vswr mode: y-values are VSWR, not |Γ|, per sample", () => {
+    const { container } = renderChart("vswr", { sweep: SWEEP });
+    const canvas = container.querySelector("canvas.sweep") as HTMLCanvasElement;
+    expect(canvas.dataset.points).toBe("3");
+    expect(canvas.dataset.yValues).toBe("1.0000,2.0000,2.0000");
+  });
+
+  it("the two modes never render identical y-values for the same sweep", () => {
+    const gamma = render(<SweepChart mode="gamma" r={0} x={0} z0={50} size={180} sweep={SWEEP} measFreqMhz={14} running={false} multiFeed={false} />);
+    const vswr = render(<SweepChart mode="vswr" r={0} x={0} z0={50} size={180} sweep={SWEEP} measFreqMhz={14} running={false} multiFeed={false} />);
+    const gVals = (gamma.container.querySelector("canvas.sweep") as HTMLCanvasElement).dataset.yValues;
+    const vVals = (vswr.container.querySelector("canvas.sweep") as HTMLCanvasElement).dataset.yValues;
+    expect(gVals).not.toBe(vVals);
+  });
+
+  it("current-Z marker reflects the live result, converted by the chart's own mode", () => {
+    const gamma = renderChart("gamma", { sweep: SWEEP, r: 100, x: 0, z0: 50 });
+    const gCanvas = gamma.container.querySelector("canvas.sweep") as HTMLCanvasElement;
+    expect(gCanvas.dataset.current).toBe("0.3333");
+
+    const vswr = renderChart("vswr", { sweep: SWEEP, r: 100, x: 0, z0: 50 });
+    const vCanvas = vswr.container.querySelector("canvas.sweep") as HTMLCanvasElement;
+    expect(vCanvas.dataset.current).toBe("2.0000");
+  });
+});
+
+describe("multi-feed sweeps (mirrors SmithChart's feeds_z_re/feeds_z_im policy)", () => {
+  it("uses the per-feed arrays when present and shaped for it", () => {
+    const multi: SweepData = {
+      freqs_mhz: [10, 14, 18],
+      z_re: [50, 100, 25], // legacy single-trace fields, should be ignored
+      z_im: [0, 0, 0],
+      feeds_z_re: [
+        [50, 200],
+        [100, 200],
+        [25, 200],
+      ],
+      feeds_z_im: [
+        [0, 0],
+        [0, 0],
+        [0, 0],
+      ],
+    };
+    const { container } = renderChart("gamma", { sweep: multi });
+    const canvas = container.querySelector("canvas.sweep") as HTMLCanvasElement;
+    expect(canvas.dataset.feeds).toBe("2");
+    // Feed-0's trace is what data-y-values reports (the legacy single-trace
+    // convention), and it must come from feeds_z_re[*][0], not the
+    // top-level z_re — same fallback order as SmithChart's zAt().
+    expect(canvas.dataset.yValues).toBe("0.0000,0.3333,0.3333");
+  });
+
+  it("falls back to the legacy single trace when feeds_z_re is absent or too short", () => {
+    const { container } = renderChart("gamma", { sweep: SWEEP });
+    const canvas = container.querySelector("canvas.sweep") as HTMLCanvasElement;
+    expect(canvas.dataset.feeds).toBe("1");
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/ViewGrid.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/ViewGrid.test.tsx
@@ -1,0 +1,136 @@
+// The grid-mode stage's presentational component (unit 3, docs/plan-view-
+// rail-scaling.md). Decoupled from DesignSession's solve/session state on
+// purpose (see ViewGrid.tsx's own comment) so it can be mounted directly
+// instead of needing the fetch/WebSocket harness a real DesignSession mount
+// would — matching this suite's existing precedent of testing pieces PULLED
+// OUT of DesignSession (SolveOverlays.test.tsx, ViewPicker.test.tsx) rather
+// than the monolith itself.
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createRef } from "react";
+import { VIEW_META, type View } from "../lib/view";
+import { ViewGrid } from "../components/results/ViewGrid";
+
+const cellsOf = (ids: View[]) => ids.map((id) => VIEW_META[id]);
+
+function renderGrid(overrides: Partial<Parameters<typeof ViewGrid>[0]> = {}) {
+  const setView = vi.fn();
+  const onMaximize = vi.fn();
+  const renderCell = vi.fn((v: View, size: number) => (
+    <div data-testid={`cell-content-${v}`}>{`${v}@${size}`}</div>
+  ));
+  const props = {
+    gridRef: createRef<HTMLDivElement>(),
+    cells: cellsOf(["antenna", "azimuth", "elevation", "smith"]),
+    view: "antenna" as View,
+    setView,
+    onMaximize,
+    cellSize: 240,
+    rows: 2,
+    cols: 2,
+    renderCell,
+    ...overrides,
+  };
+  const view = render(<ViewGrid {...props} />);
+  return { ...view, setView, onMaximize, renderCell, props };
+}
+
+// --- 1. Cell order and shape ------------------------------------------------
+
+describe("cell order and shape", () => {
+  // Mutation probe 4(a) target: reversing (or otherwise reordering) the
+  // `cells` prop before it reaches ViewGrid must fail this.
+  it("renders cells in exactly the given (pin) order", () => {
+    renderGrid({ cells: cellsOf(["smith", "antenna", "azimuth"]), rows: 2, cols: 2 });
+    const ids = screen
+      .getAllByRole("button", { name: /^Focus / })
+      .map((el) => el.getAttribute("aria-label"));
+    expect(ids).toEqual(["Focus Smith", "Focus Antenna", "Focus Azimuth (xy)"]);
+  });
+
+  it("1x2 for two pins: two cells, no hint", () => {
+    renderGrid({ cells: cellsOf(["antenna", "azimuth"]), rows: 1, cols: 2 });
+    expect(screen.getAllByRole("button", { name: /^Focus / })).toHaveLength(2);
+    expect(screen.queryByText("Pin a 4th view")).toBeNull();
+  });
+
+  it("2x2 for four pins: four cells, no hint", () => {
+    renderGrid({ cells: cellsOf(["antenna", "azimuth", "elevation", "smith"]), rows: 2, cols: 2 });
+    expect(screen.getAllByRole("button", { name: /^Focus / })).toHaveLength(4);
+    expect(screen.queryByText("Pin a 4th view")).toBeNull();
+  });
+
+  it("2x2 with a hint cell for three pins", () => {
+    renderGrid({ cells: cellsOf(["antenna", "azimuth", "elevation"]), rows: 2, cols: 2 });
+    expect(screen.getAllByRole("button", { name: /^Focus / })).toHaveLength(3);
+    expect(screen.getByText("Pin a 4th view")).not.toBeNull();
+  });
+
+  it("one full cell for a single pin", () => {
+    renderGrid({ cells: cellsOf(["antenna"]), rows: 1, cols: 1 });
+    expect(screen.getAllByRole("button", { name: /^Focus / })).toHaveLength(1);
+  });
+
+  it("sets the grid-template from rows/cols", () => {
+    const { container } = renderGrid({ rows: 2, cols: 2 });
+    const grid = container.querySelector(".view-grid") as HTMLElement;
+    expect(grid.style.gridTemplateColumns).toBe("repeat(2, 1fr)");
+    expect(grid.style.gridTemplateRows).toBe("repeat(2, 1fr)");
+  });
+
+  it("passes cellSize through to renderCell", () => {
+    const { renderCell } = renderGrid({ cellSize: 333 });
+    expect(renderCell).toHaveBeenCalledWith("antenna", 333);
+  });
+});
+
+// --- 2. Focus ring -----------------------------------------------------------
+
+describe("focus ring", () => {
+  it("marks the cell matching `view` and no other", () => {
+    const { container } = renderGrid({ view: "elevation" });
+    const focused = container.querySelectorAll(".grid-cell-focus");
+    expect(focused).toHaveLength(1);
+    expect(focused[0].querySelector(".grid-cell-maximize")?.getAttribute("title")).toBe(
+      "Maximize Elevation (yz)",
+    );
+  });
+});
+
+// --- 3. Click vs. maximize ----------------------------------------------------
+
+describe("cell click vs. maximize", () => {
+  it("clicking a cell body focuses it without maximizing", async () => {
+    const user = userEvent.setup();
+    const { setView, onMaximize } = renderGrid();
+    await user.click(screen.getByTestId("cell-content-azimuth"));
+    expect(setView).toHaveBeenCalledWith("azimuth");
+    expect(onMaximize).not.toHaveBeenCalled();
+  });
+
+  it("clicking the maximize glyph maximizes without also focusing", async () => {
+    const user = userEvent.setup();
+    const { setView, onMaximize } = renderGrid();
+    await user.click(screen.getByTitle("Maximize Smith"));
+    expect(onMaximize).toHaveBeenCalledWith("smith");
+    expect(setView).not.toHaveBeenCalled();
+  });
+
+  it("double-clicking a cell body maximizes it", async () => {
+    const user = userEvent.setup();
+    const { onMaximize } = renderGrid();
+    await user.dblClick(screen.getByTestId("cell-content-elevation"));
+    expect(onMaximize).toHaveBeenCalledWith("elevation");
+  });
+});
+
+// --- 4. The HUD never renders per-cell ---------------------------------------
+
+describe("solve-readout HUD", () => {
+  it("is never rendered by ViewGrid itself (unit 3 renders it once, at the stage level)", () => {
+    const { container } = renderGrid();
+    expect(container.querySelectorAll(".stage-readout")).toHaveLength(0);
+    expect(container.querySelectorAll(".readout")).toHaveLength(0);
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/ViewPicker.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/ViewPicker.test.tsx
@@ -1,12 +1,15 @@
-// Pins the "All views" overflow picker and the two rules that only bite on a
-// roster bigger than the five views we ship today: the 6-pin cap and the NEW
-// badge (unit 2 of docs/plan-view-rail-scaling.md).
+// Pins the "All views" overflow picker and the one rule that only bites on a
+// roster bigger than the cap: the 6-pin limit (unit 2 of
+// docs/plan-view-rail-scaling.md).
 //
 // The registry is mocked up to the plan's 9-view design target rather than
-// waiting for those views to exist — with 5 real views the cap is
-// unreachable, and every real view is in the picker's `seen` seed, so nothing
-// could ever badge. The mock is the roster of a NEAR-FUTURE release, which is
-// exactly the situation both rules are written for.
+// waiting for those views to exist: the cap cannot be reached while the
+// shipped roster is smaller than six. The mock is the roster of a NEAR-FUTURE
+// release, which is exactly the situation the rule is written for.
+//
+// Every expectation below is derived from the mocked VIEWS, so the roster
+// growing under this file (as it did when |Γ| and VSWR landed mid-unit)
+// changes nothing here.
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, renderHook, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -14,14 +17,16 @@ import { useState } from "react";
 
 vi.mock("../lib/view", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/view")>();
-  // Ids outside the shipped `View` union, so they need the cast the real
-  // registry does not.
+  // Tops the shipped roster up past the cap with the plan's two still-unbuilt
+  // views (items 8/9). Ids already shipped are skipped — a sibling unit
+  // landing one of these for real must not produce a duplicate row, which is
+  // precisely how this mock broke when |Γ| and VSWR shipped. Their ids sit
+  // outside the shipped `View` union, hence the cast the real registry
+  // does not need.
   const soon = [
-    { id: "gamma", label: "|Γ| vs freq", defaultPinned: false },
-    { id: "vswr", label: "VSWR vs freq", defaultPinned: false },
     { id: "optim", label: "Optimization", defaultPinned: false },
     { id: "converge", label: "Convergence", defaultPinned: false },
-  ] as unknown as typeof actual.VIEWS;
+  ].filter((v) => !actual.VIEWS.some((a) => a.id === v.id)) as unknown as typeof actual.VIEWS;
   const VIEWS = [...actual.VIEWS, ...soon];
   return {
     ...actual,
@@ -31,14 +36,24 @@ vi.mock("../lib/view", async (importOriginal) => {
 });
 
 // Imported AFTER the mock declaration for readability only — vi.mock is
-// hoisted above every import in this file.
-import type { View } from "../lib/view";
-import { VIEW_PREFS_KEY, useViewPrefs } from "../components/session/useViewPrefs";
+// hoisted above every import in this file. VIEWS/VIEW_META here are the
+// mocked ones; PIN_CAP and the hook are real.
+import { VIEW_META, VIEWS, type View } from "../lib/view";
+import {
+  PIN_CAP,
+  VIEW_PREFS_KEY,
+  useViewPrefs,
+} from "../components/session/useViewPrefs";
 import { ViewPicker } from "../components/session/ViewPicker";
 
 const FOUNDING: View[] = ["antenna", "azimuth", "elevation", "smith"];
-const SHIPPED = [...FOUNDING, "schematic"];
-const SOON = ["gamma", "vswr", "optim", "converge"];
+const ROSTER = VIEWS.map((v) => v.id);
+// A deliberate mirror of useViewPrefs' SEEN_SEED (not exported: it is a
+// frozen historical fact, not a knob). Copying it here means a change to the
+// production seed shows up as a failure in the badge tests, which is where
+// the seed's whole meaning lives.
+const PRE_PICKER: View[] = ["antenna", "azimuth", "elevation", "smith", "schematic"];
+const label = (id: View) => VIEW_META[id].label;
 
 beforeEach(() => {
   localStorage.clear();
@@ -83,10 +98,9 @@ const rows = () =>
 describe("the All-views button", () => {
   it("counts the unpinned views", () => {
     render(<Harness />);
-    // 9 views, 4 pinned by default.
     expect(
       screen.getByRole("button", { name: /all views/i }).textContent,
-    ).toContain("+5");
+    ).toContain(`+${ROSTER.length - FOUNDING.length}`);
   });
 });
 
@@ -97,17 +111,9 @@ describe("the picker popover", () => {
     const user = userEvent.setup();
     render(<Harness />);
     await openPicker(user);
-    expect(rows()).toEqual([
-      "Antenna",
-      "Azimuth (xy)",
-      "Elevation (yz)",
-      "Smith",
-      "Schematic",
-      "|Γ| vs freq",
-      "VSWR vs freq",
-      "Optimization",
-      "Convergence",
-    ]);
+    // The WHOLE roster, pinned or not, in registry order — that is the
+    // picker's contract with every view that ships after it.
+    expect(rows()).toEqual(ROSTER.map(label));
   });
 
   it("marks the active row", async () => {
@@ -173,47 +179,63 @@ describe("pin-dot click", () => {
     const user = userEvent.setup();
     render(<Harness />);
     await openPicker(user);
-    await user.click(dot("Pin VSWR vs freq"));
-    await user.click(dot("Pin Schematic"));
-    expect(probe("pinned")).toBe([...FOUNDING, "vswr", "schematic"].join(","));
+    // Pinned bottom-up, so registry order would give the opposite answer.
+    const spare = ROSTER.filter((id) => !FOUNDING.includes(id));
+    const [first, last] = [spare[0], spare[spare.length - 1]];
+    await user.click(dot(`Pin ${label(last)}`));
+    await user.click(dot(`Pin ${label(first)}`));
+    expect(probe("pinned")).toBe([...FOUNDING, last, first].join(","));
   });
 });
 
 // --- 4. The cap -------------------------------------------------------------
 
 describe("the 6-pin cap", () => {
-  it("refuses a 7th pin and disables its dot", async () => {
+  // The mocked roster exists to make this reachable at all.
+  const spare = ROSTER.filter((id) => !FOUNDING.includes(id));
+  const capped = [...FOUNDING, ...spare.slice(0, PIN_CAP - FOUNDING.length)];
+  const refused = ROSTER.filter((id) => !capped.includes(id));
+
+  it("has a roster that can actually overrun the cap", () => {
+    expect(capped).toHaveLength(PIN_CAP);
+    expect(refused.length).toBeGreaterThan(0);
+  });
+
+  it(`refuses pin ${PIN_CAP + 1} and disables its dot`, async () => {
     const user = userEvent.setup();
     render(<Harness />);
     await openPicker(user);
-    await user.click(dot("Pin Schematic"));
-    await user.click(dot("Pin |Γ| vs freq"));
-    const capped = [...FOUNDING, "schematic", "gamma"].join(",");
-    expect(probe("pinned")).toBe(capped);
+    for (const id of capped.filter((id) => !FOUNDING.includes(id))) {
+      await user.click(dot(`Pin ${label(id)}`));
+    }
+    expect(probe("pinned")).toBe(capped.join(","));
 
     // Every remaining unpinned dot is now inert, and says why.
-    for (const label of ["Pin VSWR vs freq", "Pin Optimization", "Pin Convergence"]) {
-      expect((dot(label) as HTMLButtonElement).disabled).toBe(true);
-      expect(dot(label).getAttribute("title")).toBe("Unpin a view first");
+    for (const id of refused) {
+      const d = dot(`Pin ${label(id)}`) as HTMLButtonElement;
+      expect(d.disabled).toBe(true);
+      expect(d.getAttribute("title")).toBe("Unpin a view first");
     }
     // Pointer events cannot reach a disabled button, so drive the model
     // directly to prove the refusal is the hook's, not just the DOM's.
     const { result } = renderHook(() => useViewPrefs());
-    act(() => result.current.togglePin("vswr" as View));
-    expect(result.current.pinned.join(",")).toBe(capped);
+    act(() => result.current.togglePin(refused[0]));
+    expect(result.current.pinned.join(",")).toBe(capped.join(","));
 
     // Unpinning frees exactly one slot.
-    await user.click(dot("Unpin Smith"));
-    expect((dot("Pin VSWR vs freq") as HTMLButtonElement).disabled).toBe(false);
+    await user.click(dot(`Unpin ${label(FOUNDING[3])}`));
+    expect((dot(`Pin ${label(refused[0])}`) as HTMLButtonElement).disabled).toBe(
+      false,
+    );
   });
 
   it("clamps an over-full stored record on load", () => {
     localStorage.setItem(
       VIEW_PREFS_KEY,
-      JSON.stringify({ pinned: [...SHIPPED, ...SOON], seen: [] }),
+      JSON.stringify({ pinned: ROSTER, seen: [] }),
     );
     const { result } = renderHook(() => useViewPrefs());
-    expect(result.current.pinned).toEqual([...SHIPPED, "gamma"]);
+    expect(result.current.pinned).toEqual(ROSTER.slice(0, PIN_CAP));
   });
 });
 
@@ -222,24 +244,21 @@ describe("the 6-pin cap", () => {
 const badges = () =>
   screen.getAllByText("NEW").map((el) => el.parentElement?.textContent ?? "");
 
+const POST_PICKER = ROSTER.filter((id) => !PRE_PICKER.includes(id));
+
 describe("the NEW badge", () => {
   it("marks views the seed does not cover, and stops after the picker is opened", async () => {
     const user = userEvent.setup();
     render(<Harness />);
     await openPicker(user);
-    // The five pre-picker views are seeded as seen; the four later ones are
-    // announced even though they ship unpinned.
-    expect(badges()).toEqual([
-      "|Γ| vs freqNEW",
-      "VSWR vs freqNEW",
-      "OptimizationNEW",
-      "ConvergenceNEW",
-    ]);
+    // The pre-picker views are seeded as seen; everything that shipped after
+    // is announced, even though it all ships unpinned.
+    expect(badges()).toEqual(POST_PICKER.map((id) => `${label(id)}NEW`));
     // Opening is what marks them seen — but the badges must survive the open
     // that revealed them.
     expect(JSON.parse(localStorage.getItem(VIEW_PREFS_KEY) ?? "{}").seen).toEqual([
-      ...SHIPPED,
-      ...SOON,
+      ...PRE_PICKER,
+      ...POST_PICKER,
     ]);
 
     await user.click(screen.getByRole("button", { name: /all views/i }));
@@ -251,7 +270,7 @@ describe("the NEW badge", () => {
     const user = userEvent.setup();
     localStorage.setItem(
       VIEW_PREFS_KEY,
-      JSON.stringify({ pinned: FOUNDING, seen: [...SHIPPED, ...SOON] }),
+      JSON.stringify({ pinned: FOUNDING, seen: ROSTER }),
     );
     render(<Harness />);
     await openPicker(user);

--- a/src/antennaknobs/web/frontend/src/__tests__/ViewPicker.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/ViewPicker.test.tsx
@@ -1,0 +1,260 @@
+// Pins the "All views" overflow picker and the two rules that only bite on a
+// roster bigger than the five views we ship today: the 6-pin cap and the NEW
+// badge (unit 2 of docs/plan-view-rail-scaling.md).
+//
+// The registry is mocked up to the plan's 9-view design target rather than
+// waiting for those views to exist — with 5 real views the cap is
+// unreachable, and every real view is in the picker's `seen` seed, so nothing
+// could ever badge. The mock is the roster of a NEAR-FUTURE release, which is
+// exactly the situation both rules are written for.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, renderHook, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+
+vi.mock("../lib/view", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/view")>();
+  // Ids outside the shipped `View` union, so they need the cast the real
+  // registry does not.
+  const soon = [
+    { id: "gamma", label: "|Γ| vs freq", defaultPinned: false },
+    { id: "vswr", label: "VSWR vs freq", defaultPinned: false },
+    { id: "optim", label: "Optimization", defaultPinned: false },
+    { id: "converge", label: "Convergence", defaultPinned: false },
+  ] as unknown as typeof actual.VIEWS;
+  const VIEWS = [...actual.VIEWS, ...soon];
+  return {
+    ...actual,
+    VIEWS,
+    VIEW_META: Object.fromEntries(VIEWS.map((v) => [v.id, v])),
+  };
+});
+
+// Imported AFTER the mock declaration for readability only — vi.mock is
+// hoisted above every import in this file.
+import type { View } from "../lib/view";
+import { VIEW_PREFS_KEY, useViewPrefs } from "../components/session/useViewPrefs";
+import { ViewPicker } from "../components/session/ViewPicker";
+
+const FOUNDING: View[] = ["antenna", "azimuth", "elevation", "smith"];
+const SHIPPED = [...FOUNDING, "schematic"];
+const SOON = ["gamma", "vswr", "optim", "converge"];
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+// The picker as DesignSession wires it: real prefs hook, real active-view
+// state, plus probes for the two things the rail derives.
+function Harness({ initialView = "antenna" as View }) {
+  const [view, setView] = useState<View>(initialView);
+  const prefs = useViewPrefs();
+  return (
+    <>
+      <div data-testid="view">{view}</div>
+      <div data-testid="pinned">{prefs.pinned.join(",")}</div>
+      <div data-testid="rail">
+        {prefs.railViews(view).map((v) => v.id).join(",")}
+      </div>
+      <ViewPicker
+        view={view}
+        setView={setView}
+        pinned={prefs.pinned}
+        newIds={prefs.newIds}
+        togglePin={prefs.togglePin}
+        markRosterSeen={prefs.markRosterSeen}
+      />
+    </>
+  );
+}
+
+const probe = (id: string) => screen.getByTestId(id).textContent;
+const openPicker = async (user: ReturnType<typeof userEvent.setup>) =>
+  user.click(screen.getByRole("button", { name: /all views/i }));
+const dot = (label: string | RegExp) =>
+  screen.getByRole("button", { name: label });
+const rows = () =>
+  screen
+    .getAllByRole("menuitem")
+    .map((el) => el.textContent?.replace(/NEW$/, "") ?? "");
+
+// --- 1. The button ----------------------------------------------------------
+
+describe("the All-views button", () => {
+  it("counts the unpinned views", () => {
+    render(<Harness />);
+    // 9 views, 4 pinned by default.
+    expect(
+      screen.getByRole("button", { name: /all views/i }).textContent,
+    ).toContain("+5");
+  });
+});
+
+// --- 2. The roster listing --------------------------------------------------
+
+describe("the picker popover", () => {
+  it("lists the whole roster in registry order", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await openPicker(user);
+    expect(rows()).toEqual([
+      "Antenna",
+      "Azimuth (xy)",
+      "Elevation (yz)",
+      "Smith",
+      "Schematic",
+      "|Γ| vs freq",
+      "VSWR vs freq",
+      "Optimization",
+      "Convergence",
+    ]);
+  });
+
+  it("marks the active row", async () => {
+    const user = userEvent.setup();
+    render(<Harness initialView={"smith" as View} />);
+    await openPicker(user);
+    const current = screen
+      .getAllByRole("menuitem")
+      .filter((el) => el.getAttribute("aria-current") === "true");
+    expect(current.map((el) => el.textContent)).toEqual(["Smith"]);
+  });
+
+  it("closes on a backdrop click", async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Harness />);
+    await openPicker(user);
+    await user.click(container.querySelector(".view-picker-backdrop") as Element);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+});
+
+// --- 3. Row click vs. dot click ---------------------------------------------
+
+describe("row click", () => {
+  it("shows an unpinned view WITHOUT pinning it (peek), and closes", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await openPicker(user);
+    await user.click(screen.getByRole("menuitem", { name: "Schematic" }));
+    expect(probe("view")).toBe("schematic");
+    expect(probe("pinned")).toBe(FOUNDING.join(","));
+    // Peek displaces no thumb: the rail is every pin.
+    expect(probe("rail")).toBe(FOUNDING.join(","));
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("switches to a pinned view and drops it from the rail", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await openPicker(user);
+    await user.click(screen.getByRole("menuitem", { name: "Smith" }));
+    expect(probe("view")).toBe("smith");
+    expect(probe("rail")).toBe("antenna,azimuth,elevation");
+  });
+});
+
+describe("pin-dot click", () => {
+  it("toggles the pin without switching the view or closing", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await openPicker(user);
+    await user.click(dot("Pin Schematic"));
+    expect(probe("pinned")).toBe([...FOUNDING, "schematic"].join(","));
+    expect(probe("view")).toBe("antenna");
+    expect(screen.getByRole("menu")).not.toBeNull();
+    // Curating is a run of gestures, so the dot stays available, now inverted.
+    await user.click(dot("Unpin Schematic"));
+    expect(probe("pinned")).toBe(FOUNDING.join(","));
+    expect(probe("view")).toBe("antenna");
+  });
+
+  it("appends new pins in the order pinned (no reorder in v1)", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await openPicker(user);
+    await user.click(dot("Pin VSWR vs freq"));
+    await user.click(dot("Pin Schematic"));
+    expect(probe("pinned")).toBe([...FOUNDING, "vswr", "schematic"].join(","));
+  });
+});
+
+// --- 4. The cap -------------------------------------------------------------
+
+describe("the 6-pin cap", () => {
+  it("refuses a 7th pin and disables its dot", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await openPicker(user);
+    await user.click(dot("Pin Schematic"));
+    await user.click(dot("Pin |Γ| vs freq"));
+    const capped = [...FOUNDING, "schematic", "gamma"].join(",");
+    expect(probe("pinned")).toBe(capped);
+
+    // Every remaining unpinned dot is now inert, and says why.
+    for (const label of ["Pin VSWR vs freq", "Pin Optimization", "Pin Convergence"]) {
+      expect((dot(label) as HTMLButtonElement).disabled).toBe(true);
+      expect(dot(label).getAttribute("title")).toBe("Unpin a view first");
+    }
+    // Pointer events cannot reach a disabled button, so drive the model
+    // directly to prove the refusal is the hook's, not just the DOM's.
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.togglePin("vswr" as View));
+    expect(result.current.pinned.join(",")).toBe(capped);
+
+    // Unpinning frees exactly one slot.
+    await user.click(dot("Unpin Smith"));
+    expect((dot("Pin VSWR vs freq") as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("clamps an over-full stored record on load", () => {
+    localStorage.setItem(
+      VIEW_PREFS_KEY,
+      JSON.stringify({ pinned: [...SHIPPED, ...SOON], seen: [] }),
+    );
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.pinned).toEqual([...SHIPPED, "gamma"]);
+  });
+});
+
+// --- 5. The NEW badge -------------------------------------------------------
+
+const badges = () =>
+  screen.getAllByText("NEW").map((el) => el.parentElement?.textContent ?? "");
+
+describe("the NEW badge", () => {
+  it("marks views the seed does not cover, and stops after the picker is opened", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await openPicker(user);
+    // The five pre-picker views are seeded as seen; the four later ones are
+    // announced even though they ship unpinned.
+    expect(badges()).toEqual([
+      "|Γ| vs freqNEW",
+      "VSWR vs freqNEW",
+      "OptimizationNEW",
+      "ConvergenceNEW",
+    ]);
+    // Opening is what marks them seen — but the badges must survive the open
+    // that revealed them.
+    expect(JSON.parse(localStorage.getItem(VIEW_PREFS_KEY) ?? "{}").seen).toEqual([
+      ...SHIPPED,
+      ...SOON,
+    ]);
+
+    await user.click(screen.getByRole("button", { name: /all views/i }));
+    await openPicker(user);
+    expect(screen.queryByText("NEW")).toBeNull();
+  });
+
+  it("badges nothing when the stored seen already covers the roster", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(
+      VIEW_PREFS_KEY,
+      JSON.stringify({ pinned: FOUNDING, seen: [...SHIPPED, ...SOON] }),
+    );
+    render(<Harness />);
+    await openPicker(user);
+    expect(screen.queryByText("NEW")).toBeNull();
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/gridLayoutPlacement.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/gridLayoutPlacement.test.ts
@@ -1,0 +1,57 @@
+// Two unit-3 placement facts about DesignSession.tsx (docs/plan-view-rail-
+// scaling.md "Layout modes") that a behavioral test can't reach cheaply:
+// the segmented control is desktop-only, and the grid-mode HUD renders once
+// at the stage level rather than per cell.
+//
+// DesignSession.tsx is the one component this whole test suite never mounts
+// directly — see every other file here testing a piece PULLED OUT of it
+// instead (SolveOverlays.test.tsx, ViewPicker.test.tsx, StageOverlays'
+// LayoutModeToggle.test.tsx, ViewGrid.test.tsx). It owns a WebSocket, a
+// fetch-backed catalog, a capabilities gate and more; building that harness
+// to check two placement facts would cost far more than the facts are
+// worth. So this is a structural check instead: it slices the file's own
+// source at the two branch boundaries the code already documents in its own
+// comments ("if (isMobile) {" and the desktop return's `.stage` element,
+// both read verbatim, not by line number) and asserts on what appears in
+// each slice.
+//
+// Source pulled in via Vite's `?raw` (a string import, no bundling) rather
+// than node:fs — this project has no Node type references at all (browser-
+// only code throughout), and one `?raw` import is a smaller footprint than
+// adding one.
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import designSessionSrc from "../components/session/DesignSession.tsx?raw";
+import viewGridSrc from "../components/results/ViewGrid.tsx?raw";
+
+const SRC = designSessionSrc;
+
+const mobileStart = SRC.indexOf("if (isMobile) {");
+const stageStart = SRC.indexOf('className="stage"');
+
+describe("DesignSession's mobile/desktop branch split", () => {
+  it("has both anchors, in the expected order (sanity: this test isn't vacuous)", () => {
+    expect(mobileStart).toBeGreaterThan(-1);
+    expect(stageStart).toBeGreaterThan(mobileStart);
+  });
+
+  const mobileBranch = SRC.slice(mobileStart, stageStart);
+  const desktopBranch = SRC.slice(stageStart);
+
+  it("never renders the layout segmented control in the mobile branch", () => {
+    expect(mobileBranch).not.toContain("LayoutModeToggle");
+  });
+
+  it("renders the layout segmented control in the desktop branch", () => {
+    expect(desktopBranch).toContain("LayoutModeToggle");
+  });
+
+  it("renders the solve-readout HUD exactly three times: mobile Info screen, rail's primary slide, grid's stage level — never per grid cell", () => {
+    const count = (SRC.match(/<SolveReadout/g) ?? []).length;
+    expect(count).toBe(3);
+  });
+
+  it("never imports SolveReadout into the (per-cell) ViewGrid component", () => {
+    expect(viewGridSrc).not.toContain("SolveReadout");
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/math.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/math.test.ts
@@ -5,8 +5,10 @@ import { describe, it, expect } from "vitest";
 import { reflectionCoefficient } from "../lib/format";
 import {
   feedwiseRichardson,
+  gammaDbFromMag,
   gammaMagFromZ,
   richardsonExtrap,
+  S11_DB_FLOOR,
   VSWR_CEILING,
   vswrFromGammaMag,
 } from "../lib/math";
@@ -188,5 +190,33 @@ describe("vswrFromGammaMag", () => {
     const v = vswrFromGammaMag(0.9);
     expect(v).toBeLessThan(VSWR_CEILING);
     expect(v).toBeGreaterThan(vswrFromGammaMag(0.5));
+  });
+});
+
+// S11 log-magnitude — the negative-dB VNA convention the gamma sweep view
+// plots (0 dB = total reflection, dips are good). Pinned against closed
+// forms so a sign flip (positive "return loss") or a base-10/ratio-20 slip
+// fails here, not just in a chart eyeball.
+describe("gammaDbFromMag", () => {
+  it("is 0 dB at total reflection (dead short/open)", () => {
+    expect(gammaDbFromMag(1)).toBeCloseTo(0, 12);
+  });
+
+  it("is 20·log10 of the magnitude, negative for any partial reflection", () => {
+    expect(gammaDbFromMag(1 / 3)).toBeCloseTo(20 * Math.log10(1 / 3), 12);
+    expect(gammaDbFromMag(1 / 3)).toBeCloseTo(-9.542425094393249, 12);
+    expect(gammaDbFromMag(0.1)).toBeCloseTo(-20, 12);
+  });
+
+  it("floors a perfect (or numerically zero) match instead of -Infinity", () => {
+    expect(gammaDbFromMag(0)).toBe(S11_DB_FLOOR);
+    expect(gammaDbFromMag(1e-9)).toBe(S11_DB_FLOOR);
+    expect(Number.isFinite(gammaDbFromMag(0))).toBe(true);
+  });
+
+  it("agrees with the gammaMagFromZ oracle pairs end to end", () => {
+    expect(gammaDbFromMag(gammaMagFromZ(50, 0, 50))).toBe(S11_DB_FLOOR);
+    expect(gammaDbFromMag(gammaMagFromZ(100, 0, 50))).toBeCloseTo(-9.5424, 4);
+    expect(gammaDbFromMag(gammaMagFromZ(25, 0, 50))).toBeCloseTo(-9.5424, 4);
   });
 });

--- a/src/antennaknobs/web/frontend/src/__tests__/math.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/math.test.ts
@@ -3,7 +3,13 @@
 // convergence sweep and the SWR/Smith-chart readouts.
 import { describe, it, expect } from "vitest";
 import { reflectionCoefficient } from "../lib/format";
-import { feedwiseRichardson, richardsonExtrap } from "../lib/math";
+import {
+  feedwiseRichardson,
+  gammaMagFromZ,
+  richardsonExtrap,
+  VSWR_CEILING,
+  vswrFromGammaMag,
+} from "../lib/math";
 
 describe("richardsonExtrap", () => {
   it("returns null for fewer than 3 points", () => {
@@ -122,5 +128,65 @@ describe("reflectionCoefficient", () => {
     expect(gRe).toBeCloseTo(0.2, 12);
     expect(gIm).toBeCloseTo(0.4, 12);
     expect(gMag).toBeCloseTo(0.447213595499958, 12);
+  });
+});
+
+// --- gammaMagFromZ / vswrFromGammaMag ---------------------------------------
+// Closed-form oracle values for the gamma/VSWR-vs-frequency sweep charts
+// (issue #700 unit 5). gammaMagFromZ is a wrapper over reflectionCoefficient,
+// but pinned independently here — a caller that swapped the gamma/VSWR
+// conversion (e.g. plotting VSWR numbers under the gamma label) must fail
+// against these, not just against reflectionCoefficient's own suite.
+describe("gammaMagFromZ", () => {
+  it("is zero at a matched load", () => {
+    expect(gammaMagFromZ(50, 0, 50)).toBeCloseTo(0, 12);
+  });
+
+  it("is 1/3 for a 2:1 real mismatch, either direction", () => {
+    expect(gammaMagFromZ(100, 0, 50)).toBeCloseTo(1 / 3, 12);
+    expect(gammaMagFromZ(25, 0, 50)).toBeCloseTo(1 / 3, 12);
+  });
+
+  // R == X == Z0: a real-part-only (or naive-magnitude) shortcut would read
+  // this as gRe alone (0.2) — the true value needs the reactive component
+  // folded in via Math.hypot, which is what distinguishes a complex |·|
+  // from real-part arithmetic.
+  it("is 1/sqrt(5) for a reactive load, not the real-part-only value", () => {
+    const g = gammaMagFromZ(50, 50, 50);
+    expect(g).toBeCloseTo(1 / Math.sqrt(5), 12);
+    expect(g).not.toBeCloseTo(0.2, 3);
+  });
+
+  it("is 1 at a dead short or dead open", () => {
+    expect(gammaMagFromZ(0, 0, 50)).toBeCloseTo(1, 12);
+  });
+});
+
+describe("vswrFromGammaMag", () => {
+  it("is 1 (perfectly matched) at |Γ| = 0", () => {
+    expect(vswrFromGammaMag(0)).toBeCloseTo(1, 12);
+  });
+
+  it("is 2 at |Γ| = 1/3 (the 2:1 real-mismatch oracle pair)", () => {
+    expect(vswrFromGammaMag(1 / 3)).toBeCloseTo(2, 12);
+  });
+
+  it("agrees with the gammaMagFromZ oracle pairs end to end", () => {
+    expect(vswrFromGammaMag(gammaMagFromZ(50, 0, 50))).toBeCloseTo(1, 12);
+    expect(vswrFromGammaMag(gammaMagFromZ(100, 0, 50))).toBeCloseTo(2, 12);
+    expect(vswrFromGammaMag(gammaMagFromZ(25, 0, 50))).toBeCloseTo(2, 12);
+  });
+
+  it("clamps to the finite ceiling at and beyond |Γ| = 1", () => {
+    expect(vswrFromGammaMag(1)).toBe(VSWR_CEILING);
+    expect(vswrFromGammaMag(1.5)).toBe(VSWR_CEILING);
+  });
+
+  it("stays under the ceiling and monotonic below the point it clamps", () => {
+    // (1+0.98)/(1-0.98) = 99 exactly, so 0.9 stays comfortably under the
+    // ceiling while still exercising the un-clamped branch of the formula.
+    const v = vswrFromGammaMag(0.9);
+    expect(v).toBeLessThan(VSWR_CEILING);
+    expect(v).toBeGreaterThan(vswrFromGammaMag(0.5));
   });
 });

--- a/src/antennaknobs/web/frontend/src/__tests__/mobileCarousel.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/mobileCarousel.test.ts
@@ -1,0 +1,132 @@
+// The mobile carousel's index arithmetic, away from React (#700 unit 4).
+//
+// Both functions here answer the same question — "which page is the user on,
+// now that pages are `pinned ++ [Info]`?" — and every hard case of the unit is
+// a statement about one of them, so they are pinned as pure values rather than
+// inferred from a rendered carousel. jsdom has no layout and therefore no real
+// scroll-snap, which is the other half of the reason: the DOM cannot answer
+// "which page snapped" here at all. MobileCarousel.test.tsx drives the same
+// mappings through the hook with a stubbed scroll geometry.
+import { describe, it, expect } from "vitest";
+import { VIEW_META, mobileScreens, type View } from "../lib/view";
+import { reconcileCarousel } from "../components/session/useMobileCarousel";
+
+const ids = (pinned: View[]) => mobileScreens(pinned).map((s) => s.id);
+
+// Deliberately NOT registry order: pin order is page order, and a mapping that
+// quietly re-sorted into registry order would still pass a same-order fixture.
+const TWO: View[] = ["smith", "antenna"];
+const FOUR: View[] = ["smith", "antenna", "vswr", "azimuth"];
+const SIX: View[] = ["smith", "antenna", "vswr", "azimuth", "schematic", "gamma"];
+
+describe("mobileScreens", () => {
+  it.each([
+    ["2 pins", TWO],
+    ["4 pins", FOUR],
+    ["6 pins", SIX],
+  ])("pages %s in pin order with Info trailing", (_name, pinned) => {
+    expect(ids(pinned)).toEqual([...pinned, "info"]);
+    // Info is the LAST page at every pin count — its index is pinned.length,
+    // which is why nothing may compare against the registry's length.
+    expect(ids(pinned).indexOf("info")).toBe(pinned.length);
+  });
+
+  it("labels the chart pages from the registry", () => {
+    expect(mobileScreens(FOUR).map((s) => s.label)).toEqual([
+      ...FOUR.map((id) => VIEW_META[id].label),
+      "Info",
+    ]);
+  });
+
+  it("still has a page and a dot at the pin floor of one", () => {
+    expect(ids(["gamma"])).toEqual(["gamma", "info"]);
+  });
+});
+
+describe("reconcileCarousel", () => {
+  // Hard case 1: `view` has no page. Stored prefs changed under a parked
+  // `view`, or the desktop handed one over that it was peeking. index 0 is
+  // what a fresh mobile tree holds, so this reads as "snap to the first pin".
+  it("snaps a view with no page onto the first pinned page", () => {
+    expect(reconcileCarousel(FOUR, FOUR, 0, "elevation")).toEqual({
+      index: 0,
+      view: "smith",
+    });
+  });
+
+  // Hard case 2: the page under the thumb was unpinned from the open sheet.
+  it("holds the slot when the current page is unpinned, adopting its successor", () => {
+    const after: View[] = ["smith", "vswr", "azimuth"]; // antenna dropped
+    expect(reconcileCarousel(FOUR, after, 1, "antenna")).toEqual({
+      index: 1,
+      view: "vswr",
+    });
+  });
+
+  it("clamps when the unpinned page was the last one", () => {
+    const after: View[] = ["smith", "antenna", "vswr"]; // azimuth dropped
+    expect(reconcileCarousel(FOUR, after, 3, "azimuth")).toEqual({
+      index: 2,
+      view: "vswr",
+    });
+  });
+
+  it("lands on the only remaining page at the floor", () => {
+    expect(reconcileCarousel(TWO, ["antenna"], 0, "smith")).toEqual({
+      index: 0,
+      view: "antenna",
+    });
+  });
+
+  // Hard case 3: pinning appends, so the page under the thumb must not move.
+  it("leaves the current page exactly where it is when a pin is appended", () => {
+    const after: View[] = [...TWO, "schematic"];
+    expect(reconcileCarousel(TWO, after, 1, "antenna")).toEqual({
+      index: 1,
+      view: "antenna",
+    });
+  });
+
+  it("follows the current view when an EARLIER page is unpinned", () => {
+    const after: View[] = ["antenna", "vswr", "azimuth"]; // smith dropped
+    expect(reconcileCarousel(FOUR, after, 2, "vswr")).toEqual({
+      index: 1,
+      view: "vswr",
+    });
+  });
+
+  // Hard case 4: Info's index is pinned.length, so it moves with every pin —
+  // and a user parked there must stay parked, not get shunted onto a chart.
+  describe("parked on Info", () => {
+    it("follows Info to its new index when a pin is appended", () => {
+      const after: View[] = [...TWO, "schematic"];
+      expect(reconcileCarousel(TWO, after, 2, "antenna")).toEqual({
+        index: 3,
+        view: "antenna",
+      });
+    });
+
+    it("follows Info back when some other page is unpinned", () => {
+      const after: View[] = ["smith", "vswr", "azimuth"];
+      expect(reconcileCarousel(FOUR, after, 4, "azimuth")).toEqual({
+        index: 3,
+        view: "azimuth",
+      });
+    });
+
+    it("re-parks `view` on the last page when the parked one is unpinned", () => {
+      const after: View[] = ["smith", "antenna", "vswr"];
+      expect(reconcileCarousel(FOUR, after, 4, "azimuth")).toEqual({
+        index: 3,
+        view: "vswr",
+      });
+    });
+
+    it("keeps Info reachable at the floor of one pin", () => {
+      expect(reconcileCarousel(TWO, ["antenna"], 2, "smith")).toEqual({
+        index: 1,
+        view: "antenna",
+      });
+    });
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/useViewPrefs.grid.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useViewPrefs.grid.test.tsx
@@ -1,0 +1,221 @@
+// Unit 3 of docs/plan-view-rail-scaling.md ("Layout modes"): the `layout`
+// field useViewPrefs.test.tsx's comments promised room for, plus the pure
+// grid-shape helpers (gridCells/gridShape/gridFix) that decide what grid
+// mode shows and how it recovers when the focus ring drifts off-grid.
+//
+// A separate file rather than additions to useViewPrefs.test.tsx: that file
+// is the pre-existing baseline this arc must keep passing UNEDITED (its
+// exact-keys assertion is what proves the sparse-write design below is
+// correct), so anything new lives here instead.
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { type View } from "../lib/view";
+import {
+  VIEW_PREFS_KEY,
+  gridCells,
+  gridFix,
+  gridShape,
+  useViewPrefs,
+} from "../components/session/useViewPrefs";
+
+const FOUNDING: View[] = ["antenna", "azimuth", "elevation", "smith"];
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+function stored() {
+  return JSON.parse(localStorage.getItem(VIEW_PREFS_KEY) ?? "null");
+}
+
+// --- 1. Defaults --------------------------------------------------------
+
+describe("layout defaults", () => {
+  it("is rail with no stored state", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.layout).toBe("rail");
+  });
+
+  it("writes nothing extra until setLayout is called", () => {
+    renderHook(() => useViewPrefs());
+    expect(localStorage.getItem(VIEW_PREFS_KEY)).toBeNull();
+  });
+});
+
+// --- 2. Persistence + sparse write --------------------------------------
+
+describe("layout persistence", () => {
+  it("round-trips a grid pick through storage to the next mount", () => {
+    const first = renderHook(() => useViewPrefs());
+    act(() => first.result.current.setLayout("grid"));
+    expect(first.result.current.layout).toBe("grid");
+    expect(stored().layout).toBe("grid");
+    first.unmount();
+
+    const second = renderHook(() => useViewPrefs());
+    expect(second.result.current.layout).toBe("grid");
+  });
+
+  it("round-trips back to rail too", () => {
+    const first = renderHook(() => useViewPrefs());
+    act(() => first.result.current.setLayout("grid"));
+    act(() => first.result.current.setLayout("rail"));
+    first.unmount();
+    const second = renderHook(() => useViewPrefs());
+    expect(second.result.current.layout).toBe("rail");
+  });
+
+  // The whole point of the sparse write (see useViewPrefs.ts's ViewPrefs
+  // comment): a pin/unpin that never touches layout must not grow the
+  // stored record's key set, or useViewPrefs.test.tsx's pre-unit-3
+  // exact-keys assertion (["pinned","seen"]) would break on THIS build even
+  // though that test file is untouched.
+  it("omits `layout` from storage while it is rail (togglePin only)", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.togglePin("schematic"));
+    const rec = stored();
+    expect(Object.keys(rec).sort()).toEqual(["pinned", "seen"]);
+  });
+
+  it("includes `layout` once it is grid, even from an unrelated pin toggle", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.setLayout("grid"));
+    act(() => result.current.togglePin("schematic"));
+    const rec = stored();
+    expect(Object.keys(rec).sort()).toEqual(["layout", "pinned", "seen"]);
+    expect(rec.layout).toBe("grid");
+  });
+
+  it("drops the key again on a return to rail", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.setLayout("grid"));
+    act(() => result.current.setLayout("rail"));
+    expect(Object.keys(stored()).sort()).toEqual(["pinned", "seen"]);
+  });
+});
+
+// --- 3. Corrupt / unknown values fall back to rail ----------------------
+
+describe("layout validation", () => {
+  const cases = [
+    ["absent", '{"pinned":["antenna"],"seen":["antenna"]}'],
+    ["wrong type", '{"pinned":["antenna"],"seen":["antenna"],"layout":3}'],
+    ["unknown string", '{"pinned":["antenna"],"seen":["antenna"],"layout":"list"}'],
+    ["null", '{"pinned":["antenna"],"seen":["antenna"],"layout":null}'],
+  ] as const;
+
+  for (const [what, raw] of cases) {
+    it(`falls back to rail on a ${what} layout field`, () => {
+      localStorage.setItem(VIEW_PREFS_KEY, raw);
+      const { result } = renderHook(() => useViewPrefs());
+      expect(result.current.layout).toBe("rail");
+    });
+  }
+
+  it("still recovers the good pinned/seen fields alongside a bad layout", () => {
+    localStorage.setItem(
+      VIEW_PREFS_KEY,
+      '{"pinned":["smith"],"seen":["smith"],"layout":"bogus"}',
+    );
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.pinned).toEqual(["smith"]);
+    expect(result.current.layout).toBe("rail");
+  });
+
+  it("honours a stored grid value", () => {
+    localStorage.setItem(
+      VIEW_PREFS_KEY,
+      '{"pinned":["smith"],"seen":["smith"],"layout":"grid"}',
+    );
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.layout).toBe("grid");
+  });
+});
+
+// --- 4. gridCells / gridShape --------------------------------------------
+
+describe("gridCells", () => {
+  it("shows the first ≤4 pins, in pin order — mutation target: order", () => {
+    expect(gridCells(["smith", "antenna"])).toEqual(["smith", "antenna"]);
+    expect(gridCells(["elevation", "antenna", "azimuth", "smith"])).toEqual([
+      "elevation",
+      "antenna",
+      "azimuth",
+      "smith",
+    ]);
+  });
+
+  it("never shows a 5th or 6th pin", () => {
+    const six: View[] = [
+      "antenna",
+      "azimuth",
+      "elevation",
+      "smith",
+      "schematic",
+      "gamma",
+    ];
+    expect(gridCells(six)).toEqual(FOUNDING);
+    expect(gridCells(six)).toHaveLength(4);
+  });
+
+  it("passes a single pin through unchanged", () => {
+    expect(gridCells(["smith"])).toEqual(["smith"]);
+  });
+});
+
+describe("gridShape", () => {
+  it("is 1x1 for one cell", () => {
+    expect(gridShape(1)).toEqual({ rows: 1, cols: 1 });
+  });
+  it("is 1x2 for two cells", () => {
+    expect(gridShape(2)).toEqual({ rows: 1, cols: 2 });
+  });
+  it("is 2x2 for three cells (the 4th slot is the hint)", () => {
+    expect(gridShape(3)).toEqual({ rows: 2, cols: 2 });
+  });
+  it("is 2x2 for four cells", () => {
+    expect(gridShape(4)).toEqual({ rows: 2, cols: 2 });
+  });
+});
+
+// --- 5. gridFix — the off-grid recovery decision table -------------------
+
+describe("gridFix", () => {
+  it("is a no-op outside grid mode", () => {
+    expect(gridFix("rail", false, "schematic", FOUNDING)).toBeNull();
+  });
+
+  it("is a no-op when the ring is already on a displayed cell", () => {
+    expect(gridFix("grid", true, "smith", FOUNDING)).toBeNull();
+  });
+
+  it("snaps to cell 1 when ENTERING grid with a peeked view active", () => {
+    // wasGrid=false ⇒ just switched rail→grid; "schematic" is unpinned.
+    expect(gridFix("grid", false, "schematic", FOUNDING)).toEqual({
+      view: "antenna",
+    });
+  });
+
+  it("snaps to cell 1 when ENTERING grid with pin #5 active", () => {
+    const sixPins = [...FOUNDING, "schematic", "gamma"] as View[];
+    expect(gridFix("grid", false, "gamma", sixPins)).toEqual({
+      view: "antenna",
+    });
+  });
+
+  it("snaps to cell 1 when ALREADY in grid and a pinned off-grid view (pin #5) is picked", () => {
+    const sixPins = [...FOUNDING, "schematic", "gamma"] as View[];
+    // wasGrid=true ⇒ grid did not just start; the picker activated "gamma".
+    expect(gridFix("grid", true, "gamma", sixPins)).toEqual({
+      view: "antenna",
+    });
+  });
+
+  // The one branch mutation probe 4(b) targets: drop this and the peek stays
+  // stranded on a nonexistent cell instead of falling back to rail.
+  it("leaves grid for rail when ALREADY in grid and an unpinned peek is picked", () => {
+    expect(gridFix("grid", true, "schematic", FOUNDING)).toEqual({
+      layout: "rail",
+    });
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/useViewPrefs.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useViewPrefs.test.tsx
@@ -1,9 +1,15 @@
 // Pins the view-preference model against the SHIPPED roster (unit 2 of
 // docs/plan-view-rail-scaling.md): the default pin set, what the desktop rail
-// derives from it, the arrow-key cycle, and the localStorage contract —
-// including every way the stored record can be garbage. The cap and the NEW
-// badge need a roster bigger than the five views we ship, so they live in
+// derives from it, the arrow-key cycle, the NEW badge, and the localStorage
+// contract — including every way the stored record can be garbage. The 6-pin
+// cap needs a roster bigger than the cap itself, so it lives in
 // ViewPicker.test.tsx, which mocks a larger one.
+//
+// Roster growth is the normal case here (|Γ| and VSWR landed while this file
+// was being written), so anything sized by the roster is DERIVED from VIEWS.
+// Two literals are deliberate: FOUNDING, because "the founding four are the
+// defaults and later views ship unpinned" is the claim itself, and
+// PRE_PICKER, which mirrors the frozen seed inside useViewPrefs.
 //
 // Isolation: the prefs store is module-level (one truth for every open
 // session), and it drops its cache when the last subscriber unmounts, so
@@ -11,7 +17,7 @@
 // whatever it wrote into localStorage.
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
-import type { View } from "../lib/view";
+import { VIEWS, type View } from "../lib/view";
 import {
   PIN_CAP,
   VIEW_PREFS_KEY,
@@ -22,6 +28,15 @@ import {
 import { useViewState } from "../components/session/useViewState";
 
 const FOUNDING: View[] = ["antenna", "azimuth", "elevation", "smith"];
+const ROSTER = VIEWS.map((v) => v.id);
+// A deliberate mirror of useViewPrefs' SEEN_SEED (not exported: it records a
+// frozen historical fact rather than offering a knob). Copying it here means a
+// change to the production seed surfaces as a failure in the badge tests,
+// which is exactly where the seed's meaning lives.
+const PRE_PICKER: View[] = ["antenna", "azimuth", "elevation", "smith", "schematic"];
+// Views that shipped after the picker did — the population the NEW badge
+// exists for. Empty on the day the picker shipped, non-empty ever since.
+const POST_PICKER = ROSTER.filter((id) => !PRE_PICKER.includes(id));
 
 beforeEach(() => {
   localStorage.clear();
@@ -55,9 +70,16 @@ describe("defaults", () => {
     ]);
   });
 
-  it("badges nothing for a first-time user (seen is seeded, not empty)", () => {
+  // The seed's whole purpose, now firing for real: a first-time user is shown
+  // the pre-picker roster as already-seen and every view that shipped AFTER
+  // the picker as NEW. Seeding from the live VIEWS instead would badge none of
+  // them, ever, for exactly the users who have never seen any of it.
+  it("badges the views that shipped after the picker, and only those", () => {
     const { result } = renderHook(() => useViewPrefs());
-    expect([...result.current.newIds]).toEqual([]);
+    expect([...result.current.newIds]).toEqual(POST_PICKER);
+    expect(POST_PICKER).toContain("gamma");
+    expect(POST_PICKER).toContain("vswr");
+    for (const id of PRE_PICKER) expect(result.current.newIds.has(id)).toBe(false);
   });
 });
 
@@ -122,13 +144,20 @@ describe("persistence", () => {
 // --- 4. Nothing read back from storage is trusted ---------------------------
 
 describe("stored-record validation", () => {
+  // Ids no release will ever ship — a stale pin from a REMOVED view, or a
+  // hand-edited key. Asserted, not assumed: "gamma" was this file's stand-in
+  // for an unknown id until the day it became a real view.
+  it("uses id fixtures the registry really does not know", () => {
+    for (const id of ["bogus", "no-such-view"]) expect(ROSTER).not.toContain(id);
+  });
+
   const falls_back = [
     ["corrupt JSON", "{not json"],
     ["a bare array", '["antenna"]'],
     ["a null record", "null"],
     ["no pinned field", '{"seen":["antenna"]}'],
     ["a non-array pinned field", '{"pinned":"antenna"}'],
-    ["only unknown ids", '{"pinned":["bogus","gamma"]}'],
+    ["only unknown ids", '{"pinned":["bogus","no-such-view"]}'],
     ["an empty pin set", '{"pinned":[]}'],
   ] as const;
 
@@ -149,21 +178,21 @@ describe("stored-record validation", () => {
     expect(result.current.pinned).toEqual(["smith", "antenna"]);
   });
 
+  // A `seen` that sanitises to nothing is indistinguishable from an absent
+  // one, so it takes the seed — which leaves the same badges a first-time
+  // user gets, not a blank slate and not the whole roster.
   it("re-seeds `seen` when the stored one has nothing usable left", () => {
     localStorage.setItem(VIEW_PREFS_KEY, '{"pinned":["smith"],"seen":["bogus"]}');
     const { result } = renderHook(() => useViewPrefs());
-    expect([...result.current.newIds]).toEqual([]);
+    expect([...result.current.newIds]).toEqual(POST_PICKER);
   });
 
-  it("honours a partial `seen` — the unseen views badge", () => {
+  it("honours a partial `seen` — every other view badges", () => {
     localStorage.setItem(VIEW_PREFS_KEY, '{"pinned":["smith"],"seen":["antenna"]}');
     const { result } = renderHook(() => useViewPrefs());
-    expect([...result.current.newIds].sort()).toEqual([
-      "azimuth",
-      "elevation",
-      "schematic",
-      "smith",
-    ]);
+    expect([...result.current.newIds]).toEqual(
+      ROSTER.filter((id) => id !== "antenna"),
+    );
   });
 });
 

--- a/src/antennaknobs/web/frontend/src/__tests__/useViewPrefs.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useViewPrefs.test.tsx
@@ -1,0 +1,262 @@
+// Pins the view-preference model against the SHIPPED roster (unit 2 of
+// docs/plan-view-rail-scaling.md): the default pin set, what the desktop rail
+// derives from it, the arrow-key cycle, and the localStorage contract —
+// including every way the stored record can be garbage. The cap and the NEW
+// badge need a roster bigger than the five views we ship, so they live in
+// ViewPicker.test.tsx, which mocks a larger one.
+//
+// Isolation: the prefs store is module-level (one truth for every open
+// session), and it drops its cache when the last subscriber unmounts, so
+// Testing Library's per-test cleanup already gives each test a fresh read of
+// whatever it wrote into localStorage.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import type { View } from "../lib/view";
+import {
+  PIN_CAP,
+  VIEW_PREFS_KEY,
+  cycleOrder,
+  pinBlockedReason,
+  useViewPrefs,
+} from "../components/session/useViewPrefs";
+import { useViewState } from "../components/session/useViewState";
+
+const FOUNDING: View[] = ["antenna", "azimuth", "elevation", "smith"];
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+function stored() {
+  return JSON.parse(localStorage.getItem(VIEW_PREFS_KEY) ?? "null");
+}
+
+// --- 1. Defaults come from the registry metadata ----------------------------
+
+describe("defaults", () => {
+  it("pins exactly the views VIEWS marks defaultPinned", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.pinned).toEqual(FOUNDING);
+  });
+
+  it("writes nothing until the user acts", () => {
+    renderHook(() => useViewPrefs());
+    expect(localStorage.getItem(VIEW_PREFS_KEY)).toBeNull();
+  });
+
+  // Gate: the one intended visible change is that the schematic leaves the
+  // rail. Three non-active founding views, in pin order.
+  it("rails the three non-active founding views", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.railViews("antenna").map((v) => v.id)).toEqual([
+      "azimuth",
+      "elevation",
+      "smith",
+    ]);
+  });
+
+  it("badges nothing for a first-time user (seen is seeded, not empty)", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    expect([...result.current.newIds]).toEqual([]);
+  });
+});
+
+// --- 2. Peek ----------------------------------------------------------------
+
+describe("peek", () => {
+  it("shows every pin while an unpinned view is active, and pins nothing", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.railViews("schematic").map((v) => v.id)).toEqual(
+      FOUNDING,
+    );
+    expect(result.current.pinned).toEqual(FOUNDING);
+  });
+});
+
+// --- 3. Persistence ---------------------------------------------------------
+
+describe("persistence", () => {
+  it("round-trips a pin through storage to the next mount", () => {
+    const first = renderHook(() => useViewPrefs());
+    act(() => first.result.current.togglePin("schematic"));
+    expect(first.result.current.pinned).toEqual([...FOUNDING, "schematic"]);
+    expect(stored().pinned).toEqual([...FOUNDING, "schematic"]);
+    first.unmount();
+
+    const second = renderHook(() => useViewPrefs());
+    expect(second.result.current.pinned).toEqual([...FOUNDING, "schematic"]);
+  });
+
+  it("round-trips an unpin too", () => {
+    const first = renderHook(() => useViewPrefs());
+    act(() => first.result.current.togglePin("smith"));
+    first.unmount();
+    const second = renderHook(() => useViewPrefs());
+    expect(second.result.current.pinned).toEqual(["antenna", "azimuth", "elevation"]);
+  });
+
+  // The stored record is an open object of independent fields so unit 3 can
+  // add `layout` without a key bump: fields it does not know must survive a
+  // write from this build.
+  it("stores a named-field object, not a bare array", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.togglePin("schematic"));
+    const rec = stored();
+    expect(Array.isArray(rec)).toBe(false);
+    expect(Object.keys(rec).sort()).toEqual(["pinned", "seen"]);
+  });
+
+  it("keeps working when storage is disabled", () => {
+    const spy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("storage disabled");
+      });
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.togglePin("schematic"));
+    expect(result.current.pinned).toContain("schematic");
+    spy.mockRestore();
+  });
+});
+
+// --- 4. Nothing read back from storage is trusted ---------------------------
+
+describe("stored-record validation", () => {
+  const falls_back = [
+    ["corrupt JSON", "{not json"],
+    ["a bare array", '["antenna"]'],
+    ["a null record", "null"],
+    ["no pinned field", '{"seen":["antenna"]}'],
+    ["a non-array pinned field", '{"pinned":"antenna"}'],
+    ["only unknown ids", '{"pinned":["bogus","gamma"]}'],
+    ["an empty pin set", '{"pinned":[]}'],
+  ] as const;
+
+  for (const [what, raw] of falls_back) {
+    it(`falls back to the defaults on ${what}`, () => {
+      localStorage.setItem(VIEW_PREFS_KEY, raw);
+      const { result } = renderHook(() => useViewPrefs());
+      expect(result.current.pinned).toEqual(FOUNDING);
+    });
+  }
+
+  it("drops unknown ids and duplicates from a salvageable record", () => {
+    localStorage.setItem(
+      VIEW_PREFS_KEY,
+      '{"pinned":["smith","bogus","smith","antenna"],"seen":["antenna"]}',
+    );
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.pinned).toEqual(["smith", "antenna"]);
+  });
+
+  it("re-seeds `seen` when the stored one has nothing usable left", () => {
+    localStorage.setItem(VIEW_PREFS_KEY, '{"pinned":["smith"],"seen":["bogus"]}');
+    const { result } = renderHook(() => useViewPrefs());
+    expect([...result.current.newIds]).toEqual([]);
+  });
+
+  it("honours a partial `seen` — the unseen views badge", () => {
+    localStorage.setItem(VIEW_PREFS_KEY, '{"pinned":["smith"],"seen":["antenna"]}');
+    const { result } = renderHook(() => useViewPrefs());
+    expect([...result.current.newIds].sort()).toEqual([
+      "azimuth",
+      "elevation",
+      "schematic",
+      "smith",
+    ]);
+  });
+});
+
+// --- 5. The pin floor -------------------------------------------------------
+
+describe("pin floor", () => {
+  // An empty pin set is what loadPrefs reads as corruption, so it must not be
+  // reachable through the UI or the stored state stops being a fixed point.
+  it("refuses to unpin the last pin", () => {
+    localStorage.setItem(VIEW_PREFS_KEY, '{"pinned":["smith"],"seen":["smith"]}');
+    const { result } = renderHook(() => useViewPrefs());
+    expect(pinBlockedReason(result.current.pinned, "smith")).toBe(
+      "Keep at least one view pinned",
+    );
+    act(() => result.current.togglePin("smith"));
+    expect(result.current.pinned).toEqual(["smith"]);
+  });
+});
+
+// --- 6. Arrow-key cycling ---------------------------------------------------
+
+// Dispatch from an ELEMENT, never window: the listener's focus guard reads
+// event.target's tagName, and a real keydown always originates at an element
+// (document.body when nothing is focused).
+function press(key: string, target?: HTMLElement) {
+  act(() => {
+    (target ?? document.body).dispatchEvent(
+      new KeyboardEvent("keydown", { key, bubbles: true }),
+    );
+  });
+}
+
+function renderCycler(pinned: View[]) {
+  return renderHook(() =>
+    useViewState({ currentExample: undefined, active: true, pinned }),
+  );
+}
+
+describe("arrow-key cycling", () => {
+  it("walks exactly the pinned views and wraps", () => {
+    const { result } = renderCycler(FOUNDING);
+    const seen: View[] = [];
+    for (let i = 0; i < FOUNDING.length; i++) {
+      press("ArrowDown");
+      seen.push(result.current.view);
+    }
+    // Four stops return to the start; the schematic is never among them.
+    expect(seen).toEqual(["azimuth", "elevation", "smith", "antenna"]);
+  });
+
+  it("cycles in PIN order, not registry order", () => {
+    const { result } = renderCycler(["smith", "antenna"]);
+    press("ArrowDown");
+    expect(result.current.view).toBe("smith");
+    press("ArrowDown");
+    expect(result.current.view).toBe("antenna");
+  });
+
+  it("keeps a peeked view in the cycle so the arrows can leave it", () => {
+    const { result } = renderCycler(FOUNDING);
+    act(() => result.current.setView("schematic"));
+    press("ArrowDown");
+    expect(result.current.view).toBe("antenna");
+    // …and it sits at the end of the order, so ArrowUp from the first pin
+    // lands back on the peek rather than on the last pin.
+    act(() => result.current.setView("antenna"));
+    press("ArrowUp");
+    expect(result.current.view).toBe("smith");
+  });
+
+  it("leaves the arrows alone while an input or a knob has focus", () => {
+    const { result } = renderCycler(FOUNDING);
+    for (const el of [
+      document.createElement("input"),
+      Object.assign(document.createElement("div"), { className: "knob" }),
+    ]) {
+      document.body.appendChild(el);
+      press("ArrowDown", el);
+      expect(result.current.view).toBe("antenna");
+      el.remove();
+    }
+  });
+});
+
+describe("cycleOrder", () => {
+  it("appends the active view only when it is unpinned", () => {
+    expect(cycleOrder(FOUNDING, "smith")).toEqual(FOUNDING);
+    expect(cycleOrder(FOUNDING, "schematic")).toEqual([...FOUNDING, "schematic"]);
+  });
+});
+
+describe("the cap constant", () => {
+  it("is the six the column math bought", () => {
+    expect(PIN_CAP).toBe(6);
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/useViewState.grid.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useViewState.grid.test.tsx
@@ -1,0 +1,153 @@
+// Unit 3 of docs/plan-view-rail-scaling.md ("Layout modes"/"Keyboard"): the
+// grid-mode half of useViewState — arrow cycling over the displayed cells
+// only, and the off-grid-ring recovery effect wired to the pure gridFix
+// decision (useViewPrefs.grid.test.tsx tests that function directly; this
+// file proves the HOOK actually applies it, which is what mutation probe
+// 4(b) — "drop the off-grid snap" — needs to catch).
+//
+// Rail mode's own arrow-cycling behavior (pinned ∪ active, cap, wrap, the
+// input/knob focus guard) is pinned in useViewPrefs.test.tsx and is
+// UNTOUCHED by this unit — nothing here repeats it beyond the one sanity
+// check that layout defaulting to "rail" doesn't change it.
+import { describe, it, expect, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { type View } from "../lib/view";
+import { useViewState } from "../components/session/useViewState";
+import { type Layout } from "../components/session/useViewPrefs";
+
+const FOUNDING: View[] = ["antenna", "azimuth", "elevation", "smith"];
+
+function press(key: string, target?: HTMLElement) {
+  act(() => {
+    (target ?? document.body).dispatchEvent(
+      new KeyboardEvent("keydown", { key, bubbles: true }),
+    );
+  });
+}
+
+// --- 1. Grid-mode arrow cycling ------------------------------------------
+
+describe("grid-mode arrow cycling", () => {
+  it("cycles exactly the displayed cells (first ≤4 pins) and wraps", () => {
+    const { result } = renderHook(() =>
+      useViewState({ currentExample: undefined, active: true, pinned: FOUNDING, layout: "grid" }),
+    );
+    const seen: View[] = [];
+    for (let i = 0; i < FOUNDING.length; i++) {
+      press("ArrowDown");
+      seen.push(result.current.view);
+    }
+    expect(seen).toEqual(["azimuth", "elevation", "smith", "antenna"]);
+  });
+
+  it("never lands on pin #5 or #6, even though they're pinned", () => {
+    const sixPins: View[] = [...FOUNDING, "schematic", "gamma"];
+    const { result } = renderHook(() =>
+      useViewState({ currentExample: undefined, active: true, pinned: sixPins, layout: "grid" }),
+    );
+    const seen = new Set<View>([result.current.view]);
+    for (let i = 0; i < 8; i++) {
+      press("ArrowDown");
+      seen.add(result.current.view);
+    }
+    expect(seen).toEqual(new Set(FOUNDING));
+  });
+
+  it("does not affect rail mode's pinned ∪ active cycle (default layout)", () => {
+    const { result } = renderHook(() =>
+      useViewState({ currentExample: undefined, active: true, pinned: FOUNDING }),
+    );
+    act(() => result.current.setView("schematic"));
+    press("ArrowDown");
+    // Same as useViewPrefs.test.tsx's "keeps a peeked view in the cycle":
+    // schematic (a peek, unpinned) sits at the end of pinned ∪ active.
+    expect(result.current.view).toBe("antenna");
+  });
+});
+
+// --- 2. Off-grid ring recovery (mutation probe 4b target) -----------------
+
+describe("off-grid ring recovery", () => {
+  it("snaps to cell 1 when the hook mounts already in grid with an off-grid view", () => {
+    // The ring starts at useViewState's own default ("antenna"), which IS
+    // displayed here, so peek a pinned-but-off-grid view first, THEN mount
+    // fresh at layout="grid" to simulate "entering grid with it active" —
+    // renderHook's initial render already has layout="grid", so wasGridRef
+    // inits to true and this exercises the "already in grid" branch instead;
+    // see the next test for the true "just switched into grid" transition.
+    const sixPins: View[] = [...FOUNDING, "schematic", "gamma"];
+    const { result } = renderHook(() =>
+      useViewState({ currentExample: undefined, active: true, pinned: sixPins, layout: "grid" }),
+    );
+    act(() => result.current.setView("gamma"));
+    expect(result.current.view).toBe("antenna");
+  });
+
+  it("snaps to cell 1 on the rail→grid transition with a peeked view active", () => {
+    const setLayout = vi.fn();
+    const { result, rerender } = renderHook<ReturnType<typeof useViewState>, { layout: Layout }>(
+      ({ layout }) =>
+        useViewState({
+          currentExample: undefined,
+          active: true,
+          pinned: FOUNDING,
+          layout,
+          setLayout,
+        }),
+      { initialProps: { layout: "rail" } },
+    );
+    act(() => result.current.setView("schematic")); // peek, still rail
+    expect(result.current.view).toBe("schematic");
+    rerender({ layout: "grid" }); // the segmented control's click
+    // Entering grid with a peek active snaps the ring — grid mode itself is
+    // NOT abandoned (setLayout must not have been called).
+    expect(result.current.view).toBe("antenna");
+    expect(setLayout).not.toHaveBeenCalled();
+  });
+
+  it("snaps to cell 1 on the rail→grid transition with pin #5 active", () => {
+    const sixPins: View[] = [...FOUNDING, "schematic", "gamma"];
+    const setLayout = vi.fn();
+    const { result, rerender } = renderHook<ReturnType<typeof useViewState>, { layout: Layout }>(
+      ({ layout }) =>
+        useViewState({
+          currentExample: undefined,
+          active: true,
+          pinned: sixPins,
+          layout,
+          setLayout,
+        }),
+      { initialProps: { layout: "rail" } },
+    );
+    act(() => result.current.setView("gamma"));
+    rerender({ layout: "grid" });
+    expect(result.current.view).toBe("antenna");
+    expect(setLayout).not.toHaveBeenCalled();
+  });
+
+  it("leaves grid for rail when already-in-grid picks an unpinned peek", () => {
+    const setLayout = vi.fn();
+    const { result } = renderHook(() =>
+      useViewState({
+        currentExample: undefined,
+        active: true,
+        pinned: FOUNDING,
+        layout: "grid",
+        setLayout,
+      }),
+    );
+    // Simulates the picker's row-click landing on an unpinned view while
+    // already in grid mode.
+    act(() => result.current.setView("schematic"));
+    expect(setLayout).toHaveBeenCalledWith("rail");
+    // The view itself is left as the peek — rail mode shows it as primary.
+    expect(result.current.view).toBe("schematic");
+  });
+
+  it("does nothing when setLayout is omitted (the branch is simply inert)", () => {
+    const { result } = renderHook(() =>
+      useViewState({ currentExample: undefined, active: true, pinned: FOUNDING, layout: "grid" }),
+    );
+    expect(() => act(() => result.current.setView("schematic"))).not.toThrow();
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/viewRegistry.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/viewRegistry.test.tsx
@@ -67,7 +67,7 @@ describe("view metadata", () => {
       ["elevation", "Elevation (yz)"],
       ["smith", "Smith"],
       ["schematic", "Schematic"],
-      ["gamma", "|Γ| vs freq"],
+      ["gamma", "S11 (dB) vs freq"],
       ["vswr", "VSWR vs freq"],
     ]);
   });

--- a/src/antennaknobs/web/frontend/src/__tests__/viewRegistry.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/viewRegistry.test.tsx
@@ -36,6 +36,8 @@ const EVERY_VIEW: Record<View, true> = {
   elevation: true,
   smith: true,
   schematic: true,
+  gamma: true,
+  vswr: true,
 };
 const ALL_VIEWS = Object.keys(EVERY_VIEW) as View[];
 
@@ -65,11 +67,14 @@ describe("view metadata", () => {
       ["elevation", "Elevation (yz)"],
       ["smith", "Smith"],
       ["schematic", "Schematic"],
+      ["gamma", "|Γ| vs freq"],
+      ["vswr", "VSWR vs freq"],
     ]);
   });
 
   // The founding four are pinned by default; schematic and every later view
-  // ship unpinned (docs/plan-view-rail-scaling.md, "The pin model").
+  // ship unpinned (docs/plan-view-rail-scaling.md, "The pin model") — gamma
+  // and vswr are the roster's first test of that rule beyond schematic.
   it("defaults exactly the founding four to pinned", () => {
     expect(VIEWS.filter((v) => v.defaultPinned).map((v) => v.id).sort()).toEqual(
       ["antenna", "azimuth", "elevation", "smith"],
@@ -114,6 +119,8 @@ const MARKERS: Record<View, string> = {
   elevation: 'canvas.farfield[data-cut="yz"]',
   smith: "canvas.smith",
   schematic: ".schematic-fill",
+  gamma: 'canvas.sweep[data-mode="gamma"]',
+  vswr: 'canvas.sweep[data-mode="vswr"]',
 };
 
 describe("dispatch", () => {

--- a/src/antennaknobs/web/frontend/src/__tests__/viewRegistry.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/viewRegistry.test.tsx
@@ -1,0 +1,154 @@
+// Pins the view registry (unit 1 of docs/plan-view-rail-scaling.md): the
+// metadata half in lib/view.ts and the render half in
+// components/results/viewRegistry.tsx are two records keyed by the same View
+// ids, and ViewPanel is nothing but the lookup between them. What this file
+// guards is that the two halves stay in step and that dispatch lands on the
+// right component — a wiring swap (schematic's id pointing at the Smith
+// renderer) typechecks fine, so only a mounted probe catches it.
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { VIEWS, type View } from "../lib/view";
+import { VIEW_RENDERERS, type ViewRenderProps } from "../components/results/viewRegistry";
+import { ViewPanel } from "../components/results/ViewPanel";
+
+// Azimuth and elevation are the same component differing only by its `cut`
+// prop, which drives canvas drawing and leaves no DOM trace. Stubbing that
+// one component surfaces `cut` as an attribute so an az↔el swap fails here;
+// every other view's component renders for real.
+vi.mock("../components/charts/FarFieldChart", () => ({
+  FarFieldChart: ({ cut }: { cut: string }) => (
+    <canvas className="farfield" data-cut={cut} />
+  ),
+}));
+
+// jsdom ships no 2-D context, and every chart mounted below already guards on
+// a null one and takes its no-draw path. Returning null directly keeps that
+// path while dropping jsdom's "not implemented" stack trace per mount.
+HTMLCanvasElement.prototype.getContext =
+  (() => null) as unknown as HTMLCanvasElement["getContext"];
+
+// Compile-time enumeration of the View union: a missing or misspelled member
+// fails tsc (npm run build), so the runtime lists below cannot drift from the
+// type.
+const EVERY_VIEW: Record<View, true> = {
+  antenna: true,
+  azimuth: true,
+  elevation: true,
+  smith: true,
+  schematic: true,
+};
+const ALL_VIEWS = Object.keys(EVERY_VIEW) as View[];
+
+// --- 1. The two halves cover the union, once each ---------------------------
+
+describe("registry coverage", () => {
+  it("has exactly one VIEWS entry per member of the View union", () => {
+    expect(VIEWS.map((v) => v.id).sort()).toEqual([...ALL_VIEWS].sort());
+    expect(new Set(VIEWS.map((v) => v.id)).size).toBe(VIEWS.length);
+  });
+
+  it("has exactly one render entry per member of the View union", () => {
+    expect(Object.keys(VIEW_RENDERERS).sort()).toEqual([...ALL_VIEWS].sort());
+    for (const id of ALL_VIEWS) {
+      expect(typeof VIEW_RENDERERS[id]).toBe("function");
+    }
+  });
+});
+
+// --- 2. Metadata values -----------------------------------------------------
+
+describe("view metadata", () => {
+  it("keeps the shipped labels and their rail order", () => {
+    expect(VIEWS.map((v) => [v.id, v.label])).toEqual([
+      ["antenna", "Antenna"],
+      ["azimuth", "Azimuth (xy)"],
+      ["elevation", "Elevation (yz)"],
+      ["smith", "Smith"],
+      ["schematic", "Schematic"],
+    ]);
+  });
+
+  // The founding four are pinned by default; schematic and every later view
+  // ship unpinned (docs/plan-view-rail-scaling.md, "The pin model").
+  it("defaults exactly the founding four to pinned", () => {
+    expect(VIEWS.filter((v) => v.defaultPinned).map((v) => v.id).sort()).toEqual(
+      ["antenna", "azimuth", "elevation", "smith"],
+    );
+  });
+});
+
+// --- 3. Dispatch lands on the right component -------------------------------
+
+const PROPS: Omit<ViewRenderProps, "showWireLabels" | "showFeedNames" | "schematicSvg" | "schematicUnavailable"> = {
+  size: 180,
+  fill: true,
+  result: null,
+  preview: null,
+  sweep: null,
+  converge: null,
+  measured: null,
+  pattern: null,
+  pinnedPatterns: [],
+  measFreqMhz: 14.1,
+  sweepRunning: false,
+  convergeRunning: false,
+  azElevDeg: 0,
+  elevAzDeg: 0,
+  cameraProjection: "xy",
+  showHeatmap: false,
+  showEnvelope: false,
+  multiFeed: false,
+  fineNorm: null,
+};
+
+function mount(view: View, overrides: Partial<React.ComponentProps<typeof ViewPanel>> = {}) {
+  return render(<ViewPanel view={view} {...PROPS} {...overrides} />).container;
+}
+
+// One selector per view's own component. Each probe asserts its own marker is
+// present AND that the neighbours it could be confused with are absent, so a
+// swapped pair fails on both sides.
+const MARKERS: Record<View, string> = {
+  antenna: ".canvas-viewport",
+  azimuth: 'canvas.farfield[data-cut="xy"]',
+  elevation: 'canvas.farfield[data-cut="yz"]',
+  smith: "canvas.smith",
+  schematic: ".schematic-fill",
+};
+
+describe("dispatch", () => {
+  for (const view of ALL_VIEWS) {
+    it(`renders only the ${view} view's component`, () => {
+      const container = mount(view);
+      expect(container.querySelector(MARKERS[view])).not.toBeNull();
+      for (const other of ALL_VIEWS) {
+        if (other === view) continue;
+        expect(container.querySelector(MARKERS[other])).toBeNull();
+      }
+    });
+  }
+
+  it("keeps the antenna view's preview fallback and thumb sizing", () => {
+    const preview = { z_in_re: 50, z_in_im: 0 } as ViewRenderProps["preview"];
+    const thumb = mount("antenna", { fill: false, size: 96, preview });
+    const wrapper = thumb.querySelector(".antenna-thumb") as HTMLElement;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper.style.width).toBe("96px");
+    expect(wrapper.style.height).toBe("96px");
+    expect(thumb.querySelector(".antenna-fill")).toBeNull();
+    // fill drives the canvas's interactive affordances, so the Fit button is
+    // the thumb/stage discriminator.
+    expect(thumb.querySelector(".viewport-fit")).toBeNull();
+    expect(mount("antenna").querySelector(".viewport-fit")).not.toBeNull();
+  });
+
+  it("passes the schematic view its own props", () => {
+    const svg = '<svg viewBox="0 0 10 10"><path d="M 0,0 L 10,10" /></svg>';
+    expect(mount("schematic", { schematicSvg: svg }).innerHTML).toContain("viewBox");
+    const empty = mount("schematic", { schematicUnavailable: true });
+    expect(empty.textContent).toMatch(/no feed circuit/i);
+    // Thumb sizing is the panel's, not the wrapper div's.
+    const thumb = mount("schematic", { fill: false, size: 96 });
+    expect(thumb.querySelector(".schematic-thumb")).not.toBeNull();
+  });
+});

--- a/src/antennaknobs/web/frontend/src/components/charts/SweepChart.tsx
+++ b/src/antennaknobs/web/frontend/src/components/charts/SweepChart.tsx
@@ -1,0 +1,282 @@
+import { useContext, useEffect, useRef } from "react";
+import type { FeedEntry, SweepData } from "../../lib/api";
+import { gammaMagFromZ, vswrFromGammaMag } from "../../lib/math";
+import { ThemeContext } from "../hooks";
+import { feedColor, feedSweepColor, plotColors } from "./palette";
+
+// The two output views the sweep already pays for: |Γ| vs. frequency and
+// VSWR vs. frequency (issue #700 unit 5, docs/plan-view-rail-scaling.md
+// items 6/7). One component, precedent FarFieldChart's `cut` prop — the two
+// modes differ only in the y-axis domain/ticks and which lib/math.ts
+// conversion turns a swept Z into a y-value.
+export type SweepMode = "gamma" | "vswr";
+
+// y-domain per mode. gamma is bounded [0,1] by construction (|Γ| can't
+// exceed 1 for a passive Z0). VSWR is unbounded as |Γ| → 1; the ham-
+// instrument convention is a linear 1..10 scale with an off-scale
+// indication for anything hotter — matching a real SWR meter's needle
+// pinned at the peg rather than a y-axis that silently rescales every time
+// a knob drags through a bad match.
+const DOMAIN: Record<SweepMode, { lo: number; hi: number; ticks: number[]; title: string }> = {
+  gamma: { lo: 0, hi: 1, ticks: [0, 0.2, 0.4, 0.6, 0.8, 1.0], title: "|Γ|" },
+  vswr: { lo: 1, hi: 10, ticks: [1, 2, 4, 6, 8, 10], title: "VSWR" },
+};
+
+// Z -> this mode's y-value. Both modes go through gammaMagFromZ first (the
+// one place |Γ| gets computed), so a bug there shows up identically in both
+// charts instead of two independently-wrong formulas.
+function valueFor(mode: SweepMode, re: number, im: number, z0: number): number {
+  const g = gammaMagFromZ(re, im, z0);
+  return mode === "gamma" ? g : vswrFromGammaMag(g);
+}
+
+export function SweepChart({
+  mode,
+  r,
+  x,
+  z0,
+  size,
+  sweep,
+  measFreqMhz,
+  running,
+  feeds,
+  multiFeed,
+}: {
+  mode: SweepMode;
+  r: number;
+  x: number;
+  z0: number;
+  size: number;
+  sweep: SweepData | null;
+  measFreqMhz: number;
+  running: boolean;
+  /** Multi-feed geometries pass the per-feed Z list from the latest solve so
+   *  the chart can mark N current points, one per port (same prop SmithChart
+   *  takes for the same reason). */
+  feeds?: FeedEntry[];
+  multiFeed: boolean;
+}) {
+  const theme = useContext(ThemeContext); // repaint on theme toggle (dep below)
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const dom = DOMAIN[mode];
+
+  // Pure derivation from props, computed outside the canvas effect so it's
+  // available for the data-* attributes below even when there is no 2-D
+  // context to draw with (jsdom in tests). This is also the one place the
+  // mode's conversion runs per sample — the draw effect below reuses it
+  // rather than recomputing.
+  const hasSweep = !!sweep && sweep.freqs_mhz.length > 1;
+  const hasMulti =
+    hasSweep &&
+    !!sweep!.feeds_z_re &&
+    !!sweep!.feeds_z_im &&
+    sweep!.feeds_z_re!.length === sweep!.freqs_mhz.length &&
+    sweep!.feeds_z_re![0].length > 1;
+  const nFeeds = hasSweep ? (hasMulti ? sweep!.feeds_z_re![0].length : 1) : 0;
+  const zAt = (fi: number, i: number) =>
+    hasMulti
+      ? { re: sweep!.feeds_z_re![i][fi], im: sweep!.feeds_z_im![i][fi] }
+      : { re: sweep!.z_re[i], im: sweep!.z_im[i] };
+  // Feed-0 (or the legacy single trace)'s y-values, exposed for tests: a
+  // mutation that swapped gamma<->vswr math changes these numbers even
+  // though the DOM shape (canvas, data-mode) stays identical.
+  const traceY = hasSweep
+    ? sweep!.freqs_mhz.map((_, i) => {
+        const z = zAt(0, i);
+        return valueFor(mode, z.re, z.im, z0);
+      })
+    : [];
+
+  // Current-Z marker(s): one per feed (or the single r/x pair), same
+  // fallback SmithChart uses. Undefined/zero Z (no solve yet) yields no
+  // marker rather than a spurious point at the origin.
+  const markerPoints: Array<{ v: number; fi: number }> =
+    feeds && feeds.length > 0
+      ? feeds.map((f, fi) => ({ v: valueFor(mode, f.z_re, f.z_im, z0), fi }))
+      : r > 0 || x !== 0
+        ? [{ v: valueFor(mode, r, x, z0), fi: 0 }]
+        : [];
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.floor(size * dpr);
+    canvas.height = Math.floor(size * dpr);
+    canvas.style.width = `${size}px`;
+    canvas.style.height = `${size}px`;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+    const PC = plotColors();
+    ctx.fillStyle = PC.bg;
+    ctx.fillRect(0, 0, size, size);
+
+    // Plot rectangle: left margin fits the y-axis tick labels, bottom margin
+    // fits the freq-range / status text (same corner SmithChart uses).
+    const marginL = 26;
+    const marginR = 8;
+    const marginT = 16;
+    const marginB = 20;
+    const plotW = size - marginL - marginR;
+    const plotH = size - marginT - marginB;
+
+    // domain -> [0,1] -> canvas y (top = hi, bottom = lo, same sense as any
+    // chart axis).
+    const frac = (v: number) =>
+      Math.max(0, Math.min(1, (v - dom.lo) / (dom.hi - dom.lo)));
+    const yOf = (v: number) => marginT + plotH * (1 - frac(v));
+    // A value at/above the domain top for VSWR means "off the chart" (a real
+    // SWR meter pins its needle rather than rescaling); gamma never needs
+    // this since |Γ| ≤ 1 always fits.
+    const offScale = (v: number) => v > dom.hi;
+
+    ctx.strokeStyle = PC.grid;
+    ctx.lineWidth = 0.6;
+    ctx.fillStyle = PC.labelDim;
+    ctx.font = "9px ui-monospace, monospace";
+    for (const t of dom.ticks) {
+      const y = yOf(t);
+      ctx.beginPath();
+      ctx.moveTo(marginL, y);
+      ctx.lineTo(marginL + plotW, y);
+      ctx.stroke();
+      const label = mode === "gamma" ? t.toFixed(1) : t.toFixed(0);
+      ctx.fillText(label, 2, y + 3);
+    }
+    // Axis frame.
+    ctx.strokeStyle = PC.axis;
+    ctx.lineWidth = 1;
+    ctx.strokeRect(marginL, marginT, plotW, plotH);
+
+    // Mode title, top-left (same corner SmithChart's Z0 label uses).
+    ctx.fillStyle = PC.labelDim;
+    ctx.font = "10px ui-monospace, monospace";
+    ctx.fillText(dom.title, marginL, 12);
+
+    // Maps a frequency to canvas x within the swept band; undefined (null)
+    // when there is no band to map against. Shared by the trail, the
+    // current-freq guide line, and the current-Z marker's x position so all
+    // three agree about where on the axis a given frequency sits.
+    const fLo = hasSweep ? sweep!.freqs_mhz[0] : null;
+    const fHi = hasSweep ? sweep!.freqs_mhz[sweep!.freqs_mhz.length - 1] : null;
+    const xOf = (f: number) =>
+      marginL + plotW * ((f - fLo!) / ((fHi! - fLo!) || 1));
+
+    if (hasSweep) {
+      const freqs = sweep!.freqs_mhz;
+
+      // One polyline per feed, dim "trail" color (SmithChart's convention:
+      // dim = sweep trail, bright = current-Z marker). Unlike the Smith
+      // chart's 2-D Γ-plane locus, frequency is a natural ordering axis
+      // here, so — unlike that chart's unconnected scatter — a connected
+      // line is the correct read, not an artifact of interpolation.
+      for (let fi = 0; fi < nFeeds; fi++) {
+        ctx.strokeStyle = feedSweepColor(fi);
+        ctx.lineWidth = 1.3;
+        ctx.beginPath();
+        let started = false;
+        for (let i = 0; i < freqs.length; i++) {
+          const z = zAt(fi, i);
+          const v = valueFor(mode, z.re, z.im, z0);
+          const px = xOf(freqs[i]);
+          const py = offScale(v) ? marginT : yOf(v);
+          if (!started) { ctx.moveTo(px, py); started = true; }
+          else ctx.lineTo(px, py);
+        }
+        ctx.stroke();
+
+        // Off-scale samples get an upward tick at the top edge instead of a
+        // dot sitting exactly on the frame — a real VSWR meter's pinned
+        // needle, not a plausible-looking in-range value.
+        ctx.fillStyle = feedSweepColor(fi);
+        for (let i = 0; i < freqs.length; i++) {
+          const z = zAt(fi, i);
+          const v = valueFor(mode, z.re, z.im, z0);
+          if (!offScale(v)) continue;
+          const px = xOf(freqs[i]);
+          ctx.beginPath();
+          ctx.moveTo(px - 3, marginT + 5);
+          ctx.lineTo(px + 3, marginT + 5);
+          ctx.lineTo(px, marginT);
+          ctx.closePath();
+          ctx.fill();
+        }
+      }
+
+      // Freq range label, bottom-right (same convention as SmithChart).
+      ctx.fillStyle = PC.labelBright;
+      ctx.font = "10px ui-monospace, monospace";
+      const txt = `${fLo!.toFixed(2)} → ${fHi!.toFixed(2)} MHz`;
+      ctx.fillText(txt, size - 6 - ctx.measureText(txt).width, size - 6);
+
+      // Current-frequency guide: a dashed vertical line at measFreqMhz (only
+      // meaningful inside the swept band — outside it there is nothing on
+      // this axis to point at) plus a bright per-feed marker where that line
+      // crosses each trail. Mirrors SmithChart's dim-trail/bright-marker
+      // grammar, projected onto a frequency x-axis instead of the Γ-plane.
+      if (measFreqMhz >= fLo! && measFreqMhz <= fHi!) {
+        const gx = xOf(measFreqMhz);
+        ctx.strokeStyle = PC.spoke;
+        ctx.lineWidth = 0.8;
+        ctx.setLineDash([3, 3]);
+        ctx.beginPath();
+        ctx.moveTo(gx, marginT);
+        ctx.lineTo(gx, marginT + plotH);
+        ctx.stroke();
+        ctx.setLineDash([]);
+      }
+    }
+
+    // Current-Z marker(s): bright dot per feed at the measured frequency
+    // (or centered if outside the swept band / no sweep at all — the
+    // reading is still valid, it just has nowhere better to sit on this
+    // axis than the plot's horizontal middle).
+    if (markerPoints.length > 0) {
+      const inBand = hasSweep && measFreqMhz >= fLo! && measFreqMhz <= fHi!;
+      const gx = inBand ? xOf(measFreqMhz) : marginL + plotW / 2;
+      for (const m of markerPoints) {
+        const py = offScale(m.v) ? marginT : yOf(m.v);
+        ctx.fillStyle = feedColor(m.fi);
+        ctx.beginPath();
+        ctx.arc(gx, py, 3.5, 0, 2 * Math.PI);
+        ctx.fill();
+        ctx.strokeStyle = `rgba(${PC.bgRgb}, 0.85)`;
+        ctx.lineWidth = 1;
+        ctx.stroke();
+      }
+    }
+
+    if (running) {
+      ctx.fillStyle = PC.label;
+      ctx.font = "10px ui-monospace, monospace";
+      ctx.fillText("sweeping…", marginL, size - 6);
+    }
+    // multiFeed isn't read directly (nFeeds/hasMulti already derive the same
+    // thing from the sweep payload's own shape) but is kept as a dep so a
+    // descriptor flip that changes it without changing the sweep shape still
+    // redraws — same reasoning as SmithChart's identical comment.
+    //
+    // dom/hasSweep/hasMulti/nFeeds/traceY/markerPoints are pure functions of
+    // the props already listed, not separate state — omitted here (as
+    // opposed to listed like SmithChart's locals) because they're fresh
+    // array/object literals every render; listing them would defeat the
+    // memoization this dep array exists for. mode is listed directly since
+    // it's the one prop dom/valueFor key off that isn't otherwise present.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, r, x, z0, size, sweep, measFreqMhz, running, feeds, multiFeed, theme]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className={`sweep sweep-${mode}`}
+      data-mode={mode}
+      data-points={hasSweep ? sweep!.freqs_mhz.length : 0}
+      data-feeds={nFeeds}
+      data-y-values={traceY.map((v) => v.toFixed(4)).join(",")}
+      data-current={markerPoints.length > 0 ? markerPoints[0].v.toFixed(4) : ""}
+    />
+  );
+}

--- a/src/antennaknobs/web/frontend/src/components/charts/SweepChart.tsx
+++ b/src/antennaknobs/web/frontend/src/components/charts/SweepChart.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useRef } from "react";
 import type { FeedEntry, SweepData } from "../../lib/api";
-import { gammaMagFromZ, vswrFromGammaMag } from "../../lib/math";
+import { gammaDbFromMag, gammaMagFromZ, vswrFromGammaMag } from "../../lib/math";
 import { ThemeContext } from "../hooks";
 import { feedColor, feedSweepColor, plotColors } from "./palette";
 
@@ -11,14 +11,16 @@ import { feedColor, feedSweepColor, plotColors } from "./palette";
 // conversion turns a swept Z into a y-value.
 export type SweepMode = "gamma" | "vswr";
 
-// y-domain per mode. gamma is bounded [0,1] by construction (|Γ| can't
-// exceed 1 for a passive Z0). VSWR is unbounded as |Γ| → 1; the ham-
-// instrument convention is a linear 1..10 scale with an off-scale
-// indication for anything hotter — matching a real SWR meter's needle
-// pinned at the peg rather than a y-axis that silently rescales every time
-// a knob drags through a bad match.
+// y-domain per mode. gamma plots S11 in negative dB (20·log₁₀|Γ|), the
+// VNA/NanoVNA convention: 0 dB at the top, a good match is a downward dip
+// toward −30; anything deeper clamps to the bottom edge (below −30 dB the
+// match is beyond caring, and beyond most VNAs' honesty). VSWR is unbounded
+// as |Γ| → 1; the ham-instrument convention is a linear 1..10 scale with an
+// off-scale indication for anything hotter — matching a real SWR meter's
+// needle pinned at the peg rather than a y-axis that silently rescales
+// every time a knob drags through a bad match.
 const DOMAIN: Record<SweepMode, { lo: number; hi: number; ticks: number[]; title: string }> = {
-  gamma: { lo: 0, hi: 1, ticks: [0, 0.2, 0.4, 0.6, 0.8, 1.0], title: "|Γ|" },
+  gamma: { lo: -30, hi: 0, ticks: [-30, -20, -10, 0], title: "S11 dB" },
   vswr: { lo: 1, hi: 10, ticks: [1, 2, 4, 6, 8, 10], title: "VSWR" },
 };
 
@@ -27,7 +29,7 @@ const DOMAIN: Record<SweepMode, { lo: number; hi: number; ticks: number[]; title
 // charts instead of two independently-wrong formulas.
 function valueFor(mode: SweepMode, re: number, im: number, z0: number): number {
   const g = gammaMagFromZ(re, im, z0);
-  return mode === "gamma" ? g : vswrFromGammaMag(g);
+  return mode === "gamma" ? gammaDbFromMag(g) : vswrFromGammaMag(g);
 }
 
 export function SweepChart({
@@ -130,7 +132,9 @@ export function SweepChart({
     const yOf = (v: number) => marginT + plotH * (1 - frac(v));
     // A value at/above the domain top for VSWR means "off the chart" (a real
     // SWR meter pins its needle rather than rescaling); gamma never needs
-    // this since |Γ| ≤ 1 always fits.
+    // this since S11 ≤ 0 dB for anything passive. Below the gamma floor the
+    // trace just clamps to the bottom edge — an over-deep dip is good news,
+    // not a hazard worth a pinned-needle glyph.
     const offScale = (v: number) => v > dom.hi;
 
     ctx.strokeStyle = PC.grid;
@@ -143,8 +147,7 @@ export function SweepChart({
       ctx.moveTo(marginL, y);
       ctx.lineTo(marginL + plotW, y);
       ctx.stroke();
-      const label = mode === "gamma" ? t.toFixed(1) : t.toFixed(0);
-      ctx.fillText(label, 2, y + 3);
+      ctx.fillText(t.toFixed(0), 2, y + 3);
     }
     // Axis frame.
     ctx.strokeStyle = PC.axis;

--- a/src/antennaknobs/web/frontend/src/components/hooks.ts
+++ b/src/antennaknobs/web/frontend/src/components/hooks.ts
@@ -40,6 +40,43 @@ export function useSlideSize(maxSize = 720, reattachKey?: unknown) {
   return { ref, size };
 }
 
+// Grid mode's per-cell chart size (unit 3, docs/plan-view-rail-scaling.md):
+// same "measure the box, hand charts a square that fits it" idiom as
+// useSlideSize, but the box is the WHOLE grid (rows × cols of equal cells
+// with a CSS gap) rather than one slide. `rows`/`cols` must be the same
+// numbers the caller feeds `.view-grid`'s inline grid-template (ViewGrid and
+// DesignSession both derive them from useViewPrefs' gridShape), or the
+// divided-up size disagrees with the actual cell box.
+const GRID_GAP = 8; // mirrors .view-grid's `gap: var(--space-4)` in styles.css
+export function useGridCellSize(
+  rows: number,
+  cols: number,
+  maxSize = 560,
+  reattachKey?: unknown, // see useSlideSize
+) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState(maxSize);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const update = () => {
+      const rect = el.getBoundingClientRect();
+      const cellW = (rect.width - GRID_GAP * (cols - 1)) / cols;
+      const cellH = (rect.height - GRID_GAP * (rows - 1)) / rows;
+      const s = Math.min(cellW, cellH, maxSize);
+      // -16 is the cell's own padding (8px each side, .grid-cell in
+      // styles.css) — same overhead subtraction useSlideSize does for the
+      // slide's padding.
+      setSize(Math.max(160, Math.floor(s) - 16));
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [rows, cols, maxSize, reattachKey]);
+  return { ref, size };
+}
+
 // Mirror of the stylesheet's phone breakpoint. The query string MUST stay
 // identical to the mobile `@media` prelude in styles.css so the JS layout
 // branch and the CSS rules can never disagree about which viewports are

--- a/src/antennaknobs/web/frontend/src/components/hooks.ts
+++ b/src/antennaknobs/web/frontend/src/components/hooks.ts
@@ -7,7 +7,6 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { VIEWS } from "../lib/view";
 
 // Shared between App.tsx (which owns the Provider and the theme-toggle
 // control) and the chart components under components/charts/ (which read it
@@ -108,18 +107,27 @@ export function useFullscreen() {
   };
 }
 
+// Height the "All views" picker button occupies at the foot of the strip:
+// its own fixed 28 px (see .view-picker-btn in styles.css) plus the one extra
+// strip gap it adds. Changing either number here or there desyncs the model
+// from the layout and the bottom thumb starts clipping.
+const PICKER_SLOT = 28 + 8;
+
 export function useThumbColumnSize(
   stripRef: React.RefObject<HTMLDivElement>,
+  nThumbs: number,
   maxThumb = 280,
   reattachKey?: unknown, // see useSlideSize
 ) {
-  // Vertical thumbstrip: the non-active views scaled so they ALWAYS fit (the
-  // strip never scrolls — overflow:hidden in CSS). Fixed overhead per the CSS:
-  //   strip padding (12+12) + (n-1) gaps of 8 +
+  // Vertical thumbstrip: the rail views scaled so they ALWAYS fit (the strip
+  // never scrolls — overflow:hidden in CSS). Fixed overhead per the CSS:
+  //   strip padding (12+12) + (n-1) gaps of 8 + the picker slot +
   //   per-thumb (button padding 8+6 + label ~14 + gap 6 + border 2) ≈ 36 each,
   // biased slightly high (26 base) so they fit with a hair of slack rather
   // than clip; floor low so a short window shrinks them instead of
-  // overflowing. n tracks the view registry: every view but the active one.
+  // overflowing. n comes from the CALLER because the rail is now the user's
+  // pinned set, not the registry: pinned−1 normally, pinned while peeking an
+  // unpinned view. Zero thumbs still has to divide by something.
   //
   // Two dimensions since the schematic view made it 4 thumbs (issue #652):
   // `width` stays what the column measured in its 3-thumb era — chart text
@@ -127,8 +135,11 @@ export function useThumbColumnSize(
   // collide their left/right labels. Each thumb is a width × height
   // rectangle; the chart renders at width and scales down uniformly to
   // height (a true miniature — text shrinks with it instead of colliding).
-  const nThumbs = VIEWS.length - 1;
-  const overhead = 26 + (nThumbs - 1) * 8 + nThumbs * 36;
+  // That reference column is the 3-thumb era's, picker and all — it is a
+  // fixed yardstick for text legibility, not a measurement of today's strip,
+  // so the picker slot deliberately stays out of it.
+  const n = Math.max(1, nThumbs);
+  const overhead = 26 + (n - 1) * 8 + n * 36 + PICKER_SLOT;
   const widthOverhead = 26 + 2 * 8 + 3 * 36;
   const [size, setSize] = useState({ width: 180, height: 180 });
   useEffect(() => {
@@ -139,7 +150,7 @@ export function useThumbColumnSize(
       const h = el.clientHeight;
       if (h <= 0) return;
       const width = clamp((h - widthOverhead) / 3);
-      const height = clamp((h - overhead) / nThumbs);
+      const height = clamp((h - overhead) / n);
       setSize((s) =>
         s.width === width && s.height === height ? s : { width, height },
       );
@@ -148,6 +159,6 @@ export function useThumbColumnSize(
     const ro = new ResizeObserver(update);
     ro.observe(el);
     return () => ro.disconnect();
-  }, [stripRef, maxThumb, reattachKey]);
+  }, [stripRef, n, overhead, maxThumb, reattachKey]);
   return size;
 }

--- a/src/antennaknobs/web/frontend/src/components/results/StageOverlays.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/StageOverlays.tsx
@@ -4,9 +4,46 @@ import type { GroundModel } from "../../lib/ground";
 import type { ExampleDescriptor } from "../../lib/params";
 import type { Projection, View } from "../../lib/view";
 import { PROJECTIONS } from "../../lib/view";
+import type { Layout } from "../session/useViewPrefs";
 import type { PatternMetrics, PinnedPattern } from "../charts/types";
 import { Knob } from "../params/Knob";
 import { PatternCompareTable } from "./PatternCompareTable";
+
+// The rail/grid segmented control (unit 3, docs/plan-view-rail-scaling.md
+// "Layout modes"): two presets over the same pinned set. Placed by the
+// caller in the stage's top-right corner, desktop only — it lives in
+// DesignSession's desktop return branch, which the mobile branch never
+// reaches, so "hidden on mobile" needs no prop here.
+export function LayoutModeToggle({
+  layout,
+  setLayout,
+}: {
+  layout: Layout;
+  setLayout: (l: Layout) => void;
+}) {
+  return (
+    <div className="layout-toggle" role="group" aria-label="Stage layout">
+      <button
+        type="button"
+        className={layout === "rail" ? "active" : ""}
+        aria-pressed={layout === "rail"}
+        title="Rail: one primary view plus the pinned thumbnails"
+        onClick={() => setLayout("rail")}
+      >
+        ▤
+      </button>
+      <button
+        type="button"
+        className={layout === "grid" ? "active" : ""}
+        aria-pressed={layout === "grid"}
+        title="Grid: equal cells over the first pinned views"
+        onClick={() => setLayout("grid")}
+      >
+        ⊞
+      </button>
+    </div>
+  );
+}
 
 export function AntennaOverlayControls({
   cameraProjection,

--- a/src/antennaknobs/web/frontend/src/components/results/ViewGrid.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/ViewGrid.tsx
@@ -1,0 +1,87 @@
+import type { ReactNode, RefObject } from "react";
+import type { View, ViewMeta } from "../../lib/view";
+
+// Grid layout mode's stage (unit 3, docs/plan-view-rail-scaling.md "Layout
+// modes"): equal cells over the caller's displayed views, no primary. Purely
+// presentational — `cells` (already sliced to the first ≤4 pins, in pin
+// order — see useViewPrefs' gridCells) and `renderCell` come from the
+// caller, so this file has no dependency on the solve/session state that
+// makes DesignSession itself too heavy to mount in a test.
+//
+// The solve-readout HUD is deliberately NOT rendered here: unit 3 puts it
+// once at the stage level (a sibling of this component), matching
+// renderOutput's own "the HUD stays OUT of it" contract (DesignSession.tsx).
+export function ViewGrid({
+  gridRef,
+  cells,
+  view,
+  setView,
+  onMaximize,
+  cellSize,
+  rows,
+  cols,
+  renderCell,
+}: {
+  // Attached to the measured element (components/hooks.ts useGridCellSize) —
+  // rows/cols must be the exact numbers that hook was called with, or the
+  // measured cell size disagrees with the grid-template below.
+  gridRef: RefObject<HTMLDivElement>;
+  cells: ViewMeta[];
+  view: View;
+  setView: (v: View) => void;
+  // Maximize glyph or double-click (Blender's cell↔full toggle): jump to
+  // rail mode with this view primary. DesignSession supplies the
+  // setView+setLayout("rail") pair as one callback.
+  onMaximize: (v: View) => void;
+  cellSize: number;
+  rows: number;
+  cols: number;
+  renderCell: (v: View, size: number) => ReactNode;
+}) {
+  return (
+    <div
+      className="view-grid"
+      ref={gridRef}
+      style={{
+        gridTemplateColumns: `repeat(${cols}, 1fr)`,
+        gridTemplateRows: `repeat(${rows}, 1fr)`,
+      }}
+    >
+      {cells.map((v) => (
+        <div
+          key={v.id}
+          className={`grid-cell${v.id === view ? " grid-cell-focus" : ""}`}
+          role="button"
+          tabIndex={0}
+          aria-label={`Focus ${v.label}`}
+          aria-pressed={v.id === view}
+          onClick={() => setView(v.id)}
+          onDoubleClick={() => onMaximize(v.id)}
+        >
+          <button
+            type="button"
+            className="grid-cell-maximize"
+            title={`Maximize ${v.label}`}
+            onClick={(e) => {
+              // Without this the click also bubbles to the cell's own
+              // onClick above — harmless (setView to the view this cell
+              // already is), but stopping it keeps "maximize" a single,
+              // unambiguous action rather than two.
+              e.stopPropagation();
+              onMaximize(v.id);
+            }}
+          >
+            ⛶
+          </button>
+          {renderCell(v.id, cellSize)}
+        </div>
+      ))}
+      {/* A 3-pin grid still draws a 2×2 (see gridShape) — the 4th slot is an
+          invitation, not a blank hole. Not a cell: no view, no focus ring,
+          no maximize glyph. */}
+      {cells.length === 3 && (
+        <div className="grid-cell grid-cell-hint">Pin a 4th view</div>
+      )}
+    </div>
+  );
+}

--- a/src/antennaknobs/web/frontend/src/components/results/ViewPanel.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/ViewPanel.tsx
@@ -1,134 +1,33 @@
-import type { ConvergeData, MeasuredData, SolveResponse, SweepData } from "../../lib/api";
-import type { Projection, View } from "../../lib/view";
-import { CurrentCanvas } from "../charts/CurrentCanvas";
-import { FarFieldChart } from "../charts/FarFieldChart";
-import { SmithChart } from "../charts/SmithChart";
-import type { PatternData, PinnedPattern } from "../charts/types";
-import { SchematicPanel } from "./SchematicPanel";
+import type { View } from "../../lib/view";
+import { VIEW_RENDERERS, type ViewRenderProps } from "./viewRegistry";
 
+// Dispatch only: look the view's renderer up in the registry and invoke it.
+// The lookup is exact per id — there is no fallthrough view, so a missing
+// entry is a typecheck failure rather than a silently wrong chart.
 export function ViewPanel({
   view,
-  size,
-  fill,
-  result,
-  preview,
-  sweep,
-  converge,
-  measured,
-  pattern,
-  pinnedPatterns,
-  measFreqMhz,
-  sweepRunning,
-  convergeRunning,
-  azElevDeg,
-  elevAzDeg,
-  cameraProjection,
-  showHeatmap,
-  showEnvelope,
   showWireLabels = false,
   showFeedNames = true,
-  multiFeed,
-  fineNorm,
   schematicSvg = null,
   schematicUnavailable = false,
-}: {
+  ...rest
+}: Omit<
+  ViewRenderProps,
+  "showWireLabels" | "showFeedNames" | "schematicSvg" | "schematicUnavailable"
+> & {
   view: View;
-  size: number;
-  fill: boolean;
-  result: SolveResponse | null;
-  preview: SolveResponse | null;
-  sweep: SweepData | null;
-  converge: ConvergeData | null;
-  measured: MeasuredData | null;
-  pattern: PatternData | null;
-  pinnedPatterns: PinnedPattern[];
-  measFreqMhz: number;
-  sweepRunning: boolean;
-  convergeRunning: boolean;
-  azElevDeg: number;
-  elevAzDeg: number;
-  cameraProjection: Projection;
-  showHeatmap: boolean;
-  showEnvelope: boolean;
+  // Optional at the call sites (the thumbstrip omits them); resolved here so
+  // every registry entry sees a complete prop bag.
   showWireLabels?: boolean;
   showFeedNames?: boolean;
-  multiFeed: boolean;
-  fineNorm?: number | null;
   schematicSvg?: string | null;
   schematicUnavailable?: boolean;
 }) {
-  if (view === "antenna") {
-    // Fall back to the geometry-only preview while the real solve is in
-    // flight, but with the current heatmap/waveform overlays forced off —
-    // the preview has no currents, so only the bare wires + feed are drawn.
-    const showingPreview = !result && !!preview;
-    return (
-      <div className={fill ? "antenna-fill" : "antenna-thumb"}
-           style={fill ? undefined : { width: size, height: size }}>
-        <CurrentCanvas
-          result={result ?? preview}
-          projection={cameraProjection}
-          showHeatmap={showingPreview ? false : showHeatmap}
-          showEnvelope={showingPreview ? false : showEnvelope}
-          showWireLabels={showWireLabels}
-          showFeedNames={showFeedNames}
-          interactive={fill}
-        />
-      </div>
-    );
-  }
-  if (view === "azimuth") {
-    return (
-      <FarFieldChart
-        result={result}
-        pattern={pattern}
-        pinned={pinnedPatterns}
-        size={size}
-        cut="xy"
-        azElevDeg={azElevDeg}
-        elevAzDeg={elevAzDeg}
-        fineNorm={fineNorm}
-      />
-    );
-  }
-  if (view === "elevation") {
-    return (
-      <FarFieldChart
-        result={result}
-        pattern={pattern}
-        pinned={pinnedPatterns}
-        size={size}
-        cut="yz"
-        azElevDeg={azElevDeg}
-        elevAzDeg={elevAzDeg}
-        fineNorm={fineNorm}
-      />
-    );
-  }
-  if (view === "schematic") {
-    return (
-      <SchematicPanel
-        svg={schematicSvg}
-        unavailable={schematicUnavailable}
-        size={size}
-        fill={fill}
-      />
-    );
-  }
-  return (
-    <SmithChart
-      r={result?.z_in_re ?? 0}
-      x={result?.z_in_im ?? 0}
-      z0={result?.z0_ohms ?? 50}
-      size={size}
-      sweep={sweep}
-      converge={converge}
-      measured={measured}
-      measFreqMhz={measFreqMhz}
-      running={sweepRunning}
-      convergeRunning={convergeRunning}
-      feeds={result?.feeds}
-      multiFeed={multiFeed}
-    />
-  );
+  return VIEW_RENDERERS[view]({
+    ...rest,
+    showWireLabels,
+    showFeedNames,
+    schematicSvg,
+    schematicUnavailable,
+  });
 }

--- a/src/antennaknobs/web/frontend/src/components/results/viewRegistry.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/viewRegistry.tsx
@@ -1,0 +1,117 @@
+import type { ReactElement } from "react";
+import type { ConvergeData, MeasuredData, SolveResponse, SweepData } from "../../lib/api";
+import type { Projection, View } from "../../lib/view";
+import { CurrentCanvas } from "../charts/CurrentCanvas";
+import { FarFieldChart } from "../charts/FarFieldChart";
+import { SmithChart } from "../charts/SmithChart";
+import type { PatternData, PinnedPattern } from "../charts/types";
+import { SchematicPanel } from "./SchematicPanel";
+
+// The render half of the view registry (the metadata half — id, label,
+// defaultPinned — is VIEWS in lib/view.ts, which stays component-free).
+//
+// Every view receives the same prop bag: the stage hands out one set of
+// inputs and each view takes what it needs, so adding a view is one entry
+// here plus its component, with no plumbing at the call sites.
+export type ViewRenderProps = {
+  size: number;
+  fill: boolean;
+  result: SolveResponse | null;
+  preview: SolveResponse | null;
+  sweep: SweepData | null;
+  converge: ConvergeData | null;
+  measured: MeasuredData | null;
+  pattern: PatternData | null;
+  pinnedPatterns: PinnedPattern[];
+  measFreqMhz: number;
+  sweepRunning: boolean;
+  convergeRunning: boolean;
+  azElevDeg: number;
+  elevAzDeg: number;
+  cameraProjection: Projection;
+  showHeatmap: boolean;
+  showEnvelope: boolean;
+  showWireLabels: boolean;
+  showFeedNames: boolean;
+  multiFeed: boolean;
+  fineNorm?: number | null;
+  schematicSvg: string | null;
+  schematicUnavailable: boolean;
+};
+
+// Plain functions, not components: ViewPanel calls the entry rather than
+// mounting it, so the rendered tree has exactly the depth it had when this
+// was a conditional — no extra fiber between the panel and the chart.
+//
+// Record<View, …> is the exhaustiveness gate: a new member of the View union
+// fails to typecheck until it has an entry.
+export const VIEW_RENDERERS: Record<View, (p: ViewRenderProps) => ReactElement> = {
+  antenna: (p) => {
+    // Fall back to the geometry-only preview while the real solve is in
+    // flight, but with the current heatmap/waveform overlays forced off —
+    // the preview has no currents, so only the bare wires + feed are drawn.
+    const showingPreview = !p.result && !!p.preview;
+    return (
+      <div className={p.fill ? "antenna-fill" : "antenna-thumb"}
+           style={p.fill ? undefined : { width: p.size, height: p.size }}>
+        <CurrentCanvas
+          result={p.result ?? p.preview}
+          projection={p.cameraProjection}
+          showHeatmap={showingPreview ? false : p.showHeatmap}
+          showEnvelope={showingPreview ? false : p.showEnvelope}
+          showWireLabels={p.showWireLabels}
+          showFeedNames={p.showFeedNames}
+          interactive={p.fill}
+        />
+      </div>
+    );
+  },
+  azimuth: (p) => (
+    <FarFieldChart
+      result={p.result}
+      pattern={p.pattern}
+      pinned={p.pinnedPatterns}
+      size={p.size}
+      cut="xy"
+      azElevDeg={p.azElevDeg}
+      elevAzDeg={p.elevAzDeg}
+      fineNorm={p.fineNorm}
+    />
+  ),
+  elevation: (p) => (
+    <FarFieldChart
+      result={p.result}
+      pattern={p.pattern}
+      pinned={p.pinnedPatterns}
+      size={p.size}
+      cut="yz"
+      azElevDeg={p.azElevDeg}
+      elevAzDeg={p.elevAzDeg}
+      fineNorm={p.fineNorm}
+    />
+  ),
+  smith: (p) => (
+    <SmithChart
+      r={p.result?.z_in_re ?? 0}
+      x={p.result?.z_in_im ?? 0}
+      z0={p.result?.z0_ohms ?? 50}
+      size={p.size}
+      sweep={p.sweep}
+      converge={p.converge}
+      measured={p.measured}
+      measFreqMhz={p.measFreqMhz}
+      running={p.sweepRunning}
+      convergeRunning={p.convergeRunning}
+      feeds={p.result?.feeds}
+      multiFeed={p.multiFeed}
+    />
+  ),
+  schematic: (p) => (
+    <SchematicPanel
+      svg={p.schematicSvg}
+      unavailable={p.schematicUnavailable}
+      size={p.size}
+      fill={p.fill}
+    />
+  ),
+};

--- a/src/antennaknobs/web/frontend/src/components/results/viewRegistry.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/viewRegistry.tsx
@@ -4,6 +4,7 @@ import type { Projection, View } from "../../lib/view";
 import { CurrentCanvas } from "../charts/CurrentCanvas";
 import { FarFieldChart } from "../charts/FarFieldChart";
 import { SmithChart } from "../charts/SmithChart";
+import { SweepChart } from "../charts/SweepChart";
 import type { PatternData, PinnedPattern } from "../charts/types";
 import { SchematicPanel } from "./SchematicPanel";
 
@@ -112,6 +113,38 @@ export const VIEW_RENDERERS: Record<View, (p: ViewRenderProps) => ReactElement> 
       unavailable={p.schematicUnavailable}
       size={p.size}
       fill={p.fill}
+    />
+  ),
+  // |Γ| vs. frequency and VSWR vs. frequency (issue #700 unit 5): one
+  // component, `mode` prop, same split FarFieldChart uses for azimuth vs.
+  // elevation above. z0 fallback matches the Smith chart's exact fallback —
+  // both read the same result field for the same reason.
+  gamma: (p) => (
+    <SweepChart
+      mode="gamma"
+      r={p.result?.z_in_re ?? 0}
+      x={p.result?.z_in_im ?? 0}
+      z0={p.result?.z0_ohms ?? 50}
+      size={p.size}
+      sweep={p.sweep}
+      measFreqMhz={p.measFreqMhz}
+      running={p.sweepRunning}
+      feeds={p.result?.feeds}
+      multiFeed={p.multiFeed}
+    />
+  ),
+  vswr: (p) => (
+    <SweepChart
+      mode="vswr"
+      r={p.result?.z_in_re ?? 0}
+      x={p.result?.z_in_im ?? 0}
+      z0={p.result?.z0_ohms ?? 50}
+      size={p.size}
+      sweep={p.sweep}
+      measFreqMhz={p.measFreqMhz}
+      running={p.sweepRunning}
+      feeds={p.result?.feeds}
+      multiFeed={p.multiFeed}
     />
   ),
 };

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -27,7 +27,7 @@ import {
   type SchemaItem,
   type SchemaParamSpec,
 } from "../../lib/params";
-import { MOBILE_SCREENS, VIEWS, type View } from "../../lib/view";
+import { MOBILE_SCREENS, type View } from "../../lib/view";
 import type {
   MeasuredData,
   SolveRequest,
@@ -74,7 +74,9 @@ import { useOptimizer } from "./useOptimizer";
 import { useSchematic } from "./useSchematic";
 import { useSolveChannel } from "./useSolveChannel";
 import { useSolverSlots } from "./useSolverSlots";
+import { useViewPrefs } from "./useViewPrefs";
 import { useViewState } from "./useViewState";
+import { ViewPicker } from "./ViewPicker";
 import { VfoPanel } from "./VfoPanel";
 
 // One antenna design session: the entire left sidebar + right stage plus all
@@ -383,6 +385,16 @@ function DesignSessionBody({
   useEffect(() => {
     reportSummary(id, tabSummary);
   }, [id, tabSummary, reportSummary]);
+  // Which views are resident in the desktop rail (global, persisted) — read
+  // before useViewState because the arrow-key cycler walks the pinned set.
+  // (`togglePin` is renamed: the pattern-pin context below owns that name.)
+  const {
+    pinned,
+    newIds,
+    railViews,
+    togglePin: toggleViewPin,
+    markRosterSeen,
+  } = useViewPrefs();
   // Output view, camera and canvas display toggles (#642 seam 5b-3).
   const {
     azElevDeg,
@@ -401,7 +413,7 @@ function DesignSessionBody({
     setShowWireLabels,
     showFeedNames,
     setShowFeedNames,
-  } = useViewState({ currentExample, active });
+  } = useViewState({ currentExample, active, pinned });
 
   // When linked, design and measurement freq move together.
   function updateDesignFreq(v: number) {
@@ -580,7 +592,10 @@ function DesignSessionBody({
   const { isMobile, orientation } = useIsMobile();
   const { ref: slideRef, size: chartSize } = useSlideSize(720, isMobile);
   const thumbStripRef = useRef<HTMLDivElement>(null);
-  const thumbSize = useThumbColumnSize(thumbStripRef, 280, isMobile);
+  // The rail is the pinned set minus whatever is on the stage; peeking an
+  // unpinned view subtracts nothing, so the count the sizer needs varies.
+  const rail = railViews(view);
+  const thumbSize = useThumbColumnSize(thumbStripRef, rail.length, 280, isMobile);
 
   const {
     mobileIndex,
@@ -1499,7 +1514,7 @@ function DesignSessionBody({
       <main className="stage" aria-label="Antenna output views">
         {solveOverlays}
         <div className="thumbstrip" ref={thumbStripRef}>
-          {VIEWS.filter((v) => v.id !== view).map((v) => (
+          {rail.map((v) => (
             <button
               key={v.id}
               className="thumb"
@@ -1552,6 +1567,16 @@ function DesignSessionBody({
               <div className="thumb-label">{v.label}</div>
             </button>
           ))}
+          {/* Everything not pinned lives behind here. Fixed height by design:
+              useThumbColumnSize subtracts exactly this slot. */}
+          <ViewPicker
+            view={view}
+            setView={setView}
+            pinned={pinned}
+            newIds={newIds}
+            togglePin={toggleViewPin}
+            markRosterSeen={markRosterSeen}
+          />
         </div>
         <div
           className={`carousel-slide${stale ? " stale" : ""}`}

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -27,7 +27,7 @@ import {
   type SchemaItem,
   type SchemaParamSpec,
 } from "../../lib/params";
-import { MOBILE_SCREENS, type View } from "../../lib/view";
+import { mobileScreens, type View } from "../../lib/view";
 import type {
   MeasuredData,
   SolveRequest,
@@ -69,6 +69,7 @@ import {
 import { useCapabilities } from "./useCapabilities";
 import { useDesignCatalog } from "./useDesignCatalog";
 import { useGroundConfig } from "./useGroundConfig";
+import { MobileDots } from "./MobileDots";
 import { useMobileCarousel } from "./useMobileCarousel";
 import { useOptimizer } from "./useOptimizer";
 import { useSchematic } from "./useSchematic";
@@ -604,7 +605,11 @@ function DesignSessionBody({
     mobChartSize,
     onMobileCarouselScroll,
     goToMobileScreen,
-  } = useMobileCarousel({ isMobile, orientation, view, setView });
+  } = useMobileCarousel({ isMobile, orientation, pinned, view, setView });
+  // The carousel's pages: the pinned views in pin order plus the trailing Info
+  // screen. The dots row renders the SAME list, so a page can never exist
+  // without a dot (or the reverse) — see MobileDots.
+  const screens = useMemo(() => mobileScreens(pinned), [pinned]);
   // The pinned-pattern comparison table minimizes to a "{n} pinned" chip so
   // it can get off the chart — it grows a row per pin and swallows a phone
   // screen. Starts collapsed on mobile, expanded on desktop (the pre-existing
@@ -1437,8 +1442,10 @@ function DesignSessionBody({
     </>
   );
 
-  // Mobile: knobs pane + a 5-screen scroll-snap output carousel, instead of
-  // the desktop thumbstrip/HUD stage. A distinct tree (not CSS-hiding the
+  // Mobile: knobs pane + a scroll-snap output carousel over the PINNED views
+  // plus Info (#700 unit 4 — the roster lives behind the dots row's "⋯" sheet,
+  // as the rail's picker does on desktop), instead of the desktop
+  // thumbstrip/HUD stage. A distinct tree (not CSS-hiding the
   // desktop one) keeps both layouts honest; the shared pieces are exactly the
   // hoisted consts above. All hooks already ran, so branching here is safe.
   if (isMobile) {
@@ -1456,7 +1463,7 @@ function DesignSessionBody({
             ref={mobileCarouselRef}
             onScroll={onMobileCarouselScroll}
           >
-            {MOBILE_SCREENS.map((s) => (
+            {screens.map((s) => (
               <div
                 key={s.id}
                 className={`mobile-screen${s.id === "info" ? " mobile-screen-info" : ""}`}
@@ -1490,18 +1497,16 @@ function DesignSessionBody({
               </div>
             ))}
           </div>
-          <div className="mobile-dots" aria-label="Output screens">
-            {MOBILE_SCREENS.map((s, i) => (
-              <button
-                key={s.id}
-                type="button"
-                className={i === mobileIndex ? "active" : ""}
-                aria-label={`Show ${s.label}`}
-                title={s.label}
-                onClick={() => goToMobileScreen(i)}
-              />
-            ))}
-          </div>
+          <MobileDots
+            screens={screens}
+            index={mobileIndex}
+            goToScreen={goToMobileScreen}
+            view={view}
+            pinned={pinned}
+            newIds={newIds}
+            togglePin={toggleViewPin}
+            markRosterSeen={markRosterSeen}
+          />
         </section>
       </div>
     );

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -27,7 +27,7 @@ import {
   type SchemaItem,
   type SchemaParamSpec,
 } from "../../lib/params";
-import { mobileScreens, type View } from "../../lib/view";
+import { mobileScreens, VIEW_META, type View } from "../../lib/view";
 import type {
   MeasuredData,
   SolveRequest,
@@ -40,6 +40,7 @@ import type { PatternMetrics } from "../charts/types";
 import {
   ThemeContext,
   useFullscreen,
+  useGridCellSize,
   useIsMobile,
   useSlideSize,
   useThumbColumnSize,
@@ -50,8 +51,10 @@ import {
   CompareOverlay,
   CutAngleOverlay,
   FarFieldOverlayControls,
+  LayoutModeToggle,
   SmithOverlayControls,
 } from "../results/StageOverlays";
+import { ViewGrid } from "../results/ViewGrid";
 import { ViewPanel } from "../results/ViewPanel";
 import { fetchMetrics, PinsContext, SessionsContext, ThemeControlContext } from "./contexts";
 import { CatalogPanel } from "./CatalogPanel";
@@ -75,7 +78,7 @@ import { useOptimizer } from "./useOptimizer";
 import { useSchematic } from "./useSchematic";
 import { useSolveChannel } from "./useSolveChannel";
 import { useSolverSlots } from "./useSolverSlots";
-import { useViewPrefs } from "./useViewPrefs";
+import { gridCells, gridShape, useViewPrefs } from "./useViewPrefs";
 import { useViewState } from "./useViewState";
 import { ViewPicker } from "./ViewPicker";
 import { VfoPanel } from "./VfoPanel";
@@ -395,26 +398,9 @@ function DesignSessionBody({
     railViews,
     togglePin: toggleViewPin,
     markRosterSeen,
+    layout,
+    setLayout,
   } = useViewPrefs();
-  // Output view, camera and canvas display toggles (#642 seam 5b-3).
-  const {
-    azElevDeg,
-    setAzElevDeg,
-    elevAzDeg,
-    setElevAzDeg,
-    view,
-    setView,
-    cameraProjection,
-    setCameraProjection,
-    showHeatmap,
-    setShowHeatmap,
-    showEnvelope,
-    setShowEnvelope,
-    showWireLabels,
-    setShowWireLabels,
-    showFeedNames,
-    setShowFeedNames,
-  } = useViewState({ currentExample, active, pinned });
 
   // When linked, design and measurement freq move together.
   function updateDesignFreq(v: number) {
@@ -591,12 +577,65 @@ function DesignSessionBody({
   // reattach key, so no desktop viewport is affected; the key makes both
   // hooks re-measure if the window is resized across the breakpoint.
   const { isMobile, orientation } = useIsMobile();
+  // Grid mode is desktop-only (the segmented control never renders on
+  // mobile, so `setLayout("grid")` is never reachable there) — but `layout`
+  // itself is a global persisted flag, so a phone can still load a value of
+  // "grid" left over from a desktop session. Forcing "rail" here keeps the
+  // mobile carousel's arrow-key cycling (pinned ∪ active, unit 2) exactly as
+  // it was; nothing below the mobile branch ever sees "grid".
+  const effectiveLayout = isMobile ? "rail" : layout;
+  // Output view, camera and canvas display toggles (#642 seam 5b-3); the
+  // grid-mode off-grid snap (unit 3) lives inside this hook too, since it
+  // already owns `view` and now needs `layout`/`setLayout` alongside it.
+  const {
+    azElevDeg,
+    setAzElevDeg,
+    elevAzDeg,
+    setElevAzDeg,
+    view,
+    setView,
+    cameraProjection,
+    setCameraProjection,
+    showHeatmap,
+    setShowHeatmap,
+    showEnvelope,
+    setShowEnvelope,
+    showWireLabels,
+    setShowWireLabels,
+    showFeedNames,
+    setShowFeedNames,
+  } = useViewState({
+    currentExample,
+    active,
+    pinned,
+    layout: effectiveLayout,
+    setLayout,
+  });
   const { ref: slideRef, size: chartSize } = useSlideSize(720, isMobile);
   const thumbStripRef = useRef<HTMLDivElement>(null);
   // The rail is the pinned set minus whatever is on the stage; peeking an
   // unpinned view subtracts nothing, so the count the sizer needs varies.
   const rail = railViews(view);
   const thumbSize = useThumbColumnSize(thumbStripRef, rail.length, 280, isMobile);
+  // Grid mode's displayed cells (unit 3): the first ≤4 pins, in pin order.
+  // gridCells/gridShape are pure (useViewPrefs.ts) so this and useViewState's
+  // internal cycling can never disagree about "what's on screen".
+  const gridViewIds = gridCells(pinned);
+  const gridViews = gridViewIds.map((id) => VIEW_META[id]);
+  const { rows: gridRows, cols: gridCols } = gridShape(gridViewIds.length);
+  const { ref: gridRef, size: gridCellSize } = useGridCellSize(
+    gridRows,
+    gridCols,
+    560,
+    effectiveLayout,
+  );
+  // Maximize (glyph or double-click, Blender's cell↔full toggle): jump to
+  // rail mode with this view primary. The segmented control's rail button
+  // returns to grid.
+  const maximizeView = (v: View) => {
+    setView(v);
+    setLayout("rail");
+  };
 
   const {
     mobileIndex,
@@ -1518,92 +1557,129 @@ function DesignSessionBody({
 
       <main className="stage" aria-label="Antenna output views">
         {solveOverlays}
-        <div className="thumbstrip" ref={thumbStripRef}>
-          {rail.map((v) => (
-            <button
-              key={v.id}
-              className="thumb"
-              onClick={() => setView(v.id)}
-              title={`Switch to ${v.label}`}
-            >
-              <div
-                className="thumb-canvas"
-                style={{ width: thumbSize.width, height: thumbSize.height }}
-              >
-                {/* The chart draws at the column's full (3-thumb-era) width
-                    — where its fixed-px labels fit — and scales down
-                    uniformly into the shorter rectangle, a true miniature
-                    (issue #652; see useThumbColumnSize). */}
-                <div
-                  className="thumb-scale"
-                  style={{
-                    width: thumbSize.width,
-                    height: thumbSize.width,
-                    transform: `translate(-50%, -50%) scale(${
-                      thumbSize.height / thumbSize.width
-                    })`,
-                  }}
+        {/* Rail/grid presets over the same pinned set (unit 3) — visible in
+            both modes so either one can switch to the other. Desktop-only by
+            placement: this branch is never reached while isMobile. */}
+        <LayoutModeToggle layout={effectiveLayout} setLayout={setLayout} />
+        {effectiveLayout === "grid" ? (
+          <>
+            <ViewGrid
+              gridRef={gridRef}
+              cells={gridViews}
+              view={view}
+              setView={setView}
+              onMaximize={maximizeView}
+              cellSize={gridCellSize}
+              rows={gridRows}
+              cols={gridCols}
+              renderCell={(v, size) => renderOutput(v, size, v === "antenna")}
+            />
+            {/* Grid mode has no single primary slide to float the HUD over
+                (unit 3), so it anchors to the STAGE itself instead of one
+                cell — same look (stage-readout family), one instance rather
+                than per-cell. `.stage` is the positioned ancestor here, same
+                role `.carousel-slide` plays in rail mode below. */}
+            <SolveReadout
+              className="stage-readout"
+              result={result}
+              rttMs={rttMs}
+              currentExample={currentExample}
+              effectiveMultiFeed={effectiveMultiFeed}
+              normCheck={normCheck}
+              normCheckEnabled={normCheckEnabled}
+              onPlaneChange={pickPlane}
+            />
+          </>
+        ) : (
+          <>
+            <div className="thumbstrip" ref={thumbStripRef}>
+              {rail.map((v) => (
+                <button
+                  key={v.id}
+                  className="thumb"
+                  onClick={() => setView(v.id)}
+                  title={`Switch to ${v.label}`}
                 >
-                <ViewPanel
-                  view={v.id}
-                  size={thumbSize.width}
-                  fill={false}
-                  result={result}
-                  preview={preview}
-                  sweep={sweep}
-                  converge={converge}
-                  measured={measured}
-                  pattern={pattern}
-                  pinnedPatterns={[]}
-                  measFreqMhz={measFreq}
-                  sweepRunning={sweepRunning}
-                  convergeRunning={convergeRunning}
-                  azElevDeg={azElevDeg}
-                  elevAzDeg={elevAzDeg}
-                  cameraProjection={cameraProjection}
-                  showHeatmap={showHeatmap}
-                  showEnvelope={showEnvelope}
-                  multiFeed={effectiveMultiFeed}
-                  schematicSvg={schematicSvg}
-                  schematicUnavailable={schematicUnavailable}
-                />
-                </div>
-              </div>
-              <div className="thumb-label">{v.label}</div>
-            </button>
-          ))}
-          {/* Everything not pinned lives behind here. Fixed height by design:
-              useThumbColumnSize subtracts exactly this slot. */}
-          <ViewPicker
-            view={view}
-            setView={setView}
-            pinned={pinned}
-            newIds={newIds}
-            togglePin={toggleViewPin}
-            markRosterSeen={markRosterSeen}
-          />
-        </div>
-        <div
-          className={`carousel-slide${stale ? " stale" : ""}`}
-          ref={slideRef}
-        >
-          {renderOutput(view, chartSize, view === "antenna")}
-          {/* Solve readout, pinned to the lower-left of whichever view the
-              carousel is centered on. Floats over the canvas as a HUD so the
-              left input rail stays inputs-only. It sits INSIDE the slide, so
-              the slide's stale dim already covers it — no own stale class, or
-              the two opacities would compound. */}
-          <SolveReadout
-            className="stage-readout"
-            result={result}
-            rttMs={rttMs}
-            currentExample={currentExample}
-            effectiveMultiFeed={effectiveMultiFeed}
-            normCheck={normCheck}
-            normCheckEnabled={normCheckEnabled}
-            onPlaneChange={pickPlane}
-          />
-        </div>
+                  <div
+                    className="thumb-canvas"
+                    style={{ width: thumbSize.width, height: thumbSize.height }}
+                  >
+                    {/* The chart draws at the column's full (3-thumb-era) width
+                        — where its fixed-px labels fit — and scales down
+                        uniformly into the shorter rectangle, a true miniature
+                        (issue #652; see useThumbColumnSize). */}
+                    <div
+                      className="thumb-scale"
+                      style={{
+                        width: thumbSize.width,
+                        height: thumbSize.width,
+                        transform: `translate(-50%, -50%) scale(${
+                          thumbSize.height / thumbSize.width
+                        })`,
+                      }}
+                    >
+                    <ViewPanel
+                      view={v.id}
+                      size={thumbSize.width}
+                      fill={false}
+                      result={result}
+                      preview={preview}
+                      sweep={sweep}
+                      converge={converge}
+                      measured={measured}
+                      pattern={pattern}
+                      pinnedPatterns={[]}
+                      measFreqMhz={measFreq}
+                      sweepRunning={sweepRunning}
+                      convergeRunning={convergeRunning}
+                      azElevDeg={azElevDeg}
+                      elevAzDeg={elevAzDeg}
+                      cameraProjection={cameraProjection}
+                      showHeatmap={showHeatmap}
+                      showEnvelope={showEnvelope}
+                      multiFeed={effectiveMultiFeed}
+                      schematicSvg={schematicSvg}
+                      schematicUnavailable={schematicUnavailable}
+                    />
+                    </div>
+                  </div>
+                  <div className="thumb-label">{v.label}</div>
+                </button>
+              ))}
+              {/* Everything not pinned lives behind here. Fixed height by design:
+                  useThumbColumnSize subtracts exactly this slot. */}
+              <ViewPicker
+                view={view}
+                setView={setView}
+                pinned={pinned}
+                newIds={newIds}
+                togglePin={toggleViewPin}
+                markRosterSeen={markRosterSeen}
+              />
+            </div>
+            <div
+              className={`carousel-slide${stale ? " stale" : ""}`}
+              ref={slideRef}
+            >
+              {renderOutput(view, chartSize, view === "antenna")}
+              {/* Solve readout, pinned to the lower-left of whichever view the
+                  carousel is centered on. Floats over the canvas as a HUD so the
+                  left input rail stays inputs-only. It sits INSIDE the slide, so
+                  the slide's stale dim already covers it — no own stale class, or
+                  the two opacities would compound. */}
+              <SolveReadout
+                className="stage-readout"
+                result={result}
+                rttMs={rttMs}
+                currentExample={currentExample}
+                effectiveMultiFeed={effectiveMultiFeed}
+                normCheck={normCheck}
+                normCheckEnabled={normCheckEnabled}
+                onPlaneChange={pickPlane}
+              />
+            </div>
+          </>
+        )}
         <div className="status">
           ws: {status}
           {stale && <span className="status-busy"> · solving…</span>}

--- a/src/antennaknobs/web/frontend/src/components/session/MobileDots.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/MobileDots.tsx
@@ -1,0 +1,55 @@
+import { type MobileScreen, type View } from "../../lib/view";
+import { ViewSheet } from "./ViewPicker";
+
+// The mobile carousel's page indicator: one dot per screen — the user's pinned
+// views in pin order plus the trailing Info page (#700 unit 4) — followed by
+// the "⋯" overflow affordance that opens the roster as a bottom sheet.
+//
+// Its own component (rather than inline in DesignSession's mobile branch) so
+// the dot-count ↔ page-count contract is testable without mounting a whole
+// session: an extra or missing dot is precisely how a bad index mapping shows
+// itself. `screens` comes from the caller because the carousel tree renders
+// the very same list — one derivation, two consumers, no way to disagree.
+export function MobileDots({
+  screens,
+  index,
+  goToScreen,
+  view,
+  pinned,
+  newIds,
+  togglePin,
+  markRosterSeen,
+}: {
+  screens: MobileScreen[];
+  index: number;
+  goToScreen: (i: number) => void;
+  view: View;
+  pinned: View[];
+  newIds: Set<View>;
+  togglePin: (v: View) => void;
+  markRosterSeen: () => void;
+}) {
+  return (
+    <div className="mobile-dots" aria-label="Output screens">
+      {screens.map((s, i) => (
+        <button
+          key={s.id}
+          type="button"
+          className={i === index ? "active" : ""}
+          aria-label={`Show ${s.label}`}
+          title={s.label}
+          onClick={() => goToScreen(i)}
+        />
+      ))}
+      {/* Not a dot: it addresses no page, it changes WHICH pages exist. It
+          rides this row anyway because the dots are the page set. */}
+      <ViewSheet
+        view={view}
+        pinned={pinned}
+        newIds={newIds}
+        togglePin={togglePin}
+        markRosterSeen={markRosterSeen}
+      />
+    </div>
+  );
+}

--- a/src/antennaknobs/web/frontend/src/components/session/ViewPicker.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/ViewPicker.tsx
@@ -1,0 +1,127 @@
+import { useState } from "react";
+import { VIEWS, type View } from "../../lib/view";
+import { PIN_CAP, pinBlockedReason } from "./useViewPrefs";
+
+// The overflow affordance: a fixed-height "All views ⌄ +N" button at the foot
+// of the thumbstrip opening a popover over the WHOLE roster in registry order
+// (unit 2 of docs/plan-view-rail-scaling.md). Two gestures per row, on purpose:
+//
+//   row click  → show that view (a peek if it is unpinned — no pin spent) and
+//                close, because you asked to look at something.
+//   dot click  → pin/unpin only. It neither switches the view nor closes: the
+//                point of curating is doing several in a row.
+//
+// Popover mechanics copy SessionGearMenu (transparent backdrop catches the
+// outside click); the row idiom is the instrument-panel channel-enable row the
+// plan's survey settled on — every view listed, each with a visible on/off pin.
+export function ViewPicker({
+  view,
+  setView,
+  pinned,
+  newIds,
+  togglePin,
+  markRosterSeen,
+}: {
+  view: View;
+  setView: (v: View) => void;
+  pinned: View[];
+  newIds: Set<View>;
+  togglePin: (v: View) => void;
+  markRosterSeen: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  // The badges shown while the popover is open are snapshotted as it opens.
+  // Opening MARKS the roster seen — that is what "since you last looked"
+  // means — so rendering `newIds` live would blank every badge in the same
+  // frame the user opened the picker to read them.
+  const [badged, setBadged] = useState<Set<View>>(new Set());
+
+  const toggleOpen = () => {
+    setOpen((was) => {
+      if (!was) {
+        setBadged(new Set(newIds));
+        markRosterSeen();
+      }
+      return !was;
+    });
+  };
+
+  const unpinnedCount = VIEWS.length - pinned.length;
+
+  return (
+    <div className="view-picker-wrap">
+      <button
+        type="button"
+        className="view-picker-btn"
+        onClick={toggleOpen}
+        title="Every output view — pin the ones you want resident in the rail"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        All views ⌄
+        {unpinnedCount > 0 && (
+          <span className="view-picker-count">+{unpinnedCount}</span>
+        )}
+      </button>
+      {open && (
+        <>
+          <div
+            className="view-picker-backdrop"
+            onClick={() => setOpen(false)}
+          />
+          <div className="view-picker" role="menu">
+            {VIEWS.map((v) => {
+              const isPinned = pinned.includes(v.id);
+              const blocked = pinBlockedReason(pinned, v.id);
+              return (
+                <div
+                  key={v.id}
+                  className={`view-picker-row${isPinned ? " pinned" : " unpinned"}${
+                    v.id === view ? " active" : ""
+                  }`}
+                >
+                  <button
+                    type="button"
+                    className="view-picker-name"
+                    role="menuitem"
+                    aria-current={v.id === view}
+                    onClick={() => {
+                      setView(v.id);
+                      setOpen(false);
+                    }}
+                  >
+                    <span>{v.label}</span>
+                    {badged.has(v.id) && (
+                      <span className="view-picker-new">NEW</span>
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    className="view-picker-dot"
+                    aria-pressed={isPinned}
+                    disabled={blocked !== null}
+                    title={
+                      blocked ??
+                      (isPinned
+                        ? `Unpin ${v.label} from the rail`
+                        : `Pin ${v.label} to the rail`)
+                    }
+                    aria-label={
+                      isPinned ? `Unpin ${v.label}` : `Pin ${v.label}`
+                    }
+                    onClick={() => togglePin(v.id)}
+                  >
+                    <span />
+                  </button>
+                </div>
+              );
+            })}
+            <div className="view-picker-note">
+              Row = show · dot = keep in rail · max {PIN_CAP} pinned
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/antennaknobs/web/frontend/src/components/session/ViewPicker.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/ViewPicker.tsx
@@ -2,6 +2,77 @@ import { useRef, useState } from "react";
 import { VIEWS, type View } from "../../lib/view";
 import { PIN_CAP, pinBlockedReason } from "./useViewPrefs";
 
+// The roster listing both containers share: same rows, same pin dots, same
+// NEW badges, whole registry in registry order. Only the NAME button's gesture
+// differs between them, which is what `onRowClick`/`rowBlocked` parameterize.
+//
+// `rowBlocked` is undefined on desktop, where a row is always clickable (it
+// shows a view, and showing can't be refused). Undefined props render as
+// absent attributes, so the popover's DOM is byte-identical to what it was
+// before the sheet existed — the picker tests pin that.
+function ViewRosterRows({
+  view,
+  pinned,
+  badged,
+  onRowClick,
+  togglePin,
+  rowBlocked,
+}: {
+  view: View;
+  pinned: View[];
+  badged: Set<View>;
+  onRowClick: (v: View) => void;
+  togglePin: (v: View) => void;
+  rowBlocked?: (v: View) => string | null;
+}) {
+  return (
+    <>
+      {VIEWS.map((v) => {
+        const isPinned = pinned.includes(v.id);
+        const blocked = pinBlockedReason(pinned, v.id);
+        const rowStop = rowBlocked ? rowBlocked(v.id) : null;
+        return (
+          <div
+            key={v.id}
+            className={`view-picker-row${isPinned ? " pinned" : " unpinned"}${
+              v.id === view ? " active" : ""
+            }`}
+          >
+            <button
+              type="button"
+              className="view-picker-name"
+              role="menuitem"
+              aria-current={v.id === view}
+              disabled={rowBlocked ? rowStop !== null : undefined}
+              title={rowBlocked ? (rowStop ?? undefined) : undefined}
+              onClick={() => onRowClick(v.id)}
+            >
+              <span>{v.label}</span>
+              {badged.has(v.id) && <span className="view-picker-new">NEW</span>}
+            </button>
+            <button
+              type="button"
+              className="view-picker-dot"
+              aria-pressed={isPinned}
+              disabled={blocked !== null}
+              title={
+                blocked ??
+                (isPinned
+                  ? `Unpin ${v.label} from the rail`
+                  : `Pin ${v.label} to the rail`)
+              }
+              aria-label={isPinned ? `Unpin ${v.label}` : `Pin ${v.label}`}
+              onClick={() => togglePin(v.id)}
+            >
+              <span />
+            </button>
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
 // The overflow affordance: a fixed-height "All views ⌄ +N" button at the foot
 // of the thumbstrip opening a popover over the WHOLE roster in registry order
 // (unit 2 of docs/plan-view-rail-scaling.md). Two gestures per row, on purpose:
@@ -87,52 +158,16 @@ export function ViewPicker({
             role="menu"
             style={{ left: anchor.left, bottom: anchor.bottom }}
           >
-            {VIEWS.map((v) => {
-              const isPinned = pinned.includes(v.id);
-              const blocked = pinBlockedReason(pinned, v.id);
-              return (
-                <div
-                  key={v.id}
-                  className={`view-picker-row${isPinned ? " pinned" : " unpinned"}${
-                    v.id === view ? " active" : ""
-                  }`}
-                >
-                  <button
-                    type="button"
-                    className="view-picker-name"
-                    role="menuitem"
-                    aria-current={v.id === view}
-                    onClick={() => {
-                      setView(v.id);
-                      setOpen(false);
-                    }}
-                  >
-                    <span>{v.label}</span>
-                    {badged.has(v.id) && (
-                      <span className="view-picker-new">NEW</span>
-                    )}
-                  </button>
-                  <button
-                    type="button"
-                    className="view-picker-dot"
-                    aria-pressed={isPinned}
-                    disabled={blocked !== null}
-                    title={
-                      blocked ??
-                      (isPinned
-                        ? `Unpin ${v.label} from the rail`
-                        : `Pin ${v.label} to the rail`)
-                    }
-                    aria-label={
-                      isPinned ? `Unpin ${v.label}` : `Pin ${v.label}`
-                    }
-                    onClick={() => togglePin(v.id)}
-                  >
-                    <span />
-                  </button>
-                </div>
-              );
-            })}
+            <ViewRosterRows
+              view={view}
+              pinned={pinned}
+              badged={badged}
+              togglePin={togglePin}
+              onRowClick={(v) => {
+                setView(v);
+                setOpen(false);
+              }}
+            />
             <div className="view-picker-note">
               Row = show · dot = keep in rail · max {PIN_CAP} pinned
             </div>
@@ -140,5 +175,85 @@ export function ViewPicker({
         </>
       )}
     </div>
+  );
+}
+
+// The mobile half of the same affordance (#700 unit 4): a "⋯" button riding
+// the dots row that opens the SAME roster as a bottom sheet. It renders its
+// own trigger, exactly as ViewPicker does, so opening — and therefore marking
+// the roster seen and snapshotting the NEW badges — has one implementation.
+//
+// The row gesture is the one real difference: here a row tap PINS/unpins,
+// like the desktop pin dot, and there is NO peek. A peeked page would be a
+// carousel page with no pin behind it, breaking the "pages = pinned + Info"
+// mapping (and every index compare in useMobileCarousel) for one gesture's
+// worth of convenience — the plan spells this out. So both row and dot toggle,
+// and both are inert for the same reason at the cap and at the floor of one.
+export function ViewSheet({
+  view,
+  pinned,
+  newIds,
+  togglePin,
+  markRosterSeen,
+}: {
+  view: View;
+  pinned: View[];
+  newIds: Set<View>;
+  togglePin: (v: View) => void;
+  markRosterSeen: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  // Snapshotted as the sheet opens, for the same reason as the popover's:
+  // opening is what marks the roster seen, so live `newIds` would blank every
+  // badge in the frame the user opened the sheet to read them.
+  const [badged, setBadged] = useState<Set<View>>(new Set());
+
+  const toggleOpen = () => {
+    setOpen((was) => {
+      if (!was) {
+        setBadged(new Set(newIds));
+        markRosterSeen();
+      }
+      return !was;
+    });
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        className="mobile-dots-more"
+        onClick={toggleOpen}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="All views"
+        title="Every output view — tap one to add or remove its page"
+      >
+        ⋯
+      </button>
+      {open && (
+        <>
+          <div className="view-sheet-backdrop" onClick={() => setOpen(false)} />
+          {/* No anchor measurement, unlike the popover: the sheet is pinned to
+              the viewport's bottom edge, which is also the only place a phone
+              can put a list this tall within thumb reach. */}
+          <div className="view-sheet" role="menu" aria-label="All views">
+            <ViewRosterRows
+              view={view}
+              pinned={pinned}
+              badged={badged}
+              togglePin={togglePin}
+              // Curating is a run of gestures — the sheet does NOT close on a
+              // tap, so several pages can be added or dropped in one visit.
+              onRowClick={togglePin}
+              rowBlocked={(id) => pinBlockedReason(pinned, id)}
+            />
+            <div className="view-picker-note">
+              Tap a view to add or remove its page · max {PIN_CAP} pages
+            </div>
+          </div>
+        </>
+      )}
+    </>
   );
 }

--- a/src/antennaknobs/web/frontend/src/components/session/ViewPicker.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/ViewPicker.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { VIEWS, type View } from "../../lib/view";
 import { PIN_CAP, pinBlockedReason } from "./useViewPrefs";
 
@@ -30,6 +30,14 @@ export function ViewPicker({
   markRosterSeen: () => void;
 }) {
   const [open, setOpen] = useState(false);
+  // The popover is position:FIXED and placed from a measurement, not
+  // position:absolute inside the strip: .thumbstrip is overflow:hidden by
+  // design (thumbs are scaled to fit and must never scroll), which would clip
+  // an absolutely-positioned child. Fixed elements escape that clip. Measured
+  // at open only — the stage layout doesn't scroll, and the backdrop swallows
+  // everything until the popover closes.
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const [anchor, setAnchor] = useState({ left: 0, bottom: 0 });
   // The badges shown while the popover is open are snapshotted as it opens.
   // Opening MARKS the roster seen — that is what "since you last looked"
   // means — so rendering `newIds` live would blank every badge in the same
@@ -39,6 +47,11 @@ export function ViewPicker({
   const toggleOpen = () => {
     setOpen((was) => {
       if (!was) {
+        const r = wrapRef.current?.getBoundingClientRect();
+        // Opens to the RIGHT of its button and grows upward from the strip's
+        // foot: the rail hugs the window's left edge, and the short columns
+        // this whole feature exists for have no room below.
+        if (r) setAnchor({ left: r.right + 6, bottom: window.innerHeight - r.bottom });
         setBadged(new Set(newIds));
         markRosterSeen();
       }
@@ -49,7 +62,7 @@ export function ViewPicker({
   const unpinnedCount = VIEWS.length - pinned.length;
 
   return (
-    <div className="view-picker-wrap">
+    <div className="view-picker-wrap" ref={wrapRef}>
       <button
         type="button"
         className="view-picker-btn"
@@ -69,7 +82,11 @@ export function ViewPicker({
             className="view-picker-backdrop"
             onClick={() => setOpen(false)}
           />
-          <div className="view-picker" role="menu">
+          <div
+            className="view-picker"
+            role="menu"
+            style={{ left: anchor.left, bottom: anchor.bottom }}
+          >
             {VIEWS.map((v) => {
               const isPinned = pinned.includes(v.id);
               const blocked = pinBlockedReason(pinned, v.id);

--- a/src/antennaknobs/web/frontend/src/components/session/useMobileCarousel.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useMobileCarousel.ts
@@ -1,34 +1,82 @@
 import { useEffect, useRef, useState } from "react";
-import { VIEWS, type View } from "../../lib/view";
+import { type View } from "../../lib/view";
 import { useSlideSize } from "../hooks";
 
-// The mobile output carousel's state, refs and the two effects that keep the
-// DOM scroll position and `view` in agreement (#642 seam 5b-3). Lifted whole
-// out of DesignSession so the cluster's internal hook order is preserved
-// exactly; the caller keeps `view`/`setView` because the desktop tree and the
-// arrow-key cycler share them.
+// Where the carousel must sit after the PINNED list changed under it — the one
+// piece of index arithmetic worth having outside React, because every hard
+// case of #700 unit 4 is a statement about this function. `prevPinned` is the
+// list `index` was measured against; `pinned` is the new one (never empty —
+// useViewPrefs enforces a floor of one pin).
+//
+// Pages are `pinned ++ [Info]`, so:
+//   - Info is index `pinned.length` and MOVES with every pin/unpin;
+//   - a chart page is `pinned[index]`, so `view` and `index` must agree or the
+//     dots point at a page the user is not looking at.
+export function reconcileCarousel(
+  prevPinned: View[],
+  pinned: View[],
+  index: number,
+  view: View,
+): { index: number; view: View } {
+  if (index >= prevPinned.length) {
+    // Parked on Info (or past where Info used to be, after a shrink). Info
+    // keeps the user: it is the page they chose. `view` stays parked on a
+    // chart page and only needs rescuing if THAT page was just unpinned.
+    return {
+      index: pinned.length,
+      view: pinned.includes(view) ? view : pinned[pinned.length - 1],
+    };
+  }
+  const at = pinned.indexOf(view);
+  // The page under the thumb survived. Follow it rather than the old index:
+  // pinning appends, so this is a no-op for the common case (no visible jump),
+  // and it stays correct if a future reorder lands.
+  if (at >= 0) return { index: at, view };
+  // The page under the thumb was just unpinned. Hold the SLOT and adopt
+  // whatever slid into it — clamped, because unpinning the last chart page
+  // leaves the old index one past the end of the new list.
+  const i = Math.min(index, pinned.length - 1);
+  return { index: i, view: pinned[i] };
+}
+
+// The mobile output carousel's state, refs and the effects that keep the DOM
+// scroll position and `view` in agreement (#642 seam 5b-3). Lifted whole out of
+// DesignSession so the cluster's internal hook order is preserved exactly; the
+// caller keeps `view`/`setView` because the desktop tree and the arrow-key
+// cycler share them.
 //
 // `compareCollapsed` deliberately stays behind in DesignSession: its
 // `useState(isMobile)` initializer has to run after `useIsMobile()` there.
 export function useMobileCarousel({
   isMobile,
   orientation,
+  pinned,
   view,
   setView,
 }: {
   isMobile: boolean;
   orientation: "portrait" | "landscape";
+  // The pinned views (useViewPrefs) — the carousel's page list, in pin order.
+  // Every index compare below is against THIS, not the registry: an unpinned
+  // view has no page, so a VIEWS-based bound would map a swipe onto a view the
+  // carousel never rendered (#700 unit 4).
+  pinned: View[];
   view: View;
   setView: (v: View) => void;
 }) {
   // Mobile output carousel (all hooks unconditional — desktop leaves them
-  // inert). mobileIndex is which of the 5 screens the snap carousel rests on;
-  // `view` stays the source of truth for the 4 chart screens and their data
-  // effects, kept in sync by the scroll handler / reverse-sync effect below.
+  // inert). mobileIndex is which screen the snap carousel rests on — there are
+  // `pinned.length + 1` of them; `view` stays the source of truth for the
+  // chart screens and their data effects, kept in sync by the scroll handler /
+  // reverse-sync effect below.
   const [mobileIndex, setMobileIndex] = useState(0);
   const mobileCarouselRef = useRef<HTMLDivElement>(null);
   const mobileScrollRafRef = useRef<number | null>(null);
   const { ref: mobRef, size: mobChartSize } = useSlideSize(720, isMobile);
+  // The pinned list `mobileIndex` was last valid against. null while the
+  // desktop tree is up, so entering mobile always re-reconciles: a desktop
+  // peek leaves `view` unpinned, and an unpinned view has no page here.
+  const prevPinnedRef = useRef<View[] | null>(null);
 
   // Track where a swipe/fling snaps and mirror it into state. rAF-throttled:
   // scroll events arrive per frame during a fling, one rounding per frame is
@@ -42,7 +90,7 @@ export function useMobileCarousel({
       if (!el || el.clientWidth === 0) return;
       const i = Math.round(el.scrollLeft / el.clientWidth);
       setMobileIndex((prev) => (prev === i ? prev : i));
-      if (i < VIEWS.length) setView(VIEWS[i].id);
+      if (i < pinned.length) setView(pinned[i]);
     });
   };
 
@@ -50,10 +98,38 @@ export function useMobileCarousel({
   // and by swipe — it deliberately leaves `view` on the last chart screen.
   const goToMobileScreen = (i: number) => {
     setMobileIndex(i);
-    if (i < VIEWS.length) setView(VIEWS[i].id);
+    if (i < pinned.length) setView(pinned[i]);
     const el = mobileCarouselRef.current;
     if (el) el.scrollTo({ left: i * el.clientWidth, behavior: "smooth" });
   };
+
+  // The page list changed under us (the picker sheet pinned or unpinned
+  // something), or we just arrived from a desktop tree holding an unpinned
+  // view. Either way the (index, view) pair can name a page that no longer
+  // exists; reconcileCarousel says where it goes. Declared BEFORE the
+  // reverse-sync effect so that effect's stale `view` closure finds no target
+  // and stands down for one commit rather than paging somewhere else first.
+  useEffect(() => {
+    if (!isMobile) {
+      prevPinnedRef.current = null;
+      return;
+    }
+    const prev = prevPinnedRef.current;
+    prevPinnedRef.current = pinned;
+    // Same list AND a view that has a page: nothing to fix here, and
+    // re-deriving would fight whatever the swipe/arrow paths just did.
+    if (prev === pinned && pinned.includes(view)) return;
+    const next = reconcileCarousel(prev ?? pinned, pinned, mobileIndex, view);
+    if (next.view !== view) setView(next.view);
+    if (next.index !== mobileIndex) setMobileIndex(next.index);
+    const el = mobileCarouselRef.current;
+    if (!el || el.clientWidth === 0) return;
+    // Only when the DOM actually sits elsewhere: pinning appends a page
+    // without moving the current one, and a scrollTo there is a visible jump.
+    if (Math.round(el.scrollLeft / el.clientWidth) !== next.index) {
+      el.scrollTo({ left: next.index * el.clientWidth, behavior: "smooth" });
+    }
+  }, [isMobile, pinned, view, mobileIndex, setView]);
 
   // Reverse sync: anything else that sets `view` (the arrow-key cycler) pages
   // the carousel to match. The DOM scroll position is the ground truth for
@@ -63,12 +139,12 @@ export function useMobileCarousel({
     if (!isMobile) return;
     const el = mobileCarouselRef.current;
     if (!el || el.clientWidth === 0) return;
-    const target = VIEWS.findIndex((v) => v.id === view);
+    const target = pinned.indexOf(view);
     const current = Math.round(el.scrollLeft / el.clientWidth);
-    if (target < 0 || current >= VIEWS.length || current === target) return;
+    if (target < 0 || current >= pinned.length || current === target) return;
     setMobileIndex(target);
     el.scrollTo({ left: target * el.clientWidth, behavior: "smooth" });
-  }, [view, isMobile]);
+  }, [view, isMobile, pinned]);
 
   // An orientation flip (or any pane resize) changes the screen width, so
   // scrollLeft no longer sits on a snap point; re-center the active screen

--- a/src/antennaknobs/web/frontend/src/components/session/useViewPrefs.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useViewPrefs.ts
@@ -29,12 +29,24 @@ export const VIEW_PREFS_KEY = "akb.viewPrefs.v1";
 // picker shipped", which is what the user reads it as.
 const SEEN_SEED: View[] = ["antenna", "azimuth", "elevation", "smith", "schematic"];
 
+// Unit 3 of docs/plan-view-rail-scaling.md: the desktop stage's two layout
+// presets over the same pinned set. "rail" is today's primary+thumbstrip;
+// "grid" is equal cells over the first GRID_CELL_CAP pins. Exported so
+// components (the segmented control, useViewState) share one type instead of
+// re-deriving the string union.
+export type Layout = "rail" | "grid";
+
 // The persisted record. Fields are independent and each is optional on read,
-// so unit 3 can add `layout: "rail" | "grid"` by extending this type and the
-// writer — no v2 key, and a build that predates a field simply ignores it.
+// so a field can be added by extending this type and the writer — no v2 key,
+// and a build that predates a field simply ignores it. `layout` (unit 3)
+// is also optional on WRITE: update() below omits it entirely while it's
+// "rail" (the default), so a session that never touches layout persists the
+// exact `{pinned, seen}` shape unit 2 shipped — see the exact-keys assertion
+// in useViewPrefs.test.tsx, which this deliberately keeps passing unedited.
 type ViewPrefs = {
   pinned: View[];
   seen: View[];
+  layout: Layout;
 };
 
 const KNOWN = new Set<string>(VIEWS.map((v) => v.id));
@@ -58,6 +70,15 @@ function sanitizeIds(raw: unknown): View[] {
   return out;
 }
 
+// Anything other than the literal "grid" reads as "rail" — an absent field
+// (pre-unit-3 storage or a rail session that never wrote it, see the type's
+// comment), a wrong type, or hand-edited garbage. A bad layout does not
+// condemn the whole record the way an empty `pinned` does: the other two
+// fields are still perfectly good, so only this one falls back.
+function sanitizeLayout(raw: unknown): Layout {
+  return raw === "grid" ? "grid" : "rail";
+}
+
 function loadPrefs(): ViewPrefs {
   try {
     const raw = localStorage.getItem(VIEW_PREFS_KEY);
@@ -73,14 +94,18 @@ function loadPrefs(): ViewPrefs {
         // corrupt rather than honour an empty rail, which is never what a user
         // meant and leaves no visible way back.
         if (pinned.length > 0) {
-          return { pinned, seen: seen.length > 0 ? seen : SEEN_SEED };
+          return {
+            pinned,
+            seen: seen.length > 0 ? seen : SEEN_SEED,
+            layout: sanitizeLayout(rec.layout),
+          };
         }
       }
     }
   } catch {
     /* corrupt JSON or storage disabled — the defaults below are the answer */
   }
-  return { pinned: defaultPins(), seen: SEEN_SEED };
+  return { pinned: defaultPins(), seen: SEEN_SEED, layout: "rail" };
 }
 
 // --- module store ------------------------------------------------------------
@@ -110,7 +135,19 @@ function subscribe(onChange: () => void): () => void {
 function update(next: ViewPrefs): void {
   cached = next;
   try {
-    localStorage.setItem(VIEW_PREFS_KEY, JSON.stringify(next));
+    // Sparse write: `layout` joins the JSON only when it is not the default
+    // — JSON.stringify drops a key whose value is `undefined`. A pin/unpin
+    // that never touches layout (the common case, and every case before
+    // unit 3) writes exactly `{pinned, seen}`, so existing stored records
+    // and the pre-unit-3 test fixture stay byte-shaped as before.
+    localStorage.setItem(
+      VIEW_PREFS_KEY,
+      JSON.stringify({
+        pinned: next.pinned,
+        seen: next.seen,
+        layout: next.layout === "rail" ? undefined : next.layout,
+      }),
+    );
   } catch {
     /* storage disabled — the in-memory prefs still work for this session,
        exactly as App.tsx's theme toggle degrades */
@@ -140,9 +177,67 @@ export function pinBlockedReason(pinned: View[], id: View): string | null {
   return pinned.length >= PIN_CAP ? "Unpin a view first" : null;
 }
 
+// --- grid layout mode (unit 3) ------------------------------------------
+
+// Grid mode never goes past 4 cells: below ~⅓-stage cells the antenna canvas
+// stops being steerable, which defeats the mode's whole point (plan doc
+// "Layout modes"), so pins #5/#6 stay rail-only rather than making a 3×2.
+export const GRID_CELL_CAP = 4;
+
+// Grid mode's displayed cells: the first ≤4 pins, in pin order. Pure slice —
+// used both for what renders (ViewGrid) and what the arrow keys cycle
+// (useViewState), so the two can never disagree about "what's on screen".
+export function gridCells(pinned: View[]): View[] {
+  return pinned.slice(0, GRID_CELL_CAP);
+}
+
+// The grid's row/column count for a given number of displayed cells:
+// 1 → one full cell, 2 → 1×2, 3–4 → 2×2 (3 leaves the 4th cell the "pin a
+// 4th view" hint — ViewGrid draws that, this only says the shape is square).
+export function gridShape(nCells: number): { rows: number; cols: number } {
+  if (nCells <= 1) return { rows: 1, cols: 1 };
+  if (nCells === 2) return { rows: 1, cols: 2 };
+  return { rows: 2, cols: 2 };
+}
+
+// What to do when the grid-mode focus ring (`view`) is not one of the
+// displayed cells — see docs/plan-view-rail-scaling.md "Layout modes" and
+// "Keyboard". There are two distinct causes, told apart by `wasGrid` (was
+// the layout already "grid" the last time this ran):
+//
+//   - `wasGrid` false: we just switched INTO grid (rail → grid). The view
+//     that was active carries over regardless of WHY it's off-grid — a peek
+//     or a pinned view beyond cell 4 (pin #5/#6) — either way there is
+//     nowhere to put the ring but cell 1, so grid mode itself is not
+//     disturbed.
+//   - `wasGrid` true and the view IS pinned: already in grid, and a picker
+//     row-click landed on a pinned-but-off-grid view (pin #5/#6) — same
+//     fix, snap the ring to cell 1.
+//   - `wasGrid` true and the view is NOT pinned: the row-click activated a
+//     peek. A peek has no cell by definition — it costs no pin slot (see
+//     the plan doc's "Peek" note), so it never gets one — there is nothing
+//     to snap the ring to. Leave grid for rail, where the peek becomes
+//     rail's primary instead of being stranded off-screen.
+//
+// Returns null when the ring is already on a displayed cell (the common
+// case on every render that isn't one of the above transitions).
+export type GridFix = { view: View } | { layout: "rail" } | null;
+export function gridFix(
+  layout: Layout,
+  wasGrid: boolean,
+  view: View,
+  pinned: View[],
+): GridFix {
+  if (layout !== "grid") return null;
+  const cells = gridCells(pinned);
+  if (cells.includes(view)) return null;
+  if (!wasGrid || pinned.includes(view)) return { view: cells[0] };
+  return { layout: "rail" };
+}
+
 export function useViewPrefs() {
   const prefs = useSyncExternalStore(subscribe, getSnapshot);
-  const { pinned, seen } = prefs;
+  const { pinned, seen, layout } = prefs;
 
   // Views the user has never been offered. Seeded (not empty) on a first run,
   // so the badge only ever fires for views added after the picker shipped.
@@ -183,5 +278,13 @@ export function useViewPrefs() {
     update({ ...cur, seen: [...cur.seen, ...missing] });
   }, []);
 
-  return { pinned, seen, newIds, railViews, togglePin, markRosterSeen };
+  // Unit 3: the desktop layout preset. No validation needed beyond the type
+  // itself — unlike pins, there is no cap or floor to enforce here.
+  const setLayout = useCallback((next: Layout) => {
+    const cur = getSnapshot();
+    if (cur.layout === next) return; // keeps snapshot identity, as markRosterSeen does
+    update({ ...cur, layout: next });
+  }, []);
+
+  return { pinned, seen, newIds, railViews, togglePin, markRosterSeen, layout, setLayout };
 }

--- a/src/antennaknobs/web/frontend/src/components/session/useViewPrefs.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useViewPrefs.ts
@@ -1,0 +1,187 @@
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { VIEW_META, VIEWS, type View, type ViewMeta } from "../../lib/view";
+
+// The desktop view preferences: which views are PINNED (resident in the
+// thumbstrip) and which the user has already been shown in the picker.
+// Unit 2 of docs/plan-view-rail-scaling.md.
+//
+// Global, not per-design: every design has every view, and the user's
+// watching habits ("I care about VSWR and the pattern") span designs, so a
+// per-design pin set would reshuffle the workspace on every catalog switch.
+// Global also means every open session tab must agree, which is why the state
+// lives in a module store read through useSyncExternalStore (the same idiom
+// hooks.ts uses for media queries) rather than in per-component useState —
+// two mounted sessions holding private copies would drift and race on the key.
+
+// Six pins ⇒ five rail thumbs ⇒ ~96 px thumbs on a 720 px column, which is
+// above the legibility floor with margin (the column math is in the plan's
+// context table). Above six the rail is smudges again, so this is a hard cap,
+// not a nudge.
+export const PIN_CAP = 6;
+
+export const VIEW_PREFS_KEY = "akb.viewPrefs.v1";
+
+// What `seen` is seeded with on a first run: the roster as it stood when the
+// picker shipped, written out rather than derived from VIEWS. Seeding from the
+// live roster would mark every FUTURE view as already-seen for anyone whose
+// first visit happens after that view ships — the NEW badge would never fire
+// for the users it exists for. A literal makes the badge mean "added after the
+// picker shipped", which is what the user reads it as.
+const SEEN_SEED: View[] = ["antenna", "azimuth", "elevation", "smith", "schematic"];
+
+// The persisted record. Fields are independent and each is optional on read,
+// so unit 3 can add `layout: "rail" | "grid"` by extending this type and the
+// writer — no v2 key, and a build that predates a field simply ignores it.
+type ViewPrefs = {
+  pinned: View[];
+  seen: View[];
+};
+
+const KNOWN = new Set<string>(VIEWS.map((v) => v.id));
+
+const defaultPins = (): View[] =>
+  VIEWS.filter((v) => v.defaultPinned)
+    .map((v) => v.id)
+    .slice(0, PIN_CAP);
+
+// localStorage is user-editable and outlives roster changes, so nothing read
+// back is trusted: non-arrays become empty, ids we no longer ship are dropped,
+// duplicates collapse (a duplicate would render two rail thumbs of one view).
+function sanitizeIds(raw: unknown): View[] {
+  if (!Array.isArray(raw)) return [];
+  const out: View[] = [];
+  for (const v of raw) {
+    if (typeof v === "string" && KNOWN.has(v) && !out.includes(v as View)) {
+      out.push(v as View);
+    }
+  }
+  return out;
+}
+
+function loadPrefs(): ViewPrefs {
+  try {
+    const raw = localStorage.getItem(VIEW_PREFS_KEY);
+    if (raw) {
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        const rec = parsed as Record<string, unknown>;
+        // Clamp to the cap on the way in too: the cap can shrink between
+        // releases, and the picker's disabled dots can only refuse NEW pins.
+        const pinned = sanitizeIds(rec.pinned).slice(0, PIN_CAP);
+        const seen = sanitizeIds(rec.seen);
+        // Everything surviving sanitisation was garbage ⇒ treat the record as
+        // corrupt rather than honour an empty rail, which is never what a user
+        // meant and leaves no visible way back.
+        if (pinned.length > 0) {
+          return { pinned, seen: seen.length > 0 ? seen : SEEN_SEED };
+        }
+      }
+    }
+  } catch {
+    /* corrupt JSON or storage disabled — the defaults below are the answer */
+  }
+  return { pinned: defaultPins(), seen: SEEN_SEED };
+}
+
+// --- module store ------------------------------------------------------------
+
+let cached: ViewPrefs | null = null;
+const listeners = new Set<() => void>();
+
+// useSyncExternalStore compares snapshots by identity, so this must hand back
+// the SAME object until something actually changes — hence the cache.
+function getSnapshot(): ViewPrefs {
+  if (!cached) cached = loadPrefs();
+  return cached;
+}
+
+function subscribe(onChange: () => void): () => void {
+  listeners.add(onChange);
+  return () => {
+    listeners.delete(onChange);
+    // Nothing is mounted any more, so drop the cache and let the next mount
+    // re-read storage. In the app that only happens before the first session
+    // mounts (sessions never all unmount); in tests it makes every mount a
+    // fresh read of whatever the test put in localStorage.
+    if (listeners.size === 0) cached = null;
+  };
+}
+
+function update(next: ViewPrefs): void {
+  cached = next;
+  try {
+    localStorage.setItem(VIEW_PREFS_KEY, JSON.stringify(next));
+  } catch {
+    /* storage disabled — the in-memory prefs still work for this session,
+       exactly as App.tsx's theme toggle degrades */
+  }
+  for (const l of listeners) l();
+}
+
+// --- pure helpers the UI and the key cycler share ----------------------------
+
+// ArrowUp/Down walks `pinned ∪ {active}`: a peeked view (active but unpinned)
+// joins the cycle transiently at the end so the arrows can never strand you on
+// a view they cannot leave. The full roster stays picker-only, which is the
+// point — cycling is short by construction.
+export function cycleOrder(pinned: View[], active: View): View[] {
+  return pinned.includes(active) ? pinned : [...pinned, active];
+}
+
+// Why a pin dot is inert, or null when it is live — the picker shows this as
+// the dot's tooltip. togglePin enforces the same two rules itself: the dots
+// are the affordance, these are the invariant.
+export function pinBlockedReason(pinned: View[], id: View): string | null {
+  if (pinned.includes(id)) {
+    // A floor of one keeps the stored set a fixed point of loadPrefs, which
+    // reads an empty pinned list as corruption and hands back the defaults.
+    return pinned.length <= 1 ? "Keep at least one view pinned" : null;
+  }
+  return pinned.length >= PIN_CAP ? "Unpin a view first" : null;
+}
+
+export function useViewPrefs() {
+  const prefs = useSyncExternalStore(subscribe, getSnapshot);
+  const { pinned, seen } = prefs;
+
+  // Views the user has never been offered. Seeded (not empty) on a first run,
+  // so the badge only ever fires for views added after the picker shipped.
+  const newIds = useMemo(
+    () => new Set(VIEWS.filter((v) => !seen.includes(v.id)).map((v) => v.id)),
+    [seen],
+  );
+
+  // The rail: pinned minus the active view. When the active view is unpinned
+  // (a peek) nothing is subtracted, so the rail shows every pin — peek costs
+  // no pin slot and displaces no thumb.
+  const railViews = useCallback(
+    (active: View): ViewMeta[] =>
+      pinned.filter((id) => id !== active).map((id) => VIEW_META[id]),
+    [pinned],
+  );
+
+  // Callbacks read the store rather than close over `pinned`, so a stale
+  // handler (a popover rendered before someone else's pin landed) still
+  // toggles against current truth.
+  const togglePin = useCallback((id: View) => {
+    const cur = getSnapshot();
+    if (pinBlockedReason(cur.pinned, id)) return;
+    const pins = cur.pinned.includes(id)
+      ? cur.pinned.filter((v) => v !== id)
+      : // Pin order is order-pinned; no drag-to-reorder in v1.
+        [...cur.pinned, id];
+    update({ ...cur, pinned: pins });
+  }, []);
+
+  // Opening the picker is what "you have now been shown the roster" means.
+  // No-ops when nothing is new, so the snapshot identity (and every memo
+  // hanging off it) survives an open.
+  const markRosterSeen = useCallback(() => {
+    const cur = getSnapshot();
+    const missing = VIEWS.map((v) => v.id).filter((id) => !cur.seen.includes(id));
+    if (missing.length === 0) return;
+    update({ ...cur, seen: [...cur.seen, ...missing] });
+  }, []);
+
+  return { pinned, seen, newIds, railViews, togglePin, markRosterSeen };
+}

--- a/src/antennaknobs/web/frontend/src/components/session/useViewState.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useViewState.ts
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { type ExampleDescriptor } from "../../lib/params";
 import { type Projection, type View } from "../../lib/view";
-import { cycleOrder } from "./useViewPrefs";
+import { cycleOrder, gridCells, gridFix, type Layout } from "./useViewPrefs";
 
 // Which output view is on screen and how it is drawn: the two far-field cut
 // angles, the selected view + camera projection, the antenna-canvas display
@@ -14,12 +14,26 @@ export function useViewState({
   currentExample,
   active,
   pinned,
+  layout = "rail",
+  setLayout,
 }: {
   currentExample: ExampleDescriptor | undefined;
   active: boolean;
   // The user's pinned views (useViewPrefs). The arrow keys cycle these plus
   // the active view, not the whole registry — see cycleOrder.
   pinned: View[];
+  // Unit 3 (docs/plan-view-rail-scaling.md "Layout modes"): grid mode's
+  // arrows cycle the displayed cells only (gridCells), not pinned ∪ active
+  // — a ring that walked onto pin #5 would vanish. Chosen as the seam here
+  // (rather than a generic `cycle` override list) because the displayed set
+  // is already fully determined by `pinned`, which this hook already takes;
+  // a second, separately-passed list could disagree with it. Defaults to
+  // "rail" so this stays a pure addition — every existing call keeps
+  // cycling pinned ∪ active exactly as before.
+  layout?: Layout;
+  // Only the grid-mode off-grid-peek fix (see the effect below) ever calls
+  // this. Omit it and that one branch is simply inert.
+  setLayout?: (l: Layout) => void;
 }) {
   // Far-field cut angles. The azimuth plot slices the pattern at elevation
   // `azElevDeg`; the elevation plot slices the vertical plane at azimuth
@@ -31,6 +45,22 @@ export function useViewState({
   const [elevAzDeg, setElevAzDeg] = useState(0);
 
   const [view, setView] = useState<View>("antenna");
+
+  // Keeps the grid-mode focus ring on a displayed cell — see gridFix's own
+  // comment for the full decision table. `wasGridRef` tracks the layout as
+  // of the last time this effect ran, which is how gridFix tells "just
+  // entered grid" from "already in grid, view just changed under it" apart;
+  // it is updated on every run regardless of which branch (or no branch)
+  // fires, so it always reflects the PREVIOUS render's layout.
+  const wasGridRef = useRef(layout === "grid");
+  useEffect(() => {
+    const fix = gridFix(layout, wasGridRef.current, view, pinned);
+    wasGridRef.current = layout === "grid";
+    if (!fix) return;
+    if ("view" in fix) setView(fix.view);
+    else setLayout?.("rail");
+  }, [layout, view, pinned, setLayout]);
+
   const [cameraProjection, setCameraProjection] = useState<Projection>("xy");
   // When the user switches antennas, reset the camera to that example's
   // natural starting view (declared on the backend via default_view).
@@ -76,7 +106,9 @@ export function useViewState({
       ) {
         return;
       }
-      const order = cycleOrder(pinned, view);
+      // Grid mode cycles the displayed cells only (unit 3's "Keyboard"
+      // section); rail mode keeps unit 2's pinned ∪ active cycle untouched.
+      const order = layout === "grid" ? gridCells(pinned) : cycleOrder(pinned, view);
       const idx = order.indexOf(view);
       const next =
         e.key === "ArrowDown"
@@ -86,7 +118,7 @@ export function useViewState({
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [view, active, pinned]);
+  }, [view, active, pinned, layout]);
 
   return {
     azElevDeg,

--- a/src/antennaknobs/web/frontend/src/components/session/useViewState.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useViewState.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { type ExampleDescriptor } from "../../lib/params";
-import { VIEWS, type Projection, type View } from "../../lib/view";
+import { type Projection, type View } from "../../lib/view";
+import { cycleOrder } from "./useViewPrefs";
 
 // Which output view is on screen and how it is drawn: the two far-field cut
 // angles, the selected view + camera projection, the antenna-canvas display
@@ -12,9 +13,13 @@ import { VIEWS, type Projection, type View } from "../../lib/view";
 export function useViewState({
   currentExample,
   active,
+  pinned,
 }: {
   currentExample: ExampleDescriptor | undefined;
   active: boolean;
+  // The user's pinned views (useViewPrefs). The arrow keys cycle these plus
+  // the active view, not the whole registry — see cycleOrder.
+  pinned: View[];
 }) {
   // Far-field cut angles. The azimuth plot slices the pattern at elevation
   // `azElevDeg`; the elevation plot slices the vertical plane at azimuth
@@ -71,13 +76,17 @@ export function useViewState({
       ) {
         return;
       }
-      const idx = VIEWS.findIndex((v) => v.id === view);
-      const next = e.key === "ArrowDown" ? (idx + 1) % VIEWS.length : (idx - 1 + VIEWS.length) % VIEWS.length;
-      setView(VIEWS[next].id);
+      const order = cycleOrder(pinned, view);
+      const idx = order.indexOf(view);
+      const next =
+        e.key === "ArrowDown"
+          ? (idx + 1) % order.length
+          : (idx - 1 + order.length) % order.length;
+      setView(order[next]);
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [view, active]);
+  }, [view, active, pinned]);
 
   return {
     azElevDeg,

--- a/src/antennaknobs/web/frontend/src/lib/math.ts
+++ b/src/antennaknobs/web/frontend/src/lib/math.ts
@@ -1,3 +1,24 @@
+import { reflectionCoefficient } from "./format";
+
+// |Γ| from Z = re + j·im referenced to z0. A thin wrapper over
+// reflectionCoefficient's gMag (lib/format.ts) rather than a second copy of
+// the formula — the Smith chart and the gamma/VSWR sweep charts (issue #700
+// unit 5) must never disagree about what |Γ| is for a given Z.
+export function gammaMagFromZ(re: number, im: number, z0: number): number {
+  return reflectionCoefficient(re, im, z0).gMag;
+}
+
+// VSWR = (1+|Γ|)/(1-|Γ|) blows up as |Γ| → 1 (a dead open/short feed). A
+// finite ceiling keeps that one sample from stretching a chart's y-axis
+// into a straight line at the horizon; 99 matches formatSwr's own
+// three-nines display cutoff (lib/format.ts) so "off the chart" means the
+// same thing in both places.
+export const VSWR_CEILING = 99;
+export function vswrFromGammaMag(gMag: number): number {
+  if (gMag >= 1) return VSWR_CEILING;
+  return Math.min((1 + gMag) / (1 - gMag), VSWR_CEILING);
+}
+
 // Richardson-style extrapolation Z(1/N) → Z(N→∞). Fits Z = a₀ + a₁·h + a₂·h²
 // (h = 1/N) on the last `nLast` points via least squares and returns a₀.
 // Quadratic gives a sane answer for O(1/N) limit (BSpline without

--- a/src/antennaknobs/web/frontend/src/lib/math.ts
+++ b/src/antennaknobs/web/frontend/src/lib/math.ts
@@ -19,6 +19,18 @@ export function vswrFromGammaMag(gMag: number): number {
   return Math.min((1 + gMag) / (1 - gMag), VSWR_CEILING);
 }
 
+// S11 log-magnitude, 20·log₁₀|Γ| — the negative-dB convention every VNA
+// (including the NanoVNA this app's users own) plots: 0 dB = total
+// reflection, a good match is a downward dip. NOT the IEEE positive
+// "return loss"; pick one sign convention and keep it. |Γ| = 0 is −∞ dB, so
+// a floor keeps a perfect match plottable and its data-* readout finite;
+// −60 dB (|Γ| = 0.001) is far below anything an antenna sweep resolves.
+export const S11_DB_FLOOR = -60;
+export function gammaDbFromMag(gMag: number): number {
+  if (gMag <= 0) return S11_DB_FLOOR;
+  return Math.max(20 * Math.log10(gMag), S11_DB_FLOOR);
+}
+
 // Richardson-style extrapolation Z(1/N) → Z(N→∞). Fits Z = a₀ + a₁·h + a₂·h²
 // (h = 1/N) on the last `nLast` points via least squares and returns a₀.
 // Quadratic gives a sane answer for O(1/N) limit (BSpline without

--- a/src/antennaknobs/web/frontend/src/lib/view.ts
+++ b/src/antennaknobs/web/frontend/src/lib/view.ts
@@ -24,7 +24,10 @@ export const VIEWS: ViewMeta[] = [
   // items 6/7): the sweep data already flows to the Smith chart, so these
   // are a second and third presentation of it, not a new data path. Ship
   // unpinned like schematic — the founding four stay the only defaults.
-  { id: "gamma", label: "|Γ| vs freq", defaultPinned: false },
+  // "gamma" keeps its id (persisted pin sets store ids) but presents as S11
+  // in dB — the VNA/NanoVNA log-magnitude convention, which is what this
+  // audience reads; linear |Γ| only ever appears as a Smith-chart radius.
+  { id: "gamma", label: "S11 (dB) vs freq", defaultPinned: false },
   { id: "vswr", label: "VSWR vs freq", defaultPinned: false },
 ];
 

--- a/src/antennaknobs/web/frontend/src/lib/view.ts
+++ b/src/antennaknobs/web/frontend/src/lib/view.ts
@@ -1,10 +1,24 @@
 export type View = "antenna" | "azimuth" | "elevation" | "smith" | "schematic";
-export const VIEWS: { id: View; label: string }[] = [
-  { id: "antenna", label: "Antenna" },
-  { id: "azimuth", label: "Azimuth (xy)" },
-  { id: "elevation", label: "Elevation (yz)" },
-  { id: "smith", label: "Smith" },
-  { id: "schematic", label: "Schematic" },
+
+// The view registry's metadata half. The render half — one function per id —
+// lives in components/results/viewRegistry.tsx, keyed by these same ids:
+// lib/ stays component-free, so the two halves cannot be one object here.
+// Adding a view = one entry below + one render entry there (the render map is
+// a Record<View, …>, so the compiler names the gap).
+export type ViewMeta = {
+  id: View;
+  label: string;
+  // Whether the view starts in the user's pinned set. Dormant until the pin
+  // model lands — unit 2 of docs/plan-view-rail-scaling.md is the only
+  // consumer. Nothing reads it today.
+  defaultPinned: boolean;
+};
+export const VIEWS: ViewMeta[] = [
+  { id: "antenna", label: "Antenna", defaultPinned: true },
+  { id: "azimuth", label: "Azimuth (xy)", defaultPinned: true },
+  { id: "elevation", label: "Elevation (yz)", defaultPinned: true },
+  { id: "smith", label: "Smith", defaultPinned: true },
+  { id: "schematic", label: "Schematic", defaultPinned: false },
 ];
 
 // The mobile output carousel's screens: the 5 chart views plus a dedicated

--- a/src/antennaknobs/web/frontend/src/lib/view.ts
+++ b/src/antennaknobs/web/frontend/src/lib/view.ts
@@ -39,15 +39,23 @@ export const VIEW_META = Object.fromEntries(
   VIEWS.map((v) => [v.id, v]),
 ) as Record<View, ViewMeta>;
 
-// The mobile output carousel's screens: the 5 chart views plus a dedicated
-// Info screen for the solve readout (which floats as a HUD on desktop but
-// deserves its own page on a phone). "info" stays out of the `View` union on
-// purpose — `view` (and every data effect keyed on it) only ever holds a
-// chart view; the Info screen leaves `view` parked on the last chart.
-export const MOBILE_SCREENS: { id: View | "info"; label: string }[] = [
-  ...VIEWS,
-  { id: "info", label: "Info" },
-];
+export type MobileScreen = { id: View | "info"; label: string };
+
+// The mobile output carousel's screens: the user's PINNED views, in pin order,
+// plus a dedicated Info screen for the solve readout (which floats as a HUD on
+// desktop but deserves its own page on a phone). "info" stays out of the
+// `View` union on purpose — `view` (and every data effect keyed on it) only
+// ever holds a chart view; the Info screen leaves `view` parked on the last
+// chart.
+//
+// Pinned, not the registry (#700 unit 4, docs/plan-view-rail-scaling.md): the
+// carousel index maps onto `pinned`, so an unpinned view has no page and no
+// dot, and the roster can grow past what a thumb-swipe stack can carry. Info
+// is always the TRAILING page, so its index moves with every pin — every
+// index compare in useMobileCarousel is against pinned.length for that reason.
+export function mobileScreens(pinned: View[]): MobileScreen[] {
+  return [...pinned.map((id) => VIEW_META[id]), { id: "info", label: "Info" }];
+}
 
 // Antenna-canvas camera projections. Pick two world axes to map to canvas
 // (horizontal, vertical) and project. The hidden axis is the camera ray.

--- a/src/antennaknobs/web/frontend/src/lib/view.ts
+++ b/src/antennaknobs/web/frontend/src/lib/view.ts
@@ -1,4 +1,4 @@
-export type View = "antenna" | "azimuth" | "elevation" | "smith" | "schematic";
+export type View = "antenna" | "azimuth" | "elevation" | "smith" | "schematic" | "gamma" | "vswr";
 
 // The view registry's metadata half. The render half — one function per id —
 // lives in components/results/viewRegistry.tsx, keyed by these same ids:
@@ -19,6 +19,12 @@ export const VIEWS: ViewMeta[] = [
   { id: "elevation", label: "Elevation (yz)", defaultPinned: true },
   { id: "smith", label: "Smith", defaultPinned: true },
   { id: "schematic", label: "Schematic", defaultPinned: false },
+  // Sweep-derived views (issue #700 unit 5, docs/plan-view-rail-scaling.md
+  // items 6/7): the sweep data already flows to the Smith chart, so these
+  // are a second and third presentation of it, not a new data path. Ship
+  // unpinned like schematic — the founding four stay the only defaults.
+  { id: "gamma", label: "|Γ| vs freq", defaultPinned: false },
+  { id: "vswr", label: "VSWR vs freq", defaultPinned: false },
 ];
 
 // The mobile output carousel's screens: the 5 chart views plus a dedicated

--- a/src/antennaknobs/web/frontend/src/lib/view.ts
+++ b/src/antennaknobs/web/frontend/src/lib/view.ts
@@ -8,9 +8,10 @@ export type View = "antenna" | "azimuth" | "elevation" | "smith" | "schematic" |
 export type ViewMeta = {
   id: View;
   label: string;
-  // Whether the view starts in the user's pinned set. Dormant until the pin
-  // model lands — unit 2 of docs/plan-view-rail-scaling.md is the only
-  // consumer. Nothing reads it today.
+  // Whether the view starts in the user's pinned set — the desktop rail is
+  // `pinned \ {active}`, not the whole roster (docs/plan-view-rail-scaling.md).
+  // Read once, by useViewPrefs, to seed a first run; after that the user's
+  // stored set wins, so flipping this only affects new users.
   defaultPinned: boolean;
 };
 export const VIEWS: ViewMeta[] = [
@@ -26,6 +27,14 @@ export const VIEWS: ViewMeta[] = [
   { id: "gamma", label: "|Γ| vs freq", defaultPinned: false },
   { id: "vswr", label: "VSWR vs freq", defaultPinned: false },
 ];
+
+// Id → metadata, for the consumers that hold a list of ids in the USER's
+// order (the pinned set) rather than registry order and still need labels.
+// The cast is the Record<View, …> exhaustiveness claim VIEWS already owes —
+// viewRegistry.test.tsx pins one entry per union member.
+export const VIEW_META = Object.fromEntries(
+  VIEWS.map((v) => [v.id, v]),
+) as Record<View, ViewMeta>;
 
 // The mobile output carousel's screens: the 5 chart views plus a dedicated
 // Info screen for the solve readout (which floats as a HUD on desktop but

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -2906,6 +2906,64 @@ canvas {
   opacity: 1;
 }
 
+/* The overflow affordance at the end of the dots row (#700 unit 4). It is not
+   a page — it changes which pages exist — so it suppresses the dot pseudo and
+   draws its own glyph. */
+.mobile-dots-more::before {
+  display: none;
+}
+
+.mobile-dots-more {
+  color: var(--muted);
+  font-size: var(--text-base);
+  line-height: 1;
+}
+
+/* Dimmed, unlike the desktop picker's transparent catcher: the sheet covers
+   the bottom of the screen rather than sitting beside its button, so the
+   backdrop has to read as "this layer is above the carousel". */
+.view-sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: var(--shadow);
+}
+
+/* Bottom sheet: the phone form of the same roster popover. Full width and
+   pinned to the bottom edge — the only place a list this tall is in thumb
+   reach — and capped so the carousel stays visible behind it. */
+.view-sheet {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 41;
+  max-height: 70vh;
+  overflow-y: auto;
+  padding: var(--space-2) var(--space-3) var(--space-5);
+  background: var(--bg);
+  border-top: 1px solid var(--border-control);
+  border-radius: var(--r-md) var(--r-md) 0 0;
+  box-shadow: 0 -6px 20px var(--shadow-strong);
+}
+
+/* Touch-sized rows (cf. the coarse-pointer block below): the popover's 24 px
+   dot and tight row padding are mouse dimensions. */
+.view-sheet .view-picker-name {
+  padding: var(--space-4) var(--space-3);
+  font-size: var(--text-base);
+}
+
+.view-sheet .view-picker-dot {
+  width: 40px;
+  height: 40px;
+}
+
+.view-sheet .view-picker-name:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
 /* The solve overlays are shared with the desktop stage. Most are absolutely
    positioned and just work inside .mobile-output; .solve-error is a flow
    child on desktop, so float it over the carousel here. */

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1792,7 +1792,8 @@ input[type=checkbox] {
 }
 
 .smith,
-.farfield {
+.farfield,
+.sweep {
   display: block;
   border-radius: var(--r-sm);
 }

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1902,13 +1902,11 @@ input[type=checkbox] {
   z-index: 40;
 }
 
-/* Opens to the RIGHT of the rail, bottom-aligned with its button: the rail
-   hugs the window's left edge, so a menu dropping below would fall off the
-   short columns this whole feature exists to serve. */
+/* Placement (left/bottom) comes from the component's measurement of its
+   button — .thumbstrip is overflow:hidden, which would clip an absolutely
+   positioned child, and a fixed one escapes that. */
 .view-picker {
-  position: absolute;
-  bottom: 0;
-  left: calc(100% + var(--space-3));
+  position: fixed;
   z-index: 41;
   min-width: 200px;
   max-height: min(70vh, 460px);

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -2011,6 +2011,119 @@ input[type=checkbox] {
   font-size: var(--text-xs);
 }
 
+/* ---- Rail/grid segmented control (unit 3, docs/plan-view-rail-scaling.md
+   "Layout modes") — stage top-right, desktop only. Same look family as
+   .projection-toggle: a pill of plain buttons, one active. ---- */
+.layout-toggle {
+  position: absolute;
+  top: var(--space-6);
+  right: var(--space-6);
+  z-index: 3;
+  display: flex;
+  gap: var(--space-2);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: var(--space-2);
+  box-shadow: 0 2px 10px var(--shadow);
+}
+
+.layout-toggle button {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  font: var(--text-sm) var(--font-mono);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+}
+
+.layout-toggle button:hover {
+  color: var(--fg);
+  background: var(--inset);
+}
+
+.layout-toggle button.active {
+  color: var(--accent);
+  background: var(--accent-active);
+}
+
+/* ---- Grid layout mode (unit 3): equal cells over the first ≤4 pins, no
+   primary. Row/column count comes from JS (useGridCellSize/ViewGrid share
+   gridShape's math) as an inline style, not fixed classes here — the shape
+   changes with the pin count. ---- */
+.view-grid {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: grid;
+  gap: var(--space-4);
+  padding: var(--space-4);
+}
+
+.grid-cell {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--panel);
+  border: 1px solid var(--border-control);
+  border-radius: var(--r-md);
+  padding: var(--space-4);
+  box-sizing: border-box;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.grid-cell:hover {
+  border-color: var(--accent-border);
+}
+
+/* The active view's cell — Blender-quad-viewport focus ring: the arrow keys
+   and a cell-body click both move this, per-cell overlays anchor inside it
+   the same way they anchor inside .carousel-slide. */
+.grid-cell-focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent) inset;
+}
+
+/* The 3-pin "pin a 4th view" invitation cell (see ViewGrid) — dashed like
+   .view-picker-btn's own "this slot isn't resident yet" idiom. */
+.grid-cell-hint {
+  color: var(--muted);
+  font-size: var(--text-xs);
+  border-style: dashed;
+  cursor: default;
+}
+
+/* Top-LEFT (not top-right, where AntennaOverlayControls/SmithOverlayControls/
+   FarFieldOverlayControls already anchor per cell) so the glyph never
+   overlaps a view's own overlay controls. */
+.grid-cell-maximize {
+  position: absolute;
+  top: var(--space-3);
+  left: var(--space-3);
+  z-index: 3;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  color: var(--muted);
+  cursor: pointer;
+  box-shadow: 0 2px 8px var(--shadow);
+}
+
+.grid-cell-maximize:hover {
+  color: var(--accent);
+  border-color: var(--accent-border);
+}
+
 .carousel-slide {
   flex: 1;
   min-width: 0;

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1855,6 +1855,164 @@ input[type=checkbox] {
   letter-spacing: 0.03em;
 }
 
+/* ---- "All views" overflow picker (thumbstrip foot) ---------------------
+   The button's height is FIXED and mirrored by PICKER_SLOT in
+   components/hooks.ts, which subtracts it from the column before dividing
+   the rest among the thumbs — change one and the bottom thumb clips. */
+.view-picker-wrap {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.view-picker-btn {
+  box-sizing: border-box;
+  width: 100%;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-3);
+  background: var(--inset);
+  color: var(--muted);
+  /* Dashed: this slot holds views that are NOT resident, unlike the solid
+     thumbs above it. */
+  border: 1px dashed var(--border-control);
+  border-radius: var(--r-md);
+  font: inherit;
+  font-size: var(--text-xs);
+  cursor: pointer;
+}
+
+.view-picker-btn:hover {
+  color: var(--accent);
+  border-color: var(--border-hover);
+}
+
+.view-picker-count {
+  color: var(--fg);
+  font-weight: 600;
+}
+
+/* Transparent full-screen catcher so a click anywhere closes the popover
+   (same idiom as .gear-menu-backdrop). */
+.view-picker-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+}
+
+/* Opens to the RIGHT of the rail, bottom-aligned with its button: the rail
+   hugs the window's left edge, so a menu dropping below would fall off the
+   short columns this whole feature exists to serve. */
+.view-picker {
+  position: absolute;
+  bottom: 0;
+  left: calc(100% + var(--space-3));
+  z-index: 41;
+  min-width: 200px;
+  max-height: min(70vh, 460px);
+  overflow-y: auto;
+  padding: var(--space-1);
+  background: var(--bg);
+  border: 1px solid var(--border-control);
+  border-radius: var(--r-md);
+  box-shadow: 0 6px 20px var(--shadow-strong);
+}
+
+.view-picker-row {
+  display: flex;
+  align-items: center;
+  border-radius: var(--r-sm);
+}
+
+.view-picker-row:hover {
+  background: var(--accent-soft);
+}
+
+.view-picker-name {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  text-align: left;
+  white-space: nowrap;
+  background: none;
+  border: none;
+  border-radius: var(--r-sm);
+  color: var(--fg);
+  font: inherit;
+  font-size: var(--text-sm);
+  cursor: pointer;
+}
+
+.view-picker-row.unpinned .view-picker-name {
+  color: var(--muted);
+}
+
+.view-picker-row.active .view-picker-name {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.view-picker-name:hover {
+  color: var(--accent);
+}
+
+/* The pin state IS the indicator (instrument channel-enable idiom): filled =
+   resident in the rail. The button is a 24 px hit target around a 12 px dot. */
+.view-picker-dot {
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  margin-right: var(--space-2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.view-picker-dot span {
+  box-sizing: border-box;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid var(--accent-border);
+}
+
+.view-picker-row.pinned .view-picker-dot span {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.view-picker-dot:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.view-picker-new {
+  padding: 0 var(--space-2);
+  border-radius: var(--r-sm);
+  background: var(--hot);
+  color: var(--panel);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+
+.view-picker-note {
+  margin-top: var(--space-1);
+  padding: var(--space-2) var(--space-3) var(--space-1);
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: var(--text-xs);
+}
+
 .carousel-slide {
   flex: 1;
   min-width: 0;


### PR DESCRIPTION
Integration PR for the #700 stacked arc, implementing the accepted design in `docs/plan-view-rail-scaling.md` (design issue #684, PR #699). Every unit landed as a reviewed, CI-green stacked sub-PR; this PR carries the assembled batch to main as 13 rebase-verbatim commits.

## Units (all merged)
- [x] Unit 1 — view registry (#703): metadata half in `lib/view.ts` (+`defaultPinned`), render half `viewRegistry.tsx` (`Record<View,…>` exhaustiveness), ViewPanel = dispatch.
- [x] Unit 2 — pin model + "All views" picker (#707): ordered pins (default 4, cap 6, floor 1), localStorage `akb.viewPrefs.v1`, peek, NEW badges seeded to the 5 pre-picker views, cycling over pinned ∪ {active}.
- [x] Unit 3 — grid layout mode (#713): ▤/⊞ presets over the pinned set, ≤4 equal cells in pin order, focus ring, maximize→rail, `gridFix` off-grid decision table, sparse `layout` persistence.
- [x] Unit 4 — mobile pinned carousel + picker sheet (#710): pages = pinned + Info, `reconcileCarousel` pure index reconciliation, "⋯" bottom sheet (row tap pins; no peek on mobile), shared `ViewRosterRows`.
- [x] Unit 5 — |Γ|/VSWR views (#706) + S11-dB amendment (#709): `SweepChart` (mode prop), oracle-pinned conversions, S11 in negative dB (VNA/NanoVNA convention), VSWR 1–10 with pinned-needle off-scale ticks; both ship unpinned.

## Assembled-branch verification
- Fresh `npm ci` + full suite: **35 files / 565 tests green** (baseline was 23/394 at arc start). `npm run build` (tsc + vite) green.
- Skip-ci contagion grep over all 13 commit messages: clean.
- Live visual pass (desktop Chrome against the built app): rail + "All views ⌄ +3" button; grid mode 2×2 with focus ring, per-cell maximize, single stage HUD; NEW badges on {gamma, vswr} for a first-time profile.
- Every unit built by a delegated subagent and independently reviewed: full diff read, gates re-run, and a reviewer-side mutation probe per unit (all caught).

## Acceptance (from #700)
- Both layout modes render the pinned set; default-pin rail behavior matches today's minus the schematic thumb (ships unpinned) ✅
- Pin cap (and floor) enforced; persistence survives reload; roster growth surfaces NEW badges ✅
- Suite + typecheck + build green per unit and assembled ✅

## Deferred follow-ups (to file after merge)
- Drag-to-reorder pins (plan: explicitly out of v1).
- Analysis gating on residency (sweep/converge/schematic triggers unchanged this arc).
- Cross-browser-tab `storage` sync for view prefs (same policy as theme).
- Mobile peek-at-cap gap (sheet can only pin; weaker than desktop at the 6-pin cap).
- A light DesignSession mount harness (two unit-3 placement facts are asserted structurally via `?raw` source slicing).
- SmithChart's `measFreqMhz` prop is effect-dep only; SweepChart gave it its first drawn use — consider aligning.

Closes #700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01522PMkNyJbRX772WV5DwaA