### PR TITLE
Overlay & mobile fixes: idle-fading layout toggle, fully reachable readout, escapable view sheet

### DIFF
--- a/src/antennaknobs/web/frontend/src/__tests__/MobileCarousel.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/MobileCarousel.test.tsx
@@ -246,10 +246,37 @@ describe("the ⋯ affordance", () => {
   it("closes on a backdrop click", async () => {
     const user = userEvent.setup();
     seed(TWO);
-    const { container } = render(<Mobile initialView="smith" />);
+    render(<Mobile initialView="smith" />);
     await openSheet(user);
-    await user.click(container.querySelector(".view-sheet-backdrop") as Element);
+    // document, not container: the sheet portals to <body> (a transformed
+    // ancestor — .mobile-dots — would otherwise hijack its fixed
+    // positioning), so it is deliberately NOT in the render container.
+    await user.click(document.querySelector(".view-sheet-backdrop") as Element);
     expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("closes on the sheet's own ✕ — dismissal must not depend on backdrop real estate", async () => {
+    const user = userEvent.setup();
+    seed(TWO);
+    render(<Mobile initialView="smith" />);
+    await openSheet(user);
+    await user.click(screen.getByRole("button", { name: "Close" }));
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("portals the sheet out of the transformed dots row", async () => {
+    const user = userEvent.setup();
+    seed(TWO);
+    render(<Mobile initialView="smith" />);
+    await openSheet(user);
+    // The regression this pins: .mobile-dots centers itself with a CSS
+    // transform, and a transformed ancestor is the containing block for
+    // position:fixed descendants — a sheet rendered inside it was "fixed"
+    // to the dots strip (clipped, backdrop useless). The sheet must never
+    // again be a DOM descendant of the dots row.
+    const sheet = document.querySelector(".view-sheet") as Element;
+    expect(sheet).toBeTruthy();
+    expect(sheet.closest(".mobile-dots")).toBeNull();
   });
 });
 

--- a/src/antennaknobs/web/frontend/src/__tests__/StageOverlays.idle.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/StageOverlays.idle.test.tsx
@@ -1,0 +1,86 @@
+// The layout toggle floats over chart content, so it fades after
+// LAYOUT_TOGGLE_IDLE_MS without mouse activity and returns on movement;
+// hover and keyboard focus hold it visible (a resting cursor is intent,
+// not idleness). The idle class also drops pointer-events (styles.css) so
+// faded means the data underneath is hoverable — presence of the class is
+// the whole behavioral contract, pinned here.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, act, fireEvent } from "@testing-library/react";
+import {
+  LayoutModeToggle,
+  LAYOUT_TOGGLE_IDLE_MS,
+} from "../components/results/StageOverlays";
+
+function renderToggle() {
+  return render(<LayoutModeToggle layout="rail" setLayout={() => {}} />);
+}
+
+const toggle = () =>
+  document.querySelector(".layout-toggle") as HTMLElement;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("layout toggle idle fade", () => {
+  it("is visible on mount and fades after the idle window", () => {
+    renderToggle();
+    expect(toggle().className).not.toContain("layout-toggle-idle");
+    act(() => {
+      vi.advanceTimersByTime(LAYOUT_TOGGLE_IDLE_MS + 50);
+    });
+    expect(toggle().className).toContain("layout-toggle-idle");
+  });
+
+  it("returns on mouse movement and fades again when it stops", () => {
+    renderToggle();
+    act(() => {
+      vi.advanceTimersByTime(LAYOUT_TOGGLE_IDLE_MS + 50);
+    });
+    expect(toggle().className).toContain("layout-toggle-idle");
+    act(() => {
+      fireEvent.mouseMove(window);
+    });
+    expect(toggle().className).not.toContain("layout-toggle-idle");
+    act(() => {
+      vi.advanceTimersByTime(LAYOUT_TOGGLE_IDLE_MS + 50);
+    });
+    expect(toggle().className).toContain("layout-toggle-idle");
+  });
+
+  it("never fades while hovered", () => {
+    renderToggle();
+    act(() => {
+      fireEvent.mouseEnter(toggle());
+    });
+    act(() => {
+      vi.advanceTimersByTime(LAYOUT_TOGGLE_IDLE_MS * 3);
+    });
+    expect(toggle().className).not.toContain("layout-toggle-idle");
+    // Leaving without movement re-arms nothing by itself — the NEXT idle
+    // window after leaving is what fades it.
+    act(() => {
+      fireEvent.mouseLeave(toggle());
+      fireEvent.mouseMove(window);
+    });
+    act(() => {
+      vi.advanceTimersByTime(LAYOUT_TOGGLE_IDLE_MS + 50);
+    });
+    expect(toggle().className).toContain("layout-toggle-idle");
+  });
+
+  it("never fades while a button inside has keyboard focus", () => {
+    renderToggle();
+    const btn = toggle().querySelector("button")!;
+    act(() => {
+      fireEvent.focus(btn);
+    });
+    act(() => {
+      vi.advanceTimersByTime(LAYOUT_TOGGLE_IDLE_MS * 3);
+    });
+    expect(toggle().className).not.toContain("layout-toggle-idle");
+  });
+});

--- a/src/antennaknobs/web/frontend/src/components/results/SolveReadout.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/SolveReadout.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from "react";
+import { Fragment, useEffect, useRef, useState } from "react";
 import type { NormCheckData, SolveResponse } from "../../lib/api";
 import { formatOhms, formatSwr } from "../../lib/format";
 import type { ExampleDescriptor } from "../../lib/params";
@@ -50,8 +50,38 @@ export function SolveReadout({
   className?: string;
 }) {
   const planes = result?.planes;
+  // Overflow guard for the floating stage HUD: with enough content (a
+  // multi-feed Z table plus a design's own readout rows), the card can
+  // outgrow the stage. CSS caps its height; this effect detects that the
+  // cap actually bit (scrollHeight > clientHeight) and flips a class that
+  // makes the card scrollable — which also requires giving it back the
+  // pointer-events the passive HUD normally renounces, so drag-through is
+  // sacrificed only when there is hidden content worth scrolling to.
+  // Watched with a ResizeObserver rather than computed per render: the
+  // readout grows on solve responses and dwell results, not renders.
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [overflowing, setOverflowing] = useState(false);
+  const check = () => {
+    const el = rootRef.current;
+    if (el) setOverflowing(el.scrollHeight > el.clientHeight + 1);
+  };
+  // Re-measure on every render (content changes arrive as renders)…
+  useEffect(check);
+  // …and on container resizes, which happen with no render at all.
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(check);
+    ro.observe(el);
+    return () => ro.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `check` reads
+    // only refs/setState; recreating the observer per render buys nothing.
+  }, []);
   return (
-    <div className={`readout${className ? " " + className : ""}`}>
+    <div
+      ref={rootRef}
+      className={`readout${className ? " " + className : ""}${overflowing ? " readout-overflowing" : ""}`}
+    >
       {onPlaneChange && planes && planes.length > 1 && (
         <div
           className="row"

--- a/src/antennaknobs/web/frontend/src/components/results/StageOverlays.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/StageOverlays.tsx
@@ -1,4 +1,5 @@
 
+import { useEffect, useRef, useState } from "react";
 import type { MeasuredData, NormCheckData, SolveResponse } from "../../lib/api";
 import type { GroundModel } from "../../lib/ground";
 import type { ExampleDescriptor } from "../../lib/params";
@@ -9,11 +10,24 @@ import type { PatternMetrics, PinnedPattern } from "../charts/types";
 import { Knob } from "../params/Knob";
 import { PatternCompareTable } from "./PatternCompareTable";
 
+// How long the mouse must be still before the layout toggle fades. Long
+// enough that it never flickers during normal pointer travel toward it,
+// short enough that reading the chart under it is never blocked.
+export const LAYOUT_TOGGLE_IDLE_MS = 1200;
+
 // The rail/grid segmented control (unit 3, docs/plan-view-rail-scaling.md
 // "Layout modes"): two presets over the same pinned set. Placed by the
 // caller in the stage's top-right corner, desktop only — it lives in
 // DesignSession's desktop return branch, which the mobile branch never
 // reaches, so "hidden on mobile" needs no prop here.
+//
+// It sits ON TOP of chart content (the stage corner is not reserved), so it
+// fades out after LAYOUT_TOGGLE_IDLE_MS without mouse activity and comes
+// back on any movement — present while the user is driving, gone while they
+// are reading. While faded it also drops pointer-events, so the data under
+// it is hoverable, not just visible. Hover and keyboard focus hold it
+// visible: a cursor resting on the control (or a Tab stop inside it) is
+// intent, not idleness.
 export function LayoutModeToggle({
   layout,
   setLayout,
@@ -21,8 +35,43 @@ export function LayoutModeToggle({
   layout: Layout;
   setLayout: (l: Layout) => void;
 }) {
+  const [idle, setIdle] = useState(false);
+  const holdRef = useRef(false); // hovered or focus-within: never fade
+  const timerRef = useRef<number | null>(null);
+  useEffect(() => {
+    const arm = () => {
+      if (timerRef.current) window.clearTimeout(timerRef.current);
+      timerRef.current = window.setTimeout(() => {
+        if (!holdRef.current) setIdle(true);
+      }, LAYOUT_TOGGLE_IDLE_MS);
+    };
+    const wake = () => {
+      setIdle(false);
+      arm();
+    };
+    window.addEventListener("mousemove", wake);
+    window.addEventListener("pointerdown", wake);
+    arm();
+    return () => {
+      window.removeEventListener("mousemove", wake);
+      window.removeEventListener("pointerdown", wake);
+      if (timerRef.current) window.clearTimeout(timerRef.current);
+    };
+  }, []);
+  const hold = (v: boolean) => {
+    holdRef.current = v;
+    if (v) setIdle(false);
+  };
   return (
-    <div className="layout-toggle" role="group" aria-label="Stage layout">
+    <div
+      className={`layout-toggle${idle ? " layout-toggle-idle" : ""}`}
+      role="group"
+      aria-label="Stage layout"
+      onMouseEnter={() => hold(true)}
+      onMouseLeave={() => hold(false)}
+      onFocus={() => hold(true)}
+      onBlur={() => hold(false)}
+    >
       <button
         type="button"
         className={layout === "rail" ? "active" : ""}

--- a/src/antennaknobs/web/frontend/src/components/session/ViewPicker.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/ViewPicker.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { VIEWS, type View } from "../../lib/view";
 import { PIN_CAP, pinBlockedReason } from "./useViewPrefs";
 
@@ -275,30 +276,58 @@ export function ViewSheet({
       >
         ⋯
       </button>
-      {open && (
-        <>
-          <div className="view-sheet-backdrop" onClick={() => setOpen(false)} />
-          {/* No anchor measurement, unlike the popover: the sheet is pinned to
-              the viewport's bottom edge, which is also the only place a phone
-              can put a list this tall within thumb reach. */}
-          <div className="view-sheet" role="menu" aria-label="All views">
-            <ViewRosterRows
-              view={view}
-              pinned={pinned}
-              badged={badged}
-              togglePin={togglePin}
-              movePin={movePin}
-              // Curating is a run of gestures — the sheet does NOT close on a
-              // tap, so several pages can be added or dropped in one visit.
-              onRowClick={togglePin}
-              rowBlocked={(id) => pinBlockedReason(pinned, id)}
+      {open &&
+        // PORTALED to <body>, not rendered in place: this component lives
+        // inside .mobile-dots, whose translateX(-50%) centering makes it a
+        // CONTAINING BLOCK for fixed-position descendants (any transformed
+        // ancestor is — CSS transforms spec). Rendered in place, the sheet
+        // and its backdrop were "fixed" relative to the dots strip: the
+        // sheet clipped to a sliver and the tap-to-dismiss backdrop covered
+        // almost nothing of the screen it was supposed to catch.
+        createPortal(
+          <>
+            <div
+              className="view-sheet-backdrop"
+              onClick={() => setOpen(false)}
             />
-            <div className="view-picker-note">
-              Tap a view to add or remove its page · max {PIN_CAP} pages
+            {/* No anchor measurement, unlike the popover: the sheet is pinned
+                to the viewport's bottom edge, which is also the only place a
+                phone can put a list this tall within thumb reach. */}
+            <div className="view-sheet" role="menu" aria-label="All views">
+              {/* An explicit close: the backdrop only exists ABOVE the sheet,
+                  and a tall roster leaves little of it — dismissal must not
+                  depend on how much screen the list happened to spare. */}
+              <div className="view-sheet-head">
+                <span className="view-sheet-title">Views</span>
+                <button
+                  type="button"
+                  className="view-sheet-close"
+                  aria-label="Close"
+                  title="Close"
+                  onClick={() => setOpen(false)}
+                >
+                  ✕
+                </button>
+              </div>
+              <ViewRosterRows
+                view={view}
+                pinned={pinned}
+                badged={badged}
+                togglePin={togglePin}
+                movePin={movePin}
+                // Curating is a run of gestures — the sheet does NOT close on
+                // a tap, so several pages can be added or dropped in one
+                // visit.
+                onRowClick={togglePin}
+                rowBlocked={(id) => pinBlockedReason(pinned, id)}
+              />
+              <div className="view-picker-note">
+                Tap a view to add or remove its page · max {PIN_CAP} pages
+              </div>
             </div>
-          </div>
-        </>
-      )}
+          </>,
+          document.body,
+        )}
     </>
   );
 }

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -2077,6 +2077,16 @@ input[type=checkbox] {
   border-radius: var(--r-md);
   padding: var(--space-2);
   box-shadow: 0 2px 10px var(--shadow);
+  transition: opacity 0.35s ease;
+}
+
+/* Faded after LAYOUT_TOGGLE_IDLE_MS without mouse activity (the control
+   floats OVER chart content). pointer-events off so the data underneath is
+   hoverable while faded — any mouse movement brings the control back, so
+   nothing is ever more than a wiggle away. */
+.layout-toggle-idle {
+  opacity: 0;
+  pointer-events: none;
 }
 
 .layout-toggle button {
@@ -2421,9 +2431,23 @@ input[type=checkbox] {
   z-index: 2;
   min-width: 172px;
   max-width: 240px;
+  /* Never taller than the stage it floats over: a long readout (multi-feed
+     Z table + a design's own rows) used to grow past the top edge. The cap
+     clips; the .readout-overflowing escape hatch below restores access. */
+  max-height: calc(100% - 2 * var(--space-6));
+  overflow-y: hidden;
   line-height: 1.6;
   box-shadow: 0 4px 16px var(--shadow-strong);
   pointer-events: none; /* a passive HUD — never intercept drags on the view */
+}
+
+/* When the height cap actually bit (SolveReadout's ResizeObserver sets
+   this), the HUD becomes scrollable — which requires taking pointer-events
+   back. Drag-through over the card is sacrificed only while there is
+   hidden content to reach; the normal-sized readout stays fully passive. */
+.stage-readout.readout-overflowing {
+  overflow-y: auto;
+  pointer-events: auto;
 }
 
 /* The one interactive thing in the HUD: the measurement-plane picker
@@ -3014,10 +3038,19 @@ canvas {
 }
 
 .mobile-screen-info {
-  /* The readout can exceed a ~400px landscape pane (per-feed Z table), so
-     this screen scrolls vertically; y-scroll inside an x-snap carousel
-     coexists fine. Column: the readout with the ws status row under it. */
+  /* The readout can exceed a ~400px landscape pane (per-feed Z table, a
+     design's own readout rows — invvee_catenary's rigging group), so this
+     screen scrolls vertically; y-scroll inside an x-snap carousel coexists
+     fine. Column: the readout with the ws status row under it.
+
+     justify-content MUST be flex-start here, overriding .mobile-screen's
+     center: a centered column taller than its scrollport overflows both
+     ends, and the half above the scroll origin is UNREACHABLE — no amount
+     of panning shows the first readout rows. Top-aligned, scrolling reaches
+     everything. (Pinch-zoom needs nothing from us: the viewport meta does
+     not disable user scaling.) */
   flex-direction: column;
+  justify-content: flex-start;
   overflow-y: auto;
   align-items: stretch;
   padding: var(--space-7) 0;
@@ -3103,12 +3136,50 @@ canvas {
   bottom: 0;
   z-index: 41;
   max-height: 70vh;
+  /* dvh where supported: 70vh is 70% of the LAYOUT viewport, which on a
+     phone with the URL bar collapsed can be taller than what's actually on
+     screen — the sheet's top edge (and the backdrop above it) ended up
+     under browser chrome. dvh tracks the visible viewport. */
+  max-height: 70dvh;
   overflow-y: auto;
   padding: var(--space-2) var(--space-3) var(--space-5);
   background: var(--bg);
   border-top: 1px solid var(--border-control);
   border-radius: var(--r-md) var(--r-md) 0 0;
   box-shadow: 0 -6px 20px var(--shadow-strong);
+}
+
+/* Sticky header: the title and the explicit close stay reachable however
+   far the roster scrolls — dismissal must never depend on scroll position
+   or on how much backdrop the list left uncovered. */
+.view-sheet-head {
+  position: sticky;
+  top: calc(-1 * var(--space-2)); /* cancel the sheet's own top padding */
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: calc(-1 * var(--space-2)) 0 0;
+  padding: var(--space-3);
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  z-index: 1;
+}
+
+.view-sheet-title {
+  color: var(--muted);
+  font: var(--text-sm) var(--font-mono);
+}
+
+.view-sheet-close {
+  /* Thumb-sized like the sheet's other targets. */
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: var(--r-sm);
+  background: var(--inset);
+  color: var(--fg);
+  font-size: var(--text-base);
+  cursor: pointer;
 }
 
 /* Touch-sized rows (cf. the coarse-pointer block below): the popover's 24 px


### PR DESCRIPTION
## Summary
- **Layout toggle fades when idle**: the rail/grid control floats over chart content in the stage corner; it now fades after 1.2 s without mouse activity (dropping pointer-events so the data beneath is hoverable) and returns on any movement. Hover or keyboard focus holds it visible.
- **Mobile Info screen top was unreachable**: it inherited `justify-content: center` from `.mobile-screen`, and a centered flex column taller than its scrollport overflows both ends — the top half cannot be scrolled to. Top-aligned now, so a long readout (invvee_catenary's rigging group) pans fully; pinch-zoom already worked. The desktop stage HUD gets the same protection: a max-height cap plus a ResizeObserver-set `.readout-overflowing` class that makes the card scrollable, taking back the passive HUD's pointer-events only while there is hidden content to reach.
- **Mobile view sheet was clipped and un-dismissable**: the "⋯" roster rendered inside `.mobile-dots`, whose `translateX(-50%)` makes it the containing block for `position: fixed` descendants — sheet and tap-to-dismiss backdrop were "fixed" to the dots strip. Portaled to `<body>`, with a sticky header carrying an explicit ✕ (dismissal no longer depends on backdrop real estate) and a `dvh` height cap so collapsed browser chrome can't eat the top edge.

## Test plan
- [x] tsc --noEmit clean, eslint 0 errors, 672/672 vitest (6 new: idle-fade contract ×4, ✕ close, portal regression pin asserting the sheet is never a DOM descendant of the dots row)
- [x] ruff check + format clean (no Python changes)
- [x] Manual on LAN: catenary Info tab pans to the top row; ⋯ sheet opens full-width with working backdrop and ✕

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g