### PR TITLE
nec_portal: accept EK — the live SimNEC path's opening card (first live-session fix)

### DIFF
--- a/docs/status/2026-08-08-simnec-execute-grammar.md
+++ b/docs/status/2026-08-08-simnec-execute-grammar.md
@@ -1393,3 +1393,32 @@ declines; it is also the live example in
 
 The plane-wave `EX 1 …` excitation `PT` used to be lumped with remains
 unsupported and unchanged: `EX` type != 0 is refused by name.
+
+## §17 — EK, found the hard way (the first live-session failure)
+
+The live `NECSource` path ALWAYS emits a bare `EK` (format string `"EK\n"`,
+confirmed in the jar) — a card in none of the PDF's lists and none of the
+first 36 fixtures, so the daemon refused every live deck and SimNEC
+fabricated readouts from the failures (Windows session, 2026-08-08:
+"NEC Failure Code 1", rig Z read 4−j280 vs the real ~40−j5.7).
+
+Pinned behaviour (fixtures `dipole_ek_extended`, `dipole_ek_rearm`):
+
+- `EK` / `EK 0` = extended thin-wire kernel on; `EK -1` = standard. Echoed
+  as a normal DATA CARD line.
+- When on at a full (FR-driven) preamble: one extra line, 24-space indent,
+  `THE EXTENDED THIN WIRE KERNEL WILL BE USED`, directly after the
+  APPROXIMATE INTEGRATION note.
+- A kernel CHANGE between execute cards arms a re-execution with a PARTIAL
+  refill preamble: LOADING / ENVIRONMENT / MATRIX TIMING but no FREQUENCY
+  block and no announcement.
+- That re-execution also corrected a §11 rule: NEC RETAINS excitation
+  across an execute card — `dipole_ek_rearm`'s second AIP repeats the
+  retained source. The first EX after an execution replaces the set;
+  §11's "cleared at every XQ" described decks that always supplied
+  fresh EX cards, not the engine.
+- For momwire the kernel choice is advisory (our kernel is our own);
+  layout is reproduced exactly, values are ours.
+- Build note: the 1.17 corpus oracle aborts noisily at EOF after the last
+  NX ("Error reading input file") — post-sentinel noise, also present in
+  pre-EK fixtures, harmless to `Execute` which stops at the sentinel.

--- a/scripts/nec_portal_capture.py
+++ b/scripts/nec_portal_capture.py
@@ -304,6 +304,26 @@ def _synthetic_decks() -> dict[str, str]:
     # toggle in one run — the first XQ suppressed, the second restored — and,
     # because it carries a YY card, that Ward's `-YY` report SURVIVES the
     # suppression and is printed where the table would have been.
+    decks["dipole_ek_extended"] = (
+        "CE ek extended thin-wire kernel, as the live NECSource path sends it\n"
+        + _DIPOLE_GW
+        + "GE 0\n"
+        "EK\n"
+        "FR 0 1 0 0 30. 1\n"
+        "EX 0 1 5 0 1.\n"
+        "XQ\n"
+    )
+    decks["dipole_ek_rearm"] = (
+        "CE ek -1 echo form, and an EK between XQs re-arming without a refill\n"
+        + _DIPOLE_GW
+        + "GE 0\n"
+        "EK -1\n"
+        "FR 0 1 0 0 30. 1\n"
+        "EX 0 1 5 0 1.\n"
+        "XQ\n"
+        "EK\n"
+        "XQ\n"
+    )
     decks["dipole_pt_toggle"] = (
         "CE pt suppresses then restores the currents table\n"
         + _DIPOLE_GW
@@ -453,6 +473,7 @@ PORTAL_CARDS = frozenset(
     {
         "CM",
         "CE",  # comments
+        "EK",  # extended thin-wire kernel — the live NECSource path sends it
         "GW",
         "GM",
         "GS",

--- a/src/antennaknobs/nec_portal.py
+++ b/src/antennaknobs/nec_portal.py
@@ -362,7 +362,7 @@ _DEFERRED_CARDS = MappingProxyType(
 _EXECUTE_CARDS = frozenset({"XQ", "RP", "NE", "NH"})
 
 # Cards that make the next execute card a real run rather than a no-op.
-_ARMING_CARDS = frozenset({"EX", "FR", "LD", "GN", "NT", "TL", "YY"})
+_ARMING_CARDS = frozenset({"EX", "FR", "LD", "GN", "NT", "TL", "YY", "EK"})
 
 
 @dataclass(frozen=True)
@@ -706,6 +706,19 @@ class ExecuteGroup:
     # reason, and because ``PT`` is a TOGGLE: ``dipole_pt_toggle`` suppresses
     # the first run's table and restores the second's from one deck.
     pt: PrintControl | None = None
+    # EK in force when this group fired. Advisory for momwire (our kernel is
+    # our kernel), but the refilled preamble must announce it exactly as the
+    # oracle does — and only there: an EK between two XQs re-arms execution
+    # without a refill, and the oracle prints no announcement for it
+    # (measured: XQ / EK / XQ shows two AIP sections, one preamble, zero
+    # announcements).
+    ek: bool = False
+    # A kernel change between execute cards refills the matrix WITHOUT a new
+    # FR: the oracle then prints the LOADING / ENVIRONMENT / MATRIX TIMING
+    # part of the preamble but no FREQUENCY block and no kernel announcement
+    # (fixture dipole_ek_rearm). Advisory refill for us — the cached factors
+    # are already momwire's — but the printout must walk the same sections.
+    refilled_partial: bool = False
 
 
 @dataclass
@@ -799,6 +812,9 @@ def parse_deck(body: str) -> PortalDeck:
     reduced_field: int | None = None
     multiprocessing: Multiprocessing | None = None
     print_control: PrintControl | None = None
+    extended_kernel = False
+    kernel_dirty = False
+    sources_stale = False
 
     for line in body.splitlines():
         card = parse_card(line)
@@ -846,6 +862,20 @@ def parse_deck(body: str) -> PortalDeck:
             # new card is an MP (measured — the second XQ of `... XQ / MP 4 8 /
             # XQ` prints no block at all).
             multiprocessing = Multiprocessing.from_card(card)
+        elif card.mnemonic == "EK":
+            if card.i(0) not in (0, -1):
+                raise PortalError(
+                    f"EK {card.i(0)} is neither 0 (extended kernel) nor -1 "
+                    f"(standard kernel)"
+                )
+            if (
+                card.i(0) == 0
+                and not extended_kernel
+                or card.i(0) == -1
+                and extended_kernel
+            ):
+                kernel_dirty = executed > 0
+            extended_kernel = card.i(0) == 0
         elif card.mnemonic == "PT":
             # Also not an arming card: it changes what a run PRINTS, not what
             # a run computes, so it cannot make an XQ into a fresh execution.
@@ -865,6 +895,14 @@ def parse_deck(body: str) -> PortalDeck:
                     f"EX type {card.i(0)} is not a voltage source; this engine "
                     f"drives EX 0 only"
                 )
+            # NEC RETAINS the excitation across an execute card: a re-run
+            # with no new EX re-drives the previous set (dipole_ek_rearm's
+            # second AIP repeats tag 1 seg 5), while the first EX after an
+            # execution replaces it (every multi-group fixture). So the list
+            # is cleared lazily here, not at the execute card.
+            if sources_stale:
+                sources.clear()
+                sources_stale = False
             sources.append((card.i(1), card.i(2), complex(card.f(4), card.f(5))))
         elif card.mnemonic in _EXECUTE_CARDS:
             if not armed and executed:
@@ -882,10 +920,13 @@ def parse_deck(body: str) -> PortalDeck:
                     report=None if card.mnemonic == "XQ" else card,
                     mp=multiprocessing,
                     pt=print_control,
+                    ek=extended_kernel,
+                    refilled_partial=kernel_dirty and not (fresh_fr or not executed),
                 )
             )
+            kernel_dirty = False
             executed += 1
-            sources.clear()
+            sources_stale = True
             fresh_fr = False
             armed = False
         else:
@@ -2199,10 +2240,16 @@ def _run_block(
             f"                                WAVELENGTH: {wavelength:10.4E} Mtr",
             "",
             *_APPROX_INTEGRATION,
+            *(
+                ["                        THE EXTENDED THIN WIRE KERNEL WILL BE USED"]
+                if group.ek
+                else []
+            ),
             "",
             "",
-            _LOADING_HEADER,
         ]
+    if group.refilled or group.refilled_partial:
+        out += [_LOADING_HEADER]
         rows = _loading_rows(deck)
         if rows:
             out += [*_LOADING_TABLE_HEADER, *rows]
@@ -2411,9 +2458,12 @@ def run_deck(body: str) -> tuple[str, str]:
 _SELFTEST_DECKS = (
     # A free-space dipole, the two-source Y probe, and a TL station — the
     # three deck shapes a live SimNEC session leans on hardest.
+    # EK rides in deck 1 because the live NECSource path ALWAYS sends it —
+    # the card whose absence from the bench corpus caused the first live
+    # failure (Windows session, 2026-08-08).
     "CE selftest 1\n"
     "GW 1 11 0. -5. 10. 0. 5. 10. 0.001\n"
-    "GE 0\nEX 0 1 6 0 1.\nFR 0 1 0 0 14.0 1\nXQ\nNX\n",
+    "GE 0\nEK\nEX 0 1 6 0 1.\nFR 0 1 0 0 14.0 1\nXQ\nNX\n",
     "CE selftest 2\n"
     "GW 1 11 0. -5. 10. 0. 5. 10. 0.001\n"
     "GW 2 11 3. -5. 10. 3. 5. 10. 0.001\n"
@@ -2453,6 +2503,7 @@ def _selftest(stdout) -> int:
     checks = {
         "process exited 0": proc.returncode == 0,
         "banner present": "VERSION:" in proc.stdout,
+        "EK accepted": "EXTENDED THIN WIRE KERNEL" in proc.stdout,
         "4 solve groups answered": proc.stdout.count("ANTENNA INPUT PARAMETERS") == 4,
         "3 NX sentinels": sum(
             1

--- a/tests/fixtures/nec_portal/dipole_ek_extended.deck
+++ b/tests/fixtures/nec_portal/dipole_ek_extended.deck
@@ -1,0 +1,8 @@
+CE ek extended thin-wire kernel, as the live NECSource path sends it
+GW 1 9 0. 0. -2.5 0. 0. 2.5 0.001
+GE 0
+EK
+FR 0 1 0 0 30. 1
+EX 0 1 5 0 1.
+XQ
+NX

--- a/tests/fixtures/nec_portal/dipole_ek_extended.out
+++ b/tests/fixtures/nec_portal/dipole_ek_extended.out
@@ -1,0 +1,118 @@
+
+
+
+                               __________________________________________
+                              |                                          |
+                              |  NUMERICAL ELECTROMAGNETICS CODE (nec2c) |
+                              |   Translated to 'C' in Double Precision  |
+                              |__________________________________________|
+
+VERSION:5b4az.ae6ty.1.17
+
+
+
+                               ---------------- COMMENTS ----------------
+                               ek extended thin-wire kernel, as the live NECSource path sends it
+
+
+
+                               -------- STRUCTURE SPECIFICATION --------
+                                     COORDINATES MUST BE INPUT IN
+                                     METERS OR BE SCALED TO METERS
+                                     BEFORE STRUCTURE INPUT IS ENDED
+
+  WIRE                                                                                 SEG FIRST  LAST  TAG
+   No:        X1         Y1         Z1         X2         Y2         Z2       RADIUS   No:   SEG   SEG  No:
+     1     0.00000    0.00000   -2.50000    0.00000    0.00000    2.50000    0.00100     9     1     9    1
+
+     TOTAL SEGMENTS USED: 9   SEGMENTS IN A SYMMETRIC CELL: 9   SYMMETRY FLAG: 0
+
+
+                               ---------- SEGMENTATION DATA ----------
+                                        COORDINATES IN METERS
+                            I+ AND I- INDICATE THE SEGMENTS BEFORE AND AFTER I
+
+   SEG    COORDINATES OF SEGM CENTER     SEGM    ORIENTATION ANGLES    WIRE    CONNECTION DATA   TAG
+   No:       X         Y         Z      LENGTH     ALPHA      BETA    RADIUS    I-     I    I+   No:
+     1    0.0000    0.0000   -2.2222    0.5556   90.0000    0.0000    0.0010     0     1     2     1
+     2    0.0000    0.0000   -1.6667    0.5556   90.0000    0.0000    0.0010     1     2     3     1
+     3    0.0000    0.0000   -1.1111    0.5556   90.0000    0.0000    0.0010     2     3     4     1
+     4    0.0000    0.0000   -0.5556    0.5556   90.0000    0.0000    0.0010     3     4     5     1
+     5    0.0000    0.0000    0.0000    0.5556   90.0000    0.0000    0.0010     4     5     6     1
+     6    0.0000    0.0000    0.5556    0.5556   90.0000    0.0000    0.0010     5     6     7     1
+     7    0.0000    0.0000    1.1111    0.5556   90.0000    0.0000    0.0010     6     7     8     1
+     8    0.0000    0.0000    1.6667    0.5556   90.0000    0.0000    0.0010     7     8     9     1
+     9    0.0000    0.0000    2.2222    0.5556   90.0000    0.0000    0.0010     8     9     0     1
+
+
+
+  DATA CARD No:   1 EK   0     0     0     0  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+  DATA CARD No:   2 FR   0     1     0     0  3.00000E+01  1.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+  DATA CARD No:   3 EX   0     1     5     0  1.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+  DATA CARD No:   4 XQ   0     0     0     0  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+
+
+                               --------- FREQUENCY --------
+                                FREQUENCY : 3.0000E+01 MHz
+                                WAVELENGTH: 9.9933E+00 Mtr
+
+                        APPROXIMATE INTEGRATION EMPLOYED FOR SEGMENTS 
+                        THAT ARE MORE THAN 1.000 WAVELENGTHS APART
+                        THE EXTENDED THIN WIRE KERNEL WILL BE USED
+
+
+                          ------ STRUCTURE IMPEDANCE LOADING ------
+                                 THIS STRUCTURE IS NOT LOADED
+
+
+                            -------- ANTENNA ENVIRONMENT --------
+                            FREE SPACE
+
+
+                             ---------- MATRIX TIMING ----------
+                               FILL: 0 msec  FACTOR: 0 msec
+
+
+                        --------- ANTENNA INPUT PARAMETERS ---------
+  TAG   SEG       VOLTAGE (VOLTS)         CURRENT (AMPS)         IMPEDANCE (OHMS)        ADMITTANCE (MHOS)     POWER
+  No:   No:     REAL      IMAGINARY     REAL      IMAGINARY     REAL      IMAGINARY    REAL       IMAGINARY   (WATTS)
+    1     5  1.0000E+00  0.0000E+00  9.5048E-03 -5.4414E-03  7.9240E+01  4.5364E+01  9.5048E-03 -5.4414E-03  4.7524E-03
+
+
+                           -------- CURRENTS AND LOCATION --------
+                                  DISTANCES IN WAVELENGTHS
+
+   SEG  TAG    COORDINATES OF SEGM CENTER     SEGM    ------------- CURRENT (AMPS) -------------
+   No:  No:       X         Y         Z      LENGTH     REAL      IMAGINARY    MAGN        PHASE
+     1    1    0.0000    0.0000   -0.2224   0.05559  1.8328E-03 -1.2407E-03  2.2132E-03  -34.095
+     2    1    0.0000    0.0000   -0.1668   0.05559  4.9575E-03 -3.2571E-03  5.9317E-03  -33.305
+     3    1    0.0000    0.0000   -0.1112   0.05559  7.3943E-03 -4.6836E-03  8.7528E-03  -32.350
+     4    1    0.0000    0.0000   -0.0556   0.05559  8.9629E-03 -5.4058E-03  1.0467E-02  -31.095
+     5    1    0.0000    0.0000    0.0000   0.05559  9.5048E-03 -5.4414E-03  1.0952E-02  -29.791
+     6    1    0.0000    0.0000    0.0556   0.05559  8.9629E-03 -5.4058E-03  1.0467E-02  -31.095
+     7    1    0.0000    0.0000    0.1112   0.05559  7.3943E-03 -4.6836E-03  8.7528E-03  -32.350
+     8    1    0.0000    0.0000    0.1668   0.05559  4.9575E-03 -3.2571E-03  5.9317E-03  -33.305
+     9    1    0.0000    0.0000    0.2224   0.05559  1.8328E-03 -1.2407E-03  2.2132E-03  -34.095
+
+
+                               ---------- POWER BUDGET ---------
+                               INPUT POWER   =  4.7524E-03 Watts
+                               RADIATED POWER=  4.7524E-03 Watts
+                               STRUCTURE LOSS=  0.0000E+00 Watts
+                               NETWORK LOSS  =  0.0000E+00 Watts
+                               EFFICIENCY    =  100.00 Percent
+
+
+
+  DATA CARD No:   5 NX   0     0     0     0  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+
+
+                               __________________________________________
+                              |                                          |
+                              |  NUMERICAL ELECTROMAGNETICS CODE (nec2c) |
+                              |   Translated to 'C' in Double Precision  |
+                              |__________________________________________|
+
+VERSION:5b4az.ae6ty.1.17
+
+ERROR-NEC2C: nec2c: Error reading input file - aborting

--- a/tests/fixtures/nec_portal/dipole_ek_rearm.deck
+++ b/tests/fixtures/nec_portal/dipole_ek_rearm.deck
@@ -1,0 +1,10 @@
+CE ek -1 echo form, and an EK between XQs re-arming without a refill
+GW 1 9 0. 0. -2.5 0. 0. 2.5 0.001
+GE 0
+EK -1
+FR 0 1 0 0 30. 1
+EX 0 1 5 0 1.
+XQ
+EK
+XQ
+NX

--- a/tests/fixtures/nec_portal/dipole_ek_rearm.out
+++ b/tests/fixtures/nec_portal/dipole_ek_rearm.out
@@ -1,0 +1,164 @@
+
+
+
+                               __________________________________________
+                              |                                          |
+                              |  NUMERICAL ELECTROMAGNETICS CODE (nec2c) |
+                              |   Translated to 'C' in Double Precision  |
+                              |__________________________________________|
+
+VERSION:5b4az.ae6ty.1.17
+
+
+
+                               ---------------- COMMENTS ----------------
+                               ek -1 echo form, and an EK between XQs re-arming without a refill
+
+
+
+                               -------- STRUCTURE SPECIFICATION --------
+                                     COORDINATES MUST BE INPUT IN
+                                     METERS OR BE SCALED TO METERS
+                                     BEFORE STRUCTURE INPUT IS ENDED
+
+  WIRE                                                                                 SEG FIRST  LAST  TAG
+   No:        X1         Y1         Z1         X2         Y2         Z2       RADIUS   No:   SEG   SEG  No:
+     1     0.00000    0.00000   -2.50000    0.00000    0.00000    2.50000    0.00100     9     1     9    1
+
+     TOTAL SEGMENTS USED: 9   SEGMENTS IN A SYMMETRIC CELL: 9   SYMMETRY FLAG: 0
+
+
+                               ---------- SEGMENTATION DATA ----------
+                                        COORDINATES IN METERS
+                            I+ AND I- INDICATE THE SEGMENTS BEFORE AND AFTER I
+
+   SEG    COORDINATES OF SEGM CENTER     SEGM    ORIENTATION ANGLES    WIRE    CONNECTION DATA   TAG
+   No:       X         Y         Z      LENGTH     ALPHA      BETA    RADIUS    I-     I    I+   No:
+     1    0.0000    0.0000   -2.2222    0.5556   90.0000    0.0000    0.0010     0     1     2     1
+     2    0.0000    0.0000   -1.6667    0.5556   90.0000    0.0000    0.0010     1     2     3     1
+     3    0.0000    0.0000   -1.1111    0.5556   90.0000    0.0000    0.0010     2     3     4     1
+     4    0.0000    0.0000   -0.5556    0.5556   90.0000    0.0000    0.0010     3     4     5     1
+     5    0.0000    0.0000    0.0000    0.5556   90.0000    0.0000    0.0010     4     5     6     1
+     6    0.0000    0.0000    0.5556    0.5556   90.0000    0.0000    0.0010     5     6     7     1
+     7    0.0000    0.0000    1.1111    0.5556   90.0000    0.0000    0.0010     6     7     8     1
+     8    0.0000    0.0000    1.6667    0.5556   90.0000    0.0000    0.0010     7     8     9     1
+     9    0.0000    0.0000    2.2222    0.5556   90.0000    0.0000    0.0010     8     9     0     1
+
+
+
+  DATA CARD No:   1 EK  -1     0     0     0  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+  DATA CARD No:   2 FR   0     1     0     0  3.00000E+01  1.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+  DATA CARD No:   3 EX   0     1     5     0  1.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+  DATA CARD No:   4 XQ   0     0     0     0  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+
+
+                               --------- FREQUENCY --------
+                                FREQUENCY : 3.0000E+01 MHz
+                                WAVELENGTH: 9.9933E+00 Mtr
+
+                        APPROXIMATE INTEGRATION EMPLOYED FOR SEGMENTS 
+                        THAT ARE MORE THAN 1.000 WAVELENGTHS APART
+
+
+                          ------ STRUCTURE IMPEDANCE LOADING ------
+                                 THIS STRUCTURE IS NOT LOADED
+
+
+                            -------- ANTENNA ENVIRONMENT --------
+                            FREE SPACE
+
+
+                             ---------- MATRIX TIMING ----------
+                               FILL: 0 msec  FACTOR: 0 msec
+
+
+                        --------- ANTENNA INPUT PARAMETERS ---------
+  TAG   SEG       VOLTAGE (VOLTS)         CURRENT (AMPS)         IMPEDANCE (OHMS)        ADMITTANCE (MHOS)     POWER
+  No:   No:     REAL      IMAGINARY     REAL      IMAGINARY     REAL      IMAGINARY    REAL       IMAGINARY   (WATTS)
+    1     5  1.0000E+00  0.0000E+00  9.5048E-03 -5.4414E-03  7.9240E+01  4.5364E+01  9.5048E-03 -5.4414E-03  4.7524E-03
+
+
+                           -------- CURRENTS AND LOCATION --------
+                                  DISTANCES IN WAVELENGTHS
+
+   SEG  TAG    COORDINATES OF SEGM CENTER     SEGM    ------------- CURRENT (AMPS) -------------
+   No:  No:       X         Y         Z      LENGTH     REAL      IMAGINARY    MAGN        PHASE
+     1    1    0.0000    0.0000   -0.2224   0.05559  1.8328E-03 -1.2407E-03  2.2132E-03  -34.095
+     2    1    0.0000    0.0000   -0.1668   0.05559  4.9575E-03 -3.2571E-03  5.9317E-03  -33.305
+     3    1    0.0000    0.0000   -0.1112   0.05559  7.3943E-03 -4.6836E-03  8.7528E-03  -32.350
+     4    1    0.0000    0.0000   -0.0556   0.05559  8.9629E-03 -5.4058E-03  1.0467E-02  -31.095
+     5    1    0.0000    0.0000    0.0000   0.05559  9.5048E-03 -5.4414E-03  1.0952E-02  -29.791
+     6    1    0.0000    0.0000    0.0556   0.05559  8.9629E-03 -5.4058E-03  1.0467E-02  -31.095
+     7    1    0.0000    0.0000    0.1112   0.05559  7.3943E-03 -4.6836E-03  8.7528E-03  -32.350
+     8    1    0.0000    0.0000    0.1668   0.05559  4.9575E-03 -3.2571E-03  5.9317E-03  -33.305
+     9    1    0.0000    0.0000    0.2224   0.05559  1.8328E-03 -1.2407E-03  2.2132E-03  -34.095
+
+
+                               ---------- POWER BUDGET ---------
+                               INPUT POWER   =  4.7524E-03 Watts
+                               RADIATED POWER=  4.7524E-03 Watts
+                               STRUCTURE LOSS=  0.0000E+00 Watts
+                               NETWORK LOSS  =  0.0000E+00 Watts
+                               EFFICIENCY    =  100.00 Percent
+
+
+
+  DATA CARD No:   5 EK   0     0     0     0  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+  DATA CARD No:   6 XQ   0     0     0     0  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+
+
+                          ------ STRUCTURE IMPEDANCE LOADING ------
+                                 THIS STRUCTURE IS NOT LOADED
+
+
+                            -------- ANTENNA ENVIRONMENT --------
+                            FREE SPACE
+
+
+                             ---------- MATRIX TIMING ----------
+                               FILL: 0 msec  FACTOR: 0 msec
+
+
+                        --------- ANTENNA INPUT PARAMETERS ---------
+  TAG   SEG       VOLTAGE (VOLTS)         CURRENT (AMPS)         IMPEDANCE (OHMS)        ADMITTANCE (MHOS)     POWER
+  No:   No:     REAL      IMAGINARY     REAL      IMAGINARY     REAL      IMAGINARY    REAL       IMAGINARY   (WATTS)
+    1     5  1.0000E+00  0.0000E+00  9.5048E-03 -5.4414E-03  7.9240E+01  4.5364E+01  9.5048E-03 -5.4414E-03  4.7524E-03
+
+
+                           -------- CURRENTS AND LOCATION --------
+                                  DISTANCES IN WAVELENGTHS
+
+   SEG  TAG    COORDINATES OF SEGM CENTER     SEGM    ------------- CURRENT (AMPS) -------------
+   No:  No:       X         Y         Z      LENGTH     REAL      IMAGINARY    MAGN        PHASE
+     1    1    0.0000    0.0000   -0.2224   0.05559  1.8328E-03 -1.2407E-03  2.2132E-03  -34.095
+     2    1    0.0000    0.0000   -0.1668   0.05559  4.9575E-03 -3.2571E-03  5.9317E-03  -33.305
+     3    1    0.0000    0.0000   -0.1112   0.05559  7.3943E-03 -4.6836E-03  8.7528E-03  -32.350
+     4    1    0.0000    0.0000   -0.0556   0.05559  8.9629E-03 -5.4058E-03  1.0467E-02  -31.095
+     5    1    0.0000    0.0000    0.0000   0.05559  9.5048E-03 -5.4414E-03  1.0952E-02  -29.791
+     6    1    0.0000    0.0000    0.0556   0.05559  8.9629E-03 -5.4058E-03  1.0467E-02  -31.095
+     7    1    0.0000    0.0000    0.1112   0.05559  7.3943E-03 -4.6836E-03  8.7528E-03  -32.350
+     8    1    0.0000    0.0000    0.1668   0.05559  4.9575E-03 -3.2571E-03  5.9317E-03  -33.305
+     9    1    0.0000    0.0000    0.2224   0.05559  1.8328E-03 -1.2407E-03  2.2132E-03  -34.095
+
+
+                               ---------- POWER BUDGET ---------
+                               INPUT POWER   =  4.7524E-03 Watts
+                               RADIATED POWER=  4.7524E-03 Watts
+                               STRUCTURE LOSS=  0.0000E+00 Watts
+                               NETWORK LOSS  =  0.0000E+00 Watts
+                               EFFICIENCY    =  100.00 Percent
+
+
+
+  DATA CARD No:   7 NX   0     0     0     0  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+
+
+                               __________________________________________
+                              |                                          |
+                              |  NUMERICAL ELECTROMAGNETICS CODE (nec2c) |
+                              |   Translated to 'C' in Double Precision  |
+                              |__________________________________________|
+
+VERSION:5b4az.ae6ty.1.17
+
+ERROR-NEC2C: nec2c: Error reading input file - aborting

--- a/tests/fixtures/nec_portal/manifest.json
+++ b/tests/fixtures/nec_portal/manifest.json
@@ -73,6 +73,20 @@
       "stderr": "\nERROR-NEC2C: nec2c: Error reading input file - aborting\n"
     },
     {
+      "name": "dipole_ek_extended",
+      "returncode": 253,
+      "deck_sha256": "a17f68e92bb680b4d1d2d32e652930c7614e56ae141dab15677dc393c8207d25",
+      "out_sha256": "9a627b3ae7f3fe2f1528cdea53f8edc5e3b0089b2d779ba4e1882d18e1eb486d",
+      "stderr": "\nERROR-NEC2C: nec2c: Error reading input file - aborting\n"
+    },
+    {
+      "name": "dipole_ek_rearm",
+      "returncode": 253,
+      "deck_sha256": "a505e8624c94a0481f421775e83fdf0b396ffa70e58bca48608850b0676cc76a",
+      "out_sha256": "2a0bf81e3d01d0b0e1816fcc96829fc9f206a23b6dc2a5cb2a68436b87c592ea",
+      "stderr": "\nERROR-NEC2C: nec2c: Error reading input file - aborting\n"
+    },
+    {
       "name": "dipole_fr_sweep",
       "returncode": 253,
       "deck_sha256": "9231eaeda66dc09a63b1760b92d87de9e4210c8201aa98f192ad7cea7c21fc3e",


### PR DESCRIPTION
## Summary
The Windows live session (#804) failed on every deck with NEC Failure Code 1: **`NECSource` unconditionally emits a bare `EK`** (extended thin-wire kernel) — absent from Ward's doc, the jar test deck, and all 36 bench fixtures — so the daemon refused each deck and SimNEC fabricated readouts (4 − j280 vs the real ~40 − j5.7).

- EK pinned against the oracle (2 new fixtures, corpus 38/38 byte-layout): on/off forms, DATA CARD echo, the announcement in FR-driven preambles, and the newly discovered **partial refill preamble** for a kernel change between execute cards.
- That discovery corrected a unit-2 semantic: **NEC retains excitation across XQ** (first EX after an execution replaces the set) — `dipole_ek_rearm`'s second AIP repeats the retained source.
- `--selftest` now carries EK in its first deck: the deployment gate can never again pass while the live path's opening card is refused.
- Grammar doc §17 records it all, including the diagnosis chain from the necLogFile.

## Gates
- [x] 666 portal tests green; `--check` OK (77 files, re-runs the oracle); ruff clean
- [x] `--selftest` PASS (8 checks incl. the new EK gate)

Found live, fixed against the oracle. Part of #804's session findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvF4yHgNxjhyZ7P286g3z8