### PR TITLE
Infrastructure tier 1: test lanes, worktree tripwire, CI diet, config fixes

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,5 +1,10 @@
 name: Ruff
-on: [push, pull_request]
+# pull_request + main-push only: `on: [push, pull_request]` fired BOTH events
+# for same-repo branches, running every PR's ruff twice (#734).
+on:
+  pull_request:
+  push:
+    branches: ["main"]
 jobs:
   ruff:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       # `pip install -e ".[test]"`.
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools numpy scipy matplotlib scikit-rf pybind11
+        pip install setuptools numpy scipy matplotlib pybind11
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
     - name: Install PyNEC from the python-necpp release wheel
@@ -112,8 +112,30 @@ jobs:
       if: github.event_name == 'push'
       run: coverage run --source=src/ -m pytest -m "not heavy_mesh" --durations=15 tests/
 
-    - name: Coverage comment
+    - name: Upload coverage data (push to main only)
+      # The coverage-comment CONTAINER action used to live here as a step:
+      # container actions build their Docker image at job start even when the
+      # step's `if` is false, so every PR paid ~8 s building an image for a
+      # step that only runs on push (#734). The data ships to a push-gated
+      # job instead; include-hidden-files because `.coverage` is a dotfile.
       if: github.event_name == 'push'
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-data
+        path: .coverage
+        include-hidden-files: true
+
+  coverage-comment:
+    # Push-to-main only: PRs never build this action's container (#734).
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - uses: actions/download-artifact@v4
+      with:
+        name: coverage-data
+    - name: Coverage comment
       uses: py-cov-action/python-coverage-comment-action@v3
       with:
         GITHUB_TOKEN: ${{ github.token }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+# Named development lanes (issue #733). The point is that each lane is a
+# command you can type, not an incantation you must remember — and that the
+# fast lane is EXACTLY the PR CI gate's pytest invocation, so "make test
+# passed" and "CI will pass" mean the same thing.
+#
+# Lane economics (measured 2026-08-05, 4-core box):
+#   make test    ~59 s  — what the PR gate runs: skips the per-design solver
+#                          catalogs (antenna_computation_check) and the
+#                          benchmark-class heavy_mesh solves. 66% of the full
+#                          suite's wall time is in those 172 deselected tests.
+#   make gates   ~3 min — ruff + the FULL suite (what a merge to main runs,
+#                          minus coverage instrumentation). Run once before
+#                          /create-pr, not per edit.
+#   make frontend ~15 s — tsc --noEmit + vitest, the frontend half of CI.
+
+PY = python -m
+FRONTEND = src/antennaknobs/web/frontend
+
+.PHONY: test gates frontend test-all lint
+
+# The PR fast lane, verbatim from .github/workflows/test.yml.
+test:
+	$(PY) pytest -m "not antenna_computation_check and not heavy_mesh" --durations=15 tests/
+
+# Everything a merge to main will check, locally: lint + the full suite.
+gates: lint test-all frontend
+
+# The full suite (still excludes heavy_mesh, same as CI's push lane — those
+# are benchmark-class runs invoked manually after nec-import/engine changes).
+test-all:
+	$(PY) pytest -m "not heavy_mesh" --durations=15 tests/
+
+lint:
+	ruff check .
+	ruff format --check .
+
+frontend:
+	cd $(FRONTEND) && npx tsc --noEmit && npx vitest run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "Scriptable antenna design with live, knob-driven tuning"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"  # PEP 604 unions in 21 src files; 3.8/3.9 die at import (#735)
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/src/antennaknobs/web/frontend/vitest.config.ts
+++ b/src/antennaknobs/web/frontend/vitest.config.ts
@@ -10,7 +10,10 @@ export default defineConfig({
     // #642), so importing it from a Node environment throws before any test
     // runs. jsdom supplies window/document without starting a real browser.
     environment: "jsdom",
-    include: ["src/__tests__/**/*.test.ts", "src/__tests__/**/*.test.tsx"],
+    // src-wide, not src/__tests__ only: a co-located test next to its
+    // component used to be silently ignored — never run, never reported,
+    // green CI (#735). The __tests__ layout keeps working verbatim.
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
     // No `globals: true` — tests import describe/it/expect explicitly so
     // they typecheck under tsc without adding vitest's ambient types to
     // tsconfig (npm run build's tsc --noEmit covers all of src/).

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -21,6 +21,7 @@ import asyncio
 import hashlib
 import json
 import logging
+from datetime import datetime, timezone
 import math
 import os
 import time
@@ -2348,4 +2349,16 @@ async def ws_endpoint(ws: WebSocket):
 # built bundle as package data — serves the whole app from this one process.
 _FRONTEND_DIR = Path(__file__).resolve().parent / "static"
 if _FRONTEND_DIR.is_dir():
+    # One line of staleness signal (#733): the mount is unconditional, so a
+    # source checkout serves whatever bundle was last built — which can trail
+    # frontend/src by days with no other symptom than "my change isn't
+    # showing up". The build time in the log gives that failure a timestamp.
+    _index = _FRONTEND_DIR / "index.html"
+    if _index.is_file():
+        _built = datetime.fromtimestamp(_index.stat().st_mtime, tz=timezone.utc)
+        logging.getLogger(__name__).info(
+            "serving frontend bundle built %s (%s)",
+            _built.strftime("%Y-%m-%d %H:%M UTC"),
+            _FRONTEND_DIR,
+        )
     app.mount("/", StaticFiles(directory=_FRONTEND_DIR, html=True), name="frontend")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,8 +14,55 @@
 import importlib.util
 import os
 import tempfile
+import warnings
 
 os.environ.setdefault("MPLBACKEND", "Agg")
+
+
+def pytest_collection(session):
+    """Fail fast when the collected tests and the imported packages come from
+    different checkouts (issue #733).
+
+    The editable installs' `__editable__*.pth` files hard-code the MAIN
+    checkout's absolute path, so running this venv's pytest from a git
+    worktree collects the WORKTREE's tests while importing the main
+    checkout's code — every assertion then exercises the wrong source, and
+    nothing says so. Comparing each package's resolved location against
+    pytest's rootdir turns that silent wrong-code run into an immediate,
+    self-explanatory collection error. (Worktree escape hatch:
+    `PYTHONPATH=$PWD/src:$PWD/momwire/src` outranks the .pth entries.)
+    """
+    import pathlib
+
+    import antennaknobs
+    import momwire
+
+    root = pathlib.Path(str(session.config.rootpath)).resolve()
+    ak_file = pathlib.Path(antennaknobs.__file__).resolve()
+    if root not in ak_file.parents:
+        raise pytest.UsageError(
+            f"antennaknobs imports from {ak_file}, which is outside this "
+            f"checkout ({root}). You are almost certainly running from a git "
+            "worktree against the main checkout's editable install — the "
+            "tests here would silently exercise the OTHER checkout's code. "
+            "Fix: PYTHONPATH=$PWD/src (outranks the .pth entries), or a "
+            "per-worktree venv (issue #733)."
+        )
+    # momwire is an exact-pinned dependency, not this repo's own code: a
+    # worktree that never touches it can legitimately import the main
+    # checkout's copy (worktrees do not populate submodules). Warn — so a
+    # deliberate momwire-editing worktree isn't silently wrong — instead of
+    # failing the overwhelmingly common momwire-untouched case.
+    mw_file = pathlib.Path(momwire.__file__).resolve()
+    if root not in mw_file.parents:
+        warnings.warn(
+            f"momwire imports from {mw_file} (outside {root}); fine unless "
+            "this worktree modifies momwire — then run "
+            "`git submodule update --init` here and set "
+            "PYTHONPATH=$PWD/momwire/src (issue #733).",
+            stacklevel=1,
+        )
+
 
 import matplotlib  # noqa: E402
 


### PR DESCRIPTION
Tier 1 of the 2026-08-05 infrastructure audit (issues #733–#738; both stack audits ran as read-only delegates with measured evidence).

## What
- **Named lanes** (`Makefile`): `make test` = the PR CI gate's pytest invocation verbatim (**56s measured** vs 174s full — 66% of full-suite wall time was 172 physics tests the PR gate never runs); `make gates` = ruff + full suite + frontend; `make frontend`.
- **Worktree tripwire** (`tests/conftest.py`): running this venv's pytest from a git worktree used to silently import the MAIN checkout's code (editable `.pth` hard-codes it) while collecting the worktree's tests. Now: hard collection error for `antennaknobs` with the fix in the message; advisory warning for `momwire` (exact-pinned dependency — the main-checkout copy is legitimate for worktrees that don't touch it, and worktrees don't populate submodules anyway). **Probed end-to-end in a real worktree**: bare → the error; `PYTHONPATH=$PWD/src` → 46 passed + 1 advisory.
- **CI diet** (#734): dead `scikit-rf` dropped from the install (removed from the codebase in #332 — a test asserts it's never imported); the coverage-comment **container** action moved to a push-gated job via an artifact handoff (container actions build at job start even when their step's `if` is false — every PR paid ~8s for a step that never ran); `ruff.yml` no longer double-fires on PRs.
- **Config correctness** (#735): vitest `include` widened to `src/**` (a co-located test used to be silently ignored — never run, green CI); `requires-python` corrected `>=3.8` → `>=3.10` (PEP 604 unions in 21 files made the old floor a lie that failed at import).
- **Bundle staleness signal** (#733): the server logs the mounted bundle's build time at startup — the "my change isn't showing up" failure now has a timestamp in line one of the log.
- Local (not in diff): stale editable dist-info refreshed via `--no-deps` reinstalls — locally-rendered charts now stamp 0.42.0, not 0.36.1.

## Not in this PR
Repo settings (branch protection with required checks, auto-merge, delete-branch-on-merge) need your credentials — exact commands in the session log. Tiers 2 remain as #736 (frontend guardrails), #737 (contract/trap guards), #738 (dependency hygiene).

## Gates (measured)
- `make gates`: ruff clean · full suite **3360 passed, 2 skipped** · frontend **615 passed** + tsc clean
- `make test` (new fast lane): **3189 passed, 172 deselected, 56s**
- Tripwire probed live in a scratch worktree, both directions (see above)
- CI on this PR itself demonstrates #734: single ruff run, no coverage-container build step

Closes #733, closes #734, closes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g