### PR TITLE
feat: honor the EK card end to end — portal, engine, CLI, web UI (#849)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/sta
 # install below sees its requirement already satisfied, then the package with the
 # web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install "momwire==0.24.0" \
+ && pip install "momwire==0.26.0" \
  && pip install -e ".[web]"
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in

--- a/docs/status/2026-08-08-simnec-execute-grammar.md
+++ b/docs/status/2026-08-08-simnec-execute-grammar.md
@@ -1405,8 +1405,14 @@ fabricated readouts from the failures (Windows session, 2026-08-08:
 
 Pinned behaviour (fixtures `dipole_ek_extended`, `dipole_ek_rearm`):
 
-- `EK` / `EK 0` = extended thin-wire kernel on; `EK -1` = standard. Echoed
-  as a normal DATA CARD line.
+- The card's one field is tested for `-1` and for nothing else: `EK`, `EK 0`,
+  `EK 1`, `EK 2` and even `EK -2` all turn the extended thin-wire kernel ON,
+  and only `EK -1` turns it off (re-measured on 5b4az.ae6ty.1.23, 2026-08-10;
+  it is NEC-2's own card reader — `nec2dx.f` sets `IEXK = 1` on an EK card and
+  clears it for `ITMP1 = -1` alone). Echoed as a normal DATA CARD line.
+  This engine refused anything outside `{0, -1}` until issue #849 — the same
+  failure class as #814, a deck the reference engine runs turned into a
+  fabricated SimNEC readout by our refusal.
 - When on at a full (FR-driven) preamble: one extra line, 24-space indent,
   `THE EXTENDED THIN WIRE KERNEL WILL BE USED`, directly after the
   APPROXIMATE INTEGRATION note.
@@ -1418,8 +1424,28 @@ Pinned behaviour (fixtures `dipole_ek_extended`, `dipole_ek_rearm`):
   retained source. The first EX after an execution replaces the set;
   §11's "cleared at every XQ" described decks that always supplied
   fresh EX cards, not the engine.
-- For momwire the kernel choice is advisory (our kernel is our own);
-  layout is reproduced exactly, values are ours.
+- ~~For momwire the kernel choice is advisory (our kernel is our own);
+  layout is reproduced exactly, values are ours.~~ **Superseded by issue
+  #849 (momwire 0.26.0).** The card is HONOURED: the solver an execute group
+  is answered from is built with `extended_kernel=True`, momwire's own O(a²)
+  on-axis tube expansion (momwire#249/#259/#269/#270). Consequences worth
+  writing down:
+  - It is per EXECUTE GROUP, not per deck, and the per-deck fill cache is
+    keyed on `(frequency, kernel)` accordingly — `dipole_ek_rearm` is one
+    deck, one frequency, two operators.
+  - Magnitude: nothing, on any deck in the fixture corpus. Every committed
+    EK deck is `Δ/a ≈ 500`, where the correction measures 0.017 %. On a
+    `Δ/a = 2.27` wire both engines move ~8 %, and momwire's reduced answer
+    is 0.5 % from nec2c's while its extended answer is 3.1 % from nec2c's.
+  - **The two Galerkin portal entries cannot serve a live SimNEC session.**
+    momwire#246 leaves the extended kernel unimplemented on the Galerkin
+    fill, and `NECSource` sends `EK` on every deck, so `--basis
+    sinusoidal-galerkin[-converged]` now refuses every live deck with a
+    named `ERROR:` frame (and its NX sentinel). That is deliberate — the
+    alternative is serving a reduced-kernel answer under an extended-kernel
+    request — but it means those two dialog entries are bench instruments
+    rather than session engines until momwire#246 lands. `--basis
+    sinusoidal` is the point-matched sibling that does carry EK.
 - Build note: the 1.17 corpus oracle aborts noisily at EOF after the last
   NX ("Error reading input file") — post-sentinel noise, also present in
   pre-EK fixtures, harmless to `Execute` which stops at the sentinel.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire==0.24.0",
+    "momwire==0.26.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",

--- a/site/src/content/docs/advanced/convergence.md
+++ b/site/src/content/docs/advanced/convergence.md
@@ -145,6 +145,18 @@ growth up the ladder). The d=2 basis is immune — a Galerkin method
 regularizes the reduced-kernel ill-posedness — which is also why a flat
 bs2 next to an exploding sin curve is the tell.
 
+When the low Δ/a is the *design* rather than a meshing slip — tubing,
+cages, a fat-wire imported deck — the fix is not a finer mesh but a
+better kernel:
+[the extended thin-wire kernel](/reference/solver/#the-extended-thin-wire-kernel-ek)
+(the **extended kernel (EK)** check in a solver slot's gear menu,
+`--extended-kernel` on the CLI) integrates the O(a²) term the filament
+approximation drops. It is worth several percent below Δ/a ≈ 3 and a
+fraction of a percent above Δ/a ≈ 10 — so it moves a genuinely fat wire
+and tells you nothing about a thin one. It does not rescue a segment
+shorter than its own radius: below Δ/a ≈ 1 the discretization is
+ill-posed whichever kernel fills it.
+
 One genuine residue survives the Δ/a accounting, and it is now pinned
 ([issue #484](https://github.com/stevenmburns/antennaknobs/issues/484)):
 **multi-wire fan feeds** — several dipole pairs sharing one feed wire —

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -258,6 +258,28 @@ disagreement between solver bases — see
 engine to reach for — including when the accelerated `hmatrix` / `arrayblock`
 solvers pay off.
 
+### The extended kernel
+
+`--extended-kernel` applies NEC's extended thin-wire kernel (the `EK` card) on
+the momwire engine, wherever `--engine` is accepted:
+
+```bash
+python -m antennaknobs sweep --builder wire.dipole --extended-kernel
+```
+
+It matters for **fat wires** — segments not much longer than the wire radius —
+and is a fraction of a percent on ordinary thin wire; see
+[the extended thin-wire kernel](/reference/solver/#the-extended-thin-wire-kernel-ek).
+Every momwire basis serves it except `sinusoidal-galerkin`, which refuses
+(momwire#246), as does the combination with `use_singular_enrichment`
+(momwire#271) — both exit with a named message rather than a reduced-kernel
+answer under an extended-kernel request. The flag applies only to momwire:
+passing it with `--engine pynec` is an error.
+
+An imported deck brings its own: a `@file.nec` design whose deck carries an
+`EK` card is solved with the kernel on without the flag, and either source
+turns it on (`EK -1`, like an absent card, leaves it off).
+
 ## Comparing engines
 
 Solve the same design two ways and overlay the patterns — the built-in

--- a/site/src/content/docs/reference/nec-import.md
+++ b/site/src/content/docs/reference/nec-import.md
@@ -242,8 +242,12 @@ Real-world decks are mostly written *for 4nec2*, and the importer reads that
 dialect natively: `SY` symbolic variables with full expressions (BASIC-style
 — trig in degrees, `^` power, unit suffixes like `1.5*mm` or `36.6pF`),
 `'`-comments, fused mnemonics (`GW1,8,…`), and `#14`-style AWG wire-gauge
-radii. A deck's `EK` card (extended thin-wire kernel) is honoured by the
-PyNEC engine so fat-wire decks solve kernel-for-kernel with NEC. A remote
+radii. A deck's `EK` card (extended thin-wire kernel) is honoured on both
+engines — momwire builds the solver with its own O(a²) tube expansion, PyNEC
+with NEC's — so fat-wire decks solve kernel-for-kernel with NEC without a flag
+(`EK -1`, like an absent card, stays reduced; see
+[the extended thin-wire kernel](/reference/solver/#the-extended-thin-wire-kernel-ek)).
+A remote
 1-segment wire parked hundreds of wavelengths away purely to terminate a
 `TL` card is recognised and replaced by a virtual circuit node (the deck
 solves in seconds instead of meshing an electrically irrelevant wire; the

--- a/site/src/content/docs/reference/simnec.md
+++ b/site/src/content/docs/reference/simnec.md
@@ -270,7 +270,8 @@ Everything SimNEC's portal actually emits for wire antennas:
 | Cliffs | `RP 2` linear and `RP 3` circular cliffs — the second medium and edge geometry from a `GD` card (or from `GN`'s own `F3`–`F6`), selected per segment at its own reflection point |
 | Near fields | `NE` / `NH` rectangular grids in free space or over perfect ground |
 | Networks | `NT` two-port admittance branches and `TL` transmission lines between segments |
-| Housekeeping | `EK` extended-kernel, `MP` multicore hints, `PT` print control — accepted and echoed exactly as nec2c does (advisory where momwire's own physics governs) |
+| Kernel | `EK` — the extended thin-wire kernel, honoured per execute group: the group's solver is built with momwire's own O(a²) tube expansion, and `EK -1` (like an absent card) stays reduced. The Galerkin basis refuses it as a `NEC ERROR` rather than answering reduced under an extended-kernel request (momwire#246) — `--basis sinusoidal` is the point-matched sibling that carries it |
+| Housekeeping | `MP` multicore hints, `PT` print control — accepted and echoed exactly as nec2c does (advisory where momwire's own physics governs) |
 
 One thing is faster than the engine it replaces, structurally. SimNEC probes an
 N-port antenna by sending N excitation groups in one deck, and a stock nec2c

--- a/site/src/content/docs/reference/solver.mdx
+++ b/site/src/content/docs/reference/solver.mdx
@@ -52,6 +52,42 @@ Plus two **accelerated** solvers for large problems:
 - **`arrayblock`** — element-aware block-low-rank, near-linear on arrays of
   identical / few-shape elements.
 
+## The extended thin-wire kernel (EK)
+
+Every basis above solves a *thin-wire* integral equation: the current is
+treated as a filament on the wire axis, and the field is matched on the
+surface. That approximation is excellent while each segment is long compared
+to the wire's radius, and it degrades as the ratio **Δ/a** falls — the same
+axis that produces
+[convergence failure class 4](/advanced/convergence/#the-four-ways-a-curve-refuses-to-settle).
+NEC's answer is the **extended thin-wire kernel** — the `EK` card — which
+replaces the on-axis Green's function with an O(a²) expansion integrated over
+the tube. The correction is a fraction of a percent at Δ/a > 10 and several
+percent below Δ/a ≈ 3, and it moves the answer *toward* NEC's: on a Δ/a = 2.27
+dipole, nec2c reads 123.7+28.6 j reduced and 113.6+29.0 j extended — an 8 %
+step — and momwire's sinusoidal basis tracks both sides of the card to 0.5 %
+and 3.1 % respectively.
+
+momwire serves it on four of its five solver families — **`sinusoidal`**,
+**`bspline`**, **`hmatrix`** and **`arrayblock`**, in free space and over
+every ground model, at about 1.0–1.3× the reduced-kernel solve. Two
+combinations refuse, loudly rather than silently:
+
+- **`sinusoidal-galerkin`** — NEC's `EKSCX` has no counterpart for the
+  Galerkin fill's folded third source shape (momwire#246). Reach for the
+  point-matched `sinusoidal` sibling instead.
+- **singular enrichment** — the enrichment degrees of freedom carry their own
+  quadrature and bypass the moment kernels the extended kernel corrects
+  (momwire#271).
+
+Three ways to ask for it: the **extended kernel (EK)** check in a solver
+slot's gear menu (per slot, so you can put the same basis and mesh in two
+slots and read the difference); `--extended-kernel` on the CLI; or an `EK`
+card in an imported deck, which is honoured on its own. Reach for it on thick
+elements — tubing, cages, fat-wire imported decks — and when cross-checking a
+NEC model whose deck carries the card. On ordinary thin wire, leave it off:
+it changes the answer by less than the mesh does.
+
 ## Which solver should I use?
 
 The choice turns on two axes — total problem size, and single-structure vs.

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -276,6 +276,40 @@ instance: a local install is **unlocked** (solve as big as your own machine
 allows, sweep as long as you like). See `docs/deploy.md`.
 :::
 
+### The extended kernel (EK)
+
+Beside **wire radius**, every momwire slot's gear menu carries an **extended
+kernel (EK)** check — NEC's extended thin-wire kernel, the `EK` card. It
+changes how the solve treats the wire's radius on-axis: instead of collapsing
+the current to a filament, it integrates NEC's O(a²) expansion over the tube.
+That only matters when a wire is **fat relative to its own segments** — the
+Δ/a ratio. Above Δ/a ≈ 10 it moves the impedance a fraction of a percent;
+below Δ/a ≈ 3 it moves it several percent, in NEC's direction. It costs about
+1.0–1.3× the ordinary solve.
+
+Turn it on when you're modelling thick elements (tubing, cages, a fat-wire
+imported deck) or cross-checking a NEC model whose deck carries an `EK`
+card — the flag is per slot, so the natural use is **A against B: the same
+basis and mesh, one slot with the kernel and one without**, and the readouts
+side by side. A slot running it is labelled **+EK** on its chip
+(e.g. `B-spline d=2 +EK`), so the pair stays tellable apart.
+
+Two combinations are unavailable, and the check greys out and says which:
+
+- **Sin-Galerkin** cannot run it — momwire implements the extended kernel on
+  the point-matched Sinusoidal solver and the B-spline family, and refuses on
+  the Galerkin sibling rather than quietly serving a reduced-kernel answer
+  (momwire#246). Use the **Sinusoidal** slot for an extended-kernel run on
+  that basis family.
+- **K≥3 junction singular enrichment** (the validation-only B-spline knob)
+  cannot run alongside it: the enrichment degrees of freedom bypass the very
+  kernels the extended kernel corrects (momwire#271). The two grey each other
+  out, so you can always back out of either.
+
+**PyNEC** has no such check — the toggle drives momwire's kernel. Changing a
+slot's solver resets the check along with that solver's other options, so an
+armed kernel never rides silently onto a basis you just switched to.
+
 ### The feed model (Sin-Galerkin only)
 
 Pick **Sin-Galerkin** and its gear menu grows one more control, **feed

--- a/src/antennaknobs/cli.py
+++ b/src/antennaknobs/cli.py
@@ -347,7 +347,23 @@ def parse_engine_spec(spec):
     return name, {"solver": MOMWIRE_BASES[basis]}
 
 
-def make_engine_factory(engine_spec, ground_spec):
+def make_engine_factory(
+    engine_spec, ground_spec, *, extended_kernel=False, deck_extended_kernel=False
+):
+    """Bind an engine spec (+ optional ground) into a builder->engine factory.
+
+    ``extended_kernel`` is an explicit user request (CLI ``--extended-kernel``);
+    ``deck_extended_kernel`` is a ``@file.nec`` deck's own parsed ``EK`` card
+    (issue #849). Either turns the momwire extended thin-wire kernel on — the
+    combination rule is OR, so a deck that already carries ``EK`` doesn't need
+    the flag repeated, and the flag still works on a deck (or a built-in
+    design) that carries none. Only momwire consumes the kernel this way:
+    an explicit ``--extended-kernel`` on any other engine is a clear user
+    error (PyNEC's own extended-kernel support, issue #414, is a separate,
+    unexposed constructor kwarg — not driven by this flag); a deck-only
+    request on a non-momwire engine is silently left alone, matching the
+    pre-#849 status quo for that engine.
+    """
     name, kwargs = parse_engine_spec(engine_spec)
     cls = ENGINE_CLASSES[name]
     # PyNECEngine's default ground IS finite; momwire's default is free.
@@ -355,12 +371,32 @@ def make_engine_factory(engine_spec, ground_spec):
     # when they don't, we use whatever the engine's own default is.
     if ground_spec is not _GROUND_UNSET:
         kwargs["ground"] = ground_spec
+    if extended_kernel or deck_extended_kernel:
+        if name != "momwire":
+            if extended_kernel:
+                raise argparse.ArgumentTypeError(
+                    f"--extended-kernel only applies to the momwire engine "
+                    f"(got {name!r}, issue #849, momwire >= 0.26.0)"
+                )
+            # A deck-only EK request on a non-momwire engine: left alone,
+            # same as before this issue — PyNEC's own EK support (#414)
+            # isn't wired to a deck or this flag.
+        else:
+            kwargs["extended_kernel"] = True
     if not kwargs:
         return cls
     return partial(cls, **kwargs)
 
 
 _GROUND_UNSET = object()
+
+
+def deck_extended_kernel_flag(builder_cls) -> bool:
+    """True if `builder_cls` came from an `@file.nec`/`@file.ssn` spec whose
+    deck carries an EK card (issue #849) — see `file_designs._make_builder`'s
+    `file_extended_kernel` attribute. False for every ordinary catalog/user
+    design (the attribute doesn't exist on those classes at all)."""
+    return bool(getattr(builder_cls, "file_extended_kernel", False))
 
 
 def cli(arguments=None):
@@ -447,6 +483,21 @@ def cli(arguments=None):
             "(reflection-coefficient approximation) "
             "(default: engine-specific — finite for pynec, free for momwire).",
         )
+        p.add_argument(
+            "--extended-kernel",
+            dest="extended_kernel",
+            default=False,
+            action="store_true",
+            help="Apply NEC's extended thin-wire kernel (the EK card) on the "
+            "momwire engine (issue #849, needs momwire >= 0.26.0). Every "
+            "momwire basis serves it except sinusoidal-galerkin, which "
+            "refuses (momwire#246 — no EKSCX counterpart for its folded "
+            "testing shape); combining it with model_options "
+            "use_singular_enrichment also refuses (momwire#271). Matters for "
+            "fat wires (radius comparable to segment length). A "
+            '"@file.nec" deck\'s own EK card is honoured too — either one '
+            "turns the kernel on (OR). Only applies to the momwire engine.",
+        )
 
     def add_pattern_common(p):
         p.add_argument(
@@ -468,11 +519,16 @@ def cli(arguments=None):
             help="Azimuth angle (rear) for the elevation plot.",
         )
 
-    def engine_factory_from_args(args):
+    def engine_factory_from_args(args, deck_extended_kernel=False):
         ground = (
             args.ground if args.ground is _GROUND_UNSET else parse_ground(args.ground)
         )
-        return make_engine_factory(args.engine, ground)
+        return make_engine_factory(
+            args.engine,
+            ground,
+            extended_kernel=args.extended_kernel,
+            deck_extended_kernel=deck_extended_kernel,
+        )
 
     p = subparsers.add_parser("draw", help="Draw antenna")
     add_common(p)
@@ -541,7 +597,7 @@ def cli(arguments=None):
 
     def f(args):
         builder = get_builder(args.builder)
-        engine = engine_factory_from_args(args)
+        engine = engine_factory_from_args(args, deck_extended_kernel_flag(builder))
         measured = read_measured(args.measured, z0=args.z0) if args.measured else None
         if measured is not None and (args.patterns or args.gain):
             # Measured S11 has nothing to say about a pattern or gain chart.
@@ -630,7 +686,7 @@ def cli(arguments=None):
 
     def f(args):
         builder = get_builder(args.builder)
-        engine = engine_factory_from_args(args)
+        engine = engine_factory_from_args(args, deck_extended_kernel_flag(builder))
         opt_builder = optimize(
             builder(),
             args.params,
@@ -802,14 +858,17 @@ def cli(arguments=None):
         elif args.line:
             raise SystemExit("--line only applies with --plane station")
 
-        builder = get_builder(args.builder)()
+        builder_cls = get_builder(args.builder)
+        builder = builder_cls()
         try:
             result = fit(
                 builder,
                 read_measured(args.measured),
                 args.params,
                 z0=args.z0,
-                engine=engine_factory_from_args(args),
+                engine=engine_factory_from_args(
+                    args, deck_extended_kernel_flag(builder_cls)
+                ),
                 bounds=pairs,
                 fractions=args.fractions,
                 npoints=args.npoints,
@@ -943,7 +1002,8 @@ def cli(arguments=None):
     def f(args):
         from .schematic import lower, render_svg
 
-        builder = get_builder(args.builder)()
+        builder_cls = get_builder(args.builder)
+        builder = builder_cls()
         net = builder.build_network() if hasattr(builder, "build_network") else None
         if net is None:
             raise SystemExit(
@@ -952,7 +1012,9 @@ def cli(arguments=None):
             )
         budget = p_in = None
         if args.power:
-            eng = engine_factory_from_args(args)(builder)
+            eng = engine_factory_from_args(
+                args, deck_extended_kernel_flag(builder_cls)
+            )(builder)
             eng.current_distribution()
             budget = getattr(eng, "_excited_power_budget", None)
             # With p_in the annotation reads as the budget table's percent
@@ -983,7 +1045,7 @@ def cli(arguments=None):
 
     def f(args):
         builder = get_builder(args.builder)
-        engine = engine_factory_from_args(args)
+        engine = engine_factory_from_args(args, deck_extended_kernel_flag(builder))
         eng = engine(builder())
         if args.wireframe:
             pattern3d(eng, fn=args.fn)
@@ -1026,8 +1088,14 @@ def cli(arguments=None):
         instances = []
         labels = []
         for bname, espec in pairs:
-            eng = make_engine_factory(espec, ground)
-            instances.append(eng(get_builder(bname)()))
+            builder_cls = get_builder(bname)
+            eng = make_engine_factory(
+                espec,
+                ground,
+                extended_kernel=args.extended_kernel,
+                deck_extended_kernel=deck_extended_kernel_flag(builder_cls),
+            )
+            instances.append(eng(builder_cls()))
             if multi_engine and multi_builder:
                 labels.append(f"{bname}/{espec}")
             elif multi_engine:
@@ -1256,5 +1324,14 @@ def cli(arguments=None):
     except DesignNotTrustedError as exc:
         # A design the user hasn't allowed yet: show the clean guidance, not a
         # traceback.
+        print(str(exc))
+        raise SystemExit(1) from None
+    except NotImplementedError as exc:
+        # A momwire engine refusing a request it cannot honour — e.g.
+        # --extended-kernel on sinusoidal-galerkin (momwire#246) — raises
+        # this at engine construction (MomwireEngine._require_extended_kernel,
+        # issue #849) with a message that already names the problem; print
+        # it instead of a traceback, same convention as the other clean
+        # user-facing errors above.
         print(str(exc))
         raise SystemExit(1) from None

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -153,6 +153,48 @@ def _solver_supports_wire_loading(solver):
     return getattr(solver, "__name__", None) in _WIRE_LOADING_SOLVERS
 
 
+# NEC's extended thin-wire kernel — the `EK` card — on the momwire bases that
+# implement it (momwire 0.26.0: BSpline + its HMatrix/ArrayBlock subclasses,
+# and the point-matched SinusoidalSolver; issues momwire#249/#259/#269/#270).
+# Two combinations REFUSE upstream, both at solver construction, both with a
+# NotImplementedError. They are re-raised here — same type, same shape — for
+# one reason: the engine can say no BEFORE a fill is attempted, so the caller's
+# error path (the portal's `NEC ERROR` frame, the web solve's error envelope)
+# reports a named refusal instead of a traceback out of the middle of a solve.
+def _extended_kernel_refusal(solver, solver_kwargs):
+    """Why this solver + kwargs pair cannot run the extended kernel, or None.
+
+    * ``SinusoidalGalerkinSolver`` — momwire#246/#233: NEC's ``EKSCX`` has no
+      counterpart for the Galerkin fill's folded third source shape, so momwire
+      ships EK on the point-matched sibling only and refuses rather than
+      silently serving a reduced-kernel answer under an EK request.
+    * ``use_singular_enrichment=True`` — momwire#271/#249 follow-up C: the
+      enrichment DOFs carry their own singular quadrature and bypass the moment
+      kernels entirely, and the O(a²) tube expansion was never derived for the
+      s^(-1/2) shapes.
+
+    Everything else — including finite ground, which momwire#269 lifted — is
+    served.
+    """
+    name = getattr(solver, "__name__", str(solver))
+    if name == "SinusoidalGalerkinSolver":
+        return (
+            "the extended thin-wire kernel is not available on the "
+            "sinusoidal-galerkin basis: momwire implements NEC's extended "
+            "kernel on the point-matched SinusoidalSolver only (momwire#246). "
+            "Use the sinusoidal basis for an extended-kernel run, or drop the "
+            "kernel request for the reduced-kernel Galerkin fill"
+        )
+    if (solver_kwargs or {}).get("use_singular_enrichment"):
+        return (
+            "the extended thin-wire kernel and singular enrichment cannot be "
+            "used together (momwire#271): the enrichment DOFs bypass the "
+            "moment kernels the extended kernel corrects. Turn one of the two "
+            "off"
+        )
+    return None
+
+
 class MomwireEngine(SimulationEngine):
     supports_far_field = True
 
@@ -165,6 +207,7 @@ class MomwireEngine(SimulationEngine):
         solver_kwargs=None,
         ground=None,
         ground_z=0.0,
+        extended_kernel=False,
         cancel=None,
     ):
         """
@@ -184,6 +227,21 @@ class MomwireEngine(SimulationEngine):
           Dict of solver-specific kwargs passed straight to the constructor
           (e.g. `{"degree": 1}` for BSplineSolver, or `{"n_qp_const": 16}`
           for SinusoidalSolver). None = solver defaults.
+        extended_kernel:
+          NEC's extended thin-wire kernel — the `EK` card (issue #849,
+          momwire >= 0.26.0). False (the default) is the reduced kernel every
+          release before this one solved with, and the reduced path passes no
+          `extended_kernel` kwarg at all, so an EK-off solve stays bit-identical
+          to older pins. True moves the on-axis Green's function to NEC's O(a²)
+          tube expansion, which matters exactly where the thin-wire
+          approximation is under strain: it is a fraction of a percent at
+          Δ/a > 10 and several percent below Δ/a ~ 3.
+          `solver_kwargs={"extended_kernel": ...}` is accepted as the same
+          knob (a local web instance forwards model_options verbatim) and is
+          folded into this option rather than reaching the constructor twice.
+          Two combinations refuse — see `_extended_kernel_refusal`; the
+          refusal is raised HERE, at engine construction, not from inside a
+          fill.
         ground:
           None or "free"           — no ground (default)
           "pec"                    — PEC plane at z=ground_z (image method)
@@ -219,6 +277,16 @@ class MomwireEngine(SimulationEngine):
         self._cancel = cancel
         self._solver = solver
         self._solver_kwargs = dict(solver_kwargs) if solver_kwargs else {}
+        # The kernel knob has two spellings — the named option and a
+        # solver_kwargs entry (a local web instance forwards model_options
+        # verbatim, and `_make_solver` splices solver_kwargs LAST, so leaving
+        # it in place would let it silently win over a per-call override).
+        # Fold them into one flag, validated once.
+        self._extended_kernel = bool(
+            self._solver_kwargs.pop("extended_kernel", False)
+        ) or bool(extended_kernel)
+        if self._extended_kernel:
+            self._require_extended_kernel()
         # Per-instance parity: sinusoidal wants odd, bspline depends on
         # degree. Set before _coerce_wire_tuples runs.
         self.segment_parity = _parity_for_solver(self._solver, self._solver_kwargs)
@@ -583,11 +651,38 @@ class MomwireEngine(SimulationEngine):
             kw["ground_model"] = "sommerfeld"
         return kw
 
-    def _make_solver(self, *, wavelength, end_port_voltages=None):
+    def _require_extended_kernel(self):
+        """Raise if this basis (or these kwargs) cannot serve the extended
+        kernel. Same exception type and the same class of message momwire's own
+        constructors use, so an engine-level refusal and an upstream one are
+        indistinguishable to a caller's error path."""
+        reason = _extended_kernel_refusal(self._solver, self._solver_kwargs)
+        if reason is not None:
+            raise NotImplementedError(reason)
+
+    def _kernel_solver_kwargs(self, extended_kernel=None):
+        """Extra kernel kwargs for solver construction.
+
+        ``extended_kernel`` overrides the engine's own setting for one call —
+        the NEC portal needs it because ``EK`` is per EXECUTE GROUP, so one
+        deck's two groups can want two different operators out of one engine.
+        The reduced path returns an EMPTY dict rather than
+        ``extended_kernel=False`` so a kernel-off solve keeps passing exactly
+        the kwargs it passed before momwire 0.26.0.
+        """
+        ek = self._extended_kernel if extended_kernel is None else bool(extended_kernel)
+        if not ek:
+            return {}
+        self._require_extended_kernel()
+        return {"extended_kernel": True}
+
+    def _make_solver(self, *, wavelength, end_port_voltages=None, extended_kernel=None):
         """Solver instance. ``end_port_voltages`` (issue #579): per-end-port
         complex voltages in `self._end_ports` order; None means 0 V on every
         end port (the Y-matrix path enumerates ports, so drive levels are
-        irrelevant there)."""
+        irrelevant there). ``extended_kernel`` overrides the engine's kernel
+        setting for this one solver (issue #849 — the portal's per-group
+        ``EK``); None keeps it."""
         kw = {}
         if self._end_port_junctions:
             volts = (
@@ -610,6 +705,7 @@ class MomwireEngine(SimulationEngine):
             **kw,
             **self._loading_kwargs,
             **self._ground_solver_kwargs(),
+            **self._kernel_solver_kwargs(extended_kernel),
             **self._solver_kwargs,
         )
 
@@ -887,6 +983,7 @@ class MomwireEngine(SimulationEngine):
             **kw,
             **self._loading_kwargs,
             **self._ground_solver_kwargs(),
+            **self._kernel_solver_kwargs(),
             **self._solver_kwargs,
         )
 

--- a/src/antennaknobs/file_designs.py
+++ b/src/antennaknobs/file_designs.py
@@ -59,7 +59,9 @@ def _seed_freq(freq_range):
     )
 
 
-def _make_builder(stem, freq, meas_range, notes, wires_fn, network_fn):
+def _make_builder(
+    stem, freq, meas_range, notes, wires_fn, network_fn, *, extended_kernel=False
+):
     ui: dict = {}
     if meas_range:
         ui["meas_freq_range"] = tuple(meas_range)
@@ -74,6 +76,13 @@ def _make_builder(stem, freq, meas_range, notes, wires_fn, network_fn):
         label = stem
 
         default_params = MappingProxyType(params)
+
+        # The file's own EK card (NecDeck.extended_kernel), issue #849: the
+        # CLI's `--extended-kernel` handling ORs this in for a momwire engine
+        # (see `cli.engine_factory_from_args`) so a deck that asks for the
+        # extended thin-wire kernel gets it without an extra flag, and a
+        # deck that doesn't still honors an explicit `--extended-kernel`.
+        file_extended_kernel = extended_kernel
 
         def build_wires(self):
             return wires_fn()
@@ -97,6 +106,7 @@ def _nec_builder(path: Path, text: str):
         [deck.skipped_note(), freq_note],
         lambda: deck.wire_tuples(specs=True),
         deck.network,
+        extended_kernel=deck.extended_kernel,
     )
 
 
@@ -138,6 +148,7 @@ def _ssn_builder(path: Path, text: str):
         [circuit.skipped_note(), _ground_note(circuit.ground), freq_note],
         lambda: deck.wire_tuples(specs=True),
         circuit.network,
+        extended_kernel=deck.extended_kernel,
     )
 
 

--- a/src/antennaknobs/nec_portal.py
+++ b/src/antennaknobs/nec_portal.py
@@ -991,12 +991,18 @@ class ExecuteGroup:
     # reason, and because ``PT`` is a TOGGLE: ``dipole_pt_toggle`` suppresses
     # the first run's table and restores the second's from one deck.
     pt: PrintControl | None = None
-    # EK in force when this group fired. Advisory for momwire (our kernel is
-    # our kernel), but the refilled preamble must announce it exactly as the
-    # oracle does — and only there: an EK between two XQs re-arms execution
-    # without a refill, and the oracle prints no announcement for it
-    # (measured: XQ / EK / XQ shows two AIP sections, one preamble, zero
-    # announcements).
+    # EK in force when this group fired. HONOURED since issue #849 (momwire
+    # 0.26.0): the solver this group is answered from is built with
+    # `extended_kernel=True`, the same O(a²) on-axis tube expansion NEC's card
+    # asks for. It was advisory before that — momwire had no extended kernel to
+    # switch to — which is why it is per GROUP rather than per deck: the
+    # printout always had to distinguish the two, and now the operator does
+    # too (`DeckSolver.at` keys its per-frequency fill on the kernel as well).
+    #
+    # The refilled preamble must announce it exactly as the oracle does — and
+    # only there: an EK between two XQs re-arms execution without a refill, and
+    # the oracle prints no announcement for it (measured: XQ / EK / XQ shows
+    # two AIP sections, one preamble, zero announcements).
     ek: bool = False
     # A kernel change between execute cards refills the matrix WITHOUT a new
     # FR: the oracle then prints the LOADING / ENVIRONMENT / MATRIX TIMING
@@ -1188,19 +1194,20 @@ def parse_deck(body: str) -> PortalDeck:
             # XQ` prints no block at all).
             multiprocessing = Multiprocessing.from_card(card)
         elif card.mnemonic == "EK":
-            if card.i(0) not in (0, -1):
-                raise PortalError(
-                    f"EK {card.i(0)} is neither 0 (extended kernel) nor -1 "
-                    f"(standard kernel)"
-                )
-            if (
-                card.i(0) == 0
-                and not extended_kernel
-                or card.i(0) == -1
-                and extended_kernel
-            ):
+            # The oracle's test is `I1 == -1`, and NOTHING else: measured on
+            # nec2c 5b4az.ae6ty.1.23, `EK`, `EK 0`, `EK 1`, `EK 2` and even
+            # `EK -2` all print THE EXTENDED THIN WIRE KERNEL WILL BE USED,
+            # and only `EK -1` does not. (It is NEC-2's own card reader —
+            # nec2dx.f sets IEXK = 1 on an EK card and clears it only for
+            # ITMP1 = -1.) This used to refuse anything outside {0, -1}, which
+            # is the #814 class of bug: refusing a card the reference engine
+            # accepts turns a runnable deck into a fabricated readout. Match
+            # the oracle. `nec_import.parse_nec` already read the card this
+            # way, so the two card readers now agree as well.
+            wanted = card.i(0) != -1
+            if wanted != extended_kernel:
                 kernel_dirty = executed > 0
-            extended_kernel = card.i(0) == 0
+            extended_kernel = wanted
         elif card.mnemonic == "PT":
             # Also not an arming card: it changes what a run PRINTS, not what
             # a run computes, so it cannot make an XQ into a fresh execution.
@@ -2023,7 +2030,8 @@ class DeckSolver:
             self.network_rows.append((a, b, branch, length))
 
         self._smallest_radius = min(w.radius for w in self.wires)
-        self._cache: dict[float, dict] = {}
+        # (frequency, extended kernel) -> one filled and factored operator.
+        self._cache: dict[tuple[float, bool], dict] = {}
 
     def _line_length(self, branch: LineBranch, a: int, b: int) -> float:
         """A ``TL`` card's resolved length: its own, or — when the card says
@@ -2142,15 +2150,24 @@ class DeckSolver:
 
     # -- per-frequency operator -------------------------------------------
 
-    def at(self, freq_mhz: float) -> dict:
+    def at(self, freq_mhz: float, extended_kernel: bool = False) -> dict:
         """The cached (Y, X, solver) for a frequency — one fill, one factor.
 
         When this instance came out of the cross-deck cache (``_solver_for``)
         these entries came with it, so a re-probed deck answers with no fill at
         all, and the same structure at a NEW frequency pays one fill on top of
         a geometry parse and mesh it did not repeat.
+
+        ``extended_kernel`` is the group's ``EK`` (issue #849) and is part of
+        the cache key, not just of the fill: ``dipole_ek_rearm`` is one deck
+        whose two execute groups ask for two different kernels at the SAME
+        frequency, so keying on the frequency alone would answer the second
+        from the first's operator. The key is written ``(freq, ek)`` rather
+        than as two dicts so that adding a third operator axis later cannot
+        forget one of them.
         """
-        cached = self._cache.get(freq_mhz)
+        key = (freq_mhz, bool(extended_kernel))
+        cached = self._cache.get(key)
         if cached is not None:
             return cached
         if _cache_serving or _cache_stats_path is not None:
@@ -2160,7 +2177,9 @@ class DeckSolver:
             _cache_stats["fills"] += 1
         wavelength = C_LIGHT / (freq_mhz * 1e6)
         started = time.perf_counter()
-        solver = self.engine._make_solver(wavelength=wavelength)
+        solver = self.engine._make_solver(
+            wavelength=wavelength, extended_kernel=bool(extended_kernel)
+        )
         y_sub, coeffs = _y_and_port_coeffs(solver)
         fill_ms = int(round((time.perf_counter() - started) * 1000.0))
         entry = {
@@ -2170,7 +2189,7 @@ class DeckSolver:
             "X": coeffs,
             "fill_ms": fill_ms,
         }
-        self._cache[freq_mhz] = entry
+        self._cache[key] = entry
         return entry
 
     def _load_impedances(self, omega: float) -> np.ndarray:
@@ -2193,8 +2212,11 @@ class DeckSolver:
 
     def solve_group(self, group: ExecuteGroup, freq_mhz: float) -> dict:
         """One execute group at one frequency: port currents, segment
-        currents, and the power budget — all from the cached factorisation."""
-        entry = self.at(freq_mhz)
+        currents, and the power budget — all from the cached factorisation.
+
+        The group's ``EK`` picks the operator (issue #849), so two groups of
+        one deck under two kernels get two fills and two answers."""
+        entry = self.at(freq_mhz, extended_kernel=group.ek)
         omega = 2.0 * math.pi * freq_mhz * 1e6
         y = entry["Y"]
         v_source = np.zeros(self.n_ports, dtype=np.complex128)
@@ -2536,11 +2558,14 @@ def _operator_key(deck: PortalDeck) -> tuple:
       is the proof, and it compares against a FRESH PROCESS rather than
       against itself, so it stays a proof if ``GD`` ever grows a far field.
 
-    ``EK`` is the conservative entry. Our kernel is momwire's kernel, so today
-    the flag is advisory and could be left out for a better hit rate — but it
-    is a kernel SELECTION, the one card in this list whose whole meaning is
-    "compute the operator differently", and a wrong hit here would be silent.
-    One bool per group is not a hit rate worth spending.
+    ``EK`` used to be the conservative entry — kept on the argument that a
+    card whose whole meaning is "compute the operator differently" must never
+    be answered from an entry built without it, even while momwire had no
+    other kernel to build with. Since issue #849 it is an ordinary one: the
+    flag IS the operator now (``DeckSolver.at`` fills per kernel), and a wrong
+    hit here would serve a reduced-kernel answer to a deck that asked for the
+    extended one. The tuple stays per GROUP, because that is the granularity
+    the card has.
     """
     cls, kwargs, suffix = _active_basis
     return (
@@ -3248,7 +3273,7 @@ def render_deck(body: str) -> tuple[list[str], list[str]]:
     except PortalError as exc:
         _append_error(out, exc)
         return out, err
-    except (ValueError, np.linalg.LinAlgError) as exc:
+    except (ValueError, NotImplementedError, np.linalg.LinAlgError) as exc:
         _append_error(out, exc)
         return out, err
 
@@ -3290,7 +3315,17 @@ def render_deck(body: str) -> tuple[list[str], list[str]]:
                 if i:
                     out += ["", ""]
                 out += _run_block(deck, solver, group, freq)
-        except (PortalError, ValueError, np.linalg.LinAlgError) as exc:
+        except (
+            PortalError,
+            ValueError,
+            # A basis that cannot serve this group's kernel (issue #849:
+            # sinusoidal-galerkin under EK, momwire#246). momwire raises it,
+            # and `MomwireEngine` re-raises it before the fill; either way it
+            # is a refusal SimNEC must see as a NEC ERROR, not as a daemon
+            # traceback that costs the deck its NX sentinel.
+            NotImplementedError,
+            np.linalg.LinAlgError,
+        ) as exc:
             _append_error(out, exc)
         out += ["", "", ""]
     return out, err
@@ -3408,31 +3443,64 @@ def _selftest(stdout) -> int:
         "TL network row present": "STRAIGHT" in proc.stdout,
         "stderr quiet": proc.stderr.strip() == "",
     }
+
     # One deck per alternate basis: the point is that the entry is wired and
     # answers on THIS box, not that it is fast or converged. The selftest deck
     # is a single small dipole, which for `hmatrix`/`arrayblock` means a
     # near-field-only operator and (for arrayblock) a degenerate element
     # partition that degrades to the parent — the graceful-degradation path,
     # which is exactly the one a smoke test wants to prove never raises.
+    def _alt(basis: str, deck: str):
+        return subprocess.run(
+            [sys.executable, "-m", "antennaknobs.nec_portal", "--basis", basis],
+            input=deck,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
     for basis, suffix in (
-        ("sinusoidal-galerkin-converged", "+sgc"),
         ("sinusoidal", "+sin"),
         ("bspline-d1", "+bs1"),
         ("hmatrix", "+hm"),
         ("arrayblock", "+ab"),
     ):
-        alt = subprocess.run(
-            [sys.executable, "-m", "antennaknobs.nec_portal", "--basis", basis],
-            input=_SELFTEST_DECKS[0],
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
+        alt = _alt(basis, _SELFTEST_DECKS[0])
         checks[f"alt basis answers ({suffix})"] = (
             alt.returncode == 0
             and suffix in alt.stdout
             and "ANTENNA INPUT PARAMETERS" in alt.stdout
         )
+    # The Galerkin entries are the exception, and the check is deliberately
+    # two-sided rather than dropped (issue #849). momwire#246 leaves NEC's
+    # extended kernel unimplemented on the Galerkin fill, and deck 1 carries
+    # `EK` precisely because the live NECSource path always sends it — so
+    # honouring the card for real means these two roster entries cannot answer
+    # a live SimNEC deck at all. What a deployment gate can still prove, and
+    # what a box must never get wrong, is that the refusal is the DOCUMENTED
+    # one: a named `ERROR:` line and the NX sentinel behind it (a hang here is
+    # what stalls SimNEC's readLine forever) — and that the SESSION survives
+    # it, which is why both decks go down ONE process: the EK deck refuses,
+    # the same deck without the card answers, from the same resident engine.
+    galerkin = _alt(
+        "sinusoidal-galerkin-converged",
+        _SELFTEST_DECKS[0] + _SELFTEST_DECKS[0].replace("EK\n", ""),
+    )
+    sentinels = sum(
+        1
+        for ln in galerkin.stdout.splitlines()
+        if ln.lstrip().startswith("DATA CARD No:") and " NX " in ln
+    )
+    checks["galerkin refuses EK by name, session survives"] = (
+        galerkin.returncode == 0
+        and any(
+            ln.split()[:1] == ["ERROR:"] and "extended thin-wire kernel" in ln
+            for ln in galerkin.stdout.splitlines()
+        )
+        and sentinels == 2
+        and "+sgc" in galerkin.stdout
+        and galerkin.stdout.count("ANTENNA INPUT PARAMETERS") == 1
+    )
     for name, ok in checks.items():
         stdout.write(f"  {'ok  ' if ok else 'FAIL'} {name}\n")
     passed = all(checks.values())

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -400,6 +400,15 @@ _HOSTED_MODEL_OPTIONS = {
     "tikhonov_lambda": _float_in(0.0, 1e3),
     "auto_tap_ratio_threshold": _float_in(0.0, 1.0),
     "enrichment_min_k": _int_in(2, 64),
+    # NEC's extended thin-wire kernel (the EK card, issue #849, momwire >=
+    # 0.26.0). A physics selection like feed_model, not a compute-
+    # amplification lever, so it belongs on the hosted allowlist.
+    # `_make_momwire_engine` pulls it back out and passes it as the named
+    # `extended_kernel=` constructor kwarg rather than leaving it here —
+    # MomwireEngine folds either spelling the same way (issue #849's
+    # engine-side note), but the named kwarg keeps the adapter's intent
+    # explicit and is what unit 1 documented at this call site.
+    "extended_kernel": _bool_opt,
 }
 
 
@@ -1454,6 +1463,16 @@ def _make_momwire_engine(req: dict, builder, cancel=None):
     wire_radius = _positive_finite("wire_radius", req.get("wire_radius", 0.0005))
     ground = _ground_for_engine(req, 0.0)
     solver_kwargs = sanitize_model_options(req)
+    # Extended thin-wire kernel (issue #849): pulled out of model_options and
+    # passed as the named constructor kwarg instead, so it reaches the engine
+    # the same way whether hosted (filtered through _HOSTED_MODEL_OPTIONS
+    # above) or local (model_options forwarded verbatim, sanitize_model_options
+    # skips the whitelist). MomwireEngine folds either spelling identically,
+    # but the named kwarg is the explicit, testable path.
+    extended_kernel = False
+    if solver_kwargs and "extended_kernel" in solver_kwargs:
+        solver_kwargs = dict(solver_kwargs)
+        extended_kernel = bool(solver_kwargs.pop("extended_kernel"))
     if _SWEPT_MEM_MB is not None and issubclass(solver_cls, BSplineSolver):
         # Deployment-owned memory policy (momwire >= 0.9): cap the batched
         # frequency sweep's transient memory per solve. Server-side value
@@ -1470,6 +1489,7 @@ def _make_momwire_engine(req: dict, builder, cancel=None):
         wire_radius=wire_radius,
         solver_kwargs=solver_kwargs,
         ground=ground,
+        extended_kernel=extended_kernel,
         cancel=cancel,
     )
 

--- a/src/antennaknobs/web/frontend/src/__tests__/BackendConfigModal.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/BackendConfigModal.test.tsx
@@ -19,6 +19,8 @@ import {
 } from "../components/backend/BackendConfigModal";
 import {
   BSPLINE_DEFAULT_OPTS,
+  EK_ENRICHMENT_REASON,
+  EK_GALERKIN_REASON,
   RESTRICTED_BACKEND_REASON,
   defaultOptsFor,
   type BackendOpts,
@@ -200,6 +202,107 @@ describe("BackendConfigModal — per-backend knob visibility", () => {
     unmount();
     renderModal({ backend: "bspline" });
     expect(screen.queryByText(/no extra solver knobs/)).toBeNull();
+  });
+});
+
+describe("BackendConfigModal — extended kernel (#849)", () => {
+  const EK = /extended kernel \(EK\)/;
+  const ENRICHMENT = /junction singular enrichment/;
+  const MOMWIRE = NAMES.filter((n) => entry(n).kind === "momwire");
+
+  it.each(MOMWIRE)("offers the toggle on %s, off by default", (name) => {
+    renderModal({ backend: name });
+    expect(screen.getByRole("checkbox", { name: EK })).toHaveProperty(
+      "checked",
+      false,
+    );
+  });
+
+  it("offers no toggle on pynec — its extended kernel is not this knob (#414)", () => {
+    renderModal({ backend: "pynec" });
+    expect(screen.queryByRole("checkbox", { name: EK })).toBeNull();
+  });
+
+  it("patches extendedKernel on and off", async () => {
+    const off = renderModal({ backend: "bspline" });
+    await off.user.click(screen.getByRole("checkbox", { name: EK }));
+    expect(off.onPatch).toHaveBeenCalledWith({ extendedKernel: true });
+    off.unmount();
+
+    const on = renderModal({
+      backend: "bspline",
+      opts: { ...defaultOptsFor(entry("bspline")), extendedKernel: true },
+    });
+    expect(screen.getByRole("checkbox", { name: EK })).toHaveProperty("checked", true);
+    await on.user.click(screen.getByRole("checkbox", { name: EK }));
+    expect(on.onPatch).toHaveBeenCalledWith({ extendedKernel: false });
+  });
+
+  it("greys the toggle out on Sin-Galerkin and says why on the page", () => {
+    renderModal({ backend: "sinusoidal-galerkin" });
+    const box = screen.getByRole("checkbox", { name: EK });
+    expect(box).toHaveProperty("disabled", true);
+    expect(box).toHaveProperty("checked", false);
+    // The reason is visible, not tooltip-only: a greyed box with no
+    // explanation is the silence #849 is about.
+    expect(screen.getByText(EK_GALERKIN_REASON)).toBeTruthy();
+    expect(within(screen.getByTitle(EK_GALERKIN_REASON)).getByRole("checkbox")).toBe(box);
+  });
+
+  it("shows a set flag as UNCHECKED on the basis that refuses it", async () => {
+    // A slot cannot normally reach this (a backend swap resets the flag), but
+    // the row must never claim a kernel that isn't running.
+    const { user, onPatch } = renderModal({
+      backend: "sinusoidal-galerkin",
+      opts: {
+        ...defaultOptsFor(entry("sinusoidal-galerkin")),
+        extendedKernel: true,
+      },
+    });
+    const box = screen.getByRole("checkbox", { name: EK });
+    expect(box).toHaveProperty("checked", false);
+    await user.click(box);
+    expect(onPatch).not.toHaveBeenCalled(); // disabled: the click does nothing
+  });
+
+  it("keeps the Δ/a hint on the servable backends", () => {
+    renderModal({ backend: "bspline" });
+    expect(screen.getByText(/Δ\/a/)).toBeTruthy();
+    expect(screen.queryByText(EK_GALERKIN_REASON)).toBeNull();
+  });
+
+  // momwire#271: the two are mutually exclusive, and the exclusion is
+  // symmetric so neither box can lock the other out permanently.
+  it("greys the kernel out while enrichment is on", () => {
+    renderModal({
+      backend: "bspline",
+      opts: bsplineOpts("bspline", { useSingularEnrichment: true }),
+    });
+    expect(screen.getByRole("checkbox", { name: EK })).toHaveProperty("disabled", true);
+    expect(screen.getByText(EK_ENRICHMENT_REASON)).toBeTruthy();
+    // …and enrichment itself is still live, so the user can back out.
+    expect(screen.getByRole("checkbox", { name: ENRICHMENT })).toHaveProperty(
+      "disabled",
+      false,
+    );
+  });
+
+  it("greys enrichment out while the kernel is on", () => {
+    const opts = bsplineOpts("bspline", { useSingularEnrichment: false });
+    renderModal({ backend: "bspline", opts: { ...opts, extendedKernel: true } });
+    const enrich = screen.getByRole("checkbox", { name: ENRICHMENT });
+    expect(enrich).toHaveProperty("disabled", true);
+    expect(within(screen.getByTitle(EK_ENRICHMENT_REASON)).getByRole("checkbox")).toBe(enrich);
+    // …and the kernel itself is still live.
+    expect(screen.getByRole("checkbox", { name: EK })).toHaveProperty("disabled", false);
+  });
+
+  it("leaves enrichment alone when the kernel is off", () => {
+    renderModal({ backend: "bspline", opts: bsplineOpts("bspline") });
+    expect(screen.getByRole("checkbox", { name: ENRICHMENT })).toHaveProperty(
+      "disabled",
+      false,
+    );
   });
 });
 

--- a/src/antennaknobs/web/frontend/src/__tests__/backends.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/backends.test.ts
@@ -14,11 +14,17 @@ import {
   comboInappropriate,
   defaultOptsFor,
   defaultSlots,
+  EK_ENRICHMENT_REASON,
+  EK_GALERKIN_REASON,
+  EK_UNSUPPORTED_BACKEND,
+  extendedKernelActive,
+  extendedKernelRefusal,
   findBackend,
   hasBSplinePanel,
   normalizeBackend,
   slotFromSeed,
   type BackendEntry,
+  type BackendOpts,
 } from "../lib/backends";
 import {
   backendEntry,
@@ -89,6 +95,62 @@ describe("defaultOptsFor", () => {
     expect(defaultOptsFor(entry("sinusoidal-galerkin")).bspline).toBeUndefined();
     expect(defaultOptsFor(entry("sinusoidal")).bspline).toBeUndefined();
     expect(defaultOptsFor(entry("sinusoidal")).feedModel).toBeUndefined();
+  });
+
+  // Absence, not `false`: that is the EK card's own convention, and it is what
+  // keeps a stock request byte-identical to the pre-#849 one (pinned as JSON
+  // in modelOptions.test.ts).
+  it("leaves the extended kernel unset on every backend (#849)", () => {
+    for (const b of SERVED_ROSTER) {
+      expect(defaultOptsFor(b).extendedKernel).toBeUndefined();
+      expect(extendedKernelActive(b, defaultOptsFor(b))).toBe(false);
+    }
+  });
+});
+
+describe("extendedKernelRefusal (#849)", () => {
+  const on = (name: string) => ({ ...defaultOptsFor(entry(name)), extendedKernel: true });
+
+  it("passes every backend that momwire serves the kernel on", () => {
+    for (const name of ["sinusoidal", "bspline", "hmatrix", "arrayblock"]) {
+      expect(extendedKernelRefusal(entry(name), on(name))).toBeNull();
+      expect(extendedKernelActive(entry(name), on(name))).toBe(true);
+    }
+  });
+
+  it("refuses the Galerkin basis by name, citing momwire#246", () => {
+    const b = entry("sinusoidal-galerkin");
+    expect(b.name).toBe(EK_UNSUPPORTED_BACKEND); // the constant IS the roster name
+    expect(extendedKernelRefusal(b, on(b.name))).toBe(EK_GALERKIN_REASON);
+    expect(EK_GALERKIN_REASON).toContain("momwire#246");
+    // …and it refuses whether or not the flag is set: the predicate describes
+    // the backend, and the toggle greys out before anything is armed.
+    expect(extendedKernelRefusal(b, defaultOptsFor(b))).toBe(EK_GALERKIN_REASON);
+    expect(extendedKernelActive(b, on(b.name))).toBe(false);
+  });
+
+  it("refuses alongside singular enrichment, citing momwire#271", () => {
+    const opts = on("bspline");
+    opts.bspline = { ...BSPLINE_DEFAULT_OPTS, useSingularEnrichment: true };
+    expect(extendedKernelRefusal(entry("bspline"), opts)).toBe(EK_ENRICHMENT_REASON);
+    expect(EK_ENRICHMENT_REASON).toContain("momwire#271");
+    expect(extendedKernelActive(entry("bspline"), opts)).toBe(false);
+    // Enrichment off again and the same slot serves it.
+    opts.bspline = { ...BSPLINE_DEFAULT_OPTS, useSingularEnrichment: false };
+    expect(extendedKernelActive(entry("bspline"), opts)).toBe(true);
+  });
+
+  it("never activates on PyNEC, which takes no model_options at all", () => {
+    // PyNEC's own extended-kernel support (issue #414) is a separate,
+    // unexposed kwarg — this toggle must not claim to drive it.
+    expect(extendedKernelActive(entry("pynec"), on("pynec"))).toBe(false);
+  });
+
+  it("serves a momwire backend the roster invented and nobody hardcoded", () => {
+    const fake = backendEntry({ name: "fake-solver", label: "Fake" });
+    expect(
+      extendedKernelActive(fake, { ...defaultOptsFor(fake), extendedKernel: true }),
+    ).toBe(true);
   });
 });
 
@@ -275,5 +337,54 @@ describe("backendDisplayLabel", () => {
       options_schema: [backendOption()],
     });
     expect(backendDisplayLabel(fake, defaultOptsFor(fake))).toBe("Fake");
+  });
+
+  // The A/B story of #849 is "same basis, one slot with the kernel": if the
+  // chips don't say which, the comparison is unreadable.
+  it('affixes "+EK" wherever the extended kernel is in force', () => {
+    const ek = (name: string, over: Partial<BackendOpts> = {}) =>
+      backendDisplayLabel(entry(name), {
+        ...defaultOptsFor(entry(name)),
+        extendedKernel: true,
+        ...over,
+      });
+    expect(ek("sinusoidal")).toBe("Sinusoidal +EK");
+    expect(ek("bspline")).toBe("B-spline d=2 +EK");
+    expect(ek("bspline", { bspline: { ...BSPLINE_DEFAULT_OPTS, degree: 1 } })).toBe(
+      "B-spline d=1 +EK",
+    );
+    expect(ek("hmatrix")).toBe("H-matrix (ACA) d=2 +EK");
+    expect(ek("arrayblock")).toBe("Array-block d=2 +EK");
+  });
+
+  it("leaves the label alone when the kernel is off or refused", () => {
+    // Off: the default, and the other half of every A/B pair.
+    expect(
+      backendDisplayLabel(entry("bspline"), defaultOptsFor(entry("bspline"))),
+    ).toBe("B-spline d=2");
+    // Refused by basis — a set flag on a Galerkin slot is not a running
+    // kernel, and the chip must not claim it is.
+    expect(
+      backendDisplayLabel(entry("sinusoidal-galerkin"), {
+        ...defaultOptsFor(entry("sinusoidal-galerkin")),
+        feedModel: "point",
+        extendedKernel: true,
+      }),
+    ).toBe("Sin-Galerkin (converged)");
+    // Refused by enrichment.
+    expect(
+      backendDisplayLabel(entry("bspline"), {
+        ...defaultOptsFor(entry("bspline")),
+        bspline: { ...BSPLINE_DEFAULT_OPTS, useSingularEnrichment: true },
+        extendedKernel: true,
+      }),
+    ).toBe("B-spline d=2");
+    // Never on PyNEC.
+    expect(
+      backendDisplayLabel(entry("pynec"), {
+        ...defaultOptsFor(entry("pynec")),
+        extendedKernel: true,
+      }),
+    ).toBe("PyNEC");
   });
 });

--- a/src/antennaknobs/web/frontend/src/__tests__/extendedKernel.session.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/extendedKernel.session.test.tsx
@@ -1,0 +1,163 @@
+// The extended thin-wire kernel, end to end through a real <DesignSession>
+// (issue #849 unit 3). The unit pins live in backends.test.ts (the predicate),
+// modelOptions.test.ts (the wire key) and BackendConfigModal.test.tsx (the
+// row); what those cannot show is the thing the toggle exists for — TWO SLOTS,
+// same basis, one with the kernel and one without, each sending its own
+// request and each saying so on its own chip.
+//
+// The wire body is read off the /geometry preview POST, which is buildRequest()
+// verbatim, the same seam newBackend.test.tsx uses.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DesignSession } from "../components/session/DesignSession";
+import type { ExampleDescriptor } from "../lib/params";
+import { SERVED_ROSTER } from "./backendFixtures";
+
+const EXAMPLE: ExampleDescriptor = {
+  name: "dipoles.probe",
+  label: "Probe dipole",
+  multi_feed: false,
+  param_schema: [],
+  result_schema: [],
+  bands: [],
+  meas_freq_range_mhz: null,
+  default_view: "xz",
+  default_freq: null,
+  default_design_freq: null,
+  default_backend: null,
+  requires_backends: null,
+  has_design_freq: true,
+  variants: ["default"],
+  variant_values: {},
+  sweep_policy: { anchor: "design_freq", lo_factor: 0.8, hi_factor: 1.25 },
+};
+
+let geometryPosts: Record<string, unknown>[] = [];
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+/** model_options of the most recent request the session built. */
+function lastModelOptions(): Record<string, unknown> {
+  return (geometryPosts.at(-1)?.model_options ?? {}) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  geometryPosts = [];
+  vi.stubGlobal("fetch", async (url: string, init?: RequestInit) => {
+    const path = String(url);
+    if (path.startsWith("/capabilities"))
+      return jsonResponse({
+        have_pynec: true,
+        backends: SERVED_ROSTER,
+        terrain_presets: [],
+      });
+    if (path.startsWith("/examples"))
+      return jsonResponse({ examples: [EXAMPLE], errors: [] });
+    if (path.startsWith("/geometry")) {
+      geometryPosts.push(JSON.parse(String(init?.body ?? "{}")));
+      return jsonResponse({ wires: [] });
+    }
+    return jsonResponse({});
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** Mount the session, wait for the served roster, and park the live solve so
+ *  every request refresh goes out over POST /geometry. */
+async function mountSession() {
+  const user = userEvent.setup();
+  render(<DesignSession id={1} active />);
+  await screen.findByRole("tab", { name: /Solver slot A/ });
+  await user.click(screen.getByRole("button", { name: "Live" }));
+  return user;
+}
+
+async function toggleExtendedKernel(user: ReturnType<typeof userEvent.setup>, slot: string) {
+  await user.click(screen.getByRole("button", { name: `Slot ${slot} options` }));
+  await user.click(screen.getByRole("checkbox", { name: /extended kernel \(EK\)/ }));
+  await user.click(screen.getByRole("button", { name: "Close" }));
+}
+
+describe("the extended-kernel toggle, slot by slot (#849)", () => {
+  it("arms one slot's request and leaves the other's alone", async () => {
+    const user = await mountSession();
+
+    // Baseline: the stock A slot (B-spline d=2, N=15) sends no kernel key.
+    await waitFor(() => expect(geometryPosts.length).toBeGreaterThan(0));
+    expect(lastModelOptions()).not.toHaveProperty("extended_kernel");
+
+    // Arm slot A.
+    await toggleExtendedKernel(user, "A");
+    await waitFor(() =>
+      expect(lastModelOptions()).toHaveProperty("extended_kernel", true),
+    );
+    // The rest of the request is untouched: same basis, same mesh — which is
+    // what makes the A/B difference readable as the kernel and nothing else.
+    expect(geometryPosts.at(-1)?.momwire_model).toBe("bspline");
+    expect(geometryPosts.at(-1)?.n_per_wire).toBe(15);
+    expect(lastModelOptions().degree).toBe(2);
+
+    // Slot B is a separate configuration and never saw the toggle.
+    await user.click(screen.getByRole("tab", { name: /Solver slot B/ }));
+    await waitFor(() => {
+      expect(geometryPosts.at(-1)?.n_per_wire).toBe(20); // B is d=1 @ N=20
+      expect(lastModelOptions()).not.toHaveProperty("extended_kernel");
+    });
+
+    // …and coming back to A restores it: the flag is per-slot state, not a
+    // session-wide mode.
+    await user.click(screen.getByRole("tab", { name: /Solver slot A/ }));
+    await waitFor(() =>
+      expect(lastModelOptions()).toHaveProperty("extended_kernel", true),
+    );
+  });
+
+  it('says "+EK" on the armed slot\'s chip and nowhere else', async () => {
+    const user = await mountSession();
+    // Both b-spline slots start unaffixed.
+    expect(screen.getByRole("tab", { name: /Solver slot A: B-spline d=2, N=15/ })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: /Solver slot B: B-spline d=1, N=20/ })).toBeTruthy();
+
+    await toggleExtendedKernel(user, "A");
+
+    await screen.findByRole("tab", {
+      name: /Solver slot A: B-spline d=2 \+EK, N=15/,
+    });
+    // B is untouched — the affix marks a slot, not the session.
+    expect(screen.getByRole("tab", { name: /Solver slot B: B-spline d=1, N=20/ })).toBeTruthy();
+  });
+
+  it("drops the flag when the slot's backend changes under it", async () => {
+    const user = await mountSession();
+    await toggleExtendedKernel(user, "A");
+    await waitFor(() =>
+      expect(lastModelOptions()).toHaveProperty("extended_kernel", true),
+    );
+
+    // Swapping the backend resets that slot's model kwargs to the new
+    // backend's defaults, the kernel among them — so the Galerkin basis that
+    // cannot serve it never inherits an armed flag.
+    await user.click(screen.getByRole("button", { name: "Slot A options" }));
+    await user.click(screen.getByRole("tab", { name: "Sin-Galerkin" }));
+    expect(
+      screen.getByRole("checkbox", { name: /extended kernel \(EK\)/ }),
+    ).toHaveProperty("disabled", true);
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    await waitFor(() => {
+      expect(geometryPosts.at(-1)?.momwire_model).toBe("sinusoidal-galerkin");
+      expect(lastModelOptions()).not.toHaveProperty("extended_kernel");
+    });
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/modelOptions.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/modelOptions.test.ts
@@ -145,6 +145,72 @@ describe("modelOptionsForRequest", () => {
     });
   });
 
+  // --- the extended thin-wire kernel (issue #849) --------------------------
+  //
+  // The wire key is `extended_kernel`, which adapter.py pulls back out of
+  // model_options and passes as MomwireEngine's named constructor kwarg. The
+  // contract that matters here is the ASYMMETRY: present-and-true when armed,
+  // absent otherwise — never `false`. The stock-JSON test above is the guard
+  // for the "absent" half, and it is unchanged by #849 on purpose.
+  describe("extended_kernel", () => {
+    const armed = (name: string) => ({
+      ...defaultOptsFor(entry(name)),
+      extendedKernel: true,
+    });
+
+    it("rides as `extended_kernel: true` on every basis that serves it", () => {
+      for (const name of ["sinusoidal", "bspline", "hmatrix", "arrayblock"]) {
+        expect(modelOptionsForRequest(entry(name), armed(name))).toHaveProperty(
+          "extended_kernel",
+          true,
+        );
+      }
+    });
+
+    it("is ABSENT — not false — with the toggle off", () => {
+      for (const name of ["sinusoidal", "bspline", "hmatrix", "arrayblock"]) {
+        const b = entry(name);
+        expect(modelOptionsForRequest(b, defaultOptsFor(b))).not.toHaveProperty(
+          "extended_kernel",
+        );
+        // …and explicitly off is the same request as never armed: toggling on
+        // and back off must return to the pre-#849 body byte for byte.
+        expect(
+          JSON.stringify(
+            modelOptionsForRequest(b, {
+              ...defaultOptsFor(b),
+              extendedKernel: false,
+            }),
+          ),
+        ).toBe(JSON.stringify(modelOptionsForRequest(b, defaultOptsFor(b))));
+      }
+    });
+
+    it("never reaches the wire on a basis that refuses it (momwire#246/#271)", () => {
+      // Galerkin: momwire#246.
+      expect(
+        modelOptionsForRequest(
+          entry("sinusoidal-galerkin"),
+          armed("sinusoidal-galerkin"),
+        ),
+      ).toEqual({ n_qp_const: 8, feed_model: "segment" });
+      // Singular enrichment: momwire#271. Sending both would be a refusal at
+      // engine construction; the UI greys the pair out, and this is the lock
+      // behind that.
+      const enriched = {
+        ...armed("bspline"),
+        bspline: { ...BSPLINE_DEFAULT_OPTS, useSingularEnrichment: true },
+      };
+      const out = modelOptionsForRequest(entry("bspline"), enriched);
+      expect(out.use_singular_enrichment).toBe(true);
+      expect(out).not.toHaveProperty("extended_kernel");
+    });
+
+    it("stays off the wire for pynec, which sends no model_options", () => {
+      expect(modelOptionsForRequest(entry("pynec"), armed("pynec"))).toEqual({});
+    });
+  });
+
   it("uses the panel's own defaults when a b-spline slot carries no panel state", () => {
     const result = modelOptionsForRequest(entry("bspline"), {
       nPerWire: 30,

--- a/src/antennaknobs/web/frontend/src/components/backend/BackendConfigModal.tsx
+++ b/src/antennaknobs/web/frontend/src/components/backend/BackendConfigModal.tsx
@@ -2,6 +2,10 @@ import { useEffect } from "react";
 import {
   backendAllowed,
   BSPLINE_DEFAULT_OPTS,
+  EK_ENRICHMENT_REASON,
+  EK_HINT,
+  extendedKernelActive,
+  extendedKernelRefusal,
   PANEL_BSPLINE,
   PANEL_PYNEC,
   PANEL_SIN_GALERKIN,
@@ -114,6 +118,16 @@ export function BackendConfigModal({
             onChange={(v) => onPatch({ wireRadius: v })}
           />
 
+          {/* The extended thin-wire kernel (issue #849) sits next to the wire
+              radius on purpose — it is the knob that decides how the on-axis
+              Green's function treats that radius. Common to every momwire
+              backend, so it lives here rather than in a bespoke panel; PyNEC
+              gets no row at all (it sends no model_options, and its own
+              extended kernel — issue #414 — is a separate, unexposed kwarg). */}
+          {backend.kind === "momwire" && (
+            <ExtendedKernelField backend={backend} opts={opts} onPatch={onPatch} />
+          )}
+
           {/* Generic numeric knobs, straight from the served options_schema —
               the same schema-driven loop the terrain panel uses (#560). */}
           {backend.options_schema.map((f) => (
@@ -144,6 +158,7 @@ export function BackendConfigModal({
           {backend.panel === PANEL_BSPLINE && (
             <BSplineFields
               opts={opts.bspline ?? BSPLINE_DEFAULT_OPTS}
+              extendedKernel={extendedKernelActive(backend, opts)}
               onPatch={(p) =>
                 onPatch({
                   bspline: { ...(opts.bspline ?? BSPLINE_DEFAULT_OPTS), ...p },
@@ -166,6 +181,44 @@ export function BackendConfigModal({
           </button>
         </div>
       </div>
+    </div>
+  );
+}
+
+// The muted one-liner under a control, as the Converged-feed hint spells it.
+const NOTE_STYLE = { color: "var(--muted)", fontSize: "var(--text-sm)" };
+
+// The EK card as a per-slot checkbox. Two combinations refuse upstream
+// (momwire#246 Galerkin, momwire#271 enrichment); rather than let the user
+// arm one and read the refusal out of the error banner, the box greys out and
+// the reason is on the page. `checked` reads the ACTIVE state, so a disabled
+// row is never shown ticked.
+function ExtendedKernelField({
+  backend,
+  opts,
+  onPatch,
+}: {
+  backend: BackendEntry;
+  opts: BackendOpts;
+  onPatch: (patch: Partial<BackendOpts>) => void;
+}) {
+  const refusal = extendedKernelRefusal(backend, opts);
+  return (
+    <div className="field">
+      <label className="link-toggle" title={refusal ?? EK_HINT}>
+        <input
+          type="checkbox"
+          checked={extendedKernelActive(backend, opts)}
+          disabled={refusal !== null}
+          onChange={(e) => onPatch({ extendedKernel: e.target.checked })}
+        />
+        extended kernel (EK)
+      </label>
+      <em style={NOTE_STYLE}>
+        {refusal ??
+          "For fat wires — segments not much longer than the radius (Δ/a " +
+            "below ~10). Thin-wire designs move a fraction of a percent."}
+      </em>
     </div>
   );
 }
@@ -232,9 +285,14 @@ function FeedModelField({
 
 function BSplineFields({
   opts,
+  extendedKernel,
   onPatch,
 }: {
   opts: BSplineOpts;
+  /** The slot's extended kernel is in force — enrichment is unavailable while
+   *  it is (momwire#271). The exclusion is symmetric (the EK row greys out
+   *  while enrichment is on), so neither box can lock the other. */
+  extendedKernel: boolean;
   onPatch: (p: Partial<BSplineOpts>) => void;
 }) {
   return (
@@ -306,10 +364,18 @@ function BSplineFields({
         junction singularity genuinely matters. Not needed for production.
       </p>
       <div className="field">
-        <label className="link-toggle" title="VALIDATION ONLY. Adds (u/h)·log(u/h) singular basis at K ≥ enrichment_min_k junctions. This flips O(1/N) → ~O(1/N^(d+1)) for LOW-ORDER bases (sinusoidal); the d=2 B-spline already converges at that rate on its own, so enrichment is redundant here and adds a coarse-mesh transient. See issue #565.">
+        <label
+          className="link-toggle"
+          title={
+            extendedKernel
+              ? EK_ENRICHMENT_REASON
+              : "VALIDATION ONLY. Adds (u/h)·log(u/h) singular basis at K ≥ enrichment_min_k junctions. This flips O(1/N) → ~O(1/N^(d+1)) for LOW-ORDER bases (sinusoidal); the d=2 B-spline already converges at that rate on its own, so enrichment is redundant here and adds a coarse-mesh transient. See issue #565."
+          }
+        >
           <input
             type="checkbox"
             checked={opts.useSingularEnrichment}
+            disabled={extendedKernel}
             onChange={(e) => onPatch({ useSingularEnrichment: e.target.checked })}
           />
           K≥3 junction singular enrichment

--- a/src/antennaknobs/web/frontend/src/lib/backends.ts
+++ b/src/antennaknobs/web/frontend/src/lib/backends.ts
@@ -197,6 +197,14 @@ export type BackendOpts = {
   // offered on plain sinusoidal: the point gap has no collocation RHS
   // (momwire#212), so that solver's roster entry names no panel.
   feedModel?: FeedModel;
+  // NEC's extended thin-wire kernel — the `EK` card (issue #849, momwire >=
+  // 0.26.0). Common to every momwire backend rather than panel-specific, so
+  // it sits beside wire radius rather than inside a bespoke panel: it is the
+  // knob that says how the on-axis Green's function treats that radius.
+  // ABSENT = off, which is the EK card's own convention (a deck with no `EK`
+  // card, and `EK -1`, both read as the reduced kernel) and what keeps a
+  // kernel-off request byte-identical to what every release before #849 sent.
+  extendedKernel?: boolean;
 };
 
 /** A backend's stock options: served numeric defaults plus the bespoke
@@ -212,6 +220,61 @@ export function defaultOptsFor(b: BackendEntry): BackendOpts {
   // on near-open designs (#640).
   if (b.panel === PANEL_SIN_GALERKIN) opts.feedModel = "segment";
   return opts;
+}
+
+// ---------------------------------------------------------------------------
+// The extended thin-wire kernel (issue #849)
+// ---------------------------------------------------------------------------
+
+// One-line "why you'd want this", used as the toggle's tooltip.
+export const EK_HINT =
+  "NEC's extended thin-wire kernel (the EK card): the on-axis Green's " +
+  "function uses NEC's O(a²) tube expansion instead of the filament " +
+  "approximation. It matters where the wire is FAT relative to its segments " +
+  "— a fraction of a percent at Δ/a > 10, several percent below Δ/a ≈ 3 — " +
+  "and costs about 1.0–1.3× the reduced-kernel solve.";
+
+// The one basis that cannot serve the kernel. Named here rather than read off
+// the roster because the roster carries no capability field for it: momwire
+// implements EK on the point-matched SinusoidalSolver and the B-spline family,
+// and refuses on the Galerkin sibling (momwire#246). This is the frontend twin
+// of engines/momwire.py::_extended_kernel_refusal, which raises the same two
+// refusals server-side — so a stale name here costs a clear error dialog, not
+// a wrong answer. If a second basis ever refuses, that is the moment to serve
+// the capability as a roster field instead of extending this constant.
+export const EK_UNSUPPORTED_BACKEND = "sinusoidal-galerkin";
+
+export const EK_GALERKIN_REASON =
+  "The Sin-Galerkin basis cannot run the extended kernel: NEC's EKSCX has no " +
+  "counterpart for its folded testing shape (momwire#246). Use the " +
+  "Sinusoidal or B-spline slots for an extended-kernel run.";
+
+export const EK_ENRICHMENT_REASON =
+  "The extended kernel and K≥3 junction singular enrichment cannot be used " +
+  "together (momwire#271): the enrichment DOFs bypass the moment kernels the " +
+  "extended kernel corrects. Turn one of the two off.";
+
+/** Why this slot cannot run the extended kernel, or null if it can. Mirrors
+ *  the engine-side refusals so the gear menu can grey the toggle out and say
+ *  why, instead of letting the solve come back as an error dialog. */
+export function extendedKernelRefusal(
+  b: BackendEntry,
+  opts: BackendOpts,
+): string | null {
+  if (b.name === EK_UNSUPPORTED_BACKEND) return EK_GALERKIN_REASON;
+  if (opts.bspline?.useSingularEnrichment) return EK_ENRICHMENT_REASON;
+  return null;
+}
+
+/** Is the extended kernel actually in force for this slot? True only when the
+ *  user asked for it AND this backend can serve it — a slot whose backend
+ *  changed under a set flag solves reduced rather than erroring, and the chip
+ *  and the request agree with the toggle the gear menu is showing. PyNEC is
+ *  excluded outright: it sends no `model_options` at all, and its own
+ *  extended-kernel support (issue #414) is a separate, unexposed kwarg. */
+export function extendedKernelActive(b: BackendEntry, opts: BackendOpts): boolean {
+  if (b.kind !== "momwire" || !opts.extendedKernel) return false;
+  return extendedKernelRefusal(b, opts) === null;
 }
 
 // Three abstract solver slots. Each holds one backend choice and its
@@ -231,13 +294,19 @@ export type SlotConfig = {
 // spline degree so two b-spline slots (the default A d=2 / B d=1 pair) stay
 // distinguishable at a glance.
 export function backendDisplayLabel(b: BackendEntry, opts: BackendOpts): string {
+  // "+EK" affixes the extended thin-wire kernel (issue #849) to whatever the
+  // slot is already called. The whole point of the toggle is A-vs-B — one slot
+  // with the kernel, one without — so the chips have to say which is which.
+  // Affixed only when the kernel is actually IN FORCE, never when a backend
+  // that refuses it is carrying a set flag.
+  const ek = extendedKernelActive(b, opts) ? " +EK" : "";
   if (b.panel === PANEL_BSPLINE)
-    return `${b.label} d=${opts.bspline?.degree ?? BSPLINE_DEFAULT_OPTS.degree}`;
+    return `${b.label} d=${opts.bspline?.degree ?? BSPLINE_DEFAULT_OPTS.degree}${ek}`;
   // Surface the non-default feed model on the slot chip: two Sin-Galerkin
   // slots differing only in feed model must be tellable apart at a glance.
   if (b.panel === PANEL_SIN_GALERKIN && opts.feedModel === "point")
-    return `${b.label} (converged)`;
-  return b.label;
+    return `${b.label} (converged)${ek}`;
+  return `${b.label}${ek}`;
 }
 
 /** Seed for one default slot: a backend NAME (resolved against the served
@@ -324,5 +393,14 @@ export function modelOptionsForRequest(
     // (momwire#212) and must not receive the key at all.
     out.feed_model = opts.feedModel ?? "segment";
   }
+  // The extended thin-wire kernel travels as a model option (the server pulls
+  // it back out of model_options and passes it as the named `extended_kernel=`
+  // constructor kwarg). Sent ONLY when in force: absence is the reduced
+  // kernel — the EK card's own convention, and the spelling that keeps a
+  // kernel-off request byte-identical to what every release before #849 sent.
+  // The `extendedKernelActive` gate is also what keeps a refused combination
+  // off the wire; the UI disables the toggle on those, so this is the second
+  // of the two locks, not the only one.
+  if (extendedKernelActive(b, opts)) out.extended_kernel = true;
   return out;
 }

--- a/tests/test_engine_spec.py
+++ b/tests/test_engine_spec.py
@@ -1,13 +1,17 @@
 import argparse
+from types import MappingProxyType
 
 import pytest
 
 import antennaknobs as ant
+from antennaknobs import AntennaBuilder, Wire, WireSpec
 from antennaknobs.cli import (
     MOMWIRE_BASES,
     parse_engine_spec,
     make_engine_factory,
     broadcast_pairs,
+    deck_extended_kernel_flag,
+    get_builder,
     _GROUND_UNSET,
 )
 from antennaknobs.engines import PyNECEngine, MomwireEngine
@@ -243,3 +247,191 @@ def test_cli_pattern_with_basis_spec():
     ant.cli(
         f"pattern --builder dipoles.invvee:dipole --engine momwire:sinusoidal{O}".split()
     )
+
+
+# ---------------------------------------------------------------------------
+# --extended-kernel (issue #849): NEC's EK card on the momwire CLI path, plus
+# @file.nec decks honoring their own EK card. See engines/momwire.py's
+# `_extended_kernel_refusal` for what refuses and why.
+# ---------------------------------------------------------------------------
+
+# Half-wave dipole with a/h ~ 0.24 (8 mm radius, ~33 mm segments) at 300 MHz —
+# deliberately fat so the reduced and extended kernels visibly disagree, the
+# same fixture shape as test_pynec_extended_kernel.py's PyNEC-side oracle.
+_FAT_DIPOLE_FREQ_MHZ = 300.0
+_FAT_DIPOLE_SPEC = WireSpec(radius=0.008)
+
+
+def _fat_dipole_builder():
+    class _B(AntennaBuilder):
+        default_params = MappingProxyType({"freq": _FAT_DIPOLE_FREQ_MHZ})
+
+        def build_wires(self):
+            return [
+                Wire(
+                    (-0.25, 0.0, 0.0), (0.0, 0.0, 0.0), 7, None, None, _FAT_DIPOLE_SPEC
+                ),
+                Wire(
+                    (0.0, 0.0, 0.0), (0.25, 0.0, 0.0), 8, 1 + 0j, None, _FAT_DIPOLE_SPEC
+                ),
+            ]
+
+    return _B()
+
+
+def test_make_factory_extended_kernel_binds_kwarg():
+    factory = make_engine_factory("momwire", _GROUND_UNSET, extended_kernel=True)
+    assert factory.func is MomwireEngine
+    assert factory.keywords == {"extended_kernel": True}
+    # Off by default: no kwarg at all, not extended_kernel=False (an EK-off
+    # solve must keep passing exactly what it passed before this issue).
+    assert make_engine_factory("momwire", _GROUND_UNSET) is MomwireEngine
+
+
+@pytest.mark.parametrize(
+    "flag,deck",
+    [(True, False), (False, True), (True, True)],
+)
+def test_make_factory_extended_kernel_ors_flag_and_deck(flag, deck):
+    """Either the explicit --extended-kernel flag or a deck's own EK card
+    turns the kernel on — the combination rule is OR (issue #849)."""
+    factory = make_engine_factory(
+        "momwire", _GROUND_UNSET, extended_kernel=flag, deck_extended_kernel=deck
+    )
+    assert factory.keywords == {"extended_kernel": True}
+
+
+def test_make_factory_extended_kernel_off_when_neither_set():
+    factory = make_engine_factory(
+        "momwire", _GROUND_UNSET, extended_kernel=False, deck_extended_kernel=False
+    )
+    assert factory is MomwireEngine
+
+
+def test_make_factory_extended_kernel_moves_fat_wire_impedance_and_matches_direct():
+    """Z must actually move with the flag, and match constructing
+    MomwireEngine(extended_kernel=True) directly on the same design."""
+    factory_off = make_engine_factory("momwire", _GROUND_UNSET)
+    factory_on = make_engine_factory("momwire", _GROUND_UNSET, extended_kernel=True)
+    z_off = factory_off(_fat_dipole_builder()).impedance()[0]
+    z_on = factory_on(_fat_dipole_builder()).impedance()[0]
+    assert abs(z_on - z_off) > 0.3  # the kernels must actually disagree here
+
+    z_direct = MomwireEngine(_fat_dipole_builder(), extended_kernel=True).impedance()[0]
+    assert z_on == z_direct
+
+
+@needs_pynec
+def test_make_factory_extended_kernel_rejected_for_non_momwire():
+    """An explicit --extended-kernel is a momwire-only flag; a request to
+    apply it on another engine is a clear user error, not a silent no-op
+    (PyNEC's own EK support, issue #414, is a separate unexposed kwarg)."""
+    with pytest.raises(argparse.ArgumentTypeError, match="momwire"):
+        make_engine_factory("pynec", _GROUND_UNSET, extended_kernel=True)
+
+
+@needs_pynec
+def test_make_factory_deck_extended_kernel_silently_ignored_for_non_momwire():
+    """A deck-only EK request (no explicit flag) on a non-momwire engine is
+    left alone — unchanged from before issue #849, since PyNEC's EK support
+    isn't wired to the deck by this issue."""
+    factory = make_engine_factory("pynec", _GROUND_UNSET, deck_extended_kernel=True)
+    assert factory is PyNECEngine
+
+
+def test_make_factory_extended_kernel_refuses_sinusoidal_galerkin_at_construction():
+    """momwire#246: no EKSCX counterpart for the Galerkin fill's folded
+    testing shape, so the solver refuses at construction — the same
+    NotImplementedError the engine raises directly (issue #849)."""
+    factory = make_engine_factory(
+        "momwire:sinusoidal-galerkin", _GROUND_UNSET, extended_kernel=True
+    )
+    with pytest.raises(NotImplementedError, match="sinusoidal-galerkin"):
+        factory(_fat_dipole_builder())
+
+
+def test_cli_extended_kernel_flag_runs():
+    ant.cli(
+        f"pattern --builder dipoles.invvee:dipole --engine momwire "
+        f"--extended-kernel{O}".split()
+    )
+
+
+def test_cli_extended_kernel_galerkin_refusal_is_a_clean_systemexit(capsys):
+    """The CLI must print the refusal and exit cleanly (exit code 1, the
+    message on stdout), not dump a traceback (cli()'s NotImplementedError
+    handler, issue #849)."""
+    with pytest.raises(SystemExit) as exc:
+        ant.cli(
+            f"pattern --builder dipoles.invvee:dipole "
+            f"--engine momwire:sinusoidal-galerkin --extended-kernel{O}".split()
+        )
+    assert exc.value.code == 1
+    assert "sinusoidal-galerkin" in capsys.readouterr().out
+
+
+@needs_pynec
+def test_cli_extended_kernel_flag_rejected_for_pynec():
+    with pytest.raises(argparse.ArgumentTypeError):
+        ant.cli(
+            f"pattern --builder dipoles.invvee:dipole --engine pynec "
+            f"--extended-kernel{O}".split()
+        )
+
+
+# --- @file.nec decks honoring their own EK card ---------------------------
+
+_FAT_DIPOLE_DECK = """CE fat dipole
+GW 1 15 -0.25 0 0 0.25 0 0 0.008
+GE 0
+{ek}FR 0 1 0 0 300.0
+EX 0 1 8 0 1.0 0.0
+EN
+"""
+
+
+def test_deck_extended_kernel_flag_absence_vs_explicit_off_vs_on(tmp_path):
+    """NecDeck.extended_kernel semantics carried onto the synthesized @file
+    builder: absence and `EK -1` both read as off, any other EK reads as on
+    (issue #849's chosen, documented combination rule)."""
+    on = tmp_path / "on.nec"
+    on.write_text(_FAT_DIPOLE_DECK.format(ek="EK\n"))
+    off = tmp_path / "off.nec"
+    off.write_text(_FAT_DIPOLE_DECK.format(ek="EK -1\n"))
+    absent = tmp_path / "absent.nec"
+    absent.write_text(_FAT_DIPOLE_DECK.format(ek=""))
+
+    assert deck_extended_kernel_flag(get_builder(f"@{on}")) is True
+    assert deck_extended_kernel_flag(get_builder(f"@{off}")) is False
+    assert deck_extended_kernel_flag(get_builder(f"@{absent}")) is False
+    # An ordinary catalog design carries no such attribute at all.
+    assert deck_extended_kernel_flag(get_builder("dipoles.invvee")) is False
+
+
+def test_file_nec_deck_ek_card_honored_on_momwire_engine(tmp_path):
+    """A `@file.nec` deck's own EK card turns the kernel on for the momwire
+    engine with no --extended-kernel flag needed, and matches constructing
+    MomwireEngine(extended_kernel=True) directly on the same geometry."""
+    path = tmp_path / "fatdipole.nec"
+    path.write_text(_FAT_DIPOLE_DECK.format(ek="EK\n"))
+
+    builder_cls = get_builder(f"@{path}")
+    factory = make_engine_factory(
+        "momwire",
+        _GROUND_UNSET,
+        deck_extended_kernel=deck_extended_kernel_flag(builder_cls),
+    )
+    z_via_deck = factory(builder_cls()).impedance()[0]
+    z_direct_on = MomwireEngine(builder_cls(), extended_kernel=True).impedance()[0]
+    z_direct_off = MomwireEngine(builder_cls(), extended_kernel=False).impedance()[0]
+
+    assert z_via_deck == z_direct_on
+    assert abs(z_via_deck - z_direct_off) > 0.3
+
+
+def test_cli_file_nec_deck_ek_card_runs_end_to_end(tmp_path):
+    """Smoke-level: the CLI actually runs a momwire solve against an
+    @file.nec deck carrying an EK card, with no --extended-kernel flag."""
+    path = tmp_path / "fatdipole.nec"
+    path.write_text(_FAT_DIPOLE_DECK.format(ek="EK\n"))
+    ant.cli(f"pattern --builder @{path} --engine momwire{O}".split())

--- a/tests/test_nec_portal.py
+++ b/tests/test_nec_portal.py
@@ -2518,6 +2518,247 @@ def test_require_lattice_fft_names_the_unmet_gate_on_a_single_pair():
         nec_portal._y_and_port_coeffs(solver)
 
 
+# --- the EK card, honoured for real (issue #849) ------------------------------
+#
+# Until momwire 0.26.0 the portal parsed `EK`, threaded it through the execute
+# groups, and printed its announcement — but momwire had one kernel, so the
+# card moved no number and the grammar doc called it advisory. It is real now,
+# and the tests below are the four halves of "real": the operator moves, it
+# moves to MOMWIRE's own extended kernel and not to something this file invented
+# on the way, it moves in nec2c's direction and by nec2c's amount, and the
+# bases that cannot serve it say so.
+#
+# Every EK deck in the fixture corpus is a 0.001 m wire at Δ/a ≈ 500, where the
+# extended kernel is a 0.02 % correction by construction — the card's whole
+# subject is the O(a²) term the reduced kernel drops. So the decks here are
+# FAT: 11 segments of a 5 m dipole at a = 0.2 m is Δ/a = 2.27, and both engines
+# move by ~8 % across the card.
+
+# λ = 10 m at 30 MHz; 11 segments over 5 m is Δ = 0.4545 m, so Δ/a = 2.27.
+_FAT_WIRE = "GW 1 11 0. 0. -2.5 0. 0. 2.5 0.2\n"
+
+
+def _fat_deck(kernel_card: str = "") -> str:
+    card = f"{kernel_card}\n" if kernel_card else ""
+    return (
+        f"CE ek fat wire\n{_FAT_WIRE}GE 0\n{card}"
+        "FR 0 1 0 0 30. 1\nEX 0 1 6 0 1.\nXQ\nNX\n"
+    )
+
+
+# nec2c 5b4az.ae6ty.1.23 (SimNEC 5.1's shipped `nec2c-ubuntu-x86` — the version
+# the repo pins as `minimumNEC2CVersion`), on `_fat_deck()` and
+# `_fat_deck("EK")` respectively. Captured 2026-08-10 the same way
+# scripts/nec_portal_capture.py captures the corpus: the deck on stdin, the
+# ANTENNA INPUT PARAMETERS row read off stdout.
+NEC2C_FAT_REDUCED = complex(1.2368e02, 2.8585e01)
+NEC2C_FAT_EXTENDED = complex(1.1357e02, 2.8980e01)
+
+
+def _first_z(text: str) -> complex:
+    """The impedance of the first ANTENNA INPUT PARAMETERS row."""
+    columns = aip_impedances(text)
+    assert columns, f"no AIP row:\n{text[-800:]}"
+    return complex(float(columns[0][0]), float(columns[0][1]))
+
+
+def _relative(a: complex, b: complex) -> float:
+    return abs(a - b) / max(abs(a), abs(b))
+
+
+@pytest.fixture
+def restore_basis():
+    """`--basis` is a process-global (`_active_basis`), set by `main` and never
+    reset by `run_deck` — the ordering hazard `cache_reset` documents. A test
+    that asks for an alternate basis puts it back, so it cannot decide what a
+    later test's `run_deck`/`printout` call solves with."""
+    from antennaknobs import nec_portal
+
+    saved = nec_portal._active_basis
+    yield
+    nec_portal._active_basis = saved
+
+
+def test_the_ek_card_moves_the_impedance_on_a_fat_wire(restore_basis):
+    """The card is no longer advisory: same deck, one card, a different answer.
+
+    Asserted on the DEFAULT basis as well as the NEC-closest one, because the
+    passthrough is the engine's and every basis in the roster but Galerkin has
+    to carry it.
+    """
+    for basis in ([], ["--basis", "sinusoidal"]):
+        rc_off, off, err_off = _run_main(basis, deck=_fat_deck())
+        rc_on, on, err_on = _run_main(basis, deck=_fat_deck("EK"))
+        assert (rc_off, rc_on) == (0, 0) and not err_off and not err_on
+        assert "ERROR-NEC2C" not in off and "ERROR-NEC2C" not in on
+        shift = _relative(_first_z(off), _first_z(on))
+        assert shift >= 0.02, f"{basis}: EK moved the impedance by only {shift:.3%}"
+
+
+def test_the_ek_answer_is_momwires_own_extended_kernel_solve(restore_basis):
+    """Which extended kernel — the identity behind the number.
+
+    A deck through the portal under `--basis sinusoidal` must be the same solve
+    as `SinusoidalSolver(extended_kernel=...)` built straight off the deck's own
+    mesh: one straight wire, 11 uniform segments, the gap at the centre. The
+    only slack allowed is the printout's own `%13.5E` rounding, so this catches
+    a kernel flag that reached a DIFFERENT constructor, a mesh the portal built
+    differently under EK, or an announcement printed over a reduced-kernel fill.
+    """
+    import numpy as np
+    from momwire import SinusoidalSolver
+
+    for card, kwargs in (("", {}), ("EK", {"extended_kernel": True})):
+        solver = SinusoidalSolver(
+            wires=[np.array([[0.0, 0.0, -2.5], [0.0, 0.0, 2.5]])],
+            n_per_edge_per_wire=[[11]],
+            feeds=[(0, 2.5, 1.0)],
+            wavelength=299_792_458.0 / 30e6,
+            wire_radius=0.2,
+            **kwargs,
+        )
+        direct, _coeffs = solver.compute_impedance()
+        _rc, out, _err = _run_main(["--basis", "sinusoidal"], deck=_fat_deck(card))
+        assert _relative(_first_z(out), direct) <= 1e-4, (
+            f"EK={card!r}: portal {_first_z(out)} vs direct {direct}"
+        )
+
+
+def test_the_fat_wire_ek_pair_tracks_nec2c_on_both_sides_of_the_card(restore_basis):
+    """The card's physics, against the reference engine rather than ourselves.
+
+    Both kernels are held at the differential harness's ordinary 5 % bar, and
+    the SHIFT is held too — a passthrough that quietly did nothing would keep
+    the reduced side inside 5 % and fail here, which is the mode this exists
+    to catch. The sinusoidal basis is used because it is the roster's
+    NEC-closest rung (issue #822); on this deck it lands 0.5 % from nec2c
+    reduced and 3.1 % extended.
+    """
+    _rc, off, _e = _run_main(["--basis", "sinusoidal"], deck=_fat_deck())
+    _rc, on, _e = _run_main(["--basis", "sinusoidal"], deck=_fat_deck("EK"))
+    z_off, z_on = _first_z(off), _first_z(on)
+    assert _relative(z_off, NEC2C_FAT_REDUCED) <= 0.05, f"{z_off} vs nec2c reduced"
+    assert _relative(z_on, NEC2C_FAT_EXTENDED) <= 0.05, f"{z_on} vs nec2c extended"
+    # nec2c's own move across the card is -10.1 Ω of resistance (8.0 %); ours
+    # must be the same sign and the same order, not merely "different".
+    theirs = NEC2C_FAT_EXTENDED - NEC2C_FAT_REDUCED
+    ours = z_on - z_off
+    assert ours.real < 0 and theirs.real < 0, f"{ours} vs {theirs}"
+    assert 0.5 <= abs(ours) / abs(theirs) <= 2.0, f"{ours} vs {theirs}"
+
+
+@pytest.mark.parametrize("card", ["EK", "EK 0", "EK 1", "EK 2", "EK -2"])
+def test_every_ek_field_but_minus_one_is_the_extended_kernel(card):
+    """What the oracle actually does with the card's one field.
+
+    Measured on nec2c 5b4az.ae6ty.1.23: `EK`, `EK 0`, `EK 1`, `EK 2` and even
+    `EK -2` all print THE EXTENDED THIN WIRE KERNEL WILL BE USED, and only
+    `EK -1` does not — NEC-2's card reader sets the flag on an EK card and
+    clears it for `-1` alone. The portal used to REFUSE anything outside
+    {0, -1}, which is the #814 failure class exactly: a deck the reference
+    engine runs, turned into a fabricated SimNEC readout by our refusal.
+    """
+    rc, out, err = _run_main([], deck=_fat_deck(card))
+    assert rc == 0 and err == ""
+    assert "ERROR-NEC2C" not in out, out[-600:]
+    assert "THE EXTENDED THIN WIRE KERNEL WILL BE USED" in out
+    assert _first_z(out) == _first_z(_run_main([], deck=_fat_deck("EK"))[1])
+
+
+def test_ek_minus_one_is_the_reduced_kernel():
+    """The other side of the same rule, and the no-card default with it."""
+    z_bare = _first_z(_run_main([], deck=_fat_deck())[1])
+    rc, out, _err = _run_main([], deck=_fat_deck("EK -1"))
+    assert rc == 0 and "THE EXTENDED THIN WIRE KERNEL WILL BE USED" not in out
+    assert _first_z(out) == z_bare
+
+
+def test_two_groups_of_one_deck_under_two_kernels_get_two_operators():
+    """`dipole_ek_rearm`'s shape, on a wire fat enough to show it.
+
+    One deck, one frequency, two execute groups — the second under a kernel the
+    first was not. The per-deck fill cache is keyed on the frequency ALONE
+    unless the kernel is in the key too, so this is the intra-deck half of the
+    staleness gate: getting it wrong prints the first group's answer twice and
+    every other assertion in this file still passes.
+    """
+    deck = (
+        f"CE ek rearm fat\n{_FAT_WIRE}GE 0\nEK -1\n"
+        "FR 0 1 0 0 30. 1\nEX 0 1 6 0 1.\nXQ\nEK\nXQ\nNX\n"
+    )
+    rc, out, err = _run_main([], deck=deck)
+    assert rc == 0 and err == "" and "ERROR-NEC2C" not in out
+    rows = aip_impedances(out)
+    assert len(rows) == 2, rows
+    first, second = complex(*map(float, rows[0])), complex(*map(float, rows[1]))
+    assert first == _first_z(_run_main([], deck=_fat_deck("EK -1"))[1])
+    assert second == _first_z(_run_main([], deck=_fat_deck("EK"))[1])
+    assert _relative(first, second) >= 0.02, f"{first} vs {second}"
+
+
+@pytest.mark.parametrize(
+    "basis", ["sinusoidal-galerkin", "sinusoidal-galerkin-converged"]
+)
+def test_a_galerkin_basis_refuses_an_ek_deck_as_a_nec_error(basis, restore_basis):
+    """The refusal path, on the class of deck that reaches it in real life.
+
+    momwire#246 leaves NEC's extended kernel unimplemented on the Galerkin fill
+    — its folded third source shape has no EKSCX counterpart — so the solver
+    refuses at construction with a NotImplementedError. The live `NECSource`
+    path sends `EK` on EVERY deck (grammar doc §17), so a SimNEC user who picks
+    a Galerkin portal entry hits this on their first solve, and what they must
+    get is the documented refusal frame: a token-0 `ERROR:` line naming the
+    kernel, the oracle-shaped `ERROR-NEC2C:` line behind it, and — the one that
+    decides whether the session survives — the NX sentinel. A traceback out of
+    `main` would cost the sentinel and stall `Execute.readLine` forever.
+    """
+    rc, out, err = _run_main(["--basis", basis], deck=_fat_deck("EK"))
+    assert rc == 0 and err == ""
+    assert "Traceback" not in out
+    errors = [ln for ln in out.splitlines() if ln.split()[:1] == ["ERROR:"]]
+    assert errors, out[-800:]
+    assert "extended thin-wire kernel" in errors[0]
+    assert "sinusoidal-galerkin" in errors[0]
+    assert "ERROR-NEC2C: " in out
+    assert NX_ECHO.search(out), "no NX sentinel on the kernel-refusal path"
+    # ... and the same basis answers the same deck once the card is gone, so
+    # the refusal is the KERNEL's and not the basis failing on a fat wire.
+    rc, plain, _err = _run_main(["--basis", basis], deck=_fat_deck())
+    assert rc == 0 and "ERROR-NEC2C" not in plain and aip_impedances(plain)
+
+
+def test_the_thin_wire_ek_fixtures_barely_move_and_move_towards_nec2c():
+    """The armor's own measurement, kept next to the numbers that justify it.
+
+    43 of the 45 corpus fixtures carry no `EK` and are byte-identical across
+    this change. The two that do carry it are Δ/a ≈ 500 dipoles, where the
+    extended kernel is the correction it is designed to be small: measured,
+    both move 0.017 % — inside momwire's own no-op bar — and both move CLOSER
+    to nec2c (0.761 % → 0.745 %). `dipole_ek_rearm`'s first group is `EK -1`
+    and must not move at all, which is the assertion that the reduced path is
+    still the reduced path.
+    """
+
+    def render(name):
+        # Through `main` rather than `printout`, so the process-global basis is
+        # this test's own whatever ran before it.
+        return _run_main([], deck=fixture_deck(name) + "\nNX\n")[1]
+
+    extended = _first_z(render("dipole_ek_extended"))
+    oracle = complex(7.9240e01, 4.5364e01)  # the fixture's own captured row
+    reduced = _first_z(render("dipole_free_space"))  # same wire, no EK card
+    assert _relative(extended, reduced) <= 1e-3, (
+        f"a Δ/a≈500 wire moved {_relative(extended, reduced):.4%} across EK"
+    )
+    assert _relative(extended, oracle) < _relative(reduced, oracle)
+
+    rows = aip_impedances(render("dipole_ek_rearm"))
+    assert len(rows) == 2
+    first, second = complex(*map(float, rows[0])), complex(*map(float, rows[1]))
+    assert first == reduced, "the EK -1 group is no longer the reduced-kernel one"
+    assert second == extended
+
+
 # --- the cross-deck solver cache (issue #823) --------------------------------
 #
 # The cache's whole claim is that the printout is IDENTICAL whether a deck was
@@ -2694,6 +2935,20 @@ CACHE_NET_BASE = mutate(
     "EX 0 1 5 0 1.\nTL 1 3 1 7 600. 2.5 0. 0. 0. 0.\nNT 1 3 1 7 0. 0.02 0. 0. 0. 0.02\n",
 )
 
+# A free-space deck at Δ/a = 2.27 — the regime where the extended kernel is
+# worth several percent (issue #849). The plain CACHE_BASE wire is 500× too
+# thin for an EK mutation to move a printed digit, so a cross-deck cache test
+# on it can only ever assert the MISS; this one asserts the answer too.
+CACHE_FAT_BASE = (
+    "CM cross-deck cache probe, fat\n"
+    "CE\n"
+    "GW 1 11 0. 0. -2.5 0. 0. 2.5 0.2\n"
+    "GE 0\n"
+    "EX 0 1 6 0 1.\n"
+    "FR 0 1 0 0 30. 0\n"
+    "XQ\n"
+)
+
 
 # (label, base deck, mutant deck, does this move the printed numbers?)
 _OPERATOR_MUTATIONS = (
@@ -2744,11 +2999,21 @@ _OPERATOR_MUTATIONS = (
         mutate("600. 2.5", "-600. 2.5", CACHE_NET_BASE),
         True,
     ),
-    # EK is the conservative key entry: momwire's kernel is momwire's kernel, so
-    # the flag moves no number here — the gate is that it still MISSES, because
-    # a card whose meaning is "compute the operator differently" must never be
-    # answered from an entry built without it.
+    # EK used to be the conservative key entry — kept for the principle that a
+    # card whose meaning is "compute the operator differently" must never be
+    # answered from an entry built without it, back when momwire had no other
+    # kernel and the flag moved no number. Issue #849 made it an ordinary one.
+    # This deck's wire is Δ/a ≈ 500, where the extended kernel is a 0.02 %
+    # correction that does not survive `%13.5E`, so `moves_numbers` stays False
+    # HERE and the fat-wire deck below carries the "and it answers with its own
+    # physics" half.
     ("EK toggled", CACHE_BASE, mutate("EX 0 1 5 0 1.\n", "EK\nEX 0 1 5 0 1.\n"), False),
+    (
+        "EK toggled (fat wire)",
+        CACHE_FAT_BASE,
+        mutate("GE 0\n", "GE 0\nEK\n", CACHE_FAT_BASE),
+        True,
+    ),
 )
 
 

--- a/tests/test_nec_portal_differential.py
+++ b/tests/test_nec_portal_differential.py
@@ -36,6 +36,8 @@ catalog_multiband_trap_dipole         2.66%   2.66%       -   0.68%      -
 catalog_specialty_bowtie              1.25%   1.25%       -   0.54%      -
 catalog_verticals_vertical            2.79%   2.79%       -   0.18%      -
 catalog_wire_w8jk                     1.98%   1.99%       -   0.84%      -
+dipole_ek_extended                    0.74%   0.75%       -   0.96%      -   (i)
+dipole_ek_rearm                       0.76%   0.76%       -   0.96%      -   (i)
 dipole_fr_sweep                       1.29%   1.29%       -   0.96%      -
 dipole_free_space                     0.76%   0.76%       -   0.96%      -
 dipole_gd_cliff_sommerfeld            2.24%   2.23%       -   4.35%      -   (f)
@@ -155,6 +157,19 @@ fails.
     Since #802 the far-field half is no longer "and there we refuse": the
     cliff modes run, so the same control is asserted on them too, by
     ``test_the_cliff_never_reaches_the_matrix``.
+
+(i) are the two ``EK`` fixtures, added to this table in issue #849 when the
+    card stopped being advisory (momwire 0.26.0 ships NEC's extended thin-wire
+    kernel; the portal now builds the group's solver with it). Both moved, and
+    both moved the way the card's own arithmetic says they must: these are
+    0.001 m wires at ``Δ/a ≈ 500``, where the O(a²) term the extended kernel
+    restores is worth **0.017 %** — measured, on both — and agreement with
+    nec2c went from 0.761 % to 0.745 %. ``dipole_ek_rearm``'s FIRST group is
+    ``EK -1`` and did not move at all, to the digit, which is the reduced path
+    still being the reduced path. The card's real magnitude cannot be read off
+    this corpus at all (no committed deck is fat enough); it is measured
+    against the oracle in ``test_nec_portal.py``'s fat-wire pair, where
+    ``Δ/a = 2.27`` and both engines move ~8 %.
 """
 
 from __future__ import annotations

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -2474,6 +2474,7 @@ def test_cache_key_recurses_into_model_options():
         ("use_singular_enrichment", False),
         ("enrichment_variant", "off"),
         ("tikhonov_lambda", 1e-2),
+        ("extended_kernel", True),
     ]:
         mutant = dict(_CANONICAL_REQ)
         mutant["model_options"] = {**_CANONICAL_REQ["model_options"], k: alt}
@@ -3089,6 +3090,128 @@ def test_swept_mem_budget_injected_for_bspline_family(monkeypatch):
         {**req_base, "momwire_model": "bspline"}, builder
     )
     assert "swept_mem_mb" not in (eng._solver_kwargs or {})
+
+
+# ---------------------------------------------------------------------------
+# extended_kernel (issue #849): NEC's EK card as a hosted model option, wired
+# through to MomwireEngine's named `extended_kernel=` kwarg rather than left
+# inside solver_kwargs (unit 1's engine-side note + this unit's adapter site).
+# ---------------------------------------------------------------------------
+
+
+def test_extended_kernel_reaches_momwire_engine():
+    import importlib
+
+    from antennaknobs.web import adapter
+
+    design = importlib.import_module("antennaknobs.designs.dipoles.invvee")
+    req_base = {"measurement_freq_mhz": 28.47}
+    builder = adapter._build_builder(design.Builder, req_base)
+
+    eng_off = adapter._make_momwire_engine(
+        {**req_base, "momwire_model": "bspline"}, builder
+    )
+    assert eng_off._extended_kernel is False
+
+    eng_on = adapter._make_momwire_engine(
+        {
+            **req_base,
+            "momwire_model": "bspline",
+            "model_options": {"extended_kernel": True},
+        },
+        builder,
+    )
+    assert eng_on._extended_kernel is True
+    # Pulled out and passed as the named kwarg — not left sitting in
+    # solver_kwargs (unit 1's engine-side fold would still work either way,
+    # but the adapter's contract is the named kwarg specifically).
+    assert "extended_kernel" not in (eng_on._solver_kwargs or {})
+
+
+def test_hosted_extended_kernel_option_is_whitelisted(monkeypatch):
+    """The EK toggle is a physics selection like feed_model, not a compute-
+    amplification lever, so it must survive the hosted allowlist."""
+    from antennaknobs.web import adapter
+
+    monkeypatch.setattr(adapter, "_HOSTED", True)
+    out = adapter.sanitize_model_options({"model_options": {"extended_kernel": True}})
+    assert out == {"extended_kernel": True}
+    with pytest.raises(ValueError, match="extended_kernel"):
+        adapter.sanitize_model_options({"model_options": {"extended_kernel": "yes"}})
+
+
+def test_extended_kernel_moves_impedance_and_matches_direct_engine():
+    """Full server.solve() path: the kernel toggle must actually move Z, and
+    match constructing MomwireEngine(extended_kernel=True) directly on the
+    same builder."""
+    import importlib
+
+    from antennaknobs.engines import MomwireEngine
+    from antennaknobs.web import adapter
+
+    base = {
+        "geometry": "dipoles.invvee",
+        "solver": "momwire",
+        "momwire_model": "bspline",
+        "measurement_freq_mhz": 28.47,
+        "wire_radius": 0.008,  # fat wire — the kernels must visibly disagree
+    }
+    z_off = server.solve(dict(base))
+    z_on = server.solve({**base, "model_options": {"extended_kernel": True}})
+    assert (
+        abs(z_on["z_in_re"] - z_off["z_in_re"]) > 0.05
+        or abs(z_on["z_in_im"] - z_off["z_in_im"]) > 0.05
+    )
+
+    design = importlib.import_module("antennaknobs.designs.dipoles.invvee")
+    builder = adapter._build_builder(design.Builder, base)
+    builder.freq = base["measurement_freq_mhz"]
+    z_direct = MomwireEngine(
+        builder, wire_radius=0.008, extended_kernel=True
+    ).impedance()[0]
+    assert z_on["z_in_re"] == pytest.approx(z_direct.real)
+    assert z_on["z_in_im"] == pytest.approx(z_direct.imag)
+
+
+def test_geometry_extended_kernel_galerkin_refusal_is_structured(client: TestClient):
+    """issue #849: EK + sinusoidal-galerkin refuses at engine construction
+    (momwire#246 — no EKSCX counterpart for the Galerkin fill). The web path
+    must surface this as a clean {"error": ...} body (200), not a
+    500/traceback — the same structured-error contract as a broken user
+    design (test_geometry_endpoint_surfaces_build_error)."""
+    resp = client.post(
+        "/geometry",
+        json={
+            "geometry": "dipoles.invvee",
+            "momwire_model": "sinusoidal-galerkin",
+            "model_options": {"extended_kernel": True},
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "error" in body
+    assert "sinusoidal-galerkin" in body["error"]
+
+
+def test_ws_extended_kernel_galerkin_refusal_keeps_socket_alive(client: TestClient):
+    """Same refusal on the live /ws solve path: an error frame, not a torn
+    down socket — the next (healthy) request on the same socket must still
+    solve (mirrors test_ws_solve_error_keeps_socket_alive)."""
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(
+            json.dumps(
+                {
+                    "geometry": "dipoles.invvee",
+                    "momwire_model": "sinusoidal-galerkin",
+                    "model_options": {"extended_kernel": True},
+                }
+            )
+        )
+        bad = json.loads(ws.receive_text())
+        assert "sinusoidal-galerkin" in bad["error"]
+        ws.send_text(json.dumps({"geometry": "dipoles.invvee"}))
+        ok = json.loads(ws.receive_text())
+        assert "error" not in ok
 
 
 def test_momwire_ground_off_reports_free_model():


### PR DESCRIPTION
Closes #849. Integration PR for the stacked arc, pinning momwire 0.26.0 (the ground-under-the-kernel release: EK on 4/5 solver families, C++-fast everywhere including finite ground — the default here).

## Units (each reviewed + probed by the session model; sub-PR CI green on all)
- #850 — pin ritual + `engines/momwire.py` extended_kernel passthrough + the portal stops treating EK as advisory. **EK 1 finding**: on the pinned nec2c every field value except -1 enables EK — our {0,-1} refusal was an #814-class bug, fixed. 43/45 armor fixtures byte-identical; the two EK-carrying ones move 0.017%, toward nec2c.
- #851 — `--extended-kernel` CLI flag (+ `@file.nec` decks honor their own card, OR-combined); `model_options.extended_kernel` web option; refusals ride the existing structured error paths.
- #852 — per-slot EK toggle (galerkin/enrichment greyed with reasons), `+EK` identity chips, A/B comparison, six doc pages present-tense.

## Product notes
- **sinusoidal-galerkin roster entries now refuse live SimNEC decks** (NECSource always sends EK) until momwire#246 — honest NEC ERROR, SimNEC's UseExtendedKernel hatch is the workaround, grammar doc §17 records it.
- EK toggle costs ~1.1× on the default finite-ground path (momwire#269's numbers).

## Gates
Python suite 4621 passed, 2 skipped; frontend 731 passed + tsc/build/lint clean; portal-vs-direct 6e-6; nec2c ±EK captures pinned; cross-deck cache mutation battery extended. Reviewer probes per unit: advisory-regression (7 fail), adapter fold (4 fail), emit silence (3 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvF4yHgNxjhyZ7P286g3z8