### PR TITLE
momwire 0.24.0: pin, portal on the public port API, measured dense-footprint model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/sta
 # install below sees its requirement already satisfied, then the package with the
 # web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install "momwire==0.23.0" \
+ && pip install "momwire==0.24.0" \
  && pip install -e ".[web]"
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in

--- a/docs/status/2026-08-09-arrayblock-lattice-benchmark.md
+++ b/docs/status/2026-08-09-arrayblock-lattice-benchmark.md
@@ -273,3 +273,28 @@ python scripts/bench_arrayblock_lattice.py --worker dense 32 9 0.6 14.0 8.0
 
 Manual-only. The benchmark is a script, never wired into CI, per the repo test
 policy (no per-design certs in CI; PR #392 precedent).
+
+---
+
+## Addendum 2026-08-10 — the dense wall moved (momwire 0.24.0, issue #847)
+
+momwire#235 (momwire PR #237, in 0.24.0) routed `compute_y_matrix` through
+the chunked dense fill, and the flat 12× above is history. Re-measured with
+the same probe method on 0.24.0 (peak RSS net of the ~80 MB import floor):
+
+| n_basis | peak | factor over n²·16 B |
+|---|---|---|
+| 1296 | 272 MB | 10.61× (tensor still fits the 256 MB budget) |
+| 2304 | 637 MB | 7.87× |
+| 5184 | 1134 MB | 2.77× |
+| 9216 | 2469 MB | 1.91× |
+
+The chunked regime fits an affine model, peak ≈ 1.44 × n²·16 B + 515 MB
+(predicts the n=5184 point to 0.1%). `dense_estimate_gb` in the bench script
+now implements the piecewise model with margin (`10.7×` tensor regime /
+`1.5× + 0.55 GB` chunked); `DENSE_FOOTPRINT_FACTOR = 12.0` is retired. The
+32×32 rung this run recorded as `skipped (est 15.19 GB > cap)` now solves
+dense in 2.47 GB — the dense wall under an 8 GB cap moves from ~9.2k to
+~18k bases. The 24×24 rung's dense column re-measures at 9.0 s / 1.1 GB
+(was 8.0 s / 5.3 GB): the chunked fill trades ~13% wall clock for 4.7×
+memory. Timings and the `arrayblock` column are otherwise unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire==0.23.0",
+    "momwire==0.24.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",

--- a/scripts/bench_arrayblock_lattice.py
+++ b/scripts/bench_arrayblock_lattice.py
@@ -37,10 +37,11 @@ Caveats, stated up front so the tables aren't misread:
     three bases ride the accelerated path on ground already, which is a
     separate question.
   - **The dense column has a wall and we find it by estimate.** Dense peak RSS
-    runs about 12x the n_basis^2 * 16 bytes of Z itself (see
-    `DENSE_FOOTPRINT_FACTOR` — the batched assembly's quadrature gather, not
-    the matrix, sets the peak), so a rung whose estimate exceeds the cap is
-    recorded `skipped (est > cap)` rather than discovered the hard way. Once a
+    follows the measured piecewise model at `dense_estimate_gb` (momwire >=
+    0.24.0: ~10.6x Z in the small-n tensor regime, ~1.5x Z + 0.55 GB chunked
+    — issue #847; it was a flat 12x before momwire#235), so a rung whose
+    estimate exceeds the cap is recorded `skipped (est > cap)` rather than
+    discovered the hard way. Once a
     column caps, times out, or is skipped, that column is CLOSED — larger
     rungs are not probed.
 
@@ -90,15 +91,22 @@ DEFAULT_FREQ_MHZ = 14.0
 DEFAULT_CAP_GB = 8.0
 DEFAULT_TIMEOUT = 600.0
 
-# Dense live-footprint estimate, as a multiple of Z itself (n^2 complex128).
-# The obvious arithmetic — Z plus the LU's working copy — says ~2.2x, and that
-# is WRONG by a factor of five: the batched C++ assembly materialises a
-# per-pair quadrature gather before it reduces to Z, so the peak lands well
-# above the matrix. Measured on the 2026-08-09 run (peak RSS minus the ~91 MB
-# import floor, divided by n^2*16): 12.3x at n=1296, 12.1x at n=2304, 12.1x at
-# n=5184. Flat enough across a 4x span in n to extrapolate with, so this is the
-# measurement, not the arithmetic.
-DENSE_FOOTPRINT_FACTOR = 12.0
+# Dense live-footprint model (momwire >= 0.24.0, issue #847). The flat 12x
+# this constant used to hold was compute_y_matrix bypassing the issue-#136
+# chunked fill — the full (d+1, d+1, N, N) moment tensor, momwire#235, fixed
+# in momwire PR #237. Post-fix the peak is piecewise (measured 2026-08-09 on
+# 0.24.0, peak RSS net of the ~80 MB import floor):
+#   - tensor regime (9 * n^2 * 16 B fits swept_mem_mb, i.e. n <~ 1365 at the
+#     default 256 MB): the tensor path still runs — 10.61x at n=1296;
+#   - chunked regime: affine in Z, 1.44 * n^2 * 16 B + 515 MB, fitting the
+#     measured 637 MB / 1134 MB / 2469 MB at n = 2304 / 5184 / 9216 to
+#     better than 0.1%. The 0.44 * Z excess over Z itself plus the fixed
+#     transient are measured shape, not derived arithmetic — re-measure if
+#     the assembly changes (probe: this file's worker on the dense solver).
+DENSE_TENSOR_REGIME_FACTOR = 10.7  # tensor-path factor, small margin over 10.61
+DENSE_CHUNKED_SLOPE = 1.5  # margin over the fitted 1.44
+DENSE_CHUNKED_FIXED_GB = 0.55  # margin over the fitted 515 MB
+_SWEPT_MEM_MB_DEFAULT = 256  # momwire's default fill-transient budget
 
 # Agreement bound the accelerated columns are held to (issue #833 gate 3).
 AGREEMENT_BOUND = 1e-4
@@ -142,8 +150,18 @@ def n_basis_of(grid: int, segs: int) -> int:
 
 
 def dense_estimate_gb(n_basis: int) -> float:
-    """Estimated live footprint (GB) of the dense fill + factor at `n_basis`."""
-    return n_basis**2 * 16 * DENSE_FOOTPRINT_FACTOR / 1024**3
+    """Estimated live footprint (GB) of the dense fill + factor at `n_basis`.
+
+    Piecewise per the measured model above: the tensor path while the moment
+    tensor fits momwire's default budget, the chunked affine model beyond it.
+    Deliberately a slight over-estimate (the constants carry margin) — this
+    gates whether a dense rung is attempted under the address-space cap, and
+    a skipped-but-feasible rung is a cheaper mistake than an OOM-killed one.
+    """
+    z_gb = n_basis**2 * 16 / 1024**3
+    if 9 * n_basis**2 * 16 <= _SWEPT_MEM_MB_DEFAULT * 1024**2:
+        return z_gb * DENSE_TENSOR_REGIME_FACTOR
+    return z_gb * DENSE_CHUNKED_SLOPE + DENSE_CHUNKED_FIXED_GB
 
 
 # --------------------------------------------------------------------------

--- a/site/src/content/docs/reference/simnec.md
+++ b/site/src/content/docs/reference/simnec.md
@@ -236,9 +236,11 @@ telling you something about conditioning, not about basis choice.
 
 How much it buys, measured on a 2017 quad-core laptop over a square lattice of
 half-wave dipoles at 0.6 λ pitch: a 24×24 array (576 elements, 5184 unknowns)
-takes 8.0 s and 5.3 GB with the dense fill and **0.77 s and 137 MB on
-`arrayblock`**, and a 32×32 array will not solve at all inside an 8 GB budget
-— it needs about 15 GB — while `arrayblock` answers it in 1.3 s and 173 MB. At
+takes 9.0 s and 1.1 GB with the dense fill and **0.77 s and 137 MB on
+`arrayblock`**. (Dense memory improved a lot in momwire 0.24.0 — the same
+rung needed 5.3 GB before, and a 32×32 array that previously would not solve
+inside an 8 GB budget now fits dense in ~2.5 GB — but `arrayblock` still
+answers the 32×32 in 1.3 s and 173 MB against dense's minutes.) At
 48×48 (2304 elements) `arrayblock` takes 3.0 s and 272 MB where `hmatrix`
 needs 158 s and 2.0 GB. The crossover is around 8×8; below that the dense fill
 is the cheaper tool. Agreement with the dense solve stays within a few parts

--- a/src/antennaknobs/nec_portal.py
+++ b/src/antennaknobs/nec_portal.py
@@ -1763,132 +1763,26 @@ def _gain_db(power_gain: float) -> float:
 
 def _y_and_port_coeffs(solver):
     """``(Y, X)`` from ONE momwire fill: the short-circuit port admittance
-    matrix and the per-port basis-coefficient columns behind it.
+    matrix and the per-port basis-coefficient columns behind it — momwire's
+    public ``compute_port_solution()`` (momwire#232, momwire 0.24.0).
 
-    ``compute_y_matrix`` already computes ``X = solve(Z, B)`` — one LU of the
-    KCL-augmented operator, one back-substitution per port — and then throws X
-    away, returning only ``Y = Bᵀ·X``. Column j of X is the solution for a 1 V
-    drive at port j, so keeping it turns ANY later excitation into
-    ``coeffs = X @ V`` with no second fill. That is the whole single-fill
-    architecture: the alternative (``compute_impedance`` once per execute
-    group) refills and refactors per source, which is exactly what the oracle
-    does and what this daemon exists to avoid.
+    Until 0.24.0 this function was a four-branch dispatch keyed on each
+    family's private port algebra: verbatim copies of the Galerkin and
+    point-matched Y paths, plus an instance-level dual spy on
+    ``_solve_with_kcl_ports`` / ``_solve_hmatrix`` for the spline families —
+    the private-API debt momwire#232 tracked. The public API returns the same
+    ``(y, coeffs)`` pair from the same one-fill-all-ports solve; the swap was
+    verified bit-identical on all four branches before landing (momwire
+    PR #250's sufficiency check: dY = dX = 0 exactly, and this repo's
+    420-test portal battery passed unchanged against it).
 
-    The capture is an instance-level shim rather than a subclass on purpose:
-    ``engines/momwire.py`` gates ground models and distributed wire loading on
-    the solver class NAME, so a subclass would silently drop a Sommerfeld deck
-    back onto a PEC image.
-
-    The three branches are keyed on the port algebra each family owns, not on
-    the class: ``_assemble_Z_ported`` exists only on the Galerkin subclass and
-    ``_solve_with_kcl_ports`` only on the B-spline family, so a basis added to
-    ``_BASES`` lands on the branch whose algebra it actually has. Inside the
-    B-spline branch the same rule picks the SOLVE: the accelerated subclasses
-    own ``_solve_hmatrix``, so that is what gets spied for them.
+    Family refusals (the point-matched junction-port span rule, Galerkin
+    junction ports over finite ground) surface from momwire with the same
+    exception types and messages the branches raised — pinned momwire-side
+    in ``tests/test_port_solution.py``.
     """
-    if hasattr(solver, "_assemble_Z_ported"):
-        # Sinusoidal-Galerkin family: no KCL-port solve to spy on, but
-        # compute_y_matrix's own algebra IS the (Y, X) pair — alphas is the
-        # per-port coefficient matrix it computes and throws away. Kept
-        # verbatim from momwire's compute_y_matrix so the two can never
-        # disagree; the private reach is the same momwire#232 debt as the
-        # shim below.
-        import scipy.linalg
-
-        solver._refuse_junction_port_solve()
-        geom = solver._build_geometry()
-        G, seg_view = solver._assemble_Z_ported(geom, solver.k)
-        U = solver._drive_columns(geom, seg_view, solver.k)
-        alphas = scipy.linalg.solve(G, U)
-        y = np.stack(
-            [
-                solver._port_currents(alphas[:, j], geom, seg_view, U)
-                for j in range(solver.n_ports)
-            ],
-            axis=1,
-        )
-        return y, alphas
-
-    if not hasattr(solver, "_solve_with_kcl_ports"):
-        # Point-matched sinusoidal: neither a KCL-port solve to spy on nor the
-        # Galerkin port algebra — its ports ARE the Eq-187 delta gaps, so the
-        # RHS is -1/h at each feed segment and column j of the solution is
-        # already the 1 V drive at port j (``compute_impedance`` builds the
-        # same column, scaled by V). Kept verbatim from momwire's
-        # ``compute_y_matrix``, same momwire#232 debt as the branches around
-        # it. No junction-port refusal belongs here: this solver rejects
-        # ``junction_ports=`` at CONSTRUCTION (momwire#177 — the basis
-        # enforces KCL identically, so a node-current port is outside its
-        # span), and a deck's ports are all EX segment gaps anyway.
-        import scipy.linalg
-
-        geom = solver._build_geometry()
-        G, seg_view = solver._assemble_Z(geom, solver.k)
-        feed_segs = geom["feed_segs"]
-        B = np.zeros((geom["n_segs"], len(feed_segs)), dtype=np.complex128)
-        for j, fi in enumerate(feed_segs):
-            B[fi, j] = -1.0 / geom["seg_h"][fi]
-        alphas = scipy.linalg.solve(G, B)
-        y = np.array(
-            [
-                [
-                    solver._feed_segment_current(alphas[:, j], seg_view, fi)
-                    for j in range(len(feed_segs))
-                ]
-                for fi in feed_segs
-            ],
-            dtype=np.complex128,
-        )
-        return y, alphas
-
-    # B-spline family, and TWO solve routes to spy on (issue #830). The dense
-    # path back-substitutes in `_solve_with_kcl_ports`. The accelerated
-    # subclasses — HMatrixSolver and ArrayBlockSolver, both `_BASES` entries —
-    # never reach it: their `compute_y_matrix` builds the same source columns
-    # B and runs the constrained block-GMRES in `_solve_hmatrix`, returning
-    # ``Bᵀ·X`` and dropping X on the floor exactly as the dense path does.
-    # ``_solve_hmatrix``'s X is the same object under the same convention —
-    # (n_basis, n_ports), Lagrange rows already stripped — so the two captures
-    # are interchangeable downstream.
-    #
-    # Which route runs is `_hmatrix_unsupported()`, i.e. singular enrichment
-    # ONLY (momwire hmatrix.py / array_block.py): mesh size does not select it,
-    # and every ground model the portal can emit — PEC image, reflection
-    # coefficient, Sommerfeld — is carried on the accelerated path. The portal
-    # never asks for enrichment, so in practice the accelerated bases always
-    # take `_solve_hmatrix`; the dense capture stays wired anyway so a momwire
-    # that grows a new fallback degrades to a slower answer, not an error.
-    captured: dict[str, np.ndarray] = {}
-    dense = solver._solve_with_kcl_ports
-
-    def spy_dense(z, v, kcl_a, overwrite=False):
-        x = dense(z, v, kcl_a, overwrite=overwrite)
-        captured["dense"] = x
-        return x
-
-    solver._solve_with_kcl_ports = spy_dense
-    accel = getattr(solver, "_solve_hmatrix", None)
-    if accel is not None:
-
-        def spy_accel(h, kcl_a, b):
-            x = accel(h, kcl_a, b)
-            captured["accel"] = x
-            return x
-
-        solver._solve_hmatrix = spy_accel
-    try:
-        y = np.asarray(solver.compute_y_matrix(), dtype=np.complex128)
-    finally:
-        del solver._solve_with_kcl_ports
-        if accel is not None:
-            del solver._solve_hmatrix
-    # Accelerated first: a solve that reached `_solve_hmatrix` never touched
-    # the dense route, so the two keys are mutually exclusive in practice and
-    # the preference only decides a hypothetical future hybrid.
-    x = captured.get("accel", captured.get("dense"))
-    if x is None:  # pragma: no cover - momwire internals moved
-        raise PortalError("momwire did not expose the per-port solution")
-    return y, x
+    sol = solver.compute_port_solution()
+    return sol.y, sol.coeffs
 
 
 def _synthesize_union_deck(deck: PortalDeck, ports: list[tuple[int, int]]) -> str:

--- a/tests/test_nec_portal.py
+++ b/tests/test_nec_portal.py
@@ -2168,9 +2168,9 @@ def test_sinusoidal_has_no_converged_variant():
 
 
 def test_bspline_d1_basis_flag_solves_and_stamps_the_banner():
-    """`bspline-d1` is BSplineSolver with degree=1 bound — same one-fill shim
-    as plain `bspline` (dispatch is on `hasattr(solver, "_solve_with_kcl_ports")`,
-    not on degree), so it answers a deck and stamps +bs1 in the banner."""
+    """`bspline-d1` is BSplineSolver with degree=1 bound — same public
+    `compute_port_solution()` path as plain `bspline` (momwire#232; degree is
+    just a constructor knob), so it answers a deck and stamps +bs1."""
     deck = (
         "CE basis\n"
         "GW 1 11 0. -5. 10. 0. 5. 10. 0.001\n"
@@ -2289,8 +2289,10 @@ def _accel_pair(cls, volts=(1.0, 0.0), **kwargs):
 
 def _route_spy(solver):
     """Record which of the two B-spline solve routes momwire takes, without
-    disturbing either. Installed BEFORE the shim, so the shim wraps these and
-    its own ``del`` on the instance attribute tidies them away."""
+    disturbing either. Instance-attribute spies intercept the calls
+    ``compute_port_solution()`` makes internally (momwire#232 replaced the
+    portal's own spy shim, but the route question is still observable from
+    outside the public API this way)."""
     routes: list[str] = []
     dense = solver._solve_with_kcl_ports
 


### PR DESCRIPTION
Adopts momwire 0.24.0 ("the kernels-and-ports release": momwire#235/#234/#205/#233/#232) in three commits:

1. **The pin trio** (one commit, per the release runbook): `momwire==0.24.0` in pyproject, the Dockerfile install, and the submodule pointer at the release's bump commit.
2. **Portal migration onto `compute_port_solution()`** (momwire#232): the four-branch private shim in `_y_and_port_coeffs` — verbatim copies of two solver families' Y paths plus the dual `_solve_with_kcl_ports`/`_solve_hmatrix` spy — collapses to one public-API call. The swap was proven bit-identical on all four branches before momwire#232 merged (momwire PR #250's sufficiency check, dY = dX = 0 exactly); the 420-test portal battery passes unchanged, and two test docstrings that described the old mechanics are updated.
3. **Measured dense-footprint model** (closes #847): the flat `DENSE_FOOTPRINT_FACTOR = 12.0` was momwire#235's bug, not physics. Re-measured on 0.24.0: 10.61x while the moment tensor fits momwire's budget, then affine 1.44xZ + 515 MB (three points fit to 0.1%). `dense_estimate_gb` implements the piecewise model with margin; the benchmark run record gets a dated addendum; simnec.md's 24x24 dense column re-measured at 9.0 s / 1.1 GB (was 8.0 s / 5.3 GB — the chunked fill trades ~13% wall for 4.7x memory). The dense wall under an 8 GB cap moves from ~9.2k to ~18k bases.

Not in this PR (deliberate): wiring the EK card to `extended_kernel=True` — that waits for the C++ EK path (momwire#245) so honoring EK doesn't carry a surprise 8.5x, and rides the #841 EK-honesty arc.

## Gates
- Full suite: **4587 passed, 2 skipped** under `prlimit --as=8G` against the pinned momwire.
- Portal battery: 420 passed, zero behavioral change.
- Dense model: reviewer-measured points at n = 1296/2304/5184/9216; the n=5184 prediction validates to 0.1%.
- momwire side: v0.24.0 wheels published (16 assets), PyPI serves 0.24.0, momwire main green after the cross-machine armor-tolerance fix (momwire PR #253).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvF4yHgNxjhyZ7P286g3z8