### PR TITLE
Stream optimizer progress to the UI over SSE (closes #773)

### DIFF
--- a/src/antennaknobs/web/frontend/src/__tests__/VfoPanel.optProgress.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/VfoPanel.optProgress.test.tsx
@@ -1,0 +1,90 @@
+// The live optimizer progress readout (issue #773 unit 4) as rendered DOM,
+// not just hook state — useOptimizer.streaming.test.tsx pins the state
+// transitions; this pins that optRunning/optProgress actually reach the
+// screen, and that the settled optResult readout takes over once a run ends.
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { VfoPanel } from "../components/session/VfoPanel";
+import type { OptimizeResult, OptProgress } from "../components/session/VfoPanel";
+
+const METRICS = { z_in_re: 48.2, z_in_im: -3.1, z0_ohms: 50.0, swr: 1.12 };
+
+const PROGRESS: OptProgress = {
+  n_evals: 7,
+  params: { length_factor: 0.981 },
+  objective: 1.34,
+  metrics: METRICS,
+};
+
+const RESULT: OptimizeResult = {
+  objective: "swr",
+  params: { length_factor: 0.99 },
+  objective_before: 2.0,
+  objective_after: 1.05,
+  metrics_before: METRICS,
+  metrics_after: { ...METRICS, swr: 1.05 },
+  n_evals: 12,
+  improved: true,
+};
+
+function baseProps() {
+  return {
+    currentBands: [],
+    measLocked: false,
+    measFreq: 14.1,
+    bandContaining: () => null,
+    measBand: "",
+    selectMeasBand: vi.fn(),
+    currentExample: undefined,
+    measBandAnchor: 14.1,
+    freqWindowCeiling: 30,
+    setMeasFreq: vi.fn(),
+    measLockable: false,
+    linkMeas: false,
+    toggleLink: vi.fn(),
+    autoSim: true,
+    setAutoSim: vi.fn(),
+    optEnabled: true,
+    setOptEnabled: vi.fn(),
+    setOptPausedBy: vi.fn(),
+    optObjective: "swr" as const,
+    setOptObjective: vi.fn(),
+    optError: null,
+    optPausedBy: null,
+  };
+}
+
+describe("VfoPanel live optimizer readout (#773 unit 4)", () => {
+  it("shows the live eval count and SWR while a run is in flight", () => {
+    render(
+      <VfoPanel
+        {...baseProps()}
+        optRunning
+        optResult={null}
+        optProgress={PROGRESS}
+      />,
+    );
+    expect(screen.getByText("#7 SWR 1.12")).toBeTruthy();
+  });
+
+  it("shows nothing extra before the first progress frame lands", () => {
+    render(
+      <VfoPanel {...baseProps()} optRunning optResult={null} optProgress={null} />,
+    );
+    expect(screen.queryByText(/SWR/)).toBeNull();
+  });
+
+  it("switches to the settled result readout once the run ends", () => {
+    render(
+      <VfoPanel
+        {...baseProps()}
+        optRunning={false}
+        optResult={RESULT}
+        optProgress={PROGRESS}
+      />,
+    );
+    // The final metrics_after figure, not the last-seen progress frame.
+    expect(screen.getByText("SWR 1.05")).toBeTruthy();
+    expect(screen.queryByText("#7 SWR 1.12")).toBeNull();
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/smithLiveZ.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/smithLiveZ.test.tsx
@@ -1,0 +1,96 @@
+// The Smith chart's dot must follow a streamed optimizer run (issue #773).
+//
+// Reported from live use: the readout chip ticked toward SWR 1 while the dot
+// sat still until the run ended. The cause is structural, not a rendering
+// bug — an optimizer run never touches the knobs until it finishes, so the
+// /ws solve channel produces nothing and `result` holds the PRE-RUN solve for
+// the whole run. The per-eval frames carry the trial Z; `liveZ` is how it
+// reaches the chart.
+//
+// These tests drive the registry entry rather than the hook, because the
+// defect lived in which source the chart reads, not in how frames arrive.
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { VIEW_RENDERERS, type ViewRenderProps } from "../components/results/viewRegistry";
+import type { SolveResponse } from "../lib/api";
+
+// The chart draws to a canvas, so assert on the props it receives rather than
+// on pixels: what is under test is the SOURCE the dot comes from.
+const smithSpy = vi.hoisted(() => vi.fn());
+vi.mock("../components/charts/SmithChart", () => ({
+  SmithChart: (props: Record<string, unknown>) => {
+    smithSpy(props);
+    return <div data-testid="smith" />;
+  },
+}));
+
+const SETTLED = {
+  z_in_re: 22.0,
+  z_in_im: -18.0,
+  z0_ohms: 50,
+  feeds: [{ z_re: 22.0, z_im: -18.0 }],
+} as unknown as SolveResponse;
+
+const TRIAL = { z_in_re: 49.4, z_in_im: 1.2, z0_ohms: 50 };
+
+function renderSmith(over: Partial<ViewRenderProps>) {
+  smithSpy.mockClear();
+  const props = {
+    size: 300,
+    fill: true,
+    result: null,
+    liveZ: null,
+    preview: null,
+    sweep: null,
+    converge: null,
+    measured: null,
+    pattern: null,
+    pinnedPatterns: [],
+    measFreqMhz: 28.5,
+    sweepRunning: false,
+    convergeRunning: false,
+    azElevDeg: 0,
+    elevAzDeg: 0,
+    cameraProjection: "xy",
+    showHeatmap: false,
+    showEnvelope: false,
+    showWireLabels: false,
+    showFeedNames: false,
+    multiFeed: false,
+    schematicSvg: null,
+    schematicUnavailable: false,
+    ...over,
+  } as unknown as ViewRenderProps;
+  render(VIEW_RENDERERS.smith(props));
+  return smithSpy.mock.calls[0][0] as Record<string, unknown>;
+}
+
+describe("Smith chart during a streamed optimizer run", () => {
+  it("plots the settled solve when nothing is being tried", () => {
+    const p = renderSmith({ result: SETTLED });
+    expect(p.r).toBe(22.0);
+    expect(p.x).toBe(-18.0);
+    expect(p.trial).toBe(false);
+  });
+
+  it("plots the trial impedance instead, while a run is in flight", () => {
+    // The regression: with `liveZ` ignored these would still be the settled
+    // 22 − j18, which is exactly the frozen dot that was reported.
+    const p = renderSmith({ result: SETTLED, liveZ: TRIAL });
+    expect(p.r).toBe(49.4);
+    expect(p.x).toBe(1.2);
+    expect(p.trial).toBe(true);
+  });
+
+  it("keeps a reference impedance when the trial frame carries one", () => {
+    // z0 must come from the same place as the point, or a design on a
+    // non-50 Ω reference would plot its trial dot against the wrong circles.
+    const p = renderSmith({ result: SETTLED, liveZ: { ...TRIAL, z0_ohms: 200 } });
+    expect(p.z0).toBe(200);
+  });
+
+  it("falls back to the settled solve's reference when there is no trial", () => {
+    const p = renderSmith({ result: { ...SETTLED, z0_ohms: 75 } as SolveResponse });
+    expect(p.z0).toBe(75);
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/useOptimizer.streaming.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useOptimizer.streaming.test.tsx
@@ -1,0 +1,292 @@
+// Live optimizer progress over SSE (issue #773 unit 4), against the pinned
+// contract: `Accept: text/event-stream` opts in, the server answers with
+// `event: progress` frames and exactly one terminal `event: result` or
+// `event: error`. The backend doesn't stream yet — these tests stub the
+// transport and drive it by hand.
+//
+// The reader stub below queues frames and resolves reads on demand rather
+// than inline, and its `cancel()` resolves any read that's still pending
+// with `{done: true}` — exactly what a real ReadableStream does when a
+// reader is canceled mid-read. That's the behavior the abort test depends
+// on: useOptimizer's abort handler calls `reader.cancel()` rather than
+// trusting fetch's own AbortSignal wiring, because a stubbed transport has
+// none of that wiring to trust.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useOptimizer } from "../components/session/useOptimizer";
+import type { OptimizeResult, OptProgress } from "../components/session/VfoPanel";
+import type { SolveRequest } from "../lib/api";
+
+type QueuedRead = { done: boolean; value?: Uint8Array };
+
+function makeSseReader() {
+  const queue: QueuedRead[] = [];
+  let waiting: ((r: QueuedRead) => void) | null = null;
+  let canceled = false;
+  const encoder = new TextEncoder();
+
+  function feed(item: QueuedRead) {
+    if (waiting) {
+      const resolve = waiting;
+      waiting = null;
+      resolve(item);
+    } else {
+      queue.push(item);
+    }
+  }
+
+  return {
+    reader: {
+      read: () =>
+        new Promise<QueuedRead>((resolve) => {
+          if (queue.length > 0) resolve(queue.shift()!);
+          else waiting = resolve;
+        }),
+      cancel: () => {
+        canceled = true;
+        // Real ReadableStream semantics: canceling resolves a pending read
+        // as done, rather than leaving it hanging forever.
+        feed({ done: true });
+        return Promise.resolve();
+      },
+      releaseLock: () => {},
+    },
+    push(event: string, data: unknown) {
+      feed({
+        done: false,
+        value: encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`),
+      });
+    },
+    close() {
+      feed({ done: true });
+    },
+    get canceled() {
+      return canceled;
+    },
+  };
+}
+
+function sseResponse(reader: ReturnType<typeof makeSseReader>["reader"]) {
+  return {
+    headers: { get: (k: string) => (k.toLowerCase() === "content-type" ? "text/event-stream" : null) },
+    body: { getReader: () => reader } as unknown as ReadableStream<Uint8Array>,
+  } as unknown as Response;
+}
+
+const METRICS = { z_in_re: 48.2, z_in_im: -3.1, z0_ohms: 50.0, swr: 1.12 };
+
+function progressFrame(n_evals: number): OptProgress {
+  return {
+    n_evals,
+    params: { length_factor: 0.981 },
+    objective: 1.34,
+    metrics: METRICS,
+  };
+}
+
+const RESULT: OptimizeResult = {
+  objective: "swr",
+  params: { length_factor: 0.99 },
+  objective_before: 2.0,
+  objective_after: 1.05,
+  metrics_before: METRICS,
+  metrics_after: { ...METRICS, swr: 1.05 },
+  n_evals: 12,
+  improved: true,
+};
+
+type SetParamAtPath = (path: (string | number)[], value: number | string | boolean) => void;
+
+let fetchMock: ReturnType<typeof vi.fn>;
+let setParamAtPath: ReturnType<typeof vi.fn> & SetParamAtPath;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  setParamAtPath = vi.fn() as unknown as ReturnType<typeof vi.fn> & SetParamAtPath;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+function mount() {
+  return renderHook(() =>
+    useOptimizer({
+      geometry: "dipoles.probe",
+      currentValues: { length_factor: 1.0 },
+      currentValuesKey: "length_factor=1",
+      currentSchema: [],
+      backend: "momwire",
+      designFreq: 14.1,
+      measFreq: 14.1,
+      autoSim: true,
+      active: true,
+      buildRequest: () => ({ geometry: "dipoles.probe" }) as SolveRequest,
+      setParamAtPath,
+    }),
+  );
+}
+
+// Marks length_factor as free and turns Optimize on, then advances the
+// 400ms reactive-retune debounce so runOptimize actually fires.
+async function armAndFire(result: { current: ReturnType<typeof useOptimizer> }) {
+  act(() => {
+    result.current.setKnobOpt({
+      "dipoles.probe": {
+        length_factor: { vary: true, optMin: 0.8, optMax: 1.2, dispMin: 0.8, dispMax: 1.2, step: 0.001 },
+      },
+    });
+  });
+  act(() => {
+    result.current.setOptEnabled(true);
+  });
+  await act(async () => {
+    vi.advanceTimersByTime(400);
+    await Promise.resolve();
+  });
+}
+
+describe("useOptimizer SSE progress (#773 unit 4)", () => {
+  it("progress events update n_evals, objective, and Z/SWR live, before any terminal event", async () => {
+    const sse = makeSseReader();
+    fetchMock = vi.fn(async () => sseResponse(sse.reader));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = mount();
+    await armAndFire(result);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>).Accept).toBe("text/event-stream");
+    expect(result.current.optRunning).toBe(true);
+
+    act(() => sse.push("progress", progressFrame(1)));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.optProgress?.n_evals).toBe(1);
+    expect(result.current.optProgress?.metrics.swr).toBeCloseTo(1.12);
+    // Still running — no terminal event yet, and no params applied.
+    expect(result.current.optRunning).toBe(true);
+    expect(setParamAtPath).not.toHaveBeenCalled();
+
+    act(() => sse.push("progress", progressFrame(7)));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.optProgress?.n_evals).toBe(7);
+  });
+
+  it("a terminal result event applies params through setParamAtPath, same as the non-streaming path", async () => {
+    const sse = makeSseReader();
+    fetchMock = vi.fn(async () => sseResponse(sse.reader));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = mount();
+    await armAndFire(result);
+
+    act(() => sse.push("progress", progressFrame(3)));
+    act(() => sse.push("result", RESULT));
+    act(() => sse.close());
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.optResult).toEqual(RESULT);
+    expect(setParamAtPath).toHaveBeenCalledWith(["length_factor"], 0.99);
+    expect(result.current.optRunning).toBe(false);
+  });
+
+  it("a terminal error event surfaces via optError, same path as today's data.error", async () => {
+    const sse = makeSseReader();
+    fetchMock = vi.fn(async () => sseResponse(sse.reader));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = mount();
+    await armAndFire(result);
+
+    act(() => sse.push("error", { detail: "no feasible point" }));
+    act(() => sse.close());
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.optError).toBe("no feasible point");
+    expect(result.current.optResult).toBeNull();
+    expect(setParamAtPath).not.toHaveBeenCalled();
+    expect(result.current.optRunning).toBe(false);
+  });
+
+  it("abort mid-stream tears the reader down and stops further updates", async () => {
+    // Each fetch call gets ITS OWN reader — a superseded run's frames must
+    // not leak into the run that replaced it, only its abort/cancel should.
+    const streams: ReturnType<typeof makeSseReader>[] = [];
+    fetchMock = vi.fn(async () => {
+      const s = makeSseReader();
+      streams.push(s);
+      return sseResponse(s.reader);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = mount();
+    await armAndFire(result);
+    const sse = streams[0];
+
+    act(() => sse.push("progress", progressFrame(1)));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.optProgress?.n_evals).toBe(1);
+
+    // A knob change marked free re-triggers the reactive effect with a new
+    // signature, which supersedes the in-flight run — the same path a real
+    // fixed-input edit takes.
+    act(() => {
+      result.current.setKnobOpt({
+        "dipoles.probe": {
+          length_factor: { vary: true, optMin: 0.7, optMax: 1.3, dispMin: 0.7, dispMax: 1.3, step: 0.001 },
+        },
+      });
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+      await Promise.resolve();
+    });
+
+    // The superseded run's reader was torn down...
+    expect(sse.canceled).toBe(true);
+    // ...and a frame pushed to the now-abandoned stream after that must not
+    // land: this is exactly what breaks if the `ctrl.signal.aborted` guard
+    // inside the SSE loop is dropped.
+    act(() => sse.push("progress", progressFrame(99)));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.optProgress?.n_evals).not.toBe(99);
+
+    // A fresh run is what's actually in flight now.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("without a streaming content-type, falls back to the plain-JSON path unchanged", async () => {
+    fetchMock = vi.fn(async () => ({
+      headers: { get: () => "application/json" },
+      json: async () => RESULT,
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = mount();
+    await armAndFire(result);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.optResult).toEqual(RESULT);
+    expect(setParamAtPath).toHaveBeenCalledWith(["length_factor"], 0.99);
+    expect(result.current.optProgress).toBeNull();
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/viewRegistry.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/viewRegistry.test.tsx
@@ -88,6 +88,7 @@ const PROPS: Omit<ViewRenderProps, "showWireLabels" | "showFeedNames" | "schemat
   size: 180,
   fill: true,
   result: null,
+  liveZ: null,
   preview: null,
   sweep: null,
   converge: null,

--- a/src/antennaknobs/web/frontend/src/__tests__/viewRegistry.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/viewRegistry.test.tsx
@@ -7,7 +7,7 @@
 // renderer) typechecks fine, so only a mounted probe catches it.
 import { describe, it, expect, vi } from "vitest";
 import { render } from "@testing-library/react";
-import { VIEWS, type View } from "../lib/view";
+import { VIEWS, VIEW_META, type View } from "../lib/view";
 import { VIEW_RENDERERS, type ViewRenderProps } from "../components/results/viewRegistry";
 import { ViewPanel } from "../components/results/ViewPanel";
 
@@ -79,6 +79,21 @@ describe("view metadata", () => {
     expect(VIEWS.filter((v) => v.defaultPinned).map((v) => v.id).sort()).toEqual(
       ["antenna", "azimuth", "elevation", "smith"],
     );
+  });
+
+  // An optimizer run leaves the knobs alone until it finishes, so anything
+  // drawn from the last solve describes the PRE-RUN design while the readout
+  // ticks through candidates (#773). Those views dim; the two that stay
+  // honest must not, and that is the half worth pinning — dimming the Smith
+  // chart would hide the one live thing on screen, and dimming the schematic
+  // would disown a drawing that is still exactly right.
+  it("marks every pre-run view stale while optimizing, and only those", () => {
+    const stale = VIEWS.filter((v) => v.staleWhileOptimizing).map((v) => v.id);
+    expect(stale.sort()).toEqual(
+      ["antenna", "azimuth", "elevation", "gamma", "vswr"],
+    );
+    expect(VIEW_META.smith.staleWhileOptimizing).toBe(false);
+    expect(VIEW_META.schematic.staleWhileOptimizing).toBe(false);
   });
 });
 

--- a/src/antennaknobs/web/frontend/src/components/charts/SmithChart.tsx
+++ b/src/antennaknobs/web/frontend/src/components/charts/SmithChart.tsx
@@ -18,6 +18,7 @@ export function SmithChart({
   feeds,
   multiFeed,
   connectSweep = false,
+  trial = false,
 }: {
   r: number;
   x: number;
@@ -45,6 +46,10 @@ export function SmithChart({
    *  polyline read as artificial kinks") is exactly what refinement
    *  removes. Off (refinement disabled) keeps the honest dot cloud. */
   connectSweep?: boolean;
+  /** `r`/`x` are a PROPOSED point (a streamed optimizer eval, #773), not a
+   *  settled solve: draw a hollow ring and ignore `feeds`, which still holds
+   *  the previous solve's per-port dots. */
+  trial?: boolean;
 }) {
   const theme = useContext(ThemeContext); // repaint on theme toggle (dep below)
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -474,8 +479,16 @@ export function SmithChart({
     // (freq sweep), bright = "you are here." The previous golden +
     // glow + line-from-centre treatment for single-feed is gone —
     // single-feed and feed-0-of-multi-feed now look identical.
-    const markerPoints: Array<{ re: number; im: number; fi: number }> =
-      feeds && feeds.length > 0
+    // `trial` overrides the feed list rather than joining it: a proposed
+    // point is one driven-port impedance, while `feeds` still holds the LAST
+    // SOLVE's per-port dots. Letting those win would leave a multi-feed
+    // design showing stale dots and no trial point at all — the frozen-dot
+    // bug this prop exists to fix, hiding in the multi-feed branch.
+    const markerPoints: Array<{ re: number; im: number; fi: number }> = trial
+      ? r > 0 || x !== 0
+        ? [{ re: r, im: x, fi: 0 }]
+        : []
+      : feeds && feeds.length > 0
         ? feeds.map((f, fi) => ({ re: f.z_re, im: f.z_im, fi }))
         : r > 0 || x !== 0
           ? [{ re: r, im: x, fi: 0 }]
@@ -485,6 +498,20 @@ export function SmithChart({
       const { gRe, gIm } = reflectionCoefficient(m.re, m.im, z0);
       const px = cx + gRe * R;
       const py = cy - gIm * R;
+      if (trial) {
+        // Hollow ring, not a filled dot. The chart's grammar is already
+        // filled = settled / hollow = the other end of a trail, so a ring
+        // reads as "being tried" rather than "this is your antenna" — which
+        // matters because nothing else on the chart has caught up yet: the
+        // sweep locus and any measured overlay still describe the geometry
+        // as it was before the run started.
+        ctx.strokeStyle = feedColor(m.fi);
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.arc(px, py, 5, 0, 2 * Math.PI);
+        ctx.stroke();
+        continue;
+      }
       ctx.fillStyle = feedColor(m.fi);
       ctx.beginPath();
       ctx.arc(px, py, 4, 0, 2 * Math.PI);
@@ -582,7 +609,10 @@ export function SmithChart({
     // initial false to the real /examples value (true for bowtie /
     // hexbeam_5band) — the user saw only one Z* annotation in the
     // legend because the closure stayed wedged on the single-feed branch.
-  }, [r, x, z0, size, sweep, converge, measured, measFreqMhz, running, convergeRunning, feeds, multiFeed, connectSweep, theme]);
+    // `trial` is in the deps for the same reason: it decides both the marker
+    // shape and whether `feeds` is consulted at all, so a stale closure would
+    // leave the last trial ring on screen after a run settled.
+  }, [r, x, z0, size, sweep, converge, measured, measFreqMhz, running, convergeRunning, feeds, multiFeed, connectSweep, trial, theme]);
 
   return <canvas ref={canvasRef} className="smith" />;
 }

--- a/src/antennaknobs/web/frontend/src/components/results/viewRegistry.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/viewRegistry.tsx
@@ -41,6 +41,17 @@ export type ViewRenderProps = {
    *  frequency-sorted samples finally support one). Optional: thumbnail
    *  call sites omit it and keep the dot trail. */
   refineEnabled?: boolean;
+  // A trial impedance to plot INSTEAD of `result`'s, while something drives
+  // the design faster than the solve channel can follow — today the streamed
+  // optimizer (#773), whose per-eval frames carry Z but do not touch the
+  // knobs until the run ends, so `result` sits at the last real solve for the
+  // whole run and the dot appears frozen.
+  //
+  // Structural rather than the optimizer's own type: the view layer does not
+  // care who is proposing the point. REQUIRED, not defaulted — a new view
+  // surface that forgot it would silently show a frozen dot again, which is
+  // the defect this exists to fix, so the compiler names every call site.
+  liveZ: { z_in_re: number; z_in_im: number; z0_ohms: number } | null;
   schematicSvg: string | null;
   schematicUnavailable: boolean;
 };
@@ -96,11 +107,16 @@ export const VIEW_RENDERERS: Record<View, (p: ViewRenderProps) => ReactElement> 
       fineNorm={p.fineNorm}
     />
   ),
+  // liveZ wins over result while it is set: during an optimizer run it is the
+  // only current impedance there is (see ViewRenderProps.liveZ). The z0
+  // fallback chain still ends at result's, so a trial point is plotted on the
+  // same reference the settled dot uses.
   smith: (p) => (
     <SmithChart
-      r={p.result?.z_in_re ?? 0}
-      x={p.result?.z_in_im ?? 0}
-      z0={p.result?.z0_ohms ?? 50}
+      r={p.liveZ?.z_in_re ?? p.result?.z_in_re ?? 0}
+      x={p.liveZ?.z_in_im ?? p.result?.z_in_im ?? 0}
+      z0={p.liveZ?.z0_ohms ?? p.result?.z0_ohms ?? 50}
+      trial={p.liveZ != null}
       size={p.size}
       sweep={p.sweep}
       converge={p.converge}

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -782,6 +782,7 @@ function DesignSessionBody({
     setKnobMenu,
     optRunning,
     optResult,
+    optProgress,
     optError,
     optPausedBy,
     setOptPausedBy,
@@ -1425,6 +1426,7 @@ function DesignSessionBody({
           optObjective={optObjective}
           setOptObjective={setOptObjective}
           optResult={optResult}
+          optProgress={optProgress}
           optError={optError}
           optPausedBy={optPausedBy}
         />

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -1579,6 +1579,11 @@ function DesignSessionBody({
             size={size}
             fill={fill}
             result={result}
+            // An optimizer run never touches the knobs until it finishes, so
+            // `result` holds the pre-run solve for its whole duration and the
+            // Smith dot would sit frozen while the readout ticks (#773). The
+            // per-eval frames carry the trial Z, so hand it to the chart.
+            liveZ={optRunning && optProgress ? optProgress.metrics : null}
             preview={preview}
             sweep={sweep}
             converge={converge}
@@ -1747,6 +1752,10 @@ function DesignSessionBody({
                       size={thumbSize.width}
                       fill={false}
                       result={result}
+                      // Same live trial point as the primary stage: the
+                      // thumbnail is the same chart, so a frozen dot there
+                      // would be the same defect at a smaller size.
+                      liveZ={optRunning && optProgress ? optProgress.metrics : null}
                       preview={preview}
                       sweep={sweep}
                       converge={converge}

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -1502,6 +1502,19 @@ function DesignSessionBody({
     />
   );
 
+  // Is what's on the stage describing something other than what the numbers
+  // say? Two independent causes, same honest answer — dim it (#773).
+  //
+  //  - a solve is in flight (`stale` from the channel): the old answer is
+  //    still up while a new one computes;
+  //  - an optimizer run is in flight: the knobs are untouched until it
+  //    finishes, so every pre-run view keeps describing the pre-run design
+  //    while the readout ticks through candidates. Per view, because the
+  //    Smith chart follows the run live and the schematic stays accurate —
+  //    dimming those would be the same lie in the other direction.
+  const outputStale =
+    stale || (optRunning && VIEW_META[view].staleWhileOptimizing);
+
   // One output view: the per-view overlays plus the main <ViewPanel>. A
   // closure (not a component) so the ~30 captured locals need no props. The
   // solve-readout HUD stays OUT of it — mobile chart screens must not
@@ -1626,7 +1639,7 @@ function DesignSessionBody({
         >
           {solveOverlays}
           <div
-            className={`mobile-carousel${stale ? " stale" : ""}`}
+            className={`mobile-carousel${outputStale ? " stale" : ""}`}
             ref={mobileCarouselRef}
             onScroll={onMobileCarouselScroll}
           >
@@ -1792,7 +1805,7 @@ function DesignSessionBody({
               />
             </div>
             <div
-              className={`carousel-slide${stale ? " stale" : ""}`}
+              className={`carousel-slide${outputStale ? " stale" : ""}`}
               ref={slideRef}
             >
               {renderOutput(view, chartSize, view === "antenna")}

--- a/src/antennaknobs/web/frontend/src/components/session/VfoPanel.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/VfoPanel.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import type { BandSpec, ExampleDescriptor } from "../../lib/params";
 
 // Response from POST /optimize.
-type OptMetrics = { z_in_re: number; z_in_im: number; z0_ohms: number; swr: number };
+export type OptMetrics = { z_in_re: number; z_in_im: number; z0_ohms: number; swr: number };
 export type OptimizeResult = {
   objective: string;
   params: Record<string, number>;
@@ -14,6 +14,15 @@ export type OptimizeResult = {
   metrics_after: OptMetrics;
   n_evals: number;
   improved: boolean;
+};
+// One `event: progress` frame from the streamed /optimize (issue #773 unit
+// 4) — a mid-run snapshot, not a final outcome; `objective` is the raw
+// scalar being minimised, unlike OptimizeResult's before/after pair.
+export type OptProgress = {
+  n_evals: number;
+  params: Record<string, number>;
+  objective: number;
+  metrics: OptMetrics;
 };
 export type OptObjective = "swr" | "resonance" | "match_z0";
 const OPT_OBJECTIVE_LABELS: Record<OptObjective, string> = {
@@ -44,6 +53,7 @@ function SimControls({
   optObjective,
   setOptObjective,
   optResult,
+  optProgress,
   optError,
   optPausedBy,
 }: {
@@ -56,6 +66,7 @@ function SimControls({
   optObjective: OptObjective;
   setOptObjective: (v: OptObjective) => void;
   optResult: OptimizeResult | null;
+  optProgress: OptProgress | null;
   optError: string | null;
   optPausedBy: OptPause | null;
 }) {
@@ -129,7 +140,20 @@ function SimControls({
           </>
         )}
       </div>
-      {optEnabled && optResult && (
+      {/* Live progress (#773 unit 4): while a run is in flight, the eval
+          count/objective/Z-SWR readout tracks the latest `progress` frame
+          instead of the previous run's settled result — optProgress is reset
+          to null at the start of every run, so this only shows once the
+          first frame lands. */}
+      {optEnabled && optRunning && optProgress && (
+        <span
+          className="opt-readout opt-readout-progress"
+          title={`eval ${optProgress.n_evals} — objective ${optProgress.objective.toFixed(4)}, Z ${optProgress.metrics.z_in_re.toFixed(1)} ${optProgress.metrics.z_in_im >= 0 ? "+" : "−"} j${Math.abs(optProgress.metrics.z_in_im).toFixed(1)} Ω`}
+        >
+          #{optProgress.n_evals} SWR {optProgress.metrics.swr.toFixed(2)}
+        </span>
+      )}
+      {optEnabled && !optRunning && optResult && (
         <span className="opt-readout" title="SWR after optimisation">
           SWR {optResult.metrics_after.swr.toFixed(2)}
         </span>
@@ -188,6 +212,7 @@ export function VfoPanel({
   optObjective,
   setOptObjective,
   optResult,
+  optProgress,
   optError,
   optPausedBy,
 }: {
@@ -213,6 +238,7 @@ export function VfoPanel({
   optObjective: OptObjective;
   setOptObjective: (v: OptObjective) => void;
   optResult: OptimizeResult | null;
+  optProgress: OptProgress | null;
   optError: string | null;
   optPausedBy: OptPause | null;
 }) {
@@ -262,6 +288,7 @@ export function VfoPanel({
             optObjective={optObjective}
             setOptObjective={setOptObjective}
             optResult={optResult}
+            optProgress={optProgress}
             optError={optError}
             optPausedBy={optPausedBy}
           />

--- a/src/antennaknobs/web/frontend/src/components/session/useOptimizer.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useOptimizer.ts
@@ -11,7 +11,56 @@ import {
   type OptimizeResult,
   type OptObjective,
   type OptPause,
+  type OptProgress,
 } from "./VfoPanel";
+
+// One decoded `event: X\ndata: Y` frame off an SSE byte stream.
+type SseFrame = { event: string; data: string };
+
+// Frames `event:`/`data:` lines separated by a blank line (issue #773 unit
+// 4's pinned contract: progress/result/error, exactly one terminal event per
+// stream). Multi-line `data:` fields join with `\n` per the SSE spec, though
+// this contract only ever sends one JSON line per field.
+//
+// `signal`'s abort cancels the reader directly rather than relying on the
+// fetch's own abort propagation: a stubbed test transport's stream has no
+// such propagation, and canceling a reader with a read pending resolves that
+// read as done (WHATWG streams), which is what unblocks the loop below.
+async function* readSseFrames(
+  body: ReadableStream<Uint8Array>,
+  signal: AbortSignal,
+): AsyncGenerator<SseFrame> {
+  const reader = body.getReader();
+  const onAbort = () => {
+    reader.cancel().catch(() => {});
+  };
+  signal.addEventListener("abort", onAbort);
+  const decoder = new TextDecoder();
+  let buf = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      let sep = buf.indexOf("\n\n");
+      while (sep !== -1) {
+        const block = buf.slice(0, sep);
+        buf = buf.slice(sep + 2);
+        let event = "message";
+        const dataLines: string[] = [];
+        for (const line of block.split("\n")) {
+          if (line.startsWith("event:")) event = line.slice(6).trim();
+          else if (line.startsWith("data:")) dataLines.push(line.slice(5).trim());
+        }
+        if (dataLines.length > 0) yield { event, data: dataLines.join("\n") };
+        sep = buf.indexOf("\n\n");
+      }
+    }
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+    reader.releaseLock();
+  }
+}
 
 // --- Reactive knob optimiser (POST /optimize) ---
 //
@@ -66,6 +115,9 @@ export function useOptimizer({
   );
   const [optRunning, setOptRunning] = useState(false);
   const [optResult, setOptResult] = useState<OptimizeResult | null>(null);
+  // Latest `progress` frame of the in-flight run; reset to null at the start
+  // of every runOptimize call so a stale frame never outlives its run.
+  const [optProgress, setOptProgress] = useState<OptProgress | null>(null);
   const [optError, setOptError] = useState<string | null>(null);
   // When something auto-pauses the optimizer, this holds *why* for a brief cue
   // (cleared on re-enable / after a few seconds): grabbing a knob marked for
@@ -95,6 +147,7 @@ export function useOptimizer({
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setKnobMenu(null);
     setOptResult(null);
+    setOptProgress(null);
     setOptError(null);
     if (optEnabledRef.current) {
       setOptEnabled(false);
@@ -103,11 +156,27 @@ export function useOptimizer({
     // optEnabledRef is read (not a dep) on purpose — see its declaration.
   }, [geometry]);
 
+  // Apply a settled /optimize outcome exactly as before: stash it for the
+  // readout, and push every returned param through the normal onChange path
+  // (which re-solves). Shared by the streaming `result` event and the
+  // non-streaming JSON body.
+  function applyOptimizeResult(data: OptimizeResult) {
+    setOptResult(data);
+    for (const [name, val] of Object.entries(data.params)) {
+      setParamAtPath([name], val);
+    }
+  }
+
   // Run the optimiser once: POST the current solve request + the free knobs
   // (from each knob's menu) and objective, then apply the returned params to the
   // knobs (re-solving via the normal onChange path). Warm-started from the
   // current values; a newer run aborts the previous so stale results are
   // dropped. Always uses the momwire engine server-side.
+  //
+  // Requests `text/event-stream` (issue #773's pinned contract) to get live
+  // `progress` frames; a server that doesn't stream yet ignores the header
+  // and answers with today's plain JSON, which the content-type check below
+  // routes to the unchanged single-shot path.
   async function runOptimize() {
     const settings = knobOpt[geometry] ?? {};
     const free = Object.entries(settings)
@@ -119,10 +188,14 @@ export function useOptimizer({
     optAbortRef.current = ctrl;
     setOptRunning(true);
     setOptError(null);
+    setOptProgress(null);
     try {
       const resp = await fetch("/optimize", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "text/event-stream",
+        },
         signal: ctrl.signal,
         body: JSON.stringify({
           ...buildRequest(),
@@ -130,14 +203,28 @@ export function useOptimizer({
           optimize: { free, objective: optObjective, max_evals: 40 },
         }),
       });
-      const data = await resp.json();
       if (ctrl.signal.aborted) return; // superseded by a newer run
-      if (data.error) {
-        setOptError(String(data.error));
+      const streaming = (resp.headers.get("content-type") ?? "").includes(
+        "text/event-stream",
+      );
+      if (streaming && resp.body) {
+        for await (const { event, data } of readSseFrames(resp.body, ctrl.signal)) {
+          if (ctrl.signal.aborted) break; // superseded mid-stream
+          if (event === "progress") {
+            setOptProgress(JSON.parse(data) as OptProgress);
+          } else if (event === "result") {
+            applyOptimizeResult(JSON.parse(data) as OptimizeResult);
+          } else if (event === "error") {
+            setOptError(String((JSON.parse(data) as { detail: string }).detail));
+          }
+        }
       } else {
-        setOptResult(data as OptimizeResult);
-        for (const [name, val] of Object.entries((data as OptimizeResult).params)) {
-          setParamAtPath([name], val);
+        const data = await resp.json();
+        if (ctrl.signal.aborted) return; // superseded while the body was read
+        if (data.error) {
+          setOptError(String(data.error));
+        } else {
+          applyOptimizeResult(data as OptimizeResult);
         }
       }
     } catch (e) {
@@ -245,6 +332,7 @@ export function useOptimizer({
     setKnobMenu,
     optRunning,
     optResult,
+    optProgress,
     optError,
     optPausedBy,
     setOptPausedBy,

--- a/src/antennaknobs/web/frontend/src/lib/view.ts
+++ b/src/antennaknobs/web/frontend/src/lib/view.ts
@@ -13,13 +13,34 @@ export type ViewMeta = {
   // Read once, by useViewPrefs, to seed a first run; after that the user's
   // stored set wins, so flipping this only affects new users.
   defaultPinned: boolean;
+  // Whether this view goes STALE for the duration of an optimizer run (#773).
+  //
+  // A run never touches the knobs until it finishes, so anything drawn from
+  // the last solve keeps describing the pre-run design while the readout
+  // ticks through candidates — a screen of mixed provenance, where the number
+  // and the picture disagree and nothing says so. Views that are entirely
+  // pre-run dim (the same `.stale` treatment a slow solve already uses);
+  // views carrying live or still-accurate content must not.
+  //
+  // Required, not defaulted: a new view's answer is never obviously false, so
+  // the compiler should make someone decide.
+  staleWhileOptimizing: boolean;
 };
 export const VIEWS: ViewMeta[] = [
-  { id: "antenna", label: "Antenna", defaultPinned: true },
-  { id: "azimuth", label: "Azimuth (xy)", defaultPinned: true },
-  { id: "elevation", label: "Elevation (yz)", defaultPinned: true },
-  { id: "smith", label: "Smith", defaultPinned: true },
-  { id: "schematic", label: "Schematic", defaultPinned: false },
+  // Geometry and currents are both drawn from the last solve, i.e. the knobs
+  // as they stand — which is not the candidate being evaluated.
+  { id: "antenna", label: "Antenna", defaultPinned: true, staleWhileOptimizing: true },
+  { id: "azimuth", label: "Azimuth (xy)", defaultPinned: true, staleWhileOptimizing: true },
+  { id: "elevation", label: "Elevation (yz)", defaultPinned: true, staleWhileOptimizing: true },
+  // NOT stale: the dot follows the run's per-eval frames (ViewRenderProps'
+  // liveZ), so this is the one view that is live. Its sweep locus is still
+  // pre-run, which is why the live point draws as a hollow ring rather than
+  // claiming to be a settled solve.
+  { id: "smith", label: "Smith", defaultPinned: true, staleWhileOptimizing: false },
+  // NOT stale: built from `build_network()` on the CURRENT knob values, and
+  // an optimizer run leaves those alone until it applies its result — so the
+  // drawing on screen stays accurate for the whole run.
+  { id: "schematic", label: "Schematic", defaultPinned: false, staleWhileOptimizing: false },
   // Sweep-derived views (issue #700 unit 5, docs/plan-view-rail-scaling.md
   // items 6/7): the sweep data already flows to the Smith chart, so these
   // are a second and third presentation of it, not a new data path. Ship
@@ -27,8 +48,10 @@ export const VIEWS: ViewMeta[] = [
   // "gamma" keeps its id (persisted pin sets store ids) but presents as S11
   // in dB — the VNA/NanoVNA log-magnitude convention, which is what this
   // audience reads; linear |Γ| only ever appears as a Smith-chart radius.
-  { id: "gamma", label: "S11 (dB) vs freq", defaultPinned: false },
-  { id: "vswr", label: "VSWR vs freq", defaultPinned: false },
+  // Frequency sweeps of the pre-run geometry: the whole curve is stale for
+  // the duration, and unlike the Smith chart there is no live point on them.
+  { id: "gamma", label: "S11 (dB) vs freq", defaultPinned: false, staleWhileOptimizing: true },
+  { id: "vswr", label: "VSWR vs freq", defaultPinned: false, staleWhileOptimizing: true },
 ];
 
 // Id → metadata, for the consumers that hold a list of ids in the USER's

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -2893,6 +2893,11 @@ canvas {
 .opt-readout-err {
   color: var(--danger, #c0392b);
 }
+/* Live progress (#773 unit 4): accent color, same family as opt-pip, marks
+   the readout as updating mid-run rather than the settled post-run figure. */
+.opt-readout-progress {
+  color: var(--accent);
+}
 /* Auto-pause cue: the optimizer stepped aside because the user grabbed a
    marked knob. Use the "hot" accent so it reads as a deliberate, momentary
    state change rather than an error. */

--- a/src/antennaknobs/web/optimize.py
+++ b/src/antennaknobs/web/optimize.py
@@ -75,12 +75,17 @@ def optimize(
     *,
     solve_fn: Callable[[dict], dict],
     max_evals: int | None = None,
+    on_progress: Callable[[dict], None] | None = None,
 ) -> dict:
     """Optimise ``objective`` over the ``free`` params within their bounds.
 
     ``free`` is a list of ``{"name", "min", "max"}``. ``solve_fn`` takes a solve
     request and returns a response carrying ``z_in_re``/``z_in_im``/``z0_ohms``.
     Returns the best params found plus before/after objective + metrics.
+
+    ``on_progress``, if given, is called once per solve (see ``_solve_at``) with
+    ``{"n_evals", "params", "objective", "metrics"}``. ``None`` (the default)
+    leaves behaviour identical to no callback support at all.
     """
     if not free:
         raise ValueError("no free params selected to optimise")
@@ -102,10 +107,31 @@ def optimize(
     def _solve_at(x) -> dict:
         nonlocal n_evals
         req = dict(base_req)
+        params = {}
         for name, v in zip(names, x):
-            req[name] = float(v)
+            val = float(v)
+            req[name] = val
+            params[name] = val
         n_evals += 1
-        return solve_fn(req)
+        out = solve_fn(req)
+        # Emitted here, not via scipy's minimize(callback=...): that callback
+        # fires once per Nelder-Mead ITERATION (a reflection/expansion/contraction
+        # that itself costs 1-2 evals), not once per eval — e.g. ~30 callbacks for
+        # 60 evals — and it doesn't fire at all until the initial simplex (N+1
+        # evals) is built, leaving a dead zone at the start of every run. Every
+        # solve, in every phase (baseline, simplex, confirmation), goes through
+        # this one choke point, so hooking here is the only way to get gapless
+        # per-eval granularity that also covers the initial-simplex evals.
+        if on_progress is not None:
+            on_progress(
+                {
+                    "n_evals": n_evals,
+                    "params": params,
+                    "objective": _objective_value(out, objective),
+                    "metrics": _metrics(out),
+                }
+            )
+        return out
 
     def f(x) -> float:
         return _objective_value(_solve_at(x), objective)

--- a/src/antennaknobs/web/progress_stream.py
+++ b/src/antennaknobs/web/progress_stream.py
@@ -1,0 +1,301 @@
+"""Thread-safe progress bridge: threadpool worker → asyncio consumer (issue #773).
+
+The optimiser's objective runs under ``run_in_threadpool``, so its
+``on_progress`` callback fires on an anyio worker thread and cannot ``await``.
+The endpoint that streams those events is an async ``StreamingResponse`` on the
+event loop. :class:`ProgressStream` is that bridge and nothing else — no web
+framework, no optimiser import — so its concurrency claims are provable in
+isolation. Producer side is :meth:`ProgressStream.publish` (one dict, matching
+the ``Callable[[dict], None]`` of contract C3); consumer side is
+:meth:`ProgressStream.events`.
+
+Why this mechanism
+------------------
+``asyncio.Queue`` is not thread safe: its ``put_nowait`` mutates a deque and
+wakes futures with no lock, so calling it from a worker corrupts waiter state
+under contention — the classic defect that survives single-user local dev and
+falls over under load. ``queue.Queue.get`` is thread safe but *blocks*, which
+on the loop thread stalls every other request; wrapping it in
+``run_in_executor`` costs one more parked thread per pending get, which is the
+same disease. ``janus`` exists precisely for this and would be the obvious
+answer, but a new third-party dependency is out of scope here.
+
+So: a plain :class:`collections.deque` under a :class:`threading.Lock` holds
+the events (mutation from either thread is safe), and the consumer is woken
+through ``loop.call_soon_threadsafe`` — the *only* loop API documented as
+callable from another OS thread.
+
+INVARIANT: no asyncio object is touched from the worker thread except
+``loop.call_soon_threadsafe`` inside :meth:`_wake_consumer`. That method is the
+single documented entry point; everything else the producer calls (``publish``,
+``finish``, ``fail``, ``close``) touches only the lock, the deque and plain
+attributes. The loop reference itself is captured by the *consumer* in
+:meth:`events` and only ever read (under the lock) by ``_wake_consumer``.
+
+Bounded queue: drop oldest, with a counter
+------------------------------------------
+The buffer is capped at ``maxsize`` and a full ``publish`` discards the OLDEST
+pending event, increments :attr:`dropped`, and returns without blocking.
+Rejected alternatives and why:
+
+* *Unbounded* — a browser that stops reading (backgrounded tab, dead TCP
+  socket that has not timed out yet) grows the buffer for the whole run.
+* *Block, with or without timeout* — parks an anyio worker thread on a
+  consumer that may never drain. anyio's default limiter is 40 threads for the
+  whole process, so a handful of stalled browsers stalls every solve on the
+  box. A blocked producer is exactly the "works locally, fails under load"
+  failure this unit exists to rule out.
+
+Dropping the oldest (rather than the newest) is what a progress readout wants:
+these events are *state*, not a ledger. A superseded eval count / objective /
+SWR has no value once a newer one exists, so a slow consumer should see the
+current state, not a stale prefix. Delivered events keep their relative order —
+they are a subsequence of what was published, never a reordering.
+
+Terminal events bypass the bound entirely: they are stored in a separate slot,
+so the run's actual result can never be dropped no matter how far behind the
+consumer is.
+
+Termination
+-----------
+Exactly one terminal event (``result`` or ``error``) ends a stream, matching
+contract C2. The iterator yields it and then stops, so a consumer can always
+distinguish "the run ended" (iteration finished, and the last event says how)
+from "nothing yet" (iteration still pending). Teardown works from either end:
+
+* consumer gone — :meth:`events` calls :meth:`close` on exit (return, break,
+  task cancellation, generator finalisation), after which :meth:`publish`
+  raises :class:`ProgressStreamClosed` on the worker, which propagates out of
+  the objective and aborts the run promptly instead of computing solves nobody
+  will read.
+* producer gone — :meth:`sealed` guarantees a terminal event even if the
+  producer raises or returns without one, so the consumer can never hang
+  waiting on a thread that has already died.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections import deque
+from collections.abc import AsyncIterator, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Literal
+
+# Event kinds are the SSE event names of contract C2 verbatim, so a consumer
+# can frame one as ``f"event: {ev.kind}\ndata: {json.dumps(ev.data)}\n\n"``
+# without a translation table.
+EventKind = Literal["progress", "result", "error"]
+
+_TERMINAL_KINDS = ("result", "error")
+
+# Events buffered before the oldest starts being dropped. One progress event is
+# a few hundred bytes and is produced at most once per MoM solve (seconds
+# apart), so this is minutes of backlog for a consumer that is merely slow —
+# deep enough that only a consumer that has genuinely stopped reading hits it.
+DEFAULT_MAXSIZE = 64
+
+
+class ProgressStreamClosed(RuntimeError):
+    """Raised by :meth:`ProgressStream.publish` once the stream is finished —
+    the consumer disconnected, its loop died, or a terminal event was already
+    delivered. Producers are expected to let it propagate: it is the signal
+    that the work being reported on is no longer wanted."""
+
+
+@dataclass(frozen=True, slots=True)
+class ProgressEvent:
+    """One SSE-shaped event. ``data`` is the caller's payload, stored by
+    reference and never mutated by this module."""
+
+    kind: EventKind
+    data: dict
+
+    @property
+    def terminal(self) -> bool:
+        return self.kind in _TERMINAL_KINDS
+
+
+class ProgressStream:
+    """A single-producer / single-consumer bridge from a worker thread to the
+    event loop. See the module docstring for the mechanism and the drop policy.
+
+    Every public method is safe to call from any thread. Only :meth:`events`
+    requires a running loop, and only it may be called concurrently by one
+    consumer.
+    """
+
+    def __init__(self, *, maxsize: int = DEFAULT_MAXSIZE) -> None:
+        if maxsize < 1:
+            raise ValueError("maxsize must be >= 1")
+        self._maxsize = int(maxsize)
+        self._lock = threading.Lock()
+        self._pending: deque[ProgressEvent] = deque()
+        self._terminal: ProgressEvent | None = None
+        self._closed = False
+        self._dropped = 0
+        # Written once by the consumer in events(); read under the lock by
+        # _wake_consumer. The producer never touches either object directly.
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._wake: asyncio.Event | None = None
+
+    # -- producer side (any thread) -----------------------------------------
+
+    def publish(self, payload: dict) -> None:
+        """Queue one ``progress`` event. Never blocks.
+
+        Signature-compatible with contract C3's ``on_progress``. Raises
+        :class:`ProgressStreamClosed` if nobody is listening any more.
+        """
+        with self._lock:
+            if self._closed:
+                raise ProgressStreamClosed("progress stream closed by consumer")
+            if self._terminal is not None:
+                raise ProgressStreamClosed("progress stream already terminated")
+            if len(self._pending) >= self._maxsize:
+                self._pending.popleft()
+                self._dropped += 1
+            self._pending.append(ProgressEvent("progress", payload))
+        self._wake_consumer()
+
+    def finish(self, result: dict) -> bool:
+        """Terminate the stream with the run's final payload. Returns False if
+        the stream was already terminal or closed (first terminal wins, so a
+        late ``fail`` after a ``finish`` cannot rewrite history)."""
+        return self._terminate("result", result)
+
+    def fail(self, detail: str) -> bool:
+        """Terminate the stream with an error. Returns False if already
+        terminal or closed."""
+        return self._terminate("error", {"detail": detail})
+
+    def close(self) -> None:
+        """Abandon the stream from either end. Idempotent. Pending events are
+        discarded and the next :meth:`publish` raises. The consumer calls this
+        on its way out; a producer can call it to disown a stream nobody
+        terminated."""
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._pending.clear()
+        self._wake_consumer()
+
+    @contextmanager
+    def sealed(self) -> Iterator[ProgressStream]:
+        """Guarantee exactly one terminal event around a producer body.
+
+        An exception escaping the body becomes an ``error`` event before it
+        propagates; a body that returns without calling :meth:`finish` gets a
+        terminal event anyway. Without this, a producer that dies between
+        events leaves the consumer awaiting a thread that no longer exists.
+        :class:`ProgressStreamClosed` is re-raised untouched — the consumer is
+        already gone, so there is nothing left to seal.
+        """
+        try:
+            yield self
+        except ProgressStreamClosed:
+            raise
+        except BaseException as exc:
+            self.fail(f"{type(exc).__name__}: {exc}")
+            raise
+        finally:
+            # No-op when a terminal event was already set.
+            self.fail("producer exited without a result")
+
+    # -- consumer side (event loop only) ------------------------------------
+
+    async def events(self) -> AsyncIterator[ProgressEvent]:
+        """Yield events in publication order, ending with the terminal one.
+
+        Iteration stops after a ``result``/``error`` event, or immediately if
+        the stream was closed without one. :meth:`close` runs on the way out
+        however iteration ends, so a disconnected client tears the producer
+        down.
+        """
+        loop = asyncio.get_running_loop()
+        with self._lock:
+            if self._loop is not None:
+                raise RuntimeError("ProgressStream supports a single consumer")
+            self._loop = loop
+            self._wake = asyncio.Event()
+        wake = self._wake
+        try:
+            while True:
+                # Clear BEFORE draining: a publish that lands between the
+                # drain and the await has already scheduled its set(), which
+                # then runs on the loop and cannot be lost.
+                wake.clear()
+                while True:
+                    event, last = self._take()
+                    if event is not None:
+                        yield event
+                    if last:
+                        return
+                    if event is None:
+                        break  # drained; go wait
+                await wake.wait()
+        finally:
+            self.close()
+
+    def __aiter__(self) -> AsyncIterator[ProgressEvent]:
+        return self.events()
+
+    # -- state ---------------------------------------------------------------
+
+    @property
+    def dropped(self) -> int:
+        """Progress events discarded because the consumer fell behind. A
+        consumer can report this alongside the result; a non-zero value means
+        the readout skipped evals, never that the run did."""
+        with self._lock:
+            return self._dropped
+
+    @property
+    def done(self) -> bool:
+        """True once a terminal event exists or the stream was closed — i.e.
+        no further progress will ever be published."""
+        with self._lock:
+            return self._closed or self._terminal is not None
+
+    # -- internals -----------------------------------------------------------
+
+    def _terminate(self, kind: EventKind, data: dict) -> bool:
+        with self._lock:
+            if self._closed or self._terminal is not None:
+                return False
+            self._terminal = ProgressEvent(kind, data)
+        self._wake_consumer()
+        return True
+
+    def _take(self) -> tuple[ProgressEvent | None, bool]:
+        """Pop the next deliverable event. Returns ``(event, last)``; a None
+        event with ``last`` False means "drained, nothing terminal yet"."""
+        with self._lock:
+            if self._pending:
+                return self._pending.popleft(), False
+            if self._terminal is not None:
+                # Terminal delivered: the stream is over, so later publishes
+                # must raise rather than queue into a stream nobody reads.
+                self._closed = True
+                return self._terminal, True
+            return None, self._closed
+
+    def _wake_consumer(self) -> None:
+        """THE loop entry point (see the module invariant). Called from either
+        thread; a no-op until a consumer has bound its loop."""
+        with self._lock:
+            loop, wake = self._loop, self._wake
+        if loop is None or wake is None:
+            return
+        try:
+            loop.call_soon_threadsafe(wake.set)
+        except RuntimeError:
+            # Loop already closed — the consumer's process/task is gone for
+            # good, so close so the producer's next publish raises rather than
+            # queueing into a void. (A merely *stopped* loop accepts the
+            # callback silently; only a closed one raises.)
+            with self._lock:
+                self._closed = True
+                self._pending.clear()

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -26,6 +26,7 @@ import math
 import os
 import time
 from collections import OrderedDict
+from collections.abc import AsyncIterator
 from copy import deepcopy
 from pathlib import Path
 
@@ -45,6 +46,7 @@ from . import cost as _cost
 from . import pynec_backend, user_designs
 from .examples import REGISTRY as EXAMPLES
 from .lane import LaneRegistry, Superseded, cancel_on_disconnect
+from .progress_stream import ProgressStream, ProgressStreamClosed
 
 _logger = logging.getLogger(__name__)
 
@@ -2042,8 +2044,118 @@ async def geometry_endpoint(req: dict):
     return out
 
 
+# ---------------------------------------------------------------------------
+# Streamed /optimize (issue #773): one endpoint, two representations, chosen
+# by Accept. `text/event-stream` reports the run per eval; anything else (and
+# no Accept at all) gets today's single JSON object, unchanged. Validation,
+# the hosted caps and the _shed dispatch are shared — the stream changes only
+# how a run is *reported*, never what it computes.
+# ---------------------------------------------------------------------------
+
+_SSE_MEDIA_TYPE = "text/event-stream"
+
+# Idle gap before the stream writes a comment frame. The write is what
+# discovers a silently-vanished client (see _sse_progress_body), and it also
+# keeps a proxy from reaping a connection that is merely thinking. Shorter
+# than an eval on any mesh worth streaming, so a live run's own progress
+# frames usually pre-empt it.
+_SSE_KEEPALIVE_S = 5.0
+
+# create_task alone leaves the loop holding a weak reference: a producer whose
+# consumer has already been finalised would be collectable mid-run.
+_OPT_STREAM_TASKS: set[asyncio.Task] = set()
+
+
+def _sse_frame(kind: str, data: dict) -> str:
+    """One SSE frame, contract C2's wire form.
+
+    The trailing BLANK LINE is load-bearing: an SSE parser emits on "\\n\\n",
+    so a terminal frame written without it sits in the client's buffer and is
+    never delivered. `default=str` is a fuse, not a converter — every payload
+    this endpoint builds is already plain floats/ints/strings, and a stream
+    must not die mid-flight over one odd value in a user design's metrics.
+    """
+    return f"event: {kind}\ndata: {json.dumps(data, default=str)}\n\n"
+
+
+def _sse_response(gen) -> StreamingResponse:
+    return StreamingResponse(
+        gen,
+        media_type=_SSE_MEDIA_TYPE,
+        # no-store: progress is never replayable. X-Accel-Buffering: a
+        # buffering reverse proxy would hold every frame until the run ended,
+        # which is precisely what streaming exists to avoid.
+        headers={"Cache-Control": "no-store", "X-Accel-Buffering": "no"},
+    )
+
+
+def _sse_terminal_only(kind: str, data: dict) -> StreamingResponse:
+    """A stream that is nothing but its one terminal event — the SSE form of a
+    request rejected before any work started."""
+
+    async def gen():
+        yield _sse_frame(kind, data)
+
+    return _sse_response(gen())
+
+
+async def _next_event(events):
+    """`anext` with exhaustion as a value, so the wait below can hold the
+    pending pull in a Future without StopAsyncIteration crossing it."""
+    try:
+        return await events.__anext__()
+    except StopAsyncIteration:
+        return None
+
+
+async def _sse_progress_body(
+    request: Request, stream: ProgressStream, drive
+) -> AsyncIterator[str]:
+    """Frame `stream`'s events as SSE for as long as the client is there.
+
+    Starts `drive` (the producer, an argument-free coroutine function) when
+    the body starts, and closes the stream on the way out however the body
+    ends — terminal event, disconnect, cancellation. Closing is what stops the
+    run: the producer's next publish() raises, unwinding the optimiser at its
+    next eval instead of computing solves nobody will read.
+
+    The idle tick is not decoration. This loop parks awaiting the next event
+    for as long as one MoM solve takes, and Starlette only finalises a
+    streaming body at its next send — so without a probe, a browser closed at
+    eval 3 would keep burning solves until eval 4 landed. The tick both polls
+    the receive channel and writes a comment, so either half alone catches it.
+    """
+    task = asyncio.create_task(drive())
+    _OPT_STREAM_TASKS.add(task)
+    task.add_done_callback(_OPT_STREAM_TASKS.discard)
+    events = stream.events().__aiter__()
+    pending = None
+    try:
+        while True:
+            if pending is None:
+                # Carried across ticks rather than re-issued per tick:
+                # cancelling an __anext__ tears the iterator's generator down,
+                # so the pull must never be the thing that times out.
+                pending = asyncio.ensure_future(_next_event(events))
+            done, _ = await asyncio.wait({pending}, timeout=_SSE_KEEPALIVE_S)
+            if not done:
+                if await request.is_disconnected():
+                    return
+                yield ": keepalive\n\n"
+                continue
+            event = pending.result()
+            pending = None
+            if event is None:
+                return  # closed without a terminal event: the consumer left
+            yield _sse_frame(event.kind, event.data)
+    finally:
+        if pending is not None:
+            pending.cancel()
+        stream.close()
+
+
 @app.post("/optimize")
-async def optimize_endpoint(req: dict):
+async def optimize_endpoint(req: dict, request: Request):
     """Tune a chosen subset of knobs to optimise an electrical objective.
 
     The request is a normal solve request plus an `optimize` block:
@@ -2057,22 +2169,38 @@ async def optimize_endpoint(req: dict):
     impedance-only momwire_solve (cheap — no far field), so a run is dozens of
     quick solves rather than a far-field sweep. Always uses the momwire engine
     regardless of the request's `solver` (PyNEC would be far too slow per eval).
+
+    With `Accept: text/event-stream` the same run is streamed instead: one
+    `progress` event per eval, then exactly one terminal `result` (that same
+    JSON object) or `error`. Every other Accept keeps the single-response form.
     """
     from .optimize import OBJECTIVES, optimize as _optimize
+
+    wants_sse = _SSE_MEDIA_TYPE in (request.headers.get("accept") or "")
+
+    def _reject(payload: dict):
+        """One rejection, rendered either way: the JSON path returns exactly
+        the payload it always did, the stream turns it into its one terminal
+        event. Neither ever emits progress — nothing ran."""
+        if not wants_sse:
+            return payload
+        return _sse_terminal_only("error", {"detail": payload["error"]})
 
     opt = req.get("optimize") or {}
     free = opt.get("free") or []
     if not free:
-        return {"error": "select at least one knob to vary"}
+        return _reject({"error": "select at least one knob to vary"})
     objective = opt.get("objective", "swr")
     if objective not in OBJECTIVES:
-        return {"error": f"unknown objective {objective!r}"}
+        return _reject({"error": f"unknown objective {objective!r}"})
     max_evals = opt.get("max_evals")
     if max_evals is not None:
         try:
             max_evals = int(max_evals)
         except (TypeError, ValueError):
-            return {"error": f"max_evals must be an integer (got {max_evals!r})"}
+            return _reject(
+                {"error": f"max_evals must be an integer (got {max_evals!r})"}
+            )
         if max_evals <= 0:
             max_evals = None
         elif _HOSTED:
@@ -2090,9 +2218,14 @@ async def optimize_endpoint(req: dict):
     try:
         _check_solve_size(base, use_pynec=False)
     except SolveTooLargeError as e:
-        return {"geometry": geometry, "error": str(e)}
-    try:
-        result = await run_in_threadpool(
+        return _reject({"geometry": geometry, "error": str(e)})
+
+    def _run(on_progress):
+        # THE dispatch, shared by both representations so _shed can never be
+        # on one path and not the other: it formats the error while the
+        # traceback exists and drops the frame chain before the exception
+        # crosses the thread boundary (issue #382's multi-GiB retention).
+        return run_in_threadpool(
             _shed,
             _optimize,
             base,
@@ -2100,11 +2233,40 @@ async def optimize_endpoint(req: dict):
             objective,
             solve_fn=ex.momwire_solve,
             max_evals=max_evals,
+            on_progress=on_progress,
         )
-    except Exception as exc:  # noqa: BLE001 — a user design's build_wires can raise
-        return {"geometry": geometry, "error": user_designs.format_solve_error(exc)}
-    result["geometry"] = geometry
-    return result
+
+    if not wants_sse:
+        try:
+            result = await _run(None)
+        except Exception as exc:  # noqa: BLE001 — a user design's build_wires can raise
+            return {"geometry": geometry, "error": user_designs.format_solve_error(exc)}
+        result["geometry"] = geometry
+        return result
+
+    stream = ProgressStream()
+
+    async def _drive() -> None:
+        try:
+            # sealed() is the guarantee that the consumer can never be left
+            # awaiting a producer that already died: a body that returns or
+            # raises without a terminal event gets one anyway.
+            with stream.sealed():
+                try:
+                    result = await _run(stream.publish)
+                except ProgressStreamClosed:
+                    # The consumer left and publish() aborted the run. Not an
+                    # error — and not reportable, there is nobody to report to.
+                    raise
+                except Exception as exc:  # noqa: BLE001 — user design build_wires
+                    stream.fail(user_designs.format_solve_error(exc))
+                    return
+                result["geometry"] = geometry
+                stream.finish(result)
+        except ProgressStreamClosed:
+            pass
+
+    return _sse_response(_sse_progress_body(request, stream, _drive))
 
 
 @app.get("/healthz")

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -105,7 +105,17 @@ def test_unknown_objective_falls_back_to_swr():
     assert res["objective"] == "swr"
 
 
-def test_on_progress_none_is_byte_identical_to_no_callback():
+def test_on_progress_never_perturbs_the_result():
+    """Observing a run must not change it.
+
+    Three ways of asking for the same optimisation — omitted, explicit None,
+    and a live callback — must return the identical dict. The third is the
+    one with teeth: the hook runs arbitrary caller code between the solve and
+    the return, inside the choke point every eval passes through, so a hook
+    that mutated the request, the params dict, or the eval count would steer
+    the search. Omitted-vs-None alone would not catch that.
+    """
+
     # A fixed, order-independent stub: same req in, same dict out, always.
     def solve(req: dict) -> dict:
         x = float(req["x"])
@@ -120,7 +130,17 @@ def test_on_progress_none_is_byte_identical_to_no_callback():
     )
     res_default = optimize(**kwargs)
     res_explicit_none = optimize(**kwargs, on_progress=None)
+
+    # A callback that both reads and writes what it is handed — the hostile
+    # case. Mutating the payload must not reach the optimiser's own state.
+    def meddle(ev: dict) -> None:
+        ev["params"].clear()
+        ev["n_evals"] = -1
+
+    res_observed = optimize(**kwargs, on_progress=meddle)
+
     assert res_default == res_explicit_none
+    assert res_default == res_observed
 
 
 def test_on_progress_fires_once_per_solve_with_contiguous_n_evals():

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -105,6 +105,71 @@ def test_unknown_objective_falls_back_to_swr():
     assert res["objective"] == "swr"
 
 
+def test_on_progress_none_is_byte_identical_to_no_callback():
+    # A fixed, order-independent stub: same req in, same dict out, always.
+    def solve(req: dict) -> dict:
+        x = float(req["x"])
+        return {"z_in_re": 50.0, "z_in_im": 100.0 * (x - 1.05), "z0_ohms": 50.0}
+
+    kwargs = dict(
+        base_req={"x": 0.80},
+        free=[{"name": "x", "min": 0.5, "max": 1.5}],
+        objective="resonance",
+        solve_fn=solve,
+        max_evals=15,
+    )
+    res_default = optimize(**kwargs)
+    res_explicit_none = optimize(**kwargs, on_progress=None)
+    assert res_default == res_explicit_none
+
+
+def test_on_progress_fires_once_per_solve_with_contiguous_n_evals():
+    # 2-param probe: Nelder-Mead's initial simplex needs 3 vertices (N+1 for
+    # N=2), so this exercises the dead zone scipy's own callback= misses.
+    def solve(req: dict) -> dict:
+        a, b = float(req["a"]), float(req["b"])
+        x_im = 100.0 * (a - 1.10) + 80.0 * (b - 0.90)
+        return {"z_in_re": 50.0, "z_in_im": x_im, "z0_ohms": 50.0}
+
+    calls = []
+    res = optimize(
+        {"a": 1.0, "b": 1.0},
+        [{"name": "a", "min": 0.8, "max": 1.3}, {"name": "b", "min": 0.7, "max": 1.1}],
+        "resonance",
+        solve_fn=solve,
+        max_evals=25,
+        on_progress=calls.append,
+    )
+
+    # Gate 1: exactly one callback per _solve_at call.
+    assert len(calls) == res["n_evals"]
+
+    # Gate 2 (the important one): n_evals values are gapless 1..N, proving
+    # per-eval (not per-iteration) granularity and initial-simplex coverage.
+    seen = [c["n_evals"] for c in calls]
+    assert seen == list(range(1, len(calls) + 1))
+
+    # Payload shape: objective/metrics come from the same helpers optimize()
+    # itself uses, keyed by the params passed for that particular solve.
+    first = calls[0]
+    assert set(first["params"]) == {"a", "b"}
+    assert first["objective"] == pytest.approx(
+        _objective_value_for_test(first["params"], "resonance")
+    )
+    assert set(first["metrics"]) == {"z_in_re", "z_in_im", "z0_ohms", "swr"}
+
+
+def _objective_value_for_test(params: dict, objective: str) -> float:
+    """Recompute the same |X| the stub in the contiguity test would report,
+    to cross-check the callback's reported objective independently of the
+    module's own _objective_value (avoids the test trivially re-deriving the
+    exact call under test)."""
+    a, b = params["a"], params["b"]
+    x_im = 100.0 * (a - 1.10) + 80.0 * (b - 0.90)
+    assert objective == "resonance"
+    return abs(x_im)
+
+
 @pytest.mark.antenna_computation_check
 def test_optimize_real_geometry_improves_resonance():
     """End-to-end through a real momwire solve (slow): tuning a length knob

--- a/tests/test_progress_stream.py
+++ b/tests/test_progress_stream.py
@@ -1,0 +1,598 @@
+"""Threadpool → event-loop progress bridge (issue #773, unit 2).
+
+Every concurrency claim here is pinned with an explicit handshake — a
+``threading.Event`` in one direction, an awaited task in the other — never a
+wall-clock sleep. A broken wakeup path therefore shows up as a *hang* caught by
+``asyncio.wait_for``/``join(timeout=...)``, not as an intermittent failure.
+
+The producer always runs on a real OS thread (``threading.Thread``, or
+``run_in_threadpool`` where the production shape matters); nothing here fakes
+the thread boundary the bridge exists to cross.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+from fastapi.concurrency import run_in_threadpool
+
+from antennaknobs.web.progress_stream import (
+    ProgressEvent,
+    ProgressStream,
+    ProgressStreamClosed,
+)
+
+TIMEOUT = 4.0  # only ever reached on a HANG; kept under the suite's 5 s ceiling
+
+
+def _kinds(events: list[ProgressEvent]) -> list[str]:
+    return [e.kind for e in events]
+
+
+def _ns(events: list[ProgressEvent]) -> list[int]:
+    return [e.data["n"] for e in events if e.kind == "progress"]
+
+
+# ---------------------------------------------------------------------------
+# Gate 1 — ordering across a real thread boundary
+# ---------------------------------------------------------------------------
+
+
+def test_ordering_preserved_with_a_free_running_worker_thread():
+    """200 events published from a worker while the consumer drains: the
+    delivered sequence is exactly the published one, terminal event last."""
+
+    async def main():
+        stream = ProgressStream(maxsize=1024)  # deliberately never full here
+
+        def producer():
+            for n in range(200):
+                stream.publish({"n": n})
+            stream.finish({"ok": True})
+
+        thread = threading.Thread(target=producer, name="probe-producer")
+        received: list[ProgressEvent] = []
+
+        async def drain():
+            async for event in stream.events():
+                received.append(event)
+
+        task = asyncio.ensure_future(drain())
+        await asyncio.sleep(0)  # consumer is parked on the wake event
+        thread.start()
+        await asyncio.wait_for(task, TIMEOUT)
+        thread.join(TIMEOUT)
+        return stream, received
+
+    stream, received = asyncio.run(main())
+    assert _ns(received) == list(range(200))
+    assert _kinds(received)[-1] == "result"
+    assert _kinds(received).count("result") == 1
+    assert received[-1].data == {"ok": True}
+    assert stream.dropped == 0
+
+
+def test_ordering_holds_under_lockstep_ping_pong():
+    """The strongest ordering probe: the worker publishes only after the loop
+    has acknowledged the previous event, so every single event genuinely
+    crosses the thread boundary while the consumer is live. Also proves the
+    wakeup path — with no wakeup this deadlocks rather than passing slowly."""
+
+    async def main():
+        stream = ProgressStream(maxsize=4)
+        acked = threading.Event()
+        waits_ok: list[bool] = []
+
+        def producer():
+            for n in range(25):
+                stream.publish({"n": n})
+                waits_ok.append(acked.wait(TIMEOUT))
+                acked.clear()
+            stream.finish({"evals": 25})
+
+        thread = threading.Thread(target=producer, name="pingpong-producer")
+        received: list[ProgressEvent] = []
+
+        async def drain():
+            async for event in stream.events():
+                received.append(event)
+                acked.set()  # threading.Event.set is safe from the loop thread
+
+        task = asyncio.ensure_future(drain())
+        await asyncio.sleep(0)
+        thread.start()
+        await asyncio.wait_for(task, TIMEOUT)
+        thread.join(TIMEOUT)
+        return received, waits_ok
+
+    received, waits_ok = asyncio.run(main())
+    assert all(waits_ok) and len(waits_ok) == 25
+    assert _ns(received) == list(range(25))
+    assert _kinds(received)[-1] == "result"
+
+
+def test_ordering_holds_under_run_in_threadpool():
+    """The production shape: the producer is an anyio worker started by
+    ``run_in_threadpool``, exactly as ``_solve_at`` will be."""
+
+    async def main():
+        stream = ProgressStream(maxsize=64)
+        received: list[ProgressEvent] = []
+        worker_threads: set[int] = set()
+
+        def producer():
+            for n in range(50):
+                worker_threads.add(threading.get_ident())
+                stream.publish({"n": n})
+
+        async def drain():
+            async for event in stream.events():
+                received.append(event)
+
+        task = asyncio.ensure_future(drain())
+        await asyncio.sleep(0)
+        with stream.sealed():
+            await run_in_threadpool(producer)
+            stream.finish({"ok": True})
+        await asyncio.wait_for(task, TIMEOUT)
+        return received, worker_threads
+
+    received, worker_threads = asyncio.run(main())
+    assert worker_threads and threading.get_ident() not in worker_threads
+    assert _ns(received) == list(range(50))
+    assert _kinds(received)[-1] == "result"
+
+
+# ---------------------------------------------------------------------------
+# Gate 2 — consumer disconnect terminates the producer
+# ---------------------------------------------------------------------------
+
+
+def test_consumer_disconnect_raises_in_the_producer_and_frees_its_thread():
+    """The consumer breaks out mid-run (a client disconnect). The next publish
+    on the worker raises ProgressStreamClosed, the thread exits, and the
+    process is back to its baseline thread count — nothing parked."""
+    baseline = threading.active_count()
+    permit = threading.Event()
+    published: list[int] = []
+    raised: list[BaseException] = []
+
+    async def main():
+        stream = ProgressStream(maxsize=4)
+
+        def producer():
+            try:
+                for n in range(10_000):
+                    assert permit.wait(TIMEOUT)
+                    permit.clear()
+                    stream.publish({"n": n})
+                    published.append(n)
+            except BaseException as exc:
+                raised.append(exc)
+
+        thread = threading.Thread(target=producer, name="disconnect-producer")
+        thread.start()
+        permit.set()  # release exactly one publish
+
+        seen = 0
+        async for _event in stream.events():
+            seen += 1
+            if seen == 3:
+                break  # client disconnected; the generator's finally closes
+            permit.set()  # let the worker produce the next one
+        return stream, thread, seen
+
+    stream, thread, seen = asyncio.run(main())
+    assert seen == 3
+    assert stream.done
+
+    # The worker is parked on our test permit, not on the stream: publish never
+    # blocks under the drop policy. Release it and it must die immediately.
+    permit.set()
+    thread.join(TIMEOUT)
+    assert not thread.is_alive()
+    assert isinstance(raised[0], ProgressStreamClosed)
+    assert len(published) == 3  # stopped at the disconnect, not at 10_000
+    # No thread leaked. "<=" rather than "==" only because an unrelated pool
+    # elsewhere in the suite may wind down during this test; it can never go up.
+    assert threading.active_count() <= baseline
+
+
+def test_publish_after_close_raises_from_either_caller():
+    stream = ProgressStream()
+    stream.publish({"n": 0})
+    stream.close()
+    with pytest.raises(ProgressStreamClosed):
+        stream.publish({"n": 1})
+    assert stream.done
+    assert stream.finish({"late": True}) is False
+
+
+def test_close_is_idempotent_and_drops_the_backlog():
+    stream = ProgressStream(maxsize=8)
+    for n in range(4):
+        stream.publish({"n": n})
+    stream.close()
+    stream.close()
+
+    async def main():
+        return [e async for e in stream.events()]
+
+    assert asyncio.run(main()) == []
+
+
+def test_a_closed_loop_closes_the_stream_instead_of_queueing_into_a_void():
+    """If the consumer's loop is gone (worker outliving the request), the one
+    loop entry point raises RuntimeError; the bridge must convert that into a
+    closed stream rather than buffering for a consumer that cannot return."""
+    stream = ProgressStream()
+
+    async def bind():
+        async for _event in stream.events():  # pragma: no cover - never yields
+            break
+
+    loop = asyncio.new_event_loop()
+    task = loop.create_task(bind())
+    loop.run_until_complete(asyncio.sleep(0))
+    task.cancel()
+    loop.run_until_complete(asyncio.gather(task, return_exceptions=True))
+    # events()'s finally already closed the stream; re-open it to isolate the
+    # closed-loop path from the ordinary disconnect path.
+    stream._closed = False
+    loop.close()
+
+    with pytest.raises(ProgressStreamClosed):
+        for n in range(2):  # first publish trips the closed loop, second raises
+            stream.publish({"n": n})
+    assert stream.done
+
+
+# ---------------------------------------------------------------------------
+# Gate 3 — bounded buffer: drop oldest, count the drops
+# ---------------------------------------------------------------------------
+
+
+def test_overflow_drops_the_oldest_and_counts_them():
+    """No consumer has ever bound a loop — the worst case for a buffer, and
+    fully deterministic: maxsize + k publishes leave exactly the newest
+    maxsize, with k counted."""
+    stream = ProgressStream(maxsize=5)
+
+    def producer():
+        for n in range(12):
+            stream.publish({"n": n})
+        stream.finish({"ok": True})
+
+    thread = threading.Thread(target=producer, name="overflow-producer")
+    thread.start()
+    thread.join(TIMEOUT)
+
+    async def main():
+        return [e async for e in stream.events()]
+
+    received = asyncio.run(main())
+    assert _ns(received) == [7, 8, 9, 10, 11]  # newest five, in order
+    assert stream.dropped == 7
+    assert _kinds(received)[-1] == "result"
+
+
+def test_a_stalled_consumer_sees_the_newest_state_and_never_loses_the_result():
+    """Consumer slower than producer, with a live loop. It takes one event,
+    stalls until the worker has finished producing, then drains: it sees the
+    newest maxsize progress events plus the terminal one, which is exempt from
+    the bound. Ordering of what survives is still publication order."""
+
+    async def main():
+        stream = ProgressStream(maxsize=4)
+        saw_first = threading.Event()
+        settled = threading.Event()
+
+        def producer():
+            stream.publish({"n": 0})
+            assert saw_first.wait(TIMEOUT)
+            for n in range(1, 13):
+                stream.publish({"n": n})
+            stream.finish({"ok": True})
+            settled.set()  # every producer action is now complete
+
+        thread = threading.Thread(target=producer, name="stall-producer")
+        received: list[ProgressEvent] = []
+
+        async def drain():
+            async for event in stream.events():
+                received.append(event)
+                if len(received) == 1:
+                    saw_first.set()
+                    # Stall on the loop without blocking it, and without a
+                    # sleep: resume only once the producer is provably done.
+                    await asyncio.to_thread(settled.wait, TIMEOUT)
+
+        task = asyncio.ensure_future(drain())
+        await asyncio.sleep(0)
+        thread.start()
+        await asyncio.wait_for(task, TIMEOUT)
+        thread.join(TIMEOUT)
+        return stream, received
+
+    stream, received = asyncio.run(main())
+    assert _ns(received) == [0, 9, 10, 11, 12]
+    assert stream.dropped == 8  # events 1..8, the stale ones
+    assert received[-1].kind == "result"  # terminal bypasses the bound
+
+
+def test_maxsize_must_be_positive():
+    with pytest.raises(ValueError):
+        ProgressStream(maxsize=0)
+
+
+# ---------------------------------------------------------------------------
+# Gate 4 — the loop is touched through exactly one entry point
+# ---------------------------------------------------------------------------
+
+
+class _LoopSpy:
+    """Records every attribute the bridge reads off the loop, and the thread
+    that read it. Anything other than ``call_soon_threadsafe`` reaching this
+    from a worker thread is a violation of the module invariant."""
+
+    def __init__(self, loop):
+        self._loop = loop
+        self.touched: list[tuple[str, str]] = []
+        self.callback_threads: list[str] = []
+
+    def call_soon_threadsafe(self, callback, *args):
+        self.touched.append(("call_soon_threadsafe", threading.current_thread().name))
+
+        def wrapped():
+            self.callback_threads.append(threading.current_thread().name)
+            callback(*args)
+
+        return self._loop.call_soon_threadsafe(wrapped)
+
+    def __getattr__(self, name):
+        self.touched.append((name, threading.current_thread().name))
+        return getattr(self._loop, name)
+
+
+def test_worker_touches_the_loop_only_through_call_soon_threadsafe():
+    async def main():
+        stream = ProgressStream(maxsize=16)
+        received: list[ProgressEvent] = []
+
+        async def drain():
+            async for event in stream.events():
+                received.append(event)
+
+        task = asyncio.ensure_future(drain())
+        for _ in range(100):  # bounded: binding takes one scheduling step
+            if stream._loop is not None:
+                break
+            await asyncio.sleep(0)
+        assert stream._loop is not None
+        spy = _LoopSpy(stream._loop)
+        stream._loop = spy
+
+        loop_thread = threading.current_thread().name
+        no_loop_in_worker: list[bool] = []
+
+        def producer():
+            try:
+                asyncio.get_running_loop()
+                no_loop_in_worker.append(False)
+            except RuntimeError:
+                no_loop_in_worker.append(True)
+            for n in range(5):
+                stream.publish({"n": n})
+            stream.finish({"ok": True})
+
+        thread = threading.Thread(target=producer, name="invariant-producer")
+        thread.start()
+        await asyncio.wait_for(task, TIMEOUT)
+        thread.join(TIMEOUT)
+        return spy, received, loop_thread, no_loop_in_worker
+
+    spy, received, loop_thread, no_loop_in_worker = asyncio.run(main())
+    assert no_loop_in_worker == [True]  # the worker has no loop of its own
+    assert len(received) == 6
+    # Every loop access came from the worker, and every one of them was the
+    # single documented entry point.
+    assert {name for name, _ in spy.touched} == {"call_soon_threadsafe"}
+    assert {thread for _, thread in spy.touched} == {"invariant-producer"}
+    # ...and the scheduled callback (the asyncio.Event set) ran on the loop.
+    assert set(spy.callback_threads) == {loop_thread}
+
+
+def test_publishing_before_any_consumer_needs_no_loop_at_all():
+    stream = ProgressStream(maxsize=8)
+    done = threading.Event()
+
+    def producer():
+        for n in range(3):
+            stream.publish({"n": n})
+        done.set()
+
+    thread = threading.Thread(target=producer, name="preconsumer-producer")
+    thread.start()
+    assert done.wait(TIMEOUT)
+    thread.join(TIMEOUT)
+    assert stream._loop is None
+    assert not stream.done
+
+
+# ---------------------------------------------------------------------------
+# Gate 5 — completion is distinguishable from silence
+# ---------------------------------------------------------------------------
+
+
+def test_silence_leaves_the_consumer_pending_and_finish_ends_it():
+    async def main():
+        stream = ProgressStream()
+        received: list[ProgressEvent] = []
+
+        async def drain():
+            async for event in stream.events():
+                received.append(event)
+
+        task = asyncio.ensure_future(drain())
+        for _ in range(5):
+            await asyncio.sleep(0)
+        pending_while_silent = not task.done()
+        done_while_silent = stream.done
+
+        stream.publish({"n": 0})
+        stream.finish({"ok": True})
+        await asyncio.wait_for(task, TIMEOUT)
+        return received, pending_while_silent, done_while_silent, stream.done
+
+    received, pending, done_while_silent, done_after = asyncio.run(main())
+    assert pending is True  # silence: still listening, nothing decided
+    assert done_while_silent is False
+    assert done_after is True
+    assert _kinds(received) == ["progress", "result"]
+
+
+def test_error_terminates_the_stream_like_a_result():
+    async def main():
+        stream = ProgressStream()
+        stream.publish({"n": 0})
+        stream.fail("solver exploded")
+        return [e async for e in stream.events()]
+
+    received = asyncio.run(main())
+    assert _kinds(received) == ["progress", "error"]
+    assert received[-1].data == {"detail": "solver exploded"}
+
+
+def test_first_terminal_event_wins():
+    stream = ProgressStream()
+    assert stream.finish({"ok": True}) is True
+    assert stream.fail("too late") is False
+
+    async def main():
+        return [e async for e in stream.events()]
+
+    received = asyncio.run(main())
+    assert _kinds(received) == ["result"]
+    assert received[0].data == {"ok": True}
+
+
+def test_publish_after_a_terminal_event_raises():
+    stream = ProgressStream()
+    stream.finish({"ok": True})
+    with pytest.raises(ProgressStreamClosed):
+        stream.publish({"n": 0})
+
+
+def test_event_kinds_match_the_sse_names_of_contract_c2():
+    stream = ProgressStream()
+    stream.publish({"n": 0})
+    stream.finish({"ok": True})
+
+    async def main():
+        return [e async for e in stream.events()]
+
+    received = asyncio.run(main())
+    assert [e.kind for e in received] == ["progress", "result"]
+    assert [e.terminal for e in received] == [False, True]
+    assert ProgressEvent("error", {}).terminal is True
+
+
+# ---------------------------------------------------------------------------
+# Producer death — sealed() guarantees the consumer never hangs
+# ---------------------------------------------------------------------------
+
+
+def test_sealed_converts_a_dead_producer_into_an_error_event():
+    async def main():
+        stream = ProgressStream()
+        escaped: list[BaseException] = []
+
+        def producer():
+            try:
+                with stream.sealed():
+                    stream.publish({"n": 0})
+                    raise ValueError("boom")
+            except BaseException as exc:
+                escaped.append(exc)
+
+        thread = threading.Thread(target=producer, name="dying-producer")
+        received: list[ProgressEvent] = []
+
+        async def drain():
+            async for event in stream.events():
+                received.append(event)
+
+        task = asyncio.ensure_future(drain())
+        await asyncio.sleep(0)
+        thread.start()
+        await asyncio.wait_for(task, TIMEOUT)
+        thread.join(TIMEOUT)
+        return received, escaped
+
+    received, escaped = asyncio.run(main())
+    assert isinstance(escaped[0], ValueError)  # the producer still sees it
+    assert _kinds(received) == ["progress", "error"]
+    assert received[-1].data["detail"] == "ValueError: boom"
+
+
+def test_sealed_terminates_a_producer_that_forgot_to_finish():
+    async def main():
+        stream = ProgressStream()
+
+        def producer():
+            with stream.sealed():
+                stream.publish({"n": 0})
+
+        thread = threading.Thread(target=producer, name="forgetful-producer")
+        received: list[ProgressEvent] = []
+
+        async def drain():
+            async for event in stream.events():
+                received.append(event)
+
+        task = asyncio.ensure_future(drain())
+        await asyncio.sleep(0)
+        thread.start()
+        await asyncio.wait_for(task, TIMEOUT)
+        thread.join(TIMEOUT)
+        return received
+
+    received = asyncio.run(main())
+    assert _kinds(received) == ["progress", "error"]
+    assert "without a result" in received[-1].data["detail"]
+
+
+def test_sealed_leaves_a_real_result_alone():
+    stream = ProgressStream()
+    with stream.sealed():
+        stream.publish({"n": 0})
+        stream.finish({"ok": True})
+
+    async def main():
+        return [e async for e in stream.events()]
+
+    received = asyncio.run(main())
+    assert _kinds(received) == ["progress", "result"]
+
+
+def test_sealed_reraises_consumer_disconnect_without_masking_it():
+    stream = ProgressStream()
+    stream.close()
+    with pytest.raises(ProgressStreamClosed):
+        with stream.sealed():
+            stream.publish({"n": 0})
+
+
+def test_second_consumer_is_refused():
+    async def main():
+        stream = ProgressStream()
+        stream.finish({"ok": True})
+        first = [e async for e in stream.events()]
+        with pytest.raises(RuntimeError, match="single consumer"):
+            async for _event in stream.events():  # pragma: no cover
+                pass
+        return first
+
+    assert _kinds(asyncio.run(main())) == ["result"]

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -12,11 +12,13 @@ integration territory and want their own targeted tests.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import math
 import threading
 import time
 from copy import deepcopy
+from types import SimpleNamespace
 
 import momwire
 import numpy as np
@@ -25,6 +27,7 @@ from fastapi.testclient import TestClient
 
 from antennaknobs.web import server, user_designs
 from antennaknobs.web.examples import REGISTRY
+from antennaknobs.web.progress_stream import ProgressStream, ProgressStreamClosed
 
 
 # ---------------------------------------------------------------------------
@@ -3167,3 +3170,433 @@ def test_schematic_ignores_a_malformed_budget(client: TestClient):
     assert resp.status_code == 200
     data = resp.json()
     assert data["available"] is True and "%" not in data["svg"]
+
+
+# ---------------------------------------------------------------------------
+# Streamed /optimize (issue #773 unit 3).
+#
+# `Accept: text/event-stream` reports a run as it happens — one `progress`
+# event per eval, then exactly one terminal `result` or `error`; every other
+# Accept keeps today's single JSON object. The two representations share the
+# validation, the hosted caps and the _shed dispatch, so the tests below pin
+# BOTH the stream's shape and the JSON path's unchanged bytes.
+#
+# The stub example makes an optimizer run arithmetic (no MoM solve), which is
+# what lets eval counts, frame counts and the disconnect handshake be asserted
+# rather than timed.
+# ---------------------------------------------------------------------------
+
+_SSE_HEADERS = {"Accept": "text/event-stream"}
+
+
+def _sse_frames(text: str) -> list[tuple[str, dict]]:
+    """Parse an SSE body the way the frontend's reader does (issue #773 unit
+    4): frames separated by a blank line, `data` decoded, comment lines
+    (keepalives) contributing nothing."""
+    frames = []
+    for block in text.split("\n\n"):
+        if not block.strip():
+            continue
+        kind, data = None, None
+        for line in block.split("\n"):
+            if line.startswith("event:"):
+                kind = line[len("event:") :].strip()
+            elif line.startswith("data:"):
+                data = json.loads(line[len("data:") :])
+        if data is not None:
+            frames.append((kind, data))
+    return frames
+
+
+def _stub_optimize_example():
+    """A registry stand-in whose solve is arithmetic: R = 50 + 400·(lf−1)²,
+    so the SWR objective has one clean minimum at length_factor = 1 and the
+    whole run is deterministic and instant. Returns (example, calls)."""
+    calls: list[dict] = []
+
+    def momwire_solve(req, cancel=None):
+        calls.append(dict(req))
+        lf = float(req.get("length_factor", 1.0))
+        return {
+            "z_in_re": 50.0 + 400.0 * (lf - 1.0) ** 2,
+            "z_in_im": 0.0,
+            "z0_ohms": 50.0,
+        }
+
+    ex = SimpleNamespace(
+        multi_feed=False,
+        count_basis=lambda req: 100,
+        momwire_solve=momwire_solve,
+    )
+    return ex, calls
+
+
+def _opt_req(**opt) -> dict:
+    o = {
+        "free": [{"name": "length_factor", "min": 0.9, "max": 1.1}],
+        "objective": "swr",
+    }
+    o.update(opt)
+    # Start off the optimum so the run has somewhere to go.
+    return {"geometry": "fake.opt", "length_factor": 1.08, "optimize": o}
+
+
+class _FakeRequest:
+    """The one method _sse_progress_body asks of a Request, plus a flag the
+    test flips to make the client vanish silently."""
+
+    def __init__(self, disconnected: bool = False) -> None:
+        self.disconnected = disconnected
+        self.polls = 0
+
+    async def is_disconnected(self) -> bool:
+        self.polls += 1
+        return self.disconnected
+
+
+def test_optimize_sse_streams_one_progress_per_eval_then_one_result(
+    client: TestClient, monkeypatch
+):
+    ex, calls = _stub_optimize_example()
+    monkeypatch.setitem(server.EXAMPLES, "fake.opt", ex)
+    resp = client.post("/optimize", json=_opt_req(), headers=_SSE_HEADERS)
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+
+    frames = _sse_frames(resp.text)
+    kinds = [k for k, _ in frames]
+    # Exactly one terminal event, and it is last.
+    assert kinds.count("result") + kinds.count("error") == 1
+    assert kinds[-1] == "result"
+    assert set(kinds[:-1]) == {"progress"}
+    # One progress event per eval, in order, none dropped — and the count
+    # agrees with both the result payload and the engine's own call log.
+    assert [d["n_evals"] for _, d in frames[:-1]] == list(range(1, len(frames)))
+    assert len(calls) == frames[-1][1]["n_evals"] == len(frames) - 1
+    for _, d in frames[:-1]:
+        assert set(d) == {"n_evals", "params", "objective", "metrics"}
+        assert set(d["params"]) == {"length_factor"}
+
+
+def test_optimize_without_the_sse_header_is_todays_json_response(
+    client: TestClient, monkeypatch
+):
+    """Opting in is the ONLY thing that changes the response. Key order is
+    asserted, not membership: the JSON path's bytes are the contract."""
+    ex, _calls = _stub_optimize_example()
+    monkeypatch.setitem(server.EXAMPLES, "fake.opt", ex)
+    for headers in ({}, {"Accept": "application/json"}, {"Accept": "*/*"}):
+        resp = client.post("/optimize", json=_opt_req(), headers=headers)
+        assert resp.headers["content-type"] == "application/json"
+        body = resp.json()
+        assert list(body) == [
+            "objective",
+            "params",
+            "objective_before",
+            "objective_after",
+            "metrics_before",
+            "metrics_after",
+            "n_evals",
+            "improved",
+            "geometry",
+        ]
+        assert list(body["metrics_before"]) == ["z_in_re", "z_in_im", "z0_ohms", "swr"]
+        assert body["geometry"] == "fake.opt"
+        assert body["improved"] is True
+        assert body["objective_after"] < body["objective_before"]
+
+
+def test_the_result_event_is_the_json_response_verbatim(
+    client: TestClient, monkeypatch
+):
+    """Same run, two representations: the terminal frame's payload must be the
+    single-shot response byte for byte, including its trailing blank line."""
+    ex, _calls = _stub_optimize_example()
+    monkeypatch.setitem(server.EXAMPLES, "fake.opt", ex)
+    body = client.post("/optimize", json=_opt_req()).json()
+    text = client.post("/optimize", json=_opt_req(), headers=_SSE_HEADERS).text
+    assert _sse_frames(text)[-1] == ("result", body)
+    # The blank line is load-bearing (unit 4's parser emits on "\n\n"); a
+    # terminal frame without it would never be delivered.
+    assert text.endswith("event: result\ndata: " + json.dumps(body) + "\n\n")
+
+
+def test_every_sse_frame_is_two_lines_and_a_blank_one(client: TestClient, monkeypatch):
+    ex, _calls = _stub_optimize_example()
+    monkeypatch.setitem(server.EXAMPLES, "fake.opt", ex)
+    text = client.post("/optimize", json=_opt_req(), headers=_SSE_HEADERS).text
+    assert text.endswith("\n\n")
+    # Splitting on the separator must leave nothing but well-formed frames and
+    # one empty tail — a missing blank line would fuse two frames into one.
+    blocks = text.split("\n\n")
+    assert blocks[-1] == ""
+    for block in blocks[:-1]:
+        lines = block.split("\n")
+        assert len(lines) == 2, block
+        assert lines[0].startswith("event: ")
+        assert lines[1].startswith("data: ")
+
+
+def test_optimize_sse_reports_a_failed_run_as_one_error_event(
+    client: TestClient, monkeypatch
+):
+    ex, calls = _stub_optimize_example()
+
+    def boom(req, cancel=None):
+        calls.append(dict(req))
+        raise ValueError("build_wires exploded")
+
+    ex.momwire_solve = boom
+    monkeypatch.setitem(server.EXAMPLES, "fake.opt", ex)
+    frames = _sse_frames(
+        client.post("/optimize", json=_opt_req(), headers=_SSE_HEADERS).text
+    )
+    assert len(frames) == 1
+    kind, data = frames[0]
+    assert kind == "error"
+    assert set(data) == {"detail"}
+    assert "build_wires exploded" in data["detail"]
+    # The same failure on the JSON path keeps its own shape.
+    body = client.post("/optimize", json=_opt_req()).json()
+    assert body["geometry"] == "fake.opt"
+    assert "build_wires exploded" in body["error"]
+
+
+def test_optimize_sse_failure_mid_run_still_ends_in_exactly_one_terminal(
+    client: TestClient, monkeypatch
+):
+    ex, calls = _stub_optimize_example()
+    inner = ex.momwire_solve
+
+    def fails_on_the_third(req, cancel=None):
+        if len(calls) >= 2:
+            raise RuntimeError("solver gave up")
+        return inner(req)
+
+    ex.momwire_solve = fails_on_the_third
+    monkeypatch.setitem(server.EXAMPLES, "fake.opt", ex)
+    frames = _sse_frames(
+        client.post("/optimize", json=_opt_req(), headers=_SSE_HEADERS).text
+    )
+    kinds = [k for k, _ in frames]
+    assert kinds == ["progress", "progress", "error"]
+    assert "solver gave up" in frames[-1][1]["detail"]
+
+
+def test_optimize_sse_rejects_a_request_with_no_free_knobs(client: TestClient):
+    frames = _sse_frames(
+        client.post(
+            "/optimize",
+            json={"geometry": "fake.opt", "optimize": {"free": []}},
+            headers=_SSE_HEADERS,
+        ).text
+    )
+    assert frames == [("error", {"detail": "select at least one knob to vary"})]
+
+
+def test_optimize_sse_rejects_oversized_request_when_hosted(hosted, client: TestClient):
+    """The hosted matrix cap gates the streaming path too — a request that
+    would be refused as JSON must not become a stream that starts solving."""
+    req = _oversized_req(
+        optimize={
+            "free": [{"name": "length_factor", "min": 0.9, "max": 1.1}],
+            "objective": "swr",
+        }
+    )
+    resp = client.post("/optimize", json=req, headers=_SSE_HEADERS)
+    assert resp.status_code == 200
+    frames = _sse_frames(resp.text)
+    assert len(frames) == 1
+    kind, data = frames[0]
+    assert kind == "error" and "segments / wire" in data["detail"]
+
+
+def test_optimize_sse_max_evals_clamped_when_hosted(
+    hosted, client: TestClient, monkeypatch
+):
+    """The eval budget is clamped on the streaming path as well (issue #346).
+
+    The ceiling bounds the OPTIMIZER's evals; optimize() also runs a baseline
+    and a confirmation solve outside that budget, so the honest bound is
+    clamp + 2 — asserted here against the engine's call log, the progress
+    frames and the result payload at once.
+    """
+    monkeypatch.setattr(server, "_MAX_OPT_EVALS", 3)
+    ex, calls = _stub_optimize_example()
+    monkeypatch.setitem(server.EXAMPLES, "fake.opt", ex)
+    frames = _sse_frames(
+        client.post(
+            "/optimize", json=_opt_req(max_evals=10**9), headers=_SSE_HEADERS
+        ).text
+    )
+    kind, result = frames[-1]
+    assert kind == "result"
+    assert result["n_evals"] <= 3 + 2
+    assert len(calls) == result["n_evals"]
+    assert len(frames) - 1 == result["n_evals"]
+
+
+def test_the_streaming_path_still_dispatches_through_shed(
+    client: TestClient, monkeypatch
+):
+    """_shed drops the exception frame chain at the thread boundary; without
+    it a failed solve pins its arrays for the life of the process (issue
+    #382). A streaming path that dispatched around it would reintroduce that,
+    so assert the call itself rather than the symptom."""
+    ex, _calls = _stub_optimize_example()
+    monkeypatch.setitem(server.EXAMPLES, "fake.opt", ex)
+    dispatched = []
+    real_shed = server._shed
+
+    def spy(fn, *args, **kwargs):
+        dispatched.append(fn)
+        return real_shed(fn, *args, **kwargs)
+
+    monkeypatch.setattr(server, "_shed", spy)
+    frames = _sse_frames(
+        client.post("/optimize", json=_opt_req(), headers=_SSE_HEADERS).text
+    )
+    assert frames[-1][0] == "result"
+    assert [fn.__name__ for fn in dispatched] == ["optimize"]
+
+
+def test_sse_body_keepalives_while_the_producer_is_thinking(monkeypatch):
+    """An idle stream must still write. The comment frame is what discovers a
+    dead socket (Starlette finalises a streaming body only at its next send)
+    and what stops a proxy reaping a connection between evals."""
+    monkeypatch.setattr(server, "_SSE_KEEPALIVE_S", 0.01)
+
+    async def main():
+        stream = ProgressStream()
+        request = _FakeRequest()
+
+        async def drive():
+            await asyncio.sleep(0.06)  # one long "solve"
+            stream.finish({"ok": True})
+
+        chunks = [c async for c in server._sse_progress_body(request, stream, drive)]
+        return chunks, request
+
+    chunks, request = asyncio.run(asyncio.wait_for(main(), 10))
+    assert ": keepalive\n\n" in chunks
+    assert request.polls >= 1
+    assert chunks[-1] == 'event: result\ndata: {"ok": true}\n\n'
+
+
+def test_sse_body_stops_a_producer_whose_client_vanished(monkeypatch):
+    """A client that disappears without closing the socket must still be
+    noticed promptly: the body polls on the same tick as the keepalive, and
+    closing the stream makes the producer's next publish raise."""
+    monkeypatch.setattr(server, "_SSE_KEEPALIVE_S", 0.01)
+
+    async def main():
+        stream = ProgressStream()
+        request = _FakeRequest()
+        aborted = asyncio.Event()
+
+        async def drive():
+            try:
+                for i in range(100):
+                    stream.publish({"n_evals": i})
+                    await asyncio.sleep(0.02)
+            except ProgressStreamClosed:
+                aborted.set()
+
+        chunks = []
+        async for chunk in server._sse_progress_body(request, stream, drive):
+            chunks.append(chunk)
+            request.disconnected = True  # the client goes away, silently
+        await asyncio.wait_for(aborted.wait(), 5)
+        return chunks
+
+    chunks = asyncio.run(asyncio.wait_for(main(), 10))
+    # It stopped at the first frame — not after all 100 the producer offered.
+    assert len(chunks) == 1
+    assert chunks[0].startswith("event: progress\n")
+
+
+def test_a_vanished_client_stops_the_optimizer_mid_run(monkeypatch):
+    """The gate, end to end: a browser closed mid-run must not leave a worker
+    burning solves.
+
+    Driven at the ASGI layer because TestClient's receive channel never
+    reports a disconnect, and at spec_version 2.4 Starlette runs no disconnect
+    watcher of its own — so the body's own poll is the only thing that can
+    notice. The stub blocks inside the second eval, which is the window the
+    client disappears in; a run that ignored the disconnect would sail on
+    through the remaining evals instead of raising at the next publish.
+    """
+    monkeypatch.setattr(server, "_SSE_KEEPALIVE_S", 0.01)
+    ex, calls = _stub_optimize_example()
+    inner = ex.momwire_solve
+    in_second_solve = threading.Event()
+    release = threading.Event()
+
+    def gated(req, cancel=None):
+        out = inner(req)
+        if len(calls) == 2:
+            in_second_solve.set()
+            release.wait(10)
+        return out
+
+    ex.momwire_solve = gated
+    monkeypatch.setitem(server.EXAMPLES, "fake.opt", ex)
+
+    raw = json.dumps(_opt_req()).encode()
+    gone = threading.Event()
+    sent: list[dict] = []
+
+    async def main():
+        state = {"body_sent": False}
+
+        async def receive():
+            if not state["body_sent"]:
+                state["body_sent"] = True
+                return {"type": "http.request", "body": raw, "more_body": False}
+            if gone.is_set():
+                return {"type": "http.disconnect"}
+            # Still here: is_disconnected() polls this channel and has to be
+            # able to get a non-disconnect answer without blocking.
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message):
+            sent.append(message)
+
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.4"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/optimize",
+            "raw_path": b"/optimize",
+            "query_string": b"",
+            "root_path": "",
+            "headers": [
+                (b"host", b"testserver"),
+                (b"content-type", b"application/json"),
+                (b"accept", b"text/event-stream"),
+                (b"content-length", str(len(raw)).encode()),
+            ],
+            "client": ("testclient", 50000),
+            "server": ("testserver", 80),
+        }
+        task = asyncio.create_task(server.app(scope, receive, send))
+        await asyncio.to_thread(in_second_solve.wait, 10)
+        gone.set()
+        # The response must end on its own: nothing cancels this task, so a
+        # body that never noticed the disconnect would still be parked here.
+        await asyncio.wait_for(task, 5)
+        release.set()
+        # A run that ignored the disconnect blows through its remaining evals
+        # (all arithmetic) well inside this window.
+        await asyncio.sleep(0.5)
+
+    asyncio.run(asyncio.wait_for(main(), 40))
+    assert len(calls) == 2
+    body = "".join(
+        m.get("body", b"").decode() for m in sent if m["type"] == "http.response.body"
+    )
+    # The first eval's progress frame made it to the wire; no terminal event
+    # follows, because there was nobody left to send one to.
+    assert [k for k, _ in _sse_frames(body)] == ["progress"]


### PR DESCRIPTION
Integration PR for the #773 arc. Each unit landed as its own reviewed, CI-green sub-PR onto this branch; this merges the batch to main once.

## Units

| Unit | What | Sub-PR |
|---|---|---|
| 1 | `on_progress` hook in the optimizer core | #777 |
| 2 | thread-safe worker→loop progress bridge | #779 |
| 4 | live progress in the workbench | #778 |
| 3 | stream `/optimize` over SSE | #784 |

## Acceptance (from the issue)

- [x] `optimize()` takes an optional `on_progress`, once per eval including the initial simplex; existing callers unaffected when omitted
- [x] `/optimize` streams progress + a terminal result; non-streaming clients still get a usable final payload
- [x] UI shows live eval count, current objective, and current Z/SWR
- [x] Client abort tears the stream down without leaking a threadpool worker
- [x] Hosted eval caps and solve-size gating unchanged
- [x] Tests cover progress-per-eval, `on_progress=None` unchanged, abort mid-run

## What it does

Mark knobs for optimization and run it: the readout now ticks `#1 SWR 2.41 → #2 SWR 2.38 → #7 SWR 1.52` — one update **per solve**, from eval #1 — instead of a boolean spinner that eventually says "done". Hovering gives the eval number, the raw objective, and the full complex Z.

`Accept: text/event-stream` opts in; **every other Accept, including none, gets today's JSON object unchanged**, so nothing that already calls `/optimize` notices.

## Why it decomposed this way

The contracts — SSE event schema, `Accept`-based negotiation, and the `on_progress` signature — were pinned **in the issue before any code**, which is what let the endpoint (unit 3) and the client (unit 4) be built against one wire format without either waiting on the other. Units 1, 2 and 4 ran in parallel on disjoint files; unit 3 integrated them.

Unit 2 was isolated precisely because the issue flags it as the piece that "will appear to work under a single-user local dev server and fail under load" — separating it means its concurrency claims are provable with no web framework in the picture.

## Findings that crossed unit boundaries

Each was found by a unit that could not fix it, and became a requirement for the one that could. This is the main argument for the decomposition:

1. **Silent-disconnect blindness** (found by unit 2). The bridge only learns the consumer is gone when its generator is finalised, and Starlette finalises a streaming body at its *next send* — so a browser closed at eval 3 would keep burning MoM solves until eval 4 landed. Unit 3 fixed it with a 5 s idle tick that both polls `is_disconnected()` **and** writes a keepalive comment, so either half alone catches it.
2. **Frames must end with a blank line** (found by unit 4). Its parser emits on `\n\n`; a terminal frame without it would sit in the client buffer forever. Unit 3 pins the exact bytes.
3. **`n_evals` can exceed `max_evals` by 2** (found by unit 1) — the baseline and confirmation solves aren't counted against the cap. Pre-existing; unit 3's cap test doesn't assert an off-by-two ceiling.

## Verification

Every unit was built by a subagent and then reviewed by the session model: whole diff read, all gates re-run independently, and at least one **adversarial mutation** run by the reviewer rather than accepting the builder's word.

| Unit | Reviewer's own probe | Result |
|---|---|---|
| 1 | emit every *other* eval (scipy-callback granularity) | contiguity fails, 13 vs 27 |
| 2 | unbound the buffer / make terminals droppable | 2 and **14** tests fail |
| 4 | remove the explicit `reader.cancel()` | abort test fails |
| 3 | drop the trailing blank line / bypass `_shed` / skip the cost gate | **5**, 1, 1 tests fail |

**Assembled-branch gates, run in the main checkout after rebasing onto current main:**

- Python suite **3511 passed, 2 skipped**
- Frontend **698 tests / 50 files**, `tsc --noEmit` clean, `npm run build` clean
- `eslint .` **0 errors** (223 warnings — unchanged from baseline)
- skip-ci contagion check across all 7 commits: **clean** (this repo rebase-merges, so every message lands on main verbatim)
- momwire submodule pointer not in the diff

Rebased onto main after the last sub-PR merged (main gained the `@file` builder-specs commit mid-arc); no conflicts.

## Follow-ups I'd file, not fix here

- `_SSE_KEEPALIVE_S = 5.0` is a constant, not a setting — worth an env knob if a proxy wants a different idle budget.
- No cap on **concurrent** streams; each holds a worker thread. Unchanged by this arc, but now easier to hold many open.
- A UI polish idea from unit 4: annotate the live trial value on the knob itself, not just in the tooltip.