### PR TITLE
ci: workflow_dispatch trigger, and lanes that cover every event

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   push:
     branches: ["main"]
+  # Manual re-trigger — see test.yml's workflow_dispatch note (the 2026-08-06
+  # outage). Nothing here is event-gated, so a dispatched run is identical to
+  # a PR run.
+  workflow_dispatch:
 jobs:
   ruff:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,14 @@ on:
   push:
     branches:
       - "main"
+  # Manual re-trigger. Earned during the 2026-08-06 Actions outage: the
+  # `pull_request` events for three open PRs fired while runners were
+  # unavailable and produced ZERO runs, and GitHub does not backfill them.
+  # Auto-merge then waits forever on checks that will never arrive, which is
+  # indistinguishable from "still queueing" in the UI. Without this trigger
+  # the only remedies are closing/reopening each PR or pushing a commit; on
+  # a rebase-merge repo the latter lands a junk commit on main verbatim.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -101,7 +109,15 @@ jobs:
       # Skips the antenna_computation_check tests (the per-design solver
       # catalogs). Keeps representative engine/solver coverage + all
       # load/schema/unit tests. No coverage instrumentation on PRs.
-      if: github.event_name == 'pull_request'
+      #
+      # Gated on "not a merge to main" rather than "is a pull_request": the
+      # two lanes must between them cover EVERY event this workflow accepts.
+      # Listing events instead means a newly added trigger — workflow_dispatch
+      # was exactly this — matches neither lane, so the job installs
+      # dependencies, runs no tests at all, and reports GREEN. An unnecessary
+      # fast-lane run is the harmless direction to be wrong in; a green run
+      # that tested nothing is not.
+      if: github.event_name != 'push'
       # `python -m pytest` (not bare `pytest`) keeps CWD on sys.path, the
       # conventional form shared with the main-lane command below. The web
       # server now lives at src/antennaknobs/web and imports as the installed


### PR DESCRIPTION
Follow-up to the 2026-08-06 Actions outage.

## Why

During the outage, the `pull_request` events for three open PRs fired while runners were unavailable and produced **zero** workflow runs — and GitHub does not backfill them. Auto-merge then waits forever on checks that will never arrive. The stall is invisible: `gh pr view` reports `BLOCKED` with auto-merge armed, which is exactly what a healthy queueing PR looks like. The tell is `gh api ".../actions/runs?branch=X" --jq .total_count` returning `0`.

Without a manual trigger the only fixes are closing and reopening each PR (which also silently cancels auto-merge — a second trap) or pushing a commit, and on this rebase-merge repo that junk commit lands on main verbatim.

## The part that matters

**Adding the trigger alone would have been worse than not adding it.** `test.yml`'s two lanes were gated:

| Lane | Was |
|---|---|
| Fast lane | `if: github.event_name == 'pull_request'` |
| Full suite + coverage | `if: github.event_name == 'push'` |

A `workflow_dispatch` run matches **neither**. The job would check out, install the full dependency set, run **no tests at all**, and report **green** — a manual re-trigger that appears to validate a PR while testing nothing.

So the fast lane is now gated `!= 'push'` — *"anything that is not a merge to main"* — rather than enumerating events. The two lanes provably partition every event the workflow accepts:

```
  pull_request       fast=True  full=False -> OK
  push               fast=False full=True  -> OK
  workflow_dispatch  fast=True  full=False -> OK
```

An unnecessary fast-lane run is the harmless direction to be wrong in; a green run that tested nothing is not. This also means a trigger added later cannot reintroduce the gap.

Coverage upload and the `coverage-comment` job stay `== 'push'` deliberately — a manual run has no business republishing the badge or the coverage data branch.

`ruff.yml` has no event gating at all, so its dispatch is a plain addition.

## Usage

```bash
gh workflow run test.yml --ref <branch>
gh workflow run ruff.yml --ref <branch>
```

Note the standing limitation, which is why this could not have rescued the three PRs it was born from: `workflow_dispatch` is only available on a ref whose own copy of the workflow carries the trigger, so it works for branches cut **after** this merges.

## Review notes

Session model (opus), no subagent. Verified by parsing both `on:` blocks rather than reading them — grep context around `pull_request:` misleadingly attaches the `push:` key's `branches:` filter to the wrong trigger, which I got wrong earlier today and want on the record. The lane-partition table above is machine-checked, not eyeballed.