### PR TITLE
Audit and close out the react-hooks compiler diagnostics; rules to error (closes #768)

### DIFF
--- a/src/antennaknobs/web/frontend/eslint.config.js
+++ b/src/antennaknobs/web/frontend/eslint.config.js
@@ -37,17 +37,26 @@ export default tseslint.config(
       // react-hooks was pinned to 5.2.0 while eslint 9 allowed it, because
       // 6.x/7.x fold the React Compiler's diagnostic suite into
       // `recommended`. eslint 10 forced the 7.x major (5.2.0 peer-depends on
-      // eslint <=9), so the containment moved from the version pin to rule
-      // severity: the four compiler diagnostics below run at `warn` — visible
-      // in `npm run lint`, not failing the `--max-warnings` CI gate. At
-      // adoption time they flagged 28 sites, dominated by the deliberate
-      // sync-setState clear/dwell idiom in useAnalysisRunners and
-      // DesignSession; migrating those is a real project, not a deps bump.
+      // eslint <=9), so containment moved from the version pin to rule
+      // severity — the four compiler diagnostics ran at `warn` while the
+      // ~30 pre-existing sites were triaged (#756, #768).
+      //
+      // That triage is done, so they are `error` now. A rule at `warn` with
+      // 30 standing warnings does not contain anything: nobody sees number
+      // 31. Every remaining site carries an inline disable stating WHY it is
+      // intentional, which is the artifact worth having — the audit in #768
+      // found the two real defects hiding among them (an eager
+      // `useRef(f())` minting a discarded UUID and rebuilding a discarded
+      // SolveRequest every render) precisely because each site had to be
+      // justified one at a time.
+      //
+      // Deliberately per-site disables rather than a file- or rule-level
+      // exemption: a new violation in these same files still fails.
       ...reactHooks.configs.recommended.rules,
-      "react-hooks/set-state-in-effect": "warn",
-      "react-hooks/refs": "warn",
-      "react-hooks/immutability": "warn",
-      "react-hooks/purity": "warn",
+      "react-hooks/set-state-in-effect": "error",
+      "react-hooks/refs": "error",
+      "react-hooks/immutability": "error",
+      "react-hooks/purity": "error",
       // The issue calls for exhaustive-deps at error (the plugin default is
       // "warn"); rules-of-hooks is already "error" in `recommended`.
       "react-hooks/exhaustive-deps": "error",
@@ -70,6 +79,14 @@ export default tseslint.config(
       "testing-library": testingLibrary,
     },
     rules: {
+      // The compiler's ref diagnostic does not apply to a test harness
+      // component (#768): a harness exists precisely to surface a hook's
+      // internals — it renders `car.mobileCarouselRef` into the tree so an
+      // assertion can reach it. That is reading a ref during render on
+      // purpose, and it ships to nobody. Scoped off here rather than
+      // disabled at each of the four call sites, because in this tree it is
+      // the rule that is wrong, not the code.
+      "react-hooks/refs": "off",
       ...testingLibrary.configs.react.rules,
       // 42 legacy `container.querySelector`/`.contains` sites predate this
       // config (role-based queries already lead 138-to-42). Downgraded to

--- a/src/antennaknobs/web/frontend/src/__tests__/numericDraft.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/numericDraft.test.tsx
@@ -1,0 +1,69 @@
+// The numeric-draft contract in components/backend/fields.tsx.
+//
+// These fields hold a TEXT draft rather than binding straight to the number,
+// because binding to the number coerced "" → 0 on backspace: the field could
+// not be cleared, and the forced 0 left a leading zero when you typed again.
+// That behaviour was carried only by a comment until issue #768 moved the
+// prop-sync out of an effect and into a render-time adjustment — a refactor
+// with no test under it. These are that test.
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+import { NumberField } from "../components/backend/fields";
+
+function Harness({ initial, onChange }: { initial: number; onChange?: (v: number) => void }) {
+  const [value, setValue] = useState(initial);
+  return (
+    <>
+      <NumberField
+        label="N"
+        value={value}
+        onChange={(v) => {
+          setValue(v);
+          onChange?.(v);
+        }}
+      />
+      {/* Drives `value` from OUTSIDE, the way a backend swap or reset does. */}
+      <button onClick={() => setValue(42)}>external</button>
+    </>
+  );
+}
+
+describe("numeric draft", () => {
+  it("can be emptied mid-edit without committing a 0", () => {
+    const onChange = vi.fn();
+    render(<Harness initial={15} onChange={onChange} />);
+    const input = screen.getByRole("spinbutton");
+
+    fireEvent.change(input, { target: { value: "" } });
+
+    // The draft is empty — the field is clearable...
+    expect((input as HTMLInputElement).value).toBe("");
+    // ...and nothing was committed, so no 0 snaps back into the model.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps a half-typed value that parses to the number already committed", () => {
+    render(<Harness initial={1.5} />);
+    const input = screen.getByRole("spinbutton");
+
+    // "1.50" parses to 1.5, which is what `value` already holds. The sync must
+    // not fire, or the trailing zero would vanish from under the cursor.
+    fireEvent.change(input, { target: { value: "1.50" } });
+
+    expect((input as HTMLInputElement).value).toBe("1.50");
+  });
+
+  it("re-syncs when the value changes from outside", () => {
+    render(<Harness initial={15} />);
+    const input = screen.getByRole("spinbutton");
+    fireEvent.change(input, { target: { value: "" } });
+    expect((input as HTMLInputElement).value).toBe("");
+
+    fireEvent.click(screen.getByText("external"));
+
+    // An outside change overrides whatever was being typed — that is the whole
+    // point of the sync, and what the removed effect used to provide.
+    expect((input as HTMLInputElement).value).toBe("42");
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/useSolveChannel.firstSend.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useSolveChannel.firstSend.test.tsx
@@ -1,0 +1,113 @@
+// The send path's one precondition (issue #768): `controlsRef` is null until
+// the component decides what to solve, and a send it cannot fill is DEFERRED
+// rather than faked.
+//
+// This became reachable when controlsRef stopped being seeded with an eager
+// `useRef(buildRequest())` — that spelling rebuilt a whole SolveRequest on
+// every render to discard it. The seed also meant `onopen` had something to
+// send even when the solve effect had deliberately withheld a solve (an
+// antenna switch whose preview has not landed), so removing it makes the
+// gate authoritative. Nothing else in the suite drives the socket: the
+// DesignSession harness mounts with an InertWebSocket that never opens.
+import { renderHook, act } from "@testing-library/react";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { useSolveChannel } from "../components/session/useSolveChannel";
+import type { SolveRequest } from "../lib/api";
+
+class FakeWebSocket {
+  static OPEN = 1;
+  readyState = 0;
+  sent: string[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  static last: FakeWebSocket | null = null;
+  constructor() {
+    FakeWebSocket.last = this;
+  }
+  send(payload: string) {
+    this.sent.push(payload);
+  }
+  close() {}
+  /** What the browser does when the server accepts the connection. */
+  open() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+}
+
+// requestSolve coalesces a burst into one send per animation frame. The stub
+// QUEUES the callback and returns a handle, rather than running it inline:
+// requestSolve stores that handle as its throttle flag, so a stub that ran the
+// callback first would let the callback's own `= null` be overwritten by the
+// returned handle and wedge the throttle shut for every later send. Real rAF
+// never does that; running frames explicitly keeps the test honest about it.
+const frames: FrameRequestCallback[] = [];
+const flushFrame = () => {
+  const pending = frames.splice(0);
+  pending.forEach((cb) => cb(0));
+};
+const realRaf = globalThis.requestAnimationFrame;
+const realWs = globalThis.WebSocket;
+
+function mount(controlsRef: { current: SolveRequest | null }) {
+  return renderHook(() =>
+    useSolveChannel({
+      active: true,
+      controlsRef,
+      geometryRef: { current: "dipoles.probe" },
+      previewSigRef: { current: null },
+      setResult: () => {},
+      setSolveError: () => {},
+    }),
+  );
+}
+
+describe("useSolveChannel first send", () => {
+  beforeEach(() => {
+    FakeWebSocket.last = null;
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+    frames.length = 0;
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) =>
+      frames.push(cb)) as typeof requestAnimationFrame;
+  });
+
+  afterEach(() => {
+    globalThis.WebSocket = realWs;
+    globalThis.requestAnimationFrame = realRaf;
+    vi.restoreAllMocks();
+  });
+
+  it("sends nothing when the socket opens before anything is decided", () => {
+    const controlsRef: { current: SolveRequest | null } = { current: null };
+    mount(controlsRef);
+
+    // onopen calls requestSolve unconditionally. With nothing decided there is
+    // no request to send, and inventing one would solve a design the component
+    // is deliberately holding back.
+    act(() => FakeWebSocket.last!.open());
+    act(() => flushFrame());
+
+    expect(FakeWebSocket.last!.sent).toEqual([]);
+  });
+
+  it("sends once a request has been decided, and stamps it with a seq", () => {
+    const controlsRef: { current: SolveRequest | null } = { current: null };
+    const { result } = mount(controlsRef);
+    act(() => FakeWebSocket.last!.open());
+    act(() => flushFrame()); // the onopen send, deferred — nothing decided yet
+
+    controlsRef.current = { geometry: "dipoles.probe" } as SolveRequest;
+    act(() => result.current.requestSolve());
+    act(() => flushFrame());
+
+    expect(FakeWebSocket.last!.sent).toHaveLength(1);
+    const payload = JSON.parse(FakeWebSocket.last!.sent[0]);
+    expect(payload.geometry).toBe("dipoles.probe");
+    // The latest-wins protocol is what the deferral must not disturb: a
+    // deferred send must not burn a sequence number, or the watermark would
+    // run ahead of what was actually put on the wire.
+    expect(payload._seq).toBe(1);
+  });
+});

--- a/src/antennaknobs/web/frontend/src/components/backend/fields.tsx
+++ b/src/antennaknobs/web/frontend/src/components/backend/fields.tsx
@@ -1,4 +1,25 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
+
+// A text draft of a numeric prop, re-synced whenever the prop changes from
+// outside (backend swap, auto-seed, reset) but left alone while you type.
+//
+// Adjusted DURING RENDER rather than in an effect (issue #768). The effect
+// spelling — `useEffect(() => setDraft(String(value)), [value])` — is the
+// anti-pattern React's "You Might Not Need an Effect" is about: it paints the
+// stale draft first and corrects it on a second pass. Comparing against the
+// last-synced value here means React re-renders before committing to the DOM,
+// so the stale text is never shown. Behaviour is otherwise identical: the
+// guard is false while typing (committing a parsed value leaves `value`
+// unchanged), which is what keeps a half-typed "1.50" from snapping to "1.5".
+function useNumericDraft(value: number) {
+  const [draft, setDraft] = useState(String(value));
+  const [synced, setSynced] = useState(value);
+  if (value !== synced) {
+    setSynced(value);
+    setDraft(String(value));
+  }
+  return [draft, setDraft] as const;
+}
 
 // Bare numeric input with the same clear-without-snapping-to-0 draft treatment
 // as NumberField (which carries its own label/value chrome and doesn't fit the
@@ -10,10 +31,7 @@ export function KnobMenuNumber({
   value: number;
   onChange: (v: number) => void;
 }) {
-  const [draft, setDraft] = useState(String(value));
-  useEffect(() => {
-    setDraft(String(value));
-  }, [value]);
+  const [draft, setDraft] = useNumericDraft(value);
   return (
     <input
       type="number"
@@ -51,12 +69,8 @@ export function NumberField({
   // Local text draft so the field can be emptied mid-edit. Binding the input
   // straight to the number coerced "" → 0 on backspace (you couldn't clear it,
   // and the forced 0 left a leading zero when you typed again). The draft holds
-  // raw text; a value is only committed when it parses, and re-syncs whenever
-  // `value` changes from outside (backend swap, auto-seed, reset).
-  const [draft, setDraft] = useState(String(value));
-  useEffect(() => {
-    setDraft(String(value));
-  }, [value]);
+  // raw text; a value is only committed when it parses.
+  const [draft, setDraft] = useNumericDraft(value);
   return (
     <div className="field">
       <label>

--- a/src/antennaknobs/web/frontend/src/components/charts/CurrentCanvas.tsx
+++ b/src/antennaknobs/web/frontend/src/components/charts/CurrentCanvas.tsx
@@ -68,6 +68,10 @@ export function CurrentCanvas({
   // (Projection switches within a design carry the viewport — see draw().)
   const geometryName = result?.geometry ?? "";
   useEffect(() => {
+    // Re-fit on a DESIGN switch: the viewport was aimed at the old geometry.
+    // Deliberate — projection switches within a design carry the viewport
+    // instead (#768).
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     resetViewport();
     frameRef.current = null;
     // The main draw effect below re-runs on any new result, so the re-fit

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -688,6 +688,9 @@ function DesignSessionBody({
   // onmessage handler can drop responses for an antenna the user already
   // switched away from. Updated every render — cheap and always current.
   const geometryRef = useRef(geometry);
+  // geometry mirrored for the mount-once WebSocket handler, which must drop
+  // responses for an antenna the user has already switched away from (#768).
+  // eslint-disable-next-line react-hooks/refs
   geometryRef.current = geometry;
 
   // Solve-lane session id (issue #382): one per workbench tab (A/B compare
@@ -889,6 +892,10 @@ function DesignSessionBody({
   useEffect(() => {
     if (!currentExample) return;
     if (currentBands.length === 0) {
+      // Derived state cleared when its inputs change — the reset IS the
+      // effect's purpose, not a sync that could be computed during render
+      // (#768).
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       if (band !== "") setBand("");
       return;
     }
@@ -1021,6 +1028,10 @@ function DesignSessionBody({
   const comparing = pinCount > 0 && (view === "azimuth" || view === "elevation");
   useEffect(() => {
     if (!comparing || !result || !active) {
+      // Derived state cleared when its inputs change — the reset IS the
+      // effect's purpose, not a sync that could be computed during render
+      // (#768).
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setLiveMetrics(null);
       return;
     }
@@ -1047,6 +1058,9 @@ function DesignSessionBody({
   // stale approval. Defined before the solve effect so it runs first.
   useEffect(() => {
     approvedComboRef.current = false;
+    // Derived state cleared when its inputs change — the reset IS the effect's
+    // purpose, not a sync that could be computed during render (#768).
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setComboApproved(false);
   }, [geometry, backend, backendOptsKey]);
 
@@ -1057,12 +1071,19 @@ function DesignSessionBody({
     // antenna keep solving freely — previewReady stays equal to geometry until
     // the next switch resets it to null.
     if (previewReady !== geometry) return;
+    // Writing the latest request into controlsRef is this effect's whole job;
+    // the channel reads it on send (#768).
+    // eslint-disable-next-line react-hooks/immutability
     controlsRef.current = buildRequest();
     // Paused: keep controlsRef fresh (so resuming sends the latest design) but
     // don't solve, and suppress the combo warning — nothing is running to warn
     // about. Toggling Live back on re-runs this effect (autoSim is a dep) and
     // solves the current state.
     if (!autoSim) {
+      // Derived state cleared when its inputs change — the reset IS the
+      // effect's purpose, not a sync that could be computed during render
+      // (#768).
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setSolverWarning(false);
       // Live is off, so no solve will run to redraw the geometry. Keep the
       // preview wireframe in sync with the knobs ourselves: a variant switch
@@ -1157,6 +1178,9 @@ function DesignSessionBody({
     // — building and rendering a geometry nobody asked for, only to be replaced a
     // beat later. Bail here so the first preview is the real default.
     if (!geometry) return;
+    // Derived state cleared when its inputs change — the reset IS the effect's
+    // purpose, not a sync that could be computed during render (#768).
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setResult(null);
     setPreview(null);
     setSolveError(null);

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -694,7 +694,12 @@ function DesignSessionBody({
   // tabs are separate App instances, hence separate sessions). The server
   // keys its single-lane scheduler on this — everything this tab asks for
   // runs one-at-a-time server-side, live solve first.
-  const sessionIdRef = useRef<string>(
+  //
+  // useState's LAZY initializer, not useRef(makeSessionId()): a bare
+  // useRef argument is evaluated on every render and discarded after the
+  // first, so that spelling minted — and threw away — a fresh UUID on every
+  // knob frame. The lazy form runs the impure call exactly once (issue #768).
+  const [sessionId] = useState(() =>
     typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
       ? crypto.randomUUID()
       : `s-${Math.random().toString(36).slice(2)}`,
@@ -708,7 +713,7 @@ function DesignSessionBody({
     // ships the real εr/σ for the pattern either way).
     const groundActive = groundEnabled && backendSupportsGround(backend);
     const base: SolveRequest = {
-      _session: sessionIdRef.current,
+      _session: sessionId,
       geometry,
       variant: currentVariant,
       solver: backend.kind === "pynec" ? "pynec" : "momwire",
@@ -954,7 +959,15 @@ function DesignSessionBody({
 
   // The latest control values, used to send a new request when the prior one
   // completes (drops intermediate values rather than queuing them all up).
-  const controlsRef = useRef<SolveRequest>(buildRequest());
+  //
+  // Starts null rather than seeded with buildRequest(): a useRef argument is
+  // evaluated every render and discarded after the first, so seeding it here
+  // rebuilt a whole 59-line SolveRequest per knob frame to throw it away
+  // (issue #768). Null means "nothing decided to solve yet" — every writer
+  // (the solve effect, solveAnyway) fills it before asking to send, and
+  // useSolveChannel defers a send it cannot fill, exactly as it already
+  // defers one it cannot deliver down a closed socket.
+  const controlsRef = useRef<SolveRequest | null>(null);
 
   // The /ws solve channel (#642 seam 5b-3): the socket, the latest-wins `_seq`
   // protocol and the busy-chrome dwell. Called right after controlsRef — the
@@ -990,9 +1003,14 @@ function DesignSessionBody({
   }
 
   function pinCurrentPattern() {
-    if (!result) return;
+    // A result exists only because a solve was sent, which fills controlsRef —
+    // so the second test never fires in practice. It is here because the pin
+    // stores the request that PRODUCED this result; pinning a result against
+    // a missing request would silently mislabel the ghost trace (issue #768).
+    const controls = controlsRef.current;
+    if (!result || !controls) return;
     const label = `${currentExample?.label ?? geometry} @ ${measFreq.toFixed(2)} MHz`;
-    addPin(label, result, controlsRef.current);
+    addPin(label, result, controls);
   }
 
   // Keep the live antenna's metrics fresh for the table, but only while a
@@ -1008,7 +1026,12 @@ function DesignSessionBody({
     }
     let cancelled = false;
     const h = window.setTimeout(() => {
-      fetchMetrics(controlsRef.current).then((m) => {
+      // Read at fire time, not at schedule time: the dwell is 300 ms and the
+      // metrics must describe the design as it now stands. Null only before
+      // the first solve, which `result` above already excludes (issue #768).
+      const controls = controlsRef.current;
+      if (!controls) return;
+      fetchMetrics(controls).then((m) => {
         if (!cancelled) setLiveMetrics(m);
       });
     }, 300);

--- a/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
@@ -260,8 +260,16 @@ export function useAnalysisRunners({
   // than captured at chain start — a mid-chain toggle-off or pin change
   // must not run a stale plan to the end of its budget.
   const refineEnabledRef = useRef(refineEnabled);
+  // Mirrored every render so each refinement ROUND reads the current value;
+  // capturing at chain start would let a mid-chain toggle-off run a stale plan
+  // to the end of its budget (#768).
+  // eslint-disable-next-line react-hooks/refs
   refineEnabledRef.current = refineEnabled;
   const residentSweepViewsRef = useRef(residentSweepViews);
+  // Mirrored every render so each refinement ROUND reads the current value;
+  // capturing at chain start would let a mid-chain toggle-off run a stale plan
+  // to the end of its budget (#768).
+  // eslint-disable-next-line react-hooks/refs
   residentSweepViewsRef.current = residentSweepViews;
   const patternTimerRef = useRef<number | null>(null);
   const patternAbortRef = useRef<AbortController | null>(null);
@@ -291,6 +299,11 @@ export function useAnalysisRunners({
     if (sweepRefineTimerRef.current) {
       window.clearTimeout(sweepRefineTimerRef.current);
     }
+    // Cancel-then-blank is the contract (#692/#715): the overlay must go blank
+    // the instant its inputs change, or a stale curve reads as current while
+    // the new one dwells. Synchronous blanking is what makes 'stale'
+    // unrepresentable.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setSweep(null);
     setSweepRunning(false);
     // Paused (Live off) holds the engine (issue #612): an enabled sweep must
@@ -302,6 +315,9 @@ export function useAnalysisRunners({
     }
     // The 500 ms dwell only debounces network churn; ordering against the
     // live solve is the server lane's job now (live outranks sweeps).
+    // `runSweep` is an async function DECLARATION, so the binding is live
+    // before this effect runs; the compiler cannot see hoisting (#768).
+    // eslint-disable-next-line react-hooks/immutability
     sweepTimerRef.current = window.setTimeout(runSweep, 500);
     return () => {
       if (sweepTimerRef.current) window.clearTimeout(sweepTimerRef.current);
@@ -346,6 +362,10 @@ export function useAnalysisRunners({
   // marginal cost is the new projection's points alone.
   const residentSweepKey = `${residentSweepViews.vswr},${residentSweepViews.gamma},${residentSweepViews.smith}`;
   const sweepRef = useRef<SweepData | null>(null);
+  // Mirrored every render so each refinement ROUND reads the current value;
+  // capturing at chain start would let a mid-chain toggle-off run a stale plan
+  // to the end of its budget (#768).
+  // eslint-disable-next-line react-hooks/refs
   sweepRef.current = sweep;
   useEffect(() => {
     if (!refineEnabled || !sweepRef.current || sweepRunning) return;
@@ -354,6 +374,9 @@ export function useAnalysisRunners({
     }
     const settled = sweepRef.current;
     sweepRefineTimerRef.current = window.setTimeout(
+      // `runSweepRefine` is an async function DECLARATION, so the binding is
+      // live before this effect runs; the compiler cannot see hoisting (#768).
+      // eslint-disable-next-line react-hooks/immutability
       () => runSweepRefine(settled),
       SWEEP_REFINE_DWELL_MS,
     );
@@ -380,6 +403,11 @@ export function useAnalysisRunners({
     if (convergeTimerRef.current) {
       window.clearTimeout(convergeTimerRef.current);
     }
+    // Cancel-then-blank is the contract (#692/#715): the overlay must go blank
+    // the instant its inputs change, or a stale curve reads as current while
+    // the new one dwells. Synchronous blanking is what makes 'stale'
+    // unrepresentable.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setConverge(null);
     setConvergeRunning(false);
     // Held when Paused (issue #612) — see the sweep effect. autoSim is a dep so
@@ -388,6 +416,9 @@ export function useAnalysisRunners({
       return;
     }
     // Debounce only; the server lane orders it behind the live solve.
+    // `runConverge` is an async function DECLARATION, so the binding is live
+    // before this effect runs; the compiler cannot see hoisting (#768).
+    // eslint-disable-next-line react-hooks/immutability
     convergeTimerRef.current = window.setTimeout(runConverge, 500);
     return () => {
       if (convergeTimerRef.current) window.clearTimeout(convergeTimerRef.current);
@@ -416,12 +447,20 @@ export function useAnalysisRunners({
     if (normCheckTimerRef.current) {
       window.clearTimeout(normCheckTimerRef.current);
     }
+    // Cancel-then-blank is the contract (#692/#715): the overlay must go blank
+    // the instant its inputs change, or a stale curve reads as current while
+    // the new one dwells. Synchronous blanking is what makes 'stale'
+    // unrepresentable.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setNormCheck(null);
     // Held when Paused (issue #612): the norm check re-solves, so it must not
     // run while the engine is held. autoSim is a dep — resuming Live re-runs it.
     if (!autoSim || !normCheckEnabled || !active) {
       return;
     }
+    // `runNormCheck` is an async function DECLARATION, so the binding is live
+    // before this effect runs; the compiler cannot see hoisting (#768).
+    // eslint-disable-next-line react-hooks/immutability
     normCheckTimerRef.current = window.setTimeout(runNormCheck, 500);
     return () => {
       if (normCheckTimerRef.current) window.clearTimeout(normCheckTimerRef.current);
@@ -447,6 +486,11 @@ export function useAnalysisRunners({
   // when the user switches the overlay off.
   useEffect(() => {
     if (patternTimerRef.current) window.clearTimeout(patternTimerRef.current);
+    // Cancel-then-blank is the contract (#692/#715): the overlay must go blank
+    // the instant its inputs change, or a stale curve reads as current while
+    // the new one dwells. Synchronous blanking is what makes 'stale'
+    // unrepresentable.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setPattern(null);
     if (
       !autoSim || // Paused holds the engine (issue #612) — no NEC re-solve.
@@ -459,6 +503,9 @@ export function useAnalysisRunners({
       return;
     }
     patternTimerRef.current = window.setTimeout(() => {
+      // `runPattern` is an async function DECLARATION, so the binding is live
+      // before this effect runs; the compiler cannot see hoisting (#768).
+      // eslint-disable-next-line react-hooks/immutability
       runPattern();
       patternTimerRef.current = null;
     }, 500);

--- a/src/antennaknobs/web/frontend/src/components/session/useDesignCatalog.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useDesignCatalog.ts
@@ -67,6 +67,9 @@ export function useDesignCatalog({
   }, []);
 
   useEffect(() => {
+    // Fetch-on-mount; the setState happens in the async result, not as a
+    // render-derivable value (#768).
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     loadExamples();
   }, [loadExamples]);
 

--- a/src/antennaknobs/web/frontend/src/components/session/useOptimizer.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useOptimizer.ts
@@ -78,6 +78,9 @@ export function useOptimizer({
   // running — to show the pause cue only then — without taking optEnabled as a
   // dep (which would re-run the reset on every toggle).
   const optEnabledRef = useRef(false);
+  // optEnabled mirrored so the design-load reset can tell whether the
+  // optimizer was actually running, without taking it as a dep (#768).
+  // eslint-disable-next-line react-hooks/refs
   optEnabledRef.current = optEnabled; // mirror latest for the design-load reset
   // Per-knob settings persist per geometry (knobOpt is keyed by geometry); just
   // close any open menu / clear the last result / abort any in-flight run when
@@ -87,6 +90,9 @@ export function useOptimizer({
   // running toggle is switched off. Show the cue only if it was actually on.
   useEffect(() => {
     optAbortRef.current?.abort();
+    // Design-load reset: clears the optimizer's result/menu and shows the
+    // pause cue. A reset on input change, not a derivable value (#768).
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setKnobMenu(null);
     setOptResult(null);
     setOptError(null);

--- a/src/antennaknobs/web/frontend/src/components/session/useSolveChannel.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useSolveChannel.ts
@@ -36,7 +36,9 @@ const BUSY_MIN_VISIBLE_MS = 400;
 //
 // `controlsRef` stays owned by the component: the solve effect writes the
 // latest request into it and this hook only ever reads `.current`, so a
-// reconnect resends whatever the component last decided to solve.
+// reconnect resends whatever the component last decided to solve. It is null
+// until the component has decided anything (issue #768) — a send with nothing
+// to send is deferred, not faked.
 export function useSolveChannel({
   active,
   controlsRef,
@@ -46,7 +48,7 @@ export function useSolveChannel({
   setSolveError,
 }: {
   active: boolean;
-  controlsRef: MutableRefObject<SolveRequest>;
+  controlsRef: MutableRefObject<SolveRequest | null>;
   geometryRef: MutableRefObject<string>;
   previewSigRef: MutableRefObject<string | null>;
   setResult: (r: SolveResponse | null) => void;
@@ -166,15 +168,22 @@ export function useSolveChannel({
       solveRafRef.current = null;
       const sock = wsRef.current;
       if (!sock || sock.readyState !== WebSocket.OPEN) return;
+      // Nothing decided to solve yet (issue #768). onopen calls requestSolve
+      // unconditionally, and on a first connect it can win the race against
+      // the solve effect that fills this — so deferring here is the same
+      // "can't send now" the closed-socket branch above takes, not a new
+      // failure mode: the solve effect sends as soon as it has a request.
+      const controls = controlsRef.current;
+      if (!controls) return;
       const seq = ++seqRef.current;
       lastSentSeqRef.current = seq;
       sentAtRef.current.set(seq, performance.now());
-      sock.send(JSON.stringify({ ...controlsRef.current, _seq: seq }));
+      sock.send(JSON.stringify({ ...controls, _seq: seq }));
       // Keep the preview signature current so that toggling Live *off* right
       // after a solve doesn't see a stale signature and needlessly refetch the
       // wireframe / drop the just-solved result — the solved geometry already
       // matches these controls.
-      previewSigRef.current = JSON.stringify(controlsRef.current);
+      previewSigRef.current = JSON.stringify(controls);
       syncSolving();
     });
   }

--- a/src/antennaknobs/web/frontend/src/components/session/useViewState.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useViewState.ts
@@ -72,6 +72,10 @@ export function useViewState({
   // snapping to a wrong provisional view and flipping when the preview arrives.
   useEffect(() => {
     if (currentExample?.default_view) {
+      // Sets the camera to the new antenna's declared default view on an
+      // actual antenna switch; the user's later pick must survive re-renders
+      // (#768).
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setCameraProjection(currentExample.default_view);
     }
     // Keyed on the name, not currentExample.default_view directly: a value


### PR DESCRIPTION
Closes #768. Two commits: the audit + the two defects it found, then the close-out that restores containment.

## Why this ends at `error`

The issue's own framing is that containment "died with eslint 10" and moved from a version pin to rule severity — four diagnostics at `warn`. But **a rule at `warn` with ~30 standing warnings contains nothing: nobody sees number 31.** So this finishes the triage and promotes all four to `error`. That is the load-bearing change here; everything else is what it took to get there honestly.

## The audit

17 sites in the `immutability`/`refs`/`purity` group (not 13 — counts drifted since filing), plus 15 `set-state-in-effect`. Four classes, and the issue's predictions were inverted twice:

| Class | Sites | Verdict |
|---|---|---|
| Eager `useRef(f())` initializer | 2 | **Real defects** |
| Effect-synced draft from a prop | 2 | **Real defect** (in a file the issue never mentions) |
| `ref.current = prop` mirror during render | 5 | Deliberate, load-bearing |
| `async function` decls "used before declared" | 5 | False alarm — hoisted |
| Cancel-then-blank / reset-on-input-change effects | 13 | Deliberate |
| Ref reads in a test harness | 4 | Rule is wrong here, not the code |

The `immutability` group the issue flagged as most likely to hide genuine bugs is **entirely false alarms**. The genuine defects were all in classes it didn't predict.

## The defects (4, all the same family)

JavaScript evaluates the argument eagerly and the hook discards it, or an effect does work that belongs in render:

- `DesignSession:700` — minted a discarded `crypto.randomUUID()` **every render** *(purity)*
- `DesignSession:957` — rebuilt a discarded **59-line** `SolveRequest` **every render** *(refs)*
- `fields.tsx` ×2 — synced a text draft from a prop through an effect, painting the stale draft and correcting on a second pass

In a component with 30 `useState` hooks, the first two are per-frame garbage during a knob drag. Fixes: lazy `useState` initializer, a null ref filled by the writers that already fill it, and a shared `useNumericDraft` that adjusts during render.

## Why the null ref is the interesting one

`onopen` calls `requestSolve` unconditionally, so the eager seed always gave it something to send — **including when the solve effect was deliberately withholding a solve** (antenna switch, preview not landed). Removing it makes that gate authoritative; the channel now defers a send it cannot fill exactly as it already defers one it cannot push down a closed socket.

## Everything else says why

24 inline disables, each with its specific reason — cancel-then-blank overlay semantics (#692/#715), prop mirrors read per refinement round rather than captured at chain start, hoisted `async function` declarations. **Per-site, not a file- or rule-level exemption, so a new violation in these same files still fails.** The 4 test-harness reads are scoped off for `src/__tests__/**` instead: a harness renders a hook's refs so assertions can reach them.

eslint reports unused disable directives, so all 24 are machine-verified as necessary and correctly placed rather than taken on trust.

## Gates

| Gate | Result |
|---|---|
| `react-hooks` diagnostics | **0** (from 32) — and `eslint .` exits **0 errors** with the rules at `error` |
| Frontend suite | **690 / 48 files** (685 / 46 before — 5 new) |
| New tests fail without their fix | ✅ both — the channel guard fails on `_seq`, proving a deferred send must not burn a sequence number |
| `numericDraft.test.tsx` vs **old** implementation | ✅ passes — which is what makes the draft change a refactor, not a behaviour change |
| `tsc --noEmit` | clean |
| Vite build | clean |

## Review notes

Session model (opus) throughout; no subagent. Two things I'd flag to a human reviewer:

1. **`numericDraft.test.tsx` had no predecessor.** The clear-without-snapping-to-0 behaviour was carried by a comment alone, so I wrote the test and verified it passes against the *pre-existing* effect spelling before trusting the refactor.
2. **CI could not run** — GitHub Actions is in a major outage (from 15:22 UTC), which is also why main shows red: `The job was not acquired by Runner of type hosted`, not a broken tree. Every gate above was run locally. I disarmed auto-merge on this PR while adding the second commit so it could not land mid-edit; **re-arm or merge when checks can actually run.**