### PR TITLE
Two-knob design-space contour maps for optimizer diagnostics

### DIFF
--- a/scripts/design_space_contour.py
+++ b/scripts/design_space_contour.py
@@ -1,0 +1,319 @@
+"""Two-knob design-space contour maps: |Γ| level curves, optionally with the
+R=1 / X=0 families overlaid.
+
+Optimizers report a point. This reports the *shape of the space around it*,
+which answers questions a point cannot:
+
+  1. **How many answers are there?** A design whose |Γ| basins are two closed
+     regions joined by a saddle (``verticals.stub_matched_vertical``) has two
+     genuine matches, and an optimizer slides to whichever one it started
+     nearest. The map counts them; the optimizer never mentions the other.
+  2. **Which knobs is the answer trustworthy on?** A basin shaped like a cigar
+     rather than a bowl means one knob is pinned and the other is nearly free.
+     For ``dipoles.invvee`` the ``length_factor`` at the optimum is determined
+     to under 1 % while ``angle_deg`` wanders ~15° for the same SWR — so a
+     returned droop angle is close to arbitrary, and two optimizer runs from
+     different starts will disagree on it while agreeing on length.
+  3. **Why?** ``--rx`` overlays the two level sets whose intersection *is* the
+     match: R/Z₀ = 1 and X/Z₀ = 0. Their geometry shows the mechanism the |Γ|
+     map only shows the consequence of — for the inv-vee, X=0 runs almost
+     vertically (resonance is set by length alone, indifferent to droop) while
+     R=1 sweeps diagonally (resistance depends on both), which is exactly why
+     the basin is a near-vertical canyon.
+
+``--rx`` is opt-in rather than the default because the R=1 ∩ X=0 reading is
+only valid for a pure impedance-match objective. Add a gain term — as
+``antennaknobs.opt.optimize(opt_gain=True)`` does — and the optimum leaves the
+intersection entirely, at which point the overlay is actively misleading. The
+|Γ| map stays honest either way.
+
+Cost. Every grid point is a solve, so an N×N map is N² of them: at ~20 ms for
+``dipoles.invvee`` an 81×81 map is ~30 s, but at ~0.85 s for
+``arrays.bowtie16x1`` the same map is over three hours. Start coarse.
+
+The exception is a design whose knobs are *network-only* — ``line_wl`` and
+``stub_wl`` on the stub-matched vertical change no wire — where the geometry
+solve is identical at every grid point. This script detects that case by
+comparing ``build_wires()`` across the corners of the sweep, and when it holds
+solves the wire ONCE and re-reduces the network per point: 14641 points in
+~3 s rather than the ~3 min the same grid costs the slow way.
+
+Usage:
+    python scripts/design_space_contour.py --builder dipoles.invvee \
+        --params length_factor angle_deg --n 81 --ground pec
+    python scripts/design_space_contour.py --builder dipoles.invvee \
+        --params length_factor angle_deg --rx --out invvee.png
+    python scripts/design_space_contour.py \
+        --builder verticals.stub_matched_vertical \
+        --params line_wl stub_wl --n 121 --rx
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from antennaknobs.cli import get_builder  # noqa: E402
+from antennaknobs.engines.momwire import MomwireEngine  # noqa: E402
+from antennaknobs.network_reduce import NetworkReducer  # noqa: E402
+from antennaknobs.opt import _get_path, _set_path  # noqa: E402
+
+# The SWR values an operator actually thinks in. Labelling contours "2:1"
+# rather than "-9.5 dB" is the difference between a chart you read and a
+# chart you decode.
+SWR_LEVELS = (3.0, 2.0, 1.5, 1.25, 1.1, 1.05, 1.02, 1.01)
+
+
+def swr_to_db(swr: float) -> float:
+    return float(20 * np.log10((swr - 1) / (swr + 1)))
+
+
+def db_to_swr(db: float) -> float:
+    rho = 10 ** (db / 20)
+    return float("inf") if rho >= 1 else (1 + rho) / (1 - rho)
+
+
+def parse_ground(spec: str):
+    """'free' | 'pec' | 'finite:<eps>:<sigma>' -> a MomwireEngine ground arg."""
+    if spec in ("free", "pec"):
+        return None if spec == "free" else "pec"
+    kind, _, rest = spec.partition(":")
+    if kind in ("finite", "finite-fast"):
+        try:
+            eps, sigma = (float(v) for v in rest.split(":"))
+        except ValueError:
+            raise SystemExit(f"bad ground spec {spec!r}: want '{kind}:<eps>:<sigma>'")
+        return (kind, eps, sigma)
+    raise SystemExit(
+        f"unknown ground {spec!r}: want free, pec, or finite:<eps>:<sigma>"
+    )
+
+
+def axis_range(builder, name, explicit):
+    """Sweep bounds for one knob: --range if given, else the design's own
+    ui_params min/max (the slider range it ships to the workbench, which is
+    the author's statement of what values are meaningful), else ±25 %."""
+    if explicit is not None:
+        return float(explicit[0]), float(explicit[1])
+    ui = getattr(builder, "ui_params", {}) or {}
+    spec = ui.get(name.split(".")[-1])
+    if isinstance(spec, dict) and "min" in spec and "max" in spec:
+        return float(spec["min"]), float(spec["max"])
+    v = float(_get_path(builder, name))
+    return (v * 0.75, v * 1.25) if v else (-1.0, 1.0)
+
+
+def _wires_of(factory, names, values):
+    b = factory()
+    for nm, v in zip(names, values):
+        _set_path(b, nm, float(v))
+    return repr(b.build_wires())
+
+
+def network_only(factory, names, xs, ys) -> bool:
+    """True when neither knob moves a wire, so the geometry solve is shared.
+
+    Compared across all four corners of the sweep, not just one pair: a knob
+    that happens to leave the geometry alone at one corner but not another
+    would otherwise be misread as network-only and silently produce a map of
+    the wrong design.
+    """
+    try:
+        ref = _wires_of(factory, names, (xs[0], ys[0]))
+        corners = ((xs[-1], ys[0]), (xs[0], ys[-1]), (xs[-1], ys[-1]))
+        return all(_wires_of(factory, names, c) == ref for c in corners)
+    except Exception:
+        return False
+
+
+def sweep(factory, names, xs, ys, ground, *, verbose=True):
+    """Z over the (ys, xs) grid — fast path when the knobs are network-only."""
+    Z = np.empty((len(ys), len(xs)), dtype=complex)
+    t0 = time.time()
+
+    fast = network_only(factory, names, xs, ys)
+    if fast:
+        b0 = factory()
+        for nm, v in zip(names, (xs[0], ys[0])):
+            _set_path(b0, nm, float(v))
+        eng = MomwireEngine(b0, ground=ground)
+        if eng._network is None:
+            fast = False  # network-only knobs but no network to re-stamp
+        else:
+            wl = eng._wavelength_for(b0.freq)
+            Y = eng._compute_y_matrix(wl)
+            port_to_idx, n_total = eng._reducer.port_to_idx, eng._reducer.n_total_ports
+            if verbose:
+                print(
+                    "network-only knobs: solving the wire once, re-reducing per point"
+                )
+            for j, x in enumerate(xs):
+                for i, y in enumerate(ys):
+                    b = factory()
+                    for nm, v in zip(names, (x, y)):
+                        _set_path(b, nm, float(v))
+                    red = NetworkReducer(b.build_network(), port_to_idx, n_total)
+                    Z[i, j] = red.driven_impedance(Y, wl)[0]
+
+    if not fast:
+        if verbose:
+            print(f"full solve per point: {len(xs) * len(ys)} solves")
+        for j, x in enumerate(xs):
+            for i, y in enumerate(ys):
+                b = factory()
+                for nm, v in zip(names, (x, y)):
+                    _set_path(b, nm, float(v))
+                Z[i, j] = MomwireEngine(b, ground=ground).impedance()[0]
+            if verbose and len(xs) > 20 and j % max(1, len(xs) // 8) == 0:
+                print(f"  column {j}/{len(xs)}  {time.time() - t0:.0f} s", flush=True)
+
+    if verbose:
+        print(f"{len(xs) * len(ys)} points in {time.time() - t0:.1f} s")
+    return Z
+
+
+def plot(xs, ys, Z, names, *, z0, title, rx, out):
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    gdb = 20 * np.log10(np.abs((Z - z0) / (Z + z0)))
+    levels = sorted(swr_to_db(s) for s in SWR_LEVELS)
+    label = {swr_to_db(s): f"{s:g}:1" for s in SWR_LEVELS}
+
+    fig, ax = plt.subplots(figsize=(8.5, 7))
+    ax.contourf(
+        xs, ys, gdb, levels=[*levels, 0], cmap="Blues_r", alpha=0.35, extend="min"
+    )
+    # Every level is negative dB, which matplotlib would dash by default.
+    cs = ax.contour(
+        xs, ys, gdb, levels=levels, colors="#14507a", linewidths=1.1, linestyles="solid"
+    )
+    ax.clabel(
+        cs,
+        fontsize=7.5,
+        fmt=lambda v: label.get(min(label, key=lambda k: abs(k - v)), ""),
+    )
+
+    if rx:
+        R, X = Z.real / z0, Z.imag / z0
+        ax.contour(xs, ys, R, levels=[1.0], colors="#1a7f37", linewidths=2.6)
+        ax.contour(
+            xs,
+            ys,
+            X,
+            levels=[0.0],
+            colors="#b3541e",
+            linewidths=2.6,
+            linestyles="dashed",
+        )
+        ax.plot([], [], color="#1a7f37", lw=2.6, label="R/Z₀ = 1")
+        ax.plot([], [], color="#b3541e", lw=2.6, ls="--", label="X/Z₀ = 0")
+
+    i, j = np.unravel_index(np.argmin(gdb), gdb.shape)
+    ax.plot(
+        xs[j],
+        ys[i],
+        "*",
+        ms=17,
+        color="crimson",
+        mec="k",
+        mew=0.6,
+        zorder=6,
+        label="best grid point",
+    )
+    ax.legend(loc="best", fontsize=8, framealpha=0.92)
+    ax.set_xlabel(names[0])
+    ax.set_ylabel(names[1])
+    ax.set_title(
+        f"{title}\nbest ({xs[j]:.4g}, {ys[i]:.4g}) → "
+        f"{Z[i, j].real:.1f}{Z[i, j].imag:+.1f}j Ω, "
+        f"SWR {db_to_swr(gdb[i, j]):.2f}:1",
+        fontsize=10,
+    )
+    fig.tight_layout()
+    fig.savefig(out, dpi=110)
+    print(f"wrote {out}")
+    return (xs[j], ys[i], Z[i, j], gdb[i, j])
+
+
+def conditioning(xs, ys, gdb, threshold_swr=2.0):
+    """Extent of the sub-threshold region through the best point, per axis.
+
+    This is the number the map exists to produce: a knob whose span is a large
+    fraction of its swept range is not actually determined by the optimum, and
+    an optimizer's value for it should not be quoted as though it were.
+    """
+    lim = swr_to_db(threshold_swr)
+    i, j = np.unravel_index(np.argmin(gdb), gdb.shape)
+    out = {}
+    for name, axis, vals, sl in (("x", 0, xs, gdb[i, :]), ("y", 1, ys, gdb[:, j])):
+        inside = vals[sl < lim]
+        span = float(inside.max() - inside.min()) if inside.size else 0.0
+        full = float(vals[-1] - vals[0])
+        out[name] = (span, span / full if full else 0.0)
+    return out
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument(
+        "--builder", default="dipoles.invvee", help="design spec, name[:variant]"
+    )
+    p.add_argument(
+        "--params",
+        nargs=2,
+        default=["length_factor", "angle_deg"],
+        metavar=("X", "Y"),
+        help="the two knobs (dotted paths allowed)",
+    )
+    p.add_argument("--xrange", nargs=2, type=float, default=None)
+    p.add_argument("--yrange", nargs=2, type=float, default=None)
+    p.add_argument("--n", type=int, default=61, help="grid points per axis")
+    p.add_argument("--ground", default="free", help="free | pec | finite:<eps>:<sigma>")
+    p.add_argument("--z0", type=float, default=50.0)
+    p.add_argument("--rx", action="store_true", help="overlay the R=1 and X=0 families")
+    p.add_argument("--out", default="design_space.png")
+    p.add_argument(
+        "--save-grid", default=None, help="also write the raw grid to a .npz"
+    )
+    a = p.parse_args(argv)
+
+    factory = get_builder(a.builder)
+    b = factory()
+    ground = parse_ground(a.ground)
+    x0, x1 = axis_range(b, a.params[0], a.xrange)
+    y0, y1 = axis_range(b, a.params[1], a.yrange)
+    xs, ys = np.linspace(x0, x1, a.n), np.linspace(y0, y1, a.n)
+    print(
+        f"{a.builder}: {a.params[0]} {x0:g}..{x1:g}  {a.params[1]} {y0:g}..{y1:g}  "
+        f"{a.n}x{a.n}  ground={a.ground}"
+    )
+
+    Z = sweep(factory, a.params, xs, ys, ground)
+    if a.save_grid:
+        np.savez(a.save_grid, xs=xs, ys=ys, Z=Z, params=np.array(a.params))
+        print(f"wrote {a.save_grid}")
+
+    title = f"{a.builder} — {a.params[1]} vs {a.params[0]} (ground={a.ground})"
+    plot(xs, ys, Z, a.params, z0=a.z0, title=title, rx=a.rx, out=a.out)
+
+    gdb = 20 * np.log10(np.abs((Z - a.z0) / (Z + a.z0)))
+    cond = conditioning(xs, ys, gdb)
+    print("\nconditioning at the optimum (extent of the SWR<2 region):")
+    for key, name in (("x", a.params[0]), ("y", a.params[1])):
+        span, frac = cond[key]
+        note = "  <-- weakly determined" if frac > 0.5 else ""
+        print(f"  {name:<20s} {span:.4g} ({frac:.0%} of the swept range){note}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_design_space_contour.py
+++ b/tests/test_design_space_contour.py
@@ -1,0 +1,173 @@
+"""Unit tests for the two-knob design-space contour map.
+
+Exercises the plumbing of ``scripts/design_space_contour.py`` — the SWR/dB
+conversions the contour labels rest on, the ground-spec parser, the sweep-range
+defaulting, the network-only fast-path detector, and the conditioning report —
+plus one small end-to-end sweep on each path (network-only and full-solve) to
+pin that they agree with a direct engine solve.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# The script lives in scripts/, not on the package path — load it by file.
+_PATH = Path(__file__).resolve().parent.parent / "scripts" / "design_space_contour.py"
+_spec = importlib.util.spec_from_file_location("design_space_contour", _PATH)
+dsc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(dsc)
+
+
+@pytest.mark.parametrize("swr", [1.01, 1.5, 2.0, 3.0, 10.0])
+def test_swr_db_roundtrip(swr):
+    assert dsc.db_to_swr(dsc.swr_to_db(swr)) == pytest.approx(swr, rel=1e-9)
+
+
+def test_swr_levels_are_monotone_in_db():
+    """The contour labels are only correct if the dB levels sort the same way
+    the SWR values do — a mislabelled contour is worse than no label."""
+    dbs = [dsc.swr_to_db(s) for s in dsc.SWR_LEVELS]
+    assert dbs == sorted(dbs, reverse=True)  # SWR_LEVELS runs high -> low
+    assert all(d < 0 for d in dbs)
+    assert dsc.swr_to_db(2.0) == pytest.approx(-9.542, abs=1e-3)
+
+
+def test_parse_ground():
+    assert dsc.parse_ground("free") is None
+    assert dsc.parse_ground("pec") == "pec"
+    assert dsc.parse_ground("finite:13:0.005") == ("finite", 13.0, 0.005)
+    assert dsc.parse_ground("finite-fast:5:0.001") == ("finite-fast", 5.0, 0.001)
+
+
+@pytest.mark.parametrize("spec", ["dirt", "finite", "finite:13", "finite:a:b"])
+def test_parse_ground_rejects_junk(spec):
+    with pytest.raises(SystemExit):
+        dsc.parse_ground(spec)
+
+
+def test_axis_range_prefers_the_designs_own_ui_slider():
+    """A design's ui_params min/max is its author's statement of which values
+    are meaningful; the ±25% fallback is a guess. Prefer the statement."""
+    from antennaknobs.designs.dipoles.invvee import Builder
+
+    b = Builder()
+    assert dsc.axis_range(b, "angle_deg", None) == (0.0, 60.0)
+    assert dsc.axis_range(b, "length_factor", None) == (0.8, 1.25)
+    # An explicit --range always wins.
+    assert dsc.axis_range(b, "angle_deg", [10, 20]) == (10.0, 20.0)
+
+
+def test_axis_range_falls_back_to_a_window_around_the_default():
+    """base carries no min/max in ui_params... unless the design added one."""
+    from antennaknobs.designs.verticals.vertical import Builder
+
+    b = Builder()
+    lo, hi = dsc.axis_range(b, "freq", None)
+    assert lo < float(b.freq) < hi
+
+
+def test_network_only_detects_network_knobs():
+    """The stub-matched vertical's two knobs are pure circuit values: no wire
+    moves, so the geometry solve can be hoisted out of the grid loop."""
+    from antennaknobs.cli import get_builder
+
+    factory = get_builder("verticals.stub_matched_vertical")
+    xs, ys = np.linspace(0.05, 0.45, 3), np.linspace(0.05, 0.45, 3)
+    assert dsc.network_only(factory, ["line_wl", "stub_wl"], xs, ys)
+
+
+def test_network_only_rejects_geometry_knobs():
+    """Both invvee knobs move wires. Misreading them as network-only would
+    hoist the geometry solve and map a single fixed antenna instead."""
+    from antennaknobs.cli import get_builder
+
+    factory = get_builder("dipoles.invvee")
+    xs, ys = np.linspace(0.9, 1.1, 3), np.linspace(10.0, 50.0, 3)
+    assert not dsc.network_only(factory, ["length_factor", "angle_deg"], xs, ys)
+
+
+def test_network_only_rejects_a_mixed_pair():
+    """One network knob and one geometry knob is still a geometry sweep. The
+    four-corner comparison is what catches this."""
+    from antennaknobs.cli import get_builder
+
+    factory = get_builder("verticals.stub_matched_vertical")
+    xs, ys = np.linspace(0.05, 0.45, 3), np.linspace(9.0, 11.0, 3)
+    assert not dsc.network_only(factory, ["line_wl", "base"], xs, ys)
+
+
+def test_fast_path_matches_a_direct_solve():
+    """The hoisted-geometry path must reproduce what the ordinary engine
+    returns — it is an optimization, not a different model."""
+    from antennaknobs.cli import get_builder
+    from antennaknobs.engines.momwire import MomwireEngine
+
+    factory = get_builder("verticals.stub_matched_vertical")
+    names = ["line_wl", "stub_wl"]
+    xs, ys = np.linspace(0.10, 0.40, 3), np.linspace(0.10, 0.40, 3)
+    Z = dsc.sweep(factory, names, xs, ys, None, verbose=False)
+
+    for j, x in enumerate(xs):
+        for i, y in enumerate(ys):
+            b = factory()
+            b.line_wl, b.stub_wl = float(x), float(y)
+            assert Z[i, j] == pytest.approx(
+                MomwireEngine(b).impedance()[0], rel=1e-9, abs=1e-9
+            )
+
+
+def test_fast_path_finds_the_documented_match():
+    """The design docstring names (0.406, 0.1408) as a solved 50 Ω match; a
+    grid straddling it must show it as such."""
+    from antennaknobs.cli import get_builder
+
+    factory = get_builder("verticals.stub_matched_vertical")
+    xs, ys = np.array([0.400, 0.406, 0.412]), np.array([0.135, 0.1408, 0.146])
+    Z = dsc.sweep(factory, ["line_wl", "stub_wl"], xs, ys, None, verbose=False)
+    assert Z[1, 1].real == pytest.approx(50.0, abs=1.0)
+    assert Z[1, 1].imag == pytest.approx(0.0, abs=2.0)
+
+
+def test_full_solve_path_tracks_geometry():
+    """A geometry sweep must actually vary with geometry — the regression this
+    guards is the fast path firing when it should not, which would return the
+    same impedance at every point."""
+    from antennaknobs.cli import get_builder
+
+    factory = get_builder("dipoles.invvee")
+    xs, ys = np.array([0.90, 1.05]), np.array([10.0, 45.0])
+    Z = dsc.sweep(factory, ["length_factor", "angle_deg"], xs, ys, None, verbose=False)
+    assert len(set(np.round(Z.ravel(), 6))) == 4
+    # Longer wire -> more inductive at fixed droop.
+    assert Z[0, 1].imag > Z[0, 0].imag
+
+
+def test_conditioning_flags_the_loose_axis():
+    """A synthetic valley that is narrow in x and spans the whole y range: the
+    report exists to say 'your optimizer's y is not determined'."""
+    xs = np.linspace(0.0, 1.0, 51)
+    ys = np.linspace(0.0, 1.0, 51)
+    # |Γ| depends on x only, so every y is equally good. The x curvature has to
+    # be steep enough that the SWR<2 band is genuinely narrow — a shallow bowl
+    # is legitimately "loose in both", which is not what this test is about.
+    gdb = -40 + 4000 * (xs[None, :] - 0.5) ** 2 + 0 * ys[:, None]
+    cond = dsc.conditioning(xs, ys, gdb)
+    x_span, x_frac = cond["x"]
+    y_span, y_frac = cond["y"]
+    assert x_frac < 0.5  # pinned
+    assert y_frac == pytest.approx(1.0)  # entirely undetermined
+    assert math.isclose(y_span, 1.0, abs_tol=1e-9)
+
+
+def test_conditioning_on_a_round_basin_pins_both():
+    xs = ys = np.linspace(-1.0, 1.0, 41)
+    gdb = -40 + 600 * (xs[None, :] ** 2 + ys[:, None] ** 2)
+    cond = dsc.conditioning(xs, ys, gdb)
+    assert cond["x"][1] < 0.5
+    assert cond["y"][1] < 0.5
+    assert cond["x"][0] == pytest.approx(cond["y"][0], rel=0.15)


### PR DESCRIPTION
## Summary

- Adds `scripts/design_space_contour.py`: sweeps any design over two knobs and draws **|Γ| level curves labelled by SWR** (`3:1`, `2:1`, `1.5:1`, …) rather than raw dB — the unit the levels actually mean something in. `--rx` overlays the **R/Z₀ = 1** and **X/Z₀ = 0** families whose intersection *is* the match.
- The map answers two questions a returned optimum cannot:
  - **How many answers exist.** `verticals.stub_matched_vertical`'s two documented matches render as two basins joined by a saddle inside the 3:1 contour — one connected region at 3:1, two at 2:1 and tighter. An optimizer slides to whichever it started nearest and never mentions the other; the script puts both minima on the design's own documented knob settings, `line_wl/stub_wl` ≈ **(0.406, 0.142)** and **(0.096, 0.361)**, each at **SWR ≈ 1.02:1**, stable across n = 121/161/241. (Quoting knob coordinates rather than the impedance at the best grid point is deliberate: near a match X crosses zero steeply, so the *sampled* Z is a grid-alignment accident — its reactance changes sign between those resolutions — while the knob location does not move.)
  - **Which knobs the answer is trustworthy on.** `dipoles.invvee`'s basin is a near-vertical canyon: at 81×81, `length_factor` is pinned to **under 10%** of its swept range while `angle_deg` is loose over **three quarters or more** of its own (10%/75% over PEC, 9%/85% in free space — the exact fractions move with grid and ground, the shape does not). The droop angle `opt.optimize` returns is close to arbitrary — two runs from different starts will disagree on it while agreeing on length — and the ground model moves it (**36.0°** free space vs **26.2°** over PEC) while barely moving `length_factor` (**0.980 → 0.974**). The script prints this conditioning report automatically.
- `--rx` is deliberately opt-in: R=1 ∩ X=0 is only the optimum for a *pure impedance* objective. `opt.optimize(opt_gain=True)` subtracts a gain term and moves the optimum off the intersection, at which point the overlay would mislead. The |Γ| map stays honest either way.
- **Network-only knobs get a fast path.** When neither knob moves a wire (`line_wl`/`stub_wl` on the stub-matched vertical), the geometry is solved once and only the network re-reduced per point: 14641 points in ~3 s instead of ~3 min. Detection compares `build_wires()` across all four corners of the sweep, not one pair, so a knob that leaves geometry alone at one corner but not another can't be misread.

Scoped to `scripts/` as an exploration tool — no CLI or web surface. Cost scales as N² solves (~30 s for an 81×81 `invvee` map, but >3 h for `arrays.bowtie16x1`), which is the main argument against wiring it to a user-facing button as-is.

## Test plan

- [x] `pytest tests/test_design_space_contour.py` — 21 passing: SWR/dB roundtrip and label monotonicity, ground-spec parsing, `ui_params`-derived sweep ranges, fast-path detection (accepts network knobs, rejects geometry and mixed pairs), fast path numerically equal to a direct `MomwireEngine` solve, geometry path actually varying with geometry, and the conditioning report on synthetic loose/round basins.
- [x] `ruff check .` and `ruff format --check .` clean repo-wide.
- [x] Full fast lane run locally: 3207 passed. 13 pre-existing Windows-only failures in `test_schematic.py` (cp1252 can't encode `Ω`) and 9 pre-existing collection errors in `tests/test_bench_*` (`import resource` is Unix-only) — both reproduce unchanged on `main` and are green on Linux CI.
- [x] Sanity-check the two rendered maps in CI-free local use:
  `python scripts/design_space_contour.py --builder dipoles.invvee --params length_factor angle_deg --n 81 --ground pec --rx`
  `python scripts/design_space_contour.py --builder verticals.stub_matched_vertical --params line_wl stub_wl --n 121 --rx`

  Both run clean. Stub-matched map: 14641 points in **2.7 s** on the network-only fast path. Inv-vee map: 6561 solves in **22 s** per ground. Findings folded into the summary above; full verification in [the review comment](https://github.com/stevenmburns/antennaknobs/pull/771#issuecomment-5209153790), including the basin topology re-derived from the saved grids at three resolutions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

