### PR TITLE
CLI: @file builder specs — load .nec card decks directly

### DIFF
--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -206,9 +206,17 @@ def list_variants(cls):
 def get_builder(nm):
     """Resolve a builder spec into a zero-arg factory.
 
-    Spec is "name" or "name:variant". A variant binds the named '<variant>_params'
-    class attribute as the builder's params; absent or ':default' uses default_params.
+    Spec is "name", "name:variant", or "@path/to/file.nec". A variant binds
+    the named '<variant>_params' class attribute as the builder's params;
+    absent or ':default' uses default_params. An "@" spec loads an antenna
+    data file directly (see ``file_designs``) — pure data, no trust step —
+    and takes no variant suffix, so colons in the path (Windows drive
+    letters) pass through untouched.
     """
+    if nm.startswith("@"):
+        from .file_designs import builder_from_file
+
+        return builder_from_file(nm[1:])
     name, _, variant = nm.partition(":")
     cls = resolve_class(name)
     if cls is None:
@@ -244,8 +252,11 @@ def emit_params_name(builder_spec):
 
     A ``name:variant`` spec emits ``<variant>_params`` (so the block drops
     straight back beside the variant it came from); a bare name or ``:default``
-    emits ``default_params``.
+    emits ``default_params``. An ``@file`` spec has no variants (and its path
+    may contain colons), so it always emits ``default_params``.
     """
+    if builder_spec.startswith("@"):
+        return "default_params"
     _, _, variant = builder_spec.partition(":")
     if variant and variant != "default":
         return f"{variant}_params"
@@ -371,14 +382,18 @@ def cli(arguments=None):
                 type=str,
                 nargs="+",
                 default=["dipoles.invvee:dipole", "dipoles.invvee"],
-                help="Use this list of antenna builders.",
+                help="Use this list of antenna builders. Each spec is "
+                '"family.design[:variant]", "user.<name>", or "@file.nec" '
+                "to load a NEC card deck directly.",
             )
         else:
             p.add_argument(
                 "--builder",
                 type=str,
                 default="dipoles.invvee:dipole",
-                help="Use this antenna builder.",
+                help='Use this antenna builder: "family.design[:variant]", '
+                '"user.<name>", or "@file.nec" to load a NEC card deck '
+                "directly.",
             )
 
     def add_engine_args(p, plural=False):
@@ -633,7 +648,7 @@ def cli(arguments=None):
         "--builder",
         type=str,
         default="dipoles.invvee:dipole",
-        help="Antenna builder (name or name:variant) to dump.",
+        help="Antenna builder (name, name:variant, or @file.nec) to dump.",
     )
     p.add_argument(
         "--name",
@@ -1024,7 +1039,7 @@ def cli(arguments=None):
         "--builder",
         type=str,
         default="dipoles.invvee:dipole",
-        help="Antenna builder to export.",
+        help="Antenna builder to export (name, name:variant, or @file.nec).",
     )
     p.add_argument(
         "--ground",

--- a/src/antennaknobs/file_designs.py
+++ b/src/antennaknobs/file_designs.py
@@ -1,0 +1,122 @@
+"""Builders synthesized from antenna data files — the CLI's ``@file`` specs.
+
+``builder_from_file`` turns a NEC card deck (``.nec``) into a ready-to-run
+``AntennaBuilder`` class, so every CLI subcommand can consume a file directly
+wherever a builder spec goes:
+
+    antennaknobs draw --builder @decks/yagi.nec
+    antennaknobs compare_patterns --builders dipoles.invvee @measured/invvee.nec
+    python -m antennaknobs.simnec_export @decks/yagi.nec   # .nec -> .ssn
+
+The ``@`` sigil keeps the spec grammar unambiguous — a bare ``foo.nec`` would
+parse as family ``foo``, design ``nec`` — and an ``@`` spec never takes a
+``:variant`` suffix (a deck has no variants), so colons in paths (Windows
+drive letters) pass through untouched.
+
+Unlike a ``user.<name>`` design (arbitrary Python, gated by the trust store),
+these files are pure data — ``parse_nec`` never executes anything — so an
+``@`` spec loads with no allow/screen step.
+
+The synthesized builder is the authoring guide's deck-stub recipe, generated
+on the fly: ``build_wires`` returns the deck's wires with per-wire specs,
+``build_network`` the deck's translated network, ``freq`` is seeded from the
+deck's FR card (whose range also seeds ``ui_params["meas_freq_range"]``), and
+whatever the import left behind lands under ``ui_params["notes"]``. A deck is
+frozen geometry, so the only knob is ``freq`` — port the design to a real
+``AntennaBuilder`` when dimensions should tune.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import MappingProxyType
+
+from .builder import AntennaBuilder
+from .nec_import import parse_nec
+
+__all__ = ["builder_from_file"]
+
+# Seed for a file that names no frequency at all (no FR card). Arbitrary but
+# common (20 m); the note tells the user to set theirs.
+DEFAULT_FREQ_MHZ = 14.0
+
+
+def _seed_freq(freq_range):
+    """(freq, meas_freq_range, note) from a file's (lo, hi) MHz range."""
+    if freq_range:
+        lo, hi = freq_range
+        return round(0.5 * (lo + hi), 6), (lo, hi), None
+    return (
+        DEFAULT_FREQ_MHZ,
+        None,
+        f"The file names no frequency; measurement freq defaults to "
+        f"{DEFAULT_FREQ_MHZ:g} MHz — set it to the design's real band.",
+    )
+
+
+def _make_builder(stem, freq, meas_range, notes, wires_fn, network_fn):
+    ui: dict = {}
+    if meas_range:
+        ui["meas_freq_range"] = tuple(meas_range)
+    note = " ".join(n for n in notes if n)
+    if note:
+        ui["notes"] = note
+    params = {"freq": freq, "design_freq": freq}
+    if ui:
+        params["ui_params"] = MappingProxyType(ui)
+
+    class Builder(AntennaBuilder):
+        label = stem
+
+        default_params = MappingProxyType(params)
+
+        def build_wires(self):
+            return wires_fn()
+
+        def build_network(self):
+            return network_fn()
+
+    # The dotted-name machinery (display titles, simnec_export's block name)
+    # keys off the class identity; make it the file's, not this factory's.
+    Builder.__name__ = Builder.__qualname__ = stem
+    return Builder
+
+
+def _nec_builder(path: Path, text: str):
+    deck = parse_nec(text, name=path.name, network=True)
+    freq, meas_range, freq_note = _seed_freq(deck.freq_mhz)
+    return _make_builder(
+        path.stem,
+        freq,
+        meas_range,
+        [deck.skipped_note(), freq_note],
+        lambda: deck.wire_tuples(specs=True),
+        deck.network,
+    )
+
+
+# extension -> loader; the seam a future format (e.g. SimNEC .ssn) plugs into
+_LOADERS = {".nec": _nec_builder}
+
+
+def builder_from_file(spec: str):
+    """The builder class for an ``@``-spec path (the leading ``@`` already
+    stripped): dispatch on the extension, parse once, and synthesize the
+    design. Raises ``SystemExit`` with a clear message for a missing file or
+    an unsupported extension (matching ``get_builder``'s unknown-builder
+    behavior); parse errors propagate as ``ValueError`` so the real cause —
+    file, line, card — reaches the user."""
+    path = Path(spec).expanduser()
+    loader = _LOADERS.get(path.suffix.lower())
+    if loader is None:
+        raise SystemExit(
+            f"@{spec}: unsupported design-file extension "
+            f"{path.suffix.lower() or '(none)'!r} — an @ spec loads "
+            f"{' / '.join(sorted(_LOADERS))} antenna files"
+        )
+    if not path.is_file():
+        raise SystemExit(f"@{spec}: no such file")
+    # Old decks in the wild carry cp1252/latin-1 comment text; geometry cards
+    # are ASCII, so replace rather than refuse on a stray comment byte.
+    text = path.read_text(encoding="utf-8", errors="replace")
+    return loader(path, text)

--- a/src/antennaknobs/simnec_export.py
+++ b/src/antennaknobs/simnec_export.py
@@ -294,7 +294,11 @@ def main(argv=None):
         prog="antennaknobs.simnec_export",
         description="Emit a SimNEC (.ssn) circuit for an antenna-only design.",
     )
-    ap.add_argument("builder", help="Design name, e.g. dipoles.invvee[:variant]")
+    ap.add_argument(
+        "builder",
+        help="Design name, e.g. dipoles.invvee[:variant] — or @file.nec to "
+        "convert a NEC card deck straight to a SimNEC circuit",
+    )
     ap.add_argument(
         "--freq", type=float, default=None, help="MHz (default: builder.freq)"
     )

--- a/tests/test_file_designs.py
+++ b/tests/test_file_designs.py
@@ -1,0 +1,116 @@
+"""``@file`` builder specs: NEC card decks as CLI designs.
+
+``get_builder("@path/to/file.nec")`` synthesizes a frozen-geometry builder on
+the fly (``file_designs.builder_from_file``) — pure data, no trust gate — so
+every subcommand that takes a builder spec can consume a deck directly, and
+decks mix freely with named designs in ``--builders`` lists.
+"""
+
+import pytest
+
+import antennaknobs as ant
+from antennaknobs.cli import emit_params_name, get_builder
+from antennaknobs.network import Load, Wire
+
+DECK = """\
+CM a 20 m dipole at 10 m
+CE
+GW 1 11 0 -5 10 0 5 10 0.001
+GE
+FR 0 3 0 0 14.0 0.1
+EX 0 1 6 0 1 0
+LD 0 1 3 3 10 0 0
+EN
+"""
+
+
+@pytest.fixture
+def deck_path(tmp_path):
+    p = tmp_path / "flat_dipole.nec"
+    p.write_text(DECK)
+    return p
+
+
+def test_at_nec_builds_and_seeds_from_the_deck(deck_path):
+    cls = get_builder(f"@{deck_path}")
+    b = cls()
+    # FR 3 points from 14.0 step 0.1 -> band (14.0, 14.2), freq at its middle
+    assert b.freq == pytest.approx(14.1)
+    assert b.ui_params["meas_freq_range"] == (pytest.approx(14.0), pytest.approx(14.2))
+    wires = b.build_wires()
+    assert wires and all(isinstance(w, Wire) for w in wires)
+    assert all(w.spec is not None for w in wires)  # per-wire radius from GW
+    net = b.build_network()
+    assert net.sources and any(isinstance(br, Load) for br in net.branches)
+
+
+def test_at_nec_display_identity_is_the_file_stem(deck_path):
+    cls = get_builder(f"@{deck_path}")
+    assert cls.label == "flat_dipole"
+    assert cls.__qualname__ == "flat_dipole"
+
+
+def test_at_spec_never_splits_a_variant_colon(tmp_path):
+    # Colons are legal in POSIX filenames (and in Windows drive letters);
+    # an @ spec must consume the whole token as a path.
+    p = tmp_path / "de:ck.nec"
+    p.write_text(DECK)
+    b = get_builder(f"@{p}")()
+    assert b.freq == pytest.approx(14.1)
+    assert emit_params_name(f"@{p}") == "default_params"
+
+
+def test_at_nec_without_fr_defaults_and_notes(tmp_path):
+    p = tmp_path / "nofr.nec"
+    p.write_text("GW 1 11 0 -5 10 0 5 10 0.001\nGE\nEX 0 1 6 0 1 0\nEN\n")
+    b = get_builder(f"@{p}")()
+    assert b.freq == pytest.approx(14.0)
+    assert "names no frequency" in b.ui_params["notes"]
+
+
+# --- error paths -------------------------------------------------------------
+
+
+def test_at_unknown_extension_is_a_clear_error(tmp_path):
+    p = tmp_path / "foo.yaml"
+    p.write_text("wires: []")
+    with pytest.raises(SystemExit, match=r"foo\.yaml.*extension"):
+        get_builder(f"@{p}")
+
+
+def test_at_missing_file_is_a_clear_error(tmp_path):
+    with pytest.raises(SystemExit, match="no such file"):
+        get_builder(f"@{tmp_path}/nope.nec")
+
+
+def test_at_parse_error_carries_file_and_line(tmp_path):
+    p = tmp_path / "bad.nec"
+    p.write_text("GW 1 11 0 -5 10 0 5 10 0.001\nQZ 1 2 3\nEN\n")
+    with pytest.raises(ValueError, match=r"bad\.nec, line 2"):
+        get_builder(f"@{p}")
+
+
+# --- through the real CLI ----------------------------------------------------
+
+
+def test_cli_draw_at_nec(deck_path):
+    ant.cli(f"draw --builder @{deck_path} --fn /dev/null".split())
+
+
+def test_cli_params_at_nec(deck_path, capsys):
+    ant.cli(f"params --builder @{deck_path}".split())
+    out = capsys.readouterr().out
+    assert "default_params" in out and "14.1" in out
+
+
+def test_simnec_export_cli_converts_at_nec(deck_path, capsys):
+    """python -m antennaknobs.simnec_export @deck.nec — .nec -> .ssn."""
+    import xml.etree.ElementTree as ET
+
+    from antennaknobs.simnec_export import main
+
+    main([f"@{deck_path}"])
+    out = capsys.readouterr().out
+    root = ET.fromstring(out)
+    assert root.find(".//XMLVersionControl") is not None
+    assert "//flat_dipole" in out  # block name from the file stem


### PR DESCRIPTION
## Summary
- **`@path` as a third builder-spec form**: `get_builder` now accepts `"@decks/yagi.nec"` anywhere a builder spec goes — `draw`, `sweep`, `pattern`, `schematic`, `params`, `export`, and mixed into `--builders` lists (`compare_patterns dipoles.invvee @measured/invvee.nec`). The sigil keeps the grammar unambiguous — a bare `foo.nec` already parses as family `foo`, design `nec` — and an `@` spec never splits a `:variant` suffix, so colons in paths (Windows drive letters, POSIX filenames) pass through untouched (`emit_params_name` gets the same guard).
- **Synthesized frozen-geometry builder** (new `antennaknobs.file_designs`): the authoring guide's deck-stub recipe generated at resolve time — `build_wires` → `wire_tuples(specs=True)` (per-wire radius/conductivity/insulation), `build_network` → the deck's translated network. `freq` seeds from the FR card (14 MHz plus a note when the deck has none), `ui_params["meas_freq_range"]` from the FR range, and `skipped_note()` lands under `ui_params["notes"]`. Display identity (label, qualname, SimNEC block name) is the file stem.
- **No trust gate, by design**: unlike `user.<name>` designs (arbitrary Python behind the screen/allow ritual), a deck is pure data — `parse_nec` never executes anything — so an `@` spec loads instantly.
- **A conversion falls out for free**: `python -m antennaknobs.simnec_export @deck.nec` (.nec → .ssn). Help text updated on `--builder`/`--builders`, `params`, `export`, and the simnec_export CLI.
- **Errors stay actionable**: missing file / unsupported extension exit cleanly like an unknown builder name; parse errors keep their file-and-line `ValueError` so the offending card is named.

Split out from the original #782 scope so this merges independently of the `.ssn` import work: the loader is an extension→builder table, and `@file.ssn` support plugs into that seam in a follow-up PR stacked on #781.

## Test plan
- [x] 11 tests: deck seeding (FR band → freq/meas range, per-wire specs, LD loads in the network), file-stem identity, colon-in-filename safety, no-FR default + note, the three error paths, and real-CLI passes (`draw`, `params`, and the `simnec_export @deck.nec` conversion).
- [x] Fast lane on this branch (based on `main`): 3281 passed; the one failure (`test_pynec_intersection_check`) reproduces without these changes (environment's PyNEC wheel vs CI's `pynec-accel`).
- [x] `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XAoTa1Qu2JuTBEPo4iEiX