### PR TITLE
Release v0.46.0 — momwire inside SimNEC

### DIFF
--- a/docs/status/2026-08-08-ward-simnec-momwire-notes.md
+++ b/docs/status/2026-08-08-ward-simnec-momwire-notes.md
@@ -17,7 +17,7 @@ with a different electromagnetics kernel underneath.
 
 ## What we validated
 
-**Layout: 36 of 36.** We captured 36 deck/printout pairs from your bundled
+**Layout: 40 of 40.** We captured 40 deck/printout pairs from your bundled
 `nec2c` — its own `NEC2Daemon` test deck, hand-written decks for every card
 class the portal emits, ten real designs, and a two-decks-one-process
 residency case. Our engine reproduces all 36 section for section, column for
@@ -27,7 +27,7 @@ card renumbering, and the matrix-rebuild-only frequency preamble.
 **Numbers: inside engineering tolerance.** momwire is a B-spline Galerkin
 solver and `nec2c` uses NEC-2's sinusoidal basis with point matching, so they
 will never agree digit for digit — and SimNEC doesn't need them to. Worst
-case over every row of every table in all 36 fixtures:
+case over every row of every table in all 40 fixtures:
 
 | quantity | corpus worst |
 | --- | --- |
@@ -133,6 +133,16 @@ of 4 keeps up on a 16 GB machine. We refuse, with the sentinel intact, what
 we don't model: surface patches (`SP`/`SM` — momwire is a wire solver), `IS`,
 `RP` modes other than 0, spherical `NE`/`NH`, near fields over finite ground,
 and `GN` radial-wire screens. The live session also showed user decks carry
-cards the portal documentation's card list doesn't (`EK`, now supported;
-`GD` and `RP 3` from the EZNEC-derived examples, in progress) — each has
-been about an hour's turnaround with your engine on hand as the oracle.
+cards the portal documentation's card list doesn't — `EK` (sent
+unconditionally by `NECSource`) and `GD` (your EZNEC-derived examples all
+carry one) are both supported now; each was about an hour's turnaround with
+your engine on hand as the oracle. `RP 3` — where those examples' cliff
+parameters actually land — is the remaining gap.
+
+One more thing the launch mechanism makes possible: since the portal command
+runs through the shell, a `--basis` flag on the command line picks the
+solver's basis (`bspline`, `sinusoidal-galerkin`, or the
+`sinusoidal-galerkin-converged` setting for near-open feeds). **Two portal
+entries differing only in `--basis` give your users cross-basis validation
+inside SimNEC** — an engine-side second opinion no single-basis NEC build
+can offer, with your nec2c as the third.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.45.0"
+version = "0.46.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,21 +25,22 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.45.0" icon="star">
-  **The SimNEC round-trip release: your station, checked by a second
-  solver.** antennaknobs now speaks SimNEC's `.ssn` circuit format in
-  **both directions**. Export any design — the antenna alone, or a whole
-  station with feedline, tuner tee, and transformer — as a circuit SimNEC
-  opens natively, element values and cable-loss coefficients intact; the
-  mapping is **validated against a real SimNEC installation**, load-tested
-  element by element. Designs whose physics lives in the common mode
-  (balanced tuners, floating baluns) refuse to export with a clear reason
-  instead of producing a confidently-wrong circuit. Coming back, `.ssn`
-  files load as designs — geometry, ground, and the matching chain as a
-  real feed network — and every CLI subcommand takes **`@file.ssn`**
-  directly, just like `@file.nec`. Round-trip identity tests pin the two
-  sides together so they can never drift apart. Start at the new
-  [SimNEC round-trip](/reference/simnec/) reference page.
+<Card title="New in v0.46.0" icon="star">
+  **The engine-for-hire release: momwire now runs *inside* SimNEC.** Point
+  SimNEC's NEC-portal dialog at the new **`momwire-nec2c`** drop-in and its
+  Smith chart, tuners, and sweeps run on momwire's solver — no change to
+  SimNEC needed. The protocol was reverse-engineered against SimNEC's own
+  bundled engine (40 captured printout pairs, reproduced column-for-column)
+  and then **validated in a live SimNEC session**: a real station circuit
+  within a few percent through a high-Q tuner, pattern levels agreeing to
+  ~0.01 dB, and SimNEC's own 4-source phased-array example matching to 1 Ω
+  of reactance. A **`--basis`** flag picks the physics from the portal
+  dialog itself — paste two entries and you have cross-basis validation
+  inside SimNEC, with `sinusoidal-galerkin-converged` on call for near-open
+  high-Q feeds. Structurally faster where it counts: N-port probes cost one
+  matrix fill, not N. Plus: multi-feed \`.ssn\` exports now refuse rather
+  than silently losing their drive phasing. Start at
+  [Using momwire as SimNEC's engine](/reference/simnec/#using-momwire-as-simnecs-engine).
 </Card>
 
 ## The whole pitch, in one line

--- a/site/src/content/docs/reference/simnec.md
+++ b/site/src/content/docs/reference/simnec.md
@@ -126,13 +126,17 @@ numbers per feedpoint out of each printout to build the antenna's Y matrix.
 B-spline Galerkin solver behind it. Your Smith chart, tuner, and sweeps stay
 SimNEC's; the electromagnetics become momwire's.
 
-:::caution[Experimental, and unblessed upstream]
-This is validated against a real SimNEC installation's own NEC2 — 30 captured
-deck/printout pairs, reproduced layout-identically, with the numbers agreeing
-to better than 5% on impedance and 0.12 dB on pattern gain — but it is not
-something SimNEC's author has reviewed or endorsed, and no part of SimNEC
-knows momwire exists. Treat it as a cross-check you can run yourself, not as a
-supported configuration.
+:::caution[Validated live — but unblessed upstream]
+This has driven a real SimNEC session end to end (Windows, SimNEC 6p4d6):
+knob tracking, sweeps, patterns, and multi-source phased-array examples, with
+a validated station circuit reading within a few percent of the bundled
+nec2c through a high-Q tuner, pattern levels agreeing to ~0.01 dB once the
+gain/directivity conventions are lined up, and SimNEC's own 4-source
+Lindenblad example matching to 1 Ω of reactance. Under the session sits a
+bench corpus of 40 captured deck/printout pairs reproduced
+layout-identically. It is still not something SimNEC's author has reviewed
+or endorsed, and no part of SimNEC knows momwire exists — treat it as a
+cross-check you can run yourself, not a supported configuration.
 :::
 
 ### Pointing SimNEC at it
@@ -163,12 +167,32 @@ knowing because the failure modes look nothing like their causes:
   printout banner instead, where every SimNEC session logs it:
   `VERSION:nec2c.ae6ty.momwire.9.1`.
 
-Before a live session, the repo's smoke script runs three decks through one
-resident process the way SimNEC does and prints PASS or FAIL:
+Before a live session, run the built-in smoke — it needs no checkout, spawns
+one resident copy of itself, runs embedded decks through it the way SimNEC
+does, and prints PASS or FAIL:
 
 ```bash
-bash scripts/nec_portal_smoke.sh
+momwire-nec2c --selftest
 ```
+
+### Choosing the physics: `--basis`
+
+SimNEC launches engines through the shell, so the command you paste into the
+portal dialog can carry arguments. The portal accepts a `--basis` flag:
+
+```text
+momwire-nec2c --basis bspline                        # the default
+momwire-nec2c --basis sinusoidal-galerkin            # closest to NEC's own formulation
+momwire-nec2c --basis sinusoidal-galerkin-converged  # recommended for near-open high-Q feeds
+```
+
+**Paste two portal entries that differ only in `--basis` and you have
+cross-basis validation inside SimNEC itself** — switch engines from the
+dialog and watch whether the answer holds. The printout banner records which
+physics answered (`VERSION:...momwire.9.1+sgc`), a mistyped basis fails the
+version probe loudly at configure time, and the `-converged` variant is the
+documented setting for feeds near a current null — the one antenna class
+where bases legitimately disagree at coarse segmentation.
 
 ### What works
 
@@ -183,7 +207,8 @@ Everything SimNEC's portal actually emits for wire antennas:
 | Loading | `LD 0` / `1` / `4` / `5` — series RLC traps, distributed loading, wire conductivity |
 | Patterns | `RP 0` far-field grids, gain and polarisation, normalised to input power |
 | Near fields | `NE` / `NH` rectangular grids in free space or over perfect ground |
-| Networks | `NT` two-port admittance branches between segments |
+| Networks | `NT` two-port admittance branches and `TL` transmission lines between segments |
+| Housekeeping | `EK` extended-kernel, `MP` multicore hints, `PT` print control, `GD` second-medium parameters — accepted and echoed exactly as nec2c does (advisory where momwire's own physics governs) |
 
 One thing is faster than the engine it replaces, structurally. SimNEC probes an
 N-port antenna by sending N excitation groups in one deck, and a stock nec2c
@@ -203,15 +228,12 @@ worse than an error message.) The daemon survives it and runs the next deck.
 Refused today:
 
 - **Surface patches** (`SP`, `SM`) — momwire is a wire solver.
-- **`PT`, `MP`, `IS`** — print control, the multiprocessing hint SimNEC emits
-  on large structures, and NEC-4.2 wire insulation. Their printout shapes are
-  unpinned, so they are refused rather than approximated.
-- **`TL` transmission lines** — momwire models the network fine; it is the
-  NETWORK DATA table's column layout for `TL` that has never been observed.
-  Use `NT`, or keep the line on the SimNEC side as a `SERIES_TLINE` element,
-  which is where a station's feedline belongs anyway.
-- **`RP` modes 1–6 and the gain-only form** — mode 0 is the only one SimNEC
-  emits; the others print a different table.
+- **`IS`** — NEC-4.2 wire insulation; momwire's insulation model is not
+  wired through the portal.
+- **`RP` modes 1–6 and the gain-only form** — mode 0 is the only one
+  SimNEC's own path emits; the others print different tables (they are what
+  the `GD` cliff parameters feed, so a deck asking a cliff question refuses
+  rather than answering it as flat ground).
 - **Spherical `NE` / `NH` grids** (`I1 = 1`) — rectangular only.
 - **Near fields over finite ground** — the near field of a Sommerfeld
   half-space is not an image, and pretending otherwise would be quietly wrong.


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` to **0.46.0** — the release that makes the Ward notes' `pip install antennaknobs` true.
- What's-new card: the engine release (portal drop-in, live-session validation, `--basis`, one-fill-N-sources).
- Docs de-stale: `reference/simnec.md` engine section upgraded from bench-only to live-validated (session numbers), `--basis` + `--selftest` documented, EK/MP/PT/GD/TL moved out of the refusal list.
- Ward notes de-staled in the same pass: corpus 40/40, GD supported, the `--basis` cross-validation offer added.

## Test plan
- [x] `cd site && npm run build` — 27 pages, clean; card anchor verified in built HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvF4yHgNxjhyZ7P286g3z8