### PR TITLE
feat(nec_portal): --basis sinusoidal — the NEC-closest rung of the ladder

### DIFF
--- a/site/src/content/docs/reference/simnec.md
+++ b/site/src/content/docs/reference/simnec.md
@@ -182,9 +182,18 @@ portal dialog can carry arguments. The portal accepts a `--basis` flag:
 
 ```text
 momwire-nec2c --basis bspline                        # the default
-momwire-nec2c --basis sinusoidal-galerkin            # closest to NEC's own formulation
+momwire-nec2c --basis sinusoidal                     # closest to NEC-2's own formulation
+momwire-nec2c --basis sinusoidal-galerkin            # the same basis, tested variationally
 momwire-nec2c --basis sinusoidal-galerkin-converged  # recommended for near-open high-Q feeds
 ```
+
+Those four are a ladder: NEC-2 itself, then `sinusoidal` — the three-term
+basis, point matched, with NEC's own delta-gap source, so it answers "does
+this reproduce NEC-2's behaviour, mesh walk and all" — then the Galerkin
+variants and the B-spline default, which answer "what does a better-converged
+basis say". There is no `sinusoidal-converged`: a zero-width gap cannot be
+expressed under point matching (momwire#212), and the flag does not offer a
+name the solver would refuse.
 
 **Paste two portal entries that differ only in `--basis` and you have
 cross-basis validation inside SimNEC itself** — switch engines from the

--- a/src/antennaknobs/nec_portal.py
+++ b/src/antennaknobs/nec_portal.py
@@ -85,7 +85,7 @@ from dataclasses import dataclass, field
 from types import MappingProxyType
 
 import numpy as np
-from momwire import BSplineSolver, SinusoidalGalerkinSolver
+from momwire import BSplineSolver, SinusoidalGalerkinSolver, SinusoidalSolver
 
 
 from .builder import AntennaBuilder
@@ -100,8 +100,16 @@ from .network_reduce import SingularNetworkError, tl_admittance_2x2
 # cross-basis validation inside SimNEC itself; `-converged` is the
 # recommended setting for near-open high-Q feeds (momwire#213), the class
 # where the live session measured the largest cross-engine gap.
+# `sinusoidal` is the NEC-closest rung of that ladder — three-term basis,
+# collocation testing, Eq-187 delta gap — so it answers "does momwire
+# reproduce NEC-2's behaviour, mesh walk and all" rather than "what does a
+# better-converged basis say". It has no `-converged` twin on purpose: the
+# zero-width point gap has no collocation RHS (momwire#212) and the solver
+# refuses it rather than silently serving the segment gap, which is the same
+# constraint the CLI's MOMWIRE_BASIS_VARIANTS records.
 _BASES = {
     "bspline": (BSplineSolver, {}, ""),
+    "sinusoidal": (SinusoidalSolver, {}, "+sin"),
     "sinusoidal-galerkin": (SinusoidalGalerkinSolver, {}, "+sg"),
     "sinusoidal-galerkin-converged": (
         SinusoidalGalerkinSolver,
@@ -1438,8 +1446,13 @@ def _y_and_port_coeffs(solver):
     ``engines/momwire.py`` gates ground models and distributed wire loading on
     the solver class NAME, so a subclass would silently drop a Sommerfeld deck
     back onto a PEC image.
+
+    The three branches are keyed on the port algebra each family owns, not on
+    the class: ``_assemble_Z_ported`` exists only on the Galerkin subclass and
+    ``_solve_with_kcl_ports`` only on the B-spline family, so a basis added to
+    ``_BASES`` lands on the branch whose algebra it actually has.
     """
-    if not hasattr(solver, "_solve_with_kcl_ports"):
+    if hasattr(solver, "_assemble_Z_ported"):
         # Sinusoidal-Galerkin family: no KCL-port solve to spy on, but
         # compute_y_matrix's own algebra IS the (Y, X) pair — alphas is the
         # per-port coefficient matrix it computes and throws away. Kept
@@ -1459,6 +1472,38 @@ def _y_and_port_coeffs(solver):
                 for j in range(solver.n_ports)
             ],
             axis=1,
+        )
+        return y, alphas
+
+    if not hasattr(solver, "_solve_with_kcl_ports"):
+        # Point-matched sinusoidal: neither a KCL-port solve to spy on nor the
+        # Galerkin port algebra — its ports ARE the Eq-187 delta gaps, so the
+        # RHS is -1/h at each feed segment and column j of the solution is
+        # already the 1 V drive at port j (``compute_impedance`` builds the
+        # same column, scaled by V). Kept verbatim from momwire's
+        # ``compute_y_matrix``, same momwire#232 debt as the branches around
+        # it. No junction-port refusal belongs here: this solver rejects
+        # ``junction_ports=`` at CONSTRUCTION (momwire#177 — the basis
+        # enforces KCL identically, so a node-current port is outside its
+        # span), and a deck's ports are all EX segment gaps anyway.
+        import scipy.linalg
+
+        geom = solver._build_geometry()
+        G, seg_view = solver._assemble_Z(geom, solver.k)
+        feed_segs = geom["feed_segs"]
+        B = np.zeros((geom["n_segs"], len(feed_segs)), dtype=np.complex128)
+        for j, fi in enumerate(feed_segs):
+            B[fi, j] = -1.0 / geom["seg_h"][fi]
+        alphas = scipy.linalg.solve(G, B)
+        y = np.array(
+            [
+                [
+                    solver._feed_segment_current(alphas[:, j], seg_view, fi)
+                    for j in range(len(feed_segs))
+                ]
+                for fi in feed_segs
+            ],
+            dtype=np.complex128,
         )
         return y, alphas
 
@@ -2698,24 +2743,22 @@ def _selftest(stdout) -> int:
         "TL network row present": "STRAIGHT" in proc.stdout,
         "stderr quiet": proc.stderr.strip() == "",
     }
-    alt = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "antennaknobs.nec_portal",
-            "--basis",
-            "sinusoidal-galerkin-converged",
-        ],
-        input=_SELFTEST_DECKS[0],
-        capture_output=True,
-        text=True,
-        timeout=120,
-    )
-    checks["alt basis answers (+sgc)"] = (
-        alt.returncode == 0
-        and "+sgc" in alt.stdout
-        and "ANTENNA INPUT PARAMETERS" in alt.stdout
-    )
+    for basis, suffix in (
+        ("sinusoidal-galerkin-converged", "+sgc"),
+        ("sinusoidal", "+sin"),
+    ):
+        alt = subprocess.run(
+            [sys.executable, "-m", "antennaknobs.nec_portal", "--basis", basis],
+            input=_SELFTEST_DECKS[0],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        checks[f"alt basis answers ({suffix})"] = (
+            alt.returncode == 0
+            and suffix in alt.stdout
+            and "ANTENNA INPUT PARAMETERS" in alt.stdout
+        )
     for name, ok in checks.items():
         stdout.write(f"  {'ok  ' if ok else 'FAIL'} {name}\n")
     passed = all(checks.values())

--- a/tests/test_nec_portal.py
+++ b/tests/test_nec_portal.py
@@ -1854,6 +1854,21 @@ def test_sinusoidal_basis_impedance_tracks_the_nec2c_fixture():
     assert abs(ours - theirs) / abs(theirs) < 0.05, f"{ours} vs {theirs}"
 
 
+def test_sinusoidal_basis_answer_differs_from_the_default_basis():
+    """Disabled-path probe: every other +sin test would still pass if the
+    ``_BASES`` entry silently served the default B-spline solver (its answer
+    is inside the 5% oracle bound too, and the banner stamps regardless of
+    what solved). The two bases genuinely disagree on this deck — measured
+    79.205+45.150j (+sin) vs 79.524+46.003j (default), 1.0% apart — so a
+    collapse to the default is detectable."""
+    deck = (FIXTURE_DIR / "dipole_free_space.deck").read_text()
+    _rc, out_sin, _err = _run_main(["--basis", "sinusoidal"], deck=deck)
+    _rc, out_default, _err = _run_main([], deck=deck)
+    z_sin = complex(*_aip_rows(out_sin)[0][4:6])
+    z_default = complex(*_aip_rows(out_default)[0][4:6])
+    assert abs(z_sin - z_default) / abs(z_default) > 0.003, (z_sin, z_default)
+
+
 def test_sinusoidal_basis_stamps_the_banner():
     deck = (
         "CE basis\n"

--- a/tests/test_nec_portal.py
+++ b/tests/test_nec_portal.py
@@ -1743,3 +1743,132 @@ def test_default_basis_banner_is_unchanged():
     rc, out, _ = _run_main([], deck=deck)
     assert rc == 0
     assert "VERSION:nec2c.ae6ty.momwire.9.1\n" in out and "+sg" not in out
+
+
+# --- --basis sinusoidal: the NEC-closest rung (issue #822) -------------------
+
+# Point-matched sinusoidal has neither the B-spline family's KCL-port solve nor
+# the Galerkin family's ported operator, so `_y_and_port_coeffs` grows a third
+# branch that reproduces `compute_y_matrix`'s algebra. These pin the copy to
+# momwire's own: if either drifts, the daemon's single fill and the library's
+# per-source refill stop being the same solve.
+
+
+def _sin_solver(**kwargs):
+    """A 9-segment 5 m dipole on plain SinusoidalSolver, fed at its centre."""
+    import numpy as np
+    from momwire import SinusoidalSolver
+
+    return SinusoidalSolver(
+        wires=[np.array([[0.0, 0.0, -2.5], [0.0, 0.0, 2.5]])],
+        n_per_edge_per_wire=[[9]],
+        feeds=[(0, 2.5, 1.0)],
+        wavelength=nec_portal.C_LIGHT / 14.0e6,
+        wire_radius=0.001,
+        **kwargs,
+    )
+
+
+def test_the_sinusoidal_shim_reproduces_momwires_own_y_matrix():
+    import numpy as np
+
+    y_shim, _x = nec_portal._y_and_port_coeffs(_sin_solver())
+    y_lib = np.asarray(_sin_solver().compute_y_matrix(), dtype=np.complex128)
+    assert np.allclose(y_shim, y_lib, rtol=1e-10, atol=0.0)
+
+
+def test_the_sinusoidal_shim_columns_are_the_one_volt_drive_coefficients():
+    """Column j of X must be the solve momwire would do for a 1 V drive at
+    port j — that identity is what lets `solve_group` reuse one fill for
+    every excitation (``coeffs = X @ V``)."""
+    import numpy as np
+
+    _y, x = nec_portal._y_and_port_coeffs(_sin_solver())
+    _z, alpha = _sin_solver().compute_impedance()
+    driven = x @ np.array([1.0 + 0.0j])
+    assert np.allclose(driven, alpha, rtol=1e-10, atol=0.0)
+
+
+# The classes that exercise everything the shim's coefficients feed: a
+# Sommerfeld and a two-medium ground (solver-name-gated in engines/momwire.py),
+# both network branch types, a lumped load (power budget), the PT/YY readout,
+# and a pattern (which resamples the solved current through
+# `currents_at_knots`).
+_SIN_HARD_FIXTURES = (
+    "dipole_sommerfeld_ground",
+    "dipole_gd_second_medium",
+    "dipole_tl_network",
+    "dipole_nt_network",
+    "dipole_load_ld4",
+    "dipole_pt_toggle",
+    "dipole_rp_pattern",
+)
+
+
+def _aip_rows(text: str) -> list[list[float]]:
+    """Every ANTENNA INPUT PARAMETERS data row, as floats past the tag/seg
+    pair."""
+    rows, inside = [], False
+    for line in text.splitlines():
+        if line.strip(" -") == "ANTENNA INPUT PARAMETERS":
+            inside = True
+            continue
+        if not inside:
+            continue
+        tokens = line.split()
+        if len(tokens) == 11 and tokens[0].isdigit() and tokens[1].isdigit():
+            rows.append([float(t) for t in tokens[2:]])
+        elif rows and not line.strip():
+            inside = False
+    return rows
+
+
+@pytest.mark.parametrize("name", _SIN_HARD_FIXTURES)
+def test_sinusoidal_basis_answers_the_hard_fixture_classes(name):
+    import math
+
+    deck = (FIXTURE_DIR / f"{name}.deck").read_text()
+    rc, out, err = _run_main(["--basis", "sinusoidal"], deck=deck)
+    assert rc == 0 and err == ""
+    assert "ERROR-NEC2C" not in out, f"{name} took the error path under +sin"
+    missing = set(section_walk(fixture_out(name))) - set(section_walk(out))
+    assert not missing, f"{name} lost sections under +sin: {sorted(missing)}"
+    rows = _aip_rows(out)
+    assert rows, f"no AIP data row for {name} under +sin"
+    assert all(math.isfinite(v) for row in rows for v in row), (
+        f"non-finite AIP value for {name} under +sin"
+    )
+
+
+def test_sinusoidal_basis_impedance_tracks_the_nec2c_fixture():
+    """The point-matched sinusoidal basis is the closest of the roster to
+    NEC-2's own formulation, so the free-space dipole's driving-point
+    impedance has to sit near the oracle's — a looser bound than a digit
+    match, but tight enough to catch a wrong RHS scaling or a dropped
+    ``-1/h``."""
+    deck = (FIXTURE_DIR / "dipole_free_space.deck").read_text()
+    rc, out, err = _run_main(["--basis", "sinusoidal"], deck=deck)
+    assert rc == 0 and err == ""
+    ours = complex(*_aip_rows(out)[0][4:6])
+    theirs = complex(*_aip_rows(fixture_out("dipole_free_space"))[0][4:6])
+    assert abs(ours - theirs) / abs(theirs) < 0.05, f"{ours} vs {theirs}"
+
+
+def test_sinusoidal_basis_stamps_the_banner():
+    deck = (
+        "CE basis\n"
+        "GW 1 11 0. -5. 10. 0. 5. 10. 0.001\n"
+        "GE 0\nEX 0 1 6 0 1.\nFR 0 1 0 0 14.0 1\nXQ\nNX\n"
+    )
+    rc, out, err = _run_main(["--basis", "sinusoidal"], deck=deck)
+    assert rc == 0 and err == ""
+    assert "VERSION:nec2c.ae6ty.momwire.9.1+sin" in out
+    assert _aip_rows(out)
+
+
+def test_sinusoidal_has_no_converged_variant():
+    """The zero-width point gap has no collocation RHS (momwire#212), so the
+    flag must not offer a name the solver would refuse — same constraint the
+    CLI's MOMWIRE_BASIS_VARIANTS records."""
+    rc, out, _ = _run_main(["--basis", "sinusoidal-converged", "-version"])
+    assert rc == 3 and "sinusoidal-converged" not in out.split("choices:")[1]


### PR DESCRIPTION
Closes #822.

Bare point-matched sinusoidal joins the SimNEC portal's `--basis` roster, completing the comparison ladder: NEC-2 itself → NEC-like momwire (`sinusoidal`, `+sin` banner) → Galerkin (`+sg`/`+sgc`) → B-spline (default). The one-fill shim `_y_and_port_coeffs` gains a third branch reproducing `SinusoidalSolver.compute_y_matrix`'s algebra verbatim (−1/h delta-gap RHS, `_feed_segment_current` readout), and the dispatch is re-keyed on the port algebra each family actually owns (`_assemble_Z_ported` → Galerkin, `_solve_with_kcl_ports` → B-spline spy, neither → point-matched) instead of the old two-way hasattr that would have misrouted this solver. No `sinusoidal-converged` twin, on purpose: the zero-width point gap has no collocation RHS (momwire#212) — a test pins that the name is not offered.

## Gates (measured)
- Shim vs `compute_y_matrix`: Y bit-identical (max rel err 0.0); `X @ [1V]` vs `compute_impedance`'s alpha: 1.68e-16.
- Seven hard fixture classes under `--basis sinusoidal` (Sommerfeld + GD grounds, TL, NT, LD4, PT/YY, RP): rc 0, quiet stderr, no lost printout sections, finite AIP rows.
- Numeric anchor, `dipole_free_space`: 79.205+j45.150 vs nec2c fixture 79.240+j45.364 → **0.24%** (default B-spline is 0.70% — sinusoidal is ~3× closer to the oracle, as the formulation predicts).
- Disabled-path probe (reviewer-added): the `+sin` answer must differ from the default basis's (measured 1.0% apart) — without it, every other test also passes if the `_BASES` entry silently serves the default solver.
- `--selftest`: 11 checks PASS (alt-basis loop now covers `+sgc` and `+sin`).
- Banner `+sin`; `-version` probe line unchanged; unknown-basis fail-fast and default banner pinned unchanged.
- Full suite: **4297 passed, 2 skipped** (main is 4287; +13 tests here), ruff clean.

## Review notes
Implemented by a delegated opus builder; reviewed by the session model (Fable). Independently verified: the full diff; the shim algebra against `momwire/src/momwire/sinusoidal.py:1898` line by line (RHS scaling, solve, Y index order); the junction claim (`SinusoidalSolver._reject_junction_ports` raises at construction, momwire#177, Galerkin overrides at solve time — so no refusal call belongs in this branch); `wire_loss_power`/`currents_at_knots` signatures on the point-matched solver; selftest re-run and full suite re-run on this box. The disabled-path probe commit (0876152) is the reviewer's.

Note for momwire#232: the portal now carries **three** verbatim copies of momwire-private port algebra. The two shim tests here are the tripwire if `compute_y_matrix` and the daemon's fill ever drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvF4yHgNxjhyZ7P286g3z8