### PR TITLE
Generic server-driven readouts panel for the workbench

### DIFF
--- a/src/antennaknobs/designs/dipoles/invvee_catenary.py
+++ b/src/antennaknobs/designs/dipoles/invvee_catenary.py
@@ -182,6 +182,44 @@ _N_PER_LBF = 4.4482216152605
 # same value `dipoles.invvee` and `wire.doublet_ladder_tuner` use.
 _EPS = 0.05
 
+# Group heading every `readout_rows()` row below is clustered under in the
+# workbench readout (issue #712).
+_RIG_GROUP = "rigging"
+
+
+def _tension_row(label: str, newtons: float) -> dict:
+    """One tension readout row carrying BOTH units in a single string value
+    ("22.5 N (5.06 lbf)"): issue #698's acceptance criterion asks for newtons
+    and pounds-force, and a rigger reads them together — two numeric rows
+    would double the height of a HUD that floats over the canvas, and a
+    "lbf" row alone reads as a different measurement rather than the same
+    one restated. The row is pre-formatted here because unit choice is the
+    server's job in this contract (the frontend prints strings verbatim)."""
+    n = float(newtons)
+    return {
+        "label": label,
+        "value": f"{n:.4g} N ({n / _N_PER_LBF:.3g} lbf)",
+        "unit": None,
+        "group": _RIG_GROUP,
+    }
+
+
+def _length_row(label: str, metres: float) -> dict:
+    """One length readout row, in whichever unit keeps it legible: sub-metre
+    lengths (the sags — a few centimetres at realistic tensions, sub-
+    millimetre on a taut halyard) go out in millimetres, everything else in
+    metres. The frontend has no notion of "a length" at all, so this choice
+    can only be made here."""
+    m = float(metres)
+    if abs(m) < 1.0:
+        return {
+            "label": label,
+            "value": m * 1.0e3,
+            "unit": "mm",
+            "group": _RIG_GROUP,
+        }
+    return {"label": label, "value": m, "unit": "m", "group": _RIG_GROUP}
+
 
 class Builder(AntennaBuilder):
     """A subclass of `AntennaBuilder` directly, not `dipoles.invvee`: the
@@ -408,6 +446,52 @@ class Builder(AntennaBuilder):
             "rope_length_m": rope_seg.arc_length_m if rope_seg is not None else None,
             "wire_end_height_m": float(wire_seg.points[-1][1]),
         }
+
+    def readout_rows(self) -> list[dict]:
+        """Workbench readout rows (issue #712): the same numbers `rig_report()`
+        returns, re-expressed as the generic self-describing row list the web
+        adapter surfaces under "readouts" and the frontend renders with no
+        design-specific code — `{label, value, unit, group}` per row, where
+        `value` is a number the client formats, a short string it prints
+        verbatim, or None (an em-dash).
+
+        `rig_report()` stays the machine-readable dict (its keys are a
+        response contract of their own); this method is the *display*
+        projection of it, so the two can disagree about presentation —
+        millimetres instead of metres for a sub-metre sag, one combined
+        "N (lbf)" string instead of two keys — without either one bending to
+        the other's audience. It is called once, and only rows that mean
+        something for the active `rig_model` are emitted (the rope rows exist
+        only under "anchored_rope"), which is exactly the freedom the dict's
+        fixed-key shape does not have.
+        """
+        r = self.rig_report()
+        rows: list[dict] = [
+            {
+                "label": "rig model",
+                "value": str(r["rig_model"]),
+                "unit": None,
+                "group": _RIG_GROUP,
+            },
+            _tension_row("apex tension", r["apex_tension_n"]),
+            _tension_row("end tension", r["end_tension_n"]),
+            {
+                "label": "horizontal tension",
+                "value": float(r["horizontal_tension_n"]),
+                "unit": "N",
+                "group": _RIG_GROUP,
+            },
+            _length_row("wire sag", r["wire_sag_m"]),
+        ]
+        if r["rope_sag_m"] is not None:
+            # Model 2 only: model 1's rope is massless and never solved, so
+            # a "rope sag: —" row there would imply a number that does not
+            # exist rather than one that is merely missing.
+            rows.append(_length_row("rope sag", r["rope_sag_m"]))
+        if r["rope_length_m"] is not None:
+            rows.append(_length_row("rope cut length", r["rope_length_m"]))
+        rows.append(_length_row("wire end height", r["wire_end_height_m"]))
+        return rows
 
     # build_wire_material() is intentionally NOT overridden: the inherited
     # AntennaBuilder default already resolves a `wire_type` param via

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -1345,6 +1345,105 @@ def _rig_report_results(builder) -> dict:
         return {}
 
 
+# Every key a readout row may carry, and nothing else (issue #712). The row
+# contract is deliberately tiny: `label` (display text), `value` (a number the
+# frontend formats, a short string it prints verbatim, or None -> em-dash),
+# `unit` (appended after the value), `group` (small heading rows cluster
+# under; None = ungrouped, rendered first).
+_READOUT_KEYS = frozenset({"label", "value", "unit", "group"})
+
+
+def _readout_row(raw, owner: str) -> dict | None:
+    """Validate one `readout_rows()` row, returning the normalised row (all
+    four keys present) or None if it is malformed.
+
+    Validation is server-side and per-row on purpose: these rows come from
+    arbitrary design code — catalog designs AND whatever is in
+    ~/.antennaknobs/designs — and the whole point of the contract is that a
+    design author writes Python and gets a readout with no TypeScript. The
+    other half of that bargain is that their typo cannot reach the client:
+    one bad row is dropped, its siblings still render, and the browser never
+    has to defend itself against a value it cannot display.
+    """
+
+    def bad(why: str) -> None:
+        _logger.debug("dropping readout row from %s: %s (%r)", owner, why, raw)
+        return None
+
+    if not isinstance(raw, Mapping):
+        return bad("not a mapping")
+    extra = set(raw) - _READOUT_KEYS
+    if extra:
+        return bad(f"unknown key(s) {sorted(extra)}")
+    label = raw.get("label")
+    if not isinstance(label, str) or not label:
+        return bad("label must be a non-empty string")
+    value = raw.get("value")
+    if isinstance(value, bool):
+        # bool is an int subclass; a True/False readout is a design bug, not
+        # a number to plot next to a tension.
+        return bad("value must not be a bool")
+    if isinstance(value, (int, float)):
+        value = float(value)
+        if not math.isfinite(value):
+            # NaN/Infinity are not JSON, and the browser's JSON.parse
+            # rejects them outright (same trap as the measured-open clamp).
+            return bad("value is not finite")
+    elif not (value is None or isinstance(value, str)):
+        return bad(
+            f"value must be a number, string or None, got {type(value).__name__}"
+        )
+    unit = raw.get("unit")
+    if not (unit is None or isinstance(unit, str)):
+        return bad("unit must be a string or None")
+    group = raw.get("group")
+    if not (group is None or isinstance(group, str)):
+        return bad("group must be a string or None")
+    return {"label": label, "value": value, "unit": unit, "group": group}
+
+
+def _readout_rows_results(builder) -> dict:
+    """Generic workbench readout rows (issue #712), surfaced under "readouts"
+    beside `_wire_material_results` / `_rig_report_results`. {} for every
+    design that defines no `readout_rows()` — the duck-typed per-design
+    method is the discovery mechanism, the same idiom `rig_report()` and
+    `build_wire_material()` use, so a user design in ~/.antennaknobs/designs
+    gets a readout the moment it grows the method, with no registry entry and
+    no frontend change.
+
+    This is the generic successor to `_rig_report_results`'s bespoke "rig"
+    key (which stays, unchanged, for compatibility): the rows are
+    self-describing, so every future construction feature that wants numbers
+    on screen is Python-only.
+
+    Same omit-on-error contract as `_rig_report_results` — the readout is
+    garnish on a solve that already stands on its own, so a producer that
+    raises (a mid-scrub infeasible rig) is debug-logged and omitted, never
+    surfaced as an error field and never allowed to fail the response. Rows
+    are additionally validated one by one: a malformed row is dropped while
+    its valid siblings survive, so one design-author typo cannot blank the
+    whole panel.
+    """
+    readout_rows = getattr(builder, "readout_rows", None)
+    if not callable(readout_rows):
+        return {}
+    owner = type(builder).__name__
+    try:
+        raw_rows = readout_rows()
+        if not isinstance(raw_rows, (list, tuple)):
+            _logger.debug(
+                "readout_rows() for %r returned %s, not a list",
+                owner,
+                type(raw_rows).__name__,
+            )
+            return {}
+        rows = [r for r in (_readout_row(raw, owner) for raw in raw_rows) if r]
+    except Exception:
+        _logger.debug("readout_rows() failed for %r", owner, exc_info=True)
+        return {}
+    return {"readouts": rows} if rows else {}
+
+
 def _make_momwire_engine(req: dict, builder, cancel=None):
     # "bspline" is the default and the fallback for unknown/retired model
     # names (a stale client may still send "triangular").
@@ -2272,6 +2371,9 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             "input_power_w": float(eng.input_power()),
             **_wire_material_results(builder),
             **_rig_report_results(builder),
+            # Generic self-describing readout rows (issue #712): the same
+            # duck-typed discovery, rendered by one frontend component.
+            **_readout_rows_results(builder),
         }
         if planes is not None:
             # Measurement plane (issue #652 c): which port this solve is
@@ -2453,6 +2555,9 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             "input_power_w": float(getattr(eng, "_excited_p_in", None) or 0.0),
             **_wire_material_results(builder),
             **_rig_report_results(builder),
+            # Generic self-describing readout rows (issue #712): the same
+            # duck-typed discovery, rendered by one frontend component.
+            **_readout_rows_results(builder),
         }
         if planes is not None:
             # Same plane fields as the momwire path (issue #652 c).

--- a/src/antennaknobs/web/frontend/src/__tests__/ReadoutsPanel.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/ReadoutsPanel.test.tsx
@@ -1,0 +1,129 @@
+// The generic server-driven readouts contract (issue #712). The feature's
+// whole promise is that a NEW design idea reaches the workbench with zero
+// TypeScript, so these rows are deliberately synthetic and look nothing
+// like the rigging rows that motivated the feature — if this file ever
+// needs to know what a row MEANS, the guarantee is gone.
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  ReadoutsPanel,
+  formatReadoutValue,
+} from "../components/results/ReadoutsPanel";
+import { SolveReadout } from "../components/results/SolveReadout";
+import type { ReadoutRow, SolveResponse } from "../lib/api";
+
+function rowText(label: string): string {
+  // The value sits in the row's second span, beside its label.
+  const labelEl = screen.getByText(label);
+  return labelEl.parentElement?.querySelector(".val")?.textContent ?? "";
+}
+
+describe("ReadoutsPanel", () => {
+  it("renders every value type from rows it has never seen before", () => {
+    const rows: ReadoutRow[] = [
+      { label: "flux capacitance", value: 1.21, unit: "GW", group: null },
+      { label: "coolant", value: "liquid nitrogen", unit: null, group: "plumbing" },
+      { label: "leak rate", value: 0.5, unit: "mL/h", group: "plumbing" },
+      { label: "spare hose", value: null, unit: "m", group: "plumbing" },
+    ];
+    render(<ReadoutsPanel rows={rows} />);
+
+    expect(rowText("flux capacitance")).toBe("1.21 GW");
+    // A string value is printed verbatim — no unit, no reformatting.
+    expect(rowText("coolant")).toBe("liquid nitrogen");
+    expect(rowText("leak rate")).toBe("0.5 mL/h");
+    // A null value is an em-dash and drops its unit (no "— m").
+    expect(rowText("spare hose")).toBe("—");
+    // Group heading rendered once for the three rows that share it.
+    expect(screen.getAllByText("plumbing")).toHaveLength(1);
+  });
+
+  it("clusters rows by group, ungrouped first, order preserved", () => {
+    const rows: ReadoutRow[] = [
+      { label: "b-first", value: 1, unit: null, group: "beta" },
+      { label: "loose", value: 2, unit: null, group: null },
+      { label: "a-only", value: 3, unit: null, group: "alpha" },
+      { label: "b-second", value: 4, unit: null, group: "beta" },
+    ];
+    const { container } = render(<ReadoutsPanel rows={rows} />);
+    const labels = Array.from(
+      container.querySelectorAll(".readout-row > span:first-child"),
+    ).map((el) => el.textContent);
+    // Ungrouped leads; each group keeps first-appearance order, and rows
+    // stay in the order the server sent them within their group.
+    expect(labels).toEqual(["loose", "b-first", "b-second", "a-only"]);
+  });
+
+  it("renders nothing at all when there are no rows", () => {
+    for (const rows of [undefined, null, [] as ReadoutRow[]]) {
+      const { container } = render(<ReadoutsPanel rows={rows} />);
+      expect(container.innerHTML).toBe("");
+    }
+  });
+
+  it("formats numbers to fixed significant digits, trimming float dust", () => {
+    expect(formatReadoutValue(1234.5678)).toBe("1235");
+    expect(formatReadoutValue(0.00123456)).toBe("0.001235");
+    expect(formatReadoutValue(64.08740188881157)).toBe("64.09");
+    expect(formatReadoutValue(22.53)).toBe("22.53");
+    expect(formatReadoutValue(0)).toBe("0");
+    expect(formatReadoutValue(-1.0 / 3.0)).toBe("-0.3333");
+    expect(formatReadoutValue(null)).toBe("—");
+  });
+});
+
+describe("SolveReadout's readouts section", () => {
+  function fakeResult(extra: Partial<SolveResponse> = {}): SolveResponse {
+    return {
+      geometry: "dipoles.invvee_catenary",
+      wires: [
+        {
+          label: "w",
+          knot_positions: [[0, 0, 0]],
+          knot_currents_re: [0],
+          knot_currents_im: [0],
+        },
+      ],
+      feed_wire_index: 0,
+      feed_knot_index: 0,
+      z_in_re: 44,
+      z_in_im: -4,
+      design_freq_mhz: 28.47,
+      measurement_freq_mhz: 28.47,
+      solve_ms: 1.0,
+      z0_ohms: 50,
+      ...extra,
+    } as SolveResponse;
+  }
+
+  function renderReadout(result: SolveResponse | null) {
+    return render(
+      <SolveReadout
+        result={result}
+        rttMs={null}
+        currentExample={undefined}
+        effectiveMultiFeed={false}
+        normCheck={null}
+        normCheckEnabled={false}
+      />,
+    );
+  }
+
+  it("shows the solve's rows inside the readout HUD", () => {
+    renderReadout(
+      fakeResult({
+        readouts: [
+          { label: "wire sag", value: 64.087, unit: "mm", group: "rigging" },
+        ],
+      }),
+    );
+    expect(screen.getByText("rigging")).toBeTruthy();
+    expect(rowText("wire sag")).toBe("64.09 mm");
+  });
+
+  it("is absent for a solve that carries no readouts", () => {
+    renderReadout(fakeResult());
+    expect(screen.queryByText("rigging")).toBeNull();
+    expect(document.querySelectorAll(".readout-row")).toHaveLength(0);
+  });
+});

--- a/src/antennaknobs/web/frontend/src/components/results/ReadoutsPanel.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/ReadoutsPanel.tsx
@@ -1,0 +1,79 @@
+import type { ReadoutRow } from "../../lib/api";
+
+// Generic server-driven readouts (issue #712). This component is the ONLY
+// frontend code any design-side readout ever needs: the server sends
+// self-describing {label, value, unit, group} rows (see ReadoutRow), this
+// renders them, and a new construction feature — a bungee closure's
+// stretch/tension drift, a user design in ~/.antennaknobs/designs — costs
+// zero TypeScript. That guarantee is why nothing below may branch on a
+// label, a unit or a group name: the rows are opaque display data.
+
+// Significant digits every numeric row is formatted to. One constant, one
+// call site: the server picks the UNIT (it alone knows whether a length is
+// a sag in millimetres or a mast height in metres), the client picks the
+// precision, and neither has to know the other's choice.
+const SIG_FIGS = 4;
+
+export function formatReadoutValue(value: ReadoutRow["value"]): string {
+  // A missing value is a real state — a rope sag on a model that has no
+  // rope — not an error; it reads as an em-dash like every other blank in
+  // the readout.
+  if (value === null || value === undefined) return "—";
+  // Strings are printed verbatim: the server already chose their wording
+  // (e.g. a tension quoted in both N and lbf), and re-formatting them here
+  // would be exactly the per-design knowledge this component must not have.
+  if (typeof value === "string") return value;
+  if (!Number.isFinite(value)) return "—";
+  if (value === 0) return "0";
+  // toPrecision then parseFloat: fixed sig-figs without the trailing zeros
+  // (22.53000 -> "22.53") that make a HUD column look ragged.
+  return String(parseFloat(value.toPrecision(SIG_FIGS)));
+}
+
+function formatRow(row: ReadoutRow): string {
+  const text = formatReadoutValue(row.value);
+  return row.unit && text !== "—" ? `${text} ${row.unit}` : text;
+}
+
+export function ReadoutsPanel({ rows }: { rows?: ReadoutRow[] | null }) {
+  // Nothing to say -> nothing rendered, not an empty card: most designs
+  // send no rows at all and their readout must look exactly as it did
+  // before this feature existed.
+  if (!rows || rows.length === 0) return null;
+
+  // Cluster by group, preserving the server's row order inside each group
+  // and grouping by FIRST appearance, so a design controls the whole
+  // layout from Python. Ungrouped rows lead (they belong to no heading, so
+  // a heading above them would be a lie).
+  const groups: { name: string | null; rows: ReadoutRow[] }[] = [];
+  for (const row of rows) {
+    const name = row.group ?? null;
+    const bucket = groups.find((g) => g.name === name);
+    if (bucket) bucket.rows.push(row);
+    else groups.push({ name, rows: [row] });
+  }
+  const ungroupedFirst = [
+    ...groups.filter((g) => g.name === null),
+    ...groups.filter((g) => g.name !== null),
+  ];
+
+  return (
+    <>
+      {ungroupedFirst.map((g) => (
+        // .feeds-table is the readout's existing "separated block of rows"
+        // wrapper (the power budget and per-feed Z tables use it); reusing
+        // it keeps a design's rows visually part of the readout rather
+        // than a second card bolted on.
+        <div className="feeds-table" key={`readout-group-${g.name ?? ""}`}>
+          {g.name && <div className="feeds-table-header">{g.name}</div>}
+          {g.rows.map((row, i) => (
+            <div className="row readout-row" key={`readout-${g.name ?? ""}-${i}`}>
+              <span>{row.label}</span>
+              <span className="val">{formatRow(row)}</span>
+            </div>
+          ))}
+        </div>
+      ))}
+    </>
+  );
+}

--- a/src/antennaknobs/web/frontend/src/components/results/SolveReadout.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/SolveReadout.tsx
@@ -2,6 +2,7 @@ import { Fragment } from "react";
 import type { NormCheckData, SolveResponse } from "../../lib/api";
 import { formatOhms, formatSwr } from "../../lib/format";
 import type { ExampleDescriptor } from "../../lib/params";
+import { ReadoutsPanel } from "./ReadoutsPanel";
 import { ResultPanel } from "./ResultPanel";
 
 function feedMag(r: SolveResponse): number {
@@ -228,6 +229,13 @@ export function SolveReadout({
           </div>
         );
       })()}
+      {/* Design-supplied readouts (issue #712): whatever rows the geometry's
+          own readout_rows() produced, rendered generically. They sit with
+          the antenna's other physical numbers, above the engine timing.
+          Mounted HERE rather than at DesignSession's three call sites so
+          every layout (mobile Info screen, desktop rail slide, grid stage
+          HUD) gets them with no layout-specific code. */}
+      <ReadoutsPanel rows={result?.readouts} />
       {/* Engine timing grouped last: solve/rtt describe how fast the answer
           arrived, not what the antenna is doing, so they sit below the RF
           readout (and below the power budget when one is shown). The

--- a/src/antennaknobs/web/frontend/src/lib/api.ts
+++ b/src/antennaknobs/web/frontend/src/lib/api.ts
@@ -38,6 +38,25 @@ export type PatternCuts = {
   elevation: number[];
 };
 
+/** One server-driven readout row (issue #712). Designs produce these from a
+ *  duck-typed `readout_rows()` on the builder and the adapter validates them,
+ *  so a NEW design feature — catalog or a user design in
+ *  ~/.antennaknobs/designs — reaches the workbench readout with zero
+ *  TypeScript. Nothing here may be interpreted per design:
+ *   - `label`: display text, printed as-is.
+ *   - `value`: a number (ReadoutsPanel formats it to fixed sig-figs), a short
+ *     string (printed verbatim — the server already chose its wording), or
+ *     null (an em-dash: a value that legitimately doesn't exist).
+ *   - `unit`: appended after the value; the server owns the unit choice
+ *     (mm vs m and so on), the client never converts.
+ *   - `group`: small heading rows cluster under; null = ungrouped (first). */
+export type ReadoutRow = {
+  label: string;
+  value: number | string | null;
+  unit: string | null;
+  group: string | null;
+};
+
 export type SolveResponse = {
   geometry: string;
   wires: Wire[];
@@ -125,6 +144,11 @@ export type SolveResponse = {
    *  first). Absent for designs with no network or a multi-feed drive. */
   plane?: string;
   planes?: string[];
+  /** Generic design-supplied readout rows (issue #712), rendered by
+   *  ReadoutsPanel. Absent for the designs (nearly all of them) that define
+   *  no `readout_rows()`, and absent rather than empty when every row a
+   *  design produced was malformed or its producer raised. */
+  readouts?: ReadoutRow[];
   k_meas_m_inv?: number;
   // V-specific
   arm_len_m?: number;

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -1791,6 +1791,20 @@ input[type=checkbox] {
   color: var(--muted);
 }
 
+/* Design-supplied readout rows (issue #712). The label is written by
+   arbitrary design code, so unlike every hand-authored row above it can be
+   longer than the HUD is wide: let it wrap under itself rather than squeeze
+   the value out of the card, and keep the value on one line hugging the
+   right edge (a wrapped "22.5 N (5.06 lbf)" reads as two numbers). */
+.readout .readout-row > span:first-child {
+  overflow-wrap: anywhere;
+}
+
+.readout .readout-row .val {
+  white-space: nowrap;
+  text-align: right;
+}
+
 .smith,
 .farfield,
 .sweep {

--- a/tests/test_invvee_catenary.py
+++ b/tests/test_invvee_catenary.py
@@ -414,3 +414,43 @@ def test_anchored_model_rejects_wire_that_already_overshoots_the_anchor():
     b = _builder(rig_model="anchored_rope", stake_dist=0.1, stake_height=6.9)
     with pytest.raises(ValueError, match="already reaches past the anchor"):
         b.rig_report()
+
+
+# ---------------------------------------------------------------------------
+# 15. Readout rows: the display projection of rig_report() (issue #712)
+# ---------------------------------------------------------------------------
+
+
+def test_readout_rows_project_the_report_for_both_models():
+    """`readout_rows()` is the generic-readouts (issue #712) display
+    projection of `rig_report()`: self-describing {label, value, unit,
+    group} rows the web adapter ships verbatim. Both models emit a schema-
+    clean, grouped list; only the anchored model — the only one with a real
+    rope — emits the rope rows, and sub-metre lengths come out in
+    millimetres because the unit choice is the design's, not the browser's.
+    """
+    for rig_model in ("halyard", "anchored_rope"):
+        rows = _builder(rig_model=rig_model).readout_rows()
+        for row in rows:
+            assert set(row) == {"label", "value", "unit", "group"}, row
+            assert isinstance(row["label"], str) and row["label"]
+            assert row["group"] == "rigging"
+            v = row["value"]
+            assert v is None or isinstance(v, str) or math.isfinite(v)
+        by_label = {r["label"]: r for r in rows}
+        assert "N" in by_label["apex tension"]["value"]
+        assert "lbf" in by_label["apex tension"]["value"]
+        assert by_label["rig model"]["value"] == rig_model
+        # Sub-metre sag reads in mm; the metre-scale height stays in metres.
+        assert by_label["wire sag"]["unit"] == "mm"
+        assert by_label["wire end height"]["unit"] == "m"
+        has_rope = rig_model == "anchored_rope"
+        assert ("rope sag" in by_label) is has_rope
+        assert ("rope cut length" in by_label) is has_rope
+        if has_rope:
+            # Read back off the same solve, in the same units rig_report()
+            # reported (metres) — this is a re-expression, not a re-solve.
+            report = _builder(rig_model=rig_model).rig_report()
+            assert by_label["rope cut length"]["value"] == pytest.approx(
+                report["rope_length_m"]
+            )

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -659,6 +659,126 @@ def test_rig_report_failure_never_fails_the_solve(monkeypatch):
     assert math.isfinite(out["z_in_re"])
 
 
+def _assert_readout_schema(rows):
+    """The issue #712 row contract, in one place: every readout row is
+    exactly {label, value, unit, group}, with `label` a non-empty string,
+    `value` a finite number / short string / None, and `unit`/`group`
+    strings or None. This is what the frontend's single generic renderer is
+    allowed to assume about rows it has never seen before, so it is asserted
+    on the wire rather than on a builder's return value."""
+    assert isinstance(rows, list) and rows
+    for row in rows:
+        assert set(row) == {"label", "value", "unit", "group"}, row
+        assert isinstance(row["label"], str) and row["label"], row
+        v = row["value"]
+        assert v is None or isinstance(v, str) or isinstance(v, (int, float)), row
+        assert not isinstance(v, bool), row
+        if isinstance(v, (int, float)):
+            assert math.isfinite(v), row
+        assert row["unit"] is None or isinstance(row["unit"], str), row
+        assert row["group"] is None or isinstance(row["group"], str), row
+
+
+def test_solve_carries_generic_readout_rows_for_designs_that_have_them():
+    """The generic readouts contract (issue #712): a design defining
+    `readout_rows()` — dipoles.invvee_catenary — ships its rows under
+    "readouts" in the solve response, schema-clean, and a design that
+    defines no such method ships no "readouts" key at all. Same duck-typed
+    discovery as `rig_report()` / `build_wire_material()`, which is what
+    makes a user design in ~/.antennaknobs/designs cost zero frontend
+    code."""
+    out = server.solve(
+        {
+            "geometry": "dipoles.invvee_catenary",
+            # Own freq (see test_rig_report_failure_never_fails_the_solve):
+            # _SOLVE_CACHE is keyed on the request.
+            "measurement_freq_mhz": 28.53,
+            "design_freq_mhz": 28.47,
+            "momwire_model": "bspline",
+        }
+    )
+    rows = out["readouts"]
+    _assert_readout_schema(rows)
+    assert len(rows) >= 4
+    # The rigging rows are grouped, and the design's own numbers are there.
+    assert {r["group"] for r in rows} == {"rigging"}
+    labels = [r["label"] for r in rows]
+    assert "apex tension" in labels and "wire sag" in labels
+    # The bespoke pre-#712 key is untouched (compatibility).
+    assert out["rig"]["rig_model"] == "halyard"
+
+    bare = server.solve(
+        {
+            "geometry": "dipoles.invvee",
+            "measurement_freq_mhz": 28.53,
+            "design_freq_mhz": 28.47,
+            "momwire_model": "bspline",
+        }
+    )
+    assert "readouts" not in bare
+
+
+def test_readout_rows_failure_never_fails_the_solve(monkeypatch):
+    """Omit-on-error extends to the row list (issue #712, inheriting #698's
+    contract): a `readout_rows()` that raises leaves a normal solve response
+    with the "readouts" key simply absent."""
+    from antennaknobs.designs.dipoles.invvee_catenary import Builder
+
+    def boom(self):
+        raise ValueError("mid-scrub infeasible rig")
+
+    monkeypatch.setattr(Builder, "readout_rows", boom)
+    out = server.solve(
+        {
+            "geometry": "dipoles.invvee_catenary",
+            "measurement_freq_mhz": 28.55,
+            "design_freq_mhz": 28.47,
+            "momwire_model": "bspline",
+        }
+    )
+    assert "readouts" not in out
+    assert math.isfinite(out["z_in_re"])
+
+
+def test_malformed_readout_rows_are_dropped_not_shipped(monkeypatch):
+    """Per-row validation (issue #712): rows come from arbitrary design code
+    (catalog AND ~/.antennaknobs/designs), so one author's typo must cost
+    that row alone — the malformed ones are dropped server-side, their valid
+    siblings still reach the client, and nothing the browser cannot render
+    (NaN, a bool, a dict value, an unknown key) is ever put on the wire."""
+    from antennaknobs.designs.dipoles.invvee_catenary import Builder
+
+    def mixed(self):
+        return [
+            {"label": "good", "value": 1.5, "unit": "N", "group": "g"},
+            {"label": "", "value": 1.0, "unit": None, "group": None},  # no label
+            {"value": 1.0, "unit": None, "group": None},  # label missing
+            {"label": "nan", "value": float("nan"), "unit": None, "group": None},
+            {"label": "bool", "value": True, "unit": None, "group": None},
+            {"label": "dict", "value": {"a": 1}, "unit": None, "group": None},
+            {"label": "unit", "value": 1.0, "unit": 7, "group": None},
+            {"label": "group", "value": 1.0, "unit": None, "group": 7},
+            {"label": "extra", "value": 1.0, "colour": "red"},  # unknown key
+            "not a mapping",
+            # Sparse but legal: the omitted keys default to None.
+            {"label": "sparse"},
+        ]
+
+    monkeypatch.setattr(Builder, "readout_rows", mixed)
+    out = server.solve(
+        {
+            "geometry": "dipoles.invvee_catenary",
+            "measurement_freq_mhz": 28.59,
+            "design_freq_mhz": 28.47,
+            "momwire_model": "bspline",
+        }
+    )
+    rows = out["readouts"]
+    _assert_readout_schema(rows)
+    assert [r["label"] for r in rows] == ["good", "sparse"]
+    assert rows[1] == {"label": "sparse", "value": None, "unit": None, "group": None}
+
+
 def _design_builder(dotted):
     import importlib
 


### PR DESCRIPTION
Implements #712 — one readout contract so every future construction feature (catalog or a user design in `~/.antennaknobs/designs/`) reaches the workbench with zero per-feature TypeScript.

## Summary
- **Contract**: duck-typed `readout_rows()` on the builder → adapter validates per-row (`{label, value, unit, group}`; malformed rows dropped with a debug log, valid siblings survive; producer failure or all-bad list → key omitted, never an error) → `SolveResponse.readouts` → one `ReadoutsPanel` component renders grouped rows. Server owns unit choice (mm vs m, combined "N (lbf)" strings); client owns precision (4 sig-figs, one constant, one call site). Nothing in the frontend may branch on a label/unit/group — the rows are opaque display data, and the component's header comment says so.
- `invvee_catenary.readout_rows()` projects `rig_report()` (unchanged, as is the `rig` key) into 6 rows (halyard) / 8 rows (anchored) under a "rigging" group.
- Mounted inside `SolveReadout` between the power budget and engine timing, so all three layout sites (mobile Info, desktop rail, grid HUD) get it with no layout-specific code — the `gridLayoutPlacement` structural test stays untouched.
- Tests: 4 web-adapter tests (contract schema, absence, raise → omit, mixed-rows filtering), a design-level both-models projection test, and 6 vitest tests incl. the synthetic-arbitrary-rows case that IS the no-TS guarantee.

## Gates (builder + reviewer runs agree)
- `pytest tests/test_web_server.py tests/test_invvee_catenary.py`: **209 passed**
- Full suite: **3349 passed, 2 skipped** (both runs; this branch predates #724's 12 new catenary tests)
- `npx tsc --noEmit`: clean · `npx vitest run`: **571 passed** (36 files)
- ruff check/format: clean · `web/static/` deliberately not rebuilt (release ritual owns bundles)

## Review notes (session model reviewing an opus builder)
- Read the full 603-line diff.
- **End-to-end generality probe**: monkeypatched `readout_rows` to emit rows that look nothing like rigging (mast bending moment N·m, an ice-load class string, a null with unit, plus a NaN row and an empty-label row) — the three valid rows flowed through `server.solve` verbatim, the two malformed ones were dropped. The "no TS per idea" guarantee holds at the API layer.
- **Mutation probe**: changing the formatter's SIG_FIGS 4→2 fails 3 vitest tests; pristine re-verified.
- **Flake note**: one vitest run showed a single unrelated-file failure that did not reproduce in four subsequent full runs (571/571 ×4); likely a timing-sensitive test from the recent #700 batch, name not captured. Flagging for awareness rather than hiding it.
- Builder judgment calls reviewed and accepted: combined N/lbf strings (HUD height), bool-rejection stricter than specced (bool ⊂ int in Python), the extra design-level test covering the anchored model's rows and the mm/m switch.

Closes #712

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g