### PR TITLE
Unit 2: thread-safe progress bridge, worker → event loop (#773)

### DIFF
--- a/src/antennaknobs/web/progress_stream.py
+++ b/src/antennaknobs/web/progress_stream.py
@@ -1,0 +1,301 @@
+"""Thread-safe progress bridge: threadpool worker → asyncio consumer (issue #773).
+
+The optimiser's objective runs under ``run_in_threadpool``, so its
+``on_progress`` callback fires on an anyio worker thread and cannot ``await``.
+The endpoint that streams those events is an async ``StreamingResponse`` on the
+event loop. :class:`ProgressStream` is that bridge and nothing else — no web
+framework, no optimiser import — so its concurrency claims are provable in
+isolation. Producer side is :meth:`ProgressStream.publish` (one dict, matching
+the ``Callable[[dict], None]`` of contract C3); consumer side is
+:meth:`ProgressStream.events`.
+
+Why this mechanism
+------------------
+``asyncio.Queue`` is not thread safe: its ``put_nowait`` mutates a deque and
+wakes futures with no lock, so calling it from a worker corrupts waiter state
+under contention — the classic defect that survives single-user local dev and
+falls over under load. ``queue.Queue.get`` is thread safe but *blocks*, which
+on the loop thread stalls every other request; wrapping it in
+``run_in_executor`` costs one more parked thread per pending get, which is the
+same disease. ``janus`` exists precisely for this and would be the obvious
+answer, but a new third-party dependency is out of scope here.
+
+So: a plain :class:`collections.deque` under a :class:`threading.Lock` holds
+the events (mutation from either thread is safe), and the consumer is woken
+through ``loop.call_soon_threadsafe`` — the *only* loop API documented as
+callable from another OS thread.
+
+INVARIANT: no asyncio object is touched from the worker thread except
+``loop.call_soon_threadsafe`` inside :meth:`_wake_consumer`. That method is the
+single documented entry point; everything else the producer calls (``publish``,
+``finish``, ``fail``, ``close``) touches only the lock, the deque and plain
+attributes. The loop reference itself is captured by the *consumer* in
+:meth:`events` and only ever read (under the lock) by ``_wake_consumer``.
+
+Bounded queue: drop oldest, with a counter
+------------------------------------------
+The buffer is capped at ``maxsize`` and a full ``publish`` discards the OLDEST
+pending event, increments :attr:`dropped`, and returns without blocking.
+Rejected alternatives and why:
+
+* *Unbounded* — a browser that stops reading (backgrounded tab, dead TCP
+  socket that has not timed out yet) grows the buffer for the whole run.
+* *Block, with or without timeout* — parks an anyio worker thread on a
+  consumer that may never drain. anyio's default limiter is 40 threads for the
+  whole process, so a handful of stalled browsers stalls every solve on the
+  box. A blocked producer is exactly the "works locally, fails under load"
+  failure this unit exists to rule out.
+
+Dropping the oldest (rather than the newest) is what a progress readout wants:
+these events are *state*, not a ledger. A superseded eval count / objective /
+SWR has no value once a newer one exists, so a slow consumer should see the
+current state, not a stale prefix. Delivered events keep their relative order —
+they are a subsequence of what was published, never a reordering.
+
+Terminal events bypass the bound entirely: they are stored in a separate slot,
+so the run's actual result can never be dropped no matter how far behind the
+consumer is.
+
+Termination
+-----------
+Exactly one terminal event (``result`` or ``error``) ends a stream, matching
+contract C2. The iterator yields it and then stops, so a consumer can always
+distinguish "the run ended" (iteration finished, and the last event says how)
+from "nothing yet" (iteration still pending). Teardown works from either end:
+
+* consumer gone — :meth:`events` calls :meth:`close` on exit (return, break,
+  task cancellation, generator finalisation), after which :meth:`publish`
+  raises :class:`ProgressStreamClosed` on the worker, which propagates out of
+  the objective and aborts the run promptly instead of computing solves nobody
+  will read.
+* producer gone — :meth:`sealed` guarantees a terminal event even if the
+  producer raises or returns without one, so the consumer can never hang
+  waiting on a thread that has already died.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections import deque
+from collections.abc import AsyncIterator, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Literal
+
+# Event kinds are the SSE event names of contract C2 verbatim, so a consumer
+# can frame one as ``f"event: {ev.kind}\ndata: {json.dumps(ev.data)}\n\n"``
+# without a translation table.
+EventKind = Literal["progress", "result", "error"]
+
+_TERMINAL_KINDS = ("result", "error")
+
+# Events buffered before the oldest starts being dropped. One progress event is
+# a few hundred bytes and is produced at most once per MoM solve (seconds
+# apart), so this is minutes of backlog for a consumer that is merely slow —
+# deep enough that only a consumer that has genuinely stopped reading hits it.
+DEFAULT_MAXSIZE = 64
+
+
+class ProgressStreamClosed(RuntimeError):
+    """Raised by :meth:`ProgressStream.publish` once the stream is finished —
+    the consumer disconnected, its loop died, or a terminal event was already
+    delivered. Producers are expected to let it propagate: it is the signal
+    that the work being reported on is no longer wanted."""
+
+
+@dataclass(frozen=True, slots=True)
+class ProgressEvent:
+    """One SSE-shaped event. ``data`` is the caller's payload, stored by
+    reference and never mutated by this module."""
+
+    kind: EventKind
+    data: dict
+
+    @property
+    def terminal(self) -> bool:
+        return self.kind in _TERMINAL_KINDS
+
+
+class ProgressStream:
+    """A single-producer / single-consumer bridge from a worker thread to the
+    event loop. See the module docstring for the mechanism and the drop policy.
+
+    Every public method is safe to call from any thread. Only :meth:`events`
+    requires a running loop, and only it may be called concurrently by one
+    consumer.
+    """
+
+    def __init__(self, *, maxsize: int = DEFAULT_MAXSIZE) -> None:
+        if maxsize < 1:
+            raise ValueError("maxsize must be >= 1")
+        self._maxsize = int(maxsize)
+        self._lock = threading.Lock()
+        self._pending: deque[ProgressEvent] = deque()
+        self._terminal: ProgressEvent | None = None
+        self._closed = False
+        self._dropped = 0
+        # Written once by the consumer in events(); read under the lock by
+        # _wake_consumer. The producer never touches either object directly.
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._wake: asyncio.Event | None = None
+
+    # -- producer side (any thread) -----------------------------------------
+
+    def publish(self, payload: dict) -> None:
+        """Queue one ``progress`` event. Never blocks.
+
+        Signature-compatible with contract C3's ``on_progress``. Raises
+        :class:`ProgressStreamClosed` if nobody is listening any more.
+        """
+        with self._lock:
+            if self._closed:
+                raise ProgressStreamClosed("progress stream closed by consumer")
+            if self._terminal is not None:
+                raise ProgressStreamClosed("progress stream already terminated")
+            if len(self._pending) >= self._maxsize:
+                self._pending.popleft()
+                self._dropped += 1
+            self._pending.append(ProgressEvent("progress", payload))
+        self._wake_consumer()
+
+    def finish(self, result: dict) -> bool:
+        """Terminate the stream with the run's final payload. Returns False if
+        the stream was already terminal or closed (first terminal wins, so a
+        late ``fail`` after a ``finish`` cannot rewrite history)."""
+        return self._terminate("result", result)
+
+    def fail(self, detail: str) -> bool:
+        """Terminate the stream with an error. Returns False if already
+        terminal or closed."""
+        return self._terminate("error", {"detail": detail})
+
+    def close(self) -> None:
+        """Abandon the stream from either end. Idempotent. Pending events are
+        discarded and the next :meth:`publish` raises. The consumer calls this
+        on its way out; a producer can call it to disown a stream nobody
+        terminated."""
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._pending.clear()
+        self._wake_consumer()
+
+    @contextmanager
+    def sealed(self) -> Iterator[ProgressStream]:
+        """Guarantee exactly one terminal event around a producer body.
+
+        An exception escaping the body becomes an ``error`` event before it
+        propagates; a body that returns without calling :meth:`finish` gets a
+        terminal event anyway. Without this, a producer that dies between
+        events leaves the consumer awaiting a thread that no longer exists.
+        :class:`ProgressStreamClosed` is re-raised untouched — the consumer is
+        already gone, so there is nothing left to seal.
+        """
+        try:
+            yield self
+        except ProgressStreamClosed:
+            raise
+        except BaseException as exc:
+            self.fail(f"{type(exc).__name__}: {exc}")
+            raise
+        finally:
+            # No-op when a terminal event was already set.
+            self.fail("producer exited without a result")
+
+    # -- consumer side (event loop only) ------------------------------------
+
+    async def events(self) -> AsyncIterator[ProgressEvent]:
+        """Yield events in publication order, ending with the terminal one.
+
+        Iteration stops after a ``result``/``error`` event, or immediately if
+        the stream was closed without one. :meth:`close` runs on the way out
+        however iteration ends, so a disconnected client tears the producer
+        down.
+        """
+        loop = asyncio.get_running_loop()
+        with self._lock:
+            if self._loop is not None:
+                raise RuntimeError("ProgressStream supports a single consumer")
+            self._loop = loop
+            self._wake = asyncio.Event()
+        wake = self._wake
+        try:
+            while True:
+                # Clear BEFORE draining: a publish that lands between the
+                # drain and the await has already scheduled its set(), which
+                # then runs on the loop and cannot be lost.
+                wake.clear()
+                while True:
+                    event, last = self._take()
+                    if event is not None:
+                        yield event
+                    if last:
+                        return
+                    if event is None:
+                        break  # drained; go wait
+                await wake.wait()
+        finally:
+            self.close()
+
+    def __aiter__(self) -> AsyncIterator[ProgressEvent]:
+        return self.events()
+
+    # -- state ---------------------------------------------------------------
+
+    @property
+    def dropped(self) -> int:
+        """Progress events discarded because the consumer fell behind. A
+        consumer can report this alongside the result; a non-zero value means
+        the readout skipped evals, never that the run did."""
+        with self._lock:
+            return self._dropped
+
+    @property
+    def done(self) -> bool:
+        """True once a terminal event exists or the stream was closed — i.e.
+        no further progress will ever be published."""
+        with self._lock:
+            return self._closed or self._terminal is not None
+
+    # -- internals -----------------------------------------------------------
+
+    def _terminate(self, kind: EventKind, data: dict) -> bool:
+        with self._lock:
+            if self._closed or self._terminal is not None:
+                return False
+            self._terminal = ProgressEvent(kind, data)
+        self._wake_consumer()
+        return True
+
+    def _take(self) -> tuple[ProgressEvent | None, bool]:
+        """Pop the next deliverable event. Returns ``(event, last)``; a None
+        event with ``last`` False means "drained, nothing terminal yet"."""
+        with self._lock:
+            if self._pending:
+                return self._pending.popleft(), False
+            if self._terminal is not None:
+                # Terminal delivered: the stream is over, so later publishes
+                # must raise rather than queue into a stream nobody reads.
+                self._closed = True
+                return self._terminal, True
+            return None, self._closed
+
+    def _wake_consumer(self) -> None:
+        """THE loop entry point (see the module invariant). Called from either
+        thread; a no-op until a consumer has bound its loop."""
+        with self._lock:
+            loop, wake = self._loop, self._wake
+        if loop is None or wake is None:
+            return
+        try:
+            loop.call_soon_threadsafe(wake.set)
+        except RuntimeError:
+            # Loop already closed — the consumer's process/task is gone for
+            # good, so close so the producer's next publish raises rather than
+            # queueing into a void. (A merely *stopped* loop accepts the
+            # callback silently; only a closed one raises.)
+            with self._lock:
+                self._closed = True
+                self._pending.clear()

--- a/tests/test_progress_stream.py
+++ b/tests/test_progress_stream.py
@@ -1,0 +1,598 @@
+"""Threadpool → event-loop progress bridge (issue #773, unit 2).
+
+Every concurrency claim here is pinned with an explicit handshake — a
+``threading.Event`` in one direction, an awaited task in the other — never a
+wall-clock sleep. A broken wakeup path therefore shows up as a *hang* caught by
+``asyncio.wait_for``/``join(timeout=...)``, not as an intermittent failure.
+
+The producer always runs on a real OS thread (``threading.Thread``, or
+``run_in_threadpool`` where the production shape matters); nothing here fakes
+the thread boundary the bridge exists to cross.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+from fastapi.concurrency import run_in_threadpool
+
+from antennaknobs.web.progress_stream import (
+    ProgressEvent,
+    ProgressStream,
+    ProgressStreamClosed,
+)
+
+TIMEOUT = 4.0  # only ever reached on a HANG; kept under the suite's 5 s ceiling
+
+
+def _kinds(events: list[ProgressEvent]) -> list[str]:
+    return [e.kind for e in events]
+
+
+def _ns(events: list[ProgressEvent]) -> list[int]:
+    return [e.data["n"] for e in events if e.kind == "progress"]
+
+
+# ---------------------------------------------------------------------------
+# Gate 1 — ordering across a real thread boundary
+# ---------------------------------------------------------------------------
+
+
+def test_ordering_preserved_with_a_free_running_worker_thread():
+    """200 events published from a worker while the consumer drains: the
+    delivered sequence is exactly the published one, terminal event last."""
+
+    async def main():
+        stream = ProgressStream(maxsize=1024)  # deliberately never full here
+
+        def producer():
+            for n in range(200):
+                stream.publish({"n": n})
+            stream.finish({"ok": True})
+
+        thread = threading.Thread(target=producer, name="probe-producer")
+        received: list[ProgressEvent] = []
+
+        async def drain():
+            async for event in stream.events():
+                received.append(event)
+
+        task = asyncio.ensure_future(drain())
+        await asyncio.sleep(0)  # consumer is parked on the wake event
+        thread.start()
+        await asyncio.wait_for(task, TIMEOUT)
+        thread.join(TIMEOUT)
+        return stream, received
+
+    stream, received = asyncio.run(main())
+    assert _ns(received) == list(range(200))
+    assert _kinds(received)[-1] == "result"
+    assert _kinds(received).count("result") == 1
+    assert received[-1].data == {"ok": True}
+    assert stream.dropped == 0
+
+
+def test_ordering_holds_under_lockstep_ping_pong():
+    """The strongest ordering probe: the worker publishes only after the loop
+    has acknowledged the previous event, so every single event genuinely
+    crosses the thread boundary while the consumer is live. Also proves the
+    wakeup path — with no wakeup this deadlocks rather than passing slowly."""
+
+    async def main():
+        stream = ProgressStream(maxsize=4)
+        acked = threading.Event()
+        waits_ok: list[bool] = []
+
+        def producer():
+            for n in range(25):
+                stream.publish({"n": n})
+                waits_ok.append(acked.wait(TIMEOUT))
+                acked.clear()
+            stream.finish({"evals": 25})
+
+        thread = threading.Thread(target=producer, name="pingpong-producer")
+        received: list[ProgressEvent] = []
+
+        async def drain():
+            async for event in stream.events():
+                received.append(event)
+                acked.set()  # threading.Event.set is safe from the loop thread
+
+        task = asyncio.ensure_future(drain())
+        await asyncio.sleep(0)
+        thread.start()
+        await asyncio.wait_for(task, TIMEOUT)
+        thread.join(TIMEOUT)
+        return received, waits_ok
+
+    received, waits_ok = asyncio.run(main())
+    assert all(waits_ok) and len(waits_ok) == 25
+    assert _ns(received) == list(range(25))
+    assert _kinds(received)[-1] == "result"
+
+
+def test_ordering_holds_under_run_in_threadpool():
+    """The production shape: the producer is an anyio worker started by
+    ``run_in_threadpool``, exactly as ``_solve_at`` will be."""
+
+    async def main():
+        stream = ProgressStream(maxsize=64)
+        received: list[ProgressEvent] = []
+        worker_threads: set[int] = set()
+
+        def producer():
+            for n in range(50):
+                worker_threads.add(threading.get_ident())
+                stream.publish({"n": n})
+
+        async def drain():
+            async for event in stream.events():
+                received.append(event)
+
+        task = asyncio.ensure_future(drain())
+        await asyncio.sleep(0)
+        with stream.sealed():
+            await run_in_threadpool(producer)
+            stream.finish({"ok": True})
+        await asyncio.wait_for(task, TIMEOUT)
+        return received, worker_threads
+
+    received, worker_threads = asyncio.run(main())
+    assert worker_threads and threading.get_ident() not in worker_threads
+    assert _ns(received) == list(range(50))
+    assert _kinds(received)[-1] == "result"
+
+
+# ---------------------------------------------------------------------------
+# Gate 2 — consumer disconnect terminates the producer
+# ---------------------------------------------------------------------------
+
+
+def test_consumer_disconnect_raises_in_the_producer_and_frees_its_thread():
+    """The consumer breaks out mid-run (a client disconnect). The next publish
+    on the worker raises ProgressStreamClosed, the thread exits, and the
+    process is back to its baseline thread count — nothing parked."""
+    baseline = threading.active_count()
+    permit = threading.Event()
+    published: list[int] = []
+    raised: list[BaseException] = []
+
+    async def main():
+        stream = ProgressStream(maxsize=4)
+
+        def producer():
+            try:
+                for n in range(10_000):
+                    assert permit.wait(TIMEOUT)
+                    permit.clear()
+                    stream.publish({"n": n})
+                    published.append(n)
+            except BaseException as exc:
+                raised.append(exc)
+
+        thread = threading.Thread(target=producer, name="disconnect-producer")
+        thread.start()
+        permit.set()  # release exactly one publish
+
+        seen = 0
+        async for _event in stream.events():
+            seen += 1
+            if seen == 3:
+                break  # client disconnected; the generator's finally closes
+            permit.set()  # let the worker produce the next one
+        return stream, thread, seen
+
+    stream, thread, seen = asyncio.run(main())
+    assert seen == 3
+    assert stream.done
+
+    # The worker is parked on our test permit, not on the stream: publish never
+    # blocks under the drop policy. Release it and it must die immediately.
+    permit.set()
+    thread.join(TIMEOUT)
+    assert not thread.is_alive()
+    assert isinstance(raised[0], ProgressStreamClosed)
+    assert len(published) == 3  # stopped at the disconnect, not at 10_000
+    # No thread leaked. "<=" rather than "==" only because an unrelated pool
+    # elsewhere in the suite may wind down during this test; it can never go up.
+    assert threading.active_count() <= baseline
+
+
+def test_publish_after_close_raises_from_either_caller():
+    stream = ProgressStream()
+    stream.publish({"n": 0})
+    stream.close()
+    with pytest.raises(ProgressStreamClosed):
+        stream.publish({"n": 1})
+    assert stream.done
+    assert stream.finish({"late": True}) is False
+
+
+def test_close_is_idempotent_and_drops_the_backlog():
+    stream = ProgressStream(maxsize=8)
+    for n in range(4):
+        stream.publish({"n": n})
+    stream.close()
+    stream.close()
+
+    async def main():
+        return [e async for e in stream.events()]
+
+    assert asyncio.run(main()) == []
+
+
+def test_a_closed_loop_closes_the_stream_instead_of_queueing_into_a_void():
+    """If the consumer's loop is gone (worker outliving the request), the one
+    loop entry point raises RuntimeError; the bridge must convert that into a
+    closed stream rather than buffering for a consumer that cannot return."""
+    stream = ProgressStream()
+
+    async def bind():
+        async for _event in stream.events():  # pragma: no cover - never yields
+            break
+
+    loop = asyncio.new_event_loop()
+    task = loop.create_task(bind())
+    loop.run_until_complete(asyncio.sleep(0))
+    task.cancel()
+    loop.run_until_complete(asyncio.gather(task, return_exceptions=True))
+    # events()'s finally already closed the stream; re-open it to isolate the
+    # closed-loop path from the ordinary disconnect path.
+    stream._closed = False
+    loop.close()
+
+    with pytest.raises(ProgressStreamClosed):
+        for n in range(2):  # first publish trips the closed loop, second raises
+            stream.publish({"n": n})
+    assert stream.done
+
+
+# ---------------------------------------------------------------------------
+# Gate 3 — bounded buffer: drop oldest, count the drops
+# ---------------------------------------------------------------------------
+
+
+def test_overflow_drops_the_oldest_and_counts_them():
+    """No consumer has ever bound a loop — the worst case for a buffer, and
+    fully deterministic: maxsize + k publishes leave exactly the newest
+    maxsize, with k counted."""
+    stream = ProgressStream(maxsize=5)
+
+    def producer():
+        for n in range(12):
+            stream.publish({"n": n})
+        stream.finish({"ok": True})
+
+    thread = threading.Thread(target=producer, name="overflow-producer")
+    thread.start()
+    thread.join(TIMEOUT)
+
+    async def main():
+        return [e async for e in stream.events()]
+
+    received = asyncio.run(main())
+    assert _ns(received) == [7, 8, 9, 10, 11]  # newest five, in order
+    assert stream.dropped == 7
+    assert _kinds(received)[-1] == "result"
+
+
+def test_a_stalled_consumer_sees_the_newest_state_and_never_loses_the_result():
+    """Consumer slower than producer, with a live loop. It takes one event,
+    stalls until the worker has finished producing, then drains: it sees the
+    newest maxsize progress events plus the terminal one, which is exempt from
+    the bound. Ordering of what survives is still publication order."""
+
+    async def main():
+        stream = ProgressStream(maxsize=4)
+        saw_first = threading.Event()
+        settled = threading.Event()
+
+        def producer():
+            stream.publish({"n": 0})
+            assert saw_first.wait(TIMEOUT)
+            for n in range(1, 13):
+                stream.publish({"n": n})
+            stream.finish({"ok": True})
+            settled.set()  # every producer action is now complete
+
+        thread = threading.Thread(target=producer, name="stall-producer")
+        received: list[ProgressEvent] = []
+
+        async def drain():
+            async for event in stream.events():
+                received.append(event)
+                if len(received) == 1:
+                    saw_first.set()
+                    # Stall on the loop without blocking it, and without a
+                    # sleep: resume only once the producer is provably done.
+                    await asyncio.to_thread(settled.wait, TIMEOUT)
+
+        task = asyncio.ensure_future(drain())
+        await asyncio.sleep(0)
+        thread.start()
+        await asyncio.wait_for(task, TIMEOUT)
+        thread.join(TIMEOUT)
+        return stream, received
+
+    stream, received = asyncio.run(main())
+    assert _ns(received) == [0, 9, 10, 11, 12]
+    assert stream.dropped == 8  # events 1..8, the stale ones
+    assert received[-1].kind == "result"  # terminal bypasses the bound
+
+
+def test_maxsize_must_be_positive():
+    with pytest.raises(ValueError):
+        ProgressStream(maxsize=0)
+
+
+# ---------------------------------------------------------------------------
+# Gate 4 — the loop is touched through exactly one entry point
+# ---------------------------------------------------------------------------
+
+
+class _LoopSpy:
+    """Records every attribute the bridge reads off the loop, and the thread
+    that read it. Anything other than ``call_soon_threadsafe`` reaching this
+    from a worker thread is a violation of the module invariant."""
+
+    def __init__(self, loop):
+        self._loop = loop
+        self.touched: list[tuple[str, str]] = []
+        self.callback_threads: list[str] = []
+
+    def call_soon_threadsafe(self, callback, *args):
+        self.touched.append(("call_soon_threadsafe", threading.current_thread().name))
+
+        def wrapped():
+            self.callback_threads.append(threading.current_thread().name)
+            callback(*args)
+
+        return self._loop.call_soon_threadsafe(wrapped)
+
+    def __getattr__(self, name):
+        self.touched.append((name, threading.current_thread().name))
+        return getattr(self._loop, name)
+
+
+def test_worker_touches_the_loop_only_through_call_soon_threadsafe():
+    async def main():
+        stream = ProgressStream(maxsize=16)
+        received: list[ProgressEvent] = []
+
+        async def drain():
+            async for event in stream.events():
+                received.append(event)
+
+        task = asyncio.ensure_future(drain())
+        for _ in range(100):  # bounded: binding takes one scheduling step
+            if stream._loop is not None:
+                break
+            await asyncio.sleep(0)
+        assert stream._loop is not None
+        spy = _LoopSpy(stream._loop)
+        stream._loop = spy
+
+        loop_thread = threading.current_thread().name
+        no_loop_in_worker: list[bool] = []
+
+        def producer():
+            try:
+                asyncio.get_running_loop()
+                no_loop_in_worker.append(False)
+            except RuntimeError:
+                no_loop_in_worker.append(True)
+            for n in range(5):
+                stream.publish({"n": n})
+            stream.finish({"ok": True})
+
+        thread = threading.Thread(target=producer, name="invariant-producer")
+        thread.start()
+        await asyncio.wait_for(task, TIMEOUT)
+        thread.join(TIMEOUT)
+        return spy, received, loop_thread, no_loop_in_worker
+
+    spy, received, loop_thread, no_loop_in_worker = asyncio.run(main())
+    assert no_loop_in_worker == [True]  # the worker has no loop of its own
+    assert len(received) == 6
+    # Every loop access came from the worker, and every one of them was the
+    # single documented entry point.
+    assert {name for name, _ in spy.touched} == {"call_soon_threadsafe"}
+    assert {thread for _, thread in spy.touched} == {"invariant-producer"}
+    # ...and the scheduled callback (the asyncio.Event set) ran on the loop.
+    assert set(spy.callback_threads) == {loop_thread}
+
+
+def test_publishing_before_any_consumer_needs_no_loop_at_all():
+    stream = ProgressStream(maxsize=8)
+    done = threading.Event()
+
+    def producer():
+        for n in range(3):
+            stream.publish({"n": n})
+        done.set()
+
+    thread = threading.Thread(target=producer, name="preconsumer-producer")
+    thread.start()
+    assert done.wait(TIMEOUT)
+    thread.join(TIMEOUT)
+    assert stream._loop is None
+    assert not stream.done
+
+
+# ---------------------------------------------------------------------------
+# Gate 5 — completion is distinguishable from silence
+# ---------------------------------------------------------------------------
+
+
+def test_silence_leaves_the_consumer_pending_and_finish_ends_it():
+    async def main():
+        stream = ProgressStream()
+        received: list[ProgressEvent] = []
+
+        async def drain():
+            async for event in stream.events():
+                received.append(event)
+
+        task = asyncio.ensure_future(drain())
+        for _ in range(5):
+            await asyncio.sleep(0)
+        pending_while_silent = not task.done()
+        done_while_silent = stream.done
+
+        stream.publish({"n": 0})
+        stream.finish({"ok": True})
+        await asyncio.wait_for(task, TIMEOUT)
+        return received, pending_while_silent, done_while_silent, stream.done
+
+    received, pending, done_while_silent, done_after = asyncio.run(main())
+    assert pending is True  # silence: still listening, nothing decided
+    assert done_while_silent is False
+    assert done_after is True
+    assert _kinds(received) == ["progress", "result"]
+
+
+def test_error_terminates_the_stream_like_a_result():
+    async def main():
+        stream = ProgressStream()
+        stream.publish({"n": 0})
+        stream.fail("solver exploded")
+        return [e async for e in stream.events()]
+
+    received = asyncio.run(main())
+    assert _kinds(received) == ["progress", "error"]
+    assert received[-1].data == {"detail": "solver exploded"}
+
+
+def test_first_terminal_event_wins():
+    stream = ProgressStream()
+    assert stream.finish({"ok": True}) is True
+    assert stream.fail("too late") is False
+
+    async def main():
+        return [e async for e in stream.events()]
+
+    received = asyncio.run(main())
+    assert _kinds(received) == ["result"]
+    assert received[0].data == {"ok": True}
+
+
+def test_publish_after_a_terminal_event_raises():
+    stream = ProgressStream()
+    stream.finish({"ok": True})
+    with pytest.raises(ProgressStreamClosed):
+        stream.publish({"n": 0})
+
+
+def test_event_kinds_match_the_sse_names_of_contract_c2():
+    stream = ProgressStream()
+    stream.publish({"n": 0})
+    stream.finish({"ok": True})
+
+    async def main():
+        return [e async for e in stream.events()]
+
+    received = asyncio.run(main())
+    assert [e.kind for e in received] == ["progress", "result"]
+    assert [e.terminal for e in received] == [False, True]
+    assert ProgressEvent("error", {}).terminal is True
+
+
+# ---------------------------------------------------------------------------
+# Producer death — sealed() guarantees the consumer never hangs
+# ---------------------------------------------------------------------------
+
+
+def test_sealed_converts_a_dead_producer_into_an_error_event():
+    async def main():
+        stream = ProgressStream()
+        escaped: list[BaseException] = []
+
+        def producer():
+            try:
+                with stream.sealed():
+                    stream.publish({"n": 0})
+                    raise ValueError("boom")
+            except BaseException as exc:
+                escaped.append(exc)
+
+        thread = threading.Thread(target=producer, name="dying-producer")
+        received: list[ProgressEvent] = []
+
+        async def drain():
+            async for event in stream.events():
+                received.append(event)
+
+        task = asyncio.ensure_future(drain())
+        await asyncio.sleep(0)
+        thread.start()
+        await asyncio.wait_for(task, TIMEOUT)
+        thread.join(TIMEOUT)
+        return received, escaped
+
+    received, escaped = asyncio.run(main())
+    assert isinstance(escaped[0], ValueError)  # the producer still sees it
+    assert _kinds(received) == ["progress", "error"]
+    assert received[-1].data["detail"] == "ValueError: boom"
+
+
+def test_sealed_terminates_a_producer_that_forgot_to_finish():
+    async def main():
+        stream = ProgressStream()
+
+        def producer():
+            with stream.sealed():
+                stream.publish({"n": 0})
+
+        thread = threading.Thread(target=producer, name="forgetful-producer")
+        received: list[ProgressEvent] = []
+
+        async def drain():
+            async for event in stream.events():
+                received.append(event)
+
+        task = asyncio.ensure_future(drain())
+        await asyncio.sleep(0)
+        thread.start()
+        await asyncio.wait_for(task, TIMEOUT)
+        thread.join(TIMEOUT)
+        return received
+
+    received = asyncio.run(main())
+    assert _kinds(received) == ["progress", "error"]
+    assert "without a result" in received[-1].data["detail"]
+
+
+def test_sealed_leaves_a_real_result_alone():
+    stream = ProgressStream()
+    with stream.sealed():
+        stream.publish({"n": 0})
+        stream.finish({"ok": True})
+
+    async def main():
+        return [e async for e in stream.events()]
+
+    received = asyncio.run(main())
+    assert _kinds(received) == ["progress", "result"]
+
+
+def test_sealed_reraises_consumer_disconnect_without_masking_it():
+    stream = ProgressStream()
+    stream.close()
+    with pytest.raises(ProgressStreamClosed):
+        with stream.sealed():
+            stream.publish({"n": 0})
+
+
+def test_second_consumer_is_refused():
+    async def main():
+        stream = ProgressStream()
+        stream.finish({"ok": True})
+        first = [e async for e in stream.events()]
+        with pytest.raises(RuntimeError, match="single consumer"):
+            async for _event in stream.events():  # pragma: no cover
+                pass
+        return first
+
+    assert _kinds(asyncio.run(main())) == ["result"]


### PR DESCRIPTION
Unit 2 of the #773 arc. Stacked onto `issue-773-optimizer-progress-sse`. Deliberately standalone — no FastAPI, no optimizer import — so its concurrency claims are provable in isolation. Wiring is unit 3.

## What

`ProgressStream` in a new `src/antennaknobs/web/progress_stream.py`. Producer side (`publish`, signature-compatible with unit 1's `on_progress`) is callable from any thread; consumer side is `async for ev in stream.events()`. `ProgressEvent.kind` is `"progress" | "result" | "error"` — contract C2's SSE names verbatim, so unit 3 frames them with no translation table.

**Mechanism**: a lock-guarded `deque`, with the consumer woken through `loop.call_soon_threadsafe` — the only loop API documented as callable from another OS thread. `asyncio.Queue` is not thread-safe; `queue.Queue.get` blocks the loop, and wrapping it in an executor parks another thread per pending get; `janus` is the right library but a new dependency.

**Bounded queue: drop oldest, with a counter.** Blocking — with or without timeout — parks an anyio worker on a browser that may never read again, and the default limiter is 40 threads for the whole process, so a handful of stalled clients would stall every solve on the box. Progress events are *state*, not a ledger: a superseded eval count has no value once a newer one exists. **Terminal events bypass the bound entirely**, so a run's result can never be dropped.

## Gates

| Gate | Result |
|---|---|
| Ordering, real worker thread | 200 events → `[0..199]` + terminal, `dropped == 0` |
| Consumer disconnect | published 3 of a possible 10 000, raised `ProgressStreamClosed`, thread dead, `active_count()` back to baseline |
| Bounded (stalled consumer) | `maxsize=4` → delivered `[0,9,10,11,12]` + result, `dropped == 8` |
| Loop invariant | a loop-spy records the touched attribute set as exactly `{"call_soon_threadsafe"}`, from the producer thread only |
| Completion vs silence | pending + `done` False before; `["progress","result"]` + `done` True after |
| Full suite | **3485 passed, 3 skipped** (195 s) |
| ruff check / format --check | clean |

## Review notes

Built by an **opus** subagent — chosen because the issue flags this as the piece that "will appear to work under a single-user local dev server and fail under load", i.e. self-consistency-gated, where a weaker builder yields subtly-wrong-but-plausible concurrency code that passes its own tests. Reviewed and re-gated by the session model (also opus), so **this review is a peer read, not a stronger one** — I leaned on mutation probes rather than on out-reasoning it.

**Probes I ran independently** (the builder reported its own; these are mine):
- **Unbound the buffer** → 2 tests fail. The drop policy is genuinely pinned.
- **Let terminal events be droppable** → **14** tests fail. The result-survives-backpressure property is heavily covered.

**One honest non-finding.** I mutated the `wake.clear()`-before-drain ordering — the subtlest thing in the file — and no test failed. Rather than log a coverage gap I traced it: a `call_soon_threadsafe` set can only execute once the consumer yields to the loop, and the only suspension points are the `yield` and the `await`, so a publish landing anywhere in the synchronous drain still wakes the consumer. The code is correct under either ordering; the comment claims a fragility that isn't there. Not worth a change, worth not believing.

## Carried forward to unit 3 (the builder's own load-analysis, which I'd act on)

1. **Silent-disconnect blindness — the important one.** This module only learns the consumer is gone when the async generator is finalised, and Starlette finalises a `StreamingResponse` body at its *next send*. If the consumer is parked awaiting a wake while the producer is mid-solve (tens of seconds), a client that vanished isn't noticed until the next event publishes — so a browser closed at eval 3 keeps burning MoM solves until eval 4 lands. Unit 3 should race the drain against `request.is_disconnected()` or emit a periodic SSE keepalive comment. Unit 4's parser already skips comment lines, so keepalives are free on the client.
2. **A stopped-but-not-closed loop never raises** — `call_soon_threadsafe` only raises on a *closed* loop. Not reachable under uvicorn, hence untested.
3. **Payloads are stored by reference.** Unit 1 builds a fresh dict per eval so this is fine today, but anyone widening the payload to carry a whole solve response reintroduces the #382 retention class `_shed` exists to prevent.
4. **Nothing here bounds concurrent streams** — one worker thread per in-flight run is `_check_solve_size` / lane territory.