### PR TITLE
Reorder pinned views from the picker (button-based v1)

### DIFF
--- a/src/antennaknobs/web/frontend/src/__tests__/MobileCarousel.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/MobileCarousel.test.tsx
@@ -108,6 +108,7 @@ function Mobile({
         pinned={prefs.pinned}
         newIds={prefs.newIds}
         togglePin={prefs.togglePin}
+        movePin={prefs.movePin}
         markRosterSeen={prefs.markRosterSeen}
       />
     </>
@@ -326,6 +327,43 @@ describe("a sheet row tap", () => {
     await user.click(sheetRow("azimuth"));
     expect(probe("index")).toBe("3"); // Info, one page earlier
     expect(probe("view")).toBe("vswr"); // the new last chart page
+  });
+});
+
+// --- 3b. Reorder buttons (issue #714) — same rows, so the sheet inherits ----
+//     them for free; this proves the carousel's page order (mobileScreens,
+//     which `pages` above is built from) follows a reorder same as it
+//     follows a pin/unpin.
+
+describe("a sheet reorder", () => {
+  it("moves a page earlier and the carousel's page order follows", async () => {
+    const user = userEvent.setup();
+    seed(FOUR);
+    render(<Mobile initialView="smith" />);
+    await openSheet(user);
+    await user.click(dot(`Move ${label("vswr")} earlier`));
+    expect(probe("pages")).toBe(["smith", "vswr", "antenna", "azimuth", "info"].join(","));
+    const reordered: View[] = ["smith", "vswr", "antenna", "azimuth"];
+    expect(dots()).toEqual([...reordered.map(label), "Info"]);
+  });
+
+  it("is absent for an unpinned row", async () => {
+    const user = userEvent.setup();
+    seed(TWO);
+    render(<Mobile initialView="smith" />);
+    await openSheet(user);
+    expect(
+      screen.queryByRole("button", { name: `Move ${label("schematic")} earlier` }),
+    ).toBeNull();
+  });
+
+  it("is disabled at the boundaries", async () => {
+    const user = userEvent.setup();
+    seed(FOUR);
+    render(<Mobile initialView="smith" />);
+    await openSheet(user);
+    expect(dot(`Move ${label(FOUR[0])} earlier`).disabled).toBe(true);
+    expect(dot(`Move ${label(FOUR[FOUR.length - 1])} later`).disabled).toBe(true);
   });
 });
 

--- a/src/antennaknobs/web/frontend/src/__tests__/ViewPicker.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/ViewPicker.test.tsx
@@ -77,6 +77,7 @@ function Harness({ initialView = "antenna" as View }) {
         pinned={prefs.pinned}
         newIds={prefs.newIds}
         togglePin={prefs.togglePin}
+        movePin={prefs.movePin}
         markRosterSeen={prefs.markRosterSeen}
       />
     </>
@@ -185,6 +186,82 @@ describe("pin-dot click", () => {
     await user.click(dot(`Pin ${label(last)}`));
     await user.click(dot(`Pin ${label(first)}`));
     expect(probe("pinned")).toBe([...FOUNDING, last, first].join(","));
+  });
+});
+
+// --- 3b. Reorder buttons (issue #714) ----------------------------------------
+
+describe("pin reorder buttons", () => {
+  it("appear only on pinned rows", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await openPicker(user);
+    for (const id of FOUNDING) {
+      expect(screen.getByRole("button", { name: `Move ${label(id)} earlier` })).toBeTruthy();
+      expect(screen.getByRole("button", { name: `Move ${label(id)} later` })).toBeTruthy();
+    }
+    for (const id of ROSTER.filter((id) => !FOUNDING.includes(id))) {
+      expect(screen.queryByRole("button", { name: `Move ${label(id)} earlier` })).toBeNull();
+      expect(screen.queryByRole("button", { name: `Move ${label(id)} later` })).toBeNull();
+    }
+  });
+
+  it("are disabled at the boundaries only", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await openPicker(user);
+    const up = (id: View) => dot(`Move ${label(id)} earlier`) as HTMLButtonElement;
+    const down = (id: View) => dot(`Move ${label(id)} later`) as HTMLButtonElement;
+    expect(up(FOUNDING[0]).disabled).toBe(true);
+    expect(down(FOUNDING[FOUNDING.length - 1]).disabled).toBe(true);
+    // Everything in between is live in both directions.
+    for (const id of FOUNDING.slice(1, -1)) {
+      expect(up(id).disabled).toBe(false);
+      expect(down(id).disabled).toBe(false);
+    }
+    expect(down(FOUNDING[0]).disabled).toBe(false);
+    expect(up(FOUNDING[FOUNDING.length - 1]).disabled).toBe(false);
+  });
+
+  it("moves the pin earlier and re-renders the new order", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await openPicker(user);
+    await user.click(dot(`Move ${label(FOUNDING[2])} earlier`));
+    expect(probe("pinned")).toBe(["antenna", "elevation", "azimuth", "smith"].join(","));
+    // The rail derives straight from `pinned` — no separate reorder path.
+    expect(probe("rail")).toBe(["elevation", "azimuth", "smith"].join(","));
+  });
+
+  it("moves the pin later and re-renders the new order", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await openPicker(user);
+    await user.click(dot(`Move ${label(FOUNDING[0])} later`));
+    expect(probe("pinned")).toBe(["azimuth", "antenna", "elevation", "smith"].join(","));
+  });
+
+  it("does not switch the view, close the popover, or toggle the pin", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await openPicker(user);
+    await user.click(dot(`Move ${label(FOUNDING[1])} earlier`));
+    expect(probe("view")).toBe("antenna");
+    expect(screen.getByRole("menu")).not.toBeNull();
+    expect(probe("pinned")).toContain(FOUNDING[1]); // still pinned, just reordered
+  });
+
+  it("leaves the row's own click-to-show and pin-dot gestures intact", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await openPicker(user);
+    // Reorder first, then prove the row's other two gestures still work.
+    await user.click(dot(`Move ${label(FOUNDING[2])} earlier`));
+    await user.click(dot(`Pin ${label("schematic")}`));
+    expect(probe("pinned")).toBe(["antenna", "elevation", "azimuth", "smith", "schematic"].join(","));
+    await user.click(screen.getByRole("menuitem", { name: "Smith" }));
+    expect(probe("view")).toBe("smith");
+    expect(screen.queryByRole("menu")).toBeNull();
   });
 });
 

--- a/src/antennaknobs/web/frontend/src/__tests__/useViewPrefs.reorder.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useViewPrefs.reorder.test.tsx
@@ -1,0 +1,178 @@
+// Issue #714, deferred from #700 (docs/plan-view-rail-scaling.md: "pin order
+// = order pinned" was explicitly out of v1). Pin order IS rail/grid/carousel
+// order (railViews, gridCells, mobileScreens all derive straight from
+// `pinned`), so the whole reorder feature is one swap in the stored array —
+// movePinned is the pure half, movePin the hook action that persists it.
+//
+// A separate file rather than additions to useViewPrefs.test.tsx, for the
+// same reason useViewPrefs.grid.test.tsx and useViewPrefs.storage.test.tsx
+// are separate: that file is the pre-existing baseline kept passing UNEDITED.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { type View } from "../lib/view";
+import {
+  VIEW_PREFS_KEY,
+  movePinned,
+  useViewPrefs,
+} from "../components/session/useViewPrefs";
+
+const FOUNDING: View[] = ["antenna", "azimuth", "elevation", "smith"];
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+function stored() {
+  return JSON.parse(localStorage.getItem(VIEW_PREFS_KEY) ?? "null");
+}
+
+// --- 1. movePinned, the pure swap --------------------------------------
+
+describe("movePinned", () => {
+  it("swaps a pin with its earlier neighbor", () => {
+    expect(movePinned(FOUNDING, "elevation", -1)).toEqual([
+      "antenna",
+      "elevation",
+      "azimuth",
+      "smith",
+    ]);
+  });
+
+  it("swaps a pin with its later neighbor", () => {
+    expect(movePinned(FOUNDING, "azimuth", 1)).toEqual([
+      "antenna",
+      "elevation",
+      "azimuth",
+      "smith",
+    ]);
+  });
+
+  it("returns the SAME array reference at the front edge (no earlier neighbor)", () => {
+    const next = movePinned(FOUNDING, "antenna", -1);
+    expect(next).toBe(FOUNDING);
+  });
+
+  it("returns the SAME array reference at the back edge (no later neighbor)", () => {
+    const next = movePinned(FOUNDING, "smith", 1);
+    expect(next).toBe(FOUNDING);
+  });
+
+  it("returns the SAME array reference for an unpinned id", () => {
+    const next = movePinned(FOUNDING, "schematic", -1);
+    expect(next).toBe(FOUNDING);
+  });
+
+  it("returns the SAME array reference for an id the registry does not know", () => {
+    const next = movePinned(FOUNDING, "no-such-view" as View, 1);
+    expect(next).toBe(FOUNDING);
+  });
+
+  it("does not mutate its input", () => {
+    const copy = [...FOUNDING];
+    movePinned(copy, "elevation", -1);
+    expect(copy).toEqual(FOUNDING);
+  });
+});
+
+// --- 2. movePin, the hook action ----------------------------------------
+
+describe("movePin", () => {
+  it("swaps the neighbor and persists it", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.movePin("elevation", -1));
+    expect(result.current.pinned).toEqual([
+      "antenna",
+      "elevation",
+      "azimuth",
+      "smith",
+    ]);
+    expect(stored().pinned).toEqual([
+      "antenna",
+      "elevation",
+      "azimuth",
+      "smith",
+    ]);
+  });
+
+  it("round-trips a reorder through storage to the next mount", () => {
+    const first = renderHook(() => useViewPrefs());
+    act(() => first.result.current.movePin("smith", -1));
+    first.unmount();
+
+    const second = renderHook(() => useViewPrefs());
+    expect(second.result.current.pinned).toEqual([
+      "antenna",
+      "azimuth",
+      "smith",
+      "elevation",
+    ]);
+  });
+
+  it("no-ops at the front edge, and writes nothing", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.movePin("antenna", -1));
+    expect(result.current.pinned).toEqual(FOUNDING);
+    expect(localStorage.getItem(VIEW_PREFS_KEY)).toBeNull();
+  });
+
+  it("no-ops at the back edge, and writes nothing", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.movePin("smith", 1));
+    expect(result.current.pinned).toEqual(FOUNDING);
+    expect(localStorage.getItem(VIEW_PREFS_KEY)).toBeNull();
+  });
+
+  it("no-ops for an unpinned id, and writes nothing", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.movePin("schematic", -1));
+    expect(result.current.pinned).toEqual(FOUNDING);
+    expect(localStorage.getItem(VIEW_PREFS_KEY)).toBeNull();
+  });
+
+  it("no-ops for an unknown id, and writes nothing", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.movePin("no-such-view" as View, 1));
+    expect(result.current.pinned).toEqual(FOUNDING);
+    expect(localStorage.getItem(VIEW_PREFS_KEY)).toBeNull();
+  });
+
+  it("never calls setItem on a no-op — a genuine reorder is the only thing that writes", () => {
+    const spy = vi.spyOn(Storage.prototype, "setItem");
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.movePin("antenna", -1)); // front edge
+    act(() => result.current.movePin("schematic", 1)); // unpinned
+    expect(spy).not.toHaveBeenCalled();
+    act(() => result.current.movePin("smith", -1)); // genuine
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+
+  // Cross-window sync (issue #716): movePin persists through the same
+  // update() path togglePin/setLayout use, so a reorder in one window fires
+  // the ordinary localStorage write, and that write is exactly what #716's
+  // `storage` listener (registered once, module scope, in useViewPrefs.ts)
+  // relays to every OTHER open window — no reorder-specific wiring needed.
+  // This proves the OTHER half: an inbound reorder, arriving as a `storage`
+  // event the way #716's own tests simulate one, updates a mounted hook here
+  // too.
+  it("propagates to another window via the #716 storage listener", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: VIEW_PREFS_KEY,
+          newValue: JSON.stringify({
+            pinned: ["antenna", "elevation", "azimuth", "smith"],
+            seen: FOUNDING,
+          }),
+        }),
+      );
+    });
+    expect(result.current.pinned).toEqual([
+      "antenna",
+      "elevation",
+      "azimuth",
+      "smith",
+    ]);
+  });
+});

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -397,6 +397,7 @@ function DesignSessionBody({
     newIds,
     railViews,
     togglePin: toggleViewPin,
+    movePin,
     markRosterSeen,
     layout,
     setLayout,
@@ -1544,6 +1545,7 @@ function DesignSessionBody({
             pinned={pinned}
             newIds={newIds}
             togglePin={toggleViewPin}
+            movePin={movePin}
             markRosterSeen={markRosterSeen}
           />
         </section>
@@ -1654,6 +1656,7 @@ function DesignSessionBody({
                 pinned={pinned}
                 newIds={newIds}
                 togglePin={toggleViewPin}
+                movePin={movePin}
                 markRosterSeen={markRosterSeen}
               />
             </div>

--- a/src/antennaknobs/web/frontend/src/components/session/MobileDots.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/MobileDots.tsx
@@ -18,6 +18,7 @@ export function MobileDots({
   pinned,
   newIds,
   togglePin,
+  movePin,
   markRosterSeen,
 }: {
   screens: MobileScreen[];
@@ -27,6 +28,7 @@ export function MobileDots({
   pinned: View[];
   newIds: Set<View>;
   togglePin: (v: View) => void;
+  movePin: (id: View, direction: -1 | 1) => void;
   markRosterSeen: () => void;
 }) {
   return (
@@ -48,6 +50,7 @@ export function MobileDots({
         pinned={pinned}
         newIds={newIds}
         togglePin={togglePin}
+        movePin={movePin}
         markRosterSeen={markRosterSeen}
       />
     </div>

--- a/src/antennaknobs/web/frontend/src/components/session/ViewPicker.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/ViewPicker.tsx
@@ -16,6 +16,7 @@ function ViewRosterRows({
   badged,
   onRowClick,
   togglePin,
+  movePin,
   rowBlocked,
 }: {
   view: View;
@@ -23,12 +24,14 @@ function ViewRosterRows({
   badged: Set<View>;
   onRowClick: (v: View) => void;
   togglePin: (v: View) => void;
+  movePin: (id: View, direction: -1 | 1) => void;
   rowBlocked?: (v: View) => string | null;
 }) {
   return (
     <>
       {VIEWS.map((v) => {
-        const isPinned = pinned.includes(v.id);
+        const pinIndex = pinned.indexOf(v.id);
+        const isPinned = pinIndex >= 0;
         const blocked = pinBlockedReason(pinned, v.id);
         const rowStop = rowBlocked ? rowBlocked(v.id) : null;
         return (
@@ -66,6 +69,42 @@ function ViewRosterRows({
             >
               <span />
             </button>
+            {/* Issue #714: reorder buttons. Unpinned rows get none — there is
+                no rail/grid/carousel position to move, and pinning already
+                has its own "where it lands" rule (the end). stopPropagation
+                is defensive: this row has no click handler of its own today,
+                but the buttons sit between two that do, and a future row
+                gesture must not inherit a click meant for one of these. */}
+            {isPinned && (
+              <div className="view-picker-move">
+                <button
+                  type="button"
+                  className="view-picker-move-btn"
+                  disabled={pinIndex === 0}
+                  aria-label={`Move ${v.label} earlier`}
+                  title={`Move ${v.label} earlier`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    movePin(v.id, -1);
+                  }}
+                >
+                  ▲
+                </button>
+                <button
+                  type="button"
+                  className="view-picker-move-btn"
+                  disabled={pinIndex === pinned.length - 1}
+                  aria-label={`Move ${v.label} later`}
+                  title={`Move ${v.label} later`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    movePin(v.id, 1);
+                  }}
+                >
+                  ▼
+                </button>
+              </div>
+            )}
           </div>
         );
       })}
@@ -91,6 +130,7 @@ export function ViewPicker({
   pinned,
   newIds,
   togglePin,
+  movePin,
   markRosterSeen,
 }: {
   view: View;
@@ -98,6 +138,7 @@ export function ViewPicker({
   pinned: View[];
   newIds: Set<View>;
   togglePin: (v: View) => void;
+  movePin: (id: View, direction: -1 | 1) => void;
   markRosterSeen: () => void;
 }) {
   const [open, setOpen] = useState(false);
@@ -163,6 +204,7 @@ export function ViewPicker({
               pinned={pinned}
               badged={badged}
               togglePin={togglePin}
+              movePin={movePin}
               onRowClick={(v) => {
                 setView(v);
                 setOpen(false);
@@ -194,12 +236,14 @@ export function ViewSheet({
   pinned,
   newIds,
   togglePin,
+  movePin,
   markRosterSeen,
 }: {
   view: View;
   pinned: View[];
   newIds: Set<View>;
   togglePin: (v: View) => void;
+  movePin: (id: View, direction: -1 | 1) => void;
   markRosterSeen: () => void;
 }) {
   const [open, setOpen] = useState(false);
@@ -243,6 +287,7 @@ export function ViewSheet({
               pinned={pinned}
               badged={badged}
               togglePin={togglePin}
+              movePin={movePin}
               // Curating is a run of gestures — the sheet does NOT close on a
               // tap, so several pages can be added or dropped in one visit.
               onRowClick={togglePin}

--- a/src/antennaknobs/web/frontend/src/components/session/useViewPrefs.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useViewPrefs.ts
@@ -244,6 +244,30 @@ export function pinBlockedReason(pinned: View[], id: View): string | null {
   return pinned.length >= PIN_CAP ? "Unpin a view first" : null;
 }
 
+// Issue #714: reorder a pin by swapping it with its neighbor toward
+// `direction` (-1 = earlier, +1 = later). Pin order IS rail/grid/carousel
+// order (railViews, gridCells, mobileScreens all derive from `pinned`
+// directly), so one swap is the whole reorder story for all three — nothing
+// downstream needs to know reordering happened.
+//
+// Returns the SAME array reference — not just an equal one — when there is
+// nothing to do: `id` is unpinned/unknown, or already at that end. movePin
+// below uses that identity to skip persisting a no-op change, the same way
+// setLayout skips writing when the layout didn't actually change.
+//
+// A future drag-to-reorder UI (out of scope for #714, see the issue) can call
+// this unchanged — dragging and the up/down buttons both just need "swap id
+// with its neighbor", which is all this function knows how to do.
+export function movePinned(pinned: View[], id: View, direction: -1 | 1): View[] {
+  const at = pinned.indexOf(id);
+  if (at < 0) return pinned;
+  const to = at + direction;
+  if (to < 0 || to >= pinned.length) return pinned;
+  const next = [...pinned];
+  [next[at], next[to]] = [next[to], next[at]];
+  return next;
+}
+
 // --- grid layout mode (unit 3) ------------------------------------------
 
 // Grid mode never goes past 4 cells: below ~⅓-stage cells the antenna canvas
@@ -330,9 +354,27 @@ export function useViewPrefs() {
     if (pinBlockedReason(cur.pinned, id)) return;
     const pins = cur.pinned.includes(id)
       ? cur.pinned.filter((v) => v !== id)
-      : // Pin order is order-pinned; no drag-to-reorder in v1.
+      : // A new pin always joins at the end — movePin (issue #714) is the
+        // separate action that reorders after the fact.
         [...cur.pinned, id];
     update({ ...cur, pinned: pins });
+  }, []);
+
+  // Issue #714: the picker's up/down reorder buttons. Reads the store rather
+  // than closing over `pinned`, for the same reason togglePin does. Skips the
+  // update()/persist call entirely when movePinned hands back the identical
+  // array (id unpinned/unknown, or already at that end) — no write means no
+  // localStorage churn and no spurious `storage` event in other windows.
+  //
+  // Persistence goes through the normal update() path, so a reorder gets
+  // cross-window sync for free via the #716 storage listener — the window
+  // that reordered writes it, and every OTHER open window picks it up the
+  // same way it would a pin/unpin.
+  const movePin = useCallback((id: View, direction: -1 | 1) => {
+    const cur = getSnapshot();
+    const next = movePinned(cur.pinned, id, direction);
+    if (next === cur.pinned) return;
+    update({ ...cur, pinned: next });
   }, []);
 
   // Opening the picker is what "you have now been shown the roster" means.
@@ -353,5 +395,15 @@ export function useViewPrefs() {
     update({ ...cur, layout: next });
   }, []);
 
-  return { pinned, seen, newIds, railViews, togglePin, markRosterSeen, layout, setLayout };
+  return {
+    pinned,
+    seen,
+    newIds,
+    railViews,
+    togglePin,
+    movePin,
+    markRosterSeen,
+    layout,
+    setLayout,
+  };
 }

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -2006,6 +2006,43 @@ input[type=checkbox] {
   opacity: 0.4;
 }
 
+/* Issue #714: the pinned-row reorder buttons. A tight 2-up stack rather than
+   two more 24 px hit targets — the row is already busy with the name and the
+   pin dot, and a reorder is a fine-motor action a user reaches for less often
+   than either of those. */
+.view-picker-move {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.view-picker-move-btn {
+  width: 18px;
+  height: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  background: none;
+  border: none;
+  border-radius: var(--r-sm);
+  color: var(--muted);
+  font-size: 9px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.view-picker-move-btn:hover:not(:disabled) {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.view-picker-move-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.25;
+}
+
 .view-picker-new {
   padding: 0 var(--space-2);
   border-radius: var(--r-sm);
@@ -3084,6 +3121,14 @@ canvas {
 .view-sheet .view-picker-dot {
   width: 40px;
   height: 40px;
+}
+
+/* The popover's 18×14 reorder buttons are mouse-scaled like its dot — a thumb
+   needs the same touch-sized bump here. */
+.view-sheet .view-picker-move-btn {
+  width: 32px;
+  height: 24px;
+  font-size: var(--text-sm);
 }
 
 .view-sheet .view-picker-name:disabled {


### PR DESCRIPTION
Implements #714 with the triage decision: **button-based reorder, not HTML5 drag** — deterministic in jsdom, identical on touch, keyboard-accessible by construction. The store operation (`movePinned`) is the seam a future drag UI would reuse unchanged.

## Summary
- `useViewPrefs.movePinned(pinned, id, ±1)`: pure neighbor-swap helper returning the SAME array reference on any no-op (unknown/unpinned id, already at that end); the `movePin` action skips persistence entirely on identity, so no-ops never touch localStorage or fire storage events. Real reorders persist through the normal path — which means they sync across browser windows for free via #716's listener.
- `ViewRosterRows` (shared by the desktop popover AND the mobile sheet) gains ▲/▼ buttons on pinned rows only, aria-labeled ("Move <label> earlier/later"), disabled at the ends, with stopPropagation guarding the row's other gestures. One affordance genuinely serves rail order, grid cell order, and mobile page order — none of those derivations changed.
- +24 tests: 15 store-level (incl. a setItem spy proving no-op writes never happen), 6 desktop UI, 3 mobile-sheet propagation (move button → carousel pages/dots reorder).

## Gates (builder + reviewer runs agree)
- `npx tsc --noEmit` clean · `npx vitest run`: **613 passed** (589 baseline + 24)
- Python suite on the branch (roster/TS-contract): **3361 passed, 2 skipped**
- Order propagation asserted through two existing derivations (railViews probe, mobile carousel pages) — untouched by the change

## Review notes (session model reviewing a sonnet builder)
- Read the full diff; re-ran all gates in the isolated worktree.
- Mutation probe: inverting the swap direction (`at + direction` → `at - direction`) fails **12 tests** across store and UI levels; pristine re-verified (15/15).
- Verified the guard test exists for the subtle interaction: clicking a move button "does not switch the view, close the popover, or toggle the pin".
- Note: this branch predates #728 (PR #729, in flight); if #729 merges first, this rebases trivially (disjoint files — the one shared file, MobileCarousel.test.tsx, is touched only by this PR).

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g