### PR TITLE
Release v0.44.0 — watch it tune

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.43.0"
+version = "0.44.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,23 +25,24 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.43.0" icon="star">
-  **The visible-rigging release: your antenna's tension, on screen — and a
-  faster, tidier workbench.** The catenary inverted vee's physics now shows
-  its numbers: **rigging tension (N and lbf), sag, and the rope length
-  you'd actually cut** appear in the solve readout, via a new generic
-  readouts channel any design — including your own in
-  `~/.antennaknobs/designs/` — can feed with no frontend code. The library
-  grows **`solve_sprung`**, the bungee/shock-cord rig closure (exact at
-  every length where the other closures are, with the stiff- and soft-limit
-  identities proven in tests). The workbench got quicker twice over:
-  **momwire 0.23.0's dense assembly** (~1.9× on interactive solves — an
-  outside contribution, thanks @happykawayigt!) and **view-residency
-  gating** — background sweeps only run while a view that draws them is on
-  screen. Plus: **reorder your pinned views** from the picker (rail, grid,
-  and phone pages all follow), pin/layout changes now sync across browser
-  windows live, and the Smith chart marks the sweep point nearest your
-  measurement frequency — the Γ-plane's first frequency anchor.
+<Card title="New in v0.44.0" icon="star">
+  **The watch-it-tune release: the optimizer shows its work, and the charts
+  sharpen themselves.** Turn on Optimize and the workbench now **streams
+  every evaluation live** — the readout ticks through candidates, the Smith
+  dot follows the search, and the views describing the pre-run design dim
+  until the result lands. Multi-feed arrays are scored honestly: the
+  objective now drives the **worst feed**, so an optimized array means *no*
+  element is badly matched. Sweeps and pattern cuts gained **adaptive
+  resolution** — hold still a moment and the charts refine themselves where
+  the curve actually bends (a sharp SWR notch resolves to sub-pixel instead
+  of hiding between samples), which also lets the base sweep start ~2×
+  faster and the Smith locus draw as a connected curve. The S11 chart now
+  shows **active-port reflection above 0 dB** instead of clamping it — on a
+  detuned array element, arguably the most important fact a sweep can show.
+  Plus: point any CLI subcommand straight at a NEC deck with
+  **`@file.nec`** builder specs, transmission-line stamps and a
+  Γ-referenced readout in the network reducer, and a Windows fix for the
+  schematic writer's Ω.
 </Card>
 
 ## The whole pitch, in one line

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -31,6 +31,25 @@ Designs are addressed as `family.name` (the same names `list` prints):
 python -m antennaknobs list            # arrays.bowtiearray, beams.yagi, loops.delta_loop, ...
 ```
 
+Three spec forms work anywhere a `--builder` / `--builders` argument does:
+
+- **`family.name`** — a catalog or user design.
+- **`family.name:variant`** — a stored knob-set overlay
+  (see [Variants are overlays](#variants-are-overlays)).
+- **`@path/to/deck.nec`** — a NEC card deck, loaded on the fly as a
+  frozen-geometry design via [`read_nec`](/reference/nec-import/). No
+  user-design stub to write: `draw`, `sweep`, `pattern`, `schematic`, and
+  `export` all take it directly, and decks mix freely with named designs in
+  `--builders` lists —
+
+  ```bash
+  python -m antennaknobs compare_patterns --builders dipoles.invvee @measured/invvee.nec
+  ```
+
+  The `@` sigil keeps the grammar unambiguous (a bare `foo.nec` would parse
+  as family `foo`, design `nec`), and an `@` spec never splits off a
+  `:variant` suffix, so colons in paths (Windows drive letters) pass through.
+
 ## Patterns
 
 ```bash

--- a/site/src/content/docs/reference/nec-import.md
+++ b/site/src/content/docs/reference/nec-import.md
@@ -22,6 +22,13 @@ is worth porting to a real `AntennaBuilder`.
 
 ## Quick start
 
+For one-off CLI work you don't need a stub at all: every subcommand accepts
+an **`@file.nec`** builder spec that loads the deck on the fly —
+`python -m antennaknobs draw --builder @my_yagi.nec` — and decks mix with
+named designs in `--builders` lists (see
+[Naming a design](/reference/cli/#naming-a-design)). Write the stub when the
+deck should live in your design catalog:
+
 Drop the deck next to a small design stub in `~/.antennaknobs/designs/`:
 
 ```python

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -159,6 +159,41 @@ and raised when off:
   Live back on. Useful when you want to set several knobs before paying for a
   solve, or when a heavy design makes continuous solving sluggish.
 
+## Adaptive resolution
+
+The frequency sweep and the far-field cuts sample **where the curve actually
+bends**, not just on a fixed grid. Hold the design still for a moment after a
+sweep settles and the workbench quietly buys extra samples where the drawn
+polyline still misses the true curve — a sharp SWR notch that a uniform grid
+would step right over resolves down to sub-pixel, and a pattern lobe's edge
+gets angles a uniform circle wouldn't spend there.
+
+What you'll notice:
+
+- **Sweeps start faster.** With refinement on, the base grid's job is only to
+  *detect* features, so it opens at 17 log-spaced points instead of 41 and the
+  S11/VSWR/Smith views fill in sooner; the refinement rounds then sharpen
+  whatever the base grid straddled.
+- **The Smith locus is a connected curve.** Refinement removes the sparse-
+  sample kinks that made a polyline dishonest, so the per-feed sweep trail
+  draws as a stroke instead of a dot cloud.
+- **Only what's on screen refines.** Like the sweeps themselves
+  (view-residency gating, above), refinement spends solves only on the
+  projections and cuts whose views are pinned or open.
+- **It's a setting.** The gear menu's **adaptive resolution** toggle (default
+  on, stored per browser like the theme) turns the whole machinery off, and
+  the base grids revert to their historical sizes (41-point sweeps) and become
+  final. For unusually difficult designs the budgets can be nudged via
+  `localStorage` overrides (`antennaknobs.sweepBaseN`,
+  `antennaknobs.sweepRefineBudget`, `antennaknobs.cutRefineBudget`,
+  `antennaknobs.refineTolerance`) — deliberately not knobs in the menu.
+
+Relatedly, the **S11 chart no longer clamps at 0 dB**: a driven-array port's
+*active* reflection is not bounded by |Γ| ≤ 1 (mutual coupling can push more
+power into a detuned element than its own generator supplies), so when any
+drawn value crosses zero the axis top rises to show it, with the 0 dB line
+kept as the tick a healthy passive port never crosses.
+
 ## Optimizing
 
 Next to Live is an **Optimize** toggle (same depressed-when-on look), with a
@@ -178,6 +213,15 @@ knobs you've marked to hit a target:
    time you change a *fixed* knob, it re-tunes the *marked* knobs (a short
    debounce, then a few dozen solves) and writes the best values back, so the
    antenna stays on target as you explore.
+
+**A run shows its work.** Progress streams back per evaluation: the VFO
+panel's readout ticks through each candidate's eval count, impedance, and SWR
+as the search moves, and the **Smith chart follows the run live** — its dot
+walks the Γ-plane with every trial. Every other view keeps describing the
+design you started from (the knobs aren't touched until the run finishes), so
+those views **dim** for the duration — the same stale-fade a mid-solve view
+wears — and light up when the result lands. The schematic stays bright: it's
+drawn from the current knob values and stays right throughout.
 
 Under the hood it's a derivative-free **Nelder–Mead** search (each evaluation is
 a full MoM solve), bounded by your Optimize ranges, and it always runs on the


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` to **0.44.0**.
- Refresh the what's-new card for the release: streamed optimizer progress (#773), worst-feed multi-feed objective (#785), adaptive sweep/cut resolution (#744), active-port S11 above 0 dB, `@file.nec` CLI builder specs, MNA reducer hardening (#746), Windows Ω encoding fix (#772).
- Docs de-stale sweep (the feature arcs carried no `site/` changes): `web.md` gains an **Adaptive resolution** section and the optimizer's live-progress behavior; `cli.md` documents the three builder-spec forms including `@file.nec`; `nec-import.md` cross-references the `@` spec for stub-free CLI use.

## Test plan
- [x] `cd site && npm run build` — 26 pages, clean
- [x] No solver/code changes in this PR beyond the version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvF4yHgNxjhyZ7P286g3z8