### PR TITLE
nec_portal: accept the GD card — SimNEC's EZNEC examples all carry one (#800)

### DIFF
--- a/docs/status/2026-08-08-simnec-execute-grammar.md
+++ b/docs/status/2026-08-08-simnec-execute-grammar.md
@@ -579,15 +579,16 @@ Other messages in the binary: `nec2c: Bad YY card format`,
 ## 9. The fixture corpus
 
 `scripts/nec_portal_capture.py` regenerates
-`tests/fixtures/nec_portal/` — 36 `<name>.deck` / `<name>.out` pairs plus
+`tests/fixtures/nec_portal/` — 40 `<name>.deck` / `<name>.out` pairs plus
 `manifest.json` (per-deck exit code, both SHA-256s, and the captured stderr).
 
 * `jar_testdeck`, `jar_testdeck_daemon_framed` — the deck embedded in
   `nec2/NEC2Daemon`, raw and with the daemon's `CM FF 2` prefix.
-* 23 hand-authored decks: free space, `FR` sweep, PEC / reflection-coefficient
+* 27 hand-authored decks: free space, `FR` sweep, PEC / reflection-coefficient
   / Sommerfeld grounds, `LD 0` / `LD 4` / `LD 5`, `GS`, `GM`, `NT`, two `TL`
-  decks (§15), two `MP` decks and two `PT` decks (§16), `RP`, `NE`, the 2-port
-  sensor-line probe and the 2-port `YY` probe.
+  decks (§15), two `MP` decks and two `PT` decks (§16), two `EK` decks (§17),
+  two `GD` decks (§18), `RP`, `NE`, `NH`, the 2-port sensor-line probe and the
+  2-port `YY` probe.
 * 10 catalog designs through `antennaknobs.nec_export.export_nec`, massaged
   into the portal dialect (`EN` dropped, `NX` appended).
 * `resident_two_decks` — two decks down one process, the residency pin.
@@ -1422,3 +1423,85 @@ Pinned behaviour (fixtures `dipole_ek_extended`, `dipole_ek_rearm`):
 - Build note: the 1.17 corpus oracle aborts noisily at EOF after the last
   NX ("Error reading input file") — post-sentinel noise, also present in
   pre-EK fixtures, harmless to `Execute` which stops at the sentinel.
+
+## §18 — GD, the second-medium card SimNEC's EZNEC examples carry
+
+The second live-session refusal, and the same shape as §17: SimNEC's
+EZNEC-derived examples — `Cardioid (EZNEC).ssn`, `4-square (EZNEC).ssn` —
+carry a `GD` card, `NECSource` forwards it verbatim, and a daemon that
+refused it failed every one of those decks with fabricated R = 0 / X = 0
+readouts.
+
+The live line is comma-delimited: `GD 2,0,0,0,13.,.005,0.,0.`, alongside
+`GN 1`, `NT` cards and an `RP 3`.
+
+### The fields, read off the oracle rather than a manual
+
+`GD` is `GD <i1> <i2> <i3> <i4> <EPSR2> <SIG2> <CLT> <CHT>`. The four
+integer columns are echoed and used by nothing (the Cardioid writes `2` in
+the first, mirroring `GN`'s type field; a bare `GD` echoes four zeros and
+runs identically). The four reals are:
+
+| field | name    | meaning                                              |
+| ----- | ------- | ---------------------------------------------------- |
+| `F1`  | `EPSR2` | relative dielectric constant of the SECOND medium     |
+| `F2`  | `SIG2`  | conductivity of the second medium, mhos/metre         |
+| `F3`  | `CLT`   | distance from the origin to the edge joining the media |
+| `F4`  | `CHT`   | height of medium 2's surface relative to medium 1's, signed |
+
+That mapping is the oracle's own naming, recovered by running
+`GD 0 0 0 0 5. .001 20. -2.` under `RP 2`, which prints:
+
+```
+                               ------ FAR FIELD GROUND PARAMETERS ------
+
+
+                               --- LINEAR CLIFF ---
+                               EDGE DISTANCE=     20.00 METERS
+                                      HEIGHT=     -2.00 METERS
+                               --- SECOND MEDIUM ---
+                               RELATIVE DIELECTRIC CONST=      5.000
+                                     GROUND CONDUCTIVITY=      0.001 MHOS
+```
+
+### What the card changes in the printout: its own echo, and nothing else
+
+- One ordinary `DATA CARD No:` line, four integers then six `%13.5E` reals,
+  the generic layout every data card gets. Comma- and space-delimited forms
+  produce byte-identical output (measured).
+- **No line anywhere in the `ANTENNA ENVIRONMENT` block.** Probed for
+  explicitly under `GN 1` and under `GN 2`, where a "second medium"
+  announcement was the likeliest place one would appear. There is none.
+- **No change to any number.** Fixtures `dipole_gd_second_medium` and
+  `dipole_gd_cliff_sommerfeld` are `dipole_pec_ground` and
+  `dipole_sommerfeld_ground` plus one card; each printout differs from its
+  base only in the echo and the card ordinals it shifts.
+- **Not an arming card.** Measured: `... XQ / GD 2 0 0 0 13. .005 0. 0. /
+  XQ` prints one block, not two — the same rule `MP` and `PT` follow (§16).
+- A non-numeric field is where this engine deliberately parts company with
+  the oracle: nec2c's free-format reader SKIPS the bad token and shifts the
+  remaining fields left (`GD 2 0 0 0 marsh .005 0. 0.` echoes `.005` as
+  EPSR2), which is a wrong answer dressed as a right one. This engine names
+  the token on the ordinary error path and still emits the sentinel (§8).
+
+### Fidelity — where the second medium WOULD matter
+
+NEC-2 uses `GD` in the FAR FIELD alone; the moment method never sees it,
+which is why every impedance and segment current is unchanged. In the far
+field it is reached only through `RP`'s cliff and ground-screen modes.
+Measured both ways with the cliff card above:
+
+- `RP 0` — the only mode `nec2/NECSource` ever writes, and the only one this
+  engine computes — the `RADIATION PATTERNS` table is **byte-identical** with
+  and without the card;
+- `RP 2` (linear cliff) — the `FAR FIELD GROUND PARAMETERS` block above
+  appears and every gain moves.
+
+So the deck shapes in which `GD` is inert are exactly the deck shapes this
+engine runs, and the shapes in which it is not are already refused by name at
+the `RP` card (`RP mode <n> is not supported`, issue #802). Accepting `GD`
+therefore cannot make this engine answer a cliff question as if the ground
+were flat — it never gets asked one. A `GD` deck whose `RP` is mode 3, like
+the Cardioid's, still refuses on the `RP`, which is correct until #802 lands.
+
+Corpus 38 -> 40; layout gate 40/40.

--- a/docs/status/2026-08-08-simnec-live-session-ritual.md
+++ b/docs/status/2026-08-08-simnec-live-session-ritual.md
@@ -113,7 +113,8 @@ MNA over its own nec2c, and the antennaknobs workbench).
 **Session date: 2026-08-08, Windows box, SimNEC 6p4d6, crew 4.** Live
 discoveries: `EK` sent unconditionally by `NECSource` (fixed same-day,
 PR #814, selftest now gates on it); `GD` + `RP 3` in EZNEC-derived examples
-still refused (cardioid / 4-square blocked; GD fix queued, RP 3 = #802);
+still refused (cardioid / 4-square blocked; GD fix has since landed —
+grammar doc §18, selftest now gates on it too; RP 3 = #802);
 multi-feed `.ssn` export loses drive phasing (#815). Every row green —
 the Ward notes are cleared to send.
 

--- a/scripts/nec_portal_capture.py
+++ b/scripts/nec_portal_capture.py
@@ -9,9 +9,10 @@ momwire, so we first need byte-level ground truth for what the real engine
 prints.
 
 This script builds a small, deterministic corpus of decks in SimNEC's *portal
-dialect* (the card subset ``nec2/NECSource`` actually emits — CM/CE, GW, GM,
-GS, GE, GN, LD, IS, EX, NT, TL, FR, RP, NE, NH, PT, MP, XQ, plus Ward's custom
-``YY`` — terminated by ``NX``), runs each one through the oracle binary, and
+dialect* (the card subset ``nec2/NECSource`` actually emits — CM/CE, EK, GW,
+GM, GS, GE, GN, GD, LD, IS, EX, NT, TL, FR, RP, NE, NH, PT, MP, XQ, plus
+Ward's custom ``YY`` — terminated by ``NX``), runs each one through the oracle
+binary, and
 commits the deck/printout pairs as fixtures under
 ``tests/fixtures/nec_portal/``.
 
@@ -148,6 +149,42 @@ def _synthetic_decks() -> dict[str, str]:
         "GW 1 9 0. 0. 5.0 0. 0. 10.0 0.001\n"
         "GE -1\n"
         "GN 2 0 0 0 13. 0.005\n"
+        "EX 0 1 5 0 1.\n"
+        "FR 0 1 0 0 14.1 0\n"
+        "XQ\n"
+    )
+
+    # GD — NEC-2's "additional ground parameters" card (issue #800's tail).
+    # SimNEC's EZNEC-derived examples (`Cardioid (EZNEC).ssn`,
+    # `4-square (EZNEC).ssn`) carry one and NECSource forwards it verbatim, so
+    # refusing it failed every one of those decks live. This deck is
+    # `dipole_pec_ground` plus the card, written in the COMMA-delimited form
+    # SimNEC actually emits (`GD 2,0,0,0,13.,.005,0.,0.`) — measured identical
+    # to the space-separated form on the oracle — so the pair is a clean
+    # with/without diff of the card's entire observable effect.
+    decks["dipole_gd_second_medium"] = (
+        "CE dipole over perfect ground\n"
+        "GW 1 9 0. 0. 2.0 0. 0. 7.0 0.001\n"
+        "GE -1\n"
+        "GN 1\n"
+        "GD 2,0,0,0,13.,.005,0.,0.\n"
+        "EX 0 1 5 0 1.\n"
+        "FR 0 1 0 0 14.1 0\n"
+        "XQ\n"
+    )
+
+    # The same card with all four REAL fields non-zero, over the Sommerfeld
+    # ground. The Cardioid's own card leaves CLT and CHT at zero, which would
+    # leave the last two columns of the echo unpinned; this one is a genuine
+    # linear cliff (edge 20 m out, second medium 2 m below) and is
+    # `dipole_sommerfeld_ground` plus the card, for the second with/without
+    # pair.
+    decks["dipole_gd_cliff_sommerfeld"] = (
+        "CE dipole over sommerfeld ground\n"
+        "GW 1 9 0. 0. 5.0 0. 0. 10.0 0.001\n"
+        "GE -1\n"
+        "GN 2 0 0 0 13. 0.005\n"
+        "GD 0 0 0 0 5. .001 20. -2.\n"
         "EX 0 1 5 0 1.\n"
         "FR 0 1 0 0 14.1 0\n"
         "XQ\n"
@@ -479,8 +516,9 @@ PORTAL_CARDS = frozenset(
         "GS",
         "GE",  # geometry
         "GN",
+        "GD",
         "LD",
-        "IS",  # environment / loading / insulation
+        "IS",  # environment / second medium / loading / insulation
         "EX",
         "NT",
         "TL",

--- a/src/antennaknobs/nec_portal.py
+++ b/src/antennaknobs/nec_portal.py
@@ -36,6 +36,17 @@ Scope (units 2 and 3 — the whole portal dialect bar the long tail):
   toggle on the ``CURRENTS AND LOCATION`` table rather than anything entangled
   with the plane-wave excitation SimNEC wraps it in (see
   :class:`PrintControl`);
+* issue #800 (tail): ``GD``, NEC-2's additional-ground-parameters card, which
+  SimNEC's EZNEC-derived examples carry and forward — parsed, echoed, and
+  otherwise inert. **Fidelity note:** ``GD``'s second medium reaches NEC only
+  through the far field, and only through the ``RP`` card's cliff and
+  ground-screen modes (``RP 1``-``RP 6``); it never enters the matrix, so
+  every impedance and current is unchanged by it, and the ``RP 0`` pattern
+  this engine computes is byte-identical with and without the card (measured
+  both ways on the oracle). The modes where it WOULD move the pattern are
+  already refused by name at the ``RP`` card, so nothing here answers a
+  second-medium question by pretending the medium is not there
+  (see :class:`SecondMedium`);
 * the printout sections SimNEC's state machine walks: banner, comments, data
   cards, structure specification, segmentation data, frequency, structure
   impedance loading, antenna environment, network data, matrix timing, antenna
@@ -464,6 +475,90 @@ class Ground:
 
 
 @dataclass(frozen=True)
+class SecondMedium:
+    """One ``GD`` card: NEC-2's *additional ground parameters*. Echoed, and
+    then genuinely inert for everything this engine computes.
+
+    **What the card is.** ``GD`` states a SECOND ground medium and the edge
+    where medium 1 stops: four real fields, and — measured against the oracle
+    — nothing else. The four integer columns of the echo are read as integers
+    and used by nothing; a bare ``GD`` echoes four zero integers and six zero
+    reals and runs the deck exactly as a fully populated one does.
+
+    ==========  =========================================================
+    field       meaning
+    ==========  =========================================================
+    ``F1``      ``EPSR2`` — relative dielectric constant of medium 2
+    ``F2``      ``SIG2`` — conductivity of medium 2, mhos/metre
+    ``F3``      ``CLT`` — distance from the origin to the edge where the
+                two media join (the cliff's EDGE DISTANCE)
+    ``F4``      ``CHT`` — height of medium 2's surface relative to
+                medium 1's, signed (negative = the far side is lower)
+    ==========  =========================================================
+
+    The readings come from the oracle's own printout, not from a manual: a
+    deck carrying ``GD 0 0 0 0 5. .001 20. -2.`` under ``RP 2`` prints
+
+    .. code-block:: text
+
+                                       --- LINEAR CLIFF ---
+                                       EDGE DISTANCE=     20.00 METERS
+                                              HEIGHT=     -2.00 METERS
+                                       --- SECOND MEDIUM ---
+                                       RELATIVE DIELECTRIC CONST=      5.000
+                                             GROUND CONDUCTIVITY=      0.001 MHOS
+
+    which names all four fields in card order.
+
+    **Why it had to land.** SimNEC's EZNEC-derived examples — ``Cardioid
+    (EZNEC).ssn``, ``4-square (EZNEC).ssn`` — carry a ``GD`` and ``NECSource``
+    forwards it verbatim, so refusing the card failed those decks outright and
+    SimNEC fabricated readouts from the failure (R = 0, X = 0; the same shape
+    of live failure the ``EK`` card caused, grammar doc §17).
+
+    **What it changes in the printout: nothing.** No ``DATA CARD`` line beyond
+    its own echo, no line in the ``ANTENNA ENVIRONMENT`` block — not even
+    under ``GN 2``, where a second medium might plausibly have announced
+    itself — and no change to any number. Fixtures
+    ``dipole_gd_second_medium`` and ``dipole_gd_cliff_sommerfeld`` are
+    ``dipole_pec_ground`` and ``dipole_sommerfeld_ground`` plus one card, and
+    the only differences in either printout are the echo itself and the
+    ordinals it shifts.
+
+    It is also **not an arming card**: measured on the oracle, ``... XQ / GD
+    2 0 0 0 13. .005 0. 0. / XQ`` prints one block, not two. A ``GD`` alone
+    does not make the next execute card a real run.
+
+    **Fidelity — where the second medium WOULD matter, and why ignoring it
+    here is not a silent lie.** NEC-2 uses ``GD`` in the far field alone; the
+    moment method never sees it, which is why every impedance and every
+    segment current above is unchanged. In the far field it is reached only
+    through the ``RP`` card's cliff and ground-screen modes (``RP 1``-``RP
+    6``). Measured both ways on the oracle with the cliff card above:
+
+    * under ``RP 0`` — the only mode ``nec2/NECSource`` ever writes, and the
+      only one this engine computes — the ``RADIATION PATTERNS`` table is
+      byte-identical with and without the card;
+    * under ``RP 2`` (linear cliff) it is not: the block quoted above appears
+      and every gain moves.
+
+    So the deck shapes where ``GD`` is inert are exactly the deck shapes this
+    engine runs, and the deck shapes where it is not are already refused by
+    name at the ``RP`` card (issue #802). Accepting ``GD`` cannot make this
+    engine answer a cliff question wrongly, because it never gets asked one.
+    """
+
+    eps_r2: float = 0.0
+    sigma2: float = 0.0
+    edge_distance: float = 0.0  # CLT
+    height: float = 0.0  # CHT
+
+    @classmethod
+    def from_card(cls, card: Card) -> SecondMedium:
+        return cls(card.f(4), card.f(5), card.f(6), card.f(7))
+
+
+@dataclass(frozen=True)
 class NetworkBranch:
     """One ``NT`` card: a reciprocal two-port admittance across two segments.
 
@@ -737,6 +832,9 @@ class PortalDeck:
     networks: tuple[NetworkBranch | LineBranch, ...] = ()
     loads: tuple[Card, ...] = ()
     ground: Ground = field(default_factory=Ground)
+    # The deck's ``GD`` card, if it carried one. Kept so the deck is a full
+    # record of what arrived; it moves no number here (see :class:`SecondMedium`).
+    second_medium: SecondMedium | None = None
     ground_plane_flag: bool = False
     yy_points: tuple[tuple[int, int], ...] = ()
     quiet: bool = False
@@ -807,6 +905,7 @@ def parse_deck(body: str) -> PortalDeck:
     armed = True
     executed = 0
     ground = Ground()
+    second_medium: SecondMedium | None = None
     ground_plane_flag = False
     quiet = False
     reduced_field: int | None = None
@@ -857,6 +956,12 @@ def parse_deck(body: str) -> PortalDeck:
             networks.append(NetworkBranch.from_card(card))
         elif card.mnemonic == "TL":
             networks.append(LineBranch.from_card(card))
+        elif card.mnemonic == "GD":
+            # Also not an arming card (measured: `... XQ / GD ... / XQ` prints
+            # one block). The second medium reaches NEC's far field only
+            # through RP's cliff modes, which this engine refuses by name, so
+            # the card is recorded and nothing else — see SecondMedium.
+            second_medium = SecondMedium.from_card(card)
         elif card.mnemonic == "MP":
             # Not an arming card: the oracle runs nothing for an XQ whose only
             # new card is an MP (measured — the second XQ of `... XQ / MP 4 8 /
@@ -940,6 +1045,7 @@ def parse_deck(body: str) -> PortalDeck:
         networks=tuple(networks),
         loads=tuple(loads),
         ground=ground,
+        second_medium=second_medium,
         ground_plane_flag=ground_plane_flag,
         yy_points=tuple(yy_points),
         quiet=quiet,
@@ -2456,8 +2562,9 @@ def run_deck(body: str) -> tuple[str, str]:
 
 
 _SELFTEST_DECKS = (
-    # A free-space dipole, the two-source Y probe, and a TL station — the
-    # three deck shapes a live SimNEC session leans on hardest.
+    # A free-space dipole, the two-source Y probe, a TL station, and a
+    # grounded vertical carrying GD — the four deck shapes a live SimNEC
+    # session leans on hardest.
     # EK rides in deck 1 because the live NECSource path ALWAYS sends it —
     # the card whose absence from the bench corpus caused the first live
     # failure (Windows session, 2026-08-08).
@@ -2475,6 +2582,15 @@ _SELFTEST_DECKS = (
     "GW 2 3 20. -0.5 10. 20. 0.5 10. 0.001\n"
     "GE 0\nTL 2 2 1 6 600. 20.\n"
     "EX 0 2 2 0 1.\nFR 0 1 0 0 14.0 1\nXQ\nNX\n",
+    # Deck 4 is the EZNEC-example shape, comma-delimited exactly as
+    # NECSource writes it: a ground card followed by GD, the second card
+    # whose refusal broke a live session (see SecondMedium). It rides here
+    # for the same reason EK rides in deck 1 — so a deployment gate can never
+    # pass while a card the live path sends is being refused.
+    "CE selftest 4\n"
+    "GW 1 11 0. 0. 0.5 0. 0. 10.5 0.001\n"
+    "GE -1\nGN 1\nGD 2,0,0,0,13.,.005,0.,0.\n"
+    "EX 0 1 1 0 1.\nFR 0 1 0 0 14.0 1\nXQ\nNX\n",
 )
 
 
@@ -2486,7 +2602,7 @@ def _selftest(stdout) -> int:
     what a SimNEC session depends on and what matters when the install is a
     bare ``pip install`` with no checkout (e.g. the Windows box, where SimNEC
     launches engines through ``cmd.exe`` and text I/O is CRLF). It spawns
-    itself exactly once, feeds three embedded decks down the one process, and
+    itself exactly once, feeds four embedded decks down the one process, and
     requires per deck: the banner (first deck only), an ANTENNA INPUT
     PARAMETERS section, and the NX data-card echo sentinel — miss that and a
     live SimNEC hangs forever, which is the failure this exists to catch.
@@ -2504,13 +2620,17 @@ def _selftest(stdout) -> int:
         "process exited 0": proc.returncode == 0,
         "banner present": "VERSION:" in proc.stdout,
         "EK accepted": "EXTENDED THIN WIRE KERNEL" in proc.stdout,
-        "4 solve groups answered": proc.stdout.count("ANTENNA INPUT PARAMETERS") == 4,
-        "3 NX sentinels": sum(
+        "GD accepted": any(
+            ln.lstrip().startswith("DATA CARD No:") and " GD " in ln
+            for ln in proc.stdout.splitlines()
+        ),
+        "5 solve groups answered": proc.stdout.count("ANTENNA INPUT PARAMETERS") == 5,
+        "4 NX sentinels": sum(
             1
             for ln in proc.stdout.splitlines()
             if ln.lstrip().startswith("DATA CARD No:") and " NX " in ln
         )
-        == 3,
+        == 4,
         "-YY row present": "    -YY " in proc.stdout,
         "TL network row present": "STRAIGHT" in proc.stdout,
         "stderr quiet": proc.stderr.strip() == "",

--- a/tests/fixtures/nec_portal/dipole_gd_cliff_sommerfeld.deck
+++ b/tests/fixtures/nec_portal/dipole_gd_cliff_sommerfeld.deck
@@ -1,0 +1,9 @@
+CE dipole over sommerfeld ground
+GW 1 9 0. 0. 5.0 0. 0. 10.0 0.001
+GE -1
+GN 2 0 0 0 13. 0.005
+GD 0 0 0 0 5. .001 20. -2.
+EX 0 1 5 0 1.
+FR 0 1 0 0 14.1 0
+XQ
+NX

--- a/tests/fixtures/nec_portal/dipole_gd_cliff_sommerfeld.out
+++ b/tests/fixtures/nec_portal/dipole_gd_cliff_sommerfeld.out
@@ -1,0 +1,124 @@
+
+
+
+                               __________________________________________
+                              |                                          |
+                              |  NUMERICAL ELECTROMAGNETICS CODE (nec2c) |
+                              |   Translated to 'C' in Double Precision  |
+                              |__________________________________________|
+
+VERSION:5b4az.ae6ty.1.17
+
+
+
+                               ---------------- COMMENTS ----------------
+                               dipole over sommerfeld ground
+
+
+
+                               -------- STRUCTURE SPECIFICATION --------
+                                     COORDINATES MUST BE INPUT IN
+                                     METERS OR BE SCALED TO METERS
+                                     BEFORE STRUCTURE INPUT IS ENDED
+
+  WIRE                                                                                 SEG FIRST  LAST  TAG
+   No:        X1         Y1         Z1         X2         Y2         Z2       RADIUS   No:   SEG   SEG  No:
+     1     0.00000    0.00000    5.00000    0.00000    0.00000   10.00000    0.00100     9     1     9    1
+
+     GROUND PLANE SPECIFIED.
+
+     TOTAL SEGMENTS USED: 9   SEGMENTS IN A SYMMETRIC CELL: 9   SYMMETRY FLAG: 0
+
+
+                               ---------- SEGMENTATION DATA ----------
+                                        COORDINATES IN METERS
+                            I+ AND I- INDICATE THE SEGMENTS BEFORE AND AFTER I
+
+   SEG    COORDINATES OF SEGM CENTER     SEGM    ORIENTATION ANGLES    WIRE    CONNECTION DATA   TAG
+   No:       X         Y         Z      LENGTH     ALPHA      BETA    RADIUS    I-     I    I+   No:
+     1    0.0000    0.0000    5.2778    0.5556   90.0000    0.0000    0.0010     0     1     2     1
+     2    0.0000    0.0000    5.8333    0.5556   90.0000    0.0000    0.0010     1     2     3     1
+     3    0.0000    0.0000    6.3889    0.5556   90.0000    0.0000    0.0010     2     3     4     1
+     4    0.0000    0.0000    6.9444    0.5556   90.0000    0.0000    0.0010     3     4     5     1
+     5    0.0000    0.0000    7.5000    0.5556   90.0000    0.0000    0.0010     4     5     6     1
+     6    0.0000    0.0000    8.0556    0.5556   90.0000    0.0000    0.0010     5     6     7     1
+     7    0.0000    0.0000    8.6111    0.5556   90.0000    0.0000    0.0010     6     7     8     1
+     8    0.0000    0.0000    9.1667    0.5556   90.0000    0.0000    0.0010     7     8     9     1
+     9    0.0000    0.0000    9.7222    0.5556   90.0000    0.0000    0.0010     8     9     0     1
+
+
+
+  DATA CARD No:   1 GN   2     0     0     0  1.30000E+01  5.00000E-03  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+  DATA CARD No:   2 GD   0     0     0     0  5.00000E+00  1.00000E-03  2.00000E+01 -2.00000E+00  0.00000E+00  0.00000E+00
+  DATA CARD No:   3 EX   0     1     5     0  1.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+  DATA CARD No:   4 FR   0     1     0     0  1.41000E+01  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+  DATA CARD No:   5 XQ   0     0     0     0  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+
+
+                               --------- FREQUENCY --------
+                                FREQUENCY : 1.4100E+01 MHz
+                                WAVELENGTH: 2.1262E+01 Mtr
+
+                        APPROXIMATE INTEGRATION EMPLOYED FOR SEGMENTS 
+                        THAT ARE MORE THAN 1.000 WAVELENGTHS APART
+
+
+                          ------ STRUCTURE IMPEDANCE LOADING ------
+                                 THIS STRUCTURE IS NOT LOADED
+
+
+                            -------- ANTENNA ENVIRONMENT --------
+Somnec Computation Time 0
+                            FINITE GROUND - SOMMERFELD SOLUTION
+                            RELATIVE DIELECTRIC CONST: 13.000
+                            CONDUCTIVITY:  5.000E-03 MHOS/METER
+                            COMPLEX DIELECTRIC CONSTANT:  1.3000E+01-6.3745E+00j
+
+
+                             ---------- MATRIX TIMING ----------
+                               FILL: 0 msec  FACTOR: 0 msec
+
+
+                        --------- ANTENNA INPUT PARAMETERS ---------
+  TAG   SEG       VOLTAGE (VOLTS)         CURRENT (AMPS)         IMPEDANCE (OHMS)        ADMITTANCE (MHOS)     POWER
+  No:   No:     REAL      IMAGINARY     REAL      IMAGINARY     REAL      IMAGINARY    REAL       IMAGINARY   (WATTS)
+    1     5  1.0000E+00  0.0000E+00  1.4326E-05  1.0635E-03  1.2664E+01 -9.4010E+02  1.4326E-05  1.0635E-03  7.1632E-06
+
+
+                           -------- CURRENTS AND LOCATION --------
+                                  DISTANCES IN WAVELENGTHS
+
+   SEG  TAG    COORDINATES OF SEGM CENTER     SEGM    ------------- CURRENT (AMPS) -------------
+   No:  No:       X         Y         Z      LENGTH     REAL      IMAGINARY    MAGN        PHASE
+     1    1    0.0000    0.0000    0.2482   0.02613  3.2793E-06  1.4679E-04  1.4683E-04   88.720
+     2    1    0.0000    0.0000    0.2743   0.02613  8.2469E-06  4.0924E-04  4.0932E-04   88.846
+     3    1    0.0000    0.0000    0.3005   0.02613  1.1672E-05  6.5293E-04  6.5304E-04   88.976
+     4    1    0.0000    0.0000    0.3266   0.02613  1.3694E-05  8.8645E-04  8.8655E-04   89.115
+     5    1    0.0000    0.0000    0.3527   0.02613  1.4326E-05  1.0635E-03  1.0636E-03   89.228
+     6    1    0.0000    0.0000    0.3789   0.02613  1.3580E-05  8.8653E-04  8.8664E-04   89.122
+     7    1    0.0000    0.0000    0.4050   0.02613  1.1478E-05  6.5308E-04  6.5318E-04   88.993
+     8    1    0.0000    0.0000    0.4311   0.02613  8.0403E-06  4.0940E-04  4.0948E-04   88.875
+     9    1    0.0000    0.0000    0.4572   0.02613  3.1691E-06  1.4688E-04  1.4691E-04   88.764
+
+
+                               ---------- POWER BUDGET ---------
+                               INPUT POWER   =  7.1632E-06 Watts
+                               RADIATED POWER=  7.1632E-06 Watts
+                               STRUCTURE LOSS=  0.0000E+00 Watts
+                               NETWORK LOSS  =  0.0000E+00 Watts
+                               EFFICIENCY    =  100.00 Percent
+
+
+
+  DATA CARD No:   6 NX   0     0     0     0  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+
+
+                               __________________________________________
+                              |                                          |
+                              |  NUMERICAL ELECTROMAGNETICS CODE (nec2c) |
+                              |   Translated to 'C' in Double Precision  |
+                              |__________________________________________|
+
+VERSION:5b4az.ae6ty.1.17
+
+ERROR-NEC2C: nec2c: Error reading input file - aborting

--- a/tests/fixtures/nec_portal/dipole_gd_second_medium.deck
+++ b/tests/fixtures/nec_portal/dipole_gd_second_medium.deck
@@ -1,0 +1,9 @@
+CE dipole over perfect ground
+GW 1 9 0. 0. 2.0 0. 0. 7.0 0.001
+GE -1
+GN 1
+GD 2,0,0,0,13.,.005,0.,0.
+EX 0 1 5 0 1.
+FR 0 1 0 0 14.1 0
+XQ
+NX

--- a/tests/fixtures/nec_portal/dipole_gd_second_medium.out
+++ b/tests/fixtures/nec_portal/dipole_gd_second_medium.out
@@ -1,0 +1,120 @@
+
+
+
+                               __________________________________________
+                              |                                          |
+                              |  NUMERICAL ELECTROMAGNETICS CODE (nec2c) |
+                              |   Translated to 'C' in Double Precision  |
+                              |__________________________________________|
+
+VERSION:5b4az.ae6ty.1.17
+
+
+
+                               ---------------- COMMENTS ----------------
+                               dipole over perfect ground
+
+
+
+                               -------- STRUCTURE SPECIFICATION --------
+                                     COORDINATES MUST BE INPUT IN
+                                     METERS OR BE SCALED TO METERS
+                                     BEFORE STRUCTURE INPUT IS ENDED
+
+  WIRE                                                                                 SEG FIRST  LAST  TAG
+   No:        X1         Y1         Z1         X2         Y2         Z2       RADIUS   No:   SEG   SEG  No:
+     1     0.00000    0.00000    2.00000    0.00000    0.00000    7.00000    0.00100     9     1     9    1
+
+     GROUND PLANE SPECIFIED.
+
+     TOTAL SEGMENTS USED: 9   SEGMENTS IN A SYMMETRIC CELL: 9   SYMMETRY FLAG: 0
+
+
+                               ---------- SEGMENTATION DATA ----------
+                                        COORDINATES IN METERS
+                            I+ AND I- INDICATE THE SEGMENTS BEFORE AND AFTER I
+
+   SEG    COORDINATES OF SEGM CENTER     SEGM    ORIENTATION ANGLES    WIRE    CONNECTION DATA   TAG
+   No:       X         Y         Z      LENGTH     ALPHA      BETA    RADIUS    I-     I    I+   No:
+     1    0.0000    0.0000    2.2778    0.5556   90.0000    0.0000    0.0010     0     1     2     1
+     2    0.0000    0.0000    2.8333    0.5556   90.0000    0.0000    0.0010     1     2     3     1
+     3    0.0000    0.0000    3.3889    0.5556   90.0000    0.0000    0.0010     2     3     4     1
+     4    0.0000    0.0000    3.9444    0.5556   90.0000    0.0000    0.0010     3     4     5     1
+     5    0.0000    0.0000    4.5000    0.5556   90.0000    0.0000    0.0010     4     5     6     1
+     6    0.0000    0.0000    5.0556    0.5556   90.0000    0.0000    0.0010     5     6     7     1
+     7    0.0000    0.0000    5.6111    0.5556   90.0000    0.0000    0.0010     6     7     8     1
+     8    0.0000    0.0000    6.1667    0.5556   90.0000    0.0000    0.0010     7     8     9     1
+     9    0.0000    0.0000    6.7222    0.5556   90.0000    0.0000    0.0010     8     9     0     1
+
+
+
+  DATA CARD No:   1 GN   1     0     0     0  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+  DATA CARD No:   2 GD   2     0     0     0  1.30000E+01  5.00000E-03  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+  DATA CARD No:   3 EX   0     1     5     0  1.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+  DATA CARD No:   4 FR   0     1     0     0  1.41000E+01  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+  DATA CARD No:   5 XQ   0     0     0     0  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+
+
+                               --------- FREQUENCY --------
+                                FREQUENCY : 1.4100E+01 MHz
+                                WAVELENGTH: 2.1262E+01 Mtr
+
+                        APPROXIMATE INTEGRATION EMPLOYED FOR SEGMENTS 
+                        THAT ARE MORE THAN 1.000 WAVELENGTHS APART
+
+
+                          ------ STRUCTURE IMPEDANCE LOADING ------
+                                 THIS STRUCTURE IS NOT LOADED
+
+
+                            -------- ANTENNA ENVIRONMENT --------
+                            PERFECT GROUND
+
+
+                             ---------- MATRIX TIMING ----------
+                               FILL: 0 msec  FACTOR: 0 msec
+
+
+                        --------- ANTENNA INPUT PARAMETERS ---------
+  TAG   SEG       VOLTAGE (VOLTS)         CURRENT (AMPS)         IMPEDANCE (OHMS)        ADMITTANCE (MHOS)     POWER
+  No:   No:     REAL      IMAGINARY     REAL      IMAGINARY     REAL      IMAGINARY    REAL       IMAGINARY   (WATTS)
+    1     5  1.0000E+00  0.0000E+00  2.1360E-05  1.0665E-03  1.8771E+01 -9.3726E+02  2.1360E-05  1.0665E-03  1.0680E-05
+
+
+                           -------- CURRENTS AND LOCATION --------
+                                  DISTANCES IN WAVELENGTHS
+
+   SEG  TAG    COORDINATES OF SEGM CENTER     SEGM    ------------- CURRENT (AMPS) -------------
+   No:  No:       X         Y         Z      LENGTH     REAL      IMAGINARY    MAGN        PHASE
+     1    1    0.0000    0.0000    0.1071   0.02613  5.0013E-06  1.4791E-04  1.4800E-04   88.063
+     2    1    0.0000    0.0000    0.1333   0.02613  1.2510E-05  4.1173E-04  4.1192E-04   88.260
+     3    1    0.0000    0.0000    0.1594   0.02613  1.7606E-05  6.5605E-04  6.5629E-04   88.463
+     4    1    0.0000    0.0000    0.1855   0.02613  2.0538E-05  8.8968E-04  8.8992E-04   88.678
+     5    1    0.0000    0.0000    0.2116   0.02613  2.1360E-05  1.0665E-03  1.0667E-03   88.853
+     6    1    0.0000    0.0000    0.2378   0.02613  2.0125E-05  8.8903E-04  8.8926E-04   88.703
+     7    1    0.0000    0.0000    0.2639   0.02613  1.6904E-05  6.5493E-04  6.5515E-04   88.522
+     8    1    0.0000    0.0000    0.2900   0.02613  1.1765E-05  4.1052E-04  4.1069E-04   88.358
+     9    1    0.0000    0.0000    0.3162   0.02613  4.6070E-06  1.4726E-04  1.4733E-04   88.208
+
+
+                               ---------- POWER BUDGET ---------
+                               INPUT POWER   =  1.0680E-05 Watts
+                               RADIATED POWER=  1.0680E-05 Watts
+                               STRUCTURE LOSS=  0.0000E+00 Watts
+                               NETWORK LOSS  =  0.0000E+00 Watts
+                               EFFICIENCY    =  100.00 Percent
+
+
+
+  DATA CARD No:   6 NX   0     0     0     0  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00  0.00000E+00
+
+
+                               __________________________________________
+                              |                                          |
+                              |  NUMERICAL ELECTROMAGNETICS CODE (nec2c) |
+                              |   Translated to 'C' in Double Precision  |
+                              |__________________________________________|
+
+VERSION:5b4az.ae6ty.1.17
+
+ERROR-NEC2C: nec2c: Error reading input file - aborting

--- a/tests/fixtures/nec_portal/manifest.json
+++ b/tests/fixtures/nec_portal/manifest.json
@@ -101,6 +101,20 @@
       "stderr": "\nERROR-NEC2C: nec2c: Error reading input file - aborting\n"
     },
     {
+      "name": "dipole_gd_cliff_sommerfeld",
+      "returncode": 253,
+      "deck_sha256": "bb26c229132d96e327ac610911ab6dac27915e06ede7078b7c91a330e04022e8",
+      "out_sha256": "4ac26d86becb0c8d05a871cd81be90c5e7984b0d6cb8a32469771cde10a754c3",
+      "stderr": "\nERROR-NEC2C: nec2c: Error reading input file - aborting\n"
+    },
+    {
+      "name": "dipole_gd_second_medium",
+      "returncode": 253,
+      "deck_sha256": "a18d1cdf5bfbdfaf67bec22416fd27dcbb01242804d25720c3d06bced9d68673",
+      "out_sha256": "1e9e7f2cdac699985b6bcbd4414ddf88b29f075724adc535486a0bba84447701",
+      "stderr": "\nERROR-NEC2C: nec2c: Error reading input file - aborting\n"
+    },
+    {
       "name": "dipole_gm_translated_pair",
       "returncode": 253,
       "deck_sha256": "2ef6e978f4f18e467826c62e53a9454932ad39ccc367ba854608377411879033",

--- a/tests/test_nec_portal.py
+++ b/tests/test_nec_portal.py
@@ -1307,6 +1307,167 @@ def test_pt_is_not_an_arming_card():
 
 
 # --------------------------------------------------------------------------
+# issue #800 (tail): GD, the additional-ground-parameters card
+# --------------------------------------------------------------------------
+
+# The two committed pairs: (with the card, the identical deck without it).
+GD_PAIRS = (
+    ("dipole_gd_second_medium", "dipole_pec_ground"),
+    ("dipole_gd_cliff_sommerfeld", "dipole_sommerfeld_ground"),
+)
+
+
+def test_gd_deck_runs_instead_of_being_refused():
+    """The reason the card had to land: SimNEC's EZNEC-derived examples
+    (``Cardioid (EZNEC).ssn``, ``4-square (EZNEC).ssn``) carry a ``GD`` and
+    ``NECSource`` forwards it, so refusing it failed those decks outright and
+    the live session read back fabricated R = 0 / X = 0."""
+    for name, _base in GD_PAIRS:
+        text = printout(name)
+        assert "ERROR-NEC2C" not in text, name
+        assert "ANTENNA INPUT PARAMETERS" in text, name
+
+
+@pytest.mark.parametrize(("name", "_base"), GD_PAIRS)
+def test_gd_echo_is_the_oracles_bytes(name, _base):
+    """The whole of the card's printed output, verbatim.
+
+    ``dipole_gd_cliff_sommerfeld`` is the one that matters here: its card
+    carries all four reals (``5. .001 20. -2.``), so the echo pins EPSR2,
+    SIG2, CLT *and* CHT in their card-order columns. The Cardioid's own form
+    leaves the last two at zero and would not.
+    """
+    ours = printout(name)
+    theirs = fixture_out(name)
+    echo = next(ln for ln in theirs.splitlines() if " GD" in ln.split("No:")[-1])
+    assert echo in ours, f"our echo differs from the oracle's:\n  {echo!r}"
+    assert echo.split()[4] == "GD"
+
+
+def test_the_cliff_gd_echo_carries_all_four_reals_in_card_order():
+    """``GD 0 0 0 0 5. .001 20. -2.`` -> EPSR2, SIG2, CLT, CHT, then zeros.
+
+    Read off the oracle's own ``RP 2`` printout, which names them:
+    ``EDGE DISTANCE= 20.00 METERS`` / ``HEIGHT= -2.00 METERS`` /
+    ``RELATIVE DIELECTRIC CONST= 5.000`` / ``GROUND CONDUCTIVITY= 0.001``.
+    """
+    for text in (
+        printout("dipole_gd_cliff_sommerfeld"),
+        fixture_out("dipole_gd_cliff_sommerfeld"),
+    ):
+        echo = next(ln for ln in text.splitlines() if " GD" in ln.split("No:")[-1])
+        reals = [float(v) for v in echo.split()[9:]]
+        assert reals == [5.0, 0.001, 20.0, -2.0, 0.0, 0.0], echo
+        assert [int(v) for v in echo.split()[5:9]] == [0, 0, 0, 0], echo
+
+
+@pytest.mark.parametrize(("name", "_base"), GD_PAIRS)
+def test_gd_adds_no_line_to_the_antenna_environment_block(name, _base):
+    """Probed for and not there — including under ``GN 2``, where a second
+    medium is the likeliest place an announcement would have appeared."""
+    for text in (printout(name), fixture_out(name)):
+        lines = text.splitlines()
+        start = next(i for i, ln in enumerate(lines) if "ANTENNA ENVIRONMENT" in ln)
+        end = next(i for i, ln in enumerate(lines) if "MATRIX TIMING" in ln)
+        block = " ".join(lines[start:end]).upper()
+        assert "SECOND MEDIUM" not in block, block
+        assert "CLIFF" not in block, block
+        assert "MEDIUM 2" not in block, block
+
+
+@pytest.mark.parametrize(("name", "base"), GD_PAIRS)
+def test_gd_changes_nothing_but_its_own_echo(name, base):
+    """Asserted rather than assumed, exactly as ``MP`` is.
+
+    Each fixture IS its base deck plus one card. Strip the ``GD`` echo and
+    the ordinals it shifts and the two printouts are identical — ours and the
+    oracle's alike. If that ever stops being true, ``GD`` has become physics
+    and this engine is wrong to record it and move on.
+    """
+
+    def stripped(text: str) -> list[str]:
+        out = []
+        for line in body_lines(text):
+            if "DATA CARD No:" in line:
+                _ordinal, rest = line.split("No:")[1].strip().split(maxsplit=1)
+                if rest.split()[0] != "GD":
+                    out.append(rest)
+                continue
+            out.append(line)
+        return out
+
+    for plain, with_gd in (
+        (printout(base), printout(name)),
+        (fixture_out(base), fixture_out(name)),
+    ):
+        assert stripped(with_gd) == stripped(plain)
+
+
+def test_gd_is_not_an_arming_card():
+    """Measured on the oracle: ``... XQ / GD 2 0 0 0 13. .005 0. 0. / XQ``
+    prints one block, not two."""
+    text = run_deck(
+        "CE gd arming\nGW 1 9 0. 0. 0.5 0. 0. 5.0 0.001\nGE 1\nGN 1\n"
+        "EX 0 1 1 0 1.\nFR 0 1 0 0 14.1 0\nXQ\nGD 2 0 0 0 13. .005 0. 0.\nXQ\n"
+    )[0]
+    assert text.count("ANTENNA INPUT PARAMETERS") == 1
+    assert text.count("MATRIX TIMING") == 1
+    # ...and both execute cards are still echoed.
+    assert len(re.findall(r"DATA CARD No:\s+\d+ XQ", text)) == 2
+
+
+def test_the_comma_delimited_gd_simnec_sends_parses_like_the_spaced_form():
+    """``NECSource`` writes the card comma-delimited — ``GD
+    2,0,0,0,13.,.005,0.,0.`` is the literal Cardioid line. Measured identical
+    to the spaced form on the oracle; identical here too."""
+    head = "CE gd commas\nGW 1 9 0. 0. 0.5 0. 0. 5.0 0.001\nGE 1\nGN 1\n"
+    tail = "EX 0 1 1 0 1.\nFR 0 1 0 0 14.1 0\nXQ\n"
+    commas = run_deck(head + "GD 2,0,0,0,13.,.005,0.,0.\n" + tail)[0]
+    spaces = run_deck(head + "GD 2 0 0 0 13. .005 0. 0.\n" + tail)[0]
+    assert body_lines(commas) == body_lines(spaces)
+    assert "ERROR-NEC2C" not in commas
+
+
+def test_a_bare_gd_is_a_card_like_any_other():
+    """The oracle echoes ``GD`` with four zero integers and six zero reals and
+    runs the deck; nothing here may trip over the missing fields."""
+    text = run_deck(
+        "CE bare gd\nGW 1 9 0. 0. 0.5 0. 0. 5.0 0.001\nGE 1\nGN 1\nGD\n"
+        "EX 0 1 1 0 1.\nFR 0 1 0 0 14.1 0\nXQ\n"
+    )[0]
+    assert "ERROR-NEC2C" not in text
+    echo = next(ln for ln in text.splitlines() if " GD" in ln.split("No:")[-1])
+    assert [float(v) for v in echo.split()[5:]] == [0.0] * 10, echo
+
+
+def test_the_rp_modes_that_would_use_a_gd_are_still_refused():
+    """The fidelity gate — why accepting ``GD`` is not a silent lie.
+
+    NEC-2 reaches the second medium in the far field ALONE, and there only
+    through ``RP``'s cliff and ground-screen modes. Measured on the oracle
+    with the cliff card of ``dipole_gd_cliff_sommerfeld``: under ``RP 0`` the
+    pattern table is byte-identical with and without it; under ``RP 2`` a
+    ``FAR FIELD GROUND PARAMETERS`` block appears and every gain moves. So
+    the deck shapes where ``GD`` is inert are the shapes this engine runs,
+    and the shapes where it is not are refused by name (issue #802) — this
+    engine can never be asked a cliff question and answer it as flat ground.
+    """
+    head = (
+        "CE gd cliff pattern\nGW 1 9 0. 0. 0.5 0. 0. 5.0 0.001\nGE 1\n"
+        "GN 0 0 0 0 13. .005\nGD 0 0 0 0 5. .001 20. -2.\n"
+        "EX 0 1 1 0 1.\nFR 0 1 0 0 14.1 0\n"
+    )
+    for mode in (1, 2, 3, 4, 5, 6):
+        text = run_deck(head + f"RP {mode} 3 3 1001 0 0 30 30 1000\nXQ\n")[0]
+        assert f"RP mode {mode} is not supported" in text, mode
+        assert NX_ECHO.search(text), mode
+    # ...and the mode SimNEC actually writes runs, second medium or not.
+    text = run_deck(head + "RP 0 3 3 1001 0 0 30 30 1000\nXQ\n")[0]
+    assert "ERROR-NEC2C" not in text
+    assert "RADIATION PATTERNS" in text
+
+
+# --------------------------------------------------------------------------
 # unit 3: robustness — the daemon must survive anything on stdin
 # --------------------------------------------------------------------------
 
@@ -1352,6 +1513,16 @@ BAD_DECKS = {
         "CE worded mp\nGW 1 9 0. 0. -2.5 0. 0. 2.5 0.001\nGE 0\n"
         "EX 0 1 5 0 1.\nMP lots fast\nFR 0 1 0 0 30. 0\nXQ\n",
         "lots",
+    ),
+    "a GD with a word in it": (
+        # The ORACLE's free-format reader silently SKIPS a non-numeric token
+        # and shifts the rest left, so `GD 2 0 0 0 marsh .005 0. 0.` echoes
+        # .005 as EPSR2 — a wrong answer dressed as a right one. This engine
+        # names the token instead, on the same error path every other card
+        # uses, and still emits the sentinel.
+        "CE worded gd\nGW 1 9 0. 0. 0.5 0. 0. 5.0 0.001\nGE 1\nGN 1\n"
+        "GD 2 0 0 0 marsh .005 0. 0.\nEX 0 1 1 0 1.\nFR 0 1 0 0 14.1 0\nXQ\n",
+        "marsh",
     ),
     "a current source we do not model": (
         "CE ex type 6\nGW 1 9 0. 0. -2.5 0. 0. 2.5 0.001\nGE 0\n"

--- a/tests/test_nec_portal_differential.py
+++ b/tests/test_nec_portal_differential.py
@@ -37,6 +37,8 @@ catalog_verticals_vertical            2.79%   2.79%       -   0.18%      -
 catalog_wire_w8jk                     1.98%   1.99%       -   0.84%      -
 dipole_fr_sweep                       1.29%   1.29%       -   0.96%      -
 dipole_free_space                     0.76%   0.76%       -   0.96%      -
+dipole_gd_cliff_sommerfeld            2.24%   2.23%       -   4.35%      -   (f)
+dipole_gd_second_medium               2.23%   2.23%       -   4.35%      -   (f)
 dipole_gm_translated_pair             1.10%   1.10%       -   1.13%      -
 dipole_gs_scaled                      0.76%   0.76%       -   0.96%      -
 dipole_load_ld0                       1.79%   1.79%       -   1.95%      -
@@ -112,6 +114,15 @@ fails.
     what it computes, so there is nothing in it for momwire to honour. If these
     rows ever drift away from ``dipole_free_space``'s, the card has stopped
     being advisory and this engine is wrong to ignore it.
+
+(f) is the same kind of control, for ``GD`` (issue #800's tail). Each fixture
+    is its ground fixture plus one card — ``dipole_pec_ground`` and
+    ``dipole_sommerfeld_ground`` respectively — and each reproduces its base
+    row to the digit on BOTH engines. That is the claim GD's treatment rests
+    on: NEC-2 uses the second medium in the FAR FIELD only, and there only in
+    ``RP``'s cliff modes, so nothing in the matrix can see it. If these rows
+    ever drift away from their bases', the card has stopped being inert for
+    the impedance path and this engine is wrong to record it and move on.
 """
 
 from __future__ import annotations
@@ -493,6 +504,33 @@ def test_mp_moves_no_number_on_either_engine(name, pair):
         for table, reference in zip(mine.ports, base.ports, strict=True):
             assert table == reference, f"{name}: MP moved an impedance row"
         assert mine.currents == base.currents, f"{name}: MP moved a segment current"
+
+
+GD_FIXTURES = (
+    ("dipole_gd_second_medium", "dipole_pec_ground"),
+    ("dipole_gd_cliff_sommerfeld", "dipole_sommerfeld_ground"),
+)
+
+
+@pytest.mark.parametrize(("name", "base"), GD_FIXTURES)
+def test_gd_moves_no_number_on_either_engine(name, base, pair):
+    """Justifies accepting ``GD`` and computing nothing from it.
+
+    The card names a SECOND ground medium and the cliff edge between the two.
+    If the moment method saw it, these fixtures would differ from their bases
+    — same geometry, same ground, same drive, same frequency, one extra card.
+    They do not, on the oracle's side OR ours, which is the measured form of
+    "NEC-2 uses GD in the far field alone". The far-field half of the claim
+    lives in ``test_nec_portal.py`` (``RP 0`` byte-identical, ``RP 1``-``6``
+    refused by name).
+    """
+    ours, theirs = pair(name)
+    base_ours, base_theirs = pair(base)
+    for mine, reference in ((ours, base_ours), (theirs, base_theirs)):
+        assert [len(t) for t in mine.ports] == [len(t) for t in reference.ports]
+        for table, expected in zip(mine.ports, reference.ports, strict=True):
+            assert table == expected, f"{name}: GD moved an impedance row"
+        assert mine.currents == reference.currents, f"{name}: GD moved a current"
 
 
 TL_FIXTURES = ("dipole_tl_network", "dipole_tl_shunt_crossed")


### PR DESCRIPTION
## Summary
Live-session follow-up: SimNEC's EZNEC-derived examples (Cardioid, 4-square) forward a `GD` second-medium card our daemon refused, failing every deck. Now accepted and pinned against the oracle (2 fixtures, corpus 40/40 byte-layout):
- Echo layout exact; **no environment line exists** (probed under GN 1 and GN 2); GD does not arm an execute; comma form byte-identical; GD without GN accepted.
- Field meanings recovered from the oracle's own `RP 2` printout: EPSR2, SIG2, cliff edge distance, cliff height. **With/without diffs move no number** — the second medium is far-field-only, and the RP modes where it matters (1–6) already refuse by name (#802), so this engine can never answer a cliff question as flat ground.
- One deliberate divergence, documented: nec2c silently skips garbage tokens and shifts fields left (a wrong answer dressed as right); we name the token on the error path with the sentinel intact.
- Selftest grows a GD deck (9 checks). Grammar doc §18.

## Gates (orchestrator-verified)
- [x] 709 portal tests green (reproduced); `--check` OK (81 files); byte-layout 40/40; selftest 9/9
- [x] Mutation probe: adding GD to the arming set → test fails; restored → green

Builder: opus (delegated-build contract). Part of #800's remit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvF4yHgNxjhyZ7P286g3z8