### PR TITLE
Release v0.43.0 (the visible-rigging release)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.42.0"
+version = "0.43.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,27 +25,23 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.42.0" icon="star">
-  **The bench release: your VNA sweep, your feed network, your rope.**
-  Sweep an antenna straight off a USB **NanoVNA** into a `.s1p`
-  (`capture`), overlay it on any impedance chart — CLI or the workbench
-  Smith chart — and then invert the question with **`fit`**: solve for the
-  parameters a tape measure can't give you (site ground constants, as-built
-  length, buried feedline length), with a **residual** that tells you when
-  the measurement doesn't constrain what you asked
-  ([Calibrating against your VNA](/advanced/calibrating/)). The **feed
-  network is now drawn** — `schematic` renders feedline, tuner, balun and
-  source as a chain, in the CLI and as a workbench view, with the power
-  budget folded into it — and you can **pick the measurement plane**, so
-  the solve is what a VNA clipped on at that port would see. The output
-  stage scales too: **pin the views you watch**, reach the rest through an
-  overflow picker, switch to a 2×2 grid, and page the same set on a phone —
-  plus new **S11 (dB)** and **VSWR** sweep views. Station stdlib grows
-  **stubs and stub tuners**, balanced line from physical geometry, and
-  ferrite loss from **measured complex permeability** instead of one flat
-  Q; and `dipoles.invvee_catenary` hangs its arms with the sag real wire
-  takes under halyard tension.
-  [All release notes →](/reference/releases/)
+<Card title="New in v0.43.0" icon="star">
+  **The visible-rigging release: your antenna's tension, on screen — and a
+  faster, tidier workbench.** The catenary inverted vee's physics now shows
+  its numbers: **rigging tension (N and lbf), sag, and the rope length
+  you'd actually cut** appear in the solve readout, via a new generic
+  readouts channel any design — including your own in
+  `~/.antennaknobs/designs/` — can feed with no frontend code. The library
+  grows **`solve_sprung`**, the bungee/shock-cord rig closure (exact at
+  every length where the other closures are, with the stiff- and soft-limit
+  identities proven in tests). The workbench got quicker twice over:
+  **momwire 0.23.0's dense assembly** (~1.9× on interactive solves — an
+  outside contribution, thanks @happykawayigt!) and **view-residency
+  gating** — background sweeps only run while a view that draws them is on
+  screen. Plus: **reorder your pinned views** from the picker (rail, grid,
+  and phone pages all follow), pin/layout changes now sync across browser
+  windows live, and the Smith chart marks the sweep point nearest your
+  measurement frequency — the Γ-plane's first frequency anchor.
 </Card>
 
 ## The whole pitch, in one line

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -102,7 +102,16 @@ frequency.
   unpinning takes it away.
 - **Pins are yours, not the design's**: the set (and the layout mode) is
   stored in the browser and shared by every design session, since which views
-  you care about is a habit, not a property of the antenna.
+  you care about is a habit, not a property of the antenna. Since v0.43.0
+  the picker's **▲/▼ buttons reorder** the pinned set — pin order IS rail
+  order, grid-cell order, and phone-page order, so one reorder serves all
+  three — and a second browser **window** picks up pin/order/layout changes
+  live instead of on reload.
+- **Analyses follow the views** (v0.43.0): the freq sweep, convergence
+  sweep, and NEC pattern overlay only run while a view that renders them is
+  pinned or open — an enabled sweep with no Smith/S11/VSWR view on screen
+  costs nothing, and pinning one starts it. The norm check is the deliberate
+  exception (its number lives in the always-present solve readout).
 
 ## The antenna viewer
 
@@ -348,6 +357,13 @@ connection physical over **PEC** ground only (finite-ground contact is a
 NEC-4 feature), so solve ground-connected designs with PEC selected;
 elevated designs are unaffected.
 
+Designs can add their own rows to the solve readout (v0.43.0): a builder
+that computes physical diagnostics — the catenary inverted vee reports its
+**rigging tension in N and lbf**, sag, and derived rope cut length — sends
+them as self-describing rows the readout renders generically, so a new
+design idea (including a user design in `~/.antennaknobs/designs/`) gets its
+numbers on screen with no frontend change.
+
 ## Power budget
 
 Designs with a lossy feed network — a real coax or ladder-line run, a
@@ -447,7 +463,9 @@ The CLI has the same control on `fit` via `--plane`.
 To check that your chosen N is **converged** — i.e. adding more segments no
 longer moves the impedance — run a **convergence sweep**. It re-solves the
 current antenna across a range of N values and plots the resulting feed-point
-impedance, so you can see where the curve flattens out. Basics:
+impedance, so you can see where the curve flattens out. (Like the freq
+sweep, it runs only while the Smith view that draws it is on screen —
+v0.43.0's view-residency gating.) Basics:
 [Segments & convergence](/reference/solver/#segments--convergence); the full
 method (ladders, cross-basis validation with a second solver slot, and what a
 non-settling curve is telling you): [How many segments?](/advanced/convergence/).


### PR DESCRIPTION
The release-PR ritual: version bump, what's-new card refresh, docs de-stale sweep (view-rail: pin reorder + cross-window sync + residency gating; sweep sections: residency notes; solve readout: design-supplied rows), site builds clean (26 pages).

Since v0.42.0: #708 solve_sprung · #712 generic readouts (rig tension visible) · #714 pin reorder · #715 residency gating · #716 cross-window sync · #719 Smith frequency anchor · #718/#728 test-infra · momwire 0.23.0 adoption (#743 — 1.9× interactive solves, incl. the external #211 contribution) · infrastructure tiers 1+2 (#733–#738) · requires-python metadata fix.

After merge: tag v0.43.0 → four pipelines (PyPI, simulator deploy, docs deploy, Docker) with fleet-convergence verification, then the Discussions announcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g