### PR TITLE
#849 unit 3: the per-slot EK toggle, the +EK chip, and the docs

### DIFF
--- a/site/src/content/docs/advanced/convergence.md
+++ b/site/src/content/docs/advanced/convergence.md
@@ -145,6 +145,18 @@ growth up the ladder). The d=2 basis is immune — a Galerkin method
 regularizes the reduced-kernel ill-posedness — which is also why a flat
 bs2 next to an exploding sin curve is the tell.
 
+When the low Δ/a is the *design* rather than a meshing slip — tubing,
+cages, a fat-wire imported deck — the fix is not a finer mesh but a
+better kernel:
+[the extended thin-wire kernel](/reference/solver/#the-extended-thin-wire-kernel-ek)
+(the **extended kernel (EK)** check in a solver slot's gear menu,
+`--extended-kernel` on the CLI) integrates the O(a²) term the filament
+approximation drops. It is worth several percent below Δ/a ≈ 3 and a
+fraction of a percent above Δ/a ≈ 10 — so it moves a genuinely fat wire
+and tells you nothing about a thin one. It does not rescue a segment
+shorter than its own radius: below Δ/a ≈ 1 the discretization is
+ill-posed whichever kernel fills it.
+
 One genuine residue survives the Δ/a accounting, and it is now pinned
 ([issue #484](https://github.com/stevenmburns/antennaknobs/issues/484)):
 **multi-wire fan feeds** — several dipole pairs sharing one feed wire —

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -258,6 +258,28 @@ disagreement between solver bases — see
 engine to reach for — including when the accelerated `hmatrix` / `arrayblock`
 solvers pay off.
 
+### The extended kernel
+
+`--extended-kernel` applies NEC's extended thin-wire kernel (the `EK` card) on
+the momwire engine, wherever `--engine` is accepted:
+
+```bash
+python -m antennaknobs sweep --builder wire.dipole --extended-kernel
+```
+
+It matters for **fat wires** — segments not much longer than the wire radius —
+and is a fraction of a percent on ordinary thin wire; see
+[the extended thin-wire kernel](/reference/solver/#the-extended-thin-wire-kernel-ek).
+Every momwire basis serves it except `sinusoidal-galerkin`, which refuses
+(momwire#246), as does the combination with `use_singular_enrichment`
+(momwire#271) — both exit with a named message rather than a reduced-kernel
+answer under an extended-kernel request. The flag applies only to momwire:
+passing it with `--engine pynec` is an error.
+
+An imported deck brings its own: a `@file.nec` design whose deck carries an
+`EK` card is solved with the kernel on without the flag, and either source
+turns it on (`EK -1`, like an absent card, leaves it off).
+
 ## Comparing engines
 
 Solve the same design two ways and overlay the patterns — the built-in

--- a/site/src/content/docs/reference/nec-import.md
+++ b/site/src/content/docs/reference/nec-import.md
@@ -242,8 +242,12 @@ Real-world decks are mostly written *for 4nec2*, and the importer reads that
 dialect natively: `SY` symbolic variables with full expressions (BASIC-style
 — trig in degrees, `^` power, unit suffixes like `1.5*mm` or `36.6pF`),
 `'`-comments, fused mnemonics (`GW1,8,…`), and `#14`-style AWG wire-gauge
-radii. A deck's `EK` card (extended thin-wire kernel) is honoured by the
-PyNEC engine so fat-wire decks solve kernel-for-kernel with NEC. A remote
+radii. A deck's `EK` card (extended thin-wire kernel) is honoured on both
+engines — momwire builds the solver with its own O(a²) tube expansion, PyNEC
+with NEC's — so fat-wire decks solve kernel-for-kernel with NEC without a flag
+(`EK -1`, like an absent card, stays reduced; see
+[the extended thin-wire kernel](/reference/solver/#the-extended-thin-wire-kernel-ek)).
+A remote
 1-segment wire parked hundreds of wavelengths away purely to terminate a
 `TL` card is recognised and replaced by a virtual circuit node (the deck
 solves in seconds instead of meshing an electrically irrelevant wire; the

--- a/site/src/content/docs/reference/simnec.md
+++ b/site/src/content/docs/reference/simnec.md
@@ -270,7 +270,8 @@ Everything SimNEC's portal actually emits for wire antennas:
 | Cliffs | `RP 2` linear and `RP 3` circular cliffs — the second medium and edge geometry from a `GD` card (or from `GN`'s own `F3`–`F6`), selected per segment at its own reflection point |
 | Near fields | `NE` / `NH` rectangular grids in free space or over perfect ground |
 | Networks | `NT` two-port admittance branches and `TL` transmission lines between segments |
-| Housekeeping | `EK` extended-kernel, `MP` multicore hints, `PT` print control — accepted and echoed exactly as nec2c does (advisory where momwire's own physics governs) |
+| Kernel | `EK` — the extended thin-wire kernel, honoured per execute group: the group's solver is built with momwire's own O(a²) tube expansion, and `EK -1` (like an absent card) stays reduced. The Galerkin basis refuses it as a `NEC ERROR` rather than answering reduced under an extended-kernel request (momwire#246) — `--basis sinusoidal` is the point-matched sibling that carries it |
+| Housekeeping | `MP` multicore hints, `PT` print control — accepted and echoed exactly as nec2c does (advisory where momwire's own physics governs) |
 
 One thing is faster than the engine it replaces, structurally. SimNEC probes an
 N-port antenna by sending N excitation groups in one deck, and a stock nec2c

--- a/site/src/content/docs/reference/solver.mdx
+++ b/site/src/content/docs/reference/solver.mdx
@@ -52,6 +52,42 @@ Plus two **accelerated** solvers for large problems:
 - **`arrayblock`** — element-aware block-low-rank, near-linear on arrays of
   identical / few-shape elements.
 
+## The extended thin-wire kernel (EK)
+
+Every basis above solves a *thin-wire* integral equation: the current is
+treated as a filament on the wire axis, and the field is matched on the
+surface. That approximation is excellent while each segment is long compared
+to the wire's radius, and it degrades as the ratio **Δ/a** falls — the same
+axis that produces
+[convergence failure class 4](/advanced/convergence/#the-four-ways-a-curve-refuses-to-settle).
+NEC's answer is the **extended thin-wire kernel** — the `EK` card — which
+replaces the on-axis Green's function with an O(a²) expansion integrated over
+the tube. The correction is a fraction of a percent at Δ/a > 10 and several
+percent below Δ/a ≈ 3, and it moves the answer *toward* NEC's: on a Δ/a = 2.27
+dipole, nec2c reads 123.7+28.6 j reduced and 113.6+29.0 j extended — an 8 %
+step — and momwire's sinusoidal basis tracks both sides of the card to 0.5 %
+and 3.1 % respectively.
+
+momwire serves it on four of its five solver families — **`sinusoidal`**,
+**`bspline`**, **`hmatrix`** and **`arrayblock`**, in free space and over
+every ground model, at about 1.0–1.3× the reduced-kernel solve. Two
+combinations refuse, loudly rather than silently:
+
+- **`sinusoidal-galerkin`** — NEC's `EKSCX` has no counterpart for the
+  Galerkin fill's folded third source shape (momwire#246). Reach for the
+  point-matched `sinusoidal` sibling instead.
+- **singular enrichment** — the enrichment degrees of freedom carry their own
+  quadrature and bypass the moment kernels the extended kernel corrects
+  (momwire#271).
+
+Three ways to ask for it: the **extended kernel (EK)** check in a solver
+slot's gear menu (per slot, so you can put the same basis and mesh in two
+slots and read the difference); `--extended-kernel` on the CLI; or an `EK`
+card in an imported deck, which is honoured on its own. Reach for it on thick
+elements — tubing, cages, fat-wire imported decks — and when cross-checking a
+NEC model whose deck carries the card. On ordinary thin wire, leave it off:
+it changes the answer by less than the mesh does.
+
 ## Which solver should I use?
 
 The choice turns on two axes — total problem size, and single-structure vs.

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -276,6 +276,40 @@ instance: a local install is **unlocked** (solve as big as your own machine
 allows, sweep as long as you like). See `docs/deploy.md`.
 :::
 
+### The extended kernel (EK)
+
+Beside **wire radius**, every momwire slot's gear menu carries an **extended
+kernel (EK)** check — NEC's extended thin-wire kernel, the `EK` card. It
+changes how the solve treats the wire's radius on-axis: instead of collapsing
+the current to a filament, it integrates NEC's O(a²) expansion over the tube.
+That only matters when a wire is **fat relative to its own segments** — the
+Δ/a ratio. Above Δ/a ≈ 10 it moves the impedance a fraction of a percent;
+below Δ/a ≈ 3 it moves it several percent, in NEC's direction. It costs about
+1.0–1.3× the ordinary solve.
+
+Turn it on when you're modelling thick elements (tubing, cages, a fat-wire
+imported deck) or cross-checking a NEC model whose deck carries an `EK`
+card — the flag is per slot, so the natural use is **A against B: the same
+basis and mesh, one slot with the kernel and one without**, and the readouts
+side by side. A slot running it is labelled **+EK** on its chip
+(e.g. `B-spline d=2 +EK`), so the pair stays tellable apart.
+
+Two combinations are unavailable, and the check greys out and says which:
+
+- **Sin-Galerkin** cannot run it — momwire implements the extended kernel on
+  the point-matched Sinusoidal solver and the B-spline family, and refuses on
+  the Galerkin sibling rather than quietly serving a reduced-kernel answer
+  (momwire#246). Use the **Sinusoidal** slot for an extended-kernel run on
+  that basis family.
+- **K≥3 junction singular enrichment** (the validation-only B-spline knob)
+  cannot run alongside it: the enrichment degrees of freedom bypass the very
+  kernels the extended kernel corrects (momwire#271). The two grey each other
+  out, so you can always back out of either.
+
+**PyNEC** has no such check — the toggle drives momwire's kernel. Changing a
+slot's solver resets the check along with that solver's other options, so an
+armed kernel never rides silently onto a basis you just switched to.
+
 ### The feed model (Sin-Galerkin only)
 
 Pick **Sin-Galerkin** and its gear menu grows one more control, **feed

--- a/src/antennaknobs/web/frontend/src/__tests__/BackendConfigModal.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/BackendConfigModal.test.tsx
@@ -19,6 +19,8 @@ import {
 } from "../components/backend/BackendConfigModal";
 import {
   BSPLINE_DEFAULT_OPTS,
+  EK_ENRICHMENT_REASON,
+  EK_GALERKIN_REASON,
   RESTRICTED_BACKEND_REASON,
   defaultOptsFor,
   type BackendOpts,
@@ -200,6 +202,107 @@ describe("BackendConfigModal — per-backend knob visibility", () => {
     unmount();
     renderModal({ backend: "bspline" });
     expect(screen.queryByText(/no extra solver knobs/)).toBeNull();
+  });
+});
+
+describe("BackendConfigModal — extended kernel (#849)", () => {
+  const EK = /extended kernel \(EK\)/;
+  const ENRICHMENT = /junction singular enrichment/;
+  const MOMWIRE = NAMES.filter((n) => entry(n).kind === "momwire");
+
+  it.each(MOMWIRE)("offers the toggle on %s, off by default", (name) => {
+    renderModal({ backend: name });
+    expect(screen.getByRole("checkbox", { name: EK })).toHaveProperty(
+      "checked",
+      false,
+    );
+  });
+
+  it("offers no toggle on pynec — its extended kernel is not this knob (#414)", () => {
+    renderModal({ backend: "pynec" });
+    expect(screen.queryByRole("checkbox", { name: EK })).toBeNull();
+  });
+
+  it("patches extendedKernel on and off", async () => {
+    const off = renderModal({ backend: "bspline" });
+    await off.user.click(screen.getByRole("checkbox", { name: EK }));
+    expect(off.onPatch).toHaveBeenCalledWith({ extendedKernel: true });
+    off.unmount();
+
+    const on = renderModal({
+      backend: "bspline",
+      opts: { ...defaultOptsFor(entry("bspline")), extendedKernel: true },
+    });
+    expect(screen.getByRole("checkbox", { name: EK })).toHaveProperty("checked", true);
+    await on.user.click(screen.getByRole("checkbox", { name: EK }));
+    expect(on.onPatch).toHaveBeenCalledWith({ extendedKernel: false });
+  });
+
+  it("greys the toggle out on Sin-Galerkin and says why on the page", () => {
+    renderModal({ backend: "sinusoidal-galerkin" });
+    const box = screen.getByRole("checkbox", { name: EK });
+    expect(box).toHaveProperty("disabled", true);
+    expect(box).toHaveProperty("checked", false);
+    // The reason is visible, not tooltip-only: a greyed box with no
+    // explanation is the silence #849 is about.
+    expect(screen.getByText(EK_GALERKIN_REASON)).toBeTruthy();
+    expect(within(screen.getByTitle(EK_GALERKIN_REASON)).getByRole("checkbox")).toBe(box);
+  });
+
+  it("shows a set flag as UNCHECKED on the basis that refuses it", async () => {
+    // A slot cannot normally reach this (a backend swap resets the flag), but
+    // the row must never claim a kernel that isn't running.
+    const { user, onPatch } = renderModal({
+      backend: "sinusoidal-galerkin",
+      opts: {
+        ...defaultOptsFor(entry("sinusoidal-galerkin")),
+        extendedKernel: true,
+      },
+    });
+    const box = screen.getByRole("checkbox", { name: EK });
+    expect(box).toHaveProperty("checked", false);
+    await user.click(box);
+    expect(onPatch).not.toHaveBeenCalled(); // disabled: the click does nothing
+  });
+
+  it("keeps the Δ/a hint on the servable backends", () => {
+    renderModal({ backend: "bspline" });
+    expect(screen.getByText(/Δ\/a/)).toBeTruthy();
+    expect(screen.queryByText(EK_GALERKIN_REASON)).toBeNull();
+  });
+
+  // momwire#271: the two are mutually exclusive, and the exclusion is
+  // symmetric so neither box can lock the other out permanently.
+  it("greys the kernel out while enrichment is on", () => {
+    renderModal({
+      backend: "bspline",
+      opts: bsplineOpts("bspline", { useSingularEnrichment: true }),
+    });
+    expect(screen.getByRole("checkbox", { name: EK })).toHaveProperty("disabled", true);
+    expect(screen.getByText(EK_ENRICHMENT_REASON)).toBeTruthy();
+    // …and enrichment itself is still live, so the user can back out.
+    expect(screen.getByRole("checkbox", { name: ENRICHMENT })).toHaveProperty(
+      "disabled",
+      false,
+    );
+  });
+
+  it("greys enrichment out while the kernel is on", () => {
+    const opts = bsplineOpts("bspline", { useSingularEnrichment: false });
+    renderModal({ backend: "bspline", opts: { ...opts, extendedKernel: true } });
+    const enrich = screen.getByRole("checkbox", { name: ENRICHMENT });
+    expect(enrich).toHaveProperty("disabled", true);
+    expect(within(screen.getByTitle(EK_ENRICHMENT_REASON)).getByRole("checkbox")).toBe(enrich);
+    // …and the kernel itself is still live.
+    expect(screen.getByRole("checkbox", { name: EK })).toHaveProperty("disabled", false);
+  });
+
+  it("leaves enrichment alone when the kernel is off", () => {
+    renderModal({ backend: "bspline", opts: bsplineOpts("bspline") });
+    expect(screen.getByRole("checkbox", { name: ENRICHMENT })).toHaveProperty(
+      "disabled",
+      false,
+    );
   });
 });
 

--- a/src/antennaknobs/web/frontend/src/__tests__/backends.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/backends.test.ts
@@ -14,11 +14,17 @@ import {
   comboInappropriate,
   defaultOptsFor,
   defaultSlots,
+  EK_ENRICHMENT_REASON,
+  EK_GALERKIN_REASON,
+  EK_UNSUPPORTED_BACKEND,
+  extendedKernelActive,
+  extendedKernelRefusal,
   findBackend,
   hasBSplinePanel,
   normalizeBackend,
   slotFromSeed,
   type BackendEntry,
+  type BackendOpts,
 } from "../lib/backends";
 import {
   backendEntry,
@@ -89,6 +95,62 @@ describe("defaultOptsFor", () => {
     expect(defaultOptsFor(entry("sinusoidal-galerkin")).bspline).toBeUndefined();
     expect(defaultOptsFor(entry("sinusoidal")).bspline).toBeUndefined();
     expect(defaultOptsFor(entry("sinusoidal")).feedModel).toBeUndefined();
+  });
+
+  // Absence, not `false`: that is the EK card's own convention, and it is what
+  // keeps a stock request byte-identical to the pre-#849 one (pinned as JSON
+  // in modelOptions.test.ts).
+  it("leaves the extended kernel unset on every backend (#849)", () => {
+    for (const b of SERVED_ROSTER) {
+      expect(defaultOptsFor(b).extendedKernel).toBeUndefined();
+      expect(extendedKernelActive(b, defaultOptsFor(b))).toBe(false);
+    }
+  });
+});
+
+describe("extendedKernelRefusal (#849)", () => {
+  const on = (name: string) => ({ ...defaultOptsFor(entry(name)), extendedKernel: true });
+
+  it("passes every backend that momwire serves the kernel on", () => {
+    for (const name of ["sinusoidal", "bspline", "hmatrix", "arrayblock"]) {
+      expect(extendedKernelRefusal(entry(name), on(name))).toBeNull();
+      expect(extendedKernelActive(entry(name), on(name))).toBe(true);
+    }
+  });
+
+  it("refuses the Galerkin basis by name, citing momwire#246", () => {
+    const b = entry("sinusoidal-galerkin");
+    expect(b.name).toBe(EK_UNSUPPORTED_BACKEND); // the constant IS the roster name
+    expect(extendedKernelRefusal(b, on(b.name))).toBe(EK_GALERKIN_REASON);
+    expect(EK_GALERKIN_REASON).toContain("momwire#246");
+    // …and it refuses whether or not the flag is set: the predicate describes
+    // the backend, and the toggle greys out before anything is armed.
+    expect(extendedKernelRefusal(b, defaultOptsFor(b))).toBe(EK_GALERKIN_REASON);
+    expect(extendedKernelActive(b, on(b.name))).toBe(false);
+  });
+
+  it("refuses alongside singular enrichment, citing momwire#271", () => {
+    const opts = on("bspline");
+    opts.bspline = { ...BSPLINE_DEFAULT_OPTS, useSingularEnrichment: true };
+    expect(extendedKernelRefusal(entry("bspline"), opts)).toBe(EK_ENRICHMENT_REASON);
+    expect(EK_ENRICHMENT_REASON).toContain("momwire#271");
+    expect(extendedKernelActive(entry("bspline"), opts)).toBe(false);
+    // Enrichment off again and the same slot serves it.
+    opts.bspline = { ...BSPLINE_DEFAULT_OPTS, useSingularEnrichment: false };
+    expect(extendedKernelActive(entry("bspline"), opts)).toBe(true);
+  });
+
+  it("never activates on PyNEC, which takes no model_options at all", () => {
+    // PyNEC's own extended-kernel support (issue #414) is a separate,
+    // unexposed kwarg — this toggle must not claim to drive it.
+    expect(extendedKernelActive(entry("pynec"), on("pynec"))).toBe(false);
+  });
+
+  it("serves a momwire backend the roster invented and nobody hardcoded", () => {
+    const fake = backendEntry({ name: "fake-solver", label: "Fake" });
+    expect(
+      extendedKernelActive(fake, { ...defaultOptsFor(fake), extendedKernel: true }),
+    ).toBe(true);
   });
 });
 
@@ -275,5 +337,54 @@ describe("backendDisplayLabel", () => {
       options_schema: [backendOption()],
     });
     expect(backendDisplayLabel(fake, defaultOptsFor(fake))).toBe("Fake");
+  });
+
+  // The A/B story of #849 is "same basis, one slot with the kernel": if the
+  // chips don't say which, the comparison is unreadable.
+  it('affixes "+EK" wherever the extended kernel is in force', () => {
+    const ek = (name: string, over: Partial<BackendOpts> = {}) =>
+      backendDisplayLabel(entry(name), {
+        ...defaultOptsFor(entry(name)),
+        extendedKernel: true,
+        ...over,
+      });
+    expect(ek("sinusoidal")).toBe("Sinusoidal +EK");
+    expect(ek("bspline")).toBe("B-spline d=2 +EK");
+    expect(ek("bspline", { bspline: { ...BSPLINE_DEFAULT_OPTS, degree: 1 } })).toBe(
+      "B-spline d=1 +EK",
+    );
+    expect(ek("hmatrix")).toBe("H-matrix (ACA) d=2 +EK");
+    expect(ek("arrayblock")).toBe("Array-block d=2 +EK");
+  });
+
+  it("leaves the label alone when the kernel is off or refused", () => {
+    // Off: the default, and the other half of every A/B pair.
+    expect(
+      backendDisplayLabel(entry("bspline"), defaultOptsFor(entry("bspline"))),
+    ).toBe("B-spline d=2");
+    // Refused by basis — a set flag on a Galerkin slot is not a running
+    // kernel, and the chip must not claim it is.
+    expect(
+      backendDisplayLabel(entry("sinusoidal-galerkin"), {
+        ...defaultOptsFor(entry("sinusoidal-galerkin")),
+        feedModel: "point",
+        extendedKernel: true,
+      }),
+    ).toBe("Sin-Galerkin (converged)");
+    // Refused by enrichment.
+    expect(
+      backendDisplayLabel(entry("bspline"), {
+        ...defaultOptsFor(entry("bspline")),
+        bspline: { ...BSPLINE_DEFAULT_OPTS, useSingularEnrichment: true },
+        extendedKernel: true,
+      }),
+    ).toBe("B-spline d=2");
+    // Never on PyNEC.
+    expect(
+      backendDisplayLabel(entry("pynec"), {
+        ...defaultOptsFor(entry("pynec")),
+        extendedKernel: true,
+      }),
+    ).toBe("PyNEC");
   });
 });

--- a/src/antennaknobs/web/frontend/src/__tests__/extendedKernel.session.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/extendedKernel.session.test.tsx
@@ -1,0 +1,163 @@
+// The extended thin-wire kernel, end to end through a real <DesignSession>
+// (issue #849 unit 3). The unit pins live in backends.test.ts (the predicate),
+// modelOptions.test.ts (the wire key) and BackendConfigModal.test.tsx (the
+// row); what those cannot show is the thing the toggle exists for — TWO SLOTS,
+// same basis, one with the kernel and one without, each sending its own
+// request and each saying so on its own chip.
+//
+// The wire body is read off the /geometry preview POST, which is buildRequest()
+// verbatim, the same seam newBackend.test.tsx uses.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DesignSession } from "../components/session/DesignSession";
+import type { ExampleDescriptor } from "../lib/params";
+import { SERVED_ROSTER } from "./backendFixtures";
+
+const EXAMPLE: ExampleDescriptor = {
+  name: "dipoles.probe",
+  label: "Probe dipole",
+  multi_feed: false,
+  param_schema: [],
+  result_schema: [],
+  bands: [],
+  meas_freq_range_mhz: null,
+  default_view: "xz",
+  default_freq: null,
+  default_design_freq: null,
+  default_backend: null,
+  requires_backends: null,
+  has_design_freq: true,
+  variants: ["default"],
+  variant_values: {},
+  sweep_policy: { anchor: "design_freq", lo_factor: 0.8, hi_factor: 1.25 },
+};
+
+let geometryPosts: Record<string, unknown>[] = [];
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+/** model_options of the most recent request the session built. */
+function lastModelOptions(): Record<string, unknown> {
+  return (geometryPosts.at(-1)?.model_options ?? {}) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  geometryPosts = [];
+  vi.stubGlobal("fetch", async (url: string, init?: RequestInit) => {
+    const path = String(url);
+    if (path.startsWith("/capabilities"))
+      return jsonResponse({
+        have_pynec: true,
+        backends: SERVED_ROSTER,
+        terrain_presets: [],
+      });
+    if (path.startsWith("/examples"))
+      return jsonResponse({ examples: [EXAMPLE], errors: [] });
+    if (path.startsWith("/geometry")) {
+      geometryPosts.push(JSON.parse(String(init?.body ?? "{}")));
+      return jsonResponse({ wires: [] });
+    }
+    return jsonResponse({});
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** Mount the session, wait for the served roster, and park the live solve so
+ *  every request refresh goes out over POST /geometry. */
+async function mountSession() {
+  const user = userEvent.setup();
+  render(<DesignSession id={1} active />);
+  await screen.findByRole("tab", { name: /Solver slot A/ });
+  await user.click(screen.getByRole("button", { name: "Live" }));
+  return user;
+}
+
+async function toggleExtendedKernel(user: ReturnType<typeof userEvent.setup>, slot: string) {
+  await user.click(screen.getByRole("button", { name: `Slot ${slot} options` }));
+  await user.click(screen.getByRole("checkbox", { name: /extended kernel \(EK\)/ }));
+  await user.click(screen.getByRole("button", { name: "Close" }));
+}
+
+describe("the extended-kernel toggle, slot by slot (#849)", () => {
+  it("arms one slot's request and leaves the other's alone", async () => {
+    const user = await mountSession();
+
+    // Baseline: the stock A slot (B-spline d=2, N=15) sends no kernel key.
+    await waitFor(() => expect(geometryPosts.length).toBeGreaterThan(0));
+    expect(lastModelOptions()).not.toHaveProperty("extended_kernel");
+
+    // Arm slot A.
+    await toggleExtendedKernel(user, "A");
+    await waitFor(() =>
+      expect(lastModelOptions()).toHaveProperty("extended_kernel", true),
+    );
+    // The rest of the request is untouched: same basis, same mesh — which is
+    // what makes the A/B difference readable as the kernel and nothing else.
+    expect(geometryPosts.at(-1)?.momwire_model).toBe("bspline");
+    expect(geometryPosts.at(-1)?.n_per_wire).toBe(15);
+    expect(lastModelOptions().degree).toBe(2);
+
+    // Slot B is a separate configuration and never saw the toggle.
+    await user.click(screen.getByRole("tab", { name: /Solver slot B/ }));
+    await waitFor(() => {
+      expect(geometryPosts.at(-1)?.n_per_wire).toBe(20); // B is d=1 @ N=20
+      expect(lastModelOptions()).not.toHaveProperty("extended_kernel");
+    });
+
+    // …and coming back to A restores it: the flag is per-slot state, not a
+    // session-wide mode.
+    await user.click(screen.getByRole("tab", { name: /Solver slot A/ }));
+    await waitFor(() =>
+      expect(lastModelOptions()).toHaveProperty("extended_kernel", true),
+    );
+  });
+
+  it('says "+EK" on the armed slot\'s chip and nowhere else', async () => {
+    const user = await mountSession();
+    // Both b-spline slots start unaffixed.
+    expect(screen.getByRole("tab", { name: /Solver slot A: B-spline d=2, N=15/ })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: /Solver slot B: B-spline d=1, N=20/ })).toBeTruthy();
+
+    await toggleExtendedKernel(user, "A");
+
+    await screen.findByRole("tab", {
+      name: /Solver slot A: B-spline d=2 \+EK, N=15/,
+    });
+    // B is untouched — the affix marks a slot, not the session.
+    expect(screen.getByRole("tab", { name: /Solver slot B: B-spline d=1, N=20/ })).toBeTruthy();
+  });
+
+  it("drops the flag when the slot's backend changes under it", async () => {
+    const user = await mountSession();
+    await toggleExtendedKernel(user, "A");
+    await waitFor(() =>
+      expect(lastModelOptions()).toHaveProperty("extended_kernel", true),
+    );
+
+    // Swapping the backend resets that slot's model kwargs to the new
+    // backend's defaults, the kernel among them — so the Galerkin basis that
+    // cannot serve it never inherits an armed flag.
+    await user.click(screen.getByRole("button", { name: "Slot A options" }));
+    await user.click(screen.getByRole("tab", { name: "Sin-Galerkin" }));
+    expect(
+      screen.getByRole("checkbox", { name: /extended kernel \(EK\)/ }),
+    ).toHaveProperty("disabled", true);
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    await waitFor(() => {
+      expect(geometryPosts.at(-1)?.momwire_model).toBe("sinusoidal-galerkin");
+      expect(lastModelOptions()).not.toHaveProperty("extended_kernel");
+    });
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/modelOptions.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/modelOptions.test.ts
@@ -145,6 +145,72 @@ describe("modelOptionsForRequest", () => {
     });
   });
 
+  // --- the extended thin-wire kernel (issue #849) --------------------------
+  //
+  // The wire key is `extended_kernel`, which adapter.py pulls back out of
+  // model_options and passes as MomwireEngine's named constructor kwarg. The
+  // contract that matters here is the ASYMMETRY: present-and-true when armed,
+  // absent otherwise — never `false`. The stock-JSON test above is the guard
+  // for the "absent" half, and it is unchanged by #849 on purpose.
+  describe("extended_kernel", () => {
+    const armed = (name: string) => ({
+      ...defaultOptsFor(entry(name)),
+      extendedKernel: true,
+    });
+
+    it("rides as `extended_kernel: true` on every basis that serves it", () => {
+      for (const name of ["sinusoidal", "bspline", "hmatrix", "arrayblock"]) {
+        expect(modelOptionsForRequest(entry(name), armed(name))).toHaveProperty(
+          "extended_kernel",
+          true,
+        );
+      }
+    });
+
+    it("is ABSENT — not false — with the toggle off", () => {
+      for (const name of ["sinusoidal", "bspline", "hmatrix", "arrayblock"]) {
+        const b = entry(name);
+        expect(modelOptionsForRequest(b, defaultOptsFor(b))).not.toHaveProperty(
+          "extended_kernel",
+        );
+        // …and explicitly off is the same request as never armed: toggling on
+        // and back off must return to the pre-#849 body byte for byte.
+        expect(
+          JSON.stringify(
+            modelOptionsForRequest(b, {
+              ...defaultOptsFor(b),
+              extendedKernel: false,
+            }),
+          ),
+        ).toBe(JSON.stringify(modelOptionsForRequest(b, defaultOptsFor(b))));
+      }
+    });
+
+    it("never reaches the wire on a basis that refuses it (momwire#246/#271)", () => {
+      // Galerkin: momwire#246.
+      expect(
+        modelOptionsForRequest(
+          entry("sinusoidal-galerkin"),
+          armed("sinusoidal-galerkin"),
+        ),
+      ).toEqual({ n_qp_const: 8, feed_model: "segment" });
+      // Singular enrichment: momwire#271. Sending both would be a refusal at
+      // engine construction; the UI greys the pair out, and this is the lock
+      // behind that.
+      const enriched = {
+        ...armed("bspline"),
+        bspline: { ...BSPLINE_DEFAULT_OPTS, useSingularEnrichment: true },
+      };
+      const out = modelOptionsForRequest(entry("bspline"), enriched);
+      expect(out.use_singular_enrichment).toBe(true);
+      expect(out).not.toHaveProperty("extended_kernel");
+    });
+
+    it("stays off the wire for pynec, which sends no model_options", () => {
+      expect(modelOptionsForRequest(entry("pynec"), armed("pynec"))).toEqual({});
+    });
+  });
+
   it("uses the panel's own defaults when a b-spline slot carries no panel state", () => {
     const result = modelOptionsForRequest(entry("bspline"), {
       nPerWire: 30,

--- a/src/antennaknobs/web/frontend/src/components/backend/BackendConfigModal.tsx
+++ b/src/antennaknobs/web/frontend/src/components/backend/BackendConfigModal.tsx
@@ -2,6 +2,10 @@ import { useEffect } from "react";
 import {
   backendAllowed,
   BSPLINE_DEFAULT_OPTS,
+  EK_ENRICHMENT_REASON,
+  EK_HINT,
+  extendedKernelActive,
+  extendedKernelRefusal,
   PANEL_BSPLINE,
   PANEL_PYNEC,
   PANEL_SIN_GALERKIN,
@@ -114,6 +118,16 @@ export function BackendConfigModal({
             onChange={(v) => onPatch({ wireRadius: v })}
           />
 
+          {/* The extended thin-wire kernel (issue #849) sits next to the wire
+              radius on purpose — it is the knob that decides how the on-axis
+              Green's function treats that radius. Common to every momwire
+              backend, so it lives here rather than in a bespoke panel; PyNEC
+              gets no row at all (it sends no model_options, and its own
+              extended kernel — issue #414 — is a separate, unexposed kwarg). */}
+          {backend.kind === "momwire" && (
+            <ExtendedKernelField backend={backend} opts={opts} onPatch={onPatch} />
+          )}
+
           {/* Generic numeric knobs, straight from the served options_schema —
               the same schema-driven loop the terrain panel uses (#560). */}
           {backend.options_schema.map((f) => (
@@ -144,6 +158,7 @@ export function BackendConfigModal({
           {backend.panel === PANEL_BSPLINE && (
             <BSplineFields
               opts={opts.bspline ?? BSPLINE_DEFAULT_OPTS}
+              extendedKernel={extendedKernelActive(backend, opts)}
               onPatch={(p) =>
                 onPatch({
                   bspline: { ...(opts.bspline ?? BSPLINE_DEFAULT_OPTS), ...p },
@@ -166,6 +181,44 @@ export function BackendConfigModal({
           </button>
         </div>
       </div>
+    </div>
+  );
+}
+
+// The muted one-liner under a control, as the Converged-feed hint spells it.
+const NOTE_STYLE = { color: "var(--muted)", fontSize: "var(--text-sm)" };
+
+// The EK card as a per-slot checkbox. Two combinations refuse upstream
+// (momwire#246 Galerkin, momwire#271 enrichment); rather than let the user
+// arm one and read the refusal out of the error banner, the box greys out and
+// the reason is on the page. `checked` reads the ACTIVE state, so a disabled
+// row is never shown ticked.
+function ExtendedKernelField({
+  backend,
+  opts,
+  onPatch,
+}: {
+  backend: BackendEntry;
+  opts: BackendOpts;
+  onPatch: (patch: Partial<BackendOpts>) => void;
+}) {
+  const refusal = extendedKernelRefusal(backend, opts);
+  return (
+    <div className="field">
+      <label className="link-toggle" title={refusal ?? EK_HINT}>
+        <input
+          type="checkbox"
+          checked={extendedKernelActive(backend, opts)}
+          disabled={refusal !== null}
+          onChange={(e) => onPatch({ extendedKernel: e.target.checked })}
+        />
+        extended kernel (EK)
+      </label>
+      <em style={NOTE_STYLE}>
+        {refusal ??
+          "For fat wires — segments not much longer than the radius (Δ/a " +
+            "below ~10). Thin-wire designs move a fraction of a percent."}
+      </em>
     </div>
   );
 }
@@ -232,9 +285,14 @@ function FeedModelField({
 
 function BSplineFields({
   opts,
+  extendedKernel,
   onPatch,
 }: {
   opts: BSplineOpts;
+  /** The slot's extended kernel is in force — enrichment is unavailable while
+   *  it is (momwire#271). The exclusion is symmetric (the EK row greys out
+   *  while enrichment is on), so neither box can lock the other. */
+  extendedKernel: boolean;
   onPatch: (p: Partial<BSplineOpts>) => void;
 }) {
   return (
@@ -306,10 +364,18 @@ function BSplineFields({
         junction singularity genuinely matters. Not needed for production.
       </p>
       <div className="field">
-        <label className="link-toggle" title="VALIDATION ONLY. Adds (u/h)·log(u/h) singular basis at K ≥ enrichment_min_k junctions. This flips O(1/N) → ~O(1/N^(d+1)) for LOW-ORDER bases (sinusoidal); the d=2 B-spline already converges at that rate on its own, so enrichment is redundant here and adds a coarse-mesh transient. See issue #565.">
+        <label
+          className="link-toggle"
+          title={
+            extendedKernel
+              ? EK_ENRICHMENT_REASON
+              : "VALIDATION ONLY. Adds (u/h)·log(u/h) singular basis at K ≥ enrichment_min_k junctions. This flips O(1/N) → ~O(1/N^(d+1)) for LOW-ORDER bases (sinusoidal); the d=2 B-spline already converges at that rate on its own, so enrichment is redundant here and adds a coarse-mesh transient. See issue #565."
+          }
+        >
           <input
             type="checkbox"
             checked={opts.useSingularEnrichment}
+            disabled={extendedKernel}
             onChange={(e) => onPatch({ useSingularEnrichment: e.target.checked })}
           />
           K≥3 junction singular enrichment

--- a/src/antennaknobs/web/frontend/src/lib/backends.ts
+++ b/src/antennaknobs/web/frontend/src/lib/backends.ts
@@ -197,6 +197,14 @@ export type BackendOpts = {
   // offered on plain sinusoidal: the point gap has no collocation RHS
   // (momwire#212), so that solver's roster entry names no panel.
   feedModel?: FeedModel;
+  // NEC's extended thin-wire kernel — the `EK` card (issue #849, momwire >=
+  // 0.26.0). Common to every momwire backend rather than panel-specific, so
+  // it sits beside wire radius rather than inside a bespoke panel: it is the
+  // knob that says how the on-axis Green's function treats that radius.
+  // ABSENT = off, which is the EK card's own convention (a deck with no `EK`
+  // card, and `EK -1`, both read as the reduced kernel) and what keeps a
+  // kernel-off request byte-identical to what every release before #849 sent.
+  extendedKernel?: boolean;
 };
 
 /** A backend's stock options: served numeric defaults plus the bespoke
@@ -212,6 +220,61 @@ export function defaultOptsFor(b: BackendEntry): BackendOpts {
   // on near-open designs (#640).
   if (b.panel === PANEL_SIN_GALERKIN) opts.feedModel = "segment";
   return opts;
+}
+
+// ---------------------------------------------------------------------------
+// The extended thin-wire kernel (issue #849)
+// ---------------------------------------------------------------------------
+
+// One-line "why you'd want this", used as the toggle's tooltip.
+export const EK_HINT =
+  "NEC's extended thin-wire kernel (the EK card): the on-axis Green's " +
+  "function uses NEC's O(a²) tube expansion instead of the filament " +
+  "approximation. It matters where the wire is FAT relative to its segments " +
+  "— a fraction of a percent at Δ/a > 10, several percent below Δ/a ≈ 3 — " +
+  "and costs about 1.0–1.3× the reduced-kernel solve.";
+
+// The one basis that cannot serve the kernel. Named here rather than read off
+// the roster because the roster carries no capability field for it: momwire
+// implements EK on the point-matched SinusoidalSolver and the B-spline family,
+// and refuses on the Galerkin sibling (momwire#246). This is the frontend twin
+// of engines/momwire.py::_extended_kernel_refusal, which raises the same two
+// refusals server-side — so a stale name here costs a clear error dialog, not
+// a wrong answer. If a second basis ever refuses, that is the moment to serve
+// the capability as a roster field instead of extending this constant.
+export const EK_UNSUPPORTED_BACKEND = "sinusoidal-galerkin";
+
+export const EK_GALERKIN_REASON =
+  "The Sin-Galerkin basis cannot run the extended kernel: NEC's EKSCX has no " +
+  "counterpart for its folded testing shape (momwire#246). Use the " +
+  "Sinusoidal or B-spline slots for an extended-kernel run.";
+
+export const EK_ENRICHMENT_REASON =
+  "The extended kernel and K≥3 junction singular enrichment cannot be used " +
+  "together (momwire#271): the enrichment DOFs bypass the moment kernels the " +
+  "extended kernel corrects. Turn one of the two off.";
+
+/** Why this slot cannot run the extended kernel, or null if it can. Mirrors
+ *  the engine-side refusals so the gear menu can grey the toggle out and say
+ *  why, instead of letting the solve come back as an error dialog. */
+export function extendedKernelRefusal(
+  b: BackendEntry,
+  opts: BackendOpts,
+): string | null {
+  if (b.name === EK_UNSUPPORTED_BACKEND) return EK_GALERKIN_REASON;
+  if (opts.bspline?.useSingularEnrichment) return EK_ENRICHMENT_REASON;
+  return null;
+}
+
+/** Is the extended kernel actually in force for this slot? True only when the
+ *  user asked for it AND this backend can serve it — a slot whose backend
+ *  changed under a set flag solves reduced rather than erroring, and the chip
+ *  and the request agree with the toggle the gear menu is showing. PyNEC is
+ *  excluded outright: it sends no `model_options` at all, and its own
+ *  extended-kernel support (issue #414) is a separate, unexposed kwarg. */
+export function extendedKernelActive(b: BackendEntry, opts: BackendOpts): boolean {
+  if (b.kind !== "momwire" || !opts.extendedKernel) return false;
+  return extendedKernelRefusal(b, opts) === null;
 }
 
 // Three abstract solver slots. Each holds one backend choice and its
@@ -231,13 +294,19 @@ export type SlotConfig = {
 // spline degree so two b-spline slots (the default A d=2 / B d=1 pair) stay
 // distinguishable at a glance.
 export function backendDisplayLabel(b: BackendEntry, opts: BackendOpts): string {
+  // "+EK" affixes the extended thin-wire kernel (issue #849) to whatever the
+  // slot is already called. The whole point of the toggle is A-vs-B — one slot
+  // with the kernel, one without — so the chips have to say which is which.
+  // Affixed only when the kernel is actually IN FORCE, never when a backend
+  // that refuses it is carrying a set flag.
+  const ek = extendedKernelActive(b, opts) ? " +EK" : "";
   if (b.panel === PANEL_BSPLINE)
-    return `${b.label} d=${opts.bspline?.degree ?? BSPLINE_DEFAULT_OPTS.degree}`;
+    return `${b.label} d=${opts.bspline?.degree ?? BSPLINE_DEFAULT_OPTS.degree}${ek}`;
   // Surface the non-default feed model on the slot chip: two Sin-Galerkin
   // slots differing only in feed model must be tellable apart at a glance.
   if (b.panel === PANEL_SIN_GALERKIN && opts.feedModel === "point")
-    return `${b.label} (converged)`;
-  return b.label;
+    return `${b.label} (converged)${ek}`;
+  return `${b.label}${ek}`;
 }
 
 /** Seed for one default slot: a backend NAME (resolved against the served
@@ -324,5 +393,14 @@ export function modelOptionsForRequest(
     // (momwire#212) and must not receive the key at all.
     out.feed_model = opts.feedModel ?? "segment";
   }
+  // The extended thin-wire kernel travels as a model option (the server pulls
+  // it back out of model_options and passes it as the named `extended_kernel=`
+  // constructor kwarg). Sent ONLY when in force: absence is the reduced
+  // kernel — the EK card's own convention, and the spelling that keeps a
+  // kernel-off request byte-identical to what every release before #849 sent.
+  // The `extendedKernelActive` gate is also what keeps a refused combination
+  // off the wire; the UI disables the toggle on those, so this is the second
+  // of the two locks, not the only one.
+  if (extendedKernelActive(b, opts)) out.extended_kernel = true;
   return out;
 }


### PR DESCRIPTION
Unit 3 of the #849 stacked arc. Per-slot `extended kernel (EK)` checkbox in the gear menu (momwire slots only, under wire radius); emits `model_options.extended_kernel` only when armed (stock-JSON byte-regression guard untouched); `extendedKernelRefusal` is the frontend twin of the engine predicate — galerkin (momwire#246) and enrichment (momwire#271) grey it out WITH the reason on the page, symmetric with the enrichment box; `+EK` affix on every solver-identity chip via `backendDisplayLabel`; A/B slots compare EK on/off. Six doc pages updated present-tense (solver.mdx EK section, web.md, cli.md — unit 2's flag was undocumented, simnec.md advisory row retired, nec-import.md, convergence.md failure class 4).

Gates: frontend 731 passed (+28), tsc + vite build + astro check clean, lint 0 errors; reviewer probe (silenced request emit → 3 tests fail, matching the builder's own mutation check). No Python changes.

Review notes: opus builder; session model ran the emit probe + full frontend gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvF4yHgNxjhyZ7P286g3z8