### PR TITLE
#792 unit 4: momwire-nec2c console script, docs, and the notes for Ward

### DIFF
--- a/docs/status/2026-08-08-simnec-execute-grammar.md
+++ b/docs/status/2026-08-08-simnec-execute-grammar.md
@@ -1,8 +1,8 @@
 # SimNEC's `nec2/Execute` printout grammar — the contract a momwire engine must meet
 
 Status doc for issue #792 ("momwire as a SimNEC engine").  §1–§10 are unit
-1's survey; §11 is what unit 2 resolved, §12 what unit 3 resolved, and §13 is
-what is still open.
+1's survey; §11 is what unit 2 resolved, §12 unit 3, §13 what was still open
+after it, and §14 what unit 4 resolved (§14.5 is the live open list).
 
 This is the empirical contract later units are written against. Two independent
 sources:
@@ -960,10 +960,9 @@ to 1.3 %).
 
 From §10, still open: items 1 (`processResponse` has no timeout — what, if
 anything, on the Java side notices a stalled engine), 2 (`MATRIX_LINE`),
-3 (`checkNEC42Fields`), 4/11 (`SimNEC.minimumNEC2CVersion`, and whether SimNEC
-has anywhere else to record an engine's name), 6 (`processExcitation`'s
-caller), 7 (patch/surface support), and 10 (what drops the blank lines around a
-multi-point `FR`'s `NX` echo).
+3 (`checkNEC42Fields`), 6 (`processExcitation`'s caller), 7 (patch/surface
+support), and 10 (what drops the blank lines around a multi-point `FR`'s `NX`
+echo). Items 4/11 closed in unit 4 — see §14.
 
 Item 5 shrank but did not close: `RP`, `NE`, `NH` and `NT` are now pinned; `PT`
 (and the plane-wave `EX i1 …` / `PT -1` / `XQ` / `PT -2` sequence), `MP` and
@@ -985,3 +984,78 @@ New for unit 4:
    is normalised by source input power, which is the antennaknobs convention;
    if SimNEC assumes directivity instead, the plots will differ by the
    efficiency even though every number here is self-consistent.
+
+## 14. Resolved by unit 4 (packaging, and two reads of the installed jar)
+
+### 14.1 `SimNEC.minimumNEC2CVersion` = **1.23** (§10 item 4, closed)
+
+Read straight out of the installed jar's static initialiser:
+
+```
+$ javap -p -c -constants -classpath ~/SimNEC/SimNEC.jar ae6ty.SimNEC
+  public static double minimumNEC2CVersion;
+  ...
+      13: ldc2_w   #49    // double 1.23d
+      16: putstatic #51   // Field minimumNEC2CVersion:D
+```
+
+`Execute.testCommand` parses group(1) of whichever of `versionA`/`versionB`/
+`versionC` matches, and accepts iff `value >= minimumNEC2CVersion`; below it,
+`NEC2PortalDialog.setVersion("<none>")` and the user is told "nec2c version too
+old". `nec_portal.PROBE_VERSION`'s tail is `9.1`, which clears it with room.
+
+The floor is not arbitrary: **it is exactly the version of the nec2c SimNEC
+currently ships**. This machine has two locale trees — the stale
+`~/.SimNEC/2/3` the corpus was captured from (`5b4az.ae6ty.1.17`) and the live
+`~/.SimNEC/5/1` belonging to SimNEC 6p4d6 (`5b4az.ae6ty.1.23`). So the floor
+moves with the shipped oracle, and a future SimNEC could in principle raise it
+past 9.1 — one more reason to ask Ward for a blessed convention rather than to
+squat on a number (see `2026-08-08-ward-simnec-momwire-notes.md`).
+
+### 14.2 There is still nowhere to put an engine's *name* (§10 item 11, closed)
+
+`testCommand` ends with `NEC2PortalDialog.setVersion(line)` — the **whole
+trimmed first line**, not group(1) — so SimNEC does record and display the
+probe string verbatim. That is the only such place. It does not help: the line
+still has to satisfy a regex whose greedy `(.*)` runs to end-of-line and is
+then handed to `Double.valueOf`, so any name anywhere after `nec2c.ae6ty.`
+fails the parse. The printout banner (`VERSION:nec2c.ae6ty.momwire.9.1`)
+remains the only place we can say who we are.
+
+### 14.3 The corpus is portable across the oracle's own versions
+
+Re-capturing all 30 fixtures with the live 1.23 oracle
+(`NEC_PORTAL_ORACLE=~/.SimNEC/5/1/Examples/nec2c.ae6ty/bin/nec2c-ubuntu-x86
+python scripts/nec_portal_capture.py`) and diffing against the committed 1.17
+set gives, over the whole corpus, **only**:
+
+* the `VERSION:` banner line itself;
+* signed zero on three `CURRENTS AND LOCATION` coordinate cells
+  (`-0.0000` → `0.0000`, `jar_testdeck` and its daemon-framed twin);
+* one denormal (`NETWORK LOSS = 0.0000E+00` → `-2.6021E-18`,
+  `dipole_nt_network`).
+
+No section, column, header or token count moves. The fixtures were therefore
+left as captured — re-capturing would churn 30 files to buy nothing, and the
+1.17 set is now known to be layout-representative of at least 1.17 through
+1.23.
+
+### 14.4 Packaging
+
+The daemon ships as the `momwire-nec2c` console script
+(`[project.scripts]` → `antennaknobs.nec_portal:main`). The name is contract:
+`NEC2PortalDialog` picks the engine dialect off the lowercased **filename**,
+and the sibling substrings `nec5`/`nec42` would select a different column
+layout. `NEC2Daemon` launches it via `sh -c` with cwd=`$HOME`, so the entry
+point is working-directory independent; both properties are pinned in
+`tests/test_nec_portal.py` (the cwd test is the file's one subprocess).
+`scripts/nec_portal_smoke.sh` is the hand check for the process contract —
+three decks down one resident process from an unrelated cwd, PASS/FAIL.
+
+### 14.5 Still open after unit 4
+
+Unchanged from §13 bar items 4/11: `processResponse`'s missing timeout,
+`MATRIX_LINE`, `checkNEC42Fields`, `processExcitation`'s caller, patch/surface
+support, the multi-point-`FR` blank lines, `TL`/`PT`/`MP`/`IS` printout
+layouts, `RP` modes 1-6, spherical `NE`/`NH`, and the `FieldStore`
+gain-vs-directivity convention. The last four are asks on Ward's desk.

--- a/docs/status/2026-08-08-ward-simnec-momwire-notes.md
+++ b/docs/status/2026-08-08-ward-simnec-momwire-notes.md
@@ -1,0 +1,196 @@
+# Notes for Ward: running momwire as SimNEC's NEC engine
+
+**Date:** 2026-08-08 · **Issue:** antennaknobs #792 · **Against:** SimNEC 6p4d6
+and its bundled `nec2c-ubuntu-x86` (`5b4az.ae6ty.1.23`; the corpus was captured
+from an older 1.17 copy on the same machine and re-verified against 1.23 —
+identical bar the banner, one signed zero and one denormal)
+
+*Written to be sent nearly as-is. Everything below is measured or read out of
+the shipped code; the questions at the end are genuinely open on our side.*
+
+---
+
+## What we built
+
+We have momwire — our open-source method-of-moments solver — standing in for
+`nec2c` behind SimNEC's NEC portal, as a **pure drop-in**: it is an executable
+that answers `-version`, reads decks from stdin framed by `NX`, and writes the
+NEC-2 printout back on stdout in the layout `nec2/Execute` parses. **No change
+to SimNEC is needed today.** A user installs our package, pastes
+`<venv>/bin/momwire-nec2c` into the NEC portal dialog, and SimNEC's Smith
+chart, MNA solver, tuner and sweeps all work unmodified with a different
+electromagnetics kernel underneath. We wrote it against the printout, not
+against your internals, so nothing in it depends on a SimNEC version.
+
+## What we validated
+
+**Layout: 30 of 30.** We captured 30 deck/printout pairs from the oracle
+`nec2c` your installation ships — the `NEC2Daemon` test deck raw and
+daemon-framed, hand-written decks for every card class, ten real designs from
+our catalog, and a two-decks-down-one-process residency case. Our engine
+reproduces all 30 **section for section, column for column, token-arity for
+token-arity**, including the details that bite: the `SENSE` column blanking
+when both field components fall under the degenerate-field floor (which is what
+makes a pattern row 11 tokens instead of 12, and would otherwise shift
+`E(THETA)`/`E(PHI)` by one column on half the table); card numbering restarting
+at 1 inside each deck; the frequency preamble printing only when the matrix is
+rebuilt; the blanked zero cell in `STRUCTURE IMPEDANCE LOADING`.
+
+**Numbers: agreement well inside engineering tolerance.** momwire is a B-spline
+Galerkin solver and `nec2c` is pulse-basis point-matched, so they will never
+agree digit for digit — and SimNEC does not need them to, since it reads two
+numbers per `ANTENNA INPUT PARAMETERS` row and builds a Y matrix. Worst case
+over every row of every table in all 30 fixtures, momwire 0.23.0 against
+`nec2c 5b4az.ae6ty.1.17`:
+
+| quantity | our bar | corpus worst | notes |
+| --- | --- | --- | --- |
+| `ANTENNA INPUT PARAMETERS` Z and I | 5 % | **2.83 %** | plus three explained outliers, below |
+| `-YY` report-card currents | 5 % | **2.83 %** | 12.02 % on the `NEC2Daemon` deck's near-open port |
+| current distribution (peak-normalised, complex) | 8 % | **6.00 %** | same distribution, segment for segment |
+| `RADIATION PATTERNS` TOTAL gain | 0.5 dB | **0.12 dB** | |
+| peak-gain direction | 1 step | **0 steps** | |
+| near field, off the conductor | — | **0.7 % / 0.4°** | |
+
+The three fixtures over 5 % are all one phenomenon — a small residual between
+two large, nearly cancelling numbers — and each carries a test asserting the
+identity that makes it benign: a 0.25 λ dipole with a +818 Ω loading coil at the
+feed (`Re(Z)` agrees to 1.8 %, and the reactance gap is 1.0 % *of the coil*);
+port 1 of your `NEC2Daemon` test deck, which is the centre gap of a full-wave
+split dipole at |Z| ≈ 3.5 kΩ — a current null, and the known basis-sensitive
+class — where the deck's other two ports agree to 0.4 %; and an `NT` deck where
+the branch carries most of the current, so the *segment* current printed in
+`STRUCTURE EXCITATION DATA` is a residual (12 %) while the *source* current
+SimNEC actually reads agrees to 1.3 %.
+
+One genuine bug fell out of that comparison, which is the argument for doing it
+this way: two crossing wires share a segment midpoint exactly, and our
+segment-to-element mapping had been position-only, so a crossed-dipole deck
+printed one wire's port current on the other wire's segment — a 90° error
+behind a perfectly plausible magnitude, invisible to every self-consistency
+check.
+
+**Live sessions: not yet.** Everything above is bench-tested against your
+oracle's committed output, with a smoke script that runs decks through one
+resident process exactly as `NEC2Daemon` does. Driving a real SimNEC session
+end to end is the next step on our side, and we will report what breaks before
+suggesting anyone else try it.
+
+## Asks, smallest first
+
+**1. Bless (or widen) the version-banner convention for third-party engines.**
+`Execute.testCommand()` matches the first `-version` line against
+`nec2c\.ae6ty\.(.*)` and feeds group(1) to `Double.valueOf`. The group is
+greedy, so *any* non-numeric tail throws and is reported to the user as
+"nec2c version too old" — the one message guaranteed to send them looking in
+the wrong place. So we cannot say who we are in the probe. We currently answer:
+
+```
+nec2c.ae6ty.9.1
+```
+
+and carry our real identity in the printout banner, which no regex is anchored
+to reach:
+
+```
+VERSION:nec2c.ae6ty.momwire.9.1
+```
+
+We picked `9.1` because `minimumNEC2CVersion` is currently `1.23` — which is
+exactly the version of the `nec2c` 6p4d6 ships, so the floor evidently tracks
+the bundled build and could rise. We would rather not squat on a number you may
+want.
+
+So: is there a form you would be willing to accept that lets a third-party
+engine *name itself*? A tolerant parse that takes the leading numeric run and
+ignores the rest would do it (`nec2c.ae6ty.9.1.momwire-0.23.0`), or a second
+line in the probe output, or a separate vendor field. `setVersion()` already
+stores and shows the whole trimmed line, so the display side is there — it is
+only `Double.valueOf` on a greedy group that forces us to be anonymous. We are
+happy to emit whatever you specify, and to gate it on a version so old builds
+keep working.
+
+**2. Confirm the error-reporting convention.** When a deck asks for something we
+do not model, we report it in the printout and **always** still emit the `NX`
+data-card echo, because `processResponse` blocks in `readLine()` with no
+timeout and an engine that stays quiet hangs the UI rather than showing a
+message. We copy the oracle's own prefix:
+
+```
+ERROR-NEC2C: <card> is not supported by this engine
+```
+
+deliberately *not* leading with the bare token `ERROR:`, which trips your
+`NEC ERROR (1)` warning frame. Is that the shape you want, or would you rather
+a third-party engine trip that frame so the user sees a dialog? Related: is
+there anything on the Java side that notices a *stalled* engine, or is the
+sentinel genuinely the only thing standing between a bad engine and a hung UI?
+
+**3. The gain-vs-directivity question for `FieldStore`.** This one could make
+plots differ without any number being wrong. `PROCESSINGPATTERN` and
+`PROCESSINGNEARFIELD` fill `FieldStore`, but we cannot see who consumes it or
+with what convention. Our `RADIATION PATTERNS` block normalises to the
+**source's input power** — i.e. the `POWER GAINS` columns are *gain*, including
+antenna losses. If whatever reads `FieldStore` assumes **directivity**
+(normalised to radiated power), then for a lossless antenna the two are
+identical and nothing shows, but a lossy one — ground losses, a loading coil,
+resistive wire — plots systematically low or high by exactly its efficiency:
+a 60 %-efficient antenna is 2.2 dB apart on the two conventions, with both
+engines self-consistent and neither obviously wrong. NEC-2's own `RP 0` prints
+power gain relative to input power, so we believe we match the oracle here;
+what we want to know is what SimNEC *assumes* it is being handed, and whether
+you would want an engine to be able to say which one it sent.
+
+**4. How much do users touch `_NECBLOCK.Nearfield`?** We support `NE`/`NH`
+rectangular grids in free space and over a perfect ground. We deliberately
+refuse them over finite ground — the near field of a Sommerfeld half-space is
+not an image field, and approximating it would be quietly wrong at exactly the
+distances people care about. We also refuse the spherical form (`I1 = 1`),
+although `WAITINGFORMETERSMETERSMETERS` accepts a `METERS DEGREES DEGREES`
+header, which suggests something in SimNEC expects to see it. Both are real
+work for us, and we would rather spend it where your users actually are: is the
+near-field block a corner feature, or does it get used enough that lossy-ground
+near fields matter?
+
+## What momwire would offer your users
+
+- **A genuinely independent second opinion.** Different basis (B-spline
+  Galerkin), different kernel, independently written — so agreement means
+  something. momwire also ships a sinusoidal-basis solver as a built-in
+  cross-check, which is much closer to NEC's own formulation.
+- **One fill, N sources.** `NECSource.sensorLines` probes an N-port antenna
+  with N excitation groups in a single deck, and stock `nec2c` refills and
+  refactors the whole moment matrix for each — N fills for one matrix. We take
+  the union of every group's ports, fill and factor **once** per geometry and
+  frequency, and answer each group by back-substitution on the cached factors.
+  A three-port deck costs one fill. This is where the multi-port probe gets its
+  time back.
+- **Speed on the dense assembly**, which is where MoM time actually goes, and
+  an **H-matrix solver at O(N log N)** for structures where the dense matrix
+  stops being reasonable — large arrays, long wires, dense meshes.
+- **Sommerfeld ground on every solver**, not as a special path.
+- **Active development**, MIT-licensed, with a public issue tracker; if you
+  want something changed on our side, it is a conversation rather than a fork.
+
+## If you want to try it
+
+```bash
+pip install antennaknobs
+which momwire-nec2c            # paste this path into the NEC portal dialog
+momwire-nec2c -version         # nec2c.ae6ty.9.1
+```
+
+Two caveats worth stating up front. The filename must keep `nec2c` in it —
+`NEC2PortalDialog` decides the engine dialect on the lowercased file name, so a
+tidier name is refused outright. And a momwire process is not a 2 MB C binary:
+each carries NumPy/SciPy/momwire, ~90 MB resident before it solves anything,
+plus the dense matrix and its factors. It is much quicker per deck once warm
+(~2 ms for a small dipole, ~130 ms for a 106-segment design), so a smaller crew
+keeps up with a larger one of the C engine — we suggest a NEC crew size of 4 on
+a 16 GB machine.
+
+We refuse, clearly and with the sentinel intact, anything we do not model:
+surface patches (`SP`/`SM` — momwire is a wire solver), `PT`/`MP`/`IS`, `TL`
+(we model the network fine; it is the `NETWORK DATA` layout for `TL` we have
+never observed), `RP` modes other than 0, spherical `NE`/`NH`, near fields over
+finite ground, and `GN` radial-wire ground screens.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,26 @@ test = ["antennaknobs[web]", "antennaknobs[schematic]", "pytest", "coverage", "h
 #     CI install never pull it in.
 dev = ["ruff"]
 
+# Console scripts.
+#
+# `momwire-nec2c` is the SimNEC portal daemon (antennaknobs.nec_portal, issue
+# #792) — momwire standing in for the nec2c binary SimNEC shells out to. The
+# NAME IS PART OF THE CONTRACT and must not be "prettified":
+# `nec2/NEC2PortalDialog` accepts a configured engine only if the executable's
+# FILENAME, lowercased, CONTAINS the substring "nec2c" (the same check picks
+# NEC5/NEC4.2 dialects off "nec5"/"nec42", so a name containing one of those
+# instead would select the wrong column layout). A user points the portal
+# dialog at `<venv>/bin/momwire-nec2c`; renaming it to, say, `momwire-portal`
+# makes SimNEC silently refuse the engine with "NO NEC Command Available".
+#
+# SimNEC then probes `<cmd> -version` and matches the first line against
+# `nec2c\.ae6ty\.(.*)` — see nec_portal.PROBE_VERSION for why that tail has to
+# be a bare one-dot number — and afterwards runs the command through `sh -c`
+# with cwd=$HOME, so the entry point must never depend on the working
+# directory. Both properties are pinned in tests/test_nec_portal.py.
+[project.scripts]
+momwire-nec2c = "antennaknobs.nec_portal:main"
+
 [project.urls]
 Homepage = "https://github.com/stevenmburns/antennaknobs"
 Issues = "https://github.com/stevenmburns/antennaknobs/issues"

--- a/scripts/nec_portal_smoke.sh
+++ b/scripts/nec_portal_smoke.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Hand smoke test for the momwire SimNEC portal daemon (issue #792).
+#
+# The unit suite proves the printout is right. This proves the PROCESS is
+# right — the part a SimNEC session actually depends on and that no in-process
+# test can see:
+#
+#   * `-version` prints exactly the one line `Execute.testCommand()` parses;
+#   * three real decks go down ONE resident process, in order, each answered
+#     with its own `NX` data-card echo (the sentinel `processResponse` blocks
+#     in `readLine()` waiting for — miss it and the SimNEC UI hangs forever,
+#     with no timeout on the Java side);
+#   * it all works from a working directory that has nothing to do with the
+#     checkout, because SimNEC launches the engine through `sh -c` with
+#     cwd=$HOME.
+#
+# Run it before pointing a live SimNEC at a new build:
+#
+#     bash scripts/nec_portal_smoke.sh
+#
+# PYTHON overrides the interpreter (default: the repo's .venv, else python3).
+set -uo pipefail
+
+here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo=$(dirname "$here")
+fixtures="$repo/tests/fixtures/nec_portal"
+
+# The engine must never need the checkout on the path at runtime, but a source
+# tree that was never `pip install`ed does — so offer src/ and let an installed
+# antennaknobs win or not on its own.
+export PYTHONPATH="$repo/src${PYTHONPATH:+:$PYTHONPATH}"
+
+# Interpreter: $PYTHON if set, else the first candidate that can import momwire.
+# A git worktree has no .venv of its own and borrows the main checkout's, which
+# is what --git-common-dir finds.
+candidates=("$repo/.venv/bin/python")
+if main_git=$(git -C "$repo" rev-parse --path-format=absolute --git-common-dir 2>/dev/null); then
+  candidates+=("$(dirname "$main_git")/.venv/bin/python")
+fi
+candidates+=(python3)
+
+python=${PYTHON:-}
+if [[ -z $python ]]; then
+  for c in "${candidates[@]}"; do
+    if command -v "$c" >/dev/null 2>&1 && "$c" -c 'import momwire' >/dev/null 2>&1; then
+      python=$c
+      break
+    fi
+  done
+fi
+if [[ -z $python ]]; then
+  echo "FAIL  no interpreter with momwire installed; set PYTHON=/path/to/python"
+  exit 1
+fi
+
+# Free space, the two-port YY probe (the sensor path SimNEC drives an N-port
+# antenna with), and a radiation pattern — one deck per printout family.
+decks=(dipole_free_space two_source_yy_card dipole_rp_pattern)
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+fail=0
+note() { printf '  %s\n' "$*"; }
+check() { # check <description> <condition-already-evaluated-as-exit-status>
+  if [[ $2 -eq 0 ]]; then note "ok    $1"; else note "FAIL  $1"; fail=1; fi
+}
+
+echo "engine: $python -m antennaknobs.nec_portal"
+echo "cwd:    $work  (unrelated to $repo, as SimNEC's sh -c would be)"
+echo
+
+# ---------------------------------------------------------------- version ---
+echo "version probe"
+probe=$(cd "$work" && "$python" -m antennaknobs.nec_portal -version 2>"$work/probe.err")
+probe_rc=$?
+check "exit 0" $probe_rc
+[[ $(printf '%s\n' "$probe" | wc -l) -eq 1 ]]
+check "exactly one line of stdout" $?
+# nec2/Execute.versionA, plus the Double.valueOf(group(1)) trap: the tail has
+# to be a bare one-dot number or SimNEC says "nec2c version too old".
+[[ $probe =~ ^nec2c\.ae6ty\.[0-9]+\.[0-9]+$ ]]
+check "matches nec2c.ae6ty.<double>  (got: ${probe:-<empty>})" $?
+[[ ! -s $work/probe.err ]]
+check "stderr empty" $?
+echo
+
+# ------------------------------------------------------------------ decks ---
+echo "resident run: ${decks[*]}"
+for d in "${decks[@]}"; do
+  cat "$fixtures/$d.deck"
+done >"$work/in.deck"
+
+(cd "$work" && "$python" -m antennaknobs.nec_portal <"$work/in.deck" \
+  >"$work/out.txt" 2>"$work/out.err")
+run_rc=$?
+check "exit 0" $run_rc
+
+sentinels=$(grep -cE '^ *DATA CARD No: +[0-9]+ NX' "$work/out.txt")
+[[ $sentinels -eq ${#decks[@]} ]]
+check "one NX sentinel per deck (${sentinels}/${#decks[@]})" $?
+
+inputs=$(grep -c 'ANTENNA INPUT PARAMETERS' "$work/out.txt")
+[[ $inputs -ge 4 ]]  # 1 + 2 (the YY probe's two groups) + 1
+check "every deck produced ANTENNA INPUT PARAMETERS ($inputs)" $?
+
+grep -q 'VERSION:nec2c.ae6ty.momwire' "$work/out.txt"
+check "printout banner carries the momwire identity" $?
+
+grep -qE '^ *-YY ' "$work/out.txt"
+check "the YY report card came back" $?
+
+grep -q 'RADIATION PATTERNS' "$work/out.txt"
+check "the pattern table came back" $?
+
+! grep -q 'ERROR' "$work/out.txt"
+check "no error line in the printout" $?
+
+# NEC2Daemon never drains the child's stderr, so anything we write there can
+# fill the pipe buffer and deadlock a long session. CM FF is the only licence.
+[[ ! -s $work/out.err ]]
+check "stderr empty" $?
+echo
+
+if [[ $fail -eq 0 ]]; then
+  echo "PASS  ${#decks[@]} decks, one process, sentinels intact"
+else
+  echo "FAIL  see above; printout is at $work/out.txt (kept below)"
+  cp "$work/out.txt" "$work/out.err" "${TMPDIR:-/tmp}/" 2>/dev/null || true
+  echo "      copies in ${TMPDIR:-/tmp}/out.txt, ${TMPDIR:-/tmp}/out.err"
+fi
+exit $fail

--- a/site/src/content/docs/reference/simnec.md
+++ b/site/src/content/docs/reference/simnec.md
@@ -1,6 +1,6 @@
 ---
 title: SimNEC round-trip
-description: Export any design — antenna or whole station — as a SimNEC .ssn circuit, and load .ssn files back as designs, for cross-validation against an independent solver.
+description: Export any design — antenna or whole station — as a SimNEC .ssn circuit, load .ssn files back as designs, or run momwire as the NEC engine behind SimNEC itself.
 ---
 
 [SimNEC](https://ae6ty.com/smith_charts/) (AE6TY) is the successor to
@@ -112,8 +112,133 @@ loss coefficients, both capacitors, coil and its Q) survive the full cycle
 unchanged. If the two sides ever disagree about a convention, the suite
 fails rather than the circuits quietly diverging.
 
+## Using momwire as SimNEC's engine
+
+The round-trip above hands SimNEC a file and lets SimNEC's own bundled NEC2
+solve it. There is a second, tighter connection: **momwire can be the solver
+SimNEC calls.**
+
+SimNEC does not link NEC2 — it shells out to a `nec2c` executable, starts one
+copy, and keeps it. Decks go down that process's stdin framed by an `NX` card,
+printouts come back on stdout, and SimNEC's MNA circuit solver reads two
+numbers per feedpoint out of each printout to build the antenna's Y matrix.
+`antennaknobs.nec_portal` is a drop-in for that process, with momwire's
+B-spline Galerkin solver behind it. Your Smith chart, tuner, and sweeps stay
+SimNEC's; the electromagnetics become momwire's.
+
+:::caution[Experimental, and unblessed upstream]
+This is validated against a real SimNEC installation's own NEC2 — 30 captured
+deck/printout pairs, reproduced layout-identically, with the numbers agreeing
+to better than 5% on impedance and 0.12 dB on pattern gain — but it is not
+something SimNEC's author has reviewed or endorsed, and no part of SimNEC
+knows momwire exists. Treat it as a cross-check you can run yourself, not as a
+supported configuration.
+:::
+
+### Pointing SimNEC at it
+
+Install antennaknobs anywhere with a Python environment; the package ships a
+console script:
+
+```bash
+pip install antennaknobs
+which momwire-nec2c          # e.g. ~/.venvs/ak/bin/momwire-nec2c
+momwire-nec2c -version       # nec2c.ae6ty.9.1
+```
+
+Then open SimNEC's NEC portal dialog and paste that path in as the NEC
+command. Two rules decide whether SimNEC accepts it, and both are worth
+knowing because the failure modes look nothing like their causes:
+
+- **The filename must contain `nec2c`.** SimNEC picks the engine's dialect off
+  the command's file name, lowercased — a name with none of `nec2c` / `nec5` /
+  `nec42` in it is refused outright with *NO NEC Command Available*. That is
+  why the script is called `momwire-nec2c` and not something tidier; if you
+  wrap it in a shell script or a symlink, keep `nec2c` in the name.
+- **The version probe must answer.** SimNEC runs `<command> -version` and reads
+  the first line, which has to be `nec2c.ae6ty.` followed by a plain number it
+  can parse as a decimal. The portal answers `nec2c.ae6ty.9.1`. It cannot say
+  "momwire" there — an extra dot makes the parse fail and SimNEC reports
+  *nec2c version too old* — so the engine puts its real identity in the
+  printout banner instead, where every SimNEC session logs it:
+  `VERSION:nec2c.ae6ty.momwire.9.1`.
+
+Before a live session, the repo's smoke script runs three decks through one
+resident process the way SimNEC does and prints PASS or FAIL:
+
+```bash
+bash scripts/nec_portal_smoke.sh
+```
+
+### What works
+
+Everything SimNEC's portal actually emits for wire antennas:
+
+| | |
+| --- | --- |
+| Feedpoint impedance | `EX 0` voltage sources, one or many, and the `YY` report card SimNEC probes multi-port antennas with |
+| Frequency sweeps | multi-point `FR`, the whole sweep in one deck |
+| Geometry | `GW` wires with `GM` / `GX` / `GR` / `GS` / `GA` / `GH` transforms |
+| Ground | free space, `GE ±1` perfect ground, `GN 0` reflection-coefficient and `GN 2` Sommerfeld finite ground |
+| Loading | `LD 0` / `1` / `4` / `5` — series RLC traps, distributed loading, wire conductivity |
+| Patterns | `RP 0` far-field grids, gain and polarisation, normalised to input power |
+| Near fields | `NE` / `NH` rectangular grids in free space or over perfect ground |
+| Networks | `NT` two-port admittance branches between segments |
+
+One thing is faster than the engine it replaces, structurally. SimNEC probes an
+N-port antenna by sending N excitation groups in one deck, and a stock nec2c
+refills and refactors the whole moment matrix for each — N fills for one
+matrix. The portal takes the union of every group's ports, fills and factors
+**once** per geometry and frequency, and answers each group by back-substitution
+on the cached factors. A three-port deck costs one fill, not three.
+
+### What refuses — cleanly
+
+A deck the engine cannot model is *reported and stepped over*, never guessed
+at: the printout names the offending card and why, and still carries the `NX`
+sentinel that SimNEC blocks in `readLine()` waiting for. (An engine that dies
+or forgets the sentinel hangs SimNEC's UI with no timeout, which is strictly
+worse than an error message.) The daemon survives it and runs the next deck.
+
+Refused today:
+
+- **Surface patches** (`SP`, `SM`) — momwire is a wire solver.
+- **`PT`, `MP`, `IS`** — print control, the multiprocessing hint SimNEC emits
+  on large structures, and NEC-4.2 wire insulation. Their printout shapes are
+  unpinned, so they are refused rather than approximated.
+- **`TL` transmission lines** — momwire models the network fine; it is the
+  NETWORK DATA table's column layout for `TL` that has never been observed.
+  Use `NT`, or keep the line on the SimNEC side as a `SERIES_TLINE` element,
+  which is where a station's feedline belongs anyway.
+- **`RP` modes 1–6 and the gain-only form** — mode 0 is the only one SimNEC
+  emits; the others print a different table.
+- **Spherical `NE` / `NH` grids** (`I1 = 1`) — rectangular only.
+- **Near fields over finite ground** — the near field of a Sommerfeld
+  half-space is not an image, and pretending otherwise would be quietly wrong.
+  Far-field patterns over finite ground are fine.
+- **`GN` radial-wire ground screens** (a non-zero radial count) — momwire has
+  no screen model, and ignoring the field would silently change the answer.
+
+### How many engines to run
+
+SimNEC keeps a crew of engine processes and hands decks out among them. A
+momwire process is not a 2 MB C binary: each one carries NumPy, SciPy and
+momwire — about 90 MB resident before it solves anything — plus the dense
+complex matrix and its factors, which grow as the square of the segment count.
+It is also much quicker per deck once warm (a 106-segment design solves in
+~130 ms, a small dipole in ~2 ms), so a smaller crew keeps up with a larger one
+of the C engine.
+
+**On a 16 GB machine, set the NEC crew size to 4.** Larger crews buy little,
+because the win here is the single fill per geometry rather than parallelism
+across decks, and they multiply the per-process floor by the segment count you
+are least expecting.
+
 ## Licensing
 
 SimNEC is proprietary freeware. antennaknobs emits and parses its *open file
 format* for interoperability — like emitting a NEC deck or a Touchstone
-file — and copies none of SimNEC's bundled assets.
+file — and copies none of SimNEC's bundled assets. The engine portal is the
+same kind of interoperability in the other direction: it reproduces the
+printout *layout* SimNEC's reader expects, worked out from observed output,
+and contains no nec2c code.

--- a/tests/test_nec_portal.py
+++ b/tests/test_nec_portal.py
@@ -1,7 +1,8 @@
-"""The momwire SimNEC portal daemon (issue #792, units 2 and 3).
+"""The momwire SimNEC portal daemon (issue #792, units 2 to 4).
 
-Everything here runs in-process against the committed oracle fixtures — no
-``nec2c`` binary, no subprocess. The oracle's *numbers* are not the contract
+Everything here runs against the committed oracle fixtures — no ``nec2c``
+binary — and, bar the one cwd-independence test at the foot of the file, in
+process. The oracle's *numbers* are not the contract
 (a different basis and kernel will never match digit for digit); its *layout*
 is, so the fixtures are compared structurally: same section sequence, same
 column geometry, same token arity — for every deck in the corpus, not just a
@@ -15,13 +16,23 @@ execute-card semantics of ``RP``/``NE``/``NH``, the pattern and near-field
 tables, ``NT`` port algebra, and the robustness contract — a malformed deck
 must be REPORTED and stepped over, never swallowed and never fatal, because
 ``Execute.processResponse`` blocks in ``readLine()`` with no timeout.
+
+Unit 4 adds the packaging contract: the ``momwire-nec2c`` console script whose
+NAME is what SimNEC's portal dialog accepts an engine on, and the fact that the
+daemon runs from any working directory (SimNEC launches it via ``sh -c`` with
+cwd=$HOME).
 """
 
 from __future__ import annotations
 
+import importlib
 import io
 import json
+import os
 import re
+import subprocess
+import sys
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -951,3 +962,87 @@ def test_a_blank_deck_still_frames():
     out, err = deck_frame("")
     assert NX_ECHO.search("\n".join(out))
     assert err == []
+
+
+# --------------------------------------------------------------------------
+# packaging: the console script SimNEC is pointed at (unit 4)
+# --------------------------------------------------------------------------
+
+ENTRY_POINT_NAME = "momwire-nec2c"
+
+
+def _console_scripts() -> dict[str, str]:
+    text = (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text()
+    return tomllib.loads(text)["project"]["scripts"]
+
+
+def test_the_console_script_name_passes_simnecs_filename_check():
+    """``nec2/NEC2PortalDialog`` accepts an engine on its FILENAME alone.
+
+    The check is a lowercased substring test for ``nec2c`` on the configured
+    command's file name — nothing inside the file is consulted until the
+    ``-version`` probe. Renaming the entry point to something tidier
+    (``momwire-portal``) makes SimNEC refuse it outright, so the name is
+    contract, not cosmetics.
+    """
+    scripts = _console_scripts()
+    assert ENTRY_POINT_NAME in scripts, (
+        f"pyproject [project.scripts] must ship {ENTRY_POINT_NAME!r}; has {sorted(scripts)}"
+    )
+    assert "nec2c" in ENTRY_POINT_NAME.lower()
+    # The sibling dialect prefixes select a DIFFERENT column layout
+    # (checkNEC42Fields, samplesWidth 12) that this engine does not emit.
+    assert "nec5" not in ENTRY_POINT_NAME.lower()
+    assert "nec42" not in ENTRY_POINT_NAME.lower()
+
+
+def test_the_console_script_target_resolves():
+    """The ``module:attr`` string must actually import — a typo here is only
+    discovered by a user whose SimNEC session dies at the version probe."""
+    target = _console_scripts()[ENTRY_POINT_NAME]
+    module_name, _, attr = target.partition(":")
+    assert attr, f"{target!r} names no callable"
+    entry = getattr(importlib.import_module(module_name), attr)
+    assert entry is nec_portal.main
+    assert callable(entry)
+
+
+def test_the_entry_point_runs_from_an_unrelated_cwd(tmp_path):
+    """SimNEC launches the engine via ``sh -c`` with cwd=$HOME.
+
+    Nothing in the daemon may resolve a relative path — not the fixtures, not
+    the momwire import, not a config file. Both halves of the protocol are
+    exercised out of a directory that has no relationship to the checkout: the
+    ``-version`` probe SimNEC gates on, and one real deck framed by ``NX``.
+    """
+    src_root = str(Path(nec_portal.__file__).resolve().parents[2])
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join([src_root, os.environ.get("PYTHONPATH", "")]),
+    }
+    argv = [sys.executable, "-m", "antennaknobs.nec_portal"]
+
+    probe = subprocess.run(
+        [*argv, "-version"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert probe.returncode == 0, probe.stderr
+    assert probe.stdout.splitlines() == [nec_portal.PROBE_VERSION]
+
+    solve = subprocess.run(
+        argv,
+        cwd=tmp_path,
+        env=env,
+        input=fixture_deck("dipole_free_space") + "\nNX\n",
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert solve.returncode == 0, solve.stderr
+    assert NX_ECHO.search(solve.stdout), "no sentinel — SimNEC would block forever"
+    assert "ANTENNA INPUT PARAMETERS" in solve.stdout
+    assert f"VERSION:{nec_portal.BANNER_VERSION}" in solve.stdout


### PR DESCRIPTION
## Summary
Final unit of the #792 stacked arc.
- `momwire-nec2c` console script (`[project.scripts]` → `antennaknobs.nec_portal:main`) — the name deliberately contains `nec2c` for SimNEC's filename check; cwd-independent (SimNEC runs engines via `sh -c` from $HOME).
- `scripts/nec_portal_smoke.sh` — the pre-live-test ritual: 3 decks, one resident process, 12 assertions.
- `reference/simnec.md` gains **Using momwire as SimNEC's engine** (honest experimental framing; crew-size guidance).
- `docs/status/2026-08-08-ward-simnec-momwire-notes.md` — send-ready notes: what we built/validated, four asks smallest-first (banner convention, error convention, gain-vs-directivity for FieldStore, near-field usage), what momwire offers.
- Grammar doc §14: `minimumNEC2CVersion = 1.23` read from the jar (our 9.1 tail clears it with room); corpus proven layout-portable 1.17→1.23 (re-captured all 30, only banner/signed-zero/denormal drift).

## Gates (orchestrator-verified in the worktree)
- [x] ruff clean; 522 portal tests green (reproduced)
- [x] `nec_portal_smoke.sh` PASS (3 decks, sentinels intact)
- [x] Site builds: 27 pages, 0 errors
- [x] Mutation probe: renaming the script without `nec2c` → 2 tests fail; restored → green

Builder: opus (delegated-build contract). Part of #792; merges into `issue-792-simnec-portal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvF4yHgNxjhyZ7P286g3z8