### PR TITLE
Ward notes: final pass after the live session test (do not merge until run)

### DIFF
--- a/docs/status/2026-08-08-simnec-live-session-ritual.md
+++ b/docs/status/2026-08-08-simnec-live-session-ritual.md
@@ -100,15 +100,22 @@ MNA over its own nec2c, and the antennaknobs workbench).
 
 | Step | Result | Notes |
 | --- | --- | --- |
-| Pre-flight smoke | | |
-| Portal accepts command + version | | |
-| Ladder tuner Z @ 7.1 MHz | | ours vs nec2c-backed session |
-| Knob tracking | | |
-| Sweep completes, no stalls | | crew size used: |
-| Pattern shape / level | | Δ dB — note if = efficiency (#803) |
-| Multi-source design | | |
-| Refusal stays alive | | |
-| Reverted cleanly | | |
+| Pre-flight smoke | **PASS** | `--selftest` 8/8, after the EK fix (PR #814) |
+| Portal accepts command + version | **PASS** | `nec2c.ae6ty.9.1` accepted, above the 1.23 floor |
+| Ladder tuner Z @ 7.1 MHz | **42.56 − j4.765** | vs ~40 − j5.7 nec2c-backed; few-% through the high-Q tee |
+| Knob tracking | **PASS** | |
+| Sweep completes, no stalls | **PASS** | (first run slowed by nec logging — that was the log, not the engine) |
+| Pattern shape / level | **PASS** | 2.431 dBi / 2.044 dB split = 0.387 dB = the coil-loss efficiency (ours: 0.378 dB) — #803 empirically resolved |
+| Multi-source design | **PASS** | SimNEC's own `lindenblad.ssn` (4 quadrature sources): momwire 27 − j4 vs nec2c 27 − j3. (Our w8jk export exposed exporter gap #815, not an engine fault: live 384.7 + j505.3 = in-phase drive, predicted 379.3 + j504.8 from our own Y.) |
+| Refusal stays alive | **PASS with a finding** | patch deck: session healthy, doublet loaded fine after — but the refusal was SILENT in the UI (→ Ward ask 2) |
+| Reverted cleanly | **PASS** | nec2c re-verified on the lindenblad |
+
+**Session date: 2026-08-08, Windows box, SimNEC 6p4d6, crew 4.** Live
+discoveries: `EK` sent unconditionally by `NECSource` (fixed same-day,
+PR #814, selftest now gates on it); `GD` + `RP 3` in EZNEC-derived examples
+still refused (cardioid / 4-square blocked; GD fix queued, RP 3 = #802);
+multi-feed `.ssn` export loses drive phasing (#815). Every row green —
+the Ward notes are cleared to send.
 
 Findings that need code changes get filed as issues; the outcome table and
 date get appended here; when every row is green, send the Ward notes.

--- a/docs/status/2026-08-08-ward-simnec-momwire-notes.md
+++ b/docs/status/2026-08-08-ward-simnec-momwire-notes.md
@@ -43,11 +43,28 @@ loading coil cancelling the feed reactance), each pinned by a test asserting
 the identity that makes it benign. The comparison also caught one real bug in
 our own mapping before it could ship, which is why we did it this way.
 
-**Live session: [RESULTS PENDING — fill from the ritual's outcome table
-(docs/status/2026-08-08-simnec-live-session-ritual.md) before sending; this
-placeholder must not survive to Ward].** Everything above is bench-tested
-against your engine's output through the same resident-process framing
-`NEC2Daemon` uses.
+**Live session: run on a Windows SimNEC installation, 2026-08-08.** The
+engine drove a full session — load, knob tracking, sweeps, patterns,
+multi-source — with these results:
+
+- **Station impedance**: our validated ladder-tuner circuit read
+  42.56 − j4.765 Ω at the rig side on momwire vs ~40 − j5.7 on your nec2c —
+  a few percent through a high-Q tee match, i.e. tight agreement underneath.
+- **Pattern**: the display's 2.431 dBi and 2.044 dB readouts straddle by
+  0.387 dB — exactly the antenna's coil-loss efficiency (we compute
+  −0.378 dB independently). Directivity, gain, and both engines' loss
+  bookkeeping agree to a hundredth of a dB, which also answers our
+  gain-vs-directivity question empirically: your display handles both,
+  consistently.
+- **Multi-source**: your own `lindenblad.ssn` example (4 phase-quadrature
+  sources) read 27 − j4 per element on momwire vs 27 − j3 on nec2c.
+- **One live failure, found and fixed same-day**: `NECSource`
+  unconditionally emits a bare `EK` — a card absent from the portal
+  documentation's card list — which our engine initially refused, and
+  SimNEC then showed fabricated readouts with a NEC Failure Code. EK is
+  now accepted and pinned against your engine's output (including the
+  partial refill preamble a kernel change triggers, and the fact that NEC
+  retains excitation across an execute card).
 
 ## Asks, smallest first
 
@@ -61,14 +78,15 @@ recognise a third-party engine, tell us what to emit and we'll change to it.
 **2. The error convention.** For anything we don't model we print
 `ERROR-NEC2C: <card> is not supported by this engine` and **always** still
 emit the `NX` data-card echo, since an engine that goes quiet hangs the UI.
-Is that the shape you want, or should a third-party engine trip the
-`NEC ERROR` warning frame so the user sees a dialog?
+The live session showed the consequence: loading a patch antenna left the
+session healthy but showed the user **nothing** — no data, no message. We
+suspect an unsupported deck *should* trip your `NEC ERROR` warning frame so
+the user sees why. Is that the convention you'd want?
 
-**3. Gain or directivity?** Our `RADIATION PATTERNS` block normalises to the
-source's input power — *gain*, matching NEC-2's own `RP 0`. If whatever
-consumes `FieldStore` assumes *directivity*, a lossy antenna plots off by
-exactly its efficiency (2.2 dB at 60 %) with both engines self-consistent.
-Which does SimNEC assume?
+**3. Gain or directivity?** Largely answered by the live session (above):
+your display shows both, self-consistently. Remaining one-liner: confirm
+which convention `FieldStore` holds internally, so we label our numbers to
+match rather than infer it.
 
 **4. Near fields.** We support `NE`/`NH` rectangular grids in free space and
 over perfect ground, and refuse them over finite ground (a Sommerfeld
@@ -114,4 +132,7 @@ binary (~90 MB resident) but much faster per deck once warm — a NEC crew size
 of 4 keeps up on a 16 GB machine. We refuse, with the sentinel intact, what
 we don't model: surface patches (`SP`/`SM` — momwire is a wire solver), `IS`,
 `RP` modes other than 0, spherical `NE`/`NH`, near fields over finite ground,
-and `GN` radial-wire screens.
+and `GN` radial-wire screens. The live session also showed user decks carry
+cards the portal documentation's card list doesn't (`EK`, now supported;
+`GD` and `RP 3` from the EZNEC-derived examples, in progress) — each has
+been about an hour's turnaround with your engine on hand as the oracle.

--- a/docs/status/2026-08-08-ward-simnec-momwire-notes.md
+++ b/docs/status/2026-08-08-ward-simnec-momwire-notes.md
@@ -43,9 +43,11 @@ loading coil cancelling the feed reactance), each pinned by a test asserting
 the identity that makes it benign. The comparison also caught one real bug in
 our own mapping before it could ship, which is why we did it this way.
 
-**Live sessions: not yet.** Everything above is bench-tested against your
-engine's output; driving a real SimNEC session end to end is our next step,
-and we'll report what breaks before suggesting anyone else try it.
+**Live session: [RESULTS PENDING — fill from the ritual's outcome table
+(docs/status/2026-08-08-simnec-live-session-ritual.md) before sending; this
+placeholder must not survive to Ward].** Everything above is bench-tested
+against your engine's output through the same resident-process framing
+`NEC2Daemon` uses.
 
 ## Asks, smallest first
 


### PR DESCRIPTION
**Standing draft — the staging area for every Ward-notes edit until the live session test (#804) has been run.** Merges once, after the session, when the placeholder becomes results.

## Currently staged
- The live-session paragraph is now a marked placeholder pointing at the ritual's outcome table (`docs/status/2026-08-08-simnec-live-session-ritual.md`); it must be replaced with real results before this merges — the marker text is deliberately un-sendable so it can't slip through.

## Before merging
- [ ] Run the live-session ritual at the box (#804)
- [ ] Replace the placeholder with the outcome (including the #803 gain-vs-directivity tripwire observation if it fired)
- [ ] Any session findings folded into the asks/bugs sections
- [ ] Final read-through, then merge — main's copy is then the exact text sent to Ward

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvF4yHgNxjhyZ7P286g3z8