### PR TITLE
feat(nec_portal): remember the operator across decks — the cross-deck solve cache

### DIFF
--- a/site/src/content/docs/reference/simnec.md
+++ b/site/src/content/docs/reference/simnec.md
@@ -258,6 +258,17 @@ matrix. The portal takes the union of every group's ports, fills and factors
 **once** per geometry and frequency, and answers each group by back-substitution
 on the cached factors. A three-port deck costs one fill, not three.
 
+The deck is not the boundary either. The protocol is stateless — a sweep
+arrives as N separate decks, each re-sending the whole geometry — but the
+engine remembers: a solved structure is kept under a key built from everything
+that decides its moment matrix (geometry after transforms, ground, loading,
+port placement, network branches, kernel flag, basis), so a knob dragged back
+to a value already probed, a restarted sweep, or the same antenna handed to
+another engine in the crew is answered without parsing, meshing or filling
+anything. The same structure at a *new* frequency reuses the mesh and pays only
+the fill. The biggest bench deck (106 segments) takes ~150 ms cold and ~11 ms
+on the repeat, and what is left in the repeat is the printout itself.
+
 ### What refuses — cleanly
 
 A deck the engine cannot model is *reported and stepped over*, never guessed
@@ -301,6 +312,12 @@ complex matrix and its factors, which grow as the square of the segment count.
 It is also much quicker per deck once warm (a 106-segment design solves in
 ~130 ms, a small dipole in ~2 ms), so a smaller crew keeps up with a larger one
 of the C engine.
+
+Its memory of past structures is capped, per process, at a few hundred MB, and
+a full cache costs a re-solve rather than a failure — so the worst case for a
+crew of four stays well inside a 16 GB machine. In practice a bench-sized
+design's entry measures tens of kilobytes, so the cap is a safety net for
+array-scale work rather than something a session reaches.
 
 **On a 16 GB machine, set the NEC crew size to 4.** Larger crews buy little,
 because the win here is the single fill per geometry rather than parallelism

--- a/site/src/content/docs/reference/simnec.md
+++ b/site/src/content/docs/reference/simnec.md
@@ -258,16 +258,57 @@ matrix. The portal takes the union of every group's ports, fills and factors
 **once** per geometry and frequency, and answers each group by back-substitution
 on the cached factors. A three-port deck costs one fill, not three.
 
-The deck is not the boundary either. The protocol is stateless — a sweep
+The deck need not be the boundary either. The protocol is stateless — a sweep
 arrives as N separate decks, each re-sending the whole geometry — but the
-engine remembers: a solved structure is kept under a key built from everything
-that decides its moment matrix (geometry after transforms, ground, loading,
-port placement, network branches, kernel flag, basis), so a knob dragged back
-to a value already probed, a restarted sweep, or the same antenna handed to
-another engine in the crew is answered without parsing, meshing or filling
-anything. The same structure at a *new* frequency reuses the mesh and pays only
-the fill. The biggest bench deck (106 segments) takes ~150 ms cold and ~11 ms
-on the repeat, and what is left in the repeat is the printout itself.
+engine *can* remember: with `--cache`, a solved structure is kept under a key
+built from everything that decides its moment matrix (geometry after
+transforms, ground, loading, port placement, network branches, kernel flag,
+basis), so a knob dragged back to a value already probed, a restarted sweep, or
+the same antenna handed to another engine in the crew is answered without
+parsing, meshing or filling anything. The same structure at a *new* frequency
+reuses the mesh and pays only the fill. The biggest bench deck (106 segments)
+takes ~150 ms cold and ~11 ms on the repeat, and what is left in the repeat is
+the printout itself.
+
+### Measure before you cache
+
+That is **off by default**, and the reason is that the bench is not the
+workload. What the cache exploits is how often a real session re-sends a
+structure it has already sent, and nobody has measured a real session. So the
+shipped default stays the behaviour that has been validated, and the engine
+offers to answer the question instead:
+
+```text
+momwire-nec2c --cache-stats /tmp/nec-cache-stats.json
+```
+
+Put that in the portal dialog's engine command and run a normal session. Every
+deck is solved exactly as it is today — nothing is cached, nothing is retained,
+the answers are the stock answers — but the engine computes each deck's key and
+counts how many decks a cache *would* have served. The file is rewritten after
+every deck (SimNEC ends a session by killing the process, so anything written
+at exit is never written) and holds one small JSON object:
+
+```json
+{"mode": "dry-run", "decks_rendered": 412, "hits": 273, "misses": 139,
+ "fills": 412, "evictions": 0, "bytes": 0, "entries": 0}
+```
+
+`hits` against `decks_rendered` is the saving on offer. If it is worth having,
+turn serving on:
+
+```text
+momwire-nec2c --cache
+momwire-nec2c --cache --cache-stats /tmp/nec-cache-stats.json
+```
+
+The first serves; the second serves *and* keeps measuring, which is the one to
+run for a while after switching over — `entries` and `bytes` then report what
+the process is actually holding.
+
+Neither flag changes a byte of the printout, and neither writes anything to the
+session — the transcript is identical in all three modes, which is what the
+test suite asserts deck by deck against a process carrying no flags at all.
 
 ### What refuses — cleanly
 
@@ -313,11 +354,14 @@ It is also much quicker per deck once warm (a 106-segment design solves in
 ~130 ms, a small dipole in ~2 ms), so a smaller crew keeps up with a larger one
 of the C engine.
 
-Its memory of past structures is capped, per process, at a few hundred MB, and
-a full cache costs a re-solve rather than a failure — so the worst case for a
-crew of four stays well inside a 16 GB machine. In practice a bench-sized
-design's entry measures tens of kilobytes, so the cap is a safety net for
-array-scale work rather than something a session reaches.
+Without `--cache` that is the whole budget — a process keeps nothing between
+decks. With it, its memory of past structures is capped per process at a few
+hundred MB, and a full cache costs a re-solve rather than a failure, so the
+worst case for a crew of four stays well inside a 16 GB machine. In practice a
+bench-sized design's entry measures tens of kilobytes, so the cap is a safety
+net for array-scale work rather than something a session reaches; run
+`--cache --cache-stats` for a while and the `bytes` field says exactly what
+yours is holding.
 
 **On a 16 GB machine, set the NEC crew size to 4.** Larger crews buy little,
 because the win here is the single fill per geometry rather than parallelism

--- a/src/antennaknobs/nec_portal.py
+++ b/src/antennaknobs/nec_portal.py
@@ -87,20 +87,31 @@ group after that is linear algebra on cached factors: the group's port
 voltages give ``coeffs = X @ V`` and its currents ``I = Y @ V``. N sources
 cost one fill, not N.
 
-And the deck is not the boundary either. The protocol is stateless — a sweep
-arrives as N independent decks, each re-sending the whole geometry — but the
-ENGINE may remember, so a solver is kept ACROSS decks under a key that is the
-operator's own identity (``_operator_key``, ``_solver_for``). A knob returned
-to a value already probed, a restarted sweep, a crew member handed the same
-structure at a different frequency: geometry parse, mesh, port maps and every
-fill already paid are reused, bounded by an LRU cap on estimated resident
-bytes. The printout is identical either way — that is the whole correctness
-claim, and it is what the tests assert.
+And the deck need not be the boundary either. The protocol is stateless — a
+sweep arrives as N independent decks, each re-sending the whole geometry — but
+the ENGINE may remember, so with ``--cache`` a solver is kept ACROSS decks
+under a key that is the operator's own identity (``_operator_key``,
+``_solver_for``). A knob returned to a value already probed, a restarted
+sweep, a crew member handed the same structure at a different frequency:
+geometry parse, mesh, port maps and every fill already paid are reused,
+bounded by an LRU cap on estimated resident bytes. The printout is identical
+either way — that is the whole correctness claim, and it is what the tests
+assert.
+
+That is OFF by default. The saving is real and measured on the bench, but the
+workload it exploits is a live SimNEC session's re-probe rate, which nobody
+has measured — so the shipped default stays the behaviour that has been
+validated, and ``--cache-stats PATH`` answers the question first: it counts
+what a cache WOULD have served while solving every deck fresh, and writes the
+tally to a file after every deck. Nothing about either flag reaches stdout or
+stderr; the protocol is byte-identical in all three modes.
 """
 
 from __future__ import annotations
 
+import json
 import math
+import os
 import sys
 import time
 from collections import OrderedDict
@@ -2248,7 +2259,11 @@ class DeckSolver:
         cached = self._cache.get(freq_mhz)
         if cached is not None:
             return cached
-        _cache_stats["fills"] += 1
+        if _cache_serving or _cache_stats_path is not None:
+            # Counted only when something asked to be measured: with the cache
+            # off the instrument is off too, so its zeros are evidence rather
+            # than an unread accumulator.
+            _cache_stats["fills"] += 1
         wavelength = C_LIGHT / (freq_mhz * 1e6)
         started = time.perf_counter()
         solver = self.engine._make_solver(wavelength=wavelength)
@@ -2471,6 +2486,10 @@ class DeckSolver:
 # from the parsed deck rather than its text (so comments, whitespace and card
 # formatting cannot split it) and it carries EVERYTHING that moves a number in
 # the operator — see ``_operator_key``.
+#
+# Serving is opt-in (``--cache``) and off by default; ``--cache-stats PATH``
+# measures the hit rate a live session would see without serving anything.
+# ``_solver_for`` is where the three modes part company.
 
 # A few hundred MB is inside the machine budget for a crew of four engines, and
 # the cache degrades to exactly the pre-#823 behaviour when it is full (every
@@ -2498,15 +2517,87 @@ _cache_sizes: dict[tuple, int] = {}
 # cannot be the evidence. Nothing here is ever printed to SimNEC.
 _cache_stats = {"hits": 0, "misses": 0, "evictions": 0, "fills": 0, "bytes": 0}
 
+# Serving is OFF unless the portal-dialog command line asks for it (``--cache``).
+# The cache is an optimisation for a workload nobody has measured yet: a live
+# SimNEC session's real re-probe rate is an empirical question, and until it is
+# answered the default has to be the behaviour that has been shipped and
+# validated. `--cache-stats PATH` answers it at zero risk — see `_solver_for`.
+_cache_serving = False
+_cache_stats_path: str | None = None
+
+# The keys seen this invocation in DRY-RUN mode. A key-set, never solvers: the
+# point of the dry run is to measure the hit rate without retaining a single
+# byte of physics, so there is no memory growth and no way for a stale answer
+# to be served by a mode that is only supposed to be counting.
+_dry_run_keys: set[tuple] = set()
+
+# Decks framed this invocation — the DENOMINATOR of the hit rate, and not a
+# cache statistic: a refused deck moves nothing in `_cache_stats` but is still
+# a deck the session sent.
+_decks_rendered = 0
+
+
+def _cache_mode() -> str:
+    """``serving`` / ``dry-run`` / ``off`` — what the command line asked for."""
+    if _cache_serving:
+        return "serving"
+    return "dry-run" if _cache_stats_path is not None else "off"
+
 
 def _reset_solver_cache() -> None:
     """Empty the cache and zero the instrument. Called by ``main`` for the same
     reason it re-reads ``--basis``: engine state is per invocation, never
     sticky, and a fresh process must be indistinguishable from a fresh call."""
+    global _decks_rendered
     _solver_cache.clear()
     _cache_sizes.clear()
+    _dry_run_keys.clear()
+    _decks_rendered = 0
     for key in _cache_stats:
         _cache_stats[key] = 0
+
+
+def _write_cache_stats() -> None:
+    """The measurement file, rewritten after EVERY deck.
+
+    After every deck because SimNEC ends a session with ``Process.destroy()``
+    — a kill, not an EOF — so an exit-time write is a write that never happens.
+    The file is tiny (one flat object), so the cost is a few hundred bytes of
+    I/O against seconds of physics, and it goes out through a temp file and a
+    rename so a reader never catches a half-written object.
+
+    Read it as: ``hits`` is the answer to "would a cache have helped" —
+    decks whose operator had already been solved in this session. In dry-run
+    mode ``fills`` is what the stock engine actually paid, so ``hits`` against
+    ``decks_rendered`` is the saving on offer; ``entries`` and ``bytes`` are
+    zero there because nothing is retained.
+
+    Failures are swallowed on purpose. This engine may write NOTHING to stdout
+    (it would corrupt the transcript) and nothing to stderr (NEC2Daemon never
+    drains it, so a full pipe buffer deadlocks the UI — grammar doc §10.9), so
+    an unwritable path can only be allowed to cost the measurement, never the
+    session.
+    """
+    if _cache_stats_path is None:
+        return
+    payload = {
+        "mode": _cache_mode(),
+        "decks_rendered": _decks_rendered,
+        "hits": _cache_stats["hits"],
+        "misses": _cache_stats["misses"],
+        "fills": _cache_stats["fills"],
+        "evictions": _cache_stats["evictions"],
+        "bytes": _cache_stats["bytes"],
+        "entries": len(_solver_cache),
+    }
+    tmp = f"{_cache_stats_path}.tmp"
+    try:
+        with open(tmp, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle)
+            handle.write("\n")
+        os.replace(tmp, _cache_stats_path)
+    except OSError:
+        pass
 
 
 def _operator_key(deck: PortalDeck) -> tuple:
@@ -2633,22 +2724,53 @@ def _cache_evict() -> None:
 
 
 def _solver_for(deck: PortalDeck) -> DeckSolver:
-    """The :class:`DeckSolver` for this deck — the cached one when its operator
-    has been seen in this process, a fresh one otherwise.
+    """The :class:`DeckSolver` for this deck, in whichever of the three modes
+    the command line asked for.
+
+    **off** (the default). A fresh solver, and nothing else happens: no key is
+    computed, no counter moves, no reference is kept. This branch is the
+    pre-#823 code path to the byte, which is the point — the cache is opt-in
+    until a live session says it earns its keep, and "opt-in" has to mean the
+    default costs nothing rather than costs a little.
+
+    **dry-run** (``--cache-stats PATH`` alone). The key IS computed and
+    counted against the keys already seen, so the stats file answers "how many
+    of this session's decks would a cache have served" — but the solver is
+    built fresh every time and never retained. Nothing can be served from a
+    mode that is only measuring, and the process grows no memory for it. This
+    is the zero-risk live experiment.
+
+    **serving** (``--cache``). The cached instance when its operator has been
+    seen, a fresh one otherwise.
 
     A hit rebinds ``portal_deck`` to the ARRIVING deck. Everything the cached
     instance derived from the old one is in the key and therefore identical,
     but the attribute is a live reference the printout reads through
     (``_pattern_lines``, ``_near_field_lines``), and the arriving deck is the
     honest answer to "which deck is being rendered" for anything read from it
-    later — the ``GD`` exclusion above rests on exactly this.
+    later — the ``GD`` exclusion above rests on exactly this, and #842's cliff
+    modes made it load-bearing.
 
-    The cap is enforced HERE, at deck arrival: the entry the PREVIOUS deck
-    rendered through is re-sized (its fills are done now), the arriving deck's
-    entry is sized or created, and the oldest go. So the deck about to be
-    rendered is always resident, and the overshoot is one deck's worth of new
-    frequencies.
+    The cap is enforced in the serving branch, at deck arrival: the entry the
+    PREVIOUS deck rendered through is re-sized (its fills are done now), the
+    arriving deck's entry is sized or created, and the oldest go. So the deck
+    about to be rendered is always resident, and the overshoot is one deck's
+    worth of new frequencies.
     """
+    if not _cache_serving:
+        if _cache_stats_path is None:
+            return DeckSolver(deck)
+        key = _operator_key(deck)
+        # Construction first here too, so a refused deck moves no statistic in
+        # dry-run either — the counts stay comparable with serving mode's.
+        solver = DeckSolver(deck)
+        if key in _dry_run_keys:
+            _cache_stats["hits"] += 1
+        else:
+            _cache_stats["misses"] += 1
+            _dry_run_keys.add(key)
+        return solver
+
     if _solver_cache:
         _cache_measure(next(reversed(_solver_cache)))
     key = _operator_key(deck)
@@ -3285,7 +3407,12 @@ def deck_frame(body: str) -> tuple[list[str], list[str]]:
 
     Card numbering restarts at 1 inside every deck, so the sentinel's ordinal
     is the deck's own card count plus one (grammar doc §1).
+
+    This is also the frame boundary the measurement file is written at (a deck
+    is done, its fills are paid), and the boundary a REFUSED deck still counts
+    at — it is a deck the session sent, so it belongs in the denominator.
     """
+    global _decks_rendered
     out, err = render_deck(body)
     echoed = sum(1 for line in out if line.startswith("  DATA CARD No:"))
     out.append(fmt_data_card(echoed + 1, Card("NX", (), "NX")))
@@ -3293,6 +3420,8 @@ def deck_frame(body: str) -> tuple[list[str], list[str]]:
     # of the next deck; SEEKING ignores it. Reproduced so a resident
     # transcript frames identically (grammar doc §1, §10.8).
     out += list(_banner_lines()[1:])
+    _decks_rendered += 1
+    _write_cache_stats()
     return out, err
 
 
@@ -3435,12 +3564,14 @@ def main(argv: list[str] | None = None, stdin=None, stdout=None, stderr=None) ->
     # arguments — two entries differing only in --basis are two engines. An
     # unknown basis fails FAST and nonzero so the -version probe surfaces the
     # mistake at configure time instead of a silent wrong default.
-    global _active_basis
+    global _active_basis, _cache_serving, _cache_stats_path
     _active_basis = _BASES["bspline"]  # per-invocation default, never sticky
-    # The cross-deck cache is per invocation for the same reason, and because
-    # entries built under one basis must not outlive it (the key carries the
-    # basis, so they could not be served anyway — this just stops them
-    # occupying the cap).
+    # The cross-deck cache and its two flags are per invocation for the same
+    # reason, and the cache also because entries built under one basis must not
+    # outlive it (the key carries the basis, so they could not be served anyway
+    # — this just stops them occupying the cap).
+    _cache_serving = False
+    _cache_stats_path = None
     _reset_solver_cache()
     rest = list(argv)
     while "--basis" in rest or any(a.startswith("--basis=") for a in rest):
@@ -3458,7 +3589,35 @@ def main(argv: list[str] | None = None, stdin=None, stdout=None, stderr=None) ->
             stdout.flush()
             return 3
         _active_basis = _BASES[name]
-    argv = rest
+
+    # --cache-stats PATH writes the measurement file (see `_write_cache_stats`)
+    # and, on its own, turns the daemon into a COUNTER: every deck is solved
+    # fresh exactly as today and the file records how many of them a cache
+    # would have served. That is the live experiment the default-off decision
+    # is waiting on, and it cannot change an answer because nothing is
+    # retained. `--cache` on top of it serves as well as counts.
+    #
+    # A missing path fails fast and nonzero for the same reason an unknown
+    # --basis does: the -version probe is the configure-time moment to catch
+    # a malformed portal-dialog line, not the first deck of a live session.
+    while "--cache-stats" in rest or any(a.startswith("--cache-stats=") for a in rest):
+        if "--cache-stats" in rest:
+            k = rest.index("--cache-stats")
+            path = rest[k + 1] if k + 1 < len(rest) else ""
+            del rest[k : k + 2]
+        else:
+            k = next(i for i, a in enumerate(rest) if a.startswith("--cache-stats="))
+            path = rest.pop(k).split("=", 1)[1]
+        if not path or path.startswith("-"):
+            stdout.write("--cache-stats needs a file path\n")
+            stdout.flush()
+            return 3
+        _cache_stats_path = path
+
+    # --cache is a bare flag on purpose: it has no parameter to get wrong, and
+    # the cap is a constant rather than a knob (see `_CACHE_BYTES_CAP`).
+    _cache_serving = "--cache" in rest
+    argv = [a for a in rest if a != "--cache"]
 
     # --legacy-probe swaps the honest versionNECd identity for the pre-#828
     # versionA masquerade — for a SimNEC build old enough to predate

--- a/src/antennaknobs/nec_portal.py
+++ b/src/antennaknobs/nec_portal.py
@@ -2472,11 +2472,15 @@ class DeckSolver:
 # formatting cannot split it) and it carries EVERYTHING that moves a number in
 # the operator — see ``_operator_key``.
 
-# A few hundred MB is inside the machine budget for a crew of four engines and
-# holds a working set of tens of structures; the cache degrades to exactly the
-# pre-#823 behaviour when it is full (every arrival misses and re-solves).
-# Deliberately a constant and not a knob: a per-process daemon with a tunable
-# memory cap is a support surface nobody asked for.
+# A few hundred MB is inside the machine budget for a crew of four engines, and
+# the cache degrades to exactly the pre-#823 behaviour when it is full (every
+# arrival misses and re-solves). It is a SAFETY NET rather than a working
+# limit: momwire drops the factored operator after its solve, so what an entry
+# retains is X (n_basis × n_ports per cached frequency) and the solver's own
+# geometry — the whole bench corpus MEASURES at 44 to 111 kB an entry, which is
+# thousands of structures before the cap binds. It bites where it should, on
+# array-scale meshes. Deliberately a constant and not a knob: a per-process
+# daemon with a tunable memory cap is a support surface nobody asked for.
 _CACHE_BYTES_CAP = 384 * 1024 * 1024
 
 # operator key → the solver built for it, least-recently-used first.

--- a/src/antennaknobs/nec_portal.py
+++ b/src/antennaknobs/nec_portal.py
@@ -86,6 +86,16 @@ back-substitution that produces the short-circuit Y matrix. Every execute
 group after that is linear algebra on cached factors: the group's port
 voltages give ``coeffs = X @ V`` and its currents ``I = Y @ V``. N sources
 cost one fill, not N.
+
+And the deck is not the boundary either. The protocol is stateless — a sweep
+arrives as N independent decks, each re-sending the whole geometry — but the
+ENGINE may remember, so a solver is kept ACROSS decks under a key that is the
+operator's own identity (``_operator_key``, ``_solver_for``). A knob returned
+to a value already probed, a restarted sweep, a crew member handed the same
+structure at a different frequency: geometry parse, mesh, port maps and every
+fill already paid are reused, bounded by an LRU cap on estimated resident
+bytes. The printout is identical either way — that is the whole correctness
+claim, and it is what the tests assert.
 """
 
 from __future__ import annotations
@@ -93,6 +103,7 @@ from __future__ import annotations
 import math
 import sys
 import time
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from types import MappingProxyType
 
@@ -1884,6 +1895,33 @@ def _synthesize_union_deck(deck: PortalDeck, ports: list[tuple[int, int]]) -> st
     return "\n".join(lines) + "\n"
 
 
+def _union_ports(deck: PortalDeck) -> list[tuple[int, int]]:
+    """Every ``(tag, segment)`` the deck needs a gap at, in discovery order:
+    the union of every execute group's ``EX`` segments, then every ``NT``/``TL``
+    endpoint (NEC cuts the segment to hang the network off it, so it needs a
+    gap whether or not anything drives it).
+
+    Lifted out of :class:`DeckSolver` so the cross-deck cache key is built from
+    the SAME walk the solver's port columns come from. The port set is part of
+    the operator — it decides the union deck's gaps, the drive columns B, and
+    the column order of X — so two decks alike but for a moved ``EX`` are two
+    different operators, and a key that computed the set its own way could
+    drift from the one the solver actually built.
+    """
+    ports: list[tuple[int, int]] = []
+    for group in deck.groups:
+        if group is None:
+            continue
+        for tag, seg, _v in group.sources:
+            if (tag, seg) not in ports:
+                ports.append((tag, seg))
+    for branch in deck.networks:
+        for point in (branch.a, branch.b):
+            if point not in ports:
+                ports.append(point)
+    return ports
+
+
 def _locate(wires, tag: int, seg: int) -> tuple[int, int]:
     """NEC (tag, segment) → (wire index, 1-based local segment); ``tag`` 0
     means an absolute segment number. Mirrors ``nec_import._locate_segment``
@@ -2019,20 +2057,7 @@ class DeckSolver:
 
     def __init__(self, deck: PortalDeck):
         self.portal_deck = deck
-        ports: list[tuple[int, int]] = []
-        for group in deck.groups:
-            if group is None:
-                continue
-            for tag, seg, _v in group.sources:
-                if (tag, seg) not in ports:
-                    ports.append((tag, seg))
-        # An NT or TL endpoint is a port too: NEC cuts the segment to hang the
-        # network off it, so it needs a gap in the momwire model whether or not
-        # anything drives it.
-        for branch in deck.networks:
-            for point in (branch.a, branch.b):
-                if point not in ports:
-                    ports.append(point)
+        ports = _union_ports(deck)
         if not ports:
             raise PortalError("deck has no EX card — nothing drives the structure")
         self.ports = ports
@@ -2213,10 +2238,17 @@ class DeckSolver:
     # -- per-frequency operator -------------------------------------------
 
     def at(self, freq_mhz: float) -> dict:
-        """The cached (Y, X, solver) for a frequency — one fill, one factor."""
+        """The cached (Y, X, solver) for a frequency — one fill, one factor.
+
+        When this instance came out of the cross-deck cache (``_solver_for``)
+        these entries came with it, so a re-probed deck answers with no fill at
+        all, and the same structure at a NEW frequency pays one fill on top of
+        a geometry parse and mesh it did not repeat.
+        """
         cached = self._cache.get(freq_mhz)
         if cached is not None:
             return cached
+        _cache_stats["fills"] += 1
         wavelength = C_LIGHT / (freq_mhz * 1e6)
         started = time.perf_counter()
         solver = self.engine._make_solver(wavelength=wavelength)
@@ -2420,6 +2452,218 @@ class DeckSolver:
             sign = 1.0 if float(np.dot(dirs[j], seg.direction)) >= 0 else -1.0
             out[i] = sign * vals[j]
         return out
+
+
+# --------------------------------------------------------------------------
+# the cross-deck solver cache
+# --------------------------------------------------------------------------
+#
+# The protocol is stateless per deck — every deck re-sends its whole geometry
+# and a sweep arrives as N independent decks — but nothing in it forbids the
+# ENGINE remembering. ``DeckSolver`` already caches (geometry, frequency) →
+# factors WITHIN a deck; this keeps the whole ``DeckSolver`` across decks, so a
+# re-probed structure reuses the parse, the mesh, the port maps, the network
+# rows AND the per-frequency fills, and the same structure at a new frequency
+# pays only the new fill (issue #823).
+#
+# What a hit must guarantee is that the cached instance is the operator the
+# arriving deck asks for. That makes the key the whole contract: it is built
+# from the parsed deck rather than its text (so comments, whitespace and card
+# formatting cannot split it) and it carries EVERYTHING that moves a number in
+# the operator — see ``_operator_key``.
+
+# A few hundred MB is inside the machine budget for a crew of four engines and
+# holds a working set of tens of structures; the cache degrades to exactly the
+# pre-#823 behaviour when it is full (every arrival misses and re-solves).
+# Deliberately a constant and not a knob: a per-process daemon with a tunable
+# memory cap is a support surface nobody asked for.
+_CACHE_BYTES_CAP = 384 * 1024 * 1024
+
+# operator key → the solver built for it, least-recently-used first.
+_solver_cache: OrderedDict[tuple, DeckSolver] = OrderedDict()
+
+# operator key → its last measured size in bytes. Kept alongside rather than
+# recomputed per sweep because sizing an entry costs a graph walk (~1 ms) and
+# only ONE entry can have grown since the last arrival: the one the previous
+# deck rendered through. Re-walking the whole cache per deck would put the
+# eviction pass in front of the physics it exists to save.
+_cache_sizes: dict[tuple, int] = {}
+
+# The instrument. Tests read these instead of parsing timing text — the point
+# of the cache is that the printout is IDENTICAL either way, so the printout
+# cannot be the evidence. Nothing here is ever printed to SimNEC.
+_cache_stats = {"hits": 0, "misses": 0, "evictions": 0, "fills": 0, "bytes": 0}
+
+
+def _reset_solver_cache() -> None:
+    """Empty the cache and zero the instrument. Called by ``main`` for the same
+    reason it re-reads ``--basis``: engine state is per invocation, never
+    sticky, and a fresh process must be indistinguishable from a fresh call."""
+    _solver_cache.clear()
+    _cache_sizes.clear()
+    for key in _cache_stats:
+        _cache_stats[key] = 0
+
+
+def _operator_key(deck: PortalDeck) -> tuple:
+    """The identity of the linear operator this deck describes.
+
+    Everything that changes the matrix, the drive columns, or their ordering:
+
+    * the geometry cards after nothing — ``GW``/``GA``/``GH``/``GM``/``GX``/
+      ``GR``/``GS``/``GE`` by mnemonic and numeric fields, which is what
+      ``_synthesize_union_deck`` hands the translator (endpoints, segment
+      counts, radii, transforms, and the ``GE`` ground-plane flag);
+    * the ground — ``GN``'s kind and its parameters, and its ABSENCE (a
+      free-space :class:`Ground` is a distinct value, not a missing one);
+    * the loads — ``LD`` cards by fields, in force at the end of the deck,
+      which is the set ``_synthesize_union_deck`` writes and the set
+      ``_load_impedances`` stamps;
+    * the port set, in order — the walk in :func:`_union_ports`;
+    * the ``NT``/``TL`` branches — they stamp ``y_constant`` and the line rows,
+      and their endpoints are ports;
+    * the kernel flag, per execute group — see below;
+    * the basis: solver class, solver kwargs and banner suffix. One process has
+      one ``--basis``, so this can never differ between two live decks; it is in
+      the key anyway because a self-contained key cannot be read wrong.
+
+    Deliberately NOT in the key, because none of them move the operator:
+
+    * ``FR`` — frequency is the key of ``DeckSolver.at``, one level down. Two
+      decks alike but for their ``FR`` SHARE this entry and that is the point.
+    * ``EX`` VOLTAGES — X's columns are per-1 V and the voltage applies at
+      readout (``solve_group``). Only an EX's PLACEMENT is in the key, via the
+      port set.
+    * ``RP``/``NE``/``NH``/``PT``/``YY``/``XQ``/``MP`` — readout and print
+      control, computed from the result after the solve.
+    * ``CM``/``CE`` comments, and card formatting — the key is built from the
+      parsed deck, so a re-sent deck that differs only in whitespace hits.
+    * ``GD`` — the second medium reaches NEC's far field only through ``RP``'s
+      cliff modes and moves nothing in the operator (grammar doc §12.6). It is
+      excluded so a GD knob-drag HITS, which is safe because a hit rebinds
+      ``portal_deck`` to the arriving deck (``_solver_for``): no cached
+      instance ever carries a stale ``GD``, whatever a later far-field path
+      chooses to read. ``test_a_gd_card_change_hits_and_still_answers_fresh``
+      is the proof, and it compares against a FRESH PROCESS rather than
+      against itself, so it stays a proof if ``GD`` ever grows a far field.
+
+    ``EK`` is the conservative entry. Our kernel is momwire's kernel, so today
+    the flag is advisory and could be left out for a better hit rate — but it
+    is a kernel SELECTION, the one card in this list whose whole meaning is
+    "compute the operator differently", and a wrong hit here would be silent.
+    One bool per group is not a hit rate worth spending.
+    """
+    cls, kwargs, suffix = _active_basis
+    return (
+        tuple((c.mnemonic, c.values) for c in deck.geometry),
+        (deck.ground.kind, deck.ground.eps_r, deck.ground.sigma),
+        tuple((c.mnemonic, c.values) for c in deck.loads),
+        tuple(_union_ports(deck)),
+        deck.networks,
+        tuple(g.ek for g in deck.groups if g is not None),
+        (cls.__name__, tuple(sorted(kwargs.items())), suffix),
+    )
+
+
+def _resident_bytes(root: object, limit: int = 50_000) -> int:
+    """A cache entry's honest size: every distinct object reachable from it,
+    numpy arrays at their ``nbytes`` and everything else at ``getsizeof``.
+
+    Walked rather than computed because the entry's cost is not one formula:
+    ``X`` is ``n_basis × n_ports`` complex128 per cached frequency, ``Y`` is
+    small, and whatever the momwire solver retains after its solve (geometry,
+    basis polynomials, any factor it holds) is momwire's business and changes
+    between releases. The per-object term is in there because it MEASURES as
+    the bigger half — a mid-size fixture's entry is ~30 kB of array against
+    ~900 Python objects — so an arrays-only estimate would let the cache hold
+    several times the memory the cap names.
+
+    Distinct objects only (id-keyed), and the object count is bounded: this is
+    accounting, not a measurement, and it runs once per cached deck.
+    """
+    seen: set[int] = set()
+    total = 0
+    stack: list[object] = [root]
+    while stack and len(seen) < limit:
+        obj = stack.pop()
+        if id(obj) in seen:
+            continue
+        seen.add(id(obj))
+        if isinstance(obj, np.ndarray):
+            total += obj.nbytes
+            continue
+        total += sys.getsizeof(obj)
+        if isinstance(obj, dict):
+            stack += list(obj.values())
+        elif isinstance(obj, (list, tuple, set, frozenset)):
+            stack += list(obj)
+        elif hasattr(obj, "__dict__"):
+            stack += list(vars(obj).values())
+    return total
+
+
+def _cache_measure(key: tuple) -> None:
+    """(Re)size one entry. An entry GROWS after it is stored — every new
+    frequency adds an ``at()`` fill to the instance the cache is holding — so
+    the size taken at insertion drifts low exactly on the sweep the cache
+    exists to serve, and the entry that just rendered is re-walked."""
+    solver = _solver_cache.get(key)
+    if solver is not None:
+        _cache_sizes[key] = _resident_bytes(solver)
+
+
+def _cache_evict() -> None:
+    """Drop least-recently-used entries until the estimate is under the cap.
+
+    The most recent entry is never evicted: one structure too big for the cap
+    should still answer its own second execute group from its own factors,
+    which is what a cache that "degrades to today's behaviour" means — a full
+    cache costs a re-solve per arrival and nothing else.
+    """
+    total = sum(_cache_sizes.values())
+    while total > _CACHE_BYTES_CAP and len(_solver_cache) > 1:
+        key, _solver = _solver_cache.popitem(last=False)
+        total -= _cache_sizes.pop(key, 0)
+        _cache_stats["evictions"] += 1
+    _cache_stats["bytes"] = total
+
+
+def _solver_for(deck: PortalDeck) -> DeckSolver:
+    """The :class:`DeckSolver` for this deck — the cached one when its operator
+    has been seen in this process, a fresh one otherwise.
+
+    A hit rebinds ``portal_deck`` to the ARRIVING deck. Everything the cached
+    instance derived from the old one is in the key and therefore identical,
+    but the attribute is a live reference the printout reads through
+    (``_pattern_lines``, ``_near_field_lines``), and the arriving deck is the
+    honest answer to "which deck is being rendered" for anything read from it
+    later — the ``GD`` exclusion above rests on exactly this.
+
+    The cap is enforced HERE, at deck arrival: the entry the PREVIOUS deck
+    rendered through is re-sized (its fills are done now), the arriving deck's
+    entry is sized or created, and the oldest go. So the deck about to be
+    rendered is always resident, and the overshoot is one deck's worth of new
+    frequencies.
+    """
+    if _solver_cache:
+        _cache_measure(next(reversed(_solver_cache)))
+    key = _operator_key(deck)
+    cached = _solver_cache.get(key)
+    if cached is not None:
+        _cache_stats["hits"] += 1
+        _solver_cache.move_to_end(key)
+        cached.portal_deck = deck
+        _cache_evict()
+        return cached
+    # Construction first, and the counter after it: a deck this engine refuses
+    # raises here and moves NOTHING — no entry, no statistic — so a refusal is
+    # neither served from the cache nor recorded in it.
+    solver = DeckSolver(deck)
+    _cache_stats["misses"] += 1
+    _solver_cache[key] = solver
+    _cache_measure(key)
+    _cache_evict()
+    return solver
 
 
 # --------------------------------------------------------------------------
@@ -2980,7 +3224,7 @@ def render_deck(body: str) -> tuple[list[str], list[str]]:
     out += ["", "", ""]
 
     try:
-        solver = DeckSolver(deck)
+        solver = _solver_for(deck)
     except PortalError as exc:
         _append_error(out, exc)
         return out, err
@@ -3189,6 +3433,11 @@ def main(argv: list[str] | None = None, stdin=None, stdout=None, stderr=None) ->
     # mistake at configure time instead of a silent wrong default.
     global _active_basis
     _active_basis = _BASES["bspline"]  # per-invocation default, never sticky
+    # The cross-deck cache is per invocation for the same reason, and because
+    # entries built under one basis must not outlive it (the key carries the
+    # basis, so they could not be served anyway — this just stops them
+    # occupying the cap).
+    _reset_solver_cache()
     rest = list(argv)
     while "--basis" in rest or any(a.startswith("--basis=") for a in rest):
         if "--basis" in rest:

--- a/tests/test_nec_portal.py
+++ b/tests/test_nec_portal.py
@@ -2514,3 +2514,505 @@ def test_require_lattice_fft_names_the_unmet_gate_on_a_single_pair():
     solver = _accel_pair(ArrayBlockSolver, require_lattice_fft=True)
     with pytest.raises(LatticeFFTUnavailable):
         nec_portal._y_and_port_coeffs(solver)
+
+
+# --- the cross-deck solver cache (issue #823) --------------------------------
+#
+# The cache's whole claim is that the printout is IDENTICAL whether a deck was
+# solved or served — so the printout cannot be the evidence that it WAS served.
+# These tests read `nec_portal._cache_stats` for that half and hold the
+# printout to the other half: that a served answer is the answer the arriving
+# deck asked for, byte for byte against the same deck rendered from an empty
+# cache. Nothing here parses a timing line.
+#
+# A stale factor would be silent and wrong, so the battery below is the point
+# of the feature: one mutation per class of card that moves the operator, each
+# asserting a MISS, and one per class that does not, each asserting a HIT.
+
+
+def cache_render(body: str) -> str:
+    """One deck through the daemon's own per-deck path, cache as it stands."""
+    return "\n".join(deck_frame(body)[0])
+
+
+def cold_render(body: str) -> str:
+    """The same deck from an EMPTY cache — what a fresh process prints."""
+    nec_portal._reset_solver_cache()
+    return cache_render(body)
+
+
+def cache_counts() -> dict:
+    return dict(nec_portal._cache_stats)
+
+
+def deck_chunks(transcript: str) -> list[str]:
+    """A daemon transcript split after each ``NX`` echo — one chunk per deck."""
+    chunks: list[str] = []
+    current: list[str] = []
+    for line in transcript.splitlines():
+        current.append(line)
+        if NX_ECHO.match(line):
+            chunks.append("\n".join(current))
+            current = []
+    return chunks
+
+
+def fill_lines(text: str) -> list[str]:
+    """The MATRIX TIMING lines `body_lines` drops. A hit reuses the cached
+    entry's measured fill, so between two passes of one process even these
+    repeat to the digit — the token arity never moves either way."""
+    return [line for line in text.splitlines() if "FILL:" in line]
+
+
+def frame_lines(text: str) -> list[str]:
+    """`body_lines` minus the ASCII banner box, so ONE deck's in-process frame
+    and a whole process's transcript of the same deck compare."""
+    return [
+        line
+        for line in body_lines(text)
+        if "|" not in line and set(line.strip()) != {"_"}
+    ]
+
+
+def aip_impedances(text: str) -> list[tuple[str, str]]:
+    """The impedance columns of every ANTENNA INPUT PARAMETERS row."""
+    return [(row[6], row[7]) for table in aip_tables(text) for row in table]
+
+
+@pytest.mark.parametrize("name", ALL_NAMES)
+def test_a_second_pass_of_every_fixture_prints_what_the_first_did(name):
+    """The identity gate, over the whole corpus: every fixture sent TWICE down
+    one process, compared under the harness's own canonicalisation.
+
+    Fixtures that are multi-deck residency transcripts are compared deck for
+    deck, first half against second. `misses` may not grow on the second pass —
+    that is the assertion that the second half was SERVED rather than re-solved
+    into an identical answer, which is what makes the identity meaningful.
+    """
+    text = (FIXTURE_DIR / f"{name}.deck").read_text()
+    if not text.endswith("\n"):
+        text += "\n"
+    buffer = io.StringIO()
+    rc = main([], stdin=io.StringIO(text * 2), stdout=buffer, stderr=io.StringIO())
+    assert rc == 0
+    chunks = deck_chunks(buffer.getvalue())
+    half = len(chunks) // 2
+    assert half >= 1 and len(chunks) == 2 * half
+    for first, second in zip(chunks[:half], chunks[half:]):
+        assert body_lines(second) == body_lines(first)
+        assert fill_lines(second) == fill_lines(first)
+    assert nec_portal._cache_stats["hits"] >= half
+    assert nec_portal._cache_stats["misses"] <= half
+
+
+@pytest.mark.parametrize("name", ("dipole_free_space", "dipole_rp_pattern"))
+def test_a_served_deck_matches_a_genuinely_fresh_process(name):
+    """And the served printout is not merely self-consistent: it is what a
+    process that never saw the deck before prints. `dipole_rp_pattern` carries
+    the far-field path, where a stale solver would show up as a wrong pattern
+    table rather than a wrong impedance."""
+    text = fixture_deck(name) + "\nNX\n"
+    proc = subprocess.run(
+        [sys.executable, "-m", "antennaknobs.nec_portal"],
+        input=text,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 0 and proc.stderr == ""
+    buffer = io.StringIO()
+    assert (
+        main([], stdin=io.StringIO(text * 2), stdout=buffer, stderr=io.StringIO()) == 0
+    )
+    chunks = deck_chunks(buffer.getvalue())
+    assert len(chunks) == 2 and nec_portal._cache_stats["hits"] == 1
+    assert frame_lines(chunks[1]) == frame_lines(proc.stdout)
+
+
+# A deck carrying one of everything the key has to watch, so each mutation
+# below is a single-token edit against the same base: a wire over a
+# reflection-coefficient ground, scaled, loaded, driven off-centre.
+CACHE_BASE = (
+    "CM cross-deck cache probe\n"
+    "CE\n"
+    "GW 1 9 0. 0. 5.0 0. 0. 10.0 0.001\n"
+    "GS 0 0 1.0\n"
+    "GE -1\n"
+    "GN 0 0 0 0 13. 0.005\n"
+    "LD 0 1 3 3 50. 1.e-6 0.\n"
+    "EX 0 1 5 0 1.\n"
+    "FR 0 1 0 0 14.1 0\n"
+    "XQ\n"
+)
+
+
+def mutate(old: str, new: str, base: str = CACHE_BASE) -> str:
+    """A deck with one substring replaced — asserted unique, so a mutant can
+    never silently edit a card it did not mean to."""
+    assert base.count(old) == 1, old
+    return base.replace(old, new)
+
+
+# The same base with both network branch types hung across the same pair of
+# segments, so a branch's VALUES can be mutated without moving the port set —
+# the case the port component of the key cannot catch.
+CACHE_NET_BASE = mutate(
+    "EX 0 1 5 0 1.\n",
+    "EX 0 1 5 0 1.\nTL 1 3 1 7 600. 2.5 0. 0. 0. 0.\nNT 1 3 1 7 0. 0.02 0. 0. 0. 0.02\n",
+)
+
+
+# (label, base deck, mutant deck, does this move the printed numbers?)
+_OPERATOR_MUTATIONS = (
+    ("GW endpoint", CACHE_BASE, mutate("0. 0. 10.0 0.001", "0. 0. 10.4 0.001"), True),
+    ("wire radius", CACHE_BASE, mutate("0.001", "0.0025"), True),
+    ("segment count", CACHE_BASE, mutate("GW 1 9", "GW 1 11"), True),
+    ("GS scale", CACHE_BASE, mutate("GS 0 0 1.0", "GS 0 0 1.1"), True),
+    # The GE flag is the ground-plane ANNOTATION on this deck (the wire is well
+    # clear of z = 0, and GN carries the physics), so it moves the printout
+    # without moving a number. It is in the key because on a deck whose wire
+    # touches the plane it moves both.
+    ("GE flag", CACHE_BASE, mutate("GE -1", "GE 0"), False),
+    ("GN parameter", CACHE_BASE, mutate("13. 0.005", "20. 0.005"), True),
+    ("GN removed", CACHE_BASE, mutate("GN 0 0 0 0 13. 0.005\n", ""), True),
+    ("LD value", CACHE_BASE, mutate("50. 1.e-6", "150. 1.e-6"), True),
+    ("LD removed", CACHE_BASE, mutate("LD 0 1 3 3 50. 1.e-6 0.\n", ""), True),
+    ("EX moved", CACHE_BASE, mutate("EX 0 1 5", "EX 0 1 4"), True),
+    (
+        "NT added",
+        CACHE_BASE,
+        mutate("EX 0 1 5 0 1.\n", "EX 0 1 5 0 1.\nNT 1 3 1 7 0. 0.02 0. 0. 0. 0.02\n"),
+        True,
+    ),
+    (
+        "TL added",
+        CACHE_BASE,
+        mutate("EX 0 1 5 0 1.\n", "EX 0 1 5 0 1.\nTL 1 3 1 7 600. 2.5 0. 0. 0. 0.\n"),
+        True,
+    ),
+    # Branch VALUES across an unchanged pair of segments: the port set is
+    # identical, so only the `networks` component of the key can catch these.
+    (
+        "NT admittance",
+        CACHE_NET_BASE,
+        mutate("0. 0.02 0. 0. 0. 0.02", "0. 0.03 0. 0. 0. 0.03", CACHE_NET_BASE),
+        True,
+    ),
+    (
+        "TL impedance",
+        CACHE_NET_BASE,
+        mutate("600. 2.5", "450. 2.5", CACHE_NET_BASE),
+        True,
+    ),
+    ("TL length", CACHE_NET_BASE, mutate("600. 2.5", "600. 3.5", CACHE_NET_BASE), True),
+    (
+        "TL crossed",
+        CACHE_NET_BASE,
+        mutate("600. 2.5", "-600. 2.5", CACHE_NET_BASE),
+        True,
+    ),
+    # EK is the conservative key entry: momwire's kernel is momwire's kernel, so
+    # the flag moves no number here — the gate is that it still MISSES, because
+    # a card whose meaning is "compute the operator differently" must never be
+    # answered from an entry built without it.
+    ("EK toggled", CACHE_BASE, mutate("EX 0 1 5 0 1.\n", "EK\nEX 0 1 5 0 1.\n"), False),
+)
+
+
+@pytest.mark.parametrize(
+    "base,mutant,moves_numbers",
+    [(m[1], m[2], m[3]) for m in _OPERATOR_MUTATIONS],
+    ids=[m[0] for m in _OPERATOR_MUTATIONS],
+)
+def test_an_operator_change_misses_the_cross_deck_cache(base, mutant, moves_numbers):
+    """The care point. One mutation per class of card that moves the operator;
+    each must be a MISS and each must answer with its own physics, checked
+    against the same deck rendered from an empty cache."""
+    baseline = cold_render(base)
+    assert "ERROR-NEC2C" not in baseline, baseline
+    before = cache_counts()
+    served = cache_render(mutant)
+    after = cache_counts()
+    assert after["hits"] == before["hits"], "served a stale operator"
+    assert after["misses"] == before["misses"] + 1
+    assert "ERROR-NEC2C" not in served, served
+    assert body_lines(served) == body_lines(cold_render(mutant))
+    if moves_numbers:
+        assert aip_impedances(served) != aip_impedances(baseline)
+
+
+# Cards that change what is PRINTED or how the answer is read out, never the
+# operator behind it. Each must be served from the base's entry.
+_READOUT_MUTATIONS = (
+    ("CM text", mutate("CM cross-deck cache probe", "CM something else entirely")),
+    (
+        "card formatting",
+        mutate(
+            "GW 1 9 0. 0. 5.0 0. 0. 10.0 0.001",
+            "GW,1,9,0.,0.,5.,0.,0.,10.,.001",
+        ),
+    ),
+    ("EX voltage", mutate("EX 0 1 5 0 1.", "EX 0 1 5 0 2.5")),
+    ("RP grid", mutate("XQ\n", "RP 0 7 13 1001 0 0 30 30 1000\nXQ\n")),
+    ("YY card", mutate("EX 0 1 5 0 1.\n", "YY 1 3 1 7\nEX 0 1 5 0 1.\n")),
+    ("PT card", mutate("XQ\n", "PT -1\nXQ\n")),
+    ("MP card", mutate("XQ\n", "MP 16 32\nXQ\n")),
+)
+
+
+@pytest.mark.parametrize(
+    "mutant",
+    [m[1] for m in _READOUT_MUTATIONS],
+    ids=[m[0] for m in _READOUT_MUTATIONS],
+)
+def test_a_readout_change_hits_the_cross_deck_cache_and_answers_fresh(mutant):
+    """The other half of the care point: a deck that differs only in what it
+    prints must be SERVED — no parse, no mesh, no fill — and must still print
+    exactly what a cold cache prints for it."""
+    cold_render(CACHE_BASE)
+    before = cache_counts()
+    served = cache_render(mutant)
+    after = cache_counts()
+    assert after["hits"] == before["hits"] + 1, "re-solved an operator it had"
+    assert after["misses"] == before["misses"]
+    assert after["fills"] == before["fills"], "a hit at one frequency must not fill"
+    assert "ERROR-NEC2C" not in served, served
+    assert body_lines(served) == body_lines(cold_render(mutant))
+
+
+def test_a_new_frequency_reuses_the_geometry_and_pays_only_the_fill():
+    """The issue's third bullet: a crew member handed the same structure at
+    another frequency skips the parse and the mesh — a solver-level HIT — and
+    pays exactly one new fill inside it."""
+    mutant = mutate("14.1", "21.1")
+    cold_render(CACHE_BASE)
+    before = cache_counts()
+    served = cache_render(mutant)
+    after = cache_counts()
+    assert after["hits"] == before["hits"] + 1
+    assert after["misses"] == before["misses"]
+    assert after["fills"] == before["fills"] + 1
+    assert body_lines(served) == body_lines(cold_render(mutant))
+
+
+# The GD proof. The second medium reaches NEC's far field only through RP's
+# cliff modes, so it is deliberately OUT of the key and a GD knob-drag HITS.
+# What makes that safe is that a hit rebinds `portal_deck` to the arriving
+# deck, and the comparison here is against a FRESH PROCESS rather than against
+# the served run itself — so this stays a proof if GD ever grows a far field.
+GD_BASE = (
+    "CE gd probe\n"
+    "GW 1 9 0. 0. 2.0 0. 0. 7.0 0.001\n"
+    "GE -1\nGN 1\nGD 2,0,0,0,13.,.005,0.,0.\n"
+    "EX 0 1 5 0 1.\nFR 0 1 0 0 14.1 0\nXQ\n"
+)
+
+
+def test_a_gd_card_change_hits_the_cache_and_still_answers_fresh():
+    moved = GD_BASE.replace("13.,.005", "80.,.01")
+    assert moved != GD_BASE
+    cold_render(GD_BASE)
+    before = cache_counts()
+    served = cache_render(moved)
+    assert cache_counts()["hits"] == before["hits"] + 1
+    assert "ERROR-NEC2C" not in served, served
+    proc = subprocess.run(
+        [sys.executable, "-m", "antennaknobs.nec_portal"],
+        input=moved + "NX\n",
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 0 and proc.stderr == ""
+    assert frame_lines(served) == frame_lines(proc.stdout)
+
+
+def test_a_hit_rebinds_the_arriving_deck_onto_the_cached_solver():
+    """The invariant the GD exclusion rests on. Everything a cached instance
+    derived from its original deck is in the key and therefore identical, but
+    `portal_deck` is a live reference the printout reads through — so a hit
+    hands it the deck actually being rendered, and no cached instance can carry
+    a stale card that the key deliberately does not watch."""
+    cold_render(GD_BASE)
+    solver = next(iter(nec_portal._solver_cache.values()))
+    assert (
+        solver.portal_deck.second_medium == nec_portal.parse_deck(GD_BASE).second_medium
+    )
+    moved = GD_BASE.replace("13.,.005", "80.,.01")
+    cache_render(moved)
+    assert (
+        solver.portal_deck.second_medium == nec_portal.parse_deck(moved).second_medium
+    )
+
+
+def test_a_cached_entry_is_re_sized_by_the_fills_it_grew():
+    """An entry GROWS after it is stored — a sweep adds an `at()` fill per
+    frequency — so the size taken at insertion drifts low exactly on the deck
+    the cache exists to serve. The entry that just rendered is re-walked when
+    the next deck arrives, which is what keeps the cap honest."""
+    nec_portal._reset_solver_cache()
+    cache_render(CACHE_BASE)
+    key = next(iter(nec_portal._solver_cache))
+    at_insert = nec_portal._cache_sizes[key]
+    for mhz in ("18.1", "21.1", "24.1", "28.1", "50.1"):
+        cache_render(mutate("14.1", mhz))
+    cache_render(_bound_deck(99.0))
+    # Six frequencies through one geometry, plus the arrival that re-sized it.
+    counts = cache_counts()
+    assert (counts["hits"], counts["misses"], counts["fills"]) == (5, 2, 7)
+    assert nec_portal._cache_sizes[key] > at_insert
+
+
+def test_a_repeated_probe_costs_less_than_the_solve_it_skips():
+    """The reason the feature exists. Measured at authoring time on
+    `catalog_wire_w8jk`, the biggest committed deck (106 segments): 154 ms cold
+    against 11 ms served, a factor of fourteen. What is left in the served pass
+    is the readout algebra and the printout itself, which no cache can skip —
+    so the ratio is bounded by the FORMATTING, not by the physics, and it grows
+    with the structure. The bar is deliberately loose: the claim is "much
+    cheaper", and a tight ratio on a shared box is a flaky test, not a better
+    one."""
+    import time
+
+    body = fixture_deck("catalog_wire_w8jk")
+    nec_portal._reset_solver_cache()
+    started = time.perf_counter()
+    cache_render(body)
+    cold = time.perf_counter() - started
+    started = time.perf_counter()
+    cache_render(body)
+    served = time.perf_counter() - started
+    assert nec_portal._cache_stats["hits"] == 1
+    assert served < 0.5 * cold, (cold * 1e3, served * 1e3)
+
+
+def _bound_deck(z: float) -> str:
+    return (
+        "CE bound probe\n"
+        f"GW 1 9 0. 0. {z} 0. 0. {z + 5.0} 0.001\n"
+        "GE 0\nEX 0 1 5 0 1.\nFR 0 1 0 0 14.1 0\nXQ\n"
+    )
+
+
+def test_the_cache_evicts_by_bytes_and_an_evicted_geometry_re_solves(monkeypatch):
+    """The bound. The cap is patched to about two and a half entries rather
+    than filling the shipped few hundred MB, because what needs proving is the
+    eviction ORDER and that an evicted structure comes back correct — not the
+    value of a constant."""
+    nec_portal._reset_solver_cache()
+    assert "ERROR-NEC2C" not in cache_render(_bound_deck(10.0))
+    first_key = next(iter(nec_portal._solver_cache))
+    # The second arrival re-sizes the first entry now that its fill is done, so
+    # this is a grown entry's size and not an empty one's.
+    cache_render(_bound_deck(20.0))
+    monkeypatch.setattr(
+        nec_portal, "_CACHE_BYTES_CAP", int(nec_portal._cache_sizes[first_key] * 2.5)
+    )
+    for z in (30.0, 40.0, 50.0, 60.0):
+        cache_render(_bound_deck(z))
+    assert nec_portal._cache_stats["evictions"] >= 2
+    assert nec_portal._cache_stats["bytes"] <= nec_portal._CACHE_BYTES_CAP
+    assert len(nec_portal._solver_cache) <= 3
+    assert first_key not in nec_portal._solver_cache
+    assert first_key not in nec_portal._cache_sizes
+
+    # Newest still resident.
+    before = cache_counts()
+    cache_render(_bound_deck(60.0))
+    assert cache_counts()["hits"] == before["hits"] + 1
+
+    # Oldest gone — and it re-solves to the same printout it gave when it was
+    # resident, which is what "degrades to today's behaviour" has to mean.
+    before = cache_counts()
+    served = cache_render(_bound_deck(10.0))
+    assert cache_counts()["misses"] == before["misses"] + 1
+    assert body_lines(served) == body_lines(cold_render(_bound_deck(10.0)))
+
+
+def test_the_cache_evicts_the_least_RECENTLY_used_not_the_oldest(monkeypatch):
+    """A knob returned to a value probed long ago is the hit this feature is
+    for, so a re-used entry has to be young again. Without the reorder on a
+    hit this is a FIFO and the entry just served would be the next to go."""
+    nec_portal._reset_solver_cache()
+    for z in (10.0, 20.0, 30.0):
+        cache_render(_bound_deck(z))
+    oldest, middle, _newest = list(nec_portal._solver_cache)
+    monkeypatch.setattr(
+        nec_portal, "_CACHE_BYTES_CAP", int(nec_portal._cache_sizes[oldest] * 2.5)
+    )
+    before = cache_counts()
+    cache_render(_bound_deck(10.0))  # touched: the oldest becomes the newest
+    assert cache_counts()["hits"] == before["hits"] + 1
+    cache_render(_bound_deck(40.0))
+    assert oldest in nec_portal._solver_cache
+    assert middle not in nec_portal._solver_cache
+
+
+@pytest.mark.parametrize(
+    "refused",
+    [
+        # Refused while PARSING — never reaches the cache at all.
+        CACHE_BASE.replace("EX 0 1 5 0 1.\n", "SP 0 0 0. 0. 0. 0. 0.\n"),
+        # Refused while BUILDING the solver: tag 2 does not exist, and a deck
+        # with no EX has no ports. Both raise out of `DeckSolver.__init__`,
+        # after the key has been computed and before anything is stored.
+        CACHE_BASE.replace("EX 0 1 5", "EX 0 2 5"),
+        CACHE_BASE.replace("EX 0 1 5 0 1.\n", ""),
+    ],
+    ids=["parse refusal", "unknown tag", "no EX card"],
+)
+def test_a_refused_deck_neither_poisons_nor_consults_the_cache(refused):
+    """#829's error path against #823's cache. A refusal must move nothing —
+    no entry, no statistic — and the same structure sent valid afterwards must
+    solve fresh and print what a cold cache prints for it."""
+    nec_portal._reset_solver_cache()
+    before = cache_counts()
+    out = cache_render(refused)
+    assert "ERROR-NEC2C" in out, out
+    assert cache_counts() == before
+    assert not nec_portal._solver_cache
+    assert not nec_portal._cache_sizes
+
+    served = cache_render(CACHE_BASE)
+    assert "ERROR-NEC2C" not in served, served
+    assert cache_counts()["misses"] == before["misses"] + 1
+    assert body_lines(served) == body_lines(cold_render(CACHE_BASE))
+
+
+def test_a_refusal_after_a_hit_leaves_the_hit_entry_intact():
+    """The other order: a good deck, a refused one, then the good deck again —
+    the refusal must not have disturbed the entry standing behind it."""
+    cold_render(CACHE_BASE)
+    cache_render(CACHE_BASE.replace("EX 0 1 5", "EX 0 2 5"))
+    before = cache_counts()
+    served = cache_render(CACHE_BASE)
+    assert cache_counts()["hits"] == before["hits"] + 1
+    assert body_lines(served) == body_lines(cold_render(CACHE_BASE))
+
+
+def test_the_cache_is_per_invocation_like_the_basis():
+    """`main` empties the cache exactly where it re-reads `--basis`: engine
+    state is per invocation, so a second call cannot be served from the
+    first's — which is also what keeps entries built under one basis from
+    occupying the cap under another."""
+    deck = fixture_deck("dipole_free_space") + "\nNX\n"
+    for _ in range(2):
+        _rc, _out, _err = _run_main([], deck=deck)
+        counts = cache_counts()
+        assert (counts["hits"], counts["misses"], counts["fills"]) == (0, 1, 1)
+        assert len(nec_portal._solver_cache) == 1
+
+
+def test_the_operator_key_carries_the_basis():
+    """One process has one `--basis`, so this can never differ between two live
+    decks — the key carries it anyway so it cannot be read wrong, and so a
+    future in-process basis switch cannot serve the wrong physics."""
+    deck = nec_portal.parse_deck(CACHE_BASE)
+    default = nec_portal._operator_key(deck)
+    original = nec_portal._active_basis
+    try:
+        nec_portal._active_basis = nec_portal._BASES["sinusoidal"]
+        assert nec_portal._operator_key(deck) != default
+    finally:
+        nec_portal._active_basis = original
+    assert nec_portal._operator_key(deck) == default

--- a/tests/test_nec_portal.py
+++ b/tests/test_nec_portal.py
@@ -2536,7 +2536,16 @@ def cache_render(body: str) -> str:
 
 
 def cold_render(body: str) -> str:
-    """The same deck from an EMPTY cache — what a fresh process prints."""
+    """The same deck from an EMPTY cache — what a fresh process prints.
+
+    That claim needs the DEFAULT basis too: ``main()`` resets
+    ``_active_basis`` at the START of its next invocation, not on exit, so a
+    ``--basis`` probe test leaves its basis behind for every direct
+    ``deck_frame`` render that follows. A fresh-subprocess comparison after
+    such a test would then diff two different physics — an ordering hazard,
+    not a cache bug (it predates the cache; the subprocess-identity tests are
+    just the first to be sensitive to it)."""
+    nec_portal._active_basis = nec_portal._BASES["bspline"]
     nec_portal._reset_solver_cache()
     return cache_render(body)
 
@@ -2843,6 +2852,40 @@ def test_a_hit_rebinds_the_arriving_deck_onto_the_cached_solver():
     assert (
         solver.portal_deck.second_medium == nec_portal.parse_deck(moved).second_medium
     )
+
+
+def test_a_second_medium_change_through_a_warm_cache_moves_the_cliff_pattern():
+    """The combined pin for #823 × #842. The cliff modes made the second
+    medium load-bearing in the far field, and it is read through
+    ``solver.portal_deck.second_medium`` — exactly the attribute a cache hit
+    rebinds. So a GD edit through a WARM cache must (a) hit, (b) move the
+    RADIATION PATTERNS rows, and (c) match a fresh process byte for byte. A
+    stale second medium would pass (a) and fail (b) or (c)."""
+    base = fixture_deck("dipole_rp2_linear_cliff")
+    moved = base.replace("GD 0 0 0 0 5. .001 10. -2.", "GD 0 0 0 0 80. .04 10. -2.")
+    assert moved != base
+    first = cold_render(base)
+    before = cache_counts()
+    served = cache_render(moved)
+    assert cache_counts()["hits"] == before["hits"] + 1
+    pattern_rows = lambda text: [  # noqa: E731 - two-line local helper
+        ln for ln in text.splitlines() if len(ln.split()) == 12 and "." in ln
+    ]
+    assert pattern_rows(served) != pattern_rows(first), (
+        "the warm-cache answer ignored the new second medium"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-m", "antennaknobs.nec_portal"],
+        # fixture_deck strips the framing NX AND the trailing newline.
+        input=moved + "\nNX\n",
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 0 and proc.stderr == ""
+    fresh = frame_lines(proc.stdout)
+    assert fresh, "the fresh process rendered nothing — deck framing bug"
+    assert frame_lines(served) == fresh
 
 
 def test_a_cached_entry_is_re_sized_by_the_fills_it_grew():

--- a/tests/test_nec_portal.py
+++ b/tests/test_nec_portal.py
@@ -2863,27 +2863,26 @@ def test_a_cached_entry_is_re_sized_by_the_fills_it_grew():
     assert nec_portal._cache_sizes[key] > at_insert
 
 
-def test_a_repeated_probe_costs_less_than_the_solve_it_skips():
+def test_a_repeated_probe_skips_the_solve_it_paid_for():
     """The reason the feature exists. Measured at authoring time on
     `catalog_wire_w8jk`, the biggest committed deck (106 segments): 154 ms cold
-    against 11 ms served, a factor of fourteen. What is left in the served pass
-    is the readout algebra and the printout itself, which no cache can skip —
-    so the ratio is bounded by the FORMATTING, not by the physics, and it grows
-    with the structure. The bar is deliberately loose: the claim is "much
-    cheaper", and a tight ratio on a shared box is a flaky test, not a better
-    one."""
-    import time
-
+    against 11 ms served, a factor of fourteen — what is left in the served
+    pass is the readout algebra and the printout itself, which no cache can
+    skip. The ASSERT is on the counters, not the clock: even a "deliberately
+    loose" wall-clock ratio proved flaky under full-suite load (warm BLAS
+    shrinks the cold fill, a GC pause inflates the served one), and the
+    deterministic form of "costs less than the solve it skips" is that the
+    second pass performs zero geometry parses and zero fills."""
     body = fixture_deck("catalog_wire_w8jk")
     nec_portal._reset_solver_cache()
-    started = time.perf_counter()
     cache_render(body)
-    cold = time.perf_counter() - started
-    started = time.perf_counter()
+    after_cold = dict(nec_portal._cache_stats)
+    assert (after_cold["misses"], after_cold["fills"]) == (1, 1)
     cache_render(body)
-    served = time.perf_counter() - started
-    assert nec_portal._cache_stats["hits"] == 1
-    assert served < 0.5 * cold, (cold * 1e3, served * 1e3)
+    after_served = nec_portal._cache_stats
+    assert after_served["hits"] == 1
+    assert after_served["misses"] == after_cold["misses"], "second pass re-parsed"
+    assert after_served["fills"] == after_cold["fills"], "second pass re-filled"
 
 
 def _bound_deck(z: float) -> str:

--- a/tests/test_nec_portal.py
+++ b/tests/test_nec_portal.py
@@ -2528,6 +2528,27 @@ def test_require_lattice_fft_names_the_unmet_gate_on_a_single_pair():
 # A stale factor would be silent and wrong, so the battery below is the point
 # of the feature: one mutation per class of card that moves the operator, each
 # asserting a MISS, and one per class that does not, each asserting a HIT.
+#
+# Serving is OFF in the shipped default and opted into with `--cache`, so a
+# test OF the cache has to ask for it: `cache_reset` is the state every test
+# here starts from, and the `main()`-driven ones pass the flag. The default-off
+# and dry-run modes get their own tests further down.
+
+
+def cache_reset(serving: bool = True) -> None:
+    """Empty cache, default basis, no stats file, serving as asked.
+
+    The basis pin is not decoration: ``main()`` resets ``_active_basis`` at the
+    START of its next invocation, not on exit, so a ``--basis`` probe test
+    leaves its basis behind for every direct ``deck_frame`` render that
+    follows. A fresh-subprocess comparison after such a test would then diff
+    two different physics — an ordering hazard, not a cache bug (it predates
+    the cache; the subprocess-identity tests are just the first to be sensitive
+    to it)."""
+    nec_portal._active_basis = nec_portal._BASES["bspline"]
+    nec_portal._cache_serving = serving
+    nec_portal._cache_stats_path = None
+    nec_portal._reset_solver_cache()
 
 
 def cache_render(body: str) -> str:
@@ -2536,17 +2557,8 @@ def cache_render(body: str) -> str:
 
 
 def cold_render(body: str) -> str:
-    """The same deck from an EMPTY cache — what a fresh process prints.
-
-    That claim needs the DEFAULT basis too: ``main()`` resets
-    ``_active_basis`` at the START of its next invocation, not on exit, so a
-    ``--basis`` probe test leaves its basis behind for every direct
-    ``deck_frame`` render that follows. A fresh-subprocess comparison after
-    such a test would then diff two different physics — an ordering hazard,
-    not a cache bug (it predates the cache; the subprocess-identity tests are
-    just the first to be sensitive to it)."""
-    nec_portal._active_basis = nec_portal._BASES["bspline"]
-    nec_portal._reset_solver_cache()
+    """The same deck from an EMPTY cache — what a fresh process prints."""
+    cache_reset()
     return cache_render(body)
 
 
@@ -2602,7 +2614,9 @@ def test_a_second_pass_of_every_fixture_prints_what_the_first_did(name):
     if not text.endswith("\n"):
         text += "\n"
     buffer = io.StringIO()
-    rc = main([], stdin=io.StringIO(text * 2), stdout=buffer, stderr=io.StringIO())
+    rc = main(
+        ["--cache"], stdin=io.StringIO(text * 2), stdout=buffer, stderr=io.StringIO()
+    )
     assert rc == 0
     chunks = deck_chunks(buffer.getvalue())
     half = len(chunks) // 2
@@ -2630,8 +2644,16 @@ def test_a_served_deck_matches_a_genuinely_fresh_process(name):
     )
     assert proc.returncode == 0 and proc.stderr == ""
     buffer = io.StringIO()
+    # The subprocess is deliberately STOCK — no `--cache` — so this compares a
+    # served answer against the shipped default's, not against itself.
     assert (
-        main([], stdin=io.StringIO(text * 2), stdout=buffer, stderr=io.StringIO()) == 0
+        main(
+            ["--cache"],
+            stdin=io.StringIO(text * 2),
+            stdout=buffer,
+            stderr=io.StringIO(),
+        )
+        == 0
     )
     chunks = deck_chunks(buffer.getvalue())
     assert len(chunks) == 2 and nec_portal._cache_stats["hits"] == 1
@@ -2893,7 +2915,7 @@ def test_a_cached_entry_is_re_sized_by_the_fills_it_grew():
     frequency — so the size taken at insertion drifts low exactly on the deck
     the cache exists to serve. The entry that just rendered is re-walked when
     the next deck arrives, which is what keeps the cap honest."""
-    nec_portal._reset_solver_cache()
+    cache_reset()
     cache_render(CACHE_BASE)
     key = next(iter(nec_portal._solver_cache))
     at_insert = nec_portal._cache_sizes[key]
@@ -2917,7 +2939,7 @@ def test_a_repeated_probe_skips_the_solve_it_paid_for():
     deterministic form of "costs less than the solve it skips" is that the
     second pass performs zero geometry parses and zero fills."""
     body = fixture_deck("catalog_wire_w8jk")
-    nec_portal._reset_solver_cache()
+    cache_reset()
     cache_render(body)
     after_cold = dict(nec_portal._cache_stats)
     assert (after_cold["misses"], after_cold["fills"]) == (1, 1)
@@ -2941,7 +2963,7 @@ def test_the_cache_evicts_by_bytes_and_an_evicted_geometry_re_solves(monkeypatch
     than filling the shipped few hundred MB, because what needs proving is the
     eviction ORDER and that an evicted structure comes back correct — not the
     value of a constant."""
-    nec_portal._reset_solver_cache()
+    cache_reset()
     assert "ERROR-NEC2C" not in cache_render(_bound_deck(10.0))
     first_key = next(iter(nec_portal._solver_cache))
     # The second arrival re-sizes the first entry now that its fill is done, so
@@ -2975,7 +2997,7 @@ def test_the_cache_evicts_the_least_RECENTLY_used_not_the_oldest(monkeypatch):
     """A knob returned to a value probed long ago is the hit this feature is
     for, so a re-used entry has to be young again. Without the reorder on a
     hit this is a FIFO and the entry just served would be the next to go."""
-    nec_portal._reset_solver_cache()
+    cache_reset()
     for z in (10.0, 20.0, 30.0):
         cache_render(_bound_deck(z))
     oldest, middle, _newest = list(nec_portal._solver_cache)
@@ -3007,7 +3029,7 @@ def test_a_refused_deck_neither_poisons_nor_consults_the_cache(refused):
     """#829's error path against #823's cache. A refusal must move nothing —
     no entry, no statistic — and the same structure sent valid afterwards must
     solve fresh and print what a cold cache prints for it."""
-    nec_portal._reset_solver_cache()
+    cache_reset()
     before = cache_counts()
     out = cache_render(refused)
     assert "ERROR-NEC2C" in out, out
@@ -3039,7 +3061,7 @@ def test_the_cache_is_per_invocation_like_the_basis():
     occupying the cap under another."""
     deck = fixture_deck("dipole_free_space") + "\nNX\n"
     for _ in range(2):
-        _rc, _out, _err = _run_main([], deck=deck)
+        _rc, _out, _err = _run_main(["--cache"], deck=deck)
         counts = cache_counts()
         assert (counts["hits"], counts["misses"], counts["fills"]) == (0, 1, 1)
         assert len(nec_portal._solver_cache) == 1
@@ -3058,3 +3080,217 @@ def test_the_operator_key_carries_the_basis():
     finally:
         nec_portal._active_basis = original
     assert nec_portal._operator_key(deck) == default
+
+
+# --- the three cache modes: off, dry-run, serving -----------------------------
+#
+# Serving is opt-in and the shipped default is OFF, because the workload the
+# cache exploits is a live SimNEC session's re-probe rate and nobody has
+# measured one. So the default path has to be provably the pre-#823 path — not
+# "the cache with nothing in it" — and there has to be a way to measure the
+# session without serving anything, which is what `--cache-stats` alone is.
+#
+# The evidence here is a spy on the two things the off path may not do:
+# construct fewer solvers than there are decks, and compute an operator key.
+
+
+def _spy_cache_machinery(monkeypatch) -> tuple[list, list]:
+    """(solver constructions, operator-key computations) for one test.
+
+    A counter cannot prove the off path, because the off path does not count —
+    that is the property under test. These do, from outside."""
+    built: list[str] = []
+    keyed: list[str] = []
+    real_init = nec_portal.DeckSolver.__init__
+    real_key = nec_portal._operator_key
+
+    def init_spy(self, deck):
+        built.append("build")
+        real_init(self, deck)
+
+    def key_spy(deck):
+        keyed.append("key")
+        return real_key(deck)
+
+    monkeypatch.setattr(nec_portal.DeckSolver, "__init__", init_spy)
+    monkeypatch.setattr(nec_portal, "_operator_key", key_spy)
+    return built, keyed
+
+
+def _twice(name: str = "dipole_free_space") -> str:
+    """One fixture deck, framed and sent twice — the repeat probe in miniature."""
+    text = fixture_deck(name) + "\nNX\n"
+    return text * 2
+
+
+def _stream_main(argv: list[str], stdin_text: str) -> list[str]:
+    """`main` over a stdin stream, returning one chunk per deck."""
+    buffer = io.StringIO()
+    rc = main(argv, stdin=io.StringIO(stdin_text), stdout=buffer, stderr=io.StringIO())
+    assert rc == 0
+    return deck_chunks(buffer.getvalue())
+
+
+def test_the_cache_is_off_unless_the_command_line_asks(monkeypatch):
+    """The shipped default. Two identical decks, and the second is genuinely
+    re-solved: two constructions, and NO key computed — the off branch is the
+    pre-#823 path to the byte, not a cache that happens to be empty."""
+    built, keyed = _spy_cache_machinery(monkeypatch)
+    chunks = _stream_main([], _twice())
+    assert len(chunks) == 2
+    assert body_lines(chunks[1]) == body_lines(chunks[0])
+    assert len(built) == 2, "the second deck was served rather than re-solved"
+    assert keyed == [], "the off path computed a cache key"
+    assert nec_portal._cache_mode() == "off"
+    assert not nec_portal._solver_cache and not nec_portal._cache_sizes
+    assert set(nec_portal._cache_stats.values()) == {0}
+
+
+def test_the_cache_flag_turns_serving_on(monkeypatch):
+    """And `--cache` is all it takes: one construction for two decks, the
+    second answered from the first's factors, same printout."""
+    built, keyed = _spy_cache_machinery(monkeypatch)
+    chunks = _stream_main(["--cache"], _twice())
+    assert len(chunks) == 2
+    assert body_lines(chunks[1]) == body_lines(chunks[0])
+    assert len(built) == 1 and len(keyed) == 2
+    assert nec_portal._cache_mode() == "serving"
+    counts = cache_counts()
+    assert (counts["hits"], counts["misses"], counts["fills"]) == (1, 1, 1)
+
+
+def test_cache_stats_alone_counts_the_hits_without_serving(monkeypatch, tmp_path):
+    """The zero-risk live experiment. `--cache-stats` on its own solves every
+    deck fresh — stock behaviour, stock answers, nothing retained — and records
+    how many of them a cache WOULD have served. That is the number the
+    default-off decision is waiting on, obtainable from a real session without
+    putting a served answer anywhere near it."""
+    path = tmp_path / "stats.json"
+    built, keyed = _spy_cache_machinery(monkeypatch)
+    chunks = _stream_main(["--cache-stats", str(path)], _twice())
+    assert len(chunks) == 2
+    assert body_lines(chunks[1]) == body_lines(chunks[0])
+    assert nec_portal._cache_mode() == "dry-run"
+    assert len(built) == 2, "a dry run served a deck"
+    assert len(keyed) == 2, "a dry run has to key every deck to count it"
+    assert not nec_portal._solver_cache and not nec_portal._cache_sizes
+
+    stats = json.loads(path.read_text())
+    assert stats["mode"] == "dry-run"
+    assert (stats["hits"], stats["misses"]) == (1, 1)
+    assert stats["decks_rendered"] == 2
+    assert stats["fills"] == 2, "a dry run still pays every fill — that is the point"
+    assert (stats["entries"], stats["bytes"], stats["evictions"]) == (0, 0, 0)
+
+
+def test_a_dry_run_answers_exactly_what_a_stock_process_answers(tmp_path):
+    """Counting may not perturb the physics: a dry-run deck is compared to the
+    same deck through a process carrying no flags at all."""
+    path = tmp_path / "stats.json"
+    text = fixture_deck("dipole_rp_pattern") + "\nNX\n"
+    proc = subprocess.run(
+        [sys.executable, "-m", "antennaknobs.nec_portal"],
+        input=text,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 0 and proc.stderr == ""
+    chunks = _stream_main(["--cache-stats", str(path)], text)
+    assert len(chunks) == 1
+    assert frame_lines(chunks[0]) == frame_lines(proc.stdout)
+
+
+def test_both_flags_together_count_the_real_cache(tmp_path):
+    """`--cache --cache-stats PATH` is serve AND measure — the mode to run once
+    the dry run says the hit rate is worth having."""
+    path = tmp_path / "stats.json"
+    chunks = _stream_main(["--cache", "--cache-stats", str(path)], _twice())
+    assert len(chunks) == 2
+    stats = json.loads(path.read_text())
+    assert stats["mode"] == "serving"
+    assert (stats["hits"], stats["misses"], stats["fills"]) == (1, 1, 1)
+    assert stats["entries"] == 1 and stats["bytes"] > 0
+
+
+def test_the_stats_file_is_rewritten_after_every_deck(tmp_path):
+    """SimNEC ends a session with `Process.destroy()` — a kill, not an EOF — so
+    a file written at exit is a file that never appears. It is written at every
+    deck boundary instead, which this reads BETWEEN the two decks by holding up
+    the stdin stream."""
+    path = tmp_path / "stats.json"
+    text = fixture_deck("dipole_free_space") + "\nNX\n"
+    midway: list[dict] = []
+
+    def stream():
+        yield from io.StringIO(text)
+        # `main` asks for this line only after deck one has been framed.
+        midway.append(json.loads(path.read_text()))
+        yield from io.StringIO(text)
+
+    buffer = io.StringIO()
+    rc = main(
+        [f"--cache-stats={path}"],
+        stdin=stream(),
+        stdout=buffer,
+        stderr=io.StringIO(),
+    )
+    assert rc == 0
+    assert midway and midway[0]["decks_rendered"] == 1
+    assert midway[0]["mode"] == "dry-run"
+    assert json.loads(path.read_text())["decks_rendered"] == 2
+    # And the transcript is untouched by any of it.
+    assert len(deck_chunks(buffer.getvalue())) == 2
+
+
+def test_a_refused_deck_still_counts_in_the_stats_denominator(tmp_path):
+    """The hit rate needs an honest denominator, and a refused deck is a deck
+    the session sent. It moves no cache statistic — that is the #829 contract —
+    but it is counted as rendered."""
+    path = tmp_path / "stats.json"
+    good = fixture_deck("dipole_free_space") + "\nNX\n"
+    bad = "CE refused\nGW 1 9 0. 0. -2.5 0. 0. 2.5 0.001\nGE 0\nSP 0 0\nNX\n"
+    chunks = _stream_main(["--cache-stats", str(path)], good + bad)
+    assert len(chunks) == 2 and "ERROR-NEC2C" in chunks[1]
+    stats = json.loads(path.read_text())
+    assert stats["decks_rendered"] == 2
+    assert (stats["hits"], stats["misses"]) == (0, 1)
+
+
+def test_the_cache_flags_ride_the_version_probe_unchanged():
+    """SimNEC probes `<full command line> -version`, so every flag the portal
+    dialog can carry has to leave that line alone."""
+    for argv in (
+        ["--cache", "-version"],
+        ["--cache-stats", "/nonexistent/dir/stats.json", "-version"],
+        ["--cache", "--cache-stats=/nonexistent/dir/stats.json", "-version"],
+        ["--basis", "sinusoidal", "--cache", "-version"],
+    ):
+        rc, out, _err = _run_main(argv)
+        assert (rc, out) == (0, f"{nec_portal.PROBE_VERSION}\n"), argv
+
+
+def test_cache_stats_without_a_path_fails_fast_and_nonzero():
+    """Same contract as an unknown `--basis`: a malformed portal-dialog line is
+    caught by the configure-time probe, not by the first deck of a session."""
+    for argv in (["--cache-stats"], ["--cache-stats", "--cache"], ["--cache-stats="]):
+        rc, out, _err = _run_main([*argv, "-version"])
+        assert rc == 3 and "--cache-stats" in out, argv
+
+
+def test_an_unwritable_stats_path_costs_the_measurement_not_the_session(tmp_path):
+    """This engine may write NOTHING to stdout or stderr, so a bad path can
+    only be allowed to lose the file. The decks still answer."""
+    path = tmp_path / "no-such-dir" / "stats.json"
+    buffer = io.StringIO()
+    errors = io.StringIO()
+    rc = main(
+        ["--cache-stats", str(path)],
+        stdin=io.StringIO(_twice()),
+        stdout=buffer,
+        stderr=errors,
+    )
+    assert rc == 0 and errors.getvalue() == ""
+    assert not path.exists()
+    chunks = deck_chunks(buffer.getvalue())
+    assert len(chunks) == 2 and "ERROR-NEC2C" not in buffer.getvalue()


### PR DESCRIPTION
Closes #823.

**Caching is OFF by default** (repo-owner decision): the daemon serves from the cross-deck cache only when the portal command line opts in with `--cache`, and `--cache-stats PATH` provides a **zero-risk dry-run measurement mode** — keys computed and would-be hits counted against a key set (no solver ever retained, nothing servable), answers always solved fresh, a small JSON written after every deck (tmp+rename, because SimNEC tears the daemon down with Process.destroy()). The default path is the pre-#823 code path to the byte: no key, no counters, no references.

Portal-dialog lines for the live experiment:
```
momwire-nec2c --cache-stats /tmp/nec-cache-stats.json    # dry run: stock answers + hit counting
momwire-nec2c --cache                                    # serving, once the numbers justify it
momwire-nec2c --cache --cache-stats /tmp/…               # serving + measuring
```

## The cache itself (serving mode)
Whole-`DeckSolver` LRU keyed on the operator's parsed identity — geometry after transforms, ground-as-a-value, loads, the ordered port set via a `_union_ports` helper shared with `DeckSolver.__init__`, NT/TL branches (frozen dataclasses; hash-equality across independent parses verified), per-group EK, basis — frequency one level down in `at()`, so same-structure-new-frequency reuses parse+mesh and pays one fill. GD/second-medium excluded for hit rate, made safe by rebinding `portal_deck` on every hit — **now load-bearing**: main carries #842's cliff modes, which read the second medium through exactly that attribute, and the combined pin (a GD edit through a warm cache must hit, move the pattern, and match a fresh process) passes. 384 MB byte-bound safety net (entries 44–111 kB measured); most-recent entry never evicted.

## Measured
- Repeat probes: 154 ms → 11 ms (×14) on the biggest committed deck.
- Four modes on the same two-deck stream: **md5-identical transcripts** (FILL lines aside); dry-run stats `{"hits": 1, "misses": 1, "fills": 2}` vs serving `{"fills": 1}` — the saving made visible without being taken.

## Gates
- Targeted suites **685 passed**; full suite **4586 passed** (3 skipped, the known worktree-environment skip); selftest 14/14 **on the default-off path**; ruff clean.
- Default-off proven by spy, not counter (the off path doesn't count — that's the property): 2 constructions, 0 keys, empty cache, all-zero stats.
- The 17-mutation invalidation battery + 7 readout-hit cases + two-pass corpus identity + eviction/LRU/refusal-bypass all run in serving mode; dry-run compared against a genuinely stock subprocess; flags ride `-version` unchanged; missing stats path fails fast rc 3.
- Mutation-probed mechanism (both rounds): dropping any key component, any mechanism line, serving-by-default, dry-run retention, counting-while-off, or the per-deck write each fails at least one committed test.

## Review notes
Implemented and reworked by a delegated opus builder; reviewed by the session model (Fable) across two rounds. Reviewer commits: the repeat-probe gate rewritten from wall-clock to counters (flaked once under full-suite load); the combined #823×#842 pin; and a `cold_render` fix for a **pre-existing** ordering hazard the pin surfaced — `main()` resets `_active_basis` only at its next invocation's start, so `--basis` probe tests leak their basis into subsequent direct renders (0.4% numeric drift vs a fresh default process). Independently re-verified this round: the three-mode transcript identity (md5), the dry-run stats file, targeted + full suites, selftest. Nit noted, pre-existing: `test_selftest_passes_and_reports` is at 4.4 s as the selftest's alt-basis loop has grown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvF4yHgNxjhyZ7P286g3z8