### PR TITLE
Wave-hybrid hardening of the MNA reducer: ABCD line stamps, Γ-referenced readout, Touchstone S→Y guard

### DIFF
--- a/src/antennaknobs/designs/wire/sterba_tl.py
+++ b/src/antennaknobs/designs/wire/sterba_tl.py
@@ -32,11 +32,13 @@ Differences from the all-wires `sterba`:
     construction (the all-wires version achieves the same end by current
     cancellation in the offset pair).
 
-Note on the half-wave TL: this engine's nodal TL admittance
-1/(jZ0 sin βl)·[[cos βl,-1],[-1,cos βl]] is SINGULAR at βl = π (length =
-λ/2). The phasing lines are nominally λ/2, so `length_factor` defaults to
-0.99 (TL length ≈ 0.495 λ) to sit just off the singularity. lf = 1.0
-exactly will raise in `network_reduce.tl_admittance_2x2`; keep lf away from 1.0.
+Note on the half-wave TL (amended 2026-08-06, issue #746): the reducer used
+to stamp a line as its nodal admittance 1/(jZ0 sin βl)·[[cos βl,-1],
+[-1,cos βl]], which is SINGULAR at βl = π (length = λ/2) — so `length_factor`
+defaults to 0.99 (TL length ≈ 0.495 λ) to sit just off it. It now stamps the
+chain matrix, which at βl = π is simply [[-1,0],[0,-1]], and lf = 1.0 solves.
+The 0.99 default stays for continuity with the published numbers; it is no
+longer a workaround.
 """
 
 from antennaknobs import AntennaBuilder

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -756,10 +756,13 @@ class MomwireEngine(SimulationEngine):
         return [complex(zi) for zi in z_arr]
 
     def _reduce_at(self, y_real, wavelength):
-        """One frequency's branch stamp + driven-port reduction."""
-        return self._reducer.impedance_from_y(
-            self._reducer.apply_branches(y_real, wavelength)
-        )
+        """One frequency's branch stamp + driven-port reduction.
+
+        Γ-referenced (issue #746) — a sweep is where a design most often walks
+        its own port onto a short or an open, which is exactly what the
+        ideal-generator stamp cannot survive.
+        """
+        return self._reducer.driven_impedance(y_real, wavelength)
 
     def impedance_sweep(self, freqs):
         freqs = np.asarray(freqs, dtype=float)

--- a/src/antennaknobs/network.py
+++ b/src/antennaknobs/network.py
@@ -691,17 +691,22 @@ class BalancedLine:
     radiate; a structure whose riser antenna-mode current matters beyond its
     boundary condition needs real wires.
 
-    Stamped through the shared `NetworkReducer` as a frequency-dependent 4×4
-    Group-1 admittance block (see ``network_reduce.balanced_admittance_4x4``):
-    in differential variables it is an ordinary 2-port TL with z0 = zdiff, so
-    the 4×4 is ``tl_admittance_2x2(zdiff, …)`` expanded through the pair
-    incidence — each 2×2 entry ``y`` becomes the block ``y·[[1,−1],[−1,1]]``;
-    ``zcomm`` adds ``kron(tl_admittance_2x2(zcomm, …), ¼·ones)``, which
-    annihilates differential vectors — the exact even/odd decomposition, no
-    cross-terms, so the differential behaviour is untouched. It reuses that
-    helper's matched-loss model and half-wave singularity guard: a lossless
-    line at exactly k·vf·λ/2 raises, and real open-wire ``k1`` loss
-    regularises the exactly-λ/2 riser physically (no length-factor fudge).
+    Stamped through the shared `NetworkReducer` as one chain-matrix 2-port
+    per mode (issue #746): in differential variables it is an ordinary 2-port
+    TL with z0 = zdiff, carried on the pair incidence (+1, −1) at each end;
+    ``zcomm`` adds a second, orthogonal 2-port on the (½, ½) common-mode
+    incidence — the exact even/odd decomposition, no cross-terms, so the
+    differential behaviour is untouched. ``network_reduce.
+    balanced_admittance_4x4`` is the closed 4×4 form of the same thing, kept
+    as the oracle. A lossless line at exactly k·vf·λ/2 is an ordinary
+    through-line here (the addendum below); real open-wire ``k1`` loss is
+    still worth giving the exactly-λ/2 riser, but for its physics rather than
+    to dodge a pole.
+
+    Addendum 2026-08-06 (issue #746): before the chain-matrix stamp, a
+    lossless k·vf·λ/2 line RAISED — the 4×4 admittance form has a pole
+    there — and designs carried length fudges to avoid it. That is gone; the
+    half-wave case is now the best-conditioned length there is.
 
     **No ``transposed`` flag**: with four explicit terminals a crossover (the
     Sterba's half-twist) is just wiring port B as ``(b2, b1)`` — visible in

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -23,6 +23,16 @@ multiport Y already assumes. Elements that a bare admittance matrix cannot
 represent — ideal voltage sources, ideal shorts, 0 Ω / 0 H series elements —
 become Group-2 unknowns: the branch current joins the solution vector with a
 constitutive row, so no element value is ever inverted.
+
+Issue #746 pushed that principle through the two places it was still being
+violated. Transmission lines are stamped as their CHAIN matrix rather than
+their admittance (two branch currents each), because a k·λ/2 line has no
+admittance matrix at all while its ABCD is [[±1, 0], [0, ±1]]. And the
+impedance/Γ solve stamps each driven port's EMF behind a reference impedance
+rather than pinning the node, because Z_s = 0 is what made a short across the
+port unsolvable — Z = E/j − z_ref is the same answer, Γ comes out natively,
+and an open reads a finite +1 instead of ∞. The excited / far-field solve
+keeps the ideal generator, deliberately: see `excited_state`.
 """
 
 from __future__ import annotations
@@ -66,11 +76,20 @@ NEPER_PER_DB = 1.0 / (20.0 / np.log(10.0))  # 1/8.6859: dB → nepers
 class SingularNetworkError(ValueError):
     """The network has no finite solution at this frequency (issue #647).
 
-    Raised by the construction-time guards (a lossless k·λ/2 line, whose
-    admittance itself is infinite) and by the solve (a network the branches
-    made singular *as a system* — the classic case being a lossless quarter-
-    wave open stub, whose Z_in = 0 shorts the port it hangs on, with every
-    individual stamp perfectly finite).
+    Raised by the solve, when the branches made the system singular even
+    though every individual stamp was finite: a node reachable only through
+    open-circuited branches, or a subnetwork with no return path. Also by the
+    Touchstone conversions, whose poles are the same fact about a description
+    rather than about a circuit.
+
+    Addendum 2026-08-06 (issue #746): the two cases this type was WRITTEN for
+    are gone. A lossless k·λ/2 line raised because the reducer stamped its
+    admittance, which does not exist there; it now stamps the chain matrix,
+    which does. A lossless λ/4 open stub raised because Z_in = 0 shorts the
+    port and an IDEAL generator cannot drive a short; the driven port now sits
+    behind `Z_REF_DEFAULT` and the short is simply the answer. What remains is
+    genuine rank deficiency — and the far-field path, which keeps the ideal
+    generator on purpose and so can still meet the second case.
 
     A `ValueError` subclass so the guards that predate it keep their contract;
     a distinct type so `impedance_sweep` can poison one sample and carry on
@@ -79,14 +98,22 @@ class SingularNetworkError(ValueError):
 
 
 # Reciprocal condition number below which the MNA solve is called singular.
-# 1e-12 is the same threshold the stamp-time guards use for |sinh γl| — one
-# policy for "this is a pole, not a stiff problem".
+# 1e-12 is the same threshold `tl_admittance_2x2` uses for |sinh γl| and the
+# Touchstone conversions for their own inverses — one policy across the
+# package for "this is a pole, not a stiff problem".
 _logger = logging.getLogger(__name__)
 
 RCOND_SINGULAR = 1e-12
 # Between the two, the answer exists but its leading digits are being eaten by
 # the pole; worth saying so, not worth refusing.
 RCOND_SUSPECT = 1e-9
+
+# Source impedance the impedance/Γ solve stamps behind each driven port
+# (issue #746). Z is algebraically independent of it — the readout subtracts
+# it back out — so this is not a physical constant of any design; it is the
+# reference Γ is quoted against, and 50 Ω is the reference every VNA, every
+# `.s1p` and every SWR number in this package already uses.
+Z_REF_DEFAULT = 50.0
 
 
 def _tl_gamma_l(length, wavelength, vf, k1, k2):
@@ -408,13 +435,21 @@ class MNASystem:
     z_chain)`` for the per-port source/load termination branch (see
     ``NetworkReducer.apply_branches``); its current ``j[column]`` is the
     current the termination delivers INTO the node. Kind "v": value is
-    the EMF and the driven impedance is ``emf / j[column]``; kind "i"
-    (forced current, issue #442): value is the forced amps and the
+    the EMF and the driven impedance is ``emf / j[column] − z_ref_at[k]``;
+    kind "i" (forced current, issue #442): value is the forced amps and the
     impedance is ``v_k / j[column] + z_chain``.
     """
 
     def __init__(
-        self, G, elements, terminations, probes=None, diagnose=None, couplings=()
+        self,
+        G,
+        elements,
+        terminations,
+        probes=None,
+        diagnose=None,
+        couplings=(),
+        z_ref=0j,
+        z_ref_at=None,
     ):
         n = G.shape[0]
         m = len(elements)
@@ -452,6 +487,14 @@ class MNASystem:
         self.A = A
         self.rhs = rhs
         self.terminations = terminations
+        # The source impedance the DRIVEN terminations were stamped behind
+        # (issue #746); 0 is the ideal generator. Readouts subtract it back
+        # out, so nothing about the answers depends on the value. `z_ref_at`
+        # is the per-node truth — an undriven, load-only termination gets
+        # none, because a fictitious 50 Ω inside a real load chain would
+        # change the design rather than reference it.
+        self.z_ref = complex(z_ref)
+        self.z_ref_at = dict(z_ref_at or {})
         self.elements = elements
         # (label, kind, payload) probes for the power budget (issue #299):
         # kind "group1" → payload (node_idx_list, stamped Y block);
@@ -520,21 +563,24 @@ class MNASystem:
             # dissipation and the other half negative.
             idx, r = payload
             return 0.5 * float(r) * float(abs(j[idx])) ** 2
-        # termination: the Load part of the source/load branch at node k.
+        # termination: the Load part of the source/load branch at node k. The
+        # z_ref the driven stamp sits behind is a modelling reference, not a
+        # resistor in the design, so its share of the drop comes back out.
         col, e, tkind, z_chain = self.terminations[payload]
         if tkind == "i":
             return 0.5 * float(np.real(z_chain)) * float(abs(j[col])) ** 2
-        return 0.5 * float(np.real((e - v[payload]) * np.conj(j[col])))
+        drop = e - v[payload] - self.z_ref_at.get(payload, 0j) * j[col]
+        return 0.5 * float(np.real(drop * np.conj(j[col])))
 
     def solve(self):
         """Solve once (cached); returns ``(v, j)``.
 
         Uses LAPACK's expert driver rather than a bare ``np.linalg.solve``,
         because the failure this guards against is usually not an exception
-        (issue #647). A lossless quarter-wave open stub puts a dead short
-        across its port: exactly on the pole the system is singular, but a few
-        kHz off it is merely *nearly* singular, and a plain solve answers with
-        enormous, meaningless numbers and no complaint at all.
+        (issue #647): a nearly-singular system answers with enormous,
+        meaningless numbers and no complaint at all. That is worth catching
+        for any cause — a floating subnetwork, contradictory sources, or the
+        ideal-generator excitation the far-field path still uses.
 
         The subtlety is that a raw condition number is useless here. An MNA
         matrix mixes admittance rows with unit-valued constitutive rows, so a
@@ -581,9 +627,13 @@ class MNASystem:
 def poison_singular_sample(fn, *args, where="", **kwargs):
     """Run a per-frequency reduction, returning NaNs if it is singular (#647).
 
-    A sweep is a series of independent questions, and one of them landing
-    exactly on a lossless line's pole is no reason to lose the answers to the
-    other forty. The bad sample becomes NaN — which the web adapter already
+    A sweep is a series of independent questions, and one of them landing on a
+    topology with no solution is no reason to lose the answers to the other
+    forty. (Issue #746 removed the lossless-line poles that used to be the
+    common cause; what is left is genuine rank deficiency — a node reachable
+    only through opens — which no frequency shift dissolves, so a whole sweep
+    of a broken design now poisons every sample rather than one.) The bad
+    sample becomes NaN — which the web adapter already
     converts to its ``Z_OPEN_OHMS`` JSON sentinel, and which every plotting
     path already skips — and the reason is logged once, with the same
     attribution a single-point solve would have raised.
@@ -702,9 +752,13 @@ class NetworkReducer:
         Anything with real loss is skipped, because loss is what regularises
         it, and that is also the remedy the message recommends.
 
-        The k·λ/2 half of this walk is gone (issue #746): a line between two
-        live nodes is now stamped as its chain matrix, which is finite at
-        every length, so a half-wave line is no longer a cause of anything.
+        Issue #746 narrowed this to one caller and one branch. The k·λ/2 half
+        of the walk is gone: a line between two live nodes is stamped as its
+        chain matrix now, finite at every length. The odd-λ/4 half survives
+        because the EXCITED path keeps the ideal generator, which still cannot
+        drive the dead short an open stub puts across the feed — so when this
+        text appears it is a far-field / power-budget solve talking, and the
+        impedance of that same design is a perfectly good Z = 0.
         """
         f_mhz = C_LIGHT / wavelength / 1e6
         open_nodes = self._open_ended_nodes()
@@ -739,7 +793,9 @@ class NetworkReducer:
                     f"  {name}open-ended line {'→'.join(str(e) for e in ends)} "
                     f"is {n_half / 2:.4f} λ at {f_mhz:.4f} MHz — an odd "
                     "multiple of λ/4, where an open stub's Z_in = 0 shorts "
-                    f"the port it hangs on (z0 = {z0:g} Ω)"
+                    f"the port it hangs on (z0 = {z0:g} Ω), which no IDEAL "
+                    "source can drive — the impedance of this same design is "
+                    "a perfectly ordinary Z = 0"
                 )
         if not suspects:
             return (
@@ -753,11 +809,53 @@ class NetworkReducer:
             + "\n".join(suspects)
             + "\nGive the line the loss it really has (k1/k2, or cable=...): "
             "any real attenuation moves the pole off the real axis and the "
-            "solve becomes well-posed."
+            "excitation becomes well-posed."
         )
 
-    def apply_branches(self, Y_real, wavelength):
+    def _reference_node(self):
+        """The one port node a ``z_ref`` may be stamped behind, or ``None``.
+
+        A reference plane is a one-port idea: it needs the rest of the network,
+        seen from this port, to be PASSIVE. Then moving the generator behind an
+        impedance changes the operating point but not the ratio, and
+        Z = E/j − z_ref is exactly the ideal generator's answer.
+
+        A second *active* source breaks that, and not subtly. With two voltage
+        generators, port 0's mutual term y01·E1 is a current injection fixed
+        independently of v0, so any source impedance at port 0 changes v0/i0
+        itself — measured 23 % on the two-source fixture in test_network_mna.
+        A `DrivenCurrent` elsewhere does the same. This package's contract is
+        the classical driven-array Z_k = V_k/I_k at the ideal operating point,
+        so a network with more than one active source keeps the ideal stamp
+        and converts Γ from Z the way `sweep` already does.
+
+        A source at exactly 0 V is not active: `Driven(port, 0)` is the datum
+        trick, a hard V = 0 pin, and it leaves the rest passive. It also never
+        gets the reference itself — with no EMF there is no incident wave, so
+        its Γ is undefined rather than badly conditioned.
+        """
+        active = [
+            (k, kind)
+            for k, kind, val in zip(
+                self.driven_port_idx, self._source_kinds, self._source_values
+            )
+            if val != 0
+        ]
+        if len(active) != 1 or active[0][1] != "v":
+            return None
+        return active[0][0]
+
+    def apply_branches(self, Y_real, wavelength, *, z_ref=0j):
         """Stamp the antenna Y and every network branch into one MNA system.
+
+        ``z_ref`` is the source impedance the driven port's EMF sits behind
+        (issue #746). The default 0 is the historical ideal generator, which
+        the excited / far-field path keeps because its port voltages ARE the
+        excitation; the impedance and Γ paths pass ``Z_REF_DEFAULT``. See
+        :meth:`excited_state` for why the two solves are separate and
+        :meth:`_reference_node` for the one network shape it applies to — a
+        request to reference a network that has no reference plane is honored
+        as "quote Γ against this z0", not stamped.
 
         Group 1 (node-admittance block G):
           - the antenna's dense multiport short-circuit Y at the real-feed
@@ -775,11 +873,12 @@ class NetworkReducer:
           - one TERMINATION branch per port that is driven and/or loaded:
             an EMF (0 if undriven) in series with the port's Load impedance
             (0 if unloaded) from the datum into the node. Its constitutive
-            row v_k + Z_L·j = E is the Thevenin boundary condition, and its
-            current j is the delivered port current — so the driven-point
-            impedance E/j and the load dissipation (E − v_k)·j* both read
-            off the solution. Driven-only ports (Z_L = 0) degenerate to the
-            ideal voltage-source pin v_k = E; loaded-only ports (E = 0) to
+            row v_k + (z_ref + Z_L)·j = E is the Thevenin boundary condition,
+            and its current j is the delivered port current — so the
+            driven-point impedance E/j − z_ref and the load dissipation
+            (E − v_k − z_ref·j)·j* both read off the solution. With the
+            ideal-generator z_ref = 0 a driven-only port (Z_L = 0) degenerates
+            to the voltage-source pin v_k = E; loaded-only ports (E = 0) to
             the series load termination v_k = −Z_L·j. A `Load` is thus a
             series impedance between the antenna gap and the common return,
             matching NEC2's ld_card physics.
@@ -1130,6 +1229,8 @@ class NetworkReducer:
                 "current source is contradictory — drive the port one way"
             )
         terminations = {}
+        z_ref_at = {}
+        z_ref_node = self._reference_node() if z_ref else None
         for k in sorted(set(emf) | set(forced) | set(loads_by_node)):
             loads = loads_by_node.get(k, [])
             zs = [load_impedance(br, omega) for br in loads]
@@ -1153,18 +1254,35 @@ class NetworkReducer:
                     probes.append((f"Load {'+'.join(names)}", "termination", k))
                 continue
             e = emf.get(k, 0j)
+            # Γ-referenced source (issue #746): a DRIVEN port's EMF sits behind
+            # z_ref instead of pinning its node, which is the difference
+            # between an ideal generator and a real one on a real feedline. The
+            # answer Z = E/j − z_ref is algebraically independent of z_ref;
+            # what changes is the conditioning, because Z_s = 0 is what made a
+            # dead short across the port (a lossless λ/4 open stub, a k·λ/2
+            # shorted one) unsolvable rather than simply Γ = −1. Undriven,
+            # load-only terminations get NO z_ref — a fictitious 50 Ω inside a
+            # real load chain would be a modelling error, not a reference —
+            # and neither does any port but the one reference node.
+            zr = complex(z_ref) if k == z_ref_node else 0j
+            if zr:
+                z_ref_at[k] = zr
             if len(loads) == 1 and loads[0].parallel:
                 # Parallel-LC trap: the tank admittance is the finite
                 # quantity (→ 0 at resonance, the intended open circuit);
-                # the impedance form would blow up there.
+                # the impedance form would blow up there. Putting z_ref in
+                # series is y → y/(1 + z_ref·y), which stays finite at both
+                # ends (→ 0 at resonance, → 1/z_ref for a shorted tank).
                 y = load_series_admittance(loads[0], omega)
+                y = y / (1.0 + zr * y)
                 el = _Group2Element(None, k, c_v=y, c_j=1.0 + 0j, e=y * e)
             elif all(np.isfinite(z) for z in zs):
                 # Series composition of every load (plus the EMF). Includes
                 # the no-load case z = 0: an ideal voltage-source pin.
-                el = _Group2Element(None, k, c_v=1.0 + 0j, c_j=sum(zs, 0j), e=e)
+                el = _Group2Element(None, k, c_v=1.0 + 0j, c_j=sum(zs, zr), e=e)
             else:
-                # A chain containing an at-resonance trap is an open.
+                # A chain containing an at-resonance trap is an open — z_ref in
+                # series with an open is still an open, and its Γ is +1.
                 el = _Group2Element(None, k, c_v=0j, c_j=1.0 + 0j, e=0j)
             terminations[k] = (len(elements), e, "v", 0j)
             elements.append(el)
@@ -1179,6 +1297,8 @@ class NetworkReducer:
             probes=probes,
             diagnose=lambda wl=wavelength: self._singularity_report(wl),
             couplings=couplings,
+            z_ref=z_ref,
+            z_ref_at=z_ref_at,
         )
 
     def _physical_port_voltages(self, v):
@@ -1236,6 +1356,25 @@ class NetworkReducer:
 
             p_in   = ½ Σ Re(E_k · j_k*)          (E = 0 terms vanish)
 
+        This path deliberately keeps the IDEAL-generator stamp (``z_ref = 0``)
+        while the impedance/Γ path uses `Z_REF_DEFAULT` — a second solve, not
+        an rcond-triggered fallback (issue #746). Two reasons. The port
+        voltages here *are* the excitation forced into the MoM solver and the
+        normaliser p_in = ½ΣRe(E·j*) is defined at the source terminals, so a
+        source impedance would divide the drive and rescale every gain in the
+        package. And a fallback would make those numbers depend on a
+        conditioning threshold — the same design at two frequencies either
+        side of it would report gains normalised differently, silently. The
+        cost is one extra (n_ports + n_branches)-sized zgesvx per solve, which
+        is nothing beside the MoM factorisation that produced Y, and the two
+        systems were already assembled separately anyway.
+
+        The consequence to know: a topology that shorts the driven port (a
+        lossless λ/4 open stub across the feed) now has a perfectly good
+        impedance answer, Z = 0 / Γ = −1, and still has no far field — the
+        current an ideal source drives into a dead short is unbounded, so
+        there is nothing to normalise against. That asymmetry is physical.
+
         Reactive elements burn nothing and report ~0 in the budget.
         Efficiency counts EVERY dissipative network branch — resistive
         TwoPort/Shunt elements and lossy TLs included (issue #299; the
@@ -1269,9 +1408,10 @@ class NetworkReducer:
 
     def impedance_from_y(self, system):
         """Driven-point impedance per Driven source from an `apply_branches`
-        result: Z = E / j_term, the termination EMF over its delivered
-        current — read straight off the solution vector, no Y·V
-        post-multiply."""
+        result: Z = E / j_term − z_ref, the termination EMF over its delivered
+        current less the source impedance it was stamped behind — read
+        straight off the solution vector, no Y·V post-multiply. ``z_ref`` is 0
+        for the ideal-generator stamp, so this is the historical E/j there."""
         v, j = system.solve()
         out = []
         for k, kind in zip(self.driven_port_idx, self._source_kinds):
@@ -1280,7 +1420,8 @@ class NetworkReducer:
                 # Forced-current port (issue #442): the source impedance is
                 # the gap voltage over the forced current, plus the series
                 # load chain it drives through — mirroring how the voltage
-                # form's E/j includes its series loads.
+                # form's E/j includes its series loads. A current source is
+                # its own reference (Z_s = ∞), so z_ref never applies here.
                 if j[col] == 0:
                     out.append(complex(float("inf"), 0.0))
                 else:
@@ -1292,13 +1433,78 @@ class NetworkReducer:
                 # which is an open, not an absent element). The physical
                 # driving-point impedance is ∞; report it as a clean real
                 # infinity instead of dividing by zero (numpy would warn
-                # and produce inf+nanj). Issue #289.
+                # and produce inf+nanj). Issue #289. Its Γ is a finite +1,
+                # which is the whole argument for emitting Γ as well.
                 out.append(complex(float("inf"), 0.0))
             else:
-                out.append(complex(e / j[col]))
+                out.append(complex(e / j[col] - system.z_ref_at.get(k, 0j)))
         return out
 
-    def driven_impedance(self, Y_real, wavelength):
+    def reflection_from_y(self, system):
+        """Driven-port reflection coefficient Γ, referenced to the ``z_ref``
+        the system was stamped with (issue #746).
+
+        Γ = (2·v_ref − E)/E with v_ref = E − z_ref·j the voltage at the
+        reference plane — the junction between the source impedance and
+        whatever the port drives. For an unloaded port that plane IS the port
+        node, so this is literally (2·v_k − E)/E; with a series `Load` the
+        plane sits ahead of the load, matching `impedance_from_y`'s contract
+        that Z includes the load chain.
+
+        Read this way Γ never has a pole. The two cases that break Z break it
+        by dividing: a shorted port (a lossless λ/4 open stub, a k·λ/2 shorted
+        one) is Γ = −1, and an open port — where j is exactly 0 and Z is
+        reported as ∞ — is Γ = +1 exactly, no sentinel and no clamp.
+
+        A forced-current port has no z_ref (Z_s = ∞ is its reference), so its
+        Γ is converted from Z; that conversion is the one that can still meet
+        an infinity, and it maps to Γ = +1 by the same limit.
+        """
+        z_ref = system.z_ref
+        if z_ref == 0:
+            raise ValueError(
+                "Γ is undefined for an ideal-generator solve (z_ref = 0): the "
+                "reference plane has no impedance to reflect against. Stamp "
+                "with apply_branches(..., z_ref=...) — driven_reflection() does"
+            )
+        _v, j = system.solve()
+        out = []
+        for k, kind, z in zip(
+            self.driven_port_idx, self._source_kinds, self.impedance_from_y(system)
+        ):
+            col, e, _tkind, _z_chain = system.terminations[k]
+            zr = system.z_ref_at.get(k)
+            if kind == "i" or zr is None:
+                # No reference plane at this port: a forced-current source is
+                # its own reference (Z_s = ∞), and a 0 V pin has no incident
+                # wave. Fall back to the definition, which meets an infinity
+                # only at a true open — Γ = +1 by the same limit.
+                out.append(
+                    complex(1.0, 0.0)
+                    if not np.isfinite(z)
+                    else complex((z - z_ref) / (z + z_ref))
+                )
+                continue
+            out.append(complex((2.0 * (e - zr * j[col]) - e) / e))
+        return out
+
+    def driven_impedance(self, Y_real, wavelength, *, z_ref=None):
         """Convenience: stamp branches onto the raw real-port Y and reduce
-        to the driven-port impedance(s) in one call."""
-        return self.impedance_from_y(self.apply_branches(Y_real, wavelength))
+        to the driven-port impedance(s) in one call.
+
+        Uses the Γ-referenced source stamp by default (issue #746). Z is
+        algebraically independent of ``z_ref`` — what it buys is a system that
+        stays well-conditioned when the port is shorted or opened, which the
+        ideal generator does not.
+        """
+        z_ref = Z_REF_DEFAULT if z_ref is None else z_ref
+        return self.impedance_from_y(
+            self.apply_branches(Y_real, wavelength, z_ref=z_ref)
+        )
+
+    def driven_reflection(self, Y_real, wavelength, *, z_ref=None):
+        """Convenience: driven-port Γ referenced to ``z_ref`` in one call."""
+        z_ref = Z_REF_DEFAULT if z_ref is None else z_ref
+        return self.reflection_from_y(
+            self.apply_branches(Y_real, wavelength, z_ref=z_ref)
+        )

--- a/src/antennaknobs/network_reduce.py
+++ b/src/antennaknobs/network_reduce.py
@@ -89,9 +89,50 @@ RCOND_SINGULAR = 1e-12
 RCOND_SUSPECT = 1e-9
 
 
+def _tl_gamma_l(length, wavelength, vf, k1, k2):
+    """Complex propagation γ·length = (α + jβ)·length.
+
+    β = 2π/(vf·λ); α comes from the cable-table matched-loss model
+    k1·√f_MHz + k2·f_MHz in dB per 100 ft (see `network.TL`). Shared by the
+    admittance and chain-matrix forms so the two can never disagree about
+    what line they describe.
+    """
+    beta = 2.0 * np.pi / (vf * wavelength)
+    f_mhz = C_LIGHT / wavelength / 1e6
+    loss_db_per_100ft = k1 * np.sqrt(f_mhz) + k2 * f_mhz
+    alpha = loss_db_per_100ft * NEPER_PER_DB * FEET_PER_M / 100.0  # nepers/m
+    return (alpha + 1j * beta) * length
+
+
+def tl_abcd(z0, length, wavelength, vf=1.0, k1=0.0, k2=0.0):
+    """Ideal-TL chain (ABCD) matrix ``(A, B, C, D)`` — the reducer's stamp
+    (issue #746).
+
+        [v_a; i_a] = [[cosh γl, Z0 sinh γl], [sinh γl / Z0, cosh γl]] · [v_b; i_b]
+
+    with i_a into port A and i_b out of port B. Every entry is an entire
+    function of γl, so unlike `tl_admittance_2x2` — the same line, written as
+    the ratio 1/(Z0 sinh γl) — this has no pole anywhere: at the lossless
+    k·λ/2 point it is exactly [[±1, 0], [0, ±1]], the through-line the
+    admittance description cannot spell because its currents are unconstrained
+    by its voltages there. That is the whole reason the reducer carries two
+    Group-2 currents per line instead of a 2×2 Group-1 block.
+
+    A crossed ("half-twist") line is NOT a flag here: it is port B's weights
+    negated where the pair is stamped, which is what a polarity inversion is.
+    """
+    gl = _tl_gamma_l(length, wavelength, vf, k1, k2)
+    sh, ch = np.sinh(gl), np.cosh(gl)
+    return ch, z0 * sh, sh / z0, ch
+
+
 def tl_admittance_2x2(z0, length, wavelength, transposed=False, vf=1.0, k1=0.0, k2=0.0):
     """Ideal-TL nodal admittance between its two terminals — lossless or
     lossy (issue #297).
+
+    No longer what the reducer stamps (issue #746 moved that to `tl_abcd`);
+    kept as the closed-form 2×2 that composition oracles and the balanced
+    4×4's even/odd decomposition are written against.
 
     For complex propagation γl = (α + jβ)·length with β = 2π/(vf·λ):
         Y_TL = 1/(Z0 sinh γl) · [[cosh γl, -1], [-1, cosh γl]]
@@ -101,8 +142,10 @@ def tl_admittance_2x2(z0, length, wavelength, transposed=False, vf=1.0, k1=0.0, 
     model k1·√f_MHz + k2·f_MHz in dB per 100 ft (see `network.TL`).
 
     Singular only for an exactly-lossless half-wavelength multiple
-    (sinh γl = 0 requires α = 0); raise rather than return garbage so
-    callers can pick a different length. Any nonzero loss regularizes it.
+    (sinh γl = 0 requires α = 0), where the line HAS no admittance matrix;
+    raise rather than return garbage. This is a statement about the
+    description, not about the physics — the reducer solves that same line
+    through `tl_abcd` without complaint.
 
     `transposed=True` models a crossed ("half-twist") line: port B's
     polarity is inverted, which flips the sign of the off-diagonal
@@ -111,17 +154,16 @@ def tl_admittance_2x2(z0, length, wavelength, transposed=False, vf=1.0, k1=0.0, 
     ZL-Special). Note it is NOT the same as a negative z0, which would
     (wrongly) negate the diagonal self terms too.
     """
-    beta = 2.0 * np.pi / (vf * wavelength)
-    f_mhz = C_LIGHT / wavelength / 1e6
-    loss_db_per_100ft = k1 * np.sqrt(f_mhz) + k2 * f_mhz
-    alpha = loss_db_per_100ft * NEPER_PER_DB * FEET_PER_M / 100.0  # nepers/m
-    gl = (alpha + 1j * beta) * length
+    gl = _tl_gamma_l(length, wavelength, vf, k1, k2)
     sh, ch = np.sinh(gl), np.cosh(gl)
     if abs(sh) < 1e-12:
+        f_mhz = C_LIGHT / wavelength / 1e6
         raise SingularNetworkError(
             f"lossless TL length {length} is ~k·vf·λ/2 at "
-            f"f={f_mhz:.4f} MHz (sinh γl ≈ 0); admittance is singular — give "
-            "the line the loss it really has (k1/k2, or cable=...)"
+            f"f={f_mhz:.4f} MHz (sinh γl ≈ 0); the admittance is singular "
+            "there because the line has no admittance matrix at all — ask for "
+            "its chain matrix (`tl_abcd`) instead, which is what the reducer "
+            "stamps and which stays finite"
         )
     scale = 1.0 / (z0 * sh)
     off = 1.0 if transposed else -1.0
@@ -146,8 +188,12 @@ def balanced_admittance_4x4(
     zdiff, length, wavelength, vf=1.0, k1=0.0, k2=0.0, zcomm=None
 ):
     """Balanced two-conductor TL nodal admittance (issues #575/#576) — a 4×4
-    Group-1 block over the terminal order ``(a1, a2, b1, b2)`` (port A =
-    (a1, a2), port B = (b1, b2)).
+    block over the terminal order ``(a1, a2, b1, b2)`` (port A = (a1, a2),
+    port B = (b1, b2)).
+
+    The closed form of the even/odd decomposition, and the oracle the
+    reducer's per-mode chain-matrix stamp is checked against; it is no longer
+    itself the stamp (issue #746).
 
     In differential variables the element is an ordinary 2-port TL with
     z0 = ``zdiff``, so the differential block is that 2×2 expanded through the
@@ -173,8 +219,9 @@ def balanced_admittance_4x4(
     when (and how honestly) a CM path can be modelled at all.
 
     Inherits `tl_admittance_2x2`'s matched-loss model and its half-wave
-    singularity guard — a lossless line at exactly k·vf·λ/2 raises; real
-    open-wire ``k1`` loss regularises it. Grounding conductor 2 at both ends
+    singularity — a lossless line at exactly k·vf·λ/2 has no admittance
+    matrix, so this raises there while the reducer solves it. Grounding
+    conductor 2 at both ends
     (dropping rows/cols a2, b2) collapses the ``zcomm=None`` stamp exactly
     back to that 2×2."""
     y2 = tl_admittance_2x2(zdiff, length, wavelength, vf=vf, k1=k1, k2=k2)
@@ -235,6 +282,15 @@ class _Group2Element:
     pins kc = c_vc = −n (the row equals the current column, as for a/b), so
     the ideal element is lossless. ``c=None`` (the default) is a plain
     two-terminal branch, bit-identical to before.
+
+    Arbitrary arity (issue #746, the chain-matrix lines): ``terms`` — a
+    sequence of ``(node, k, c_v)`` triples with the same meanings (``k·j``
+    leaves ``node``; ``c_v·v_node`` appears in the constitutive row) —
+    REPLACES a/b/c entirely when set. A `BalancedLine`'s differential
+    chain-matrix row spans four terminals (a1, a2, b1, b2), one more than
+    the a/b/c form can name, and a chain matrix also needs terminals whose
+    voltage it senses without drawing current (k = 0) — neither fits the
+    two-scaling shape above.
     """
 
     a: int | None
@@ -249,6 +305,59 @@ class _Group2Element:
     c: int | None = None
     kc: complex = 0j
     c_vc: complex = 0j
+    terms: tuple[tuple[int, complex, complex], ...] | None = None
+
+
+def _stamp_abcd(elements, couplings, port_a, port_b, abcd):
+    """Stamp a 2-port given by its chain matrix; return its power-probe leg.
+
+    ``port_a`` / ``port_b`` are ``[(node, weight), ...]``: the port voltage is
+    ``Σ w·v_node`` and the port current ``j`` leaves each node as ``w·j``. One
+    weight list per port is a congruence, so the port pair carries exactly the
+    power ``v·j`` however many terminals it spans — which is what lets the
+    same routine stamp a coax (``[(a, 1)]`` / ``[(b, 1)]``), a crossed line
+    (``[(b, −1)]`` — a polarity inversion IS a negated weight), and a balanced
+    pair's differential (``[(a1, 1), (a2, −1)]``) and common (``[(a1, ½),
+    (a2, ½)]``) modes, whose incidences are orthogonal.
+
+    Two auxiliary currents, j₁ into port A and j₂ out of port B, with the
+    chain relations as their constitutive rows::
+
+        v_a − A·v_b − B·j₂ = 0
+        j₁  − C·v_b − D·j₂ = 0
+
+    Both rows stay finite for every line length, which the 2×2 admittance
+    block they replace does not (issue #746). The j₂ terms are the only
+    off-diagonal entries in the branch-current block, so they ride the
+    ``couplings`` channel added for the Autotransformer (issue #594).
+    """
+    a_, b_, c_, d_ = abcd
+    i1, i2 = len(elements), len(elements) + 1
+    elements.append(
+        _Group2Element(
+            None,
+            None,
+            c_v=0j,
+            c_j=0j,
+            e=0j,
+            # v_a with its own current's incidence; v_b sensed, no current.
+            terms=tuple([(n, w, w) for n, w in port_a])
+            + tuple((n, 0j, -a_ * w) for n, w in port_b),
+        )
+    )
+    elements.append(
+        _Group2Element(
+            None,
+            None,
+            c_v=0j,
+            c_j=-d_,
+            e=0j,
+            terms=tuple((n, -w, -c_ * w) for n, w in port_b),
+        )
+    )
+    couplings.append((i1, i2, -b_))
+    couplings.append((i2, i1, 1.0 + 0j))
+    return (i1, i2, tuple(port_a), tuple(port_b))
 
 
 def magnetizing_impedance(br, omega):
@@ -314,15 +423,22 @@ class MNASystem:
         rhs = np.zeros(n + m, dtype=np.complex128)
         for x, el in enumerate(elements):
             col = n + x
-            if el.a is not None:
-                A[el.a, col] += el.ka  # ka·j leaves node a
-                A[col, el.a] += -el.c_v if el.c_va is None else el.c_va
-            if el.b is not None:
-                A[el.b, col] -= el.kb  # kb·j enters node b
-                A[col, el.b] += el.c_v if el.c_vb is None else el.c_vb
-            if el.c is not None:
-                A[el.c, col] += el.kc  # kc·j leaves node c (third terminal)
-                A[col, el.c] += el.c_vc
+            if el.terms is not None:
+                # Arbitrary-arity form (issue #746): the a/b/c fields are not
+                # consulted at all.
+                for node, k, c_v in el.terms:
+                    A[node, col] += k  # k·j leaves this node
+                    A[col, node] += c_v
+            else:
+                if el.a is not None:
+                    A[el.a, col] += el.ka  # ka·j leaves node a
+                    A[col, el.a] += -el.c_v if el.c_va is None else el.c_va
+                if el.b is not None:
+                    A[el.b, col] -= el.kb  # kb·j enters node b
+                    A[col, el.b] += el.c_v if el.c_vb is None else el.c_vb
+                if el.c is not None:
+                    A[el.c, col] += el.kc  # kc·j leaves node c (third terminal)
+                    A[col, el.c] += el.c_vc
             A[col, col] = el.c_j
             rhs[col] = el.e
         # Mutual coupling between two Group-2 rows (issue #594): an
@@ -382,6 +498,19 @@ class MNASystem:
             if el.c is not None:
                 p += v[el.c] * np.conj(el.kc * j[payload])
             return 0.5 * float(np.real(p))
+        if kind == "group2abcd":
+            # Chain-matrix 2-port (issue #746): power IN at port A minus power
+            # OUT at port B, ½Re(v_a·j₁* − v_b·j₂*), with the port voltages
+            # read through the same weights that distribute the port currents.
+            # A lossless line reports ~0; a lossy one its attenuation. The
+            # payload is a tuple of legs because a BalancedLine carrying a
+            # common-mode path is TWO orthogonal 2-ports under one label.
+            total = 0.0
+            for i1, i2, port_a, port_b in payload:
+                va = sum(w * v[node] for node, w in port_a)
+                vb = sum(w * v[node] for node, w in port_b)
+                total += 0.5 * float(np.real(va * np.conj(j[i1]) - vb * np.conj(j[i2])))
+            return total
         if kind == "group2r":
             # Resistive dissipation ONLY (issue #594). The generic "group2"
             # probe reads ½Re((v_a − v_b)·j*), which for a mutually-coupled
@@ -568,11 +697,14 @@ class NetworkReducer:
 
         Attribution rather than a bare "matrix is singular": a lossless line
         is singular at a *specific* electrical length, so the walk asks each
-        lossless line how close it sits to its own pole — k·λ/2 for a line
-        between two live nodes (no finite admittance), odd λ/4 for one hanging
-        open (Z_in = 0, a dead short across the port it hangs on). Anything
-        with real loss is skipped, because loss is exactly what regularises
-        both, and that is also the remedy the message recommends.
+        lossless line how close it sits to its own pole — an odd λ/4 for one
+        hanging open (Z_in = 0, a dead short across the port it hangs on).
+        Anything with real loss is skipped, because loss is what regularises
+        it, and that is also the remedy the message recommends.
+
+        The k·λ/2 half of this walk is gone (issue #746): a line between two
+        live nodes is now stamped as its chain matrix, which is finite at
+        every length, so a half-wave line is no longer a cause of anything.
         """
         f_mhz = C_LIGHT / wavelength / 1e6
         open_nodes = self._open_ended_nodes()
@@ -591,33 +723,24 @@ class NetworkReducer:
                 continue
             if k1 or k2:
                 continue  # a lossy line has no pole to sit on
-            wl_line = wavelength * vf
-            n_half = br.length / (0.5 * wl_line)  # length in half-wavelengths
             hanging = any(
                 self.port_to_idx.get(e) in open_nodes
                 for e in ends
                 if isinstance(e, str)
             )
-            name = f"{path[:-1]}: " if path else ""
-            if hanging:
-                # Odd quarter-waves: n_half at an odd multiple of 0.5.
-                off = abs(n_half % 1.0 - 0.5)
-                if off < 0.02:
-                    suspects.append(
-                        f"  {name}open-ended line {'→'.join(str(e) for e in ends)} "
-                        f"is {n_half / 2:.4f} λ at {f_mhz:.4f} MHz — an odd "
-                        "multiple of λ/4, where an open stub's Z_in = 0 shorts "
-                        f"the port it hangs on (z0 = {z0:g} Ω)"
-                    )
-            else:
-                off = min(n_half % 1.0, 1.0 - n_half % 1.0)
-                if off < 0.02:
-                    suspects.append(
-                        f"  {name}line {'→'.join(str(e) for e in ends)} is "
-                        f"{n_half / 2:.4f} λ at {f_mhz:.4f} MHz — a multiple of "
-                        f"λ/2, where a lossless line has no finite admittance "
-                        f"(z0 = {z0:g} Ω)"
-                    )
+            if not hanging:
+                continue
+            wl_line = wavelength * vf
+            n_half = br.length / (0.5 * wl_line)  # length in half-wavelengths
+            # Odd quarter-waves: n_half at an odd multiple of 0.5.
+            if abs(n_half % 1.0 - 0.5) < 0.02:
+                name = f"{path[:-1]}: " if path else ""
+                suspects.append(
+                    f"  {name}open-ended line {'→'.join(str(e) for e in ends)} "
+                    f"is {n_half / 2:.4f} λ at {f_mhz:.4f} MHz — an odd "
+                    "multiple of λ/4, where an open stub's Z_in = 0 shorts "
+                    f"the port it hangs on (z0 = {z0:g} Ω)"
+                )
         if not suspects:
             return (
                 "No lossless line sits on a pole at this frequency, so the "
@@ -639,14 +762,16 @@ class NetworkReducer:
         Group 1 (node-admittance block G):
           - the antenna's dense multiport short-circuit Y at the real-feed
             nodes vs. datum;
-          - TL branches (their 2×2 has shunt legs, so it is a natural
-            admittance stamp; the half-wave singularity still raises);
           - parallel-mode Shunt (the tank admittance is the natural finite
             quantity, → 0 at trap resonance).
 
         Group 2 (auxiliary branch currents):
           - TwoPort and series-mode Shunt — series elements, exact for the
             ideal short z = 0 and the 0 F open;
+          - TL and BalancedLine as chain-matrix 2-ports, two currents each
+            (issue #746): every entry of an ABCD matrix is entire, so the
+            k·λ/2 line that has no admittance matrix at all stamps as the
+            ordinary through-line it is;
           - one TERMINATION branch per port that is driven and/or loaded:
             an EMF (0 if undriven) in series with the port's Load impedance
             (0 if unloaded) from the datum into the node. Its constitutive
@@ -697,44 +822,60 @@ class NetworkReducer:
             lab = lambda s, p=_bpath: f"{p[:-1]}: {s}" if p else s  # noqa: E731
             if isinstance(br, TL):
                 a, b = self.port_to_idx[br.a], self.port_to_idx[br.b]
-                y_tl = tl_admittance_2x2(
-                    br.z0,
-                    br.length,
-                    wavelength,
-                    transposed=br.transposed,
-                    vf=br.vf,
-                    k1=br.k1,
-                    k2=br.k2,
+                leg = _stamp_abcd(
+                    elements,
+                    couplings,
+                    [(a, 1.0 + 0j)],
+                    [(b, -1.0 + 0j if br.transposed else 1.0 + 0j)],
+                    tl_abcd(br.z0, br.length, wavelength, vf=br.vf, k1=br.k1, k2=br.k2),
                 )
-                G[np.ix_([a, b], [a, b])] += y_tl
                 probes.append(
-                    (lab(f"TL {_short(br.a)}→{_short(br.b)}"), "group1", ([a, b], y_tl))
+                    (lab(f"TL {_short(br.a)}→{_short(br.b)}"), "group2abcd", (leg,))
                 )
             elif isinstance(br, BalancedLine):
-                # Balanced 4-terminal line (issues #575/#576): a frequency-
-                # dependent 4×4 Group-1 block, the differential 2×2 TL expanded
-                # through the pair incidence. Common mode is structurally open
-                # (rank 2) unless the element declares a `zcomm` CM path; the
-                # half-wave singularity guard is inherited.
-                idxs = [self.port_to_idx[p] for p in (br.a1, br.a2, br.b1, br.b2)]
-                yb = balanced_admittance_4x4(
-                    br.zdiff,
-                    br.length,
-                    wavelength,
-                    vf=br.vf,
-                    k1=br.k1,
-                    k2=br.k2,
-                    zcomm=br.zcomm,
+                # Balanced 4-terminal line (issues #575/#576/#746): the same
+                # even/odd decomposition `balanced_admittance_4x4` writes as a
+                # 4×4 Group-1 block, stamped instead as one chain-matrix
+                # 2-port per mode. The differential mode's port weights
+                # (+1, −1) force I(a1) = −I(a2) at each end, so with
+                # `zcomm=None` the common mode remains STRUCTURALLY open
+                # (rank 2) exactly as before — that is a topological property
+                # of the incidence, not of which description carries it.
+                a1, a2, b1, b2 = (
+                    self.port_to_idx[p] for p in (br.a1, br.a2, br.b1, br.b2)
                 )
-                G[np.ix_(idxs, idxs)] += yb
+                kw = dict(vf=br.vf, k1=br.k1, k2=br.k2)
+                legs = [
+                    _stamp_abcd(
+                        elements,
+                        couplings,
+                        [(a1, 1.0 + 0j), (a2, -1.0 + 0j)],
+                        [(b1, 1.0 + 0j), (b2, -1.0 + 0j)],
+                        tl_abcd(br.zdiff, br.length, wavelength, **kw),
+                    )
+                ]
+                if br.zcomm is not None:
+                    # The pair driven as ONE conductor: voltage the pair
+                    # average, current the total, splitting equally. Its
+                    # ½-weights annihilate differential vectors, so the two
+                    # legs never cross-couple.
+                    legs.append(
+                        _stamp_abcd(
+                            elements,
+                            couplings,
+                            [(a1, 0.5 + 0j), (a2, 0.5 + 0j)],
+                            [(b1, 0.5 + 0j), (b2, 0.5 + 0j)],
+                            tl_abcd(br.zcomm, br.length, wavelength, **kw),
+                        )
+                    )
                 probes.append(
                     (
                         lab(
                             f"BalancedLine {_short(br.a1)},{_short(br.a2)}"
                             f"→{_short(br.b1)},{_short(br.b2)}"
                         ),
-                        "group1",
-                        (idxs, yb),
+                        "group2abcd",
+                        tuple(legs),
                     )
                 )
             elif isinstance(br, Admittance):

--- a/src/antennaknobs/station.py
+++ b/src/antennaknobs/station.py
@@ -393,8 +393,10 @@ def shunt_shorted_stub(
     `shunt_open_stub`, and the flavor real installations prefer (DC-grounded,
     weatherable, adjustable with a shorting bar). The quarter-wave shorted
     stub is an open — the "metal insulator" / RF choke — and needs no guard,
-    being a plain zero admittance; the half-wave one is a dead short and
-    trips `TL`'s own half-wave singularity guard at stamp time. Lengths in
+    being a plain zero admittance; the half-wave one really is a dead short
+    across the port, which an ideal voltage source cannot drive, so the SOLVE
+    reports it (issue #746 retired the stamp-time half-wave guard that used
+    to fire first, on every half-wave line whether shorted or not). Lengths in
     wavelengths at ``freq_mhz`` (section header). Formal: ``port``."""
     z0, length, vf, k1, k2 = _stub_line(freq_mhz, length_wl, z0, vf, k1, k2, cable)
     return Composite(

--- a/src/antennaknobs/station.py
+++ b/src/antennaknobs/station.py
@@ -30,7 +30,6 @@ import math
 
 from .builder import C_LIGHT_MHZ_M
 from .schematic import series, shunt
-from .network_reduce import SingularNetworkError
 from .network import (
     Autotransformer,
     TL,
@@ -314,34 +313,22 @@ def _stub_line(freq_mhz, length_wl, z0, vf, k1, k2, cable):
     return z0, length_wl * vf * C_LIGHT_MHZ_M / freq_mhz, vf, k1, k2
 
 
-def _guard_open_stub(freq_mhz, length_wl, k1, k2):
-    """The open stub's odd-quarter-wave singularity, guarded with the SAME
-    policy (and the same 1e-12 threshold) as the half-wave guard in
-    ``network_reduce.tl_admittance_2x2`` — raise rather than hand the solver
-    a singular matrix, and let any real loss regularize it.
-
-    Same coin, other face: that guard trips when ``sinh γl`` → 0 (a lossless
-    k·λ/2 line has no finite admittance); an open stub goes singular when
-    ``cosh γl`` → 0, i.e. at an odd multiple of λ/4, where Z_in = 0 puts a
-    dead short across the port and no ideal source can drive it. Lossless is
-    the precondition for both (with α > 0 neither function reaches zero), so
-    a lossy ``k1``/``k2`` — or ``cable=`` — buys the exact λ/4 open stub.
-    The shorted flavors need nothing here: their λ/4 is Z_in = ∞, a
-    perfectly well-behaved zero admittance.
-
-    Checked at construction, not at stamp time, because ``freq_mhz`` and
-    ``length_wl`` are exactly the pair that makes it decidable; a sweep can
-    still walk a lossless stub onto a λ/4 point elsewhere, where the TL guard
-    (half-wave) or a singular solve reports it."""
-    if k1 or k2:
-        return
-    if abs(math.cos(2.0 * math.pi * length_wl)) < 1e-12:
-        raise SingularNetworkError(
-            f"lossless open stub of {length_wl} λ is an odd multiple of λ/4 at "
-            f"f={freq_mhz:.4f} MHz (cos βl ≈ 0); Z_in = 0 shorts the port and "
-            "the admittance is singular — pick a different length, or give the "
-            "stub the loss it really has (k1/k2, or cable=...)"
-        )
+# Retired 2026-08-06 (issue #746): `_guard_open_stub` refused a lossless open
+# stub at an odd multiple of λ/4 at construction, because Z_in = 0 there puts a
+# dead short across the port and NO IDEAL SOURCE CAN DRIVE A SHORT. That was
+# always a statement about the source model, not about the stub — the reducer
+# now stamps the driven port as an EMF behind `Z_REF_DEFAULT`, so the same stub
+# solves with the equilibrated condition it has at every other length (measured
+# flat at 0.065 across 30–40 MHz on the test_singular_network fixture, against
+# 1e-17 for the ideal generator at the pole) and reports the answer: Z = 0,
+# Γ = −1. The quarter-wave open stub is a short, and a short is a perfectly
+# ordinary thing for a network to be.
+#
+# What does NOT follow it: the FAR-FIELD path, which keeps the ideal generator
+# because its port voltages are the excitation (see
+# `network_reduce.excited_state`). Driving a dead short with an ideal source
+# takes unbounded current, so a design that shorts its own feed has an
+# impedance and no pattern — reported by the solve, with attribution.
 
 
 def shunt_open_stub(
@@ -363,10 +350,10 @@ def shunt_open_stub(
     — capacitive below λ/4, inductive between λ/4 and λ/2, and repeating: the
     quarter-wave open stub is a short (the harmonic-notch trap), the half-wave
     open stub an open. Lengths in wavelengths at ``freq_mhz``; see this
-    section's header for the convention and `_guard_open_stub` for why an
-    exactly-λ/4 LOSSLESS open stub raises. Formal: ``port``."""
+    section's header for the convention, and the note above it for why an
+    exactly-λ/4 LOSSLESS open stub used to be refused and no longer is.
+    Formal: ``port``."""
     z0, length, vf, k1, k2 = _stub_line(freq_mhz, length_wl, z0, vf, k1, k2, cable)
-    _guard_open_stub(freq_mhz, length_wl, k1, k2)
     return Composite(
         ports=("port",),
         branches=(TL(a="port", b="far", z0=z0, length=length, vf=vf, k1=k1, k2=k2),),
@@ -436,10 +423,11 @@ def series_open_stub(
     ZERO current — the differential stamp forces I(far2) = −I(far1) and
     ``far1`` is open — so it is a common-mode reference pin, not a
     termination, and the element stays genuinely floating at ``a``/``b``.
-    Same lossless-λ/4 guard as `shunt_open_stub` (there it shorts the port;
-    here it shorts the line's two halves together). Formals: ``a``, ``b``."""
+    A lossless odd-λ/4 length shorts the element's two terminals together
+    rather than the port to the datum, and — like `shunt_open_stub`'s — is now
+    an ordinary answer rather than a refusal (issue #746). Formals: ``a``,
+    ``b``."""
     z0, length, vf, k1, k2 = _stub_line(freq_mhz, length_wl, z0, vf, k1, k2, cable)
-    _guard_open_stub(freq_mhz, length_wl, k1, k2)
     return Composite(
         ports=("a", "b"),
         branches=(

--- a/src/antennaknobs/touchstone.py
+++ b/src/antennaknobs/touchstone.py
@@ -21,6 +21,7 @@ Only 1- and 2-port ``S`` / ``Y`` / ``Z`` files are supported (the VNA case);
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 import numpy as np
@@ -34,8 +35,28 @@ __all__ = [
     "format_s1p",
 ]
 
+_logger = logging.getLogger(__name__)
+
 # Touchstone frequency-unit keywords → multiplier to Hz.
 _FUNIT = {"HZ": 1.0, "KHZ": 1e3, "MHZ": 1e6, "GHZ": 1e9}
+
+
+def _reciprocal_condition(m: np.ndarray, scale: float) -> float:
+    """How far ``m`` sits from rank-deficient, measured against ``scale``.
+
+    The textbook σ_min/σ_max is blind to the 1-port case: a 1×1 matrix has one
+    singular value and therefore condition 1 however close to zero it sits, so
+    a ``.s1p`` at S11 = −1 + 1e-16 would look perfectly healthy. Every matrix
+    inverted in this module has a known natural scale instead — 1 for the
+    I ± S family (‖S‖ ≤ 1 for a passive network), z0 for an impedance matrix,
+    1/z0 for an admittance one — so σ_min divided by that scale is the number
+    that means "singular" at either port count. Taking max(σ_max, scale) keeps
+    it the ordinary reciprocal condition whenever the matrix is larger than
+    its own reference.
+    """
+    s = np.linalg.svd(m, compute_uv=False)
+    denom = max(float(s[0]), float(scale))
+    return 0.0 if denom == 0.0 else float(s[-1]) / denom
 
 
 @dataclass(frozen=True, eq=False)
@@ -53,10 +74,56 @@ class Touchstone:
     params: np.ndarray
     ptype: str
     z0: float
+    name: str = ""  # source filename, for error messages; "" when parsed inline
 
     @property
     def nports(self) -> int:
         return self.params.shape[1]
+
+    def _inv(self, m: np.ndarray, f_hz: float, scale: float, what: str, cause: str):
+        """``m⁻¹``, refusing when ``m`` is too close to rank-deficient.
+
+        Every parameter conversion below is a Möbius transform with a pole,
+        and a bare ``np.linalg.inv`` reports that pole two useless ways: an
+        untyped ``LinAlgError`` exactly on it, and enormous finite numbers
+        just off it (a matched half-wave coax ``.s2p`` reaches I + S ≈ 0 and
+        stamps |y11| ~ 1e14 into the reducer's G with no complaint at all).
+        Both become one house error naming the file, the frequency and the
+        physics — the pole of a network parameter is always a short or an
+        open, and saying which is what makes the message actionable.
+
+        The threshold is the reducer's, not a second policy: `network_reduce`
+        is imported here at call time rather than at module scope because
+        network_reduce → network → touchstone would close an import cycle,
+        and touchstone is otherwise a leaf.
+        """
+        from .network_reduce import (
+            RCOND_SINGULAR,
+            RCOND_SUSPECT,
+            SingularNetworkError,
+        )
+
+        rc = _reciprocal_condition(m, scale)
+        where = f"{self.name}: " if self.name else "Touchstone data: "
+        if rc < RCOND_SINGULAR:
+            raise SingularNetworkError(
+                f"{where}{what} has no inverse at {f_hz / 1e6:.6g} MHz "
+                f"(reciprocal condition {rc:.2e}) — {cause}. Ask for the "
+                "parameter set the file already carries (S is always finite), "
+                "or move off this frequency."
+            )
+        if rc < RCOND_SUSPECT:
+            _logger.warning(
+                "%s%s is nearly singular at %.6g MHz (reciprocal condition "
+                "%.2e) — %s, so the converted value is dominated by proximity "
+                "to that pole and its leading digits are unreliable.",
+                where,
+                what,
+                f_hz / 1e6,
+                rc,
+                cause,
+            )
+        return np.linalg.inv(m)
 
     def _interp(self, f_hz: float) -> np.ndarray:
         """Linear-interpolate the parameter matrix onto ``f_hz`` (Hz).
@@ -83,14 +150,36 @@ class Touchstone:
         return m
 
     def s_at(self, f_hz: float) -> np.ndarray:
-        """S-parameter matrix at ``f_hz`` (converting from Y/Z if needed)."""
+        """S-parameter matrix at ``f_hz`` (converting from Y/Z if needed).
+
+        S is bounded for every passive network, so the Y route goes
+        ``S = (I − z0·Y)(I + z0·Y)⁻¹`` directly rather than through Z: an
+        open-circuit Y (whose Z does not exist) still has the perfectly
+        ordinary S = I, and the detour would have refused it.
+        """
         m = self._interp(f_hz)
         if self.ptype == "S":
             return m
         n = self.nports
         eye = np.eye(n)
-        z = m if self.ptype == "Z" else np.linalg.inv(m)
-        return (z - self.z0 * eye) @ np.linalg.inv(z + self.z0 * eye)
+        if self.ptype == "Y":
+            zy = self.z0 * m
+            return (eye - zy) @ self._inv(
+                eye + zy,
+                f_hz,
+                1.0,
+                "I + z0·Y",
+                "z0·Y → −I is a negative-resistance network with no "
+                "scattering description at this reference impedance",
+            )
+        return (m - self.z0 * eye) @ self._inv(
+            m + self.z0 * eye,
+            f_hz,
+            self.z0,
+            "Z + z0·I",
+            f"Z → −{self.z0:g} Ω is a negative-resistance network with no "
+            "scattering description at this reference impedance",
+        )
 
     def y_at(self, f_hz: float) -> np.ndarray:
         """Admittance matrix (siemens) at ``f_hz`` — what the reducer stamps."""
@@ -98,11 +187,28 @@ class Touchstone:
         if self.ptype == "Y":
             return m
         if self.ptype == "Z":
-            return np.linalg.inv(m)
+            return self._inv(
+                m,
+                f_hz,
+                self.z0,
+                "Z",
+                "a Z matrix with no inverse is a short circuit, whose "
+                "admittance is unbounded",
+            )
         n = self.nports
         eye = np.eye(n)
         # real reference z0:  Y = (1/z0)·(I − S)·(I + S)⁻¹
-        return (1.0 / self.z0) * (eye - m) @ np.linalg.inv(eye + m)
+        return (
+            (1.0 / self.z0)
+            * (eye - m)
+            @ self._inv(
+                eye + m,
+                f_hz,
+                1.0,
+                "I + S",
+                "S → −1 is a short circuit, whose admittance is unbounded",
+            )
+        )
 
     def z_at(self, f_hz: float) -> np.ndarray:
         """Impedance matrix (ohms) at ``f_hz``."""
@@ -110,10 +216,27 @@ class Touchstone:
         if self.ptype == "Z":
             return m
         if self.ptype == "Y":
-            return np.linalg.inv(m)
+            return self._inv(
+                m,
+                f_hz,
+                1.0 / self.z0,
+                "Y",
+                "a Y matrix with no inverse is an open circuit, whose "
+                "impedance is unbounded",
+            )
         n = self.nports
         eye = np.eye(n)
-        return self.z0 * (eye + m) @ np.linalg.inv(eye - m)
+        return (
+            self.z0
+            * (eye + m)
+            @ self._inv(
+                eye - m,
+                f_hz,
+                1.0,
+                "I − S",
+                "S → +1 is an open circuit, whose impedance is unbounded",
+            )
+        )
 
 
 def _nports_from_name(name: str) -> int:
@@ -128,8 +251,13 @@ def _nports_from_name(name: str) -> int:
     )
 
 
-def parse_touchstone(text: str, *, nports: int | None = None) -> Touchstone:
+def parse_touchstone(
+    text: str, *, nports: int | None = None, name: str = ""
+) -> Touchstone:
     """Parse Touchstone ``text`` into a :class:`Touchstone`.
+
+    ``name`` is carried purely so a conversion that hits a pole can say which
+    file it was reading; :func:`read_touchstone` fills it in.
 
     ``nports`` is taken from the file extension by :func:`read_touchstone`; when
     omitted here it is inferred from the first data record's width
@@ -210,7 +338,11 @@ def parse_touchstone(text: str, *, nports: int | None = None) -> Touchstone:
 
     order = np.argsort(freqs)
     return Touchstone(
-        freqs=freqs[order], params=params[order], ptype=ptype, z0=float(z0)
+        freqs=freqs[order],
+        params=params[order],
+        ptype=ptype,
+        z0=float(z0),
+        name=name,
     )
 
 
@@ -248,4 +380,4 @@ def read_touchstone(builder, name: str) -> Touchstone:
         return Network(..., branches=[TouchstoneLoad("ant", s), ...])
     """
     nports = _nports_from_name(name)  # validate extension before touching disk
-    return parse_touchstone(read_data(builder, name), nports=nports)
+    return parse_touchstone(read_data(builder, name), nports=nports, name=name)

--- a/tests/test_cebik_designs.py
+++ b/tests/test_cebik_designs.py
@@ -2424,17 +2424,27 @@ def test_t2fd_broadband_gain_agrees_across_engines():
         assert abs(g - g_ref) < 0.8
 
 
-def test_g5rv_ideal_halfwave_line_is_singular_on_every_engine():
-    """An ideal lossless TL is singular at exactly k*lambda/2 (sin betaL = 0);
-    the guard fires identically on PyNEC and every momwire basis -- a shared
-    network-layer limitation, not a momwire-specific hole. The default sits just
-    off the half wave to avoid it."""
-    import pytest
+def test_g5rv_ideal_halfwave_line_repeats_on_every_engine():
+    """Rewritten for issue #746, which retired this test's premise.
 
+    An ideal lossless TL used to be SINGULAR at exactly k·λ/2 (sin βl = 0 — the
+    pole of the ADMITTANCE form the reducer stamped), and this pinned the guard
+    firing identically on PyNEC and every momwire basis. The reducer now stamps
+    the chain matrix, which at k·λ/2 is [[−1, 0], [0, −1]], so the matching
+    line is simply the impedance repeater it physically is: the half-wave and
+    full-wave lines hand the shack the SAME impedance — the doublet's own
+    feedpoint, carried down unchanged — and both engines agree on it."""
     from antennaknobs.designs.broadband.g5rv import Builder
+    from antennaknobs.engines import MomwireEngine
 
-    with pytest.raises(ValueError):
-        _z(Builder(dict(Builder.default_params, match_len_frac=0.5)))
+    z_half = _z(Builder(dict(Builder.default_params, match_len_frac=0.5)))
+    z_full = _z(Builder(dict(Builder.default_params, match_len_frac=1.0)))
+    assert np.isfinite(z_half)
+    assert abs(z_half - z_full) / abs(z_full) < 1e-9
+    z_mw = MomwireEngine(
+        Builder(dict(Builder.default_params, match_len_frac=0.5)), ground=None
+    ).impedance()[0]
+    assert np.isfinite(z_mw)
 
 
 def test_bruce_high_z_feed_is_well_conditioned_across_bases():

--- a/tests/test_chain_matrix_lines.py
+++ b/tests/test_chain_matrix_lines.py
@@ -1,0 +1,282 @@
+"""Transmission lines stamped as chain matrices (issue #746, increment 2).
+
+A line's 2×2 nodal admittance is 1/(Z0 sinh γl) × …, a ratio with a pole: at a
+lossless k·λ/2 the line HAS no admittance matrix, and the reducer used to
+refuse the whole solve there. Its chain (ABCD) matrix is entire — [[±1, 0],
+[0, ±1]] at exactly that point, which is what a through-line is — so the
+reducer now carries two auxiliary currents per line and stamps
+
+    v_a − A·v_b − B·j₂ = 0
+    j₁  − C·v_b − D·j₂ = 0
+
+instead. These tests pin the three things that buys: exactness AT the pole,
+a well-conditioned system there, and bit-for-bit-equivalent answers
+everywhere the admittance form was valid.
+"""
+
+import numpy as np
+import pytest
+
+from antennaknobs.network import (
+    TL,
+    BalancedLine,
+    Driven,
+    Network,
+    PortOnWire,
+    PortVirtual,
+    Shunt,
+)
+from antennaknobs.network_reduce import (
+    C_LIGHT,
+    NetworkReducer,
+    SingularNetworkError,
+    balanced_admittance_4x4,
+    tl_abcd,
+    tl_admittance_2x2,
+)
+
+F_MHZ = 10.0
+WL = C_LIGHT / (F_MHZ * 1e6)
+
+
+def _rig(tl):
+    """Virtual "rig" port driven through `tl` into the real "ant" port."""
+    net = Network(
+        ports={"ant": PortOnWire("ant"), "rig": PortVirtual("rig")},
+        branches=[tl],
+        sources=[Driven("rig", 1 + 0j)],
+    )
+    return NetworkReducer(net, {"ant": 0, "rig": 1}, 2)
+
+
+def _rcond(system):
+    """The equilibrated reciprocal condition the solve itself measures."""
+    from scipy.linalg.lapack import zgesvx
+
+    return float(zgesvx(system.A, system.rhs.reshape(-1, 1))[8])
+
+
+def _y1(z):
+    return np.array([[1.0 / z]], dtype=np.complex128)
+
+
+# ---------------------------------------------------------------------------
+# 1. the chain matrix itself
+# ---------------------------------------------------------------------------
+def test_abcd_and_the_admittance_stamp_describe_the_same_line():
+    """Where both exist they are the same 2-port: y11 = D/B, y12 = −1/B,
+    y22 = A/B — and AD − BC = 1, the reciprocity the pair of them encodes."""
+    for z0, length, vf, k1 in [
+        (50.0, 3.7, 1.0, 0.0),
+        (300.0, 0.18 * WL, 0.91, 0.0),
+        (75.0, 12.0, 0.66, 0.31),
+    ]:
+        a, b, c, d = tl_abcd(z0, length, WL, vf=vf, k1=k1)
+        y = tl_admittance_2x2(z0, length, WL, vf=vf, k1=k1)
+        assert a * d - b * c == pytest.approx(1.0, rel=1e-14)
+        assert y[0, 0] == pytest.approx(d / b, rel=1e-12)
+        assert y[0, 1] == pytest.approx(-1.0 / b, rel=1e-12)
+        assert y[1, 1] == pytest.approx(a / b, rel=1e-12)
+
+
+def test_the_half_wave_chain_matrix_is_the_identity_up_to_sign():
+    """The point of the whole exercise: the description the admittance form
+    cannot spell is the simplest one there is."""
+    a, b, c, d = tl_abcd(50.0, WL / 2.0, WL)
+    assert (a, d) == pytest.approx((-1.0, -1.0), abs=1e-15)
+    assert abs(b) < 1e-13 and abs(c) < 1e-15
+
+
+# ---------------------------------------------------------------------------
+# 2. the acceptance criterion: exact AT the pole
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("k", [1, 2, 3])
+@pytest.mark.parametrize("z_load", [120.0 + 0j, 12.0 - 90.0j, 3000.0 + 1.0j])
+def test_a_lossless_half_wave_line_repeats_its_load_exactly(k, z_load):
+    """A k·λ/2 line is an impedance repeater. Measured worst case across this
+    grid: 8.5e-14 relative — the analytic answer, not an approximation to it.
+    Under the admittance stamp this raised."""
+    for vf in (1.0, 0.66):
+        tl = TL("rig", "ant", z0=50.0, length=k * vf * WL / 2.0, vf=vf)
+        z = _rig(tl).driven_impedance(_y1(z_load), WL)[0]
+        assert abs(z - z_load) / abs(z_load) < 1e-12
+
+
+def test_the_half_wave_solve_is_well_conditioned_not_merely_survivable():
+    """Equilibrated rcond at the exact pole: 0.1667, five orders above
+    RCOND_SUSPECT. The answer is not being scraped off a near-singularity —
+    there is no singularity."""
+    tl = TL("rig", "ant", z0=50.0, length=WL / 2.0)
+    red = _rig(tl)
+    assert _rcond(red.apply_branches(_y1(120.0 + 0j), WL)) > 0.1
+
+
+def test_the_admittance_form_still_refuses_and_says_which_form_to_ask_for():
+    """`tl_admittance_2x2` keeps its guard — the admittance genuinely does not
+    exist there — but the message now points at the form that does."""
+    with pytest.raises(SingularNetworkError, match="tl_abcd"):
+        tl_admittance_2x2(50.0, WL / 2.0, WL)
+
+
+def test_a_zero_length_line_is_an_ideal_short():
+    """The other end of the same story: the admittance form's other pole."""
+    z = _rig(TL("rig", "ant", z0=50.0, length=0.0)).driven_impedance(
+        _y1(73.0 + 42.0j), WL
+    )[0]
+    assert z == pytest.approx(73.0 + 42.0j, rel=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# 3. no drift where the old stamp was valid
+# ---------------------------------------------------------------------------
+def test_agrees_with_the_admittance_stamp_wherever_that_existed():
+    """The regression this change could plausibly cause. 600 random lines
+    (z0, length, vf, loss, transposition) against the nodal solve of the
+    admittance stamp: worst relative |ΔZ| measured 1.4e-12."""
+    rng = np.random.default_rng(0)
+    worst, n = 0.0, 0
+    for _ in range(600):
+        z0 = float(rng.uniform(35.0, 700.0))
+        length = float(rng.uniform(0.02, 3.0)) * WL
+        vf = float(rng.uniform(0.6, 1.0))
+        k1 = float(rng.choice([0.0, 0.0, 0.3]))
+        transposed = bool(rng.integers(0, 2))
+        z_load = complex(rng.uniform(5.0, 500.0), rng.uniform(-500.0, 500.0))
+        try:
+            y_tl = tl_admittance_2x2(
+                z0, length, WL, transposed=transposed, vf=vf, k1=k1
+            )
+        except SingularNetworkError:
+            continue  # exactly the samples the old stamp could not answer
+        y_full = y_tl.copy()
+        y_full[0, 0] += 1.0 / z_load
+        v = np.array([-y_full[0, 1] / y_full[0, 0], 1.0 + 0j])
+        z_old = v[1] / (y_full @ v)[1]
+        tl = TL("rig", "ant", z0=z0, length=length, vf=vf, k1=k1, transposed=transposed)
+        z_new = _rig(tl).driven_impedance(_y1(z_load), WL)[0]
+        worst = max(worst, abs(z_new - z_old) / abs(z_old))
+        n += 1
+    assert n > 500
+    assert worst < 1e-9, worst
+
+
+def test_transposition_is_a_negated_port_weight():
+    """A half-twist inverts port B's polarity: the driving-point impedance is
+    blind to it (the load is the same load), the far-end voltage is not."""
+    kw = dict(z0=450.0, length=0.31 * WL)
+    z_load = 220.0 - 60.0j
+    straight, crossed = TL("rig", "ant", **kw), TL("rig", "ant", transposed=True, **kw)
+    zs = _rig(straight).driven_impedance(_y1(z_load), WL)[0]
+    zc = _rig(crossed).driven_impedance(_y1(z_load), WL)[0]
+    assert zc == pytest.approx(zs, rel=1e-12)
+    red_s, red_c = _rig(straight), _rig(crossed)
+    v_s = red_s.resolve_voltages(red_s.apply_branches(_y1(z_load), WL))
+    v_c = red_c.resolve_voltages(red_c.apply_branches(_y1(z_load), WL))
+    assert v_c[0] == pytest.approx(-v_s[0], rel=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# 4. the power budget across the new element
+# ---------------------------------------------------------------------------
+def test_a_lossy_half_wave_line_reports_its_attenuation_in_the_budget():
+    """The 2-current probe reads ½Re(v_a·j₁* − v_b·j₂*): in minus out. At the
+    half-wave point, which the budget could not previously reach at all."""
+    tl = TL("rig", "ant", z0=50.0, length=WL / 2.0, k1=0.40, k2=0.008)
+    _v, eff, p_in, budget = _rig(tl).excited_state(_y1(50.0 + 0j), WL)
+    ((label, watts),) = budget
+    assert label == "TL rig→ant"
+    matched_db = tl.k1 * np.sqrt(F_MHZ) + tl.k2 * F_MHZ
+    # 100 ft of catalog loss over a λ/2 (15 m) section, matched at both ends.
+    expect_db = matched_db * (tl.length / (100.0 * 0.3048))
+    assert 10.0 * np.log10(p_in / (p_in - watts)) == pytest.approx(expect_db, rel=1e-9)
+    assert eff == pytest.approx(1.0 - watts / p_in, rel=1e-12)
+
+
+def test_a_lossless_line_still_reports_no_dissipation():
+    tl = TL("rig", "ant", z0=450.0, length=0.37 * WL)
+    _v, eff, p_in, budget = _rig(tl).excited_state(_y1(180.0 + 40.0j), WL)
+    assert abs(budget[0][1]) < 1e-9 * p_in
+    assert eff == 1.0
+
+
+# ---------------------------------------------------------------------------
+# 5. BalancedLine: the same expansion, one 2-port per mode
+# ---------------------------------------------------------------------------
+def _grounded_pair(bl):
+    """Conductor 2 bonded to the datum at both ends by ideal shorts, which is
+    the wiring under which a balanced pair IS a coax (test_balanced_line's
+    `y4 → y2` collapse, driven end to end)."""
+    net = Network(
+        ports={
+            "a1": PortOnWire("a1"),
+            "a2": PortVirtual("a2"),
+            "b1": PortVirtual("b1"),
+            "b2": PortVirtual("b2"),
+        },
+        branches=[bl, Shunt("a2", r=0.0), Shunt("b2", r=0.0)],
+        sources=[Driven("b1", 1 + 0j)],
+    )
+    return NetworkReducer(net, {"a1": 0, "a2": 1, "b1": 2, "b2": 3}, 4)
+
+
+@pytest.mark.parametrize("k", [1, 2])
+def test_a_balanced_half_wave_pair_repeats_its_load_exactly(k):
+    bl = BalancedLine("a1", "a2", "b1", "b2", zdiff=450.0, length=k * WL / 2.0)
+    z_load = 180.0 + 40.0j
+    z = _grounded_pair(bl).driven_impedance(_y1(z_load), WL)[0]
+    assert abs(z - z_load) / abs(z_load) < 1e-12
+
+
+def test_balanced_stamp_agrees_with_the_4x4_wherever_that_existed():
+    """Same regression check as the coax, through the pair incidence."""
+    rng = np.random.default_rng(1)
+    worst, n = 0.0, 0
+    for _ in range(200):
+        zdiff = float(rng.uniform(200.0, 700.0))
+        length = float(rng.uniform(0.02, 1.5)) * WL
+        vf = float(rng.uniform(0.8, 1.0))
+        k1 = float(rng.choice([0.0, 0.0, 0.05]))
+        z_load = complex(rng.uniform(50.0, 600.0), rng.uniform(-300.0, 300.0))
+        bl = BalancedLine(
+            "a1", "a2", "b1", "b2", zdiff=zdiff, length=length, vf=vf, k1=k1
+        )
+        try:
+            y4 = balanced_admittance_4x4(zdiff, length, WL, vf=vf, k1=k1)
+        except SingularNetworkError:
+            continue
+        # Grounding conductor 2 at both ends drops rows/cols a2, b2.
+        y_full = y4[np.ix_([0, 2], [0, 2])].copy()
+        y_full[0, 0] += 1.0 / z_load
+        v = np.array([-y_full[0, 1] / y_full[0, 0], 1.0 + 0j])
+        z_old = v[1] / (y_full @ v)[1]
+        z_new = _grounded_pair(bl).driven_impedance(_y1(z_load), WL)[0]
+        worst = max(worst, abs(z_new - z_old) / abs(z_old))
+        n += 1
+    assert n > 150
+    assert worst < 1e-9, worst
+
+
+def test_zcomm_none_keeps_the_common_mode_structurally_open():
+    """The load-bearing property of a differential-only pair: it forces
+    I(a1) = −I(a2) at each end, so a common-mode drive sees nothing at all.
+
+    In the 4×4 admittance form that was visible as rank 2. In the chain-matrix
+    form it is the port weights: the differential leg's incidence is (+1, −1)
+    at each end, so the branch's contribution to the two node rows cancels
+    identically. Asserted on the assembled matrix because that is the claim —
+    a topological zero, not a small number.
+    """
+    bl_open = BalancedLine("a1", "a2", "b1", "b2", zdiff=450.0, length=0.3 * WL)
+    bl_cm = BalancedLine(
+        "a1", "a2", "b1", "b2", zdiff=450.0, length=0.3 * WL, zcomm=200.0
+    )
+    for bl, cm_open in ((bl_open, True), (bl_cm, False)):
+        system = _grounded_pair(bl).apply_branches(_y1(300.0), WL)
+        cols = system.A[:, 4:]  # every Group-2 current column
+        pair_a = cols[0] + cols[1]  # rows a1 + a2 — the common-mode direction
+        pair_b = cols[2] + cols[3]
+        # The two 0 Ω shunts also touch a2 and b2; look only at the line's own
+        # two (or four) currents, which are stamped first.
+        n_line = 2 if cm_open else 4
+        assert np.all(pair_a[:n_line] == 0) == cm_open
+        assert np.all(pair_b[:n_line] == 0) == cm_open

--- a/tests/test_gamma_reference.py
+++ b/tests/test_gamma_reference.py
@@ -1,0 +1,271 @@
+"""Γ-referenced driven ports (issue #746, increment 3).
+
+The reducer used to pin a driven port at its EMF: an IDEAL generator, Z_s = 0.
+That is what made a short across the port unsolvable — not the short, which is
+an ordinary circuit, but the source model, which cannot deliver a finite
+current into 0 Ω. Stamping the EMF behind a reference impedance instead costs
+nothing (Z = E/j − z_ref is algebraically the same answer) and buys three
+things at once: a system that stays conditioned at the short, a native Γ, and
+a finite +1 where Z is reported as ∞.
+
+The far-field path deliberately keeps the ideal generator — its port voltages
+ARE the excitation and p_in is defined at the source terminals — so this file
+also pins that the two solves stay separate.
+"""
+
+import numpy as np
+import pytest
+
+from antennaknobs.network import (
+    TL,
+    Driven,
+    DrivenCurrent,
+    Load,
+    Network,
+    PortOnWire,
+    PortVirtual,
+    Shunt,
+)
+from antennaknobs.network_reduce import (
+    C_LIGHT,
+    RCOND_SINGULAR,
+    NetworkReducer,
+    SingularNetworkError,
+    Z_REF_DEFAULT,
+)
+
+F_MHZ = 14.0
+WL = C_LIGHT / (F_MHZ * 1e6)
+
+
+def _reducer(net):
+    real = [n for n, p in net.ports.items() if isinstance(p, PortOnWire)]
+    virt = [n for n, p in net.ports.items() if isinstance(p, PortVirtual)]
+    idx = {n: i for i, n in enumerate(real + virt)}
+    return NetworkReducer(net, idx, len(idx))
+
+
+def _bare(z_ant, branches=(), sources=None, n1=False):
+    """One real port carrying `z_ant`, driven, plus whatever branches.
+
+    ``n1`` adds a spare virtual node for branches that need a far end; it is
+    left out otherwise, because a node nothing touches is exactly the
+    genuinely-singular topology these tests must not accidentally build.
+    """
+    ports = {"feed": PortOnWire("feed")}
+    if n1:
+        ports["n1"] = PortVirtual("n1")
+    net = Network(
+        ports=ports,
+        branches=list(branches),
+        sources=list(sources or [Driven(port="feed")]),
+    )
+    return _reducer(net), np.array([[1.0 / z_ant]], dtype=np.complex128)
+
+
+def _rcond(system):
+    from scipy.linalg.lapack import zgesvx
+
+    return float(zgesvx(system.A, system.rhs.reshape(-1, 1))[8])
+
+
+# ---------------------------------------------------------------------------
+# 1. Γ agrees with the conversion it replaces, and Z does not move
+# ---------------------------------------------------------------------------
+def test_native_gamma_equals_the_downstream_conversion():
+    """Gate (a): the native readout and (Z − z0)/(Z + z0) are the same number
+    at ordinary frequencies. Measured worst |ΔΓ| here: ~1e-16."""
+    rng = np.random.default_rng(4)
+    worst = 0.0
+    for _ in range(200):
+        z_ant = complex(rng.uniform(3.0, 900.0), rng.uniform(-800.0, 800.0))
+        red, y = _bare(z_ant)
+        z = red.driven_impedance(y, WL)[0]
+        g = red.driven_reflection(y, WL)[0]
+        worst = max(worst, abs(g - (z - Z_REF_DEFAULT) / (z + Z_REF_DEFAULT)))
+    assert worst < 1e-10, worst
+
+
+def test_the_impedance_answer_is_independent_of_the_reference():
+    """Z = E/j − z_ref really is z_ref-free: three references, one answer,
+    and it is the ideal generator's."""
+    red, y = _bare(
+        73.0 + 42.0j, branches=[TL("feed", "n1", z0=450.0, length=3.1)], n1=True
+    )
+    ideal = red.impedance_from_y(red.apply_branches(y, WL))[0]
+    for zr in (12.5, 50.0, 600.0):
+        assert red.driven_impedance(y, WL, z_ref=zr)[0] == pytest.approx(
+            ideal, rel=1e-10
+        )
+
+
+def test_a_series_load_stays_inside_the_impedance():
+    """The reference plane sits between the source impedance and the load
+    chain, so Z keeps including the Load the way it always did."""
+    net = Network(
+        ports={"feed": PortOnWire("feed")},
+        branches=[Load(port="feed", r=25.0)],
+        sources=[Driven(port="feed")],
+    )
+    red = _reducer(net)
+    y = np.array([[1.0 / 50.0]], dtype=np.complex128)
+    z = red.driven_impedance(y, WL)[0]
+    assert z == pytest.approx(75.0, rel=1e-10)
+    g = red.driven_reflection(y, WL)[0]
+    assert g == pytest.approx((75.0 - 50.0) / (75.0 + 50.0), rel=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# 2. the two boundary cases Z cannot express
+# ---------------------------------------------------------------------------
+def test_a_shorted_port_is_gamma_minus_one_and_well_conditioned():
+    """Gate (b), in its pure form: a 0 Ω shunt across the driven port. The
+    ideal generator's system is rank-deficient; the referenced one is not."""
+    red, y = _bare(50.0, branches=[Shunt(port="feed", r=0.0)])
+    assert _rcond(red.apply_branches(y, WL)) < RCOND_SINGULAR
+    referenced = red.apply_branches(y, WL, z_ref=Z_REF_DEFAULT)
+    assert _rcond(referenced) > 0.1
+    assert abs(red.impedance_from_y(referenced)[0]) < 1e-12
+    assert abs(red.reflection_from_y(referenced)[0] + 1.0) < 1e-12
+
+
+def test_an_open_port_is_exactly_gamma_plus_one():
+    """Gate (c). Z is reported as a clean real ∞ (issue #289) and cannot be
+    anything else; Γ is +1, exactly, with no sentinel and no clamp."""
+    # The port itself must be the open, not merely lead to one: a
+    # parallel-LC trap Load at its own resonance.
+    net = Network(
+        ports={"feed": PortOnWire("feed")},
+        branches=[
+            Load(
+                port="feed",
+                parallel=True,
+                l=1e-6,
+                c=1.0 / (1e-6 * (2 * np.pi * F_MHZ * 1e6) ** 2),
+            )
+        ],
+        sources=[Driven(port="feed")],
+    )
+    red = _reducer(net)
+    y = np.array([[1.0 / 50.0]], dtype=np.complex128)
+    system = red.apply_branches(y, WL, z_ref=Z_REF_DEFAULT)
+    z = red.impedance_from_y(system)[0]
+    assert z == complex(float("inf"), 0.0)
+    assert red.reflection_from_y(system)[0] == 1.0 + 0j
+
+
+# ---------------------------------------------------------------------------
+# 3. where the reference is NOT stamped, and why
+# ---------------------------------------------------------------------------
+def test_two_generators_keep_the_ideal_operating_point():
+    """A driven array's Z_k = V_k/I_k is defined with every other feed held at
+    its stated voltage. A source impedance at port 0 changes v0 itself — the
+    mutual term y01·E1 injects current independently of it — so the ratio
+    moves, measured 23 % on this fixture. The reducer therefore declines to
+    stamp a reference at all when more than one source is active, and quotes Γ
+    from Z instead."""
+    net = Network(
+        ports={"f1": PortOnWire("f1"), "f2": PortOnWire("f2")},
+        sources=[Driven(port="f1", voltage=1 + 0j), Driven(port="f2", voltage=0.5j)],
+    )
+    red = _reducer(net)
+    y = np.array([[0.02 + 0.008j, 0.004 + 0.001j], [0.004 + 0.001j, 0.02 + 0.008j]])
+    system = red.apply_branches(y, WL, z_ref=Z_REF_DEFAULT)
+    assert system.z_ref_at == {}  # nothing stamped
+    zs = red.impedance_from_y(system)
+    ideal = red.impedance_from_y(red.apply_branches(y, WL))
+    np.testing.assert_allclose(zs, ideal, rtol=1e-12)
+    gs = red.reflection_from_y(system)
+    for g, z in zip(gs, zs):
+        assert g == pytest.approx((z - 50.0) / (z + 50.0), rel=1e-12)
+
+
+def test_a_zero_volt_pin_keeps_its_hard_short():
+    """`Driven(port, 0)` is the datum trick, not a generator: it must stay a
+    hard V = 0 pin, and it leaves the rest of the network passive so the OTHER
+    port still gets its reference."""
+    net = Network(
+        ports={"f1": PortOnWire("f1"), "f2": PortOnWire("f2")},
+        sources=[Driven(port="f1"), Driven(port="f2", voltage=0j)],
+    )
+    red = _reducer(net)
+    y = np.array([[0.02 + 0.008j, 0.004 + 0.001j], [0.004 + 0.001j, 0.02 + 0.008j]])
+    system = red.apply_branches(y, WL, z_ref=Z_REF_DEFAULT)
+    assert list(system.z_ref_at) == [0]  # f1 referenced, f2 pinned
+    v, _j = system.solve()
+    assert v[1] == 0j
+    assert red.impedance_from_y(system)[1] == 0.0
+
+
+def test_a_current_source_is_its_own_reference():
+    """Z_s = ∞ already: no z_ref is stamped, and Γ comes from Z."""
+    net = Network(
+        ports={"feed": PortOnWire("feed")},
+        sources=[DrivenCurrent(port="feed", current=1 + 0j)],
+    )
+    red = _reducer(net)
+    y = np.array([[1.0 / (120.0 - 30.0j)]], dtype=np.complex128)
+    system = red.apply_branches(y, WL, z_ref=Z_REF_DEFAULT)
+    assert system.z_ref_at == {}
+    z = red.impedance_from_y(system)[0]
+    assert z == pytest.approx(120.0 - 30.0j, rel=1e-10)
+    assert red.reflection_from_y(system)[0] == pytest.approx(
+        (z - 50.0) / (z + 50.0), rel=1e-12
+    )
+
+
+def test_gamma_from_an_ideal_generator_solve_is_refused():
+    """There is no reference plane to reflect against — say so rather than
+    return (2E − E)/E = 1 for every network."""
+    red, y = _bare(50.0)
+    with pytest.raises(ValueError, match="ideal-generator"):
+        red.reflection_from_y(red.apply_branches(y, WL))
+
+
+# ---------------------------------------------------------------------------
+# 4. the excited path is untouched
+# ---------------------------------------------------------------------------
+def test_the_excited_solve_keeps_the_ideal_generator():
+    """Gate (d): p_in and the port voltages are the drive, so a source
+    impedance would halve the excitation and rescale every gain. The excited
+    path stamps z_ref = 0 and its numbers are the historical ones."""
+    red, y = _bare(50.0 + 0j)
+    v, eff, p_in, _budget = red.excited_state(y, WL)
+    assert v[0] == pytest.approx(1.0 + 0j, rel=1e-12)  # the applied EMF, whole
+    assert p_in == pytest.approx(0.5 * (1.0 / 50.0), rel=1e-12)
+    assert eff == 1.0
+
+
+def test_a_shorted_port_has_an_impedance_but_no_far_field():
+    """The documented asymmetry the split produces. Driving a dead short with
+    an ideal source takes unbounded current, so there is nothing to normalise
+    a pattern against — while the impedance question still has its answer."""
+    red, y = _bare(50.0, branches=[Shunt(port="feed", r=0.0)])
+    assert abs(red.driven_impedance(y, WL)[0]) < 1e-12
+    with pytest.raises(SingularNetworkError):
+        red.excited_state(y, WL)
+
+
+def test_the_reference_leaves_no_trace_in_the_power_budget():
+    """z_ref is a modelling reference, not a resistor in the design: the Load
+    probe reports the Load's watts and nothing else, at either stamp."""
+    net = Network(
+        ports={"feed": PortOnWire("feed")},
+        branches=[Load(port="feed", r=25.0)],
+        sources=[Driven(port="feed")],
+    )
+    red = _reducer(net)
+    y = np.array([[1.0 / 50.0]], dtype=np.complex128)
+    watts = []
+    for zr in (0j, Z_REF_DEFAULT):
+        system = red.apply_branches(y, WL, z_ref=zr)
+        probe = system.probes[0]
+        assert probe[0] == "Load feed"
+        watts.append(system.branch_power(probe))
+    # ½·R·|j|² at each stamp's own current; the referenced solve draws less,
+    # but neither reading contains a watt of z_ref.
+    for w, system_zr in zip(watts, (0j, Z_REF_DEFAULT)):
+        system = red.apply_branches(y, WL, z_ref=system_zr)
+        _v, j = system.solve()
+        col = system.terminations[0][0]
+        assert w == pytest.approx(0.5 * 25.0 * abs(j[col]) ** 2, rel=1e-10)

--- a/tests/test_singular_network.py
+++ b/tests/test_singular_network.py
@@ -16,7 +16,16 @@ import pytest
 
 from antennaknobs import AntennaBuilder
 from antennaknobs.engines import MomwireEngine
-from antennaknobs.network import Driven, Instance, Network, PortOnWire, Wire
+from antennaknobs.network import (
+    Driven,
+    Instance,
+    Network,
+    PortOnWire,
+    PortVirtual,
+    Shunt,
+    TwoPort,
+    Wire,
+)
 from antennaknobs.network_reduce import (
     RCOND_SINGULAR,
     RCOND_SUSPECT,
@@ -62,30 +71,61 @@ def engine(**knobs):
 
 
 # ---------------------------------------------------------------------------
-# detection + attribution
+# the λ/4 open stub: an answer, not a pole (issue #746)
+#
+# These four tests premised that the exact quarter-wave was unanswerable. It
+# never was: Z_in = 0 shorts the port, and only an IDEAL generator — Z_s = 0 —
+# cannot drive a short. The reducer's impedance path now stamps the source
+# behind `Z_REF_DEFAULT`, so the same stub returns Z = 0 / Γ = −1 with the
+# conditioning it has everywhere else. Rewritten to pin that, since a test
+# asserting the old refusal would now be asserting a bug.
 # ---------------------------------------------------------------------------
-def test_a_single_point_on_the_pole_raises_with_the_element_named():
-    """The whole value of the guard is the sentence it prints."""
-    with pytest.raises(SingularNetworkError) as exc:
-        engine(freq=POLE_MHZ).impedance()
-    msg = str(exc.value)
-    assert "stub" in msg  # the instance path, so you know WHICH element
-    assert "λ/4" in msg and f"{POLE_MHZ:.4f}" in msg
-    assert "k1/k2" in msg or "cable=" in msg  # ...and what to do about it
+def _rcond_at(freq, *, z_ref, **knobs):
+    """The equilibrated reciprocal condition of the assembled system."""
+    from scipy.linalg.lapack import zgesvx
+
+    e = engine(freq=freq, **knobs)
+    wl = e._wavelength_for(freq)
+    system = e._reducer.apply_branches(e._compute_y_matrix(wl), wl, z_ref=z_ref)
+    return float(zgesvx(system.A, system.rhs.reshape(-1, 1))[8])
 
 
-def test_the_message_says_the_stamps_were_individually_fine():
-    """This is the distinguishing feature of the reducer-level case: no single
-    branch is singular, so the user should not go looking for one."""
-    with pytest.raises(SingularNetworkError) as exc:
-        engine(freq=POLE_MHZ).impedance()
-    assert "assembled system" in str(exc.value)
+def test_a_single_point_on_the_pole_is_a_dead_short_and_says_so():
+    """The quarter-wave open stub is the harmonic-notch trap: it puts 0 Ω
+    across the feed. That is an answer."""
+    z = engine(freq=POLE_MHZ).impedance()[0]
+    assert abs(z) < 1e-9, z
 
 
-def test_real_loss_dissolves_the_singularity():
-    """The remedy the message recommends has to actually work."""
+def test_the_shorted_port_reads_as_total_reflection():
+    """Γ = −1 to within a rounding error — the sign that says short, not open.
+
+    (The issue text asked for Γ ≈ +1 here; that is the OPEN. A λ/4 open stub is
+    a short across the port, and the measured value is −1 + 1.2e-16j.)"""
+    e = engine(freq=POLE_MHZ)
+    wl = e._wavelength_for(POLE_MHZ)
+    g = e._reducer.driven_reflection(e._compute_y_matrix(wl), wl)[0]
+    assert abs(g + 1.0) < 1e-6, g
+
+
+def test_the_pole_is_no_worse_conditioned_than_any_other_frequency():
+    """The strong form of the claim: not "survivable at the pole" but "there
+    is no pole". Measured 2026-08-06 — the ideal-generator stamp collapses
+    from 3.2e-2 at 30 MHz to 1.0e-17 at 35, while the Γ-referenced stamp holds
+    0.0649 → 0.0656 across the same span."""
+    rc_pole = _rcond_at(POLE_MHZ, z_ref=50.0)
+    rc_off = _rcond_at(POLE_MHZ * 0.857, z_ref=50.0)  # 30 MHz
+    assert rc_pole > 0.05
+    assert abs(rc_pole - rc_off) / rc_off < 0.05
+    # ...and the thing it replaced really was singular there.
+    assert _rcond_at(POLE_MHZ, z_ref=0j) < RCOND_SINGULAR
+
+
+def test_real_loss_still_gives_the_lossy_answer():
+    """Loss used to be the escape hatch; it is now just loss. The stub's own
+    copper makes Z_in real and small instead of exactly zero."""
     z = engine(freq=POLE_MHZ, stub_k1=0.2).impedance()[0]
-    assert np.isfinite(z)
+    assert np.isfinite(z) and z.real > 0.0
     assert abs(z) < 1e6
 
 
@@ -95,27 +135,52 @@ def test_off_the_pole_solves_normally():
 
 
 # ---------------------------------------------------------------------------
-# a sweep loses one sample, not the sweep
+# a sweep across the λ/4 keeps every sample
 # ---------------------------------------------------------------------------
-def test_sweep_across_the_pole_poisons_only_that_sample():
-    """The acceptance criterion: a lossless open stub swept across its λ/4."""
+def test_sweep_across_the_pole_loses_nothing():
+    """Was: "poisons only that sample". The poisoning machinery stays for
+    topologies that are genuinely singular (below); this stub is not one."""
     freqs = np.array([33.0, 34.0, POLE_MHZ, 36.0, 37.0])
     zs = engine().impedance_sweep(freqs)[:, 0]
 
-    assert not np.isfinite(zs[2])  # the pole
-    assert np.all(np.isfinite(np.delete(zs, 2)))  # everything either side
-    # ...and the surviving samples are the real answer, not garbage: an open
+    assert np.all(np.isfinite(zs))
+    assert abs(zs[2]) < 1e-9  # the short, in the middle of the sweep
+    # ...and the samples either side are the real answer, not garbage: an open
     # stub is capacitive below λ/4 and inductive above.
     assert zs[1].imag < 0 < zs[3].imag
 
 
-def test_the_poisoned_sample_is_logged_with_its_reason(caplog):
-    """NaN with no explanation would be its own kind of silent failure."""
+class FloatingNode(StubbedDipole):
+    """A dipole with a virtual node reachable only through opens.
+
+    The remaining shape of genuine singularity, now that the lossless-line
+    poles are gone: a 0 F series capacitor (the inert end of a
+    matching-network slider) into a node whose only other branch is another
+    open, so nothing in the system determines its voltage. No source impedance
+    fixes this and no loss regularises it — the equation is simply missing.
+    """
+
+    def build_network(self):
+        return Network(
+            ports={"feed": PortOnWire("feed"), "dead": PortVirtual("dead")},
+            branches=[TwoPort(a="feed", b="dead", c=0.0), Shunt(port="dead", c=0.0)],
+            sources=[Driven(port="feed")],
+        )
+
+
+def floating_engine():
+    return MomwireEngine(FloatingNode(dict(FloatingNode.default_params)), ground=None)
+
+
+def test_a_genuinely_singular_topology_still_poisons_its_sample(caplog):
+    """The machinery, exercised on something that really has no solution.
+    NaN with no explanation would be its own kind of silent failure."""
     with caplog.at_level("WARNING"):
-        engine().impedance_sweep(np.array([34.0, POLE_MHZ, 36.0]))
-    text = caplog.text
-    assert "singular network" in text and f"{POLE_MHZ:g}" in text
-    assert "stub" in text
+        zs = floating_engine().impedance_sweep(np.array([28.0, 30.0]))[:, 0]
+    assert not np.isfinite(zs).any()
+    assert "singular network" in caplog.text
+    with pytest.raises(SingularNetworkError, match="assembled system"):
+        floating_engine().impedance()
 
 
 def test_a_half_wave_line_mid_sweep_fails_for_its_real_reason_now():
@@ -204,7 +269,9 @@ def test_web_sweep_stays_json_clean_through_a_singular_sample():
     import antennaknobs.web.examples  # noqa: F401
     from antennaknobs.web.adapter import Z_OPEN_OHMS
 
-    zs = engine().impedance_sweep(np.array([34.0, POLE_MHZ, 36.0]))
+    # Retargeted (issue #746) onto `FloatingNode`: the λ/4 open stub this used
+    # to sweep no longer produces a NaN to serialise.
+    zs = floating_engine().impedance_sweep(np.array([28.0, 30.0]))
     # This is the clamp the /sweep adapter applies before serialising.
     clamped = np.where(np.isfinite(zs), zs, complex(Z_OPEN_OHMS, 0.0))
     body = json.dumps({"z_re": clamped[:, 0].real.tolist()})

--- a/tests/test_singular_network.py
+++ b/tests/test_singular_network.py
@@ -118,22 +118,38 @@ def test_the_poisoned_sample_is_logged_with_its_reason(caplog):
     assert "stub" in text
 
 
-def test_a_lossless_half_wave_line_mid_sweep_also_degrades():
-    """The other pole: a plain TL at k·λ/2, caught by the stamp-time guard.
+def test_a_half_wave_line_mid_sweep_fails_for_its_real_reason_now():
+    """Rewritten for issue #746, which retired this test's original premise.
 
-    That guard raises from inside the stamp, so before this change it aborted
-    the entire sweep rather than one sample of it. `wire.doublet_balanced_tuner`
-    walks its lossless line through exactly this.
+    A plain TL at k·λ/2 used to trip a stamp-time guard, from inside the
+    stamp, so it aborted the whole sweep rather than one sample of it; #647's
+    fix was to poison the sample. The chain-matrix stamp is finite at every
+    length, so the line is no longer the complaint — and what the old guard
+    was hiding at this exact frequency turns out to be a genuinely singular
+    topology. `wire.doublet_balanced_tuner`'s common-mode return runs through
+    that same line, open-terminated at the doublet's floating gap, and an
+    open-terminated lossless line at k·λ/2 presents an OPEN. The floating
+    tuner section is then referenced to nothing at all.
+
+    Measured 2026-08-06: the sample dies at 16.0387 MHz — the line's own
+    half-wave, 14.1 · ½ · 0.91 / 0.40 — for zcomm = 100, 250 and 400 Ω alike.
+    Insensitivity to the value is what makes it topological rather than a
+    near-pole; the surrounding samples solve normally.
     """
     from antennaknobs.designs.wire.doublet_balanced_tuner import Builder
 
     b = Builder()
+    f_half = b.freq * 0.5 * b.line_vf / b.line_len_factor
     zs = MomwireEngine(b, ground=None).impedance_sweep(
-        np.linspace(b.freq * 0.8, b.freq * 1.25, 9)
+        np.array([f_half * 0.99, f_half, f_half * 1.01])
     )[:, 0]
-    finite = np.isfinite(zs)
-    assert finite.sum() >= zs.size - 2  # at most the pole samples are lost
-    assert finite.sum() >= 1  # ...and the sweep is not a total loss
+    assert np.isfinite(zs[[0, 2]]).all()
+    assert not np.isfinite(zs[1])
+
+    with pytest.raises(SingularNetworkError, match="assembled system"):
+        MomwireEngine(
+            Builder(dict(Builder.default_params, freq=f_half)), ground=None
+        ).impedance()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_station_stubs.py
+++ b/tests/test_station_stubs.py
@@ -23,11 +23,7 @@ from antennaknobs.network import (
     PortVirtual,
     Shunt,
 )
-from antennaknobs.network_reduce import (
-    C_LIGHT,
-    NetworkReducer,
-    SingularNetworkError,
-)
+from antennaknobs.network_reduce import C_LIGHT, NetworkReducer
 from antennaknobs.station import (
     double_stub_tuner,
     series_open_stub,
@@ -177,13 +173,19 @@ def test_quarter_wave_shorted_stub_is_an_open_and_needs_no_guard():
     assert abs(z) > 1e12
 
 
-def test_lossless_quarter_wave_open_stub_raises_like_the_tl_guard():
-    """λ/4 open = a dead short across the port: singular, and refused at
-    construction with the TL guard's message shape and escape hatch."""
-    with pytest.raises(ValueError, match=r"odd multiple of λ/4"):
-        shunt_open_stub(F_MHZ, 0.25, z0=Z0)
-    with pytest.raises(ValueError, match=r"odd multiple of λ/4"):
-        series_open_stub(F_MHZ, 0.75, z0=Z0)  # every odd multiple, not just λ/4
+@pytest.mark.parametrize("length_wl", [0.25, 0.75, 1.25])
+def test_lossless_quarter_wave_open_stub_is_a_short_at_every_odd_multiple(length_wl):
+    """λ/4 open = a dead short across the port. Rewritten for issue #746:
+    `station._guard_open_stub` refused this at construction because an IDEAL
+    generator cannot drive a short — a fact about the source model, not the
+    stub. The driven port is now stamped behind a reference impedance, so the
+    answer comes back: 0 Ω."""
+    assert abs(z_shunt(shunt_open_stub(F_MHZ, length_wl, z0=Z0))) < 1e-9
+    # In series it shorts the element's two terminals to each other instead,
+    # so the driven port sees the load alone.
+    assert z_series(series_open_stub(F_MHZ, length_wl, z0=Z0)) == pytest.approx(
+        Z0, rel=1e-9
+    )
 
 
 def test_loss_is_the_escape_hatch_for_the_quarter_wave_open_stub():
@@ -203,17 +205,16 @@ def test_loss_is_the_escape_hatch_for_the_quarter_wave_open_stub():
 
 
 def test_half_wave_shorted_stub_is_a_dead_short_across_the_port():
-    """A k·λ/2 shorted stub repeats its short, so it really does put 0 Ω
-    across the port — and an ideal voltage source cannot drive that.
+    """A k·λ/2 shorted stub repeats its short, so it puts 0 Ω across the port.
 
-    Rewritten for issue #746: the failure used to come from TL's stamp-time
-    admittance guard, which raised on ANY lossless half-wave line whether or
-    not it was shorted. The chain-matrix stamp is finite there, so the line
-    itself is no longer the complaint; what is left is the genuine topological
-    short, reported by the solve.
-    """
-    with pytest.raises(SingularNetworkError, match="assembled system"):
-        z_shunt(shunt_shorted_stub(F_MHZ, 0.5, z0=Z0))
+    Rewritten for issue #746, in two steps. The failure used to come from TL's
+    stamp-time admittance guard, which fired on ANY lossless half-wave line
+    whether or not it was shorted; the chain-matrix stamp is finite there, so
+    what was left was the genuine topological short, which an ideal generator
+    could not drive. Now the driven port sits behind a reference impedance and
+    the short is simply the answer — the same one the λ/4 OPEN stub gives, as
+    it must, the two being the same circuit."""
+    assert abs(z_shunt(shunt_shorted_stub(F_MHZ, 0.5, z0=Z0))) < 1e-9
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_station_stubs.py
+++ b/tests/test_station_stubs.py
@@ -23,7 +23,11 @@ from antennaknobs.network import (
     PortVirtual,
     Shunt,
 )
-from antennaknobs.network_reduce import C_LIGHT, NetworkReducer
+from antennaknobs.network_reduce import (
+    C_LIGHT,
+    NetworkReducer,
+    SingularNetworkError,
+)
 from antennaknobs.station import (
     double_stub_tuner,
     series_open_stub,
@@ -198,10 +202,17 @@ def test_loss_is_the_escape_hatch_for_the_quarter_wave_open_stub():
     assert z.real > 0.0 and abs(z.imag) < 1e-9
 
 
-def test_half_wave_shorted_stub_trips_the_tl_guard_at_stamp_time():
-    """The other face of the same coin is TL's own: a lossless k·λ/2 line has
-    no finite admittance, so the reducer raises when it stamps."""
-    with pytest.raises(ValueError, match="sinh γl"):
+def test_half_wave_shorted_stub_is_a_dead_short_across_the_port():
+    """A k·λ/2 shorted stub repeats its short, so it really does put 0 Ω
+    across the port — and an ideal voltage source cannot drive that.
+
+    Rewritten for issue #746: the failure used to come from TL's stamp-time
+    admittance guard, which raised on ANY lossless half-wave line whether or
+    not it was shorted. The chain-matrix stamp is finite there, so the line
+    itself is no longer the complaint; what is left is the genuine topological
+    short, reported by the solve.
+    """
+    with pytest.raises(SingularNetworkError, match="assembled system"):
         z_shunt(shunt_shorted_stub(F_MHZ, 0.5, z0=Z0))
 
 

--- a/tests/test_touchstone.py
+++ b/tests/test_touchstone.py
@@ -14,16 +14,21 @@ import pytest
 
 from antennaknobs import AntennaBuilder, read_touchstone
 from antennaknobs.network import (
+    TL,
     Driven,
     Network,
     PortOnWire,
     PortVirtual,
-    TL,
     TouchstoneLoad,
     TouchstoneTwoPort,
     Wire,
 )
-from antennaknobs.network_reduce import C_LIGHT, NetworkReducer, tl_admittance_2x2
+from antennaknobs.network_reduce import (
+    C_LIGHT,
+    NetworkReducer,
+    SingularNetworkError,
+    tl_admittance_2x2,
+)
 from antennaknobs.touchstone import parse_touchstone
 
 FREQ_MHZ = 14.0
@@ -139,6 +144,105 @@ def test_infer_port_count_from_width():
 def test_gh_parameters_rejected():
     with pytest.raises(ValueError, match="not supported"):
         parse_touchstone("# HZ G RI R 50\n1 0 0\n")
+
+
+# ---------------------------------------------------------------------------
+# 1b. the poles of the parameter conversions (issue #746)
+#
+# S is bounded for every passive network; Y and Z are not. Each conversion is
+# a Möbius transform whose pole is a physical short (S = −1) or open (S = +1),
+# and the two ways a bare `np.linalg.inv` used to report that pole — an
+# untyped LinAlgError exactly on it, astronomical finite numbers just off it —
+# were both useless to the person holding the file.
+# ---------------------------------------------------------------------------
+def _s1p(s11, *, name=""):
+    return parse_touchstone(
+        f"# HZ S RI R 50\n1e7 {s11.real!r} {s11.imag!r}\n"
+        f"2e7 {s11.real!r} {s11.imag!r}\n",
+        name=name,
+    )
+
+
+def test_s1p_at_a_dead_short_raises_the_house_error():
+    """S11 = −1 exactly: `inv(I + S)` used to raise a bare LinAlgError."""
+    with pytest.raises(SingularNetworkError) as exc:
+        _s1p(-1.0 + 0j, name="shorted.s1p").y_at(1.5e7)
+    msg = str(exc.value)
+    assert "shorted.s1p" in msg  # which file
+    assert "15 MHz" in msg  # ...at which frequency
+    assert "I + S" in msg and "short circuit" in msg  # ...and why
+
+
+def test_s1p_a_hair_off_the_short_raises_too():
+    """The silent half of the bug: just off the pole there was no exception at
+    all, only a 1e13-siemens admittance stamped into the reducer's G."""
+    with pytest.raises(SingularNetworkError, match="I \\+ S"):
+        _s1p(-1.0 + 1e-13j).y_at(1.5e7)
+
+
+def test_s1p_near_but_not_at_the_short_is_finite_and_says_so(caplog):
+    """1e-10 from the pole is a legitimate near-short, not a singularity: the
+    admittance is enormous but correct, and the warning is the whole report."""
+    with caplog.at_level("WARNING"):
+        y = _s1p(-1.0 + 1e-10j, name="near.s1p").y_at(1.5e7)[0, 0]
+    # Y = (1/z0)(1 − S)/(1 + S) with S = −1 + 1e-10j
+    assert y == pytest.approx((1.0 / 50.0) * (2.0 - 1e-10j) / 1e-10j, rel=1e-6)
+    assert "near.s1p" in caplog.text and "nearly singular" in caplog.text
+
+
+def test_s1p_at_an_open_raises_from_z_at():
+    """The dual pole: S11 = +1 is an open, and it is `z_at` that hits it."""
+    with pytest.raises(SingularNetworkError) as exc:
+        _s1p(1.0 + 0j).z_at(1.5e7)
+    assert "I − S" in str(exc.value) and "open circuit" in str(exc.value)
+    # ...while the admittance of that same open is a perfectly ordinary zero.
+    assert _s1p(1.0 + 0j).y_at(1.5e7)[0, 0] == pytest.approx(0.0, abs=1e-15)
+
+
+def test_matched_coax_at_half_wave_s2p_no_longer_stamps_1e14():
+    """The case the issue names: a 50 Ω coax measured into a 50 Ω reference at
+    exactly 180° electrical has S = [[0, −1], [−1, 0]], so I + S is rank 1.
+    Nothing about the file is unusual and nothing about the physics is
+    singular — the *admittance description* of a half-wave line is what does
+    not exist."""
+    s21 = np.exp(-1j * np.pi)  # −1 to within one ulp, as a real file records it
+    s = np.array([[0.0, s21], [s21, 0.0]], dtype=complex)
+    t = parse_touchstone(
+        _s2p_from_matrix([13e6, 15e6], lambda f: s), nports=2, name="coax180.s2p"
+    )
+    # What the unguarded conversion produced: no exception, just an absurdity.
+    # The ulp is exactly what kept `inv` from noticing.
+    eye = np.eye(2)
+    y_unguarded = (1.0 / 50.0) * (eye - s) @ np.linalg.inv(eye + s)
+    assert np.isfinite(y_unguarded).all() and abs(y_unguarded[0, 0]) > 1e13
+
+    with pytest.raises(SingularNetworkError) as exc:
+        t.y_at(14e6)
+    assert "coax180.s2p" in str(exc.value) and "I + S" in str(exc.value)
+
+    # And exactly on it, where `inv` raised an untyped LinAlgError instead.
+    exact = parse_touchstone(
+        _s2p_from_matrix([13e6, 15e6], lambda f: np.array([[0.0, -1.0], [-1.0, 0.0]])),
+        nports=2,
+    )
+    with pytest.raises(SingularNetworkError):
+        exact.y_at(14e6)
+
+
+def test_an_open_y_file_still_has_an_ordinary_s():
+    """`s_at` goes Y → S directly rather than through Z, because S exists where
+    Z does not: a zero admittance is an open, whose reflection is simply +1."""
+    t = parse_touchstone("# HZ Y RI R 50\n1e7 0 0\n2e7 0 0\n")
+    assert t.s_at(1.5e7)[0, 0] == pytest.approx(1.0, rel=1e-12)
+    with pytest.raises(SingularNetworkError, match="open circuit"):
+        t.z_at(1.5e7)
+
+
+def test_a_shorted_z_file_reports_the_short():
+    t = parse_touchstone("# HZ Z RI R 50\n1e7 0 0\n2e7 0 0\n")
+    with pytest.raises(SingularNetworkError, match="short circuit"):
+        t.y_at(1.5e7)
+    assert t.s_at(1.5e7)[0, 0] == pytest.approx(-1.0, rel=1e-12)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Implements #746 in three increments (one commit each):

1. **Touchstone pole guard**: `y_at`/`z_at`/`s_at` raise `SingularNetworkError` (reused from #647 — the type already existed) naming the file, frequency, and physics when the inverted matrix is within `RCOND_SINGULAR` of rank-deficient; between `RCOND_SINGULAR` and `RCOND_SUSPECT` they warn, mirroring the solve's two-tier policy. rcond is σ_min against the matrix's *natural scale* (1 for I±S, z0 for Z, 1/z0 for Y) because σ_min/σ_max is structurally blind to the 1×1 `.s1p` case. The silent |y11|≈1.6e14 half-wave-coax `.s2p` now raises. Import cycle resolved with a function-local import (touchstone stays a leaf).
2. **ABCD Group-2 stamps for TL/BalancedLine**: `tl_abcd` + `_stamp_abcd` with two auxiliary currents per line, the j₂ coupling on #594's `couplings` channel. `_Group2Element` gains an arbitrary-arity `terms` form; per-port **weight lists** make coax/crossed/differential/common-mode one routine (a crossed line is a negated port weight, not a flag). BalancedLine's CM-open rank-2 is preserved **structurally** — the (+1,−1) incidence cancels identically (verified exact zero). `branch_power` gains a `"group2abcd"` kind per the `"group2r"` precedent; labels byte-identical. The λ/2 guard is retired from the reducer path; `tl_admittance_2x2`/`balanced_admittance_4x4` stay as closed-form oracles (still raising, tests unmodified).
3. **Γ-referenced driven port**: the impedance/Γ solve stamps the EMF behind `Z_REF_DEFAULT=50`; `impedance_from_y` subtracts it back (Z algebraically unchanged); new `reflection_from_y`/`driven_reflection` read Γ=(2v_ref−E)/E natively — a short is Γ=−1, a true open exactly Γ=+1. The excited/far-field path deliberately keeps the ideal generator (**second solve, not an rcond fallback** — a fallback would make gain normalization depend on a conditioning threshold). The reference is stamped only where a reference plane exists: exactly one active voltage source (a second generator gives a measured 23% error; those networks keep the ideal stamp and convert Γ from Z). `station._guard_open_stub` retired.

## Measured (builder's figures, key ones re-derived in review)
- Half-wave through-line: Z = Z_load to **8.5e-14** worst over vf×k×load grid (reviewer reproduction: 2.2e-16 on a 73 Ω fixture); rcond healthy at the exact pole.
- Old-vs-new stamp agreement where the old stamp existed: TL **1.4e-12** over 600 random lines, BalancedLine **1.0e-13** over 267.
- Γ vs (Z−z0)/(Z+z0): **~1e-16** over 200 random loads (reviewer reproduction: 5e-17).
- λ/4-open-stub pole now solves: Γ = **−1** + 1.2e-16j (see review notes), rcond flat through the pole vs 1.2e-13-and-raise before.
- tl_card and nt_card engine-parity oracles: green **unmodified**. Power-budget labels byte-identical.

## Gates
- Full suite (`-m "not heavy_mesh"`, includes the per-design solver catalogs): **3409 passed** on this branch rebased onto current main, with pynec-accel 1.7.6.
- ruff check + format clean.
- Test rewrites confined to the files whose premise the issue retires (`test_singular_network`, `test_station_stubs`, G5RV in `test_cebik_designs` — now asserts half-wave and full-wave agree to 1e-9, stronger than "both raise"); each justified in its commit.

## Review notes (session model reviewing an opus builder)
- Read the full 1,493-line diff; re-derived the ABCD constitutive rows and KCL signs (j₁ into A, j₂ out of B, couplings −B/+1), the weight-list congruence (power-invariant), and the Γ readout algebra ((2v_ref−E)/E = (Z−z_ref)/(Z+z_ref) with the plane ahead of the load chain). No changes needed.
- **The builder corrected the issue/brief on physics**: a λ/4 *open* stub presents Z=0 across the port, so its Γ is **−1**; the issue's "Γ=+1" applies to true Z=∞ opens (which now do return exactly +1). It also kept `_singularity_report`'s odd-λ/4 branch (the brief expected retirement) because the far-field path retains the ideal generator and can still legitimately fail there — the attribution now explains that asymmetry. I verified both calls and endorse them.
- Deviations from the issue, documented in code: the sweep.py/fit.py/measured.py Z→Γ migration was **not** done (each site consumes engine-API Z arrays at a chart-settable z0; `driven_reflection` is exposed for when an engine-level `reflection_sweep()` makes it worthwhile).
- Follow-up candidates (not filed): route `TouchstoneTwoPort` through `_stamp_abcd` (a half-wave coax `.s2p` has a finite ABCD but no Y, so it currently raises where it could solve); engine-level `reflection()`; a `_singularity_report` branch for open-terminated k·λ/2 lines (the real cause of the one remaining `doublet_balanced_tuner` poisoned sample, confirmed topological).

Closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g