### PR TITLE
nec_portal: --selftest deployment smoke + Windows live-session instructions

### DIFF
--- a/docs/status/2026-08-08-simnec-live-session-ritual.md
+++ b/docs/status/2026-08-08-simnec-live-session-ritual.md
@@ -7,6 +7,30 @@ end. This is the script for that session. Run it at the box with SimNEC
 installed; record the outcome in the table at the bottom. **This is the last
 gate before the notes in `2026-08-08-ward-simnec-momwire-notes.md` go out.**
 
+## 0a. Running this on a Windows box instead
+
+The ritual works unchanged on any machine with SimNEC — and Windows is
+arguably the stronger test (SimNEC's user base, the `cmd.exe /c` launch
+path, CRLF through `Execute.readLine()`). Windows translation of the setup:
+
+```bat
+py -3.12 -m venv %USERPROFILE%\momwire-portal
+%USERPROFILE%\momwire-portal\Scripts\pip install https://github.com/stevenmburns/antennaknobs/archive/refs/heads/main.zip
+%USERPROFILE%\momwire-portal\Scripts\momwire-nec2c.exe -version
+%USERPROFILE%\momwire-portal\Scripts\momwire-nec2c.exe --selftest
+```
+
+(momwire ships `win_amd64` wheels for CPython 3.10–3.14; the zip install
+needs no git client; the `.exe` name still contains `nec2c` so the portal's
+filename check passes.) `--selftest` replaces the bash smoke script — it
+needs no checkout: it spawns one resident copy of itself, runs three
+embedded decks (plain dipole, two-source Y probe, TL station) down the one
+process, and PASSes only if every solve answered with its NX sentinel. In
+step 1, paste the full `...\Scripts\momwire-nec2c.exe` path into the portal
+dialog; SimNEC's per-user state lives under `%USERPROFILE%\.SimNEC`. If the
+box has less RAM than 16 GB, drop `necCrewSize` accordingly (~90 MB per
+resident engine before solve data). Everything from step 2 on is identical.
+
 ## 0. Pre-flight (no GUI needed)
 
 ```bash

--- a/src/antennaknobs/nec_portal.py
+++ b/src/antennaknobs/nec_portal.py
@@ -2408,6 +2408,70 @@ def run_deck(body: str) -> tuple[str, str]:
 # --------------------------------------------------------------------------
 
 
+_SELFTEST_DECKS = (
+    # A free-space dipole, the two-source Y probe, and a TL station — the
+    # three deck shapes a live SimNEC session leans on hardest.
+    "CE selftest 1\n"
+    "GW 1 11 0. -5. 10. 0. 5. 10. 0.001\n"
+    "GE 0\nEX 0 1 6 0 1.\nFR 0 1 0 0 14.0 1\nXQ\nNX\n",
+    "CE selftest 2\n"
+    "GW 1 11 0. -5. 10. 0. 5. 10. 0.001\n"
+    "GW 2 11 3. -5. 10. 3. 5. 10. 0.001\n"
+    "GE 0\nYY 1 6 2 6\n"
+    "EX 0 1 6 0 1.\nFR 0 1 0 0 14.0 1\nXQ\n"
+    "EX 0 2 6 0 1.\nFR 0 1 0 0 14.0 1\nXQ\nNX\n",
+    "CE selftest 3\n"
+    "GW 1 11 0. -5. 10. 0. 5. 10. 0.001\n"
+    "GW 2 3 20. -0.5 10. 20. 0.5 10. 0.001\n"
+    "GE 0\nTL 2 2 1 6 600. 20.\n"
+    "EX 0 2 2 0 1.\nFR 0 1 0 0 14.0 1\nXQ\nNX\n",
+)
+
+
+def _selftest(stdout) -> int:
+    """Deployment smoke with no files needed (``momwire-nec2c --selftest``).
+
+    The unit suite proves the printout; this proves the PROCESS on the box it
+    will actually run on — the resident loop under a real OS pipe, which is
+    what a SimNEC session depends on and what matters when the install is a
+    bare ``pip install`` with no checkout (e.g. the Windows box, where SimNEC
+    launches engines through ``cmd.exe`` and text I/O is CRLF). It spawns
+    itself exactly once, feeds three embedded decks down the one process, and
+    requires per deck: the banner (first deck only), an ANTENNA INPUT
+    PARAMETERS section, and the NX data-card echo sentinel — miss that and a
+    live SimNEC hangs forever, which is the failure this exists to catch.
+    """
+    import subprocess
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "antennaknobs.nec_portal"],
+        input="".join(_SELFTEST_DECKS),
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    checks = {
+        "process exited 0": proc.returncode == 0,
+        "banner present": "VERSION:" in proc.stdout,
+        "4 solve groups answered": proc.stdout.count("ANTENNA INPUT PARAMETERS") == 4,
+        "3 NX sentinels": sum(
+            1
+            for ln in proc.stdout.splitlines()
+            if ln.lstrip().startswith("DATA CARD No:") and " NX " in ln
+        )
+        == 3,
+        "-YY row present": "    -YY " in proc.stdout,
+        "TL network row present": "STRAIGHT" in proc.stdout,
+        "stderr quiet": proc.stderr.strip() == "",
+    }
+    for name, ok in checks.items():
+        stdout.write(f"  {'ok  ' if ok else 'FAIL'} {name}\n")
+    passed = all(checks.values())
+    stdout.write("PASS\n" if passed else "FAIL\n")
+    stdout.flush()
+    return 0 if passed else 1
+
+
 def main(argv: list[str] | None = None, stdin=None, stdout=None, stderr=None) -> int:
     """The daemon. ``-version`` probes; otherwise read decks until stdin ends.
 
@@ -2424,6 +2488,9 @@ def main(argv: list[str] | None = None, stdin=None, stdout=None, stderr=None) ->
         stdout.write(f"{PROBE_VERSION}\n")
         stdout.flush()
         return 0
+
+    if any(a.lstrip("-").lower() == "selftest" for a in argv):
+        return _selftest(stdout)
 
     # The banner belongs to process start-up; every later one trails an NX.
     stdout.write("\n".join(_BANNER) + "\n")

--- a/tests/test_nec_portal.py
+++ b/tests/test_nec_portal.py
@@ -1494,3 +1494,20 @@ def test_the_entry_point_runs_from_an_unrelated_cwd(tmp_path):
     assert NX_ECHO.search(solve.stdout), "no sentinel — SimNEC would block forever"
     assert "ANTENNA INPUT PARAMETERS" in solve.stdout
     assert f"VERSION:{nec_portal.BANNER_VERSION}" in solve.stdout
+
+
+def test_selftest_passes_and_reports(tmp_path, monkeypatch):
+    """`momwire-nec2c --selftest` is the deployment smoke for boxes with no
+    checkout (the Windows live-session path): it must pass here, from an
+    unrelated cwd, and print the PASS verdict on its own line."""
+    import io
+
+    from antennaknobs.nec_portal import main
+
+    monkeypatch.chdir(tmp_path)
+    out = io.StringIO()
+    rc = main(["--selftest"], stdout=out)
+    text = out.getvalue()
+    assert rc == 0
+    assert text.rstrip().endswith("PASS")
+    assert "FAIL" not in text


### PR DESCRIPTION
## Summary
- `momwire-nec2c --selftest`: checkout-free deployment smoke for the live-session box — spawns one resident copy of itself, three embedded decks (dipole / two-source Y probe / TL station) down the single process, seven checks, PASS/FAIL with exit code. Replaces the bash smoke script wherever there's no repo (a pip install on the Windows box).
- Ritual doc gains a **Windows translation**: venv + zip install off GitHub main (no git client needed; momwire ships win_amd64 wheels for 3.10–3.14), the `Scripts\momwire-nec2c.exe` path (name keeps `nec2c` for the portal's filename check), `%USERPROFILE%\.SimNEC`, crew-size RAM guidance.

## Test plan
- [x] `--selftest` PASS from an unrelated cwd (7/7 checks)
- [x] New pytest pins the selftest verdict; full portal suite 638 green
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvF4yHgNxjhyZ7P286g3z8