### PR TITLE
Unit 5b: the gamma view plots S11 in dB, VNA-style (#700)

### DIFF
--- a/src/antennaknobs/web/frontend/src/__tests__/SweepChart.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/SweepChart.test.tsx
@@ -17,8 +17,9 @@ HTMLCanvasElement.prototype.getContext =
   (() => null) as unknown as HTMLCanvasElement["getContext"];
 
 // Three points chosen from the closed-form oracle pairs pinned in
-// math.test.ts: Z=50+0j -> matched (|Γ|=0, VSWR=1); Z=100+0j and Z=25+0j ->
-// the 2:1 real mismatch (|Γ|=1/3, VSWR=2) from either side of Z0=50.
+// math.test.ts: Z=50+0j -> matched (S11 floored at -60 dB, VSWR=1);
+// Z=100+0j and Z=25+0j -> the 2:1 real mismatch (|Γ|=1/3 ⇒ S11 -9.5424 dB,
+// VSWR=2) from either side of Z0=50.
 const SWEEP: SweepData = {
   freqs_mhz: [10, 14, 18],
   z_re: [50, 100, 25],
@@ -79,15 +80,15 @@ describe("empty/loading state", () => {
 });
 
 describe("a synthetic 3-point sweep produces a trace", () => {
-  it("gamma mode: y-values are |Γ|, not VSWR, per sample", () => {
+  it("gamma mode: y-values are S11 in dB, not VSWR, per sample", () => {
     const { container } = renderChart("gamma", { sweep: SWEEP });
     const canvas = container.querySelector("canvas.sweep") as HTMLCanvasElement;
     expect(canvas.dataset.points).toBe("3");
     expect(canvas.dataset.feeds).toBe("1");
-    expect(canvas.dataset.yValues).toBe("0.0000,0.3333,0.3333");
+    expect(canvas.dataset.yValues).toBe("-60.0000,-9.5424,-9.5424");
   });
 
-  it("vswr mode: y-values are VSWR, not |Γ|, per sample", () => {
+  it("vswr mode: y-values are VSWR, not S11 dB, per sample", () => {
     const { container } = renderChart("vswr", { sweep: SWEEP });
     const canvas = container.querySelector("canvas.sweep") as HTMLCanvasElement;
     expect(canvas.dataset.points).toBe("3");
@@ -105,7 +106,7 @@ describe("a synthetic 3-point sweep produces a trace", () => {
   it("current-Z marker reflects the live result, converted by the chart's own mode", () => {
     const gamma = renderChart("gamma", { sweep: SWEEP, r: 100, x: 0, z0: 50 });
     const gCanvas = gamma.container.querySelector("canvas.sweep") as HTMLCanvasElement;
-    expect(gCanvas.dataset.current).toBe("0.3333");
+    expect(gCanvas.dataset.current).toBe("-9.5424");
 
     const vswr = renderChart("vswr", { sweep: SWEEP, r: 100, x: 0, z0: 50 });
     const vCanvas = vswr.container.querySelector("canvas.sweep") as HTMLCanvasElement;
@@ -136,7 +137,7 @@ describe("multi-feed sweeps (mirrors SmithChart's feeds_z_re/feeds_z_im policy)"
     // Feed-0's trace is what data-y-values reports (the legacy single-trace
     // convention), and it must come from feeds_z_re[*][0], not the
     // top-level z_re — same fallback order as SmithChart's zAt().
-    expect(canvas.dataset.yValues).toBe("0.0000,0.3333,0.3333");
+    expect(canvas.dataset.yValues).toBe("-60.0000,-9.5424,-9.5424");
   });
 
   it("falls back to the legacy single trace when feeds_z_re is absent or too short", () => {

--- a/src/antennaknobs/web/frontend/src/__tests__/math.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/math.test.ts
@@ -5,8 +5,10 @@ import { describe, it, expect } from "vitest";
 import { reflectionCoefficient } from "../lib/format";
 import {
   feedwiseRichardson,
+  gammaDbFromMag,
   gammaMagFromZ,
   richardsonExtrap,
+  S11_DB_FLOOR,
   VSWR_CEILING,
   vswrFromGammaMag,
 } from "../lib/math";
@@ -188,5 +190,33 @@ describe("vswrFromGammaMag", () => {
     const v = vswrFromGammaMag(0.9);
     expect(v).toBeLessThan(VSWR_CEILING);
     expect(v).toBeGreaterThan(vswrFromGammaMag(0.5));
+  });
+});
+
+// S11 log-magnitude — the negative-dB VNA convention the gamma sweep view
+// plots (0 dB = total reflection, dips are good). Pinned against closed
+// forms so a sign flip (positive "return loss") or a base-10/ratio-20 slip
+// fails here, not just in a chart eyeball.
+describe("gammaDbFromMag", () => {
+  it("is 0 dB at total reflection (dead short/open)", () => {
+    expect(gammaDbFromMag(1)).toBeCloseTo(0, 12);
+  });
+
+  it("is 20·log10 of the magnitude, negative for any partial reflection", () => {
+    expect(gammaDbFromMag(1 / 3)).toBeCloseTo(20 * Math.log10(1 / 3), 12);
+    expect(gammaDbFromMag(1 / 3)).toBeCloseTo(-9.542425094393249, 12);
+    expect(gammaDbFromMag(0.1)).toBeCloseTo(-20, 12);
+  });
+
+  it("floors a perfect (or numerically zero) match instead of -Infinity", () => {
+    expect(gammaDbFromMag(0)).toBe(S11_DB_FLOOR);
+    expect(gammaDbFromMag(1e-9)).toBe(S11_DB_FLOOR);
+    expect(Number.isFinite(gammaDbFromMag(0))).toBe(true);
+  });
+
+  it("agrees with the gammaMagFromZ oracle pairs end to end", () => {
+    expect(gammaDbFromMag(gammaMagFromZ(50, 0, 50))).toBe(S11_DB_FLOOR);
+    expect(gammaDbFromMag(gammaMagFromZ(100, 0, 50))).toBeCloseTo(-9.5424, 4);
+    expect(gammaDbFromMag(gammaMagFromZ(25, 0, 50))).toBeCloseTo(-9.5424, 4);
   });
 });

--- a/src/antennaknobs/web/frontend/src/__tests__/viewRegistry.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/viewRegistry.test.tsx
@@ -67,7 +67,7 @@ describe("view metadata", () => {
       ["elevation", "Elevation (yz)"],
       ["smith", "Smith"],
       ["schematic", "Schematic"],
-      ["gamma", "|Γ| vs freq"],
+      ["gamma", "S11 (dB) vs freq"],
       ["vswr", "VSWR vs freq"],
     ]);
   });

--- a/src/antennaknobs/web/frontend/src/components/charts/SweepChart.tsx
+++ b/src/antennaknobs/web/frontend/src/components/charts/SweepChart.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useRef } from "react";
 import type { FeedEntry, SweepData } from "../../lib/api";
-import { gammaMagFromZ, vswrFromGammaMag } from "../../lib/math";
+import { gammaDbFromMag, gammaMagFromZ, vswrFromGammaMag } from "../../lib/math";
 import { ThemeContext } from "../hooks";
 import { feedColor, feedSweepColor, plotColors } from "./palette";
 
@@ -11,14 +11,16 @@ import { feedColor, feedSweepColor, plotColors } from "./palette";
 // conversion turns a swept Z into a y-value.
 export type SweepMode = "gamma" | "vswr";
 
-// y-domain per mode. gamma is bounded [0,1] by construction (|Γ| can't
-// exceed 1 for a passive Z0). VSWR is unbounded as |Γ| → 1; the ham-
-// instrument convention is a linear 1..10 scale with an off-scale
-// indication for anything hotter — matching a real SWR meter's needle
-// pinned at the peg rather than a y-axis that silently rescales every time
-// a knob drags through a bad match.
+// y-domain per mode. gamma plots S11 in negative dB (20·log₁₀|Γ|), the
+// VNA/NanoVNA convention: 0 dB at the top, a good match is a downward dip
+// toward −30; anything deeper clamps to the bottom edge (below −30 dB the
+// match is beyond caring, and beyond most VNAs' honesty). VSWR is unbounded
+// as |Γ| → 1; the ham-instrument convention is a linear 1..10 scale with an
+// off-scale indication for anything hotter — matching a real SWR meter's
+// needle pinned at the peg rather than a y-axis that silently rescales
+// every time a knob drags through a bad match.
 const DOMAIN: Record<SweepMode, { lo: number; hi: number; ticks: number[]; title: string }> = {
-  gamma: { lo: 0, hi: 1, ticks: [0, 0.2, 0.4, 0.6, 0.8, 1.0], title: "|Γ|" },
+  gamma: { lo: -30, hi: 0, ticks: [-30, -20, -10, 0], title: "S11 dB" },
   vswr: { lo: 1, hi: 10, ticks: [1, 2, 4, 6, 8, 10], title: "VSWR" },
 };
 
@@ -27,7 +29,7 @@ const DOMAIN: Record<SweepMode, { lo: number; hi: number; ticks: number[]; title
 // charts instead of two independently-wrong formulas.
 function valueFor(mode: SweepMode, re: number, im: number, z0: number): number {
   const g = gammaMagFromZ(re, im, z0);
-  return mode === "gamma" ? g : vswrFromGammaMag(g);
+  return mode === "gamma" ? gammaDbFromMag(g) : vswrFromGammaMag(g);
 }
 
 export function SweepChart({
@@ -130,7 +132,9 @@ export function SweepChart({
     const yOf = (v: number) => marginT + plotH * (1 - frac(v));
     // A value at/above the domain top for VSWR means "off the chart" (a real
     // SWR meter pins its needle rather than rescaling); gamma never needs
-    // this since |Γ| ≤ 1 always fits.
+    // this since S11 ≤ 0 dB for anything passive. Below the gamma floor the
+    // trace just clamps to the bottom edge — an over-deep dip is good news,
+    // not a hazard worth a pinned-needle glyph.
     const offScale = (v: number) => v > dom.hi;
 
     ctx.strokeStyle = PC.grid;
@@ -143,8 +147,7 @@ export function SweepChart({
       ctx.moveTo(marginL, y);
       ctx.lineTo(marginL + plotW, y);
       ctx.stroke();
-      const label = mode === "gamma" ? t.toFixed(1) : t.toFixed(0);
-      ctx.fillText(label, 2, y + 3);
+      ctx.fillText(t.toFixed(0), 2, y + 3);
     }
     // Axis frame.
     ctx.strokeStyle = PC.axis;

--- a/src/antennaknobs/web/frontend/src/lib/math.ts
+++ b/src/antennaknobs/web/frontend/src/lib/math.ts
@@ -19,6 +19,18 @@ export function vswrFromGammaMag(gMag: number): number {
   return Math.min((1 + gMag) / (1 - gMag), VSWR_CEILING);
 }
 
+// S11 log-magnitude, 20·log₁₀|Γ| — the negative-dB convention every VNA
+// (including the NanoVNA this app's users own) plots: 0 dB = total
+// reflection, a good match is a downward dip. NOT the IEEE positive
+// "return loss"; pick one sign convention and keep it. |Γ| = 0 is −∞ dB, so
+// a floor keeps a perfect match plottable and its data-* readout finite;
+// −60 dB (|Γ| = 0.001) is far below anything an antenna sweep resolves.
+export const S11_DB_FLOOR = -60;
+export function gammaDbFromMag(gMag: number): number {
+  if (gMag <= 0) return S11_DB_FLOOR;
+  return Math.max(20 * Math.log10(gMag), S11_DB_FLOOR);
+}
+
 // Richardson-style extrapolation Z(1/N) → Z(N→∞). Fits Z = a₀ + a₁·h + a₂·h²
 // (h = 1/N) on the last `nLast` points via least squares and returns a₀.
 // Quadratic gives a sane answer for O(1/N) limit (BSpline without

--- a/src/antennaknobs/web/frontend/src/lib/view.ts
+++ b/src/antennaknobs/web/frontend/src/lib/view.ts
@@ -24,7 +24,10 @@ export const VIEWS: ViewMeta[] = [
   // items 6/7): the sweep data already flows to the Smith chart, so these
   // are a second and third presentation of it, not a new data path. Ship
   // unpinned like schematic — the founding four stay the only defaults.
-  { id: "gamma", label: "|Γ| vs freq", defaultPinned: false },
+  // "gamma" keeps its id (persisted pin sets store ids) but presents as S11
+  // in dB — the VNA/NanoVNA log-magnitude convention, which is what this
+  // audience reads; linear |Γ| only ever appears as a Smith-chart radius.
+  { id: "gamma", label: "S11 (dB) vs freq", defaultPinned: false },
   { id: "vswr", label: "VSWR vs freq", defaultPinned: false },
 ];
 


### PR DESCRIPTION
Amendment to unit 5 (#706), stacked onto `issue-700-view-rail`. User review: linear |Γ| vs frequency is nonstandard — every VNA (incl. NanoVNA, this audience's instrument) plots S11 log-magnitude in negative dB.

## Summary
- `gammaDbFromMag` (= 20·log₁₀|Γ|, floored at −60 dB so a perfect match stays finite/plottable) added to `lib/math.ts`; the gamma view now plots it on a 0…−30 dB axis, dips downward, deeper dips clamp to the bottom edge (good news needs no pinned-needle glyph).
- Label → "S11 (dB) vs freq" (id stays `gamma` — persisted pin sets store ids). Deliberately the negative-dB S11 convention, not IEEE positive return loss.
- Oracle tests: 0 dB at total reflection, −9.5424 dB at the 2:1 mismatch pair, −20 dB at |Γ|=0.1, floor behavior, end-to-end agreement with `gammaMagFromZ`.

## Gates (measured)
- Suite: 27 files / 470 tests green (466 + 4 net new oracle tests; SweepChart/viewRegistry expectations updated to the dB values).
- `npm run build` green.

## Review notes
- Implemented directly by the session model (small, oracle-pinned change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01522PMkNyJbRX772WV5DwaA