### PR TITLE
Multi-feed optimizer objective: score the worst feed, web and CLI alike

### DIFF
--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -185,6 +185,17 @@ fast **momwire** engine — never PyNEC, which is too slow for an interactive lo
 It's a tuning aid, not a global optimizer: give it sensible ranges and a couple
 of free knobs, not a dozen.
 
+**Multi-feed designs score their worst feed.** On a design with several
+independently driven ports (a bowtie array, a pair of phased verticals), the
+objective is evaluated per feed and the optimizer minimizes the *worst* one —
+so "SWR 1.4" after a run means *no* element sits worse than 1.4, and one bad
+feed can't hide behind several good ones. The SWR shown while optimizing is
+that worst feed's. A design that feeds its elements from a single source
+through a network is different: there the match that matters is the network's
+input, so the optimizer scores the driven plane — the same impedance the
+readout shows. The CLI's `optimize` aggregates feeds the same way (it differs
+only in scoring |Z − Z₀| distance rather than SWR).
+
 **Loading a design pauses Optimize.** Switching antenna or picking a variant
 turns Optimize off — its objective and marks belong to the design you left —
 and briefly says so. Switching antenna *keeps* that design's marks (they're

--- a/src/antennaknobs/opt.py
+++ b/src/antennaknobs/opt.py
@@ -125,11 +125,14 @@ def optimize(
                     % (str(antenna_builder), z.real, z.imag, rho, swr, rho_db)
                 )
 
+        # Multi-feed designs score their WORST feed (minimax, issue #785): a
+        # sum lets one badly mismatched element hide behind several good ones.
+        # Same aggregation as the web optimizer; single-feed is unchanged.
         res = 0
         if resonance:
-            res += sum([abs(z.imag) for z in zs])
+            res += max((abs(z.imag) for z in zs), default=0.0)
         else:
-            res += sum([abs(z - z0) for z in zs])
+            res += max((abs(z - z0) for z in zs), default=0.0)
 
         if opt_gain:
             res -= 100 * max_gain

--- a/src/antennaknobs/web/optimize.py
+++ b/src/antennaknobs/web/optimize.py
@@ -44,28 +44,62 @@ def _swr(z_re: float, z_im: float, z0: float) -> float:
     return (1.0 + gamma) / (1.0 - gamma)
 
 
+def _feed_zs(out: dict) -> list[complex]:
+    """The impedances a solve response puts up for scoring, one per feed.
+
+    Bare multi-feed designs (several independently driven ports, no common
+    network) carry a per-feed table in ``feeds`` — every port needs a match,
+    so every entry is scored. Everything else carries only ``z_in_re``/
+    ``z_in_im``: single-feed designs trivially, and networked designs whose
+    one source drives the elements through a splitter/harness — there the
+    meaningful match is the network's driven plane, which is exactly what
+    ``z_in`` is referenced to (issues #652/#785)."""
+    feeds = out.get("feeds")
+    if feeds:
+        return [complex(float(f["z_re"]), float(f["z_im"])) for f in feeds]
+    return [complex(float(out["z_in_re"]), float(out["z_in_im"]))]
+
+
 def _objective_value(out: dict, key: str) -> float:
+    """The scalar to minimise. Multi-feed designs score their WORST feed
+    (minimax, issue #785): a sum lets one badly mismatched element hide behind
+    several good ones, and the guarantee a driven array actually wants is "no
+    element is badly matched". The CLI optimiser aggregates the same way; the
+    two still differ in *form* (CLI default: |Z−Z0| distance, web default:
+    SWR) — deliberate, each matches what its surface displays."""
     z0 = float(out.get("z0_ohms", 50.0))
-    z_re = float(out["z_in_re"])
-    z_im = float(out["z_in_im"])
+    zs = _feed_zs(out)
     if key == "resonance":
-        return abs(z_im)  # cancel reactance
+        return max(abs(z.imag) for z in zs)  # cancel reactance
     if key == "match_z0":
-        return abs(complex(z_re, z_im) - z0)  # complex distance to Z0
-    return _swr(z_re, z_im, z0)  # default: minimise SWR
+        return max(abs(z - z0) for z in zs)  # complex distance to Z0
+    return max(_swr(z.real, z.imag, z0) for z in zs)  # default: minimise SWR
 
 
 def _metrics(out: dict) -> dict:
-    """The handful of numbers the UI shows before/after, derived from one solve."""
+    """The handful of numbers the UI shows before/after, derived from one solve.
+
+    On a multi-feed design ``swr`` is the WORST feed's — the number the
+    objective drives (#785) — while ``z_in_re``/``z_in_im`` stay feed 0 to
+    match the primary readout; ``worst_feed``/``n_feeds`` say which and how
+    many. Single-feed responses keep the exact four-key shape."""
     z0 = float(out.get("z0_ohms", 50.0))
     z_re = float(out["z_in_re"])
     z_im = float(out["z_in_im"])
-    return {
+    m = {
         "z_in_re": z_re,
         "z_in_im": z_im,
         "z0_ohms": z0,
         "swr": _swr(z_re, z_im, z0),
     }
+    zs = _feed_zs(out)
+    if len(zs) > 1:
+        swrs = [_swr(z.real, z.imag, z0) for z in zs]
+        worst = max(range(len(swrs)), key=swrs.__getitem__)
+        m["swr"] = swrs[worst]
+        m["worst_feed"] = worst
+        m["n_feeds"] = len(zs)
+    return m
 
 
 def optimize(

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -12,7 +12,7 @@ import math
 
 import pytest
 
-from antennaknobs.web.optimize import _swr, optimize
+from antennaknobs.web.optimize import _metrics, _objective_value, _swr, optimize
 
 
 def test_swr_helper():
@@ -188,6 +188,101 @@ def _objective_value_for_test(params: dict, objective: str) -> float:
     x_im = 100.0 * (a - 1.10) + 80.0 * (b - 0.90)
     assert objective == "resonance"
     return abs(x_im)
+
+
+# --- Multi-feed aggregation (issue #785) -----------------------------------
+# A bare multi-feed solve response carries a per-feed table in `feeds`; the
+# objective must score the WORST feed (minimax), not feed 0 and not a sum.
+# Responses without `feeds` (single feed, or a networked design measured at
+# its driven plane) score z_in exactly as before.
+
+
+def _two_feed_out(z_a: complex, z_b: complex) -> dict:
+    """A solve response as adapter.momwire_solve shapes it for multi-feed:
+    z_in mirrors feed 0, and `feeds` carries every port."""
+    return {
+        "z_in_re": z_a.real,
+        "z_in_im": z_a.imag,
+        "z0_ohms": 50.0,
+        "feeds": [
+            {"z_re": z_a.real, "z_im": z_a.imag, "v_re": 1.0, "v_im": 0.0},
+            {"z_re": z_b.real, "z_im": z_b.imag, "v_re": 1.0, "v_im": 0.0},
+        ],
+    }
+
+
+def test_multifeed_objective_scores_the_worst_feed():
+    # Feed 0 is perfectly matched; feed 1 is 2:1. Scoring feed 0 alone (the
+    # old behaviour) would report 1.0 for swr and 0.0 for the others.
+    out = _two_feed_out(complex(50.0, 0.0), complex(100.0, 0.0))
+    assert _objective_value(out, "swr") == pytest.approx(2.0)
+    assert _objective_value(out, "match_z0") == pytest.approx(50.0)
+    out = _two_feed_out(complex(50.0, -5.0), complex(50.0, 40.0))
+    assert _objective_value(out, "resonance") == pytest.approx(40.0)
+
+
+def test_objective_without_feeds_scores_z_in():
+    # No `feeds` key -> single feed or a networked design's driven plane;
+    # unchanged single-Z scoring.
+    out = {"z_in_re": 100.0, "z_in_im": 0.0, "z0_ohms": 50.0}
+    assert _objective_value(out, "swr") == pytest.approx(2.0)
+    assert _objective_value(out, "match_z0") == pytest.approx(50.0)
+
+
+def test_multifeed_metrics_report_worst_feed_swr():
+    out = _two_feed_out(complex(50.0, 0.0), complex(100.0, 0.0))
+    m = _metrics(out)
+    assert m["swr"] == pytest.approx(2.0)  # the worst feed, not feed 0's 1.0
+    assert m["worst_feed"] == 1
+    assert m["n_feeds"] == 2
+    assert m["z_in_re"] == pytest.approx(50.0)  # Z stays feed 0 (the readout)
+    # Single-feed metrics keep the exact four-key shape the frontend types.
+    single = _metrics({"z_in_re": 50.0, "z_in_im": 0.0, "z0_ohms": 50.0})
+    assert set(single) == {"z_in_re", "z_in_im", "z0_ohms", "swr"}
+
+
+def test_optimize_minimax_balances_opposed_feeds():
+    """End-to-end discriminator: two feeds whose reactances cross zero at
+    different knob values (1.0 and 1.2). Scoring feed 0 alone would drive x
+    to 1.0; a minimax objective settles where the two |X| curves cross —
+    x = 1.1, the point that makes the WORST feed as good as possible."""
+
+    def solve(req: dict) -> dict:
+        x = float(req["x"])
+        z_a = complex(50.0, 100.0 * (x - 1.0))
+        z_b = complex(50.0, 100.0 * (1.2 - x))
+        return _two_feed_out(z_a, z_b)
+
+    res = optimize(
+        {"x": 0.9},
+        [{"name": "x", "min": 0.8, "max": 1.4}],
+        "resonance",
+        solve_fn=solve,
+    )
+    assert res["params"]["x"] == pytest.approx(1.1, abs=1e-2)
+    assert res["objective_after"] == pytest.approx(10.0, abs=0.5)  # both feeds ~10j
+
+
+@pytest.mark.antenna_computation_check
+def test_multifeed_real_geometry_objective_covers_every_feed():
+    """The issue's fixture: arrays.bowtiearray2x4 has 8 feeds with real spread
+    (4 distinct impedances). One real solve, then pin that the objective equals
+    the max over the response's own per-feed table — i.e. the wiring from
+    adapter `feeds` to the minimax objective holds on a genuine geometry."""
+    from antennaknobs.web.examples import REGISTRY
+
+    ex = REGISTRY["arrays.bowtiearray2x4"]
+    freq = ex.default_freq or 14.0
+    out = ex.momwire_solve(
+        {"geometry": "arrays.bowtiearray2x4", "measurement_freq_mhz": freq}
+    )
+    assert len(out.get("feeds", [])) > 1  # the fixture really is multi-feed
+    z0 = out["z0_ohms"]
+    per_feed_swr = [_swr(f["z_re"], f["z_im"], z0) for f in out["feeds"]]
+    assert _objective_value(out, "swr") == pytest.approx(max(per_feed_swr))
+    assert (
+        _objective_value(out, "swr") > _swr(out["z_in_re"], out["z_in_im"], z0) - 1e-9
+    )
 
 
 @pytest.mark.antenna_computation_check


### PR DESCRIPTION
## Summary
- The web optimizer scored only `z_in` — feed 0 — so on a bare multi-feed design (`arrays.bowtiearray2x4`: 8 feeds, R spread 186–235 Ω) six of eight feeds were never optimized; the CLI summed feeds, letting one bad element hide behind several good ones (#785).
- Both surfaces now aggregate **minimax**: the objective is the *worst* feed's value (SWR / |Z−Z₀| / |X|), so an optimized array guarantees no element is badly matched. Networked single-source designs are unchanged — they emit no per-feed table and keep scoring the driven plane, which is the match that matters there.
- Web `metrics.swr` reports the worst feed's SWR on multi-feed responses (plus `worst_feed`/`n_feeds`); `z_in` stays feed 0 to match the primary readout, and the single-feed metrics shape is byte-identical.
- The remaining web/CLI difference is **form only** (SWR vs complex distance), now documented in `reference/web.md` and the code.

## Test plan
- [x] New unit tests pin worst-feed scoring for all three objectives, the no-`feeds` fallback, the multi-feed metrics shape, and an end-to-end minimax discriminator (opposed feeds settle at the |X| crossover, not feed 0's zero)
- [x] Real-geometry test on `arrays.bowtiearray2x4` pins objective == max over the response's own per-feed table
- [x] Full CI fast lane locally: 3343 passed
- [x] `ruff check` + `ruff format --check` clean

Closes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvF4yHgNxjhyZ7P286g3z8