### PR TITLE
chore: release v0.47.0 (the ladder and the cliff)

### DIFF
--- a/docs/status/2026-08-09-v047-live-session.md
+++ b/docs/status/2026-08-09-v047-live-session.md
@@ -1,0 +1,52 @@
+# 2026-08-09 — v0.47.0 pre-release live SimNEC session
+
+**Setup:** local Linux SimNEC (`~/SimNEC/SimNEC`, jar dated 2026-01), engine =
+this checkout's `momwire-nec2c` at main (post-#843), driven through wrapper
+scripts in `~/nec-wrappers/` (see findings). Every deck the crew sent was
+captured verbatim by a tee wrapper (`/tmp/nec-decks.log`, 16 decks); the
+oracle for cross-checks was SimNEC's own bundled `nec2c-ubuntu-x86`
+(`5b4az.ae6ty.1.17`).
+
+## Scorecard
+
+| item | result |
+| --- | --- |
+| Honest identity (#828) | **✓** portal dialog's NECVersion row reads `NEC2momwire.0.46`; decks arrive stamped `CM version NEC2momwire.0.46` |
+| NEC ERROR frame (#829) | **✓** SimNEC surfaces our token-0 `ERROR:` refusal as an actual **error dialog** ("NEC ERROR (1)"), session stays alive. Trigger: a debug wrapper injecting a refused card, since no organically-reachable deck refuses anymore (see findings) |
+| Cliff modes (#802) | **✓** `Cardioid (EZNEC).ssn` — previously fatal — runs: `RP 3` on a 46×181 grid + `GD` second medium + 4-source EX probe arrived verbatim and answered. Feed impedance on the exact logged deck: momwire **32.022+j16.195** vs bundled nec2c **32.104+j16.386** (**0.6%**). Azimuth display shows a proper cardioid |
+| Regression anchor (#696 ladder tuner) | **✓ exact**: rig-side **42.56 − j4.765 Ω**, the v0.46 session's figure to the third decimal |
+| Surfaces examples | `monopoleOverPatch.ssn` runs — SimNEC wire-grids its Surface elements for NEC-2 engines (~3.7k one-segment `GW`s) and momwire solves the grid |
+| Cache dry run (#823) | measured — see below |
+
+## Findings (all new)
+
+1. **The engine is selected with a file dialog** in this build — no room for
+   command-line flags. Wrapper scripts are the mechanism (name must contain
+   `nec2c`, path must avoid the substring `out`). Documented in
+   `reference/simnec.md`.
+2. **SimNEC silently deletes `SP` cards from N-element scripts** before the
+   deck reaches a NEC2C engine: a pasted patch model solves as bare wire with
+   no warning from any layer (our refusal can never fire — the cards never
+   arrive). Distinct from Surface *elements*, which are wire-gridded
+   properly. One for the next note to Ward.
+3. **SimNEC's script parser errors on apostrophes in `CM` lines** ("Don't put
+   single quotes in a comment line").
+4. **The crew fragments per-process state**: SimNEC runs several daemon
+   processes; anything keyed per-process (the cache, a stats file path) sees
+   only its own stream. Stats paths need `$$`-style uniqueness; the deck log
+   is the true global stream.
+
+## Cache dry-run analysis (decides #823's default)
+
+From the 16 captured decks, keyed by the shipped `_operator_key`:
+
+- 4 unique operators → **75%** of decks would have reused parse+mesh;
+- 6 unique (operator, frequency) pairs → **62% fully servable** (zero fills);
+- one identical (deck, frequency) request was sent **5×**, another 4×.
+
+Caveats: a verification session is reload-heavy relative to design work, and
+the crew fragmentation above means per-process realized rates sit below the
+global ceiling. Verdict: the opt-in default ships as decided; the numbers go
+in the docs as the evidence for turning `--cache` on; revisit default-on
+after a longer natural session (and a protocol-v2 conversation about the
+crew).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.46.0"
+version = "0.47.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,21 +25,21 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.46.0" icon="star">
-  **The engine-for-hire release: momwire now runs *inside* SimNEC.** Point
-  SimNEC's NEC-portal dialog at the new **`momwire-nec2c`** drop-in and its
-  Smith chart, tuners, and sweeps run on momwire's solver — no change to
-  SimNEC needed. The protocol was reverse-engineered against SimNEC's own
-  bundled engine (40 captured printout pairs, reproduced column-for-column)
-  and then **validated in a live SimNEC session**: a real station circuit
-  within a few percent through a high-Q tuner, pattern levels agreeing to
-  ~0.01 dB, and SimNEC's own 4-source phased-array example matching to 1 Ω
-  of reactance. A **`--basis`** flag picks the physics from the portal
-  dialog itself — paste two entries and you have cross-basis validation
-  inside SimNEC, with `sinusoidal-galerkin-converged` on call for near-open
-  high-Q feeds. Structurally faster where it counts: N-port probes cost one
-  matrix fill, not N. Plus: multi-feed \`.ssn\` exports now refuse rather
-  than silently losing their drive phasing. Start at
+<Card title="New in v0.47.0" icon="star">
+  **The ladder-and-cliff release, shaped by SimNEC's own author.** The
+  portal's **`--basis`** roster grows from three entries to **seven** — bare
+  `sinusoidal` (the NEC-closest formulation, 0.24% from nec2c on the
+  reference dipole), `bspline-d1`, and the large-array accelerators
+  `hmatrix`/`arrayblock` (a 24×24 phased array in **0.77 s and 137 MB**
+  where the dense fill needs 8.0 s and 5.3 GB, benchmarked and committed).
+  The engine now **identifies itself honestly** — SimNEC's dialog shows
+  `NEC2momwire.0.47`, a form its author sanctioned — and refusals surface as
+  a real **NEC ERROR dialog** instead of a silently empty session. **`RP 2`/
+  `RP 3` cliff patterns** run (EZNEC-derived examples included — verified
+  live against SimNEC's bundled engine to 0.6%), and an opt-in **`--cache`**
+  remembers structures across decks (×14 on repeat probes; a `--cache-stats`
+  dry run measured 62% of a live session's decks fully servable before
+  anything was trusted). Start at
   [Using momwire as SimNEC's engine](/reference/simnec/#using-momwire-as-simnecs-engine).
 </Card>
 

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -238,6 +238,7 @@ The `--engine` flag selects the solver:
 --engine momwire:sinusoidal-galerkin            # same basis, Galerkin testing
 --engine momwire:sinusoidal-galerkin-converged  # …with the converged feed model
 --engine momwire:bspline         # B-spline Galerkin basis
+--engine momwire:bspline-d1      # …at degree 1 (bs1) — the cheapest d1-vs-d2 convergence check
 --engine momwire:hmatrix         # B-spline + hierarchical-matrix (ACA) acceleration
 --engine momwire:arrayblock      # element-aware block solver for arrays
 --engine pynec                   # the NEC-2 reference backend (needs pynec-accel)

--- a/site/src/content/docs/reference/simnec.md
+++ b/site/src/content/docs/reference/simnec.md
@@ -184,8 +184,8 @@ momwire-nec2c --selftest
 
 ### Choosing the physics: `--basis`
 
-SimNEC launches engines through the shell, so the command you paste into the
-portal dialog can carry arguments. The portal accepts a `--basis` flag:
+SimNEC launches engines through the shell, so the engine command can carry
+arguments. The portal accepts a `--basis` flag:
 
 ```text
 momwire-nec2c --basis bspline                        # the default
@@ -196,6 +196,25 @@ momwire-nec2c --basis sinusoidal-galerkin-converged  # recommended for near-open
 momwire-nec2c --basis hmatrix                        # same physics, hierarchical (ACA) solve
 momwire-nec2c --basis arrayblock                     # same physics, element-block/FFT solve — large arrays
 ```
+
+:::note[If your SimNEC build sets the engine with a file picker]
+Current SimNEC builds select the NEC command through a **file dialog**, which
+leaves nowhere to type arguments. The fix is a wrapper script per flag
+combination — the dialog picks a file, so make the flags *be* a file:
+
+```bash
+mkdir -p ~/nec-wrappers
+cat > ~/nec-wrappers/momwire-nec2c-sin <<'SH'
+#!/bin/sh
+exec /path/to/momwire-nec2c --basis sinusoidal "$@"
+SH
+chmod +x ~/nec-wrappers/momwire-nec2c-sin
+```
+
+Two hard rules carried over from the filename check: the wrapper's **name
+must contain `nec2c`**, and its **path must not contain the substring
+`out`** — either mistake and SimNEC refuses the command outright.
+:::
 
 Four of those are a ladder: NEC-2 itself, then `sinusoidal` — the three-term
 basis, point matched, with NEC's own delta-gap source, so it answers "does
@@ -294,8 +313,17 @@ at exit is never written) and holds one small JSON object:
  "fills": 412, "evictions": 0, "bytes": 0, "entries": 0}
 ```
 
-`hits` against `decks_rendered` is the saving on offer. If it is worth having,
-turn serving on:
+`hits` against `decks_rendered` is the saving on offer. One live session has
+been measured this way (2026-08-09, the v0.47.0 verification session): of 16
+decks sent, **62% were fully servable** — identical operator *and* frequency,
+zero fills needed — and 75% would have reused the parsed geometry and mesh;
+one identical solve request was sent five times in ordinary clicking. Two
+caveats travel with those numbers: a verification session is reload-heavy
+compared to design work, and SimNEC runs a **crew of engine processes**, so
+each process caches (and counts) only its own stream — give each portal entry
+its own stats path (e.g. `--cache-stats /tmp/nec-stats.$$.json` in a wrapper)
+or the crew members overwrite one file. If your numbers look like the
+measured ones, turn serving on:
 
 ```text
 momwire-nec2c --cache
@@ -324,7 +352,20 @@ shows up as a visible warning instead of a session that quietly loaded
 nothing. (Earlier builds used a differently-shaped prefix specifically to
 avoid tripping that frame; issue #829 reversed that on Ward's own say-so
 after a live session hit it — a refused patch-antenna design left the user
-staring at an empty result with no indication why.)
+staring at an empty result with no indication why.) Verified live
+(2026-08-09): SimNEC surfaces the refusal as an actual **error dialog**.
+
+Two script-layer behaviors discovered in the same live session, both
+upstream of any engine:
+
+- **SimNEC deletes `SP` cards from an N-element script silently** before the
+  deck reaches a NEC-2-class engine — a pasted patch model solves as bare
+  wire with no warning from anyone, because the engine never sees the cards.
+  (SimNEC's own *Surface elements* are properly wire-gridded instead, and
+  those run on momwire fine.) Until that changes upstream, don't paste raw
+  `SP` decks and trust the numbers.
+- **No apostrophes in `CM`/`CE` lines** pasted into the script editor —
+  SimNEC's script parser reads `'` as a quote and errors.
 
 Refused today:
 


### PR DESCRIPTION
The release PR for **v0.47.0 — the ladder and the cliff**: everything since v0.46.0 is portal work shaped directly by Ward's reply to our notes, finished with a live verification session on a real SimNEC install today.

## In this release (all previously merged)
- `--basis` roster 3 → **7**: `sinusoidal` (NEC-closest, 0.24% vs nec2c), `bspline-d1`, `hmatrix`, `arrayblock` (#826/#827/#832) — with the lattice benchmark behind the large-array claim (#836: 24×24 array 0.77 s/137 MB vs dense 8.0 s/5.3 GB; dense wall at 32×32)
- **Honest identity**: probe answers `NEC2momwire.<version>` via the Ward-sanctioned NEC-d path (#835), `--legacy-probe` fallback — **live-confirmed** in the portal dialog today
- **Visible errors**: refusals trip SimNEC's NEC ERROR frame (#831) — **live-confirmed as an actual dialog** today
- **RP 2/RP 3 cliff modes** + RFLD=0 (#842), capture-first, provenance re-grounded on the public-domain FORTRAN — **live-confirmed**: the previously-fatal Cardioid (EZNEC) example runs at **0.6%** from the bundled oracle on the exact logged deck
- **Opt-in cross-deck cache** (#843): `--cache` + `--cache-stats` dry-run — live dry-run measured **62% fully-servable decks**
- Regression anchor: the #696 ladder tuner reads **42.56 − j4.765 Ω**, the v0.46 figure exactly

## This PR
Version bump, what's-new card, cli.md roster fix (bspline-d1 was missing), simnec.md live-session findings (wrapper recipe for file-dialog builds, cache numbers + caveats, SP-silent-deletion caution, apostrophe quirk, dialog confirmation), and the session status doc. Site builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvF4yHgNxjhyZ7P286g3z8