### PR TITLE
Adaptive refinement follow-ups: settings toggle, residency-aware planning, clamp-aware deviations, lean base grid, connected Smith locus

### DIFF
--- a/src/antennaknobs/web/frontend/src/__tests__/cutRefine.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/cutRefine.test.tsx
@@ -11,6 +11,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import {
   CUT_REFINE_BUDGET,
+  setCutRefineEnabled,
   traceFor,
   useCutTraces,
 } from "../components/charts/cuts";
@@ -176,7 +177,7 @@ const refineBodies = () =>
 describe("cut refinement transport (issue #744)", () => {
   it("refines only after the dwell, at explicit angles, within budget", async () => {
     const solve = makeSolve();
-    const { result } = renderHook(() => useCutTraces([solve], 15, 0));
+    const { result } = renderHook(() => useCutTraces("xy", [solve], 15, 0));
     // The solve already carries cuts at these angles, so nothing is fetched
     // and nothing is refined until the dwell elapses.
     await settle(300);
@@ -206,7 +207,7 @@ describe("cut refinement transport (issue #744)", () => {
   it("a cut-dial drag inside the dwell issues no refinement", async () => {
     const solve = makeSolve();
     const { rerender } = renderHook(
-      (p: { az: number }) => useCutTraces([solve], p.az, 0),
+      (p: { az: number }) => useCutTraces("xy", [solve], p.az, 0),
       { initialProps: { az: 15 } },
     );
     // Drag through a run of angles, each well inside the refinement dwell.
@@ -227,7 +228,7 @@ describe("cut refinement transport (issue #744)", () => {
   it("a new solve leaves no refined sample behind", async () => {
     const first = makeSolve();
     const { result, rerender } = renderHook(
-      (p: { solve: SolveResponse }) => useCutTraces([p.solve], 15, 0),
+      (p: { solve: SolveResponse }) => useCutTraces("xy", [p.solve], 15, 0),
       { initialProps: { solve: first } },
     );
     await settle(1000);
@@ -254,8 +255,52 @@ describe("cut refinement transport (issue #744)", () => {
       solve_id: "solve-round",
       cuts: round,
     } as unknown as SolveResponse;
-    renderHook(() => useCutTraces([solve], 15, 0));
+    renderHook(() => useCutTraces("xy", [solve], 15, 0));
     await settle(1000);
     expect(refineBodies()).toHaveLength(0);
+  });
+
+  it("buys angles only for the cut whose chart is mounted", async () => {
+    // Faithful mock: echo an explicit list only for the cut that asked for
+    // one, exactly like the real server ("absent means uniform").
+    fetchMock.mockImplementation((url: string, init?: { body?: string }) => {
+      const body = JSON.parse(init?.body ?? "{}");
+      if (url === "/cuts") cutsBodies.push(body);
+      const az: number[] | undefined = body.az_angles_deg;
+      const el: number[] | undefined = body.elev_angles_deg;
+      const at = (a: number[] | undefined) =>
+        a ? [...a].sort((x, y) => x - y).map(dbiAt) : uniformCuts(24).azimuth;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            ...uniformCuts(24),
+            azimuth: at(az),
+            elevation: at(el),
+            ...(az ? { az_angles_deg: [...az].sort((x, y) => x - y) } : {}),
+            ...(el ? { elev_angles_deg: [...el].sort((x, y) => x - y) } : {}),
+          }),
+      });
+    });
+    // Only the azimuth chart is mounted (the hook registers its cut).
+    renderHook(() => useCutTraces("xy", [makeSolve()], 15, 0));
+    await settle(1000);
+    const rounds = refineBodies();
+    expect(rounds.length).toBeGreaterThan(0);
+    // Not one request spent an angle on the elevation cut: its chart is not
+    // on screen, so its uniform parameterisation travels as ABSENT.
+    for (const b of cutsBodies) expect(b.elev_angles_deg).toBeUndefined();
+  });
+
+  it("the adaptive-resolution toggle gates cut refinement entirely", async () => {
+    setCutRefineEnabled(false);
+    try {
+      renderHook(() => useCutTraces("xy", [makeSolve()], 15, 0));
+      await settle(1500);
+      expect(refineBodies()).toHaveLength(0);
+    } finally {
+      setCutRefineEnabled(true);
+    }
   });
 });

--- a/src/antennaknobs/web/frontend/src/__tests__/refine.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/refine.test.ts
@@ -286,6 +286,79 @@ describe("sweepProjections / refineSweepFreqs", () => {
   it("declines to plan for a sweep too short to have curvature", () => {
     expect(refineSweepFreqs(notchSweep([10, 11]), 50, 12)).toEqual([]);
   });
+
+  // A constant-|Γ| phase rotation: VSWR and S11-dB are FLAT (both are
+  // functions of |Γ| alone) while the Smith locus sweeps a wide arc — the
+  // cleanest separator between "the scalar charts need points" and "only
+  // the Smith chart does".
+  function arcSweep(n = 41): SweepData {
+    const freqs = Array.from({ length: n }, (_, i) => 10 + (i * 4) / (n - 1));
+    const g = 0.6;
+    return {
+      freqs_mhz: freqs,
+      // Γ = 0.6·e^{jθ}, θ swept non-uniformly so the arc has display-space
+      // curvature variation worth refining. Z = z0(1+Γ)/(1−Γ).
+      z_re: freqs.map((_f, i) => {
+        const th = Math.PI * Math.pow(i / (n - 1), 2);
+        const re = g * Math.cos(th);
+        const im = g * Math.sin(th);
+        const d = (1 - re) * (1 - re) + im * im;
+        return (50 * (1 - re * re - im * im)) / d;
+      }),
+      z_im: freqs.map((_f, i) => {
+        const th = Math.PI * Math.pow(i / (n - 1), 2);
+        const re = g * Math.cos(th);
+        const im = g * Math.sin(th);
+        const d = (1 - re) * (1 - re) + im * im;
+        return (50 * 2 * im) / d;
+      }),
+    };
+  }
+
+  it("residency filter: Smith-only curvature is skipped when Smith is not on screen (#763 follow-up era)", () => {
+    const s = arcSweep();
+    const withSmith = refineSweepFreqs(s, 50, 12, {
+      vswr: true,
+      gamma: true,
+      smith: true,
+    });
+    const withoutSmith = refineSweepFreqs(s, 50, 12, {
+      vswr: true,
+      gamma: true,
+      smith: false,
+    });
+    // The arc demands points for the Smith locus…
+    expect(withSmith.length).toBeGreaterThan(0);
+    // …and none at all once Smith is the only chart that would show them:
+    // VSWR and S11 are constant for constant |Γ|.
+    expect(withoutSmith).toEqual([]);
+  });
+
+  it("clamped vertices score zero: the corner where the curve meets the chart edge is not chased", () => {
+    // A spike clipping through the VSWR ceiling: mid samples pinned at y=1.
+    const freqs = Array.from({ length: 9 }, (_, i) => 14 + i * 0.05);
+    const s: SweepData = {
+      freqs_mhz: freqs,
+      z_re: freqs.map(() => 50),
+      // |X| huge in the middle third → VSWR far above 10, clamped flat.
+      z_im: freqs.map((_, i) => (i >= 3 && i <= 5 ? 5000 : 100)),
+    };
+    const [vswr] = sweepProjections(s, 50);
+    // The middle third really is clamped…
+    expect(vswr[4].clamped).toBe(true);
+    expect(vswr[4].y).toBe(1);
+    // …and the planner assigns those vertices no deviation: only the VSWR
+    // projection is offered, so any planned point must come from UNCLAMPED
+    // vertices' deviations, never from sharpening the ceiling corner
+    // between two clamped samples.
+    const planned = planRefinement(freqs, [vswr], { budget: 8 });
+    for (const f of planned) {
+      // No midpoint may land strictly inside the clamped run (between
+      // samples 3 and 5): both endpoints of those intervals are clamped
+      // and their drawn segment is the ceiling regardless of the truth.
+      expect(f < freqs[3] || f > freqs[5]).toBe(true);
+    }
+  });
 });
 
 describe("cut projection / refineCutAngles", () => {

--- a/src/antennaknobs/web/frontend/src/__tests__/refine.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/refine.test.ts
@@ -14,6 +14,7 @@ import {
   planRefinement,
   refineCutAngles,
   refineSweepFreqs,
+  s11DbTop,
   sweepProjections,
   turnAngles,
   type DisplayPoint,
@@ -264,6 +265,44 @@ describe("sweepProjections / refineSweepFreqs", () => {
     // Perfect match at the notch: VSWR 1 (bottom) and S11 below −30 (bottom).
     expect(vswr[1].y).toBe(0);
     expect(gamma[1].y).toBe(0);
+  });
+
+  it("s11DbTop: 0 for anything passive, ceil(max+1) once a sample crosses 0 dB", () => {
+    expect(s11DbTop([-30, -4, -0.2])).toBe(0);
+    expect(s11DbTop([])).toBe(0);
+    expect(s11DbTop([-3, 0.6])).toBe(2); // ceil(1.6)
+    expect(s11DbTop([1.28])).toBe(3); // ceil(2.28)
+    expect(s11DbTop([NaN, Infinity, -1])).toBe(0); // garbage never grows the axis
+  });
+
+  it("an over-unity active port draws ABOVE the 0 dB line, unclamped, and refinable", () => {
+    // Negative active resistance (a detuned driven-array element eating its
+    // neighbours' power): |Γ| > 1, S11 ≈ +2.8 dB.
+    const s: SweepData = {
+      freqs_mhz: [10, 12, 14, 16, 18],
+      z_re: [150, 80, -45, 80, 150],
+      z_im: [100, 100, 100, 100, 100],
+    };
+    const [gamma] = sweepProjections(s, 50, {
+      vswr: false,
+      gamma: true,
+      smith: false,
+    });
+    // The headroom (s11DbTop) means the over-unity sample sits INSIDE the
+    // axis — below the top, above where 0 dB now maps — and is not
+    // clamp-marked, so refinement resolves the crossing like any feature.
+    expect(gamma[2].clamped).toBeUndefined();
+    expect(gamma[2].y).toBeLessThan(1);
+    expect(gamma[2].y).toBeGreaterThan(gamma[0].y);
+    // On the Smith disc the same sample is OUTSIDE |Γ| = 1, which the chart
+    // clips — marked clamped so the planner doesn't chase an invisible arc.
+    const [smith] = sweepProjections(s, 50, {
+      vswr: false,
+      gamma: false,
+      smith: true,
+    });
+    expect(smith[2].clamped).toBe(true);
+    expect(smith[0].clamped).toBeUndefined();
   });
 
   it("adds points around the notch and skips the flat wings", () => {

--- a/src/antennaknobs/web/frontend/src/__tests__/sweep.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/sweep.test.ts
@@ -48,26 +48,45 @@ function baseParams(overrides: Partial<Parameters<typeof planSweepFreqs>[0]> = {
 }
 
 describe("planSweepFreqs", () => {
-  it("uses 41 points when ground is off or the model isn't Sommerfeld", () => {
-    expect(planSweepFreqs(baseParams())).toHaveLength(41);
+  it("starts lean (17 points) when adaptive resolution will refine the curve", () => {
+    // The default: the base grid only has to DETECT features (land samples
+    // in their tails); the refinement planner spends the real points.
+    expect(planSweepFreqs(baseParams())).toHaveLength(17);
     expect(
-      planSweepFreqs(baseParams({ groundEnabled: true, groundModel: "fast" })),
+      planSweepFreqs(
+        baseParams({ groundEnabled: true, groundModel: "sommerfeld" }),
+      ),
+    ).toHaveLength(17);
+  });
+
+  it("keeps the historical 41 points when refinement is off — the base grid is then the rendering", () => {
+    expect(planSweepFreqs(baseParams({ refineEnabled: false }))).toHaveLength(41);
+    expect(
+      planSweepFreqs(
+        baseParams({ refineEnabled: false, groundEnabled: true, groundModel: "fast" }),
+      ),
     ).toHaveLength(41);
   });
 
-  it("halves to 21 points for a ground-capable backend on Sommerfeld ground", () => {
+  it("refinement off + Sommerfeld ground keeps the historical 21", () => {
     expect(
       planSweepFreqs(
-        baseParams({ backend: entry("bspline"), groundEnabled: true, groundModel: "sommerfeld" }),
+        baseParams({
+          refineEnabled: false,
+          backend: entry("bspline"),
+          groundEnabled: true,
+          groundModel: "sommerfeld",
+        }),
       ),
     ).toHaveLength(21);
   });
 
-  it("stays at 41 points on Sommerfeld ground if the backend doesn't support ground", () => {
+  it("refinement off on Sommerfeld ground stays at 41 if the backend doesn't support ground", () => {
     // Every backend the server registers supports ground; a roster entry
     // carrying supports_ground: false exercises the branch (issue #628).
     const freqs = planSweepFreqs(
       baseParams({
+        refineEnabled: false,
         backend: backendEntry({ name: "future-solver", supports_ground: false }),
         groundEnabled: true,
         groundModel: "sommerfeld",

--- a/src/antennaknobs/web/frontend/src/__tests__/tuning.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/tuning.test.ts
@@ -1,0 +1,35 @@
+// The no-rebuild escape hatches for adaptive resolution's constants. Not
+// settings (the gear menu deliberately carries only the on/off toggle) —
+// just the guarantee that a difficult design can nudge the sampling
+// machinery from the devtools console and a reload.
+import { describe, it, expect, afterEach } from "vitest";
+import { tunedFloat, tunedInt } from "../lib/tuning";
+
+afterEach(() => localStorage.clear());
+
+describe("tuning overrides", () => {
+  it("falls back when nothing is set", () => {
+    expect(tunedInt("t.i", 17, 101)).toBe(17);
+    expect(tunedFloat("t.f", 0.003)).toBe(0.003);
+  });
+
+  it("reads a valid override, flooring ints and clamping to the cap", () => {
+    localStorage.setItem("t.i", "31.7");
+    expect(tunedInt("t.i", 17, 101)).toBe(31);
+    localStorage.setItem("t.i", "9999");
+    expect(tunedInt("t.i", 17, 101)).toBe(101); // the server caps stay safe
+    localStorage.setItem("t.f", "0.01");
+    expect(tunedFloat("t.f", 0.003)).toBe(0.01);
+  });
+
+  it("garbage and non-positive values fall back rather than half-apply", () => {
+    for (const bad of ["banana", "", "0", "-4", "NaN", "Infinity"]) {
+      localStorage.setItem("t.i", bad);
+      expect(tunedInt("t.i", 17, 101)).toBe(17);
+    }
+    for (const bad of ["banana", "0", "-0.5", "Infinity"]) {
+      localStorage.setItem("t.f", bad);
+      expect(tunedFloat("t.f", 0.003)).toBe(0.003);
+    }
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/useAnalysisRunners.refine.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useAnalysisRunners.refine.test.tsx
@@ -153,7 +153,9 @@ describe("adaptive sweep refinement (issue #744)", () => {
     expect(sweepBodies).toHaveLength(1);
     expect(sweepBodies[0]._refine).toBeUndefined();
     const planned = result.current.sweep!.freqs_mhz.length;
-    expect(planned).toBe(41);
+    // Lean base grid: refinement is on (the default), so the plan starts at
+    // 17 and the rounds below buy the rest where the curve bends.
+    expect(planned).toBe(17);
 
     await settle();
     expect(refineBodies().length).toBeGreaterThan(0);
@@ -202,15 +204,15 @@ describe("adaptive sweep refinement (issue #744)", () => {
     await settle();
     await settle();
     expect(refineBodies().length).toBeGreaterThan(0);
-    expect(result.current.sweep!.freqs_mhz.length).toBeGreaterThan(41);
+    expect(result.current.sweep!.freqs_mhz.length).toBeGreaterThan(17);
 
     rerender({ ...BASE, req: { geometry: "g", length_factor: 1.01 } });
     // Refined points live in the same state the signature effect clears —
     // no separate lifetime to get wrong (issue #692).
     expect(result.current.sweep).toBeNull();
     await settle();
-    // The fresh sweep carries exactly the planned grid: nothing survived.
-    expect(result.current.sweep!.freqs_mhz).toHaveLength(41);
+    // The fresh sweep carries exactly the planned lean grid: nothing survived.
+    expect(result.current.sweep!.freqs_mhz).toHaveLength(17);
   });
 
   it("a non-resident sweep receives no refinement solves", async () => {
@@ -244,9 +246,9 @@ describe("adaptive sweep refinement (issue #744)", () => {
     // Whatever it managed is on screen and consistent — budget exhaustion
     // degrades to "less refined", never to a blank or torn curve.
     const sweep = result.current.sweep!;
-    expect(sweep.freqs_mhz).toHaveLength(41 + total);
-    expect(sweep.z_re).toHaveLength(41 + total);
-    expect(sweep.z_im).toHaveLength(41 + total);
+    expect(sweep.freqs_mhz).toHaveLength(17 + total);
+    expect(sweep.z_re).toHaveLength(17 + total);
+    expect(sweep.z_im).toHaveLength(17 + total);
   });
 
   it("a smooth sweep is left alone", async () => {

--- a/src/antennaknobs/web/frontend/src/__tests__/useAnalysisRunners.refine.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useAnalysisRunners.refine.test.tsx
@@ -81,7 +81,16 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-type Props = { req: Record<string, unknown>; sweepResident: boolean };
+type Props = {
+  req: Record<string, unknown>;
+  sweepResident: boolean;
+  refineEnabled?: boolean;
+  residentSweepViews?: {
+    vswr: boolean;
+    gamma: boolean;
+    smith: boolean;
+  };
+};
 
 function renderRunners(initial: Props) {
   return renderHook(
@@ -109,6 +118,10 @@ function renderRunners(initial: Props) {
         comboApproved: false,
         recommendedBackend: null,
         z0: 50,
+        ...(p.refineEnabled === undefined ? {} : { refineEnabled: p.refineEnabled }),
+        ...(p.residentSweepViews === undefined
+          ? {}
+          : { residentSweepViews: p.residentSweepViews }),
         buildRequest: () => ({ ...p.req }) as SolveRequest,
         solveWithheld: () => false,
         seqRef: { current: 0 },
@@ -250,6 +263,69 @@ describe("adaptive sweep refinement (issue #744)", () => {
       );
     });
     renderRunners(BASE);
+    await settle();
+    await settle();
+    expect(refineBodies()).toHaveLength(0);
+  });
+
+  it("the adaptive-resolution toggle off means the base sweep is final", async () => {
+    const { result } = renderRunners({ ...BASE, refineEnabled: false });
+    await settle();
+    expect(sweepBodies).toHaveLength(1); // base sweep ran normally
+    const planned = result.current.sweep!.freqs_mhz.length;
+    await settle();
+    await settle();
+    // No refinement request, no extra points — not "refined but hidden".
+    expect(refineBodies()).toHaveLength(0);
+    expect(result.current.sweep!.freqs_mhz.length).toBe(planned);
+  });
+
+  it("switching the toggle ON refines the sweep already on screen — no base re-sweep", async () => {
+    const { result, rerender } = renderRunners({
+      ...BASE,
+      refineEnabled: false,
+    });
+    await settle();
+    await settle();
+    expect(refineBodies()).toHaveLength(0);
+    const baseCount = sweepBodies.length;
+    rerender({ ...BASE, refineEnabled: true });
+    await settle();
+    expect(refineBodies().length).toBeGreaterThan(0);
+    // Only refinement requests were added — the settled base data was reused.
+    expect(sweepBodies.length - baseCount).toBe(refineBodies().length);
+    expect(result.current.sweep!.freqs_mhz.length).toBeGreaterThan(41);
+  });
+
+  it("plans only for the resident projections (a VSWR-only session ignores Smith-only curvature)", async () => {
+    // Constant-|Γ| phase arc: VSWR/S11 flat, Smith locus curved — the same
+    // separator refine.test.ts pins at the planner level, held here through
+    // the whole runner chain.
+    fetchMock.mockImplementation((url: string, init?: { body?: string }) => {
+      if (url !== "/sweep")
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      const body = JSON.parse(init?.body ?? "{}");
+      sweepBodies.push(body);
+      const freqs: number[] = body.freqs_mhz ?? [];
+      const g = 0.6;
+      return ndjson(
+        freqs.map((f) => {
+          const th = Math.PI * Math.pow((f - 10) / 4, 2);
+          const re = g * Math.cos(th);
+          const im = g * Math.sin(th);
+          const d = (1 - re) * (1 - re) + im * im;
+          return JSON.stringify({
+            freq_mhz: f,
+            z_re: (50 * (1 - re * re - im * im)) / d,
+            z_im: (50 * 2 * im) / d,
+          });
+        }),
+      );
+    });
+    renderRunners({
+      ...BASE,
+      residentSweepViews: { vswr: true, gamma: true, smith: false },
+    });
     await settle();
     await settle();
     expect(refineBodies()).toHaveLength(0);

--- a/src/antennaknobs/web/frontend/src/components/charts/FarFieldChart.tsx
+++ b/src/antennaknobs/web/frontend/src/components/charts/FarFieldChart.tsx
@@ -40,6 +40,7 @@ export function FarFieldChart({
   // Disabled pins draw no ghost and don't stretch the radial scale.
   const enabledPins = pinned.filter((p) => p.enabled);
   const cutTraces = useCutTraces(
+    cut,
     [result, ...enabledPins.map((p) => p.result)],
     azElevDeg,
     elevAzDeg,

--- a/src/antennaknobs/web/frontend/src/components/charts/SmithChart.tsx
+++ b/src/antennaknobs/web/frontend/src/components/charts/SmithChart.tsx
@@ -17,6 +17,7 @@ export function SmithChart({
   convergeRunning,
   feeds,
   multiFeed,
+  connectSweep = false,
 }: {
   r: number;
   x: number;
@@ -36,6 +37,14 @@ export function SmithChart({
    *  per-feed summary rows. Decoupled from feeds[].length so the chart
    *  reflects antenna type rather than guessing from response shape. */
   multiFeed: boolean;
+  /** Draw the sweep trail as a CONNECTED locus instead of a point cloud.
+   *  On when adaptive resolution (issue #744) is on: the merged sweep is
+   *  sorted by frequency and refinement has smoothed the display-space
+   *  curvature, so a polyline finally reads as the curve it is — the
+   *  original objection to lines here ("sparse samples make a piecewise
+   *  polyline read as artificial kinks") is exactly what refinement
+   *  removes. Off (refinement disabled) keeps the honest dot cloud. */
+  connectSweep?: boolean;
 }) {
   const theme = useContext(ThemeContext); // repaint on theme toggle (dep below)
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -152,19 +161,38 @@ export function SmithChart({
       ctx.arc(cx, cy, R, 0, 2 * Math.PI);
       ctx.clip();
       for (let fi = 0; fi < nFeeds; fi++) {
-        // Darkened color so the sweep cloud reads as a trail underneath
-        // the bright current-Z primary marker (drawn later, full color).
-        // Same convention for single- and multi-feed so the chart's
-        // visual grammar is uniform.
-        ctx.fillStyle = feedSweepColor(fi);
-        for (let i = 0; i < sweep.freqs_mhz.length; i++) {
-          const z = zAt(fi, i);
-          const g = reflectionCoefficient(z.re, z.im, z0);
-          const px = cx + g.gRe * R;
-          const py = cy - g.gIm * R;
+        // Darkened color so the sweep trail reads underneath the bright
+        // current-Z primary marker (drawn later, full color). Same
+        // convention for single- and multi-feed so the chart's visual
+        // grammar is uniform.
+        if (connectSweep) {
+          // Connected locus (adaptive resolution on): freqs_mhz arrives
+          // sorted (mergeSweepPoints re-sorts on every refinement round),
+          // so drawing in array order IS drawing in frequency order — no
+          // chord ever jumps across the chart.
+          ctx.strokeStyle = feedSweepColor(fi);
+          ctx.lineWidth = 1.2;
           ctx.beginPath();
-          ctx.arc(px, py, 1.5, 0, 2 * Math.PI);
-          ctx.fill();
+          for (let i = 0; i < sweep.freqs_mhz.length; i++) {
+            const z = zAt(fi, i);
+            const g = reflectionCoefficient(z.re, z.im, z0);
+            const px = cx + g.gRe * R;
+            const py = cy - g.gIm * R;
+            if (i === 0) ctx.moveTo(px, py);
+            else ctx.lineTo(px, py);
+          }
+          ctx.stroke();
+        } else {
+          ctx.fillStyle = feedSweepColor(fi);
+          for (let i = 0; i < sweep.freqs_mhz.length; i++) {
+            const z = zAt(fi, i);
+            const g = reflectionCoefficient(z.re, z.im, z0);
+            const px = cx + g.gRe * R;
+            const py = cy - g.gIm * R;
+            ctx.beginPath();
+            ctx.arc(px, py, 1.5, 0, 2 * Math.PI);
+            ctx.fill();
+          }
         }
       }
       ctx.restore();
@@ -554,7 +582,7 @@ export function SmithChart({
     // initial false to the real /examples value (true for bowtie /
     // hexbeam_5band) — the user saw only one Z* annotation in the
     // legend because the closure stayed wedged on the single-feed branch.
-  }, [r, x, z0, size, sweep, converge, measured, measFreqMhz, running, convergeRunning, feeds, multiFeed, theme]);
+  }, [r, x, z0, size, sweep, converge, measured, measFreqMhz, running, convergeRunning, feeds, multiFeed, connectSweep, theme]);
 
   return <canvas ref={canvasRef} className="smith" />;
 }

--- a/src/antennaknobs/web/frontend/src/components/charts/SweepChart.tsx
+++ b/src/antennaknobs/web/frontend/src/components/charts/SweepChart.tsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useRef } from "react";
 import type { FeedEntry, SweepData } from "../../lib/api";
 import { gammaDbFromMag, gammaMagFromZ, vswrFromGammaMag } from "../../lib/math";
+import { s11DbTop } from "../../lib/refine";
 import { ThemeContext } from "../hooks";
 import { feedColor, feedSweepColor, plotColors } from "./palette";
 
@@ -60,8 +61,6 @@ export function SweepChart({
 }) {
   const theme = useContext(ThemeContext); // repaint on theme toggle (dep below)
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const dom = DOMAIN[mode];
-
   // Pure derivation from props, computed outside the canvas effect so it's
   // available for the data-* attributes below even when there is no 2-D
   // context to draw with (jsdom in tests). This is also the one place the
@@ -99,6 +98,29 @@ export function SweepChart({
         ? [{ v: valueFor(mode, r, x, z0), fi: 0 }]
         : [];
 
+  // The S11 axis top ADAPTS when any drawn value crosses 0 dB (a driven
+  // array's active Γ is not bounded by 1 — see s11DbTop, which is also what
+  // the refinement planner uses, so axis and planner cannot drift). The rule
+  // runs over every feed's trail plus the current-Z markers: whichever trace
+  // carries the over-unity port pushes the top up, headroom included, and
+  // the 0 dB boundary stays as a tick — the line a healthy port never
+  // crosses. VSWR keeps its fixed pinned-needle scale.
+  const dom = (() => {
+    const base = DOMAIN[mode];
+    if (mode !== "gamma") return base;
+    const all: number[] = markerPoints.map((m) => m.v);
+    if (hasSweep) {
+      for (let fi = 0; fi < nFeeds; fi++) {
+        for (let i = 0; i < sweep!.freqs_mhz.length; i++) {
+          const z = zAt(fi, i);
+          all.push(valueFor(mode, z.re, z.im, z0));
+        }
+      }
+    }
+    const hi = s11DbTop(all);
+    return hi > 0 ? { ...base, hi, ticks: [...base.ticks, hi] } : base;
+  })();
+
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -131,10 +153,11 @@ export function SweepChart({
       Math.max(0, Math.min(1, (v - dom.lo) / (dom.hi - dom.lo)));
     const yOf = (v: number) => marginT + plotH * (1 - frac(v));
     // A value at/above the domain top for VSWR means "off the chart" (a real
-    // SWR meter pins its needle rather than rescaling); gamma never needs
-    // this since S11 ≤ 0 dB for anything passive. Below the gamma floor the
-    // trace just clamps to the bottom edge — an over-deep dip is good news,
-    // not a hazard worth a pinned-needle glyph.
+    // SWR meter pins its needle rather than rescaling); gamma instead GROWS
+    // its top when a driven-array port crosses 0 dB (see `dom` above), so
+    // nothing is ever pinned there. Below the gamma floor the trace just
+    // clamps to the bottom edge — an over-deep dip is good news, not a
+    // hazard worth a pinned-needle glyph.
     const offScale = (v: number) => v > dom.hi;
 
     ctx.strokeStyle = PC.grid;

--- a/src/antennaknobs/web/frontend/src/components/charts/cuts.ts
+++ b/src/antennaknobs/web/frontend/src/components/charts/cuts.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import type { PatternCuts, SolveResponse } from "../../lib/api";
 import { cutDbiTop, refineCutAngles } from "../../lib/refine";
+import { tunedInt } from "../../lib/tuning";
 import type { FarFieldCut } from "./types";
 
 // --- Server-side polar cuts (issue #547) -----------------------------------
@@ -294,7 +295,13 @@ const wantedCuts = () => ({
 /** Total extra angles per cut, summed across rounds. 180 uniform + 120
  *  refined stays well under the server's 720-angle ceiling, and a far-field
  *  evaluation at 300 directions is still ~1 ms on a typical mesh. */
-export const CUT_REFINE_BUDGET = 120;
+// Overridable without a rebuild (lib/tuning.ts); capped under the server's
+// 720-angle request ceiling with the 180-point base already inside it.
+export const CUT_REFINE_BUDGET = tunedInt(
+  "antennaknobs.cutRefineBudget",
+  120,
+  500,
+);
 export const CUT_REFINE_ROUND_BUDGET = 40;
 /** Dwell after the cuts for the current dial angles resolve. A dial drag
  *  must not spend evaluations on angles the user is about to leave. */

--- a/src/antennaknobs/web/frontend/src/components/charts/cuts.ts
+++ b/src/antennaknobs/web/frontend/src/components/charts/cuts.ts
@@ -262,6 +262,35 @@ function fetchCuts(
 // the EXISTING solve's pattern re-evaluated at more directions — no solve to
 // serialize, and the same no-lane latest-wins channel a dial drag uses.
 
+// Master switch, set by DesignSession from the same "adaptive resolution"
+// setting the sweep side reads as a prop. A module flag rather than plumbing
+// through FarFieldChart's props because everything else about refinement
+// already lives at this module's scope (caches, in-flight maps).
+let cutRefineEnabled = true;
+export function setCutRefineEnabled(v: boolean): void {
+  cutRefineEnabled = v;
+}
+
+// Which cut charts are on screen right now. A chart's useCutTraces registers
+// its own cut while mounted; refinement consults this PER ROUND so it only
+// buys angles for a cut somebody can see — the polar charts are one view
+// each, and "show only the azimuth cut" used to densify the elevation cut
+// anyway. Ref-counted so a transient double-mount (layout switches) can't
+// unregister a cut the other instance still shows.
+const mountedCutCharts = new Map<FarFieldCut, number>();
+function registerCutChart(cut: FarFieldCut): () => void {
+  mountedCutCharts.set(cut, (mountedCutCharts.get(cut) ?? 0) + 1);
+  return () => {
+    const n = (mountedCutCharts.get(cut) ?? 1) - 1;
+    if (n <= 0) mountedCutCharts.delete(cut);
+    else mountedCutCharts.set(cut, n);
+  };
+}
+const wantedCuts = () => ({
+  az: mountedCutCharts.has("xy"),
+  elev: mountedCutCharts.has("yz"),
+});
+
 /** Total extra angles per cut, summed across rounds. 180 uniform + 120
  *  refined stays well under the server's 720-angle ceiling, and a far-field
  *  evaluation at 300 directions is still ~1 ms on a typical mesh. */
@@ -306,9 +335,13 @@ const mergeAngles = (
     ...added,
   ].sort((a, b) => a - b);
 
-/** Densify both cuts of one solve where the polar trace corners, in rounds,
- *  writing each round back under the plain cuts key so the charts pick it
- *  up. Any failure just stops — the uniform trace stays on screen. */
+/** Densify the ON-SCREEN cuts of one solve where the polar trace corners,
+ *  in rounds, writing each round back under the plain cuts key so the
+ *  charts pick it up. Which cuts to buy angles for comes from the mounted-
+ *  chart registry, re-read per round — a cut whose chart nobody shows gets
+ *  no angles (and gets its own pass later if its chart mounts, because the
+ *  done-marker records WHAT was refined, not just that something was). Any
+ *  failure just stops — the uniform trace stays on screen. */
 function refineCuts(
   result: SolveResponse,
   azElevDeg: number,
@@ -317,42 +350,63 @@ function refineCuts(
   const key = cutsKey(result, azElevDeg, elevAzDeg);
   const running = cutsRefineInFlight.get(key);
   if (running) return running;
-  if (cutsRefineDone.has(key)) return Promise.resolve();
+  const wantKey = (w: { az: boolean; elev: boolean }) =>
+    `${key}|${w.az ? "az" : ""}${w.elev ? "el" : ""}`;
+  if (cutsRefineDone.has(wantKey(wantedCuts()))) return Promise.resolve();
   const p = (async () => {
     let cur = cachedCuts(result, azElevDeg, elevAzDeg);
     let spent = 0;
-    while (cur && spent < CUT_REFINE_BUDGET) {
+    let want = wantedCuts();
+    while (cur && spent < CUT_REFINE_BUDGET && cutRefineEnabled) {
+      want = wantedCuts();
       const budget = Math.min(
         CUT_REFINE_ROUND_BUDGET,
         CUT_REFINE_BUDGET - spent,
       );
-      const azAdd = refineCutAngles(
-        cur.azimuth,
-        cur.az_angles_deg,
-        cutDbiTop([peakOf(cur.azimuth)]),
-        budget,
-      );
-      const elAdd = refineCutAngles(
-        cur.elevation,
-        cur.elev_angles_deg,
-        cutDbiTop([peakOf(cur.elevation)]),
-        budget,
-      );
+      const azAdd = want.az
+        ? refineCutAngles(
+            cur.azimuth,
+            cur.az_angles_deg,
+            cutDbiTop([peakOf(cur.azimuth)]),
+            budget,
+          )
+        : [];
+      const elAdd = want.elev
+        ? refineCutAngles(
+            cur.elevation,
+            cur.elev_angles_deg,
+            cutDbiTop([peakOf(cur.elevation)]),
+            budget,
+          )
+        : [];
       if (azAdd.length === 0 && elAdd.length === 0) break;
       spent += Math.max(azAdd.length, elAdd.length);
-      const next = await requestCuts(result, azElevDeg, elevAzDeg, {
-        az_angles_deg: mergeAngles(cur.az_angles_deg, cur.azimuth.length, azAdd),
-        elev_angles_deg: mergeAngles(
+      // A cut getting no new angles keeps what it already has: its held
+      // refined list travels unchanged, and a still-uniform cut is OMITTED
+      // from the request entirely — "absent means uniform" is the wire
+      // contract, and forcing an explicit list would make the response
+      // (and every cached copy of it) carry 180 angles for nothing.
+      const extra: CutAngles = {};
+      if (azAdd.length > 0 || cur.az_angles_deg) {
+        extra.az_angles_deg = mergeAngles(
+          cur.az_angles_deg,
+          cur.azimuth.length,
+          azAdd,
+        );
+      }
+      if (elAdd.length > 0 || cur.elev_angles_deg) {
+        extra.elev_angles_deg = mergeAngles(
           cur.elev_angles_deg,
           cur.elevation.length,
           elAdd,
-        ),
-      });
+        );
+      }
+      const next = await requestCuts(result, azElevDeg, elevAzDeg, extra);
       if (!next) break;
       cacheCuts(key, next);
       cur = next;
     }
-    markRefineDone(key);
+    markRefineDone(wantKey(want));
   })().finally(() => cutsRefineInFlight.delete(key));
   cutsRefineInFlight.set(key, p);
   return p;
@@ -363,12 +417,18 @@ function refineCuts(
 // right angles; otherwise the freshest known trace is returned immediately
 // (stale-while-refetch) and a debounced POST /cuts brings the real one — the
 // debounce eats the flood of intermediate angles a slider drag produces.
+//
+// `cut` is which polar chart this hook instance serves; while mounted it
+// registers that cut so refinement (below) buys angles only for cuts that
+// are actually on screen.
 export function useCutTraces(
+  cut: FarFieldCut,
   results: readonly (SolveResponse | null)[],
   azElevDeg: number,
   elevAzDeg: number,
 ): (PatternCuts | null)[] {
   const [, setFetchTick] = useState(0); // re-render when a fetch lands
+  useEffect(() => registerCutChart(cut), [cut]);
   const wantKey = results
     .map((r) => (r ? cutsKey(r, azElevDeg, elevAzDeg) : "-"))
     .join("|");
@@ -387,7 +447,7 @@ export function useCutTraces(
     // clears the pending timer, and no refinement request is ever issued
     // for an angle the user passed through.
     const scheduleRefine = () => {
-      if (!live) return;
+      if (!live || !cutRefineEnabled) return;
       refineTimer = window.setTimeout(() => {
         refineCuts(live, azElevDeg, elevAzDeg).then(() => {
           if (!cancelled) setFetchTick((t) => t + 1);

--- a/src/antennaknobs/web/frontend/src/components/results/viewRegistry.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/viewRegistry.tsx
@@ -36,6 +36,11 @@ export type ViewRenderProps = {
   showFeedNames: boolean;
   multiFeed: boolean;
   fineNorm?: number | null;
+  /** Adaptive resolution (issue #744) is ON for this session — the Smith
+   *  chart uses it to draw the sweep as a connected locus (the refined,
+   *  frequency-sorted samples finally support one). Optional: thumbnail
+   *  call sites omit it and keep the dot trail. */
+  refineEnabled?: boolean;
   schematicSvg: string | null;
   schematicUnavailable: boolean;
 };
@@ -105,6 +110,7 @@ export const VIEW_RENDERERS: Record<View, (p: ViewRenderProps) => ReactElement> 
       convergeRunning={p.convergeRunning}
       feeds={p.result?.feeds}
       multiFeed={p.multiFeed}
+      connectSweep={p.refineEnabled ?? false}
     />
   ),
   schematic: (p) => (

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -36,6 +36,7 @@ import type {
 import type { TerrainPresetSchema } from "../../lib/ground";
 import { BackendConfigModal } from "../backend/BackendConfigModal";
 import { ParamForm } from "../params/ParamForm";
+import { setCutRefineEnabled } from "../charts/cuts";
 import type { PatternMetrics } from "../charts/types";
 import {
   ThemeContext,
@@ -511,6 +512,20 @@ function DesignSessionBody({
   // convergence on slow geometries) without leaving the Smith view.
   const [sweepEnabled, setSweepEnabled] = useState(true);
   const [convergeEnabled, setConvergeEnabled] = useState(false);
+  // Adaptive resolution (issue #744): dwell-triggered display-space
+  // refinement of the sweep and cut plots. Persisted, unlike the overlay
+  // checkboxes above: turning it off is a per-machine capacity decision
+  // ("this laptop, that 4k-segment design"), not a per-session view choice,
+  // and it should survive a reload the same way the theme does.
+  const [refineEnabled, setRefineEnabled] = useState(
+    () => localStorage.getItem("antennaknobs.refineEnabled") !== "0",
+  );
+  useEffect(() => {
+    localStorage.setItem("antennaknobs.refineEnabled", refineEnabled ? "1" : "0");
+    // The cuts side reads a module flag (charts/cuts.ts) rather than a prop
+    // — same setting, kept in lockstep here.
+    setCutRefineEnabled(refineEnabled);
+  }, [refineEnabled]);
   // Measured overlay (issue #595): a VNA .s1p the user picks from their own
   // machine, drawn against the modeled locus. Deliberately client-side state —
   // the file is posted once to be parsed and is never stored server-side, which
@@ -809,6 +824,15 @@ function DesignSessionBody({
   const isResident = (v: View) => pinned.includes(v) || view === v;
   const sweepResident =
     isResident("smith") || isResident("gamma") || isResident("vswr");
+  // Per-view split of sweepResident, for refinement only (issue #744): the
+  // BASE sweep serves all three charts from one array, but refinement buys
+  // extra solves per PROJECTION, so it needs to know which of the three is
+  // actually on screen rather than merely "any".
+  const residentSweepViews = {
+    vswr: isResident("vswr"),
+    gamma: isResident("gamma"),
+    smith: isResident("smith"),
+  };
   const convergeResident = isResident("smith");
   const patternResident = isResident("azimuth") || isResident("elevation");
 
@@ -1208,6 +1232,8 @@ function DesignSessionBody({
       // `result?.z0_ohms ?? 50`), so refinement judges curvature on the
       // curve the user is actually looking at.
       z0: result?.z0_ohms ?? 50,
+      refineEnabled,
+      residentSweepViews,
       buildRequest,
       solveWithheld,
       seqRef,
@@ -1250,6 +1276,8 @@ function DesignSessionBody({
           onClearMeasured={() => setMeasured(null)}
           normCheckEnabled={normCheckEnabled}
           setNormCheckEnabled={setNormCheckEnabled}
+          refineEnabled={refineEnabled}
+          setRefineEnabled={setRefineEnabled}
           theme={theme}
           applyTheme={applyTheme}
         />
@@ -1520,6 +1548,7 @@ function DesignSessionBody({
             showFeedNames={showFeedNames}
             multiFeed={effectiveMultiFeed}
             fineNorm={normCheck?.pattern_norm ?? null}
+            refineEnabled={refineEnabled}
             schematicSvg={schematicSvg}
             schematicUnavailable={schematicUnavailable}
           />

--- a/src/antennaknobs/web/frontend/src/components/session/SessionGearMenu.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/SessionGearMenu.tsx
@@ -32,6 +32,8 @@ export function SessionGearMenu({
   onClearMeasured,
   normCheckEnabled,
   setNormCheckEnabled,
+  refineEnabled,
+  setRefineEnabled,
   theme,
   applyTheme,
 }: {
@@ -60,6 +62,8 @@ export function SessionGearMenu({
   onClearMeasured: () => void;
   normCheckEnabled: boolean;
   setNormCheckEnabled: (v: boolean) => void;
+  refineEnabled: boolean;
+  setRefineEnabled: (v: boolean) => void;
   theme: Theme;
   applyTheme: (t: Theme) => void;
 }) {
@@ -240,6 +244,18 @@ export function SessionGearMenu({
                       onChange={(e) => setNormCheckEnabled(e.target.checked)}
                     />
                     norm check
+                  </label>
+                  <div className="gear-menu-section">charts</div>
+                  <label
+                    className="gear-menu-check"
+                    title="After the knobs settle, add sample points where the sweep and pattern-cut plots still show corners (adaptive resolution, issue #744). Off = the base grids are final — no extra solves, the escape hatch for large designs where refinement rounds are real work."
+                  >
+                    <input
+                      type="checkbox"
+                      checked={refineEnabled}
+                      onChange={(e) => setRefineEnabled(e.target.checked)}
+                    />
+                    adaptive resolution
                   </label>
                 </div>
               </>

--- a/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
@@ -505,6 +505,9 @@ export function useAnalysisRunners({
       designFreq,
       currentBands,
       freqWindowCeiling,
+      // Lean base grid when refinement will polish it; the historical
+      // dense grid when the toggle says the base IS the rendering.
+      refineEnabled,
     });
 
     const body = {

--- a/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
@@ -14,7 +14,11 @@ import { type BackendEntry } from "../../lib/backends";
 import { type GroundModel } from "../../lib/ground";
 import { feedwiseRichardson, richardsonExtrap } from "../../lib/math";
 import { type BandSpec, type ExampleDescriptor } from "../../lib/params";
-import { refineSweepFreqs } from "../../lib/refine";
+import {
+  ALL_SWEEP_PROJECTIONS,
+  refineSweepFreqs,
+  type SweepProjectionSet,
+} from "../../lib/refine";
 import { solveSignature } from "../../lib/solveSignature";
 import {
   mergeSweepPoints,
@@ -164,6 +168,8 @@ export function useAnalysisRunners({
   comboApproved,
   recommendedBackend,
   z0 = 50,
+  refineEnabled = true,
+  residentSweepViews = ALL_SWEEP_PROJECTIONS,
   buildRequest,
   solveWithheld,
   seqRef,
@@ -207,6 +213,18 @@ export function useAnalysisRunners({
    *  effect — z0 is a display reference, not physics, and re-planning the
    *  whole sweep when it changes would re-solve for nothing. */
   z0?: number;
+  /** Master switch for adaptive refinement (sweep side; the cuts side reads
+   *  the module flag in charts/cuts.ts — same setting, two consumers). Off
+   *  means the base sweep is the final word: no second-dwell rounds, no
+   *  extra solves — the escape hatch for large designs where even
+   *  cache-warmed refinement rounds are real work. */
+  refineEnabled?: boolean;
+  /** Which sweep-consuming charts are on screen (finer than the boolean
+   *  sweepResident above, which gates the BASE sweep): refinement plans
+   *  against only these projections, so a VSWR-only session stops spending
+   *  solves flattening a Smith locus nobody can see. Read per refinement
+   *  ROUND via a ref, so mid-chain pin changes take effect immediately. */
+  residentSweepViews?: SweepProjectionSet;
   buildRequest: () => SolveRequest;
   solveWithheld: () => boolean;
   seqRef: MutableRefObject<number>;
@@ -238,6 +256,13 @@ export function useAnalysisRunners({
   // handle the next knob change has to abort through.
   const sweepRefineTimerRef = useRef<number | null>(null);
   const sweepRefineAbortRef = useRef<AbortController | null>(null);
+  // Live mirrors of the refinement props, read per refinement ROUND rather
+  // than captured at chain start — a mid-chain toggle-off or pin change
+  // must not run a stale plan to the end of its budget.
+  const refineEnabledRef = useRef(refineEnabled);
+  refineEnabledRef.current = refineEnabled;
+  const residentSweepViewsRef = useRef(residentSweepViews);
+  residentSweepViewsRef.current = residentSweepViews;
   const patternTimerRef = useRef<number | null>(null);
   const patternAbortRef = useRef<AbortController | null>(null);
   const convergeTimerRef = useRef<number | null>(null);
@@ -309,6 +334,41 @@ export function useAnalysisRunners({
     // effect (issue #382 — replaces the old 200 ms re-poll loop).
     comboApproved, recommendedBackend,
   ]);
+
+  // A sweep chart pinned AFTER the sweep settled (or refinement switched
+  // back on) still deserves its refinement pass — the base flow's trigger
+  // (the tail of runSweep) has already come and gone. This effect fills
+  // that gap: on a growth of the resident-projection set, re-enter the
+  // refinement dwell against the CURRENT accumulated sweep. No base
+  // re-sweep (the data is fine, only the polish is missing), and already-
+  // refined projections converge immediately (their plan comes back empty
+  // or tiny, and the server's per-freq cache answers any overlap), so the
+  // marginal cost is the new projection's points alone.
+  const residentSweepKey = `${residentSweepViews.vswr},${residentSweepViews.gamma},${residentSweepViews.smith}`;
+  const sweepRef = useRef<SweepData | null>(null);
+  sweepRef.current = sweep;
+  useEffect(() => {
+    if (!refineEnabled || !sweepRef.current || sweepRunning) return;
+    if (sweepRefineTimerRef.current) {
+      window.clearTimeout(sweepRefineTimerRef.current);
+    }
+    const settled = sweepRef.current;
+    sweepRefineTimerRef.current = window.setTimeout(
+      () => runSweepRefine(settled),
+      SWEEP_REFINE_DWELL_MS,
+    );
+    return () => {
+      if (sweepRefineTimerRef.current) {
+        window.clearTimeout(sweepRefineTimerRef.current);
+      }
+    };
+    // sweep/sweepRunning are read via ref/guard, deliberately not deps: a
+    // COMPLETING sweep must not re-fire this effect (the runSweep tail owns
+    // that trigger); only the projection set growing or the toggle flipping
+    // on re-arms it. runSweepRefine: same unmemoized-closure idiom as
+    // runSweep above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [residentSweepKey, refineEnabled]);
 
   // Debounced convergence sweep over segments-per-wire. Independent of the
   // freq sweep above: re-runs on any antenna/backend change, gated by its
@@ -481,7 +541,7 @@ export function useAnalysisRunners({
         // curve that is already drawn, and flickering the chart's busy
         // indicator back on would read as "this result is provisional".
         const settled = planned;
-        if (settled && !controller.signal.aborted) {
+        if (settled && !controller.signal.aborted && refineEnabledRef.current) {
           sweepRefineTimerRef.current = window.setTimeout(
             () => runSweepRefine(settled),
             SWEEP_REFINE_DWELL_MS,
@@ -502,6 +562,7 @@ export function useAnalysisRunners({
   // screen; nothing here is load-bearing for correctness of the curve.
   async function runSweepRefine(base: SweepData) {
     sweepRefineTimerRef.current = null;
+    if (!refineEnabledRef.current) return;
     if (solveWithheld()) return;
     sweepRefineAbortRef.current?.abort();
     const controller = new AbortController();
@@ -510,10 +571,16 @@ export function useAnalysisRunners({
     let spent = 0;
     try {
       while (spent < SWEEP_REFINE_BUDGET && !controller.signal.aborted) {
+        // The toggle and the resident-projection set are read per ROUND:
+        // switching refinement off (or unpinning the last chart that wanted
+        // a projection) takes effect at the next round boundary instead of
+        // finishing the whole budget.
+        if (!refineEnabledRef.current) break;
         const want = refineSweepFreqs(
           acc,
           z0,
           Math.min(SWEEP_REFINE_ROUND_BUDGET, SWEEP_REFINE_BUDGET - spent),
+          residentSweepViewsRef.current,
         );
         if (want.length === 0) break; // no visible kink left to remove
         spent += want.length;

--- a/src/antennaknobs/web/frontend/src/lib/refine.ts
+++ b/src/antennaknobs/web/frontend/src/lib/refine.ts
@@ -1,6 +1,7 @@
 import { reflectionCoefficient } from "./format";
 import { gammaDbFromMag, vswrFromGammaMag } from "./math";
 import type { SweepData } from "./api";
+import { tunedFloat } from "./tuning";
 
 // Adaptive sampling refinement (issue #744).
 //
@@ -50,7 +51,10 @@ export type DisplayPoint = { x: number; y: number; clamped?: boolean };
  *  vanishes as O(h²) for any smooth stretch and as O(h) even across a cusp,
  *  so "the picture is right to within a pixel" is a reachable stopping
  *  condition. */
-export const DEVIATION_TOLERANCE = 0.003;
+export const DEVIATION_TOLERANCE = tunedFloat(
+  "antennaknobs.refineTolerance",
+  0.003,
+);
 
 /** Intervals shorter than this (in normalized display units) are never
  *  split again. Two reasons, both about not burning the budget on

--- a/src/antennaknobs/web/frontend/src/lib/refine.ts
+++ b/src/antennaknobs/web/frontend/src/lib/refine.ts
@@ -266,6 +266,24 @@ export function planRefinement(
 const VSWR_DOMAIN = { lo: 1, hi: 10 };
 const GAMMA_DB_DOMAIN = { lo: -30, hi: 0 };
 
+/** Top of the S11 axis for a set of dB samples: 0 for anything passive, and
+ *  ceil(max + 1 dB headroom) when any sample crosses 0 dB. A driven-array
+ *  port's ACTIVE reflection is not bounded by |Γ| ≤ 1 — mutual coupling can
+ *  push more power into a detuned element than its own generator supplies
+ *  (bowtiearray2x4 with length_otop pulled 10% reads +1.3 dB) — and
+ *  clamping that onto the 0 dB line hid over-unity behind near-unity, the
+ *  most interesting single fact a sweep can tell you about an array tuning.
+ *  Exported for SweepChart, exactly as cutDbiTop is for FarFieldChart, so
+ *  the chart and the refinement planner cannot disagree about the axis. The
+ *  headroom also means no sample sits AT the adaptive top, so over-unity
+ *  peaks are never clamp-marked and refinement resolves them like any other
+ *  feature. */
+export function s11DbTop(dbSamples: readonly number[]): number {
+  let m = 0;
+  for (const d of dbSamples) if (Number.isFinite(d) && d > m) m = d;
+  return m > 0 ? Math.ceil(m + 1) : 0;
+}
+
 const clamp01 = (v: number) => (v < 0 ? 0 : v > 1 ? 1 : v);
 
 /** Which of the three sweep-consuming charts are actually on screen. All
@@ -312,9 +330,17 @@ export function sweepProjections(
     y: clamp01(raw),
     ...(raw <= 0 || raw >= 1 ? { clamped: true } : {}),
   });
+  const gs = f.map((_, i) =>
+    reflectionCoefficient(sweep.z_re[i], sweep.z_im[i], z0),
+  );
+  // The S11 axis top adapts to over-unity samples (see s11DbTop) — computed
+  // over the whole sweep first, the same number SweepChart derives, so the
+  // planner refines against the geometry actually drawn.
+  const dbs = include.gamma ? gs.map((g) => gammaDbFromMag(g.gMag)) : [];
+  const dbHi = s11DbTop(dbs);
   for (let i = 0; i < n; i++) {
     const x = (f[i] - f[0]) / span;
-    const g = reflectionCoefficient(sweep.z_re[i], sweep.z_im[i], z0);
+    const g = gs[i];
     if (include.vswr) {
       const v = vswrFromGammaMag(g.gMag);
       vswr.push(
@@ -322,19 +348,21 @@ export function sweepProjections(
       );
     }
     if (include.gamma) {
-      const db = gammaDbFromMag(g.gMag);
       gamma.push(
-        edge(
-          x,
-          (db - GAMMA_DB_DOMAIN.lo) /
-            (GAMMA_DB_DOMAIN.hi - GAMMA_DB_DOMAIN.lo),
-        ),
+        edge(x, (dbs[i] - GAMMA_DB_DOMAIN.lo) / (dbHi - GAMMA_DB_DOMAIN.lo)),
       );
     }
-    // Γ plane on the unit disc → the [0,1]² box the chart's circle
-    // inscribes. Never clamped: |Γ| ≤ 1 for a passive port, so the locus
-    // is on screen by construction.
-    if (include.smith) smith.push({ x: (g.gRe + 1) / 2, y: (g.gIm + 1) / 2 });
+    // Γ plane: the [0,1]² box the chart's circle inscribes, clamp-marked
+    // outside it — |Γ| ≤ 1 for a passive port, but a driven-array port's
+    // ACTIVE Γ can exceed 1 (see s11DbTop) and the chart clips the disc.
+    if (include.smith) {
+      const outside = g.gMag > 1;
+      smith.push({
+        x: (g.gRe + 1) / 2,
+        y: (g.gIm + 1) / 2,
+        ...(outside ? { clamped: true } : {}),
+      });
+    }
   }
   return [vswr, gamma, smith].filter((p) => p.length > 0);
 }

--- a/src/antennaknobs/web/frontend/src/lib/refine.ts
+++ b/src/antennaknobs/web/frontend/src/lib/refine.ts
@@ -23,8 +23,18 @@ import type { SweepData } from "./api";
  *  so the PLOT EXTENT is 1 on each axis — the sweep charts map to [0,1]²,
  *  the polar cut to [-0.5, 0.5]² — which makes one tolerance and one
  *  minimum-segment constant meaningful for both. Assumes a square-ish plot
- *  rect; a wildly non-square chart would want its own aspect factor. */
-export type DisplayPoint = { x: number; y: number };
+ *  rect; a wildly non-square chart would want its own aspect factor.
+ *
+ *  `clamped` marks a vertex whose value was PINNED to the chart's domain
+ *  edge (a VSWR above the axis ceiling, a cut sample at the radial floor).
+ *  Its drawn position is exact — the chart really does put it on the edge —
+ *  so subdividing around it cannot improve the picture: the corner where
+ *  the curve enters the clamp is an artifact of clamping, not of sampling,
+ *  and chasing it O(h) down to MIN_SEGMENT spends solves on a segment that
+ *  redraws identically. The planner zeroes a clamped vertex's deviation in
+ *  that projection; the crossing still gets ONE look via its unclamped
+ *  neighbour's deviation, which is the visible part of the corner. */
+export type DisplayPoint = { x: number; y: number; clamped?: boolean };
 
 /** Display-space error, as a fraction of the plot extent, below which the
  *  drawn polyline is indistinguishable from the true curve. 0.003 is ~1 px
@@ -194,7 +204,12 @@ export function planRefinement(
   const devs = new Array<number>(n).fill(0);
   for (const p of usable) {
     const d = chordDeviations(p, closed);
-    for (let i = 0; i < n; i++) devs[i] = Math.max(devs[i], d[i]);
+    for (let i = 0; i < n; i++) {
+      // A clamped vertex sits exactly where the chart draws it (on the
+      // domain edge) — see DisplayPoint.clamped. Another projection where
+      // the same sample is NOT clamped still scores it via the max below.
+      if (!p[i].clamped) devs[i] = Math.max(devs[i], d[i]);
+    }
   }
 
   const nIv = closed ? n : n - 1;
@@ -249,15 +264,36 @@ const GAMMA_DB_DOMAIN = { lo: -30, hi: 0 };
 
 const clamp01 = (v: number) => (v < 0 ? 0 : v > 1 ? 1 : v);
 
+/** Which of the three sweep-consuming charts are actually on screen. All
+ *  true is the pre-residency behavior; the planner refines only for the
+ *  projections listed true, because polishing a chart nobody can see spends
+ *  real solves for zero visible change (a view pinned LATER gets its own
+ *  refinement pass — the dwell machinery re-plans, and the server's per-freq
+ *  cache makes the shared points free). */
+export type SweepProjectionSet = {
+  vswr: boolean;
+  gamma: boolean;
+  smith: boolean;
+};
+
+export const ALL_SWEEP_PROJECTIONS: SweepProjectionSet = {
+  vswr: true,
+  gamma: true,
+  smith: true,
+};
+
 /** The display polylines a sweep feeds: VSWR vs f, S11 dB vs f, and the
- *  Smith Γ locus. x for the two scalar charts is LINEAR in MHz over the
- *  swept span — that is what SweepChart's `xOf` does, whatever the freq
- *  PLAN's spacing was. Out-of-domain samples clamp exactly as the charts
- *  draw them (a VSWR of 40 sits pinned at the top edge), so refinement
- *  never chases curvature that is off screen. */
+ *  Smith Γ locus — only those `include` lists, in that order. x for the two
+ *  scalar charts is LINEAR in MHz over the swept span — that is what
+ *  SweepChart's `xOf` does, whatever the freq PLAN's spacing was.
+ *  Out-of-domain samples clamp exactly as the charts draw them (a VSWR of
+ *  40 sits pinned at the top edge) and carry the `clamped` mark, so
+ *  refinement neither chases curvature that is off screen nor sharpens the
+ *  corner where the curve meets the edge. */
 export function sweepProjections(
   sweep: SweepData,
   z0: number,
+  include: SweepProjectionSet = ALL_SWEEP_PROJECTIONS,
 ): DisplayPoint[][] {
   const f = sweep.freqs_mhz;
   const n = f.length;
@@ -266,25 +302,37 @@ export function sweepProjections(
   const vswr: DisplayPoint[] = [];
   const gamma: DisplayPoint[] = [];
   const smith: DisplayPoint[] = [];
+  // y and its clamp mark in one place, so the two can never disagree.
+  const edge = (x: number, raw: number): DisplayPoint => ({
+    x,
+    y: clamp01(raw),
+    ...(raw <= 0 || raw >= 1 ? { clamped: true } : {}),
+  });
   for (let i = 0; i < n; i++) {
     const x = (f[i] - f[0]) / span;
     const g = reflectionCoefficient(sweep.z_re[i], sweep.z_im[i], z0);
-    const v = vswrFromGammaMag(g.gMag);
-    vswr.push({
-      x,
-      y: clamp01((v - VSWR_DOMAIN.lo) / (VSWR_DOMAIN.hi - VSWR_DOMAIN.lo)),
-    });
-    const db = gammaDbFromMag(g.gMag);
-    gamma.push({
-      x,
-      y: clamp01(
-        (db - GAMMA_DB_DOMAIN.lo) / (GAMMA_DB_DOMAIN.hi - GAMMA_DB_DOMAIN.lo),
-      ),
-    });
-    // Γ plane on the unit disc → the [0,1]² box the chart's circle inscribes.
-    smith.push({ x: (g.gRe + 1) / 2, y: (g.gIm + 1) / 2 });
+    if (include.vswr) {
+      const v = vswrFromGammaMag(g.gMag);
+      vswr.push(
+        edge(x, (v - VSWR_DOMAIN.lo) / (VSWR_DOMAIN.hi - VSWR_DOMAIN.lo)),
+      );
+    }
+    if (include.gamma) {
+      const db = gammaDbFromMag(g.gMag);
+      gamma.push(
+        edge(
+          x,
+          (db - GAMMA_DB_DOMAIN.lo) /
+            (GAMMA_DB_DOMAIN.hi - GAMMA_DB_DOMAIN.lo),
+        ),
+      );
+    }
+    // Γ plane on the unit disc → the [0,1]² box the chart's circle
+    // inscribes. Never clamped: |Γ| ≤ 1 for a passive port, so the locus
+    // is on screen by construction.
+    if (include.smith) smith.push({ x: (g.gRe + 1) / 2, y: (g.gIm + 1) / 2 });
   }
-  return [vswr, gamma, smith];
+  return [vswr, gamma, smith].filter((p) => p.length > 0);
 }
 
 /** Frequencies (MHz) to add to an existing sweep. Deduped against what is
@@ -294,10 +342,13 @@ export function refineSweepFreqs(
   sweep: SweepData,
   z0: number,
   budget: number,
+  include: SweepProjectionSet = ALL_SWEEP_PROJECTIONS,
 ): number[] {
-  const planned = planRefinement(sweep.freqs_mhz, sweepProjections(sweep, z0), {
-    budget,
-  });
+  const planned = planRefinement(
+    sweep.freqs_mhz,
+    sweepProjections(sweep, z0, include),
+    { budget },
+  );
   // Relative tolerance: sweep spans run 1.8–54 MHz, so an absolute epsilon
   // would be meaningless at one end of that range.
   const span = sweep.freqs_mhz[sweep.freqs_mhz.length - 1] - sweep.freqs_mhz[0];
@@ -342,14 +393,26 @@ export function cutProjection(
 ): DisplayPoint[] {
   const toFrac = cutDbiToFrac(dbiTop);
   const n = dbi.length;
+  const span = dbiTop - CUT_DBI_FLOOR;
   return Array.from({ length: n }, (_, i) => {
     const t = anglesDeg
       ? (anglesDeg[i] * Math.PI) / 180
       : (2 * Math.PI * i) / n;
     const frac = 0.5 * toFrac(dbi[i]);
+    // Radial-clamp mark (same contract as the sweep charts' domain edges):
+    // a sample at/below the −20 dBi floor draws at the origin and one
+    // at/above the adaptive top draws on the rim, wherever the true value
+    // sits — the below-horizon floor sentinel is the common case, and
+    // sharpening the corner where a null dives under the floor redraws
+    // nothing.
+    const raw = (dbi[i] - CUT_DBI_FLOOR) / span;
     // Canvas flips y, but a reflection changes no turn ANGLE — the planner
     // only reads |turn|, so the sign convention here is free.
-    return { x: Math.cos(t) * frac, y: Math.sin(t) * frac };
+    return {
+      x: Math.cos(t) * frac,
+      y: Math.sin(t) * frac,
+      ...(raw <= 0 || raw >= 1 ? { clamped: true } : {}),
+    };
   });
 }
 

--- a/src/antennaknobs/web/frontend/src/lib/sweep.ts
+++ b/src/antennaknobs/web/frontend/src/lib/sweep.ts
@@ -37,6 +37,17 @@ export function planSweepFreqs(params: {
   designFreq: number;
   currentBands: BandSpec[];
   freqWindowCeiling: number;
+  /** Adaptive resolution is on for this session (the default): the base
+   *  grid's job is then DETECTION, not resolution — it only has to land
+   *  samples in a feature's tails for the refinement planner to dig in —
+   *  so it starts lean and lets refinement spend points where the curve
+   *  actually bends. 17 log-spaced (~6% spacing) keeps every plausible
+   *  resonance signature within reach of at least one sample; much below
+   *  15 the straddled-feature blindspot (a notch no sample touches at
+   *  all) becomes a real risk. With refinement OFF the base grid IS the
+   *  final rendering, so the historical 41 (21 on Sommerfeld ground)
+   *  stays — the toggle must mean "today's behavior", not "coarser". */
+  refineEnabled?: boolean;
 }): number[] {
   const {
     backend,
@@ -49,12 +60,13 @@ export function planSweepFreqs(params: {
     designFreq,
     currentBands,
     freqWindowCeiling,
+    refineEnabled = true,
   } = params;
   const slowGround =
     backendSupportsGround(backend) &&
     groundEnabled &&
     groundModel === "sommerfeld";
-  const N = slowGround ? 21 : 41;
+  const N = refineEnabled ? 17 : slowGround ? 21 : 41;
   const policy =
     currentExample?.variant_ui?.[currentVariant]?.sweep_policy ??
     currentExample?.sweep_policy;

--- a/src/antennaknobs/web/frontend/src/lib/sweep.ts
+++ b/src/antennaknobs/web/frontend/src/lib/sweep.ts
@@ -1,4 +1,5 @@
 import type { SweepData } from "./api";
+import { tunedInt } from "./tuning";
 import { backendSupportsGround, type BackendEntry } from "./backends";
 import type { GroundModel } from "./ground";
 import type { BandSpec, ExampleDescriptor } from "./params";
@@ -66,7 +67,7 @@ export function planSweepFreqs(params: {
     backendSupportsGround(backend) &&
     groundEnabled &&
     groundModel === "sommerfeld";
-  const N = refineEnabled ? 17 : slowGround ? 21 : 41;
+  const N = refineEnabled ? SWEEP_BASE_N : slowGround ? 21 : 41;
   const policy =
     currentExample?.variant_ui?.[currentVariant]?.sweep_policy ??
     currentExample?.sweep_policy;
@@ -91,11 +92,21 @@ export function planSweepFreqs(params: {
   );
 }
 
+// The lean base grid used when refinement will polish the curve (see
+// planSweepFreqs). Overridable without a rebuild (lib/tuning.ts) for the
+// design that manages to straddle a feature at ~6% spacing.
+const SWEEP_BASE_N = tunedInt("antennaknobs.sweepBaseN", 17, 101);
+
 // Point budget for adaptive sweep refinement (issue #744), summed across
-// rounds. 41 planned + 48 refined = 89 points, an order of magnitude under
+// rounds. 17 planned + 48 refined = 65 points, an order of magnitude under
 // the hosted MAX_SWEEP_POINTS=500 cap (web/cost.py) and — thanks to the
 // server's per-freq Z cache — nearly free to re-request on a later dwell.
-export const SWEEP_REFINE_BUDGET = 48;
+// Overridable without a rebuild (lib/tuning.ts).
+export const SWEEP_REFINE_BUDGET = tunedInt(
+  "antennaknobs.sweepRefineBudget",
+  48,
+  400,
+);
 // Per round, so one round's plan (which cannot re-evaluate its own inserted
 // points) never commits the whole budget on an estimate.
 export const SWEEP_REFINE_ROUND_BUDGET = 12;

--- a/src/antennaknobs/web/frontend/src/lib/tuning.ts
+++ b/src/antennaknobs/web/frontend/src/lib/tuning.ts
@@ -1,0 +1,35 @@
+// Escape hatches for the adaptive-resolution machinery (issue #744).
+//
+// The sampling constants (base grid size, refinement budgets, the stop
+// tolerance) are deliberately NOT gear-menu settings: they'd need
+// explanation, layout and persistence for something that should never be
+// touched in normal use — the one common adjustment ("this design is too
+// heavy") is the adaptive-resolution toggle. But the day a difficult
+// design DOES show up, changing them must not require a rebuild — so each
+// constant reads a localStorage override once at module load:
+//
+//   localStorage.setItem("antennaknobs.sweepBaseN", "31");  // then reload
+//
+// Read-once is the contract: these parameterise module-scope constants and
+// mid-session changes would desynchronise planner and transport. If an
+// override earns its keep on a real design, promote it to a proper setting.
+
+/** Positive-integer override, clamped to [1, max]; the fallback on any
+ *  absent/garbage value. `max` guards the server-side caps (MAX_SWEEP_POINTS,
+ *  _CUT_MAX_ANGLES) from a fat-fingered exponent. */
+export function tunedInt(key: string, fallback: number, max: number): number {
+  const raw =
+    typeof localStorage === "undefined" ? null : localStorage.getItem(key);
+  if (raw === null) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 1 ? Math.min(Math.floor(n), max) : fallback;
+}
+
+/** Positive-float override with the same contract. */
+export function tunedFloat(key: string, fallback: number): number {
+  const raw =
+    typeof localStorage === "undefined" ? null : localStorage.getItem(key);
+  if (raw === null) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}


### PR DESCRIPTION
## Summary
Follow-ups to #744's adaptive refinement, from live use:

- **Settings toggle**: gear menu → charts → "adaptive resolution" (default on, persisted). Off = base grids are final, zero refinement solves — the escape hatch for large designs. Sweep side reads it as a prop; cuts side as a module flag kept in lockstep.
- **Refine only what's on screen**: sweep refinement plans against only the resident projections (per-view split of `sweepResident`, re-read every round), and cut refinement buys angles only for the cut whose polar chart is mounted. A chart pinned *later* gets its own refinement pass against the settled data — no base re-sweep, the per-freq cache absorbs overlap. Previously a VSWR-only session spent real solves flattening an invisible Smith locus, and showing one cut densified both.
- **Clamp-aware deviations**: vertices pinned to a chart's domain edge (VSWR/S11 ceilings-floors, polar radial floor) score zero deviation in that projection — the planner no longer chases clamp-entry corners O(h) down to `MIN_SEGMENT` for segments that redraw identically. The crossing still gets one look from its unclamped neighbour.
- **Lean 17-point base grid** when refinement is on: the base grid's job is detection, not resolution. Worst case 89 → 65 solves, smooth case 41 → 17, faster settle-to-polished. Refinement off keeps the historical 41/21 — the toggle means "today's behavior", never "coarser". Toggle flips deliberately don't re-plan the current sweep (race avoidance); new size applies from the next knob change.
- **Connected Smith locus** when refinement is on (the refinement-sorted densified samples finally support a polyline without chord artifacts); off keeps the dot cloud. Endpoints/freq-ring/current-Z marker unchanged.
- **No-rebuild tuning hatches** instead of UI params: `antennaknobs.sweepBaseN` / `sweepRefineBudget` / `cutRefineBudget` / `refineTolerance` localStorage overrides, read once at load, capped under the server request ceilings. Promote to real settings only if one earns its keep.

## Plus: adaptive S11 top (from the bowtiearray2x4 investigation)
S11 "hugging 0 dB" on a detuned bowtiearray2x4 turned out to be real physics: with all 8 ports driven, mutual coupling can drive a detuned element's *active* resistance negative (measured R = −45 Ω, S11 = +1.3 dB) — the port absorbs its neighbours' power. The S11 axis top now adapts (0 for anything passive, ceil(max+1 dB) when any drawn value crosses zero, 0 dB kept as a tick) so over-unity ports draw *above* the line instead of clamping onto it. The rule (`s11DbTop`) is shared between chart and refinement planner, so the crossing refines like any feature; over-unity Smith samples (outside the clipped unit disc) are clamp-marked instead. VSWR keeps its pinned-needle scale.

## Test plan
- [x] tsc --noEmit clean, eslint 0 errors, 683/683 vitest (10 new: toggle contracts, residency filtering end-to-end at planner and runner level, clamp rule, unmounted-cut wire contract, tuning override edge cases, lean/historical grid pins)
- [x] ruff check + format clean (no Python changes)
- [x] Manual on LAN: toggle on/off mid-session, VSWR-only pin set, Smith connected locus through a resonance loop, lean-grid settle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzu7UX3yQNTD7N49iCrq2g
