### PR TITLE
invvee_catenary: default to a visibly drooping arm (0.3 N)

### DIFF
--- a/src/antennaknobs/designs/dipoles/invvee_catenary.py
+++ b/src/antennaknobs/designs/dipoles/invvee_catenary.py
@@ -211,9 +211,14 @@ class Builder(AntennaBuilder):
             # Rope tension holding each arm's far end. LIVE under
             # rig_model="halyard" only; ignored entirely under
             # "anchored_rope", where tension is a rig_report() readout, not
-            # an input. ~9 lbf: a realistic hand-tensioned dacron halyard
-            # pull.
-            "tension_n": 40.0,
+            # an input. The default is deliberately LIGHT: this wire is only
+            # ~5 g/m, so a real hand-tensioned halyard (tens of newtons)
+            # pulls it straight to within a millimetre and the catenary —
+            # the design's whole point — becomes invisible. 0.3 N sags the
+            # stock arm ~7.5 cm (visibly bowed at stock zoom) and happens to
+            # sit near resonance at the stock length_factor; the slider's
+            # top end is the taut-halyard regime that straightens it.
+            "tension_n": 0.3,
             # Stake / ground-anchor position in the arm's vertical plane,
             # horizontal distance from the mast and height above ground.
             # Shared by both models (see the module docstring): model 1
@@ -249,7 +254,13 @@ class Builder(AntennaBuilder):
                     "rig_model": {
                         "enum_options": ("halyard", "anchored_rope"),
                     },
-                    "tension_n": {"min": 2.0, "max": 400.0},
+                    # 0.1 N (barely restrained, ~11 cm of sag on the stock
+                    # arm) up to 40 N (~9 lbf, a hand-tensioned dacron
+                    # halyard — visibly straight). The old 2–400 N range put
+                    # the ENTIRE visible-droop regime below the slider's
+                    # floor: at ~5 g/m of wire, sag is already under 2 cm at
+                    # 2 N and sub-millimetre at 400 N.
+                    "tension_n": {"min": 0.1, "max": 40.0},
                     "stake_dist": {"min": 1.0, "max": 6.0},
                     "stake_height": {"min": 0.0, "max": 3.0},
                     # 0.05 mm (near the taut/high-tension extreme a real

--- a/tests/test_invvee_catenary.py
+++ b/tests/test_invvee_catenary.py
@@ -174,11 +174,18 @@ def test_cut_length_invariant_under_tension():
             expected_arm_length, rel=1e-12
         )
 
-    # Total emitted polyline length ~= 2 arms + the short feed wire.
-    wires = b.build_wires()
-    total = sum(math.dist(w.p0, w.p1) for w in wires)
+    # Total emitted polyline length ~= 2 arms + the short feed wire. Chords
+    # under-measure a curved arc by O((sag/chord)^2), so the strict 1e-6
+    # check belongs in the taut limit, where the arm is straight; at the
+    # droopy stock default (0.3 N since the visible-droop default change)
+    # the chordal total must still come in just UNDER the true cut length,
+    # never over, and within the coarse bound the stock chord count sets.
     expected_total = 2.0 * expected_arm_length + 2.0 * _EPS
-    assert total == pytest.approx(expected_total, rel=1e-6)
+    taut = sum(math.dist(w.p0, w.p1) for w in _builder(tension_n=1.0e4).build_wires())
+    assert taut == pytest.approx(expected_total, rel=1e-6)
+    total = sum(math.dist(w.p0, w.p1) for w in b.build_wires())
+    assert total <= expected_total
+    assert total == pytest.approx(expected_total, rel=1e-3)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- User review of #698: at the shipped defaults the catenary was invisible — ~5 g/m wire means sub-2 cm sag across the ENTIRE old 2–400 N slider range, and ~1 mm at the 40 N default.
- Default `tension_n` 40 → **0.3 N**: ~7.5 cm of sag on the stock arm (meets the 'visibly droop, 5 cm or more' ask), and it happens to sit near resonance at the stock `length_factor` (X ≈ −1.4j vs +20j at 40 N; R drops to ~10 Ω as a steep droopy vee does).
- Slider range 2–400 → **0.1–40 N**: barely-restrained (~11 cm sag) up to hand-tensioned-halyard taut (visibly straight), so the whole droop↔taut transition lives on the slider.
- `test_cut_length_invariant_under_tension`: the strict 1e-6 polyline-vs-cut-length check moves to the taut limit (chords under-measure a curved arc by O((sag/chord)²) — it only passed before because the default was straight); the droopy default now pins chordal total ≤ cut length and within 1e-3.

## Test plan
- [x] `tests/test_invvee_catenary.py` + `test_catenary.py` + `test_web_server.py`: 239 passed
- [x] Full suite: 3345 passed, 2 skipped
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01522PMkNyJbRX772WV5DwaA