### PR TITLE
Pin UTF-8 at the four text-file write sites (closes #772)

### DIFF
--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -883,7 +883,9 @@ def cli(arguments=None):
             ),
         )
         if args.out:
-            with open(args.out, "w") as fh:
+            # The header comment interpolates --driver verbatim; pin the
+            # encoding rather than trust the platform default (issue #772).
+            with open(args.out, "w", encoding="utf-8") as fh:
                 fh.write(text)
             print(
                 f"wrote {args.out}: {trace.freqs.size} points, "
@@ -1056,7 +1058,9 @@ def cli(arguments=None):
             kwargs["freq"] = args.freq
         deck = export_nec(builder(), **kwargs)
         if args.out:
-            with open(args.out, "w") as fh:
+            # NEC decks are ASCII by spec, but pin the encoding rather than
+            # trust the platform default (issue #772).
+            with open(args.out, "w", encoding="utf-8") as fh:
                 fh.write(deck)
             print(f"wrote {args.out}")
         else:

--- a/src/antennaknobs/schematic.py
+++ b/src/antennaknobs/schematic.py
@@ -1795,6 +1795,9 @@ def render_svg(sch: Schematic, path=None, color: str | None = None) -> str:
     d.draw(show=False)
     svg = d.get_imagedata("svg").decode("utf-8")
     if path is not None:
-        with open(path, "w") as fh:
+        # schemdraw emits Ω in every impedance label; an unpinned encoding
+        # falls back to the platform default, which is cp1252 on stock
+        # Windows and has no code point for it (issue #772).
+        with open(path, "w", encoding="utf-8") as fh:
             fh.write(svg)
     return svg

--- a/src/antennaknobs/simnec_export.py
+++ b/src/antennaknobs/simnec_export.py
@@ -347,7 +347,9 @@ def main(argv=None):
         name=args.name,
     )
     if args.out:
-        with open(args.out, "w") as fh:
+        # --name is echoed verbatim into the script's first //comment; pin
+        # the encoding rather than trust the platform default (issue #772).
+        with open(args.out, "w", encoding="utf-8") as fh:
             fh.write(ssn)
         print(f"wrote {args.out}")
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,3 +133,41 @@ def pytest_terminal_summary(terminalreporter):
 def pytest_sessionfinish(session, exitstatus):
     if _time_budget_offenders and os.environ.get("ANTENNAKNOBS_ENFORCE_TIME_BUDGET"):
         session.exitstatus = pytest.ExitCode.TESTS_FAILED
+
+
+# --------------------------------------------------------------------------
+# UTF-8 write-site regression guard (issue #772)
+# --------------------------------------------------------------------------
+@pytest.fixture
+def cp1252_default_open(monkeypatch):
+    """Make unpinned text-mode ``open()`` calls land on cp1252 — the stock
+    Windows default — for the duration of a test.
+
+    ``monkeypatch.setattr(locale, "getencoding", lambda: "cp1252")`` looks
+    like it should work and does not: CPython's ``open()`` resolves its
+    default text encoding in C (``io.TextIOWrapper`` calls
+    ``_Py_GetLocaleEncoding``/``PyUnicode_GetLocaleEncoding`` internally)
+    without consulting the Python-level ``locale`` module, so patching
+    ``locale.getencoding`` leaves ``open()`` writing UTF-8 regardless and a
+    "regression" test built on it would pass even against unfixed code.
+    ``locale.setlocale(locale.LC_CTYPE, "C")`` does reproduce the bug, but it
+    mutates global process (not test) state.
+
+    Wrapping ``builtins.open`` itself is the one mechanism that actually
+    forces the codec an unpinned write site would get on Windows: any
+    ``open(path, "w")`` without an explicit ``encoding=`` — anywhere in the
+    call stack, not just at the immediate write site — falls back to cp1252
+    for the fixture's lifetime, so a write site missing
+    ``encoding="utf-8"`` raises ``UnicodeEncodeError`` here on Linux too.
+    Do not "simplify" this back to a ``locale`` patch — see above.
+    """
+    import builtins
+
+    real_open = builtins.open
+
+    def cp1252_default(file, mode="r", *args, encoding=None, **kwargs):
+        if "b" not in mode and encoding is None:
+            encoding = "cp1252"
+        return real_open(file, mode, *args, encoding=encoding, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", cp1252_default)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -129,3 +129,26 @@ def test_cli_default_engine_works_without_pynec(monkeypatch):
     monkeypatch.delitem(cli_mod.ENGINE_CLASSES, "pynec", raising=False)
     dipole = "dipoles.invvee:dipole"
     ant.cli(f"pattern --builder {dipole} --ground free{o}".split())
+
+
+def test_cli_export_writes_utf8_even_under_a_non_utf8_default(
+    tmp_path, monkeypatch, cp1252_default_open
+):
+    """`export` writes the NEC deck verbatim; NEC decks are ASCII by spec and
+    `export`'s CLI has no --title flag to inject through, so there is no live
+    user-facing vector today (issue #772 says as much). export_nec's return
+    value is the only thing stubbed here — the CLI dispatch and the
+    open(args.out, "w") write site both run for real — so this still fails
+    against an unpinned write site, guarding the case a future --title (or
+    similar) flag opens up.
+
+    Deliberately NOT @needs_pynec: `export` builds a deck and never solves,
+    so requiring the reference engine would skip this guard on exactly the
+    bare checkout the issue blames for the bug staying hidden."""
+    monkeypatch.setattr("antennaknobs.nec_export.export_nec", lambda *a, **k: "CM Ω\n")
+
+    out = tmp_path / "deck.nec"
+    ant.cli(f"export --builder dipoles.invvee --out {out}".split())
+
+    text = out.read_text(encoding="utf-8")
+    assert "Ω" in text

--- a/tests/test_schematic.py
+++ b/tests/test_schematic.py
@@ -441,7 +441,22 @@ def test_render_produces_an_svg(tmp_path):
     out = tmp_path / "s.svg"
     svg = render_svg(lower(build("wire.doublet_ladder_tuner").build_network()), out)
     assert svg.lstrip().startswith("<?xml") or "<svg" in svg
-    assert out.read_text() == svg
+    assert out.read_text(encoding="utf-8") == svg
+
+
+def test_render_svg_writes_utf8_even_under_a_non_utf8_default(
+    tmp_path, cp1252_default_open
+):
+    """schemdraw emits Ω in every impedance label; an unpinned write site
+    would fall back to cp1252 on stock Windows and raise UnicodeEncodeError
+    (issue #772). cp1252_default_open reproduces that platform default here
+    on Linux, so this fails against `open(path, "w")` without
+    `encoding="utf-8"`."""
+    pytest.importorskip("schemdraw")
+    out = tmp_path / "s.svg"
+    svg = render_svg(lower(build("wire.doublet_ladder_tuner").build_network()), out)
+    assert "Ω" in svg
+    assert "Ω" in out.read_text(encoding="utf-8")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_simnec_export.py
+++ b/tests/test_simnec_export.py
@@ -224,6 +224,20 @@ def test_cli_sweep_auto_band(capsys):
     assert got["from"] == "9" and got["to"] == "11" and got["doSweep"] == "y"
 
 
+def test_cli_writes_utf8_even_under_a_non_utf8_default(tmp_path, cp1252_default_open):
+    """``--name`` is echoed verbatim into the script's first //comment; a
+    name outside cp1252 reproduces the Windows failure mode here on Linux
+    (issue #772). Real CLI, real export_ssn, no mocking — the write site is
+    exercised exactly as a user hits it."""
+    from antennaknobs.simnec_export import main
+
+    out = tmp_path / "deck.ssn"
+    main(["dipoles.invvee", "--freq", "14.1", "--name", "Ω-tuned", "--out", str(out)])
+
+    text = out.read_text(encoding="utf-8")
+    assert "Ω-tuned" in text
+
+
 def test_networked_design_raises():
     from antennaknobs.designs.wire.zepp import Builder as Zepp
 

--- a/tests/test_vna.py
+++ b/tests/test_vna.py
@@ -14,6 +14,7 @@ import antennaknobs as ant
 from antennaknobs.touchstone import format_s1p, parse_touchstone
 from antennaknobs.vna import (
     DRIVERS,
+    Driver,
     NanoVNADriver,
     VNAError,
     capture,
@@ -235,6 +236,35 @@ def test_cli_capture_writes_a_file(tmp_path, monkeypatch):
     text = out.read_text()
     assert text.startswith("! captured by antennaknobs")
     assert parse_touchstone(text, nports=1).freqs.size == 11
+
+
+def test_cli_capture_writes_utf8_even_under_a_non_utf8_default(
+    tmp_path, monkeypatch, cp1252_default_open
+):
+    """The Touchstone header comment interpolates ``--driver`` verbatim; a
+    driver name outside cp1252 reproduces the Windows failure mode here on
+    Linux (issue #772). Real driver-registry dispatch, no live hardware —
+    only the transport (SerialTransport) is stubbed, exactly as
+    test_cli_capture_writes_a_file does."""
+
+    class Fake(Driver):
+        def __init__(self, transport):
+            pass
+
+        def sweep(self, start_hz, stop_hz, points):
+            f = np.linspace(start_hz, stop_hz, points)
+            return f, np.full(points, 0.25 + 0j)
+
+    monkeypatch.setitem(DRIVERS, "fakeΩ", Fake)
+    monkeypatch.setattr("antennaknobs.vna.SerialTransport", lambda *a, **k: object())
+    out = tmp_path / "bench.s1p"
+    ant.cli(
+        f"capture --out {out} --start 28 --stop 29 --points 11 "
+        "--driver fakeΩ --port /dev/fake".split()
+    )
+
+    text = out.read_text(encoding="utf-8")
+    assert "fakeΩ" in text
 
 
 def test_cli_capture_needs_a_span():


### PR DESCRIPTION
Closes #772.

`schematic --out` crashed on Windows with `UnicodeEncodeError`: the SVG is decoded as UTF-8 and written back through the *platform default* encoding — cp1252 on a stock install, which has no code point for the `Ω` schemdraw emits in every impedance label. The three sibling writers named in the issue had the same unpinned pattern, and two of them interpolate user-supplied text into their headers (`--driver`, `--name`), so they were not safe by construction either.

## The fix

`encoding="utf-8"` at all four sites:

| Site | What it writes |
|---|---|
| `schematic.py:1798` | the schematic SVG — **the live crash** |
| `cli.py:886` | Touchstone capture (`--driver` in the header) |
| `cli.py:1059` | NEC deck export |
| `simnec_export.py:350` | SimNEC session (`--name` in the first comment) |

Plus the read side at `tests/test_schematic.py:444`, which was also unpinned and would have failed on Windows *after* the fix (cp1252 decode of a UTF-8 file).

## The guard is the load-bearing part

The issue is right that a round-trip assertion doesn't guard this — `read_text(encoding="utf-8")` containing `Ω` passes on Linux either way, so CI would never catch a recurrence.

The obvious mechanism for forcing the failure is also wrong, which is worth recording: **`monkeypatch.setattr(locale, "getencoding", ...)` is a no-op here.** CPython's `open()` resolves its default text encoding in C without consulting the Python-level `locale` module, so a test built on it passes against unfixed code — a guard that looks right and guards nothing. Verified empirically before briefing, and the reasoning is in the fixture's docstring so it doesn't get "simplified" back.

What works is wrapping `builtins.open` for the duration of the test (`cp1252_default_open` in `tests/conftest.py`): any text-mode open without an explicit `encoding=`, anywhere in the call stack, lands on cp1252 — the actual stock-Windows default from the bug report.

## Gates

- **Adversarial probe, per site.** Each of the four sites was reverted *individually* and its guard confirmed to fail — so no test passes by accident of a sibling's fix:

  | Reverted site | Test | Result |
  |---|---|---|
  | `schematic.py` | `test_render_svg_writes_utf8...` | FAILED ✓ |
  | `simnec_export.py` | `test_cli_writes_utf8...` | FAILED ✓ |
  | `cli.py:888` only | `test_cli_capture_writes_utf8...` | FAILED ✓ |
  | `cli.py:1063` only | `test_cli_export_writes_utf8...` | FAILED ✓ |

- **Full suite**: 3443 passed, 2 skipped in 182s (3441 baseline + 4 new guards). No regressions, no pinned constant moved.
- **ruff** `check` + `format --check` clean on all 8 touched files.

## Review notes

Implemented by a **sonnet** subagent; reviewed, gate-re-run, and amended by the session model (opus). I read the whole diff, re-derived the guard mechanism independently *before* briefing (which is how the `locale` dead end got caught up front rather than in review), and ran the per-site adversarial probe above myself rather than taking the builder's word for it.

Two things I fixed during review rather than sending back:

1. **Dropped `@needs_pynec`** from the NEC-export guard. `export` builds a deck and never solves, so gating it on the reference engine would skip that guard on exactly the bare checkout the issue blames for the bug staying hidden. Noted in the test's docstring.
2. **`DRIVERS["fakeΩ"]` global mutation → `monkeypatch.setitem`**, so the driver registry unwinds with the test instead of via `try/finally`.

For a human reviewer: the coverage of the two ASCII-by-spec writers (NEC deck, and to a lesser degree Touchstone) is forward-looking rather than fixing a live break — the NEC guard stubs `export_nec`'s return value to inject a non-cp1252 character, since the CLI has no flag that reaches the deck body today. The CLI dispatch and the write site still run for real. The SimNEC and capture guards need no stubbing beyond the serial transport; they drive the real user-facing path.