### PR TITLE
feat(engines): NEC5Engine stage 5 — Load branches, wire material, power budget (#825)

### DIFF
--- a/src/antennaknobs/engines/nec5.py
+++ b/src/antennaknobs/engines/nec5.py
@@ -27,16 +27,20 @@ pinned by captured printouts committed under ``tests/fixtures/nec5/``
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import tempfile
 from pathlib import Path
 
 import numpy as np
 
+from momwire import insulation_inductance
+
 from ..engine import FarField, SimulationEngine, WireCurrents
 from ..network import (
     Driven,
     DrivenCurrent,
+    Load,
     PortOnWire,
     PortOnWireFloating,
     as_wire,
@@ -119,6 +123,7 @@ class NEC5Engine(SimulationEngine):
         # shape: a source at the named wire's center knot, the NEC-5 spelling
         # of PortOnWire's delta gap at the wire's middle.
         network = builder.build_network()
+        self._loads = []  # (wire_index, Load), filled by the network resolver
         if network is not None:
             self._sources = self._resolve_network_sources(network)
         else:
@@ -137,6 +142,22 @@ class NEC5Engine(SimulationEngine):
         self._radii = [
             w.spec.radius if w.spec is not None else default_radius for w in self._wires
         ]
+        # Wire material (stage 5): the same global LD cards export_nec
+        # emits — conductor loss as LD 5 (bulk conductivity, distributed
+        # over every segment) and the insulation jacket's King quasi-static
+        # series inductance as LD 2 (H/m) — momwire's own L', so the
+        # emulation matches its LD-2 parity work. NEC-5 has NO native
+        # insulated-wire card (the full 3.2/3.3 command roster carries no
+        # IS — NEC-4's card did not survive), so the emulation is the only
+        # route.
+        self._material_lines = []
+        if spec is not None and spec.conductivity is not None:
+            self._material_lines.append(f"LD 5 0 0 0 {_num(spec.conductivity)} 0. 0.")
+        if spec is not None and spec.insulation_radius:
+            l_ins = insulation_inductance(
+                spec.radius, spec.insulation_radius, spec.insulation_eps_r
+            )
+            self._material_lines.append(f"LD 2 0 0 0 0. {_num(l_ins)} 0.")
         if self.ground is not None:
             self._check_geometry_above_ground()
 
@@ -147,23 +168,30 @@ class NEC5Engine(SimulationEngine):
         center knot, ``Driven`` as ``EX 0`` (volts) and ``DrivenCurrent``
         as ``EX 4`` (amps, no NEC-2 counterpart). Branches (loads, lines,
         two-ports) are #825 stage 5+ and refuse here."""
-        if network.branches:
-            raise NotImplementedError(
-                "NEC5Engine does not stamp network branches yet "
-                "(loads are #825 stage 5; lines/two-ports have no NEC-5 "
-                "native cards on this path)"
-            )
+        for br in network.branches:
+            if not isinstance(br, Load):
+                raise NotImplementedError(
+                    f"NEC5Engine cannot stamp a {type(br).__name__} branch "
+                    "(only Load is served natively; lines/two-ports have no "
+                    "NEC-5 native cards on this path)"
+                )
+            if br.ql is not None or br.qc is not None:
+                raise NotImplementedError(
+                    "Load ql/qc (Q-derived series R) is frequency-dependent "
+                    "and has no NEC-5 LD form; spell the loss as an explicit "
+                    "r= at the frequency of interest"
+                )
         by_name = {w.name: i for i, w in enumerate(self._wires) if w.name}
         if any(w.ex is not None for w in self._wires):
             raise ValueError(
                 "design mixes legacy Wire.ex feeds with a build_network() "
                 "spec — use one excitation style"
             )
-        sources = []
-        for src in network.sources:
-            port = network.ports.get(src.port)
+
+        def wire_index(port_name):
+            port = network.ports.get(port_name)
             if port is None:
-                raise ValueError(f"network source names unknown port {src.port!r}")
+                raise ValueError(f"network names unknown port {port_name!r}")
             if isinstance(port, PortOnWireFloating):
                 raise NotImplementedError(
                     "NEC5Engine cannot expose a floating port's second "
@@ -171,26 +199,35 @@ class NEC5Engine(SimulationEngine):
                 )
             if not isinstance(port, PortOnWire):
                 raise NotImplementedError(
-                    f"port {src.port!r} is virtual — NEC5Engine only serves "
+                    f"port {port_name!r} is virtual — NEC5Engine only serves "
                     "ports on real wires"
                 )
             if port.distributed:
                 raise NotImplementedError(
-                    f"port {src.port!r} is distributed (finite gap) — "
+                    f"port {port_name!r} is distributed (finite gap) — "
                     "NEC5Engine only serves delta-gap ports"
                 )
             idx = by_name.get(port.name)
             if idx is None:
                 raise ValueError(
-                    f"port {src.port!r} names wire {port.name!r} which the "
+                    f"port {port_name!r} names wire {port.name!r} which the "
                     "geometry does not carry"
                 )
+            return idx
+
+        sources = []
+        for src in network.sources:
+            idx = wire_index(src.port)
             if isinstance(src, Driven):
                 sources.append((idx, 0, complex(src.voltage)))
             elif isinstance(src, DrivenCurrent):
                 sources.append((idx, 4, complex(src.current)))
             else:
                 raise NotImplementedError(f"unsupported source type {type(src)}")
+        # Loads land at the same center knot as a source on that port —
+        # NEC-5's series-with-the-source semantics (manual, EX card) is
+        # exactly the MNA Driven+Load termination convention.
+        self._loads = [(wire_index(br.port), br) for br in network.branches]
         return sources
 
     # ---------- ground ----------
@@ -302,6 +339,22 @@ class NEC5Engine(SimulationEngine):
         ge_line, gn_lines = self._ground_lines()
         lines.append(ge_line)
         lines.extend(gn_lines)
+        lines.extend(self._material_lines)
+        for idx, br in self._loads:
+            n_seg = self._wires[idx].n_seg
+            # Discrete LD addressing: LDTAGF picks the segment, LDTAGT the
+            # segment END (manual, LD card) — end 2 of the middle segment,
+            # the same center knot the port's source occupies.
+            where = f"{idx + 1} {n_seg // 2} 2"
+            if br.z is not None:
+                z = complex(br.z)
+                lines.append(f"LD 4 {where} {_num(z.real)} {_num(z.imag)} 0.")
+            else:
+                ldtyp = 1 if br.parallel else 0
+                r = float(br.r) if br.r is not None else 0.0
+                el = float(br.l) if br.l is not None else 0.0
+                c = float(br.c) if br.c is not None else 0.0
+                lines.append(f"LD {ldtyp} {where} {_num(r)} {_num(el)} {_num(c)}")
         for idx, ex_type, value in self._sources:
             # Source at end 2 of the middle segment = the wire's center
             # knot (even parity guarantees n_seg is even).
@@ -488,6 +541,66 @@ class NEC5Engine(SimulationEngine):
             thetas=thetas,
             phis=phis,
         )
+
+    @staticmethod
+    def _parse_power_budget(text: str) -> dict:
+        """The POWER BUDGET section as a dict (input_w, radiated_w,
+        wire_loss_w, efficiency_pct). Note the semantics pinned by capture:
+        on a plain XQ run RADIATED = INPUT − WIRE LOSS even over lossy
+        ground — ground absorption only shows through the average-gain
+        route (see average_power_gain)."""
+        try:
+            chunk = text.split("- - - POWER BUDGET - - -", 1)[1]
+        except IndexError:
+            raise NEC5Error("no POWER BUDGET in NEC-5 printout") from None
+        out = {}
+        keys = {
+            "INPUT POWER": "input_w",
+            "RADIATED POWER": "radiated_w",
+            "WIRE LOSS": "wire_loss_w",
+            "EFFICIENCY": "efficiency_pct",
+        }
+        for line in chunk.splitlines()[:10]:
+            for label, key in keys.items():
+                if label in line and "=" in line:
+                    out[key] = float(line.split("=", 1)[1].split()[0])
+        if set(out) != set(keys.values()):
+            raise NEC5Error(f"incomplete POWER BUDGET section: parsed {out}")
+        return out
+
+    def power_budget(self):
+        """Run at the builder's frequency and return the parsed POWER
+        BUDGET (input_w, radiated_w, wire_loss_w, efficiency_pct —
+        conductor efficiency; ground absorption is not in this section)."""
+        return self._parse_power_budget(self._run(self.deck([self.builder.freq])))
+
+    def average_power_gain(self, *, n_theta=18, n_phi=36):
+        """(average power gain, solid angle in steradians) from an RP run
+        with the A-digit set to average-and-suppress (XNDA=0002), sampling
+        the upper hemisphere. Over a lossy ground the average gain is the
+        ground-absorption story the plain power budget cannot tell: a
+        lossless antenna radiating avg*Omega/(4*pi) of its input."""
+        del_theta = 90.0 / n_theta
+        del_phi = 360.0 / n_phi
+        # Sample cell centers so the sector average is honest.
+        lines = self.deck([self.builder.freq]).splitlines()
+        lines = [ln for ln in lines if not ln.startswith("XQ")]
+        rp = (
+            f"RP 0 {n_theta} {n_phi} 0002 {_num(del_theta / 2)} 0.0 "
+            f"{_num(del_theta)} {_num(del_phi)}"
+        )
+        lines.insert(-1, rp)  # before EN
+        text = self._run("\n".join(lines) + "\n")
+        for line in text.splitlines():
+            if "AVERAGE POWER GAIN" in line:
+                toks = line.replace("=", " = ").split()
+                avg = float(toks[toks.index("GAIN") + 2])
+                # "...SOLID ANGLE USED IN AVERAGING=( x.xxxx)*PI STERADIANS"
+                m = re.search(r"AVERAGING=\(\s*([0-9.Ee+-]+)\)\*PI", line)
+                if not m:
+                    raise NEC5Error(f"unparseable solid angle in: {line!r}")
+                return avg, float(m.group(1)) * np.pi
+        raise NEC5Error("no AVERAGE POWER GAIN line in NEC-5 printout")
 
     def _impedances_from(self, rows: list[tuple[int, int, complex]]) -> list[complex]:
         """Match one frequency's AIP rows against this model's feeds, in

--- a/tests/test_nec5_engine.py
+++ b/tests/test_nec5_engine.py
@@ -1,6 +1,6 @@
-"""NEC5Engine (issue #825, stages 1+2): deck writer, grounds, printout
-parsers, and — where a licensed binary is present — live differential
-checks vs momwire.
+"""NEC5Engine (issue #825, stages 1-5): deck writer, grounds, patterns,
+network ports, loads and printout parsers — plus, where a licensed binary
+is present, live differential checks vs momwire.
 
 Parser tests run everywhere, pinned by the captured printouts in
 tests/fixtures/nec5/ (End-User Reports; NEC-5 is (c) LLNL,
@@ -410,15 +410,33 @@ def test_network_refusals(monkeypatch):
     monkeypatch.setenv("NEC5_EXE", sys.executable)
 
     class Branchy(_PortDipole):
+        # A TL branch has no NEC-5 native card on this path (stage 5 serves
+        # Load only) — the refusal names the branch type.
         def build_network(self):
+            from antennaknobs.network import TL, PortVirtual
+
             return Network(
-                ports={"feed": PortOnWire(name="feed")},
-                branches=[Load(port="feed", r=50.0)],
+                ports={
+                    "feed": PortOnWire(name="feed"),
+                    "v": PortVirtual(name="v"),
+                },
+                branches=[TL(a="feed", b="v", z0=50.0, length=1.0)],
                 sources=[Driven(port="feed")],
             )
 
-    with pytest.raises(NotImplementedError, match="branches"):
+    with pytest.raises(NotImplementedError, match="TL"):
         NEC5Engine(Branchy())
+
+    class QLoad(_PortDipole):
+        def build_network(self):
+            return Network(
+                ports={"feed": PortOnWire(name="feed")},
+                branches=[Load(port="feed", l=2e-6, ql=200.0)],
+                sources=[Driven(port="feed")],
+            )
+
+    with pytest.raises(NotImplementedError, match="ql/qc"):
+        NEC5Engine(QLoad())
 
     class Virtual(_PortDipole):
         def build_network(self):
@@ -483,3 +501,125 @@ def test_live_phased_current_pair():
     assert len(z5s) == 2
     for a, m in zip(z5s, zms):
         assert abs(a - m) < 10.0
+
+
+# ------------------------------------------------------- loads and material
+
+
+class _LoadedDipole(_PortDipole):
+    """_PortDipole plus a series 2uH coil load on the feed port wire."""
+
+    def build_network(self):
+        from antennaknobs.network import Driven, Load, Network, PortOnWire
+
+        return Network(
+            ports={"feed": PortOnWire(name="feed")},
+            branches=[Load(port="feed", l=2e-6)],
+            sources=[Driven(port="feed")],
+        )
+
+
+def test_load_deck_lines(monkeypatch):
+    monkeypatch.setenv("NEC5_EXE", sys.executable)
+    lines = NEC5Engine(_LoadedDipole()).deck([28.5]).splitlines()
+    ld = [ln for ln in lines if ln.startswith("LD")]
+    assert len(ld) == 1
+    toks = ld[0].split()
+    # Series RLC (LD 0) at the feed wire's center knot: tag 2, segment 1,
+    # end 2 — the same knot the source occupies (series-with-source
+    # semantics).
+    assert toks[1:5] == ["0", "2", "1", "2"]
+    assert float(toks[6]) == pytest.approx(2e-6)
+
+
+def test_fixed_z_load_deck_line(monkeypatch):
+    from antennaknobs.network import Driven, Load, Network, PortOnWire
+
+    monkeypatch.setenv("NEC5_EXE", sys.executable)
+
+    class B(_PortDipole):
+        def build_network(self):
+            return Network(
+                ports={"feed": PortOnWire(name="feed")},
+                branches=[Load(port="feed", z=50 - 25j)],
+                sources=[Driven(port="feed")],
+            )
+
+    ld = [
+        ln for ln in NEC5Engine(B()).deck([28.5]).splitlines() if ln.startswith("LD")
+    ][0].split()
+    assert ld[1] == "4"
+    assert float(ld[5]) == 50.0 and float(ld[6]) == -25.0
+
+
+def test_material_deck_lines(monkeypatch):
+    from momwire import insulation_inductance
+
+    from antennaknobs.network import WireSpec
+
+    monkeypatch.setenv("NEC5_EXE", sys.executable)
+
+    class Lossy(_Dipole):
+        def build_wire_material(self):
+            return WireSpec(
+                radius=0.0005,
+                conductivity=5.8e7,
+                insulation_radius=0.0009,
+                insulation_eps_r=3.5,
+            )
+
+    lines = NEC5Engine(Lossy()).deck([28.5]).splitlines()
+    ld5 = [ln for ln in lines if ln.startswith("LD 5")]
+    ld2 = [ln for ln in lines if ln.startswith("LD 2")]
+    assert len(ld5) == 1 and len(ld2) == 1
+    assert float(ld5[0].split()[5]) == pytest.approx(5.8e7)
+    # NEC-5 has no native insulated-wire card (no IS in the command
+    # roster) — the jacket rides the same King L' LD 2 emulation momwire
+    # and export_nec use.
+    expected = insulation_inductance(0.0005, 0.0009, 3.5)
+    assert float(ld2[0].split()[6]) == pytest.approx(expected, rel=1e-5)
+
+
+def test_parse_power_budget_fixture():
+    text = (FIXTURES / "invvee_dipole_single.out").read_text()
+    pb = NEC5Engine._parse_power_budget(text)
+    assert pb["efficiency_pct"] == pytest.approx(100.0)
+    assert pb["input_w"] == pytest.approx(pb["radiated_w"])
+    assert pb["wire_loss_w"] == 0.0
+
+
+@needs_nec5
+def test_live_loaded_dipole_matches_momwire():
+    b = _LoadedDipole()
+    z5 = NEC5Engine(b).impedance()[0]
+    zm = MomwireEngine(b).impedance()[0]
+    # Loaded impedances run large; the bar is relative.
+    assert abs(z5 - zm) / abs(zm) < 0.05
+
+
+@needs_nec5
+def test_live_power_budget_lossy_wire():
+    from antennaknobs.network import WireSpec
+
+    class Lossy(_ElevatedDipole):
+        def build_wire_material(self):
+            return WireSpec(radius=0.0005, conductivity=5.8e7)
+
+    pb = NEC5Engine(Lossy()).power_budget()
+    assert 90.0 < pb["efficiency_pct"] < 100.0
+    assert pb["wire_loss_w"] > 0.0
+    assert pb["input_w"] == pytest.approx(
+        pb["radiated_w"] + pb["wire_loss_w"], rel=1e-3
+    )
+
+
+@needs_nec5
+def test_live_average_gain_reads_ground_absorption():
+    # Lossless dipole over lossy Sommerfeld ground: the hemisphere average
+    # power gain must fall below the lossless-over-ground value of 2.0 —
+    # that shortfall IS the ground absorption (the plain power budget
+    # cannot see it: radiated == input on an XQ run, pinned by fixture).
+    e = NEC5Engine(_ElevatedDipole(), ground=("finite", 13.0, 0.005))
+    avg, omega = e.average_power_gain()
+    assert 0.2 < avg < 2.0
+    assert 0.9 * np.pi < omega < 2.1 * np.pi


### PR DESCRIPTION
Stage 5 of #825: loads and loss.

- **`Load` branches stamp natively**: fixed-Z as `LD 4`, series/parallel RLC as `LD 0`/`LD 1`, each at the port wire's center knot (`LDTAGT` is NEC-5's segment-END selector). The manual's load-in-series-with-source semantics is exactly the MNA `Driven`+`Load` termination convention, so the mapping is 1:1. `ql`/`qc` refuse — Q-derived series R is frequency-dependent and has no LD form.
- **Wire material**: `WireSpec.conductivity` → `LD 5`; the insulation jacket rides the same King-L′ `LD 2` emulation momwire and `export_nec` use — because **NEC-5 has no native insulated-wire card** (the complete §3.2/3.3 command roster carries no `IS`; NEC-4's card did not survive). The issue's hoped-for native third insulation oracle is off the table; the emulation is the only route.
- **`power_budget()`** parses INPUT/RADIATED/WIRE LOSS/EFFICIENCY — with the semantics pinned by capture: on an XQ run RADIATED == INPUT even over lossy ground. **`average_power_gain()`** (RP with XNDA A=2) is the route that actually measures ground absorption.

## Live gates
| check | result |
|---|---|
| dipole + 2×2 µH coils vs momwire | 2.1% relative at \|Z\|≈640 Ω |
| copper dipole budget | 98.4% efficiency, input = radiated + wire loss |
| lossless dipole over Sommerfeld | avg gain 1.45 vs lossless 2.0 → 27% ground absorption |

37 tests pass (16 live behind `$NEC5_EXE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)