### PR TITLE
Adopt momwire 0.23.0 (dense-dispatch release)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/sta
 # install below sees its requirement already satisfied, then the package with the
 # web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install "momwire==0.22.0" \
+ && pip install "momwire==0.23.0" \
  && pip install -e ".[web]"
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire==0.22.0",
+    "momwire==0.23.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",


### PR DESCRIPTION
The release runbook's three-place follow-up, one commit: `pyproject.toml` pin, `Dockerfile` pin, and the submodule pointer → momwire's 0.23.0 bump commit (`6254ee5`).

Brings to the workbench: #211's dense BSpline assembly within the memory budget (~1.9× on `compute_impedance` at interactive sizes, verified in that PR's review) and momwire's corrected `requires-python >=3.10` floor.

Local verification: editable momwire rebuilt at 0.23.0, fast lane green (3189). The pin-triple guard from #742 will hold all three locations in mechanical agreement from now on — this is the last hand-checked bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g