### PR TITLE
simnec_export: refuse multi-feed antennas until per-feed sources are modeled (#815 interim)

### DIFF
--- a/src/antennaknobs/simnec_export.py
+++ b/src/antennaknobs/simnec_export.py
@@ -255,6 +255,21 @@ def build_nec_portal_script(
     """
     deck = export_nec(builder, ground=ground, freq=freq_mhz, include_rp=False)
     cards = _nec_cards_for_portal(deck)
+    n_feeds = sum(1 for c in cards if c.startswith("EX"))
+    if n_feeds > 1:
+        # SimNEC's cascade template has ONE generator, so a multi-feed deck's
+        # relative drive phasing is silently lost on load — SimNEC ties every
+        # EX to the one source and drives them in phase. Measured live on
+        # wire.w8jk (issue #815): the out-of-phase design read the IN-phase
+        # impedance (384.7+505.3j vs the true 23.7+515.7j). A wrong-but-
+        # plausible circuit is exactly what this exporter promises never to
+        # emit, so refuse until per-feed SimNEC sources are modeled.
+        raise SsnUnsupported(
+            f"{n_feeds} feedpoints: SimNEC's cascade has one GENERATOR, so "
+            "the deck's relative drive phasing would be silently lost "
+            "(every feed driven in phase — issue #815); multi-feed designs "
+            "are not exported until per-feed sources are modeled"
+        )
     if name is None:
         name = _default_block_name(builder)
     return _portal_wrap(cards, name=name, ground=ground, seg_per_wl=seg_per_wl)

--- a/tests/test_simnec_export.py
+++ b/tests/test_simnec_export.py
@@ -552,3 +552,13 @@ def test_smoke_real_builtin_antenna_only():
     ET.fromstring(ssn)  # well-formed
     assert "SommerfeldGround(0.005, 13);" in ssn
     assert "segmentsPerWavelength = 80;" in ssn
+
+
+def test_multifeed_antenna_refuses_with_phasing_message():
+    """A multi-feed design must refuse rather than export a circuit whose
+    single generator drives every feed in phase (issue #815, found live:
+    w8jk read the in-phase impedance in SimNEC, not the W8JK drive)."""
+    from antennaknobs.designs.wire.w8jk import Builder as W8JK
+
+    with pytest.raises(NotImplementedError, match="phasing"):
+        export_ssn(W8JK(), ground=None)


### PR DESCRIPTION
## Summary
- Multi-feed antenna-only designs now raise `SsnUnsupported` naming the phasing loss, instead of exporting a single-generator circuit that SimNEC drives in phase (live-verified misrepresentation, #815; multi-source *stations* were already refused).
- Full per-feed-source modeling stays tracked in #815.

## Test plan
- [x] New refusal test (message names the phasing); export/import/file_designs suites green (73 + 116)
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvF4yHgNxjhyZ7P286g3z8