### PR TITLE
Test suite ordering-independence: jsdom gap-fillers move to setup.ts

### DIFF
--- a/src/antennaknobs/web/frontend/src/__tests__/DesignSession.mobile.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/DesignSession.mobile.test.tsx
@@ -51,30 +51,18 @@ beforeEach(() => {
     VIEW_PREFS_KEY,
     JSON.stringify({ pinned: PINNED, seen: VIEWS.map((v) => v.id) }),
   );
-  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
-  vi.stubGlobal(
-    "ResizeObserver",
-    class {
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    },
-  );
-  // Every query matches: this session is on a phone, in portrait.
+  // getContext/ResizeObserver/WebSocket provide-only defaults now live in
+  // setup.ts (#728) — every component test gets them unconditionally.
+  //
+  // matchMedia stays here: setup.ts's default never matches, but this
+  // session is on a phone, in portrait, so every query must match to force
+  // the mobile branch. That's behavioral (it decides which tree renders),
+  // not a gap-fill, so it's a per-file override rather than a migration.
   vi.stubGlobal("matchMedia", () => ({
     matches: true,
     addEventListener() {},
     removeEventListener() {},
   }));
-  vi.stubGlobal(
-    "WebSocket",
-    class {
-      static OPEN = 1;
-      readyState = 0;
-      close() {}
-      send() {}
-    },
-  );
   vi.stubGlobal("fetch", async (url: string) => {
     const path = String(url);
     if (path.startsWith("/capabilities"))
@@ -92,7 +80,6 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
-  vi.restoreAllMocks();
 });
 
 describe("the session's mobile tree", () => {

--- a/src/antennaknobs/web/frontend/src/__tests__/SmithChart.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/SmithChart.test.tsx
@@ -13,23 +13,14 @@
 // inspect. This is a from-scratch idiom — no prior SmithChart test and no
 // other chart test in this repo asserts drawn coordinates, only the
 // null-context no-crash path.
-import { beforeEach, describe, it, expect, vi } from "vitest";
-
-// jsdom ships no ResizeObserver; the sizing hook only needs it not to throw.
-// Stubbed HERE, per-file (the newBackend.test.tsx idiom), because vitest
-// workers do NOT guarantee another file's stub is present: this file passed
-// locally by inheriting a sibling's leaked stub and then failed on CI's
-// scheduling, which is exactly the trap a per-file stub closes.
-beforeEach(() => {
-  vi.stubGlobal(
-    "ResizeObserver",
-    class {
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    },
-  );
-});
+// A ResizeObserver stub was briefly added here while diagnosing #726's CI
+// failure — wrongly, it turned out: SmithChart takes `size` as a prop and
+// never touches the sizing hooks, and the failing file in that CI run was
+// DesignSession.mobile.test.tsx, whose OWN stub was torn down by afterEach's
+// unstubAllGlobals() before a late React passive-effect flush ran (#728's
+// real mechanism). setup.ts's unconditional defaults now close that race
+// for every file; nothing needs stubbing here.
+import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
 import { SmithChart } from "../components/charts/SmithChart";
 import { reflectionCoefficient } from "../lib/format";

--- a/src/antennaknobs/web/frontend/src/__tests__/newBackend.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/newBackend.test.tsx
@@ -75,33 +75,10 @@ function jsonResponse(body: unknown) {
 beforeEach(() => {
   geometryPosts = [];
   servedRoster = [...SERVED_ROSTER, FAKE];
-  // jsdom has neither a 2D canvas context nor ResizeObserver; the charts and
-  // the sizing hooks only need them not to throw.
-  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
-  vi.stubGlobal(
-    "ResizeObserver",
-    class {
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    },
-  );
-  // jsdom ships no matchMedia; the mobile-layout hook only needs a
-  // never-matching query so the desktop tree renders.
-  vi.stubGlobal("matchMedia", () => ({
-    matches: false,
-    addEventListener() {},
-    removeEventListener() {},
-  }));
-  vi.stubGlobal(
-    "WebSocket",
-    class {
-      static OPEN = 1;
-      readyState = 0;
-      close() {}
-      send() {}
-    },
-  );
+  // getContext/ResizeObserver/matchMedia/WebSocket provide-only defaults now
+  // live in setup.ts (#728) — every component test gets them unconditionally,
+  // including the never-matching matchMedia this file used to stub itself
+  // (this session doesn't care about layout, so the desktop tree is fine).
   vi.stubGlobal("fetch", async (url: string, init?: RequestInit) => {
     const path = String(url);
     if (path.startsWith("/capabilities"))
@@ -122,7 +99,6 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
-  vi.restoreAllMocks();
 });
 
 describe("a solver that exists only in the served roster (#628)", () => {

--- a/src/antennaknobs/web/frontend/src/__tests__/setup.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/setup.ts
@@ -11,3 +11,76 @@ import { afterEach } from "vitest";
 import { cleanup } from "@testing-library/react";
 
 afterEach(cleanup);
+
+// --- jsdom gap-fillers (issue #728) ----------------------------------------
+//
+// jsdom implements neither ResizeObserver nor matchMedia and its canvas
+// element has no 2-D context, so any component that measures itself
+// (useSlideSize/useGridCellSize/useThumbColumnSize in components/hooks.ts),
+// checks a media query (useIsMobile), or draws a chart throws unless
+// something fills the gap. A real network WebSocket is also wrong in a test
+// process — DesignSession opens one on mount (useSolveChannel).
+//
+// These four used to be stubbed per test file with `vi.stubGlobal`. Two
+// failure modes follow from that (#728). The one that actually bit, in
+// #726's CI run and as the load-sensitive "phantom flake": a stub torn down
+// by the file's own afterEach `vi.unstubAllGlobals()` while a late React
+// passive-effect flush was still pending — the effect then ran against an
+// UNDEFINED global (DesignSession.mobile.test.tsx's ResizeObserver, timing-
+// dependent, worse under CPU load). And the latent one: vitest workers host
+// several files per process, so a file that forgot its own stub could pass
+// locally off a co-hosted sibling's leak and fail under CI's different
+// packing. Unconditional defaults here close both at once — after any
+// unstub, the global falls back to a WORKING default, never to undefined,
+// and no file's pass/fail depends on its worker neighbors. The suite is
+// safe under `--sequence.shuffle` either way.
+//
+// Plain assignment, not `vi.stubGlobal` — deliberately. Per-file `afterEach`
+// hooks commonly call `vi.unstubAllGlobals()` (to drop THEIR OWN behavioral
+// stubs, e.g. `fetch`) and/or `vi.restoreAllMocks()` (to drop THEIR OWN
+// spies). Both only undo their respective vitest API (stubGlobal / spyOn), so
+// a plain `globalThis.x = ...` here is invisible to both and keeps holding
+// for every test in the suite. A file that needs different behavior (a
+// recording canvas context, a matchMedia that DOES match a breakpoint)
+// overrides the property directly or via its own `vi.stubGlobal` in its own
+// `beforeEach` — that's a per-file override of this default, not a fight
+// with it, and `vi.unstubAllGlobals()`/reassignment on the next test falls
+// straight back to what's set here.
+
+class InertResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = InertResizeObserver as unknown as typeof ResizeObserver;
+
+// Never-matching by default, so the desktop tree renders in every test that
+// never thinks about layout at all. The mobile-specific tests
+// (DesignSession.mobile.test.tsx) override this per-file with a MATCHING
+// stub to force the phone branch — that override is behavioral (it decides
+// which branch renders), not a gap-fill, so it stays local to that file.
+globalThis.matchMedia = (() => ({
+  matches: false,
+  addEventListener() {},
+  removeEventListener() {},
+})) as unknown as typeof window.matchMedia;
+
+// null is the answer every chart/canvas test that isn't inspecting drawn
+// output wants: "no 2-D context available, render your no-crash fallback."
+// SmithChart.test.tsx DOES assert on what got drawn, so it overrides this
+// per-render with its own recording context — a plain reassignment, not a
+// spy, so a sibling file's `vi.restoreAllMocks()` can't touch it either way.
+HTMLCanvasElement.prototype.getContext = (() =>
+  null) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+
+// jsdom's own WebSocket (where present) would attempt a real connection.
+// Nothing in this suite asserts on send()/readyState, so an inert stub that
+// never opens is the correct default for every test that mounts
+// <DesignSession>.
+class InertWebSocket {
+  static OPEN = 1;
+  readyState = 0;
+  close() {}
+  send() {}
+}
+globalThis.WebSocket = InertWebSocket as unknown as typeof WebSocket;


### PR DESCRIPTION
Implements #728. Four provide-only jsdom gap-fillers (`ResizeObserver`, never-matching `matchMedia`, null `getContext`, inert `WebSocket`) move from per-file `vi.stubGlobal` calls into `setup.ts` as **plain global assignments**; behavioral stubs (every `fetch` mock, the mobile matching-`matchMedia`, SmithChart's recording canvas context) stay per-file as deliberate overrides.

## The root cause, corrected during review
The issue was filed on the worker-leakage theory. Review of the actual #726 CI log found the failing file was `DesignSession.mobile.test.tsx` — **which had its own ResizeObserver stub**. The real mechanism: `afterEach`'s `vi.unstubAllGlobals()` tears the stub down while a late React passive-effect flush is still pending; the effect then constructs `ResizeObserver` against an undefined global. That race is CPU-load-sensitive — it IS the "phantom flake" seen twice during the #712/#716 reviews. The fix cures it for the right reason: plain assignments are invisible to `unstubAllGlobals()`/`restoreAllMocks()`, so any teardown falls back to a working default, never to undefined. (The latent worker-leakage mode is closed by the same change.) Comments in `setup.ts` and `SmithChart.test.tsx` carry the corrected mechanism; SmithChart, it turns out, never needed the stub at all — it takes `size` as a prop.

## Classification (from the builder's audit)
- Migrated: getContext/ResizeObserver/WebSocket (DesignSession.mobile), all four provide-only stubs (newBackend, incl. a matchMedia duplicating the new default), ResizeObserver (SmithChart, added in #726).
- Kept per-file: fetch mocks (5 files), mobile matching-matchMedia, the recording canvas context.
- The three hook-test files the issue flagged had no provide-only stubs (fetch-only) — verified, untouched.

## Gates (builder + reviewer runs agree)
- `npx vitest run`: **589 passed** · `--sequence.shuffle` × 5 total (3 builder + 2 reviewer): all green · `--no-file-parallelism`: green
- Isolation: all 6 previously-stubbing files pass alone
- `npx tsc --noEmit` clean · test-files-only diff (no production code, vitest.config untouched)

## Review notes (session model reviewing a sonnet builder)
- Read the full diff; re-ran gates. My planned probe (disable setup's ResizeObserver → expect SmithChart isolation failure) did NOT bite — which is what exposed that SmithChart never used the sizing hooks and sent me back to the CI log for the true failing file and the unstub-vs-effect-flush race above. The builder's changes were correct throughout; its narrative and two comments were corrected to the verified mechanism.
- Orphan-spy check: the removed `restoreAllMocks()` in DesignSession.mobile had no remaining spies to restore (verified zero `spyOn` in the file).

Closes #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g