### PR TITLE
Unit 4: live optimizer progress in the workbench (#773)

### DIFF
--- a/src/antennaknobs/web/frontend/src/__tests__/VfoPanel.optProgress.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/VfoPanel.optProgress.test.tsx
@@ -1,0 +1,90 @@
+// The live optimizer progress readout (issue #773 unit 4) as rendered DOM,
+// not just hook state — useOptimizer.streaming.test.tsx pins the state
+// transitions; this pins that optRunning/optProgress actually reach the
+// screen, and that the settled optResult readout takes over once a run ends.
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { VfoPanel } from "../components/session/VfoPanel";
+import type { OptimizeResult, OptProgress } from "../components/session/VfoPanel";
+
+const METRICS = { z_in_re: 48.2, z_in_im: -3.1, z0_ohms: 50.0, swr: 1.12 };
+
+const PROGRESS: OptProgress = {
+  n_evals: 7,
+  params: { length_factor: 0.981 },
+  objective: 1.34,
+  metrics: METRICS,
+};
+
+const RESULT: OptimizeResult = {
+  objective: "swr",
+  params: { length_factor: 0.99 },
+  objective_before: 2.0,
+  objective_after: 1.05,
+  metrics_before: METRICS,
+  metrics_after: { ...METRICS, swr: 1.05 },
+  n_evals: 12,
+  improved: true,
+};
+
+function baseProps() {
+  return {
+    currentBands: [],
+    measLocked: false,
+    measFreq: 14.1,
+    bandContaining: () => null,
+    measBand: "",
+    selectMeasBand: vi.fn(),
+    currentExample: undefined,
+    measBandAnchor: 14.1,
+    freqWindowCeiling: 30,
+    setMeasFreq: vi.fn(),
+    measLockable: false,
+    linkMeas: false,
+    toggleLink: vi.fn(),
+    autoSim: true,
+    setAutoSim: vi.fn(),
+    optEnabled: true,
+    setOptEnabled: vi.fn(),
+    setOptPausedBy: vi.fn(),
+    optObjective: "swr" as const,
+    setOptObjective: vi.fn(),
+    optError: null,
+    optPausedBy: null,
+  };
+}
+
+describe("VfoPanel live optimizer readout (#773 unit 4)", () => {
+  it("shows the live eval count and SWR while a run is in flight", () => {
+    render(
+      <VfoPanel
+        {...baseProps()}
+        optRunning
+        optResult={null}
+        optProgress={PROGRESS}
+      />,
+    );
+    expect(screen.getByText("#7 SWR 1.12")).toBeTruthy();
+  });
+
+  it("shows nothing extra before the first progress frame lands", () => {
+    render(
+      <VfoPanel {...baseProps()} optRunning optResult={null} optProgress={null} />,
+    );
+    expect(screen.queryByText(/SWR/)).toBeNull();
+  });
+
+  it("switches to the settled result readout once the run ends", () => {
+    render(
+      <VfoPanel
+        {...baseProps()}
+        optRunning={false}
+        optResult={RESULT}
+        optProgress={PROGRESS}
+      />,
+    );
+    // The final metrics_after figure, not the last-seen progress frame.
+    expect(screen.getByText("SWR 1.05")).toBeTruthy();
+    expect(screen.queryByText("#7 SWR 1.12")).toBeNull();
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/useOptimizer.streaming.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useOptimizer.streaming.test.tsx
@@ -1,0 +1,292 @@
+// Live optimizer progress over SSE (issue #773 unit 4), against the pinned
+// contract: `Accept: text/event-stream` opts in, the server answers with
+// `event: progress` frames and exactly one terminal `event: result` or
+// `event: error`. The backend doesn't stream yet — these tests stub the
+// transport and drive it by hand.
+//
+// The reader stub below queues frames and resolves reads on demand rather
+// than inline, and its `cancel()` resolves any read that's still pending
+// with `{done: true}` — exactly what a real ReadableStream does when a
+// reader is canceled mid-read. That's the behavior the abort test depends
+// on: useOptimizer's abort handler calls `reader.cancel()` rather than
+// trusting fetch's own AbortSignal wiring, because a stubbed transport has
+// none of that wiring to trust.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useOptimizer } from "../components/session/useOptimizer";
+import type { OptimizeResult, OptProgress } from "../components/session/VfoPanel";
+import type { SolveRequest } from "../lib/api";
+
+type QueuedRead = { done: boolean; value?: Uint8Array };
+
+function makeSseReader() {
+  const queue: QueuedRead[] = [];
+  let waiting: ((r: QueuedRead) => void) | null = null;
+  let canceled = false;
+  const encoder = new TextEncoder();
+
+  function feed(item: QueuedRead) {
+    if (waiting) {
+      const resolve = waiting;
+      waiting = null;
+      resolve(item);
+    } else {
+      queue.push(item);
+    }
+  }
+
+  return {
+    reader: {
+      read: () =>
+        new Promise<QueuedRead>((resolve) => {
+          if (queue.length > 0) resolve(queue.shift()!);
+          else waiting = resolve;
+        }),
+      cancel: () => {
+        canceled = true;
+        // Real ReadableStream semantics: canceling resolves a pending read
+        // as done, rather than leaving it hanging forever.
+        feed({ done: true });
+        return Promise.resolve();
+      },
+      releaseLock: () => {},
+    },
+    push(event: string, data: unknown) {
+      feed({
+        done: false,
+        value: encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`),
+      });
+    },
+    close() {
+      feed({ done: true });
+    },
+    get canceled() {
+      return canceled;
+    },
+  };
+}
+
+function sseResponse(reader: ReturnType<typeof makeSseReader>["reader"]) {
+  return {
+    headers: { get: (k: string) => (k.toLowerCase() === "content-type" ? "text/event-stream" : null) },
+    body: { getReader: () => reader } as unknown as ReadableStream<Uint8Array>,
+  } as unknown as Response;
+}
+
+const METRICS = { z_in_re: 48.2, z_in_im: -3.1, z0_ohms: 50.0, swr: 1.12 };
+
+function progressFrame(n_evals: number): OptProgress {
+  return {
+    n_evals,
+    params: { length_factor: 0.981 },
+    objective: 1.34,
+    metrics: METRICS,
+  };
+}
+
+const RESULT: OptimizeResult = {
+  objective: "swr",
+  params: { length_factor: 0.99 },
+  objective_before: 2.0,
+  objective_after: 1.05,
+  metrics_before: METRICS,
+  metrics_after: { ...METRICS, swr: 1.05 },
+  n_evals: 12,
+  improved: true,
+};
+
+type SetParamAtPath = (path: (string | number)[], value: number | string | boolean) => void;
+
+let fetchMock: ReturnType<typeof vi.fn>;
+let setParamAtPath: ReturnType<typeof vi.fn> & SetParamAtPath;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  setParamAtPath = vi.fn() as unknown as ReturnType<typeof vi.fn> & SetParamAtPath;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+function mount() {
+  return renderHook(() =>
+    useOptimizer({
+      geometry: "dipoles.probe",
+      currentValues: { length_factor: 1.0 },
+      currentValuesKey: "length_factor=1",
+      currentSchema: [],
+      backend: "momwire",
+      designFreq: 14.1,
+      measFreq: 14.1,
+      autoSim: true,
+      active: true,
+      buildRequest: () => ({ geometry: "dipoles.probe" }) as SolveRequest,
+      setParamAtPath,
+    }),
+  );
+}
+
+// Marks length_factor as free and turns Optimize on, then advances the
+// 400ms reactive-retune debounce so runOptimize actually fires.
+async function armAndFire(result: { current: ReturnType<typeof useOptimizer> }) {
+  act(() => {
+    result.current.setKnobOpt({
+      "dipoles.probe": {
+        length_factor: { vary: true, optMin: 0.8, optMax: 1.2, dispMin: 0.8, dispMax: 1.2, step: 0.001 },
+      },
+    });
+  });
+  act(() => {
+    result.current.setOptEnabled(true);
+  });
+  await act(async () => {
+    vi.advanceTimersByTime(400);
+    await Promise.resolve();
+  });
+}
+
+describe("useOptimizer SSE progress (#773 unit 4)", () => {
+  it("progress events update n_evals, objective, and Z/SWR live, before any terminal event", async () => {
+    const sse = makeSseReader();
+    fetchMock = vi.fn(async () => sseResponse(sse.reader));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = mount();
+    await armAndFire(result);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>).Accept).toBe("text/event-stream");
+    expect(result.current.optRunning).toBe(true);
+
+    act(() => sse.push("progress", progressFrame(1)));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.optProgress?.n_evals).toBe(1);
+    expect(result.current.optProgress?.metrics.swr).toBeCloseTo(1.12);
+    // Still running — no terminal event yet, and no params applied.
+    expect(result.current.optRunning).toBe(true);
+    expect(setParamAtPath).not.toHaveBeenCalled();
+
+    act(() => sse.push("progress", progressFrame(7)));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.optProgress?.n_evals).toBe(7);
+  });
+
+  it("a terminal result event applies params through setParamAtPath, same as the non-streaming path", async () => {
+    const sse = makeSseReader();
+    fetchMock = vi.fn(async () => sseResponse(sse.reader));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = mount();
+    await armAndFire(result);
+
+    act(() => sse.push("progress", progressFrame(3)));
+    act(() => sse.push("result", RESULT));
+    act(() => sse.close());
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.optResult).toEqual(RESULT);
+    expect(setParamAtPath).toHaveBeenCalledWith(["length_factor"], 0.99);
+    expect(result.current.optRunning).toBe(false);
+  });
+
+  it("a terminal error event surfaces via optError, same path as today's data.error", async () => {
+    const sse = makeSseReader();
+    fetchMock = vi.fn(async () => sseResponse(sse.reader));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = mount();
+    await armAndFire(result);
+
+    act(() => sse.push("error", { detail: "no feasible point" }));
+    act(() => sse.close());
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.optError).toBe("no feasible point");
+    expect(result.current.optResult).toBeNull();
+    expect(setParamAtPath).not.toHaveBeenCalled();
+    expect(result.current.optRunning).toBe(false);
+  });
+
+  it("abort mid-stream tears the reader down and stops further updates", async () => {
+    // Each fetch call gets ITS OWN reader — a superseded run's frames must
+    // not leak into the run that replaced it, only its abort/cancel should.
+    const streams: ReturnType<typeof makeSseReader>[] = [];
+    fetchMock = vi.fn(async () => {
+      const s = makeSseReader();
+      streams.push(s);
+      return sseResponse(s.reader);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = mount();
+    await armAndFire(result);
+    const sse = streams[0];
+
+    act(() => sse.push("progress", progressFrame(1)));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.optProgress?.n_evals).toBe(1);
+
+    // A knob change marked free re-triggers the reactive effect with a new
+    // signature, which supersedes the in-flight run — the same path a real
+    // fixed-input edit takes.
+    act(() => {
+      result.current.setKnobOpt({
+        "dipoles.probe": {
+          length_factor: { vary: true, optMin: 0.7, optMax: 1.3, dispMin: 0.7, dispMax: 1.3, step: 0.001 },
+        },
+      });
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+      await Promise.resolve();
+    });
+
+    // The superseded run's reader was torn down...
+    expect(sse.canceled).toBe(true);
+    // ...and a frame pushed to the now-abandoned stream after that must not
+    // land: this is exactly what breaks if the `ctrl.signal.aborted` guard
+    // inside the SSE loop is dropped.
+    act(() => sse.push("progress", progressFrame(99)));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.optProgress?.n_evals).not.toBe(99);
+
+    // A fresh run is what's actually in flight now.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("without a streaming content-type, falls back to the plain-JSON path unchanged", async () => {
+    fetchMock = vi.fn(async () => ({
+      headers: { get: () => "application/json" },
+      json: async () => RESULT,
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = mount();
+    await armAndFire(result);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.optResult).toEqual(RESULT);
+    expect(setParamAtPath).toHaveBeenCalledWith(["length_factor"], 0.99);
+    expect(result.current.optProgress).toBeNull();
+  });
+});

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -782,6 +782,7 @@ function DesignSessionBody({
     setKnobMenu,
     optRunning,
     optResult,
+    optProgress,
     optError,
     optPausedBy,
     setOptPausedBy,
@@ -1425,6 +1426,7 @@ function DesignSessionBody({
           optObjective={optObjective}
           setOptObjective={setOptObjective}
           optResult={optResult}
+          optProgress={optProgress}
           optError={optError}
           optPausedBy={optPausedBy}
         />

--- a/src/antennaknobs/web/frontend/src/components/session/VfoPanel.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/VfoPanel.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import type { BandSpec, ExampleDescriptor } from "../../lib/params";
 
 // Response from POST /optimize.
-type OptMetrics = { z_in_re: number; z_in_im: number; z0_ohms: number; swr: number };
+export type OptMetrics = { z_in_re: number; z_in_im: number; z0_ohms: number; swr: number };
 export type OptimizeResult = {
   objective: string;
   params: Record<string, number>;
@@ -14,6 +14,15 @@ export type OptimizeResult = {
   metrics_after: OptMetrics;
   n_evals: number;
   improved: boolean;
+};
+// One `event: progress` frame from the streamed /optimize (issue #773 unit
+// 4) — a mid-run snapshot, not a final outcome; `objective` is the raw
+// scalar being minimised, unlike OptimizeResult's before/after pair.
+export type OptProgress = {
+  n_evals: number;
+  params: Record<string, number>;
+  objective: number;
+  metrics: OptMetrics;
 };
 export type OptObjective = "swr" | "resonance" | "match_z0";
 const OPT_OBJECTIVE_LABELS: Record<OptObjective, string> = {
@@ -44,6 +53,7 @@ function SimControls({
   optObjective,
   setOptObjective,
   optResult,
+  optProgress,
   optError,
   optPausedBy,
 }: {
@@ -56,6 +66,7 @@ function SimControls({
   optObjective: OptObjective;
   setOptObjective: (v: OptObjective) => void;
   optResult: OptimizeResult | null;
+  optProgress: OptProgress | null;
   optError: string | null;
   optPausedBy: OptPause | null;
 }) {
@@ -129,7 +140,20 @@ function SimControls({
           </>
         )}
       </div>
-      {optEnabled && optResult && (
+      {/* Live progress (#773 unit 4): while a run is in flight, the eval
+          count/objective/Z-SWR readout tracks the latest `progress` frame
+          instead of the previous run's settled result — optProgress is reset
+          to null at the start of every run, so this only shows once the
+          first frame lands. */}
+      {optEnabled && optRunning && optProgress && (
+        <span
+          className="opt-readout opt-readout-progress"
+          title={`eval ${optProgress.n_evals} — objective ${optProgress.objective.toFixed(4)}, Z ${optProgress.metrics.z_in_re.toFixed(1)} ${optProgress.metrics.z_in_im >= 0 ? "+" : "−"} j${Math.abs(optProgress.metrics.z_in_im).toFixed(1)} Ω`}
+        >
+          #{optProgress.n_evals} SWR {optProgress.metrics.swr.toFixed(2)}
+        </span>
+      )}
+      {optEnabled && !optRunning && optResult && (
         <span className="opt-readout" title="SWR after optimisation">
           SWR {optResult.metrics_after.swr.toFixed(2)}
         </span>
@@ -188,6 +212,7 @@ export function VfoPanel({
   optObjective,
   setOptObjective,
   optResult,
+  optProgress,
   optError,
   optPausedBy,
 }: {
@@ -213,6 +238,7 @@ export function VfoPanel({
   optObjective: OptObjective;
   setOptObjective: (v: OptObjective) => void;
   optResult: OptimizeResult | null;
+  optProgress: OptProgress | null;
   optError: string | null;
   optPausedBy: OptPause | null;
 }) {
@@ -262,6 +288,7 @@ export function VfoPanel({
             optObjective={optObjective}
             setOptObjective={setOptObjective}
             optResult={optResult}
+            optProgress={optProgress}
             optError={optError}
             optPausedBy={optPausedBy}
           />

--- a/src/antennaknobs/web/frontend/src/components/session/useOptimizer.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useOptimizer.ts
@@ -11,7 +11,56 @@ import {
   type OptimizeResult,
   type OptObjective,
   type OptPause,
+  type OptProgress,
 } from "./VfoPanel";
+
+// One decoded `event: X\ndata: Y` frame off an SSE byte stream.
+type SseFrame = { event: string; data: string };
+
+// Frames `event:`/`data:` lines separated by a blank line (issue #773 unit
+// 4's pinned contract: progress/result/error, exactly one terminal event per
+// stream). Multi-line `data:` fields join with `\n` per the SSE spec, though
+// this contract only ever sends one JSON line per field.
+//
+// `signal`'s abort cancels the reader directly rather than relying on the
+// fetch's own abort propagation: a stubbed test transport's stream has no
+// such propagation, and canceling a reader with a read pending resolves that
+// read as done (WHATWG streams), which is what unblocks the loop below.
+async function* readSseFrames(
+  body: ReadableStream<Uint8Array>,
+  signal: AbortSignal,
+): AsyncGenerator<SseFrame> {
+  const reader = body.getReader();
+  const onAbort = () => {
+    reader.cancel().catch(() => {});
+  };
+  signal.addEventListener("abort", onAbort);
+  const decoder = new TextDecoder();
+  let buf = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      let sep = buf.indexOf("\n\n");
+      while (sep !== -1) {
+        const block = buf.slice(0, sep);
+        buf = buf.slice(sep + 2);
+        let event = "message";
+        const dataLines: string[] = [];
+        for (const line of block.split("\n")) {
+          if (line.startsWith("event:")) event = line.slice(6).trim();
+          else if (line.startsWith("data:")) dataLines.push(line.slice(5).trim());
+        }
+        if (dataLines.length > 0) yield { event, data: dataLines.join("\n") };
+        sep = buf.indexOf("\n\n");
+      }
+    }
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+    reader.releaseLock();
+  }
+}
 
 // --- Reactive knob optimiser (POST /optimize) ---
 //
@@ -66,6 +115,9 @@ export function useOptimizer({
   );
   const [optRunning, setOptRunning] = useState(false);
   const [optResult, setOptResult] = useState<OptimizeResult | null>(null);
+  // Latest `progress` frame of the in-flight run; reset to null at the start
+  // of every runOptimize call so a stale frame never outlives its run.
+  const [optProgress, setOptProgress] = useState<OptProgress | null>(null);
   const [optError, setOptError] = useState<string | null>(null);
   // When something auto-pauses the optimizer, this holds *why* for a brief cue
   // (cleared on re-enable / after a few seconds): grabbing a knob marked for
@@ -95,6 +147,7 @@ export function useOptimizer({
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setKnobMenu(null);
     setOptResult(null);
+    setOptProgress(null);
     setOptError(null);
     if (optEnabledRef.current) {
       setOptEnabled(false);
@@ -103,11 +156,27 @@ export function useOptimizer({
     // optEnabledRef is read (not a dep) on purpose — see its declaration.
   }, [geometry]);
 
+  // Apply a settled /optimize outcome exactly as before: stash it for the
+  // readout, and push every returned param through the normal onChange path
+  // (which re-solves). Shared by the streaming `result` event and the
+  // non-streaming JSON body.
+  function applyOptimizeResult(data: OptimizeResult) {
+    setOptResult(data);
+    for (const [name, val] of Object.entries(data.params)) {
+      setParamAtPath([name], val);
+    }
+  }
+
   // Run the optimiser once: POST the current solve request + the free knobs
   // (from each knob's menu) and objective, then apply the returned params to the
   // knobs (re-solving via the normal onChange path). Warm-started from the
   // current values; a newer run aborts the previous so stale results are
   // dropped. Always uses the momwire engine server-side.
+  //
+  // Requests `text/event-stream` (issue #773's pinned contract) to get live
+  // `progress` frames; a server that doesn't stream yet ignores the header
+  // and answers with today's plain JSON, which the content-type check below
+  // routes to the unchanged single-shot path.
   async function runOptimize() {
     const settings = knobOpt[geometry] ?? {};
     const free = Object.entries(settings)
@@ -119,10 +188,14 @@ export function useOptimizer({
     optAbortRef.current = ctrl;
     setOptRunning(true);
     setOptError(null);
+    setOptProgress(null);
     try {
       const resp = await fetch("/optimize", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "text/event-stream",
+        },
         signal: ctrl.signal,
         body: JSON.stringify({
           ...buildRequest(),
@@ -130,14 +203,28 @@ export function useOptimizer({
           optimize: { free, objective: optObjective, max_evals: 40 },
         }),
       });
-      const data = await resp.json();
       if (ctrl.signal.aborted) return; // superseded by a newer run
-      if (data.error) {
-        setOptError(String(data.error));
+      const streaming = (resp.headers.get("content-type") ?? "").includes(
+        "text/event-stream",
+      );
+      if (streaming && resp.body) {
+        for await (const { event, data } of readSseFrames(resp.body, ctrl.signal)) {
+          if (ctrl.signal.aborted) break; // superseded mid-stream
+          if (event === "progress") {
+            setOptProgress(JSON.parse(data) as OptProgress);
+          } else if (event === "result") {
+            applyOptimizeResult(JSON.parse(data) as OptimizeResult);
+          } else if (event === "error") {
+            setOptError(String((JSON.parse(data) as { detail: string }).detail));
+          }
+        }
       } else {
-        setOptResult(data as OptimizeResult);
-        for (const [name, val] of Object.entries((data as OptimizeResult).params)) {
-          setParamAtPath([name], val);
+        const data = await resp.json();
+        if (ctrl.signal.aborted) return; // superseded while the body was read
+        if (data.error) {
+          setOptError(String(data.error));
+        } else {
+          applyOptimizeResult(data as OptimizeResult);
         }
       }
     } catch (e) {
@@ -245,6 +332,7 @@ export function useOptimizer({
     setKnobMenu,
     optRunning,
     optResult,
+    optProgress,
     optError,
     optPausedBy,
     setOptPausedBy,

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -2893,6 +2893,11 @@ canvas {
 .opt-readout-err {
   color: var(--danger, #c0392b);
 }
+/* Live progress (#773 unit 4): accent color, same family as opt-pip, marks
+   the readout as updating mid-run rather than the settled post-run figure. */
+.opt-readout-progress {
+  color: var(--accent);
+}
 /* Auto-pause cue: the optimizer stepped aside because the user grabbed a
    marked knob. Use the "hot" accent so it reads as a deliberate, momentary
    state change rather than an error. */


### PR DESCRIPTION
Unit 4 of the #773 arc. Stacked onto `issue-773-optimizer-progress-sse`. Built against the contract pinned in the issue — the server does not stream yet, which is unit 3.

## What

`runOptimize()` now sends `Accept: text/event-stream` and, when the response carries that content-type, reads `progress` / `result` / `error` frames off the body as they arrive. A live readout (`#N SWR X.XX`) replaces the boolean spinner during a run.

**The non-streaming path is untouched and still taken** whenever the response isn't SSE — which is exactly the state of `main` today, so this is safe to land before unit 3.

## Gates

| Gate | Result |
|---|---|
| Live eval count / objective / Z-SWR during a run | ✅ pinned at hook level *and* component level |
| Abort tears the reader down, no post-abort writes | ✅ |
| Terminal `error` → existing `setOptError` path | ✅ |
| Terminal `result` → existing `setParamAtPath` path | ✅ + a dedicated non-streaming fallback test |
| Frontend suite | **698 / 50 files** (baseline 690 / 48) |
| `eslint .` | **0 errors**, 223 warnings — *identical* to baseline, no new disables |
| `tsc --noEmit` / `npm run build` | clean / clean |

## Review notes

Built by a **sonnet** subagent; reviewed and re-gated by the session model (opus). I re-ran every gate myself — the 698/50, the eslint counts and the build are my numbers, not the builder's report.

**Adversarial probe I ran independently:** removed the explicit `reader.cancel()` from the abort handler; the abort test fails. That is the builder's key design decision and it is genuinely load-bearing — real `fetch` propagates abort into the body stream, but a stubbed transport does not, so relying on propagation would leave a superseded run's reader dangling. Canceling a reader with a pending `read()` resolves it as `done`, which is what unblocks the loop. The builder also verified gate 5 by deleting the progress `setState` (5→3 passing); I confirmed the abort path separately rather than repeating its check.

Worth noting the parser **ignores SSE comment lines** (`:keepalive`), which matters more than it looks — see the unit 3 note below.

## Carried forward to unit 3

1. **Frames must end with a blank line.** The parser emits on `\n\n`; a terminal `result` written without the trailing blank line would sit in the buffer and never be delivered. Unit 3's SSE writer must terminate every frame, including the last.
2. **Keepalives are free on this side.** Unit 2 flagged that a client which vanishes mid-solve isn't detected until the next publish, so a closed browser keeps burning MoM solves. Emitting a periodic SSE comment is one fix, and this parser already skips comments, so it costs unit 3 nothing on the client.
3. Content-type matching uses `.includes("text/event-stream")`, so `; charset=utf-8` is fine.