### PR TITLE
View prefs sync across browser windows via storage events

### DIFF
--- a/src/antennaknobs/web/frontend/src/__tests__/useViewPrefs.storage.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useViewPrefs.storage.test.tsx
@@ -1,0 +1,134 @@
+// Issue #716, deferred from #700 (docs/plan-view-rail-scaling.md unit 2):
+// useViewPrefs already shares one module store across every session tab in
+// ONE window (see useViewPrefs.ts's module-store comment), but two browser
+// WINDOWS only used to converge on reload. A `storage` event fires in every
+// OTHER window sharing this origin the instant localStorage actually
+// changes — never in the window that wrote it — so it's the signal that
+// closes that gap. jsdom does not fire it for us on a same-document
+// `setItem` (real browsers only fire it cross-window too), so every test
+// here dispatches the event by hand, exactly as a real second window's
+// write would arrive at this one.
+//
+// A separate file rather than additions to useViewPrefs.test.tsx: that file
+// is the pre-existing baseline unit 2 shipped and unit 3 kept passing
+// UNEDITED (see useViewPrefs.grid.test.tsx's header for why it also lives
+// apart), so this arc gets its own file too.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { VIEW_PREFS_KEY, useViewPrefs } from "../components/session/useViewPrefs";
+
+const FOUNDING = ["antenna", "azimuth", "elevation", "smith"];
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+// Fires the event this suite is about: a same-key storage change arriving
+// from another window. Real browsers set `storageArea`/`url` too, but the
+// module only reads `key` and `newValue`, so those are all any test needs.
+function fireStorage(key: string | null, newValue: string | null) {
+  act(() => {
+    window.dispatchEvent(new StorageEvent("storage", { key, newValue }));
+  });
+}
+
+describe("storage event: valid payload from another window", () => {
+  it("updates a mounted hook's pinned set", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.pinned).toEqual(FOUNDING);
+
+    fireStorage(VIEW_PREFS_KEY, '{"pinned":["smith","antenna"],"seen":["antenna"]}');
+
+    expect(result.current.pinned).toEqual(["smith", "antenna"]);
+  });
+
+  it("updates layout too", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.layout).toBe("rail");
+
+    fireStorage(
+      VIEW_PREFS_KEY,
+      '{"pinned":["smith"],"seen":["smith"],"layout":"grid"}',
+    );
+
+    expect(result.current.layout).toBe("grid");
+  });
+});
+
+describe("storage event: unrelated key", () => {
+  it("is ignored — state is untouched", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    const before = result.current.pinned;
+
+    fireStorage("some.other.key", '{"pinned":["smith"],"seen":["smith"]}');
+
+    expect(result.current.pinned).toBe(before); // same array identity: no re-render fired
+  });
+});
+
+describe("storage event: corrupt or invalid payload", () => {
+  const bad = [
+    ["corrupt JSON", "{not json"],
+    ["a bare array", '["antenna"]'],
+    ["no pinned field", '{"seen":["antenna"]}'],
+    ["only unknown ids", '{"pinned":["bogus","no-such-view"]}'],
+    ["an empty pin set", '{"pinned":[]}'],
+  ] as const;
+
+  for (const [what, raw] of bad) {
+    it(`ignores ${what} — state is unchanged`, () => {
+      const { result } = renderHook(() => useViewPrefs());
+      const before = result.current.pinned;
+
+      fireStorage(VIEW_PREFS_KEY, raw);
+
+      expect(result.current.pinned).toBe(before);
+    });
+  }
+});
+
+describe("storage event: null newValue (key removed / storage.clear())", () => {
+  it("resets to the same defaults loadPrefs uses for a missing key", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.togglePin("schematic"));
+    expect(result.current.pinned).toEqual([...FOUNDING, "schematic"]);
+
+    fireStorage(VIEW_PREFS_KEY, null);
+
+    expect(result.current.pinned).toEqual(FOUNDING);
+  });
+
+  it("also resets on key === null (storage.clear())", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.togglePin("schematic"));
+
+    fireStorage(null, null);
+
+    expect(result.current.pinned).toEqual(FOUNDING);
+  });
+});
+
+describe("storage event: no echo", () => {
+  it("applying a received state does not write back to localStorage", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    const spy = vi.spyOn(Storage.prototype, "setItem");
+
+    fireStorage(VIEW_PREFS_KEY, '{"pinned":["smith","antenna"],"seen":["antenna"]}');
+
+    expect(result.current.pinned).toEqual(["smith", "antenna"]);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("does not write back even when the payload is a reset (null newValue)", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.togglePin("schematic"));
+    const spy = vi.spyOn(Storage.prototype, "setItem");
+
+    fireStorage(VIEW_PREFS_KEY, null);
+
+    expect(result.current.pinned).toEqual(FOUNDING);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/src/antennaknobs/web/frontend/src/components/session/useViewPrefs.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useViewPrefs.ts
@@ -79,33 +79,55 @@ function sanitizeLayout(raw: unknown): Layout {
   return raw === "grid" ? "grid" : "rail";
 }
 
+// What loadPrefs falls back to on any of: missing key, corrupt JSON, wrong
+// shape, or an empty pin set post-sanitisation.
+function defaultPrefs(): ViewPrefs {
+  return { pinned: defaultPins(), seen: SEEN_SEED, layout: "rail" };
+}
+
+// Parses and validates a raw stored string exactly as loadPrefs does, but
+// without touching localStorage — shared by the initial load (below) and by
+// the `storage` listener (further down), so a value ARRIVING from another
+// window is held to the same distrust as a value read from this window's own
+// storage: nothing surviving sanitisation ⇒ null, meaning "not usable",
+// never a thrown error and never a partially-applied record.
+function parseStoredPrefs(raw: string): ViewPrefs | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const rec = parsed as Record<string, unknown>;
+      // Clamp to the cap on the way in too: the cap can shrink between
+      // releases, and the picker's disabled dots can only refuse NEW pins.
+      const pinned = sanitizeIds(rec.pinned).slice(0, PIN_CAP);
+      const seen = sanitizeIds(rec.seen);
+      // Everything surviving sanitisation was garbage ⇒ treat the record as
+      // corrupt rather than honour an empty rail, which is never what a user
+      // meant and leaves no visible way back.
+      if (pinned.length > 0) {
+        return {
+          pinned,
+          seen: seen.length > 0 ? seen : SEEN_SEED,
+          layout: sanitizeLayout(rec.layout),
+        };
+      }
+    }
+  } catch {
+    /* corrupt JSON */
+  }
+  return null;
+}
+
 function loadPrefs(): ViewPrefs {
   try {
     const raw = localStorage.getItem(VIEW_PREFS_KEY);
     if (raw) {
-      const parsed: unknown = JSON.parse(raw);
-      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-        const rec = parsed as Record<string, unknown>;
-        // Clamp to the cap on the way in too: the cap can shrink between
-        // releases, and the picker's disabled dots can only refuse NEW pins.
-        const pinned = sanitizeIds(rec.pinned).slice(0, PIN_CAP);
-        const seen = sanitizeIds(rec.seen);
-        // Everything surviving sanitisation was garbage ⇒ treat the record as
-        // corrupt rather than honour an empty rail, which is never what a user
-        // meant and leaves no visible way back.
-        if (pinned.length > 0) {
-          return {
-            pinned,
-            seen: seen.length > 0 ? seen : SEEN_SEED,
-            layout: sanitizeLayout(rec.layout),
-          };
-        }
-      }
+      const parsed = parseStoredPrefs(raw);
+      if (parsed) return parsed;
     }
   } catch {
-    /* corrupt JSON or storage disabled — the defaults below are the answer */
+    /* storage disabled — the defaults below are the answer */
   }
-  return { pinned: defaultPins(), seen: SEEN_SEED, layout: "rail" };
+  return defaultPrefs();
 }
 
 // --- module store ------------------------------------------------------------
@@ -153,6 +175,51 @@ function update(next: ViewPrefs): void {
        exactly as App.tsx's theme toggle degrades */
   }
   for (const l of listeners) l();
+}
+
+// A `storage` event fires in every OTHER window/tab sharing this origin the
+// moment localStorage actually changes there — never in the window that
+// wrote it, and never for a write that doesn't change the value (MDN
+// StorageEvent). Sessions in the SAME window already share `cached` and
+// `listeners` directly (that's the whole module-store idiom above); this is
+// the one signal a second browser WINDOW gets, which is what #716 asks for —
+// #700 shipped the same-window half and left this as "converges on reload".
+//
+// Registered once, at module scope, rather than per hook mount: every mount
+// already shares the one `listeners` Set, so a listener per mount would just
+// be N redundant copies of the same dispatch. And unlike `listeners`, there
+// is no "last one out" moment to remove it at — a store with zero mounted
+// hooks is a normal, valid state (see `subscribe`'s comment: `cached` just
+// gets dropped and re-read on the next mount), not a teardown signal.
+function handleStorage(event: StorageEvent): void {
+  // Ignore writes to any other key. `event.key === null` is the browser's
+  // signal for `localStorage.clear()`, which did clear this key too, so it
+  // falls through to the same handling as an explicit removal below.
+  if (event.key !== null && event.key !== VIEW_PREFS_KEY) return;
+
+  // A null newValue means the key was removed (or storage.clear() ran) in
+  // the other window — the same situation loadPrefs sees as "nothing on
+  // disk", so it gets the same answer: the defaults.
+  const next = event.newValue === null ? defaultPrefs() : parseStoredPrefs(event.newValue);
+
+  // A corrupt or malformed value from another window is trusted no more than
+  // one read from OUR OWN storage on load: ignore it and keep whatever this
+  // window already has, rather than crashing or clobbering good state with
+  // garbage.
+  if (!next) return;
+
+  // Deliberately does NOT call update(): this window did not originate the
+  // change, so writing it back to localStorage here would only ever echo the
+  // value already sitting there. An identical write fires no further
+  // `storage` event (browsers dedupe on value), so it would be harmless, but
+  // it is also pure overhead and one more writer that could race a genuine
+  // write arriving from a THIRD window — simplest is to just not.
+  cached = next;
+  for (const l of listeners) l();
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", handleStorage);
 }
 
 // --- pure helpers the UI and the key cycler share ----------------------------


### PR DESCRIPTION
Implements #716: a single module-scope `storage` listener feeds `useViewPrefs`' module store, so two browser WINDOWS now converge live instead of on reload (same-window tabs already shared the store — this completes the other half #700 deferred).

## Summary
- Received values pass through `parseStoredPrefs` — the load path's validation, extracted so both paths share one implementation — so another window's write is trusted no more than our own storage on load: corrupt/malformed → ignored, state kept.
- `newValue === null` (key removed) and `event.key === null` (`localStorage.clear()`) both reset to defaults, matching the load path's missing-key answer (the clear() case is a builder judgment call beyond the literal spec, flagged and tested).
- No echo: applying a received state sets the cache and notifies subscribers without calling `update()` (which writes localStorage) — commented explicitly, including the third-window race rationale.
- Listener registered once at module scope: every mount shares the one listeners Set, and unlike subscribers there is no last-one-out teardown moment (a zero-mount store is a valid state, not a shutdown).

## Gates (builder + reviewer runs agree)
- `npx tsc --noEmit`: clean · `npx vitest run`: **583 passed** (571 baseline + 12 new)
- Python suite on the branch (roster/TS-contract tests): **3361 passed, 2 skipped**
- New tests: valid-payload apply (×2), unrelated-key ignore, corrupt/invalid ignore (×5), null-newValue + clear() resets (×2), no-write-on-receive setItem spies (×2)

## Review notes (session model reviewing a sonnet builder)
- Read the full diff; re-ran all gates in the isolated worktree. The `parseStoredPrefs` extraction is a faithful refactor of the previous inline validation (verified line-by-line, including the pin-cap clamp and the empty-pins-means-corrupt rule).
- Mutation probe: removing the key guard fails the unrelated-key test; pristine re-verified.
- Observed once during review: a single unrelated-file vitest failure that did not reproduce (6 further full runs clean on unmodified main; also seen once on the #712 branch under similar parallel-build CPU load). Load-sensitive flake somewhere in the #700 test batch — flagged for awareness, name not yet captured.

Closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g