### PR TITLE
Unit 2: pin model + "All views" overflow picker (#700)

### DIFF
--- a/src/antennaknobs/web/frontend/src/__tests__/ViewPicker.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/ViewPicker.test.tsx
@@ -1,12 +1,15 @@
-// Pins the "All views" overflow picker and the two rules that only bite on a
-// roster bigger than the five views we ship today: the 6-pin cap and the NEW
-// badge (unit 2 of docs/plan-view-rail-scaling.md).
+// Pins the "All views" overflow picker and the one rule that only bites on a
+// roster bigger than the cap: the 6-pin limit (unit 2 of
+// docs/plan-view-rail-scaling.md).
 //
 // The registry is mocked up to the plan's 9-view design target rather than
-// waiting for those views to exist — with 5 real views the cap is
-// unreachable, and every real view is in the picker's `seen` seed, so nothing
-// could ever badge. The mock is the roster of a NEAR-FUTURE release, which is
-// exactly the situation both rules are written for.
+// waiting for those views to exist: the cap cannot be reached while the
+// shipped roster is smaller than six. The mock is the roster of a NEAR-FUTURE
+// release, which is exactly the situation the rule is written for.
+//
+// Every expectation below is derived from the mocked VIEWS, so the roster
+// growing under this file (as it did when |Γ| and VSWR landed mid-unit)
+// changes nothing here.
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, renderHook, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -14,14 +17,16 @@ import { useState } from "react";
 
 vi.mock("../lib/view", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/view")>();
-  // Ids outside the shipped `View` union, so they need the cast the real
-  // registry does not.
+  // Tops the shipped roster up past the cap with the plan's two still-unbuilt
+  // views (items 8/9). Ids already shipped are skipped — a sibling unit
+  // landing one of these for real must not produce a duplicate row, which is
+  // precisely how this mock broke when |Γ| and VSWR shipped. Their ids sit
+  // outside the shipped `View` union, hence the cast the real registry
+  // does not need.
   const soon = [
-    { id: "gamma", label: "|Γ| vs freq", defaultPinned: false },
-    { id: "vswr", label: "VSWR vs freq", defaultPinned: false },
     { id: "optim", label: "Optimization", defaultPinned: false },
     { id: "converge", label: "Convergence", defaultPinned: false },
-  ] as unknown as typeof actual.VIEWS;
+  ].filter((v) => !actual.VIEWS.some((a) => a.id === v.id)) as unknown as typeof actual.VIEWS;
   const VIEWS = [...actual.VIEWS, ...soon];
   return {
     ...actual,
@@ -31,14 +36,24 @@ vi.mock("../lib/view", async (importOriginal) => {
 });
 
 // Imported AFTER the mock declaration for readability only — vi.mock is
-// hoisted above every import in this file.
-import type { View } from "../lib/view";
-import { VIEW_PREFS_KEY, useViewPrefs } from "../components/session/useViewPrefs";
+// hoisted above every import in this file. VIEWS/VIEW_META here are the
+// mocked ones; PIN_CAP and the hook are real.
+import { VIEW_META, VIEWS, type View } from "../lib/view";
+import {
+  PIN_CAP,
+  VIEW_PREFS_KEY,
+  useViewPrefs,
+} from "../components/session/useViewPrefs";
 import { ViewPicker } from "../components/session/ViewPicker";
 
 const FOUNDING: View[] = ["antenna", "azimuth", "elevation", "smith"];
-const SHIPPED = [...FOUNDING, "schematic"];
-const SOON = ["gamma", "vswr", "optim", "converge"];
+const ROSTER = VIEWS.map((v) => v.id);
+// A deliberate mirror of useViewPrefs' SEEN_SEED (not exported: it is a
+// frozen historical fact, not a knob). Copying it here means a change to the
+// production seed shows up as a failure in the badge tests, which is where
+// the seed's whole meaning lives.
+const PRE_PICKER: View[] = ["antenna", "azimuth", "elevation", "smith", "schematic"];
+const label = (id: View) => VIEW_META[id].label;
 
 beforeEach(() => {
   localStorage.clear();
@@ -83,10 +98,9 @@ const rows = () =>
 describe("the All-views button", () => {
   it("counts the unpinned views", () => {
     render(<Harness />);
-    // 9 views, 4 pinned by default.
     expect(
       screen.getByRole("button", { name: /all views/i }).textContent,
-    ).toContain("+5");
+    ).toContain(`+${ROSTER.length - FOUNDING.length}`);
   });
 });
 
@@ -97,17 +111,9 @@ describe("the picker popover", () => {
     const user = userEvent.setup();
     render(<Harness />);
     await openPicker(user);
-    expect(rows()).toEqual([
-      "Antenna",
-      "Azimuth (xy)",
-      "Elevation (yz)",
-      "Smith",
-      "Schematic",
-      "|Γ| vs freq",
-      "VSWR vs freq",
-      "Optimization",
-      "Convergence",
-    ]);
+    // The WHOLE roster, pinned or not, in registry order — that is the
+    // picker's contract with every view that ships after it.
+    expect(rows()).toEqual(ROSTER.map(label));
   });
 
   it("marks the active row", async () => {
@@ -173,47 +179,63 @@ describe("pin-dot click", () => {
     const user = userEvent.setup();
     render(<Harness />);
     await openPicker(user);
-    await user.click(dot("Pin VSWR vs freq"));
-    await user.click(dot("Pin Schematic"));
-    expect(probe("pinned")).toBe([...FOUNDING, "vswr", "schematic"].join(","));
+    // Pinned bottom-up, so registry order would give the opposite answer.
+    const spare = ROSTER.filter((id) => !FOUNDING.includes(id));
+    const [first, last] = [spare[0], spare[spare.length - 1]];
+    await user.click(dot(`Pin ${label(last)}`));
+    await user.click(dot(`Pin ${label(first)}`));
+    expect(probe("pinned")).toBe([...FOUNDING, last, first].join(","));
   });
 });
 
 // --- 4. The cap -------------------------------------------------------------
 
 describe("the 6-pin cap", () => {
-  it("refuses a 7th pin and disables its dot", async () => {
+  // The mocked roster exists to make this reachable at all.
+  const spare = ROSTER.filter((id) => !FOUNDING.includes(id));
+  const capped = [...FOUNDING, ...spare.slice(0, PIN_CAP - FOUNDING.length)];
+  const refused = ROSTER.filter((id) => !capped.includes(id));
+
+  it("has a roster that can actually overrun the cap", () => {
+    expect(capped).toHaveLength(PIN_CAP);
+    expect(refused.length).toBeGreaterThan(0);
+  });
+
+  it(`refuses pin ${PIN_CAP + 1} and disables its dot`, async () => {
     const user = userEvent.setup();
     render(<Harness />);
     await openPicker(user);
-    await user.click(dot("Pin Schematic"));
-    await user.click(dot("Pin |Γ| vs freq"));
-    const capped = [...FOUNDING, "schematic", "gamma"].join(",");
-    expect(probe("pinned")).toBe(capped);
+    for (const id of capped.filter((id) => !FOUNDING.includes(id))) {
+      await user.click(dot(`Pin ${label(id)}`));
+    }
+    expect(probe("pinned")).toBe(capped.join(","));
 
     // Every remaining unpinned dot is now inert, and says why.
-    for (const label of ["Pin VSWR vs freq", "Pin Optimization", "Pin Convergence"]) {
-      expect((dot(label) as HTMLButtonElement).disabled).toBe(true);
-      expect(dot(label).getAttribute("title")).toBe("Unpin a view first");
+    for (const id of refused) {
+      const d = dot(`Pin ${label(id)}`) as HTMLButtonElement;
+      expect(d.disabled).toBe(true);
+      expect(d.getAttribute("title")).toBe("Unpin a view first");
     }
     // Pointer events cannot reach a disabled button, so drive the model
     // directly to prove the refusal is the hook's, not just the DOM's.
     const { result } = renderHook(() => useViewPrefs());
-    act(() => result.current.togglePin("vswr" as View));
-    expect(result.current.pinned.join(",")).toBe(capped);
+    act(() => result.current.togglePin(refused[0]));
+    expect(result.current.pinned.join(",")).toBe(capped.join(","));
 
     // Unpinning frees exactly one slot.
-    await user.click(dot("Unpin Smith"));
-    expect((dot("Pin VSWR vs freq") as HTMLButtonElement).disabled).toBe(false);
+    await user.click(dot(`Unpin ${label(FOUNDING[3])}`));
+    expect((dot(`Pin ${label(refused[0])}`) as HTMLButtonElement).disabled).toBe(
+      false,
+    );
   });
 
   it("clamps an over-full stored record on load", () => {
     localStorage.setItem(
       VIEW_PREFS_KEY,
-      JSON.stringify({ pinned: [...SHIPPED, ...SOON], seen: [] }),
+      JSON.stringify({ pinned: ROSTER, seen: [] }),
     );
     const { result } = renderHook(() => useViewPrefs());
-    expect(result.current.pinned).toEqual([...SHIPPED, "gamma"]);
+    expect(result.current.pinned).toEqual(ROSTER.slice(0, PIN_CAP));
   });
 });
 
@@ -222,24 +244,21 @@ describe("the 6-pin cap", () => {
 const badges = () =>
   screen.getAllByText("NEW").map((el) => el.parentElement?.textContent ?? "");
 
+const POST_PICKER = ROSTER.filter((id) => !PRE_PICKER.includes(id));
+
 describe("the NEW badge", () => {
   it("marks views the seed does not cover, and stops after the picker is opened", async () => {
     const user = userEvent.setup();
     render(<Harness />);
     await openPicker(user);
-    // The five pre-picker views are seeded as seen; the four later ones are
-    // announced even though they ship unpinned.
-    expect(badges()).toEqual([
-      "|Γ| vs freqNEW",
-      "VSWR vs freqNEW",
-      "OptimizationNEW",
-      "ConvergenceNEW",
-    ]);
+    // The pre-picker views are seeded as seen; everything that shipped after
+    // is announced, even though it all ships unpinned.
+    expect(badges()).toEqual(POST_PICKER.map((id) => `${label(id)}NEW`));
     // Opening is what marks them seen — but the badges must survive the open
     // that revealed them.
     expect(JSON.parse(localStorage.getItem(VIEW_PREFS_KEY) ?? "{}").seen).toEqual([
-      ...SHIPPED,
-      ...SOON,
+      ...PRE_PICKER,
+      ...POST_PICKER,
     ]);
 
     await user.click(screen.getByRole("button", { name: /all views/i }));
@@ -251,7 +270,7 @@ describe("the NEW badge", () => {
     const user = userEvent.setup();
     localStorage.setItem(
       VIEW_PREFS_KEY,
-      JSON.stringify({ pinned: FOUNDING, seen: [...SHIPPED, ...SOON] }),
+      JSON.stringify({ pinned: FOUNDING, seen: ROSTER }),
     );
     render(<Harness />);
     await openPicker(user);

--- a/src/antennaknobs/web/frontend/src/__tests__/ViewPicker.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/ViewPicker.test.tsx
@@ -1,0 +1,260 @@
+// Pins the "All views" overflow picker and the two rules that only bite on a
+// roster bigger than the five views we ship today: the 6-pin cap and the NEW
+// badge (unit 2 of docs/plan-view-rail-scaling.md).
+//
+// The registry is mocked up to the plan's 9-view design target rather than
+// waiting for those views to exist — with 5 real views the cap is
+// unreachable, and every real view is in the picker's `seen` seed, so nothing
+// could ever badge. The mock is the roster of a NEAR-FUTURE release, which is
+// exactly the situation both rules are written for.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, renderHook, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+
+vi.mock("../lib/view", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/view")>();
+  // Ids outside the shipped `View` union, so they need the cast the real
+  // registry does not.
+  const soon = [
+    { id: "gamma", label: "|Γ| vs freq", defaultPinned: false },
+    { id: "vswr", label: "VSWR vs freq", defaultPinned: false },
+    { id: "optim", label: "Optimization", defaultPinned: false },
+    { id: "converge", label: "Convergence", defaultPinned: false },
+  ] as unknown as typeof actual.VIEWS;
+  const VIEWS = [...actual.VIEWS, ...soon];
+  return {
+    ...actual,
+    VIEWS,
+    VIEW_META: Object.fromEntries(VIEWS.map((v) => [v.id, v])),
+  };
+});
+
+// Imported AFTER the mock declaration for readability only — vi.mock is
+// hoisted above every import in this file.
+import type { View } from "../lib/view";
+import { VIEW_PREFS_KEY, useViewPrefs } from "../components/session/useViewPrefs";
+import { ViewPicker } from "../components/session/ViewPicker";
+
+const FOUNDING: View[] = ["antenna", "azimuth", "elevation", "smith"];
+const SHIPPED = [...FOUNDING, "schematic"];
+const SOON = ["gamma", "vswr", "optim", "converge"];
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+// The picker as DesignSession wires it: real prefs hook, real active-view
+// state, plus probes for the two things the rail derives.
+function Harness({ initialView = "antenna" as View }) {
+  const [view, setView] = useState<View>(initialView);
+  const prefs = useViewPrefs();
+  return (
+    <>
+      <div data-testid="view">{view}</div>
+      <div data-testid="pinned">{prefs.pinned.join(",")}</div>
+      <div data-testid="rail">
+        {prefs.railViews(view).map((v) => v.id).join(",")}
+      </div>
+      <ViewPicker
+        view={view}
+        setView={setView}
+        pinned={prefs.pinned}
+        newIds={prefs.newIds}
+        togglePin={prefs.togglePin}
+        markRosterSeen={prefs.markRosterSeen}
+      />
+    </>
+  );
+}
+
+const probe = (id: string) => screen.getByTestId(id).textContent;
+const openPicker = async (user: ReturnType<typeof userEvent.setup>) =>
+  user.click(screen.getByRole("button", { name: /all views/i }));
+const dot = (label: string | RegExp) =>
+  screen.getByRole("button", { name: label });
+const rows = () =>
+  screen
+    .getAllByRole("menuitem")
+    .map((el) => el.textContent?.replace(/NEW$/, "") ?? "");
+
+// --- 1. The button ----------------------------------------------------------
+
+describe("the All-views button", () => {
+  it("counts the unpinned views", () => {
+    render(<Harness />);
+    // 9 views, 4 pinned by default.
+    expect(
+      screen.getByRole("button", { name: /all views/i }).textContent,
+    ).toContain("+5");
+  });
+});
+
+// --- 2. The roster listing --------------------------------------------------
+
+describe("the picker popover", () => {
+  it("lists the whole roster in registry order", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await openPicker(user);
+    expect(rows()).toEqual([
+      "Antenna",
+      "Azimuth (xy)",
+      "Elevation (yz)",
+      "Smith",
+      "Schematic",
+      "|Γ| vs freq",
+      "VSWR vs freq",
+      "Optimization",
+      "Convergence",
+    ]);
+  });
+
+  it("marks the active row", async () => {
+    const user = userEvent.setup();
+    render(<Harness initialView={"smith" as View} />);
+    await openPicker(user);
+    const current = screen
+      .getAllByRole("menuitem")
+      .filter((el) => el.getAttribute("aria-current") === "true");
+    expect(current.map((el) => el.textContent)).toEqual(["Smith"]);
+  });
+
+  it("closes on a backdrop click", async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Harness />);
+    await openPicker(user);
+    await user.click(container.querySelector(".view-picker-backdrop") as Element);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+});
+
+// --- 3. Row click vs. dot click ---------------------------------------------
+
+describe("row click", () => {
+  it("shows an unpinned view WITHOUT pinning it (peek), and closes", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await openPicker(user);
+    await user.click(screen.getByRole("menuitem", { name: "Schematic" }));
+    expect(probe("view")).toBe("schematic");
+    expect(probe("pinned")).toBe(FOUNDING.join(","));
+    // Peek displaces no thumb: the rail is every pin.
+    expect(probe("rail")).toBe(FOUNDING.join(","));
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("switches to a pinned view and drops it from the rail", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await openPicker(user);
+    await user.click(screen.getByRole("menuitem", { name: "Smith" }));
+    expect(probe("view")).toBe("smith");
+    expect(probe("rail")).toBe("antenna,azimuth,elevation");
+  });
+});
+
+describe("pin-dot click", () => {
+  it("toggles the pin without switching the view or closing", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await openPicker(user);
+    await user.click(dot("Pin Schematic"));
+    expect(probe("pinned")).toBe([...FOUNDING, "schematic"].join(","));
+    expect(probe("view")).toBe("antenna");
+    expect(screen.getByRole("menu")).not.toBeNull();
+    // Curating is a run of gestures, so the dot stays available, now inverted.
+    await user.click(dot("Unpin Schematic"));
+    expect(probe("pinned")).toBe(FOUNDING.join(","));
+    expect(probe("view")).toBe("antenna");
+  });
+
+  it("appends new pins in the order pinned (no reorder in v1)", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await openPicker(user);
+    await user.click(dot("Pin VSWR vs freq"));
+    await user.click(dot("Pin Schematic"));
+    expect(probe("pinned")).toBe([...FOUNDING, "vswr", "schematic"].join(","));
+  });
+});
+
+// --- 4. The cap -------------------------------------------------------------
+
+describe("the 6-pin cap", () => {
+  it("refuses a 7th pin and disables its dot", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await openPicker(user);
+    await user.click(dot("Pin Schematic"));
+    await user.click(dot("Pin |Γ| vs freq"));
+    const capped = [...FOUNDING, "schematic", "gamma"].join(",");
+    expect(probe("pinned")).toBe(capped);
+
+    // Every remaining unpinned dot is now inert, and says why.
+    for (const label of ["Pin VSWR vs freq", "Pin Optimization", "Pin Convergence"]) {
+      expect((dot(label) as HTMLButtonElement).disabled).toBe(true);
+      expect(dot(label).getAttribute("title")).toBe("Unpin a view first");
+    }
+    // Pointer events cannot reach a disabled button, so drive the model
+    // directly to prove the refusal is the hook's, not just the DOM's.
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.togglePin("vswr" as View));
+    expect(result.current.pinned.join(",")).toBe(capped);
+
+    // Unpinning frees exactly one slot.
+    await user.click(dot("Unpin Smith"));
+    expect((dot("Pin VSWR vs freq") as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("clamps an over-full stored record on load", () => {
+    localStorage.setItem(
+      VIEW_PREFS_KEY,
+      JSON.stringify({ pinned: [...SHIPPED, ...SOON], seen: [] }),
+    );
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.pinned).toEqual([...SHIPPED, "gamma"]);
+  });
+});
+
+// --- 5. The NEW badge -------------------------------------------------------
+
+const badges = () =>
+  screen.getAllByText("NEW").map((el) => el.parentElement?.textContent ?? "");
+
+describe("the NEW badge", () => {
+  it("marks views the seed does not cover, and stops after the picker is opened", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await openPicker(user);
+    // The five pre-picker views are seeded as seen; the four later ones are
+    // announced even though they ship unpinned.
+    expect(badges()).toEqual([
+      "|Γ| vs freqNEW",
+      "VSWR vs freqNEW",
+      "OptimizationNEW",
+      "ConvergenceNEW",
+    ]);
+    // Opening is what marks them seen — but the badges must survive the open
+    // that revealed them.
+    expect(JSON.parse(localStorage.getItem(VIEW_PREFS_KEY) ?? "{}").seen).toEqual([
+      ...SHIPPED,
+      ...SOON,
+    ]);
+
+    await user.click(screen.getByRole("button", { name: /all views/i }));
+    await openPicker(user);
+    expect(screen.queryByText("NEW")).toBeNull();
+  });
+
+  it("badges nothing when the stored seen already covers the roster", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(
+      VIEW_PREFS_KEY,
+      JSON.stringify({ pinned: FOUNDING, seen: [...SHIPPED, ...SOON] }),
+    );
+    render(<Harness />);
+    await openPicker(user);
+    expect(screen.queryByText("NEW")).toBeNull();
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/useViewPrefs.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useViewPrefs.test.tsx
@@ -1,9 +1,15 @@
 // Pins the view-preference model against the SHIPPED roster (unit 2 of
 // docs/plan-view-rail-scaling.md): the default pin set, what the desktop rail
-// derives from it, the arrow-key cycle, and the localStorage contract —
-// including every way the stored record can be garbage. The cap and the NEW
-// badge need a roster bigger than the five views we ship, so they live in
+// derives from it, the arrow-key cycle, the NEW badge, and the localStorage
+// contract — including every way the stored record can be garbage. The 6-pin
+// cap needs a roster bigger than the cap itself, so it lives in
 // ViewPicker.test.tsx, which mocks a larger one.
+//
+// Roster growth is the normal case here (|Γ| and VSWR landed while this file
+// was being written), so anything sized by the roster is DERIVED from VIEWS.
+// Two literals are deliberate: FOUNDING, because "the founding four are the
+// defaults and later views ship unpinned" is the claim itself, and
+// PRE_PICKER, which mirrors the frozen seed inside useViewPrefs.
 //
 // Isolation: the prefs store is module-level (one truth for every open
 // session), and it drops its cache when the last subscriber unmounts, so
@@ -11,7 +17,7 @@
 // whatever it wrote into localStorage.
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
-import type { View } from "../lib/view";
+import { VIEWS, type View } from "../lib/view";
 import {
   PIN_CAP,
   VIEW_PREFS_KEY,
@@ -22,6 +28,15 @@ import {
 import { useViewState } from "../components/session/useViewState";
 
 const FOUNDING: View[] = ["antenna", "azimuth", "elevation", "smith"];
+const ROSTER = VIEWS.map((v) => v.id);
+// A deliberate mirror of useViewPrefs' SEEN_SEED (not exported: it records a
+// frozen historical fact rather than offering a knob). Copying it here means a
+// change to the production seed surfaces as a failure in the badge tests,
+// which is exactly where the seed's meaning lives.
+const PRE_PICKER: View[] = ["antenna", "azimuth", "elevation", "smith", "schematic"];
+// Views that shipped after the picker did — the population the NEW badge
+// exists for. Empty on the day the picker shipped, non-empty ever since.
+const POST_PICKER = ROSTER.filter((id) => !PRE_PICKER.includes(id));
 
 beforeEach(() => {
   localStorage.clear();
@@ -55,9 +70,16 @@ describe("defaults", () => {
     ]);
   });
 
-  it("badges nothing for a first-time user (seen is seeded, not empty)", () => {
+  // The seed's whole purpose, now firing for real: a first-time user is shown
+  // the pre-picker roster as already-seen and every view that shipped AFTER
+  // the picker as NEW. Seeding from the live VIEWS instead would badge none of
+  // them, ever, for exactly the users who have never seen any of it.
+  it("badges the views that shipped after the picker, and only those", () => {
     const { result } = renderHook(() => useViewPrefs());
-    expect([...result.current.newIds]).toEqual([]);
+    expect([...result.current.newIds]).toEqual(POST_PICKER);
+    expect(POST_PICKER).toContain("gamma");
+    expect(POST_PICKER).toContain("vswr");
+    for (const id of PRE_PICKER) expect(result.current.newIds.has(id)).toBe(false);
   });
 });
 
@@ -122,13 +144,20 @@ describe("persistence", () => {
 // --- 4. Nothing read back from storage is trusted ---------------------------
 
 describe("stored-record validation", () => {
+  // Ids no release will ever ship — a stale pin from a REMOVED view, or a
+  // hand-edited key. Asserted, not assumed: "gamma" was this file's stand-in
+  // for an unknown id until the day it became a real view.
+  it("uses id fixtures the registry really does not know", () => {
+    for (const id of ["bogus", "no-such-view"]) expect(ROSTER).not.toContain(id);
+  });
+
   const falls_back = [
     ["corrupt JSON", "{not json"],
     ["a bare array", '["antenna"]'],
     ["a null record", "null"],
     ["no pinned field", '{"seen":["antenna"]}'],
     ["a non-array pinned field", '{"pinned":"antenna"}'],
-    ["only unknown ids", '{"pinned":["bogus","gamma"]}'],
+    ["only unknown ids", '{"pinned":["bogus","no-such-view"]}'],
     ["an empty pin set", '{"pinned":[]}'],
   ] as const;
 
@@ -149,21 +178,21 @@ describe("stored-record validation", () => {
     expect(result.current.pinned).toEqual(["smith", "antenna"]);
   });
 
+  // A `seen` that sanitises to nothing is indistinguishable from an absent
+  // one, so it takes the seed — which leaves the same badges a first-time
+  // user gets, not a blank slate and not the whole roster.
   it("re-seeds `seen` when the stored one has nothing usable left", () => {
     localStorage.setItem(VIEW_PREFS_KEY, '{"pinned":["smith"],"seen":["bogus"]}');
     const { result } = renderHook(() => useViewPrefs());
-    expect([...result.current.newIds]).toEqual([]);
+    expect([...result.current.newIds]).toEqual(POST_PICKER);
   });
 
-  it("honours a partial `seen` — the unseen views badge", () => {
+  it("honours a partial `seen` — every other view badges", () => {
     localStorage.setItem(VIEW_PREFS_KEY, '{"pinned":["smith"],"seen":["antenna"]}');
     const { result } = renderHook(() => useViewPrefs());
-    expect([...result.current.newIds].sort()).toEqual([
-      "azimuth",
-      "elevation",
-      "schematic",
-      "smith",
-    ]);
+    expect([...result.current.newIds]).toEqual(
+      ROSTER.filter((id) => id !== "antenna"),
+    );
   });
 });
 

--- a/src/antennaknobs/web/frontend/src/__tests__/useViewPrefs.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useViewPrefs.test.tsx
@@ -1,0 +1,262 @@
+// Pins the view-preference model against the SHIPPED roster (unit 2 of
+// docs/plan-view-rail-scaling.md): the default pin set, what the desktop rail
+// derives from it, the arrow-key cycle, and the localStorage contract —
+// including every way the stored record can be garbage. The cap and the NEW
+// badge need a roster bigger than the five views we ship, so they live in
+// ViewPicker.test.tsx, which mocks a larger one.
+//
+// Isolation: the prefs store is module-level (one truth for every open
+// session), and it drops its cache when the last subscriber unmounts, so
+// Testing Library's per-test cleanup already gives each test a fresh read of
+// whatever it wrote into localStorage.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import type { View } from "../lib/view";
+import {
+  PIN_CAP,
+  VIEW_PREFS_KEY,
+  cycleOrder,
+  pinBlockedReason,
+  useViewPrefs,
+} from "../components/session/useViewPrefs";
+import { useViewState } from "../components/session/useViewState";
+
+const FOUNDING: View[] = ["antenna", "azimuth", "elevation", "smith"];
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+function stored() {
+  return JSON.parse(localStorage.getItem(VIEW_PREFS_KEY) ?? "null");
+}
+
+// --- 1. Defaults come from the registry metadata ----------------------------
+
+describe("defaults", () => {
+  it("pins exactly the views VIEWS marks defaultPinned", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.pinned).toEqual(FOUNDING);
+  });
+
+  it("writes nothing until the user acts", () => {
+    renderHook(() => useViewPrefs());
+    expect(localStorage.getItem(VIEW_PREFS_KEY)).toBeNull();
+  });
+
+  // Gate: the one intended visible change is that the schematic leaves the
+  // rail. Three non-active founding views, in pin order.
+  it("rails the three non-active founding views", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.railViews("antenna").map((v) => v.id)).toEqual([
+      "azimuth",
+      "elevation",
+      "smith",
+    ]);
+  });
+
+  it("badges nothing for a first-time user (seen is seeded, not empty)", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    expect([...result.current.newIds]).toEqual([]);
+  });
+});
+
+// --- 2. Peek ----------------------------------------------------------------
+
+describe("peek", () => {
+  it("shows every pin while an unpinned view is active, and pins nothing", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.railViews("schematic").map((v) => v.id)).toEqual(
+      FOUNDING,
+    );
+    expect(result.current.pinned).toEqual(FOUNDING);
+  });
+});
+
+// --- 3. Persistence ---------------------------------------------------------
+
+describe("persistence", () => {
+  it("round-trips a pin through storage to the next mount", () => {
+    const first = renderHook(() => useViewPrefs());
+    act(() => first.result.current.togglePin("schematic"));
+    expect(first.result.current.pinned).toEqual([...FOUNDING, "schematic"]);
+    expect(stored().pinned).toEqual([...FOUNDING, "schematic"]);
+    first.unmount();
+
+    const second = renderHook(() => useViewPrefs());
+    expect(second.result.current.pinned).toEqual([...FOUNDING, "schematic"]);
+  });
+
+  it("round-trips an unpin too", () => {
+    const first = renderHook(() => useViewPrefs());
+    act(() => first.result.current.togglePin("smith"));
+    first.unmount();
+    const second = renderHook(() => useViewPrefs());
+    expect(second.result.current.pinned).toEqual(["antenna", "azimuth", "elevation"]);
+  });
+
+  // The stored record is an open object of independent fields so unit 3 can
+  // add `layout` without a key bump: fields it does not know must survive a
+  // write from this build.
+  it("stores a named-field object, not a bare array", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.togglePin("schematic"));
+    const rec = stored();
+    expect(Array.isArray(rec)).toBe(false);
+    expect(Object.keys(rec).sort()).toEqual(["pinned", "seen"]);
+  });
+
+  it("keeps working when storage is disabled", () => {
+    const spy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("storage disabled");
+      });
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.togglePin("schematic"));
+    expect(result.current.pinned).toContain("schematic");
+    spy.mockRestore();
+  });
+});
+
+// --- 4. Nothing read back from storage is trusted ---------------------------
+
+describe("stored-record validation", () => {
+  const falls_back = [
+    ["corrupt JSON", "{not json"],
+    ["a bare array", '["antenna"]'],
+    ["a null record", "null"],
+    ["no pinned field", '{"seen":["antenna"]}'],
+    ["a non-array pinned field", '{"pinned":"antenna"}'],
+    ["only unknown ids", '{"pinned":["bogus","gamma"]}'],
+    ["an empty pin set", '{"pinned":[]}'],
+  ] as const;
+
+  for (const [what, raw] of falls_back) {
+    it(`falls back to the defaults on ${what}`, () => {
+      localStorage.setItem(VIEW_PREFS_KEY, raw);
+      const { result } = renderHook(() => useViewPrefs());
+      expect(result.current.pinned).toEqual(FOUNDING);
+    });
+  }
+
+  it("drops unknown ids and duplicates from a salvageable record", () => {
+    localStorage.setItem(
+      VIEW_PREFS_KEY,
+      '{"pinned":["smith","bogus","smith","antenna"],"seen":["antenna"]}',
+    );
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.pinned).toEqual(["smith", "antenna"]);
+  });
+
+  it("re-seeds `seen` when the stored one has nothing usable left", () => {
+    localStorage.setItem(VIEW_PREFS_KEY, '{"pinned":["smith"],"seen":["bogus"]}');
+    const { result } = renderHook(() => useViewPrefs());
+    expect([...result.current.newIds]).toEqual([]);
+  });
+
+  it("honours a partial `seen` — the unseen views badge", () => {
+    localStorage.setItem(VIEW_PREFS_KEY, '{"pinned":["smith"],"seen":["antenna"]}');
+    const { result } = renderHook(() => useViewPrefs());
+    expect([...result.current.newIds].sort()).toEqual([
+      "azimuth",
+      "elevation",
+      "schematic",
+      "smith",
+    ]);
+  });
+});
+
+// --- 5. The pin floor -------------------------------------------------------
+
+describe("pin floor", () => {
+  // An empty pin set is what loadPrefs reads as corruption, so it must not be
+  // reachable through the UI or the stored state stops being a fixed point.
+  it("refuses to unpin the last pin", () => {
+    localStorage.setItem(VIEW_PREFS_KEY, '{"pinned":["smith"],"seen":["smith"]}');
+    const { result } = renderHook(() => useViewPrefs());
+    expect(pinBlockedReason(result.current.pinned, "smith")).toBe(
+      "Keep at least one view pinned",
+    );
+    act(() => result.current.togglePin("smith"));
+    expect(result.current.pinned).toEqual(["smith"]);
+  });
+});
+
+// --- 6. Arrow-key cycling ---------------------------------------------------
+
+// Dispatch from an ELEMENT, never window: the listener's focus guard reads
+// event.target's tagName, and a real keydown always originates at an element
+// (document.body when nothing is focused).
+function press(key: string, target?: HTMLElement) {
+  act(() => {
+    (target ?? document.body).dispatchEvent(
+      new KeyboardEvent("keydown", { key, bubbles: true }),
+    );
+  });
+}
+
+function renderCycler(pinned: View[]) {
+  return renderHook(() =>
+    useViewState({ currentExample: undefined, active: true, pinned }),
+  );
+}
+
+describe("arrow-key cycling", () => {
+  it("walks exactly the pinned views and wraps", () => {
+    const { result } = renderCycler(FOUNDING);
+    const seen: View[] = [];
+    for (let i = 0; i < FOUNDING.length; i++) {
+      press("ArrowDown");
+      seen.push(result.current.view);
+    }
+    // Four stops return to the start; the schematic is never among them.
+    expect(seen).toEqual(["azimuth", "elevation", "smith", "antenna"]);
+  });
+
+  it("cycles in PIN order, not registry order", () => {
+    const { result } = renderCycler(["smith", "antenna"]);
+    press("ArrowDown");
+    expect(result.current.view).toBe("smith");
+    press("ArrowDown");
+    expect(result.current.view).toBe("antenna");
+  });
+
+  it("keeps a peeked view in the cycle so the arrows can leave it", () => {
+    const { result } = renderCycler(FOUNDING);
+    act(() => result.current.setView("schematic"));
+    press("ArrowDown");
+    expect(result.current.view).toBe("antenna");
+    // …and it sits at the end of the order, so ArrowUp from the first pin
+    // lands back on the peek rather than on the last pin.
+    act(() => result.current.setView("antenna"));
+    press("ArrowUp");
+    expect(result.current.view).toBe("smith");
+  });
+
+  it("leaves the arrows alone while an input or a knob has focus", () => {
+    const { result } = renderCycler(FOUNDING);
+    for (const el of [
+      document.createElement("input"),
+      Object.assign(document.createElement("div"), { className: "knob" }),
+    ]) {
+      document.body.appendChild(el);
+      press("ArrowDown", el);
+      expect(result.current.view).toBe("antenna");
+      el.remove();
+    }
+  });
+});
+
+describe("cycleOrder", () => {
+  it("appends the active view only when it is unpinned", () => {
+    expect(cycleOrder(FOUNDING, "smith")).toEqual(FOUNDING);
+    expect(cycleOrder(FOUNDING, "schematic")).toEqual([...FOUNDING, "schematic"]);
+  });
+});
+
+describe("the cap constant", () => {
+  it("is the six the column math bought", () => {
+    expect(PIN_CAP).toBe(6);
+  });
+});

--- a/src/antennaknobs/web/frontend/src/components/hooks.ts
+++ b/src/antennaknobs/web/frontend/src/components/hooks.ts
@@ -7,7 +7,6 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { VIEWS } from "../lib/view";
 
 // Shared between App.tsx (which owns the Provider and the theme-toggle
 // control) and the chart components under components/charts/ (which read it
@@ -108,18 +107,27 @@ export function useFullscreen() {
   };
 }
 
+// Height the "All views" picker button occupies at the foot of the strip:
+// its own fixed 28 px (see .view-picker-btn in styles.css) plus the one extra
+// strip gap it adds. Changing either number here or there desyncs the model
+// from the layout and the bottom thumb starts clipping.
+const PICKER_SLOT = 28 + 8;
+
 export function useThumbColumnSize(
   stripRef: React.RefObject<HTMLDivElement>,
+  nThumbs: number,
   maxThumb = 280,
   reattachKey?: unknown, // see useSlideSize
 ) {
-  // Vertical thumbstrip: the non-active views scaled so they ALWAYS fit (the
-  // strip never scrolls — overflow:hidden in CSS). Fixed overhead per the CSS:
-  //   strip padding (12+12) + (n-1) gaps of 8 +
+  // Vertical thumbstrip: the rail views scaled so they ALWAYS fit (the strip
+  // never scrolls — overflow:hidden in CSS). Fixed overhead per the CSS:
+  //   strip padding (12+12) + (n-1) gaps of 8 + the picker slot +
   //   per-thumb (button padding 8+6 + label ~14 + gap 6 + border 2) ≈ 36 each,
   // biased slightly high (26 base) so they fit with a hair of slack rather
   // than clip; floor low so a short window shrinks them instead of
-  // overflowing. n tracks the view registry: every view but the active one.
+  // overflowing. n comes from the CALLER because the rail is now the user's
+  // pinned set, not the registry: pinned−1 normally, pinned while peeking an
+  // unpinned view. Zero thumbs still has to divide by something.
   //
   // Two dimensions since the schematic view made it 4 thumbs (issue #652):
   // `width` stays what the column measured in its 3-thumb era — chart text
@@ -127,8 +135,11 @@ export function useThumbColumnSize(
   // collide their left/right labels. Each thumb is a width × height
   // rectangle; the chart renders at width and scales down uniformly to
   // height (a true miniature — text shrinks with it instead of colliding).
-  const nThumbs = VIEWS.length - 1;
-  const overhead = 26 + (nThumbs - 1) * 8 + nThumbs * 36;
+  // That reference column is the 3-thumb era's, picker and all — it is a
+  // fixed yardstick for text legibility, not a measurement of today's strip,
+  // so the picker slot deliberately stays out of it.
+  const n = Math.max(1, nThumbs);
+  const overhead = 26 + (n - 1) * 8 + n * 36 + PICKER_SLOT;
   const widthOverhead = 26 + 2 * 8 + 3 * 36;
   const [size, setSize] = useState({ width: 180, height: 180 });
   useEffect(() => {
@@ -139,7 +150,7 @@ export function useThumbColumnSize(
       const h = el.clientHeight;
       if (h <= 0) return;
       const width = clamp((h - widthOverhead) / 3);
-      const height = clamp((h - overhead) / nThumbs);
+      const height = clamp((h - overhead) / n);
       setSize((s) =>
         s.width === width && s.height === height ? s : { width, height },
       );
@@ -148,6 +159,6 @@ export function useThumbColumnSize(
     const ro = new ResizeObserver(update);
     ro.observe(el);
     return () => ro.disconnect();
-  }, [stripRef, maxThumb, reattachKey]);
+  }, [stripRef, n, overhead, maxThumb, reattachKey]);
   return size;
 }

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -27,7 +27,7 @@ import {
   type SchemaItem,
   type SchemaParamSpec,
 } from "../../lib/params";
-import { MOBILE_SCREENS, VIEWS, type View } from "../../lib/view";
+import { MOBILE_SCREENS, type View } from "../../lib/view";
 import type {
   MeasuredData,
   SolveRequest,
@@ -74,7 +74,9 @@ import { useOptimizer } from "./useOptimizer";
 import { useSchematic } from "./useSchematic";
 import { useSolveChannel } from "./useSolveChannel";
 import { useSolverSlots } from "./useSolverSlots";
+import { useViewPrefs } from "./useViewPrefs";
 import { useViewState } from "./useViewState";
+import { ViewPicker } from "./ViewPicker";
 import { VfoPanel } from "./VfoPanel";
 
 // One antenna design session: the entire left sidebar + right stage plus all
@@ -383,6 +385,16 @@ function DesignSessionBody({
   useEffect(() => {
     reportSummary(id, tabSummary);
   }, [id, tabSummary, reportSummary]);
+  // Which views are resident in the desktop rail (global, persisted) — read
+  // before useViewState because the arrow-key cycler walks the pinned set.
+  // (`togglePin` is renamed: the pattern-pin context below owns that name.)
+  const {
+    pinned,
+    newIds,
+    railViews,
+    togglePin: toggleViewPin,
+    markRosterSeen,
+  } = useViewPrefs();
   // Output view, camera and canvas display toggles (#642 seam 5b-3).
   const {
     azElevDeg,
@@ -401,7 +413,7 @@ function DesignSessionBody({
     setShowWireLabels,
     showFeedNames,
     setShowFeedNames,
-  } = useViewState({ currentExample, active });
+  } = useViewState({ currentExample, active, pinned });
 
   // When linked, design and measurement freq move together.
   function updateDesignFreq(v: number) {
@@ -580,7 +592,10 @@ function DesignSessionBody({
   const { isMobile, orientation } = useIsMobile();
   const { ref: slideRef, size: chartSize } = useSlideSize(720, isMobile);
   const thumbStripRef = useRef<HTMLDivElement>(null);
-  const thumbSize = useThumbColumnSize(thumbStripRef, 280, isMobile);
+  // The rail is the pinned set minus whatever is on the stage; peeking an
+  // unpinned view subtracts nothing, so the count the sizer needs varies.
+  const rail = railViews(view);
+  const thumbSize = useThumbColumnSize(thumbStripRef, rail.length, 280, isMobile);
 
   const {
     mobileIndex,
@@ -1499,7 +1514,7 @@ function DesignSessionBody({
       <main className="stage" aria-label="Antenna output views">
         {solveOverlays}
         <div className="thumbstrip" ref={thumbStripRef}>
-          {VIEWS.filter((v) => v.id !== view).map((v) => (
+          {rail.map((v) => (
             <button
               key={v.id}
               className="thumb"
@@ -1552,6 +1567,16 @@ function DesignSessionBody({
               <div className="thumb-label">{v.label}</div>
             </button>
           ))}
+          {/* Everything not pinned lives behind here. Fixed height by design:
+              useThumbColumnSize subtracts exactly this slot. */}
+          <ViewPicker
+            view={view}
+            setView={setView}
+            pinned={pinned}
+            newIds={newIds}
+            togglePin={toggleViewPin}
+            markRosterSeen={markRosterSeen}
+          />
         </div>
         <div
           className={`carousel-slide${stale ? " stale" : ""}`}

--- a/src/antennaknobs/web/frontend/src/components/session/ViewPicker.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/ViewPicker.tsx
@@ -1,0 +1,127 @@
+import { useState } from "react";
+import { VIEWS, type View } from "../../lib/view";
+import { PIN_CAP, pinBlockedReason } from "./useViewPrefs";
+
+// The overflow affordance: a fixed-height "All views ⌄ +N" button at the foot
+// of the thumbstrip opening a popover over the WHOLE roster in registry order
+// (unit 2 of docs/plan-view-rail-scaling.md). Two gestures per row, on purpose:
+//
+//   row click  → show that view (a peek if it is unpinned — no pin spent) and
+//                close, because you asked to look at something.
+//   dot click  → pin/unpin only. It neither switches the view nor closes: the
+//                point of curating is doing several in a row.
+//
+// Popover mechanics copy SessionGearMenu (transparent backdrop catches the
+// outside click); the row idiom is the instrument-panel channel-enable row the
+// plan's survey settled on — every view listed, each with a visible on/off pin.
+export function ViewPicker({
+  view,
+  setView,
+  pinned,
+  newIds,
+  togglePin,
+  markRosterSeen,
+}: {
+  view: View;
+  setView: (v: View) => void;
+  pinned: View[];
+  newIds: Set<View>;
+  togglePin: (v: View) => void;
+  markRosterSeen: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  // The badges shown while the popover is open are snapshotted as it opens.
+  // Opening MARKS the roster seen — that is what "since you last looked"
+  // means — so rendering `newIds` live would blank every badge in the same
+  // frame the user opened the picker to read them.
+  const [badged, setBadged] = useState<Set<View>>(new Set());
+
+  const toggleOpen = () => {
+    setOpen((was) => {
+      if (!was) {
+        setBadged(new Set(newIds));
+        markRosterSeen();
+      }
+      return !was;
+    });
+  };
+
+  const unpinnedCount = VIEWS.length - pinned.length;
+
+  return (
+    <div className="view-picker-wrap">
+      <button
+        type="button"
+        className="view-picker-btn"
+        onClick={toggleOpen}
+        title="Every output view — pin the ones you want resident in the rail"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        All views ⌄
+        {unpinnedCount > 0 && (
+          <span className="view-picker-count">+{unpinnedCount}</span>
+        )}
+      </button>
+      {open && (
+        <>
+          <div
+            className="view-picker-backdrop"
+            onClick={() => setOpen(false)}
+          />
+          <div className="view-picker" role="menu">
+            {VIEWS.map((v) => {
+              const isPinned = pinned.includes(v.id);
+              const blocked = pinBlockedReason(pinned, v.id);
+              return (
+                <div
+                  key={v.id}
+                  className={`view-picker-row${isPinned ? " pinned" : " unpinned"}${
+                    v.id === view ? " active" : ""
+                  }`}
+                >
+                  <button
+                    type="button"
+                    className="view-picker-name"
+                    role="menuitem"
+                    aria-current={v.id === view}
+                    onClick={() => {
+                      setView(v.id);
+                      setOpen(false);
+                    }}
+                  >
+                    <span>{v.label}</span>
+                    {badged.has(v.id) && (
+                      <span className="view-picker-new">NEW</span>
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    className="view-picker-dot"
+                    aria-pressed={isPinned}
+                    disabled={blocked !== null}
+                    title={
+                      blocked ??
+                      (isPinned
+                        ? `Unpin ${v.label} from the rail`
+                        : `Pin ${v.label} to the rail`)
+                    }
+                    aria-label={
+                      isPinned ? `Unpin ${v.label}` : `Pin ${v.label}`
+                    }
+                    onClick={() => togglePin(v.id)}
+                  >
+                    <span />
+                  </button>
+                </div>
+              );
+            })}
+            <div className="view-picker-note">
+              Row = show · dot = keep in rail · max {PIN_CAP} pinned
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/antennaknobs/web/frontend/src/components/session/ViewPicker.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/ViewPicker.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { VIEWS, type View } from "../../lib/view";
 import { PIN_CAP, pinBlockedReason } from "./useViewPrefs";
 
@@ -30,6 +30,14 @@ export function ViewPicker({
   markRosterSeen: () => void;
 }) {
   const [open, setOpen] = useState(false);
+  // The popover is position:FIXED and placed from a measurement, not
+  // position:absolute inside the strip: .thumbstrip is overflow:hidden by
+  // design (thumbs are scaled to fit and must never scroll), which would clip
+  // an absolutely-positioned child. Fixed elements escape that clip. Measured
+  // at open only — the stage layout doesn't scroll, and the backdrop swallows
+  // everything until the popover closes.
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const [anchor, setAnchor] = useState({ left: 0, bottom: 0 });
   // The badges shown while the popover is open are snapshotted as it opens.
   // Opening MARKS the roster seen — that is what "since you last looked"
   // means — so rendering `newIds` live would blank every badge in the same
@@ -39,6 +47,11 @@ export function ViewPicker({
   const toggleOpen = () => {
     setOpen((was) => {
       if (!was) {
+        const r = wrapRef.current?.getBoundingClientRect();
+        // Opens to the RIGHT of its button and grows upward from the strip's
+        // foot: the rail hugs the window's left edge, and the short columns
+        // this whole feature exists for have no room below.
+        if (r) setAnchor({ left: r.right + 6, bottom: window.innerHeight - r.bottom });
         setBadged(new Set(newIds));
         markRosterSeen();
       }
@@ -49,7 +62,7 @@ export function ViewPicker({
   const unpinnedCount = VIEWS.length - pinned.length;
 
   return (
-    <div className="view-picker-wrap">
+    <div className="view-picker-wrap" ref={wrapRef}>
       <button
         type="button"
         className="view-picker-btn"
@@ -69,7 +82,11 @@ export function ViewPicker({
             className="view-picker-backdrop"
             onClick={() => setOpen(false)}
           />
-          <div className="view-picker" role="menu">
+          <div
+            className="view-picker"
+            role="menu"
+            style={{ left: anchor.left, bottom: anchor.bottom }}
+          >
             {VIEWS.map((v) => {
               const isPinned = pinned.includes(v.id);
               const blocked = pinBlockedReason(pinned, v.id);

--- a/src/antennaknobs/web/frontend/src/components/session/useViewPrefs.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useViewPrefs.ts
@@ -1,0 +1,187 @@
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { VIEW_META, VIEWS, type View, type ViewMeta } from "../../lib/view";
+
+// The desktop view preferences: which views are PINNED (resident in the
+// thumbstrip) and which the user has already been shown in the picker.
+// Unit 2 of docs/plan-view-rail-scaling.md.
+//
+// Global, not per-design: every design has every view, and the user's
+// watching habits ("I care about VSWR and the pattern") span designs, so a
+// per-design pin set would reshuffle the workspace on every catalog switch.
+// Global also means every open session tab must agree, which is why the state
+// lives in a module store read through useSyncExternalStore (the same idiom
+// hooks.ts uses for media queries) rather than in per-component useState —
+// two mounted sessions holding private copies would drift and race on the key.
+
+// Six pins ⇒ five rail thumbs ⇒ ~96 px thumbs on a 720 px column, which is
+// above the legibility floor with margin (the column math is in the plan's
+// context table). Above six the rail is smudges again, so this is a hard cap,
+// not a nudge.
+export const PIN_CAP = 6;
+
+export const VIEW_PREFS_KEY = "akb.viewPrefs.v1";
+
+// What `seen` is seeded with on a first run: the roster as it stood when the
+// picker shipped, written out rather than derived from VIEWS. Seeding from the
+// live roster would mark every FUTURE view as already-seen for anyone whose
+// first visit happens after that view ships — the NEW badge would never fire
+// for the users it exists for. A literal makes the badge mean "added after the
+// picker shipped", which is what the user reads it as.
+const SEEN_SEED: View[] = ["antenna", "azimuth", "elevation", "smith", "schematic"];
+
+// The persisted record. Fields are independent and each is optional on read,
+// so unit 3 can add `layout: "rail" | "grid"` by extending this type and the
+// writer — no v2 key, and a build that predates a field simply ignores it.
+type ViewPrefs = {
+  pinned: View[];
+  seen: View[];
+};
+
+const KNOWN = new Set<string>(VIEWS.map((v) => v.id));
+
+const defaultPins = (): View[] =>
+  VIEWS.filter((v) => v.defaultPinned)
+    .map((v) => v.id)
+    .slice(0, PIN_CAP);
+
+// localStorage is user-editable and outlives roster changes, so nothing read
+// back is trusted: non-arrays become empty, ids we no longer ship are dropped,
+// duplicates collapse (a duplicate would render two rail thumbs of one view).
+function sanitizeIds(raw: unknown): View[] {
+  if (!Array.isArray(raw)) return [];
+  const out: View[] = [];
+  for (const v of raw) {
+    if (typeof v === "string" && KNOWN.has(v) && !out.includes(v as View)) {
+      out.push(v as View);
+    }
+  }
+  return out;
+}
+
+function loadPrefs(): ViewPrefs {
+  try {
+    const raw = localStorage.getItem(VIEW_PREFS_KEY);
+    if (raw) {
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        const rec = parsed as Record<string, unknown>;
+        // Clamp to the cap on the way in too: the cap can shrink between
+        // releases, and the picker's disabled dots can only refuse NEW pins.
+        const pinned = sanitizeIds(rec.pinned).slice(0, PIN_CAP);
+        const seen = sanitizeIds(rec.seen);
+        // Everything surviving sanitisation was garbage ⇒ treat the record as
+        // corrupt rather than honour an empty rail, which is never what a user
+        // meant and leaves no visible way back.
+        if (pinned.length > 0) {
+          return { pinned, seen: seen.length > 0 ? seen : SEEN_SEED };
+        }
+      }
+    }
+  } catch {
+    /* corrupt JSON or storage disabled — the defaults below are the answer */
+  }
+  return { pinned: defaultPins(), seen: SEEN_SEED };
+}
+
+// --- module store ------------------------------------------------------------
+
+let cached: ViewPrefs | null = null;
+const listeners = new Set<() => void>();
+
+// useSyncExternalStore compares snapshots by identity, so this must hand back
+// the SAME object until something actually changes — hence the cache.
+function getSnapshot(): ViewPrefs {
+  if (!cached) cached = loadPrefs();
+  return cached;
+}
+
+function subscribe(onChange: () => void): () => void {
+  listeners.add(onChange);
+  return () => {
+    listeners.delete(onChange);
+    // Nothing is mounted any more, so drop the cache and let the next mount
+    // re-read storage. In the app that only happens before the first session
+    // mounts (sessions never all unmount); in tests it makes every mount a
+    // fresh read of whatever the test put in localStorage.
+    if (listeners.size === 0) cached = null;
+  };
+}
+
+function update(next: ViewPrefs): void {
+  cached = next;
+  try {
+    localStorage.setItem(VIEW_PREFS_KEY, JSON.stringify(next));
+  } catch {
+    /* storage disabled — the in-memory prefs still work for this session,
+       exactly as App.tsx's theme toggle degrades */
+  }
+  for (const l of listeners) l();
+}
+
+// --- pure helpers the UI and the key cycler share ----------------------------
+
+// ArrowUp/Down walks `pinned ∪ {active}`: a peeked view (active but unpinned)
+// joins the cycle transiently at the end so the arrows can never strand you on
+// a view they cannot leave. The full roster stays picker-only, which is the
+// point — cycling is short by construction.
+export function cycleOrder(pinned: View[], active: View): View[] {
+  return pinned.includes(active) ? pinned : [...pinned, active];
+}
+
+// Why a pin dot is inert, or null when it is live — the picker shows this as
+// the dot's tooltip. togglePin enforces the same two rules itself: the dots
+// are the affordance, these are the invariant.
+export function pinBlockedReason(pinned: View[], id: View): string | null {
+  if (pinned.includes(id)) {
+    // A floor of one keeps the stored set a fixed point of loadPrefs, which
+    // reads an empty pinned list as corruption and hands back the defaults.
+    return pinned.length <= 1 ? "Keep at least one view pinned" : null;
+  }
+  return pinned.length >= PIN_CAP ? "Unpin a view first" : null;
+}
+
+export function useViewPrefs() {
+  const prefs = useSyncExternalStore(subscribe, getSnapshot);
+  const { pinned, seen } = prefs;
+
+  // Views the user has never been offered. Seeded (not empty) on a first run,
+  // so the badge only ever fires for views added after the picker shipped.
+  const newIds = useMemo(
+    () => new Set(VIEWS.filter((v) => !seen.includes(v.id)).map((v) => v.id)),
+    [seen],
+  );
+
+  // The rail: pinned minus the active view. When the active view is unpinned
+  // (a peek) nothing is subtracted, so the rail shows every pin — peek costs
+  // no pin slot and displaces no thumb.
+  const railViews = useCallback(
+    (active: View): ViewMeta[] =>
+      pinned.filter((id) => id !== active).map((id) => VIEW_META[id]),
+    [pinned],
+  );
+
+  // Callbacks read the store rather than close over `pinned`, so a stale
+  // handler (a popover rendered before someone else's pin landed) still
+  // toggles against current truth.
+  const togglePin = useCallback((id: View) => {
+    const cur = getSnapshot();
+    if (pinBlockedReason(cur.pinned, id)) return;
+    const pins = cur.pinned.includes(id)
+      ? cur.pinned.filter((v) => v !== id)
+      : // Pin order is order-pinned; no drag-to-reorder in v1.
+        [...cur.pinned, id];
+    update({ ...cur, pinned: pins });
+  }, []);
+
+  // Opening the picker is what "you have now been shown the roster" means.
+  // No-ops when nothing is new, so the snapshot identity (and every memo
+  // hanging off it) survives an open.
+  const markRosterSeen = useCallback(() => {
+    const cur = getSnapshot();
+    const missing = VIEWS.map((v) => v.id).filter((id) => !cur.seen.includes(id));
+    if (missing.length === 0) return;
+    update({ ...cur, seen: [...cur.seen, ...missing] });
+  }, []);
+
+  return { pinned, seen, newIds, railViews, togglePin, markRosterSeen };
+}

--- a/src/antennaknobs/web/frontend/src/components/session/useViewState.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useViewState.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { type ExampleDescriptor } from "../../lib/params";
-import { VIEWS, type Projection, type View } from "../../lib/view";
+import { type Projection, type View } from "../../lib/view";
+import { cycleOrder } from "./useViewPrefs";
 
 // Which output view is on screen and how it is drawn: the two far-field cut
 // angles, the selected view + camera projection, the antenna-canvas display
@@ -12,9 +13,13 @@ import { VIEWS, type Projection, type View } from "../../lib/view";
 export function useViewState({
   currentExample,
   active,
+  pinned,
 }: {
   currentExample: ExampleDescriptor | undefined;
   active: boolean;
+  // The user's pinned views (useViewPrefs). The arrow keys cycle these plus
+  // the active view, not the whole registry — see cycleOrder.
+  pinned: View[];
 }) {
   // Far-field cut angles. The azimuth plot slices the pattern at elevation
   // `azElevDeg`; the elevation plot slices the vertical plane at azimuth
@@ -71,13 +76,17 @@ export function useViewState({
       ) {
         return;
       }
-      const idx = VIEWS.findIndex((v) => v.id === view);
-      const next = e.key === "ArrowDown" ? (idx + 1) % VIEWS.length : (idx - 1 + VIEWS.length) % VIEWS.length;
-      setView(VIEWS[next].id);
+      const order = cycleOrder(pinned, view);
+      const idx = order.indexOf(view);
+      const next =
+        e.key === "ArrowDown"
+          ? (idx + 1) % order.length
+          : (idx - 1 + order.length) % order.length;
+      setView(order[next]);
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [view, active]);
+  }, [view, active, pinned]);
 
   return {
     azElevDeg,

--- a/src/antennaknobs/web/frontend/src/lib/view.ts
+++ b/src/antennaknobs/web/frontend/src/lib/view.ts
@@ -8,9 +8,10 @@ export type View = "antenna" | "azimuth" | "elevation" | "smith" | "schematic" |
 export type ViewMeta = {
   id: View;
   label: string;
-  // Whether the view starts in the user's pinned set. Dormant until the pin
-  // model lands — unit 2 of docs/plan-view-rail-scaling.md is the only
-  // consumer. Nothing reads it today.
+  // Whether the view starts in the user's pinned set — the desktop rail is
+  // `pinned \ {active}`, not the whole roster (docs/plan-view-rail-scaling.md).
+  // Read once, by useViewPrefs, to seed a first run; after that the user's
+  // stored set wins, so flipping this only affects new users.
   defaultPinned: boolean;
 };
 export const VIEWS: ViewMeta[] = [
@@ -26,6 +27,14 @@ export const VIEWS: ViewMeta[] = [
   { id: "gamma", label: "|Γ| vs freq", defaultPinned: false },
   { id: "vswr", label: "VSWR vs freq", defaultPinned: false },
 ];
+
+// Id → metadata, for the consumers that hold a list of ids in the USER's
+// order (the pinned set) rather than registry order and still need labels.
+// The cast is the Record<View, …> exhaustiveness claim VIEWS already owes —
+// viewRegistry.test.tsx pins one entry per union member.
+export const VIEW_META = Object.fromEntries(
+  VIEWS.map((v) => [v.id, v]),
+) as Record<View, ViewMeta>;
 
 // The mobile output carousel's screens: the 5 chart views plus a dedicated
 // Info screen for the solve readout (which floats as a HUD on desktop but

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1902,13 +1902,11 @@ input[type=checkbox] {
   z-index: 40;
 }
 
-/* Opens to the RIGHT of the rail, bottom-aligned with its button: the rail
-   hugs the window's left edge, so a menu dropping below would fall off the
-   short columns this whole feature exists to serve. */
+/* Placement (left/bottom) comes from the component's measurement of its
+   button — .thumbstrip is overflow:hidden, which would clip an absolutely
+   positioned child, and a fixed one escapes that. */
 .view-picker {
-  position: absolute;
-  bottom: 0;
-  left: calc(100% + var(--space-3));
+  position: fixed;
   z-index: 41;
   min-width: 200px;
   max-height: min(70vh, 460px);

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1855,6 +1855,164 @@ input[type=checkbox] {
   letter-spacing: 0.03em;
 }
 
+/* ---- "All views" overflow picker (thumbstrip foot) ---------------------
+   The button's height is FIXED and mirrored by PICKER_SLOT in
+   components/hooks.ts, which subtracts it from the column before dividing
+   the rest among the thumbs — change one and the bottom thumb clips. */
+.view-picker-wrap {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.view-picker-btn {
+  box-sizing: border-box;
+  width: 100%;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-3);
+  background: var(--inset);
+  color: var(--muted);
+  /* Dashed: this slot holds views that are NOT resident, unlike the solid
+     thumbs above it. */
+  border: 1px dashed var(--border-control);
+  border-radius: var(--r-md);
+  font: inherit;
+  font-size: var(--text-xs);
+  cursor: pointer;
+}
+
+.view-picker-btn:hover {
+  color: var(--accent);
+  border-color: var(--border-hover);
+}
+
+.view-picker-count {
+  color: var(--fg);
+  font-weight: 600;
+}
+
+/* Transparent full-screen catcher so a click anywhere closes the popover
+   (same idiom as .gear-menu-backdrop). */
+.view-picker-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+}
+
+/* Opens to the RIGHT of the rail, bottom-aligned with its button: the rail
+   hugs the window's left edge, so a menu dropping below would fall off the
+   short columns this whole feature exists to serve. */
+.view-picker {
+  position: absolute;
+  bottom: 0;
+  left: calc(100% + var(--space-3));
+  z-index: 41;
+  min-width: 200px;
+  max-height: min(70vh, 460px);
+  overflow-y: auto;
+  padding: var(--space-1);
+  background: var(--bg);
+  border: 1px solid var(--border-control);
+  border-radius: var(--r-md);
+  box-shadow: 0 6px 20px var(--shadow-strong);
+}
+
+.view-picker-row {
+  display: flex;
+  align-items: center;
+  border-radius: var(--r-sm);
+}
+
+.view-picker-row:hover {
+  background: var(--accent-soft);
+}
+
+.view-picker-name {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  text-align: left;
+  white-space: nowrap;
+  background: none;
+  border: none;
+  border-radius: var(--r-sm);
+  color: var(--fg);
+  font: inherit;
+  font-size: var(--text-sm);
+  cursor: pointer;
+}
+
+.view-picker-row.unpinned .view-picker-name {
+  color: var(--muted);
+}
+
+.view-picker-row.active .view-picker-name {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.view-picker-name:hover {
+  color: var(--accent);
+}
+
+/* The pin state IS the indicator (instrument channel-enable idiom): filled =
+   resident in the rail. The button is a 24 px hit target around a 12 px dot. */
+.view-picker-dot {
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  margin-right: var(--space-2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.view-picker-dot span {
+  box-sizing: border-box;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid var(--accent-border);
+}
+
+.view-picker-row.pinned .view-picker-dot span {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.view-picker-dot:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.view-picker-new {
+  padding: 0 var(--space-2);
+  border-radius: var(--r-sm);
+  background: var(--hot);
+  color: var(--panel);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+
+.view-picker-note {
+  margin-top: var(--space-1);
+  padding: var(--space-2) var(--space-3) var(--space-1);
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: var(--text-xs);
+}
+
 .carousel-slide {
   flex: 1;
   min-width: 0;


### PR DESCRIPTION
Unit 2 of the #700 stacked arc (docs/plan-view-rail-scaling.md), stacked onto `issue-700-view-rail` (rebased over unit 5, so the picker ships against the 7-view roster).

## Summary
- `useViewPrefs.ts`: module-level store via `useSyncExternalStore` (all session tabs share one truth), `akb.viewPrefs.v1` persistence with hostile-input sanitization, `PIN_CAP = 6`, pin floor of 1, `SEEN_SEED` = the 5 pre-picker views so later views badge NEW.
- `ViewPicker.tsx`: "All views ⌄ +N" fixed-height slot + `position:fixed` popover (escapes the thumbstrip's `overflow:hidden` clip); row click = show/peek + close, dot click = pin toggle only; badges snapshotted at open.
- Rail renders `pinned \ {active}` (peek shows all pins); `useThumbColumnSize` now takes the thumb count from the caller + a `PICKER_SLOT` overhead term; ArrowUp/Down cycles `pinned ∪ {active}` via shared `cycleOrder`.
- Mobile untouched (unit 4); `VIEW_META` id→meta map added to `lib/view.ts`.

## Deviations from the plan (deliberate, for ratification)
- **Pin floor of 1** — an empty pinned list is indistinguishable from corruption to the loader, so the last pin can't be removed (dot disabled, "Keep at least one view pinned").
- **NEW badges snapshot at open** — rendering them live would blank the badges in the frame the picker opens.

## Gates (measured)
- Suite: 27 files / 466 tests green (405 baseline + unit 5's 21 + 40 new). Zero edits to test files outside the two new ones.
- `npm run build` green.
- First real badge firing covered: first-time users see NEW on exactly {gamma, vswr} (roster minus seed) — the rebase over unit 5 flipped this test from a vacuous to a live assertion.
- Mutation probes: builder — cap-clamp drop (1 fail), togglePin guard drop (2 fails), unvalidated JSON.parse (12 fails); reviewer — rail stops subtracting the active view (2 fails). All reverted, 466 green after.

## Review notes
- Built by an opus subagent (delegated-build) with one rework round after the unit-5 rebase collision (9 roster-size test expectations — source logic needed zero changes). Reviewed by the session model: full diff read, store/cap/cycle logic re-derived, suite + build re-run, independent mutation probe.
- Cross-browser-tab `storage` events are not listened for (same policy as the theme toggle); a follow-up if anyone runs two browser windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01522PMkNyJbRX772WV5DwaA