### PR TITLE
chore: release v0.48.0 (the extended-kernel release)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.47.0"
+version = "0.48.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,22 +25,22 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.47.0" icon="star">
-  **The ladder-and-cliff release, shaped by SimNEC's own author.** The
-  portal's **`--basis`** roster grows from three entries to **seven** — bare
-  `sinusoidal` (the NEC-closest formulation, 0.24% from nec2c on the
-  reference dipole), `bspline-d1`, and the large-array accelerators
-  `hmatrix`/`arrayblock` (a 24×24 phased array in **0.77 s and 137 MB**
-  where the dense fill needs 8.0 s and 5.3 GB, benchmarked and committed).
-  The engine now **identifies itself honestly** — SimNEC's dialog shows
-  `NEC2momwire.0.47`, a form its author sanctioned — and refusals surface as
-  a real **NEC ERROR dialog** instead of a silently empty session. **`RP 2`/
-  `RP 3` cliff patterns** run (EZNEC-derived examples included — verified
-  live against SimNEC's bundled engine to 0.6%), and an opt-in **`--cache`**
-  remembers structures across decks (×14 on repeat probes; a `--cache-stats`
-  dry run measured 62% of a live session's decks fully servable before
-  anything was trusted). Start at
-  [Using momwire as SimNEC's engine](/reference/simnec/#using-momwire-as-simnecs-engine).
+<Card title="New in v0.48.0" icon="star">
+  **The extended-kernel release.** NEC's **`EK` card** — the extended
+  thin-wire kernel, the correction that matters when a wire is fat relative
+  to its own segments — is now honoured end to end, powered by momwire
+  0.26.0's C++ implementation. An imported deck's `EK` card **changes the
+  solve instead of being advisory** (and `EK 1` is no longer a refusal), the
+  CLI grows **`--extended-kernel`**, and every momwire slot in the web
+  workbench carries a per-slot **extended kernel (EK)** check — put the same
+  basis in two slots, one with the kernel and one without (the chip reads
+  **+EK**), and read the difference side by side. It runs on four of the
+  five solver families, in free space and over every ground model, at about
+  1.0–1.3× the ordinary solve; on a Δ/a = 2.27 dipole it moves the impedance
+  the same 8% step NEC takes, tracked to 0.5%/3.1% on the two sides of the
+  card. The two combinations that can't serve it refuse loudly rather than
+  quietly answering with the reduced kernel. Start at
+  [The extended thin-wire kernel](/reference/solver/#the-extended-thin-wire-kernel-ek).
 </Card>
 
 ## The whole pitch, in one line
@@ -51,6 +51,21 @@ ways: drive it from a script (sweep, optimize, compare, export a NEC deck), or
 open it in a browser and **turn the knobs live**, watching the radiation
 pattern, SWR, and impedance respond as you drag. Most antenna tools are a static
 formula calculator or a desktop app you have to install; this is neither.
+
+## See it in action
+
+A live modeling session, end to end: a 10&nbsp;m Moxon built from knobs, tuned
+by dragging, and read out in real time.
+
+<div style={{ position: "relative", paddingBottom: "56.25%", height: 0, overflow: "hidden", borderRadius: "0.5rem" }}>
+  <iframe
+    src="https://www.youtube-nocookie.com/embed/WmQ-2Kfz6dU"
+    title="AntennaKNoBs by KK7KNB: Live Antenna Modeling in the Browser (10m Moxon Demo)"
+    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
+    allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+  ></iframe>
+</div>
 
 <CardGrid stagger>
   <Card title="Antennas as Python code" icon="pencil">


### PR DESCRIPTION
Release PR for **v0.48.0 — the extended-kernel release**.

- Version bump `0.47.0` → `0.48.0`
- What's-new card refreshed for the EK arc (#849, momwire 0.26.0)
- 10m Moxon demo video embedded on the site front page
- De-stale sweep: no stale pages (the EK docs landed with #849); site builds clean

#839 (YY-card retirement) deliberately does **not** ride — deferred to v0.49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)