### PR TITLE
feat(nec_portal): --basis hmatrix and arrayblock — the large-array accelerators

### DIFF
--- a/site/src/content/docs/reference/simnec.md
+++ b/site/src/content/docs/reference/simnec.md
@@ -186,6 +186,8 @@ momwire-nec2c --basis bspline-d1                     # degree 1 (tent basis) —
 momwire-nec2c --basis sinusoidal                     # closest to NEC-2's own formulation
 momwire-nec2c --basis sinusoidal-galerkin            # the same basis, tested variationally
 momwire-nec2c --basis sinusoidal-galerkin-converged  # recommended for near-open high-Q feeds
+momwire-nec2c --basis hmatrix                        # same physics, hierarchical (ACA) solve
+momwire-nec2c --basis arrayblock                     # same physics, element-block/FFT solve — large arrays
 ```
 
 Four of those are a ladder: NEC-2 itself, then `sinusoidal` — the three-term
@@ -196,7 +198,15 @@ basis say". There is no `sinusoidal-converged`: a zero-width gap cannot be
 expressed under point matching (momwire#212), and the flag does not offer a
 name the solver would refuse. `bspline-d1` sits on a different axis — the
 same B-spline physics at degree 1, so pairing it with the default is the
-cheapest d1-vs-d2 convergence check a SimNEC user can run.
+cheapest d1-vs-d2 convergence check a SimNEC user can run. `hmatrix` and
+`arrayblock` are another axis again — not different physics but a different
+*solve*: the same B-spline operator held compressed and solved iteratively, so
+a large array answers without a dense fill. `arrayblock` is the one to reach
+for on a repeated-element array (identical elements on a regular lattice
+become an FFT convolution over the element grid); it degrades to `hmatrix`'s
+hierarchical solve on a deck with no repeated structure, so it is safe to
+leave on. Their answers should match `bspline`'s — if they do not, the deck is
+telling you something about conditioning, not about basis choice.
 
 **Paste two portal entries that differ only in `--basis` and you have
 cross-basis validation inside SimNEC itself** — switch engines from the

--- a/src/antennaknobs/nec_portal.py
+++ b/src/antennaknobs/nec_portal.py
@@ -85,7 +85,13 @@ from dataclasses import dataclass, field
 from types import MappingProxyType
 
 import numpy as np
-from momwire import BSplineSolver, SinusoidalGalerkinSolver, SinusoidalSolver
+from momwire import (
+    ArrayBlockSolver,
+    BSplineSolver,
+    HMatrixSolver,
+    SinusoidalGalerkinSolver,
+    SinusoidalSolver,
+)
 
 
 from .builder import AntennaBuilder
@@ -110,9 +116,22 @@ from .network_reduce import SingularNetworkError, tl_admittance_2x2
 # `bspline-d1` (issue #821) is the degree axis instead: same BSplineSolver
 # class as `bspline`, degree=1 bound — a d1-vs-d2 convergence check a SimNEC
 # user can run as two portal entries, zero new physics.
+# `hmatrix` and `arrayblock` (issue #830, on Ward's ask for large arrays) are
+# a third axis again: the SAME B-spline physics as `bspline`, solved by an
+# accelerated operator instead of a dense fill — hierarchical ACA compression
+# for `hmatrix`, and for `arrayblock` the element-aware block decomposition
+# that becomes an FFT convolution over a regular same-shape lattice. Neither
+# is a fidelity choice, so neither has a `-converged` twin and neither can be
+# read against `bspline` as a physics A/B: they answer "can this deck be
+# solved at array scale", and their answers must AGREE with `bspline` to the
+# iterative solve tolerance. `arrayblock` degrades to the parent H-matrix on
+# a deck with no repeated-block structure (momwire#143 `_degenerate_partition`)
+# rather than refusing, so both entries are safe on arbitrary decks.
 _BASES = {
     "bspline": (BSplineSolver, {}, ""),
     "bspline-d1": (BSplineSolver, {"degree": 1}, "+bs1"),
+    "hmatrix": (HMatrixSolver, {}, "+hm"),
+    "arrayblock": (ArrayBlockSolver, {}, "+ab"),
     "sinusoidal": (SinusoidalSolver, {}, "+sin"),
     "sinusoidal-galerkin": (SinusoidalGalerkinSolver, {}, "+sg"),
     "sinusoidal-galerkin-converged": (
@@ -1479,7 +1498,9 @@ def _y_and_port_coeffs(solver):
     The three branches are keyed on the port algebra each family owns, not on
     the class: ``_assemble_Z_ported`` exists only on the Galerkin subclass and
     ``_solve_with_kcl_ports`` only on the B-spline family, so a basis added to
-    ``_BASES`` lands on the branch whose algebra it actually has.
+    ``_BASES`` lands on the branch whose algebra it actually has. Inside the
+    B-spline branch the same rule picks the SOLVE: the accelerated subclasses
+    own ``_solve_hmatrix``, so that is what gets spied for them.
     """
     if hasattr(solver, "_assemble_Z_ported"):
         # Sinusoidal-Galerkin family: no KCL-port solve to spy on, but
@@ -1536,22 +1557,54 @@ def _y_and_port_coeffs(solver):
         )
         return y, alphas
 
+    # B-spline family, and TWO solve routes to spy on (issue #830). The dense
+    # path back-substitutes in `_solve_with_kcl_ports`. The accelerated
+    # subclasses — HMatrixSolver and ArrayBlockSolver, both `_BASES` entries —
+    # never reach it: their `compute_y_matrix` builds the same source columns
+    # B and runs the constrained block-GMRES in `_solve_hmatrix`, returning
+    # ``Bᵀ·X`` and dropping X on the floor exactly as the dense path does.
+    # ``_solve_hmatrix``'s X is the same object under the same convention —
+    # (n_basis, n_ports), Lagrange rows already stripped — so the two captures
+    # are interchangeable downstream.
+    #
+    # Which route runs is `_hmatrix_unsupported()`, i.e. singular enrichment
+    # ONLY (momwire hmatrix.py / array_block.py): mesh size does not select it,
+    # and every ground model the portal can emit — PEC image, reflection
+    # coefficient, Sommerfeld — is carried on the accelerated path. The portal
+    # never asks for enrichment, so in practice the accelerated bases always
+    # take `_solve_hmatrix`; the dense capture stays wired anyway so a momwire
+    # that grows a new fallback degrades to a slower answer, not an error.
     captured: dict[str, np.ndarray] = {}
-    original = solver._solve_with_kcl_ports
+    dense = solver._solve_with_kcl_ports
 
-    def spy(z, v, kcl_a, overwrite=False):
-        x = original(z, v, kcl_a, overwrite=overwrite)
-        captured["X"] = x
+    def spy_dense(z, v, kcl_a, overwrite=False):
+        x = dense(z, v, kcl_a, overwrite=overwrite)
+        captured["dense"] = x
         return x
 
-    solver._solve_with_kcl_ports = spy
+    solver._solve_with_kcl_ports = spy_dense
+    accel = getattr(solver, "_solve_hmatrix", None)
+    if accel is not None:
+
+        def spy_accel(h, kcl_a, b):
+            x = accel(h, kcl_a, b)
+            captured["accel"] = x
+            return x
+
+        solver._solve_hmatrix = spy_accel
     try:
         y = np.asarray(solver.compute_y_matrix(), dtype=np.complex128)
     finally:
         del solver._solve_with_kcl_ports
-    if "X" not in captured:  # pragma: no cover - momwire internals moved
+        if accel is not None:
+            del solver._solve_hmatrix
+    # Accelerated first: a solve that reached `_solve_hmatrix` never touched
+    # the dense route, so the two keys are mutually exclusive in practice and
+    # the preference only decides a hypothetical future hybrid.
+    x = captured.get("accel", captured.get("dense"))
+    if x is None:  # pragma: no cover - momwire internals moved
         raise PortalError("momwire did not expose the per-port solution")
-    return y, captured["X"]
+    return y, x
 
 
 def _synthesize_union_deck(deck: PortalDeck, ports: list[tuple[int, int]]) -> str:
@@ -2772,10 +2825,18 @@ def _selftest(stdout) -> int:
         "TL network row present": "STRAIGHT" in proc.stdout,
         "stderr quiet": proc.stderr.strip() == "",
     }
+    # One deck per alternate basis: the point is that the entry is wired and
+    # answers on THIS box, not that it is fast or converged. The selftest deck
+    # is a single small dipole, which for `hmatrix`/`arrayblock` means a
+    # near-field-only operator and (for arrayblock) a degenerate element
+    # partition that degrades to the parent — the graceful-degradation path,
+    # which is exactly the one a smoke test wants to prove never raises.
     for basis, suffix in (
         ("sinusoidal-galerkin-converged", "+sgc"),
         ("sinusoidal", "+sin"),
         ("bspline-d1", "+bs1"),
+        ("hmatrix", "+hm"),
+        ("arrayblock", "+ab"),
     ):
         alt = subprocess.run(
             [sys.executable, "-m", "antennaknobs.nec_portal", "--basis", basis],

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -241,8 +241,10 @@ _BACKENDS: tuple[_BackendSpec, ...] = (
     ),
     # Hierarchical (H-matrix / ACA) accelerator — same B-spline basis as
     # bspline; model_options forward verbatim (degree, aca_eta,
-    # aca_leaf_size, aca_tol, solve_tol, …). Ground/enrichment fall back to
-    # the dense bspline solve inside HMatrixSolver.
+    # aca_leaf_size, aca_tol, solve_tol, …). Only singular enrichment falls
+    # back to the dense bspline solve inside HMatrixSolver
+    # (`_hmatrix_unsupported`); every ground model — PEC image, reflection
+    # coefficient, Sommerfeld — rides the accelerated path (measured, #830).
     _BackendSpec(
         name="hmatrix",
         label="H-matrix (ACA)",

--- a/tests/test_nec_portal.py
+++ b/tests/test_nec_portal.py
@@ -2074,3 +2074,261 @@ def test_bspline_d1_answer_differs_from_the_default_degree():
     x_d1 = float(aip_tables(out_d1)[0][0][7])
     x_d2 = float(aip_tables(out_d2)[0][0][7])
     assert abs(x_d1 - x_d2) / abs(x_d2) > 0.05, (x_d1, x_d2)
+
+
+# --- hmatrix / arrayblock (issue #830): the large-array accelerators --------
+
+# These two entries are NOT a physics axis: HMatrixSolver and ArrayBlockSolver
+# are BSplineSolver subclasses that solve the SAME operator with a compressed
+# representation and GMRES instead of a dense fill and an LU. That makes the
+# roster's usual disabled-path probe (differ-from-default) useless — a silent
+# collapse to plain `bspline` would print the same digits — so the armour here
+# is two-sided: the printout must AGREE with the default basis, and a spy must
+# see the accelerated solve actually run.
+
+
+def _accel_pair(cls, volts=(1.0, 0.0), **kwargs):
+    """Two 9-segment 5 m dipoles 3 m apart, both centre-fed — a two-port
+    structure small enough to solve densely for comparison."""
+    import numpy as np
+
+    return cls(
+        wires=[
+            np.array([[0.0, 0.0, -2.5], [0.0, 0.0, 2.5]]),
+            np.array([[3.0, 0.0, -2.5], [3.0, 0.0, 2.5]]),
+        ],
+        n_per_edge_per_wire=[[9], [9]],
+        feeds=[(0, 2.5, volts[0]), (1, 2.5, volts[1])],
+        wavelength=nec_portal.C_LIGHT / 14.0e6,
+        wire_radius=0.001,
+        **kwargs,
+    )
+
+
+def _route_spy(solver):
+    """Record which of the two B-spline solve routes momwire takes, without
+    disturbing either. Installed BEFORE the shim, so the shim wraps these and
+    its own ``del`` on the instance attribute tidies them away."""
+    routes: list[str] = []
+    dense = solver._solve_with_kcl_ports
+
+    def spy_dense(z, v, kcl_a, overwrite=False):
+        routes.append("dense")
+        return dense(z, v, kcl_a, overwrite=overwrite)
+
+    solver._solve_with_kcl_ports = spy_dense
+    accel = getattr(solver, "_solve_hmatrix", None)
+    if accel is not None:
+
+        def spy_accel(h, kcl_a, b):
+            routes.append(f"accel:{type(h).__name__}")
+            return accel(h, kcl_a, b)
+
+        solver._solve_hmatrix = spy_accel
+    return routes
+
+
+def _accel_classes():
+    from momwire import ArrayBlockSolver, HMatrixSolver
+
+    return {"hmatrix": HMatrixSolver, "arrayblock": ArrayBlockSolver}
+
+
+@pytest.mark.parametrize("basis", ["hmatrix", "arrayblock"])
+def test_the_accelerated_shim_reproduces_momwires_own_y_matrix(basis):
+    """The accelerated subclasses never reach `_solve_with_kcl_ports` — their
+    `compute_y_matrix` runs the constrained GMRES in `_solve_hmatrix` — so the
+    shim spies that instead, and the Y it hands back has to be the library's
+    own to the iterative tolerance."""
+    import numpy as np
+
+    cls = _accel_classes()[basis]
+    y_shim, _x = nec_portal._y_and_port_coeffs(_accel_pair(cls))
+    y_lib = np.asarray(_accel_pair(cls).compute_y_matrix(), dtype=np.complex128)
+    assert np.allclose(y_shim, y_lib, rtol=1e-8, atol=0.0)
+
+
+@pytest.mark.parametrize("basis", ["hmatrix", "arrayblock"])
+def test_the_accelerated_shim_captures_the_gmres_solve_not_a_dense_fallback(basis):
+    """The one thing no printout test can see: WHICH solve answered. Without
+    it, `_BASES` could name the accelerated class while every deck quietly
+    took the dense path (`_hmatrix_unsupported`) and nothing would fail."""
+    cls = _accel_classes()[basis]
+    solver = _accel_pair(cls)
+    assert not solver._hmatrix_unsupported()
+    routes = _route_spy(solver)
+    _y, x = nec_portal._y_and_port_coeffs(solver)
+    assert routes and all(r.startswith("accel:") for r in routes), routes
+    assert x.shape[1] == 2
+
+
+@pytest.mark.parametrize("basis", ["hmatrix", "arrayblock"])
+def test_the_accelerated_shim_columns_are_the_one_volt_drive_coefficients(basis):
+    """Column j of X must be the coefficients momwire would solve for a 1 V
+    drive at port j and nothing else on — the identity `solve_group` leans on
+    when it turns one fill into every excitation (``coeffs = X @ V``). Checked
+    against the DENSE B-spline solve of the same mesh, which is the answer the
+    accelerator approximates (measured max relative deviation 8e-16 for
+    hmatrix, 2e-11 for arrayblock, both far inside the 1e-6 solve_tol)."""
+    import numpy as np
+    from momwire import BSplineSolver
+
+    cls = _accel_classes()[basis]
+    _y, x = nec_portal._y_and_port_coeffs(_accel_pair(cls))
+    for j, volts in enumerate([(1.0, 0.0), (0.0, 1.0)]):
+        _z, alpha = _accel_pair(BSplineSolver, volts=volts).compute_impedance()
+        assert np.allclose(x[:, j], alpha, rtol=1e-6, atol=1e-9 * np.abs(alpha).max())
+
+
+def test_the_dense_fallback_route_is_still_captured():
+    """`_hmatrix_unsupported()` is singular enrichment and nothing else — not
+    mesh size, not ground — so this is the ONLY way to reach the dense path on
+    an accelerated class. The portal never asks for enrichment, but the shim
+    keeps the dense spy wired so a momwire that grows a new fallback degrades
+    to a slower answer rather than a `PortalError`."""
+    import numpy as np
+    from momwire import HMatrixSolver
+
+    solver = _accel_pair(HMatrixSolver, use_singular_enrichment=True)
+    assert solver._hmatrix_unsupported()
+    routes = _route_spy(solver)
+    y_shim, x = nec_portal._y_and_port_coeffs(solver)
+    assert routes == ["dense"], routes
+    y_lib = np.asarray(
+        _accel_pair(HMatrixSolver, use_singular_enrichment=True).compute_y_matrix(),
+        dtype=np.complex128,
+    )
+    assert np.allclose(y_shim, y_lib, rtol=1e-8, atol=0.0)
+    assert x.shape == (18, 2)
+
+
+# The seven classes the roster gates on (#826/#827): a Sommerfeld and a
+# two-medium ground, both network branch types, a lumped load, the PT/YY
+# readout, and a pattern. MEASURED: all seven take the ACCELERATED route under
+# both bases — the ground decks included, because `_hmatrix_unsupported()`
+# tests only `use_singular_enrichment` and every ground model the portal emits
+# (PEC image, reflection coefficient, Sommerfeld) is carried on the fast path.
+# No fixture class reaches the dense fallback.
+_ACCEL_HARD_FIXTURES = (
+    "dipole_sommerfeld_ground",
+    "dipole_gd_second_medium",
+    "dipole_tl_network",
+    "dipole_nt_network",
+    "dipole_load_ld4",
+    "dipole_pt_toggle",
+    "dipole_rp_pattern",
+)
+
+
+@pytest.mark.parametrize("basis", ["hmatrix", "arrayblock"])
+@pytest.mark.parametrize("name", _ACCEL_HARD_FIXTURES)
+def test_the_accelerators_answer_the_hard_fixture_classes(name, basis):
+    rc, out, err = _run_main(["--basis", basis], deck=fixture_deck(name) + "\nNX\n")
+    assert rc == 0 and err == ""
+    assert "ERROR-NEC2C" not in out, f"{name} took the error path under {basis}"
+    missing = set(section_walk(fixture_out(name))) - set(section_walk(out))
+    assert not missing, f"{name} lost sections under {basis}: {sorted(missing)}"
+    tables = aip_tables(out)
+    assert tables and tables[0], f"no AIP data rows for {name} under {basis}"
+    for table in tables:
+        for row in table:
+            for tok in row:
+                assert math.isfinite(float(tok)), f"{name}: non-finite token {tok!r}"
+
+
+@pytest.mark.parametrize("basis", ["hmatrix", "arrayblock"])
+def test_the_accelerators_agree_with_the_default_basis_and_the_oracle(basis):
+    """Agreement, not difference, is the probe here: same physics as
+    `bspline`, so the accelerated answer must land on the default's to the
+    iterative solve tolerance (measured: identical to every printed digit,
+    79.524+46.003j) while still clearing the 5% oracle bound (measured 0.77%
+    from nec2c's 79.240+45.364j). A collapse to a DIFFERENT basis is what this
+    catches; a collapse to dense `bspline` is caught by the spy test above."""
+    deck = fixture_deck("dipole_free_space") + "\nNX\n"
+    rc, out, err = _run_main(["--basis", basis], deck=deck)
+    assert rc == 0 and err == ""
+    _rc, out_default, _err = _run_main([], deck=deck)
+    ours = aip_tables(out)[0][0]
+    theirs = aip_tables(out_default)[0][0]
+    oracle = aip_tables(fixture_out("dipole_free_space"))[0][0]
+    z_ours = complex(float(ours[6]), float(ours[7]))
+    z_default = complex(float(theirs[6]), float(theirs[7]))
+    z_oracle = complex(float(oracle[6]), float(oracle[7]))
+    assert abs(z_ours - z_default) / abs(z_default) < 0.005, (z_ours, z_default)
+    assert abs(z_ours - z_oracle) / abs(z_oracle) < 0.05, (z_ours, z_oracle)
+
+
+@pytest.mark.parametrize("basis,suffix", [("hmatrix", "+hm"), ("arrayblock", "+ab")])
+def test_the_accelerators_stamp_the_banner(basis, suffix):
+    deck = (
+        "CE basis\n"
+        "GW 1 11 0. -5. 10. 0. 5. 10. 0.001\n"
+        "GE 0\nEX 0 1 6 0 1.\nFR 0 1 0 0 14.0 1\nXQ\nNX\n"
+    )
+    rc, out, err = _run_main(["--basis", basis], deck=deck)
+    assert rc == 0 and err == ""
+    assert f"VERSION:nec2c.ae6ty.momwire.9.1{suffix}" in out
+    assert aip_tables(out)[0]
+
+
+@pytest.mark.parametrize("basis", ["hmatrix", "arrayblock"])
+def test_the_accelerators_ride_the_version_probe_unchanged(basis):
+    from antennaknobs.nec_portal import PROBE_VERSION
+
+    rc, out, _err = _run_main(["--basis", basis, "-version"])
+    assert rc == 0 and out == f"{PROBE_VERSION}\n"
+
+
+def test_the_lattice_fft_path_engages_and_the_shim_still_agrees():
+    """The engaged-path probe for `arrayblock`'s reason to exist. A 4x4 grid
+    of identical 3-segment half-wave dipoles meets every FFT gate (one block
+    shape, a regular lattice, P >= 16), and `require_lattice_fft=True` turns a
+    miss into `LatticeFFTUnavailable` naming the unmet gate rather than a
+    silent degradation to the parent H-matrix. The spy then pins that the
+    operator the shim's X came out of really is the spectral one, and the
+    answer is checked against the dense solve of the same mesh.
+
+    Runtime ~0.4 s (48 bases): the lattice gate is about the FFT bookkeeping,
+    not about size, so 16 three-segment elements engage it and this stays a
+    normal-suite test rather than a `heavy_mesh` one."""
+    import numpy as np
+    from momwire import ArrayBlockSolver, BSplineSolver
+
+    wavelength = nec_portal.C_LIGHT / 14.0e6
+    arm = 0.25 * wavelength
+    pitch = 0.5 * wavelength
+    wires = [
+        np.array([[ix * pitch, iy * pitch, -arm], [ix * pitch, iy * pitch, arm]])
+        for ix in range(4)
+        for iy in range(4)
+    ]
+
+    def build(cls, **kwargs):
+        return cls(
+            wires=wires,
+            n_per_edge_per_wire=[[3]] * len(wires),
+            feeds=[(0, arm, 1.0), (5, arm, 0.0)],
+            wavelength=wavelength,
+            wire_radius=0.001,
+            **kwargs,
+        )
+
+    solver = build(ArrayBlockSolver, require_lattice_fft=True)
+    routes = _route_spy(solver)
+    y_fft, x_fft = nec_portal._y_and_port_coeffs(solver)
+    assert routes == ["accel:LatticeArrayBlock"], routes
+
+    y_dense, x_dense = nec_portal._y_and_port_coeffs(build(BSplineSolver))
+    assert np.allclose(y_fft, y_dense, rtol=1e-6, atol=0.0)
+    assert np.allclose(x_fft, x_dense, rtol=1e-5, atol=1e-8 * np.abs(x_dense).max())
+
+
+def test_require_lattice_fft_names_the_unmet_gate_on_a_single_pair():
+    """The other half of the engaged-path proof: on a deck with nothing to
+    exploit the FFT gate is genuinely unmet and momwire says which one — so
+    the passing case above cannot be a vacuous assertion."""
+    from momwire import ArrayBlockSolver, LatticeFFTUnavailable
+
+    solver = _accel_pair(ArrayBlockSolver, require_lattice_fft=True)
+    with pytest.raises(LatticeFFTUnavailable):
+        nec_portal._y_and_port_coeffs(solver)


### PR DESCRIPTION
Closes #830.

`hmatrix` (+hm) and `arrayblock` (+ab) join the portal roster on Ward's explicit interest in large arrays. These are not a physics axis — both are BSplineSolver subclasses solving the same operator through a compressed representation — so the roster's usual differ-from-default probe is replaced by two-sided armor: the printout must *agree* with the default basis, and an instance-level spy must prove the accelerated solve actually ran.

The real work is in the one-fill shim: the accelerated `compute_y_matrix` never reaches `_solve_with_kcl_ports` (it runs the constrained block-GMRES in `_solve_hmatrix` and discards X), so `_y_and_port_coeffs`'s B-spline branch now spies both routes and takes whichever captured — with the dense wire kept so a future momwire fallback degrades to a slower answer, not a `PortalError`. `_solve_hmatrix`'s X is the same `(n_basis, n_ports)` drive matrix (Lagrange rows pre-stripped), so downstream consumers are unchanged.

## Gates (measured)
- Shim vs library: Y at rtol 1e-8 both classes; X columns vs dense drive coefficients 7.6e-16 (hmatrix) / 1.7e-11 (arrayblock). Dense-fallback route covered via `use_singular_enrichment=True` (the only reachable fallback).
- Spy armor: on every solve the captured route is `accel:*` — a silent collapse to dense bspline is now a test failure, not an invisible no-op.
- Seven hard fixture classes × 2 bases: clean, no lost sections, finite AIP rows. **All fourteen take the accelerated route — including every ground model** (PEC image, reflection coefficient, Sommerfeld), because `_hmatrix_unsupported()` is `use_singular_enrichment` and nothing else.
- Agreement probe, dipole_free_space: both accelerators print 79.524+j46.003 — identical to the default basis to every printed digit (bound 0.5%); 0.77% vs the nec2c oracle (bound 5%).
- Lattice-FFT engaged-path proof: 4×4 same-shape dipole lattice with `require_lattice_fft=True` — spy confirms the operator is `LatticeArrayBlock`, Y matches the dense solve at 4.6e-10, 0.42 s in-suite (no heavy_mesh marker needed). A companion test proves `LatticeFFTUnavailable` genuinely fires on a 2-element deck, so the passing assertion isn't vacuous.
- Selftest: 14 checks PASS (`+hm`, `+ab` added to the alt-basis loop). Targeted: 223 → 252 passed (+29). Full suite: **4340 passed** (3 skipped; the third is the known worktree-environment skip). ruff clean. `-version` probe and unknown-basis behavior unchanged.
- Site docs: roster block + an honest paragraph (same physics, different solve; agreement expected).

## Review notes
Implemented by a delegated opus builder; reviewed by the session model (Fable). Independently verified: the full diff; the dual-spy design against `hmatrix.py:1370-1392` (X semantics, route exclusivity, finally-cleanup); `_hmatrix_unsupported()`'s actual coverage against momwire's docstrings; targeted gates, selftest, and full suite re-run. Reviewer commit 4fecbcb: the web adapter's "ground/enrichment fall back to dense" comment was stale on the ground half (this build measured ground riding the fast path) — corrected.

Follow-ups worth filing (not in this PR): a benchmark-script demo of arrayblock vs dense on a genuinely large phased array (test-policy keeps it out of the suite); a momwire#232-class note that the dense path under enrichment + junction would hand the shim an augmented-size X (unreachable from the portal today).

**Merge note**: trivially conflicts with #831 in `tests/test_nec_portal.py` — merge either first; I'll rebase the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvF4yHgNxjhyZ7P286g3z8