### PR TITLE
bench: arrayblock vs hmatrix vs dense on a growing phased-array lattice

### DIFF
--- a/docs/status/2026-08-09-arrayblock-lattice-benchmark.md
+++ b/docs/status/2026-08-09-arrayblock-lattice-benchmark.md
@@ -1,0 +1,275 @@
+# 2026-08-09 — ArrayBlock vs H-matrix vs dense on a growing phased array
+
+## TL;DR
+
+`scripts/bench_arrayblock_lattice.py` grows one shape family — an N×N square
+lattice of identical centre-fed half-wave dipoles, 9 segments each, 0.6 λ
+pitch, free space, 14 MHz — and asks each of the three B-spline solve paths for
+the same 2×2 short-circuit admittance. One fresh subprocess per rung (clean
+`getrusage` peak RSS, 8 GB `RLIMIT_AS`), BLAS/OpenMP pinned to the physical
+core count, strictly serial, one rung at a time.
+
+**The dense wall is 32×32 (1024 elements, 9216 bases) on an 8 GB budget.**
+Estimated live footprint 15.2 GB; a confirming run under the cap died with
+`MemoryError` exactly as predicted. The largest dense rung that fits is 24×24,
+and it costs **8.0 s and 5277 MB**. The same rung on `arrayblock` costs
+**0.77 s and 137 MB** — 10.4× the speed and 38.6× less resident memory, and
+the memory ratio is the conservative reading, because 91 MB of both figures is
+the interpreter's import floor. Against the *solve's own* allocation it is
+5186 MB vs 46 MB, **113×**.
+
+Past the wall `arrayblock` keeps going on a laptop. At **48×48 — 2304
+elements, 20736 bases, a dense fill that would need ~77 GB — it answers in
+2.99 s and 272 MB.**
+
+Three findings worth stating plainly:
+
+- **`arrayblock` overtakes dense at 8×8 (64 elements) and never looks back.**
+  3.1× at 8×8, 4.5× at 16×16, 10.4× at 24×24. Below that the dense fill is
+  genuinely the cheaper tool and the FFT bookkeeping does not pay for itself.
+- **`hmatrix` never beats dense anywhere dense runs** — 0.10×–0.31× the speed
+  across the whole ladder. Its value on this geometry is not speed, it is
+  *survival*: it is still solving at 48×48 (157.6 s, 1963 MB) where dense
+  wants 77 GB. On a same-shape lattice, the generic hierarchical solve is the
+  fallback, not the answer; `arrayblock` is 52.7× faster than it at 48×48.
+- **`arrayblock`'s cost is linear in element count over this range.** 8×8 →
+  48×48 is 36× the elements and 37× the wall clock (0.08 s → 2.99 s); memory
+  above the floor tracks at a flat ~0.080 MB per element (46 MB at 576
+  elements, 181 MB at 2304). Dense memory is exactly quadratic in bases, which
+  is what puts the wall where it is.
+
+Agreement holds everywhere: worst measured relative error **3.0e-06**
+(`hmatrix` vs dense) and **3.5e-06** (`arrayblock`, vs dense while dense ran
+and vs `hmatrix` beyond), against a 1e-04 bound.
+
+## Method
+
+```
+python scripts/bench_arrayblock_lattice.py --out lattice_bench.json
+```
+
+Defaults as committed: sizes 4, 6, 8, 12, 16, 24, 32, 48; 9 segments per
+dipole; 0.6 λ pitch; 14 MHz; free space; 8 GB per-rung `RLIMIT_AS`; 600 s
+per-rung timeout.
+
+Each rung is one `compute_y_matrix()` in its own fresh interpreter:
+`OMP_WAIT_POLICY=PASSIVE`, `GOMP_SPINCOUNT=0` set before the scientific stack
+loads, BLAS/OpenMP = physical cores, serial dispatch. Wall clock is
+`perf_counter()` around `compute_y_matrix()` alone — geometry construction is
+outside it. Peak RSS is `ru_maxrss` for the whole worker, so it **includes**
+the ~91 MB import baseline.
+
+**Mesh.** 9 segments per half-wave dipole, odd so a segment centre lands on the
+feed point. The portal's engaged-path test
+(`test_the_lattice_fft_path_engages_and_the_shim_still_agrees`) uses the
+3-segment minimum, which is right for a test — the FFT gate is about lattice
+bookkeeping, not mesh size — but a benchmark quoting cost per element needs a
+mesh someone would actually model with. 9 is the catalog's own habit for a
+resonant half-wave element.
+
+**Pitch and feeds.** 0.6 λ sits inside the usual 0.5–0.7 λ broadside-array
+window and keeps the elements genuinely coupled. Two feeds on every rung —
+element 0 (a corner) and the central element — so Y is 2×2 and the agreement
+column checks a corner-to-interior mutual, not only self terms. The feed set is
+declared identically on all three solvers; the measured quantity has to be the
+same quantity.
+
+**Engaged path, asserted.** Every `arrayblock` rung is constructed with
+`require_lattice_fft=True`, so a rung that failed to meet the FFT gate (P ≥ 16,
+one block-shape class, a regular lattice) would raise `LatticeFFTUnavailable`
+naming the unmet gate and be recorded as a failed rung rather than silently
+degrading to the parent H-matrix and being credited to the wrong path. All
+eight rungs engaged; `solver_diag()` reports
+`operator=LatticeArrayBlock, lattice_fft=True, n_shapes=1` on each.
+
+**Column closure.** A rung that caps, times out, or is skipped closes its
+column — larger sizes are not probed. The dense column closes at 32×32 by
+estimate.
+
+## Machine
+
+| | |
+| --- | --- |
+| CPU | Intel Core i7-8550U @ 1.80 GHz — 4 physical cores, 8 threads |
+| RAM | 15.3 GiB |
+| OS | Linux 7.0.0-28-generic |
+| Python | 3.14.5 |
+| numpy / scipy | 2.5.0 / 1.18.0 |
+| antennaknobs | 0.46.0 |
+| momwire | 0.23.0 (submodule `c67d238`) |
+| thread policy | BLAS = OpenMP = 4, `OMP_WAIT_POLICY=PASSIVE`, `GOMP_SPINCOUNT=0` |
+
+This is a 2017 mobile quad-core, not a workstation. **Absolute times drift with
+hardware; the ratios between the three paths, and the position of the dense
+wall relative to the memory budget, are the portable findings.**
+
+## The ladder
+
+`rel err` is max|ΔY| / max|Y_ref|, referenced to dense while dense ran and to
+`hmatrix` beyond it.
+
+| grid | elements | n_basis | solver | wall s | peak RSS MB | rel err | status |
+|---|---|---|---|---|---|---|---|
+| 4×4 | 16 | 144 | dense | 0.01 | 93 | — | ok |
+| 4×4 | 16 | 144 | hmatrix | 0.11 | 91 | 2.82e-07 | ok |
+| 4×4 | 16 | 144 | arrayblock | 0.02 | 91 | 1.53e-10 | ok |
+| 6×6 | 36 | 324 | dense | 0.04 | 111 | — | ok |
+| 6×6 | 36 | 324 | hmatrix | 0.38 | 95 | 9.33e-07 | ok |
+| 6×6 | 36 | 324 | arrayblock | 0.04 | 92 | 5.97e-10 | ok |
+| 8×8 | 64 | 576 | dense | 0.25 | 157 | — | ok |
+| 8×8 | 64 | 576 | hmatrix | 1.25 | 102 | 2.40e-06 | ok |
+| 8×8 | 64 | 576 | arrayblock | 0.08 | 95 | 7.72e-08 | ok |
+| 12×12 | 144 | 1296 | dense | 0.44 | 423 | — | ok |
+| 12×12 | 144 | 1296 | hmatrix | 3.19 | 132 | 2.88e-06 | ok |
+| 12×12 | 144 | 1296 | arrayblock | 0.18 | 103 | 6.91e-07 | ok |
+| 16×16 | 256 | 2304 | dense | 1.25 | 1122 | — | ok |
+| 16×16 | 256 | 2304 | hmatrix | 9.36 | 184 | 3.02e-06 | ok |
+| 16×16 | 256 | 2304 | arrayblock | 0.28 | 111 | 9.93e-08 | ok |
+| 24×24 | 576 | 5184 | dense | 7.99 | 5277 | — | ok |
+| 24×24 | 576 | 5184 | hmatrix | 26.18 | 363 | 1.12e-06 | ok |
+| 24×24 | 576 | 5184 | arrayblock | 0.77 | 137 | 1.08e-07 | ok |
+| **32×32** | **1024** | **9216** | **dense** | **—** | **—** | **—** | **skipped (est 15.19 GB > 8 GB cap)** |
+| 32×32 | 1024 | 9216 | hmatrix | 73.94 | 724 | — | ok |
+| 32×32 | 1024 | 9216 | arrayblock | 1.29 | 173 | 3.52e-06 | ok |
+| 48×48 | 2304 | 20736 | dense | — | — | — | skipped (column closed) |
+| 48×48 | 2304 | 20736 | hmatrix | 157.64 | 1963 | — | ok |
+| 48×48 | 2304 | 20736 | arrayblock | 2.99 | 272 | 6.99e-07 | ok |
+
+Total sweep wall clock: **300.6 s** for 21 solved rungs. Highest peak RSS
+anywhere in the sweep: **5277 MB** (dense, 24×24) — comfortably inside the
+8 GB cap, which was never the binding constraint on a rung that ran.
+
+## Ratios — the portable part
+
+Dense cost ÷ accelerator cost. Above 1.00× the accelerator wins.
+
+| grid | elements | hmatrix wall | hmatrix RSS | arrayblock wall | arrayblock RSS |
+|---|---|---|---|---|---|
+| 4×4 | 16 | 0.13× | 1.02× | 0.63× | 1.03× |
+| 6×6 | 36 | 0.10× | 1.18× | 0.90× | 1.20× |
+| 8×8 | 64 | 0.20× | 1.54× | **3.09×** | 1.66× |
+| 12×12 | 144 | 0.14× | 3.21× | 2.47× | 4.11× |
+| 16×16 | 256 | 0.13× | 6.11× | 4.47× | 10.13× |
+| 24×24 | 576 | 0.31× | 14.54× | **10.41×** | **38.59×** |
+
+Beyond the dense wall, `arrayblock` against `hmatrix`:
+
+| grid | elements | wall | peak RSS |
+|---|---|---|---|
+| 32×32 | 1024 | 57.3× faster | 4.2× leaner |
+| 48×48 | 2304 | 52.7× faster | 7.2× leaner |
+
+### Above the memory floor
+
+The RSS column includes a ~91 MB interpreter + numpy + momwire import baseline,
+which flatters the accelerators' *ratios* downward at small sizes and upward
+nowhere. Subtracting it gives each path's own allocation:
+
+| grid | dense | hmatrix | arrayblock |
+|---|---|---|---|
+| 12×12 | 332 MB | 41 MB | 12 MB |
+| 16×16 | 1031 MB | 93 MB | 20 MB |
+| 24×24 | 5186 MB | 272 MB | 46 MB |
+| 32×32 | (15.2 GB est) | 633 MB | 82 MB |
+| 48×48 | (76.9 GB est) | 1872 MB | 181 MB |
+
+Dense is 113× `arrayblock`'s own allocation at 24×24. `arrayblock` holds a flat
+~0.080 MB per element across the whole ladder.
+
+## The dense wall, and what the estimate got wrong
+
+The script refuses a dense rung whose estimated live footprint exceeds the cap
+rather than discovering the cap the hard way, so the estimator has to be right.
+The obvious arithmetic — Z is n²·16 bytes, and the LU holds a working copy —
+says 2.2×. **That is wrong by a factor of five.** Measured peak RSS above the
+import floor, divided by n²·16:
+
+| n_basis | Z itself | RSS above floor | factor |
+|---|---|---|---|
+| 1296 | 26.9 MB | 332 MB | 12.3× |
+| 2304 | 85.0 MB | 1031 MB | 12.1× |
+| 5184 | 430.3 MB | 5186 MB | 12.1× |
+
+The batched C++ assembly materialises a per-pair quadrature gather before it
+reduces to Z, and *that*, not the matrix, sets the peak. The factor is flat
+across a 4× span in n_basis, so it extrapolates; `DENSE_FOOTPRINT_FACTOR = 12.0`
+in the script is this measurement, and the comment says so.
+
+At 32×32 it predicts 15.19 GB against an 8 GB cap. Confirmed with one direct
+run of the worker, bypassing the estimate:
+
+```
+python scripts/bench_arrayblock_lattice.py --worker dense 32 9 0.6 14.0 8.0
+{"error": "MemoryError: exceeded 8 GB cap", "error_kind": "capped"}
+```
+
+Note what kind of wall this is: **memory, not time.** Extrapolating the dense
+time curve (P^1.58 over 8×8 → 24×24) puts a 32×32 dense solve at roughly 20 s,
+well inside the 600 s timeout. It is the quadratic fill that ends the column,
+which is why the accelerators exist.
+
+## Agreement
+
+| column | worst rel err | at | reference | bound |
+|---|---|---|---|---|
+| hmatrix | 3.02e-06 | 16×16 | dense | 1e-04 |
+| arrayblock | 3.52e-06 | 32×32 | hmatrix | 1e-04 |
+
+Both are ~30× inside the bound. `arrayblock` against dense specifically is
+tighter still — worst 6.91e-07 at 12×12, and 1.5e-10 at 4×4 — which is the
+expected shape: the lattice-FFT path is an exact reorganisation of the same
+operator, so its deviation from dense is convolution round-off, whereas
+`hmatrix` carries a genuine ACA truncation. The 3.52e-06 on the `arrayblock`
+row at 32×32 is measured against `hmatrix`, so it is mostly `hmatrix`'s error,
+not `arrayblock`'s.
+
+## Caveats
+
+- **Memory floor.** Every RSS figure includes the ~91 MB import baseline. The
+  "above the floor" table exists so the per-path allocation is recoverable.
+- **Cold process, one fill.** Each number is a first-and-only
+  `compute_y_matrix()` — fill, factor, one back-substitution per port. A warm
+  second solve at another frequency is not measured. This is a fill story, and
+  fill dominates; a swept-frequency comparison would be a different benchmark
+  and would likely favour the accelerators further, since they amortise their
+  setup. Future work, deliberately out of scope here.
+- **Free space only.** Ground would confound the scaling comparison. All three
+  paths ride their accelerated route on ground already, which is a separate
+  question the #830-era notes cover.
+- **Ratios, not absolutes.** See the machine table. A workstation moves every
+  wall-clock number and moves the dense wall too — the wall is set by the
+  memory budget, so a 64 GB box pushes it out about one rung and a half.
+- **One geometry family.** Identical elements on a regular lattice is the best
+  case for `arrayblock` by construction. That is the point — it is Ward's case
+  — but the 8×8 crossover is specific to this family and this mesh, not a
+  universal number.
+
+## Ward-quotable summary
+
+On a plain 2017 quad-core laptop, a 24×24 array of half-wave dipoles — 576
+elements, 5184 unknowns — takes 8.0 seconds and 5.3 GB of RAM to solve with a
+conventional dense fill, and a 32×32 array cannot be solved at all inside an
+8 GB budget: it needs about 15 GB. With `--basis arrayblock` the same 24×24
+array answers in 0.77 seconds and 137 MB, and the 32×32 that dense cannot reach
+takes 1.3 seconds and 173 MB. A 48×48 array — 2304 elements, 20736 unknowns,
+where the dense matrix alone is 6.9 GB and the dense solve around it needs an
+estimated 77 GB — solves in 3.0 seconds and 272 MB.
+The answers agree with the dense solve to better than 1e-06 relative wherever
+dense can still be run, so nothing is being traded away for the speed: it is
+the same physics and the same operator, reorganised as an FFT convolution over
+the element grid. The generic hierarchical solver (`--basis hmatrix`) also
+survives past the dense wall, but on a repeated-element lattice it is roughly
+50× slower than `arrayblock` and should be regarded as the fallback for decks
+with no repeated structure.
+
+## Reproducing
+
+```
+python scripts/bench_arrayblock_lattice.py --out lattice_bench.json
+python scripts/bench_arrayblock_lattice.py --sizes 4 8 16 --solvers arrayblock
+# the dense-wall confirmation (bypasses the estimate skip, keeps the cap):
+python scripts/bench_arrayblock_lattice.py --worker dense 32 9 0.6 14.0 8.0
+```
+
+Manual-only. The benchmark is a script, never wired into CI, per the repo test
+policy (no per-design certs in CI; PR #392 precedent).

--- a/scripts/bench_arrayblock_lattice.py
+++ b/scripts/bench_arrayblock_lattice.py
@@ -325,8 +325,14 @@ def sweep(sizes, solvers, segs, pitch_lambda, freq_mhz, cap_gb, timeout):
         # Agreement: dense while it ran, hmatrix as the reference beyond it.
         y_dense = _y_of(results.get("dense"))
         y_hm = _y_of(results.get("hmatrix"))
-        ref_key = "dense" if y_dense is not None else ("hmatrix" if y_hm else None)
-        y_ref = y_dense if y_dense is not None else y_hm
+        # `is not None` throughout — these are numpy arrays, and a bare truth
+        # test on one raises rather than answering.
+        if y_dense is not None:
+            ref_key, y_ref = "dense", y_dense
+        elif y_hm is not None:
+            ref_key, y_ref = "hmatrix", y_hm
+        else:
+            ref_key, y_ref = None, None
         for key in solvers:
             if key == ref_key:
                 continue

--- a/scripts/bench_arrayblock_lattice.py
+++ b/scripts/bench_arrayblock_lattice.py
@@ -394,7 +394,8 @@ def print_report(rows, solvers):
 
     # Ratios — the portable finding; absolute times drift with hardware.
     print("\n" + "=" * 96)
-    print("RATIOS vs dense (wall clock / peak RSS), where dense ran")
+    print("RATIOS vs dense, where dense ran — dense cost / accelerator cost")
+    print("(above 1.00x the accelerator wins; below 1.00x dense is the cheaper tool)")
     print("=" * 96)
     for row in rows:
         d = row["solvers"].get("dense") or {}
@@ -408,8 +409,8 @@ def print_report(rows, solvers):
             if "wall_s" not in res:
                 continue
             parts.append(
-                f"{key}: {d['wall_s'] / res['wall_s']:5.1f}x faster, "
-                f"{d['peak_rss_mb'] / res['peak_rss_mb']:4.2f}x RSS"
+                f"{key}: {d['wall_s'] / res['wall_s']:6.2f}x wall, "
+                f"{d['peak_rss_mb'] / res['peak_rss_mb']:5.2f}x RSS"
             )
         print(f"  {row['grid']}x{row['grid']:<4} " + "   ".join(parts))
 

--- a/scripts/bench_arrayblock_lattice.py
+++ b/scripts/bench_arrayblock_lattice.py
@@ -1,0 +1,526 @@
+"""Phased-array scaling benchmark: dense vs H-matrix vs ArrayBlock on one
+lattice family grown by element count.
+
+Sizing question this answers: at what array size does the dense B-spline fill
+stop being the right tool, and what do the two accelerators buy at that point
+and beyond? One shape family — an N x N grid of identical half-wave dipoles at
+a fixed pitch, free space — is swept over N, and each rung is solved for the
+same 2x2 short-circuit admittance (`compute_y_matrix()`) by each of
+
+  dense       BSplineSolver     — the O(n^2) fill + O(n^3) LU reference
+  hmatrix     HMatrixSolver     — ACA-compressed far field, iterative solve
+  arrayblock  ArrayBlockSolver  — element-aware blocks; on a regular same-shape
+                                  lattice the block-Toeplitz FFT coupling path,
+                                  asserted here with `require_lattice_fft=True`
+                                  so a silent degradation to the parent
+                                  H-matrix is a reported rung failure, not a
+                                  number quietly attributed to the wrong path.
+
+Every rung is solved in its OWN subprocess so each gets (a) a clean
+`getrusage` peak RSS from a fresh interpreter, and (b) an `RLIMIT_AS`
+address-space cap, so an over-large dense fill dies with a clean MemoryError
+instead of thrashing the machine into swap. BLAS + OpenMP are pinned to the
+physical core count (mirrors `web/server.py`); dispatch is strictly serial,
+one rung at a time.
+
+Caveats, stated up front so the tables aren't misread:
+
+  - **Memory floor.** Peak RSS includes the fixed interpreter + numpy +
+    momwire import cost (~90 MB here), which dwarfs the operator's own
+    allocation on small grids. The report prints the observed floor (min peak
+    RSS across rungs) so the per-rung *delta* is recoverable.
+  - **Cold process, one fill.** Each number is a first-and-only
+    `compute_y_matrix()` — fill plus factor plus one back-substitution per
+    port. A warm second solve at another frequency is NOT measured here; the
+    scaling story is a fill story.
+  - **Free space only.** Ground would confound the scaling comparison; all
+    three bases ride the accelerated path on ground already, which is a
+    separate question.
+  - **The dense column has a wall and we find it by estimate.** Dense peak RSS
+    runs about 12x the n_basis^2 * 16 bytes of Z itself (see
+    `DENSE_FOOTPRINT_FACTOR` — the batched assembly's quadrature gather, not
+    the matrix, sets the peak), so a rung whose estimate exceeds the cap is
+    recorded `skipped (est > cap)` rather than discovered the hard way. Once a
+    column caps, times out, or is skipped, that column is CLOSED — larger
+    rungs are not probed.
+
+Usage:
+    python scripts/bench_arrayblock_lattice.py
+    python scripts/bench_arrayblock_lattice.py --sizes 4 8 16 --solvers arrayblock
+    python scripts/bench_arrayblock_lattice.py --out lattice_bench.json
+"""
+
+from __future__ import annotations
+
+# Mirror bench_catalog.py: libgomp reads these once, before the scientific
+# stack loads. Fresh worker subprocesses inherit them.
+import os
+
+os.environ.setdefault("OMP_WAIT_POLICY", "PASSIVE")
+os.environ.setdefault("GOMP_SPINCOUNT", "0")
+
+import argparse  # noqa: E402
+import json  # noqa: E402
+import resource  # noqa: E402
+import subprocess  # noqa: E402
+import sys  # noqa: E402
+import time  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import bench_nec_corpus as bnc  # noqa: E402
+
+C_LIGHT = 299_792_458.0
+
+SOLVER_KEYS = ("dense", "hmatrix", "arrayblock")
+
+# Lattice defaults. 9 segments per half-wave dipole: odd, so a segment centre
+# lands on the feed point, and well past the 3-segment minimum the portal test
+# uses — the FFT gate is about lattice bookkeeping, not mesh size, so the test
+# can afford a toy mesh where a benchmark cannot. 0.6 lambda pitch is inside
+# the usual 0.5-0.7 broadside-array window and keeps the elements' near fields
+# genuinely coupled. 14 MHz, free space.
+DEFAULT_SIZES = (4, 6, 8, 12, 16, 24, 32, 48)
+DEFAULT_SEGS = 9
+DEFAULT_PITCH_LAMBDA = 0.6
+DEFAULT_FREQ_MHZ = 14.0
+
+# Per-rung address-space cap (GB) and wall-clock timeout (s). 8 GB on a 16 GB
+# box leaves the OS and this driver room; a rung past either is a RESULT.
+DEFAULT_CAP_GB = 8.0
+DEFAULT_TIMEOUT = 600.0
+
+# Dense live-footprint estimate, as a multiple of Z itself (n^2 complex128).
+# The obvious arithmetic — Z plus the LU's working copy — says ~2.2x, and that
+# is WRONG by a factor of five: the batched C++ assembly materialises a
+# per-pair quadrature gather before it reduces to Z, so the peak lands well
+# above the matrix. Measured on the 2026-08-09 run (peak RSS minus the ~91 MB
+# import floor, divided by n^2*16): 12.3x at n=1296, 12.1x at n=2304, 12.1x at
+# n=5184. Flat enough across a 4x span in n to extrapolate with, so this is the
+# measurement, not the arithmetic.
+DENSE_FOOTPRINT_FACTOR = 12.0
+
+# Agreement bound the accelerated columns are held to (issue #833 gate 3).
+AGREEMENT_BOUND = 1e-4
+
+
+def lattice(grid: int, segs: int, pitch_lambda: float, freq_mhz: float):
+    """The rung's geometry: `grid` x `grid` identical centre-fed half-wave
+    dipoles on a square lattice, as momwire constructor kwargs.
+
+    Two feeds, always: element 0 (the corner) and the central element, so Y is
+    2x2 and the agreement column compares a corner-to-interior mutual as well
+    as two self terms. Both are declared on every solver identically — the
+    measured quantity has to be the same quantity."""
+    import numpy as np
+
+    wavelength = C_LIGHT / (freq_mhz * 1e6)
+    arm = 0.25 * wavelength
+    pitch = pitch_lambda * wavelength
+    wires = [
+        np.array([[ix * pitch, iy * pitch, -arm], [ix * pitch, iy * pitch, arm]])
+        for ix in range(grid)
+        for iy in range(grid)
+    ]
+    centre = (grid // 2) * grid + (grid // 2)
+    return {
+        "wires": wires,
+        "n_per_edge_per_wire": [[segs]] * len(wires),
+        # Arc-length arm is the wire's midpoint (it runs -arm..+arm).
+        "feeds": [(0, arm, 1.0), (centre, arm, 0.0)],
+        "wavelength": wavelength,
+        "wire_radius": 0.001,
+    }
+
+
+def n_basis_of(grid: int, segs: int) -> int:
+    """B-spline basis count for the rung. One basis per segment on an open
+    wire with no junctions, so it is exactly elements x segments — cheap
+    enough to compute in the parent for the dense-feasibility estimate
+    without building any geometry."""
+    return grid * grid * segs
+
+
+def dense_estimate_gb(n_basis: int) -> float:
+    """Estimated live footprint (GB) of the dense fill + factor at `n_basis`."""
+    return n_basis**2 * 16 * DENSE_FOOTPRINT_FACTOR / 1024**3
+
+
+# --------------------------------------------------------------------------
+# subprocess worker (fresh interpreter -> clean peak RSS; RLIMIT_AS guard)
+# --------------------------------------------------------------------------
+def worker_main(solver_key, grid, segs, pitch_lambda, freq_mhz, cap_gb):
+    """Runs in a fresh interpreter. Solves ONE rung and prints one JSON line.
+
+    The measured span is `compute_y_matrix()` alone — geometry construction is
+    outside it, because the interesting cost is the operator, not the python
+    list of endpoints."""
+    result = {"error": None}
+    try:
+        if cap_gb and cap_gb > 0:
+            cap = int(cap_gb * 1024**3)
+            resource.setrlimit(resource.RLIMIT_AS, (cap, cap))
+        cores = bnc.apply_server_thread_policy()
+
+        from momwire import ArrayBlockSolver, BSplineSolver, HMatrixSolver
+
+        kwargs = lattice(grid, segs, pitch_lambda, freq_mhz)
+        cls, extra = {
+            "dense": (BSplineSolver, {}),
+            "hmatrix": (HMatrixSolver, {}),
+            # The whole point of the arrayblock rung: assert the FFT path
+            # engaged rather than assume it. A miss raises
+            # LatticeFFTUnavailable naming the unmet gate, and that is a
+            # reportable failure of this rung.
+            "arrayblock": (ArrayBlockSolver, {"require_lattice_fft": True}),
+        }[solver_key]
+        solver = cls(**kwargs, **extra)
+
+        started = time.perf_counter()
+        y = solver.compute_y_matrix()
+        result["wall_s"] = time.perf_counter() - started
+        result["peak_rss_mb"] = (
+            resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024 / 1e6
+        )
+        result["cores"] = cores
+        result["n_basis"] = int(solver._build_geometry()["n_segs_total"])
+        result["y_real"] = y.real.tolist()
+        result["y_imag"] = y.imag.tolist()
+        diag = getattr(solver, "solver_diag", lambda: None)()
+        if diag is not None:
+            result["diag"] = {k: v for k, v in diag.items() if k != "reason"}
+            result["diag"]["reason"] = diag.get("reason")
+    except MemoryError:
+        result["error"] = f"MemoryError: exceeded {cap_gb:g} GB cap"
+        result["error_kind"] = "capped"
+    except Exception as e:  # noqa: BLE001 — report, never crash the sweep
+        kind = "fft" if type(e).__name__ == "LatticeFFTUnavailable" else "err"
+        result["error"] = f"{type(e).__name__}: {e}"
+        result["error_kind"] = kind
+    print(json.dumps(result))
+
+
+def run_rung(solver_key, grid, segs, pitch_lambda, freq_mhz, cap_gb, timeout):
+    """Dispatch one worker subprocess. Serial by construction — the caller
+    loops, there is no pool."""
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                __file__,
+                "--worker",
+                solver_key,
+                str(grid),
+                str(segs),
+                str(pitch_lambda),
+                str(freq_mhz),
+                str(cap_gb),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return {"error": f"timeout > {timeout:g}s", "error_kind": "timeout"}
+    if proc.returncode != 0 and not proc.stdout.strip():
+        tail = (proc.stderr or "").strip()[-200:]
+        # RLIMIT_AS usually surfaces as MemoryError inside the worker, but a
+        # C-level allocation can take the process down instead.
+        kind = "capped" if proc.returncode in (-9, 137) else "err"
+        return {"error": f"worker exited {proc.returncode}: {tail}", "error_kind": kind}
+    try:
+        return json.loads(proc.stdout.strip().splitlines()[-1])
+    except (json.JSONDecodeError, IndexError):
+        return {"error": f"unparseable worker output: {proc.stdout[-200:]!r}"}
+
+
+# --------------------------------------------------------------------------
+# driver
+# --------------------------------------------------------------------------
+def _y_of(res):
+    """The rung's Y as a complex array, or None if it did not produce one."""
+    import numpy as np
+
+    if not res or res.get("error") or "y_real" not in res:
+        return None
+    return np.array(res["y_real"]) + 1j * np.array(res["y_imag"])
+
+
+def _rel_err(y, y_ref):
+    """max|Y - Y_ref| / max|Y_ref| — one scalar per rung, normalised on the
+    reference's largest entry so the self terms don't hide a bad mutual."""
+    import numpy as np
+
+    if y is None or y_ref is None:
+        return None
+    scale = float(np.abs(y_ref).max())
+    if scale == 0.0:
+        return None
+    return float(np.abs(y - y_ref).max() / scale)
+
+
+def _status(res):
+    """ok / capped / timeout / fft-unavailable / error for one rung result."""
+    if not res:
+        return "error"
+    kind = res.get("error_kind")
+    if kind is None:
+        return "ok" if not res.get("error") else "error"
+    return {
+        "capped": "capped (MemoryError)",
+        "timeout": "timeout",
+        "fft": "fft-unavailable",
+    }.get(kind, "error")
+
+
+def sweep(sizes, solvers, segs, pitch_lambda, freq_mhz, cap_gb, timeout):
+    """Run the ladder, one rung at a time, closing a column at its first
+    non-ok rung. Returns the row list."""
+    rows = []
+    closed: dict[str, str] = {}  # solver -> why the column stopped
+    for grid in sizes:
+        n_basis = n_basis_of(grid, segs)
+        est = dense_estimate_gb(n_basis)
+        print(
+            f"\ngrid {grid}x{grid}   elements={grid * grid}  n_basis={n_basis}  "
+            f"dense est {est:.2f} GB",
+            flush=True,
+        )
+        results = {}
+        for key in solvers:
+            if key in closed:
+                results[key] = {
+                    "error": f"column closed: {closed[key]}",
+                    "error_kind": "closed",
+                }
+                print(f"  {key:<11} skipped (column closed: {closed[key]})", flush=True)
+                continue
+            if key == "dense" and cap_gb and est > cap_gb:
+                results[key] = {
+                    "error": f"skipped: dense est {est:.2f} GB > {cap_gb:g} GB cap",
+                    "error_kind": "skip-est",
+                }
+                closed[key] = (
+                    f"dense estimate {est:.2f} GB exceeded the {cap_gb:g} GB cap"
+                )
+                print(
+                    f"  {key:<11} skipped (est {est:.2f} GB > {cap_gb:g} GB cap)",
+                    flush=True,
+                )
+                continue
+            res = run_rung(key, grid, segs, pitch_lambda, freq_mhz, cap_gb, timeout)
+            results[key] = res
+            if res.get("error"):
+                print(f"  {key:<11} {_status(res):<20} {res['error'][:70]}", flush=True)
+                closed[key] = _status(res)
+            else:
+                fft = (res.get("diag") or {}).get("lattice_fft")
+                tag = "  fft" if fft else ""
+                print(
+                    f"  {key:<11} {res['wall_s']:8.2f}s  "
+                    f"{res['peak_rss_mb']:7.0f} MB{tag}",
+                    flush=True,
+                )
+
+        # Agreement: dense while it ran, hmatrix as the reference beyond it.
+        y_dense = _y_of(results.get("dense"))
+        y_hm = _y_of(results.get("hmatrix"))
+        ref_key = "dense" if y_dense is not None else ("hmatrix" if y_hm else None)
+        y_ref = y_dense if y_dense is not None else y_hm
+        for key in solvers:
+            if key == ref_key:
+                continue
+            err = _rel_err(_y_of(results.get(key)), y_ref)
+            if err is not None:
+                results[key]["rel_err"] = err
+                results[key]["rel_err_vs"] = ref_key
+                flag = "" if err <= AGREEMENT_BOUND else "   <-- OVER BOUND"
+                print(f"    {key} vs {ref_key}: rel err {err:.2e}{flag}", flush=True)
+
+        rows.append(
+            {
+                "grid": grid,
+                "elements": grid * grid,
+                "n_basis": n_basis,
+                "dense_est_gb": est,
+                "solvers": results,
+            }
+        )
+    return rows
+
+
+def print_report(rows, solvers):
+    """The table the status doc quotes, plus the floor and the ratios."""
+    print("\n" + "=" * 96)
+    print("RUNGS — wall clock, peak RSS, agreement")
+    print("=" * 96)
+    header = f"{'grid':<8} {'elem':>5} {'n_basis':>8} {'solver':<11} {'wall s':>9} {'peak MB':>8} {'rel err':>10}  status"
+    print(header)
+    print("-" * len(header))
+    for row in rows:
+        for key in solvers:
+            res = row["solvers"].get(key) or {}
+            status = (
+                "skipped (est > cap)"
+                if res.get("error_kind") == "skip-est"
+                else "skipped (column closed)"
+                if res.get("error_kind") == "closed"
+                else _status(res)
+            )
+            wall = f"{res['wall_s']:9.2f}" if "wall_s" in res else f"{'-':>9}"
+            rss = f"{res['peak_rss_mb']:8.0f}" if "peak_rss_mb" in res else f"{'-':>8}"
+            err = f"{res['rel_err']:10.2e}" if "rel_err" in res else f"{'-':>10}"
+            print(
+                f"{row['grid']}x{row['grid']:<5} {row['elements']:>5} "
+                f"{row['n_basis']:>8} {key:<11} {wall} {rss} {err}  {status}"
+            )
+
+    floors = [
+        r["solvers"][k]["peak_rss_mb"]
+        for r in rows
+        for k in solvers
+        if "peak_rss_mb" in (r["solvers"].get(k) or {})
+    ]
+    if floors:
+        print(
+            f"\nobserved memory floor (min peak RSS across rungs): {min(floors):.0f} MB"
+        )
+
+    # Ratios — the portable finding; absolute times drift with hardware.
+    print("\n" + "=" * 96)
+    print("RATIOS vs dense (wall clock / peak RSS), where dense ran")
+    print("=" * 96)
+    for row in rows:
+        d = row["solvers"].get("dense") or {}
+        if "wall_s" not in d:
+            continue
+        parts = []
+        for key in solvers:
+            if key == "dense":
+                continue
+            res = row["solvers"].get(key) or {}
+            if "wall_s" not in res:
+                continue
+            parts.append(
+                f"{key}: {d['wall_s'] / res['wall_s']:5.1f}x faster, "
+                f"{d['peak_rss_mb'] / res['peak_rss_mb']:4.2f}x RSS"
+            )
+        print(f"  {row['grid']}x{row['grid']:<4} " + "   ".join(parts))
+
+    worst = {}
+    for row in rows:
+        for key in solvers:
+            res = row["solvers"].get(key) or {}
+            if "rel_err" in res:
+                prev = worst.get(key)
+                if prev is None or res["rel_err"] > prev[0]:
+                    worst[key] = (res["rel_err"], row["grid"], res["rel_err_vs"])
+    if worst:
+        print(f"\nworst measured agreement per column (bound {AGREEMENT_BOUND:g}):")
+        for key, (err, grid, ref) in worst.items():
+            flag = "  OK" if err <= AGREEMENT_BOUND else "  OVER BOUND"
+            print(f"  {key:<11} {err:.2e} vs {ref} at {grid}x{grid}{flag}")
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--worker",
+        nargs=6,
+        metavar=("SOLVER", "GRID", "SEGS", "PITCH", "FREQ", "CAP_GB"),
+        help=argparse.SUPPRESS,
+    )
+    ap.add_argument(
+        "--sizes",
+        nargs="+",
+        type=int,
+        default=list(DEFAULT_SIZES),
+        help=f"grid edge lengths, ascending (default: {' '.join(map(str, DEFAULT_SIZES))})",
+    )
+    ap.add_argument(
+        "--solvers", nargs="+", default=list(SOLVER_KEYS), choices=SOLVER_KEYS
+    )
+    ap.add_argument(
+        "--segs",
+        type=int,
+        default=DEFAULT_SEGS,
+        help=f"segments per half-wave dipole (default {DEFAULT_SEGS}, odd)",
+    )
+    ap.add_argument(
+        "--pitch",
+        type=float,
+        default=DEFAULT_PITCH_LAMBDA,
+        help=f"lattice pitch in wavelengths (default {DEFAULT_PITCH_LAMBDA})",
+    )
+    ap.add_argument("--freq-mhz", type=float, default=DEFAULT_FREQ_MHZ)
+    ap.add_argument(
+        "--cap-gb",
+        type=float,
+        default=DEFAULT_CAP_GB,
+        help=f"per-rung address-space cap in GB (default {DEFAULT_CAP_GB}; 0 = none)",
+    )
+    ap.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT,
+        help=f"per-rung wall-clock timeout in seconds (default {DEFAULT_TIMEOUT})",
+    )
+    ap.add_argument("--out", type=Path, default=None)
+    args = ap.parse_args(argv)
+
+    if args.worker:
+        solver_key, grid, segs, pitch, freq, cap_gb = args.worker
+        worker_main(
+            solver_key, int(grid), int(segs), float(pitch), float(freq), float(cap_gb)
+        )
+        return
+
+    sizes = sorted(set(args.sizes))
+    solvers = [k for k in SOLVER_KEYS if k in args.solvers]  # canonical order
+    cores = bnc.physical_cpu_count()
+    print("arrayblock lattice scaling benchmark (free space)")
+    print(
+        f"lattice: NxN half-wave dipoles, {args.segs} segs each, "
+        f"{args.pitch}λ pitch, {args.freq_mhz} MHz"
+    )
+    print(f"sizes: {', '.join(f'{n}x{n}' for n in sizes)}")
+    print(f"solvers: {', '.join(solvers)}   feeds: corner + centre element (2x2 Y)")
+    print(
+        f"per-rung cap: {args.cap_gb or 'none'} GB address space, "
+        f"{args.timeout:g}s wall"
+    )
+    print(
+        "concurrency (mirrors web/server.py): "
+        f"BLAS={cores} OpenMP={cores} OMP_WAIT_POLICY=PASSIVE GOMP_SPINCOUNT=0  "
+        "(serial dispatch, one rung at a time)"
+    )
+
+    started = time.perf_counter()
+    rows = sweep(
+        sizes,
+        solvers,
+        args.segs,
+        args.pitch,
+        args.freq_mhz,
+        args.cap_gb,
+        args.timeout,
+    )
+    print_report(rows, solvers)
+    print(f"\ntotal sweep wall clock: {time.perf_counter() - started:.1f}s")
+
+    if args.out:
+        payload = {
+            "segs": args.segs,
+            "pitch_lambda": args.pitch,
+            "freq_mhz": args.freq_mhz,
+            "cap_gb": args.cap_gb,
+            "timeout_s": args.timeout,
+            "cores": cores,
+            "rows": rows,
+        }
+        args.out.write_text(json.dumps(payload, indent=2))
+        print(f"full results -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/site/src/content/docs/reference/simnec.md
+++ b/site/src/content/docs/reference/simnec.md
@@ -208,6 +208,17 @@ hierarchical solve on a deck with no repeated structure, so it is safe to
 leave on. Their answers should match `bspline`'s — if they do not, the deck is
 telling you something about conditioning, not about basis choice.
 
+How much it buys, measured on a 2017 quad-core laptop over a square lattice of
+half-wave dipoles at 0.6 λ pitch: a 24×24 array (576 elements, 5184 unknowns)
+takes 8.0 s and 5.3 GB with the dense fill and **0.77 s and 137 MB on
+`arrayblock`**, and a 32×32 array will not solve at all inside an 8 GB budget
+— it needs about 15 GB — while `arrayblock` answers it in 1.3 s and 173 MB. At
+48×48 (2304 elements) `arrayblock` takes 3.0 s and 272 MB where `hmatrix`
+needs 158 s and 2.0 GB. The crossover is around 8×8; below that the dense fill
+is the cheaper tool. Agreement with the dense solve stays better than 1e-06
+relative everywhere dense can still be run. Full ladder, method and caveats:
+[`docs/status/2026-08-09-arrayblock-lattice-benchmark.md`](https://github.com/stevenmburns/antennaknobs/blob/main/docs/status/2026-08-09-arrayblock-lattice-benchmark.md).
+
 **Paste two portal entries that differ only in `--basis` and you have
 cross-basis validation inside SimNEC itself** — switch engines from the
 dialog and watch whether the answer holds. The printout banner records which

--- a/site/src/content/docs/reference/simnec.md
+++ b/site/src/content/docs/reference/simnec.md
@@ -215,8 +215,8 @@ takes 8.0 s and 5.3 GB with the dense fill and **0.77 s and 137 MB on
 — it needs about 15 GB — while `arrayblock` answers it in 1.3 s and 173 MB. At
 48×48 (2304 elements) `arrayblock` takes 3.0 s and 272 MB where `hmatrix`
 needs 158 s and 2.0 GB. The crossover is around 8×8; below that the dense fill
-is the cheaper tool. Agreement with the dense solve stays better than 1e-06
-relative everywhere dense can still be run. Full ladder, method and caveats:
+is the cheaper tool. Agreement with the dense solve stays within a few parts
+in 10⁶ relative everywhere dense can still be run. Full ladder, method and caveats:
 [`docs/status/2026-08-09-arrayblock-lattice-benchmark.md`](https://github.com/stevenmburns/antennaknobs/blob/main/docs/status/2026-08-09-arrayblock-lattice-benchmark.md).
 
 **Paste two portal entries that differ only in `--basis` and you have


### PR DESCRIPTION
Closes #833.

`scripts/bench_arrayblock_lattice.py` + the dated run record `docs/status/2026-08-09-arrayblock-lattice-benchmark.md`: one same-shape lattice family (N×N centre-fed half-wave dipoles, 9 segs each, 0.6 λ pitch, free space, 14 MHz) grown until dense hits its wall, each rung solved for the same 2×2 Y by dense BSpline, HMatrix, and ArrayBlock (`require_lattice_fft=True` asserted on every arrayblock rung). Manual-only, no CI wiring, no tests.

## Headline numbers (committed run, this box)
- **Dense wall: 32×32** (1024 elements, 9216 bases) on an 8 GB budget — estimated 15.2 GB live footprint, confirmed with exactly one capped run (`MemoryError`, machine untouched). It's a memory wall, not a time wall.
- Largest dense rung (24×24, 576 elements): **8.0 s / 5277 MB dense vs 0.77 s / 137 MB arrayblock** — 10.4× wall, 38.6× RSS, and **113×** against the solve's own allocation once the ~91 MB import floor is removed.
- Past the wall: 48×48 (2304 elements, dense would need ~77 GB) — **arrayblock 3.0 s / 272 MB**, hmatrix 157.6 s / 1963 MB. Arrayblock cost is linear in element count over the ladder (~0.080 MB/element above floor).
- Honest finding: **hmatrix never beats dense anywhere dense runs** (0.10–0.31×) on this geometry — its value on a Toeplitz lattice is survival, not speed; arrayblock is the answer, 52.7× faster than hmatrix at 48×48.
- Crossover: arrayblock overtakes dense at 8×8; below that dense is genuinely cheaper.
- Agreement: worst 3.0e-06 (hmatrix) / 3.5e-06 (arrayblock) relative — ~30× inside the 1e-04 gate.

## Safety discipline (the brief's hard rules, verified)
Every rung in its own fresh interpreter under `RLIMIT_AS` (default 8 GB), in-child `getrusage` peak RSS, BLAS/OMP pinned via the bench_nec_corpus policy, strictly serial, per-rung 600 s timeout; capped/timed-out/estimate-skipped rungs are recorded rows, and a closed column is never probed larger. Highest RSS ever observed in the committed sweep: 5277 MB. A methodological catch worth keeping: the naive dense footprint arithmetic (Z + LU ≈ 2.2×) is wrong by ~5× — the batched assembly's quadrature gather sets the peak at a measured **12× n²·16 B**, which is what `DENSE_FOOTPRINT_FACTOR` now records and what makes the estimate-first policy actually safe.

## Review notes
Implemented by a delegated opus builder; reviewed by the session model (Fable). Independently verified: the full diff (worker/cap machinery, agreement logic including the mid-build numpy-truthiness fix, doc claims vs the table); reproduced the 16×16 rung — agreement 9.93e-08 bit-identical to the committed table, ratios within timing jitter; ruff clean. Reviewer commit c6a91b6: the simnec.md summary claimed "better than 1e-06" agreement where the measured worst is 3.5e-06 — corrected to "a few parts in 10⁶".

Follow-ups suggested by the builder, not filed yet: a warm/swept-frequency variant (this measures cold first fills only); a momwire issue on blocking the 12× assembly gather; a second, irregular family to price arrayblock's degradation to hmatrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvF4yHgNxjhyZ7P286g3z8