### PR TITLE
fix(nec_portal): trip SimNEC's NEC ERROR (1) warning frame on every refusal

### DIFF
--- a/site/src/content/docs/reference/simnec.md
+++ b/site/src/content/docs/reference/simnec.md
@@ -237,6 +237,14 @@ sentinel that SimNEC blocks in `readLine()` waiting for. (An engine that dies
 or forgets the sentinel hangs SimNEC's UI with no timeout, which is strictly
 worse than an error message.) The daemon survives it and runs the next deck.
 
+The refusal leads with a line whose first word is exactly `ERROR:` — that is
+what trips SimNEC's own `"NEC ERROR (1)"` warning frame, so a refused deck
+shows up as a visible warning instead of a session that quietly loaded
+nothing. (Earlier builds used a differently-shaped prefix specifically to
+avoid tripping that frame; issue #829 reversed that on Ward's own say-so
+after a live session hit it — a refused patch-antenna design left the user
+staring at an empty result with no indication why.)
+
 Refused today:
 
 - **Surface patches** (`SP`, `SM`) — momwire is a wire solver.

--- a/src/antennaknobs/nec_portal.py
+++ b/src/antennaknobs/nec_portal.py
@@ -384,10 +384,35 @@ _NEAR_FIELD_TIME = "    Near Field Compute Time 0"
 # summed as a finer chain of Hertzian elements.
 _NEAR_FIELD_SUBDIV = 8
 
-# The oracle writes this to both stdout and stderr when its input ends; the
-# grammar doc's error table (§8) makes it the one error shape SimNEC tolerates
-# without tripping the `ERROR:` warning frame (that test is on token 0 alone).
+# Reversed by issue #829 on Ward's explicit sanction (his 2026-08-08 reply):
+# refusals used to hide behind this prefix specifically to AVOID tripping
+# Execute's `"NEC ERROR (1)"` warning frame (grammar doc §8 — the frame fires
+# on token 0 being exactly `ERROR:`, an equality test, not a substring one).
+# Ward said the frame "should be fine" and that he intends to make the reader
+# bail on it, so every refusal now leads with an `_ERROR_TOKEN` line to fire
+# that frame today and anchor his future bail-fix tomorrow. This prefix stays
+# as the line right after it: it is not our own invention but the oracle's
+# own genuine stdin-EOF string (§8, "Oracle-side error strings observed"),
+# so keeping it gives grep a byte-identical, oracle-shaped needle for "this
+# was our engine's refusal" without colliding with the new warning token.
+_ERROR_TOKEN = "ERROR: "
 _ERROR_PREFIX = "ERROR-NEC2C: "
+
+
+def _append_error(out: list[str], exc: BaseException) -> None:
+    """Append the two-line refusal frame and nothing else.
+
+    Line 1 is what SimNEC's ``Execute.processResponse`` keys on — token 0
+    exactly ``ERROR:`` trips the ``"NEC ERROR (1)"`` warning and (today)
+    keeps parsing; Ward's planned reader fix anchors to the same token.
+    Line 2 repeats the message under the oracle's own ``ERROR-NEC2C:``
+    shape for our tests/logs to grep. Every caller still appends the ``NX``
+    echo itself — that sentinel is mandatory on every path, see
+    ``PortalError``'s docstring, or SimNEC blocks in ``readLine()`` forever.
+    """
+    detail = str(exc)
+    out.append(f"{_ERROR_TOKEN}{detail}")
+    out.append(f"{_ERROR_PREFIX}{detail}")
 
 
 class PortalError(Exception):
@@ -2576,7 +2601,7 @@ def render_deck(body: str) -> tuple[list[str], list[str]]:
     try:
         deck = parse_deck(body)
     except PortalError as exc:
-        out.append(f"{_ERROR_PREFIX}{exc}")
+        _append_error(out, exc)
         return out, err
 
     if deck.reduced_field is not None:
@@ -2592,10 +2617,10 @@ def render_deck(body: str) -> tuple[list[str], list[str]]:
     try:
         solver = DeckSolver(deck)
     except PortalError as exc:
-        out.append(f"{_ERROR_PREFIX}{exc}")
+        _append_error(out, exc)
         return out, err
     except (ValueError, np.linalg.LinAlgError) as exc:
-        out.append(f"{_ERROR_PREFIX}{exc}")
+        _append_error(out, exc)
         return out, err
 
     out.append(_STRUCTURE_HEADER)
@@ -2637,7 +2662,7 @@ def render_deck(body: str) -> tuple[list[str], list[str]]:
                     out += ["", ""]
                 out += _run_block(deck, solver, group, freq)
         except (PortalError, ValueError, np.linalg.LinAlgError) as exc:
-            out.append(f"{_ERROR_PREFIX}{exc}")
+            _append_error(out, exc)
         out += ["", "", ""]
     return out, err
 

--- a/tests/test_nec_portal.py
+++ b/tests/test_nec_portal.py
@@ -381,6 +381,14 @@ def test_an_unsupported_card_still_emits_the_sentinel():
     this list (#799 took ``TL``): the portal dialect can carry it, but its
     semantics are NEC-4.2's insulated-wire model, which momwire does not have —
     so it takes the error path rather than silently solving a bare wire.
+
+    Issue #829 (Ward's 2026-08-08 reply): the refusal now leads with an
+    ``ERROR:`` line — token 0 exactly, which is what trips Execute's
+    ``"NEC ERROR (1)"`` warning frame — with the oracle-shaped
+    ``ERROR-NEC2C:`` line kept right after it for grep. Before #829 the
+    prefix was chosen specifically to dodge that frame; Ward has since said
+    the frame "should be fine" and that he intends to make the reader bail
+    on it, so this test now pins the opposite of what it used to.
     """
     out, err = deck_frame(
         "CE insulation\n"
@@ -394,11 +402,85 @@ def test_an_unsupported_card_still_emits_the_sentinel():
     )
     text = "\n".join(out)
     assert NX_ECHO.search(text), "the NX sentinel is missing on the error path"
+    assert "ERROR: IS" in text
     assert "ERROR-NEC2C: IS" in text
-    # `ERROR:` as token 0 is what trips Execute's warning frame; the oracle's
-    # own prefix deliberately does not.
-    assert not any(line.split()[:1] == ["ERROR:"] for line in text.splitlines())
+    assert any(line.split()[:1] == ["ERROR:"] for line in text.splitlines()), (
+        "no line trips Execute's token-0 `ERROR:` warning frame"
+    )
     assert err == []
+
+
+# --------------------------------------------------------------------------
+# issue #829: the `ERROR:` line must trip and ONLY trip on a real refusal
+# --------------------------------------------------------------------------
+
+
+def _first_tokens(text: str) -> list[str]:
+    return [line.split()[0] for line in text.splitlines() if line.split()]
+
+
+@pytest.mark.parametrize("name", ALL_NAMES)
+def test_no_clean_fixture_carries_a_token_0_error_line(name):
+    """The corpus-wide half of the token-0 pin: a healthy deck must never
+    show Execute's warning frame — a stray ``ERROR:`` on a clean run would be
+    a false alarm in the SimNEC UI.
+
+    Walked against the committed oracle ``.out`` bytes themselves, not our
+    own printout, because that is the file most exposed to accidental
+    real-string drift (e.g. a future oracle capture, a hand edit) and the one
+    a corpus-wide gate is for. The oracle's own literal ``ERROR-NEC2C:``
+    stdin-EOF string (grammar doc §8) is a DIFFERENT token — it never
+    collides with ``ERROR:`` — which is exactly why that shape was safe to
+    reuse here.
+    """
+    assert "ERROR:" not in _first_tokens(fixture_out(name)), (
+        f"{name}: a clean oracle fixture carries a token-0 `ERROR:` line"
+    )
+
+
+@pytest.mark.parametrize("name", REPRESENTATIVE)
+def test_no_clean_regenerated_printout_carries_a_token_0_error_line(name):
+    """Same pin, our side: a handful of clean decks run back through this
+    engine must not produce the warning frame either."""
+    assert "ERROR:" not in _first_tokens(printout(name)), (
+        f"{name}: our own clean printout carries a token-0 `ERROR:` line"
+    )
+
+
+def test_patch_antenna_refusal_shows_why_nothing_loaded():
+    """Stand-in for the issue's live-session gate (no SimNEC on this box).
+
+    The live case (issue #829) was an EZNEC patch-antenna design: SimNEC
+    forwarded an ``SP``/``SM`` surface-patch deck, the daemon refused it
+    silently under the pre-#829 ``ERROR-NEC2C:``-only shape, and the user was
+    left staring at an empty session with no indication why. This synthesizes
+    the same refusal class — ``SP`` — through ``main`` exactly as the daemon
+    receives it on stdin, and pins the three things that scenario needs:
+    the deck exits cleanly (rc 0, daemon stays resident — no reason for a
+    live session to die over one bad deck), the refusal names the offending
+    card, and the ``ERROR:`` token-0 line is present to trip SimNEC's own
+    warning frame instead of leaving the UI blank.
+    """
+    deck = (
+        "CE patch antenna\n"
+        "GW 1 9 0. 0. -2.5 0. 0. 2.5 0.001\n"
+        "GE 0\n"
+        "EX 0 1 5 0 1.\n"
+        "SP 0 0 0. 0. 0. 0. 0. 1.\n"
+        "FR 0 1 0 0 30. 0\n"
+        "XQ\nNX\n"
+    )
+    rc, out, err = _run_main([], deck=deck)
+    assert rc == 0, "the daemon must exit cleanly, not die on the bad deck"
+    assert err == ""
+    error_lines = [ln for ln in out.splitlines() if ln.split()[:1] == ["ERROR:"]]
+    assert error_lines, "no token-0 `ERROR:` line — the user sees nothing again"
+    assert "SP" in error_lines[0], f"the refusal does not name SP: {error_lines[0]!r}"
+    assert NX_ECHO.search(out), "no NX sentinel on the error path"
+    # Follow-up: re-run this scenario against a live SimNEC session on the
+    # Windows box once Ward ships his reader bail-fix, to confirm the frame
+    # actually surfaces to the user end to end (tracked as a note in #829,
+    # not re-testable here — no SimNEC install on this machine).
 
 
 # --------------------------------------------------------------------------
@@ -1452,6 +1534,9 @@ def test_the_rp_modes_that_would_use_a_gd_are_still_refused():
     the deck shapes where ``GD`` is inert are the shapes this engine runs,
     and the shapes where it is not are refused by name (issue #802) — this
     engine can never be asked a cliff question and answer it as flat ground.
+
+    Issue #829: every refused mode must also lead with a token-0 ``ERROR:``
+    line so SimNEC's ``"NEC ERROR (1)"`` warning frame fires.
     """
     head = (
         "CE gd cliff pattern\nGW 1 9 0. 0. 0.5 0. 0. 5.0 0.001\nGE 1\n"
@@ -1462,6 +1547,7 @@ def test_the_rp_modes_that_would_use_a_gd_are_still_refused():
         text = run_deck(head + f"RP {mode} 3 3 1001 0 0 30 30 1000\nXQ\n")[0]
         assert f"RP mode {mode} is not supported" in text, mode
         assert NX_ECHO.search(text), mode
+        assert any(line.split()[:1] == ["ERROR:"] for line in text.splitlines()), mode
     # ...and the mode SimNEC actually writes runs, second medium or not.
     text = run_deck(head + "RP 0 3 3 1001 0 0 30 30 1000\nXQ\n")[0]
     assert "ERROR-NEC2C" not in text
@@ -1541,15 +1627,21 @@ def test_a_bad_deck_reports_and_still_emits_the_sentinel(label, case):
     (grammar doc §2, §10.1). A replacement engine that dies, or that reports
     an error and forgets the sentinel, hangs the SimNEC UI rather than showing
     a message — which is strictly worse than a wrong answer.
+
+    Issue #829 (Ward's 2026-08-08 reply): every refusal now also trips
+    Execute's ``"NEC ERROR (1)"`` warning frame on purpose (token 0 exactly
+    ``ERROR:``), so the user sees *why* nothing loaded instead of staring at
+    a session that looks like it just did nothing. That used to be exactly
+    what this test forbade; #829 reverses the call.
     """
     deck, marker = case
     out, err = deck_frame(deck)
     text = "\n".join(out)
     assert NX_ECHO.search(text), f"{label}: no NX sentinel"
     assert marker in text, f"{label}: error does not mention {marker!r}:\n{text[-500:]}"
-    # `ERROR:` as token 0 is what trips Execute's warning frame; the oracle's
-    # own prefix deliberately does not.
-    assert not any(line.split()[:1] == ["ERROR:"] for line in text.splitlines())
+    assert any(line.split()[:1] == ["ERROR:"] for line in text.splitlines()), (
+        f"{label}: no line trips Execute's token-0 `ERROR:` warning frame"
+    )
     assert err == []
 
 

--- a/tests/test_nec_portal_differential.py
+++ b/tests/test_nec_portal_differential.py
@@ -390,11 +390,26 @@ def test_unsupported_cards_take_the_documented_error_path(marker, deck):
     The oracle's own failure mode for one of these (GN 2 + radials) is to stop
     printing entirely — no NX echo, so ``Execute.processResponse`` blocks in
     ``readLine()`` forever. This engine must not inherit that.
+
+    Issue #829 (Ward's 2026-08-08 reply) added a second requirement across
+    this same class: the refusal must also lead with a line whose first
+    token is exactly ``ERROR:`` — an equality test on token 0, not a
+    substring one — because that is what trips ``Execute``'s
+    ``"NEC ERROR (1)"`` warning frame and is what Ward's planned reader
+    fix will anchor to. The oracle-shaped ``ERROR-NEC2C:`` line stays right
+    behind it, for grep.
     """
     text = run_deck(deck)[0]
     assert "ERROR-NEC2C: " in text
     assert marker in text, f"the error does not name {marker!r}:\n{text[-400:]}"
     assert NX_ECHO.search(text), "no NX sentinel on the error path"
+    error_lines = [ln for ln in text.splitlines() if ln.split()[:1] == ["ERROR:"]]
+    assert error_lines, (
+        f"no line trips Execute's token-0 `ERROR:` warning frame:\n{text[-400:]}"
+    )
+    assert marker in error_lines[0], (
+        f"the `ERROR:` line does not name {marker!r}: {error_lines[0]!r}"
+    )
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Closes #829.

Every refusal from the portal daemon now leads with a line whose first token is exactly `ERROR:` — the equality test `Execute.processResponse` keys the "NEC ERROR (1)" warning frame on (grammar survey §8) — followed by the oracle-shaped `ERROR-NEC2C:` detail line, with the NX sentinel invariant untouched. This reverses a deliberate pre-#829 choice (the old prefix was picked specifically to *dodge* the frame); Ward sanctioned the reversal in his 2026-08-08 reply and intends to anchor his reader bail-fix to the same token. The four hand-formatted refusal sites now share one `_append_error` helper, and the comment at the prefix definition records the reversal honestly.

## Gates (measured)
- Every refusal class (unsupported card, RP modes 1–6, spherical NE, GN radial screen, bad decks) emits the token-0 `ERROR:` line naming the offending card, keeps the NX echo, and leaves the daemon resident (rc 0) — parametrized across the differential suite's synthesized decks.
- Two-sided token pin: a corpus-wide scan proves **zero** token-0 `ERROR:` lines across all 36 committed oracle fixtures and across our regenerated clean printouts — the frame cannot false-alarm on a healthy deck. (The oracle's own `ERROR-NEC2C:` stdin-EOF string tokenizes differently, which is exactly why that shape was safe to keep as the detail line.)
- Patch-antenna stand-in test reproduces the live failure case (SP deck → visible `ERROR: SP …` + sentinel + clean exit) — the scenario that previously left the user staring at nothing.
- Targeted suites: 736 → 784 passed (+48). Full suite: **4360 passed, 2 skipped**. Selftest 12/12 unchanged. ruff clean.
- Site docs updated (refusal-convention section).

## Review notes
Implemented by a delegated sonnet builder; reviewed by the session model (Fable). Independently verified: the full diff; the token-equality semantics against the Execute grammar survey; a live end-to-end run of the SP refusal on this box reproducing the exact two-line shape; full suite re-run. Follow-up carried in the test comments: confirm the frame surfaces in SimNEC's UI on the next live Windows session, ideally after Ward ships his reader bail-fix.

**Merge note**: trivially conflicts with #830's PR in `tests/test_nec_portal.py` (both append test sections) — merge either first; I'll rebase the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvF4yHgNxjhyZ7P286g3z8