### PR TITLE
Adaptive refinement: densify sweep and pattern-cut sampling where the drawn curve corners, after dwell

### DIFF
--- a/src/antennaknobs/designs/dipoles/invvee.py
+++ b/src/antennaknobs/designs/dipoles/invvee.py
@@ -34,6 +34,19 @@ class Builder(AntennaBuilder):
                         "min": 0.0,
                         "max": 60.0,
                     },
+                    # The auto ±50% window around 7 m tops out at 10.5 m,
+                    # which is barely one wavelength up on 10 m — below the
+                    # height where ground interference splits the elevation
+                    # pattern into the multi-lobe fan a user needs to see to
+                    # understand takeoff angle (5–6 lobes near 1.4λ, i.e.
+                    # ~15 m on 28 MHz). 16 m also covers a full half
+                    # wavelength on 40 m and the top of a typical push-up
+                    # mast, so the slider spans "on a mast" instead of
+                    # stopping just short of it.
+                    "base": {
+                        "min": 1.0,
+                        "max": 16.0,
+                    },
                 }
             ),
         }

--- a/src/antennaknobs/web/frontend/src/__tests__/cutRefine.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/cutRefine.test.tsx
@@ -1,0 +1,261 @@
+// Adaptive cut refinement (issue #744), client side.
+//
+// Two things are pinned here. First the GEOMETRY: a refined cut is no
+// longer uniform, so the chart can no longer derive a sample's angle from
+// its index — it has to read the angles the server sent, and the drawn
+// polyline must land where those angles say. Second the TRANSPORT: the
+// refinement request only goes out after a dwell (never mid-drag), carries
+// explicit angles, respects its budget, and leaves nothing behind when the
+// solve changes.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import {
+  CUT_REFINE_BUDGET,
+  traceFor,
+  useCutTraces,
+} from "../components/charts/cuts";
+import { cutDbiToFrac, cutProjection, maxChordDeviation } from "../lib/refine";
+import type { PatternCuts, SolveResponse } from "../lib/api";
+
+// Six lobes over the circle: the null-to-lobe transitions are what a fixed
+// polar grid renders as corners.
+const dbiAt = (deg: number) =>
+  10 + 20 * Math.log10(Math.abs(Math.cos((6 * deg * Math.PI) / 180)) + 3e-3);
+
+function uniformCuts(n: number, az = 15, el = 0): PatternCuts {
+  const dbi = Array.from({ length: n }, (_, i) => dbiAt((360 * i) / n));
+  return {
+    az_elev_deg: az,
+    elev_az_deg: el,
+    n_dir: n,
+    floor_dbi: -999,
+    azimuth: dbi,
+    elevation: dbi,
+  };
+}
+
+function cutsAtAngles(anglesDeg: number[], az = 15, el = 0): PatternCuts {
+  const dbi = anglesDeg.map(dbiAt);
+  return {
+    az_elev_deg: az,
+    elev_az_deg: el,
+    n_dir: 180,
+    floor_dbi: -999,
+    azimuth: dbi,
+    elevation: dbi,
+    az_angles_deg: anglesDeg,
+    elev_angles_deg: anglesDeg,
+  };
+}
+
+// ---- geometry --------------------------------------------------------------
+
+/** FarFieldChart's screen-coordinate loop, extracted verbatim in shape:
+ *  sample i sits at 2π·i/n unless the trace carries explicit angles. */
+function chartPoints(
+  dbi: number[],
+  anglesDeg: number[] | undefined,
+  dbiTop: number,
+  cx: number,
+  cy: number,
+  R: number,
+) {
+  const toFrac = cutDbiToFrac(dbiTop);
+  const n = dbi.length;
+  const out: { x: number; y: number }[] = [];
+  for (let pi = 0; pi <= n; pi++) {
+    const i = pi % n;
+    const t = anglesDeg ? (anglesDeg[i] * Math.PI) / 180 : (2 * Math.PI * pi) / n;
+    const frac = toFrac(dbi[i]);
+    out.push({ x: cx + Math.cos(t) * frac * R, y: cy - Math.sin(t) * frac * R });
+  }
+  return out;
+}
+
+describe("non-uniform cut geometry", () => {
+  it("traceFor hands the chart the explicit angles when the cut is refined", () => {
+    const uniform = traceFor(uniformCuts(8), "xy");
+    expect(uniform!.anglesDeg).toBeUndefined();
+    const refined = traceFor(cutsAtAngles([0, 30, 45, 200, 359]), "yz");
+    expect(refined!.anglesDeg).toEqual([0, 30, 45, 200, 359]);
+  });
+
+  it("drops an angle list that does not match its samples", () => {
+    // A server/client disagreement must fall back to the uniform
+    // parameterisation, not index past the end of the list.
+    const bad = { ...cutsAtAngles([0, 90, 180, 270]), az_angles_deg: [0, 90] };
+    expect(traceFor(bad, "xy")!.anglesDeg).toBeUndefined();
+  });
+
+  it("places a refined sample at its own angle, not at its index", () => {
+    // Four samples at 0/90/180/270 plus one inserted at 315: read by index
+    // the inserted point would land at 288°, a visibly wrong place.
+    const angles = [0, 90, 180, 270, 315];
+    const dbi = angles.map(() => 10); // constant radius: the rim
+    const pts = chartPoints(dbi, angles, 10, 100, 100, 50);
+    expect(pts[4].x).toBeCloseTo(100 + 50 * Math.cos((315 * Math.PI) / 180), 9);
+    expect(pts[4].y).toBeCloseTo(100 - 50 * Math.sin((315 * Math.PI) / 180), 9);
+    // Uniform reading of the same five samples puts it at 288° — the bug
+    // this field exists to prevent.
+    const wrong = chartPoints(dbi, undefined, 10, 100, 100, 50);
+    expect(wrong[4].x).not.toBeCloseTo(pts[4].x, 3);
+  });
+
+  it("closes the polygon back to the first sample", () => {
+    const angles = [0, 90, 180, 270, 315];
+    const pts = chartPoints(angles.map(dbiAt), angles, 11, 100, 100, 50);
+    expect(pts).toHaveLength(angles.length + 1);
+    expect(pts[pts.length - 1]).toEqual(pts[0]);
+  });
+
+  it("a refined trace draws closer to the true pattern than the uniform one", () => {
+    // The acceptance shape, in display units: same chart, same radial
+    // scale, denser sampling ⇒ strictly less drawn error.
+    const n = 24;
+    const base = Array.from({ length: n }, (_, i) => dbiAt((360 * i) / n));
+    const top = 11;
+    const coarse = maxChordDeviation(cutProjection(base, undefined, top), true);
+    const dense = Array.from({ length: 4 * n }, (_, i) => (360 * i) / (4 * n));
+    const fine = maxChordDeviation(
+      cutProjection(dense.map(dbiAt), dense, top),
+      true,
+    );
+    expect(fine).toBeLessThan(coarse);
+  });
+});
+
+// ---- transport -------------------------------------------------------------
+
+let fetchMock: ReturnType<typeof vi.fn>;
+let cutsBodies: Record<string, unknown>[];
+let solveSeq = 0;
+
+function makeSolve(): SolveResponse {
+  // A fresh object per call: the cuts cache keys on solve identity, so this
+  // is what "a new solve" means to this module.
+  return {
+    solve_id: `solve-${++solveSeq}`,
+    cuts: uniformCuts(24),
+  } as unknown as SolveResponse;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  cutsBodies = [];
+  fetchMock = vi.fn((url: string, init?: { body?: string }) => {
+    const body = JSON.parse(init?.body ?? "{}");
+    if (url === "/cuts") cutsBodies.push(body);
+    const angles: number[] | undefined = body.az_angles_deg;
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve(
+          angles ? cutsAtAngles([...angles].sort((a, b) => a - b)) : uniformCuts(24),
+        ),
+    });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+async function settle(ms: number, flushes = 60) {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
+    for (let i = 0; i < flushes; i++) await Promise.resolve();
+  });
+}
+
+const refineBodies = () =>
+  cutsBodies.filter((b) => Array.isArray(b.az_angles_deg));
+
+describe("cut refinement transport (issue #744)", () => {
+  it("refines only after the dwell, at explicit angles, within budget", async () => {
+    const solve = makeSolve();
+    const { result } = renderHook(() => useCutTraces([solve], 15, 0));
+    // The solve already carries cuts at these angles, so nothing is fetched
+    // and nothing is refined until the dwell elapses.
+    await settle(300);
+    expect(refineBodies()).toHaveLength(0);
+
+    await settle(500);
+    const rounds = refineBodies();
+    expect(rounds.length).toBeGreaterThan(0);
+    for (const b of rounds) {
+      expect(b.az_elev_deg).toBe(15);
+      expect(b.elev_az_deg).toBe(0);
+      // Every request carries the WHOLE parameterisation (base + added), so
+      // the server has no state to reconcile.
+      const angles = b.az_angles_deg as number[];
+      expect(angles.length).toBeGreaterThan(24);
+      expect(angles.length).toBeLessThanOrEqual(24 + CUT_REFINE_BUDGET);
+    }
+    // The chart now sees a denser trace than the solve shipped with.
+    const trace = traceFor(result.current[0], "xy")!;
+    expect(trace.dbi.length).toBeGreaterThan(24);
+    expect(trace.anglesDeg).toBeDefined();
+    expect(trace.anglesDeg).toEqual(
+      [...trace.anglesDeg!].sort((a, b) => a - b),
+    );
+  });
+
+  it("a cut-dial drag inside the dwell issues no refinement", async () => {
+    const solve = makeSolve();
+    const { rerender } = renderHook(
+      (p: { az: number }) => useCutTraces([solve], p.az, 0),
+      { initialProps: { az: 15 } },
+    );
+    // Drag through a run of angles, each well inside the refinement dwell.
+    for (const az of [16, 17, 18, 19, 20]) {
+      rerender({ az });
+      await settle(100);
+    }
+    expect(refineBodies()).toHaveLength(0);
+    // Letting go fetches the cuts for where the dial landed (120 ms), and a
+    // dwell after THAT lands, refinement runs — for 20, never for 16..19.
+    await settle(500);
+    expect(refineBodies()).toHaveLength(0);
+    await settle(500);
+    expect(refineBodies().length).toBeGreaterThan(0);
+    for (const b of refineBodies()) expect(b.az_elev_deg).toBe(20);
+  });
+
+  it("a new solve leaves no refined sample behind", async () => {
+    const first = makeSolve();
+    const { result, rerender } = renderHook(
+      (p: { solve: SolveResponse }) => useCutTraces([p.solve], 15, 0),
+      { initialProps: { solve: first } },
+    );
+    await settle(1000);
+    expect(traceFor(result.current[0], "xy")!.dbi.length).toBeGreaterThan(24);
+
+    const second = makeSolve();
+    rerender({ solve: second });
+    // Keyed on solve identity: the new solve draws its own uniform cuts,
+    // never the previous solve's refined ones.
+    const fresh = traceFor(result.current[0], "xy")!;
+    expect(fresh.dbi).toHaveLength(24);
+    expect(fresh.anglesDeg).toBeUndefined();
+  });
+
+  it("stops when the trace is already accurate enough", async () => {
+    // A round pattern on the real 180-point grid: the drawn 180-gon misses
+    // the true circle by far less than a pixel, so no round is spent.
+    const round = {
+      ...uniformCuts(180),
+      azimuth: Array.from({ length: 180 }, () => 5),
+      elevation: Array.from({ length: 180 }, () => 5),
+    };
+    const solve = {
+      solve_id: "solve-round",
+      cuts: round,
+    } as unknown as SolveResponse;
+    renderHook(() => useCutTraces([solve], 15, 0));
+    await settle(1000);
+    expect(refineBodies()).toHaveLength(0);
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/refine.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/refine.test.ts
@@ -1,0 +1,373 @@
+// The pure half of adaptive refinement (issue #744): where extra samples
+// go, decided from display-space curvature. Everything here is
+// input-in/values-out — no fetch, no React, no canvas — so the criterion
+// itself is pinned independently of the transport that carries it.
+import { describe, it, expect } from "vitest";
+import {
+  KINK_TOLERANCE_RAD,
+  MIN_SEGMENT,
+  cutDbiToFrac,
+  cutDbiTop,
+  cutProjection,
+  maxKinkRad,
+  planRefinement,
+  refineCutAngles,
+  refineSweepFreqs,
+  sweepProjections,
+  turnAngles,
+  type DisplayPoint,
+} from "../lib/refine";
+import { mergeSweepPoints } from "../lib/sweep";
+import type { SweepData } from "../lib/api";
+
+const line = (n: number): DisplayPoint[] =>
+  Array.from({ length: n }, (_, i) => ({ x: i / (n - 1), y: 0.5 }));
+
+describe("turnAngles / maxKinkRad", () => {
+  it("a straight polyline has no curvature anywhere", () => {
+    expect(maxKinkRad(line(9))).toBe(0);
+  });
+
+  it("a right-angle corner turns by π/2 at the vertex only", () => {
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 0.5, y: 0 },
+      { x: 0.5, y: 0.5 },
+    ];
+    const t = turnAngles(pts);
+    expect(t[0]).toBe(0);
+    expect(t[1]).toBeCloseTo(Math.PI / 2, 12);
+    expect(t[2]).toBe(0);
+  });
+
+  it("a closed polyline wraps: a regular polygon turns equally at every vertex", () => {
+    const n = 12;
+    const poly = Array.from({ length: n }, (_, i) => ({
+      x: Math.cos((2 * Math.PI * i) / n),
+      y: Math.sin((2 * Math.PI * i) / n),
+    }));
+    const t = turnAngles(poly, true);
+    for (const a of t) expect(a).toBeCloseTo((2 * Math.PI) / n, 12);
+    // Open, the two ends are boundary vertices with no turn.
+    const open = turnAngles(poly, false);
+    expect(open[0]).toBe(0);
+    expect(open[n - 1]).toBe(0);
+  });
+
+  it("a repeated point is not a corner", () => {
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 0.5, y: 0 },
+      { x: 0.5, y: 0 },
+      { x: 1, y: 0.5 },
+    ];
+    expect(turnAngles(pts)[1]).toBe(0);
+  });
+});
+
+describe("planRefinement", () => {
+  const t5 = [0, 1, 2, 3, 4];
+
+  it("proposes nothing for a polyline that is already smooth", () => {
+    expect(planRefinement(t5, [line(5)], { budget: 10 })).toEqual([]);
+  });
+
+  it("puts its points at the corner, not spread over the flat stretch", () => {
+    // Flat, flat, sharp bend, flat: the kink lives at index 2.
+    const pts: DisplayPoint[] = [
+      { x: 0.0, y: 0.5 },
+      { x: 0.25, y: 0.5 },
+      { x: 0.5, y: 0.5 },
+      { x: 0.75, y: 0.0 },
+      { x: 1.0, y: 0.0 },
+    ];
+    const got = planRefinement(t5, [pts], { budget: 4 });
+    expect(got.length).toBe(4);
+    // Every point lands in the span the bend touches — the corner spans
+    // vertices 2 and 3, so intervals [1,2], [2,3] and [3,4] all help.
+    for (const v of got) expect(v).toBeGreaterThanOrEqual(1);
+    // Nothing wasted on [0,1], which is flat at both ends.
+    for (const v of got) expect(v).toBeGreaterThan(1);
+  });
+
+  it("respects the budget exactly when demand exceeds it", () => {
+    const zig: DisplayPoint[] = Array.from({ length: 21 }, (_, i) => ({
+      x: i / 20,
+      y: i % 2 === 0 ? 0.2 : 0.8,
+    }));
+    const t = Array.from({ length: 21 }, (_, i) => i);
+    for (const budget of [1, 3, 7, 20]) {
+      expect(planRefinement(t, [zig], { budget }).length).toBe(budget);
+    }
+    expect(planRefinement(t, [zig], { budget: 0 })).toEqual([]);
+  });
+
+  it("is deterministic: the same input yields the identical plan", () => {
+    const zig: DisplayPoint[] = Array.from({ length: 15 }, (_, i) => ({
+      x: i / 14,
+      y: 0.5 + 0.3 * Math.sin(i * 2.1),
+    }));
+    const t = Array.from({ length: 15 }, (_, i) => i);
+    const a = planRefinement(t, [zig], { budget: 9 });
+    expect(planRefinement(t, [zig], { budget: 9 })).toEqual(a);
+    expect(a).toEqual([...a].sort((p, q) => p - q));
+  });
+
+  it("never re-splits an interval already below the display floor", () => {
+    // A right-angle corner whose left arm is already sub-pixel: interval
+    // [1,2] carries the full 90° kink but is shorter than MIN_SEGMENT, so
+    // splitting it can never change what is drawn.
+    const step: DisplayPoint[] = [
+      { x: 0, y: 0 },
+      { x: 0.5, y: 0 },
+      { x: 0.5 + MIN_SEGMENT / 4, y: 0 },
+      { x: 0.5 + MIN_SEGMENT / 4, y: 1 },
+    ];
+    const got = planRefinement([0, 1, 2, 3], [step], { budget: 100 });
+    // Terminates strictly inside the budget instead of grinding the corner
+    // forever, and never touches the sub-pixel interval [1,2] itself.
+    expect(got.length).toBeLessThan(100);
+    for (const v of got) expect(v > 1 && v < 2).toBe(false);
+  });
+
+  it("takes the union across projections: a bend in EITHER earns points", () => {
+    const flat = line(5);
+    const bent: DisplayPoint[] = [
+      { x: 0.0, y: 0.5 },
+      { x: 0.25, y: 0.5 },
+      { x: 0.5, y: 0.5 },
+      { x: 0.75, y: 0.0 },
+      { x: 1.0, y: 0.0 },
+    ];
+    expect(planRefinement(t5, [flat], { budget: 4 })).toEqual([]);
+    expect(planRefinement(t5, [flat, bent], { budget: 4 })).toEqual(
+      planRefinement(t5, [bent], { budget: 4 }),
+    );
+  });
+
+  it("ignores projections whose length does not match the parameter array", () => {
+    expect(planRefinement(t5, [line(3)], { budget: 4 })).toEqual([]);
+  });
+
+  it("wraps the last-to-first interval when closed", () => {
+    // 4 samples of a circle: every vertex turns 90°, so the worst interval
+    // includes the wrap one, whose midpoint must be 315° — not 180°.
+    const t = [0, 90, 180, 270];
+    const pts = t.map((a) => ({
+      x: Math.cos((a * Math.PI) / 180) * 0.5,
+      y: Math.sin((a * Math.PI) / 180) * 0.5,
+    }));
+    const got = planRefinement(t, [pts], {
+      budget: 4,
+      closed: true,
+      period: 360,
+    });
+    expect(got).toEqual([45, 135, 225, 315]);
+  });
+
+  it("refinement provably lowers the worst kink on a smooth curve", () => {
+    // Sample a Lorentzian-shaped notch coarsely, then at the refined
+    // parameter set, and compare the rendered polylines' worst corner.
+    const yOf = (f: number) => 1 - 1 / (1 + 400 * (f - 0.5) * (f - 0.5));
+    const ptsOf = (fs: number[]) => fs.map((f) => ({ x: f, y: yOf(f) }));
+    const coarse = Array.from({ length: 21 }, (_, i) => i / 20);
+    const before = maxKinkRad(ptsOf(coarse));
+    const added = planRefinement(coarse, [ptsOf(coarse)], { budget: 24 });
+    const after = maxKinkRad(ptsOf([...coarse, ...added].sort((a, b) => a - b)));
+    expect(before).toBeGreaterThan(KINK_TOLERANCE_RAD);
+    expect(after).toBeLessThan(before);
+  });
+});
+
+describe("sweepProjections / refineSweepFreqs", () => {
+  // A series-RLC-shaped resonance: R(f) flat, X(f) crossing zero steeply.
+  function notchSweep(freqs: number[]): SweepData {
+    return {
+      freqs_mhz: freqs,
+      z_re: freqs.map(() => 50),
+      z_im: freqs.map((f) => 4000 * (f - 14.2)),
+    };
+  }
+
+  it("maps x linearly in MHz across the swept span (SweepChart's xOf)", () => {
+    const s = notchSweep([10, 12, 20]);
+    const [vswr] = sweepProjections(s, 50);
+    expect(vswr[0].x).toBeCloseTo(0, 12);
+    expect(vswr[1].x).toBeCloseTo(0.2, 12);
+    expect(vswr[2].x).toBeCloseTo(1, 12);
+  });
+
+  it("clamps to the charts' y domains so off-screen curvature is ignored", () => {
+    const s = notchSweep([10, 14.2, 20]);
+    const [vswr, gamma] = sweepProjections(s, 50);
+    // A wildly reactive endpoint pins at the VSWR ceiling and at 0 dB S11.
+    expect(vswr[0].y).toBe(1);
+    expect(gamma[0].y).toBeCloseTo(1, 4);
+    // Perfect match at the notch: VSWR 1 (bottom) and S11 below −30 (bottom).
+    expect(vswr[1].y).toBe(0);
+    expect(gamma[1].y).toBe(0);
+  });
+
+  it("adds points around the notch and skips the flat wings", () => {
+    const freqs = Array.from({ length: 41 }, (_, i) => 13.5 + (i * 1.4) / 40);
+    const got = refineSweepFreqs(notchSweep(freqs), 50, 12);
+    expect(got.length).toBe(12);
+    // Everything within a quarter of the span of the resonance at 14.2.
+    for (const f of got) expect(Math.abs(f - 14.2)).toBeLessThan(0.35);
+  });
+
+  it("never re-proposes a frequency already sampled", () => {
+    const freqs = Array.from({ length: 41 }, (_, i) => 13.5 + (i * 1.4) / 40);
+    const s = notchSweep(freqs);
+    const first = refineSweepFreqs(s, 50, 12);
+    const merged = mergeSweepPoints(s, notchSweep(first));
+    const second = refineSweepFreqs(merged, 50, 12);
+    for (const f of second) expect(merged.freqs_mhz).not.toContain(f);
+  });
+
+  it("declines to plan for a sweep too short to have curvature", () => {
+    expect(refineSweepFreqs(notchSweep([10, 11]), 50, 12)).toEqual([]);
+  });
+});
+
+describe("cut projection / refineCutAngles", () => {
+  it("the radial map matches FarFieldChart's: −20 dBi at the origin, clamped", () => {
+    const toFrac = cutDbiToFrac(10);
+    expect(toFrac(-20)).toBe(0);
+    expect(toFrac(10)).toBe(1);
+    expect(toFrac(-5)).toBeCloseTo(0.5, 12);
+    expect(toFrac(-999)).toBe(0); // below-horizon floor sentinel
+    expect(toFrac(40)).toBe(1);
+  });
+
+  it("the radial top expands to fit the highest lobe, with 1 dB headroom", () => {
+    // Nothing above the +10 dBi default ⇒ the chart's 1 dB headroom still
+    // applies, exactly as FarFieldChart computes it.
+    expect(cutDbiTop([2, 5])).toBe(11);
+    expect(cutDbiTop([15.2])).toBe(17);
+    expect(cutDbiTop([Infinity, 3])).toBe(11);
+  });
+
+  it("uniform cuts sit at t = 2π·i/n; explicit angles override that", () => {
+    const dbi = [10, 10, 10, 10];
+    const uniform = cutProjection(dbi, undefined, 10);
+    expect(uniform[1].x).toBeCloseTo(0, 12);
+    expect(uniform[1].y).toBeCloseTo(0.5, 12);
+    const explicit = cutProjection(dbi, [0, 180, 270, 315], 10);
+    expect(explicit[1].x).toBeCloseTo(-0.5, 12);
+    expect(explicit[1].y).toBeCloseTo(0, 12);
+  });
+
+  it("densifies a multi-lobed cut's nulls and lowers its worst corner", () => {
+    // Six lobes over the circle, sampled at 24 points — the nulls are where
+    // the polar trace corners.
+    const n = 24;
+    const dbiAt = (deg: number) =>
+      10 + 20 * Math.log10(Math.abs(Math.cos((6 * deg * Math.PI) / 180)) + 1e-3);
+    const base = Array.from({ length: n }, (_, i) => dbiAt((360 * i) / n));
+    const top = cutDbiTop([Math.max(...base)]);
+    const before = maxKinkRad(cutProjection(base, undefined, top), true);
+    const added = refineCutAngles(base, undefined, top, 40);
+    expect(added.length).toBeGreaterThan(0);
+    for (const a of added) expect(a).toBeGreaterThanOrEqual(0);
+    for (const a of added) expect(a).toBeLessThan(360);
+
+    const angles = [
+      ...Array.from({ length: n }, (_, i) => (360 * i) / n),
+      ...added,
+    ].sort((p, q) => p - q);
+    const after = maxKinkRad(
+      cutProjection(angles.map(dbiAt), angles, top),
+      true,
+    );
+    expect(after).toBeLessThan(before);
+  });
+
+  it("respects the budget and never re-proposes a held angle", () => {
+    const n = 24;
+    const base = Array.from({ length: n }, (_, i) =>
+      10 + 20 * Math.log10(Math.abs(Math.cos((6 * ((360 * i) / n) * Math.PI) / 180)) + 1e-3),
+    );
+    const got = refineCutAngles(base, undefined, 10, 6);
+    expect(got.length).toBeLessThanOrEqual(6);
+    for (const a of got) expect(a % 15).not.toBe(0);
+  });
+});
+
+describe("mergeSweepPoints", () => {
+  const base: SweepData = {
+    freqs_mhz: [10, 12, 14],
+    z_re: [1, 2, 3],
+    z_im: [-1, -2, -3],
+  };
+
+  it("re-sorts by frequency and keeps every row array index-aligned", () => {
+    const extra: SweepData = {
+      freqs_mhz: [13, 11],
+      z_re: [30, 10],
+      z_im: [-30, -10],
+    };
+    const m = mergeSweepPoints(base, extra);
+    expect(m.freqs_mhz).toEqual([10, 11, 12, 13, 14]);
+    expect(m.z_re).toEqual([1, 10, 2, 30, 3]);
+    expect(m.z_im).toEqual([-1, -10, -2, -30, -3]);
+    expect(m.feeds_z_re).toBeUndefined();
+  });
+
+  it("permutes the per-feed rows by the same ordering", () => {
+    const bf: SweepData = {
+      ...base,
+      feeds_z_re: [[1, 101], [2, 102], [3, 103]],
+      feeds_z_im: [[-1, -101], [-2, -102], [-3, -103]],
+    };
+    const extra: SweepData = {
+      freqs_mhz: [13, 11],
+      z_re: [30, 10],
+      z_im: [-30, -10],
+      feeds_z_re: [[30, 130], [10, 110]],
+      feeds_z_im: [[-30, -130], [-10, -110]],
+    };
+    const m = mergeSweepPoints(bf, extra);
+    expect(m.freqs_mhz).toEqual([10, 11, 12, 13, 14]);
+    // Row i of every array describes freqs_mhz[i] — the invariant a chart
+    // reading feeds_z_re[i] alongside freqs_mhz[i] depends on.
+    expect(m.feeds_z_re).toEqual([
+      [1, 101],
+      [10, 110],
+      [2, 102],
+      [30, 130],
+      [3, 103],
+    ]);
+    expect(m.feeds_z_im![3]).toEqual([-30, -130]);
+  });
+
+  it("drops per-feed rows rather than emit a half-populated array", () => {
+    const bf: SweepData = {
+      ...base,
+      feeds_z_re: [[1], [2], [3]],
+      feeds_z_im: [[-1], [-2], [-3]],
+    };
+    const m = mergeSweepPoints(bf, {
+      freqs_mhz: [11],
+      z_re: [10],
+      z_im: [-10],
+    });
+    expect(m.freqs_mhz).toEqual([10, 11, 12, 14]);
+    expect(m.feeds_z_re).toBeUndefined();
+    expect(m.feeds_z_im).toBeUndefined();
+  });
+
+  it("is idempotent: an already-merged frequency keeps the held value", () => {
+    const m1 = mergeSweepPoints(base, {
+      freqs_mhz: [11],
+      z_re: [10],
+      z_im: [-10],
+    });
+    const m2 = mergeSweepPoints(m1, {
+      freqs_mhz: [11],
+      z_re: [999],
+      z_im: [999],
+    });
+    expect(m2).toEqual(m1);
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/refine.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/refine.test.ts
@@ -4,11 +4,12 @@
 // itself is pinned independently of the transport that carries it.
 import { describe, it, expect } from "vitest";
 import {
-  KINK_TOLERANCE_RAD,
-  MIN_SEGMENT,
+  DEVIATION_TOLERANCE,
+  chordDeviations,
   cutDbiToFrac,
   cutDbiTop,
   cutProjection,
+  maxChordDeviation,
   maxKinkRad,
   planRefinement,
   refineCutAngles,
@@ -65,6 +66,59 @@ describe("turnAngles / maxKinkRad", () => {
   });
 });
 
+describe("chordDeviations / maxChordDeviation", () => {
+  it("a straight polyline deviates nowhere", () => {
+    expect(maxChordDeviation(line(9))).toBe(0);
+  });
+
+  it("measures the perpendicular miss of the chord across a vertex", () => {
+    // Dropping the apex would draw the chord y=0; the apex is 0.25 above it.
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 0.5, y: 0.25 },
+      { x: 1, y: 0 },
+    ];
+    expect(chordDeviations(pts)[1]).toBeCloseTo(0.25, 12);
+    expect(chordDeviations(pts)[0]).toBe(0);
+  });
+
+  it("falls as O(h^2) on a smooth curve — the property that lets it terminate", () => {
+    const arc = (n: number) =>
+      Array.from({ length: n }, (_, i) => {
+        const a = (Math.PI * i) / (n - 1);
+        return { x: Math.cos(a), y: Math.sin(a) };
+      });
+    const coarse = maxChordDeviation(arc(9));
+    const fine = maxChordDeviation(arc(17));
+    expect(fine / coarse).toBeGreaterThan(0.15);
+    expect(fine / coarse).toBeLessThan(0.35);
+  });
+
+  it("a spike whose neighbours coincide still reports its full miss", () => {
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 0.2, y: 0.4 },
+      { x: 0, y: 0 },
+    ];
+    expect(chordDeviations(pts)[1]).toBeCloseTo(Math.hypot(0.2, 0.4), 12);
+  });
+
+  it("stays finite where the turn angle does not converge (a true spike)", () => {
+    // A V with slope +-20: sampling it perfectly still turns ~174 deg at the
+    // vertex, so a turn-angle criterion would refine forever. The chord
+    // deviation of the same V halves with the sample spacing.
+    const v = (h: number) => [
+      { x: 0.5 - h, y: 20 * h },
+      { x: 0.5, y: 0 },
+      { x: 0.5 + h, y: 20 * h },
+    ];
+    expect(maxKinkRad(v(0.01))).toBeCloseTo(maxKinkRad(v(0.0001)), 3);
+    expect(maxChordDeviation(v(0.0001))).toBeLessThan(
+      maxChordDeviation(v(0.01)) / 50,
+    );
+  });
+});
+
 describe("planRefinement", () => {
   const t5 = [0, 1, 2, 3, 4];
 
@@ -113,21 +167,21 @@ describe("planRefinement", () => {
     expect(a).toEqual([...a].sort((p, q) => p - q));
   });
 
-  it("never re-splits an interval already below the display floor", () => {
-    // A right-angle corner whose left arm is already sub-pixel: interval
-    // [1,2] carries the full 90° kink but is shorter than MIN_SEGMENT, so
-    // splitting it can never change what is drawn.
+  it("a discontinuity costs a bounded handful of points, not the budget", () => {
+    // A step no amount of sampling removes. The per-split estimate
+    // (deviation is O(h^2)) has to fall fast enough that the plan gives up
+    // on it — otherwise one clamp edge on a VSWR trace eats every point.
     const step: DisplayPoint[] = [
       { x: 0, y: 0 },
-      { x: 0.5, y: 0 },
-      { x: 0.5 + MIN_SEGMENT / 4, y: 0 },
-      { x: 0.5 + MIN_SEGMENT / 4, y: 1 },
+      { x: 0.4, y: 0 },
+      { x: 0.4, y: 1 },
+      { x: 1, y: 1 },
     ];
+    // The estimate falls 4x per split, so an interval is abandoned after
+    // ~log4(dev/tolerance) levels — a bound independent of the budget.
     const got = planRefinement([0, 1, 2, 3], [step], { budget: 100 });
-    // Terminates strictly inside the budget instead of grinding the corner
-    // forever, and never touches the sub-pixel interval [1,2] itself.
-    expect(got.length).toBeLessThan(100);
-    for (const v of got) expect(v > 1 && v < 2).toBe(false);
+    expect(got.length).toBeGreaterThan(0);
+    expect(got.length).toBeLessThan(60);
   });
 
   it("takes the union across projections: a bend in EITHER earns points", () => {
@@ -165,17 +219,21 @@ describe("planRefinement", () => {
     expect(got).toEqual([45, 135, 225, 315]);
   });
 
-  it("refinement provably lowers the worst kink on a smooth curve", () => {
+  it("refinement drives the drawn error under tolerance on a smooth curve", () => {
     // Sample a Lorentzian-shaped notch coarsely, then at the refined
-    // parameter set, and compare the rendered polylines' worst corner.
+    // parameter set, and compare how far each rendered polyline misses.
     const yOf = (f: number) => 1 - 1 / (1 + 400 * (f - 0.5) * (f - 0.5));
     const ptsOf = (fs: number[]) => fs.map((f) => ({ x: f, y: yOf(f) }));
-    const coarse = Array.from({ length: 21 }, (_, i) => i / 20);
-    const before = maxKinkRad(ptsOf(coarse));
-    const added = planRefinement(coarse, [ptsOf(coarse)], { budget: 24 });
-    const after = maxKinkRad(ptsOf([...coarse, ...added].sort((a, b) => a - b)));
-    expect(before).toBeGreaterThan(KINK_TOLERANCE_RAD);
-    expect(after).toBeLessThan(before);
+    let fs = Array.from({ length: 21 }, (_, i) => i / 20);
+    const before = maxChordDeviation(ptsOf(fs));
+    expect(before).toBeGreaterThan(DEVIATION_TOLERANCE);
+    for (let round = 0; round < 6; round++) {
+      const added = planRefinement(fs, [ptsOf(fs)], { budget: 12 });
+      if (added.length === 0) break;
+      fs = [...fs, ...added].sort((a, b) => a - b);
+    }
+    expect(maxChordDeviation(ptsOf(fs))).toBeLessThan(DEVIATION_TOLERANCE);
+    expect(fs.length).toBeLessThan(21 + 6 * 12);
   });
 });
 
@@ -258,7 +316,7 @@ describe("cut projection / refineCutAngles", () => {
     expect(explicit[1].y).toBeCloseTo(0, 12);
   });
 
-  it("densifies a multi-lobed cut's nulls and lowers its worst corner", () => {
+  it("densifies a multi-lobed cut's nulls and lowers its drawn error", () => {
     // Six lobes over the circle, sampled at 24 points — the nulls are where
     // the polar trace corners.
     const n = 24;
@@ -266,7 +324,7 @@ describe("cut projection / refineCutAngles", () => {
       10 + 20 * Math.log10(Math.abs(Math.cos((6 * deg * Math.PI) / 180)) + 1e-3);
     const base = Array.from({ length: n }, (_, i) => dbiAt((360 * i) / n));
     const top = cutDbiTop([Math.max(...base)]);
-    const before = maxKinkRad(cutProjection(base, undefined, top), true);
+    const before = maxChordDeviation(cutProjection(base, undefined, top), true);
     const added = refineCutAngles(base, undefined, top, 40);
     expect(added.length).toBeGreaterThan(0);
     for (const a of added) expect(a).toBeGreaterThanOrEqual(0);
@@ -276,7 +334,7 @@ describe("cut projection / refineCutAngles", () => {
       ...Array.from({ length: n }, (_, i) => (360 * i) / n),
       ...added,
     ].sort((p, q) => p - q);
-    const after = maxKinkRad(
+    const after = maxChordDeviation(
       cutProjection(angles.map(dbiAt), angles, top),
       true,
     );

--- a/src/antennaknobs/web/frontend/src/__tests__/useAnalysisRunners.refine.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useAnalysisRunners.refine.test.tsx
@@ -1,0 +1,257 @@
+// Adaptive sweep refinement (issue #744) as a CONTRACT, not as physics: the
+// planner's criterion is pinned in refine.test.ts, so what these tests hold
+// is when refinement is allowed to run at all and what it may leave behind.
+//   - it fires only after a whole base sweep streamed AND a second dwell —
+//     never mid-scrub;
+//   - a knob change aborts it and leaves no refined point behind (the #692
+//     signature clears them like every other sweep point);
+//   - a non-resident sweep gets zero refinement requests (#715);
+//   - budget exhaustion is graceful: best-so-far stays on screen.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useAnalysisRunners } from "../components/session/useAnalysisRunners";
+import { SWEEP_REFINE_BUDGET } from "../lib/sweep";
+import type { BackendEntry } from "../lib/backends";
+import type { SolveRequest } from "../lib/api";
+
+const PYNEC: BackendEntry = {
+  name: "pynec",
+  label: "PyNEC",
+  kind: "pynec",
+  supports_ground: true,
+  options_schema: [],
+  panel: null,
+  default_n_per_wire: 8,
+  accelerator: false,
+  dense_family: false,
+};
+
+// A series-resonance Z(f) sharp enough that a 41-point grid corners at the
+// notch — the showcase failure the issue describes, in closed form.
+function zAt(f: number): { z_re: number; z_im: number } {
+  return { z_re: 50, z_im: 3000 * (f - 28.47) };
+}
+
+function ndjson(lines: string[]) {
+  let i = 0;
+  return Promise.resolve({
+    ok: true,
+    body: {
+      getReader: () => ({
+        read: () =>
+          i >= lines.length
+            ? Promise.resolve({ done: true, value: undefined })
+            : Promise.resolve({
+                done: false,
+                value: new TextEncoder().encode(lines[i++] + "\n"),
+              }),
+      }),
+    },
+  });
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+/** Every /sweep body seen, in order — base sweep first, then each
+ *  refinement round. */
+let sweepBodies: Record<string, unknown>[];
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  sweepBodies = [];
+  fetchMock = vi.fn((url: string, init?: { body?: string }) => {
+    if (url === "/sweep") {
+      const body = JSON.parse(init?.body ?? "{}");
+      sweepBodies.push(body);
+      const freqs: number[] = body.freqs_mhz ?? [];
+      return ndjson(
+        freqs.map((f) => JSON.stringify({ freq_mhz: f, ...zAt(f) })),
+      );
+    }
+    if (url === "/converge") return ndjson([]);
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ available: false }),
+    });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+type Props = { req: Record<string, unknown>; sweepResident: boolean };
+
+function renderRunners(initial: Props) {
+  return renderHook(
+    (p: Props) =>
+      useAnalysisRunners({
+        backend: PYNEC,
+        currentVariant: "default",
+        currentExample: undefined,
+        currentBands: [],
+        freqWindowCeiling: 60,
+        designFreq: 28.47,
+        measFreq: 28.47,
+        measLocked: false,
+        groundEnabled: false,
+        groundModel: "fast",
+        sweepEnabled: true,
+        convergeEnabled: false,
+        normCheckEnabled: false,
+        necOverlayEnabled: false,
+        sweepResident: p.sweepResident,
+        convergeResident: false,
+        patternResident: false,
+        autoSim: true,
+        active: true,
+        comboApproved: false,
+        recommendedBackend: null,
+        z0: 50,
+        buildRequest: () => ({ ...p.req }) as SolveRequest,
+        solveWithheld: () => false,
+        seqRef: { current: 0 },
+        approvedComboRef: { current: false },
+      }),
+    { initialProps: initial },
+  );
+}
+
+/** Run the timers out and let the streams settle. `ms` covers one dwell;
+ *  the microtask flushes cover the NDJSON reads and, on the refinement
+ *  path, the chain of rounds behind them. */
+async function settle(ms = 500, flushes = 60) {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
+    for (let i = 0; i < flushes; i++) await Promise.resolve();
+  });
+}
+
+const refineBodies = () => sweepBodies.filter((b) => b._refine === true);
+const BASE: Props = { req: { geometry: "g" }, sweepResident: true };
+
+describe("adaptive sweep refinement (issue #744)", () => {
+  it("waits for a second dwell after the base sweep, then densifies", async () => {
+    const { result } = renderRunners(BASE);
+    await settle();
+    // Base sweep streamed and drew; no refinement has been asked for yet —
+    // the dwell that authorises it has not elapsed.
+    expect(sweepBodies).toHaveLength(1);
+    expect(sweepBodies[0]._refine).toBeUndefined();
+    const planned = result.current.sweep!.freqs_mhz.length;
+    expect(planned).toBe(41);
+
+    await settle();
+    expect(refineBodies().length).toBeGreaterThan(0);
+    const refined = result.current.sweep!;
+    expect(refined.freqs_mhz.length).toBeGreaterThan(planned);
+    // Merged in frequency order, arrays index-aligned: the chart draws a
+    // polyline straight off these, so an unsorted merge would draw a mess.
+    expect(refined.freqs_mhz).toEqual([...refined.freqs_mhz].sort((a, b) => a - b));
+    for (let i = 0; i < refined.freqs_mhz.length; i++) {
+      expect(refined.z_im[i]).toBeCloseTo(zAt(refined.freqs_mhz[i]).z_im, 6);
+    }
+    // The extra points went to the notch, not spread over the flat wings.
+    const added = refined.freqs_mhz.filter(
+      (f) => !sweepBodies[0].freqs_mhz!.toString().includes(String(f)),
+    );
+    expect(added.length).toBeGreaterThan(0);
+  });
+
+  it("every refinement request carries the lane's refine marker", async () => {
+    renderRunners(BASE);
+    await settle();
+    await settle();
+    for (const b of refineBodies()) {
+      expect(b._refine).toBe(true);
+      expect(Array.isArray(b.freqs_mhz)).toBe(true);
+      expect((b.freqs_mhz as number[]).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("never fires mid-scrub: a knob change inside the dwell cancels it", async () => {
+    const { result, rerender } = renderRunners(BASE);
+    await settle();
+    expect(refineBodies()).toHaveLength(0);
+
+    // The user moves a knob while the refinement dwell is counting down.
+    rerender({ ...BASE, req: { geometry: "g", length_factor: 1.01 } });
+    expect(result.current.sweep).toBeNull(); // cleared by the signature effect
+    await settle();
+    // The new base sweep ran; the cancelled refinement never did.
+    expect(refineBodies()).toHaveLength(0);
+    expect(sweepBodies).toHaveLength(2);
+  });
+
+  it("a knob change during refinement aborts it and leaves no refined point", async () => {
+    const { result, rerender } = renderRunners(BASE);
+    await settle();
+    await settle();
+    expect(refineBodies().length).toBeGreaterThan(0);
+    expect(result.current.sweep!.freqs_mhz.length).toBeGreaterThan(41);
+
+    rerender({ ...BASE, req: { geometry: "g", length_factor: 1.01 } });
+    // Refined points live in the same state the signature effect clears —
+    // no separate lifetime to get wrong (issue #692).
+    expect(result.current.sweep).toBeNull();
+    await settle();
+    // The fresh sweep carries exactly the planned grid: nothing survived.
+    expect(result.current.sweep!.freqs_mhz).toHaveLength(41);
+  });
+
+  it("a non-resident sweep receives no refinement solves", async () => {
+    const { rerender } = renderRunners({ ...BASE, sweepResident: false });
+    await settle();
+    await settle();
+    expect(sweepBodies).toHaveLength(0);
+
+    // Gaining residency runs the base sweep and, a dwell later, refinement;
+    // losing it again silences both.
+    rerender(BASE);
+    await settle();
+    await settle();
+    const refinedWhileResident = refineBodies().length;
+    expect(refinedWhileResident).toBeGreaterThan(0);
+    rerender({ ...BASE, sweepResident: false });
+    await settle();
+    await settle();
+    expect(refineBodies()).toHaveLength(refinedWhileResident);
+  });
+
+  it("stops at the point budget and keeps the best-so-far curve", async () => {
+    const { result } = renderRunners(BASE);
+    await settle();
+    await settle(500, 400); // let every round it wants to run, run
+    const total = refineBodies().reduce(
+      (n, b) => n + (b.freqs_mhz as number[]).length,
+      0,
+    );
+    expect(total).toBeLessThanOrEqual(SWEEP_REFINE_BUDGET);
+    // Whatever it managed is on screen and consistent — budget exhaustion
+    // degrades to "less refined", never to a blank or torn curve.
+    const sweep = result.current.sweep!;
+    expect(sweep.freqs_mhz).toHaveLength(41 + total);
+    expect(sweep.z_re).toHaveLength(41 + total);
+    expect(sweep.z_im).toHaveLength(41 + total);
+  });
+
+  it("a smooth sweep is left alone", async () => {
+    // Z with no resonance in the window: the rendered VSWR/S11/Smith curves
+    // have no corner, so the planner asks for nothing and no solve is spent.
+    fetchMock.mockImplementation((url: string, init?: { body?: string }) => {
+      if (url !== "/sweep")
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      const body = JSON.parse(init?.body ?? "{}");
+      sweepBodies.push(body);
+      const freqs: number[] = body.freqs_mhz ?? [];
+      return ndjson(
+        freqs.map((f) => JSON.stringify({ freq_mhz: f, z_re: 50, z_im: 0 })),
+      );
+    });
+    renderRunners(BASE);
+    await settle();
+    await settle();
+    expect(refineBodies()).toHaveLength(0);
+  });
+});

--- a/src/antennaknobs/web/frontend/src/components/charts/FarFieldChart.tsx
+++ b/src/antennaknobs/web/frontend/src/components/charts/FarFieldChart.tsx
@@ -1,5 +1,6 @@
 import { useContext, useEffect, useRef } from "react";
 import type { SolveResponse } from "../../lib/api";
+import { cutDbiTop, cutDbiToFrac } from "../../lib/refine";
 import { ThemeContext } from "../hooks";
 import { traceFor, useCutTraces } from "./cuts";
 import { ghostRgb, plotColors } from "./palette";
@@ -44,9 +45,16 @@ export function FarFieldChart({
     elevAzDeg,
   );
   // Draw-effect dep: changes when a fetched trace replaces a stale one (the
-  // solve identities and angles are already deps of their own).
+  // solve identities and angles are already deps of their own). Sample
+  // counts are part of it because a refinement round (issue #744) replaces
+  // a trace with a DENSER one at the same angles — identical on the angle
+  // pair alone, and the redraw is the whole point of the round.
   const cutTracesKey = cutTraces
-    .map((t) => (t ? `${t.az_elev_deg},${t.elev_az_deg}` : "-"))
+    .map((t) =>
+      t
+        ? `${t.az_elev_deg},${t.elev_az_deg},${t.azimuth.length},${t.elevation.length}`
+        : "-",
+    )
     .join("|");
 
   useEffect(() => {
@@ -99,7 +107,6 @@ export function FarFieldChart({
     // lobe renders in full instead of drawing past the edge and clipping — the
     // thumbnails escaped this only because their tiny radius left slack inside
     // the margin. Labeled rings sit at +6/0/−6/−12/−18 (all inside any top).
-    const DBI_FLOOR = -20;
     const peaks: number[] = [];
     if (liveTrace) peaks.push(liveTrace.peakDbi);
     for (const gh of ghosts) if (gh.trace) peaks.push(gh.trace.peakDbi);
@@ -113,13 +120,12 @@ export function FarFieldChart({
         : null;
     // Let the radial scale grow to fit the shifted overlay when it lands higher.
     if (liveTrace && gridDeltaDb != null) peaks.push(liveTrace.peakDbi + gridDeltaDb);
-    const maxPeak = peaks.filter(Number.isFinite).reduce((a, b) => Math.max(a, b), 10);
-    const DBI_TOP = Math.max(10, Math.ceil(maxPeak + 1));
-    const DB_SPAN = DBI_TOP - DBI_FLOOR;
     // Clamp to [0, 1]: a lobe at/above the top sits on the rim instead of
-    // drawing past R and clipping against the canvas edge.
-    const dbiToFrac = (db: number) =>
-      Math.max(0, Math.min(1, (db - DBI_FLOOR) / DB_SPAN));
+    // drawing past R and clipping against the canvas edge. The map itself
+    // lives in lib/refine.ts so the refinement planner (issue #744) judges
+    // curvature against the exact geometry drawn here.
+    const dbiTop = cutDbiTop(peaks);
+    const dbiToFrac = cutDbiToFrac(dbiTop);
     ctx.strokeStyle = PC.grid;
     ctx.lineWidth = 0.6;
     ctx.fillStyle = PC.labelDim;
@@ -234,18 +240,30 @@ export function FarFieldChart({
       }
     }
 
-    // Draw one dBi trace around the polar cut (sample i at t = 2π·i/n, the
-    // server cuts' parameterisation). The live lobe closes + fills; pinned
+    // Draw one dBi trace around the polar cut. Sample i sits at t = 2π·i/n —
+    // the server cuts' default parameterisation — unless the trace carries
+    // explicit per-sample angles, which adaptive refinement (issue #744)
+    // needs because a densified cut is no longer uniform and the index no
+    // longer determines the angle. The live lobe closes + fills; pinned
     // ghosts are an open dashed stroke so the live trace reads on top.
     const strokeTrace = (
       dbi: number[],
-      o: { stroke: string; fill?: string; width: number; dash?: number[] },
+      o: {
+        stroke: string;
+        fill?: string;
+        width: number;
+        dash?: number[];
+        anglesDeg?: number[] | undefined;
+      },
     ) => {
       const n = dbi.length;
       ctx.beginPath();
       for (let pi = 0; pi <= n; pi++) {
-        const t = (2 * Math.PI * pi) / n;
-        const frac = dbiToFrac(dbi[pi % n]);
+        const i = pi % n;
+        const t = o.anglesDeg
+          ? (o.anglesDeg[i] * Math.PI) / 180
+          : (2 * Math.PI * pi) / n;
+        const frac = dbiToFrac(dbi[i]);
         const px = cx + Math.cos(t) * frac * R;
         // Canvas y flips: +y on canvas is down, so we negate to put +y at top.
         const py = cy - Math.sin(t) * frac * R;
@@ -273,6 +291,7 @@ export function FarFieldChart({
         stroke: `rgba(${ghostRgb(gh.colorIdx)}, 0.8)`,
         width: 1,
         dash: [5, 3],
+        anglesDeg: gh.trace.anglesDeg,
       });
     }
 
@@ -282,6 +301,7 @@ export function FarFieldChart({
       stroke: `rgba(${PC.lobeRgb}, 0.9)`,
       fill: `rgba(${PC.lobeRgb}, 0.12)`,
       width: 1.5,
+      anglesDeg: liveTrace.anglesDeg,
     });
 
     // Fine-grid norm overlay (dotted, same lobe hue): the live trace shifted
@@ -289,10 +309,12 @@ export function FarFieldChart({
     // the adaptive grid was fine enough; a visible gap is the grid error. Drawn
     // open (no fill) so the solid lobe still reads underneath.
     if (gridDeltaDb != null) {
-      strokeTrace(
-        liveTrace.dbi.map((d) => d + gridDeltaDb),
-        { stroke: `rgba(${PC.lobeRgb}, 0.85)`, width: 1, dash: [2, 2] },
-      );
+      strokeTrace(liveTrace.dbi.map((d) => d + gridDeltaDb), {
+        stroke: `rgba(${PC.lobeRgb}, 0.85)`,
+        width: 1,
+        dash: [2, 2],
+        anglesDeg: liveTrace.anglesDeg,
+      });
     }
 
     // NEC exact-pattern overlay (dashed cyan line) when available. Bilinear

--- a/src/antennaknobs/web/frontend/src/components/charts/cuts.ts
+++ b/src/antennaknobs/web/frontend/src/components/charts/cuts.ts
@@ -275,8 +275,20 @@ const CUT_REFINE_DWELL_MS = 400;
 // refinement chain. Keyed like cutsInFlight.
 const cutsRefineInFlight = new Map<string, Promise<void>>();
 // Keys whose refinement has run to completion (or its budget), so a
-// re-render never restarts it.
+// re-render never restarts it. Bounded like cutsCache: a long session of
+// dial drags mints a key per angle pair per solve, and a key whose cached
+// trace has already been evicted is worth nothing anyway.
 const cutsRefineDone = new Set<string>();
+function markRefineDone(key: string): void {
+  if (cutsRefineDone.size >= CUTS_CACHE_MAX) {
+    let drop = CUTS_CACHE_MAX >> 1;
+    for (const k of Array.from(cutsRefineDone)) {
+      if (drop-- <= 0) break;
+      cutsRefineDone.delete(k);
+    }
+  }
+  cutsRefineDone.add(key);
+}
 
 function peakOf(dbi: readonly number[]): number {
   let peak = -Infinity;
@@ -340,7 +352,7 @@ function refineCuts(
       cacheCuts(key, next);
       cur = next;
     }
-    cutsRefineDone.add(key);
+    markRefineDone(key);
   })().finally(() => cutsRefineInFlight.delete(key));
   cutsRefineInFlight.set(key, p);
   return p;

--- a/src/antennaknobs/web/frontend/src/components/charts/cuts.ts
+++ b/src/antennaknobs/web/frontend/src/components/charts/cuts.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import type { PatternCuts, SolveResponse } from "../../lib/api";
+import { cutDbiTop, refineCutAngles } from "../../lib/refine";
 import type { FarFieldCut } from "./types";
 
 // --- Server-side polar cuts (issue #547) -----------------------------------
@@ -38,11 +39,17 @@ function cutsKey(
 }
 
 // The cuts for a solve at exactly these angles, or null if not yet known.
+// The cache is consulted BEFORE the solve's attached cuts: a refinement pass
+// (issue #744) writes its densified trace back under the same key, and it is
+// the same cut at the same angles — only sampled better — so it must win
+// over the uniform copy the solve arrived with.
 function cachedCuts(
   result: SolveResponse,
   azElevDeg: number,
   elevAzDeg: number,
 ): PatternCuts | null {
+  const cached = cutsCache.get(cutsKey(result, azElevDeg, elevAzDeg));
+  if (cached) return cached;
   const attached = result.cuts;
   if (
     attached &&
@@ -51,7 +58,7 @@ function cachedCuts(
   ) {
     return attached;
   }
-  return cutsCache.get(cutsKey(result, azElevDeg, elevAzDeg)) ?? null;
+  return null;
 }
 
 // Cuts over the live /ws socket (issue #551): when the socket is open it
@@ -81,18 +88,36 @@ const cutsWsPending = new Map<string, (reply: CutsWsReply) => void>();
 // delivers — slower, never wrong.
 const CUTS_WS_TIMEOUT_MS = 1500;
 
-function cutsWsPendingKey(solveId: string, az: number, el: number): string {
-  return `${solveId}:${az}:${el}`;
+/** Explicit per-cut sampling angles for a refinement request (issue #744).
+ *  Absent on a plain dial request, which keeps the uniform circle. */
+type CutAngles = { az_angles_deg?: number[]; elev_angles_deg?: number[] };
+
+const isRefined = (extra: CutAngles | undefined): boolean =>
+  !!(extra?.az_angles_deg || extra?.elev_angles_deg);
+
+// The refined flag is part of the pending key (and echoed by the server):
+// a refinement and a dial request can be in flight for the same solve at
+// the same angles, and answering one with the other's trace would either
+// throw the densified samples away or hand them to a caller expecting the
+// uniform circle.
+function cutsWsPendingKey(
+  solveId: string,
+  az: number,
+  el: number,
+  refined: boolean,
+): string {
+  return `${solveId}:${az}:${el}:${refined ? 1 : 0}`;
 }
 
 function requestCutsViaWs(
   solveId: string,
   azElevDeg: number,
   elevAzDeg: number,
+  extra?: CutAngles,
 ): Promise<CutsWsReply> {
   const send = cutsWsSend;
   if (!send) return Promise.resolve({ status: "unavailable" });
-  const key = cutsWsPendingKey(solveId, azElevDeg, elevAzDeg);
+  const key = cutsWsPendingKey(solveId, azElevDeg, elevAzDeg, isRefined(extra));
   return new Promise((resolve) => {
     const timer = window.setTimeout(() => {
       cutsWsPending.delete(key);
@@ -110,6 +135,7 @@ function requestCutsViaWs(
           solve_id: solveId,
           az_elev_deg: azElevDeg,
           elev_az_deg: elevAzDeg,
+          ...(extra ?? {}),
         }),
       )
     ) {
@@ -127,12 +153,21 @@ export type CutsWsMessage = {
   solve_id: string;
   az_elev_deg: number;
   elev_az_deg: number;
+  /** Server echo of "this reply carries an explicitly-sampled cut" (issue
+   *  #744). Absent from a pre-#744 server, which only ever sent uniform
+   *  cuts — so undefined reads as false, the right answer for it. */
+  refined?: boolean;
   ok: boolean;
   cuts?: PatternCuts;
 };
 
 export function resolveCutsWsMessage(data: CutsWsMessage): void {
-  const key = cutsWsPendingKey(data.solve_id, data.az_elev_deg, data.elev_az_deg);
+  const key = cutsWsPendingKey(
+    data.solve_id,
+    data.az_elev_deg,
+    data.elev_az_deg,
+    !!data.refined,
+  );
   const pending = cutsWsPending.get(key);
   if (!pending) return; // timed out / superseded — fallback already running
   pending(data.ok && data.cuts ? { status: "ok", cuts: data.cuts } : { status: "miss" });
@@ -148,14 +183,31 @@ export function flushCutsWsPending(): void {
   }
 }
 
-function fetchCuts(
+function cacheCuts(key: string, cuts: PatternCuts): void {
+  if (cutsCache.size >= CUTS_CACHE_MAX) {
+    // Evict the oldest half (Maps iterate in insertion order).
+    let drop = CUTS_CACHE_MAX >> 1;
+    for (const k of Array.from(cutsCache.keys())) {
+      if (drop-- <= 0) break;
+      cutsCache.delete(k);
+    }
+  }
+  cutsCache.set(key, cuts);
+}
+
+/** One cuts round trip down the transport ladder (issue #551): ws id →
+ *  HTTP id → HTTP full body. Every rung is strictly a fallback of the one
+ *  above; the full-body POST remains the correctness backstop (it's how
+ *  pre-#551 responses and pins from dead server sessions resolve).
+ *  `extra` carries a refinement's explicit angles (issue #744) — it rides
+ *  every rung, so a refined cut resolves even for a pin whose server
+ *  session is long gone. */
+function requestCuts(
   result: SolveResponse,
   azElevDeg: number,
   elevAzDeg: number,
+  extra?: CutAngles,
 ): Promise<PatternCuts | null> {
-  const key = cutsKey(result, azElevDeg, elevAzDeg);
-  const inFlight = cutsInFlight.get(key);
-  if (inFlight) return inFlight;
   const postCuts = (body: object): Promise<Response> =>
     fetch("/cuts", {
       method: "POST",
@@ -164,16 +216,13 @@ function fetchCuts(
         ...body,
         az_elev_deg: azElevDeg,
         elev_az_deg: elevAzDeg,
+        ...(extra ?? {}),
       }),
     });
-  const p = (async (): Promise<PatternCuts | null> => {
-    // Transport ladder (issue #551): ws id → HTTP id → HTTP full body.
-    // Every rung is strictly a fallback of the one above; the full-body
-    // POST remains the correctness backstop (it's how pre-#551 responses
-    // and pins from dead server sessions resolve).
+  return (async (): Promise<PatternCuts | null> => {
     const solveId = result.solve_id;
     if (solveId) {
-      const viaWs = await requestCutsViaWs(solveId, azElevDeg, elevAzDeg);
+      const viaWs = await requestCutsViaWs(solveId, azElevDeg, elevAzDeg, extra);
       if (viaWs.status === "ok") return viaWs.cuts;
       if (viaWs.status === "unavailable") {
         const r = await postCuts({ solve_id: solveId });
@@ -185,24 +234,115 @@ function fetchCuts(
     }
     const r = await postCuts({ solve: result });
     return r.ok ? ((await r.json()) as PatternCuts) : null;
-  })()
+  })().catch(() => null);
+}
+
+function fetchCuts(
+  result: SolveResponse,
+  azElevDeg: number,
+  elevAzDeg: number,
+): Promise<PatternCuts | null> {
+  const key = cutsKey(result, azElevDeg, elevAzDeg);
+  const inFlight = cutsInFlight.get(key);
+  if (inFlight) return inFlight;
+  const p = requestCuts(result, azElevDeg, elevAzDeg)
     .then((cuts) => {
-      if (cuts) {
-        if (cutsCache.size >= CUTS_CACHE_MAX) {
-          // Evict the oldest half (Maps iterate in insertion order).
-          let drop = CUTS_CACHE_MAX >> 1;
-          for (const k of Array.from(cutsCache.keys())) {
-            if (drop-- <= 0) break;
-            cutsCache.delete(k);
-          }
-        }
-        cutsCache.set(key, cuts);
-      }
+      if (cuts) cacheCuts(key, cuts);
       return cuts;
     })
-    .catch(() => null)
     .finally(() => cutsInFlight.delete(key));
   cutsInFlight.set(key, p);
+  return p;
+}
+
+// --- Adaptive cut refinement (issue #744) ----------------------------------
+// Extra sample angles where the POLAR trace corners, once the cut dials have
+// settled. Deliberately NOT on the solve lane, unlike sweep refinement: the
+// cuts-source cache (issue #551) holds the moment set, so extra angles are
+// the EXISTING solve's pattern re-evaluated at more directions — no solve to
+// serialize, and the same no-lane latest-wins channel a dial drag uses.
+
+/** Total extra angles per cut, summed across rounds. 180 uniform + 120
+ *  refined stays well under the server's 720-angle ceiling, and a far-field
+ *  evaluation at 300 directions is still ~1 ms on a typical mesh. */
+export const CUT_REFINE_BUDGET = 120;
+export const CUT_REFINE_ROUND_BUDGET = 40;
+/** Dwell after the cuts for the current dial angles resolve. A dial drag
+ *  must not spend evaluations on angles the user is about to leave. */
+const CUT_REFINE_DWELL_MS = 400;
+
+// Both polar charts share one solve, so both would otherwise start the same
+// refinement chain. Keyed like cutsInFlight.
+const cutsRefineInFlight = new Map<string, Promise<void>>();
+// Keys whose refinement has run to completion (or its budget), so a
+// re-render never restarts it.
+const cutsRefineDone = new Set<string>();
+
+function peakOf(dbi: readonly number[]): number {
+  let peak = -Infinity;
+  for (const d of dbi) if (d > peak) peak = d;
+  return peak;
+}
+
+const mergeAngles = (
+  held: readonly number[] | undefined,
+  n: number,
+  added: readonly number[],
+): number[] =>
+  [
+    ...(held ?? Array.from({ length: n }, (_, i) => (360 * i) / n)),
+    ...added,
+  ].sort((a, b) => a - b);
+
+/** Densify both cuts of one solve where the polar trace corners, in rounds,
+ *  writing each round back under the plain cuts key so the charts pick it
+ *  up. Any failure just stops — the uniform trace stays on screen. */
+function refineCuts(
+  result: SolveResponse,
+  azElevDeg: number,
+  elevAzDeg: number,
+): Promise<void> {
+  const key = cutsKey(result, azElevDeg, elevAzDeg);
+  const running = cutsRefineInFlight.get(key);
+  if (running) return running;
+  if (cutsRefineDone.has(key)) return Promise.resolve();
+  const p = (async () => {
+    let cur = cachedCuts(result, azElevDeg, elevAzDeg);
+    let spent = 0;
+    while (cur && spent < CUT_REFINE_BUDGET) {
+      const budget = Math.min(
+        CUT_REFINE_ROUND_BUDGET,
+        CUT_REFINE_BUDGET - spent,
+      );
+      const azAdd = refineCutAngles(
+        cur.azimuth,
+        cur.az_angles_deg,
+        cutDbiTop([peakOf(cur.azimuth)]),
+        budget,
+      );
+      const elAdd = refineCutAngles(
+        cur.elevation,
+        cur.elev_angles_deg,
+        cutDbiTop([peakOf(cur.elevation)]),
+        budget,
+      );
+      if (azAdd.length === 0 && elAdd.length === 0) break;
+      spent += Math.max(azAdd.length, elAdd.length);
+      const next = await requestCuts(result, azElevDeg, elevAzDeg, {
+        az_angles_deg: mergeAngles(cur.az_angles_deg, cur.azimuth.length, azAdd),
+        elev_angles_deg: mergeAngles(
+          cur.elev_angles_deg,
+          cur.elevation.length,
+          elAdd,
+        ),
+      });
+      if (!next) break;
+      cacheCuts(key, next);
+      cur = next;
+    }
+    cutsRefineDone.add(key);
+  })().finally(() => cutsRefineInFlight.delete(key));
+  cutsRefineInFlight.set(key, p);
   return p;
 }
 
@@ -224,8 +364,33 @@ export function useCutTraces(
     const missing = results.filter(
       (r): r is SolveResponse => !!r && !cachedCuts(r, azElevDeg, elevAzDeg),
     );
-    if (missing.length === 0) return;
+    const live = results[0] ?? null;
     let cancelled = false;
+    let refineTimer: number | null = null;
+    // Adaptive refinement (issue #744) of the LIVE trace only. Pinned
+    // ghosts are dashed comparison references, and refining each of them
+    // would multiply the far-field evaluations by the pin count for a line
+    // nobody reads geometry off. The dwell is what makes this
+    // scrub-safe: a cut-dial drag re-fires this effect, the cleanup below
+    // clears the pending timer, and no refinement request is ever issued
+    // for an angle the user passed through.
+    const scheduleRefine = () => {
+      if (!live) return;
+      refineTimer = window.setTimeout(() => {
+        refineCuts(live, azElevDeg, elevAzDeg).then(() => {
+          if (!cancelled) setFetchTick((t) => t + 1);
+        });
+      }, CUT_REFINE_DWELL_MS);
+    };
+    if (missing.length === 0) {
+      // Already drawable at these angles (the solve shipped with them, or a
+      // previous fetch cached them) — straight to the refinement dwell.
+      scheduleRefine();
+      return () => {
+        cancelled = true;
+        if (refineTimer) window.clearTimeout(refineTimer);
+      };
+    }
     // When every missing trace can go over the ws id path (~100 bytes, and
     // the server squashes per-solve latest-wins), a much tighter debounce
     // makes cut drags feel live; the original 120 ms guard stays for the
@@ -235,13 +400,16 @@ export function useCutTraces(
     const h = window.setTimeout(() => {
       Promise.all(missing.map((r) => fetchCuts(r, azElevDeg, elevAzDeg))).then(
         () => {
-          if (!cancelled) setFetchTick((t) => t + 1);
+          if (cancelled) return;
+          setFetchTick((t) => t + 1);
+          scheduleRefine();
         },
       );
     }, delay);
     return () => {
       cancelled = true;
       window.clearTimeout(h);
+      if (refineTimer) window.clearTimeout(refineTimer);
     };
     // results/azElevDeg/elevAzDeg are read but not listed: wantKey is their
     // exact string encoding (see its definition above), the same stable-
@@ -262,16 +430,25 @@ export function useCutTraces(
 }
 
 // One chart's trace from a cuts payload: the dBi samples for the requested
-// cut plus their peak (for the adaptive radial scale and the annotation).
-// Null when there's nothing to draw (no cuts, or everything at the floor).
+// cut, their explicit angles when the cut was refined (issue #744), and
+// their peak (for the adaptive radial scale and the annotation). Null when
+// there's nothing to draw (no cuts, or everything at the floor).
 export function traceFor(
   cuts: PatternCuts | null,
   cut: FarFieldCut,
-): { dbi: number[]; peakDbi: number } | null {
+): { dbi: number[]; anglesDeg?: number[]; peakDbi: number } | null {
   if (!cuts) return null;
   const dbi = cut === "xy" ? cuts.azimuth : cuts.elevation;
+  const anglesDeg = cut === "xy" ? cuts.az_angles_deg : cuts.elev_angles_deg;
   let peak = -Infinity;
   for (const d of dbi) if (d > peak) peak = d;
   if (!(peak > cuts.floor_dbi)) return null;
-  return { dbi, peakDbi: peak };
+  // A mismatched angle list is a server/client disagreement, not something
+  // to draw through: fall back to the uniform parameterisation rather than
+  // index past the end of it.
+  return {
+    dbi,
+    ...(anglesDeg && anglesDeg.length === dbi.length ? { anglesDeg } : {}),
+    peakDbi: peak,
+  };
 }

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -1204,6 +1204,10 @@ function DesignSessionBody({
       active,
       comboApproved,
       recommendedBackend,
+      // Same reference the sweep/Smith charts plot against (viewRegistry's
+      // `result?.z0_ohms ?? 50`), so refinement judges curvature on the
+      // curve the user is actually looking at.
+      z0: result?.z0_ohms ?? 50,
       buildRequest,
       solveWithheld,
       seqRef,

--- a/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
@@ -472,8 +472,14 @@ export function useAnalysisRunners({
         // Adaptive refinement (issue #744) rides the tail of the base
         // sweep rather than its own effect: reaching here IS the dwell
         // signal — the design settled long enough for a whole sweep to
-        // stream without a knob aborting it. Only after a clean run; a
-        // torn-off partial curve is not what the user is looking at.
+        // stream without a knob aborting it. `planned` is null exactly
+        // when the stream threw (abort, transport failure), which is the
+        // case that must not refine; a stream that ended on a per-chunk
+        // {error} line still leaves a real curve worth polishing.
+        //
+        // sweepRunning stays false throughout: refinement adds points to a
+        // curve that is already drawn, and flickering the chart's busy
+        // indicator back on would read as "this result is provisional".
         const settled = planned;
         if (settled && !controller.signal.aborted) {
           sweepRefineTimerRef.current = window.setTimeout(

--- a/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
@@ -14,8 +14,14 @@ import { type BackendEntry } from "../../lib/backends";
 import { type GroundModel } from "../../lib/ground";
 import { feedwiseRichardson, richardsonExtrap } from "../../lib/math";
 import { type BandSpec, type ExampleDescriptor } from "../../lib/params";
+import { refineSweepFreqs } from "../../lib/refine";
 import { solveSignature } from "../../lib/solveSignature";
-import { planSweepFreqs } from "../../lib/sweep";
+import {
+  mergeSweepPoints,
+  planSweepFreqs,
+  SWEEP_REFINE_BUDGET,
+  SWEEP_REFINE_ROUND_BUDGET,
+} from "../../lib/sweep";
 import type { PatternData } from "../charts/types";
 
 // Log-spaced segments-per-wire ladder for the convergence sweep. Hentenna's
@@ -37,6 +43,89 @@ const CUT_ANGLE_EXEMPT = ["az_elev_deg", "elev_az_deg"] as const;
 // knobs are additionally exempt for those two. NOT for the norm check, whose
 // pattern integral runs over the facets.
 const IMPEDANCE_ANALYSIS_EXEMPT = [...CUT_ANGLE_EXEMPT, "terrain"] as const;
+
+// Extra dwell between a completed base sweep and the first refinement round
+// (issue #744). The base sweep is already post-dwell — the 500 ms debounce
+// below gates it and a knob change aborts it — so this is a second settling
+// window, not the first: it buys the stretch where the user has stopped
+// dragging but is still deciding, during which the *next* knob move should
+// find the lane empty. Same 500 ms as every other dwell in this module.
+const SWEEP_REFINE_DWELL_MS = 500;
+
+/** Accumulate a /sweep NDJSON stream into a SweepData, publishing a fresh
+ *  snapshot per point so the charts fill in as they land. Shared by the
+ *  base sweep and its refinement rounds — they differ only in which freqs
+ *  they ask for and what the caller does with the snapshots. Throws
+ *  AbortError (via fetch) when the controller is tripped; the callers own
+ *  that. */
+async function streamSweep(
+  body: object,
+  controller: AbortController,
+  onPoint: (snapshot: SweepData) => void,
+): Promise<SweepData> {
+  // feeds_z_re/feeds_z_im start OMITTED (not set to undefined): the type's
+  // doc comment says single-feed geometries omit them entirely, and
+  // exactOptionalPropertyTypes now enforces that distinction — `acc.feeds_z_re`
+  // still reads as undefined either way, so this is a no-op for behavior.
+  const acc: SweepData = { freqs_mhz: [], z_re: [], z_im: [] };
+  const snapshot = (): SweepData => ({
+    freqs_mhz: acc.freqs_mhz.slice(),
+    z_re: acc.z_re.slice(),
+    z_im: acc.z_im.slice(),
+    // Spread-conditional, not `: undefined`, so a single-feed sweep OMITS
+    // the key (matching SweepData's documented contract).
+    ...(acc.feeds_z_re
+      ? { feeds_z_re: acc.feeds_z_re.map((row) => row.slice()) }
+      : {}),
+    ...(acc.feeds_z_im
+      ? { feeds_z_im: acc.feeds_z_im.map((row) => row.slice()) }
+      : {}),
+  });
+  const resp = await fetch("/sweep", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal: controller.signal,
+  });
+  if (!resp.ok || !resp.body) throw new Error(`sweep failed: ${resp.status}`);
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    let nl;
+    while ((nl = buf.indexOf("\n")) >= 0) {
+      const line = buf.slice(0, nl).trim();
+      buf = buf.slice(nl + 1);
+      if (!line) continue;
+      const pt = JSON.parse(line);
+      if (pt.done) continue;
+      // A failed point/chunk ends the stream with {error} instead of
+      // tearing the connection down (e.g. an approved poor-match combo
+      // whose dense fill can't allocate). Keep whatever points landed.
+      if (pt.error) {
+        console.error("sweep error", pt.error);
+        continue;
+      }
+      acc.freqs_mhz.push(pt.freq_mhz);
+      acc.z_re.push(pt.z_re);
+      acc.z_im.push(pt.z_im);
+      // Multi-feed sweep records (bowtie) ship per-feed Z alongside the
+      // primary. Allocate the per-feed buffers lazily on first sight so
+      // single-feed sweeps stay on the original code path.
+      if (Array.isArray(pt.feeds_z_re) && Array.isArray(pt.feeds_z_im)) {
+        if (!acc.feeds_z_re) acc.feeds_z_re = [];
+        if (!acc.feeds_z_im) acc.feeds_z_im = [];
+        acc.feeds_z_re.push(pt.feeds_z_re);
+        acc.feeds_z_im.push(pt.feeds_z_im);
+      }
+      if (!controller.signal.aborted) onPoint(snapshot());
+    }
+  }
+  return snapshot();
+}
 
 // The four background analyses that shadow the live solve — the freq sweep,
 // the segments-per-wire convergence sweep, the far-field norm check and the
@@ -74,6 +163,7 @@ export function useAnalysisRunners({
   active,
   comboApproved,
   recommendedBackend,
+  z0 = 50,
   buildRequest,
   solveWithheld,
   seqRef,
@@ -108,6 +198,15 @@ export function useAnalysisRunners({
   active: boolean;
   comboApproved: boolean;
   recommendedBackend: BackendEntry | null;
+  /** Reference impedance the sweep charts plot against — the only thing
+   *  refinement (issue #744) needs beyond the sweep itself, since VSWR /
+   *  S11 / Smith are all functions of Γ(Z, z0). Optional with the charts'
+   *  own `result?.z0_ohms ?? 50` fallback: a caller that doesn't pass it
+   *  gets refinement against the 50 Ω reference, which is right for every
+   *  design that doesn't declare otherwise. Deliberately NOT a dep of any
+   *  effect — z0 is a display reference, not physics, and re-planning the
+   *  whole sweep when it changes would re-solve for nothing. */
+  z0?: number;
   buildRequest: () => SolveRequest;
   solveWithheld: () => boolean;
   seqRef: MutableRefObject<number>;
@@ -133,6 +232,12 @@ export function useAnalysisRunners({
 
   const sweepTimerRef = useRef<number | null>(null);
   const sweepAbortRef = useRef<AbortController | null>(null);
+  // Refinement gets its own timer/abort pair rather than sharing the base
+  // sweep's: the base sweep's finally-block clears its own ref, and a
+  // refinement scheduled from inside that block would immediately lose the
+  // handle the next knob change has to abort through.
+  const sweepRefineTimerRef = useRef<number | null>(null);
+  const sweepRefineAbortRef = useRef<AbortController | null>(null);
   const patternTimerRef = useRef<number | null>(null);
   const patternAbortRef = useRef<AbortController | null>(null);
   const convergeTimerRef = useRef<number | null>(null);
@@ -152,6 +257,15 @@ export function useAnalysisRunners({
     if (sweepTimerRef.current) {
       window.clearTimeout(sweepTimerRef.current);
     }
+    // Refinement points live in the same `sweep` state, so the clear below
+    // drops them with everything else — signature invalidation (issue #692)
+    // covers refined points for free, and must keep doing so. Killing the
+    // pending round and its in-flight stream here is what stops a
+    // superseded refinement from re-publishing them a moment later.
+    sweepRefineAbortRef.current?.abort();
+    if (sweepRefineTimerRef.current) {
+      window.clearTimeout(sweepRefineTimerRef.current);
+    }
     setSweep(null);
     setSweepRunning(false);
     // Paused (Live off) holds the engine (issue #612): an enabled sweep must
@@ -166,6 +280,9 @@ export function useAnalysisRunners({
     sweepTimerRef.current = window.setTimeout(runSweep, 500);
     return () => {
       if (sweepTimerRef.current) window.clearTimeout(sweepTimerRef.current);
+      if (sweepRefineTimerRef.current) {
+        window.clearTimeout(sweepRefineTimerRef.current);
+      }
     };
     // runSweep is read but not listed: it's a plain, unmemoized closure
     // recreated every render, and impedanceSig is the deliberate stand-in
@@ -340,75 +457,11 @@ export function useAnalysisRunners({
       _approved: approvedComboRef.current,
     };
     setSweepRunning(true);
-    // feeds_z_re/feeds_z_im start OMITTED (not set to undefined): the type's
-    // doc comment says single-feed geometries omit them entirely, and
-    // exactOptionalPropertyTypes now enforces that distinction — `acc.feeds_z_re`
-    // still reads as undefined either way, so this is a no-op for behavior.
-    const acc: SweepData = {
-      freqs_mhz: [],
-      z_re: [],
-      z_im: [],
-    };
+    let planned: SweepData | null = null;
     try {
-      const resp = await fetch("/sweep", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-        signal: controller.signal,
-      });
-      if (!resp.ok || !resp.body) throw new Error(`sweep failed: ${resp.status}`);
-      const reader = resp.body.getReader();
-      const decoder = new TextDecoder();
-      let buf = "";
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buf += decoder.decode(value, { stream: true });
-        let nl;
-        while ((nl = buf.indexOf("\n")) >= 0) {
-          const line = buf.slice(0, nl).trim();
-          buf = buf.slice(nl + 1);
-          if (!line) continue;
-          const pt = JSON.parse(line);
-          if (pt.done) continue;
-          // A failed point/chunk ends the stream with {error} instead of
-          // tearing the connection down (e.g. an approved poor-match combo
-          // whose dense fill can't allocate). Keep whatever points landed.
-          if (pt.error) {
-            console.error("sweep error", pt.error);
-            continue;
-          }
-          acc.freqs_mhz.push(pt.freq_mhz);
-          acc.z_re.push(pt.z_re);
-          acc.z_im.push(pt.z_im);
-          // Multi-feed sweep records (bowtie) ship per-feed Z alongside
-          // the primary. Allocate the per-feed buffers lazily on first
-          // sight so single-feed sweeps stay on the original code path.
-          if (Array.isArray(pt.feeds_z_re) && Array.isArray(pt.feeds_z_im)) {
-            if (!acc.feeds_z_re) acc.feeds_z_re = [];
-            if (!acc.feeds_z_im) acc.feeds_z_im = [];
-            acc.feeds_z_re.push(pt.feeds_z_re);
-            acc.feeds_z_im.push(pt.feeds_z_im);
-          }
-          if (!controller.signal.aborted) {
-            // New object so React re-renders the Smith chart per point.
-            setSweep({
-              freqs_mhz: acc.freqs_mhz.slice(),
-              z_re: acc.z_re.slice(),
-              z_im: acc.z_im.slice(),
-              // Spread-conditional, not `: undefined`, so a single-feed sweep
-              // OMITS the key (matching SweepData's documented contract)
-              // rather than setting it to undefined.
-              ...(acc.feeds_z_re
-                ? { feeds_z_re: acc.feeds_z_re.map((row) => row.slice()) }
-                : {}),
-              ...(acc.feeds_z_im
-                ? { feeds_z_im: acc.feeds_z_im.map((row) => row.slice()) }
-                : {}),
-            });
-          }
-        }
-      }
+      // New object per point so React re-renders the Smith chart as the
+      // sweep fills in.
+      planned = await streamSweep(body, controller, setSweep);
     } catch (e: unknown) {
       if (e instanceof DOMException && e.name === "AbortError") return;
       console.error("sweep error", e);
@@ -416,6 +469,75 @@ export function useAnalysisRunners({
       if (sweepAbortRef.current === controller) {
         sweepAbortRef.current = null;
         setSweepRunning(false);
+        // Adaptive refinement (issue #744) rides the tail of the base
+        // sweep rather than its own effect: reaching here IS the dwell
+        // signal — the design settled long enough for a whole sweep to
+        // stream without a knob aborting it. Only after a clean run; a
+        // torn-off partial curve is not what the user is looking at.
+        const settled = planned;
+        if (settled && !controller.signal.aborted) {
+          sweepRefineTimerRef.current = window.setTimeout(
+            () => runSweepRefine(settled),
+            SWEEP_REFINE_DWELL_MS,
+          );
+        }
+      }
+    }
+  }
+
+  // Densify the settled sweep where the rendered curve corners (issue
+  // #744). Iterative: each round asks the pure planner for the worst
+  // intervals, streams those freqs, merges them in, and re-plans against
+  // the densified curve — the planner cannot evaluate its own insertions,
+  // so re-evaluation only exists across rounds.
+  //
+  // Every round is optional. Running out of budget, an abort, or a plan
+  // that comes back empty all just stop, leaving the best-so-far merge on
+  // screen; nothing here is load-bearing for correctness of the curve.
+  async function runSweepRefine(base: SweepData) {
+    sweepRefineTimerRef.current = null;
+    if (solveWithheld()) return;
+    sweepRefineAbortRef.current?.abort();
+    const controller = new AbortController();
+    sweepRefineAbortRef.current = controller;
+    let acc = base;
+    let spent = 0;
+    try {
+      while (spent < SWEEP_REFINE_BUDGET && !controller.signal.aborted) {
+        const want = refineSweepFreqs(
+          acc,
+          z0,
+          Math.min(SWEEP_REFINE_ROUND_BUDGET, SWEEP_REFINE_BUDGET - spent),
+        );
+        if (want.length === 0) break; // no visible kink left to remove
+        spent += want.length;
+        const settled = acc; // merge target for this round's snapshots
+        const extra = await streamSweep(
+          {
+            ...buildRequest(),
+            freqs_mhz: want,
+            // Lane metadata (issue #382) + the refinement marker the server
+            // reads for its lane kind (issue #744). `_refine` is pure
+            // scheduling — it is on the server's cache-key blocklist, so a
+            // refinement request hits the same per-freq entries a base
+            // sweep would.
+            _gen: seqRef.current,
+            _approved: approvedComboRef.current,
+            _refine: true,
+          },
+          controller,
+          (snapshot) => setSweep(mergeSweepPoints(settled, snapshot)),
+        );
+        acc = mergeSweepPoints(acc, extra);
+        if (controller.signal.aborted) return;
+        setSweep(acc);
+      }
+    } catch (e: unknown) {
+      if (e instanceof DOMException && e.name === "AbortError") return;
+      console.error("sweep refine error", e);
+    } finally {
+      if (sweepRefineAbortRef.current === controller) {
+        sweepRefineAbortRef.current = null;
       }
     }
   }

--- a/src/antennaknobs/web/frontend/src/lib/api.ts
+++ b/src/antennaknobs/web/frontend/src/lib/api.ts
@@ -36,6 +36,14 @@ export type PatternCuts = {
   floor_dbi: number;
   azimuth: number[];
   elevation: number[];
+  /** Explicit per-sample angles in degrees, present only when that cut was
+   *  sampled NON-uniformly (adaptive refinement, issue #744). Absent means
+   *  the uniform `t = 2π·i/n` parameterisation above — the contract every
+   *  pre-#744 response and client relies on, so it must stay the default
+   *  rather than become a required field. `n_dir` keeps reporting the
+   *  uniform base resolution; a refined trace's own length governs. */
+  az_angles_deg?: number[];
+  elev_angles_deg?: number[];
 };
 
 /** One server-driven readout row (issue #712). Designs produce these from a

--- a/src/antennaknobs/web/frontend/src/lib/refine.ts
+++ b/src/antennaknobs/web/frontend/src/lib/refine.ts
@@ -26,10 +26,21 @@ import type { SweepData } from "./api";
  *  rect; a wildly non-square chart would want its own aspect factor. */
 export type DisplayPoint = { x: number; y: number };
 
-/** Turn angle above which a vertex reads as a corner rather than a curve.
- *  0.12 rad ≈ 6.9°: at typical chart sizes (300–450 px) that is the point
- *  where a 1.3–1.5 px stroke stops looking like a smooth bend. */
-export const KINK_TOLERANCE_RAD = 0.12;
+/** Display-space error, as a fraction of the plot extent, below which the
+ *  drawn polyline is indistinguishable from the true curve. 0.003 is ~1 px
+ *  at the 350 px charts this app draws — one stroke width.
+ *
+ *  This, not the turn angle, is what refinement drives on. A turn angle
+ *  says "there is a corner here", but a corner is not automatically a
+ *  SAMPLING artifact: a VSWR notch resolved to the last decimal still turns
+ *  ~177° at the vertex, because the true curve genuinely spikes at that
+ *  aspect ratio. Refining on turn angle therefore never terminates on the
+ *  exact features that motivated it. The chord deviation instead measures
+ *  how far the drawn line is from where the curve actually goes — it
+ *  vanishes as O(h²) for any smooth stretch and as O(h) even across a cusp,
+ *  so "the picture is right to within a pixel" is a reachable stopping
+ *  condition. */
+export const DEVIATION_TOLERANCE = 0.003;
 
 /** Intervals shorter than this (in normalized display units) are never
  *  split again. Two reasons, both about not burning the budget on
@@ -70,9 +81,8 @@ export function turnAngles(
   return out;
 }
 
-/** The worst display-space corner on a polyline, in radians. The acceptance
- *  measure for "no visible kink" — refinement is judged by whether this
- *  number falls. */
+/** The worst display-space corner on a polyline, in radians. A diagnostic,
+ *  not the refinement criterion — see DEVIATION_TOLERANCE for why. */
 export function maxKinkRad(
   pts: readonly DisplayPoint[],
   closed = false,
@@ -80,16 +90,53 @@ export function maxKinkRad(
   return turnAngles(pts, closed).reduce((a, b) => Math.max(a, b), 0);
 }
 
-type Interval = { a: number; b: number; kink: number; len: number };
-
-// score = kink × length. The kink says how bad the corner at this
-// interval's ends is; the length says how much of it THIS interval is
-// responsible for. Between a long and a short interval flanking the same
-// corner, splitting the long one removes most of the bend — the short one
-// scores lower and is left alone.
-function score(iv: Interval): number {
-  return iv.kink * iv.len;
+/** Per-vertex chord deviation: the perpendicular distance from each vertex
+ *  to the chord joining its two neighbours, in the same normalized display
+ *  units as the points.
+ *
+ *  Read it as "how wrong the picture would be here at half this
+ *  resolution": it is exactly the error the polyline would acquire if this
+ *  vertex were dropped, which makes it a direct estimate of the error the
+ *  polyline HAS between the samples it does carry. Boundary vertices of an
+ *  open polyline have no chord (0); a closed one wraps. */
+export function chordDeviations(
+  pts: readonly DisplayPoint[],
+  closed = false,
+): number[] {
+  const n = pts.length;
+  const out = new Array<number>(n).fill(0);
+  if (n < 3) return out;
+  for (let i = 0; i < n; i++) {
+    const prev = i === 0 ? (closed ? pts[n - 1] : null) : pts[i - 1];
+    const next = i === n - 1 ? (closed ? pts[0] : null) : pts[i + 1];
+    if (!prev || !next) continue;
+    const cx = next.x - prev.x;
+    const cy = next.y - prev.y;
+    const chord = Math.hypot(cx, cy);
+    const ax = pts[i].x - prev.x;
+    const ay = pts[i].y - prev.y;
+    // Degenerate chord (the neighbours coincide — a doubling-back spike):
+    // fall back to the distance from the vertex to that shared point, which
+    // is what the drawn line would miss by.
+    out[i] =
+      chord === 0
+        ? Math.hypot(ax, ay)
+        : Math.abs(ax * cy - ay * cx) / chord;
+  }
+  return out;
 }
+
+/** The worst display-space error on a polyline, as a fraction of the plot
+ *  extent. The acceptance measure: refinement is judged by whether this
+ *  number falls below DEVIATION_TOLERANCE (or at least falls). */
+export function maxChordDeviation(
+  pts: readonly DisplayPoint[],
+  closed = false,
+): number {
+  return chordDeviations(pts, closed).reduce((a, b) => Math.max(a, b), 0);
+}
+
+type Interval = { a: number; b: number; dev: number; len: number };
 
 export type RefineOptions = {
   /** Hard cap on how many new parameter values this plan may contain. */
@@ -108,20 +155,27 @@ export type RefineOptions = {
  * in degrees); `projections` are one display polyline per plot that
  * consumes this SAME data array, each index-aligned with `t`. The interval
  * score is the max across projections, because there is only one data array
- * to refine: picking a single projection would leave the others kinked. For
+ * to refine: picking a single projection would leave the others coarse. For
  * the freq sweep that union is VSWR ∪ S11-dB ∪ Smith, which is not
- * redundant — VSWR's steepest bend is off resonance where S11-dB is flat,
- * and the Smith locus bends where neither scalar projection does.
+ * redundant — VSWR's steepest bend is off resonance where S11-dB has
+ * clamped flat, and the Smith locus moves fastest where neither scalar
+ * projection does.
+ *
+ * An interval's score is the chord deviation at its two endpoints: the
+ * display-space error the drawn line already carries there. Intervals below
+ * `tolerance` are left alone (the picture is right to within a pixel) and
+ * so are intervals already shorter than `minSegment` (no subdivision can
+ * change what is drawn, and a genuine discontinuity would otherwise eat the
+ * whole budget).
  *
  * Returns midpoints of the worst intervals, sorted ascending, never more
  * than `budget` of them. Within one round the newly inserted points cannot
- * be evaluated, so an interval that is split gets its children scored by
- * the smooth-curve estimate "turn angle is O(h)": halving the interval
- * halves the kink and the length, quartering the score. That keeps one
- * pathological interval from swallowing the whole budget while still
- * concentrating points where the curve actually bends. The true re-
- * evaluation happens across ROUNDS — the caller solves this plan, then asks
- * again with the densified data.
+ * be evaluated, so a split interval's children are scored by the
+ * smooth-curve estimate "deviation is O(h²)": halving the interval quarters
+ * it. That keeps one interval from swallowing the whole budget while still
+ * concentrating points where the picture is worst. Real re-evaluation
+ * happens across ROUNDS — the caller solves this plan, then asks again with
+ * the densified data.
  */
 export function planRefinement(
   t: readonly number[],
@@ -131,16 +185,16 @@ export function planRefinement(
   const budget = Math.max(0, Math.floor(opts.budget));
   if (budget === 0 || t.length < 3) return [];
   const closed = opts.closed ?? false;
-  const tolerance = opts.tolerance ?? KINK_TOLERANCE_RAD;
+  const tolerance = opts.tolerance ?? DEVIATION_TOLERANCE;
   const minSegment = opts.minSegment ?? MIN_SEGMENT;
   const usable = projections.filter((p) => p.length === t.length);
   if (usable.length === 0) return [];
 
   const n = t.length;
-  const turns = new Array<number>(n).fill(0);
+  const devs = new Array<number>(n).fill(0);
   for (const p of usable) {
-    const ta = turnAngles(p, closed);
-    for (let i = 0; i < n; i++) turns[i] = Math.max(turns[i], ta[i]);
+    const d = chordDeviations(p, closed);
+    for (let i = 0; i < n; i++) devs[i] = Math.max(devs[i], d[i]);
   }
 
   const nIv = closed ? n : n - 1;
@@ -156,7 +210,7 @@ export function planRefinement(
     for (const p of usable) {
       len = Math.max(len, Math.hypot(p[k].x - p[j].x, p[k].y - p[j].y));
     }
-    work.push({ a: t[j], b, kink: Math.max(turns[j], turns[k]), len });
+    work.push({ a: t[j], b, dev: Math.max(devs[j], devs[k]), len });
   }
 
   const out: number[] = [];
@@ -165,20 +219,19 @@ export function planRefinement(
     let bestScore = 0;
     for (let i = 0; i < work.length; i++) {
       const iv = work[i];
-      if (iv.kink <= tolerance || iv.len <= minSegment) continue;
-      const s = score(iv);
+      if (iv.dev <= tolerance || iv.len <= minSegment) continue;
       // Strict > keeps ties on the lowest index: the plan must be
       // deterministic for the same input, regardless of iteration order.
-      if (s > bestScore) {
-        bestScore = s;
+      if (iv.dev > bestScore) {
+        bestScore = iv.dev;
         best = i;
       }
     }
-    if (best < 0) break; // every interval is smooth enough (or unsplittable)
+    if (best < 0) break; // every interval is accurate enough (or unsplittable)
     const iv = work[best];
     const mid = 0.5 * (iv.a + iv.b);
     out.push(period > 0 ? ((mid % period) + period) % period : mid);
-    const child = { kink: iv.kink / 2, len: iv.len / 2 };
+    const child = { dev: iv.dev / 4, len: iv.len / 2 };
     work[best] = { a: iv.a, b: mid, ...child };
     work.push({ a: mid, b: iv.b, ...child });
   }

--- a/src/antennaknobs/web/frontend/src/lib/refine.ts
+++ b/src/antennaknobs/web/frontend/src/lib/refine.ts
@@ -1,0 +1,323 @@
+import { reflectionCoefficient } from "./format";
+import { gammaDbFromMag, vswrFromGammaMag } from "./math";
+import type { SweepData } from "./api";
+
+// Adaptive sampling refinement (issue #744).
+//
+// A fixed grid renders smooth physics as a kinked polyline wherever the
+// curve bends faster than the grid — a sharp resonance on the freq sweep, a
+// multi-lobed elevation cut's nulls. The planners below decide WHERE to put
+// extra samples, and they decide it in DISPLAY space: the goal is "no
+// visible corner", which is a property of the drawn polyline, not of the
+// underlying data. Raw-data curvature would over-refine a physically steep
+// but visually flat stretch (a VSWR excursion far above the chart's y
+// ceiling) and under-refine a physically gentle but visually sharp one (a
+// null grazing the polar origin, where the radial map compresses dB into
+// almost no radius).
+//
+// Everything here is pure: parameter values in, parameter values out. The
+// callers own the transport (a /sweep re-request, a /cuts re-request) and
+// the dwell that decides refinement is allowed to run at all.
+
+/** A polyline vertex in normalized display units. Both planners normalize
+ *  so the PLOT EXTENT is 1 on each axis — the sweep charts map to [0,1]²,
+ *  the polar cut to [-0.5, 0.5]² — which makes one tolerance and one
+ *  minimum-segment constant meaningful for both. Assumes a square-ish plot
+ *  rect; a wildly non-square chart would want its own aspect factor. */
+export type DisplayPoint = { x: number; y: number };
+
+/** Turn angle above which a vertex reads as a corner rather than a curve.
+ *  0.12 rad ≈ 6.9°: at typical chart sizes (300–450 px) that is the point
+ *  where a 1.3–1.5 px stroke stops looking like a smooth bend. */
+export const KINK_TOLERANCE_RAD = 0.12;
+
+/** Intervals shorter than this (in normalized display units) are never
+ *  split again. Two reasons, both about not burning the budget on
+ *  something no amount of sampling fixes: a genuine DISCONTINUITY (the
+ *  below-horizon floor sentinel on a cut, a VSWR clamp at the chart
+ *  ceiling) has a kink that survives every subdivision; and a sub-pixel
+ *  segment cannot show a corner in the first place. 0.004 of the plot
+ *  extent is ~1.5 px at 380 px. */
+export const MIN_SEGMENT = 0.004;
+
+/** Discrete curvature at each vertex of a display polyline: the turn angle
+ *  between the incoming and outgoing segments, in radians. Boundary
+ *  vertices of an open polyline have no turn (0); a closed one wraps.
+ *  Degenerate (zero-length) segments contribute no turn — a repeated point
+ *  is not a corner. */
+export function turnAngles(
+  pts: readonly DisplayPoint[],
+  closed = false,
+): number[] {
+  const n = pts.length;
+  const out = new Array<number>(n).fill(0);
+  if (n < 3) return out;
+  for (let i = 0; i < n; i++) {
+    const prev = i === 0 ? (closed ? pts[n - 1] : null) : pts[i - 1];
+    const next = i === n - 1 ? (closed ? pts[0] : null) : pts[i + 1];
+    if (!prev || !next) continue;
+    const ax = pts[i].x - prev.x;
+    const ay = pts[i].y - prev.y;
+    const bx = next.x - pts[i].x;
+    const by = next.y - pts[i].y;
+    const na = Math.hypot(ax, ay);
+    const nb = Math.hypot(bx, by);
+    if (na === 0 || nb === 0) continue;
+    // atan2(|a×b|, a·b) — numerically stable at both 0 and π, unlike acos
+    // of a dot product that rounds outside [-1, 1].
+    out[i] = Math.atan2(Math.abs(ax * by - ay * bx), ax * bx + ay * by);
+  }
+  return out;
+}
+
+/** The worst display-space corner on a polyline, in radians. The acceptance
+ *  measure for "no visible kink" — refinement is judged by whether this
+ *  number falls. */
+export function maxKinkRad(
+  pts: readonly DisplayPoint[],
+  closed = false,
+): number {
+  return turnAngles(pts, closed).reduce((a, b) => Math.max(a, b), 0);
+}
+
+type Interval = { a: number; b: number; kink: number; len: number };
+
+// score = kink × length. The kink says how bad the corner at this
+// interval's ends is; the length says how much of it THIS interval is
+// responsible for. Between a long and a short interval flanking the same
+// corner, splitting the long one removes most of the bend — the short one
+// scores lower and is left alone.
+function score(iv: Interval): number {
+  return iv.kink * iv.len;
+}
+
+export type RefineOptions = {
+  /** Hard cap on how many new parameter values this plan may contain. */
+  budget: number;
+  /** Wrap the last vertex back to the first (polar cuts). */
+  closed?: boolean;
+  /** Parameter-space period, required when `closed` (360 for degrees). */
+  period?: number;
+  tolerance?: number;
+  minSegment?: number;
+};
+
+/** Plan the next round of sample points.
+ *
+ * `t` is the sorted parameter array actually sampled (freqs in MHz, angles
+ * in degrees); `projections` are one display polyline per plot that
+ * consumes this SAME data array, each index-aligned with `t`. The interval
+ * score is the max across projections, because there is only one data array
+ * to refine: picking a single projection would leave the others kinked. For
+ * the freq sweep that union is VSWR ∪ S11-dB ∪ Smith, which is not
+ * redundant — VSWR's steepest bend is off resonance where S11-dB is flat,
+ * and the Smith locus bends where neither scalar projection does.
+ *
+ * Returns midpoints of the worst intervals, sorted ascending, never more
+ * than `budget` of them. Within one round the newly inserted points cannot
+ * be evaluated, so an interval that is split gets its children scored by
+ * the smooth-curve estimate "turn angle is O(h)": halving the interval
+ * halves the kink and the length, quartering the score. That keeps one
+ * pathological interval from swallowing the whole budget while still
+ * concentrating points where the curve actually bends. The true re-
+ * evaluation happens across ROUNDS — the caller solves this plan, then asks
+ * again with the densified data.
+ */
+export function planRefinement(
+  t: readonly number[],
+  projections: readonly (readonly DisplayPoint[])[],
+  opts: RefineOptions,
+): number[] {
+  const budget = Math.max(0, Math.floor(opts.budget));
+  if (budget === 0 || t.length < 3) return [];
+  const closed = opts.closed ?? false;
+  const tolerance = opts.tolerance ?? KINK_TOLERANCE_RAD;
+  const minSegment = opts.minSegment ?? MIN_SEGMENT;
+  const usable = projections.filter((p) => p.length === t.length);
+  if (usable.length === 0) return [];
+
+  const n = t.length;
+  const turns = new Array<number>(n).fill(0);
+  for (const p of usable) {
+    const ta = turnAngles(p, closed);
+    for (let i = 0; i < n; i++) turns[i] = Math.max(turns[i], ta[i]);
+  }
+
+  const nIv = closed ? n : n - 1;
+  const period = opts.period ?? 0;
+  const work: Interval[] = [];
+  for (let j = 0; j < nIv; j++) {
+    const k = (j + 1) % n;
+    // The wrap interval's far endpoint lives one period up, so its midpoint
+    // lands between the last and first sample instead of at the middle of
+    // the whole range.
+    const b = k === 0 ? t[0] + period : t[k];
+    let len = 0;
+    for (const p of usable) {
+      len = Math.max(len, Math.hypot(p[k].x - p[j].x, p[k].y - p[j].y));
+    }
+    work.push({ a: t[j], b, kink: Math.max(turns[j], turns[k]), len });
+  }
+
+  const out: number[] = [];
+  while (out.length < budget) {
+    let best = -1;
+    let bestScore = 0;
+    for (let i = 0; i < work.length; i++) {
+      const iv = work[i];
+      if (iv.kink <= tolerance || iv.len <= minSegment) continue;
+      const s = score(iv);
+      // Strict > keeps ties on the lowest index: the plan must be
+      // deterministic for the same input, regardless of iteration order.
+      if (s > bestScore) {
+        bestScore = s;
+        best = i;
+      }
+    }
+    if (best < 0) break; // every interval is smooth enough (or unsplittable)
+    const iv = work[best];
+    const mid = 0.5 * (iv.a + iv.b);
+    out.push(period > 0 ? ((mid % period) + period) % period : mid);
+    const child = { kink: iv.kink / 2, len: iv.len / 2 };
+    work[best] = { a: iv.a, b: mid, ...child };
+    work.push({ a: mid, b: iv.b, ...child });
+  }
+  return out.sort((x, y) => x - y);
+}
+
+// --- Freq sweep (SweepChart's linear-MHz x axis, SmithChart's Γ plane) ---
+
+// SweepChart's y domains (components/charts/SweepChart.tsx DOMAIN). Kept
+// here rather than imported so this module stays free of React/canvas
+// imports; the values are the chart's published axis contract, and the
+// vitest suite pins them against the chart.
+const VSWR_DOMAIN = { lo: 1, hi: 10 };
+const GAMMA_DB_DOMAIN = { lo: -30, hi: 0 };
+
+const clamp01 = (v: number) => (v < 0 ? 0 : v > 1 ? 1 : v);
+
+/** The display polylines a sweep feeds: VSWR vs f, S11 dB vs f, and the
+ *  Smith Γ locus. x for the two scalar charts is LINEAR in MHz over the
+ *  swept span — that is what SweepChart's `xOf` does, whatever the freq
+ *  PLAN's spacing was. Out-of-domain samples clamp exactly as the charts
+ *  draw them (a VSWR of 40 sits pinned at the top edge), so refinement
+ *  never chases curvature that is off screen. */
+export function sweepProjections(
+  sweep: SweepData,
+  z0: number,
+): DisplayPoint[][] {
+  const f = sweep.freqs_mhz;
+  const n = f.length;
+  if (n < 3) return [];
+  const span = f[n - 1] - f[0] || 1;
+  const vswr: DisplayPoint[] = [];
+  const gamma: DisplayPoint[] = [];
+  const smith: DisplayPoint[] = [];
+  for (let i = 0; i < n; i++) {
+    const x = (f[i] - f[0]) / span;
+    const g = reflectionCoefficient(sweep.z_re[i], sweep.z_im[i], z0);
+    const v = vswrFromGammaMag(g.gMag);
+    vswr.push({
+      x,
+      y: clamp01((v - VSWR_DOMAIN.lo) / (VSWR_DOMAIN.hi - VSWR_DOMAIN.lo)),
+    });
+    const db = gammaDbFromMag(g.gMag);
+    gamma.push({
+      x,
+      y: clamp01(
+        (db - GAMMA_DB_DOMAIN.lo) / (GAMMA_DB_DOMAIN.hi - GAMMA_DB_DOMAIN.lo),
+      ),
+    });
+    // Γ plane on the unit disc → the [0,1]² box the chart's circle inscribes.
+    smith.push({ x: (g.gRe + 1) / 2, y: (g.gIm + 1) / 2 });
+  }
+  return [vswr, gamma, smith];
+}
+
+/** Frequencies (MHz) to add to an existing sweep. Deduped against what is
+ *  already sampled: a midpoint that collides with a point the previous
+ *  round already inserted would buy nothing and cost a solve. */
+export function refineSweepFreqs(
+  sweep: SweepData,
+  z0: number,
+  budget: number,
+): number[] {
+  const planned = planRefinement(sweep.freqs_mhz, sweepProjections(sweep, z0), {
+    budget,
+  });
+  // Relative tolerance: sweep spans run 1.8–54 MHz, so an absolute epsilon
+  // would be meaningless at one end of that range.
+  const span = sweep.freqs_mhz[sweep.freqs_mhz.length - 1] - sweep.freqs_mhz[0];
+  const eps = Math.abs(span) * 1e-6;
+  return planned.filter(
+    (f) => !sweep.freqs_mhz.some((have) => Math.abs(have - f) <= eps),
+  );
+}
+
+// --- Pattern cuts (FarFieldChart's polar projection) ---
+
+/** Origin of FarFieldChart's radial axis, in dBi. */
+export const CUT_DBI_FLOOR = -20;
+
+/** FarFieldChart's radial map: absolute dBi → fraction of the plot radius,
+ *  given the top of the (adaptive) radial scale. Exported so the chart and
+ *  the refinement planner cannot drift apart about where a sample lands. */
+export function cutDbiToFrac(dbiTop: number): (db: number) => number {
+  const span = dbiTop - CUT_DBI_FLOOR;
+  return (db: number) => clamp01((db - CUT_DBI_FLOOR) / span);
+}
+
+/** The top of the radial scale for a set of trace peaks: +10 dBi by
+ *  default, expanded (with 1 dB headroom) to fit the highest lobe on
+ *  screen. */
+export function cutDbiTop(peaks: readonly number[]): number {
+  const maxPeak = peaks
+    .filter(Number.isFinite)
+    .reduce((a, b) => Math.max(a, b), 10);
+  return Math.max(10, Math.ceil(maxPeak + 1));
+}
+
+/** One cut's polyline in polar display units, normalized to a plot extent
+ *  of 1 (radius 0.5) so the shared tolerance/min-segment constants mean the
+ *  same thing here as on the sweep charts. `anglesDeg` is the explicit
+ *  parameterisation when the cut is non-uniform; a uniform cut is at
+ *  t = 2π·i/n, exactly as the chart draws it. */
+export function cutProjection(
+  dbi: readonly number[],
+  anglesDeg: readonly number[] | undefined,
+  dbiTop: number,
+): DisplayPoint[] {
+  const toFrac = cutDbiToFrac(dbiTop);
+  const n = dbi.length;
+  return Array.from({ length: n }, (_, i) => {
+    const t = anglesDeg
+      ? (anglesDeg[i] * Math.PI) / 180
+      : (2 * Math.PI * i) / n;
+    const frac = 0.5 * toFrac(dbi[i]);
+    // Canvas flips y, but a reflection changes no turn ANGLE — the planner
+    // only reads |turn|, so the sign convention here is free.
+    return { x: Math.cos(t) * frac, y: Math.sin(t) * frac };
+  });
+}
+
+/** The angles (degrees, ascending in [0, 360)) a cut should additionally be
+ *  sampled at. Deduped against the angles already held. */
+export function refineCutAngles(
+  dbi: readonly number[],
+  anglesDeg: readonly number[] | undefined,
+  dbiTop: number,
+  budget: number,
+): number[] {
+  const n = dbi.length;
+  if (n < 3) return [];
+  const t = anglesDeg
+    ? Array.from(anglesDeg)
+    : Array.from({ length: n }, (_, i) => (360 * i) / n);
+  const planned = planRefinement(t, [cutProjection(dbi, anglesDeg, dbiTop)], {
+    budget,
+    closed: true,
+    period: 360,
+  });
+  const eps = 1e-6;
+  return planned.filter((a) => !t.some((have) => Math.abs(have - a) <= eps));
+}

--- a/src/antennaknobs/web/frontend/src/lib/solveSignature.ts
+++ b/src/antennaknobs/web/frontend/src/lib/solveSignature.ts
@@ -18,6 +18,12 @@ const METADATA_EXEMPT = [
   "_session",
   "_gen",
   "_approved",
+  // Adaptive refinement's lane-kind marker (issue #744) — scheduling, not
+  // physics. Never reaches a signature today (it is attached to the sweep
+  // BODY, not to buildRequest's output), but the two blocklists are kept in
+  // lockstep on purpose: the next field to travel both paths should not
+  // have to rediscover this.
+  "_refine",
 ] as const;
 
 /** Stable stringification of a solve request minus the metadata fields and

--- a/src/antennaknobs/web/frontend/src/lib/sweep.ts
+++ b/src/antennaknobs/web/frontend/src/lib/sweep.ts
@@ -1,3 +1,4 @@
+import type { SweepData } from "./api";
 import { backendSupportsGround, type BackendEntry } from "./backends";
 import type { GroundModel } from "./ground";
 import type { BandSpec, ExampleDescriptor } from "./params";
@@ -76,4 +77,62 @@ export function planSweepFreqs(params: {
   return Array.from({ length: N }, (_, i) =>
     Math.exp(Math.log(fLo) + (i / (N - 1)) * (Math.log(fHi) - Math.log(fLo))),
   );
+}
+
+// Point budget for adaptive sweep refinement (issue #744), summed across
+// rounds. 41 planned + 48 refined = 89 points, an order of magnitude under
+// the hosted MAX_SWEEP_POINTS=500 cap (web/cost.py) and — thanks to the
+// server's per-freq Z cache — nearly free to re-request on a later dwell.
+export const SWEEP_REFINE_BUDGET = 48;
+// Per round, so one round's plan (which cannot re-evaluate its own inserted
+// points) never commits the whole budget on an estimate.
+export const SWEEP_REFINE_ROUND_BUDGET = 12;
+
+/** Merge refinement points into an accumulated sweep, re-sorted by
+ *  frequency for display.
+ *
+ * Every row array is permuted by the SAME ordering — the per-feed Z rows
+ * (bowtie arrays) are index-aligned with `freqs_mhz` by SweepData's
+ * contract, and a chart that reads `feeds_z_re[i]` next to `freqs_mhz[i]`
+ * would otherwise plot one feed's impedance at another frequency's x. A
+ * frequency already present wins over the incoming duplicate: the existing
+ * value came from the same cached solve, so preferring it keeps the merge
+ * idempotent.
+ */
+export function mergeSweepPoints(base: SweepData, extra: SweepData): SweepData {
+  const eps =
+    Math.abs(
+      (base.freqs_mhz[base.freqs_mhz.length - 1] ?? 0) -
+        (base.freqs_mhz[0] ?? 0),
+    ) * 1e-9;
+  type Row = { from: "base" | "extra"; i: number };
+  const rows: Row[] = base.freqs_mhz.map((_, i) => ({ from: "base", i }));
+  for (let i = 0; i < extra.freqs_mhz.length; i++) {
+    const f = extra.freqs_mhz[i];
+    if (base.freqs_mhz.some((have) => Math.abs(have - f) <= eps)) continue;
+    rows.push({ from: "extra", i });
+  }
+  const freqAt = (r: Row) =>
+    (r.from === "base" ? base : extra).freqs_mhz[r.i];
+  rows.sort((a, b) => freqAt(a) - freqAt(b));
+  // Per-feed rows survive the merge only when every contributing row has
+  // one. A half-populated feeds array would be worse than none: the chart
+  // indexes it positionally, so a hole reads as another feed's impedance.
+  const pick = (
+    get: (s: SweepData) => number[][] | undefined,
+  ): number[][] | undefined => {
+    const got = rows.map((r) => get(r.from === "base" ? base : extra)?.[r.i]);
+    return got.length > 0 && got.every((row) => Array.isArray(row))
+      ? (got as number[][])
+      : undefined;
+  };
+  const feedsRe = pick((s) => s.feeds_z_re);
+  const feedsIm = pick((s) => s.feeds_z_im);
+  return {
+    freqs_mhz: rows.map(freqAt),
+    z_re: rows.map((r) => (r.from === "base" ? base : extra).z_re[r.i]),
+    z_im: rows.map((r) => (r.from === "base" ? base : extra).z_im[r.i]),
+    ...(feedsRe ? { feeds_z_re: feedsRe } : {}),
+    ...(feedsIm ? { feeds_z_im: feedsIm } : {}),
+  };
 }

--- a/src/antennaknobs/web/lane.py
+++ b/src/antennaknobs/web/lane.py
@@ -32,6 +32,11 @@ PRIORITY = {
     "pattern_metrics": 1,
     "sweep": 2,
     "converge": 2,
+    # Adaptive refinement (issue #744) is cosmetic — the curve is already
+    # drawn, refinement only removes its corners — so it sorts BELOW the
+    # batches that produce data nobody has yet. It also runs mostly out of
+    # the per-freq Z cache, so yielding costs it almost nothing.
+    "sweep_refine": 3,
 }
 _PRIORITY_DEFAULT = 9
 
@@ -39,6 +44,15 @@ _PRIORITY_DEFAULT = 9
 # client holds at most one of each (re-issuing means the old stream is
 # abandoned). pattern_metrics is deliberately absent — the compare table
 # legitimately runs one request per design row at once.
+#
+# sweep_refine is absent for a sharper reason: it is a DIFFERENT kind from
+# "sweep" precisely so a refinement request cannot kill the base sweep that
+# produced the curve it is refining (same-kind supersession ignores
+# generations, so sharing the kind would have made refinement self-
+# defeating). Successive refinement rounds carry the same generation and
+# are purely additive, so they queue rather than cancel each other; a
+# genuinely newer knob generation still supersedes them by the generation
+# rule, like every other batch.
 SAME_KIND_SUPERSEDES = frozenset({"live", "sweep", "converge", "norm_check", "pattern"})
 
 

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -492,6 +492,40 @@ _CUT_N_DIR = 180
 # dBi floor sentinel for below-horizon samples (JSON can't carry -Infinity).
 _CUT_FLOOR_DBI = -999.0
 
+# Ceiling on a caller-specified cut parameterisation (issue #744). Adaptive
+# refinement sends the base grid plus its extra angles; ~4× the uniform
+# resolution is far past what any budget asks for and bounds the per-request
+# far-field evaluation the way MAX_SWEEP_POINTS bounds a sweep.
+_CUT_MAX_ANGLES = 720
+
+
+def _cut_angles(raw, default_n: int = _CUT_N_DIR) -> np.ndarray:
+    """Sanitised cut parameterisation in RADIANS.
+
+    ``None`` gives the uniform circle the charts have always drawn (sample i
+    at t = 2π·i/n). A caller-supplied list (issue #744) is validated, wrapped
+    into [0, 360), deduped and SORTED here rather than trusted: the chart
+    strokes these in order, so an out-of-order angle would draw a chord
+    across the pattern.
+    """
+    if raw is None:
+        return 2.0 * np.pi * np.arange(default_n) / default_n
+    if not isinstance(raw, (list, tuple)):
+        raise ValueError("cut angles must be a list of numbers")
+    if len(raw) > _CUT_MAX_ANGLES:
+        raise ValueError(f"cut angle list is over the {_CUT_MAX_ANGLES}-point limit")
+    vals = []
+    for a in raw:
+        if isinstance(a, bool) or not isinstance(a, (int, float)):
+            raise ValueError("cut angles must be numbers")
+        f = float(a)
+        if not math.isfinite(f):
+            raise ValueError("cut angles must be finite")
+        vals.append(f % 360.0)
+    if not vals:
+        return 2.0 * np.pi * np.arange(default_n) / default_n
+    return np.radians(np.unique(np.asarray(vals, dtype=float)))
+
 
 def _pattern_cuts(
     out: dict,
@@ -501,17 +535,28 @@ def _pattern_cuts(
     mid=None,
     dr=None,
     i_mid=None,
+    az_angles_deg=None,
+    elev_angles_deg=None,
 ) -> dict | None:
     """The two polar-chart traces (issue #547): the azimuth cut at elevation
     `az_elev_deg` and the great-circle elevation cut through azimuth
-    `elev_az_deg`, each _CUT_N_DIR samples of absolute dBi.
+    `elev_az_deg`, each a run of absolute-dBi samples.
 
-    Both circles are parameterised as the frontend chart draws them:
-    sample i sits at t = 2π·i/N_DIR; the azimuth cut runs the horizon circle
-    at the given elevation, the elevation cut is the vertical circle whose
-    t ∈ (180°, 360°) half dips below the horizon. With ground on, below-
-    horizon samples clamp to _CUT_FLOOR_DBI. Returns None when the response
-    can't support cuts (no wires or no positive gain norm).
+    Both circles are parameterised as the frontend chart draws them: by
+    default sample i sits at t = 2π·i/N_DIR, the azimuth cut running the
+    horizon circle at the given elevation and the elevation cut the vertical
+    circle whose t ∈ (180°, 360°) half dips below the horizon. With ground
+    on, below-horizon samples clamp to _CUT_FLOOR_DBI. Returns None when the
+    response can't support cuts (no wires or no positive gain norm).
+
+    Adaptive refinement (issue #744) may replace either circle's uniform
+    parameterisation with an explicit angle list. The response then carries
+    that list back as ``az_angles_deg`` / ``elev_angles_deg``: with
+    non-uniform sampling the chart can no longer DERIVE the angle from the
+    index, so the parameterisation has to travel with the data. The fields
+    stay ABSENT for the uniform case, which keeps every pre-#744 response
+    and client valid — absent means "t = 2π·i/n", the contract that has
+    always held.
 
     Callers that already hold the moment set (the solve_id cache, issue
     #551) pass it via mid/dr/i_mid; `out` then only needs the scalar/ground
@@ -520,17 +565,27 @@ def _pattern_cuts(
     norm = float(out.get("directivity_norm") or 0.0)
     if norm <= 0.0 or (mid is None and not out.get("wires")):
         return None
-    t = 2.0 * np.pi * np.arange(_CUT_N_DIR) / _CUT_N_DIR
-    ct, st = np.cos(t), np.sin(t)
+    t_az = _cut_angles(az_angles_deg)
+    t_el = _cut_angles(elev_angles_deg)
 
     az = np.radians(az_elev_deg)
     az_rhat = np.stack(
-        [np.cos(az) * ct, np.cos(az) * st, np.full_like(t, np.sin(az))], axis=-1
+        [
+            np.cos(az) * np.cos(t_az),
+            np.cos(az) * np.sin(t_az),
+            np.full_like(t_az, np.sin(az)),
+        ],
+        axis=-1,
     )
     el = np.radians(elev_az_deg)
-    el_rhat = np.stack([np.cos(el) * ct, np.sin(el) * ct, st], axis=-1)
+    el_rhat = np.stack(
+        [np.cos(el) * np.cos(t_el), np.sin(el) * np.cos(t_el), np.sin(t_el)], axis=-1
+    )
 
-    rhat = np.stack([az_rhat, el_rhat])  # (2, N_DIR, 3)
+    # Concatenated, not stacked: refinement can leave the two cuts with
+    # different sample counts, and one evaluation over (n_az + n_el, 3) is
+    # the same work as two.
+    rhat = np.concatenate([az_rhat, el_rhat], axis=0)
     mag2 = _mag2_at_directions(out, rhat, mid=mid, dr=dr, i_mid=i_mid)
     if bool(out.get("ground", False)):
         mag2 = np.where(rhat[..., 2] < 0.0, 0.0, mag2)
@@ -538,14 +593,19 @@ def _pattern_cuts(
     with np.errstate(divide="ignore"):
         dbi = 10.0 * np.log10(np.maximum(norm * mag2, 0.0))
     dbi = np.where(np.isfinite(dbi), dbi, _CUT_FLOOR_DBI)
-    return {
+    cuts = {
         "az_elev_deg": float(az_elev_deg),
         "elev_az_deg": float(elev_az_deg),
         "n_dir": _CUT_N_DIR,
         "floor_dbi": _CUT_FLOOR_DBI,
-        "azimuth": [round(float(v), 3) for v in dbi[0]],
-        "elevation": [round(float(v), 3) for v in dbi[1]],
+        "azimuth": [round(float(v), 3) for v in dbi[: len(t_az)]],
+        "elevation": [round(float(v), 3) for v in dbi[len(t_az) :]],
     }
+    if az_angles_deg is not None:
+        cuts["az_angles_deg"] = [round(float(a), 6) for a in np.degrees(t_az)]
+    if elev_angles_deg is not None:
+        cuts["elev_angles_deg"] = [round(float(a), 6) for a in np.degrees(t_el)]
+    return cuts
 
 
 # Server-side cuts sources (issue #551): solve_id → the pre-extracted data
@@ -599,12 +659,24 @@ def _remember_cuts_source(solve_id: str, out: dict) -> None:
 
 
 def _cuts_from_source(
-    solve_id: str, az_elev_deg: float, elev_az_deg: float
+    solve_id: str,
+    az_elev_deg: float,
+    elev_az_deg: float,
+    az_angles_deg=None,
+    elev_angles_deg=None,
 ) -> dict | None:
     """Cuts computed from the server-side source for `solve_id`, or None on
     a cache miss (callers map that to 404 / ok=false). Only sources with a
     positive norm are ever cached, so None never means "can't support cuts"
-    here."""
+    here.
+
+    The cached source is the moment set — angle-independent by construction
+    — so a refinement request for extra angles against a live solve_id costs
+    one far-field evaluation and no solve at all. That is why cut refinement
+    (issue #744) does NOT take a lane turn the way sweep refinement does:
+    there is no solve to serialize, only the existing pattern re-evaluated
+    at more directions, on the same no-lane latest-wins channel cut-dial
+    drags already use."""
     src = _CUTS_SRC_CACHE.get(solve_id)
     if src is None:
         return None
@@ -616,6 +688,8 @@ def _cuts_from_source(
         mid=src["_mid"],
         dr=src["_dr"],
         i_mid=src["_i_mid"],
+        az_angles_deg=az_angles_deg,
+        elev_angles_deg=elev_angles_deg,
     )
 
 
@@ -1861,10 +1935,17 @@ def cuts_endpoint(req: dict):
       ``solve`` (wires + k_meas_m_inv + ground constants + directivity_norm
       — the client already holds all of them).
 
+    Either shape may add ``az_angles_deg`` / ``elev_angles_deg`` (issue
+    #744) to sample that cut at an explicit, possibly non-uniform, list of
+    angles instead of the uniform circle; the response then echoes the
+    parameterisation it used.
+
     Returns the same ``cuts`` object the live solve attaches. Sync def →
     FastAPI threadpool, so a big-mesh cut (~100 ms at 4k segments) never
     blocks the event loop.
     """
+    az_angles = req.get("az_angles_deg")
+    elev_angles = req.get("elev_angles_deg")
     solve_out = req.get("solve")
     if not isinstance(solve_out, dict):
         solve_id = req.get("solve_id")
@@ -1875,6 +1956,8 @@ def cuts_endpoint(req: dict):
                 solve_id,
                 float(req.get("az_elev_deg", 15.0)),
                 float(req.get("elev_az_deg", 0.0)),
+                az_angles_deg=az_angles,
+                elev_angles_deg=elev_angles,
             )
         except (KeyError, TypeError, ValueError) as e:
             raise HTTPException(status_code=400, detail=f"bad cuts request: {e}") from e
@@ -1886,6 +1969,8 @@ def cuts_endpoint(req: dict):
             solve_out,
             float(req.get("az_elev_deg", 15.0)),
             float(req.get("elev_az_deg", 0.0)),
+            az_angles_deg=az_angles,
+            elev_angles_deg=elev_angles,
         )
     except (KeyError, TypeError, ValueError) as e:
         raise HTTPException(status_code=400, detail=f"bad cuts request: {e}") from e
@@ -2305,7 +2390,17 @@ async def ws_endpoint(ws: WebSocket):
                     # running solve.
                     sid = req.get("solve_id")
                     if isinstance(sid, str) and sid:
-                        cuts_box[sid] = req
+                        # Latest-wins per solve — EXCEPT that a refinement
+                        # request (issue #744) gets its own slot. It asks
+                        # for a different thing (the same dial angles at
+                        # more sample directions), so squashing it against
+                        # a dial drag would lose it every time the user is
+                        # still moving.
+                        refined = (
+                            req.get("az_angles_deg") is not None
+                            or req.get("elev_angles_deg") is not None
+                        )
+                        cuts_box[f"{sid}|{int(refined)}"] = req
                         cuts_newer.set()
                     continue
                 mailbox[:] = [req]  # overwrite → squash anything unsolved
@@ -2340,13 +2435,19 @@ async def ws_endpoint(ws: WebSocket):
             while cuts_box:
                 if closed.is_set():
                     return
-                sid = next(iter(cuts_box))
-                creq = cuts_box.pop(sid)
+                slot = next(iter(cuts_box))
+                creq = cuts_box.pop(slot)
+                sid = creq["solve_id"]
+                az_angles = creq.get("az_angles_deg")
+                elev_angles = creq.get("elev_angles_deg")
                 resp: dict = {
                     "_kind": "cuts",
                     "solve_id": sid,
                     "az_elev_deg": creq.get("az_elev_deg"),
                     "elev_az_deg": creq.get("elev_az_deg"),
+                    # Echoed so the client can tell a refinement reply from a
+                    # plain dial reply for the same solve and angles.
+                    "refined": slot.endswith("|1"),
                 }
                 try:
                     cuts = await run_in_threadpool(
@@ -2354,6 +2455,8 @@ async def ws_endpoint(ws: WebSocket):
                         sid,
                         float(creq.get("az_elev_deg", 15.0)),
                         float(creq.get("elev_az_deg", 0.0)),
+                        az_angles,
+                        elev_angles,
                     )
                 except Exception:  # noqa: BLE001 — junk angles must not kill the socket
                     _logger.exception("ws cuts request failed")
@@ -2363,7 +2466,7 @@ async def ws_endpoint(ws: WebSocket):
                 resp["ok"] = cuts is not None
                 if cuts is not None:
                     resp["cuts"] = cuts
-                if sid in cuts_box:
+                if slot in cuts_box:
                     # Newer angles for this solve arrived while we computed —
                     # skip the doomed send; the fresh response supersedes it.
                     continue

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -878,6 +878,97 @@ def _polyline_knots(polyline: np.ndarray, npe_list: list[int]) -> np.ndarray:
 _SOLVE_CACHE: "OrderedDict[str, dict]" = OrderedDict()
 _SOLVE_CACHE_MAX = 100
 
+# Per-frequency sweep impedance cache (issue #744). /sweep deliberately
+# bypasses _SOLVE_CACHE — a sweep point is a Z, not a whole solve response,
+# and caching 41 full responses per drag would blow that cache out — so
+# until now every sweep re-solved every point from scratch. Adaptive
+# refinement makes that expensive in a new way: it re-visits the SAME design
+# repeatedly, adding a handful of frequencies each round, and would
+# otherwise pay for the whole grid again on each re-dwell.
+#
+# Keyed by (design, freq): the design half is _canonical_solve_key of the
+# request MINUS the freq list, so it inherits the blocklist — refinement
+# metadata and cut angles don't shred it, while any genuine physics field
+# (including one added next month) invalidates by default. That makes
+# server-side invalidation the same object as the client's #692 signature,
+# not a parallel hand-maintained list.
+#
+# ASYMMETRIC on purpose: every sweep WRITES, only a refinement request READS.
+#   - Writing from every sweep keeps entries fresh, so what refinement reads
+#     was produced by the very base sweep it is refining. A read-through base
+#     sweep would instead let a stale entry (a user design edited on disk
+#     under an unchanged request key — the same exposure _SOLVE_CACHE has)
+#     survive in the PRIMARY curve, with no way to force a re-solve.
+#   - Not reading on the base sweep also keeps the endpoint's compute path
+#     for a plain sweep exactly what it was, which the #382 lane tests
+#     depend on: two sessions issuing the same sweep concurrently must both
+#     compute (a cross-session read-through would answer one from cache and
+#     the lane's per-session serialization would go untested).
+# The acceptance criterion this cache exists for — "refinement requests hit
+# the cache on re-dwell" — is satisfied either way, since the refinement
+# plan is deterministic in the settled sweep.
+#
+# Entries are 2–4 floats plus per-feed lists; 4096 of them is well under a
+# megabyte, and holds ~50 full sweeps of design history.
+_SWEEP_Z_CACHE: "OrderedDict[tuple[str, int], tuple]" = OrderedDict()
+_SWEEP_Z_CACHE_MAX = 4096
+# Hit/miss counters — observability, and the only honest way to assert "this
+# request performed zero engine solves" in a test.
+_SWEEP_Z_STATS = {"hits": 0, "misses": 0}
+
+# Frequencies land back from JSON as the exact float the client sent, but
+# quantise anyway (same reasoning as _CACHE_FLOAT_QUANT): a re-plan that
+# recomputes 28.470000000000002 must still hit.
+_SWEEP_FREQ_QUANT = 1e-9
+
+
+def _sweep_design_key(req: dict) -> str:
+    """Cache namespace for a sweep request: everything about the design
+    except which frequencies were asked for.
+
+    ``measurement_freq_mhz`` stays IN the key even though the sweep
+    overrides the frequency per point. It is a request field, and the house
+    rule for this cache key is "extra miss beats wrong hit" — a builder that
+    reads the measurement frequency for anything but the excitation would
+    otherwise be silently mis-cached.
+    """
+    return _canonical_solve_key({k: v for k, v in req.items() if k != "freqs_mhz"})
+
+
+def _sweep_z_get(design_key: str, freq: float) -> tuple | None:
+    key = (design_key, round(freq / _SWEEP_FREQ_QUANT))
+    hit = _SWEEP_Z_CACHE.get(key)
+    if hit is None:
+        _SWEEP_Z_STATS["misses"] += 1
+        return None
+    _SWEEP_Z_CACHE.move_to_end(key)
+    _SWEEP_Z_STATS["hits"] += 1
+    return hit
+
+
+def _sweep_record(freq: float, value: tuple, solver_name: str) -> dict:
+    """One NDJSON sweep line from a cache value. Per-feed fields stay OMITTED
+    for single-feed geometries — the frontend allocates its per-feed buffers
+    on first sight of them."""
+    z_re, z_im, feeds_re, feeds_im = value
+    record = {
+        "freq_mhz": freq,
+        "z_re": z_re,
+        "z_im": z_im,
+        "solver": solver_name,
+    }
+    if feeds_re is not None:
+        record["feeds_z_re"] = feeds_re
+        record["feeds_z_im"] = feeds_im
+    return record
+
+
+def _sweep_z_put(design_key: str, freq: float, value: tuple) -> None:
+    _SWEEP_Z_CACHE[(design_key, round(freq / _SWEEP_FREQ_QUANT))] = value
+    _SWEEP_Z_CACHE.move_to_end((design_key, round(freq / _SWEEP_FREQ_QUANT)))
+    while len(_SWEEP_Z_CACHE) > _SWEEP_Z_CACHE_MAX:
+        _SWEEP_Z_CACHE.popitem(last=False)
+
 
 # --- Live-engine size guard (hosted only) ----------------------------------
 # A solve builds a method-of-moments system whose dimension N ≈ the total wire
@@ -976,6 +1067,11 @@ _CACHE_KEY_BLOCKLIST = frozenset(
         "_session",
         "_gen",
         "_approved",
+        # Adaptive-refinement marker (issue #744): selects the sweep's lane
+        # kind and nothing else. It MUST be blocklisted — a refinement
+        # request asks for extra frequencies of the same design, so it has
+        # to land on the same per-freq cache entries a base sweep would.
+        "_refine",
         # Polar-cut angles (issue #547): cuts are attached per-request AFTER
         # the cache, so the cached entry is angle-independent by design.
         # Leaving these in the key meant every cut-dial drag silently
@@ -1168,6 +1264,18 @@ async def sweep_endpoint(req: dict, request: Request):
         _admit(req, kind="sweep", use_pynec=use_pynec, points=len(freqs)), req
     )
     session, lane_gen = _lane_key(req)
+    # Adaptive refinement (issue #744) rides this same endpoint — the freq
+    # list has always been caller-chosen — but takes its OWN lane kind. If it
+    # shared "sweep", lane.SAME_KIND_SUPERSEDES would have the refinement
+    # request kill the base sweep whose curve it is refining, regardless of
+    # generation. It also sorts below "sweep" so a genuinely new sweep goes
+    # first; refinement runs mostly out of the per-freq cache anyway.
+    lane_kind = "sweep_refine" if req.get("_refine") else "sweep"
+    # (design, freq) impedance cache: refinement reads it (a re-dwell asks
+    # for the same deterministic plan it asked for last time), every sweep
+    # writes it. See _SWEEP_Z_CACHE for why the read side is asymmetric.
+    design_key = _sweep_design_key(req)
+    read_cache = lane_kind == "sweep_refine"
     # Validate the client's solver kwargs up front: this endpoint streams, so
     # an error surfacing mid-generator can't become a clean status code.
     # Imported here (like /optimize's optimizer import): adapter ↔ examples
@@ -1194,49 +1302,51 @@ async def sweep_endpoint(req: dict, request: Request):
             for f in freqs:
                 if await request.is_disconnected():
                     return
-                try:
-                    # One lane turn per point: a queued live solve gets the
-                    # lane at the next point boundary. PyNEC has no mid-solve
-                    # abort, so a supersession trips the token but the point
-                    # runs out; the post-turn check stops the stream there.
-                    async with _LANES.turn(session, "sweep", lane_gen) as token:
-                        if is_multifeed:
-                            primary, feeds_z = await run_in_threadpool(
-                                _shed, pynec_backend._sweep_at_multifeed, req, f
+                cached = _sweep_z_get(design_key, f) if read_cache else None
+                superseded_mid_point = False
+                if cached is None:
+                    try:
+                        # One lane turn per point: a queued live solve gets
+                        # the lane at the next point boundary. PyNEC has no
+                        # mid-solve abort, so a supersession trips the token
+                        # but the point runs out; the post-turn check stops
+                        # the stream there. A cache hit takes no turn at all
+                        # — there is no engine work to serialize.
+                        async with _LANES.turn(session, lane_kind, lane_gen) as token:
+                            if is_multifeed:
+                                primary, feeds_z = await run_in_threadpool(
+                                    _shed, pynec_backend._sweep_at_multifeed, req, f
+                                )
+                                cached = (
+                                    float(primary.real),
+                                    float(primary.imag),
+                                    [float(z_.real) for z_ in feeds_z],
+                                    [float(z_.imag) for z_ in feeds_z],
+                                )
+                            else:
+                                z = await run_in_threadpool(
+                                    _shed, pynec_backend._sweep_at, req, f
+                                )
+                                cached = (float(z.real), float(z.imag), None, None)
+                            superseded_mid_point = token.cancelled
+                    except Superseded:
+                        return
+                    except Exception as exc:  # noqa: BLE001 — solver can fail per point
+                        yield (
+                            json.dumps(
+                                {
+                                    "error": user_designs.format_solve_error(exc),
+                                    "solver": solver_name,
+                                }
                             )
-                            record = {
-                                "freq_mhz": f,
-                                "z_re": float(primary.real),
-                                "z_im": float(primary.imag),
-                                "feeds_z_re": [float(z_.real) for z_ in feeds_z],
-                                "feeds_z_im": [float(z_.imag) for z_ in feeds_z],
-                                "solver": solver_name,
-                            }
-                        else:
-                            z = await run_in_threadpool(
-                                _shed, pynec_backend._sweep_at, req, f
-                            )
-                            record = {
-                                "freq_mhz": f,
-                                "z_re": float(z.real),
-                                "z_im": float(z.imag),
-                                "solver": solver_name,
-                            }
-                        superseded_mid_point = token.cancelled
-                except Superseded:
-                    return
-                except Exception as exc:  # noqa: BLE001 — solver can fail per point
-                    yield (
-                        json.dumps(
-                            {
-                                "error": user_designs.format_solve_error(exc),
-                                "solver": solver_name,
-                            }
+                            + "\n"
                         )
-                        + "\n"
-                    )
-                    return
-                yield json.dumps(record) + "\n"
+                        return
+                    # Store only a point that ran to completion: a superseded
+                    # PyNEC point still produced a real Z (no mid-solve
+                    # abort), so it is cached like any other.
+                    _sweep_z_put(design_key, f, cached)
+                yield json.dumps(_sweep_record(f, cached, solver_name)) + "\n"
                 if superseded_mid_point:
                     return
         else:
@@ -1265,62 +1375,76 @@ async def sweep_endpoint(req: dict, request: Request):
                 if await request.is_disconnected():
                     return
                 chunk = freqs[start : start + chunk_size]
-                t0 = time.perf_counter()
-                try:
-                    # One lane turn per chunk; the token reaches the solver's
-                    # checkpoints, so a knob drag (newer generation) or a
-                    # dropped connection (the watcher) aborts THIS chunk in
-                    # ~ms instead of after minutes on a benchmark mesh.
-                    async with _LANES.turn(session, "sweep", lane_gen) as token:
-                        async with cancel_on_disconnect(request, token):
-                            sweep_result = await run_in_threadpool(
-                                _shed, sweep_fn, req, chunk, cancel=token
+                # Solve only what the (design, freq) cache doesn't already
+                # hold. On a refinement round that is the handful of new
+                # frequencies; on a re-dwell of an unchanged design it is
+                # nothing at all, and the chunk streams without ever taking
+                # a lane turn.
+                known = {
+                    f: (_sweep_z_get(design_key, f) if read_cache else None)
+                    for f in chunk
+                }
+                pending = [f for f, v in known.items() if v is None]
+                if pending:
+                    t0 = time.perf_counter()
+                    try:
+                        # One lane turn per chunk; the token reaches the
+                        # solver's checkpoints, so a knob drag (newer
+                        # generation) or a dropped connection (the watcher)
+                        # aborts THIS chunk in ~ms instead of after minutes
+                        # on a benchmark mesh.
+                        async with _LANES.turn(session, lane_kind, lane_gen) as token:
+                            async with cancel_on_disconnect(request, token):
+                                sweep_result = await run_in_threadpool(
+                                    _shed, sweep_fn, req, pending, cancel=token
+                                )
+                    except (Superseded, momwire.SolveAborted):
+                        return
+                    except Exception as exc:  # noqa: BLE001 — a chunk can fail honestly
+                        # e.g. an approved poor-match combo whose dense fill
+                        # can't allocate: end the stream with the cause
+                        # instead of tearing the NDJSON connection down
+                        # mid-line.
+                        yield (
+                            json.dumps(
+                                {
+                                    "error": user_designs.format_solve_error(exc),
+                                    "solver": solver_name,
+                                }
                             )
-                except (Superseded, momwire.SolveAborted):
-                    return
-                except Exception as exc:  # noqa: BLE001 — a chunk can fail honestly
-                    # e.g. an approved poor-match combo whose dense fill can't
-                    # allocate: end the stream with the cause instead of
-                    # tearing the NDJSON connection down mid-line.
-                    yield (
-                        json.dumps(
-                            {
-                                "error": user_designs.format_solve_error(exc),
-                                "solver": solver_name,
-                            }
+                            + "\n"
                         )
-                        + "\n"
-                    )
-                    return
-                # Multi-feed sweeps (bowtie array) return a 4-tuple with
-                # per-feed Z appended. Everything else stays on the
-                # original 2-tuple shape; the legacy z_re / z_im fields
-                # always carry the primary feed for back-compat.
-                feeds_re_chunk: list[list[float]] | None = None
-                feeds_im_chunk: list[list[float]] | None = None
-                if len(sweep_result) == 4:
-                    z_re, z_im, feeds_re_chunk, feeds_im_chunk = sweep_result
-                else:
-                    z_re, z_im = sweep_result
-                chunk_ms = (time.perf_counter() - t0) * 1000
-                for i, f in enumerate(chunk):
-                    record: dict = {
-                        "freq_mhz": f,
-                        "z_re": z_re[i],
-                        "z_im": z_im[i],
-                        "solver": solver_name,
-                    }
-                    if feeds_re_chunk is not None:
-                        record["feeds_z_re"] = feeds_re_chunk[i]
-                        record["feeds_z_im"] = feeds_im_chunk[i]
-                    yield json.dumps(record) + "\n"
+                        return
+                    # Multi-feed sweeps (bowtie array) return a 4-tuple with
+                    # per-feed Z appended. Everything else stays on the
+                    # original 2-tuple shape; the legacy z_re / z_im fields
+                    # always carry the primary feed for back-compat.
+                    if len(sweep_result) == 4:
+                        z_re, z_im, feeds_re_chunk, feeds_im_chunk = sweep_result
+                    else:
+                        z_re, z_im = sweep_result
+                        feeds_re_chunk = feeds_im_chunk = None
+                    for i, f in enumerate(pending):
+                        value = (
+                            z_re[i],
+                            z_im[i],
+                            None if feeds_re_chunk is None else feeds_re_chunk[i],
+                            None if feeds_im_chunk is None else feeds_im_chunk[i],
+                        )
+                        known[f] = value
+                        _sweep_z_put(design_key, f, value)
+                    chunk_ms = (time.perf_counter() - t0) * 1000
+                    # Adapt for the next chunk: target _CHUNK_TARGET_MS per
+                    # batch. Per-freq cost is a weak function of chunk size
+                    # (bowl curve), so this converges quickly. Timed against
+                    # the SOLVED points only — cached ones cost nothing and
+                    # would otherwise inflate the next chunk without bound.
+                    if chunk_ms > 0:
+                        per_freq_ms = chunk_ms / len(pending)
+                        chunk_size = max(1, round(_CHUNK_TARGET_MS / per_freq_ms))
+                for f in chunk:
+                    yield json.dumps(_sweep_record(f, known[f], solver_name)) + "\n"
                 start += len(chunk)
-                # Adapt for the next chunk: target _CHUNK_TARGET_MS per
-                # batch. Per-freq cost is a weak function of chunk size
-                # (bowl curve), so this converges quickly.
-                if chunk_ms > 0 and len(chunk) > 0:
-                    per_freq_ms = chunk_ms / len(chunk)
-                    chunk_size = max(1, round(_CHUNK_TARGET_MS / per_freq_ms))
 
         yield json.dumps({"done": True, "solver": solver_name}) + "\n"
 

--- a/tests/test_cut_refine.py
+++ b/tests/test_cut_refine.py
@@ -1,0 +1,320 @@
+"""Non-uniform pattern-cut sampling (issue #744).
+
+The /cuts endpoint (HTTP and the /ws sidecar) accepts an explicit angle
+list per cut so adaptive refinement can densify a multi-lobed pattern where
+the polar trace corners. What has to hold:
+
+  - the dBi at an explicit angle equals the dBi the uniform grid gives at
+    that same angle — refinement adds samples, it never changes physics;
+  - the parameterisation travels back with the data, because a non-uniform
+    trace's angle is no longer derivable from its index;
+  - a uniform request is byte-identical to what it was before this feature,
+    so pre-#744 clients keep working;
+  - the cuts-source cache stays angle-independent, so extra angles against a
+    live solve_id cost one far-field evaluation and no solve.
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+from starlette.testclient import TestClient
+
+import antennaknobs.web.server as server
+from antennaknobs.web.server import _pattern_cuts, app
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _hertzian(h: float = 2.0, ground: bool = True) -> dict:
+    """One z-directed segment at height h — a lobed elevation pattern once
+    the ground image interferes, which is exactly what refinement is for."""
+    dl = 0.01
+    out = {
+        "wires": [
+            {
+                "knot_positions": [[0.0, 0.0, h], [0.0, 0.0, h + dl]],
+                "knot_currents_re": [1.0, 1.0],
+                "knot_currents_im": [0.0, 0.0],
+            }
+        ],
+        "k_meas_m_inv": 0.44,
+        "ground": ground,
+        "ground_eps_r": 13.0,
+        "ground_eps_im": -1.0,
+        "directivity_norm": 3.0 / (2.0 * dl * dl),
+    }
+    return out
+
+
+_SOLVE_REQ = {
+    "geometry": "dipoles.invvee",
+    "measurement_freq_mhz": 28.47,
+    "momwire_model": "bspline",
+    "az_elev_deg": 15.0,
+    "elev_az_deg": 45.0,
+}
+
+
+def _ws_solve(client: TestClient, req=_SOLVE_REQ) -> dict:
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(json.dumps(req))
+        return json.loads(ws.receive_text())
+
+
+# ---- physics: extra angles are extra SAMPLES, not different physics -------
+
+
+def test_explicit_angles_agree_with_the_uniform_grid():
+    out = _hertzian()
+    uniform = _pattern_cuts(out, 15.0, 0.0)
+    n = uniform["n_dir"]
+    # Every 10th uniform angle, requested explicitly.
+    picked = [(360.0 * i) / n for i in range(0, n, 10)]
+    explicit = _pattern_cuts(
+        out, 15.0, 0.0, az_angles_deg=picked, elev_angles_deg=picked
+    )
+    assert explicit["az_angles_deg"] == pytest.approx(picked)
+    for j, i in enumerate(range(0, n, 10)):
+        assert explicit["azimuth"][j] == pytest.approx(uniform["azimuth"][i], abs=1e-3)
+        assert explicit["elevation"][j] == pytest.approx(
+            uniform["elevation"][i], abs=1e-3
+        )
+
+
+def test_a_uniform_request_is_unchanged_by_this_feature():
+    out = _hertzian()
+    cuts = _pattern_cuts(out, 15.0, 0.0)
+    # The angle arrays stay ABSENT: "absent means t = 2π·i/n" is the contract
+    # every pre-#744 client draws on.
+    assert "az_angles_deg" not in cuts
+    assert "elev_angles_deg" not in cuts
+    assert len(cuts["azimuth"]) == len(cuts["elevation"]) == cuts["n_dir"] == 180
+
+
+def test_the_two_cuts_may_carry_different_sample_counts():
+    out = _hertzian()
+    cuts = _pattern_cuts(
+        out,
+        15.0,
+        0.0,
+        az_angles_deg=[0.0, 90.0, 180.0, 270.0],
+        elev_angles_deg=[0.0, 45.0, 90.0, 135.0, 180.0, 225.0, 270.0, 315.0],
+    )
+    assert len(cuts["azimuth"]) == 4
+    assert len(cuts["elevation"]) == 8
+    # n_dir keeps reporting the uniform base resolution; a refined trace's
+    # own length governs.
+    assert cuts["n_dir"] == 180
+
+
+def test_angles_are_wrapped_deduped_and_sorted():
+    out = _hertzian()
+    cuts = _pattern_cuts(
+        out, 15.0, 0.0, az_angles_deg=[270.0, -90.0, 10.0, 370.0, 10.0]
+    )
+    # -90 wraps onto 270 and 370 onto 10; both duplicates collapse. The chart
+    # strokes these in order, so an unsorted list would draw a chord across
+    # the pattern.
+    assert cuts["az_angles_deg"] == pytest.approx([10.0, 270.0])
+    assert cuts["az_angles_deg"] == sorted(cuts["az_angles_deg"])
+
+
+def test_below_horizon_samples_still_clamp_to_the_floor():
+    out = _hertzian(ground=True)
+    cuts = _pattern_cuts(out, 15.0, 0.0, elev_angles_deg=[10.0, 190.0, 270.0, 350.0])
+    floor = cuts["floor_dbi"]
+    # t in (180, 360) dips below the horizon on the elevation circle.
+    assert cuts["elevation"][0] > floor
+    assert cuts["elevation"][2] == floor
+
+
+def test_a_refined_elevation_cut_draws_closer_to_the_true_pattern():
+    # The acceptance shape for cuts: same chart geometry, denser sampling,
+    # strictly smaller worst display-space error. Measured with the chart's
+    # own radial map (dBi -> fraction of plot radius, -20 dBi at the origin).
+    out = _hertzian(h=8.0, ground=True)  # many lobes: ~1.1 lambda up
+
+    def deviation(angles_deg, dbi):
+        floor, top = -20.0, max(10.0, np.ceil(max(dbi) + 1.0))
+        frac = np.clip((np.asarray(dbi) - floor) / (top - floor), 0.0, 1.0) * 0.5
+        t = np.radians(angles_deg)
+        p = np.stack([frac * np.cos(t), frac * np.sin(t)], axis=-1)
+        prev, nxt = np.roll(p, 1, axis=0), np.roll(p, -1, axis=0)
+        chord = nxt - prev
+        a = p - prev
+        length = np.hypot(chord[:, 0], chord[:, 1])
+        cross = np.abs(a[:, 0] * chord[:, 1] - a[:, 1] * chord[:, 0])
+        return float(np.max(np.where(length > 0, cross / np.maximum(length, 1e-15), 0)))
+
+    coarse_angles = [(360.0 * i) / 180 for i in range(180)]
+    coarse = _pattern_cuts(out, 15.0, 0.0)["elevation"]
+    fine_angles = [(360.0 * i) / 720 for i in range(720)]
+    fine = _pattern_cuts(out, 15.0, 0.0, elev_angles_deg=fine_angles)["elevation"]
+    assert deviation(fine_angles, fine) < deviation(coarse_angles, coarse)
+
+
+# ---- request plumbing -----------------------------------------------------
+
+
+def test_http_cuts_accepts_explicit_angles_by_solve_id(client: TestClient):
+    result = _ws_solve(client)
+    angles = [0.0, 12.5, 90.0, 181.25, 300.0]
+    r = client.post(
+        "/cuts",
+        json={
+            "solve_id": result["solve_id"],
+            "az_elev_deg": 15.0,
+            "elev_az_deg": 45.0,
+            "elev_angles_deg": angles,
+        },
+    )
+    assert r.status_code == 200
+    cuts = r.json()
+    assert cuts["elev_angles_deg"] == pytest.approx(angles)
+    assert len(cuts["elevation"]) == len(angles)
+    # The azimuth cut was not refined, so it stays uniform and unannotated.
+    assert "az_angles_deg" not in cuts
+    assert len(cuts["azimuth"]) == 180
+
+
+def test_http_cuts_accepts_explicit_angles_in_the_full_body_path(client: TestClient):
+    result = _ws_solve(client)
+    angles = [0.0, 45.0, 90.0]
+    by_id = client.post(
+        "/cuts",
+        json={
+            "solve_id": result["solve_id"],
+            "az_elev_deg": 15.0,
+            "elev_az_deg": 45.0,
+            "az_angles_deg": angles,
+        },
+    )
+    full = client.post(
+        "/cuts",
+        json={
+            "solve": result,
+            "az_elev_deg": 15.0,
+            "elev_az_deg": 45.0,
+            "az_angles_deg": angles,
+        },
+    )
+    # The stateless backstop must answer identically — a pin whose server
+    # session died still refines.
+    assert by_id.status_code == 200 and full.status_code == 200
+    assert by_id.json() == full.json()
+
+
+def test_non_finite_angles_are_rejected():
+    # NaN/inf can't ride JSON at all, so they're pinned at the validator
+    # rather than over the wire — but a hand-rolled client could still hand
+    # them to _pattern_cuts.
+    for bad in ([float("nan")], [float("inf")], [1.0, float("-inf")]):
+        with pytest.raises(ValueError):
+            server._cut_angles(bad)
+
+
+@pytest.mark.parametrize(
+    "angles",
+    ["not-a-list", [1.0, "x"], [True], list(range(721))],
+)
+def test_junk_angle_lists_are_a_400(client: TestClient, angles):
+    result = _ws_solve(client)
+    r = client.post(
+        "/cuts",
+        json={
+            "solve_id": result["solve_id"],
+            "az_elev_deg": 15.0,
+            "elev_az_deg": 45.0,
+            "az_angles_deg": angles,
+        },
+    )
+    assert r.status_code == 400
+
+
+def test_an_empty_angle_list_falls_back_to_the_uniform_circle(client: TestClient):
+    out = _hertzian()
+    cuts = _pattern_cuts(out, 15.0, 0.0, az_angles_deg=[])
+    assert len(cuts["azimuth"]) == 180
+
+
+def test_ws_cuts_channel_carries_explicit_angles(client: TestClient):
+    angles = [0.0, 30.0, 60.0, 200.0]
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(json.dumps(_SOLVE_REQ))
+        result = json.loads(ws.receive_text())
+        ws.send_text(
+            json.dumps(
+                {
+                    "_kind": "cuts",
+                    "solve_id": result["solve_id"],
+                    "az_elev_deg": 15.0,
+                    "elev_az_deg": 45.0,
+                    "az_angles_deg": angles,
+                }
+            )
+        )
+        msg = json.loads(ws.receive_text())
+    assert msg["ok"] is True
+    assert msg["refined"] is True
+    assert msg["cuts"]["az_angles_deg"] == pytest.approx(angles)
+    http = client.post(
+        "/cuts",
+        json={
+            "solve_id": result["solve_id"],
+            "az_elev_deg": 15.0,
+            "elev_az_deg": 45.0,
+            "az_angles_deg": angles,
+        },
+    )
+    assert msg["cuts"] == http.json()
+
+
+def test_ws_refinement_and_a_dial_request_do_not_squash_each_other(
+    client: TestClient,
+):
+    # Latest-wins per solve is right for dial drags, but a refinement asks
+    # for a different thing at the same angles; sharing a slot would lose it
+    # every time the user is still moving.
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(json.dumps(_SOLVE_REQ))
+        result = json.loads(ws.receive_text())
+        base = {
+            "_kind": "cuts",
+            "solve_id": result["solve_id"],
+            "az_elev_deg": 15.0,
+            "elev_az_deg": 45.0,
+        }
+        ws.send_text(json.dumps(base))
+        ws.send_text(json.dumps({**base, "az_angles_deg": [0.0, 90.0, 180.0]}))
+        replies = [json.loads(ws.receive_text()) for _ in range(2)]
+    by_refined = {r["refined"]: r for r in replies}
+    assert set(by_refined) == {False, True}
+    assert len(by_refined[False]["cuts"]["azimuth"]) == 180
+    assert len(by_refined[True]["cuts"]["azimuth"]) == 3
+
+
+def test_the_cuts_source_cache_stays_angle_independent(client: TestClient):
+    # Refinement never re-solves: extra angles run against the cached moment
+    # set, which is why cut refinement takes no lane turn.
+    result = _ws_solve(client)
+    solve_id = result["solve_id"]
+    before = len(server._CUTS_SRC_CACHE)
+    for angles in ([0.0, 1.0], [2.0, 3.0, 4.0], [5.0]):
+        r = client.post(
+            "/cuts",
+            json={
+                "solve_id": solve_id,
+                "az_elev_deg": 15.0,
+                "elev_az_deg": 45.0,
+                "az_angles_deg": angles,
+            },
+        )
+        assert r.status_code == 200
+        assert len(r.json()["azimuth"]) == len(angles)
+    assert len(server._CUTS_SRC_CACHE) == before

--- a/tests/test_refine_acceptance.py
+++ b/tests/test_refine_acceptance.py
@@ -1,0 +1,298 @@
+"""Acceptance scenarios for adaptive refinement (issue #744).
+
+The showcase failures from the issue, measured end to end against the real
+solver rather than against synthetic curves:
+
+  (a) the elevation cut of ``dipoles.invvee`` 15 m up on the 10 m band —
+      ~1.4λ, a 5–6 lobe pattern whose nulls a fixed 180-point circle draws
+      with visible corners;
+  (b) a sharp series resonance on the freq sweep, where the fixed 41-point
+      grid steps straight past the VSWR minimum.
+
+Both are measured in DISPLAY space, with the chart's own maps, as the
+worst chord deviation of the drawn polyline — how far the picture is from
+the curve, in fractions of the plot extent. See lib/refine.ts's
+DEVIATION_TOLERANCE for why that, and not the turn angle, is the criterion:
+a resolved VSWR notch still turns ~177° at its vertex because the true
+curve genuinely spikes there, so a turn-angle target is unreachable on
+exactly the features that motivate refinement.
+
+The planner below MIRRORS src/lib/refine.ts (planRefinement). That file and
+its vitest suite are authoritative for the criterion; this mirror exists so
+the acceptance can be measured against real physics, which only the Python
+side can produce.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+
+import numpy as np
+import pytest
+from starlette.testclient import TestClient
+
+from antennaknobs.web.server import app
+
+DEVIATION_TOLERANCE = 0.003
+MIN_SEGMENT = 0.004
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    return TestClient(app)
+
+
+# ---- display-space measurement (mirrors lib/refine.ts) ---------------------
+
+
+def chord_deviations(pts: np.ndarray, closed: bool) -> np.ndarray:
+    """Perpendicular distance from each vertex to its neighbours' chord —
+    the error the drawn polyline carries there."""
+    prev = np.roll(pts, 1, axis=0)
+    nxt = np.roll(pts, -1, axis=0)
+    chord = nxt - prev
+    a = pts - prev
+    length = np.hypot(chord[:, 0], chord[:, 1])
+    cross = np.abs(a[:, 0] * chord[:, 1] - a[:, 1] * chord[:, 0])
+    dev = np.where(length > 0, cross / np.maximum(length, 1e-300), np.hypot(*a.T))
+    if not closed:
+        dev[0] = dev[-1] = 0.0
+    return dev
+
+
+def max_deviation(pts: np.ndarray, closed: bool) -> float:
+    return float(np.max(chord_deviations(pts, closed)))
+
+
+def plan_refinement(
+    t: list[float],
+    projections: list[np.ndarray],
+    budget: int,
+    closed: bool = False,
+    period: float = 0.0,
+) -> list[float]:
+    """Greedy midpoint insertion into the worst intervals, children scored
+    by the smooth-curve estimate "deviation is O(h²)"."""
+    n = len(t)
+    if budget <= 0 or n < 3:
+        return []
+    devs = np.zeros(n)
+    for p in projections:
+        devs = np.maximum(devs, chord_deviations(p, closed))
+    work = []
+    for j in range(n if closed else n - 1):
+        k = (j + 1) % n
+        b = t[0] + period if k == 0 else t[k]
+        length = max(float(np.hypot(*(p[k] - p[j]))) for p in projections)
+        work.append([t[j], b, max(devs[j], devs[k]), length])
+    out: list[float] = []
+    while len(out) < budget:
+        best, best_score = -1, 0.0
+        for i, (_, _, dev, length) in enumerate(work):
+            if dev <= DEVIATION_TOLERANCE or length <= MIN_SEGMENT:
+                continue
+            if dev > best_score:
+                best, best_score = i, dev
+        if best < 0:
+            break
+        a, b, dev, length = work[best]
+        mid = 0.5 * (a + b)
+        out.append(mid % period if period > 0 else mid)
+        work[best] = [a, mid, dev / 4, length / 2]
+        work.append([mid, b, dev / 4, length / 2])
+    return sorted(out)
+
+
+def cut_projection(dbi, angles_deg) -> np.ndarray:
+    """FarFieldChart's polar map, normalized to a plot extent of 1."""
+    dbi = np.asarray(dbi, dtype=float)
+    top = max(10.0, math.ceil(float(np.max(dbi)) + 1.0))
+    frac = np.clip((dbi - (-20.0)) / (top - (-20.0)), 0.0, 1.0) * 0.5
+    t = np.radians(np.asarray(angles_deg, dtype=float))
+    return np.stack([frac * np.cos(t), frac * np.sin(t)], axis=-1)
+
+
+def sweep_projections(freqs, z_re, z_im, z0=50.0) -> list[np.ndarray]:
+    """SweepChart's linear-MHz x axis with both y domains, plus the Smith
+    Γ locus — the union of everything one sweep array has to draw well."""
+    f = np.asarray(freqs, dtype=float)
+    r = np.asarray(z_re, dtype=float)
+    x = np.asarray(z_im, dtype=float)
+    denom = (r + z0) ** 2 + x**2
+    g_re = (r * r - z0 * z0 + x * x) / denom
+    g_im = (2 * x * z0) / denom
+    g_mag = np.hypot(g_re, g_im)
+    px = (f - f[0]) / (f[-1] - f[0])
+    vswr = np.where(g_mag >= 1, 99.0, np.minimum((1 + g_mag) / (1 - g_mag), 99.0))
+    with np.errstate(divide="ignore"):
+        s11 = np.where(g_mag <= 0, -60.0, np.maximum(20 * np.log10(g_mag), -60.0))
+    return [
+        np.stack([px, np.clip((vswr - 1) / 9, 0, 1)], axis=-1),
+        np.stack([px, np.clip((s11 + 30) / 30, 0, 1)], axis=-1),
+        np.stack([(g_re + 1) / 2, (g_im + 1) / 2], axis=-1),
+    ]
+
+
+# ---- (a) high inverted vee: multi-lobe elevation cut -----------------------
+
+# The frontend's per-cut budget (components/charts/cuts.ts).
+CUT_REFINE_BUDGET = 120
+CUT_REFINE_ROUND_BUDGET = 40
+
+_INVVEE_15M = {
+    "geometry": "dipoles.invvee",
+    "base": 15.0,
+    "measurement_freq_mhz": 28.5,
+    "momwire_model": "bspline",
+    "ground": True,
+    "az_elev_deg": 15.0,
+    "elev_az_deg": 0.0,
+}
+
+
+def _ws_solve(client: TestClient, req: dict) -> dict:
+    """Solves arrive over /ws, not a POST route — same shape the workbench
+    uses, so the cuts the benchmark reads are the ones the UI would draw."""
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(json.dumps(req))
+        return json.loads(ws.receive_text())
+
+
+def test_invvee_15m_elevation_cut_is_multi_lobed(client: TestClient):
+    """Sanity: the benchmark really is the pattern the issue describes."""
+    out = _ws_solve(client, _INVVEE_15M)
+    el = np.asarray(out["cuts"]["elevation"])
+    upper = el[:90]  # t in [0, 180): the above-horizon half
+    lobes = sum(
+        1
+        for i in range(1, len(upper) - 1)
+        if upper[i] > upper[i - 1] and upper[i] > upper[i + 1]
+    )
+    assert 4 <= lobes <= 8, f"expected the 5-6 lobe fan, saw {lobes}"
+
+
+def test_invvee_15m_elevation_cut_refines_under_budget(client: TestClient):
+    solve = _ws_solve(client, _INVVEE_15M)
+    solve_id = solve["solve_id"]
+
+    angles = [(360.0 * i) / 180 for i in range(180)]
+    dbi = solve["cuts"]["elevation"]
+    before = max_deviation(cut_projection(dbi, angles), closed=True)
+
+    spent = 0
+    while spent < CUT_REFINE_BUDGET:
+        budget = min(CUT_REFINE_ROUND_BUDGET, CUT_REFINE_BUDGET - spent)
+        added = plan_refinement(
+            angles,
+            [cut_projection(dbi, angles)],
+            budget,
+            closed=True,
+            period=360.0,
+        )
+        if not added:
+            break
+        spent += len(added)
+        resp = client.post(
+            "/cuts",
+            json={
+                "solve_id": solve_id,
+                "az_elev_deg": 15.0,
+                "elev_az_deg": 0.0,
+                "elev_angles_deg": sorted(angles + added),
+            },
+        )
+        assert resp.status_code == 200
+        cuts = resp.json()
+        angles = cuts["elev_angles_deg"]
+        dbi = cuts["elevation"]
+
+    after = max_deviation(cut_projection(dbi, angles), closed=True)
+    assert spent <= CUT_REFINE_BUDGET
+    assert len(angles) <= 180 + CUT_REFINE_BUDGET
+    # The acceptance claim: the nulls stop reading as corners. Measured
+    # 0.0336 -> 0.0027 of the plot extent for 78 of the 120-point budget
+    # (258 samples) — from ~12 px of error on a 350 px chart to under one.
+    assert after < before / 5, f"refinement barely helped: {before} -> {after}"
+    assert after < 2 * DEVIATION_TOLERANCE
+
+
+# ---- (b) sharp resonance: the VSWR notch on the freq sweep -----------------
+
+# The frontend's sweep budget (lib/sweep.ts).
+SWEEP_REFINE_BUDGET = 48
+SWEEP_REFINE_ROUND_BUDGET = 12
+
+
+def _sweep(client: TestClient, req: dict, freqs: list[float]):
+    resp = client.post("/sweep", json={**req, "freqs_mhz": freqs})
+    assert resp.status_code == 200
+    z_re, z_im = [], []
+    for line in resp.text.splitlines():
+        if not line.strip():
+            continue
+        pt = json.loads(line)
+        if pt.get("done") or pt.get("error"):
+            continue
+        z_re.append(pt["z_re"])
+        z_im.append(pt["z_im"])
+    return z_re, z_im
+
+
+# A narrow, high-Q feed: the inverted vee's own resonance swept over a wide
+# window, so the notch is a small fraction of the span — the shape the fixed
+# grid steps past.
+_SWEEP_REQ = {
+    "geometry": "dipoles.invvee",
+    "measurement_freq_mhz": 28.47,
+    "momwire_model": "bspline",
+}
+
+
+def _vswr_min(z_re, z_im, z0=50.0) -> float:
+    r = np.asarray(z_re)
+    x = np.asarray(z_im)
+    g = np.hypot(
+        (r * r - z0 * z0 + x * x) / ((r + z0) ** 2 + x**2),
+        (2 * x * z0) / ((r + z0) ** 2 + x**2),
+    )
+    return float(np.min(np.where(g >= 1, 99.0, (1 + g) / (1 - g))))
+
+
+def test_sharp_resonance_sweep_refines_the_vswr_notch(client: TestClient):
+    lo, hi = 28.47 * 0.6, 28.47 * 1.6  # deliberately wide: a narrow notch
+    freqs = list(np.exp(np.linspace(math.log(lo), math.log(hi), 41)))
+    z_re, z_im = _sweep(client, _SWEEP_REQ, freqs)
+    before_dev = max(
+        max_deviation(p, closed=False) for p in sweep_projections(freqs, z_re, z_im)
+    )
+    before_vswr = _vswr_min(z_re, z_im)
+
+    spent = 0
+    while spent < SWEEP_REFINE_BUDGET:
+        budget = min(SWEEP_REFINE_ROUND_BUDGET, SWEEP_REFINE_BUDGET - spent)
+        added = plan_refinement(freqs, sweep_projections(freqs, z_re, z_im), budget)
+        if not added:
+            break
+        spent += len(added)
+        add_re, add_im = _sweep(client, {**_SWEEP_REQ, "_refine": True}, added)
+        merged = sorted(zip(freqs + added, z_re + add_re, z_im + add_im, strict=True))
+        freqs = [m[0] for m in merged]
+        z_re = [m[1] for m in merged]
+        z_im = [m[2] for m in merged]
+
+    after_dev = max(
+        max_deviation(p, closed=False) for p in sweep_projections(freqs, z_re, z_im)
+    )
+    after_vswr = _vswr_min(z_re, z_im)
+
+    assert spent <= SWEEP_REFINE_BUDGET
+    assert len(freqs) == 41 + spent
+    # Deeper-or-equal minimum: extra points near resonance can only find a
+    # better match than the grid stepped past.
+    assert after_vswr <= before_vswr + 1e-9
+    # And the picture is strictly better where it was worst: measured
+    # 0.284 -> 0.0029 of the plot extent for 42 of the 48-point budget, i.e.
+    # the notch goes from "not drawn at all" to sub-pixel.
+    assert after_dev < before_dev / 10
+    assert after_dev < 2 * DEVIATION_TOLERANCE

--- a/tests/test_sweep_refine.py
+++ b/tests/test_sweep_refine.py
@@ -1,0 +1,299 @@
+"""Server side of adaptive sweep refinement (issue #744).
+
+Two claims, both structural rather than numeric:
+
+  - a refinement request must not kill the base sweep it is refining. It
+    rides the same /sweep endpoint, so without its own lane kind
+    lane.SAME_KIND_SUPERSEDES would cancel the in-flight base stream
+    regardless of generation — the failure mode would be "refinement
+    deletes the curve".
+  - a refinement request re-issued for the same design and frequencies must
+    perform ZERO engine solves. Counted at the engine, not inferred from
+    latency.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from types import SimpleNamespace
+
+import httpx2
+from fastapi.testclient import TestClient
+
+from antennaknobs.web import server
+from antennaknobs.web.lane import PRIORITY, SAME_KIND_SUPERSEDES
+
+
+class _Counter:
+    """Counts engine sweep calls and the frequencies they were asked for."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.freqs: list[float] = []
+
+
+def _counting_example(counter: _Counter, dwell_s: float = 0.0):
+    def momwire_sweep(req, freqs, cancel=None):
+        counter.calls += 1
+        counter.freqs.extend(freqs)
+        if dwell_s:
+            time.sleep(dwell_s)
+        if cancel is not None:
+            cancel.raise_if_cancelled()
+        return [50.0] * len(freqs), [0.0] * len(freqs)
+
+    return SimpleNamespace(
+        multi_feed=False,
+        count_basis=lambda req: 100,
+        momwire_sweep=momwire_sweep,
+    )
+
+
+def _sweep_lines(resp):
+    return [line for line in resp.text.splitlines() if line.strip()]
+
+
+# ---- lane treatment --------------------------------------------------------
+
+
+def test_refine_is_its_own_lane_kind_that_never_supersedes():
+    # The two properties that make refinement safe to issue while a sweep is
+    # in flight, pinned as data so a future edit to either table trips here.
+    assert PRIORITY["sweep_refine"] > PRIORITY["sweep"]
+    assert "sweep_refine" not in SAME_KIND_SUPERSEDES
+    assert "sweep" in SAME_KIND_SUPERSEDES  # the trap this avoids
+
+
+def test_refinement_does_not_cancel_an_in_flight_base_sweep(monkeypatch):
+    counter = _Counter()
+    first_point_done = threading.Event()
+    release = threading.Event()
+
+    fake = _counting_example(counter)
+    inner = fake.momwire_sweep
+
+    def gated_sweep(req, freqs, cancel=None):
+        out = inner(req, freqs, cancel=cancel)
+        if not req.get("_refine"):
+            # Hold the base sweep's first chunk open until the refinement
+            # request has been issued, so the two genuinely overlap.
+            first_point_done.set()
+            release.wait(5)
+        return out
+
+    fake.momwire_sweep = gated_sweep
+    monkeypatch.setitem(server.EXAMPLES, "fake.refine", fake)
+
+    base = {
+        "geometry": "fake.refine",
+        "_session": "tab-R",
+        "_gen": 7,
+        "freqs_mhz": [14.0, 14.1, 14.2, 14.3, 14.4, 14.5, 14.6, 14.7],
+    }
+    refine = {
+        "geometry": "fake.refine",
+        "_session": "tab-R",
+        "_gen": 7,  # same generation: refinement of THIS design state
+        "_refine": True,
+        "freqs_mhz": [14.05, 14.15],
+    }
+
+    async def main():
+        transport = httpx2.ASGITransport(app=server.app)
+        async with httpx2.AsyncClient(
+            transport=transport, base_url="http://refine-test"
+        ) as c:
+            base_task = asyncio.create_task(c.post("/sweep", json=base))
+            await asyncio.wait_for(asyncio.to_thread(first_point_done.wait), 5)
+            refine_task = asyncio.create_task(c.post("/sweep", json=refine))
+            await asyncio.sleep(0.05)  # let the refine turn queue behind
+            release.set()
+            return await asyncio.wait_for(asyncio.gather(base_task, refine_task), 10)
+
+    base_resp, refine_resp = asyncio.run(asyncio.wait_for(main(), timeout=20))
+    assert base_resp.status_code == 200 and refine_resp.status_code == 200
+    # Every planned point of the base sweep survived — a same-kind
+    # supersession would have truncated the stream here.
+    assert len(_sweep_lines(base_resp)) == 8 + 1
+    assert len(_sweep_lines(refine_resp)) == 2 + 1
+
+
+def test_a_newer_generation_still_supersedes_refinement(monkeypatch):
+    # Refinement opts out of same-kind supersession, NOT out of the
+    # generation rule: a knob drag (a newer generation on the session) must
+    # still cut an in-flight refinement off at its next chunk.
+    counter = _Counter()
+    refining = threading.Event()
+
+    fake = _counting_example(counter)
+    inner = fake.momwire_sweep
+
+    def gated_sweep(req, freqs, cancel=None):
+        if req.get("_refine"):
+            refining.set()
+            deadline = time.time() + 5
+            while cancel is not None and not cancel.cancelled:
+                if time.time() > deadline:
+                    raise AssertionError("never preempted by the newer generation")
+                time.sleep(0.005)
+            cancel.raise_if_cancelled()
+        return inner(req, freqs, cancel=cancel)
+
+    fake.momwire_sweep = gated_sweep
+    monkeypatch.setitem(server.EXAMPLES, "fake.refgen", fake)
+
+    stale = {
+        "geometry": "fake.refgen",
+        "_session": "tab-S",
+        "_gen": 3,
+        "_refine": True,
+        "freqs_mhz": [14.0, 14.1, 14.2, 14.3],
+    }
+    newer = {
+        "geometry": "fake.refgen",
+        "_session": "tab-S",
+        "_gen": 9,
+        "freqs_mhz": [21.0],
+    }
+
+    async def main():
+        transport = httpx2.ASGITransport(app=server.app)
+        async with httpx2.AsyncClient(
+            transport=transport, base_url="http://refine-test"
+        ) as c:
+            stale_task = asyncio.create_task(c.post("/sweep", json=stale))
+            await asyncio.wait_for(asyncio.to_thread(refining.wait), 5)
+            newer_resp = await c.post("/sweep", json=newer)
+            return await asyncio.wait_for(stale_task, 10), newer_resp
+
+    stale_resp, newer_resp = asyncio.run(asyncio.wait_for(main(), timeout=20))
+    assert newer_resp.status_code == 200
+    assert len(_sweep_lines(newer_resp)) == 1 + 1
+    # The stale refinement was cut off: not all four points reached the wire.
+    assert stale_resp.status_code == 200
+    assert len(_sweep_lines(stale_resp)) < 4 + 1
+
+
+# ---- per-frequency solve cache --------------------------------------------
+
+
+def test_second_identical_refinement_solves_nothing(monkeypatch):
+    counter = _Counter()
+    monkeypatch.setitem(server.EXAMPLES, "fake.cache", _counting_example(counter))
+    design = {"geometry": "fake.cache", "_session": "tab-C"}
+    refine = {**design, "_refine": True, "freqs_mhz": [14.05, 14.15, 14.25]}
+    with TestClient(server.app) as c:
+        base = c.post("/sweep", json={**design, "freqs_mhz": [14.0, 14.1, 14.2]})
+        assert base.status_code == 200
+        first = c.post("/sweep", json=refine)
+        assert first.status_code == 200
+        solved_after_first = counter.calls
+        assert counter.freqs.count(14.05) == 1
+
+        second = c.post("/sweep", json=refine)
+
+    assert second.status_code == 200
+    # Same points on the wire, none of them recomputed.
+    assert _sweep_lines(second) == _sweep_lines(first)
+    assert counter.calls == solved_after_first
+    assert counter.freqs.count(14.05) == 1
+
+
+def test_refinement_reuses_the_base_sweep_points_it_overlaps(monkeypatch):
+    # A refinement plan that happens to include a frequency the base sweep
+    # already solved must not re-solve it: every sweep WRITES the cache.
+    counter = _Counter()
+    monkeypatch.setitem(server.EXAMPLES, "fake.overlap", _counting_example(counter))
+    design = {"geometry": "fake.overlap", "_session": "tab-O"}
+    with TestClient(server.app) as c:
+        c.post("/sweep", json={**design, "freqs_mhz": [21.0, 21.1, 21.2]})
+        before = counter.calls
+        r = c.post(
+            "/sweep",
+            json={**design, "_refine": True, "freqs_mhz": [21.0, 21.05, 21.1]},
+        )
+    assert r.status_code == 200
+    assert len(_sweep_lines(r)) == 3 + 1
+    assert counter.freqs.count(21.0) == 1  # solved once, by the base sweep
+    assert counter.freqs.count(21.05) == 1
+    assert counter.calls == before + 1  # one chunk, for the one new freq
+
+
+def test_a_base_sweep_never_reads_the_cache(monkeypatch):
+    # Deliberate asymmetry (see _SWEEP_Z_CACHE): the primary curve is always
+    # re-solved, so a stale entry can never survive in it.
+    counter = _Counter()
+    monkeypatch.setitem(server.EXAMPLES, "fake.fresh", _counting_example(counter))
+    design = {"geometry": "fake.fresh", "_session": "tab-F", "freqs_mhz": [28.0]}
+    with TestClient(server.app) as c:
+        c.post("/sweep", json=design)
+        c.post("/sweep", json=design)
+    assert counter.freqs.count(28.0) == 2
+
+
+def test_cache_key_ignores_metadata_but_not_physics():
+    key = server._sweep_design_key
+    base = {"geometry": "dipoles.invvee", "freqs_mhz": [14.0], "base": 7.0}
+    # Which frequencies were asked for is the other half of the cache key,
+    # never part of the design half.
+    assert key(base) == key({**base, "freqs_mhz": [21.0, 21.1]})
+    # Refinement/lane/cut metadata is blocklisted, so refinement lands on the
+    # same entries a base sweep wrote.
+    assert key(base) == key(
+        {**base, "_refine": True, "_gen": 12, "_session": "x", "az_elev_deg": 40.0}
+    )
+    # Anything physical invalidates — including a field nobody enumerated.
+    assert key(base) != key({**base, "base": 15.0})
+    assert key(base) != key({**base, "future_physics_knob": 1})
+
+
+def test_cache_is_lru_bounded(monkeypatch):
+    monkeypatch.setattr(server, "_SWEEP_Z_CACHE_MAX", 4)
+    monkeypatch.setattr(server, "_SWEEP_Z_CACHE", type(server._SWEEP_Z_CACHE)())
+    for i in range(10):
+        server._sweep_z_put("design", 14.0 + i, (50.0, 0.0, None, None))
+    assert len(server._SWEEP_Z_CACHE) == 4
+    # The four most recent survived; the oldest were evicted.
+    assert server._sweep_z_get("design", 23.0) is not None
+    assert server._sweep_z_get("design", 14.0) is None
+    # Reading refreshes recency, so a re-read entry outlives newer arrivals.
+    server._sweep_z_get("design", 20.0)
+    for i in range(3):
+        server._sweep_z_put("design", 30.0 + i, (50.0, 0.0, None, None))
+    assert server._sweep_z_get("design", 20.0) is not None
+    assert server._sweep_z_get("design", 21.0) is None
+
+
+def test_cached_points_carry_the_per_feed_rows(monkeypatch):
+    # Multi-feed sweeps ship per-feed Z alongside the primary; a cache round
+    # trip must not silently drop them (the frontend indexes them
+    # positionally against freqs_mhz).
+    def momwire_sweep(req, freqs, cancel=None):
+        n = len(freqs)
+        return (
+            [50.0] * n,
+            [0.0] * n,
+            [[50.0, 60.0]] * n,
+            [[0.0, 1.0]] * n,
+        )
+
+    monkeypatch.setitem(
+        server.EXAMPLES,
+        "fake.multifeed",
+        SimpleNamespace(
+            multi_feed=True,
+            count_basis=lambda req: 100,
+            momwire_sweep=momwire_sweep,
+        ),
+    )
+    design = {"geometry": "fake.multifeed", "_session": "tab-M"}
+    with TestClient(server.app) as c:
+        c.post("/sweep", json={**design, "freqs_mhz": [7.0]})
+        cached = c.post("/sweep", json={**design, "_refine": True, "freqs_mhz": [7.0]})
+    import json as _json
+
+    record = _json.loads(_sweep_lines(cached)[0])
+    assert record["feeds_z_re"] == [50.0, 60.0]
+    assert record["feeds_z_im"] == [0.0, 1.0]


### PR DESCRIPTION
## Summary
Implements #744. After the design settles, a refinement pass inserts sample points where the *rendered* polyline is wrong — display-space chord deviation, evaluated against the exact maps the charts draw (linear-MHz x, the active y projection, the polar radial map) — iterating under per-plot budgets.

- **Pure planners** (`lib/refine.ts`): interval scoring by chord deviation (the drawn line's actual error, which vanishes O(h²) on smooth stretches), union across VSWR ∪ S11-dB ∪ Smith for the shared sweep array, midpoint insertion, O(h²) child estimates so one interval can't eat a round's budget, `MIN_SEGMENT` so discontinuities can't eat the total.
- **Sweep refinement**: rides `/sweep` (freq list was always caller-chosen) as a **new lane kind `sweep_refine`** (priority 3, not in `SAME_KIND_SUPERSEDES`) so it can never kill the base sweep it refines; newer knob generations still supersede it. Triggered off the base sweep's clean completion + a second 500 ms dwell; refined points live in the same `sweep` state, so #692 invalidation clears them for free.
- **Per-freq Z cache** (server): keyed `(canonical_solve_key(req − freqs), freq)` so invalidation inherits the #692 blocklist; **every sweep writes, only refinement reads** — read-through on base sweeps would let stale entries into the primary curve and would break the #382 two-sessions-both-compute contract.
- **Cut refinement**: `/cuts` (HTTP + ws) accepts optional `az_angles_deg`/`elev_angles_deg`; the response echoes the parameterisation only when non-uniform, so every pre-#744 response/client stays valid. Server wraps/dedupes/sorts and caps at 720. `FarFieldChart` now imports its radial map from `lib/refine` so planner and chart cannot drift. Documented deviation from the issue: cut refinement takes **no lane turn** — the #551 cuts-source cache holds the moment set, so extra angles are a far-field re-evaluation, not a solve.
- `dipoles.invvee` gains `ui_params` bounds for `base` (1–16 m) so the acceptance scenario is reachable in the UI.

## Measured
- invvee base=15 m, 28.5 MHz elevation cut: max display error **0.0336 → 0.0027** of plot extent (~12 px → <1 px at 350 px), 78/120 budget.
- Sharp-resonance sweep: notch display error **0.284 → 0.0029**, 42/48 budget; refined VSWR minimum deeper (1.1464 → 1.1284).
- Cache: second identical refinement performs **zero engine solves** (counter-asserted).

## Gates
- Python fast lane: **3223 passed** (was 3196) with pynec-accel 1.7.6; ruff check + format clean.
- Frontend: **666/666 vitest** (was 618), `tsc --noEmit` clean, eslint 0 errors — verified on this branch **rebased onto the react-19 + eslint-10 main**.
- Existing residency (#715), signature (#692), lane (#382), and cuts-cache tests green **unmodified**; no pinned constant moved (`_CUT_N_DIR`, `MAX_SWEEP_POINTS`, chunk targets untouched).

## Review notes (session model reviewing an opus builder)
- Read the full diff; re-derived the planner's chord-deviation and wrap-interval math, the abort/dwell ordering (refine timer+controller cleared before `setSweep(null)`), the merge's index-alignment across per-feed rows, and the cache-key blocklist inheritance. No changes needed.
- The builder deviated from the issue on two documented points I endorse: (1) refinement drives on **chord deviation, not turn angle** — turn angle provably never converges on genuinely sharp features (a resolved notch still turns ~177°); chord deviation is the drawn error and reaches tolerance. (2) The issue's "server solve cache" didn't exist; the built one is deliberately write-always/read-on-refine (rationale in `_SWEEP_Z_CACHE`'s comment).
- Builder's env lacked pynec-accel (one unrelated test failed there); I re-ran everything against the real stack — all green, including that test.
- Follow-up candidates (not filed): straddled-feature blindness of any local criterion; base sweeps not reading the cache (deliberate); pinned ghosts never refined.

Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g