### PR TITLE
CLI: @file.ssn builder specs — SimNEC circuits as CLI designs

### DIFF
--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -206,11 +206,11 @@ def list_variants(cls):
 def get_builder(nm):
     """Resolve a builder spec into a zero-arg factory.
 
-    Spec is "name", "name:variant", or "@path/to/file.nec". A variant binds
-    the named '<variant>_params' class attribute as the builder's params;
-    absent or ':default' uses default_params. An "@" spec loads an antenna
-    data file directly (see ``file_designs``) — pure data, no trust step —
-    and takes no variant suffix, so colons in the path (Windows drive
+    Spec is "name", "name:variant", or "@path/to/file.nec|.ssn". A variant
+    binds the named '<variant>_params' class attribute as the builder's
+    params; absent or ':default' uses default_params. An "@" spec loads an
+    antenna data file directly (see ``file_designs``) — pure data, no trust
+    step — and takes no variant suffix, so colons in the path (Windows drive
     letters) pass through untouched.
     """
     if nm.startswith("@"):
@@ -383,8 +383,8 @@ def cli(arguments=None):
                 nargs="+",
                 default=["dipoles.invvee:dipole", "dipoles.invvee"],
                 help="Use this list of antenna builders. Each spec is "
-                '"family.design[:variant]", "user.<name>", or "@file.nec" '
-                "to load a NEC card deck directly.",
+                '"family.design[:variant]", "user.<name>", or "@file.nec" / '
+                '"@file.ssn" to load a card deck / SimNEC circuit directly.',
             )
         else:
             p.add_argument(
@@ -392,8 +392,8 @@ def cli(arguments=None):
                 type=str,
                 default="dipoles.invvee:dipole",
                 help='Use this antenna builder: "family.design[:variant]", '
-                '"user.<name>", or "@file.nec" to load a NEC card deck '
-                "directly.",
+                '"user.<name>", or "@file.nec" / "@file.ssn" to load a card '
+                "deck / SimNEC circuit directly.",
             )
 
     def add_engine_args(p, plural=False):
@@ -648,7 +648,7 @@ def cli(arguments=None):
         "--builder",
         type=str,
         default="dipoles.invvee:dipole",
-        help="Antenna builder (name, name:variant, or @file.nec) to dump.",
+        help="Antenna builder (name, name:variant, or @file.nec/@file.ssn) to dump.",
     )
     p.add_argument(
         "--name",
@@ -1039,7 +1039,9 @@ def cli(arguments=None):
         "--builder",
         type=str,
         default="dipoles.invvee:dipole",
-        help="Antenna builder to export (name, name:variant, or @file.nec).",
+        help="Antenna builder to export (name, name:variant, or "
+        "@file.nec/@file.ssn — so '@dip.ssn' converts a SimNEC circuit "
+        "to a card deck).",
     )
     p.add_argument(
         "--ground",

--- a/src/antennaknobs/file_designs.py
+++ b/src/antennaknobs/file_designs.py
@@ -1,12 +1,14 @@
 """Builders synthesized from antenna data files — the CLI's ``@file`` specs.
 
-``builder_from_file`` turns a NEC card deck (``.nec``) into a ready-to-run
-``AntennaBuilder`` class, so every CLI subcommand can consume a file directly
-wherever a builder spec goes:
+``builder_from_file`` turns a NEC card deck (``.nec``) or a SimNEC circuit
+(``.ssn``) into a ready-to-run ``AntennaBuilder`` class, so every CLI
+subcommand can consume a file directly wherever a builder spec goes:
 
     antennaknobs draw --builder @decks/yagi.nec
+    antennaknobs sweep --builder @station.ssn
     antennaknobs compare_patterns --builders dipoles.invvee @measured/invvee.nec
     python -m antennaknobs.simnec_export @decks/yagi.nec   # .nec -> .ssn
+    antennaknobs export --builder @dip.ssn                 # .ssn -> .nec
 
 The ``@`` sigil keeps the spec grammar unambiguous — a bare ``foo.nec`` would
 parse as family ``foo``, design ``nec`` — and an ``@`` spec never takes a
@@ -14,13 +16,14 @@ parse as family ``foo``, design ``nec`` — and an ``@`` spec never takes a
 drive letters) pass through untouched.
 
 Unlike a ``user.<name>`` design (arbitrary Python, gated by the trust store),
-these files are pure data — ``parse_nec`` never executes anything — so an
-``@`` spec loads with no allow/screen step.
+these files are pure data — ``parse_nec`` / ``parse_ssn`` never execute
+anything — so an ``@`` spec loads with no allow/screen step.
 
 The synthesized builder is the authoring guide's deck-stub recipe, generated
 on the fly: ``build_wires`` returns the deck's wires with per-wire specs,
-``build_network`` the deck's translated network, ``freq`` is seeded from the
-deck's FR card (whose range also seeds ``ui_params["meas_freq_range"]``), and
+``build_network`` the deck's (or station ``.ssn``'s) translated network,
+``freq`` is seeded from the file (the FR card / the Generator's MHz), the FR
+range or an armed Generator sweep seeds ``ui_params["meas_freq_range"]``, and
 whatever the import left behind lands under ``ui_params["notes"]``. A deck is
 frozen geometry, so the only knob is ``freq`` — port the design to a real
 ``AntennaBuilder`` when dimensions should tune.
@@ -28,16 +31,18 @@ frozen geometry, so the only knob is ``freq`` — port the design to a real
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from types import MappingProxyType
 
 from .builder import AntennaBuilder
 from .nec_import import parse_nec
+from .simnec_import import parse_ssn
 
 __all__ = ["builder_from_file"]
 
-# Seed for a file that names no frequency at all (no FR card). Arbitrary but
-# common (20 m); the note tells the user to set theirs.
+# Seed for a file that names no frequency at all (no FR card, no Generator
+# MHz). Arbitrary but common (20 m); the note tells the user to set theirs.
 DEFAULT_FREQ_MHZ = 14.0
 
 
@@ -95,8 +100,49 @@ def _nec_builder(path: Path, text: str):
     )
 
 
-# extension -> loader; the seam a future format (e.g. SimNEC .ssn) plugs into
-_LOADERS = {".nec": _nec_builder}
+def _ground_note(ground) -> str | None:
+    """Ground is an app/engine setting, not a design output — so a file that
+    models one gets an actionable pointer at the matching ``--ground`` spec."""
+    if ground is None:
+        return None
+    if ground == "pec":
+        arg, desc = "pec", "a perfect (PEC)"
+    else:
+        _, eps_r, sigma = ground
+        arg = f"finite:{eps_r:g},{sigma:g}"
+        desc = f"a Sommerfeld (eps_r {eps_r:g}, sigma {sigma:g} S/m)"
+    return f"The file models {desc} ground — run with --ground {arg} to match."
+
+
+def _ssn_builder(path: Path, text: str):
+    circuit = parse_ssn(text, name=path.name, network=True)
+    if circuit.conductivity is not None and circuit.deck.conductivity is None:
+        # NECOptions.mhosPerMeter is the wire material; bake it into the deck
+        # so wire_tuples(specs=True) carries it per wire, exactly as a deck
+        # LD 5 would.
+        circuit = replace(
+            circuit, deck=replace(circuit.deck, conductivity=circuit.conductivity)
+        )
+    deck = circuit.deck
+    # The Generator's MHz is the authoritative solve frequency; the deck's FR
+    # is advisory. Either can seed the measurement range (an armed sweep wins).
+    if circuit.freq_mhz is not None:
+        freq, freq_note = round(circuit.freq_mhz, 6), None
+    else:
+        freq, _, freq_note = _seed_freq(deck.freq_mhz)
+    meas_range = circuit.sweep or deck.freq_mhz
+    return _make_builder(
+        path.stem,
+        freq,
+        meas_range,
+        [circuit.skipped_note(), _ground_note(circuit.ground), freq_note],
+        lambda: deck.wire_tuples(specs=True),
+        circuit.network,
+    )
+
+
+# extension -> loader
+_LOADERS = {".nec": _nec_builder, ".ssn": _ssn_builder}
 
 
 def builder_from_file(spec: str):

--- a/tests/test_file_designs.py
+++ b/tests/test_file_designs.py
@@ -1,16 +1,28 @@
-"""``@file`` builder specs: NEC card decks as CLI designs.
+"""``@file`` builder specs: NEC decks and SimNEC circuits as CLI designs.
 
-``get_builder("@path/to/file.nec")`` synthesizes a frozen-geometry builder on
-the fly (``file_designs.builder_from_file``) — pure data, no trust gate — so
-every subcommand that takes a builder spec can consume a deck directly, and
-decks mix freely with named designs in ``--builders`` lists.
+``get_builder("@path/to/file.nec|.ssn")`` synthesizes a frozen-geometry
+builder on the fly (``file_designs.builder_from_file``) — pure data, no trust
+gate — so every subcommand that takes a builder spec can consume a file
+directly, and files mix freely with named designs in ``--builders`` lists.
 """
+
+from types import MappingProxyType
 
 import pytest
 
 import antennaknobs as ant
+from antennaknobs.builder import AntennaBuilder
 from antennaknobs.cli import emit_params_name, get_builder
-from antennaknobs.network import Load, Wire
+from antennaknobs.network import TL, Load, Wire
+from antennaknobs.simnec_export import export_ssn
+
+
+class _Dipole(AntennaBuilder):
+    default_params = MappingProxyType({"freq": 14.0, "design_freq": 14.0})
+
+    def build_wires(self):
+        return [Wire((0.0, -5.0, 10.0), (0.0, 5.0, 10.0), n_seg=11, ex=1 + 0j)]
+
 
 DECK = """\
 CM a 20 m dipole at 10 m
@@ -66,6 +78,62 @@ def test_at_nec_without_fr_defaults_and_notes(tmp_path):
     b = get_builder(f"@{p}")()
     assert b.freq == pytest.approx(14.0)
     assert "names no frequency" in b.ui_params["notes"]
+
+
+# --- .ssn specs --------------------------------------------------------------
+
+
+def test_at_ssn_seeds_from_the_generator(tmp_path):
+    p = tmp_path / "dip.ssn"
+    p.write_text(export_ssn(_Dipole(), freq_mhz=14.1, ground=None, sweep=(13.0, 15.0)))
+    b = get_builder(f"@{p}")()
+    assert b.freq == pytest.approx(14.1)  # Generator MHz, not the FR card
+    # an armed Generator sweep wins over the FR range
+    assert b.ui_params["meas_freq_range"] == (pytest.approx(13.0), pytest.approx(15.0))
+    assert b.build_wires()
+    assert b.build_network().sources
+
+
+def test_at_ssn_ground_note_points_at_the_flag(tmp_path):
+    p = tmp_path / "dip.ssn"
+    p.write_text(export_ssn(_Dipole(), freq_mhz=14.1, ground=("finite", 13.0, 0.005)))
+    b = get_builder(f"@{p}")()
+    assert "--ground finite:13,0.005" in b.ui_params["notes"]
+
+
+def test_at_ssn_conductivity_reaches_the_wire_specs(tmp_path):
+    ssn = export_ssn(_Dipole(), freq_mhz=14.1, ground=None)
+    ssn = ssn.replace(
+        "NECOptions.mhosPerMeter = 0;", "NECOptions.mhosPerMeter = 5.8e7;"
+    )
+    p = tmp_path / "dip.ssn"
+    p.write_text(ssn)
+    wires = get_builder(f"@{p}")().build_wires()
+    assert all(w.spec.conductivity == pytest.approx(5.8e7) for w in wires)
+
+
+def test_at_ssn_station_chain_acts(tmp_path):
+    """A station .ssn's chain lands in build_network(): the Driven moves to
+    the rig node and the cascade hangs rig -> ... -> feed."""
+    from test_simnec_import import _SCRIPT_M, _el, _ssn
+
+    extra = _el("SERIES_TLINE", {"Zo": 450, "VFnom": 0.91, "ft": 50})
+    p = tmp_path / "station.ssn"
+    p.write_text(_ssn(_SCRIPT_M, extra_elements=extra))
+    net = get_builder(f"@{p}")().build_network()
+    (src,) = net.sources
+    assert src.port == "rig"
+    (tl,) = [br for br in net.branches if isinstance(br, TL)]
+    assert tl.z0 == pytest.approx(450.0) and tl.length == pytest.approx(50 * 0.3048)
+
+
+def test_cli_export_converts_at_ssn(tmp_path, capsys):
+    """antennaknobs export --builder @dip.ssn — .ssn -> .nec card deck."""
+    p = tmp_path / "dip.ssn"
+    p.write_text(export_ssn(_Dipole(), freq_mhz=14.1, ground=None))
+    ant.cli(f"export --builder @{p} --ground free".split())
+    out = capsys.readouterr().out
+    assert "GW " in out and "EX " in out
 
 
 # --- error paths -------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **`@station.ssn` builder specs**: registers `.ssn` in `file_designs`' extension→loader table (the seam #782 left open), so SimNEC circuit files work everywhere `@file.nec` does — `draw`, `sweep`, `schematic`, mixed `--builders` lists.
- **Seeding follows the `.ssn` import semantics**: `freq` from the Generator's MHz (the deck's FR card is advisory in SimNEC), `ui_params["meas_freq_range"]` from an armed Generator sweep or the FR range, and `ui_params["notes"]` carries `skipped_note()` plus an actionable `--ground finite:εr,σ` hint for the file's ground model. `NECOptions.mhosPerMeter` wire conductivity is baked into the per-wire specs, exactly as a deck LD 5 would be.
- **Station chains act**: a full-station `.ssn`'s tuner cascade lands in `build_network()` via `circuit.network()` — the `Driven` on the rig node, the chain hanging down to the fed wire.
- **The reverse conversion falls out**: `antennaknobs export --builder @dip.ssn` emits the NEC card deck for an antenna-only circuit (with #782's `simnec_export @deck.nec`, both directions are now one command).

**Stacked**: base is `claude/ssn-file-import-support-g375mh` (#781, the `.ssn` import machinery), and the branch also merges in #782 (`@` spec machinery) — so this diff shows #782's commits until that merges to `main`. The unique work here is the last commit (`874c6b5`: +144/−28). Merge order: #782 → #781 → this; drafted alongside #781 since it inherits the same pending SimNEC validation.

## Test plan
- [x] 5 new tests: Generator-MHz/sweep seeding, the ground note, conductivity → wire specs, a station chain acting through `build_network`, and the `export --builder @dip.ssn` conversion through the real CLI.
- [x] Full `.nec`/`.ssn` import/export + file-designs modules: 73 passed. Fast lane: 3322 passed; the one failure (`test_pynec_intersection_check`) reproduces without these changes (environment's PyNEC wheel vs CI's `pynec-accel`).
- [x] `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XAoTa1Qu2JuTBEPo4iEiX

---
_Generated by [Claude Code](https://claude.ai/code/session_013XAoTa1Qu2JuTBEPo4iEiX)_