### PR TITLE
Unit 3: grid layout mode for the desktop stage (#700)

### DIFF
--- a/src/antennaknobs/web/frontend/src/__tests__/LayoutModeToggle.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/LayoutModeToggle.test.tsx
@@ -1,0 +1,39 @@
+// The rail/grid segmented control (unit 3, docs/plan-view-rail-scaling.md).
+// Placement (desktop only, stage top-right) is DesignSession's job, not
+// this component's — see the placement check in
+// gridLayoutPlacement.test.ts for why that's tested structurally rather
+// than by mounting this component through DesignSession.
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LayoutModeToggle } from "../components/results/StageOverlays";
+
+describe("LayoutModeToggle", () => {
+  it("marks rail active when layout is rail", () => {
+    render(<LayoutModeToggle layout="rail" setLayout={vi.fn()} />);
+    expect(screen.getByTitle(/^Rail:/).className).toContain("active");
+    expect(screen.getByTitle(/^Grid:/).className).not.toContain("active");
+  });
+
+  it("marks grid active when layout is grid", () => {
+    render(<LayoutModeToggle layout="grid" setLayout={vi.fn()} />);
+    expect(screen.getByTitle(/^Grid:/).className).toContain("active");
+    expect(screen.getByTitle(/^Rail:/).className).not.toContain("active");
+  });
+
+  it("calls setLayout('grid') from rail", async () => {
+    const user = userEvent.setup();
+    const setLayout = vi.fn();
+    render(<LayoutModeToggle layout="rail" setLayout={setLayout} />);
+    await user.click(screen.getByTitle(/^Grid:/));
+    expect(setLayout).toHaveBeenCalledWith("grid");
+  });
+
+  it("calls setLayout('rail') from grid", async () => {
+    const user = userEvent.setup();
+    const setLayout = vi.fn();
+    render(<LayoutModeToggle layout="grid" setLayout={setLayout} />);
+    await user.click(screen.getByTitle(/^Rail:/));
+    expect(setLayout).toHaveBeenCalledWith("rail");
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/ViewGrid.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/ViewGrid.test.tsx
@@ -1,0 +1,136 @@
+// The grid-mode stage's presentational component (unit 3, docs/plan-view-
+// rail-scaling.md). Decoupled from DesignSession's solve/session state on
+// purpose (see ViewGrid.tsx's own comment) so it can be mounted directly
+// instead of needing the fetch/WebSocket harness a real DesignSession mount
+// would — matching this suite's existing precedent of testing pieces PULLED
+// OUT of DesignSession (SolveOverlays.test.tsx, ViewPicker.test.tsx) rather
+// than the monolith itself.
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createRef } from "react";
+import { VIEW_META, type View } from "../lib/view";
+import { ViewGrid } from "../components/results/ViewGrid";
+
+const cellsOf = (ids: View[]) => ids.map((id) => VIEW_META[id]);
+
+function renderGrid(overrides: Partial<Parameters<typeof ViewGrid>[0]> = {}) {
+  const setView = vi.fn();
+  const onMaximize = vi.fn();
+  const renderCell = vi.fn((v: View, size: number) => (
+    <div data-testid={`cell-content-${v}`}>{`${v}@${size}`}</div>
+  ));
+  const props = {
+    gridRef: createRef<HTMLDivElement>(),
+    cells: cellsOf(["antenna", "azimuth", "elevation", "smith"]),
+    view: "antenna" as View,
+    setView,
+    onMaximize,
+    cellSize: 240,
+    rows: 2,
+    cols: 2,
+    renderCell,
+    ...overrides,
+  };
+  const view = render(<ViewGrid {...props} />);
+  return { ...view, setView, onMaximize, renderCell, props };
+}
+
+// --- 1. Cell order and shape ------------------------------------------------
+
+describe("cell order and shape", () => {
+  // Mutation probe 4(a) target: reversing (or otherwise reordering) the
+  // `cells` prop before it reaches ViewGrid must fail this.
+  it("renders cells in exactly the given (pin) order", () => {
+    renderGrid({ cells: cellsOf(["smith", "antenna", "azimuth"]), rows: 2, cols: 2 });
+    const ids = screen
+      .getAllByRole("button", { name: /^Focus / })
+      .map((el) => el.getAttribute("aria-label"));
+    expect(ids).toEqual(["Focus Smith", "Focus Antenna", "Focus Azimuth (xy)"]);
+  });
+
+  it("1x2 for two pins: two cells, no hint", () => {
+    renderGrid({ cells: cellsOf(["antenna", "azimuth"]), rows: 1, cols: 2 });
+    expect(screen.getAllByRole("button", { name: /^Focus / })).toHaveLength(2);
+    expect(screen.queryByText("Pin a 4th view")).toBeNull();
+  });
+
+  it("2x2 for four pins: four cells, no hint", () => {
+    renderGrid({ cells: cellsOf(["antenna", "azimuth", "elevation", "smith"]), rows: 2, cols: 2 });
+    expect(screen.getAllByRole("button", { name: /^Focus / })).toHaveLength(4);
+    expect(screen.queryByText("Pin a 4th view")).toBeNull();
+  });
+
+  it("2x2 with a hint cell for three pins", () => {
+    renderGrid({ cells: cellsOf(["antenna", "azimuth", "elevation"]), rows: 2, cols: 2 });
+    expect(screen.getAllByRole("button", { name: /^Focus / })).toHaveLength(3);
+    expect(screen.getByText("Pin a 4th view")).not.toBeNull();
+  });
+
+  it("one full cell for a single pin", () => {
+    renderGrid({ cells: cellsOf(["antenna"]), rows: 1, cols: 1 });
+    expect(screen.getAllByRole("button", { name: /^Focus / })).toHaveLength(1);
+  });
+
+  it("sets the grid-template from rows/cols", () => {
+    const { container } = renderGrid({ rows: 2, cols: 2 });
+    const grid = container.querySelector(".view-grid") as HTMLElement;
+    expect(grid.style.gridTemplateColumns).toBe("repeat(2, 1fr)");
+    expect(grid.style.gridTemplateRows).toBe("repeat(2, 1fr)");
+  });
+
+  it("passes cellSize through to renderCell", () => {
+    const { renderCell } = renderGrid({ cellSize: 333 });
+    expect(renderCell).toHaveBeenCalledWith("antenna", 333);
+  });
+});
+
+// --- 2. Focus ring -----------------------------------------------------------
+
+describe("focus ring", () => {
+  it("marks the cell matching `view` and no other", () => {
+    const { container } = renderGrid({ view: "elevation" });
+    const focused = container.querySelectorAll(".grid-cell-focus");
+    expect(focused).toHaveLength(1);
+    expect(focused[0].querySelector(".grid-cell-maximize")?.getAttribute("title")).toBe(
+      "Maximize Elevation (yz)",
+    );
+  });
+});
+
+// --- 3. Click vs. maximize ----------------------------------------------------
+
+describe("cell click vs. maximize", () => {
+  it("clicking a cell body focuses it without maximizing", async () => {
+    const user = userEvent.setup();
+    const { setView, onMaximize } = renderGrid();
+    await user.click(screen.getByTestId("cell-content-azimuth"));
+    expect(setView).toHaveBeenCalledWith("azimuth");
+    expect(onMaximize).not.toHaveBeenCalled();
+  });
+
+  it("clicking the maximize glyph maximizes without also focusing", async () => {
+    const user = userEvent.setup();
+    const { setView, onMaximize } = renderGrid();
+    await user.click(screen.getByTitle("Maximize Smith"));
+    expect(onMaximize).toHaveBeenCalledWith("smith");
+    expect(setView).not.toHaveBeenCalled();
+  });
+
+  it("double-clicking a cell body maximizes it", async () => {
+    const user = userEvent.setup();
+    const { onMaximize } = renderGrid();
+    await user.dblClick(screen.getByTestId("cell-content-elevation"));
+    expect(onMaximize).toHaveBeenCalledWith("elevation");
+  });
+});
+
+// --- 4. The HUD never renders per-cell ---------------------------------------
+
+describe("solve-readout HUD", () => {
+  it("is never rendered by ViewGrid itself (unit 3 renders it once, at the stage level)", () => {
+    const { container } = renderGrid();
+    expect(container.querySelectorAll(".stage-readout")).toHaveLength(0);
+    expect(container.querySelectorAll(".readout")).toHaveLength(0);
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/gridLayoutPlacement.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/gridLayoutPlacement.test.ts
@@ -1,0 +1,57 @@
+// Two unit-3 placement facts about DesignSession.tsx (docs/plan-view-rail-
+// scaling.md "Layout modes") that a behavioral test can't reach cheaply:
+// the segmented control is desktop-only, and the grid-mode HUD renders once
+// at the stage level rather than per cell.
+//
+// DesignSession.tsx is the one component this whole test suite never mounts
+// directly — see every other file here testing a piece PULLED OUT of it
+// instead (SolveOverlays.test.tsx, ViewPicker.test.tsx, StageOverlays'
+// LayoutModeToggle.test.tsx, ViewGrid.test.tsx). It owns a WebSocket, a
+// fetch-backed catalog, a capabilities gate and more; building that harness
+// to check two placement facts would cost far more than the facts are
+// worth. So this is a structural check instead: it slices the file's own
+// source at the two branch boundaries the code already documents in its own
+// comments ("if (isMobile) {" and the desktop return's `.stage` element,
+// both read verbatim, not by line number) and asserts on what appears in
+// each slice.
+//
+// Source pulled in via Vite's `?raw` (a string import, no bundling) rather
+// than node:fs — this project has no Node type references at all (browser-
+// only code throughout), and one `?raw` import is a smaller footprint than
+// adding one.
+/// <reference types="vite/client" />
+import { describe, it, expect } from "vitest";
+import designSessionSrc from "../components/session/DesignSession.tsx?raw";
+import viewGridSrc from "../components/results/ViewGrid.tsx?raw";
+
+const SRC = designSessionSrc;
+
+const mobileStart = SRC.indexOf("if (isMobile) {");
+const stageStart = SRC.indexOf('className="stage"');
+
+describe("DesignSession's mobile/desktop branch split", () => {
+  it("has both anchors, in the expected order (sanity: this test isn't vacuous)", () => {
+    expect(mobileStart).toBeGreaterThan(-1);
+    expect(stageStart).toBeGreaterThan(mobileStart);
+  });
+
+  const mobileBranch = SRC.slice(mobileStart, stageStart);
+  const desktopBranch = SRC.slice(stageStart);
+
+  it("never renders the layout segmented control in the mobile branch", () => {
+    expect(mobileBranch).not.toContain("LayoutModeToggle");
+  });
+
+  it("renders the layout segmented control in the desktop branch", () => {
+    expect(desktopBranch).toContain("LayoutModeToggle");
+  });
+
+  it("renders the solve-readout HUD exactly three times: mobile Info screen, rail's primary slide, grid's stage level — never per grid cell", () => {
+    const count = (SRC.match(/<SolveReadout/g) ?? []).length;
+    expect(count).toBe(3);
+  });
+
+  it("never imports SolveReadout into the (per-cell) ViewGrid component", () => {
+    expect(viewGridSrc).not.toContain("SolveReadout");
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/useViewPrefs.grid.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useViewPrefs.grid.test.tsx
@@ -1,0 +1,221 @@
+// Unit 3 of docs/plan-view-rail-scaling.md ("Layout modes"): the `layout`
+// field useViewPrefs.test.tsx's comments promised room for, plus the pure
+// grid-shape helpers (gridCells/gridShape/gridFix) that decide what grid
+// mode shows and how it recovers when the focus ring drifts off-grid.
+//
+// A separate file rather than additions to useViewPrefs.test.tsx: that file
+// is the pre-existing baseline this arc must keep passing UNEDITED (its
+// exact-keys assertion is what proves the sparse-write design below is
+// correct), so anything new lives here instead.
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { type View } from "../lib/view";
+import {
+  VIEW_PREFS_KEY,
+  gridCells,
+  gridFix,
+  gridShape,
+  useViewPrefs,
+} from "../components/session/useViewPrefs";
+
+const FOUNDING: View[] = ["antenna", "azimuth", "elevation", "smith"];
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+function stored() {
+  return JSON.parse(localStorage.getItem(VIEW_PREFS_KEY) ?? "null");
+}
+
+// --- 1. Defaults --------------------------------------------------------
+
+describe("layout defaults", () => {
+  it("is rail with no stored state", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.layout).toBe("rail");
+  });
+
+  it("writes nothing extra until setLayout is called", () => {
+    renderHook(() => useViewPrefs());
+    expect(localStorage.getItem(VIEW_PREFS_KEY)).toBeNull();
+  });
+});
+
+// --- 2. Persistence + sparse write --------------------------------------
+
+describe("layout persistence", () => {
+  it("round-trips a grid pick through storage to the next mount", () => {
+    const first = renderHook(() => useViewPrefs());
+    act(() => first.result.current.setLayout("grid"));
+    expect(first.result.current.layout).toBe("grid");
+    expect(stored().layout).toBe("grid");
+    first.unmount();
+
+    const second = renderHook(() => useViewPrefs());
+    expect(second.result.current.layout).toBe("grid");
+  });
+
+  it("round-trips back to rail too", () => {
+    const first = renderHook(() => useViewPrefs());
+    act(() => first.result.current.setLayout("grid"));
+    act(() => first.result.current.setLayout("rail"));
+    first.unmount();
+    const second = renderHook(() => useViewPrefs());
+    expect(second.result.current.layout).toBe("rail");
+  });
+
+  // The whole point of the sparse write (see useViewPrefs.ts's ViewPrefs
+  // comment): a pin/unpin that never touches layout must not grow the
+  // stored record's key set, or useViewPrefs.test.tsx's pre-unit-3
+  // exact-keys assertion (["pinned","seen"]) would break on THIS build even
+  // though that test file is untouched.
+  it("omits `layout` from storage while it is rail (togglePin only)", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.togglePin("schematic"));
+    const rec = stored();
+    expect(Object.keys(rec).sort()).toEqual(["pinned", "seen"]);
+  });
+
+  it("includes `layout` once it is grid, even from an unrelated pin toggle", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.setLayout("grid"));
+    act(() => result.current.togglePin("schematic"));
+    const rec = stored();
+    expect(Object.keys(rec).sort()).toEqual(["layout", "pinned", "seen"]);
+    expect(rec.layout).toBe("grid");
+  });
+
+  it("drops the key again on a return to rail", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.setLayout("grid"));
+    act(() => result.current.setLayout("rail"));
+    expect(Object.keys(stored()).sort()).toEqual(["pinned", "seen"]);
+  });
+});
+
+// --- 3. Corrupt / unknown values fall back to rail ----------------------
+
+describe("layout validation", () => {
+  const cases = [
+    ["absent", '{"pinned":["antenna"],"seen":["antenna"]}'],
+    ["wrong type", '{"pinned":["antenna"],"seen":["antenna"],"layout":3}'],
+    ["unknown string", '{"pinned":["antenna"],"seen":["antenna"],"layout":"list"}'],
+    ["null", '{"pinned":["antenna"],"seen":["antenna"],"layout":null}'],
+  ] as const;
+
+  for (const [what, raw] of cases) {
+    it(`falls back to rail on a ${what} layout field`, () => {
+      localStorage.setItem(VIEW_PREFS_KEY, raw);
+      const { result } = renderHook(() => useViewPrefs());
+      expect(result.current.layout).toBe("rail");
+    });
+  }
+
+  it("still recovers the good pinned/seen fields alongside a bad layout", () => {
+    localStorage.setItem(
+      VIEW_PREFS_KEY,
+      '{"pinned":["smith"],"seen":["smith"],"layout":"bogus"}',
+    );
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.pinned).toEqual(["smith"]);
+    expect(result.current.layout).toBe("rail");
+  });
+
+  it("honours a stored grid value", () => {
+    localStorage.setItem(
+      VIEW_PREFS_KEY,
+      '{"pinned":["smith"],"seen":["smith"],"layout":"grid"}',
+    );
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.layout).toBe("grid");
+  });
+});
+
+// --- 4. gridCells / gridShape --------------------------------------------
+
+describe("gridCells", () => {
+  it("shows the first ≤4 pins, in pin order — mutation target: order", () => {
+    expect(gridCells(["smith", "antenna"])).toEqual(["smith", "antenna"]);
+    expect(gridCells(["elevation", "antenna", "azimuth", "smith"])).toEqual([
+      "elevation",
+      "antenna",
+      "azimuth",
+      "smith",
+    ]);
+  });
+
+  it("never shows a 5th or 6th pin", () => {
+    const six: View[] = [
+      "antenna",
+      "azimuth",
+      "elevation",
+      "smith",
+      "schematic",
+      "gamma",
+    ];
+    expect(gridCells(six)).toEqual(FOUNDING);
+    expect(gridCells(six)).toHaveLength(4);
+  });
+
+  it("passes a single pin through unchanged", () => {
+    expect(gridCells(["smith"])).toEqual(["smith"]);
+  });
+});
+
+describe("gridShape", () => {
+  it("is 1x1 for one cell", () => {
+    expect(gridShape(1)).toEqual({ rows: 1, cols: 1 });
+  });
+  it("is 1x2 for two cells", () => {
+    expect(gridShape(2)).toEqual({ rows: 1, cols: 2 });
+  });
+  it("is 2x2 for three cells (the 4th slot is the hint)", () => {
+    expect(gridShape(3)).toEqual({ rows: 2, cols: 2 });
+  });
+  it("is 2x2 for four cells", () => {
+    expect(gridShape(4)).toEqual({ rows: 2, cols: 2 });
+  });
+});
+
+// --- 5. gridFix — the off-grid recovery decision table -------------------
+
+describe("gridFix", () => {
+  it("is a no-op outside grid mode", () => {
+    expect(gridFix("rail", false, "schematic", FOUNDING)).toBeNull();
+  });
+
+  it("is a no-op when the ring is already on a displayed cell", () => {
+    expect(gridFix("grid", true, "smith", FOUNDING)).toBeNull();
+  });
+
+  it("snaps to cell 1 when ENTERING grid with a peeked view active", () => {
+    // wasGrid=false ⇒ just switched rail→grid; "schematic" is unpinned.
+    expect(gridFix("grid", false, "schematic", FOUNDING)).toEqual({
+      view: "antenna",
+    });
+  });
+
+  it("snaps to cell 1 when ENTERING grid with pin #5 active", () => {
+    const sixPins = [...FOUNDING, "schematic", "gamma"] as View[];
+    expect(gridFix("grid", false, "gamma", sixPins)).toEqual({
+      view: "antenna",
+    });
+  });
+
+  it("snaps to cell 1 when ALREADY in grid and a pinned off-grid view (pin #5) is picked", () => {
+    const sixPins = [...FOUNDING, "schematic", "gamma"] as View[];
+    // wasGrid=true ⇒ grid did not just start; the picker activated "gamma".
+    expect(gridFix("grid", true, "gamma", sixPins)).toEqual({
+      view: "antenna",
+    });
+  });
+
+  // The one branch mutation probe 4(b) targets: drop this and the peek stays
+  // stranded on a nonexistent cell instead of falling back to rail.
+  it("leaves grid for rail when ALREADY in grid and an unpinned peek is picked", () => {
+    expect(gridFix("grid", true, "schematic", FOUNDING)).toEqual({
+      layout: "rail",
+    });
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/useViewState.grid.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useViewState.grid.test.tsx
@@ -1,0 +1,153 @@
+// Unit 3 of docs/plan-view-rail-scaling.md ("Layout modes"/"Keyboard"): the
+// grid-mode half of useViewState — arrow cycling over the displayed cells
+// only, and the off-grid-ring recovery effect wired to the pure gridFix
+// decision (useViewPrefs.grid.test.tsx tests that function directly; this
+// file proves the HOOK actually applies it, which is what mutation probe
+// 4(b) — "drop the off-grid snap" — needs to catch).
+//
+// Rail mode's own arrow-cycling behavior (pinned ∪ active, cap, wrap, the
+// input/knob focus guard) is pinned in useViewPrefs.test.tsx and is
+// UNTOUCHED by this unit — nothing here repeats it beyond the one sanity
+// check that layout defaulting to "rail" doesn't change it.
+import { describe, it, expect, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { type View } from "../lib/view";
+import { useViewState } from "../components/session/useViewState";
+import { type Layout } from "../components/session/useViewPrefs";
+
+const FOUNDING: View[] = ["antenna", "azimuth", "elevation", "smith"];
+
+function press(key: string, target?: HTMLElement) {
+  act(() => {
+    (target ?? document.body).dispatchEvent(
+      new KeyboardEvent("keydown", { key, bubbles: true }),
+    );
+  });
+}
+
+// --- 1. Grid-mode arrow cycling ------------------------------------------
+
+describe("grid-mode arrow cycling", () => {
+  it("cycles exactly the displayed cells (first ≤4 pins) and wraps", () => {
+    const { result } = renderHook(() =>
+      useViewState({ currentExample: undefined, active: true, pinned: FOUNDING, layout: "grid" }),
+    );
+    const seen: View[] = [];
+    for (let i = 0; i < FOUNDING.length; i++) {
+      press("ArrowDown");
+      seen.push(result.current.view);
+    }
+    expect(seen).toEqual(["azimuth", "elevation", "smith", "antenna"]);
+  });
+
+  it("never lands on pin #5 or #6, even though they're pinned", () => {
+    const sixPins: View[] = [...FOUNDING, "schematic", "gamma"];
+    const { result } = renderHook(() =>
+      useViewState({ currentExample: undefined, active: true, pinned: sixPins, layout: "grid" }),
+    );
+    const seen = new Set<View>([result.current.view]);
+    for (let i = 0; i < 8; i++) {
+      press("ArrowDown");
+      seen.add(result.current.view);
+    }
+    expect(seen).toEqual(new Set(FOUNDING));
+  });
+
+  it("does not affect rail mode's pinned ∪ active cycle (default layout)", () => {
+    const { result } = renderHook(() =>
+      useViewState({ currentExample: undefined, active: true, pinned: FOUNDING }),
+    );
+    act(() => result.current.setView("schematic"));
+    press("ArrowDown");
+    // Same as useViewPrefs.test.tsx's "keeps a peeked view in the cycle":
+    // schematic (a peek, unpinned) sits at the end of pinned ∪ active.
+    expect(result.current.view).toBe("antenna");
+  });
+});
+
+// --- 2. Off-grid ring recovery (mutation probe 4b target) -----------------
+
+describe("off-grid ring recovery", () => {
+  it("snaps to cell 1 when the hook mounts already in grid with an off-grid view", () => {
+    // The ring starts at useViewState's own default ("antenna"), which IS
+    // displayed here, so peek a pinned-but-off-grid view first, THEN mount
+    // fresh at layout="grid" to simulate "entering grid with it active" —
+    // renderHook's initial render already has layout="grid", so wasGridRef
+    // inits to true and this exercises the "already in grid" branch instead;
+    // see the next test for the true "just switched into grid" transition.
+    const sixPins: View[] = [...FOUNDING, "schematic", "gamma"];
+    const { result } = renderHook(() =>
+      useViewState({ currentExample: undefined, active: true, pinned: sixPins, layout: "grid" }),
+    );
+    act(() => result.current.setView("gamma"));
+    expect(result.current.view).toBe("antenna");
+  });
+
+  it("snaps to cell 1 on the rail→grid transition with a peeked view active", () => {
+    const setLayout = vi.fn();
+    const { result, rerender } = renderHook<ReturnType<typeof useViewState>, { layout: Layout }>(
+      ({ layout }) =>
+        useViewState({
+          currentExample: undefined,
+          active: true,
+          pinned: FOUNDING,
+          layout,
+          setLayout,
+        }),
+      { initialProps: { layout: "rail" } },
+    );
+    act(() => result.current.setView("schematic")); // peek, still rail
+    expect(result.current.view).toBe("schematic");
+    rerender({ layout: "grid" }); // the segmented control's click
+    // Entering grid with a peek active snaps the ring — grid mode itself is
+    // NOT abandoned (setLayout must not have been called).
+    expect(result.current.view).toBe("antenna");
+    expect(setLayout).not.toHaveBeenCalled();
+  });
+
+  it("snaps to cell 1 on the rail→grid transition with pin #5 active", () => {
+    const sixPins: View[] = [...FOUNDING, "schematic", "gamma"];
+    const setLayout = vi.fn();
+    const { result, rerender } = renderHook<ReturnType<typeof useViewState>, { layout: Layout }>(
+      ({ layout }) =>
+        useViewState({
+          currentExample: undefined,
+          active: true,
+          pinned: sixPins,
+          layout,
+          setLayout,
+        }),
+      { initialProps: { layout: "rail" } },
+    );
+    act(() => result.current.setView("gamma"));
+    rerender({ layout: "grid" });
+    expect(result.current.view).toBe("antenna");
+    expect(setLayout).not.toHaveBeenCalled();
+  });
+
+  it("leaves grid for rail when already-in-grid picks an unpinned peek", () => {
+    const setLayout = vi.fn();
+    const { result } = renderHook(() =>
+      useViewState({
+        currentExample: undefined,
+        active: true,
+        pinned: FOUNDING,
+        layout: "grid",
+        setLayout,
+      }),
+    );
+    // Simulates the picker's row-click landing on an unpinned view while
+    // already in grid mode.
+    act(() => result.current.setView("schematic"));
+    expect(setLayout).toHaveBeenCalledWith("rail");
+    // The view itself is left as the peek — rail mode shows it as primary.
+    expect(result.current.view).toBe("schematic");
+  });
+
+  it("does nothing when setLayout is omitted (the branch is simply inert)", () => {
+    const { result } = renderHook(() =>
+      useViewState({ currentExample: undefined, active: true, pinned: FOUNDING, layout: "grid" }),
+    );
+    expect(() => act(() => result.current.setView("schematic"))).not.toThrow();
+  });
+});

--- a/src/antennaknobs/web/frontend/src/components/hooks.ts
+++ b/src/antennaknobs/web/frontend/src/components/hooks.ts
@@ -40,6 +40,43 @@ export function useSlideSize(maxSize = 720, reattachKey?: unknown) {
   return { ref, size };
 }
 
+// Grid mode's per-cell chart size (unit 3, docs/plan-view-rail-scaling.md):
+// same "measure the box, hand charts a square that fits it" idiom as
+// useSlideSize, but the box is the WHOLE grid (rows × cols of equal cells
+// with a CSS gap) rather than one slide. `rows`/`cols` must be the same
+// numbers the caller feeds `.view-grid`'s inline grid-template (ViewGrid and
+// DesignSession both derive them from useViewPrefs' gridShape), or the
+// divided-up size disagrees with the actual cell box.
+const GRID_GAP = 8; // mirrors .view-grid's `gap: var(--space-4)` in styles.css
+export function useGridCellSize(
+  rows: number,
+  cols: number,
+  maxSize = 560,
+  reattachKey?: unknown, // see useSlideSize
+) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState(maxSize);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const update = () => {
+      const rect = el.getBoundingClientRect();
+      const cellW = (rect.width - GRID_GAP * (cols - 1)) / cols;
+      const cellH = (rect.height - GRID_GAP * (rows - 1)) / rows;
+      const s = Math.min(cellW, cellH, maxSize);
+      // -16 is the cell's own padding (8px each side, .grid-cell in
+      // styles.css) — same overhead subtraction useSlideSize does for the
+      // slide's padding.
+      setSize(Math.max(160, Math.floor(s) - 16));
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [rows, cols, maxSize, reattachKey]);
+  return { ref, size };
+}
+
 // Mirror of the stylesheet's phone breakpoint. The query string MUST stay
 // identical to the mobile `@media` prelude in styles.css so the JS layout
 // branch and the CSS rules can never disagree about which viewports are

--- a/src/antennaknobs/web/frontend/src/components/results/StageOverlays.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/StageOverlays.tsx
@@ -4,9 +4,46 @@ import type { GroundModel } from "../../lib/ground";
 import type { ExampleDescriptor } from "../../lib/params";
 import type { Projection, View } from "../../lib/view";
 import { PROJECTIONS } from "../../lib/view";
+import type { Layout } from "../session/useViewPrefs";
 import type { PatternMetrics, PinnedPattern } from "../charts/types";
 import { Knob } from "../params/Knob";
 import { PatternCompareTable } from "./PatternCompareTable";
+
+// The rail/grid segmented control (unit 3, docs/plan-view-rail-scaling.md
+// "Layout modes"): two presets over the same pinned set. Placed by the
+// caller in the stage's top-right corner, desktop only — it lives in
+// DesignSession's desktop return branch, which the mobile branch never
+// reaches, so "hidden on mobile" needs no prop here.
+export function LayoutModeToggle({
+  layout,
+  setLayout,
+}: {
+  layout: Layout;
+  setLayout: (l: Layout) => void;
+}) {
+  return (
+    <div className="layout-toggle" role="group" aria-label="Stage layout">
+      <button
+        type="button"
+        className={layout === "rail" ? "active" : ""}
+        aria-pressed={layout === "rail"}
+        title="Rail: one primary view plus the pinned thumbnails"
+        onClick={() => setLayout("rail")}
+      >
+        ▤
+      </button>
+      <button
+        type="button"
+        className={layout === "grid" ? "active" : ""}
+        aria-pressed={layout === "grid"}
+        title="Grid: equal cells over the first pinned views"
+        onClick={() => setLayout("grid")}
+      >
+        ⊞
+      </button>
+    </div>
+  );
+}
 
 export function AntennaOverlayControls({
   cameraProjection,

--- a/src/antennaknobs/web/frontend/src/components/results/ViewGrid.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/ViewGrid.tsx
@@ -1,0 +1,87 @@
+import type { ReactNode, RefObject } from "react";
+import type { View, ViewMeta } from "../../lib/view";
+
+// Grid layout mode's stage (unit 3, docs/plan-view-rail-scaling.md "Layout
+// modes"): equal cells over the caller's displayed views, no primary. Purely
+// presentational — `cells` (already sliced to the first ≤4 pins, in pin
+// order — see useViewPrefs' gridCells) and `renderCell` come from the
+// caller, so this file has no dependency on the solve/session state that
+// makes DesignSession itself too heavy to mount in a test.
+//
+// The solve-readout HUD is deliberately NOT rendered here: unit 3 puts it
+// once at the stage level (a sibling of this component), matching
+// renderOutput's own "the HUD stays OUT of it" contract (DesignSession.tsx).
+export function ViewGrid({
+  gridRef,
+  cells,
+  view,
+  setView,
+  onMaximize,
+  cellSize,
+  rows,
+  cols,
+  renderCell,
+}: {
+  // Attached to the measured element (components/hooks.ts useGridCellSize) —
+  // rows/cols must be the exact numbers that hook was called with, or the
+  // measured cell size disagrees with the grid-template below.
+  gridRef: RefObject<HTMLDivElement>;
+  cells: ViewMeta[];
+  view: View;
+  setView: (v: View) => void;
+  // Maximize glyph or double-click (Blender's cell↔full toggle): jump to
+  // rail mode with this view primary. DesignSession supplies the
+  // setView+setLayout("rail") pair as one callback.
+  onMaximize: (v: View) => void;
+  cellSize: number;
+  rows: number;
+  cols: number;
+  renderCell: (v: View, size: number) => ReactNode;
+}) {
+  return (
+    <div
+      className="view-grid"
+      ref={gridRef}
+      style={{
+        gridTemplateColumns: `repeat(${cols}, 1fr)`,
+        gridTemplateRows: `repeat(${rows}, 1fr)`,
+      }}
+    >
+      {cells.map((v) => (
+        <div
+          key={v.id}
+          className={`grid-cell${v.id === view ? " grid-cell-focus" : ""}`}
+          role="button"
+          tabIndex={0}
+          aria-label={`Focus ${v.label}`}
+          aria-pressed={v.id === view}
+          onClick={() => setView(v.id)}
+          onDoubleClick={() => onMaximize(v.id)}
+        >
+          <button
+            type="button"
+            className="grid-cell-maximize"
+            title={`Maximize ${v.label}`}
+            onClick={(e) => {
+              // Without this the click also bubbles to the cell's own
+              // onClick above — harmless (setView to the view this cell
+              // already is), but stopping it keeps "maximize" a single,
+              // unambiguous action rather than two.
+              e.stopPropagation();
+              onMaximize(v.id);
+            }}
+          >
+            ⛶
+          </button>
+          {renderCell(v.id, cellSize)}
+        </div>
+      ))}
+      {/* A 3-pin grid still draws a 2×2 (see gridShape) — the 4th slot is an
+          invitation, not a blank hole. Not a cell: no view, no focus ring,
+          no maximize glyph. */}
+      {cells.length === 3 && (
+        <div className="grid-cell grid-cell-hint">Pin a 4th view</div>
+      )}
+    </div>
+  );
+}

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -27,7 +27,7 @@ import {
   type SchemaItem,
   type SchemaParamSpec,
 } from "../../lib/params";
-import { mobileScreens, type View } from "../../lib/view";
+import { mobileScreens, VIEW_META, type View } from "../../lib/view";
 import type {
   MeasuredData,
   SolveRequest,
@@ -40,6 +40,7 @@ import type { PatternMetrics } from "../charts/types";
 import {
   ThemeContext,
   useFullscreen,
+  useGridCellSize,
   useIsMobile,
   useSlideSize,
   useThumbColumnSize,
@@ -50,8 +51,10 @@ import {
   CompareOverlay,
   CutAngleOverlay,
   FarFieldOverlayControls,
+  LayoutModeToggle,
   SmithOverlayControls,
 } from "../results/StageOverlays";
+import { ViewGrid } from "../results/ViewGrid";
 import { ViewPanel } from "../results/ViewPanel";
 import { fetchMetrics, PinsContext, SessionsContext, ThemeControlContext } from "./contexts";
 import { CatalogPanel } from "./CatalogPanel";
@@ -75,7 +78,7 @@ import { useOptimizer } from "./useOptimizer";
 import { useSchematic } from "./useSchematic";
 import { useSolveChannel } from "./useSolveChannel";
 import { useSolverSlots } from "./useSolverSlots";
-import { useViewPrefs } from "./useViewPrefs";
+import { gridCells, gridShape, useViewPrefs } from "./useViewPrefs";
 import { useViewState } from "./useViewState";
 import { ViewPicker } from "./ViewPicker";
 import { VfoPanel } from "./VfoPanel";
@@ -395,26 +398,9 @@ function DesignSessionBody({
     railViews,
     togglePin: toggleViewPin,
     markRosterSeen,
+    layout,
+    setLayout,
   } = useViewPrefs();
-  // Output view, camera and canvas display toggles (#642 seam 5b-3).
-  const {
-    azElevDeg,
-    setAzElevDeg,
-    elevAzDeg,
-    setElevAzDeg,
-    view,
-    setView,
-    cameraProjection,
-    setCameraProjection,
-    showHeatmap,
-    setShowHeatmap,
-    showEnvelope,
-    setShowEnvelope,
-    showWireLabels,
-    setShowWireLabels,
-    showFeedNames,
-    setShowFeedNames,
-  } = useViewState({ currentExample, active, pinned });
 
   // When linked, design and measurement freq move together.
   function updateDesignFreq(v: number) {
@@ -591,12 +577,65 @@ function DesignSessionBody({
   // reattach key, so no desktop viewport is affected; the key makes both
   // hooks re-measure if the window is resized across the breakpoint.
   const { isMobile, orientation } = useIsMobile();
+  // Grid mode is desktop-only (the segmented control never renders on
+  // mobile, so `setLayout("grid")` is never reachable there) — but `layout`
+  // itself is a global persisted flag, so a phone can still load a value of
+  // "grid" left over from a desktop session. Forcing "rail" here keeps the
+  // mobile carousel's arrow-key cycling (pinned ∪ active, unit 2) exactly as
+  // it was; nothing below the mobile branch ever sees "grid".
+  const effectiveLayout = isMobile ? "rail" : layout;
+  // Output view, camera and canvas display toggles (#642 seam 5b-3); the
+  // grid-mode off-grid snap (unit 3) lives inside this hook too, since it
+  // already owns `view` and now needs `layout`/`setLayout` alongside it.
+  const {
+    azElevDeg,
+    setAzElevDeg,
+    elevAzDeg,
+    setElevAzDeg,
+    view,
+    setView,
+    cameraProjection,
+    setCameraProjection,
+    showHeatmap,
+    setShowHeatmap,
+    showEnvelope,
+    setShowEnvelope,
+    showWireLabels,
+    setShowWireLabels,
+    showFeedNames,
+    setShowFeedNames,
+  } = useViewState({
+    currentExample,
+    active,
+    pinned,
+    layout: effectiveLayout,
+    setLayout,
+  });
   const { ref: slideRef, size: chartSize } = useSlideSize(720, isMobile);
   const thumbStripRef = useRef<HTMLDivElement>(null);
   // The rail is the pinned set minus whatever is on the stage; peeking an
   // unpinned view subtracts nothing, so the count the sizer needs varies.
   const rail = railViews(view);
   const thumbSize = useThumbColumnSize(thumbStripRef, rail.length, 280, isMobile);
+  // Grid mode's displayed cells (unit 3): the first ≤4 pins, in pin order.
+  // gridCells/gridShape are pure (useViewPrefs.ts) so this and useViewState's
+  // internal cycling can never disagree about "what's on screen".
+  const gridViewIds = gridCells(pinned);
+  const gridViews = gridViewIds.map((id) => VIEW_META[id]);
+  const { rows: gridRows, cols: gridCols } = gridShape(gridViewIds.length);
+  const { ref: gridRef, size: gridCellSize } = useGridCellSize(
+    gridRows,
+    gridCols,
+    560,
+    effectiveLayout,
+  );
+  // Maximize (glyph or double-click, Blender's cell↔full toggle): jump to
+  // rail mode with this view primary. The segmented control's rail button
+  // returns to grid.
+  const maximizeView = (v: View) => {
+    setView(v);
+    setLayout("rail");
+  };
 
   const {
     mobileIndex,
@@ -1518,92 +1557,129 @@ function DesignSessionBody({
 
       <main className="stage" aria-label="Antenna output views">
         {solveOverlays}
-        <div className="thumbstrip" ref={thumbStripRef}>
-          {rail.map((v) => (
-            <button
-              key={v.id}
-              className="thumb"
-              onClick={() => setView(v.id)}
-              title={`Switch to ${v.label}`}
-            >
-              <div
-                className="thumb-canvas"
-                style={{ width: thumbSize.width, height: thumbSize.height }}
-              >
-                {/* The chart draws at the column's full (3-thumb-era) width
-                    — where its fixed-px labels fit — and scales down
-                    uniformly into the shorter rectangle, a true miniature
-                    (issue #652; see useThumbColumnSize). */}
-                <div
-                  className="thumb-scale"
-                  style={{
-                    width: thumbSize.width,
-                    height: thumbSize.width,
-                    transform: `translate(-50%, -50%) scale(${
-                      thumbSize.height / thumbSize.width
-                    })`,
-                  }}
+        {/* Rail/grid presets over the same pinned set (unit 3) — visible in
+            both modes so either one can switch to the other. Desktop-only by
+            placement: this branch is never reached while isMobile. */}
+        <LayoutModeToggle layout={effectiveLayout} setLayout={setLayout} />
+        {effectiveLayout === "grid" ? (
+          <>
+            <ViewGrid
+              gridRef={gridRef}
+              cells={gridViews}
+              view={view}
+              setView={setView}
+              onMaximize={maximizeView}
+              cellSize={gridCellSize}
+              rows={gridRows}
+              cols={gridCols}
+              renderCell={(v, size) => renderOutput(v, size, v === "antenna")}
+            />
+            {/* Grid mode has no single primary slide to float the HUD over
+                (unit 3), so it anchors to the STAGE itself instead of one
+                cell — same look (stage-readout family), one instance rather
+                than per-cell. `.stage` is the positioned ancestor here, same
+                role `.carousel-slide` plays in rail mode below. */}
+            <SolveReadout
+              className="stage-readout"
+              result={result}
+              rttMs={rttMs}
+              currentExample={currentExample}
+              effectiveMultiFeed={effectiveMultiFeed}
+              normCheck={normCheck}
+              normCheckEnabled={normCheckEnabled}
+              onPlaneChange={pickPlane}
+            />
+          </>
+        ) : (
+          <>
+            <div className="thumbstrip" ref={thumbStripRef}>
+              {rail.map((v) => (
+                <button
+                  key={v.id}
+                  className="thumb"
+                  onClick={() => setView(v.id)}
+                  title={`Switch to ${v.label}`}
                 >
-                <ViewPanel
-                  view={v.id}
-                  size={thumbSize.width}
-                  fill={false}
-                  result={result}
-                  preview={preview}
-                  sweep={sweep}
-                  converge={converge}
-                  measured={measured}
-                  pattern={pattern}
-                  pinnedPatterns={[]}
-                  measFreqMhz={measFreq}
-                  sweepRunning={sweepRunning}
-                  convergeRunning={convergeRunning}
-                  azElevDeg={azElevDeg}
-                  elevAzDeg={elevAzDeg}
-                  cameraProjection={cameraProjection}
-                  showHeatmap={showHeatmap}
-                  showEnvelope={showEnvelope}
-                  multiFeed={effectiveMultiFeed}
-                  schematicSvg={schematicSvg}
-                  schematicUnavailable={schematicUnavailable}
-                />
-                </div>
-              </div>
-              <div className="thumb-label">{v.label}</div>
-            </button>
-          ))}
-          {/* Everything not pinned lives behind here. Fixed height by design:
-              useThumbColumnSize subtracts exactly this slot. */}
-          <ViewPicker
-            view={view}
-            setView={setView}
-            pinned={pinned}
-            newIds={newIds}
-            togglePin={toggleViewPin}
-            markRosterSeen={markRosterSeen}
-          />
-        </div>
-        <div
-          className={`carousel-slide${stale ? " stale" : ""}`}
-          ref={slideRef}
-        >
-          {renderOutput(view, chartSize, view === "antenna")}
-          {/* Solve readout, pinned to the lower-left of whichever view the
-              carousel is centered on. Floats over the canvas as a HUD so the
-              left input rail stays inputs-only. It sits INSIDE the slide, so
-              the slide's stale dim already covers it — no own stale class, or
-              the two opacities would compound. */}
-          <SolveReadout
-            className="stage-readout"
-            result={result}
-            rttMs={rttMs}
-            currentExample={currentExample}
-            effectiveMultiFeed={effectiveMultiFeed}
-            normCheck={normCheck}
-            normCheckEnabled={normCheckEnabled}
-            onPlaneChange={pickPlane}
-          />
-        </div>
+                  <div
+                    className="thumb-canvas"
+                    style={{ width: thumbSize.width, height: thumbSize.height }}
+                  >
+                    {/* The chart draws at the column's full (3-thumb-era) width
+                        — where its fixed-px labels fit — and scales down
+                        uniformly into the shorter rectangle, a true miniature
+                        (issue #652; see useThumbColumnSize). */}
+                    <div
+                      className="thumb-scale"
+                      style={{
+                        width: thumbSize.width,
+                        height: thumbSize.width,
+                        transform: `translate(-50%, -50%) scale(${
+                          thumbSize.height / thumbSize.width
+                        })`,
+                      }}
+                    >
+                    <ViewPanel
+                      view={v.id}
+                      size={thumbSize.width}
+                      fill={false}
+                      result={result}
+                      preview={preview}
+                      sweep={sweep}
+                      converge={converge}
+                      measured={measured}
+                      pattern={pattern}
+                      pinnedPatterns={[]}
+                      measFreqMhz={measFreq}
+                      sweepRunning={sweepRunning}
+                      convergeRunning={convergeRunning}
+                      azElevDeg={azElevDeg}
+                      elevAzDeg={elevAzDeg}
+                      cameraProjection={cameraProjection}
+                      showHeatmap={showHeatmap}
+                      showEnvelope={showEnvelope}
+                      multiFeed={effectiveMultiFeed}
+                      schematicSvg={schematicSvg}
+                      schematicUnavailable={schematicUnavailable}
+                    />
+                    </div>
+                  </div>
+                  <div className="thumb-label">{v.label}</div>
+                </button>
+              ))}
+              {/* Everything not pinned lives behind here. Fixed height by design:
+                  useThumbColumnSize subtracts exactly this slot. */}
+              <ViewPicker
+                view={view}
+                setView={setView}
+                pinned={pinned}
+                newIds={newIds}
+                togglePin={toggleViewPin}
+                markRosterSeen={markRosterSeen}
+              />
+            </div>
+            <div
+              className={`carousel-slide${stale ? " stale" : ""}`}
+              ref={slideRef}
+            >
+              {renderOutput(view, chartSize, view === "antenna")}
+              {/* Solve readout, pinned to the lower-left of whichever view the
+                  carousel is centered on. Floats over the canvas as a HUD so the
+                  left input rail stays inputs-only. It sits INSIDE the slide, so
+                  the slide's stale dim already covers it — no own stale class, or
+                  the two opacities would compound. */}
+              <SolveReadout
+                className="stage-readout"
+                result={result}
+                rttMs={rttMs}
+                currentExample={currentExample}
+                effectiveMultiFeed={effectiveMultiFeed}
+                normCheck={normCheck}
+                normCheckEnabled={normCheckEnabled}
+                onPlaneChange={pickPlane}
+              />
+            </div>
+          </>
+        )}
         <div className="status">
           ws: {status}
           {stale && <span className="status-busy"> · solving…</span>}

--- a/src/antennaknobs/web/frontend/src/components/session/useViewPrefs.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useViewPrefs.ts
@@ -29,12 +29,24 @@ export const VIEW_PREFS_KEY = "akb.viewPrefs.v1";
 // picker shipped", which is what the user reads it as.
 const SEEN_SEED: View[] = ["antenna", "azimuth", "elevation", "smith", "schematic"];
 
+// Unit 3 of docs/plan-view-rail-scaling.md: the desktop stage's two layout
+// presets over the same pinned set. "rail" is today's primary+thumbstrip;
+// "grid" is equal cells over the first GRID_CELL_CAP pins. Exported so
+// components (the segmented control, useViewState) share one type instead of
+// re-deriving the string union.
+export type Layout = "rail" | "grid";
+
 // The persisted record. Fields are independent and each is optional on read,
-// so unit 3 can add `layout: "rail" | "grid"` by extending this type and the
-// writer — no v2 key, and a build that predates a field simply ignores it.
+// so a field can be added by extending this type and the writer — no v2 key,
+// and a build that predates a field simply ignores it. `layout` (unit 3)
+// is also optional on WRITE: update() below omits it entirely while it's
+// "rail" (the default), so a session that never touches layout persists the
+// exact `{pinned, seen}` shape unit 2 shipped — see the exact-keys assertion
+// in useViewPrefs.test.tsx, which this deliberately keeps passing unedited.
 type ViewPrefs = {
   pinned: View[];
   seen: View[];
+  layout: Layout;
 };
 
 const KNOWN = new Set<string>(VIEWS.map((v) => v.id));
@@ -58,6 +70,15 @@ function sanitizeIds(raw: unknown): View[] {
   return out;
 }
 
+// Anything other than the literal "grid" reads as "rail" — an absent field
+// (pre-unit-3 storage or a rail session that never wrote it, see the type's
+// comment), a wrong type, or hand-edited garbage. A bad layout does not
+// condemn the whole record the way an empty `pinned` does: the other two
+// fields are still perfectly good, so only this one falls back.
+function sanitizeLayout(raw: unknown): Layout {
+  return raw === "grid" ? "grid" : "rail";
+}
+
 function loadPrefs(): ViewPrefs {
   try {
     const raw = localStorage.getItem(VIEW_PREFS_KEY);
@@ -73,14 +94,18 @@ function loadPrefs(): ViewPrefs {
         // corrupt rather than honour an empty rail, which is never what a user
         // meant and leaves no visible way back.
         if (pinned.length > 0) {
-          return { pinned, seen: seen.length > 0 ? seen : SEEN_SEED };
+          return {
+            pinned,
+            seen: seen.length > 0 ? seen : SEEN_SEED,
+            layout: sanitizeLayout(rec.layout),
+          };
         }
       }
     }
   } catch {
     /* corrupt JSON or storage disabled — the defaults below are the answer */
   }
-  return { pinned: defaultPins(), seen: SEEN_SEED };
+  return { pinned: defaultPins(), seen: SEEN_SEED, layout: "rail" };
 }
 
 // --- module store ------------------------------------------------------------
@@ -110,7 +135,19 @@ function subscribe(onChange: () => void): () => void {
 function update(next: ViewPrefs): void {
   cached = next;
   try {
-    localStorage.setItem(VIEW_PREFS_KEY, JSON.stringify(next));
+    // Sparse write: `layout` joins the JSON only when it is not the default
+    // — JSON.stringify drops a key whose value is `undefined`. A pin/unpin
+    // that never touches layout (the common case, and every case before
+    // unit 3) writes exactly `{pinned, seen}`, so existing stored records
+    // and the pre-unit-3 test fixture stay byte-shaped as before.
+    localStorage.setItem(
+      VIEW_PREFS_KEY,
+      JSON.stringify({
+        pinned: next.pinned,
+        seen: next.seen,
+        layout: next.layout === "rail" ? undefined : next.layout,
+      }),
+    );
   } catch {
     /* storage disabled — the in-memory prefs still work for this session,
        exactly as App.tsx's theme toggle degrades */
@@ -140,9 +177,67 @@ export function pinBlockedReason(pinned: View[], id: View): string | null {
   return pinned.length >= PIN_CAP ? "Unpin a view first" : null;
 }
 
+// --- grid layout mode (unit 3) ------------------------------------------
+
+// Grid mode never goes past 4 cells: below ~⅓-stage cells the antenna canvas
+// stops being steerable, which defeats the mode's whole point (plan doc
+// "Layout modes"), so pins #5/#6 stay rail-only rather than making a 3×2.
+export const GRID_CELL_CAP = 4;
+
+// Grid mode's displayed cells: the first ≤4 pins, in pin order. Pure slice —
+// used both for what renders (ViewGrid) and what the arrow keys cycle
+// (useViewState), so the two can never disagree about "what's on screen".
+export function gridCells(pinned: View[]): View[] {
+  return pinned.slice(0, GRID_CELL_CAP);
+}
+
+// The grid's row/column count for a given number of displayed cells:
+// 1 → one full cell, 2 → 1×2, 3–4 → 2×2 (3 leaves the 4th cell the "pin a
+// 4th view" hint — ViewGrid draws that, this only says the shape is square).
+export function gridShape(nCells: number): { rows: number; cols: number } {
+  if (nCells <= 1) return { rows: 1, cols: 1 };
+  if (nCells === 2) return { rows: 1, cols: 2 };
+  return { rows: 2, cols: 2 };
+}
+
+// What to do when the grid-mode focus ring (`view`) is not one of the
+// displayed cells — see docs/plan-view-rail-scaling.md "Layout modes" and
+// "Keyboard". There are two distinct causes, told apart by `wasGrid` (was
+// the layout already "grid" the last time this ran):
+//
+//   - `wasGrid` false: we just switched INTO grid (rail → grid). The view
+//     that was active carries over regardless of WHY it's off-grid — a peek
+//     or a pinned view beyond cell 4 (pin #5/#6) — either way there is
+//     nowhere to put the ring but cell 1, so grid mode itself is not
+//     disturbed.
+//   - `wasGrid` true and the view IS pinned: already in grid, and a picker
+//     row-click landed on a pinned-but-off-grid view (pin #5/#6) — same
+//     fix, snap the ring to cell 1.
+//   - `wasGrid` true and the view is NOT pinned: the row-click activated a
+//     peek. A peek has no cell by definition — it costs no pin slot (see
+//     the plan doc's "Peek" note), so it never gets one — there is nothing
+//     to snap the ring to. Leave grid for rail, where the peek becomes
+//     rail's primary instead of being stranded off-screen.
+//
+// Returns null when the ring is already on a displayed cell (the common
+// case on every render that isn't one of the above transitions).
+export type GridFix = { view: View } | { layout: "rail" } | null;
+export function gridFix(
+  layout: Layout,
+  wasGrid: boolean,
+  view: View,
+  pinned: View[],
+): GridFix {
+  if (layout !== "grid") return null;
+  const cells = gridCells(pinned);
+  if (cells.includes(view)) return null;
+  if (!wasGrid || pinned.includes(view)) return { view: cells[0] };
+  return { layout: "rail" };
+}
+
 export function useViewPrefs() {
   const prefs = useSyncExternalStore(subscribe, getSnapshot);
-  const { pinned, seen } = prefs;
+  const { pinned, seen, layout } = prefs;
 
   // Views the user has never been offered. Seeded (not empty) on a first run,
   // so the badge only ever fires for views added after the picker shipped.
@@ -183,5 +278,13 @@ export function useViewPrefs() {
     update({ ...cur, seen: [...cur.seen, ...missing] });
   }, []);
 
-  return { pinned, seen, newIds, railViews, togglePin, markRosterSeen };
+  // Unit 3: the desktop layout preset. No validation needed beyond the type
+  // itself — unlike pins, there is no cap or floor to enforce here.
+  const setLayout = useCallback((next: Layout) => {
+    const cur = getSnapshot();
+    if (cur.layout === next) return; // keeps snapshot identity, as markRosterSeen does
+    update({ ...cur, layout: next });
+  }, []);
+
+  return { pinned, seen, newIds, railViews, togglePin, markRosterSeen, layout, setLayout };
 }

--- a/src/antennaknobs/web/frontend/src/components/session/useViewState.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useViewState.ts
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { type ExampleDescriptor } from "../../lib/params";
 import { type Projection, type View } from "../../lib/view";
-import { cycleOrder } from "./useViewPrefs";
+import { cycleOrder, gridCells, gridFix, type Layout } from "./useViewPrefs";
 
 // Which output view is on screen and how it is drawn: the two far-field cut
 // angles, the selected view + camera projection, the antenna-canvas display
@@ -14,12 +14,26 @@ export function useViewState({
   currentExample,
   active,
   pinned,
+  layout = "rail",
+  setLayout,
 }: {
   currentExample: ExampleDescriptor | undefined;
   active: boolean;
   // The user's pinned views (useViewPrefs). The arrow keys cycle these plus
   // the active view, not the whole registry — see cycleOrder.
   pinned: View[];
+  // Unit 3 (docs/plan-view-rail-scaling.md "Layout modes"): grid mode's
+  // arrows cycle the displayed cells only (gridCells), not pinned ∪ active
+  // — a ring that walked onto pin #5 would vanish. Chosen as the seam here
+  // (rather than a generic `cycle` override list) because the displayed set
+  // is already fully determined by `pinned`, which this hook already takes;
+  // a second, separately-passed list could disagree with it. Defaults to
+  // "rail" so this stays a pure addition — every existing call keeps
+  // cycling pinned ∪ active exactly as before.
+  layout?: Layout;
+  // Only the grid-mode off-grid-peek fix (see the effect below) ever calls
+  // this. Omit it and that one branch is simply inert.
+  setLayout?: (l: Layout) => void;
 }) {
   // Far-field cut angles. The azimuth plot slices the pattern at elevation
   // `azElevDeg`; the elevation plot slices the vertical plane at azimuth
@@ -31,6 +45,22 @@ export function useViewState({
   const [elevAzDeg, setElevAzDeg] = useState(0);
 
   const [view, setView] = useState<View>("antenna");
+
+  // Keeps the grid-mode focus ring on a displayed cell — see gridFix's own
+  // comment for the full decision table. `wasGridRef` tracks the layout as
+  // of the last time this effect ran, which is how gridFix tells "just
+  // entered grid" from "already in grid, view just changed under it" apart;
+  // it is updated on every run regardless of which branch (or no branch)
+  // fires, so it always reflects the PREVIOUS render's layout.
+  const wasGridRef = useRef(layout === "grid");
+  useEffect(() => {
+    const fix = gridFix(layout, wasGridRef.current, view, pinned);
+    wasGridRef.current = layout === "grid";
+    if (!fix) return;
+    if ("view" in fix) setView(fix.view);
+    else setLayout?.("rail");
+  }, [layout, view, pinned, setLayout]);
+
   const [cameraProjection, setCameraProjection] = useState<Projection>("xy");
   // When the user switches antennas, reset the camera to that example's
   // natural starting view (declared on the backend via default_view).
@@ -76,7 +106,9 @@ export function useViewState({
       ) {
         return;
       }
-      const order = cycleOrder(pinned, view);
+      // Grid mode cycles the displayed cells only (unit 3's "Keyboard"
+      // section); rail mode keeps unit 2's pinned ∪ active cycle untouched.
+      const order = layout === "grid" ? gridCells(pinned) : cycleOrder(pinned, view);
       const idx = order.indexOf(view);
       const next =
         e.key === "ArrowDown"
@@ -86,7 +118,7 @@ export function useViewState({
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [view, active, pinned]);
+  }, [view, active, pinned, layout]);
 
   return {
     azElevDeg,

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -2011,6 +2011,119 @@ input[type=checkbox] {
   font-size: var(--text-xs);
 }
 
+/* ---- Rail/grid segmented control (unit 3, docs/plan-view-rail-scaling.md
+   "Layout modes") — stage top-right, desktop only. Same look family as
+   .projection-toggle: a pill of plain buttons, one active. ---- */
+.layout-toggle {
+  position: absolute;
+  top: var(--space-6);
+  right: var(--space-6);
+  z-index: 3;
+  display: flex;
+  gap: var(--space-2);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: var(--space-2);
+  box-shadow: 0 2px 10px var(--shadow);
+}
+
+.layout-toggle button {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  font: var(--text-sm) var(--font-mono);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+}
+
+.layout-toggle button:hover {
+  color: var(--fg);
+  background: var(--inset);
+}
+
+.layout-toggle button.active {
+  color: var(--accent);
+  background: var(--accent-active);
+}
+
+/* ---- Grid layout mode (unit 3): equal cells over the first ≤4 pins, no
+   primary. Row/column count comes from JS (useGridCellSize/ViewGrid share
+   gridShape's math) as an inline style, not fixed classes here — the shape
+   changes with the pin count. ---- */
+.view-grid {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: grid;
+  gap: var(--space-4);
+  padding: var(--space-4);
+}
+
+.grid-cell {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--panel);
+  border: 1px solid var(--border-control);
+  border-radius: var(--r-md);
+  padding: var(--space-4);
+  box-sizing: border-box;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.grid-cell:hover {
+  border-color: var(--accent-border);
+}
+
+/* The active view's cell — Blender-quad-viewport focus ring: the arrow keys
+   and a cell-body click both move this, per-cell overlays anchor inside it
+   the same way they anchor inside .carousel-slide. */
+.grid-cell-focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent) inset;
+}
+
+/* The 3-pin "pin a 4th view" invitation cell (see ViewGrid) — dashed like
+   .view-picker-btn's own "this slot isn't resident yet" idiom. */
+.grid-cell-hint {
+  color: var(--muted);
+  font-size: var(--text-xs);
+  border-style: dashed;
+  cursor: default;
+}
+
+/* Top-LEFT (not top-right, where AntennaOverlayControls/SmithOverlayControls/
+   FarFieldOverlayControls already anchor per cell) so the glyph never
+   overlaps a view's own overlay controls. */
+.grid-cell-maximize {
+  position: absolute;
+  top: var(--space-3);
+  left: var(--space-3);
+  z-index: 3;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  color: var(--muted);
+  cursor: pointer;
+  box-shadow: 0 2px 8px var(--shadow);
+}
+
+.grid-cell-maximize:hover {
+  color: var(--accent);
+  border-color: var(--accent-border);
+}
+
 .carousel-slide {
   flex: 1;
   min-width: 0;


### PR DESCRIPTION
Unit 3 (the last unit) of the #700 stacked arc, stacked onto `issue-700-view-rail` (rebased over units 4 and 5b; one import-line conflict resolved as the union).

## Summary
- `Layout = "rail" | "grid"` preset over the same pinned set: ▤/⊞ segmented control (`LayoutModeToggle` in StageOverlays, desktop stage only), new presentational `ViewGrid` — equal cells over `gridCells(pinned)` (first ≤4 pins; 1→1×1, 2→1×2, 3–4→2×2 with a "Pin a 4th view" hint at 3; pins #5/#6 stay rail-only).
- Focus ring = active view; cell click focuses, maximize glyph/double-click → rail with that view primary; grid-mode arrows cycle the displayed cells only; HUD renders once at stage level.
- `gridFix` pure decision table for the off-grid ring: entering grid (or picking an off-grid *pinned* view) snaps to cell 1; picking a *peek* while in grid falls back to rail (a peek has no cell by definition) — distinguished by a `wasGrid` previous-render flag.
- Persistence: `layout` is optional on read (non-"grid" ⇒ "rail") and **sparse on write** (omitted while "rail"), so pre-unit-3 stored records and unit 2's exact-keys test stay byte-shaped. Rail branch of DesignSession unchanged.

## Gates (measured)
- Suite: 35 files / **565 tests** green post-rebase (510 baseline unedited + 55 new).
- `npm run build` green.
- Mutation probes: builder — `gridCells` reversed (9 failures), `gridFix` disabled (8 failures); reviewer — peek branch collapsed into snap-to-cell-1 (2 failures). All reverted.

## Review notes
- Built by a sonnet subagent (delegated-build; one watchdog stall, resumed cleanly). Reviewed by the session model: full diff read, `gridFix` table and the transient off-grid arrow case re-derived, gates re-run post-rebase, independent mutation probe.
- Two placement facts (toggle absent on mobile; exactly 3 SolveReadout sites) are asserted structurally via `?raw` source-slicing because DesignSession has no mount harness — pre-existing gap, follow-up noted in the arc summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01522PMkNyJbRX772WV5DwaA