### PR TITLE
feat(nec_portal): probe honest identity — NEC2momwire via the versionNECd path

### DIFF
--- a/docs/status/2026-08-08-simnec-execute-grammar.md
+++ b/docs/status/2026-08-08-simnec-execute-grammar.md
@@ -1505,3 +1505,58 @@ were flat — it never gets asked one. A `GD` deck whose `RP` is mode 3, like
 the Cardioid's, still refuses on the `RP`, which is correct until #802 lands.
 
 Corpus 38 -> 40; layout gate 40/40.
+
+---
+
+## Addendum 2026-08-09 — the versionNECd path, traced (issue #828)
+
+Ward's reply (2026-08-08) sanctioned probing as `NEC2text#.#`; a full bytecode
+trace of the 6p4d6 jar (CFR + `javap -c -p`, plus executing the four verbatim
+patterns under Java 21) settled the questions §1 and item 11 left open. The
+portal now probes as `NEC2momwire.<major>.<minor>` (`--legacy-probe` restores
+the old versionA masquerade).
+
+**The versionNECd branch sets no state.** `Execute.testCommand`'s NECd match
+is `setVersion(line); return null` — `Matcher.group` is never invoked
+(offset 436–460: no `group`, no `Double`), so nothing is Double-parsed and
+`minimumNEC2CVersion` (1.23) is read only inside the shared A/B/C branch.
+Case-sensitive, `lookingAt()`-anchored; the character after the digit run
+must be a non-digit (`NEC\d+\D.*`).
+
+**The engine enum comes from the filename alone.** The jar's only
+`putstatic necEngine` is in `NEC2PortalDialog.safeNecCommand()`:
+`indexOf("nec2c")` → `NEC2C`, else `nec5` → `NEC5`, else `nec42` → `NEC42`,
+else the *NO NEC Command Available* refusal. Every daemon choice
+(`Workforce.eval`, `manageCrew`, `NewLocalConsumer.run`) tests
+`necEngine == NECEngine.NEC2C` → `NEC2Daemon` (stdin/stdout NX residency);
+anything else → the file-based `NEC5Daemon`. The probe response cannot reach
+any of it. Enum ctor args decoded: `samplesWidth` (sensor-row token count,
+11 for NEC2C), `samplesOffset` (index of Re(I), 4), `thetaFirst` (NEC4/5
+near-field angular convention, false).
+
+**One consumer parses the stored version text**: `Options.getEngine()`
+(`[a-zA-Z]*([0-9])+?(.*)`) — group(1) must be `"2"` or the scripting layer
+reclassifies the engine (`Insulation`'s `W7EL` gate requires `Complex.TWO`;
+NEC5-only source placements test for 5). `NEC2momwire.…` and
+`nec2c.ae6ty.9.1` both yield `"2"`.
+
+**Where the text surfaces**: the portal dialog's `NECVersion` row, a
+`CM version <text>` comment card `NECSource` prepends to every deck, and the
+saved-circuit XML via `toXMLLikeWorker`.
+
+**Corrections to the body above**:
+- §1's `versionB // <- what we ship` annotation described the *oracle*;
+  `nec_portal.py` shipped versionA's shape (`nec2c.ae6ty.9.1`) through
+  v0.46, and rides versionNECd from #828 on.
+- A first line matching *no* regex is not an error: `testCommand` falls
+  through to `setVersion(rawCommand); return null` — the probe was never
+  load-bearing for acceptance, only a matching-but-unparseable A/B/C tail
+  can refuse.
+- Item 11 (the engine name a replacement may claim) is resolved by the
+  above; the printout banner remains unparsed by the live protocol (the only
+  `NUMERICAL ELECTROMAGNETICS CODE (nec2c)` regex in the jar is
+  `ae6ty/FileStuff`, the offline `.out` import), so `BANNER_VERSION` stays
+  fixture-pinned on purpose.
+- One more filename trap found beside the `nec2c` rule: `testCommand`
+  refuses any command whose full path contains the substring `out`
+  ("Can't execute 'out' file:").

--- a/site/src/content/docs/reference/simnec.md
+++ b/site/src/content/docs/reference/simnec.md
@@ -147,25 +147,32 @@ console script:
 ```bash
 pip install antennaknobs
 which momwire-nec2c          # e.g. ~/.venvs/ak/bin/momwire-nec2c
-momwire-nec2c -version       # nec2c.ae6ty.9.1
+momwire-nec2c -version       # NEC2momwire.<major>.<minor>
 ```
 
 Then open SimNEC's NEC portal dialog and paste that path in as the NEC
 command. Two rules decide whether SimNEC accepts it, and both are worth
 knowing because the failure modes look nothing like their causes:
 
-- **The filename must contain `nec2c`.** SimNEC picks the engine's dialect off
-  the command's file name, lowercased — a name with none of `nec2c` / `nec5` /
-  `nec42` in it is refused outright with *NO NEC Command Available*. That is
-  why the script is called `momwire-nec2c` and not something tidier; if you
-  wrap it in a shell script or a symlink, keep `nec2c` in the name.
-- **The version probe must answer.** SimNEC runs `<command> -version` and reads
-  the first line, which has to be `nec2c.ae6ty.` followed by a plain number it
-  can parse as a decimal. The portal answers `nec2c.ae6ty.9.1`. It cannot say
-  "momwire" there — an extra dot makes the parse fail and SimNEC reports
-  *nec2c version too old* — so the engine puts its real identity in the
-  printout banner instead, where every SimNEC session logs it:
-  `VERSION:nec2c.ae6ty.momwire.9.1`.
+- **The filename must contain `nec2c`.** SimNEC picks the engine — the deck
+  dialect, the daemon protocol, the printout parse offsets, all of it — off
+  the command's file name, lowercased. A name with none of `nec2c` / `nec5` /
+  `nec42` in it is refused outright with *NO NEC Command Available*, and the
+  version probe cannot override the choice. That is why the script is called
+  `momwire-nec2c` and not something tidier; if you wrap it in a shell script
+  or a symlink, keep `nec2c` in the name (and keep the substring `out` out of
+  the path — SimNEC refuses any command path containing it).
+- **The version probe answers with our real name.** SimNEC runs
+  `<command> -version` and reads the first line. The portal answers
+  `NEC2momwire.<major>.<minor>` — SimNEC's own engine-family form, whose
+  `NEC2` prefix declares the deck dialect while leaving the rest of the text
+  free (sanctioned by SimNEC's author). SimNEC shows that string in the
+  portal dialog's NECVersion row, stamps it as a `CM version` comment card on
+  every deck it sends, and stores it in saved circuits — so a momwire session
+  is identifiable as one everywhere the version travels. For a SimNEC build
+  too old to know the `NEC2…` form, `--legacy-probe` on the portal command
+  line restores the old `nec2c.ae6ty.9.1` masquerade; nothing else about the
+  session changes either way.
 
 Before a live session, run the built-in smoke — it needs no checkout, spawns
 one resident copy of itself, runs embedded decks through it the way SimNEC

--- a/src/antennaknobs/nec_portal.py
+++ b/src/antennaknobs/nec_portal.py
@@ -144,6 +144,7 @@ _active_basis = _BASES["bspline"]
 
 __all__ = [
     "BANNER_VERSION",
+    "LEGACY_PROBE_VERSION",
     "PROBE_VERSION",
     "deck_frame",
     "main",
@@ -156,13 +157,39 @@ __all__ = [
 # --------------------------------------------------------------------------
 
 # ``Execute.testCommand()`` matches the FIRST LINE of `<cmd> -version`, trimmed,
-# against ``versionA = nec2c\.ae6ty\.(.*)`` and then feeds group(1) to
-# ``Double.valueOf``.  The group is greedy, so ANY non-numeric text after
-# ``nec2c.ae6ty.`` — including the word "momwire" — makes the parse throw and
-# SimNEC reports "nec2c version too old:".  The probe string therefore has to
-# end in a bare one-dot number.  (Grammar doc §1 "Version probe"; issue #792
-# unit 1 flagged the same trap for ``1.17.2``.)
-PROBE_VERSION = "nec2c.ae6ty.9.1"
+# against four anchored regexes. We answer the FOURTH, ``versionNECd =
+# (NEC\d+\D.*)`` — honest identity, sanctioned by Ward (2026-08-08: "If you
+# respond with something like NEC2text#.# things will work") and verified
+# against the 6p4d6 bytecode (issue #828; grammar doc, 2026-08-09 addendum):
+# a versionNECd match calls ``setVersion(line)`` and returns success — group(1)
+# is never read, nothing is Double-parsed, there is no version floor, and NO
+# engine state is set. The engine enum (and with it the daemon class, the
+# sensor-row offsets, and every dialect switch) comes from the EXECUTABLE
+# FILENAME alone, so the binary must keep ``nec2c`` in its name (and its path
+# must not contain the substring ``out``). The string SimNEC stores is shown
+# in the portal dialog's NECVersion row, echoed back to us as a ``CM version``
+# card on every deck, and re-read once by ``Options.getEngine()``, whose
+# ``[a-zA-Z]*([0-9])+?(.*)`` must extract "2" (the W7EL insulation gate tests
+# it) — which is why the identity must start with ``NEC2`` (exact case, and a
+# non-digit right after the 2) and why the tail after it is genuinely free.
+# The #.# tail is genuinely free on the NECd path, so it carries the real
+# package version. installed-metadata caveat: an editable install reports the
+# version recorded at `pip install -e` time, so a dev box that skipped the
+# reinstall after a bump probes the stale number — cosmetic there, and always
+# correct on a wheel install.
+try:
+    from importlib.metadata import version as _pkg_version
+
+    _MAJ, _MIN = _pkg_version("antennaknobs").split(".")[:2]
+except Exception:  # pragma: no cover - no installed metadata (source tree)
+    _MAJ, _MIN = "0", "0"
+PROBE_VERSION = f"NEC2momwire.{_MAJ}.{_MIN}"
+
+# The masquerade this build used through v0.46 — versionA's shape, whose tail
+# rides ``Double.valueOf`` against the 1.23 floor. Kept behind ``--legacy-probe``
+# for SimNEC builds old enough to predate versionNECd, until one is confirmed
+# not to exist; the flag rides the portal-dialog command line like --basis.
+LEGACY_PROBE_VERSION = "nec2c.ae6ty.9.1"
 
 # The banner inside a printout is NOT version-checked: the four regexes are
 # ``lookingAt()``, i.e. anchored, and the banner line is prefixed ``VERSION:``
@@ -2895,8 +2922,15 @@ def main(argv: list[str] | None = None, stdin=None, stdout=None, stderr=None) ->
         _active_basis = _BASES[name]
     argv = rest
 
+    # --legacy-probe swaps the honest versionNECd identity for the pre-#828
+    # versionA masquerade — for a SimNEC build old enough to predate
+    # versionNECd, should one surface. Deck behavior is identical either way
+    # (the probe response sets no engine state; see PROBE_VERSION).
+    legacy_probe = "--legacy-probe" in argv
+    argv = [a for a in argv if a != "--legacy-probe"]
+
     if any(a.lstrip("-").lower() == "version" for a in argv):
-        stdout.write(f"{PROBE_VERSION}\n")
+        stdout.write(f"{LEGACY_PROBE_VERSION if legacy_probe else PROBE_VERSION}\n")
         stdout.flush()
         return 0
 

--- a/tests/test_nec_portal.py
+++ b/tests/test_nec_portal.py
@@ -188,30 +188,67 @@ def yy_rows(text: str) -> list[list[float]]:
 # --------------------------------------------------------------------------
 
 
-def test_version_probe_matches_executes_versionA_regex():
+# Execute.testCommand's four probe regexes, verbatim from the 6p4d6 bytecode
+# (issue #828 research; grammar doc 2026-08-09 addendum). A/B/C Double-parse
+# group(1) against the 1.23 floor; NECd reads no group and sets no state.
+VERSION_B = re.compile(r"5b4az\.ae6ty\.(.*)")
+VERSION_C = re.compile(r"necpp\.nec2c\.(.*)")
+VERSION_NECD = re.compile(r"(NEC\d+\D.*)")
+# Options.getEngine()'s re-read of the stored version text: group(1) must be
+# "2" or SimNEC's scripting layer reclassifies the engine (W7EL insulation
+# refuses anything but Complex.TWO).
+OPTIONS_ENGINE_PIECE = re.compile(r"[a-zA-Z]*([0-9])+?(.*)")
+
+
+def test_version_probe_matches_executes_versionNECd_regex():
+    """The honest identity (issue #828, Ward-sanctioned): the probe answers
+    the versionNECd path, whose match sets no engine state — the engine enum,
+    daemon class, and parse offsets all come from the executable FILENAME.
+    The gates below replicate every constraint the bytecode research found
+    load-bearing, so a probe edit that would break a live SimNEC fails here.
+    """
     out = io.StringIO()
     assert main(["-version"], stdin=io.StringIO(""), stdout=out) == 0
     lines = out.getvalue().splitlines()
     assert len(lines) == 1, f"the probe must print exactly one line: {lines}"
+    probe = lines[0].strip()
 
-    match = VERSION_A.fullmatch(lines[0].strip())
-    assert match, f"{lines[0]!r} does not match nec2c\\.ae6ty\\.(.*)"
+    # lookingAt() semantics = re.match, anchored at the start only.
+    assert VERSION_NECD.match(probe), f"{probe!r} does not match (NEC\\d+\\D.*)"
+    # Must NOT match A/B/C: those branches Double-parse the tail and a
+    # non-numeric tail there is rejected as "nec2c version too old".
+    for pat in (VERSION_A, VERSION_B, VERSION_C):
+        assert not pat.match(probe), f"{probe!r} would take the {pat.pattern} path"
+    # Case-sensitive NEC2 at position 0, non-digit right after the 2 (the
+    # regex needs \D after the digit run), and Options.getEngine must read 2.
+    assert probe.startswith("NEC2") and not probe[4].isdigit(), probe
+    assert OPTIONS_ENGINE_PIECE.match(probe).group(1) == "2", probe
+    assert probe.startswith("NEC2momwire.")
 
-    # Execute.testCommand feeds group(1) straight to Double.valueOf. A greedy
-    # (.*) means ANY non-numeric tail — "momwire.9.1" included — throws and is
-    # reported as "nec2c version too old:". One dot, nothing else.
-    tail = match.group(1)
-    assert tail.count(".") == 1, f"version tail {tail!r} is not Double-parseable"
-    assert float(tail) > 0
+
+def test_legacy_probe_flag_answers_the_versionA_masquerade():
+    """``--legacy-probe`` keeps the pre-#828 identity available for a SimNEC
+    build that might predate versionNECd. That path Double-parses the tail
+    against the 1.23 floor, so the shape constraints are the old ones: one
+    dot, a bare number above the floor."""
+    out = io.StringIO()
+    assert main(["--legacy-probe", "-version"], stdin=io.StringIO(""), stdout=out) == 0
+    probe = out.getvalue().strip()
+    assert probe == nec_portal.LEGACY_PROBE_VERSION
+    tail = VERSION_A.match(probe).group(1)
+    assert tail.count(".") == 1 and float(tail) >= 1.23, tail
 
 
 def test_printout_banner_carries_the_momwire_identity():
     """The banner is not version-checked (the regexes are anchored and it is
-    prefixed ``VERSION:``), so it is where the engine says who it really is."""
+    prefixed ``VERSION:``), so it stays fixture-pinned while the PROBE now
+    carries the honest identity too (#828). The banner keeps its historical
+    shape on purpose: 40 committed fixtures pin it, and the offline .out
+    import path (``ae6ty/FileStuff``) greps the ``(nec2c)`` box line."""
     text, _err = run_deck(fixture_deck("dipole_free_space"))
     assert f"VERSION:{nec_portal.BANNER_VERSION}" in text
     assert "momwire" in nec_portal.BANNER_VERSION
-    assert "momwire" not in nec_portal.PROBE_VERSION
+    assert "momwire" in nec_portal.PROBE_VERSION
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Closes #828.

The `-version` probe now answers `NEC2momwire.<major>.<minor>` (currently `NEC2momwire.0.46`) instead of masquerading as `nec2c.ae6ty.9.1` — the `NEC2text#.#` form Ward sanctioned in his 2026-08-08 reply. `--legacy-probe` on the portal command line restores the old shape for any SimNEC build that might predate `versionNECd`.

## The verification the issue gated on (bytecode trace of the 6p4d6 jar, recorded as a dated addendum in the Execute grammar survey)
- **The `versionNECd` branch sets no state**: `setVersion(line); return null` — `Matcher.group` never invoked, nothing Double-parsed, no version floor. The switch cannot trip "version too old".
- **The daemon-protocol risk is ruled out**: the engine enum (and with it `NEC2Daemon` stdin/stdout NX residency vs the file-based `NEC5Daemon`, the sensor-row parse offsets, and every dialect switch in `NECSource`) comes from the executable **filename** alone — `indexOf("nec2c")` in `safeNecCommand()`. The probe response cannot reach any of it; `momwire-nec2c` keeps its name.
- **The one real constraint on the text**: `Options.getEngine()` re-reads the stored version with `[a-zA-Z]*([0-9])+?(.*)` and the W7EL insulation gate requires the extracted digit to be 2 — `NEC2…` satisfies it by construction, and the tail after it is genuinely free (verified by executing the four verbatim patterns under Java 21).
- **The payoff**: SimNEC displays the string in the portal dialog's NECVersion row, stamps `CM version NEC2momwire.0.46` on every deck it sends us, and stores it in saved circuits — a momwire session becomes self-identifying everywhere the version text travels.
- `BANNER_VERSION` stays fixture-pinned on purpose: nothing in the live protocol parses the printout banner, and the offline `.out` import path greps its `(nec2c)` box line.

## Gates (measured)
- New probe matches `versionNECd` and none of A/B/C; `NEC2` exact-case at position 0; non-digit after the 2; `Options.getEngine` extracts "2" — each pinned by a test replicating the verbatim regexes, so a probe edit that would break a live SimNEC fails the suite.
- `--legacy-probe -version` → `nec2c.ae6ty.9.1`, still Double-parseable above the 1.23 floor (pinned).
- Version tail derives from installed metadata (correct on every wheel install; the editable-install staleness trap is noted in the comment and my dev box was refreshed).
- Targeted: 814 passed. Full suite: **4390 passed, 2 skipped**. Selftest PASS (14 checks). ruff clean. Site docs + grammar-doc addendum updated.

## Review notes
Research by a delegated opus agent (full decompile/disassembly of `Execute.testCommand`, `NEC2PortalDialog.safeNecCommand`, both daemons, and every consumer of the version text, with empirical regex execution); implementation by the session model (Fable), which wrote the gates directly from the research's load-bearing constraints. Remaining live confirmation for the next Windows SimNEC session: the NECVersion row visibly showing `NEC2momwire.0.46` — same ritual slot as #829's warning-frame check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvF4yHgNxjhyZ7P286g3z8