### PR TITLE
Unit 5: |Γ| and VSWR vs. frequency views (#700)

### DIFF
--- a/src/antennaknobs/web/frontend/src/__tests__/SweepChart.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/SweepChart.test.tsx
@@ -1,0 +1,147 @@
+// Pins SweepChart (src/components/charts/SweepChart.tsx, issue #700 unit 5):
+// the shared |Γ|/VSWR-vs-frequency component behind the "gamma" and "vswr"
+// views. jsdom ships no 2-D canvas context, so — like every other chart —
+// the draw effect's ctx-null guard takes the no-draw path; what's asserted
+// here is the pure-derivation data-* attributes computed at render time
+// (data-mode/data-points/data-feeds/data-y-values/data-current), which are
+// available regardless of whether a real context exists. data-y-values in
+// particular is the mutation catcher: it carries the actual per-mode
+// numbers, so a conversion swap (gamma math running under the vswr label,
+// or vice versa) changes the string even though data-mode stays correct.
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { SweepChart } from "../components/charts/SweepChart";
+import type { SweepData } from "../lib/api";
+
+HTMLCanvasElement.prototype.getContext =
+  (() => null) as unknown as HTMLCanvasElement["getContext"];
+
+// Three points chosen from the closed-form oracle pairs pinned in
+// math.test.ts: Z=50+0j -> matched (|Γ|=0, VSWR=1); Z=100+0j and Z=25+0j ->
+// the 2:1 real mismatch (|Γ|=1/3, VSWR=2) from either side of Z0=50.
+const SWEEP: SweepData = {
+  freqs_mhz: [10, 14, 18],
+  z_re: [50, 100, 25],
+  z_im: [0, 0, 0],
+};
+
+function renderChart(
+  mode: "gamma" | "vswr",
+  overrides: Partial<React.ComponentProps<typeof SweepChart>> = {},
+) {
+  return render(
+    <SweepChart
+      mode={mode}
+      r={0}
+      x={0}
+      z0={50}
+      size={180}
+      sweep={null}
+      measFreqMhz={14}
+      running={false}
+      multiFeed={false}
+      {...overrides}
+    />,
+  );
+}
+
+describe("mode dispatch", () => {
+  it("renders the gamma canvas with its own marker", () => {
+    const { container } = renderChart("gamma");
+    const canvas = container.querySelector('canvas.sweep[data-mode="gamma"]');
+    expect(canvas).not.toBeNull();
+    expect(container.querySelector('canvas.sweep[data-mode="vswr"]')).toBeNull();
+  });
+
+  it("renders the vswr canvas with its own marker", () => {
+    const { container } = renderChart("vswr");
+    const canvas = container.querySelector('canvas.sweep[data-mode="vswr"]');
+    expect(canvas).not.toBeNull();
+    expect(container.querySelector('canvas.sweep[data-mode="gamma"]')).toBeNull();
+  });
+});
+
+describe("empty/loading state", () => {
+  it("renders the frame with no trace and does not crash when sweep is null", () => {
+    const { container } = renderChart("gamma", { sweep: null });
+    const canvas = container.querySelector("canvas.sweep") as HTMLCanvasElement;
+    expect(canvas).not.toBeNull();
+    expect(canvas.dataset.points).toBe("0");
+    expect(canvas.dataset.feeds).toBe("0");
+    expect(canvas.dataset.yValues).toBe("");
+  });
+
+  it("shows no current marker before any solve (r=x=0, no feeds)", () => {
+    const { container } = renderChart("vswr", { sweep: null, r: 0, x: 0 });
+    const canvas = container.querySelector("canvas.sweep") as HTMLCanvasElement;
+    expect(canvas.dataset.current).toBe("");
+  });
+});
+
+describe("a synthetic 3-point sweep produces a trace", () => {
+  it("gamma mode: y-values are |Γ|, not VSWR, per sample", () => {
+    const { container } = renderChart("gamma", { sweep: SWEEP });
+    const canvas = container.querySelector("canvas.sweep") as HTMLCanvasElement;
+    expect(canvas.dataset.points).toBe("3");
+    expect(canvas.dataset.feeds).toBe("1");
+    expect(canvas.dataset.yValues).toBe("0.0000,0.3333,0.3333");
+  });
+
+  it("vswr mode: y-values are VSWR, not |Γ|, per sample", () => {
+    const { container } = renderChart("vswr", { sweep: SWEEP });
+    const canvas = container.querySelector("canvas.sweep") as HTMLCanvasElement;
+    expect(canvas.dataset.points).toBe("3");
+    expect(canvas.dataset.yValues).toBe("1.0000,2.0000,2.0000");
+  });
+
+  it("the two modes never render identical y-values for the same sweep", () => {
+    const gamma = render(<SweepChart mode="gamma" r={0} x={0} z0={50} size={180} sweep={SWEEP} measFreqMhz={14} running={false} multiFeed={false} />);
+    const vswr = render(<SweepChart mode="vswr" r={0} x={0} z0={50} size={180} sweep={SWEEP} measFreqMhz={14} running={false} multiFeed={false} />);
+    const gVals = (gamma.container.querySelector("canvas.sweep") as HTMLCanvasElement).dataset.yValues;
+    const vVals = (vswr.container.querySelector("canvas.sweep") as HTMLCanvasElement).dataset.yValues;
+    expect(gVals).not.toBe(vVals);
+  });
+
+  it("current-Z marker reflects the live result, converted by the chart's own mode", () => {
+    const gamma = renderChart("gamma", { sweep: SWEEP, r: 100, x: 0, z0: 50 });
+    const gCanvas = gamma.container.querySelector("canvas.sweep") as HTMLCanvasElement;
+    expect(gCanvas.dataset.current).toBe("0.3333");
+
+    const vswr = renderChart("vswr", { sweep: SWEEP, r: 100, x: 0, z0: 50 });
+    const vCanvas = vswr.container.querySelector("canvas.sweep") as HTMLCanvasElement;
+    expect(vCanvas.dataset.current).toBe("2.0000");
+  });
+});
+
+describe("multi-feed sweeps (mirrors SmithChart's feeds_z_re/feeds_z_im policy)", () => {
+  it("uses the per-feed arrays when present and shaped for it", () => {
+    const multi: SweepData = {
+      freqs_mhz: [10, 14, 18],
+      z_re: [50, 100, 25], // legacy single-trace fields, should be ignored
+      z_im: [0, 0, 0],
+      feeds_z_re: [
+        [50, 200],
+        [100, 200],
+        [25, 200],
+      ],
+      feeds_z_im: [
+        [0, 0],
+        [0, 0],
+        [0, 0],
+      ],
+    };
+    const { container } = renderChart("gamma", { sweep: multi });
+    const canvas = container.querySelector("canvas.sweep") as HTMLCanvasElement;
+    expect(canvas.dataset.feeds).toBe("2");
+    // Feed-0's trace is what data-y-values reports (the legacy single-trace
+    // convention), and it must come from feeds_z_re[*][0], not the
+    // top-level z_re — same fallback order as SmithChart's zAt().
+    expect(canvas.dataset.yValues).toBe("0.0000,0.3333,0.3333");
+  });
+
+  it("falls back to the legacy single trace when feeds_z_re is absent or too short", () => {
+    const { container } = renderChart("gamma", { sweep: SWEEP });
+    const canvas = container.querySelector("canvas.sweep") as HTMLCanvasElement;
+    expect(canvas.dataset.feeds).toBe("1");
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/math.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/math.test.ts
@@ -3,7 +3,13 @@
 // convergence sweep and the SWR/Smith-chart readouts.
 import { describe, it, expect } from "vitest";
 import { reflectionCoefficient } from "../lib/format";
-import { feedwiseRichardson, richardsonExtrap } from "../lib/math";
+import {
+  feedwiseRichardson,
+  gammaMagFromZ,
+  richardsonExtrap,
+  VSWR_CEILING,
+  vswrFromGammaMag,
+} from "../lib/math";
 
 describe("richardsonExtrap", () => {
   it("returns null for fewer than 3 points", () => {
@@ -122,5 +128,65 @@ describe("reflectionCoefficient", () => {
     expect(gRe).toBeCloseTo(0.2, 12);
     expect(gIm).toBeCloseTo(0.4, 12);
     expect(gMag).toBeCloseTo(0.447213595499958, 12);
+  });
+});
+
+// --- gammaMagFromZ / vswrFromGammaMag ---------------------------------------
+// Closed-form oracle values for the gamma/VSWR-vs-frequency sweep charts
+// (issue #700 unit 5). gammaMagFromZ is a wrapper over reflectionCoefficient,
+// but pinned independently here — a caller that swapped the gamma/VSWR
+// conversion (e.g. plotting VSWR numbers under the gamma label) must fail
+// against these, not just against reflectionCoefficient's own suite.
+describe("gammaMagFromZ", () => {
+  it("is zero at a matched load", () => {
+    expect(gammaMagFromZ(50, 0, 50)).toBeCloseTo(0, 12);
+  });
+
+  it("is 1/3 for a 2:1 real mismatch, either direction", () => {
+    expect(gammaMagFromZ(100, 0, 50)).toBeCloseTo(1 / 3, 12);
+    expect(gammaMagFromZ(25, 0, 50)).toBeCloseTo(1 / 3, 12);
+  });
+
+  // R == X == Z0: a real-part-only (or naive-magnitude) shortcut would read
+  // this as gRe alone (0.2) — the true value needs the reactive component
+  // folded in via Math.hypot, which is what distinguishes a complex |·|
+  // from real-part arithmetic.
+  it("is 1/sqrt(5) for a reactive load, not the real-part-only value", () => {
+    const g = gammaMagFromZ(50, 50, 50);
+    expect(g).toBeCloseTo(1 / Math.sqrt(5), 12);
+    expect(g).not.toBeCloseTo(0.2, 3);
+  });
+
+  it("is 1 at a dead short or dead open", () => {
+    expect(gammaMagFromZ(0, 0, 50)).toBeCloseTo(1, 12);
+  });
+});
+
+describe("vswrFromGammaMag", () => {
+  it("is 1 (perfectly matched) at |Γ| = 0", () => {
+    expect(vswrFromGammaMag(0)).toBeCloseTo(1, 12);
+  });
+
+  it("is 2 at |Γ| = 1/3 (the 2:1 real-mismatch oracle pair)", () => {
+    expect(vswrFromGammaMag(1 / 3)).toBeCloseTo(2, 12);
+  });
+
+  it("agrees with the gammaMagFromZ oracle pairs end to end", () => {
+    expect(vswrFromGammaMag(gammaMagFromZ(50, 0, 50))).toBeCloseTo(1, 12);
+    expect(vswrFromGammaMag(gammaMagFromZ(100, 0, 50))).toBeCloseTo(2, 12);
+    expect(vswrFromGammaMag(gammaMagFromZ(25, 0, 50))).toBeCloseTo(2, 12);
+  });
+
+  it("clamps to the finite ceiling at and beyond |Γ| = 1", () => {
+    expect(vswrFromGammaMag(1)).toBe(VSWR_CEILING);
+    expect(vswrFromGammaMag(1.5)).toBe(VSWR_CEILING);
+  });
+
+  it("stays under the ceiling and monotonic below the point it clamps", () => {
+    // (1+0.98)/(1-0.98) = 99 exactly, so 0.9 stays comfortably under the
+    // ceiling while still exercising the un-clamped branch of the formula.
+    const v = vswrFromGammaMag(0.9);
+    expect(v).toBeLessThan(VSWR_CEILING);
+    expect(v).toBeGreaterThan(vswrFromGammaMag(0.5));
   });
 });

--- a/src/antennaknobs/web/frontend/src/__tests__/viewRegistry.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/viewRegistry.test.tsx
@@ -36,6 +36,8 @@ const EVERY_VIEW: Record<View, true> = {
   elevation: true,
   smith: true,
   schematic: true,
+  gamma: true,
+  vswr: true,
 };
 const ALL_VIEWS = Object.keys(EVERY_VIEW) as View[];
 
@@ -65,11 +67,14 @@ describe("view metadata", () => {
       ["elevation", "Elevation (yz)"],
       ["smith", "Smith"],
       ["schematic", "Schematic"],
+      ["gamma", "|Γ| vs freq"],
+      ["vswr", "VSWR vs freq"],
     ]);
   });
 
   // The founding four are pinned by default; schematic and every later view
-  // ship unpinned (docs/plan-view-rail-scaling.md, "The pin model").
+  // ship unpinned (docs/plan-view-rail-scaling.md, "The pin model") — gamma
+  // and vswr are the roster's first test of that rule beyond schematic.
   it("defaults exactly the founding four to pinned", () => {
     expect(VIEWS.filter((v) => v.defaultPinned).map((v) => v.id).sort()).toEqual(
       ["antenna", "azimuth", "elevation", "smith"],
@@ -114,6 +119,8 @@ const MARKERS: Record<View, string> = {
   elevation: 'canvas.farfield[data-cut="yz"]',
   smith: "canvas.smith",
   schematic: ".schematic-fill",
+  gamma: 'canvas.sweep[data-mode="gamma"]',
+  vswr: 'canvas.sweep[data-mode="vswr"]',
 };
 
 describe("dispatch", () => {

--- a/src/antennaknobs/web/frontend/src/components/charts/SweepChart.tsx
+++ b/src/antennaknobs/web/frontend/src/components/charts/SweepChart.tsx
@@ -1,0 +1,282 @@
+import { useContext, useEffect, useRef } from "react";
+import type { FeedEntry, SweepData } from "../../lib/api";
+import { gammaMagFromZ, vswrFromGammaMag } from "../../lib/math";
+import { ThemeContext } from "../hooks";
+import { feedColor, feedSweepColor, plotColors } from "./palette";
+
+// The two output views the sweep already pays for: |Γ| vs. frequency and
+// VSWR vs. frequency (issue #700 unit 5, docs/plan-view-rail-scaling.md
+// items 6/7). One component, precedent FarFieldChart's `cut` prop — the two
+// modes differ only in the y-axis domain/ticks and which lib/math.ts
+// conversion turns a swept Z into a y-value.
+export type SweepMode = "gamma" | "vswr";
+
+// y-domain per mode. gamma is bounded [0,1] by construction (|Γ| can't
+// exceed 1 for a passive Z0). VSWR is unbounded as |Γ| → 1; the ham-
+// instrument convention is a linear 1..10 scale with an off-scale
+// indication for anything hotter — matching a real SWR meter's needle
+// pinned at the peg rather than a y-axis that silently rescales every time
+// a knob drags through a bad match.
+const DOMAIN: Record<SweepMode, { lo: number; hi: number; ticks: number[]; title: string }> = {
+  gamma: { lo: 0, hi: 1, ticks: [0, 0.2, 0.4, 0.6, 0.8, 1.0], title: "|Γ|" },
+  vswr: { lo: 1, hi: 10, ticks: [1, 2, 4, 6, 8, 10], title: "VSWR" },
+};
+
+// Z -> this mode's y-value. Both modes go through gammaMagFromZ first (the
+// one place |Γ| gets computed), so a bug there shows up identically in both
+// charts instead of two independently-wrong formulas.
+function valueFor(mode: SweepMode, re: number, im: number, z0: number): number {
+  const g = gammaMagFromZ(re, im, z0);
+  return mode === "gamma" ? g : vswrFromGammaMag(g);
+}
+
+export function SweepChart({
+  mode,
+  r,
+  x,
+  z0,
+  size,
+  sweep,
+  measFreqMhz,
+  running,
+  feeds,
+  multiFeed,
+}: {
+  mode: SweepMode;
+  r: number;
+  x: number;
+  z0: number;
+  size: number;
+  sweep: SweepData | null;
+  measFreqMhz: number;
+  running: boolean;
+  /** Multi-feed geometries pass the per-feed Z list from the latest solve so
+   *  the chart can mark N current points, one per port (same prop SmithChart
+   *  takes for the same reason). */
+  feeds?: FeedEntry[];
+  multiFeed: boolean;
+}) {
+  const theme = useContext(ThemeContext); // repaint on theme toggle (dep below)
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const dom = DOMAIN[mode];
+
+  // Pure derivation from props, computed outside the canvas effect so it's
+  // available for the data-* attributes below even when there is no 2-D
+  // context to draw with (jsdom in tests). This is also the one place the
+  // mode's conversion runs per sample — the draw effect below reuses it
+  // rather than recomputing.
+  const hasSweep = !!sweep && sweep.freqs_mhz.length > 1;
+  const hasMulti =
+    hasSweep &&
+    !!sweep!.feeds_z_re &&
+    !!sweep!.feeds_z_im &&
+    sweep!.feeds_z_re!.length === sweep!.freqs_mhz.length &&
+    sweep!.feeds_z_re![0].length > 1;
+  const nFeeds = hasSweep ? (hasMulti ? sweep!.feeds_z_re![0].length : 1) : 0;
+  const zAt = (fi: number, i: number) =>
+    hasMulti
+      ? { re: sweep!.feeds_z_re![i][fi], im: sweep!.feeds_z_im![i][fi] }
+      : { re: sweep!.z_re[i], im: sweep!.z_im[i] };
+  // Feed-0 (or the legacy single trace)'s y-values, exposed for tests: a
+  // mutation that swapped gamma<->vswr math changes these numbers even
+  // though the DOM shape (canvas, data-mode) stays identical.
+  const traceY = hasSweep
+    ? sweep!.freqs_mhz.map((_, i) => {
+        const z = zAt(0, i);
+        return valueFor(mode, z.re, z.im, z0);
+      })
+    : [];
+
+  // Current-Z marker(s): one per feed (or the single r/x pair), same
+  // fallback SmithChart uses. Undefined/zero Z (no solve yet) yields no
+  // marker rather than a spurious point at the origin.
+  const markerPoints: Array<{ v: number; fi: number }> =
+    feeds && feeds.length > 0
+      ? feeds.map((f, fi) => ({ v: valueFor(mode, f.z_re, f.z_im, z0), fi }))
+      : r > 0 || x !== 0
+        ? [{ v: valueFor(mode, r, x, z0), fi: 0 }]
+        : [];
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.floor(size * dpr);
+    canvas.height = Math.floor(size * dpr);
+    canvas.style.width = `${size}px`;
+    canvas.style.height = `${size}px`;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+    const PC = plotColors();
+    ctx.fillStyle = PC.bg;
+    ctx.fillRect(0, 0, size, size);
+
+    // Plot rectangle: left margin fits the y-axis tick labels, bottom margin
+    // fits the freq-range / status text (same corner SmithChart uses).
+    const marginL = 26;
+    const marginR = 8;
+    const marginT = 16;
+    const marginB = 20;
+    const plotW = size - marginL - marginR;
+    const plotH = size - marginT - marginB;
+
+    // domain -> [0,1] -> canvas y (top = hi, bottom = lo, same sense as any
+    // chart axis).
+    const frac = (v: number) =>
+      Math.max(0, Math.min(1, (v - dom.lo) / (dom.hi - dom.lo)));
+    const yOf = (v: number) => marginT + plotH * (1 - frac(v));
+    // A value at/above the domain top for VSWR means "off the chart" (a real
+    // SWR meter pins its needle rather than rescaling); gamma never needs
+    // this since |Γ| ≤ 1 always fits.
+    const offScale = (v: number) => v > dom.hi;
+
+    ctx.strokeStyle = PC.grid;
+    ctx.lineWidth = 0.6;
+    ctx.fillStyle = PC.labelDim;
+    ctx.font = "9px ui-monospace, monospace";
+    for (const t of dom.ticks) {
+      const y = yOf(t);
+      ctx.beginPath();
+      ctx.moveTo(marginL, y);
+      ctx.lineTo(marginL + plotW, y);
+      ctx.stroke();
+      const label = mode === "gamma" ? t.toFixed(1) : t.toFixed(0);
+      ctx.fillText(label, 2, y + 3);
+    }
+    // Axis frame.
+    ctx.strokeStyle = PC.axis;
+    ctx.lineWidth = 1;
+    ctx.strokeRect(marginL, marginT, plotW, plotH);
+
+    // Mode title, top-left (same corner SmithChart's Z0 label uses).
+    ctx.fillStyle = PC.labelDim;
+    ctx.font = "10px ui-monospace, monospace";
+    ctx.fillText(dom.title, marginL, 12);
+
+    // Maps a frequency to canvas x within the swept band; undefined (null)
+    // when there is no band to map against. Shared by the trail, the
+    // current-freq guide line, and the current-Z marker's x position so all
+    // three agree about where on the axis a given frequency sits.
+    const fLo = hasSweep ? sweep!.freqs_mhz[0] : null;
+    const fHi = hasSweep ? sweep!.freqs_mhz[sweep!.freqs_mhz.length - 1] : null;
+    const xOf = (f: number) =>
+      marginL + plotW * ((f - fLo!) / ((fHi! - fLo!) || 1));
+
+    if (hasSweep) {
+      const freqs = sweep!.freqs_mhz;
+
+      // One polyline per feed, dim "trail" color (SmithChart's convention:
+      // dim = sweep trail, bright = current-Z marker). Unlike the Smith
+      // chart's 2-D Γ-plane locus, frequency is a natural ordering axis
+      // here, so — unlike that chart's unconnected scatter — a connected
+      // line is the correct read, not an artifact of interpolation.
+      for (let fi = 0; fi < nFeeds; fi++) {
+        ctx.strokeStyle = feedSweepColor(fi);
+        ctx.lineWidth = 1.3;
+        ctx.beginPath();
+        let started = false;
+        for (let i = 0; i < freqs.length; i++) {
+          const z = zAt(fi, i);
+          const v = valueFor(mode, z.re, z.im, z0);
+          const px = xOf(freqs[i]);
+          const py = offScale(v) ? marginT : yOf(v);
+          if (!started) { ctx.moveTo(px, py); started = true; }
+          else ctx.lineTo(px, py);
+        }
+        ctx.stroke();
+
+        // Off-scale samples get an upward tick at the top edge instead of a
+        // dot sitting exactly on the frame — a real VSWR meter's pinned
+        // needle, not a plausible-looking in-range value.
+        ctx.fillStyle = feedSweepColor(fi);
+        for (let i = 0; i < freqs.length; i++) {
+          const z = zAt(fi, i);
+          const v = valueFor(mode, z.re, z.im, z0);
+          if (!offScale(v)) continue;
+          const px = xOf(freqs[i]);
+          ctx.beginPath();
+          ctx.moveTo(px - 3, marginT + 5);
+          ctx.lineTo(px + 3, marginT + 5);
+          ctx.lineTo(px, marginT);
+          ctx.closePath();
+          ctx.fill();
+        }
+      }
+
+      // Freq range label, bottom-right (same convention as SmithChart).
+      ctx.fillStyle = PC.labelBright;
+      ctx.font = "10px ui-monospace, monospace";
+      const txt = `${fLo!.toFixed(2)} → ${fHi!.toFixed(2)} MHz`;
+      ctx.fillText(txt, size - 6 - ctx.measureText(txt).width, size - 6);
+
+      // Current-frequency guide: a dashed vertical line at measFreqMhz (only
+      // meaningful inside the swept band — outside it there is nothing on
+      // this axis to point at) plus a bright per-feed marker where that line
+      // crosses each trail. Mirrors SmithChart's dim-trail/bright-marker
+      // grammar, projected onto a frequency x-axis instead of the Γ-plane.
+      if (measFreqMhz >= fLo! && measFreqMhz <= fHi!) {
+        const gx = xOf(measFreqMhz);
+        ctx.strokeStyle = PC.spoke;
+        ctx.lineWidth = 0.8;
+        ctx.setLineDash([3, 3]);
+        ctx.beginPath();
+        ctx.moveTo(gx, marginT);
+        ctx.lineTo(gx, marginT + plotH);
+        ctx.stroke();
+        ctx.setLineDash([]);
+      }
+    }
+
+    // Current-Z marker(s): bright dot per feed at the measured frequency
+    // (or centered if outside the swept band / no sweep at all — the
+    // reading is still valid, it just has nowhere better to sit on this
+    // axis than the plot's horizontal middle).
+    if (markerPoints.length > 0) {
+      const inBand = hasSweep && measFreqMhz >= fLo! && measFreqMhz <= fHi!;
+      const gx = inBand ? xOf(measFreqMhz) : marginL + plotW / 2;
+      for (const m of markerPoints) {
+        const py = offScale(m.v) ? marginT : yOf(m.v);
+        ctx.fillStyle = feedColor(m.fi);
+        ctx.beginPath();
+        ctx.arc(gx, py, 3.5, 0, 2 * Math.PI);
+        ctx.fill();
+        ctx.strokeStyle = `rgba(${PC.bgRgb}, 0.85)`;
+        ctx.lineWidth = 1;
+        ctx.stroke();
+      }
+    }
+
+    if (running) {
+      ctx.fillStyle = PC.label;
+      ctx.font = "10px ui-monospace, monospace";
+      ctx.fillText("sweeping…", marginL, size - 6);
+    }
+    // multiFeed isn't read directly (nFeeds/hasMulti already derive the same
+    // thing from the sweep payload's own shape) but is kept as a dep so a
+    // descriptor flip that changes it without changing the sweep shape still
+    // redraws — same reasoning as SmithChart's identical comment.
+    //
+    // dom/hasSweep/hasMulti/nFeeds/traceY/markerPoints are pure functions of
+    // the props already listed, not separate state — omitted here (as
+    // opposed to listed like SmithChart's locals) because they're fresh
+    // array/object literals every render; listing them would defeat the
+    // memoization this dep array exists for. mode is listed directly since
+    // it's the one prop dom/valueFor key off that isn't otherwise present.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, r, x, z0, size, sweep, measFreqMhz, running, feeds, multiFeed, theme]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className={`sweep sweep-${mode}`}
+      data-mode={mode}
+      data-points={hasSweep ? sweep!.freqs_mhz.length : 0}
+      data-feeds={nFeeds}
+      data-y-values={traceY.map((v) => v.toFixed(4)).join(",")}
+      data-current={markerPoints.length > 0 ? markerPoints[0].v.toFixed(4) : ""}
+    />
+  );
+}

--- a/src/antennaknobs/web/frontend/src/components/results/viewRegistry.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/viewRegistry.tsx
@@ -4,6 +4,7 @@ import type { Projection, View } from "../../lib/view";
 import { CurrentCanvas } from "../charts/CurrentCanvas";
 import { FarFieldChart } from "../charts/FarFieldChart";
 import { SmithChart } from "../charts/SmithChart";
+import { SweepChart } from "../charts/SweepChart";
 import type { PatternData, PinnedPattern } from "../charts/types";
 import { SchematicPanel } from "./SchematicPanel";
 
@@ -112,6 +113,38 @@ export const VIEW_RENDERERS: Record<View, (p: ViewRenderProps) => ReactElement> 
       unavailable={p.schematicUnavailable}
       size={p.size}
       fill={p.fill}
+    />
+  ),
+  // |Γ| vs. frequency and VSWR vs. frequency (issue #700 unit 5): one
+  // component, `mode` prop, same split FarFieldChart uses for azimuth vs.
+  // elevation above. z0 fallback matches the Smith chart's exact fallback —
+  // both read the same result field for the same reason.
+  gamma: (p) => (
+    <SweepChart
+      mode="gamma"
+      r={p.result?.z_in_re ?? 0}
+      x={p.result?.z_in_im ?? 0}
+      z0={p.result?.z0_ohms ?? 50}
+      size={p.size}
+      sweep={p.sweep}
+      measFreqMhz={p.measFreqMhz}
+      running={p.sweepRunning}
+      feeds={p.result?.feeds}
+      multiFeed={p.multiFeed}
+    />
+  ),
+  vswr: (p) => (
+    <SweepChart
+      mode="vswr"
+      r={p.result?.z_in_re ?? 0}
+      x={p.result?.z_in_im ?? 0}
+      z0={p.result?.z0_ohms ?? 50}
+      size={p.size}
+      sweep={p.sweep}
+      measFreqMhz={p.measFreqMhz}
+      running={p.sweepRunning}
+      feeds={p.result?.feeds}
+      multiFeed={p.multiFeed}
     />
   ),
 };

--- a/src/antennaknobs/web/frontend/src/lib/math.ts
+++ b/src/antennaknobs/web/frontend/src/lib/math.ts
@@ -1,3 +1,24 @@
+import { reflectionCoefficient } from "./format";
+
+// |Γ| from Z = re + j·im referenced to z0. A thin wrapper over
+// reflectionCoefficient's gMag (lib/format.ts) rather than a second copy of
+// the formula — the Smith chart and the gamma/VSWR sweep charts (issue #700
+// unit 5) must never disagree about what |Γ| is for a given Z.
+export function gammaMagFromZ(re: number, im: number, z0: number): number {
+  return reflectionCoefficient(re, im, z0).gMag;
+}
+
+// VSWR = (1+|Γ|)/(1-|Γ|) blows up as |Γ| → 1 (a dead open/short feed). A
+// finite ceiling keeps that one sample from stretching a chart's y-axis
+// into a straight line at the horizon; 99 matches formatSwr's own
+// three-nines display cutoff (lib/format.ts) so "off the chart" means the
+// same thing in both places.
+export const VSWR_CEILING = 99;
+export function vswrFromGammaMag(gMag: number): number {
+  if (gMag >= 1) return VSWR_CEILING;
+  return Math.min((1 + gMag) / (1 - gMag), VSWR_CEILING);
+}
+
 // Richardson-style extrapolation Z(1/N) → Z(N→∞). Fits Z = a₀ + a₁·h + a₂·h²
 // (h = 1/N) on the last `nLast` points via least squares and returns a₀.
 // Quadratic gives a sane answer for O(1/N) limit (BSpline without

--- a/src/antennaknobs/web/frontend/src/lib/view.ts
+++ b/src/antennaknobs/web/frontend/src/lib/view.ts
@@ -1,4 +1,4 @@
-export type View = "antenna" | "azimuth" | "elevation" | "smith" | "schematic";
+export type View = "antenna" | "azimuth" | "elevation" | "smith" | "schematic" | "gamma" | "vswr";
 
 // The view registry's metadata half. The render half — one function per id —
 // lives in components/results/viewRegistry.tsx, keyed by these same ids:
@@ -19,6 +19,12 @@ export const VIEWS: ViewMeta[] = [
   { id: "elevation", label: "Elevation (yz)", defaultPinned: true },
   { id: "smith", label: "Smith", defaultPinned: true },
   { id: "schematic", label: "Schematic", defaultPinned: false },
+  // Sweep-derived views (issue #700 unit 5, docs/plan-view-rail-scaling.md
+  // items 6/7): the sweep data already flows to the Smith chart, so these
+  // are a second and third presentation of it, not a new data path. Ship
+  // unpinned like schematic — the founding four stay the only defaults.
+  { id: "gamma", label: "|Γ| vs freq", defaultPinned: false },
+  { id: "vswr", label: "VSWR vs freq", defaultPinned: false },
 ];
 
 // The mobile output carousel's screens: the 5 chart views plus a dedicated

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1792,7 +1792,8 @@ input[type=checkbox] {
 }
 
 .smith,
-.farfield {
+.farfield,
+.sweep {
   display: block;
   border-radius: var(--r-sm);
 }


### PR DESCRIPTION
Unit 5 of the #700 stacked arc (docs/plan-view-rail-scaling.md), stacked onto `issue-700-view-rail`. First registry customers after unit 1 (#703).

## Summary
- New views `gamma` ("|Γ| vs freq") and `vswr` ("VSWR vs freq"), both `defaultPinned: false`; one `SweepChart` canvas component with a `mode` prop (FarFieldChart's two-views-one-component precedent).
- `lib/math.ts`: `gammaMagFromZ` wraps `reflectionCoefficient` (single |Γ| source shared with the Smith chart); `vswrFromGammaMag` with `VSWR_CEILING = 99` matching `formatSwr`'s cutoff.
- Axes: |Γ| linear 0–1; VSWR linear 1–10 with pinned-needle off-scale ticks. Multi-feed policy mirrors SmithChart (per-feed trails when `feeds_z_re` is shaped for it, legacy single-trace fallback). Dashed current-frequency guide + bright per-feed markers.
- Mobile carousel grows to 8 pages on this branch — intentional mid-arc state; unit 4 re-maps mobile onto the pinned set.

## Gates (measured)
- Suite: 25 files / 426 tests green (baseline 405 + 21 new: 11 math oracle, 10 component). `viewRegistry.test.tsx` extended for the new roster; prior five views' assertions verbatim.
- `npm run build` green, no type suppressions.
- Oracles: |Γ|=0/1⁄3/1⁄3/1⁄√5 (reactive case pins complex |·| vs real-part arithmetic), VSWR=1/2/2, ceiling clamp.
- Mutation probes: builder swapped the mode conversion → 4 numeric-test failures; reviewer independently broke the VSWR denominator → 4 failures. Both reverted.

## Review notes
- Built by a sonnet subagent (delegated-build); reviewed by the session model: full diff read, math/oracle checks re-derived, suite + build re-run in the worktree (426 green), independent denominator mutation probed.
- Builder correctly flagged that SmithChart's `measFreqMhz` prop is effect-dep only (no drawn marker there) — SweepChart gives it its first real use; possible future alignment noted, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01522PMkNyJbRX772WV5DwaA