### PR TITLE
698 unit 2: invvee_catenary design — sagging arms under halyard tension

### DIFF
--- a/site/src/content/docs/reference/catalog.md
+++ b/site/src/content/docs/reference/catalog.md
@@ -18,6 +18,7 @@ after L. B. Cebik (W4RNL)'s articles.
 | `dipoles.folded_invvee` | Folded inverted-vee — the folded dipole's impedance step-up, with drooped arms |
 | `dipoles.folded_invvee_balun` | Folded inverted-V fed through a 4:1 balun and real coax — the `Transformer` showcase (issue #301) |
 | `dipoles.invvee` | Inverted-vee dipole — the default quickstart example · variants: `classic_edz`, `dipole`, `three_halves` |
+| `dipoles.invvee_catenary` | Inverted-vee dipole whose arms hang as real catenaries (issue #698, unit 2) |
 | `dipoles.invvee_coax_station` | Inverted-V fed through real coax — the classic "resonant antenna on 50 Ω line" station, modelled from the rig (issue #300) · variants: `classic_edz`, `dipole`, `three_halves` |
 | `dipoles.koch_dipole` | Koch fractal dipole (L. B. Cebik, W4RNL -- "fractal antennas") |
 | `dipoles.ocf_dipole` | Off-Center-Fed dipole (Windom): a half-wave fed away from the middle (L. B. Cebik, W4RNL) |

--- a/src/antennaknobs/designs/dipoles/invvee_catenary.py
+++ b/src/antennaknobs/designs/dipoles/invvee_catenary.py
@@ -1,0 +1,194 @@
+"""Inverted-vee dipole whose arms hang as real catenaries (issue #698, unit 2).
+
+Every other inv-vee in the catalog (`dipoles.invvee`) treats an arm as a
+straight chord at a fixed droop angle. A real wire does not do that: strung
+from the apex to a stake under some rope tension, it sags into the shape
+`antennaknobs.catenary` solves for — a hanging-chain equilibrium set by the
+wire's own weight per metre and how hard the halyard pulls. This design wires
+that solve into the geometry: `build_wires()` emits each arm as a chord
+polyline sampled uniformly along the solved catenary's arc length, following
+the `specialty.faceted_helix` curved-wire idiom (`Wire(p_i, p_{i+1},
+n_seg=None)`, `auto_mesh` owning the electrical density — issue #630's
+lesson: never hand-freeze `n_seg` on a chorded curve).
+
+The model: tensioned halyard (catenary's "model 1")
+----------------------------------------------------
+Each arm is `catenary.solve_tensioned`: a wire of *fixed cut length*
+`0.25 * design_wavelength * length_factor` — the same length law
+`dipoles.invvee` uses for its straight arm — hangs from the apex, and its far
+end is held by a massless rope of specified tension `tension_n` running to a
+fixed stake. The wire's end position is not an input; equilibrium places it,
+which is the whole point of the model: `tension_n` is the design knob and the
+arm's droop is the answer.
+
+This keeps the **electrical knob and the mechanical knob orthogonal by
+construction** — `length_factor` sets how much wire is up there;
+`tension_n` sets how it hangs. Scrubbing tension never changes the cut
+length, only the shape, exactly as issue #698 requires ("the electrical
+knob must not move when tension changes"). As `tension_n -> infinity` the
+arm's shape converges to the straight chord from the apex toward the stake,
+which is the design's own built-in regression oracle against a straight-arm
+inv-vee of the same geometry (see `tests/test_invvee_catenary.py`).
+
+Feasibility: the stake must be beyond the arm
+----------------------------------------------
+`solve_tensioned` requires the stake to be farther from the apex than the
+wire is long — a taut wire reaching for a stake it has already overshot has
+no equilibrium at any tension. With the apex at `(0, base)` and the stake at
+`(stake_dist, stake_height)` in the arm's own vertical plane, this needs
+
+    hypot(stake_dist, base - stake_height) > 0.25 * design_wavelength * length_factor
+
+The stock `stake_dist` (~1.15x the default arm length) and `stake_height`
+(1.0 m) satisfy this with a comfortable margin even at the top of the
+`length_factor` UI range, because most of the reach comes from the mast
+height (`base - stake_height`) rather than the horizontal offset — see the
+module tests for the numeric check. Push the knobs hard enough (a very long
+arm, a stake dragged close to directly under the apex) and the solver's own
+`ValueError` explains exactly why no rig exists; this design does not
+second-guess or clamp that error.
+
+Geometry
+--------
+The apex sits on the mast at `(0, 0, base)`. A short feed wire (the
+`doublet_ladder_tuner` / `invvee` idiom: `eps = 0.05` m either side of
+centre) carries the driven gap; each catenary arm starts from that feed
+wire's end and runs in the +y or -y azimuth (no azimuth knob in this unit —
+the two arms are always 180 deg apart). The catenary solve itself works in
+the arm's 2-D vertical plane (`horizontal`, `z`); the design maps
+`horizontal -> +-y` and holds `x = 0`.
+
+Requires a real `WireSpec`: a weightless wire has no catenary
+(`solve_tensioned` raises `ValueError` for `wire_weight_n_per_m <= 0`, and
+this module raises its own clear error first if `build_wire_material()`
+returns `None`). The stock wire is `18-awg-pvc` (via `wire_type`), which
+carries a real `weight_g_per_m` — swap the catalog entry and the antenna
+sags differently AND its loss/insulation electrical behaviour changes in one
+move (the same one-knob-two-effects story as `dipoles.pota_invvee`, issue
+#316).
+
+`chords_per_arm` (default 14) is the *geometric* fidelity knob, independent
+of the electrical mesh: it is passed straight through as
+`samples_per_segment = chords_per_arm + 1` to `solve_tensioned`, so the
+solver's own uniform-in-arc-length sampling IS the chord split.
+
+See also
+--------
+`antennaknobs.catenary` for the chain solver and its numerics/sign
+conventions; `dipoles.invvee` for the base design and param conventions;
+`specialty.faceted_helix` for the chord-polyline-as-geometry precedent.
+Issue #698.
+"""
+
+from types import MappingProxyType
+
+from antennaknobs import AntennaBuilder
+from antennaknobs.catenary import ChainSolution, solve_tensioned, weight_n_per_m
+from antennaknobs.network import WIRES, Wire
+
+# Half-gap either side of the mast centreline for the driven feed wire — the
+# same value `dipoles.invvee` and `wire.doublet_ladder_tuner` use.
+_EPS = 0.05
+
+
+class Builder(AntennaBuilder):
+    """A subclass of `AntennaBuilder` directly, not `dipoles.invvee`: the
+    variant-discovery convention (`web.adapter._discover_variants`) walks
+    `dir(cls)`, so subclassing `InvVee` would silently inherit its
+    `dipole_params` / `three_halves_params` / `classic_edz_params`
+    overlays — every one of which sets `angle_deg`, a knob this design does
+    not have (droop is physics here, not a param). Subclassing
+    `AntennaBuilder` sidesteps that entirely; the param *conventions* (name
+    the length knob `length_factor`, keep `design_freq`/`freq`/`base`) are
+    still reused, per the issue's brief.
+    """
+
+    default_params = MappingProxyType(
+        {
+            # Same band/height/length-law defaults as dipoles.invvee.
+            "design_freq": 28.47,
+            "freq": 28.47,
+            "base": 7.0,
+            "length_factor": 0.9719,
+            # Rope tension holding each arm's far end (issue #698 model 1).
+            # ~9 lbf: a realistic hand-tensioned dacron halyard pull.
+            "tension_n": 40.0,
+            # Stake position in the arm's vertical plane, horizontal
+            # distance from the mast and height above ground. Defaults
+            # chosen so hypot(stake_dist, base - stake_height) clears the
+            # longest arm the length_factor UI range can produce (see the
+            # module docstring and the feasibility test).
+            "stake_dist": 2.94,
+            "stake_height": 1.0,
+            # Chord count per arm: geometric fidelity, orthogonal to the
+            # electrical mesh density (nominal_nsegs / auto_mesh).
+            "chords_per_arm": 14,
+            # Real wire is mandatory (a weightless wire has no catenary);
+            # 18 AWG PVC is a common real-world halyard-fed hookup wire.
+            "wire_type": "18-awg-pvc",
+            "ui_params": MappingProxyType(
+                {
+                    "length_factor": {"min": 0.8, "max": 1.25},
+                    "tension_n": {"min": 2.0, "max": 400.0},
+                    "stake_dist": {"min": 1.0, "max": 6.0},
+                    "stake_height": {"min": 0.0, "max": 3.0},
+                    "chords_per_arm": {"min": 6, "max": 32, "step": 1},
+                    "wire_type": {"enum_options": tuple(sorted(WIRES))},
+                }
+            ),
+        }
+    )
+
+    def rig_solutions(self) -> ChainSolution:
+        """Solve one arm's catenary (both arms are mirror images in y, so
+        one solve in the shared vertical plane covers both).
+
+        `build_wires()` calls this same method for its geometry, so the
+        rigged shape and any diagnostics a caller reads off it (sag,
+        tension, arc length) can never drift apart.
+        """
+        spec = self.build_wire_material()
+        if spec is None or not spec.weight_g_per_m:
+            raise ValueError(
+                f"{type(self).__name__}: catenary sag needs a real WireSpec "
+                "with weight_g_per_m > 0 (a weightless wire has no "
+                f"catenary); got {spec!r} from build_wire_material() — set "
+                "wire_type to a catalog entry such as '18-awg-pvc'."
+            )
+
+        arm_length_m = 0.25 * self.design_wavelength * self.length_factor
+        wire_weight = weight_n_per_m(spec.weight_g_per_m)
+
+        return solve_tensioned(
+            apex=(_EPS, self.base),
+            wire_length_m=arm_length_m,
+            wire_weight_n_per_m=wire_weight,
+            stake=(self.stake_dist, self.stake_height),
+            rope_tension_n=self.tension_n,
+            samples_per_segment=int(self.chords_per_arm) + 1,
+            name="invvee_catenary_arm",
+        )
+
+    # build_wire_material() is intentionally NOT overridden: the inherited
+    # AntennaBuilder default already resolves a `wire_type` param via
+    # `wire_from_catalog` (the same mechanism `dipoles.pota_invvee` relies
+    # on), and the stock `wire_type` above already names a real WireSpec.
+
+    def build_wires(self):
+        b = self.base
+        solution = self.rig_solutions()
+        # (horizontal, z) samples, uniform in arc length, apex-first.
+        plane_points = solution.segments[0].points
+
+        wires = [
+            # Driven gap at the apex — the invvee/doublet_ladder_tuner
+            # idiom: a short wire from -eps to +eps carries the excitation,
+            # and each catenary arm starts from one of its ends.
+            Wire((0.0, -_EPS, b), (0.0, _EPS, b), ex=1 + 0j),
+        ]
+        for sign in (1.0, -1.0):
+            arm_points = [(0.0, sign * h, z) for h, z in plane_points]
+            wires.extend(
+                Wire(p0, p1) for p0, p1 in zip(arm_points[:-1], arm_points[1:])
+            )
+        return wires

--- a/tests/test_invvee_catenary.py
+++ b/tests/test_invvee_catenary.py
@@ -1,0 +1,232 @@
+"""dipoles.invvee_catenary (issue #698, unit 2): the sagging inv-vee arm.
+
+Engine-agnostic impedance checks follow the `tests/test_pota_invvee.py`
+precedent — build a `MomwireEngine` directly over the default (finite)
+ground and read `.impedance()`.
+"""
+
+import math
+
+import pytest
+
+from antennaknobs.designs.dipoles.invvee_catenary import Builder
+from antennaknobs.engines.momwire import MomwireEngine
+from antennaknobs.engines.pynec import DEFAULT_GROUND
+from antennaknobs.network import Wire
+
+_EPS = 0.05
+
+
+def _builder(**params):
+    b = Builder()
+    for k, v in params.items():
+        setattr(b, k, v)
+    return b
+
+
+def _z(builder):
+    return MomwireEngine(builder, ground=DEFAULT_GROUND).impedance()[0]
+
+
+# ---------------------------------------------------------------------------
+# 1. Taut-limit regression vs a hand-built straight-arm oracle
+# ---------------------------------------------------------------------------
+
+
+def test_taut_limit_matches_straight_arm_oracle():
+    """As tension_n -> infinity, `solve_tensioned` converges to the straight
+    chord of the same arc length running from the apex toward the stake
+    (the module docstring's built-in regression oracle). Build that straight
+    chord BY HAND -- not by calling the catenary solver -- so the comparison
+    is independent of the solver's own numerics, then chord it into the same
+    number of straight segments (`chords_per_arm`) that `build_wires()` uses,
+    so both geometries get the identical auto_mesh segment counts per chord
+    and the comparison isolates the sag physics, not a mesh-density delta.
+    """
+    b = _builder(tension_n=1.0e5)
+    z_catenary = _z(b)
+
+    n = int(b.chords_per_arm)
+    apex_x, apex_z = _EPS, b.base
+    dx = b.stake_dist - apex_x
+    dz = b.stake_height - apex_z
+    reach = math.hypot(dx, dz)
+    ux, uz = dx / reach, dz / reach
+    arm_length_m = 0.25 * b.design_wavelength * b.length_factor
+
+    class StraightArmOracle(Builder):
+        """Same feed wire + chord count as invvee_catenary, but each arm is
+        the exact analytic straight chord of `arm_length_m` toward the
+        stake -- the T -> infinity limit, computed without touching
+        catenary.py at all."""
+
+        def build_wires(self):
+            plane_points = []
+            for i in range(n + 1):
+                s = arm_length_m * i / n
+                plane_points.append((apex_x + s * ux, apex_z + s * uz))
+            wires = [Wire((0.0, -_EPS, apex_z), (0.0, _EPS, apex_z), ex=1 + 0j)]
+            for sign in (1.0, -1.0):
+                arm_pts = [(0.0, sign * h, z) for h, z in plane_points]
+                wires.extend(Wire(p0, p1) for p0, p1 in zip(arm_pts[:-1], arm_pts[1:]))
+            return wires
+
+    z_oracle = _z(StraightArmOracle(dict(b._params)))
+
+    rel_err = abs(z_catenary - z_oracle) / abs(z_oracle)
+    assert rel_err < 0.01, (z_catenary, z_oracle, rel_err)
+
+
+# ---------------------------------------------------------------------------
+# 2. Chord-count convergence
+# ---------------------------------------------------------------------------
+
+
+def test_chord_count_convergence():
+    """More chords per arm means a finer polyline approximation of the same
+    smooth catenary curve, so impedance should settle down as chords_per_arm
+    grows, at a fixed electrical mesh density (nominal_nsegs untouched).
+
+    16/32/64 (doubling, well above the UI slider's 6-32 sticker range) are
+    used rather than the UI's own 8/16/24 window: at very low absolute
+    per-chord segment counts (1-3 segments, since auto_mesh rounds each
+    short chord's own count independently -- issue #630's per-wire auto_mesh
+    contract), integer rounding on individual chords aliases the *total*
+    electrical segment count non-monotonically with chords_per_arm (e.g.
+    8 chords can auto-mesh to MORE total segments than 16 chords, because
+    each of the 8 longer chords rounds up to 3 segments while each of the 16
+    shorter ones rounds down to 1). That is a mesh-density artifact, not the
+    curve-fidelity convergence this test is after, and it clears up once the
+    per-chord segment counts are comfortably above 1 -- doubling from 16
+    confirms strictly shrinking steps.
+    """
+    zs = {n: _z(_builder(chords_per_arm=n)) for n in (16, 32, 64)}
+    step1 = abs(zs[32] - zs[16])
+    step2 = abs(zs[64] - zs[32])
+    assert step2 < step1, (step1, step2)
+    assert step2 < 1.0, step2
+
+
+# ---------------------------------------------------------------------------
+# 3. Physics smoke: sag vs tension, reactance vs tension
+# ---------------------------------------------------------------------------
+
+
+def test_sag_decreases_monotonically_with_tension():
+    sags = [_builder(tension_n=t).rig_solutions().max_sag_m for t in (5.0, 40.0, 300.0)]
+    assert sags[0] > sags[1] > sags[2] > 0.0
+
+
+def test_reactance_moves_monotonically_with_tension():
+    """Direction, determined by actually running the solve (not assumed):
+    reactance INCREASES with tension. A slacker (lower-tension) arm sags
+    into a shape that folds more of its fixed wire length into a smaller
+    net horizontal reach from the feed -- the same total conductor length
+    packed into a physically shorter span, which behaves like *shortening*
+    the antenna (moving it away from the taut straight-arm's tuning) and
+    pulls the reactance down/capacitive. As tension climbs toward the taut
+    limit the arm straightens back out toward the full-reach straight-arm
+    geometry (see the taut-limit oracle test above, ~+20.36 ohm), and the
+    reactance climbs back up toward that value.
+    """
+    freqs = (5.0, 40.0, 300.0)
+    reactances = [_z(_builder(tension_n=t)).imag for t in freqs]
+    assert reactances[0] < reactances[1] < reactances[2]
+
+
+def test_emitted_arm_bows_off_its_chord_by_the_solved_sag():
+    """The EMITTED wires must carry the catenary's curve, not just its
+    endpoints. Geometry-level on purpose: at hand-tension scales the
+    curve-vs-chord impedance delta is fractions of an ohm, so no electrical
+    assertion in this file can tell a correctly sagged arm from its straight
+    chord (a straight-chord mutation of build_wires survived exactly that
+    way in review) — but a flattened plane->3D mapping is still a real bug
+    the moment anything reads the geometry. Pin the interior nodes' max
+    perpendicular deviation from the arm's own chord to the solver's
+    reported max_sag_m."""
+    b = _builder(tension_n=5.0)
+    sol = b.rig_solutions()
+    wires = b.build_wires()
+    # The +y arm's chords, in emission order (apex-first).
+    arm = [w for w in wires if w.ex is None and w.p0[1] > 0]
+    nodes = [(w.p0[1], w.p0[2]) for w in arm] + [(arm[-1].p1[1], arm[-1].p1[2])]
+    (y0, z0), (y1, z1) = nodes[0], nodes[-1]
+    cy, cz = y1 - y0, z1 - z0
+    chord = math.hypot(cy, cz)
+    devs = [abs((cy * (z - z0) - cz * (y - y0)) / chord) for y, z in nodes[1:-1]]
+    # Discrete nodes sample near, not exactly at, the continuous maximum.
+    assert max(devs) == pytest.approx(sol.max_sag_m, rel=0.05)
+    assert max(devs) > 1.0e-3  # and the bow is real, not round-off
+
+
+# ---------------------------------------------------------------------------
+# 4. Cut-length invariance
+# ---------------------------------------------------------------------------
+
+
+def test_cut_length_invariant_under_tension():
+    b = _builder()
+    expected_arm_length = 0.25 * b.design_wavelength * b.length_factor
+
+    for t in (5.0, 40.0, 300.0, 1.0e4):
+        solution = _builder(tension_n=t).rig_solutions()
+        assert solution.segments[0].arc_length_m == pytest.approx(
+            expected_arm_length, rel=1e-12
+        )
+
+    # Total emitted polyline length ~= 2 arms + the short feed wire.
+    wires = b.build_wires()
+    total = sum(math.dist(w.p0, w.p1) for w in wires)
+    expected_total = 2.0 * expected_arm_length + 2.0 * _EPS
+    assert total == pytest.approx(expected_total, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# 5. Weightless wire rejected
+# ---------------------------------------------------------------------------
+
+
+def test_weightless_wire_raises():
+    class WeightlessVariant(Builder):
+        def build_wire_material(self):
+            return None
+
+    b = WeightlessVariant()
+    with pytest.raises(ValueError, match="WireSpec"):
+        b.rig_solutions()
+    with pytest.raises(ValueError, match="WireSpec"):
+        b.build_wires()
+
+
+# ---------------------------------------------------------------------------
+# 6. Wires stay above ground
+# ---------------------------------------------------------------------------
+
+
+def test_wires_stay_above_ground_at_defaults():
+    wires = Builder().build_wires()
+    zs = [w.p0[2] for w in wires] + [w.p1[2] for w in wires]
+    assert min(zs) > 0.0
+
+
+# ---------------------------------------------------------------------------
+# 7. Catalog smoke
+# ---------------------------------------------------------------------------
+
+
+def test_builds_meshes_and_solves_at_defaults():
+    b = Builder()
+    wires = b.build_wires()
+    assert len(wires) == 1 + 2 * int(b.chords_per_arm)
+
+    feed = [w for w in wires if w.ex is not None]
+    assert len(feed) == 1
+    assert feed[0].ex == 1 + 0j
+
+    for w in wires:
+        assert isinstance(w, Wire)
+        assert w.n_seg is not None and w.n_seg >= 1
+
+    z = _z(b)
+    assert math.isfinite(z.real) and math.isfinite(z.imag)
+    assert z.real > 0.0


### PR DESCRIPTION
Second unit of the #698 arc (stacked on `issue-698-catenary-wires`, builds on unit 1's `catenary.py`).

## What
`designs/dipoles/invvee_catenary.py`: inverted vee whose arms are model-1 catenary solves — fixed cut length `0.25·λ·length_factor`, halyard `tension_n` knob (2–400 N), stake position params, arms emitted as chord polylines (`chords_per_arm`, default 14) with `n_seg=None` so auto_mesh owns electrical density (the #630 contract). Stock wire `18-awg-pvc` — the same catalog WireSpec sets sag weight AND conductor loss/insulation. Plus the regenerated site catalog page.

## Gates (measured, reviewer re-run)
- `pytest tests/test_invvee_catenary.py`: **9 passed** (8 builder + 1 reviewer-added, below)
- Full suite: **3334 passed, 2 skipped** (builder run; reviewer re-runs on the assembled branch + sub-PR CI)
- `ruff check` / `format`: clean
- Taut-limit regression: catenary vs hand-built straight-chord oracle at 1e5 N agrees to **2e-6 (real) / 5e-6 (imag)** relative — far under the 1% gate
- Physics direction (documented in-test): reactance rises with tension, 18.42 Ω @ 5 N → 20.12 @ 40 → 20.33 @ 300, asymptoting to the 20.36 Ω taut value

## Review notes (session model reviewing a sonnet builder)
- Read the full diff; re-ran the design tests, ruff, and an independent parabolic sag estimate (solver sag 1.0 mm at 40 N matches `w·L²cos θ/(8T)` to 2 digits).
- **Mutation probe found a coverage gap**: silently replacing the arms with their straight chords passed all 8 original tests — the solved *end position* still moves with tension, and the curve-vs-chord impedance delta is sub-tolerance at these sags. Added `test_emitted_arm_bows_off_its_chord_by_the_solved_sag` (geometry-level: emitted interior nodes must bow off the chord by exactly the solver's `max_sag_m`); verified it fails under the mutation and passes pristine.
- Builder deviations reviewed and accepted: subclassing `AntennaBuilder` instead of `InvVee` (real variant-leak trap — `_discover_variants` walks `dir(cls)` and would inherit `angle_deg` variant overlays); chord-convergence ladder moved to 16/32/64 after demonstrating integer auto-mesh aliasing makes 8→16 non-monotone in *total* segments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g