### PR TITLE
fix(ci): coverage-comment job needs its own contents:write grant

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,6 +130,14 @@ jobs:
     if: github.event_name == 'push'
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      # The workflow default is contents: read; the action pushes the badge/
+      # data to its python-coverage-comment-action-data branch, which the old
+      # inline step could do only because the BUILD job grants contents:
+      # write. A job does not inherit a sibling's grants — the first push
+      # run after #739 failed exactly here (GitError on git push).
+      contents: write
+      pull-requests: write
     steps:
     - uses: actions/checkout@v5
     - uses: actions/download-artifact@v4


### PR DESCRIPTION
The #739 relocation of the coverage-comment container action into its own push-gated job dropped the `contents: write` permission the old inline step inherited from the build job (workflow default is `contents: read`). First main-push run failed with a GitError pushing the badge/data branch — build/wheel/frontend all green, so this was contained to coverage reporting.

One permissions block on the job; comment explains the sibling-jobs-don't-share-grants trap.

Verification: the merge of THIS PR is itself the test — its main-push run must show coverage-comment: success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g