### PR TITLE
SimNEC .ssn import: antenna blocks and differential station chains

### DIFF
--- a/src/antennaknobs/__init__.py
+++ b/src/antennaknobs/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     "read_data",
     "read_json",
     "read_nec",
+    "read_ssn",
     "read_touchstone",
     "read_measured",
     "MeasuredTrace",
@@ -63,6 +64,7 @@ from .builder import (
 )
 from .design_data import read_data, read_json
 from .nec_import import read_nec
+from .simnec_import import read_ssn
 from .touchstone import read_touchstone
 from .measured import MeasuredTrace, read_measured
 from .network import Composite, Instance, Wire, WireSpec, as_wire

--- a/src/antennaknobs/simnec_export.py
+++ b/src/antennaknobs/simnec_export.py
@@ -6,6 +6,9 @@ lets an antennaknobs design — antenna-only, or a differential-only *station*
 (antenna + feedline + tuner + transformer chain) — be round-tripped into
 SimNEC for cross-validation, without the fiddly UI step of hand-entering
 geometry or circuit values.
+The read-side twin is :mod:`antennaknobs.simnec_import` (``parse_ssn`` /
+``read_ssn``), which loads a ``.ssn`` back as wire geometry and station
+branches.
 
 How it works — the escape-hatch route
 -------------------------------------

--- a/src/antennaknobs/simnec_import.py
+++ b/src/antennaknobs/simnec_import.py
@@ -1,0 +1,391 @@
+"""Import a SimNEC (``.ssn``) circuit as antennaknobs wire geometry.
+
+The read-side twin of :mod:`antennaknobs.simnec_export`: where ``export_ssn``
+emits a SimNEC circuit for cross-validation, ``parse_ssn`` consumes one — so an
+antenna modeled (or round-tripped) in SimNEC can be loaded as a data-driven
+design, the same way ``read_nec`` loads a NEC card deck.
+
+A ``.ssn`` is XML: a ``<CIRCUIT>`` of ``<element>``s. The antenna lives in a
+NETWORK element's escape-hatch ``<equ>`` script — SimNEC's NEC-portal daemon
+language — with the NEC cards between ``NEC2`` and ``NECEND``:
+
+    P1 w1 gnd;                         // circuit ports (structural, skipped)
+    P2 w2 gnd;
+    NECUnits meters, meters;
+    SommerfeldGround(0.0303, 20);      // (mhos, dielectric) == (sigma, eps_r)
+    NECOptions.mhosPerMeter = 0;       // 0 = perfect wires
+    NECOptions.segmentsPerWavelength = 120;
+    NEC2
+    GW 1 ...
+    EX 0 1 6 0 1. 0.
+    NECEND
+
+``parse_ssn`` extracts that block, hands the cards to
+:func:`antennaknobs.nec_import.parse_nec` (so everything the NEC importer can
+model — geometry transforms, EX feeds, lumped LD loads with ``network=True`` —
+works identically), and translates the daemon directives back into antennaknobs
+terms: the ground call becomes an ``export_nec``-style ground spec, wire
+conductivity and SimNEC's re-mesh density surface as fields, and ``NECUnits``
+scales the geometry to metres (via a native ``GS`` card, so NEC's own scaling
+semantics apply; the second ``NECUnits`` argument is taken as the wire-radius
+unit, matching the export's ``NECUnits meters, meters``).
+
+The solve frequency comes from the GENERATOR element's ``MHz`` — in SimNEC the
+deck's ``FR`` card is advisory; the Generator drives the solve — and an armed
+(``doSweep y``) Generator sweep surfaces as ``sweep=(lo, hi)``.
+
+Scope mirrors the exporter: **the antenna block only**. A full-station ``.ssn``
+(tuner elements, transmission lines, transformers between the Generator and the
+antenna) is not translated into the app's port-network system; those elements
+are recorded in ``SsnCircuit.other_elements`` — and daemon statements the
+importer does not understand in ``ignored_directives`` — so a caller can tell
+the user what the file carries that the import leaves behind (see
+``skipped_note()``). The exporter's own scaffold (the open LOAD termination and
+the 50 Ohm GENERATOR) is recognised and not reported.
+"""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, replace
+
+from .design_data import read_data
+from .nec_import import NecDeck, parse_nec
+
+__all__ = ["SsnCircuit", "parse_ssn", "read_ssn"]
+
+# NECUnits values, in metres. The directive names a unit per argument:
+# (coordinates, wire radius) — the exporter writes "NECUnits meters, meters".
+_UNIT_M = {
+    "meters": 1.0,
+    "meter": 1.0,
+    "m": 1.0,
+    "centimeters": 0.01,
+    "centimeter": 0.01,
+    "cm": 0.01,
+    "millimeters": 0.001,
+    "millimeter": 0.001,
+    "mm": 0.001,
+    "feet": 0.3048,
+    "foot": 0.3048,
+    "ft": 0.3048,
+    "inches": 0.0254,
+    "inch": 0.0254,
+    "in": 0.0254,
+}
+
+# The exporter's scaffold LOAD is a 1e9 Ohm open; treat anything this large as
+# "no termination" rather than a circuit element worth reporting.
+_OPEN_OHMS = 1e8
+
+_NEC2_LINE = re.compile(r"^NEC2\s*$")
+_NECEND_LINE = re.compile(r"^NECEND\s*$")
+_PORT_DECL = re.compile(r"^P\d+\s+\S", re.IGNORECASE)
+_SOMMERFELD = re.compile(
+    r"^SommerfeldGround\s*\(\s*([^\s,()]+)\s*,\s*([^\s,()]+)\s*\)$", re.IGNORECASE
+)
+_PERFECT = re.compile(r"^PerfectGround\s*\(\s*\)$", re.IGNORECASE)
+_NECUNITS = re.compile(r"^NECUnits\s+(.+)$", re.IGNORECASE)
+_NECOPTION = re.compile(r"^NECOptions\.(\w+)\s*=\s*(\S+)$", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class SsnCircuit:
+    """A parsed ``.ssn``: the antenna block's NEC deck plus the circuit-level
+    settings SimNEC keeps outside the deck (solve frequency, ground, mesh)."""
+
+    deck: NecDeck
+    # GENERATOR MHz — the authoritative solve frequency (the deck's FR card is
+    # advisory in SimNEC; it is still exposed as ``deck.freq_mhz``).
+    freq_mhz: float | None
+    # Armed (doSweep y) Generator frequency sweep, MHz. None = no sweep armed.
+    sweep: tuple[float, float] | None
+    # Ground translated from the daemon call, in export_ssn's own spec:
+    # None (free space), "pec", or ("finite", eps_r, sigma).
+    ground: None | str | tuple
+    # NECOptions.mhosPerMeter, S/m — feed to WireSpec(conductivity=...).
+    # None when absent or 0 (perfect wires).
+    conductivity: float | None
+    # NECOptions.segmentsPerWavelength — SimNEC's re-mesh density. Advisory
+    # for antennaknobs (its engines keep the deck's segment counts).
+    seg_per_wl: int | None
+    # GENERATOR reference impedance (Zo), ohms.
+    gen_zo: float | None
+    # The block display name — the script's first // comment.
+    name: str | None
+    # Circuit element types the import leaves behind (tuner elements,
+    # extra blocks — anything beyond the antenna + exporter scaffold).
+    other_elements: tuple[str, ...] = ()
+    # Daemon statements not understood, verbatim.
+    ignored_directives: tuple[str, ...] = ()
+
+    def skipped_note(self) -> str | None:
+        """One human-readable sentence naming what the file carries that the
+        import leaves behind — untranslated circuit elements and daemon
+        directives, plus the deck-level record from ``NecDeck.skipped_note``.
+        Same use as the NEC importer's: put it under ``ui_params["notes"]``.
+        None when nothing was left behind."""
+        parts = []
+        if self.other_elements:
+            parts.append(
+                "SimNEC circuit elements not imported (antenna block only): "
+                + ", ".join(self.other_elements)
+            )
+        if self.ignored_directives:
+            parts.append(
+                "NEC-portal directives not applied: "
+                + "; ".join(self.ignored_directives)
+            )
+        note = None
+        if parts:
+            body = "; ".join(parts)
+            note = body[0].upper() + body[1:] + "."
+        deck_note = self.deck.skipped_note()
+        if note and deck_note:
+            return f"{note} {deck_note}"
+        return note or deck_note
+
+
+def _unit_scale(token: str, where: str) -> float:
+    try:
+        return _UNIT_M[token.strip().lower()]
+    except KeyError:
+        raise ValueError(f"{where}: unrecognised NECUnits unit {token!r}") from None
+
+
+def _fnum(token: str, where: str, what: str) -> float:
+    try:
+        return float(token.rstrip(";"))
+    except ValueError:
+        raise ValueError(f"{where}: bad {what} value {token!r}") from None
+
+
+class _Script:
+    """The NEC-portal ``<equ>`` script pulled apart: NEC cards, translated
+    directives, the block name, and whatever was not understood."""
+
+    def __init__(self, text: str, where: str):
+        self.cards: list[str] = []
+        self.ground: None | str | tuple = None
+        self.conductivity: float | None = None
+        self.seg_per_wl: int | None = None
+        self.coord_scale = 1.0
+        self.radius_scale = 1.0
+        self.name: str | None = None
+        self.ignored: list[str] = []
+        in_cards = False
+        for raw in text.splitlines():
+            line = raw.strip()
+            if not line:
+                continue
+            if in_cards:
+                if _NECEND_LINE.match(line):
+                    in_cards = False
+                elif not line.startswith("//") and line.split()[0].upper() != "EN":
+                    # A stray EN inside the block would make parse_nec stop
+                    # before the appended GS (units) / GE (ground) cards; the
+                    # importer supplies its own EN.
+                    self.cards.append(line)
+                continue
+            if line.startswith("//"):
+                if self.name is None:
+                    self.name = line[2:].strip() or None
+                continue
+            if _NEC2_LINE.match(line):
+                in_cards = True
+                continue
+            # Directive line: drop a trailing // comment, then take the
+            # ;-separated statements (the exporter writes one per line, but
+            # the daemon language does not require that).
+            for stmt in line.split("//", 1)[0].split(";"):
+                stmt = stmt.strip()
+                if stmt:
+                    self._directive(stmt, where)
+        if in_cards:
+            raise ValueError(f"{where}: NEC2 block is missing its NECEND")
+
+    def _directive(self, stmt: str, where: str) -> None:
+        if _PORT_DECL.match(stmt):
+            return  # port declaration (P1 w1 gnd) — circuit structure only
+        if _PERFECT.match(stmt):
+            self.ground = "pec"
+            return
+        m = _SOMMERFELD.match(stmt)
+        if m:
+            # SommerfeldGround(mhos, dielectric) == (sigma, eps_r) — the
+            # reverse of the ("finite", eps_r, sigma) spec, as on export.
+            sigma = _fnum(m.group(1), where, "SommerfeldGround")
+            eps_r = _fnum(m.group(2), where, "SommerfeldGround")
+            self.ground = ("finite", eps_r, sigma)
+            return
+        m = _NECUNITS.match(stmt)
+        if m:
+            units = [u for u in m.group(1).split(",") if u.strip()]
+            if not 1 <= len(units) <= 2:
+                raise ValueError(f"{where}: bad NECUnits directive {stmt!r}")
+            self.coord_scale = _unit_scale(units[0], where)
+            self.radius_scale = (
+                _unit_scale(units[1], where) if len(units) == 2 else self.coord_scale
+            )
+            return
+        m = _NECOPTION.match(stmt)
+        if m:
+            option, value = m.group(1), m.group(2)
+            key = option.lower()
+            if key == "mhospermeter":
+                mhos = _fnum(value, where, f"NECOptions.{option}")
+                self.conductivity = mhos if mhos > 0.0 else None
+                return
+            if key == "segmentsperwavelength":
+                self.seg_per_wl = int(_fnum(value, where, f"NECOptions.{option}"))
+                return
+        self.ignored.append(stmt)
+
+
+def _params(el) -> dict[str, str | None]:
+    """An element's top-level ``<p><n>name</n><v>value</v></p>`` params."""
+    return {p.findtext("n"): p.findtext("v") for p in el.findall("p")}
+
+
+def _gen_sweep(gen) -> tuple[float, float] | None:
+    """The Generator's armed frequency sweep, or None. SimNEC stores the range
+    in a ``<sweepParam>`` under the MHz param; only ``doSweep`` = y is live."""
+    for sp in gen.iter("sweepParam"):
+        p = {q.findtext("n"): q.findtext("v") for q in sp.findall("p")}
+        if p.get("doSweep") != "y":
+            continue
+        try:
+            return float(p["from"]), float(p["to"])
+        except (KeyError, TypeError, ValueError):
+            return None
+    return None
+
+
+def parse_ssn(
+    text: str,
+    *,
+    name: str = "SimNEC circuit",
+    network: bool = False,
+    virtualize_anchors: bool = True,
+) -> SsnCircuit:
+    """Parse the text of a SimNEC ``.ssn`` file into an :class:`SsnCircuit`.
+
+    ``network`` and ``virtualize_anchors`` forward to :func:`parse_nec` for the
+    embedded NEC cards — ``network=True`` makes ``circuit.deck.wire_tuples()``
+    and ``circuit.deck.network()`` ready to return from ``build_wires`` /
+    ``build_network``, with the deck's lumped LD loads translated.
+
+    Raises ``ValueError`` (prefixed with ``name``) on malformed XML, on a file
+    with no NEC-portal antenna block or more than one, and on anything
+    ``parse_nec`` refuses in the embedded cards.
+    """
+    try:
+        root = ET.fromstring(text)
+    except ET.ParseError as e:
+        raise ValueError(f"{name}: not well-formed .ssn XML ({e})") from None
+
+    nec_blocks: list[str] = []
+    generator = None
+    other: list[str] = []
+    elements = root.findall(".//CIRCUIT/element")
+    if not elements:
+        raise ValueError(f"{name}: no <CIRCUIT> elements — is this a .ssn file?")
+    for el in elements:
+        typ = (el.findtext("type") or "?").strip()
+        params = _params(el)
+        if typ == "NETWORK" and "equ" in params:
+            equ = params["equ"] or ""
+            if re.search(r"(?m)^\s*NEC2\s*$", equ):
+                nec_blocks.append(equ)
+            else:
+                other.append("NETWORK (non-NEC script)")
+            continue
+        if typ == "GENERATOR" and generator is None:
+            generator = el
+            continue
+        if typ == "LOAD":
+            try:
+                is_open = float(params.get("ohms") or 0) >= _OPEN_OHMS
+            except ValueError:
+                is_open = False
+            if is_open:
+                continue  # the exporter's scaffold open termination
+        other.append(typ)
+
+    if not nec_blocks:
+        raise ValueError(
+            f"{name}: no NEC-portal antenna block (a NETWORK element whose "
+            f"<equ> script carries NEC2 cards)"
+        )
+    if len(nec_blocks) > 1:
+        raise ValueError(
+            f"{name}: {len(nec_blocks)} NEC-portal blocks — antennaknobs "
+            f"imports a single-antenna circuit"
+        )
+
+    script = _Script(nec_blocks[0], name)
+
+    deck_lines = list(script.cards)
+    if script.coord_scale != 1.0:
+        # NEC's own whole-structure scale card, appended after the geometry so
+        # transforms and TL-length resolution all see metres.
+        deck_lines.append(f"GS 0 0 {script.coord_scale!r}")
+    if script.ground is not None:
+        deck_lines.append("GE 1")  # so deck.ground reflects the ground call
+    deck_lines.append("EN")
+    deck = parse_nec(
+        "\n".join(deck_lines) + "\n",
+        name=f"{name} NEC block",
+        network=network,
+        virtualize_anchors=virtualize_anchors,
+    )
+    if script.radius_scale != script.coord_scale:
+        # GS scaled radii along with coordinates; correct to the radius unit.
+        fix = script.radius_scale / script.coord_scale
+        deck = replace(
+            deck,
+            wires=tuple(replace(w, radius=w.radius * fix) for w in deck.wires),
+        )
+
+    freq_mhz = None
+    sweep = None
+    gen_zo = None
+    if generator is not None:
+        p = _params(generator)
+        try:
+            freq_mhz = float(p["MHz"]) if p.get("MHz") else None
+        except ValueError:
+            raise ValueError(f"{name}: bad GENERATOR MHz {p['MHz']!r}") from None
+        try:
+            gen_zo = float(p["Zo"]) if p.get("Zo") else None
+        except ValueError:
+            gen_zo = None
+        sweep = _gen_sweep(generator)
+
+    return SsnCircuit(
+        deck=deck,
+        freq_mhz=freq_mhz,
+        sweep=sweep,
+        ground=script.ground,
+        conductivity=script.conductivity,
+        seg_per_wl=script.seg_per_wl,
+        gen_zo=gen_zo,
+        name=script.name,
+        other_elements=tuple(other),
+        ignored_directives=tuple(script.ignored),
+    )
+
+
+def read_ssn(
+    builder, name: str, *, network: bool = False, virtualize_anchors: bool = True
+) -> SsnCircuit:
+    """``read_data`` followed by ``parse_ssn`` — load a SimNEC circuit that
+    ships next to ``builder``'s design, with the same folder confinement as
+    ``read_json`` / ``read_nec``."""
+    return parse_ssn(
+        read_data(builder, name),
+        name=name,
+        network=network,
+        virtualize_anchors=virtualize_anchors,
+    )

--- a/src/antennaknobs/simnec_import.py
+++ b/src/antennaknobs/simnec_import.py
@@ -34,14 +34,40 @@ The solve frequency comes from the GENERATOR element's ``MHz`` — in SimNEC the
 deck's ``FR`` card is advisory; the Generator drives the solve — and an armed
 (``doSweep y``) Generator sweep surfaces as ``sweep=(lo, hi)``.
 
-Scope mirrors the exporter: **the antenna block only**. A full-station ``.ssn``
-(tuner elements, transmission lines, transformers between the Generator and the
-antenna) is not translated into the app's port-network system; those elements
-are recorded in ``SsnCircuit.other_elements`` — and daemon statements the
-importer does not understand in ``ignored_directives`` — so a caller can tell
-the user what the file carries that the import leaves behind (see
-``skipped_note()``). The exporter's own scaffold (the open LOAD termination and
-the 50 Ohm GENERATOR) is recognised and not reported.
+Station circuits (issue #604's element set)
+-------------------------------------------
+A station ``.ssn`` carries circuit elements between the antenna NETWORK block
+and the GENERATOR — SimNEC's cascade, saved right-to-left (LOAD … antenna …
+chain … GENERATOR). Those elements land in ``SsnCircuit.chain`` in
+generator→antenna order, and ``SsnCircuit.network()`` translates them back
+into the app's port-network branches — the inverse of the station exporter's
+branch→element mapping, element for element:
+
+    SERIES_TLINE                      -> TL       (Zo / VFnom / ft, and the
+                                         k1·sqrt(f) + k2·f dB/100 ft matched-loss
+                                         coefficients — the same convention)
+    SERIES_IND / SERIES_CAP           -> TwoPort  (H / F, Q -> ql / qc)
+    SHUNT_IND / SHUNT_CAP             -> Shunt    (H / F, Q -> ql / qc)
+    TRANSFORMER2 (Mdl ideal)          -> Transformer (N as the generator:antenna
+                                         voltage ratio, matching the exporter)
+
+The chain hangs between a virtual generator-side node (``"rig"``, the
+``Driven`` source) and the deck's fed wire; trap ``Load``s ride in the deck as
+LD cards and translate through ``parse_nec`` as usual. Semantics notes, shared
+with the exporter: SimNEC quotes component ``Q`` at a frequency (``@MHz``)
+while ``ql``/``qc`` are frequency-independent, so the import is exact at the
+quoted frequency and Q-model-approximate across a sweep; ``Q = 0`` reads as
+the ideal (lossless) component; ``VFnom`` is taken at face value (SimNEC's
+"simplified" line model can compute a different effective vf from its
+dielectric params — the handoff doc's gotcha 2).
+
+A chain element outside that set is recorded in ``other_elements`` (see
+``skipped_note()``), and ``network()`` refuses to build a station around it —
+importing the antenna while silently dropping a tuner element would be a
+confidently-wrong circuit. Elements outside the generator→antenna span, and
+daemon statements the importer does not understand (``ignored_directives``),
+are recorded the same way. The exporter's own scaffold (the open LOAD
+termination and the 50 Ohm GENERATOR) is recognised and not reported.
 """
 
 from __future__ import annotations
@@ -50,10 +76,11 @@ import re
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass, replace
 
+from . import network as _net
 from .design_data import read_data
 from .nec_import import NecDeck, parse_nec
 
-__all__ = ["SsnCircuit", "parse_ssn", "read_ssn"]
+__all__ = ["SsnCircuit", "SsnElement", "parse_ssn", "read_ssn"]
 
 # NECUnits values, in metres. The directive names a unit per argument:
 # (coordinates, wire radius) — the exporter writes "NECUnits meters, meters".
@@ -79,6 +106,13 @@ _UNIT_M = {
 # "no termination" rather than a circuit element worth reporting.
 _OPEN_OHMS = 1e8
 
+M_PER_FT = 0.3048
+
+# Station chain elements network() can translate (issue #604's captured set).
+_SHUNT_CHAIN = frozenset({"SHUNT_IND", "SHUNT_CAP"})
+_SERIES_CHAIN = frozenset({"SERIES_TLINE", "SERIES_IND", "SERIES_CAP", "TRANSFORMER2"})
+_CHAIN_TYPES = _SHUNT_CHAIN | _SERIES_CHAIN
+
 _NEC2_LINE = re.compile(r"^NEC2\s*$")
 _NECEND_LINE = re.compile(r"^NECEND\s*$")
 _PORT_DECL = re.compile(r"^P\d+\s+\S", re.IGNORECASE)
@@ -88,6 +122,90 @@ _SOMMERFELD = re.compile(
 _PERFECT = re.compile(r"^PerfectGround\s*\(\s*\)$", re.IGNORECASE)
 _NECUNITS = re.compile(r"^NECUnits\s+(.+)$", re.IGNORECASE)
 _NECOPTION = re.compile(r"^NECOptions\.(\w+)\s*=\s*(\S+)$", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class SsnElement:
+    """One circuit element from the station chain: its SimNEC ``<type>``,
+    ``<sweeperLabel>``, and top-level params as (name, value) text pairs."""
+
+    typ: str
+    label: str | None
+    params: tuple[tuple[str, str | None], ...]
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        for n, v in self.params:
+            if n == key:
+                return v
+        return default
+
+
+def _chain_f(el: SsnElement, key: str, default: float | None = None) -> float:
+    """A chain element's numeric parameter; ``default`` for an absent one
+    (None = required)."""
+    raw = el.get(key)
+    where = f"{el.typ} element" + (f" {el.label}" if el.label else "")
+    if raw is None:
+        if default is None:
+            raise ValueError(f"{where}: missing its {key!r} parameter")
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        raise ValueError(f"{where}: bad {key!r} value {raw!r}") from None
+
+
+def _chain_q(el: SsnElement) -> float | None:
+    """SimNEC's component ``Q`` (quoted at ``@MHz``) as ``ql``/``qc``:
+    frequency-independent, so exact at the quoted frequency. ``Q = 0`` (or
+    absent) is the ideal component -> None, the SimSmith convention the
+    exporter also uses."""
+    q = _chain_f(el, "Q", default=0.0)
+    return q if q > 0.0 else None
+
+
+def _shunt_branch(el: SsnElement, node: str):
+    if el.typ == "SHUNT_IND":
+        return _net.Shunt(port=node, l=_chain_f(el, "H"), ql=_chain_q(el))
+    return _net.Shunt(port=node, c=_chain_f(el, "F"), qc=_chain_q(el))
+
+
+def _series_branch(el: SsnElement, a: str, b: str):
+    """The network branch for one series chain element, entered generator-side
+    at ``a`` — the inverse of the station exporter's ``_series_elements``."""
+    if el.typ == "SERIES_TLINE":
+        k0 = _chain_f(el, "k0", default=0.0)
+        if k0 != 0.0:
+            raise ValueError(
+                f"SERIES_TLINE {el.label or ''}: a constant k0 loss term has "
+                f"no TL equivalent — TL matched loss is k1*sqrt(f) + k2*f "
+                f"(dB/100 ft)"
+            )
+        return _net.TL(
+            a=a,
+            b=b,
+            z0=_chain_f(el, "Zo"),
+            length=_chain_f(el, "ft") * M_PER_FT,
+            vf=_chain_f(el, "VFnom", default=1.0),
+            k1=_chain_f(el, "k1", default=0.0),
+            k2=_chain_f(el, "k2", default=0.0),
+        )
+    if el.typ == "SERIES_IND":
+        return _net.TwoPort(a=a, b=b, l=_chain_f(el, "H"), ql=_chain_q(el))
+    if el.typ == "SERIES_CAP":
+        return _net.TwoPort(a=a, b=b, c=_chain_f(el, "F"), qc=_chain_q(el))
+    # TRANSFORMER2 — only the ideal ratio maps onto Transformer, exactly as
+    # only the ideal Transformer maps onto TRANSFORMER2 on export.
+    mdl = (el.get("Mdl") or "").strip().lower()
+    if mdl != "ideal":
+        raise ValueError(
+            f"TRANSFORMER2 {el.label or ''}: model {el.get('Mdl')!r} is not "
+            f"the ideal ratio; only 'Mdl ideal' translates to Transformer"
+        )
+    # The exporter emits N as the generator-side:antenna-side voltage ratio
+    # (generator-side Z = N^2 * antenna-side Z); entering at the generator
+    # side, Transformer(a, b, n) with v_a = n*v_b matches directly.
+    return _net.Transformer(a=a, b=b, n=_chain_f(el, "N"))
 
 
 @dataclass(frozen=True)
@@ -114,8 +232,13 @@ class SsnCircuit:
     gen_zo: float | None
     # The block display name — the script's first // comment.
     name: str | None
-    # Circuit element types the import leaves behind (tuner elements,
-    # extra blocks — anything beyond the antenna + exporter scaffold).
+    # The station chain: circuit elements between the GENERATOR and the
+    # antenna NETWORK block, in generator→antenna order. Translated into
+    # port-network branches by network(); empty for an antenna-only file.
+    chain: tuple[SsnElement, ...] = ()
+    # Circuit element types the import cannot translate (chain elements
+    # outside the captured set, extra blocks — anything beyond the antenna,
+    # the station chain, and the exporter scaffold).
     other_elements: tuple[str, ...] = ()
     # Daemon statements not understood, verbatim.
     ignored_directives: tuple[str, ...] = ()
@@ -129,7 +252,7 @@ class SsnCircuit:
         parts = []
         if self.other_elements:
             parts.append(
-                "SimNEC circuit elements not imported (antenna block only): "
+                "SimNEC circuit elements not imported: "
                 + ", ".join(self.other_elements)
             )
         if self.ignored_directives:
@@ -145,6 +268,74 @@ class SsnCircuit:
         if note and deck_note:
             return f"{note} {deck_note}"
         return note or deck_note
+
+    def network(self, *, rig_port: str = "rig"):
+        """The full circuit as a ``network.Network``, ready to return from
+        ``build_network()``: the deck's translated branches and feed (via
+        ``NecDeck.network()``, so parse with ``network=True``), plus the
+        station chain re-hung between a virtual generator-side ``rig_port``
+        node — where the ``Driven`` source moves to — and the deck's fed
+        wire. An antenna-only file returns the deck network unchanged.
+
+        Raises ``ValueError`` for a chain the app cannot faithfully rebuild:
+        an element outside the captured set (see ``other_elements``), a
+        non-ideal TRANSFORMER2, a k0 loss term, or a deck without exactly
+        one voltage feed to attach the chain to."""
+        net = self.deck.network()
+        if not self.chain:
+            return net
+        bad = sorted({el.typ for el in self.chain if el.typ not in _CHAIN_TYPES})
+        if bad:
+            raise ValueError(
+                f"station chain carries element(s) with no network "
+                f"translation: {', '.join(bad)} — importing the antenna "
+                f"while dropping them would misrepresent the circuit"
+            )
+        if len(net.sources) != 1 or not isinstance(net.sources[0], _net.Driven):
+            raise ValueError(
+                "a station chain attaches between the generator and one "
+                "voltage-driven feed; this deck does not have exactly one "
+                "EX voltage source"
+            )
+        src = net.sources[0]
+        feed_port = src.port
+        ports = dict(net.ports)
+        branches = list(net.branches)
+
+        series_left = sum(1 for el in self.chain if el.typ in _SERIES_CHAIN)
+        if series_left == 0:
+            # Shunt-only chain: nothing separates the generator from the
+            # feed, so the shunts hang straight across the feed terminals
+            # and the source stays where the deck put it.
+            branches.extend(_shunt_branch(el, feed_port) for el in self.chain)
+            return _net.Network(ports=ports, branches=branches, sources=[src])
+
+        if rig_port in ports:
+            raise ValueError(
+                f"rig_port {rig_port!r} collides with a deck port name — "
+                f"pass a different rig_port"
+            )
+        node = rig_port
+        ports[node] = _net.PortVirtual(node)
+        k = 0
+        for el in self.chain:
+            if el.typ in _SHUNT_CHAIN:
+                branches.append(_shunt_branch(el, node))
+                continue
+            series_left -= 1
+            if series_left == 0:
+                nxt = feed_port  # the last series element lands on the feed
+            else:
+                k += 1
+                nxt = f"chain{k}"
+                ports[nxt] = _net.PortVirtual(nxt)
+            branches.append(_series_branch(el, node, nxt))
+            node = nxt
+        return _net.Network(
+            ports=ports,
+            branches=branches,
+            sources=[_net.Driven(port=rig_port, voltage=src.voltage)],
+        )
 
 
 def _unit_scale(token: str, where: str) -> float:
@@ -273,8 +464,9 @@ def parse_ssn(
 
     ``network`` and ``virtualize_anchors`` forward to :func:`parse_nec` for the
     embedded NEC cards — ``network=True`` makes ``circuit.deck.wire_tuples()``
-    and ``circuit.deck.network()`` ready to return from ``build_wires`` /
-    ``build_network``, with the deck's lumped LD loads translated.
+    and ``circuit.network()`` ready to return from ``build_wires`` /
+    ``build_network``, with the deck's lumped LD loads and the file's station
+    chain (see the module note) translated.
 
     Raises ``ValueError`` (prefixed with ``name``) on malformed XML, on a file
     with no NEC-portal antenna block or more than one, and on anything
@@ -285,24 +477,50 @@ def parse_ssn(
     except ET.ParseError as e:
         raise ValueError(f"{name}: not well-formed .ssn XML ({e})") from None
 
-    nec_blocks: list[str] = []
-    generator = None
-    other: list[str] = []
     elements = root.findall(".//CIRCUIT/element")
     if not elements:
         raise ValueError(f"{name}: no <CIRCUIT> elements — is this a .ssn file?")
-    for el in elements:
-        typ = (el.findtext("type") or "?").strip()
-        params = _params(el)
-        if typ == "NETWORK" and "equ" in params:
-            equ = params["equ"] or ""
-            if re.search(r"(?m)^\s*NEC2\s*$", equ):
-                nec_blocks.append(equ)
-            else:
-                other.append("NETWORK (non-NEC script)")
+    infos = [((el.findtext("type") or "?").strip(), _params(el), el) for el in elements]
+
+    nec_positions = [
+        i
+        for i, (typ, params, _) in enumerate(infos)
+        if typ == "NETWORK"
+        and "equ" in params
+        and re.search(r"(?m)^\s*NEC2\s*$", params["equ"] or "")
+    ]
+    if not nec_positions:
+        raise ValueError(
+            f"{name}: no NEC-portal antenna block (a NETWORK element whose "
+            f"<equ> script carries NEC2 cards)"
+        )
+    if len(nec_positions) > 1:
+        raise ValueError(
+            f"{name}: {len(nec_positions)} NEC-portal blocks — antennaknobs "
+            f"imports a single-antenna circuit"
+        )
+    nec_pos = nec_positions[0]
+    gen_pos = next(
+        (i for i, (typ, _, _) in enumerate(infos) if typ == "GENERATOR"), None
+    )
+    generator = elements[gen_pos] if gen_pos is not None else None
+
+    # The station chain is whatever sits between the antenna block and the
+    # Generator (SimNEC saves the cascade right-to-left: LOAD … antenna …
+    # chain … GENERATOR, so that document span reads antenna→generator).
+    if gen_pos is not None:
+        lo, hi = sorted((nec_pos, gen_pos))
+        span = range(lo + 1, hi)
+    else:
+        span = range(0)
+
+    chain_doc: list[SsnElement] = []
+    other: list[str] = []
+    for i, (typ, params, el) in enumerate(infos):
+        if i == nec_pos or i == gen_pos:
             continue
-        if typ == "GENERATOR" and generator is None:
-            generator = el
+        if typ == "NETWORK" and "equ" in params:
+            other.append("NETWORK (non-NEC script)")
             continue
         if typ == "LOAD":
             try:
@@ -311,20 +529,28 @@ def parse_ssn(
                 is_open = False
             if is_open:
                 continue  # the exporter's scaffold open termination
+        if i in span:
+            chain_doc.append(
+                SsnElement(
+                    typ=typ,
+                    label=el.findtext("sweeperLabel"),
+                    params=tuple(
+                        (p.findtext("n"), p.findtext("v")) for p in el.findall("p")
+                    ),
+                )
+            )
+            if typ not in _CHAIN_TYPES:
+                # In the cascade but not translatable: report it, and
+                # network() will refuse to build a station around it.
+                other.append(typ)
+            continue
         other.append(typ)
+    # Orient the chain generator→antenna, whichever way the file ran.
+    if gen_pos is not None and nec_pos < gen_pos:
+        chain_doc.reverse()
+    chain = tuple(chain_doc)
 
-    if not nec_blocks:
-        raise ValueError(
-            f"{name}: no NEC-portal antenna block (a NETWORK element whose "
-            f"<equ> script carries NEC2 cards)"
-        )
-    if len(nec_blocks) > 1:
-        raise ValueError(
-            f"{name}: {len(nec_blocks)} NEC-portal blocks — antennaknobs "
-            f"imports a single-antenna circuit"
-        )
-
-    script = _Script(nec_blocks[0], name)
+    script = _Script(infos[nec_pos][1]["equ"] or "", name)
 
     deck_lines = list(script.cards)
     if script.coord_scale != 1.0:
@@ -372,6 +598,7 @@ def parse_ssn(
         seg_per_wl=script.seg_per_wl,
         gen_zo=gen_zo,
         name=script.name,
+        chain=chain,
         other_elements=tuple(other),
         ignored_directives=tuple(script.ignored),
     )

--- a/src/antennaknobs/simnec_import.py
+++ b/src/antennaknobs/simnec_import.py
@@ -48,8 +48,9 @@ branch→element mapping, element for element:
                                          coefficients — the same convention)
     SERIES_IND / SERIES_CAP           -> TwoPort  (H / F, Q -> ql / qc)
     SHUNT_IND / SHUNT_CAP             -> Shunt    (H / F, Q -> ql / qc)
-    TRANSFORMER2 (Mdl ideal)          -> Transformer (N as the generator:antenna
-                                         voltage ratio, matching the exporter)
+    TRANSFORMER2 (Mdl ideal)          -> Transformer (n = 1/N: SimNEC's N is
+                                         the antenna:generator voltage ratio,
+                                         validated on 6p4d6 — see export)
 
 The chain hangs between a virtual generator-side node (``"rig"``, the
 ``Driven`` source) and the deck's fed wire; trap ``Load``s ride in the deck as
@@ -202,10 +203,17 @@ def _series_branch(el: SsnElement, a: str, b: str):
             f"TRANSFORMER2 {el.label or ''}: model {el.get('Mdl')!r} is not "
             f"the ideal ratio; only 'Mdl ideal' translates to Transformer"
         )
-    # The exporter emits N as the generator-side:antenna-side voltage ratio
-    # (generator-side Z = N^2 * antenna-side Z); entering at the generator
-    # side, Transformer(a, b, n) with v_a = n*v_b matches directly.
-    return _net.Transformer(a=a, b=b, n=_chain_f(el, "N"))
+    # SimNEC's N is the ANTENNA:generator ratio — validated live on 6p4d6
+    # (2026-08-07, PR #696 signoff: an n=2 step-up emitted as N=2 read Z/4
+    # at the generator), and the exporter emits the reciprocal accordingly.
+    # Our Transformer(a, b, n) has v_a = n*v_b entered generator-side, so
+    # n = 1/N.
+    n = _chain_f(el, "N")
+    if n == 0:
+        raise ValueError(
+            f"TRANSFORMER2 {el.label or ''}: N = 0 has no impedance mapping"
+        )
+    return _net.Transformer(a=a, b=b, n=1.0 / n)
 
 
 @dataclass(frozen=True)

--- a/src/antennaknobs/web/user_design_assets/CLAUDE.md
+++ b/src/antennaknobs/web/user_design_assets/CLAUDE.md
@@ -171,6 +171,39 @@ def _seed_defaults_from_deck(cls):
     cls.default_params = MappingProxyType(params)
 ```
 
+### Loading a SimNEC circuit (`.ssn`)
+
+`read_ssn(self, name)` loads a **SimNEC** (AE6TY) circuit file with the same
+folder confinement as `read_nec`. The antenna lives in the file's NEC-portal
+block; `read_ssn` extracts it and returns an `SsnCircuit` whose `.deck` is the
+same `NecDeck` a `.nec` import produces — so the recipe is the `.nec` one with
+one extra hop, and the frozen-geometry expectations above apply unchanged:
+
+```python
+from antennaknobs import AntennaBuilder, read_ssn
+
+class Builder(AntennaBuilder):
+    def build_wires(self):
+        return read_ssn(self, "station.ssn", network=True).deck.wire_tuples(
+            specs=True
+        )
+
+    def build_network(self):
+        return read_ssn(self, "station.ssn", network=True).deck.network()
+```
+
+Circuit-level settings SimNEC keeps outside the deck surface on the
+`SsnCircuit`: `freq_mhz` is the Generator's solve frequency (use it to seed
+`freq` — the deck's FR card is advisory in SimNEC), `sweep` an armed Generator
+sweep (seed `ui_params["meas_freq_range"]`), `ground` the file's ground model
+(free / `"pec"` / `("finite", eps_r, sigma)` — tell the user to set the app
+ground to match), and `conductivity` the wire material for `WireSpec`.
+`NECUnits` in feet/inches/cm/mm is converted to metres automatically. Only the
+antenna block is imported: station elements (tuner, feedline, transformer
+blocks) are recorded in `other_elements`, and `circuit.skipped_note()` renders
+everything left behind as the same one-sentence note as `deck.skipped_note()` —
+put it under `ui_params["notes"]`.
+
 ## `default_params`
 
 Every key becomes a slider in the UI, accessed in `build_wires` as

--- a/src/antennaknobs/web/user_design_assets/CLAUDE.md
+++ b/src/antennaknobs/web/user_design_assets/CLAUDE.md
@@ -189,8 +189,20 @@ class Builder(AntennaBuilder):
         )
 
     def build_network(self):
-        return read_ssn(self, "station.ssn", network=True).deck.network()
+        # deck loads/feed PLUS the file's station chain (see below)
+        return read_ssn(self, "station.ssn", network=True).network()
 ```
+
+A **station** `.ssn` — tuner, feedline, transformer elements between the
+Generator and the antenna — imports too: `circuit.network()` translates the
+cascade back into the app's own branches (`SERIES_TLINE` → `TL` with the same
+Zo/vf/k1/k2 loss convention, `SERIES_IND`/`SERIES_CAP` → `TwoPort`,
+`SHUNT_IND`/`SHUNT_CAP` → `Shunt`, ideal `TRANSFORMER2` → `Transformer`;
+component `Q` becomes `ql`/`qc`, exact at the frequency SimNEC quoted it at),
+hung between a virtual `"rig"` node (where the `Driven` moves) and the deck's
+fed wire. An element outside that set makes `network()` raise rather than
+silently drop part of the circuit — it also shows up in `other_elements`, so
+you can tell the user before they hit it.
 
 Circuit-level settings SimNEC keeps outside the deck surface on the
 `SsnCircuit`: `freq_mhz` is the Generator's solve frequency (use it to seed
@@ -198,11 +210,10 @@ Circuit-level settings SimNEC keeps outside the deck surface on the
 sweep (seed `ui_params["meas_freq_range"]`), `ground` the file's ground model
 (free / `"pec"` / `("finite", eps_r, sigma)` — tell the user to set the app
 ground to match), and `conductivity` the wire material for `WireSpec`.
-`NECUnits` in feet/inches/cm/mm is converted to metres automatically. Only the
-antenna block is imported: station elements (tuner, feedline, transformer
-blocks) are recorded in `other_elements`, and `circuit.skipped_note()` renders
-everything left behind as the same one-sentence note as `deck.skipped_note()` —
-put it under `ui_params["notes"]`.
+`NECUnits` in feet/inches/cm/mm is converted to metres automatically.
+Whatever the import leaves behind (untranslatable elements, unknown
+directives) is rendered by `circuit.skipped_note()` as the same one-sentence
+note as `deck.skipped_note()` — put it under `ui_params["notes"]`.
 
 ## `default_params`
 

--- a/tests/test_simnec_import.py
+++ b/tests/test_simnec_import.py
@@ -11,7 +11,15 @@ import pytest
 
 from antennaknobs import user_designs
 from antennaknobs.builder import AntennaBuilder
-from antennaknobs.network import Wire
+from antennaknobs.network import (
+    TL,
+    Driven,
+    PortVirtual,
+    Shunt,
+    Transformer,
+    TwoPort,
+    Wire,
+)
 from antennaknobs.simnec_export import export_ssn
 from antennaknobs.simnec_import import parse_ssn, read_ssn
 
@@ -181,24 +189,6 @@ def test_wire_conductivity_directive():
     assert parse_ssn(_ssn(script), name="t.ssn").conductivity is None
 
 
-def test_station_elements_are_recorded_not_translated():
-    extra = """
-            <element>
-                <type>SERIES_TLINE</type>
-                <p><n>Zo</n><v>450</v></p>
-            </element>
-            <element>
-                <type>SHUNT_CAP</type>
-                <p><n>pF</n><v>74</v></p>
-            </element>"""
-    c = parse_ssn(_ssn(_SCRIPT_M, extra_elements=extra), name="t.ssn")
-    assert c.other_elements == ("SERIES_TLINE", "SHUNT_CAP")
-    note = c.skipped_note()
-    assert "SERIES_TLINE" in note and "antenna block only" in note
-    # the antenna still imported
-    assert len(c.deck.wires) == 1
-
-
 def test_non_open_load_is_recorded():
     ssn = _ssn(_SCRIPT_M).replace("1000000000", "50")
     c = parse_ssn(ssn, name="t.ssn")
@@ -271,6 +261,164 @@ def test_stray_en_card_does_not_defeat_units_or_ground():
     assert c.ground == "pec" and c.deck.ground is True
 
 
+# --- station chains (the read side of the #604 station export) ---------------
+
+
+def _el(typ, params, label=None):
+    """One chain <element> in the station exporter's emission shape."""
+    lbl = f"<sweeperLabel>{label}</sweeperLabel>" if label else ""
+    ps = "".join(f"<p><n>{n}</n><v>{v}</v></p>" for n, v in params.items())
+    return f"""
+            <element>
+                <type>{typ}</type>{lbl}{ps}
+            </element>"""
+
+
+# The Track-1 ladder tuner's cascade, in .ssn file order (right-to-left saves
+# put the antenna-side element first): openwire line, 500 pF line-side cap,
+# tee coil, 81.2 pF rig-side cap — exactly what the station exporter emits
+# for wire.doublet_ladder_tuner.
+_LADDER = (
+    _el(
+        "SERIES_TLINE",
+        {
+            "Zo": 600,
+            "VFnom": 0.95,
+            "ft": 100,
+            "k0": 0,
+            "k1": 0.02,
+            "k2": 0.0001,
+        },
+        label="T1",
+    )
+    + _el("SERIES_CAP", {"F": "5e-10", "Q": 0, "@MHz": 7.1}, label="C2")
+    + _el("SHUNT_IND", {"H": "4.218e-06", "Q": 200, "@MHz": 7.1}, label="L1")
+    + _el("SERIES_CAP", {"F": "8.12e-11", "Q": 0, "@MHz": 7.1}, label="C1")
+)
+
+
+def test_station_chain_is_parsed_generator_to_antenna():
+    c = parse_ssn(_ssn(_SCRIPT_M, extra_elements=_LADDER), name="t.ssn")
+    assert [el.typ for el in c.chain] == [
+        "SERIES_CAP",
+        "SHUNT_IND",
+        "SERIES_CAP",
+        "SERIES_TLINE",
+    ]
+    assert [el.label for el in c.chain] == ["C1", "L1", "C2", "T1"]
+    # every chain element is translatable — nothing to warn about
+    assert c.other_elements == ()
+    assert c.skipped_note() is None
+
+
+def test_station_network_rebuilds_the_full_ladder():
+    """network() is the inverse of the station exporter's cascade walk: the
+    Driven moves to a virtual rig node and the chain hangs rig → … → feed."""
+    c = parse_ssn(_ssn(_SCRIPT_M, extra_elements=_LADDER), name="t.ssn", network=True)
+    net = c.network()
+    (src,) = net.sources
+    assert isinstance(src, Driven) and src.port == "rig"
+    assert isinstance(net.ports["rig"], PortVirtual)
+
+    tl = next(b for b in net.branches if isinstance(b, TL))
+    assert (tl.a, tl.b) == ("chain2", "feed")
+    assert tl.z0 == pytest.approx(600.0)
+    assert tl.length == pytest.approx(100 * 0.3048)
+    assert tl.vf == pytest.approx(0.95)
+    assert tl.k1 == pytest.approx(0.02) and tl.k2 == pytest.approx(0.0001)
+
+    caps = [b for b in net.branches if isinstance(b, TwoPort)]
+    assert [(b.a, b.b) for b in caps] == [("rig", "chain1"), ("chain1", "chain2")]
+    assert caps[0].c == pytest.approx(8.12e-11)  # rig-side C1
+    assert caps[1].c == pytest.approx(5e-10)  # line-side C2
+    assert caps[0].qc is None  # Q = 0 -> the ideal component
+
+    (coil,) = [b for b in net.branches if isinstance(b, Shunt)]
+    assert coil.port == "chain1"  # the tee node, between the caps
+    assert coil.l == pytest.approx(4.218e-6) and coil.ql == pytest.approx(200.0)
+
+
+def test_station_deck_trap_loads_ride_along():
+    """Trap Loads travel as deck LD cards on export; they come back as Load
+    branches next to the chain."""
+    from antennaknobs.network import Load
+
+    script = _SCRIPT_M.replace("FR 0", "LD 0 1 3 3 10 2.5e-6 0\nFR 0")
+    c = parse_ssn(_ssn(script, extra_elements=_LADDER), name="t.ssn", network=True)
+    net = c.network()
+    assert any(isinstance(b, Load) for b in net.branches)
+    (src,) = net.sources
+    assert src.port == "rig"
+
+
+def test_station_ideal_transformer2():
+    extra = _el("TRANSFORMER2", {"Mdl": "ideal", "N": 2}, label="X1")
+    c = parse_ssn(_ssn(_SCRIPT_M, extra_elements=extra), name="t.ssn", network=True)
+    (x,) = [b for b in c.network().branches if isinstance(b, Transformer)]
+    # N is the generator:antenna voltage ratio; entered generator-side,
+    # Transformer(a, b, n) with v_a = n·v_b matches directly.
+    assert (x.a, x.b, x.n) == ("rig", "feed", 2.0)
+
+
+def test_station_non_ideal_transformer2_rejected():
+    extra = _el("TRANSFORMER2", {"Mdl": "lossy", "N": 2})
+    c = parse_ssn(_ssn(_SCRIPT_M, extra_elements=extra), name="t.ssn", network=True)
+    with pytest.raises(ValueError, match="ideal"):
+        c.network()
+
+
+def test_station_k0_loss_rejected():
+    extra = _el("SERIES_TLINE", {"Zo": 50, "ft": 100, "k0": 0.5})
+    c = parse_ssn(_ssn(_SCRIPT_M, extra_elements=extra), name="t.ssn", network=True)
+    with pytest.raises(ValueError, match="k0"):
+        c.network()
+
+
+def test_station_shunt_only_chain_hangs_across_the_feed():
+    """With no series element between generator and feed, the shunts sit
+    straight across the feed terminals and the Driven stays at the feed."""
+    extra = _el("SHUNT_CAP", {"F": "1e-10"})
+    c = parse_ssn(_ssn(_SCRIPT_M, extra_elements=extra), name="t.ssn", network=True)
+    net = c.network()
+    (sh,) = [b for b in net.branches if isinstance(b, Shunt)]
+    assert sh.port == "feed" and sh.c == pytest.approx(1e-10)
+    (src,) = net.sources
+    assert src.port == "feed"
+    assert "rig" not in net.ports
+
+
+def test_station_unknown_chain_element_recorded_and_refused():
+    """An untranslatable element inside the cascade is reported, and
+    network() refuses rather than silently dropping it from the circuit."""
+    extra = _el("SERIES_RES", {"ohms": 10}) + _el("SHUNT_CAP", {"F": "1e-10"})
+    c = parse_ssn(_ssn(_SCRIPT_M, extra_elements=extra), name="t.ssn", network=True)
+    assert c.other_elements == ("SERIES_RES",)
+    assert "SERIES_RES" in c.skipped_note()
+    with pytest.raises(ValueError, match="SERIES_RES"):
+        c.network()
+
+
+def test_station_missing_param_names_the_element():
+    extra = _el("SERIES_IND", {"Q": 100}, label="L1")
+    c = parse_ssn(_ssn(_SCRIPT_M, extra_elements=extra), name="t.ssn", network=True)
+    with pytest.raises(ValueError, match="SERIES_IND element L1.*'H'"):
+        c.network()
+
+
+def test_antenna_only_network_is_the_deck_network():
+    c = parse_ssn(_ssn(_SCRIPT_M), name="t.ssn", network=True)
+    net = c.network()
+    (src,) = net.sources
+    assert src.port == "feed"
+    assert "rig" not in net.ports
+
+
+def test_station_network_requires_network_mode():
+    c = parse_ssn(_ssn(_SCRIPT_M, extra_elements=_LADDER), name="t.ssn")
+    with pytest.raises(ValueError, match="network=True"):
+        c.network()
+
+
 # --- the design-stub consumption path ----------------------------------------
 
 SSN_DESIGN = """
@@ -286,7 +434,7 @@ class Builder(AntennaBuilder):
         )
 
     def build_network(self):
-        return read_ssn(self, "antenna.ssn", network=True).deck.network()
+        return read_ssn(self, "antenna.ssn", network=True).network()
 """
 
 

--- a/tests/test_simnec_import.py
+++ b/tests/test_simnec_import.py
@@ -457,3 +457,53 @@ def test_read_ssn_confined_to_design_folder(tmp_path, monkeypatch):
     b = user_designs.resolve_user_design("ssn_design")()
     with pytest.raises(ValueError, match="absolute"):
         read_ssn(b, "/etc/passwd")
+
+
+# --- full round-trip: export_ssn -> parse_ssn, both sides on one branch ------
+
+
+class _XfmrStation(AntennaBuilder):
+    """n=2 ideal transformer between rig and dipole — pins the reciprocal
+    TRANSFORMER2 N convention END TO END (export emits N=1/n, import reads
+    n=1/N; the SimNEC 6p4d6 validation finding from PR #696), so the pair
+    cannot drift apart again."""
+
+    default_params = MappingProxyType({"freq": 14.0, "design_freq": 14.0})
+
+    def build_wires(self):
+        return [Wire((0.0, -5.0, 10.0), (0.0, 5.0, 10.0), n_seg=11, name="feed")]
+
+    def build_network(self):
+        from antennaknobs.network import Network, PortOnWire
+
+        return Network(
+            ports={"feed": PortOnWire("feed"), "rig": PortVirtual("rig")},
+            branches=[Transformer(a="rig", b="feed", n=2.0)],
+            sources=[Driven(port="rig")],
+        )
+
+
+def test_roundtrip_transformer_n_identity():
+    ssn = export_ssn(_XfmrStation(), freq_mhz=14.0, ground=None)
+    net = parse_ssn(ssn, name="rt.ssn", network=True).network()
+    (x,) = [b for b in net.branches if isinstance(b, Transformer)]
+    assert x.n == pytest.approx(2.0)
+
+
+def test_roundtrip_ladder_tuner_values():
+    """The catalog station whose cascade was load-validated in SimNEC:
+    every element value survives export -> import unchanged."""
+    from antennaknobs.designs.wire.doublet_ladder_tuner import Builder
+
+    ssn = export_ssn(Builder(), ground=None)
+    net = parse_ssn(ssn, name="rt.ssn", network=True).network()
+    (tl,) = [b for b in net.branches if isinstance(b, TL)]
+    assert tl.z0 == pytest.approx(600.0) and tl.vf == pytest.approx(0.95)
+    assert tl.k1 == pytest.approx(0.02) and tl.k2 == pytest.approx(0.0001)
+    assert tl.length == pytest.approx(30.48)  # 100 ft
+    caps = sorted(
+        (b.c for b in net.branches if isinstance(b, TwoPort) and b.c is not None)
+    )
+    assert caps == [pytest.approx(8.12e-11), pytest.approx(5e-10)]
+    (coil,) = [b for b in net.branches if isinstance(b, Shunt)]
+    assert coil.l == pytest.approx(4.218e-6) and coil.ql == pytest.approx(200.0)

--- a/tests/test_simnec_import.py
+++ b/tests/test_simnec_import.py
@@ -1,0 +1,311 @@
+"""SimNEC .ssn import (the read-side twin of ``simnec_export``).
+
+Round-trips against ``export_ssn`` cover the exporter-shaped files; hand-written
+XML covers the foreign-file cases (units, station elements, unknown directives,
+malformed input) a SimNEC-saved circuit can carry.
+"""
+
+from types import MappingProxyType
+
+import pytest
+
+from antennaknobs import user_designs
+from antennaknobs.builder import AntennaBuilder
+from antennaknobs.network import Wire
+from antennaknobs.simnec_export import export_ssn
+from antennaknobs.simnec_import import parse_ssn, read_ssn
+
+
+class _Dipole(AntennaBuilder):
+    default_params = MappingProxyType({"freq": 14.0, "design_freq": 14.0})
+
+    def build_wires(self):
+        # up at z=10 m so the ground-plane cases (pec/finite) are valid geometry
+        return [Wire((0.0, -5.0, 10.0), (0.0, 5.0, 10.0), n_seg=11, ex=1 + 0j)]
+
+
+def _roundtrip(**export_kw):
+    return parse_ssn(export_ssn(_Dipole(), **export_kw), name="rt.ssn")
+
+
+# A hand-written .ssn in the shape SimNEC saves (minimal), with the script
+# injectable so foreign-dialect cases are easy to express.
+def _ssn(script, extra_elements="", generator=True):
+    gen = (
+        """
+            <element>
+                <type>GENERATOR</type>
+                <p><n>MHz</n><v>7.1</v></p>
+                <p><n>Zo</n><v>50</v></p>
+            </element>"""
+        if generator
+        else ""
+    )
+    return f"""<?xml version="1.0" encoding="utf-8"?>
+<SimNEC1p0>
+    <SmithChartCircuit>
+        <XMLVersionControl>SimNEC:5.1a1</XMLVersionControl>
+        <CIRCUIT>
+            <element>
+                <type>LOAD</type>
+                <p><n>ohms</n><v>1000000000</v></p>
+            </element>
+            <element>
+                <type>NETWORK</type>
+                <escapeHatch/>
+                <p><n>equ</n><v>{script}</v></p>
+            </element>{extra_elements}{gen}
+        </CIRCUIT>
+    </SmithChartCircuit>
+</SimNEC1p0>
+"""
+
+
+_SCRIPT_M = """//dip40
+P1 w1 gnd;
+P2 w2 gnd;
+NECUnits meters, meters;
+NEC2
+GW 1 11 0 -5 10 0 5 10 0.0005
+FR 0 1 0 0 7.1 0
+EX 0 1 6 0 1 0
+NECEND"""
+
+
+# --- round-trips against the exporter ---------------------------------------
+
+
+def test_roundtrip_geometry_and_feed():
+    c = _roundtrip(freq_mhz=14.1, ground=None)
+    (w,) = c.deck.wires
+    assert w.p1 == (0.0, -5.0, 10.0) and w.p2 == (0.0, 5.0, 10.0)
+    assert w.n_seg == 11 and w.radius == pytest.approx(0.0005)
+    (f,) = c.deck.feeds
+    assert (f.wire, f.seg, f.voltage) == (0, 6, 1 + 0j)
+
+
+def test_roundtrip_frequency_comes_from_generator():
+    c = _roundtrip(freq_mhz=14.1, ground=None)
+    assert c.freq_mhz == pytest.approx(14.1)
+    # the deck's advisory FR is still visible on the deck itself
+    assert c.deck.freq_mhz == (pytest.approx(14.1), pytest.approx(14.1))
+
+
+def test_roundtrip_grounds():
+    assert _roundtrip(freq_mhz=14.1, ground=None).ground is None
+    assert _roundtrip(freq_mhz=14.1, ground="pec").ground == "pec"
+    g = _roundtrip(freq_mhz=14.1, ground=("finite", 20.0, 0.0303)).ground
+    assert g[0] == "finite"
+    assert g[1] == pytest.approx(20.0) and g[2] == pytest.approx(0.0303)
+    # a SommerfeldGround maps back as the accurate model even from finite-fast
+    g = _roundtrip(freq_mhz=14.1, ground=("finite-fast", 13.0, 0.005)).ground
+    assert g == ("finite", pytest.approx(13.0), pytest.approx(0.005))
+
+
+def test_roundtrip_ground_sets_deck_flag():
+    assert _roundtrip(freq_mhz=14.1, ground="pec").deck.ground is True
+    assert _roundtrip(freq_mhz=14.1, ground=None).deck.ground is False
+
+
+def test_roundtrip_seg_per_wl_and_name():
+    c = _roundtrip(freq_mhz=14.1, ground=None, seg_per_wl=120, name="dip20")
+    assert c.seg_per_wl == 120
+    assert c.name == "dip20"
+    assert _roundtrip(freq_mhz=14.1, ground=None).seg_per_wl is None
+
+
+def test_roundtrip_sweep():
+    assert _roundtrip(freq_mhz=14.1, ground=None).sweep is None
+    c = _roundtrip(freq_mhz=14.1, ground=None, sweep=(13.0, 15.0))
+    assert c.sweep == (pytest.approx(13.0), pytest.approx(15.0))
+
+
+def test_roundtrip_scaffold_is_not_reported():
+    """The exporter's open LOAD + 50 Ohm GENERATOR are scaffold, not station
+    elements; a clean round-trip has nothing to warn about."""
+    c = _roundtrip(freq_mhz=14.1, ground=None)
+    assert c.other_elements == ()
+    assert c.ignored_directives == ()
+    assert c.gen_zo == pytest.approx(50.0)
+    assert c.skipped_note() is None
+
+
+def test_roundtrip_real_builtin_design():
+    from antennaknobs.designs.dipoles.invvee import Builder as InvVee
+
+    ssn = export_ssn(InvVee(), ground=("finite", 13.0, 0.005), seg_per_wl=80)
+    c = parse_ssn(ssn, name="invvee.ssn")
+    assert c.name == "invvee"
+    assert len(c.deck.wires) >= 2 and len(c.deck.feeds) == 1
+    assert c.ground == ("finite", pytest.approx(13.0), pytest.approx(0.005))
+
+
+# --- foreign files -----------------------------------------------------------
+
+
+def test_hand_written_minimal_file():
+    c = parse_ssn(_ssn(_SCRIPT_M), name="t.ssn")
+    assert c.name == "dip40"
+    assert c.freq_mhz == pytest.approx(7.1)
+    (w,) = c.deck.wires
+    assert w.p2 == (0.0, 5.0, 10.0)
+
+
+def test_necunits_feet_scales_to_metres():
+    script = _SCRIPT_M.replace("NECUnits meters, meters;", "NECUnits feet, feet;")
+    (w,) = parse_ssn(_ssn(script), name="t.ssn").deck.wires
+    assert w.p2[1] == pytest.approx(5 * 0.3048)
+    assert w.p2[2] == pytest.approx(10 * 0.3048)
+    assert w.radius == pytest.approx(0.0005 * 0.3048)
+
+
+def test_necunits_mixed_units_scale_radius_separately():
+    script = _SCRIPT_M.replace("NECUnits meters, meters;", "NECUnits feet, mm;")
+    (w,) = parse_ssn(_ssn(script), name="t.ssn").deck.wires
+    assert w.p2[1] == pytest.approx(5 * 0.3048)
+    assert w.radius == pytest.approx(0.0005 * 0.001)
+
+
+def test_necunits_unknown_unit_raises():
+    script = _SCRIPT_M.replace("NECUnits meters, meters;", "NECUnits cubits, m;")
+    with pytest.raises(ValueError, match="cubits"):
+        parse_ssn(_ssn(script), name="t.ssn")
+
+
+def test_wire_conductivity_directive():
+    script = _SCRIPT_M.replace("NEC2", "NECOptions.mhosPerMeter = 5.8e7;\nNEC2")
+    c = parse_ssn(_ssn(script), name="t.ssn")
+    assert c.conductivity == pytest.approx(5.8e7)
+    # 0 = perfect wires -> None
+    script = _SCRIPT_M.replace("NEC2", "NECOptions.mhosPerMeter = 0;\nNEC2")
+    assert parse_ssn(_ssn(script), name="t.ssn").conductivity is None
+
+
+def test_station_elements_are_recorded_not_translated():
+    extra = """
+            <element>
+                <type>SERIES_TLINE</type>
+                <p><n>Zo</n><v>450</v></p>
+            </element>
+            <element>
+                <type>SHUNT_CAP</type>
+                <p><n>pF</n><v>74</v></p>
+            </element>"""
+    c = parse_ssn(_ssn(_SCRIPT_M, extra_elements=extra), name="t.ssn")
+    assert c.other_elements == ("SERIES_TLINE", "SHUNT_CAP")
+    note = c.skipped_note()
+    assert "SERIES_TLINE" in note and "antenna block only" in note
+    # the antenna still imported
+    assert len(c.deck.wires) == 1
+
+
+def test_non_open_load_is_recorded():
+    ssn = _ssn(_SCRIPT_M).replace("1000000000", "50")
+    c = parse_ssn(ssn, name="t.ssn")
+    assert "LOAD" in c.other_elements
+
+
+def test_unknown_directive_is_recorded():
+    script = _SCRIPT_M.replace("NEC2", "FancyNewThing(1, 2);\nNEC2")
+    c = parse_ssn(_ssn(script), name="t.ssn")
+    assert c.ignored_directives == ("FancyNewThing(1, 2)",)
+    assert "FancyNewThing" in c.skipped_note()
+
+
+def test_missing_generator_leaves_freq_none():
+    c = parse_ssn(_ssn(_SCRIPT_M, generator=False), name="t.ssn")
+    assert c.freq_mhz is None and c.gen_zo is None
+    # the deck's advisory FR still gives the caller a band to seed from
+    assert c.deck.freq_mhz == (pytest.approx(7.1), pytest.approx(7.1))
+
+
+def test_network_mode_translates_lumped_loads():
+    script = _SCRIPT_M.replace("FR 0", "LD 0 1 3 3 10 2.5e-6 0\nFR 0")
+    c = parse_ssn(_ssn(script), name="t.ssn", network=True)
+    (ld,) = c.deck.loads
+    assert (ld.r, ld.l) == (10.0, 2.5e-6)
+    net = c.deck.network()  # ready for build_network
+    assert net.sources
+
+
+def test_malformed_xml_raises_with_name():
+    with pytest.raises(ValueError, match=r"bad\.ssn.*not well-formed"):
+        parse_ssn("<SimNEC1p0><oops>", name="bad.ssn")
+
+
+def test_non_circuit_xml_raises():
+    with pytest.raises(ValueError, match="no <CIRCUIT> elements"):
+        parse_ssn("<foo><bar/></foo>", name="t.ssn")
+
+
+def test_no_nec_block_raises():
+    ssn = _ssn("P1 w1 gnd; // just a circuit script, no NEC cards")
+    with pytest.raises(ValueError, match="no NEC-portal antenna block"):
+        parse_ssn(ssn, name="t.ssn")
+
+
+def test_two_nec_blocks_raise():
+    extra = f"""
+            <element>
+                <type>NETWORK</type>
+                <escapeHatch/>
+                <p><n>equ</n><v>{_SCRIPT_M}</v></p>
+            </element>"""
+    with pytest.raises(ValueError, match="2 NEC-portal blocks"):
+        parse_ssn(_ssn(_SCRIPT_M, extra_elements=extra), name="t.ssn")
+
+
+def test_missing_necend_raises():
+    script = _SCRIPT_M.replace("\nNECEND", "")
+    with pytest.raises(ValueError, match="missing its NECEND"):
+        parse_ssn(_ssn(script), name="t.ssn")
+
+
+def test_stray_en_card_does_not_defeat_units_or_ground():
+    """An EN inside the block must not truncate the appended GS/GE cards."""
+    script = _SCRIPT_M.replace(
+        "NECUnits meters, meters;", "NECUnits feet, feet;\nPerfectGround();"
+    ).replace("NECEND", "EN\nNECEND")
+    c = parse_ssn(_ssn(script), name="t.ssn")
+    assert c.deck.wires[0].p2[1] == pytest.approx(5 * 0.3048)
+    assert c.ground == "pec" and c.deck.ground is True
+
+
+# --- the design-stub consumption path ----------------------------------------
+
+SSN_DESIGN = """
+from types import MappingProxyType
+from antennaknobs import AntennaBuilder, read_ssn
+
+class Builder(AntennaBuilder):
+    default_params = MappingProxyType({"freq": 7.1})
+
+    def build_wires(self):
+        return read_ssn(self, "antenna.ssn", network=True).deck.wire_tuples(
+            specs=True
+        )
+
+    def build_network(self):
+        return read_ssn(self, "antenna.ssn", network=True).deck.network()
+"""
+
+
+def test_read_ssn_from_a_user_design(tmp_path, monkeypatch):
+    monkeypatch.setenv("ANTENNAKNOBS_USER_DIR", str(tmp_path))
+    (tmp_path / "ssn_design.py").write_text(SSN_DESIGN)
+    (tmp_path / "antenna.ssn").write_text(export_ssn(_Dipole(), freq_mhz=14.0))
+    cls = user_designs.resolve_user_design("ssn_design")
+    b = cls()
+    wires = b.build_wires()
+    assert wires and any(len(w) >= 4 for w in wires)
+    net = b.build_network()
+    assert net.sources
+
+
+def test_read_ssn_confined_to_design_folder(tmp_path, monkeypatch):
+    monkeypatch.setenv("ANTENNAKNOBS_USER_DIR", str(tmp_path))
+    (tmp_path / "ssn_design.py").write_text(SSN_DESIGN)
+    (tmp_path / "antenna.ssn").write_text(export_ssn(_Dipole(), freq_mhz=14.0))
+    b = user_designs.resolve_user_design("ssn_design")()
+    with pytest.raises(ValueError, match="absolute"):
+        read_ssn(b, "/etc/passwd")

--- a/tests/test_simnec_import.py
+++ b/tests/test_simnec_import.py
@@ -355,9 +355,9 @@ def test_station_ideal_transformer2():
     extra = _el("TRANSFORMER2", {"Mdl": "ideal", "N": 2}, label="X1")
     c = parse_ssn(_ssn(_SCRIPT_M, extra_elements=extra), name="t.ssn", network=True)
     (x,) = [b for b in c.network().branches if isinstance(b, Transformer)]
-    # N is the generator:antenna voltage ratio; entered generator-side,
-    # Transformer(a, b, n) with v_a = n·v_b matches directly.
-    assert (x.a, x.b, x.n) == ("rig", "feed", 2.0)
+    # SimNEC's N is the antenna:generator voltage ratio (validated on 6p4d6,
+    # PR #696), so entered generator-side, Transformer n = 1/N.
+    assert (x.a, x.b, x.n) == ("rig", "feed", 0.5)
 
 
 def test_station_non_ideal_transformer2_rejected():


### PR DESCRIPTION
## Summary
- **`.ssn` import** — the read-side twin of `antennaknobs.simnec_export`: new `antennaknobs.simnec_import` with `parse_ssn` / `read_ssn` (exported from the package root, same folder confinement as `read_nec`). `parse_ssn` extracts the NEC-portal antenna block from the file's NETWORK `<equ>` script and hands the cards to `parse_nec`, so everything the NEC importer models — geometry transforms, EX feeds, lumped LD loads with `network=True` — works identically for `.ssn` files.
- **Daemon directives translate back** to antennaknobs terms: `SommerfeldGround(σ, εr)` / `PerfectGround()` → the `("finite", eps_r, sigma)` / `"pec"` ground spec (and the deck's ground flag), `NECOptions.mhosPerMeter` → `conductivity`, `segmentsPerWavelength` → `seg_per_wl`, and `NECUnits` (feet/inches/cm/mm) → metres via an injected native `GS` card so NEC's own scaling semantics apply, with a separate correction when the radius unit differs. The solve frequency comes from the GENERATOR's `MHz` (the deck's FR is advisory in SimNEC); an armed (`doSweep y`) Generator sweep surfaces as `sweep=(lo, hi)`.
- **Station chains import too** — the mirror of the phase-2 station export (#696 / #604): elements between the antenna block and the GENERATOR land in `SsnCircuit.chain` (generator→antenna order), and `SsnCircuit.network()` rebuilds the full station as the exact inverse of that PR's cascade walk — `SERIES_TLINE` → `TL` (same Zo/VFnom/ft and k1·√f + k2·f dB/100 ft loss convention), `SERIES_IND`/`SERIES_CAP` → `TwoPort`, `SHUNT_IND`/`SHUNT_CAP` → `Shunt` (`Q`/`@MHz` → `ql`/`qc`, exact at the quoted frequency; `Q = 0` = ideal), ideal `TRANSFORMER2` → `Transformer` (N as the generator:antenna voltage ratio). The `Driven` moves to a virtual `rig` node, the chain hangs rig → … → the deck's fed wire, trap-`Load` LD cards ride along, a shunt-only chain hangs across the feed, and an antenna-only file returns the deck network unchanged — one `build_network` recipe covers both shapes.
- **Refusals mirror the exporter's faithfulness rule**: a chain element outside the captured set (recorded in `other_elements` / `skipped_note()`), a non-ideal `TRANSFORMER2`, or a `k0` constant-loss term makes `network()` raise rather than silently drop part of the circuit. Scaffold elements (the open LOAD, the 50 Ω GENERATOR) are recognised and not reported.
- User-design authoring guide (`web/user_design_assets/CLAUDE.md`) gains a "Loading a SimNEC circuit (`.ssn`)" section with the stub recipe and seeding notes.

## Draft — validation pending
Mirrors two sets of unvalidated conventions, so drafted until they're confirmed:
- [ ] **#696's SimNEC-machine validation**: the station element schema this import consumes is the one #696 emits (authored clean-room from the #604 schema survey, not yet load-tested in SimNEC). If validation flips `TRANSFORMER2`'s N orientation or the Q = 0 semantics there, the same fix lands here — the shared-convention tests will catch a divergence.
- [ ] **Round-trip against a real SimNEC-saved station `.ssn`** (`lastCircuit.ssn` from the Track-1 cascade): confirm element/param-name drift is nil and the imported network solves to the Track-1 rig readout (~41.9 − j5.8 at 7.1 MHz).
- [ ] **`NECUnits` vocabulary**: only `meters` appears in repo-saved files; the accepted spellings (m/cm/mm/ft/in + long forms) and the (coordinates, radius) argument order are assumptions — confirm against SimNEC's portal docs or a saved non-metric file, and extend `_UNIT_M` if SimNEC spells units differently.
- [ ] Once #696 merges: swap the hand-built ladder-cascade test fixture for a true `export_ssn` → `parse_ssn` station round-trip.

## Test plan
- [x] 36 tests: exporter round-trips (geometry/feed, frequency-from-Generator, all ground specs, seg-per-wl, sweep, scaffold non-reporting, a real built-in design), foreign-file cases (NECUnits scaling incl. mixed units, unknown units, conductivity, non-open LOAD, unknown directives, malformed XML, missing/duplicate NEC blocks, missing NECEND, stray EN cards), the full ladder-tuner station cascade element-for-element (topology, values, Q handling), transformer orientation, trap ride-along, shunt-only chains, all three station refusal paths, and the user-design stub path with folder confinement.
- [x] Fast lane (`make test`): 3307 passed; the one failure (`test_pynec_intersection_check`) reproduces without these changes (this environment's upstream PyNEC wheel vs CI's `pynec-accel`).
- [x] `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XAoTa1Qu2JuTBEPo4iEiX

---
_Generated by [Claude Code](https://claude.ai/code/session_013XAoTa1Qu2JuTBEPo4iEiX)_