### PR TITLE
Unit 1: on_progress hook in the web optimizer (#773)

### DIFF
--- a/src/antennaknobs/web/optimize.py
+++ b/src/antennaknobs/web/optimize.py
@@ -75,12 +75,17 @@ def optimize(
     *,
     solve_fn: Callable[[dict], dict],
     max_evals: int | None = None,
+    on_progress: Callable[[dict], None] | None = None,
 ) -> dict:
     """Optimise ``objective`` over the ``free`` params within their bounds.
 
     ``free`` is a list of ``{"name", "min", "max"}``. ``solve_fn`` takes a solve
     request and returns a response carrying ``z_in_re``/``z_in_im``/``z0_ohms``.
     Returns the best params found plus before/after objective + metrics.
+
+    ``on_progress``, if given, is called once per solve (see ``_solve_at``) with
+    ``{"n_evals", "params", "objective", "metrics"}``. ``None`` (the default)
+    leaves behaviour identical to no callback support at all.
     """
     if not free:
         raise ValueError("no free params selected to optimise")
@@ -102,10 +107,31 @@ def optimize(
     def _solve_at(x) -> dict:
         nonlocal n_evals
         req = dict(base_req)
+        params = {}
         for name, v in zip(names, x):
-            req[name] = float(v)
+            val = float(v)
+            req[name] = val
+            params[name] = val
         n_evals += 1
-        return solve_fn(req)
+        out = solve_fn(req)
+        # Emitted here, not via scipy's minimize(callback=...): that callback
+        # fires once per Nelder-Mead ITERATION (a reflection/expansion/contraction
+        # that itself costs 1-2 evals), not once per eval — e.g. ~30 callbacks for
+        # 60 evals — and it doesn't fire at all until the initial simplex (N+1
+        # evals) is built, leaving a dead zone at the start of every run. Every
+        # solve, in every phase (baseline, simplex, confirmation), goes through
+        # this one choke point, so hooking here is the only way to get gapless
+        # per-eval granularity that also covers the initial-simplex evals.
+        if on_progress is not None:
+            on_progress(
+                {
+                    "n_evals": n_evals,
+                    "params": params,
+                    "objective": _objective_value(out, objective),
+                    "metrics": _metrics(out),
+                }
+            )
+        return out
 
     def f(x) -> float:
         return _objective_value(_solve_at(x), objective)

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -105,7 +105,17 @@ def test_unknown_objective_falls_back_to_swr():
     assert res["objective"] == "swr"
 
 
-def test_on_progress_none_is_byte_identical_to_no_callback():
+def test_on_progress_never_perturbs_the_result():
+    """Observing a run must not change it.
+
+    Three ways of asking for the same optimisation — omitted, explicit None,
+    and a live callback — must return the identical dict. The third is the
+    one with teeth: the hook runs arbitrary caller code between the solve and
+    the return, inside the choke point every eval passes through, so a hook
+    that mutated the request, the params dict, or the eval count would steer
+    the search. Omitted-vs-None alone would not catch that.
+    """
+
     # A fixed, order-independent stub: same req in, same dict out, always.
     def solve(req: dict) -> dict:
         x = float(req["x"])
@@ -120,7 +130,17 @@ def test_on_progress_none_is_byte_identical_to_no_callback():
     )
     res_default = optimize(**kwargs)
     res_explicit_none = optimize(**kwargs, on_progress=None)
+
+    # A callback that both reads and writes what it is handed — the hostile
+    # case. Mutating the payload must not reach the optimiser's own state.
+    def meddle(ev: dict) -> None:
+        ev["params"].clear()
+        ev["n_evals"] = -1
+
+    res_observed = optimize(**kwargs, on_progress=meddle)
+
     assert res_default == res_explicit_none
+    assert res_default == res_observed
 
 
 def test_on_progress_fires_once_per_solve_with_contiguous_n_evals():

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -105,6 +105,71 @@ def test_unknown_objective_falls_back_to_swr():
     assert res["objective"] == "swr"
 
 
+def test_on_progress_none_is_byte_identical_to_no_callback():
+    # A fixed, order-independent stub: same req in, same dict out, always.
+    def solve(req: dict) -> dict:
+        x = float(req["x"])
+        return {"z_in_re": 50.0, "z_in_im": 100.0 * (x - 1.05), "z0_ohms": 50.0}
+
+    kwargs = dict(
+        base_req={"x": 0.80},
+        free=[{"name": "x", "min": 0.5, "max": 1.5}],
+        objective="resonance",
+        solve_fn=solve,
+        max_evals=15,
+    )
+    res_default = optimize(**kwargs)
+    res_explicit_none = optimize(**kwargs, on_progress=None)
+    assert res_default == res_explicit_none
+
+
+def test_on_progress_fires_once_per_solve_with_contiguous_n_evals():
+    # 2-param probe: Nelder-Mead's initial simplex needs 3 vertices (N+1 for
+    # N=2), so this exercises the dead zone scipy's own callback= misses.
+    def solve(req: dict) -> dict:
+        a, b = float(req["a"]), float(req["b"])
+        x_im = 100.0 * (a - 1.10) + 80.0 * (b - 0.90)
+        return {"z_in_re": 50.0, "z_in_im": x_im, "z0_ohms": 50.0}
+
+    calls = []
+    res = optimize(
+        {"a": 1.0, "b": 1.0},
+        [{"name": "a", "min": 0.8, "max": 1.3}, {"name": "b", "min": 0.7, "max": 1.1}],
+        "resonance",
+        solve_fn=solve,
+        max_evals=25,
+        on_progress=calls.append,
+    )
+
+    # Gate 1: exactly one callback per _solve_at call.
+    assert len(calls) == res["n_evals"]
+
+    # Gate 2 (the important one): n_evals values are gapless 1..N, proving
+    # per-eval (not per-iteration) granularity and initial-simplex coverage.
+    seen = [c["n_evals"] for c in calls]
+    assert seen == list(range(1, len(calls) + 1))
+
+    # Payload shape: objective/metrics come from the same helpers optimize()
+    # itself uses, keyed by the params passed for that particular solve.
+    first = calls[0]
+    assert set(first["params"]) == {"a", "b"}
+    assert first["objective"] == pytest.approx(
+        _objective_value_for_test(first["params"], "resonance")
+    )
+    assert set(first["metrics"]) == {"z_in_re", "z_in_im", "z0_ohms", "swr"}
+
+
+def _objective_value_for_test(params: dict, objective: str) -> float:
+    """Recompute the same |X| the stub in the contiguity test would report,
+    to cross-check the callback's reported objective independently of the
+    module's own _objective_value (avoids the test trivially re-deriving the
+    exact call under test)."""
+    a, b = params["a"], params["b"]
+    x_im = 100.0 * (a - 1.10) + 80.0 * (b - 0.90)
+    assert objective == "resonance"
+    return abs(x_im)
+
+
 @pytest.mark.antenna_computation_check
 def test_optimize_real_geometry_improves_resonance():
     """End-to-end through a real momwire solve (slow): tuning a length knob


### PR DESCRIPTION
Unit 1 of the #773 arc. Stacked onto `issue-773-optimizer-progress-sse`. No transport — that's unit 3.

## What

`optimize()` takes an optional `on_progress: Callable[[dict], None] | None = None`, invoked from `_solve_at` once per solve with `{"n_evals", "params", "objective", "metrics"}` — `objective` from the existing `_objective_value()`, `metrics` from the existing `_metrics()`, so there's no second shape to keep in sync.

Hooked at `_solve_at` rather than `minimize(callback=...)`, and the reason is recorded **in the code** so a later refactor doesn't quietly undo it: scipy's callback fires per Nelder–Mead *iteration* (~30 for 60 evals) and not at all until the initial simplex is built. `_solve_at` is the single choke point all three call sites route through — baseline, every objective eval, and the confirmation solve.

## Gates

| Gate | Result |
|---|---|
| Callback count == `n_evals` | 27 == 27 on a 2-param probe |
| **Contiguous `1..N`, no gaps** | `[1, 2, 3, … 27]` |
| `on_progress=None` unchanged | identical dict, deterministic stub |
| Payload shape | `params` keys match free params; `metrics` exactly `{z_in_re, z_in_im, z0_ohms, swr}`; `objective` cross-checked against an **independently recomputed** value rather than the module's own helper |
| Full suite | **3465 passed, 3 skipped** (227 s) |
| ruff check / format --check | clean |

## Review notes

Built by a **sonnet** subagent; reviewed and re-gated by the session model (opus). I read the whole diff and re-ran the full suite myself — 3465/3 reproduced independently, not taken from the builder's report.

**Adversarial probe I ran myself:** mutated the emit to fire only every other eval — the granularity scipy's own callback would give — and the contiguity test fails at **13 callbacks vs 27 evals**, the exact "half the progress invisible" symptom the issue describes. So the gate discriminates the thing it exists to discriminate.

**One test I added during review.** The builder's `on_progress=None` check compared *omitted* against *explicit None* — the same code path, so it could not catch a hook that steers the search. Since the callback runs arbitrary caller code inside the choke point every eval passes through, I added a third run with a **live, deliberately hostile callback** that mutates what it's handed, asserting all three return the identical dict. Verified it has teeth: the plausible "emit before solving, hand the callback the live request dict" refactor fails it.

**Carried forward to unit 3:** `n_evals` can exceed the caller's `max_evals` by up to **2** — the baseline and confirmation solves aren't counted against the cap (`max_evals=25` → 27 evals). Pre-existing, not introduced here, but unit 3's hosted-cap test must not assert an off-by-two ceiling on progress-event count.