### PR TITLE
Unit 4: the mobile carousel pages the pinned set + picker sheet (#700)

### DIFF
--- a/src/antennaknobs/web/frontend/src/__tests__/DesignSession.mobile.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/DesignSession.mobile.test.tsx
@@ -1,0 +1,119 @@
+// The wiring MobileCarousel.test.tsx cannot see: that the REAL session's
+// mobile tree derives its carousel pages and its dots from the same pinned
+// list (#700 unit 4). One mount, three facts — page count, page identity, and
+// the "⋯" affordance's presence — because everything about how those pages
+// behave is already pinned at the hook and component level.
+//
+// The stub set is newBackend.test.tsx's, with matchMedia flipped to MATCH the
+// phone breakpoint so the session renders its mobile branch instead of the
+// stage.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { DesignSession } from "../components/session/DesignSession";
+import { VIEW_META, VIEWS, type View } from "../lib/view";
+import { VIEW_PREFS_KEY } from "../components/session/useViewPrefs";
+import type { ExampleDescriptor } from "../lib/params";
+import { SERVED_ROSTER } from "./backendFixtures";
+
+const PINNED: View[] = ["smith", "antenna", "gamma"];
+
+const EXAMPLE: ExampleDescriptor = {
+  name: "dipoles.probe",
+  label: "Probe dipole",
+  multi_feed: false,
+  param_schema: [],
+  result_schema: [],
+  bands: [],
+  meas_freq_range_mhz: null,
+  default_view: "xz",
+  default_freq: null,
+  default_design_freq: null,
+  default_backend: null,
+  requires_backends: null,
+  has_design_freq: true,
+  variants: ["default"],
+  variant_values: {},
+  sweep_policy: { anchor: "design_freq", lo_factor: 0.8, hi_factor: 1.25 },
+};
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  localStorage.setItem(
+    VIEW_PREFS_KEY,
+    JSON.stringify({ pinned: PINNED, seen: VIEWS.map((v) => v.id) }),
+  );
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+  // Every query matches: this session is on a phone, in portrait.
+  vi.stubGlobal("matchMedia", () => ({
+    matches: true,
+    addEventListener() {},
+    removeEventListener() {},
+  }));
+  vi.stubGlobal(
+    "WebSocket",
+    class {
+      static OPEN = 1;
+      readyState = 0;
+      close() {}
+      send() {}
+    },
+  );
+  vi.stubGlobal("fetch", async (url: string) => {
+    const path = String(url);
+    if (path.startsWith("/capabilities"))
+      return jsonResponse({
+        have_pynec: true,
+        backends: SERVED_ROSTER,
+        terrain_presets: [],
+      });
+    if (path.startsWith("/examples"))
+      return jsonResponse({ examples: [EXAMPLE], errors: [] });
+    if (path.startsWith("/geometry")) return jsonResponse({ wires: [] });
+    return jsonResponse({});
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("the session's mobile tree", () => {
+  it("carries one carousel page and one dot per pinned view, plus Info", async () => {
+    const { container } = render(<DesignSession id={1} active />);
+    await waitFor(() =>
+      expect(container.querySelector(".mobile-carousel")).not.toBeNull(),
+    );
+
+    // Pages: the pinned views in pin order, then the Info screen — NOT the
+    // registry, which is four views longer here.
+    const pages = container.querySelectorAll(".mobile-screen");
+    expect(pages).toHaveLength(PINNED.length + 1);
+    expect(pages[pages.length - 1].classList).toContain("mobile-screen-info");
+
+    // Dots: the same list, from the same derivation.
+    expect(
+      screen.getAllByRole("button", { name: /^Show / }).map((b) => b.getAttribute("title")),
+    ).toEqual([...PINNED.map((id) => VIEW_META[id].label), "Info"]);
+
+    // The roster the pages were drawn from is one tap away.
+    expect(screen.getByRole("button", { name: "All views" })).toBeTruthy();
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/MobileCarousel.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/MobileCarousel.test.tsx
@@ -1,0 +1,414 @@
+// The phone carousel as DesignSession wires it (#700 unit 4): the real prefs
+// store, the real hook, the real dots row and the real picker sheet, over a
+// stubbed scroll geometry. What it pins is the one contract the unit is about
+// — carousel pages ARE the pinned set plus Info, in pin order — plus the four
+// ways that mapping can be walked off: a view with no page, unpinning the page
+// you are on, pinning a page while you stand somewhere, and Info's index
+// moving under both.
+//
+// jsdom has no layout: clientWidth is 0, scrollLeft never moves, and
+// Element.scrollTo does not exist, so scroll-snap cannot be exercised for
+// real. The stubs below supply exactly the three geometry facts the hook reads
+// (page width, scroll position, and a scrollTo that lands instantly), which
+// turns a swipe into "put scrollLeft on a snap point and fire scroll" — the
+// same event the browser delivers at the end of a fling.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { VIEW_META, VIEWS, mobileScreens, type View } from "../lib/view";
+import { MobileDots } from "../components/session/MobileDots";
+import { useMobileCarousel } from "../components/session/useMobileCarousel";
+import { PIN_CAP, VIEW_PREFS_KEY, useViewPrefs } from "../components/session/useViewPrefs";
+
+const W = 300; // one page wide; every snap point is a multiple of it
+const ROSTER = VIEWS.map((v) => v.id);
+const label = (id: View) => VIEW_META[id].label;
+
+let scrollPos = 0;
+let scrolls: number[] = [];
+let origClientWidth: PropertyDescriptor | undefined;
+let origScrollLeft: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  localStorage.clear();
+  scrollPos = 0;
+  scrolls = [];
+  origClientWidth = Object.getOwnPropertyDescriptor(Element.prototype, "clientWidth");
+  origScrollLeft = Object.getOwnPropertyDescriptor(Element.prototype, "scrollLeft");
+  Object.defineProperty(Element.prototype, "clientWidth", {
+    configurable: true,
+    get: () => W,
+  });
+  Object.defineProperty(Element.prototype, "scrollLeft", {
+    configurable: true,
+    get: () => scrollPos,
+    set: (v: number) => {
+      scrollPos = v;
+    },
+  });
+  // jsdom ships no Element.scrollTo at all. Landing instantly (rather than
+  // recording and ignoring) is what makes a programmatic page change visible
+  // to the next effect, exactly as a finished smooth scroll would be.
+  Object.defineProperty(Element.prototype, "scrollTo", {
+    configurable: true,
+    writable: true,
+    value: (o: ScrollToOptions) => {
+      scrolls.push(o.left ?? 0);
+      scrollPos = o.left ?? 0;
+    },
+  });
+});
+
+afterEach(() => {
+  if (origClientWidth) Object.defineProperty(Element.prototype, "clientWidth", origClientWidth);
+  if (origScrollLeft) Object.defineProperty(Element.prototype, "scrollLeft", origScrollLeft);
+  delete (Element.prototype as unknown as Record<string, unknown>).scrollTo;
+  vi.restoreAllMocks();
+});
+
+function seed(pinned: View[], seen: View[] = ROSTER) {
+  localStorage.setItem(VIEW_PREFS_KEY, JSON.stringify({ pinned, seen }));
+}
+
+// DesignSession's mobile branch, minus the charts: same hook call, same
+// derived screen list feeding both the pages and the dots, same sheet props.
+function Mobile({
+  isMobile = true,
+  initialView = "antenna" as View,
+}: {
+  isMobile?: boolean;
+  initialView?: View;
+}) {
+  const [view, setView] = useState<View>(initialView);
+  const prefs = useViewPrefs();
+  const car = useMobileCarousel({
+    isMobile,
+    orientation: "portrait",
+    pinned: prefs.pinned,
+    view,
+    setView,
+  });
+  const screens = mobileScreens(prefs.pinned);
+  return (
+    <>
+      <div data-testid="view">{view}</div>
+      <div data-testid="index">{car.mobileIndex}</div>
+      <div data-testid="pages">{screens.map((s) => s.id).join(",")}</div>
+      <div
+        data-testid="carousel"
+        ref={car.mobileCarouselRef}
+        onScroll={car.onMobileCarouselScroll}
+      />
+      <MobileDots
+        screens={screens}
+        index={car.mobileIndex}
+        goToScreen={car.goToMobileScreen}
+        view={view}
+        pinned={prefs.pinned}
+        newIds={prefs.newIds}
+        togglePin={prefs.togglePin}
+        markRosterSeen={prefs.markRosterSeen}
+      />
+    </>
+  );
+}
+
+const probe = (id: string) => screen.getByTestId(id).textContent;
+const frame = () => new Promise((r) => requestAnimationFrame(() => r(null)));
+
+// A finished swipe: the snap point becomes the scroll position and the browser
+// delivers one scroll event. The handler is rAF-throttled, hence the frames.
+//
+// The leading drain is not ceremony: the re-centre effect queues a frame every
+// time the index changes, and here scrollTo lands instantly, so an undrained
+// frame from the previous gesture would re-centre the OLD page on top of this
+// one. On a phone those frames run milliseconds after the commit, long before
+// the next swipe — draining is what makes the simulation match that.
+async function swipeTo(i: number) {
+  await act(async () => {
+    await frame();
+  });
+  scrollPos = i * W;
+  await act(async () => {
+    fireEvent.scroll(screen.getByTestId("carousel"));
+    await frame();
+  });
+}
+
+const dots = () =>
+  screen.getAllByRole("button", { name: /^Show / }).map((b) => b.getAttribute("title"));
+const openSheet = (user: ReturnType<typeof userEvent.setup>) =>
+  user.click(screen.getByRole("button", { name: "All views" }));
+const sheetRow = (id: View) => screen.getByRole("menuitem", { name: label(id) });
+const dot = (name: string) => screen.getByRole("button", { name }) as HTMLButtonElement;
+
+const TWO: View[] = ["smith", "antenna"];
+const FOUR: View[] = ["smith", "antenna", "vswr", "azimuth"];
+const SIX: View[] = ["smith", "antenna", "vswr", "azimuth", "schematic", "gamma"];
+
+// --- 1. Pages and dots ------------------------------------------------------
+
+describe("the carousel's pages", () => {
+  it.each([
+    ["2 pins", TWO],
+    ["4 pins", FOUR],
+    ["6 pins", SIX],
+  ])("are the pinned views plus Info, one dot each, at %s", (_n, pinned) => {
+    seed(pinned);
+    render(<Mobile initialView={pinned[0]} />);
+    expect(probe("pages")).toBe([...pinned, "info"].join(","));
+    // One dot per page and nothing else — an unpinned view has neither.
+    expect(dots()).toEqual([...pinned.map(label), "Info"]);
+    // The overflow affordance rides the row but is not a dot.
+    expect(screen.getByRole("button", { name: "All views" })).toBeTruthy();
+  });
+
+  it("gives an unpinned view no page at all", () => {
+    seed(TWO);
+    render(<Mobile initialView="smith" />);
+    for (const id of ROSTER.filter((v) => !TWO.includes(v))) {
+      expect(screen.queryByRole("button", { name: `Show ${label(id)}` })).toBeNull();
+    }
+  });
+});
+
+// --- 2. Index ↔ view mapping ------------------------------------------------
+
+describe("a swipe", () => {
+  it.each([
+    ["2 pins", TWO],
+    ["4 pins", FOUR],
+    ["6 pins", SIX],
+  ])("maps every page index onto the pin at that index, at %s", async (_n, pinned) => {
+    seed(pinned);
+    render(<Mobile initialView={pinned[0]} />);
+    for (let i = 0; i < pinned.length; i++) {
+      await swipeTo(i);
+      expect(probe("index")).toBe(String(i));
+      expect(probe("view")).toBe(pinned[i]);
+    }
+  });
+
+  it.each([
+    ["2 pins", TWO],
+    ["4 pins", FOUR],
+    ["6 pins", SIX],
+  ])("onto Info leaves `view` parked on the last chart page, at %s", async (_n, pinned) => {
+    seed(pinned);
+    render(<Mobile initialView={pinned[0]} />);
+    await swipeTo(pinned.length - 1);
+    await swipeTo(pinned.length); // Info
+    expect(probe("index")).toBe(String(pinned.length));
+    expect(probe("view")).toBe(pinned[pinned.length - 1]);
+  });
+});
+
+describe("a dot tap", () => {
+  it("pages to that pin and scrolls there", async () => {
+    const user = userEvent.setup();
+    seed(FOUR);
+    render(<Mobile initialView="smith" />);
+    await user.click(screen.getByRole("button", { name: `Show ${label("vswr")}` }));
+    expect(probe("view")).toBe("vswr");
+    expect(probe("index")).toBe("2");
+    expect(scrolls.at(-1)).toBe(2 * W);
+  });
+
+  it("reaches Info without moving `view` off the last chart", async () => {
+    const user = userEvent.setup();
+    seed(FOUR);
+    render(<Mobile initialView="smith" />);
+    await user.click(screen.getByRole("button", { name: `Show ${label("azimuth")}` }));
+    await user.click(screen.getByRole("button", { name: "Show Info" }));
+    expect(probe("index")).toBe("4");
+    expect(probe("view")).toBe("azimuth");
+    expect(scrolls.at(-1)).toBe(4 * W);
+  });
+});
+
+// --- 3. The sheet -----------------------------------------------------------
+
+describe("the ⋯ affordance", () => {
+  it("opens the whole roster as a sheet, in registry order", async () => {
+    const user = userEvent.setup();
+    seed(TWO);
+    render(<Mobile initialView="smith" />);
+    expect(screen.queryByRole("menu")).toBeNull();
+    await openSheet(user);
+    expect(screen.getByRole("menu")).toBeTruthy();
+    expect(
+      screen.getAllByRole("menuitem").map((el) => el.textContent?.replace(/NEW$/, "")),
+    ).toEqual(ROSTER.map(label));
+  });
+
+  it("closes on a backdrop click", async () => {
+    const user = userEvent.setup();
+    seed(TWO);
+    const { container } = render(<Mobile initialView="smith" />);
+    await openSheet(user);
+    await user.click(container.querySelector(".view-sheet-backdrop") as Element);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+});
+
+describe("a sheet row tap", () => {
+  // Hard case 3. A peek would have made `view` schematic with no page behind
+  // it; on mobile the row is the pin, and the new page lands at the end.
+  it("pins the view — it does NOT peek it — and appends its page", async () => {
+    const user = userEvent.setup();
+    seed(TWO);
+    render(<Mobile initialView="smith" />);
+    await swipeTo(1);
+    scrolls = [];
+    await openSheet(user);
+    await user.click(sheetRow("schematic"));
+    expect(probe("pages")).toBe("smith,antenna,schematic,info");
+    // The page under the thumb neither moves nor is scrolled away from.
+    expect(probe("view")).toBe("antenna");
+    expect(probe("index")).toBe("1");
+    expect(scrolls).toEqual([]);
+    // Curating is a run of gestures: the sheet stays up.
+    expect(screen.getByRole("menu")).toBeTruthy();
+    expect(dots()).toEqual([label("smith"), label("antenna"), label("schematic"), "Info"]);
+  });
+
+  // Hard case 2.
+  it("unpins the page you are on, landing on its successor with the sheet still open", async () => {
+    const user = userEvent.setup();
+    seed(FOUR);
+    render(<Mobile initialView="smith" />);
+    await swipeTo(1); // antenna
+    await openSheet(user);
+    await user.click(sheetRow("antenna"));
+    expect(probe("pages")).toBe("smith,vswr,azimuth,info");
+    // Same slot, new occupant — the page that slid into it.
+    expect(probe("index")).toBe("1");
+    expect(probe("view")).toBe("vswr");
+    expect(screen.getByRole("menu")).toBeTruthy();
+  });
+
+  it("clamps onto the new last page when the unpinned one was last", async () => {
+    const user = userEvent.setup();
+    seed(FOUR);
+    render(<Mobile initialView="smith" />);
+    await swipeTo(3); // azimuth, the last chart page
+    await openSheet(user);
+    await user.click(sheetRow("azimuth"));
+    expect(probe("index")).toBe("2");
+    expect(probe("view")).toBe("vswr");
+    expect(scrolls.at(-1)).toBe(2 * W);
+  });
+
+  // Hard case 4: Info's index is pinned.length, so both gestures move it.
+  it("moves Info under a user parked on it, without unparking them", async () => {
+    const user = userEvent.setup();
+    seed(TWO);
+    render(<Mobile initialView="smith" />);
+    await swipeTo(1); // antenna
+    await swipeTo(2); // Info, parked on antenna
+    await openSheet(user);
+    await user.click(sheetRow("schematic"));
+    expect(probe("index")).toBe("3");
+    expect(probe("view")).toBe("antenna"); // still parked where Info found it
+    await user.click(sheetRow("schematic")); // and back
+    expect(probe("index")).toBe("2");
+    expect(probe("view")).toBe("antenna");
+  });
+
+  it("re-parks `view` when the page Info parked it on is unpinned", async () => {
+    const user = userEvent.setup();
+    seed(FOUR);
+    render(<Mobile initialView="smith" />);
+    await swipeTo(3); // azimuth
+    await swipeTo(4); // Info, parked on azimuth
+    await openSheet(user);
+    await user.click(sheetRow("azimuth"));
+    expect(probe("index")).toBe("3"); // Info, one page earlier
+    expect(probe("view")).toBe("vswr"); // the new last chart page
+  });
+});
+
+// --- 4. Cap and floor (the sheet reuses togglePin, so it inherits both) ------
+
+describe("the sheet's disabled states", () => {
+  it(`refuses a ${PIN_CAP + 1}th page, on the row as well as the dot`, async () => {
+    const user = userEvent.setup();
+    seed(SIX);
+    render(<Mobile initialView="smith" />);
+    await openSheet(user);
+    const spare = ROSTER.filter((id) => !SIX.includes(id));
+    expect(spare.length).toBeGreaterThan(0); // the roster can overrun the cap
+    for (const id of spare) {
+      expect((sheetRow(id) as HTMLButtonElement).disabled).toBe(true);
+      expect(sheetRow(id).getAttribute("title")).toBe("Unpin a view first");
+      expect(dot(`Pin ${label(id)}`).disabled).toBe(true);
+      await user.click(sheetRow(id));
+    }
+    expect(probe("pages")).toBe([...SIX, "info"].join(","));
+  });
+
+  it("refuses to drop the last page", async () => {
+    const user = userEvent.setup();
+    seed(["gamma"]);
+    render(<Mobile initialView="gamma" />);
+    await openSheet(user);
+    expect((sheetRow("gamma") as HTMLButtonElement).disabled).toBe(true);
+    expect(sheetRow("gamma").getAttribute("title")).toBe("Keep at least one view pinned");
+    expect(dot(`Unpin ${label("gamma")}`).disabled).toBe(true);
+    await user.click(sheetRow("gamma"));
+    expect(probe("pages")).toBe("gamma,info");
+  });
+});
+
+// --- 5. NEW badges ----------------------------------------------------------
+
+describe("the sheet's NEW badges", () => {
+  it("announces unseen views and marks the roster seen on open", async () => {
+    const user = userEvent.setup();
+    const unseen: View[] = ["gamma", "vswr"];
+    seed(
+      TWO,
+      ROSTER.filter((id) => !unseen.includes(id)),
+    );
+    render(<Mobile initialView="smith" />);
+    await openSheet(user);
+    expect(screen.getAllByText("NEW").map((el) => el.parentElement?.textContent)).toEqual(
+      unseen.map((id) => `${label(id)}NEW`),
+    );
+    // Opening IS "you have now been shown the roster" — but the badges must
+    // survive the open that revealed them.
+    expect(JSON.parse(localStorage.getItem(VIEW_PREFS_KEY) ?? "{}").seen).toEqual(
+      expect.arrayContaining(ROSTER),
+    );
+    await openSheet(user); // close
+    await openSheet(user); // and back
+    expect(screen.queryByText("NEW")).toBeNull();
+  });
+});
+
+// --- 6. A view with no page (hard case 1) -----------------------------------
+
+describe("a `view` that is not pinned", () => {
+  it("snaps onto the first page rather than stranding on a pageless view", () => {
+    seed(FOUR);
+    // Stored prefs that do not include the view the session starts on — the
+    // carousel would otherwise sit on a page that has no dot.
+    render(<Mobile initialView="elevation" />);
+    expect(probe("view")).toBe("smith");
+    expect(probe("index")).toBe("0");
+  });
+
+  it("rescues a peek carried across the desktop → mobile breakpoint", async () => {
+    seed(FOUR);
+    // Desktop peek: `schematic` is active but unpinned, which is legal there
+    // (the rail shows every pin and the peek costs no slot).
+    const { rerender } = render(<Mobile isMobile={false} initialView="schematic" />);
+    expect(probe("view")).toBe("schematic");
+    await act(async () => {
+      rerender(<Mobile isMobile initialView="schematic" />);
+    });
+    expect(probe("view")).toBe("smith");
+    expect(probe("index")).toBe("0");
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/mobileCarousel.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/mobileCarousel.test.ts
@@ -1,0 +1,132 @@
+// The mobile carousel's index arithmetic, away from React (#700 unit 4).
+//
+// Both functions here answer the same question — "which page is the user on,
+// now that pages are `pinned ++ [Info]`?" — and every hard case of the unit is
+// a statement about one of them, so they are pinned as pure values rather than
+// inferred from a rendered carousel. jsdom has no layout and therefore no real
+// scroll-snap, which is the other half of the reason: the DOM cannot answer
+// "which page snapped" here at all. MobileCarousel.test.tsx drives the same
+// mappings through the hook with a stubbed scroll geometry.
+import { describe, it, expect } from "vitest";
+import { VIEW_META, mobileScreens, type View } from "../lib/view";
+import { reconcileCarousel } from "../components/session/useMobileCarousel";
+
+const ids = (pinned: View[]) => mobileScreens(pinned).map((s) => s.id);
+
+// Deliberately NOT registry order: pin order is page order, and a mapping that
+// quietly re-sorted into registry order would still pass a same-order fixture.
+const TWO: View[] = ["smith", "antenna"];
+const FOUR: View[] = ["smith", "antenna", "vswr", "azimuth"];
+const SIX: View[] = ["smith", "antenna", "vswr", "azimuth", "schematic", "gamma"];
+
+describe("mobileScreens", () => {
+  it.each([
+    ["2 pins", TWO],
+    ["4 pins", FOUR],
+    ["6 pins", SIX],
+  ])("pages %s in pin order with Info trailing", (_name, pinned) => {
+    expect(ids(pinned)).toEqual([...pinned, "info"]);
+    // Info is the LAST page at every pin count — its index is pinned.length,
+    // which is why nothing may compare against the registry's length.
+    expect(ids(pinned).indexOf("info")).toBe(pinned.length);
+  });
+
+  it("labels the chart pages from the registry", () => {
+    expect(mobileScreens(FOUR).map((s) => s.label)).toEqual([
+      ...FOUR.map((id) => VIEW_META[id].label),
+      "Info",
+    ]);
+  });
+
+  it("still has a page and a dot at the pin floor of one", () => {
+    expect(ids(["gamma"])).toEqual(["gamma", "info"]);
+  });
+});
+
+describe("reconcileCarousel", () => {
+  // Hard case 1: `view` has no page. Stored prefs changed under a parked
+  // `view`, or the desktop handed one over that it was peeking. index 0 is
+  // what a fresh mobile tree holds, so this reads as "snap to the first pin".
+  it("snaps a view with no page onto the first pinned page", () => {
+    expect(reconcileCarousel(FOUR, FOUR, 0, "elevation")).toEqual({
+      index: 0,
+      view: "smith",
+    });
+  });
+
+  // Hard case 2: the page under the thumb was unpinned from the open sheet.
+  it("holds the slot when the current page is unpinned, adopting its successor", () => {
+    const after: View[] = ["smith", "vswr", "azimuth"]; // antenna dropped
+    expect(reconcileCarousel(FOUR, after, 1, "antenna")).toEqual({
+      index: 1,
+      view: "vswr",
+    });
+  });
+
+  it("clamps when the unpinned page was the last one", () => {
+    const after: View[] = ["smith", "antenna", "vswr"]; // azimuth dropped
+    expect(reconcileCarousel(FOUR, after, 3, "azimuth")).toEqual({
+      index: 2,
+      view: "vswr",
+    });
+  });
+
+  it("lands on the only remaining page at the floor", () => {
+    expect(reconcileCarousel(TWO, ["antenna"], 0, "smith")).toEqual({
+      index: 0,
+      view: "antenna",
+    });
+  });
+
+  // Hard case 3: pinning appends, so the page under the thumb must not move.
+  it("leaves the current page exactly where it is when a pin is appended", () => {
+    const after: View[] = [...TWO, "schematic"];
+    expect(reconcileCarousel(TWO, after, 1, "antenna")).toEqual({
+      index: 1,
+      view: "antenna",
+    });
+  });
+
+  it("follows the current view when an EARLIER page is unpinned", () => {
+    const after: View[] = ["antenna", "vswr", "azimuth"]; // smith dropped
+    expect(reconcileCarousel(FOUR, after, 2, "vswr")).toEqual({
+      index: 1,
+      view: "vswr",
+    });
+  });
+
+  // Hard case 4: Info's index is pinned.length, so it moves with every pin —
+  // and a user parked there must stay parked, not get shunted onto a chart.
+  describe("parked on Info", () => {
+    it("follows Info to its new index when a pin is appended", () => {
+      const after: View[] = [...TWO, "schematic"];
+      expect(reconcileCarousel(TWO, after, 2, "antenna")).toEqual({
+        index: 3,
+        view: "antenna",
+      });
+    });
+
+    it("follows Info back when some other page is unpinned", () => {
+      const after: View[] = ["smith", "vswr", "azimuth"];
+      expect(reconcileCarousel(FOUR, after, 4, "azimuth")).toEqual({
+        index: 3,
+        view: "azimuth",
+      });
+    });
+
+    it("re-parks `view` on the last page when the parked one is unpinned", () => {
+      const after: View[] = ["smith", "antenna", "vswr"];
+      expect(reconcileCarousel(FOUR, after, 4, "azimuth")).toEqual({
+        index: 3,
+        view: "vswr",
+      });
+    });
+
+    it("keeps Info reachable at the floor of one pin", () => {
+      expect(reconcileCarousel(TWO, ["antenna"], 2, "smith")).toEqual({
+        index: 1,
+        view: "antenna",
+      });
+    });
+  });
+});

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -27,7 +27,7 @@ import {
   type SchemaItem,
   type SchemaParamSpec,
 } from "../../lib/params";
-import { MOBILE_SCREENS, type View } from "../../lib/view";
+import { mobileScreens, type View } from "../../lib/view";
 import type {
   MeasuredData,
   SolveRequest,
@@ -69,6 +69,7 @@ import {
 import { useCapabilities } from "./useCapabilities";
 import { useDesignCatalog } from "./useDesignCatalog";
 import { useGroundConfig } from "./useGroundConfig";
+import { MobileDots } from "./MobileDots";
 import { useMobileCarousel } from "./useMobileCarousel";
 import { useOptimizer } from "./useOptimizer";
 import { useSchematic } from "./useSchematic";
@@ -604,7 +605,11 @@ function DesignSessionBody({
     mobChartSize,
     onMobileCarouselScroll,
     goToMobileScreen,
-  } = useMobileCarousel({ isMobile, orientation, view, setView });
+  } = useMobileCarousel({ isMobile, orientation, pinned, view, setView });
+  // The carousel's pages: the pinned views in pin order plus the trailing Info
+  // screen. The dots row renders the SAME list, so a page can never exist
+  // without a dot (or the reverse) — see MobileDots.
+  const screens = useMemo(() => mobileScreens(pinned), [pinned]);
   // The pinned-pattern comparison table minimizes to a "{n} pinned" chip so
   // it can get off the chart — it grows a row per pin and swallows a phone
   // screen. Starts collapsed on mobile, expanded on desktop (the pre-existing
@@ -1437,8 +1442,10 @@ function DesignSessionBody({
     </>
   );
 
-  // Mobile: knobs pane + a 5-screen scroll-snap output carousel, instead of
-  // the desktop thumbstrip/HUD stage. A distinct tree (not CSS-hiding the
+  // Mobile: knobs pane + a scroll-snap output carousel over the PINNED views
+  // plus Info (#700 unit 4 — the roster lives behind the dots row's "⋯" sheet,
+  // as the rail's picker does on desktop), instead of the desktop
+  // thumbstrip/HUD stage. A distinct tree (not CSS-hiding the
   // desktop one) keeps both layouts honest; the shared pieces are exactly the
   // hoisted consts above. All hooks already ran, so branching here is safe.
   if (isMobile) {
@@ -1456,7 +1463,7 @@ function DesignSessionBody({
             ref={mobileCarouselRef}
             onScroll={onMobileCarouselScroll}
           >
-            {MOBILE_SCREENS.map((s) => (
+            {screens.map((s) => (
               <div
                 key={s.id}
                 className={`mobile-screen${s.id === "info" ? " mobile-screen-info" : ""}`}
@@ -1490,18 +1497,16 @@ function DesignSessionBody({
               </div>
             ))}
           </div>
-          <div className="mobile-dots" aria-label="Output screens">
-            {MOBILE_SCREENS.map((s, i) => (
-              <button
-                key={s.id}
-                type="button"
-                className={i === mobileIndex ? "active" : ""}
-                aria-label={`Show ${s.label}`}
-                title={s.label}
-                onClick={() => goToMobileScreen(i)}
-              />
-            ))}
-          </div>
+          <MobileDots
+            screens={screens}
+            index={mobileIndex}
+            goToScreen={goToMobileScreen}
+            view={view}
+            pinned={pinned}
+            newIds={newIds}
+            togglePin={toggleViewPin}
+            markRosterSeen={markRosterSeen}
+          />
         </section>
       </div>
     );

--- a/src/antennaknobs/web/frontend/src/components/session/MobileDots.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/MobileDots.tsx
@@ -1,0 +1,55 @@
+import { type MobileScreen, type View } from "../../lib/view";
+import { ViewSheet } from "./ViewPicker";
+
+// The mobile carousel's page indicator: one dot per screen — the user's pinned
+// views in pin order plus the trailing Info page (#700 unit 4) — followed by
+// the "⋯" overflow affordance that opens the roster as a bottom sheet.
+//
+// Its own component (rather than inline in DesignSession's mobile branch) so
+// the dot-count ↔ page-count contract is testable without mounting a whole
+// session: an extra or missing dot is precisely how a bad index mapping shows
+// itself. `screens` comes from the caller because the carousel tree renders
+// the very same list — one derivation, two consumers, no way to disagree.
+export function MobileDots({
+  screens,
+  index,
+  goToScreen,
+  view,
+  pinned,
+  newIds,
+  togglePin,
+  markRosterSeen,
+}: {
+  screens: MobileScreen[];
+  index: number;
+  goToScreen: (i: number) => void;
+  view: View;
+  pinned: View[];
+  newIds: Set<View>;
+  togglePin: (v: View) => void;
+  markRosterSeen: () => void;
+}) {
+  return (
+    <div className="mobile-dots" aria-label="Output screens">
+      {screens.map((s, i) => (
+        <button
+          key={s.id}
+          type="button"
+          className={i === index ? "active" : ""}
+          aria-label={`Show ${s.label}`}
+          title={s.label}
+          onClick={() => goToScreen(i)}
+        />
+      ))}
+      {/* Not a dot: it addresses no page, it changes WHICH pages exist. It
+          rides this row anyway because the dots are the page set. */}
+      <ViewSheet
+        view={view}
+        pinned={pinned}
+        newIds={newIds}
+        togglePin={togglePin}
+        markRosterSeen={markRosterSeen}
+      />
+    </div>
+  );
+}

--- a/src/antennaknobs/web/frontend/src/components/session/ViewPicker.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/ViewPicker.tsx
@@ -2,6 +2,77 @@ import { useRef, useState } from "react";
 import { VIEWS, type View } from "../../lib/view";
 import { PIN_CAP, pinBlockedReason } from "./useViewPrefs";
 
+// The roster listing both containers share: same rows, same pin dots, same
+// NEW badges, whole registry in registry order. Only the NAME button's gesture
+// differs between them, which is what `onRowClick`/`rowBlocked` parameterize.
+//
+// `rowBlocked` is undefined on desktop, where a row is always clickable (it
+// shows a view, and showing can't be refused). Undefined props render as
+// absent attributes, so the popover's DOM is byte-identical to what it was
+// before the sheet existed — the picker tests pin that.
+function ViewRosterRows({
+  view,
+  pinned,
+  badged,
+  onRowClick,
+  togglePin,
+  rowBlocked,
+}: {
+  view: View;
+  pinned: View[];
+  badged: Set<View>;
+  onRowClick: (v: View) => void;
+  togglePin: (v: View) => void;
+  rowBlocked?: (v: View) => string | null;
+}) {
+  return (
+    <>
+      {VIEWS.map((v) => {
+        const isPinned = pinned.includes(v.id);
+        const blocked = pinBlockedReason(pinned, v.id);
+        const rowStop = rowBlocked ? rowBlocked(v.id) : null;
+        return (
+          <div
+            key={v.id}
+            className={`view-picker-row${isPinned ? " pinned" : " unpinned"}${
+              v.id === view ? " active" : ""
+            }`}
+          >
+            <button
+              type="button"
+              className="view-picker-name"
+              role="menuitem"
+              aria-current={v.id === view}
+              disabled={rowBlocked ? rowStop !== null : undefined}
+              title={rowBlocked ? (rowStop ?? undefined) : undefined}
+              onClick={() => onRowClick(v.id)}
+            >
+              <span>{v.label}</span>
+              {badged.has(v.id) && <span className="view-picker-new">NEW</span>}
+            </button>
+            <button
+              type="button"
+              className="view-picker-dot"
+              aria-pressed={isPinned}
+              disabled={blocked !== null}
+              title={
+                blocked ??
+                (isPinned
+                  ? `Unpin ${v.label} from the rail`
+                  : `Pin ${v.label} to the rail`)
+              }
+              aria-label={isPinned ? `Unpin ${v.label}` : `Pin ${v.label}`}
+              onClick={() => togglePin(v.id)}
+            >
+              <span />
+            </button>
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
 // The overflow affordance: a fixed-height "All views ⌄ +N" button at the foot
 // of the thumbstrip opening a popover over the WHOLE roster in registry order
 // (unit 2 of docs/plan-view-rail-scaling.md). Two gestures per row, on purpose:
@@ -87,52 +158,16 @@ export function ViewPicker({
             role="menu"
             style={{ left: anchor.left, bottom: anchor.bottom }}
           >
-            {VIEWS.map((v) => {
-              const isPinned = pinned.includes(v.id);
-              const blocked = pinBlockedReason(pinned, v.id);
-              return (
-                <div
-                  key={v.id}
-                  className={`view-picker-row${isPinned ? " pinned" : " unpinned"}${
-                    v.id === view ? " active" : ""
-                  }`}
-                >
-                  <button
-                    type="button"
-                    className="view-picker-name"
-                    role="menuitem"
-                    aria-current={v.id === view}
-                    onClick={() => {
-                      setView(v.id);
-                      setOpen(false);
-                    }}
-                  >
-                    <span>{v.label}</span>
-                    {badged.has(v.id) && (
-                      <span className="view-picker-new">NEW</span>
-                    )}
-                  </button>
-                  <button
-                    type="button"
-                    className="view-picker-dot"
-                    aria-pressed={isPinned}
-                    disabled={blocked !== null}
-                    title={
-                      blocked ??
-                      (isPinned
-                        ? `Unpin ${v.label} from the rail`
-                        : `Pin ${v.label} to the rail`)
-                    }
-                    aria-label={
-                      isPinned ? `Unpin ${v.label}` : `Pin ${v.label}`
-                    }
-                    onClick={() => togglePin(v.id)}
-                  >
-                    <span />
-                  </button>
-                </div>
-              );
-            })}
+            <ViewRosterRows
+              view={view}
+              pinned={pinned}
+              badged={badged}
+              togglePin={togglePin}
+              onRowClick={(v) => {
+                setView(v);
+                setOpen(false);
+              }}
+            />
             <div className="view-picker-note">
               Row = show · dot = keep in rail · max {PIN_CAP} pinned
             </div>
@@ -140,5 +175,85 @@ export function ViewPicker({
         </>
       )}
     </div>
+  );
+}
+
+// The mobile half of the same affordance (#700 unit 4): a "⋯" button riding
+// the dots row that opens the SAME roster as a bottom sheet. It renders its
+// own trigger, exactly as ViewPicker does, so opening — and therefore marking
+// the roster seen and snapshotting the NEW badges — has one implementation.
+//
+// The row gesture is the one real difference: here a row tap PINS/unpins,
+// like the desktop pin dot, and there is NO peek. A peeked page would be a
+// carousel page with no pin behind it, breaking the "pages = pinned + Info"
+// mapping (and every index compare in useMobileCarousel) for one gesture's
+// worth of convenience — the plan spells this out. So both row and dot toggle,
+// and both are inert for the same reason at the cap and at the floor of one.
+export function ViewSheet({
+  view,
+  pinned,
+  newIds,
+  togglePin,
+  markRosterSeen,
+}: {
+  view: View;
+  pinned: View[];
+  newIds: Set<View>;
+  togglePin: (v: View) => void;
+  markRosterSeen: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  // Snapshotted as the sheet opens, for the same reason as the popover's:
+  // opening is what marks the roster seen, so live `newIds` would blank every
+  // badge in the frame the user opened the sheet to read them.
+  const [badged, setBadged] = useState<Set<View>>(new Set());
+
+  const toggleOpen = () => {
+    setOpen((was) => {
+      if (!was) {
+        setBadged(new Set(newIds));
+        markRosterSeen();
+      }
+      return !was;
+    });
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        className="mobile-dots-more"
+        onClick={toggleOpen}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="All views"
+        title="Every output view — tap one to add or remove its page"
+      >
+        ⋯
+      </button>
+      {open && (
+        <>
+          <div className="view-sheet-backdrop" onClick={() => setOpen(false)} />
+          {/* No anchor measurement, unlike the popover: the sheet is pinned to
+              the viewport's bottom edge, which is also the only place a phone
+              can put a list this tall within thumb reach. */}
+          <div className="view-sheet" role="menu" aria-label="All views">
+            <ViewRosterRows
+              view={view}
+              pinned={pinned}
+              badged={badged}
+              togglePin={togglePin}
+              // Curating is a run of gestures — the sheet does NOT close on a
+              // tap, so several pages can be added or dropped in one visit.
+              onRowClick={togglePin}
+              rowBlocked={(id) => pinBlockedReason(pinned, id)}
+            />
+            <div className="view-picker-note">
+              Tap a view to add or remove its page · max {PIN_CAP} pages
+            </div>
+          </div>
+        </>
+      )}
+    </>
   );
 }

--- a/src/antennaknobs/web/frontend/src/components/session/useMobileCarousel.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useMobileCarousel.ts
@@ -1,34 +1,82 @@
 import { useEffect, useRef, useState } from "react";
-import { VIEWS, type View } from "../../lib/view";
+import { type View } from "../../lib/view";
 import { useSlideSize } from "../hooks";
 
-// The mobile output carousel's state, refs and the two effects that keep the
-// DOM scroll position and `view` in agreement (#642 seam 5b-3). Lifted whole
-// out of DesignSession so the cluster's internal hook order is preserved
-// exactly; the caller keeps `view`/`setView` because the desktop tree and the
-// arrow-key cycler share them.
+// Where the carousel must sit after the PINNED list changed under it — the one
+// piece of index arithmetic worth having outside React, because every hard
+// case of #700 unit 4 is a statement about this function. `prevPinned` is the
+// list `index` was measured against; `pinned` is the new one (never empty —
+// useViewPrefs enforces a floor of one pin).
+//
+// Pages are `pinned ++ [Info]`, so:
+//   - Info is index `pinned.length` and MOVES with every pin/unpin;
+//   - a chart page is `pinned[index]`, so `view` and `index` must agree or the
+//     dots point at a page the user is not looking at.
+export function reconcileCarousel(
+  prevPinned: View[],
+  pinned: View[],
+  index: number,
+  view: View,
+): { index: number; view: View } {
+  if (index >= prevPinned.length) {
+    // Parked on Info (or past where Info used to be, after a shrink). Info
+    // keeps the user: it is the page they chose. `view` stays parked on a
+    // chart page and only needs rescuing if THAT page was just unpinned.
+    return {
+      index: pinned.length,
+      view: pinned.includes(view) ? view : pinned[pinned.length - 1],
+    };
+  }
+  const at = pinned.indexOf(view);
+  // The page under the thumb survived. Follow it rather than the old index:
+  // pinning appends, so this is a no-op for the common case (no visible jump),
+  // and it stays correct if a future reorder lands.
+  if (at >= 0) return { index: at, view };
+  // The page under the thumb was just unpinned. Hold the SLOT and adopt
+  // whatever slid into it — clamped, because unpinning the last chart page
+  // leaves the old index one past the end of the new list.
+  const i = Math.min(index, pinned.length - 1);
+  return { index: i, view: pinned[i] };
+}
+
+// The mobile output carousel's state, refs and the effects that keep the DOM
+// scroll position and `view` in agreement (#642 seam 5b-3). Lifted whole out of
+// DesignSession so the cluster's internal hook order is preserved exactly; the
+// caller keeps `view`/`setView` because the desktop tree and the arrow-key
+// cycler share them.
 //
 // `compareCollapsed` deliberately stays behind in DesignSession: its
 // `useState(isMobile)` initializer has to run after `useIsMobile()` there.
 export function useMobileCarousel({
   isMobile,
   orientation,
+  pinned,
   view,
   setView,
 }: {
   isMobile: boolean;
   orientation: "portrait" | "landscape";
+  // The pinned views (useViewPrefs) — the carousel's page list, in pin order.
+  // Every index compare below is against THIS, not the registry: an unpinned
+  // view has no page, so a VIEWS-based bound would map a swipe onto a view the
+  // carousel never rendered (#700 unit 4).
+  pinned: View[];
   view: View;
   setView: (v: View) => void;
 }) {
   // Mobile output carousel (all hooks unconditional — desktop leaves them
-  // inert). mobileIndex is which of the 5 screens the snap carousel rests on;
-  // `view` stays the source of truth for the 4 chart screens and their data
-  // effects, kept in sync by the scroll handler / reverse-sync effect below.
+  // inert). mobileIndex is which screen the snap carousel rests on — there are
+  // `pinned.length + 1` of them; `view` stays the source of truth for the
+  // chart screens and their data effects, kept in sync by the scroll handler /
+  // reverse-sync effect below.
   const [mobileIndex, setMobileIndex] = useState(0);
   const mobileCarouselRef = useRef<HTMLDivElement>(null);
   const mobileScrollRafRef = useRef<number | null>(null);
   const { ref: mobRef, size: mobChartSize } = useSlideSize(720, isMobile);
+  // The pinned list `mobileIndex` was last valid against. null while the
+  // desktop tree is up, so entering mobile always re-reconciles: a desktop
+  // peek leaves `view` unpinned, and an unpinned view has no page here.
+  const prevPinnedRef = useRef<View[] | null>(null);
 
   // Track where a swipe/fling snaps and mirror it into state. rAF-throttled:
   // scroll events arrive per frame during a fling, one rounding per frame is
@@ -42,7 +90,7 @@ export function useMobileCarousel({
       if (!el || el.clientWidth === 0) return;
       const i = Math.round(el.scrollLeft / el.clientWidth);
       setMobileIndex((prev) => (prev === i ? prev : i));
-      if (i < VIEWS.length) setView(VIEWS[i].id);
+      if (i < pinned.length) setView(pinned[i]);
     });
   };
 
@@ -50,10 +98,38 @@ export function useMobileCarousel({
   // and by swipe — it deliberately leaves `view` on the last chart screen.
   const goToMobileScreen = (i: number) => {
     setMobileIndex(i);
-    if (i < VIEWS.length) setView(VIEWS[i].id);
+    if (i < pinned.length) setView(pinned[i]);
     const el = mobileCarouselRef.current;
     if (el) el.scrollTo({ left: i * el.clientWidth, behavior: "smooth" });
   };
+
+  // The page list changed under us (the picker sheet pinned or unpinned
+  // something), or we just arrived from a desktop tree holding an unpinned
+  // view. Either way the (index, view) pair can name a page that no longer
+  // exists; reconcileCarousel says where it goes. Declared BEFORE the
+  // reverse-sync effect so that effect's stale `view` closure finds no target
+  // and stands down for one commit rather than paging somewhere else first.
+  useEffect(() => {
+    if (!isMobile) {
+      prevPinnedRef.current = null;
+      return;
+    }
+    const prev = prevPinnedRef.current;
+    prevPinnedRef.current = pinned;
+    // Same list AND a view that has a page: nothing to fix here, and
+    // re-deriving would fight whatever the swipe/arrow paths just did.
+    if (prev === pinned && pinned.includes(view)) return;
+    const next = reconcileCarousel(prev ?? pinned, pinned, mobileIndex, view);
+    if (next.view !== view) setView(next.view);
+    if (next.index !== mobileIndex) setMobileIndex(next.index);
+    const el = mobileCarouselRef.current;
+    if (!el || el.clientWidth === 0) return;
+    // Only when the DOM actually sits elsewhere: pinning appends a page
+    // without moving the current one, and a scrollTo there is a visible jump.
+    if (Math.round(el.scrollLeft / el.clientWidth) !== next.index) {
+      el.scrollTo({ left: next.index * el.clientWidth, behavior: "smooth" });
+    }
+  }, [isMobile, pinned, view, mobileIndex, setView]);
 
   // Reverse sync: anything else that sets `view` (the arrow-key cycler) pages
   // the carousel to match. The DOM scroll position is the ground truth for
@@ -63,12 +139,12 @@ export function useMobileCarousel({
     if (!isMobile) return;
     const el = mobileCarouselRef.current;
     if (!el || el.clientWidth === 0) return;
-    const target = VIEWS.findIndex((v) => v.id === view);
+    const target = pinned.indexOf(view);
     const current = Math.round(el.scrollLeft / el.clientWidth);
-    if (target < 0 || current >= VIEWS.length || current === target) return;
+    if (target < 0 || current >= pinned.length || current === target) return;
     setMobileIndex(target);
     el.scrollTo({ left: target * el.clientWidth, behavior: "smooth" });
-  }, [view, isMobile]);
+  }, [view, isMobile, pinned]);
 
   // An orientation flip (or any pane resize) changes the screen width, so
   // scrollLeft no longer sits on a snap point; re-center the active screen

--- a/src/antennaknobs/web/frontend/src/lib/view.ts
+++ b/src/antennaknobs/web/frontend/src/lib/view.ts
@@ -39,15 +39,23 @@ export const VIEW_META = Object.fromEntries(
   VIEWS.map((v) => [v.id, v]),
 ) as Record<View, ViewMeta>;
 
-// The mobile output carousel's screens: the 5 chart views plus a dedicated
-// Info screen for the solve readout (which floats as a HUD on desktop but
-// deserves its own page on a phone). "info" stays out of the `View` union on
-// purpose — `view` (and every data effect keyed on it) only ever holds a
-// chart view; the Info screen leaves `view` parked on the last chart.
-export const MOBILE_SCREENS: { id: View | "info"; label: string }[] = [
-  ...VIEWS,
-  { id: "info", label: "Info" },
-];
+export type MobileScreen = { id: View | "info"; label: string };
+
+// The mobile output carousel's screens: the user's PINNED views, in pin order,
+// plus a dedicated Info screen for the solve readout (which floats as a HUD on
+// desktop but deserves its own page on a phone). "info" stays out of the
+// `View` union on purpose — `view` (and every data effect keyed on it) only
+// ever holds a chart view; the Info screen leaves `view` parked on the last
+// chart.
+//
+// Pinned, not the registry (#700 unit 4, docs/plan-view-rail-scaling.md): the
+// carousel index maps onto `pinned`, so an unpinned view has no page and no
+// dot, and the roster can grow past what a thumb-swipe stack can carry. Info
+// is always the TRAILING page, so its index moves with every pin — every
+// index compare in useMobileCarousel is against pinned.length for that reason.
+export function mobileScreens(pinned: View[]): MobileScreen[] {
+  return [...pinned.map((id) => VIEW_META[id]), { id: "info", label: "Info" }];
+}
 
 // Antenna-canvas camera projections. Pick two world axes to map to canvas
 // (horizontal, vertical) and project. The hidden axis is the camera ray.

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -2906,6 +2906,64 @@ canvas {
   opacity: 1;
 }
 
+/* The overflow affordance at the end of the dots row (#700 unit 4). It is not
+   a page — it changes which pages exist — so it suppresses the dot pseudo and
+   draws its own glyph. */
+.mobile-dots-more::before {
+  display: none;
+}
+
+.mobile-dots-more {
+  color: var(--muted);
+  font-size: var(--text-base);
+  line-height: 1;
+}
+
+/* Dimmed, unlike the desktop picker's transparent catcher: the sheet covers
+   the bottom of the screen rather than sitting beside its button, so the
+   backdrop has to read as "this layer is above the carousel". */
+.view-sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: var(--shadow);
+}
+
+/* Bottom sheet: the phone form of the same roster popover. Full width and
+   pinned to the bottom edge — the only place a list this tall is in thumb
+   reach — and capped so the carousel stays visible behind it. */
+.view-sheet {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 41;
+  max-height: 70vh;
+  overflow-y: auto;
+  padding: var(--space-2) var(--space-3) var(--space-5);
+  background: var(--bg);
+  border-top: 1px solid var(--border-control);
+  border-radius: var(--r-md) var(--r-md) 0 0;
+  box-shadow: 0 -6px 20px var(--shadow-strong);
+}
+
+/* Touch-sized rows (cf. the coarse-pointer block below): the popover's 24 px
+   dot and tight row padding are mouse dimensions. */
+.view-sheet .view-picker-name {
+  padding: var(--space-4) var(--space-3);
+  font-size: var(--text-base);
+}
+
+.view-sheet .view-picker-dot {
+  width: 40px;
+  height: 40px;
+}
+
+.view-sheet .view-picker-name:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
 /* The solve overlays are shared with the desktop stage. Most are absolutely
    positioned and just work inside .mobile-output; .solve-error is a flow
    child on desktop, so float it over the carousel here. */


### PR DESCRIPTION
Unit 4 of the #700 stacked arc, stacked onto `issue-700-view-rail` (rebased over the S11-dB amendment).

## Summary
- Carousel pages = **pinned + Info**: `MOBILE_SCREens` → `mobileScreens(pinned)` (Info stays the trailing page and out of the `View` union); every index bound in `useMobileCarousel` is now against `pinned`, not the registry.
- `reconcileCarousel(prevPinned, pinned, index, view)` — the list-changed-under-us decision as an exported pure function: Info keeps the user (re-parking `view` only if its parked page was unpinned); a surviving page follows `view` (pinning appends without a visible jump); an unpinned current page holds the slot, clamped, and adopts what slid in. Entering mobile always re-reconciles, which rescues a desktop peek.
- `ViewPicker` split: shared `ViewRosterRows` + desktop popover (DOM byte-identical — undefined-prop attributes verified) + new `ViewSheet` bottom sheet behind the dots row's trailing "⋯" (`MobileDots`, extracted so dot-count ↔ page-count is testable). Sheet row tap **pins** — no peek on mobile, commented why; cap/floor disable the row and the dot.
- Desktop stage tree untouched; `useViewPrefs`/`useViewState` unmodified.

## Gates (measured)
- Suite: 30 files / **510 tests** green post-rebase (baseline 470 unedited + 40 new: pure reconcile/mapping tests at 2/4/6 pins, sheet behavior, Info semantics, desktop→mobile flip).
- `npm run build` green.
- Mutation probes: builder — VIEWS-based scroll-handler bound (6 failures), unclamped index on unpin-current (2 failures); reviewer — Info index frozen to the stale list length (6 failures). All reverted.

## Review notes
- Built by an opus subagent (delegated-build; one watchdog stall, resumed cleanly). Reviewed by the session model: full diff read, `reconcileCarousel` cases re-derived independently (desktop-peek, unpin-current-last, Info-parked), gates re-run post-rebase, independent mutation probe.
- Builder flagged for a future issue: at the pin cap, mobile has no way to *look at* an unpinned view without unpinning something (the plan's explicit no-peek choice) — the one place mobile is weaker than desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01522PMkNyJbRX772WV5DwaA