### PR TITLE
#849 unit 1: pin momwire 0.26.0 + engine passthrough + the EK card stops being advisory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/sta
 # install below sees its requirement already satisfied, then the package with the
 # web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install "momwire==0.24.0" \
+ && pip install "momwire==0.26.0" \
  && pip install -e ".[web]"
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in

--- a/docs/status/2026-08-08-simnec-execute-grammar.md
+++ b/docs/status/2026-08-08-simnec-execute-grammar.md
@@ -1405,8 +1405,14 @@ fabricated readouts from the failures (Windows session, 2026-08-08:
 
 Pinned behaviour (fixtures `dipole_ek_extended`, `dipole_ek_rearm`):
 
-- `EK` / `EK 0` = extended thin-wire kernel on; `EK -1` = standard. Echoed
-  as a normal DATA CARD line.
+- The card's one field is tested for `-1` and for nothing else: `EK`, `EK 0`,
+  `EK 1`, `EK 2` and even `EK -2` all turn the extended thin-wire kernel ON,
+  and only `EK -1` turns it off (re-measured on 5b4az.ae6ty.1.23, 2026-08-10;
+  it is NEC-2's own card reader — `nec2dx.f` sets `IEXK = 1` on an EK card and
+  clears it for `ITMP1 = -1` alone). Echoed as a normal DATA CARD line.
+  This engine refused anything outside `{0, -1}` until issue #849 — the same
+  failure class as #814, a deck the reference engine runs turned into a
+  fabricated SimNEC readout by our refusal.
 - When on at a full (FR-driven) preamble: one extra line, 24-space indent,
   `THE EXTENDED THIN WIRE KERNEL WILL BE USED`, directly after the
   APPROXIMATE INTEGRATION note.
@@ -1418,8 +1424,28 @@ Pinned behaviour (fixtures `dipole_ek_extended`, `dipole_ek_rearm`):
   retained source. The first EX after an execution replaces the set;
   §11's "cleared at every XQ" described decks that always supplied
   fresh EX cards, not the engine.
-- For momwire the kernel choice is advisory (our kernel is our own);
-  layout is reproduced exactly, values are ours.
+- ~~For momwire the kernel choice is advisory (our kernel is our own);
+  layout is reproduced exactly, values are ours.~~ **Superseded by issue
+  #849 (momwire 0.26.0).** The card is HONOURED: the solver an execute group
+  is answered from is built with `extended_kernel=True`, momwire's own O(a²)
+  on-axis tube expansion (momwire#249/#259/#269/#270). Consequences worth
+  writing down:
+  - It is per EXECUTE GROUP, not per deck, and the per-deck fill cache is
+    keyed on `(frequency, kernel)` accordingly — `dipole_ek_rearm` is one
+    deck, one frequency, two operators.
+  - Magnitude: nothing, on any deck in the fixture corpus. Every committed
+    EK deck is `Δ/a ≈ 500`, where the correction measures 0.017 %. On a
+    `Δ/a = 2.27` wire both engines move ~8 %, and momwire's reduced answer
+    is 0.5 % from nec2c's while its extended answer is 3.1 % from nec2c's.
+  - **The two Galerkin portal entries cannot serve a live SimNEC session.**
+    momwire#246 leaves the extended kernel unimplemented on the Galerkin
+    fill, and `NECSource` sends `EK` on every deck, so `--basis
+    sinusoidal-galerkin[-converged]` now refuses every live deck with a
+    named `ERROR:` frame (and its NX sentinel). That is deliberate — the
+    alternative is serving a reduced-kernel answer under an extended-kernel
+    request — but it means those two dialog entries are bench instruments
+    rather than session engines until momwire#246 lands. `--basis
+    sinusoidal` is the point-matched sibling that does carry EK.
 - Build note: the 1.17 corpus oracle aborts noisily at EOF after the last
   NX ("Error reading input file") — post-sentinel noise, also present in
   pre-EK fixtures, harmless to `Execute` which stops at the sentinel.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire==0.24.0",
+    "momwire==0.26.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -153,6 +153,48 @@ def _solver_supports_wire_loading(solver):
     return getattr(solver, "__name__", None) in _WIRE_LOADING_SOLVERS
 
 
+# NEC's extended thin-wire kernel — the `EK` card — on the momwire bases that
+# implement it (momwire 0.26.0: BSpline + its HMatrix/ArrayBlock subclasses,
+# and the point-matched SinusoidalSolver; issues momwire#249/#259/#269/#270).
+# Two combinations REFUSE upstream, both at solver construction, both with a
+# NotImplementedError. They are re-raised here — same type, same shape — for
+# one reason: the engine can say no BEFORE a fill is attempted, so the caller's
+# error path (the portal's `NEC ERROR` frame, the web solve's error envelope)
+# reports a named refusal instead of a traceback out of the middle of a solve.
+def _extended_kernel_refusal(solver, solver_kwargs):
+    """Why this solver + kwargs pair cannot run the extended kernel, or None.
+
+    * ``SinusoidalGalerkinSolver`` — momwire#246/#233: NEC's ``EKSCX`` has no
+      counterpart for the Galerkin fill's folded third source shape, so momwire
+      ships EK on the point-matched sibling only and refuses rather than
+      silently serving a reduced-kernel answer under an EK request.
+    * ``use_singular_enrichment=True`` — momwire#271/#249 follow-up C: the
+      enrichment DOFs carry their own singular quadrature and bypass the moment
+      kernels entirely, and the O(a²) tube expansion was never derived for the
+      s^(-1/2) shapes.
+
+    Everything else — including finite ground, which momwire#269 lifted — is
+    served.
+    """
+    name = getattr(solver, "__name__", str(solver))
+    if name == "SinusoidalGalerkinSolver":
+        return (
+            "the extended thin-wire kernel is not available on the "
+            "sinusoidal-galerkin basis: momwire implements NEC's extended "
+            "kernel on the point-matched SinusoidalSolver only (momwire#246). "
+            "Use the sinusoidal basis for an extended-kernel run, or drop the "
+            "kernel request for the reduced-kernel Galerkin fill"
+        )
+    if (solver_kwargs or {}).get("use_singular_enrichment"):
+        return (
+            "the extended thin-wire kernel and singular enrichment cannot be "
+            "used together (momwire#271): the enrichment DOFs bypass the "
+            "moment kernels the extended kernel corrects. Turn one of the two "
+            "off"
+        )
+    return None
+
+
 class MomwireEngine(SimulationEngine):
     supports_far_field = True
 
@@ -165,6 +207,7 @@ class MomwireEngine(SimulationEngine):
         solver_kwargs=None,
         ground=None,
         ground_z=0.0,
+        extended_kernel=False,
         cancel=None,
     ):
         """
@@ -184,6 +227,21 @@ class MomwireEngine(SimulationEngine):
           Dict of solver-specific kwargs passed straight to the constructor
           (e.g. `{"degree": 1}` for BSplineSolver, or `{"n_qp_const": 16}`
           for SinusoidalSolver). None = solver defaults.
+        extended_kernel:
+          NEC's extended thin-wire kernel — the `EK` card (issue #849,
+          momwire >= 0.26.0). False (the default) is the reduced kernel every
+          release before this one solved with, and the reduced path passes no
+          `extended_kernel` kwarg at all, so an EK-off solve stays bit-identical
+          to older pins. True moves the on-axis Green's function to NEC's O(a²)
+          tube expansion, which matters exactly where the thin-wire
+          approximation is under strain: it is a fraction of a percent at
+          Δ/a > 10 and several percent below Δ/a ~ 3.
+          `solver_kwargs={"extended_kernel": ...}` is accepted as the same
+          knob (a local web instance forwards model_options verbatim) and is
+          folded into this option rather than reaching the constructor twice.
+          Two combinations refuse — see `_extended_kernel_refusal`; the
+          refusal is raised HERE, at engine construction, not from inside a
+          fill.
         ground:
           None or "free"           — no ground (default)
           "pec"                    — PEC plane at z=ground_z (image method)
@@ -219,6 +277,16 @@ class MomwireEngine(SimulationEngine):
         self._cancel = cancel
         self._solver = solver
         self._solver_kwargs = dict(solver_kwargs) if solver_kwargs else {}
+        # The kernel knob has two spellings — the named option and a
+        # solver_kwargs entry (a local web instance forwards model_options
+        # verbatim, and `_make_solver` splices solver_kwargs LAST, so leaving
+        # it in place would let it silently win over a per-call override).
+        # Fold them into one flag, validated once.
+        self._extended_kernel = bool(
+            self._solver_kwargs.pop("extended_kernel", False)
+        ) or bool(extended_kernel)
+        if self._extended_kernel:
+            self._require_extended_kernel()
         # Per-instance parity: sinusoidal wants odd, bspline depends on
         # degree. Set before _coerce_wire_tuples runs.
         self.segment_parity = _parity_for_solver(self._solver, self._solver_kwargs)
@@ -583,11 +651,38 @@ class MomwireEngine(SimulationEngine):
             kw["ground_model"] = "sommerfeld"
         return kw
 
-    def _make_solver(self, *, wavelength, end_port_voltages=None):
+    def _require_extended_kernel(self):
+        """Raise if this basis (or these kwargs) cannot serve the extended
+        kernel. Same exception type and the same class of message momwire's own
+        constructors use, so an engine-level refusal and an upstream one are
+        indistinguishable to a caller's error path."""
+        reason = _extended_kernel_refusal(self._solver, self._solver_kwargs)
+        if reason is not None:
+            raise NotImplementedError(reason)
+
+    def _kernel_solver_kwargs(self, extended_kernel=None):
+        """Extra kernel kwargs for solver construction.
+
+        ``extended_kernel`` overrides the engine's own setting for one call —
+        the NEC portal needs it because ``EK`` is per EXECUTE GROUP, so one
+        deck's two groups can want two different operators out of one engine.
+        The reduced path returns an EMPTY dict rather than
+        ``extended_kernel=False`` so a kernel-off solve keeps passing exactly
+        the kwargs it passed before momwire 0.26.0.
+        """
+        ek = self._extended_kernel if extended_kernel is None else bool(extended_kernel)
+        if not ek:
+            return {}
+        self._require_extended_kernel()
+        return {"extended_kernel": True}
+
+    def _make_solver(self, *, wavelength, end_port_voltages=None, extended_kernel=None):
         """Solver instance. ``end_port_voltages`` (issue #579): per-end-port
         complex voltages in `self._end_ports` order; None means 0 V on every
         end port (the Y-matrix path enumerates ports, so drive levels are
-        irrelevant there)."""
+        irrelevant there). ``extended_kernel`` overrides the engine's kernel
+        setting for this one solver (issue #849 — the portal's per-group
+        ``EK``); None keeps it."""
         kw = {}
         if self._end_port_junctions:
             volts = (
@@ -610,6 +705,7 @@ class MomwireEngine(SimulationEngine):
             **kw,
             **self._loading_kwargs,
             **self._ground_solver_kwargs(),
+            **self._kernel_solver_kwargs(extended_kernel),
             **self._solver_kwargs,
         )
 
@@ -887,6 +983,7 @@ class MomwireEngine(SimulationEngine):
             **kw,
             **self._loading_kwargs,
             **self._ground_solver_kwargs(),
+            **self._kernel_solver_kwargs(),
             **self._solver_kwargs,
         )
 

--- a/src/antennaknobs/nec_portal.py
+++ b/src/antennaknobs/nec_portal.py
@@ -991,12 +991,18 @@ class ExecuteGroup:
     # reason, and because ``PT`` is a TOGGLE: ``dipole_pt_toggle`` suppresses
     # the first run's table and restores the second's from one deck.
     pt: PrintControl | None = None
-    # EK in force when this group fired. Advisory for momwire (our kernel is
-    # our kernel), but the refilled preamble must announce it exactly as the
-    # oracle does — and only there: an EK between two XQs re-arms execution
-    # without a refill, and the oracle prints no announcement for it
-    # (measured: XQ / EK / XQ shows two AIP sections, one preamble, zero
-    # announcements).
+    # EK in force when this group fired. HONOURED since issue #849 (momwire
+    # 0.26.0): the solver this group is answered from is built with
+    # `extended_kernel=True`, the same O(a²) on-axis tube expansion NEC's card
+    # asks for. It was advisory before that — momwire had no extended kernel to
+    # switch to — which is why it is per GROUP rather than per deck: the
+    # printout always had to distinguish the two, and now the operator does
+    # too (`DeckSolver.at` keys its per-frequency fill on the kernel as well).
+    #
+    # The refilled preamble must announce it exactly as the oracle does — and
+    # only there: an EK between two XQs re-arms execution without a refill, and
+    # the oracle prints no announcement for it (measured: XQ / EK / XQ shows
+    # two AIP sections, one preamble, zero announcements).
     ek: bool = False
     # A kernel change between execute cards refills the matrix WITHOUT a new
     # FR: the oracle then prints the LOADING / ENVIRONMENT / MATRIX TIMING
@@ -1188,19 +1194,20 @@ def parse_deck(body: str) -> PortalDeck:
             # XQ` prints no block at all).
             multiprocessing = Multiprocessing.from_card(card)
         elif card.mnemonic == "EK":
-            if card.i(0) not in (0, -1):
-                raise PortalError(
-                    f"EK {card.i(0)} is neither 0 (extended kernel) nor -1 "
-                    f"(standard kernel)"
-                )
-            if (
-                card.i(0) == 0
-                and not extended_kernel
-                or card.i(0) == -1
-                and extended_kernel
-            ):
+            # The oracle's test is `I1 == -1`, and NOTHING else: measured on
+            # nec2c 5b4az.ae6ty.1.23, `EK`, `EK 0`, `EK 1`, `EK 2` and even
+            # `EK -2` all print THE EXTENDED THIN WIRE KERNEL WILL BE USED,
+            # and only `EK -1` does not. (It is NEC-2's own card reader —
+            # nec2dx.f sets IEXK = 1 on an EK card and clears it only for
+            # ITMP1 = -1.) This used to refuse anything outside {0, -1}, which
+            # is the #814 class of bug: refusing a card the reference engine
+            # accepts turns a runnable deck into a fabricated readout. Match
+            # the oracle. `nec_import.parse_nec` already read the card this
+            # way, so the two card readers now agree as well.
+            wanted = card.i(0) != -1
+            if wanted != extended_kernel:
                 kernel_dirty = executed > 0
-            extended_kernel = card.i(0) == 0
+            extended_kernel = wanted
         elif card.mnemonic == "PT":
             # Also not an arming card: it changes what a run PRINTS, not what
             # a run computes, so it cannot make an XQ into a fresh execution.
@@ -2023,7 +2030,8 @@ class DeckSolver:
             self.network_rows.append((a, b, branch, length))
 
         self._smallest_radius = min(w.radius for w in self.wires)
-        self._cache: dict[float, dict] = {}
+        # (frequency, extended kernel) -> one filled and factored operator.
+        self._cache: dict[tuple[float, bool], dict] = {}
 
     def _line_length(self, branch: LineBranch, a: int, b: int) -> float:
         """A ``TL`` card's resolved length: its own, or — when the card says
@@ -2142,15 +2150,24 @@ class DeckSolver:
 
     # -- per-frequency operator -------------------------------------------
 
-    def at(self, freq_mhz: float) -> dict:
+    def at(self, freq_mhz: float, extended_kernel: bool = False) -> dict:
         """The cached (Y, X, solver) for a frequency — one fill, one factor.
 
         When this instance came out of the cross-deck cache (``_solver_for``)
         these entries came with it, so a re-probed deck answers with no fill at
         all, and the same structure at a NEW frequency pays one fill on top of
         a geometry parse and mesh it did not repeat.
+
+        ``extended_kernel`` is the group's ``EK`` (issue #849) and is part of
+        the cache key, not just of the fill: ``dipole_ek_rearm`` is one deck
+        whose two execute groups ask for two different kernels at the SAME
+        frequency, so keying on the frequency alone would answer the second
+        from the first's operator. The key is written ``(freq, ek)`` rather
+        than as two dicts so that adding a third operator axis later cannot
+        forget one of them.
         """
-        cached = self._cache.get(freq_mhz)
+        key = (freq_mhz, bool(extended_kernel))
+        cached = self._cache.get(key)
         if cached is not None:
             return cached
         if _cache_serving or _cache_stats_path is not None:
@@ -2160,7 +2177,9 @@ class DeckSolver:
             _cache_stats["fills"] += 1
         wavelength = C_LIGHT / (freq_mhz * 1e6)
         started = time.perf_counter()
-        solver = self.engine._make_solver(wavelength=wavelength)
+        solver = self.engine._make_solver(
+            wavelength=wavelength, extended_kernel=bool(extended_kernel)
+        )
         y_sub, coeffs = _y_and_port_coeffs(solver)
         fill_ms = int(round((time.perf_counter() - started) * 1000.0))
         entry = {
@@ -2170,7 +2189,7 @@ class DeckSolver:
             "X": coeffs,
             "fill_ms": fill_ms,
         }
-        self._cache[freq_mhz] = entry
+        self._cache[key] = entry
         return entry
 
     def _load_impedances(self, omega: float) -> np.ndarray:
@@ -2193,8 +2212,11 @@ class DeckSolver:
 
     def solve_group(self, group: ExecuteGroup, freq_mhz: float) -> dict:
         """One execute group at one frequency: port currents, segment
-        currents, and the power budget — all from the cached factorisation."""
-        entry = self.at(freq_mhz)
+        currents, and the power budget — all from the cached factorisation.
+
+        The group's ``EK`` picks the operator (issue #849), so two groups of
+        one deck under two kernels get two fills and two answers."""
+        entry = self.at(freq_mhz, extended_kernel=group.ek)
         omega = 2.0 * math.pi * freq_mhz * 1e6
         y = entry["Y"]
         v_source = np.zeros(self.n_ports, dtype=np.complex128)
@@ -2536,11 +2558,14 @@ def _operator_key(deck: PortalDeck) -> tuple:
       is the proof, and it compares against a FRESH PROCESS rather than
       against itself, so it stays a proof if ``GD`` ever grows a far field.
 
-    ``EK`` is the conservative entry. Our kernel is momwire's kernel, so today
-    the flag is advisory and could be left out for a better hit rate — but it
-    is a kernel SELECTION, the one card in this list whose whole meaning is
-    "compute the operator differently", and a wrong hit here would be silent.
-    One bool per group is not a hit rate worth spending.
+    ``EK`` used to be the conservative entry — kept on the argument that a
+    card whose whole meaning is "compute the operator differently" must never
+    be answered from an entry built without it, even while momwire had no
+    other kernel to build with. Since issue #849 it is an ordinary one: the
+    flag IS the operator now (``DeckSolver.at`` fills per kernel), and a wrong
+    hit here would serve a reduced-kernel answer to a deck that asked for the
+    extended one. The tuple stays per GROUP, because that is the granularity
+    the card has.
     """
     cls, kwargs, suffix = _active_basis
     return (
@@ -3248,7 +3273,7 @@ def render_deck(body: str) -> tuple[list[str], list[str]]:
     except PortalError as exc:
         _append_error(out, exc)
         return out, err
-    except (ValueError, np.linalg.LinAlgError) as exc:
+    except (ValueError, NotImplementedError, np.linalg.LinAlgError) as exc:
         _append_error(out, exc)
         return out, err
 
@@ -3290,7 +3315,17 @@ def render_deck(body: str) -> tuple[list[str], list[str]]:
                 if i:
                     out += ["", ""]
                 out += _run_block(deck, solver, group, freq)
-        except (PortalError, ValueError, np.linalg.LinAlgError) as exc:
+        except (
+            PortalError,
+            ValueError,
+            # A basis that cannot serve this group's kernel (issue #849:
+            # sinusoidal-galerkin under EK, momwire#246). momwire raises it,
+            # and `MomwireEngine` re-raises it before the fill; either way it
+            # is a refusal SimNEC must see as a NEC ERROR, not as a daemon
+            # traceback that costs the deck its NX sentinel.
+            NotImplementedError,
+            np.linalg.LinAlgError,
+        ) as exc:
             _append_error(out, exc)
         out += ["", "", ""]
     return out, err
@@ -3408,31 +3443,64 @@ def _selftest(stdout) -> int:
         "TL network row present": "STRAIGHT" in proc.stdout,
         "stderr quiet": proc.stderr.strip() == "",
     }
+
     # One deck per alternate basis: the point is that the entry is wired and
     # answers on THIS box, not that it is fast or converged. The selftest deck
     # is a single small dipole, which for `hmatrix`/`arrayblock` means a
     # near-field-only operator and (for arrayblock) a degenerate element
     # partition that degrades to the parent — the graceful-degradation path,
     # which is exactly the one a smoke test wants to prove never raises.
+    def _alt(basis: str, deck: str):
+        return subprocess.run(
+            [sys.executable, "-m", "antennaknobs.nec_portal", "--basis", basis],
+            input=deck,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
     for basis, suffix in (
-        ("sinusoidal-galerkin-converged", "+sgc"),
         ("sinusoidal", "+sin"),
         ("bspline-d1", "+bs1"),
         ("hmatrix", "+hm"),
         ("arrayblock", "+ab"),
     ):
-        alt = subprocess.run(
-            [sys.executable, "-m", "antennaknobs.nec_portal", "--basis", basis],
-            input=_SELFTEST_DECKS[0],
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
+        alt = _alt(basis, _SELFTEST_DECKS[0])
         checks[f"alt basis answers ({suffix})"] = (
             alt.returncode == 0
             and suffix in alt.stdout
             and "ANTENNA INPUT PARAMETERS" in alt.stdout
         )
+    # The Galerkin entries are the exception, and the check is deliberately
+    # two-sided rather than dropped (issue #849). momwire#246 leaves NEC's
+    # extended kernel unimplemented on the Galerkin fill, and deck 1 carries
+    # `EK` precisely because the live NECSource path always sends it — so
+    # honouring the card for real means these two roster entries cannot answer
+    # a live SimNEC deck at all. What a deployment gate can still prove, and
+    # what a box must never get wrong, is that the refusal is the DOCUMENTED
+    # one: a named `ERROR:` line and the NX sentinel behind it (a hang here is
+    # what stalls SimNEC's readLine forever) — and that the SESSION survives
+    # it, which is why both decks go down ONE process: the EK deck refuses,
+    # the same deck without the card answers, from the same resident engine.
+    galerkin = _alt(
+        "sinusoidal-galerkin-converged",
+        _SELFTEST_DECKS[0] + _SELFTEST_DECKS[0].replace("EK\n", ""),
+    )
+    sentinels = sum(
+        1
+        for ln in galerkin.stdout.splitlines()
+        if ln.lstrip().startswith("DATA CARD No:") and " NX " in ln
+    )
+    checks["galerkin refuses EK by name, session survives"] = (
+        galerkin.returncode == 0
+        and any(
+            ln.split()[:1] == ["ERROR:"] and "extended thin-wire kernel" in ln
+            for ln in galerkin.stdout.splitlines()
+        )
+        and sentinels == 2
+        and "+sgc" in galerkin.stdout
+        and galerkin.stdout.count("ANTENNA INPUT PARAMETERS") == 1
+    )
     for name, ok in checks.items():
         stdout.write(f"  {'ok  ' if ok else 'FAIL'} {name}\n")
     passed = all(checks.values())

--- a/tests/test_nec_portal.py
+++ b/tests/test_nec_portal.py
@@ -2518,6 +2518,247 @@ def test_require_lattice_fft_names_the_unmet_gate_on_a_single_pair():
         nec_portal._y_and_port_coeffs(solver)
 
 
+# --- the EK card, honoured for real (issue #849) ------------------------------
+#
+# Until momwire 0.26.0 the portal parsed `EK`, threaded it through the execute
+# groups, and printed its announcement — but momwire had one kernel, so the
+# card moved no number and the grammar doc called it advisory. It is real now,
+# and the tests below are the four halves of "real": the operator moves, it
+# moves to MOMWIRE's own extended kernel and not to something this file invented
+# on the way, it moves in nec2c's direction and by nec2c's amount, and the
+# bases that cannot serve it say so.
+#
+# Every EK deck in the fixture corpus is a 0.001 m wire at Δ/a ≈ 500, where the
+# extended kernel is a 0.02 % correction by construction — the card's whole
+# subject is the O(a²) term the reduced kernel drops. So the decks here are
+# FAT: 11 segments of a 5 m dipole at a = 0.2 m is Δ/a = 2.27, and both engines
+# move by ~8 % across the card.
+
+# λ = 10 m at 30 MHz; 11 segments over 5 m is Δ = 0.4545 m, so Δ/a = 2.27.
+_FAT_WIRE = "GW 1 11 0. 0. -2.5 0. 0. 2.5 0.2\n"
+
+
+def _fat_deck(kernel_card: str = "") -> str:
+    card = f"{kernel_card}\n" if kernel_card else ""
+    return (
+        f"CE ek fat wire\n{_FAT_WIRE}GE 0\n{card}"
+        "FR 0 1 0 0 30. 1\nEX 0 1 6 0 1.\nXQ\nNX\n"
+    )
+
+
+# nec2c 5b4az.ae6ty.1.23 (SimNEC 5.1's shipped `nec2c-ubuntu-x86` — the version
+# the repo pins as `minimumNEC2CVersion`), on `_fat_deck()` and
+# `_fat_deck("EK")` respectively. Captured 2026-08-10 the same way
+# scripts/nec_portal_capture.py captures the corpus: the deck on stdin, the
+# ANTENNA INPUT PARAMETERS row read off stdout.
+NEC2C_FAT_REDUCED = complex(1.2368e02, 2.8585e01)
+NEC2C_FAT_EXTENDED = complex(1.1357e02, 2.8980e01)
+
+
+def _first_z(text: str) -> complex:
+    """The impedance of the first ANTENNA INPUT PARAMETERS row."""
+    columns = aip_impedances(text)
+    assert columns, f"no AIP row:\n{text[-800:]}"
+    return complex(float(columns[0][0]), float(columns[0][1]))
+
+
+def _relative(a: complex, b: complex) -> float:
+    return abs(a - b) / max(abs(a), abs(b))
+
+
+@pytest.fixture
+def restore_basis():
+    """`--basis` is a process-global (`_active_basis`), set by `main` and never
+    reset by `run_deck` — the ordering hazard `cache_reset` documents. A test
+    that asks for an alternate basis puts it back, so it cannot decide what a
+    later test's `run_deck`/`printout` call solves with."""
+    from antennaknobs import nec_portal
+
+    saved = nec_portal._active_basis
+    yield
+    nec_portal._active_basis = saved
+
+
+def test_the_ek_card_moves_the_impedance_on_a_fat_wire(restore_basis):
+    """The card is no longer advisory: same deck, one card, a different answer.
+
+    Asserted on the DEFAULT basis as well as the NEC-closest one, because the
+    passthrough is the engine's and every basis in the roster but Galerkin has
+    to carry it.
+    """
+    for basis in ([], ["--basis", "sinusoidal"]):
+        rc_off, off, err_off = _run_main(basis, deck=_fat_deck())
+        rc_on, on, err_on = _run_main(basis, deck=_fat_deck("EK"))
+        assert (rc_off, rc_on) == (0, 0) and not err_off and not err_on
+        assert "ERROR-NEC2C" not in off and "ERROR-NEC2C" not in on
+        shift = _relative(_first_z(off), _first_z(on))
+        assert shift >= 0.02, f"{basis}: EK moved the impedance by only {shift:.3%}"
+
+
+def test_the_ek_answer_is_momwires_own_extended_kernel_solve(restore_basis):
+    """Which extended kernel — the identity behind the number.
+
+    A deck through the portal under `--basis sinusoidal` must be the same solve
+    as `SinusoidalSolver(extended_kernel=...)` built straight off the deck's own
+    mesh: one straight wire, 11 uniform segments, the gap at the centre. The
+    only slack allowed is the printout's own `%13.5E` rounding, so this catches
+    a kernel flag that reached a DIFFERENT constructor, a mesh the portal built
+    differently under EK, or an announcement printed over a reduced-kernel fill.
+    """
+    import numpy as np
+    from momwire import SinusoidalSolver
+
+    for card, kwargs in (("", {}), ("EK", {"extended_kernel": True})):
+        solver = SinusoidalSolver(
+            wires=[np.array([[0.0, 0.0, -2.5], [0.0, 0.0, 2.5]])],
+            n_per_edge_per_wire=[[11]],
+            feeds=[(0, 2.5, 1.0)],
+            wavelength=299_792_458.0 / 30e6,
+            wire_radius=0.2,
+            **kwargs,
+        )
+        direct, _coeffs = solver.compute_impedance()
+        _rc, out, _err = _run_main(["--basis", "sinusoidal"], deck=_fat_deck(card))
+        assert _relative(_first_z(out), direct) <= 1e-4, (
+            f"EK={card!r}: portal {_first_z(out)} vs direct {direct}"
+        )
+
+
+def test_the_fat_wire_ek_pair_tracks_nec2c_on_both_sides_of_the_card(restore_basis):
+    """The card's physics, against the reference engine rather than ourselves.
+
+    Both kernels are held at the differential harness's ordinary 5 % bar, and
+    the SHIFT is held too — a passthrough that quietly did nothing would keep
+    the reduced side inside 5 % and fail here, which is the mode this exists
+    to catch. The sinusoidal basis is used because it is the roster's
+    NEC-closest rung (issue #822); on this deck it lands 0.5 % from nec2c
+    reduced and 3.1 % extended.
+    """
+    _rc, off, _e = _run_main(["--basis", "sinusoidal"], deck=_fat_deck())
+    _rc, on, _e = _run_main(["--basis", "sinusoidal"], deck=_fat_deck("EK"))
+    z_off, z_on = _first_z(off), _first_z(on)
+    assert _relative(z_off, NEC2C_FAT_REDUCED) <= 0.05, f"{z_off} vs nec2c reduced"
+    assert _relative(z_on, NEC2C_FAT_EXTENDED) <= 0.05, f"{z_on} vs nec2c extended"
+    # nec2c's own move across the card is -10.1 Ω of resistance (8.0 %); ours
+    # must be the same sign and the same order, not merely "different".
+    theirs = NEC2C_FAT_EXTENDED - NEC2C_FAT_REDUCED
+    ours = z_on - z_off
+    assert ours.real < 0 and theirs.real < 0, f"{ours} vs {theirs}"
+    assert 0.5 <= abs(ours) / abs(theirs) <= 2.0, f"{ours} vs {theirs}"
+
+
+@pytest.mark.parametrize("card", ["EK", "EK 0", "EK 1", "EK 2", "EK -2"])
+def test_every_ek_field_but_minus_one_is_the_extended_kernel(card):
+    """What the oracle actually does with the card's one field.
+
+    Measured on nec2c 5b4az.ae6ty.1.23: `EK`, `EK 0`, `EK 1`, `EK 2` and even
+    `EK -2` all print THE EXTENDED THIN WIRE KERNEL WILL BE USED, and only
+    `EK -1` does not — NEC-2's card reader sets the flag on an EK card and
+    clears it for `-1` alone. The portal used to REFUSE anything outside
+    {0, -1}, which is the #814 failure class exactly: a deck the reference
+    engine runs, turned into a fabricated SimNEC readout by our refusal.
+    """
+    rc, out, err = _run_main([], deck=_fat_deck(card))
+    assert rc == 0 and err == ""
+    assert "ERROR-NEC2C" not in out, out[-600:]
+    assert "THE EXTENDED THIN WIRE KERNEL WILL BE USED" in out
+    assert _first_z(out) == _first_z(_run_main([], deck=_fat_deck("EK"))[1])
+
+
+def test_ek_minus_one_is_the_reduced_kernel():
+    """The other side of the same rule, and the no-card default with it."""
+    z_bare = _first_z(_run_main([], deck=_fat_deck())[1])
+    rc, out, _err = _run_main([], deck=_fat_deck("EK -1"))
+    assert rc == 0 and "THE EXTENDED THIN WIRE KERNEL WILL BE USED" not in out
+    assert _first_z(out) == z_bare
+
+
+def test_two_groups_of_one_deck_under_two_kernels_get_two_operators():
+    """`dipole_ek_rearm`'s shape, on a wire fat enough to show it.
+
+    One deck, one frequency, two execute groups — the second under a kernel the
+    first was not. The per-deck fill cache is keyed on the frequency ALONE
+    unless the kernel is in the key too, so this is the intra-deck half of the
+    staleness gate: getting it wrong prints the first group's answer twice and
+    every other assertion in this file still passes.
+    """
+    deck = (
+        f"CE ek rearm fat\n{_FAT_WIRE}GE 0\nEK -1\n"
+        "FR 0 1 0 0 30. 1\nEX 0 1 6 0 1.\nXQ\nEK\nXQ\nNX\n"
+    )
+    rc, out, err = _run_main([], deck=deck)
+    assert rc == 0 and err == "" and "ERROR-NEC2C" not in out
+    rows = aip_impedances(out)
+    assert len(rows) == 2, rows
+    first, second = complex(*map(float, rows[0])), complex(*map(float, rows[1]))
+    assert first == _first_z(_run_main([], deck=_fat_deck("EK -1"))[1])
+    assert second == _first_z(_run_main([], deck=_fat_deck("EK"))[1])
+    assert _relative(first, second) >= 0.02, f"{first} vs {second}"
+
+
+@pytest.mark.parametrize(
+    "basis", ["sinusoidal-galerkin", "sinusoidal-galerkin-converged"]
+)
+def test_a_galerkin_basis_refuses_an_ek_deck_as_a_nec_error(basis, restore_basis):
+    """The refusal path, on the class of deck that reaches it in real life.
+
+    momwire#246 leaves NEC's extended kernel unimplemented on the Galerkin fill
+    — its folded third source shape has no EKSCX counterpart — so the solver
+    refuses at construction with a NotImplementedError. The live `NECSource`
+    path sends `EK` on EVERY deck (grammar doc §17), so a SimNEC user who picks
+    a Galerkin portal entry hits this on their first solve, and what they must
+    get is the documented refusal frame: a token-0 `ERROR:` line naming the
+    kernel, the oracle-shaped `ERROR-NEC2C:` line behind it, and — the one that
+    decides whether the session survives — the NX sentinel. A traceback out of
+    `main` would cost the sentinel and stall `Execute.readLine` forever.
+    """
+    rc, out, err = _run_main(["--basis", basis], deck=_fat_deck("EK"))
+    assert rc == 0 and err == ""
+    assert "Traceback" not in out
+    errors = [ln for ln in out.splitlines() if ln.split()[:1] == ["ERROR:"]]
+    assert errors, out[-800:]
+    assert "extended thin-wire kernel" in errors[0]
+    assert "sinusoidal-galerkin" in errors[0]
+    assert "ERROR-NEC2C: " in out
+    assert NX_ECHO.search(out), "no NX sentinel on the kernel-refusal path"
+    # ... and the same basis answers the same deck once the card is gone, so
+    # the refusal is the KERNEL's and not the basis failing on a fat wire.
+    rc, plain, _err = _run_main(["--basis", basis], deck=_fat_deck())
+    assert rc == 0 and "ERROR-NEC2C" not in plain and aip_impedances(plain)
+
+
+def test_the_thin_wire_ek_fixtures_barely_move_and_move_towards_nec2c():
+    """The armor's own measurement, kept next to the numbers that justify it.
+
+    43 of the 45 corpus fixtures carry no `EK` and are byte-identical across
+    this change. The two that do carry it are Δ/a ≈ 500 dipoles, where the
+    extended kernel is the correction it is designed to be small: measured,
+    both move 0.017 % — inside momwire's own no-op bar — and both move CLOSER
+    to nec2c (0.761 % → 0.745 %). `dipole_ek_rearm`'s first group is `EK -1`
+    and must not move at all, which is the assertion that the reduced path is
+    still the reduced path.
+    """
+
+    def render(name):
+        # Through `main` rather than `printout`, so the process-global basis is
+        # this test's own whatever ran before it.
+        return _run_main([], deck=fixture_deck(name) + "\nNX\n")[1]
+
+    extended = _first_z(render("dipole_ek_extended"))
+    oracle = complex(7.9240e01, 4.5364e01)  # the fixture's own captured row
+    reduced = _first_z(render("dipole_free_space"))  # same wire, no EK card
+    assert _relative(extended, reduced) <= 1e-3, (
+        f"a Δ/a≈500 wire moved {_relative(extended, reduced):.4%} across EK"
+    )
+    assert _relative(extended, oracle) < _relative(reduced, oracle)
+
+    rows = aip_impedances(render("dipole_ek_rearm"))
+    assert len(rows) == 2
+    first, second = complex(*map(float, rows[0])), complex(*map(float, rows[1]))
+    assert first == reduced, "the EK -1 group is no longer the reduced-kernel one"
+    assert second == extended
+
+
 # --- the cross-deck solver cache (issue #823) --------------------------------
 #
 # The cache's whole claim is that the printout is IDENTICAL whether a deck was
@@ -2694,6 +2935,20 @@ CACHE_NET_BASE = mutate(
     "EX 0 1 5 0 1.\nTL 1 3 1 7 600. 2.5 0. 0. 0. 0.\nNT 1 3 1 7 0. 0.02 0. 0. 0. 0.02\n",
 )
 
+# A free-space deck at Δ/a = 2.27 — the regime where the extended kernel is
+# worth several percent (issue #849). The plain CACHE_BASE wire is 500× too
+# thin for an EK mutation to move a printed digit, so a cross-deck cache test
+# on it can only ever assert the MISS; this one asserts the answer too.
+CACHE_FAT_BASE = (
+    "CM cross-deck cache probe, fat\n"
+    "CE\n"
+    "GW 1 11 0. 0. -2.5 0. 0. 2.5 0.2\n"
+    "GE 0\n"
+    "EX 0 1 6 0 1.\n"
+    "FR 0 1 0 0 30. 0\n"
+    "XQ\n"
+)
+
 
 # (label, base deck, mutant deck, does this move the printed numbers?)
 _OPERATOR_MUTATIONS = (
@@ -2744,11 +2999,21 @@ _OPERATOR_MUTATIONS = (
         mutate("600. 2.5", "-600. 2.5", CACHE_NET_BASE),
         True,
     ),
-    # EK is the conservative key entry: momwire's kernel is momwire's kernel, so
-    # the flag moves no number here — the gate is that it still MISSES, because
-    # a card whose meaning is "compute the operator differently" must never be
-    # answered from an entry built without it.
+    # EK used to be the conservative key entry — kept for the principle that a
+    # card whose meaning is "compute the operator differently" must never be
+    # answered from an entry built without it, back when momwire had no other
+    # kernel and the flag moved no number. Issue #849 made it an ordinary one.
+    # This deck's wire is Δ/a ≈ 500, where the extended kernel is a 0.02 %
+    # correction that does not survive `%13.5E`, so `moves_numbers` stays False
+    # HERE and the fat-wire deck below carries the "and it answers with its own
+    # physics" half.
     ("EK toggled", CACHE_BASE, mutate("EX 0 1 5 0 1.\n", "EK\nEX 0 1 5 0 1.\n"), False),
+    (
+        "EK toggled (fat wire)",
+        CACHE_FAT_BASE,
+        mutate("GE 0\n", "GE 0\nEK\n", CACHE_FAT_BASE),
+        True,
+    ),
 )
 
 

--- a/tests/test_nec_portal_differential.py
+++ b/tests/test_nec_portal_differential.py
@@ -36,6 +36,8 @@ catalog_multiband_trap_dipole         2.66%   2.66%       -   0.68%      -
 catalog_specialty_bowtie              1.25%   1.25%       -   0.54%      -
 catalog_verticals_vertical            2.79%   2.79%       -   0.18%      -
 catalog_wire_w8jk                     1.98%   1.99%       -   0.84%      -
+dipole_ek_extended                    0.74%   0.75%       -   0.96%      -   (i)
+dipole_ek_rearm                       0.76%   0.76%       -   0.96%      -   (i)
 dipole_fr_sweep                       1.29%   1.29%       -   0.96%      -
 dipole_free_space                     0.76%   0.76%       -   0.96%      -
 dipole_gd_cliff_sommerfeld            2.24%   2.23%       -   4.35%      -   (f)
@@ -155,6 +157,19 @@ fails.
     Since #802 the far-field half is no longer "and there we refuse": the
     cliff modes run, so the same control is asserted on them too, by
     ``test_the_cliff_never_reaches_the_matrix``.
+
+(i) are the two ``EK`` fixtures, added to this table in issue #849 when the
+    card stopped being advisory (momwire 0.26.0 ships NEC's extended thin-wire
+    kernel; the portal now builds the group's solver with it). Both moved, and
+    both moved the way the card's own arithmetic says they must: these are
+    0.001 m wires at ``Δ/a ≈ 500``, where the O(a²) term the extended kernel
+    restores is worth **0.017 %** — measured, on both — and agreement with
+    nec2c went from 0.761 % to 0.745 %. ``dipole_ek_rearm``'s FIRST group is
+    ``EK -1`` and did not move at all, to the digit, which is the reduced path
+    still being the reduced path. The card's real magnitude cannot be read off
+    this corpus at all (no committed deck is fat enough); it is measured
+    against the oracle in ``test_nec_portal.py``'s fat-wire pair, where
+    ``Δ/a = 2.27`` and both engines move ~8 %.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Unit 1 of the #849 stacked arc (backend).

## What
- Pin ritual: momwire ==0.26.0 (exact, per the pin test's own doctrine — the brief said floor, the repo says exact, exact wins), Dockerfile, submodule.
- `engines/momwire.py`: `extended_kernel` passthrough with per-call override (the portal's EK is per execute group — one engine, two operators); EK-off passes NO kwarg (bit-identical to older pins); refusals (galerkin per momwire#246, enrichment per momwire#271) raised at construction through the structured pathway, never mid-fill.
- Portal: `ek` in force builds the solver with `extended_kernel=True`; `DeckSolver.at` re-keyed (freq → (freq, ek)); **EK 1 finding**: measured on the pinned nec2c, EVERY field value except -1 enables EK (`EK 1`, `EK 2`, `EK -2` all announce) — the portal's {0,-1} refusal was the #814 class; now `!= -1`, matching nec_import's reader.
- Armor: 43/45 fixtures byte-identical; the two movers are the only EK-carrying fixtures (Δ/a≈555), moving 0.017% — inside momwire's no-op gate, TOWARD nec2c (0.761%→0.745%).
- Fat-deck honesty gate: portal EK-on ≡ direct `SinusoidalSolver(extended_kernel=True)` to 6e-6; nec2c ±EK capture pinned (shift 7.97% at Δ/a=2.27).
- Cross-deck cache: `_operator_key` already carried ek (verified); fat-wire EK toggle added to the mutation battery.

## Product consequence (deliberate, needs eyes)
NECSource sends EK on every live deck, so the two **sinusoidal-galerkin roster entries now refuse every live SimNEC deck** (honestly, with the NEC ERROR dialog) until momwire#246 lands. SimNEC's UseExtendedKernel env hatch is the user-side workaround; grammar doc §17 records it; --selftest reworked to prove a refusal doesn't poison a resident session.

## Gates
Suite **4601 passed, 2 skipped** (baseline 4586+1 expected pin failure); reviewer re-ran + probe (portal forced back to advisory → 7 gates fail). Ruff clean. PyPI has 0.26.0 (verified — CI's exact pin will resolve).

## Review notes
Opus builder; session model read the portal/engine diffs, ran the advisory-regression probe, re-ran the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvF4yHgNxjhyZ7P286g3z8