### PR TITLE
feat(engines): NEC5Engine stage 4 — network ports as edge sources, native EX 4 (#825)

### DIFF
--- a/src/antennaknobs/engines/nec5.py
+++ b/src/antennaknobs/engines/nec5.py
@@ -34,7 +34,13 @@ from pathlib import Path
 import numpy as np
 
 from ..engine import FarField, SimulationEngine, WireCurrents
-from ..network import as_wire
+from ..network import (
+    Driven,
+    DrivenCurrent,
+    PortOnWire,
+    PortOnWireFloating,
+    as_wire,
+)
 
 C_LIGHT = 299_792_458.0
 
@@ -74,9 +80,12 @@ def _num(x) -> str:
 class NEC5Engine(SimulationEngine):
     """Drive a licensed NEC-5 binary through intermediate files.
 
-    Stages 1+2 of #825: plain ``Wire.ex`` feeds, impedance and currents,
-    in free space or over ground — ``"pec"`` and NEC-5's native Sommerfeld
-    ``("finite", eps_r, sigma)``. Port networks, patterns and
+    Stages 1-4 of #825: impedance, currents and radiation patterns, in
+    free space or over ground (``"pec"`` / NEC-5's native Sommerfeld
+    ``("finite", eps_r, sigma)``), fed by legacy ``Wire.ex`` entries or a
+    ``build_network()`` spec whose sources sit on ``PortOnWire`` delta
+    gaps — ``Driven`` as ``EX 0``, ``DrivenCurrent`` as NEC-5's native
+    ``EX 4`` current source. Network branches (loads, lines) and
     NEC-5-specific physics are later stages and refuse loudly here.
     """
 
@@ -97,21 +106,31 @@ class NEC5Engine(SimulationEngine):
             )
         self._exe = exe
         self._timeout = float(timeout)
-        if builder.build_network() is not None:
-            raise NotImplementedError(
-                "NEC5Engine stage 1 supports plain-fed designs only "
-                "(port networks are a later #825 stage)"
-            )
         if builder.build_tls():
             raise NotImplementedError(
                 "NEC5Engine stage 1 does not model transmission lines"
             )
         self.tups = self._coerce_wire_tuples(builder.build_wires())
         self._wires = [as_wire(t) for t in self.tups]
-        self._feeds = [(i, w) for i, w in enumerate(self._wires) if w.ex is not None]
-        if not self._feeds:
+        # Sources, in excitation order: (wire_index, ex_type, value) with
+        # ex_type NEC-5's EX I1 — 0 voltage, 4 current (native in NEC-5;
+        # NEC-2 has no current source). Legacy Wire.ex entries and
+        # build_network() Driven/DrivenCurrent sources resolve to the same
+        # shape: a source at the named wire's center knot, the NEC-5 spelling
+        # of PortOnWire's delta gap at the wire's middle.
+        network = builder.build_network()
+        if network is not None:
+            self._sources = self._resolve_network_sources(network)
+        else:
+            self._sources = [
+                (i, 0, complex(w.ex))
+                for i, w in enumerate(self._wires)
+                if w.ex is not None
+            ]
+        if not self._sources:
             raise ValueError(
-                "design has no excitation (no Wire.ex entry) — nothing to solve"
+                "design has no excitation (no Wire.ex entry or network "
+                "source) — nothing to solve"
             )
         spec = builder.build_wire_material()
         default_radius = spec.radius if spec is not None else 0.0005
@@ -120,6 +139,59 @@ class NEC5Engine(SimulationEngine):
         ]
         if self.ground is not None:
             self._check_geometry_above_ground()
+
+    def _resolve_network_sources(self, network):
+        """Map a build_network() spec onto NEC-5 edge sources — stage 4 of
+        #825, and the place NEC-5 natively out-expresses NEC-2: a
+        ``PortOnWire`` delta gap becomes a source at the named wire's
+        center knot, ``Driven`` as ``EX 0`` (volts) and ``DrivenCurrent``
+        as ``EX 4`` (amps, no NEC-2 counterpart). Branches (loads, lines,
+        two-ports) are #825 stage 5+ and refuse here."""
+        if network.branches:
+            raise NotImplementedError(
+                "NEC5Engine does not stamp network branches yet "
+                "(loads are #825 stage 5; lines/two-ports have no NEC-5 "
+                "native cards on this path)"
+            )
+        by_name = {w.name: i for i, w in enumerate(self._wires) if w.name}
+        if any(w.ex is not None for w in self._wires):
+            raise ValueError(
+                "design mixes legacy Wire.ex feeds with a build_network() "
+                "spec — use one excitation style"
+            )
+        sources = []
+        for src in network.sources:
+            port = network.ports.get(src.port)
+            if port is None:
+                raise ValueError(f"network source names unknown port {src.port!r}")
+            if isinstance(port, PortOnWireFloating):
+                raise NotImplementedError(
+                    "NEC5Engine cannot expose a floating port's second "
+                    "terminal (no circuit stamping on this engine)"
+                )
+            if not isinstance(port, PortOnWire):
+                raise NotImplementedError(
+                    f"port {src.port!r} is virtual — NEC5Engine only serves "
+                    "ports on real wires"
+                )
+            if port.distributed:
+                raise NotImplementedError(
+                    f"port {src.port!r} is distributed (finite gap) — "
+                    "NEC5Engine only serves delta-gap ports"
+                )
+            idx = by_name.get(port.name)
+            if idx is None:
+                raise ValueError(
+                    f"port {src.port!r} names wire {port.name!r} which the "
+                    "geometry does not carry"
+                )
+            if isinstance(src, Driven):
+                sources.append((idx, 0, complex(src.voltage)))
+            elif isinstance(src, DrivenCurrent):
+                sources.append((idx, 4, complex(src.current)))
+            else:
+                raise NotImplementedError(f"unsupported source type {type(src)}")
+        return sources
 
     # ---------- ground ----------
 
@@ -230,12 +302,13 @@ class NEC5Engine(SimulationEngine):
         ge_line, gn_lines = self._ground_lines()
         lines.append(ge_line)
         lines.extend(gn_lines)
-        for i, w in self._feeds:
+        for idx, ex_type, value in self._sources:
             # Source at end 2 of the middle segment = the wire's center
             # knot (even parity guarantees n_seg is even).
-            ex = complex(w.ex)
+            n_seg = self._wires[idx].n_seg
             lines.append(
-                f"EX 0 {i + 1} {w.n_seg // 2} 2 {_num(ex.real)} {_num(ex.imag)}"
+                f"EX {ex_type} {idx + 1} {n_seg // 2} 2 "
+                f"{_num(value.real)} {_num(value.imag)}"
             )
         lines.append(f"FR 0 {freqs.size} 0 0 {_num(freqs[0])} {_num(df)}")
         if rp is None:
@@ -426,7 +499,10 @@ class NEC5Engine(SimulationEngine):
         # wires prints as segment 41), while the deck's EX addresses
         # tag-relative — translate before comparing.
         offsets = np.cumsum([0] + [w.n_seg for w in self._wires[:-1]])
-        expect = [(i + 1, int(offsets[i]) + w.n_seg // 2) for i, w in self._feeds]
+        expect = [
+            (idx + 1, int(offsets[idx]) + self._wires[idx].n_seg // 2)
+            for idx, _, _ in self._sources
+        ]
         got = [(tag, seg) for tag, seg, _ in rows]
         if got != expect:
             raise NEC5Error(

--- a/tests/test_nec5_engine.py
+++ b/tests/test_nec5_engine.py
@@ -340,3 +340,146 @@ def test_live_cli_roster_includes_nec5():
 
     assert ENGINE_CLASSES.get("nec5") is NEC5Engine
     assert find_nec5() is not None
+
+
+# ------------------------------------------------------------ network ports
+
+
+class _PortDipole(AntennaBuilder):
+    """Dipole fed through a named 2-segment bridge wire and a
+    build_network() spec — stage 4's PortOnWire-at-knot mapping."""
+
+    default_params = {"freq": 28.5}
+
+    def build_wires(self):
+        from antennaknobs.network import Wire
+
+        return [
+            Wire((0, -2.5, 7), (0, -0.05, 7), n_seg=10),
+            Wire((0, -0.05, 7), (0, 0.05, 7), n_seg=2, name="feed"),
+            Wire((0, 0.05, 7), (0, 2.5, 7), n_seg=10),
+        ]
+
+    def build_network(self):
+        from antennaknobs.network import Driven, Network, PortOnWire
+
+        return Network(
+            ports={"feed": PortOnWire(name="feed")},
+            sources=[Driven(port="feed")],
+        )
+
+
+def test_network_port_deck(monkeypatch):
+    monkeypatch.setenv("NEC5_EXE", sys.executable)
+    lines = NEC5Engine(_PortDipole()).deck([28.5]).splitlines()
+    ex = [ln for ln in lines if ln.startswith("EX")]
+    assert len(ex) == 1
+    # Voltage source (EX 0) at the feed wire's center knot: tag 2, end 2 of
+    # relative segment 1.
+    assert ex[0].split()[1:5] == ["0", "2", "1", "2"]
+
+
+def test_network_current_source_deck(monkeypatch):
+    from antennaknobs.network import DrivenCurrent, Network, PortOnWire
+
+    monkeypatch.setenv("NEC5_EXE", sys.executable)
+
+    class B(_PortDipole):
+        def build_network(self):
+            return Network(
+                ports={"feed": PortOnWire(name="feed")},
+                sources=[DrivenCurrent(port="feed", current=2j)],
+            )
+
+    lines = NEC5Engine(B()).deck([28.5]).splitlines()
+    ex = [ln for ln in lines if ln.startswith("EX")][0].split()
+    # NEC-5's native current source — EX 4, no NEC-2 counterpart.
+    assert ex[1] == "4"
+    assert float(ex[5]) == 0.0 and float(ex[6]) == 2.0
+
+
+def test_network_refusals(monkeypatch):
+    from antennaknobs.network import (
+        Driven,
+        Load,
+        Network,
+        PortOnWire,
+        PortVirtual,
+    )
+
+    monkeypatch.setenv("NEC5_EXE", sys.executable)
+
+    class Branchy(_PortDipole):
+        def build_network(self):
+            return Network(
+                ports={"feed": PortOnWire(name="feed")},
+                branches=[Load(port="feed", r=50.0)],
+                sources=[Driven(port="feed")],
+            )
+
+    with pytest.raises(NotImplementedError, match="branches"):
+        NEC5Engine(Branchy())
+
+    class Virtual(_PortDipole):
+        def build_network(self):
+            return Network(
+                ports={"v": PortVirtual(name="v")}, sources=[Driven(port="v")]
+            )
+
+    with pytest.raises(NotImplementedError, match="virtual"):
+        NEC5Engine(Virtual())
+
+    class Distributed(_PortDipole):
+        def build_network(self):
+            return Network(
+                ports={"feed": PortOnWire(name="feed", distributed=True)},
+                sources=[Driven(port="feed")],
+            )
+
+    with pytest.raises(NotImplementedError, match="distributed"):
+        NEC5Engine(Distributed())
+
+
+@needs_nec5
+def test_live_network_port_impedance():
+    b = _PortDipole()
+    z5 = NEC5Engine(b).impedance()[0]
+    zm = MomwireEngine(b).impedance()[0]
+    assert abs(z5 - zm) < 10.0
+
+
+@needs_nec5
+def test_live_phased_current_pair():
+    from antennaknobs.network import DrivenCurrent, Network, PortOnWire, Wire
+
+    class PhasedPair(AntennaBuilder):
+        default_params = {"freq": 28.5}
+
+        def build_wires(self):
+            w = []
+            for k, x in enumerate((0.0, 2.63)):
+                w += [
+                    Wire((x, -2.5, 7), (x, -0.05, 7), n_seg=10),
+                    Wire((x, -0.05, 7), (x, 0.05, 7), n_seg=2, name=f"f{k}"),
+                    Wire((x, 0.05, 7), (x, 2.5, 7), n_seg=10),
+                ]
+            return w
+
+        def build_network(self):
+            return Network(
+                ports={
+                    "f0": PortOnWire(name="f0"),
+                    "f1": PortOnWire(name="f1"),
+                },
+                sources=[
+                    DrivenCurrent(port="f0", current=1),
+                    DrivenCurrent(port="f1", current=1j),
+                ],
+            )
+
+    p = PhasedPair()
+    z5s = NEC5Engine(p).impedance()
+    zms = MomwireEngine(p).impedance()
+    assert len(z5s) == 2
+    for a, m in zip(z5s, zms):
+        assert abs(a - m) < 10.0


### PR DESCRIPTION
Stage 4 of #825: the PortOnWire-at-knot mapping. `build_network()` designs now solve on NEC-5:

- **`PortOnWire`** (delta gap at a named wire's middle) → source at the wire's **center knot**, the NEC-5 edge-source spelling of the same physical port NEC-2 engines express as a middle-segment gap.
- **`Driven`** → `EX 0` (volts). **`DrivenCurrent`** → `EX 4` — NEC-5's **native current source**, which NEC-2 lacks entirely (the reducer emulates it there). Captured: `EX 4` reports the identical driving-point Z as `EX 0` on the same port, with the V/I printout columns swapping roles.
- Live gates: single network-fed dipole within 10 Ω of momwire; a 0.25 λ **phased pair under current drive** (1 A / 1j A) holds its ratio with both port impedances within 10 Ω of momwire's Group-2 reducer path.

Refusals: network **branches** (loads land in stage 5), virtual/distributed/floating ports, mixed `Wire.ex` + network excitation.

30 tests pass (12 live behind `$NEC5_EXE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)