### PR TITLE
#849 unit 2: --extended-kernel CLI flag + web backend model option

### DIFF
--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -347,7 +347,23 @@ def parse_engine_spec(spec):
     return name, {"solver": MOMWIRE_BASES[basis]}
 
 
-def make_engine_factory(engine_spec, ground_spec):
+def make_engine_factory(
+    engine_spec, ground_spec, *, extended_kernel=False, deck_extended_kernel=False
+):
+    """Bind an engine spec (+ optional ground) into a builder->engine factory.
+
+    ``extended_kernel`` is an explicit user request (CLI ``--extended-kernel``);
+    ``deck_extended_kernel`` is a ``@file.nec`` deck's own parsed ``EK`` card
+    (issue #849). Either turns the momwire extended thin-wire kernel on — the
+    combination rule is OR, so a deck that already carries ``EK`` doesn't need
+    the flag repeated, and the flag still works on a deck (or a built-in
+    design) that carries none. Only momwire consumes the kernel this way:
+    an explicit ``--extended-kernel`` on any other engine is a clear user
+    error (PyNEC's own extended-kernel support, issue #414, is a separate,
+    unexposed constructor kwarg — not driven by this flag); a deck-only
+    request on a non-momwire engine is silently left alone, matching the
+    pre-#849 status quo for that engine.
+    """
     name, kwargs = parse_engine_spec(engine_spec)
     cls = ENGINE_CLASSES[name]
     # PyNECEngine's default ground IS finite; momwire's default is free.
@@ -355,12 +371,32 @@ def make_engine_factory(engine_spec, ground_spec):
     # when they don't, we use whatever the engine's own default is.
     if ground_spec is not _GROUND_UNSET:
         kwargs["ground"] = ground_spec
+    if extended_kernel or deck_extended_kernel:
+        if name != "momwire":
+            if extended_kernel:
+                raise argparse.ArgumentTypeError(
+                    f"--extended-kernel only applies to the momwire engine "
+                    f"(got {name!r}, issue #849, momwire >= 0.26.0)"
+                )
+            # A deck-only EK request on a non-momwire engine: left alone,
+            # same as before this issue — PyNEC's own EK support (#414)
+            # isn't wired to a deck or this flag.
+        else:
+            kwargs["extended_kernel"] = True
     if not kwargs:
         return cls
     return partial(cls, **kwargs)
 
 
 _GROUND_UNSET = object()
+
+
+def deck_extended_kernel_flag(builder_cls) -> bool:
+    """True if `builder_cls` came from an `@file.nec`/`@file.ssn` spec whose
+    deck carries an EK card (issue #849) — see `file_designs._make_builder`'s
+    `file_extended_kernel` attribute. False for every ordinary catalog/user
+    design (the attribute doesn't exist on those classes at all)."""
+    return bool(getattr(builder_cls, "file_extended_kernel", False))
 
 
 def cli(arguments=None):
@@ -447,6 +483,21 @@ def cli(arguments=None):
             "(reflection-coefficient approximation) "
             "(default: engine-specific — finite for pynec, free for momwire).",
         )
+        p.add_argument(
+            "--extended-kernel",
+            dest="extended_kernel",
+            default=False,
+            action="store_true",
+            help="Apply NEC's extended thin-wire kernel (the EK card) on the "
+            "momwire engine (issue #849, needs momwire >= 0.26.0). Every "
+            "momwire basis serves it except sinusoidal-galerkin, which "
+            "refuses (momwire#246 — no EKSCX counterpart for its folded "
+            "testing shape); combining it with model_options "
+            "use_singular_enrichment also refuses (momwire#271). Matters for "
+            "fat wires (radius comparable to segment length). A "
+            '"@file.nec" deck\'s own EK card is honoured too — either one '
+            "turns the kernel on (OR). Only applies to the momwire engine.",
+        )
 
     def add_pattern_common(p):
         p.add_argument(
@@ -468,11 +519,16 @@ def cli(arguments=None):
             help="Azimuth angle (rear) for the elevation plot.",
         )
 
-    def engine_factory_from_args(args):
+    def engine_factory_from_args(args, deck_extended_kernel=False):
         ground = (
             args.ground if args.ground is _GROUND_UNSET else parse_ground(args.ground)
         )
-        return make_engine_factory(args.engine, ground)
+        return make_engine_factory(
+            args.engine,
+            ground,
+            extended_kernel=args.extended_kernel,
+            deck_extended_kernel=deck_extended_kernel,
+        )
 
     p = subparsers.add_parser("draw", help="Draw antenna")
     add_common(p)
@@ -541,7 +597,7 @@ def cli(arguments=None):
 
     def f(args):
         builder = get_builder(args.builder)
-        engine = engine_factory_from_args(args)
+        engine = engine_factory_from_args(args, deck_extended_kernel_flag(builder))
         measured = read_measured(args.measured, z0=args.z0) if args.measured else None
         if measured is not None and (args.patterns or args.gain):
             # Measured S11 has nothing to say about a pattern or gain chart.
@@ -630,7 +686,7 @@ def cli(arguments=None):
 
     def f(args):
         builder = get_builder(args.builder)
-        engine = engine_factory_from_args(args)
+        engine = engine_factory_from_args(args, deck_extended_kernel_flag(builder))
         opt_builder = optimize(
             builder(),
             args.params,
@@ -802,14 +858,17 @@ def cli(arguments=None):
         elif args.line:
             raise SystemExit("--line only applies with --plane station")
 
-        builder = get_builder(args.builder)()
+        builder_cls = get_builder(args.builder)
+        builder = builder_cls()
         try:
             result = fit(
                 builder,
                 read_measured(args.measured),
                 args.params,
                 z0=args.z0,
-                engine=engine_factory_from_args(args),
+                engine=engine_factory_from_args(
+                    args, deck_extended_kernel_flag(builder_cls)
+                ),
                 bounds=pairs,
                 fractions=args.fractions,
                 npoints=args.npoints,
@@ -943,7 +1002,8 @@ def cli(arguments=None):
     def f(args):
         from .schematic import lower, render_svg
 
-        builder = get_builder(args.builder)()
+        builder_cls = get_builder(args.builder)
+        builder = builder_cls()
         net = builder.build_network() if hasattr(builder, "build_network") else None
         if net is None:
             raise SystemExit(
@@ -952,7 +1012,9 @@ def cli(arguments=None):
             )
         budget = p_in = None
         if args.power:
-            eng = engine_factory_from_args(args)(builder)
+            eng = engine_factory_from_args(
+                args, deck_extended_kernel_flag(builder_cls)
+            )(builder)
             eng.current_distribution()
             budget = getattr(eng, "_excited_power_budget", None)
             # With p_in the annotation reads as the budget table's percent
@@ -983,7 +1045,7 @@ def cli(arguments=None):
 
     def f(args):
         builder = get_builder(args.builder)
-        engine = engine_factory_from_args(args)
+        engine = engine_factory_from_args(args, deck_extended_kernel_flag(builder))
         eng = engine(builder())
         if args.wireframe:
             pattern3d(eng, fn=args.fn)
@@ -1026,8 +1088,14 @@ def cli(arguments=None):
         instances = []
         labels = []
         for bname, espec in pairs:
-            eng = make_engine_factory(espec, ground)
-            instances.append(eng(get_builder(bname)()))
+            builder_cls = get_builder(bname)
+            eng = make_engine_factory(
+                espec,
+                ground,
+                extended_kernel=args.extended_kernel,
+                deck_extended_kernel=deck_extended_kernel_flag(builder_cls),
+            )
+            instances.append(eng(builder_cls()))
             if multi_engine and multi_builder:
                 labels.append(f"{bname}/{espec}")
             elif multi_engine:
@@ -1256,5 +1324,14 @@ def cli(arguments=None):
     except DesignNotTrustedError as exc:
         # A design the user hasn't allowed yet: show the clean guidance, not a
         # traceback.
+        print(str(exc))
+        raise SystemExit(1) from None
+    except NotImplementedError as exc:
+        # A momwire engine refusing a request it cannot honour — e.g.
+        # --extended-kernel on sinusoidal-galerkin (momwire#246) — raises
+        # this at engine construction (MomwireEngine._require_extended_kernel,
+        # issue #849) with a message that already names the problem; print
+        # it instead of a traceback, same convention as the other clean
+        # user-facing errors above.
         print(str(exc))
         raise SystemExit(1) from None

--- a/src/antennaknobs/file_designs.py
+++ b/src/antennaknobs/file_designs.py
@@ -59,7 +59,9 @@ def _seed_freq(freq_range):
     )
 
 
-def _make_builder(stem, freq, meas_range, notes, wires_fn, network_fn):
+def _make_builder(
+    stem, freq, meas_range, notes, wires_fn, network_fn, *, extended_kernel=False
+):
     ui: dict = {}
     if meas_range:
         ui["meas_freq_range"] = tuple(meas_range)
@@ -74,6 +76,13 @@ def _make_builder(stem, freq, meas_range, notes, wires_fn, network_fn):
         label = stem
 
         default_params = MappingProxyType(params)
+
+        # The file's own EK card (NecDeck.extended_kernel), issue #849: the
+        # CLI's `--extended-kernel` handling ORs this in for a momwire engine
+        # (see `cli.engine_factory_from_args`) so a deck that asks for the
+        # extended thin-wire kernel gets it without an extra flag, and a
+        # deck that doesn't still honors an explicit `--extended-kernel`.
+        file_extended_kernel = extended_kernel
 
         def build_wires(self):
             return wires_fn()
@@ -97,6 +106,7 @@ def _nec_builder(path: Path, text: str):
         [deck.skipped_note(), freq_note],
         lambda: deck.wire_tuples(specs=True),
         deck.network,
+        extended_kernel=deck.extended_kernel,
     )
 
 
@@ -138,6 +148,7 @@ def _ssn_builder(path: Path, text: str):
         [circuit.skipped_note(), _ground_note(circuit.ground), freq_note],
         lambda: deck.wire_tuples(specs=True),
         circuit.network,
+        extended_kernel=deck.extended_kernel,
     )
 
 

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -400,6 +400,15 @@ _HOSTED_MODEL_OPTIONS = {
     "tikhonov_lambda": _float_in(0.0, 1e3),
     "auto_tap_ratio_threshold": _float_in(0.0, 1.0),
     "enrichment_min_k": _int_in(2, 64),
+    # NEC's extended thin-wire kernel (the EK card, issue #849, momwire >=
+    # 0.26.0). A physics selection like feed_model, not a compute-
+    # amplification lever, so it belongs on the hosted allowlist.
+    # `_make_momwire_engine` pulls it back out and passes it as the named
+    # `extended_kernel=` constructor kwarg rather than leaving it here —
+    # MomwireEngine folds either spelling the same way (issue #849's
+    # engine-side note), but the named kwarg keeps the adapter's intent
+    # explicit and is what unit 1 documented at this call site.
+    "extended_kernel": _bool_opt,
 }
 
 
@@ -1454,6 +1463,16 @@ def _make_momwire_engine(req: dict, builder, cancel=None):
     wire_radius = _positive_finite("wire_radius", req.get("wire_radius", 0.0005))
     ground = _ground_for_engine(req, 0.0)
     solver_kwargs = sanitize_model_options(req)
+    # Extended thin-wire kernel (issue #849): pulled out of model_options and
+    # passed as the named constructor kwarg instead, so it reaches the engine
+    # the same way whether hosted (filtered through _HOSTED_MODEL_OPTIONS
+    # above) or local (model_options forwarded verbatim, sanitize_model_options
+    # skips the whitelist). MomwireEngine folds either spelling identically,
+    # but the named kwarg is the explicit, testable path.
+    extended_kernel = False
+    if solver_kwargs and "extended_kernel" in solver_kwargs:
+        solver_kwargs = dict(solver_kwargs)
+        extended_kernel = bool(solver_kwargs.pop("extended_kernel"))
     if _SWEPT_MEM_MB is not None and issubclass(solver_cls, BSplineSolver):
         # Deployment-owned memory policy (momwire >= 0.9): cap the batched
         # frequency sweep's transient memory per solve. Server-side value
@@ -1470,6 +1489,7 @@ def _make_momwire_engine(req: dict, builder, cancel=None):
         wire_radius=wire_radius,
         solver_kwargs=solver_kwargs,
         ground=ground,
+        extended_kernel=extended_kernel,
         cancel=cancel,
     )
 

--- a/tests/test_engine_spec.py
+++ b/tests/test_engine_spec.py
@@ -1,13 +1,17 @@
 import argparse
+from types import MappingProxyType
 
 import pytest
 
 import antennaknobs as ant
+from antennaknobs import AntennaBuilder, Wire, WireSpec
 from antennaknobs.cli import (
     MOMWIRE_BASES,
     parse_engine_spec,
     make_engine_factory,
     broadcast_pairs,
+    deck_extended_kernel_flag,
+    get_builder,
     _GROUND_UNSET,
 )
 from antennaknobs.engines import PyNECEngine, MomwireEngine
@@ -243,3 +247,191 @@ def test_cli_pattern_with_basis_spec():
     ant.cli(
         f"pattern --builder dipoles.invvee:dipole --engine momwire:sinusoidal{O}".split()
     )
+
+
+# ---------------------------------------------------------------------------
+# --extended-kernel (issue #849): NEC's EK card on the momwire CLI path, plus
+# @file.nec decks honoring their own EK card. See engines/momwire.py's
+# `_extended_kernel_refusal` for what refuses and why.
+# ---------------------------------------------------------------------------
+
+# Half-wave dipole with a/h ~ 0.24 (8 mm radius, ~33 mm segments) at 300 MHz —
+# deliberately fat so the reduced and extended kernels visibly disagree, the
+# same fixture shape as test_pynec_extended_kernel.py's PyNEC-side oracle.
+_FAT_DIPOLE_FREQ_MHZ = 300.0
+_FAT_DIPOLE_SPEC = WireSpec(radius=0.008)
+
+
+def _fat_dipole_builder():
+    class _B(AntennaBuilder):
+        default_params = MappingProxyType({"freq": _FAT_DIPOLE_FREQ_MHZ})
+
+        def build_wires(self):
+            return [
+                Wire(
+                    (-0.25, 0.0, 0.0), (0.0, 0.0, 0.0), 7, None, None, _FAT_DIPOLE_SPEC
+                ),
+                Wire(
+                    (0.0, 0.0, 0.0), (0.25, 0.0, 0.0), 8, 1 + 0j, None, _FAT_DIPOLE_SPEC
+                ),
+            ]
+
+    return _B()
+
+
+def test_make_factory_extended_kernel_binds_kwarg():
+    factory = make_engine_factory("momwire", _GROUND_UNSET, extended_kernel=True)
+    assert factory.func is MomwireEngine
+    assert factory.keywords == {"extended_kernel": True}
+    # Off by default: no kwarg at all, not extended_kernel=False (an EK-off
+    # solve must keep passing exactly what it passed before this issue).
+    assert make_engine_factory("momwire", _GROUND_UNSET) is MomwireEngine
+
+
+@pytest.mark.parametrize(
+    "flag,deck",
+    [(True, False), (False, True), (True, True)],
+)
+def test_make_factory_extended_kernel_ors_flag_and_deck(flag, deck):
+    """Either the explicit --extended-kernel flag or a deck's own EK card
+    turns the kernel on — the combination rule is OR (issue #849)."""
+    factory = make_engine_factory(
+        "momwire", _GROUND_UNSET, extended_kernel=flag, deck_extended_kernel=deck
+    )
+    assert factory.keywords == {"extended_kernel": True}
+
+
+def test_make_factory_extended_kernel_off_when_neither_set():
+    factory = make_engine_factory(
+        "momwire", _GROUND_UNSET, extended_kernel=False, deck_extended_kernel=False
+    )
+    assert factory is MomwireEngine
+
+
+def test_make_factory_extended_kernel_moves_fat_wire_impedance_and_matches_direct():
+    """Z must actually move with the flag, and match constructing
+    MomwireEngine(extended_kernel=True) directly on the same design."""
+    factory_off = make_engine_factory("momwire", _GROUND_UNSET)
+    factory_on = make_engine_factory("momwire", _GROUND_UNSET, extended_kernel=True)
+    z_off = factory_off(_fat_dipole_builder()).impedance()[0]
+    z_on = factory_on(_fat_dipole_builder()).impedance()[0]
+    assert abs(z_on - z_off) > 0.3  # the kernels must actually disagree here
+
+    z_direct = MomwireEngine(_fat_dipole_builder(), extended_kernel=True).impedance()[0]
+    assert z_on == z_direct
+
+
+@needs_pynec
+def test_make_factory_extended_kernel_rejected_for_non_momwire():
+    """An explicit --extended-kernel is a momwire-only flag; a request to
+    apply it on another engine is a clear user error, not a silent no-op
+    (PyNEC's own EK support, issue #414, is a separate unexposed kwarg)."""
+    with pytest.raises(argparse.ArgumentTypeError, match="momwire"):
+        make_engine_factory("pynec", _GROUND_UNSET, extended_kernel=True)
+
+
+@needs_pynec
+def test_make_factory_deck_extended_kernel_silently_ignored_for_non_momwire():
+    """A deck-only EK request (no explicit flag) on a non-momwire engine is
+    left alone — unchanged from before issue #849, since PyNEC's EK support
+    isn't wired to the deck by this issue."""
+    factory = make_engine_factory("pynec", _GROUND_UNSET, deck_extended_kernel=True)
+    assert factory is PyNECEngine
+
+
+def test_make_factory_extended_kernel_refuses_sinusoidal_galerkin_at_construction():
+    """momwire#246: no EKSCX counterpart for the Galerkin fill's folded
+    testing shape, so the solver refuses at construction — the same
+    NotImplementedError the engine raises directly (issue #849)."""
+    factory = make_engine_factory(
+        "momwire:sinusoidal-galerkin", _GROUND_UNSET, extended_kernel=True
+    )
+    with pytest.raises(NotImplementedError, match="sinusoidal-galerkin"):
+        factory(_fat_dipole_builder())
+
+
+def test_cli_extended_kernel_flag_runs():
+    ant.cli(
+        f"pattern --builder dipoles.invvee:dipole --engine momwire "
+        f"--extended-kernel{O}".split()
+    )
+
+
+def test_cli_extended_kernel_galerkin_refusal_is_a_clean_systemexit(capsys):
+    """The CLI must print the refusal and exit cleanly (exit code 1, the
+    message on stdout), not dump a traceback (cli()'s NotImplementedError
+    handler, issue #849)."""
+    with pytest.raises(SystemExit) as exc:
+        ant.cli(
+            f"pattern --builder dipoles.invvee:dipole "
+            f"--engine momwire:sinusoidal-galerkin --extended-kernel{O}".split()
+        )
+    assert exc.value.code == 1
+    assert "sinusoidal-galerkin" in capsys.readouterr().out
+
+
+@needs_pynec
+def test_cli_extended_kernel_flag_rejected_for_pynec():
+    with pytest.raises(argparse.ArgumentTypeError):
+        ant.cli(
+            f"pattern --builder dipoles.invvee:dipole --engine pynec "
+            f"--extended-kernel{O}".split()
+        )
+
+
+# --- @file.nec decks honoring their own EK card ---------------------------
+
+_FAT_DIPOLE_DECK = """CE fat dipole
+GW 1 15 -0.25 0 0 0.25 0 0 0.008
+GE 0
+{ek}FR 0 1 0 0 300.0
+EX 0 1 8 0 1.0 0.0
+EN
+"""
+
+
+def test_deck_extended_kernel_flag_absence_vs_explicit_off_vs_on(tmp_path):
+    """NecDeck.extended_kernel semantics carried onto the synthesized @file
+    builder: absence and `EK -1` both read as off, any other EK reads as on
+    (issue #849's chosen, documented combination rule)."""
+    on = tmp_path / "on.nec"
+    on.write_text(_FAT_DIPOLE_DECK.format(ek="EK\n"))
+    off = tmp_path / "off.nec"
+    off.write_text(_FAT_DIPOLE_DECK.format(ek="EK -1\n"))
+    absent = tmp_path / "absent.nec"
+    absent.write_text(_FAT_DIPOLE_DECK.format(ek=""))
+
+    assert deck_extended_kernel_flag(get_builder(f"@{on}")) is True
+    assert deck_extended_kernel_flag(get_builder(f"@{off}")) is False
+    assert deck_extended_kernel_flag(get_builder(f"@{absent}")) is False
+    # An ordinary catalog design carries no such attribute at all.
+    assert deck_extended_kernel_flag(get_builder("dipoles.invvee")) is False
+
+
+def test_file_nec_deck_ek_card_honored_on_momwire_engine(tmp_path):
+    """A `@file.nec` deck's own EK card turns the kernel on for the momwire
+    engine with no --extended-kernel flag needed, and matches constructing
+    MomwireEngine(extended_kernel=True) directly on the same geometry."""
+    path = tmp_path / "fatdipole.nec"
+    path.write_text(_FAT_DIPOLE_DECK.format(ek="EK\n"))
+
+    builder_cls = get_builder(f"@{path}")
+    factory = make_engine_factory(
+        "momwire",
+        _GROUND_UNSET,
+        deck_extended_kernel=deck_extended_kernel_flag(builder_cls),
+    )
+    z_via_deck = factory(builder_cls()).impedance()[0]
+    z_direct_on = MomwireEngine(builder_cls(), extended_kernel=True).impedance()[0]
+    z_direct_off = MomwireEngine(builder_cls(), extended_kernel=False).impedance()[0]
+
+    assert z_via_deck == z_direct_on
+    assert abs(z_via_deck - z_direct_off) > 0.3
+
+
+def test_cli_file_nec_deck_ek_card_runs_end_to_end(tmp_path):
+    """Smoke-level: the CLI actually runs a momwire solve against an
+    @file.nec deck carrying an EK card, with no --extended-kernel flag."""
+    path = tmp_path / "fatdipole.nec"
+    path.write_text(_FAT_DIPOLE_DECK.format(ek="EK\n"))
+    ant.cli(f"pattern --builder @{path} --engine momwire{O}".split())

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2474,6 +2474,7 @@ def test_cache_key_recurses_into_model_options():
         ("use_singular_enrichment", False),
         ("enrichment_variant", "off"),
         ("tikhonov_lambda", 1e-2),
+        ("extended_kernel", True),
     ]:
         mutant = dict(_CANONICAL_REQ)
         mutant["model_options"] = {**_CANONICAL_REQ["model_options"], k: alt}
@@ -3089,6 +3090,128 @@ def test_swept_mem_budget_injected_for_bspline_family(monkeypatch):
         {**req_base, "momwire_model": "bspline"}, builder
     )
     assert "swept_mem_mb" not in (eng._solver_kwargs or {})
+
+
+# ---------------------------------------------------------------------------
+# extended_kernel (issue #849): NEC's EK card as a hosted model option, wired
+# through to MomwireEngine's named `extended_kernel=` kwarg rather than left
+# inside solver_kwargs (unit 1's engine-side note + this unit's adapter site).
+# ---------------------------------------------------------------------------
+
+
+def test_extended_kernel_reaches_momwire_engine():
+    import importlib
+
+    from antennaknobs.web import adapter
+
+    design = importlib.import_module("antennaknobs.designs.dipoles.invvee")
+    req_base = {"measurement_freq_mhz": 28.47}
+    builder = adapter._build_builder(design.Builder, req_base)
+
+    eng_off = adapter._make_momwire_engine(
+        {**req_base, "momwire_model": "bspline"}, builder
+    )
+    assert eng_off._extended_kernel is False
+
+    eng_on = adapter._make_momwire_engine(
+        {
+            **req_base,
+            "momwire_model": "bspline",
+            "model_options": {"extended_kernel": True},
+        },
+        builder,
+    )
+    assert eng_on._extended_kernel is True
+    # Pulled out and passed as the named kwarg — not left sitting in
+    # solver_kwargs (unit 1's engine-side fold would still work either way,
+    # but the adapter's contract is the named kwarg specifically).
+    assert "extended_kernel" not in (eng_on._solver_kwargs or {})
+
+
+def test_hosted_extended_kernel_option_is_whitelisted(monkeypatch):
+    """The EK toggle is a physics selection like feed_model, not a compute-
+    amplification lever, so it must survive the hosted allowlist."""
+    from antennaknobs.web import adapter
+
+    monkeypatch.setattr(adapter, "_HOSTED", True)
+    out = adapter.sanitize_model_options({"model_options": {"extended_kernel": True}})
+    assert out == {"extended_kernel": True}
+    with pytest.raises(ValueError, match="extended_kernel"):
+        adapter.sanitize_model_options({"model_options": {"extended_kernel": "yes"}})
+
+
+def test_extended_kernel_moves_impedance_and_matches_direct_engine():
+    """Full server.solve() path: the kernel toggle must actually move Z, and
+    match constructing MomwireEngine(extended_kernel=True) directly on the
+    same builder."""
+    import importlib
+
+    from antennaknobs.engines import MomwireEngine
+    from antennaknobs.web import adapter
+
+    base = {
+        "geometry": "dipoles.invvee",
+        "solver": "momwire",
+        "momwire_model": "bspline",
+        "measurement_freq_mhz": 28.47,
+        "wire_radius": 0.008,  # fat wire — the kernels must visibly disagree
+    }
+    z_off = server.solve(dict(base))
+    z_on = server.solve({**base, "model_options": {"extended_kernel": True}})
+    assert (
+        abs(z_on["z_in_re"] - z_off["z_in_re"]) > 0.05
+        or abs(z_on["z_in_im"] - z_off["z_in_im"]) > 0.05
+    )
+
+    design = importlib.import_module("antennaknobs.designs.dipoles.invvee")
+    builder = adapter._build_builder(design.Builder, base)
+    builder.freq = base["measurement_freq_mhz"]
+    z_direct = MomwireEngine(
+        builder, wire_radius=0.008, extended_kernel=True
+    ).impedance()[0]
+    assert z_on["z_in_re"] == pytest.approx(z_direct.real)
+    assert z_on["z_in_im"] == pytest.approx(z_direct.imag)
+
+
+def test_geometry_extended_kernel_galerkin_refusal_is_structured(client: TestClient):
+    """issue #849: EK + sinusoidal-galerkin refuses at engine construction
+    (momwire#246 — no EKSCX counterpart for the Galerkin fill). The web path
+    must surface this as a clean {"error": ...} body (200), not a
+    500/traceback — the same structured-error contract as a broken user
+    design (test_geometry_endpoint_surfaces_build_error)."""
+    resp = client.post(
+        "/geometry",
+        json={
+            "geometry": "dipoles.invvee",
+            "momwire_model": "sinusoidal-galerkin",
+            "model_options": {"extended_kernel": True},
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "error" in body
+    assert "sinusoidal-galerkin" in body["error"]
+
+
+def test_ws_extended_kernel_galerkin_refusal_keeps_socket_alive(client: TestClient):
+    """Same refusal on the live /ws solve path: an error frame, not a torn
+    down socket — the next (healthy) request on the same socket must still
+    solve (mirrors test_ws_solve_error_keeps_socket_alive)."""
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(
+            json.dumps(
+                {
+                    "geometry": "dipoles.invvee",
+                    "momwire_model": "sinusoidal-galerkin",
+                    "model_options": {"extended_kernel": True},
+                }
+            )
+        )
+        bad = json.loads(ws.receive_text())
+        assert "sinusoidal-galerkin" in bad["error"]
+        ws.send_text(json.dumps({"geometry": "dipoles.invvee"}))
+        ok = json.loads(ws.receive_text())
+        assert "error" not in ok
 
 
 def test_momwire_ground_off_reports_free_model():


### PR DESCRIPTION
Unit 2 of the #849 stacked arc. CLI: `--extended-kernel` on every engine-args entry point; `@file.nec` decks honor their own EK card (OR-combined with the flag, documented); explicit flag on a non-momwire engine rejects per the basis-suffix precedent; the galerkin refusal exits 1 cleanly. Web: `model_options.extended_kernel` (hosted allowlist + named-kwarg fold that beats verbatim solver_kwargs); refusals ride the existing structured solve-error path on /geometry and /ws (200 + {error}, socket stays alive) — no new plumbing needed.

Gates: 20 new tests; reviewer probe (adapter fold forced False → 4 web gates fail); suite **4621 passed, 2 skipped** (reviewer re-ran). Ruff clean.

Review notes: sonnet builder on unit 1's pointers; session model ran the fold probe + touched files + full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvF4yHgNxjhyZ7P286g3z8