### PR TITLE
feat(web): NEC-5 as a local-only slot backend, gated on $NEC5_EXE (#825)

### DIFF
--- a/src/antennaknobs/engines/nec5.py
+++ b/src/antennaknobs/engines/nec5.py
@@ -654,8 +654,29 @@ class NEC5Engine(SimulationEngine):
         adjacent segment-center currents; free ends go to zero; junction
         ends carry the adjacent center current."""
         text = self._run(self.deck([self.builder.freq]))
-        per_tag = self._parse_wire_currents(text)[0]
+        return self._currents_from(self._parse_wire_currents(text)[0])
 
+    def solve_snapshot(self):
+        """One binary run serving the whole web-solve contract: impedances,
+        knot currents, and the power budget from a single printout (the
+        separate impedance()/current_distribution() calls each spawn a
+        process — a web solve wants one). Also stamps the duck-typed
+        ``_excited_efficiency`` / ``_excited_p_in`` /
+        ``_excited_power_budget`` attributes the web adapter's budget and
+        efficiency helpers read on every engine."""
+        text = self._run(self.deck([self.builder.freq]))
+        zs = self._impedances_from(self._parse_input_parameters(text)[0])
+        currents = self._currents_from(self._parse_wire_currents(text)[0])
+        budget = self._parse_power_budget(text)
+        self._excited_efficiency = budget["efficiency_pct"] / 100.0
+        self._excited_p_in = budget["input_w"]
+        self._excited_power_budget = [
+            ("Radiated", budget["radiated_w"]),
+            ("Wire loss", budget["wire_loss_w"]),
+        ]
+        return zs, currents, budget
+
+    def _currents_from(self, per_tag):
         def _key(p):
             return tuple(np.round(np.asarray(p, dtype=float), 6))
 

--- a/src/antennaknobs/web/adapter.py
+++ b/src/antennaknobs/web/adapter.py
@@ -79,6 +79,7 @@ except ImportError:
     PyNECEngine = None
     DEFAULT_GROUND = ("finite", 10.0, 0.002)
 from antennaknobs.engines.momwire import MomwireEngine
+from antennaknobs.engines.nec5 import NEC5Engine
 from antennaknobs.terrain import (
     Terrain,
     cliff_terrain,
@@ -281,19 +282,34 @@ _BACKENDS: tuple[_BackendSpec, ...] = (
         panel="pynec",
         default_n_per_wire=21,
     ),
+    # Licensed, user-supplied binary (issue #825): served only when the
+    # machine running the server resolves $NEC5_EXE. The hosted simulator
+    # never defines it, so this entry cannot appear hosted (the #824 EULA's
+    # no-SaaS term); on a personal machine it is the operator's own
+    # licensed use. Same roster-membership availability contract as pynec.
+    _BackendSpec(
+        name="nec5",
+        label="NEC-5",
+        solver=None,
+        kind="nec5",
+        panel="nec5",
+        default_n_per_wire=20,
+    ),
 )
 
 _MOMWIRE_MODELS = {b.name: b.solver for b in _BACKENDS if b.kind == "momwire"}
 
 
-def backend_roster(*, have_pynec: bool) -> list[dict]:
+def backend_roster(*, have_pynec: bool, have_nec5: bool = False) -> list[dict]:
     """The self-describing solver catalog served on GET /capabilities.
 
     Order is list order; the frontend renders its tabs, generic numeric knobs
-    and ground gating straight from this, and selects its two bespoke panels
+    and ground gating straight from this, and selects its bespoke panels
     by the `panel` hint rather than by backend name. Computed per request so
-    the PyNEC entry follows pynec_backend.HAVE_PYNEC.
+    the PyNEC entry follows pynec_backend.HAVE_PYNEC and the NEC-5 entry
+    follows the $NEC5_EXE binary probe.
     """
+    availability = {"pynec": have_pynec, "nec5": have_nec5}
     return [
         {
             "name": b.name,
@@ -317,7 +333,7 @@ def backend_roster(*, have_pynec: bool) -> list[dict]:
             "dense_family": b.dense_family,
         }
         for b in _BACKENDS
-        if b.kind != "pynec" or have_pynec
+        if availability.get(b.kind, True)
     ]
 
 
@@ -1297,6 +1313,37 @@ def _pynec_ground_spec(req: dict):
         # field pynec_solve attaches to the response.
         return ("finite",) + _terrain_from_request(req).crest_medium
     return DEFAULT_GROUND
+
+
+def _nec5_ground_spec(req: dict):
+    """Map the frontend's ground knobs to NEC5Engine's ground spec. NEC-5
+    has no reflection-coefficient model (its IPERF 0 IS full Sommerfeld),
+    so the UI's "fast" request is served by the full Sommerfeld solve and
+    `ground_model_applied` reports "sommerfeld" — the engine's honest
+    upgrade, same convention as a momwire solver falling back to its best
+    available model. Terrain rides the crest-medium hybrid exactly like
+    the PyNEC path."""
+    model = _requested_ground_model(req)
+    if model is None:
+        return None
+    if model == "pec":
+        return "pec"
+    if model == "terrain":
+        return ("finite",) + _terrain_from_request(req).crest_medium
+    # "fast" and "sommerfeld" both land on NEC-5's native Sommerfeld.
+    return DEFAULT_GROUND
+
+
+def _nec5_ground_applied(ground) -> str:
+    if isinstance(ground, tuple) and ground and ground[0] == "finite":
+        return "sommerfeld"
+    if ground == "pec" or (isinstance(ground, tuple) and ground[0] == "pec"):
+        return "pec-image"
+    return "free"
+
+
+def _make_nec5_engine(req: dict, builder):
+    return NEC5Engine(builder, ground=_nec5_ground_spec(req))
 
 
 def _wire_material_results(builder) -> dict:
@@ -2613,6 +2660,122 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
             ]
         return out
 
+    def nec5_solve(req: dict) -> dict:
+        # Mirror pynec_solve through the licensed NEC-5 binary: one
+        # subprocess run serves Z, currents and the power budget
+        # (NEC5Engine.solve_snapshot), and the response shape is identical
+        # so the frontend renders it unchanged.
+        design_freq, meas_freq = _req_freqs(req)
+        builder = _build_builder(cls, req)
+        builder.freq = meas_freq
+        if has_design_freq:
+            builder.design_freq = design_freq
+        plane, planes = _apply_plane(builder, req)
+        eng = _make_nec5_engine(req, builder)
+        t0 = time.perf_counter()
+        zs_raw, currents, _budget = eng.solve_snapshot()
+        zs = [_json_safe_z(z) for z in zs_raw]
+        solve_ms = (time.perf_counter() - t0) * 1e3
+        feed_wire_idx, feed_knot_idx = _pynec_feed_indices(builder, currents)
+        z_primary = zs[0] if zs else complex(0.0, 0.0)
+        finite = isinstance(eng.ground, tuple) and eng.ground[0] == "finite"
+        out = {
+            "geometry": name,
+            "wires": _pack_wires(currents),
+            "feed_wire_index": feed_wire_idx,
+            "feed_knot_index": feed_knot_idx,
+            "feed_position": _pynec_feed_position(builder, currents),
+            "feed_positions": _pynec_feed_positions(
+                builder, currents, hints()["multi_feed"]
+            ),
+            "z_in_re": float(z_primary.real),
+            "z_in_im": float(z_primary.imag),
+            "design_freq_mhz": design_freq,
+            "measurement_freq_mhz": meas_freq,
+            "lambda_design_m": C_LIGHT / (design_freq * 1e6),
+            "solve_ms": solve_ms,
+            "ground": bool(req.get("ground", False)),
+            "height_m": 0.0,
+            "ground_eps_r": eng.ground[1] if finite else _PEC_GROUND_EPS_R,
+            "ground_sigma": eng.ground[2] if finite else _PEC_GROUND_SIGMA,
+            "ground_model_applied": _nec5_ground_applied(eng.ground),
+            "z0_ohms": hints()["target_z0"],
+            "multi_feed": hints()["multi_feed"],
+            "default_view": hints()["default_view"],
+            "radiation_efficiency": float(getattr(eng, "_excited_efficiency", 1.0)),
+            "power_budget": _budget_rows(eng, builder),
+            "input_power_w": float(getattr(eng, "_excited_p_in", None) or 0.0),
+            **_wire_material_results(builder),
+            **_rig_report_results(builder),
+            **_readout_rows_results(builder),
+        }
+        if planes is not None:
+            out["plane"] = plane
+            out["planes"] = planes
+        if _requested_ground_model(req) == "terrain":
+            # Same crest-medium hybrid as the PyNEC path: the engine solved
+            # flat Sommerfeld at the crest constants; the facets enter in
+            # the server's far-field composition via ground_terrain.
+            out["ground_model_applied"] = "terrain"
+            gt = _pack_terrain(_terrain_from_request(req))
+            marker = _terrain_marker(req)
+            if marker:
+                gt["marker"] = marker
+            out["ground_terrain"] = gt
+        if hints()["multi_feed"] and len(zs) > 1:
+            # NEC5Engine._sources is [(wire_idx, ex_type, value)] in feed
+            # order; value is volts for EX 0 and amps for EX 4.
+            values = [v for _i, _t, v in eng._sources]
+            values += [complex(1.0, 0.0)] * (len(zs) - len(values))
+            out["feeds"] = [
+                {
+                    "z_re": float(z.real),
+                    "z_im": float(z.imag),
+                    "v_re": float(v.real),
+                    "v_im": float(v.imag),
+                }
+                for z, v in zip(zs, values)
+            ]
+        return out
+
+    def nec5_pattern(req: dict) -> dict:
+        # Same response contract as pynec_backend.pattern (46 thetas
+        # 0..90 x 73 phis 0..360, gains in dBi), from one RP deck run.
+        design_freq, meas_freq = _req_freqs(req)
+        builder = _build_builder(cls, req)
+        builder.freq = meas_freq
+        if has_design_freq:
+            builder.design_freq = design_freq
+        _apply_plane(builder, req)
+        eng = _make_nec5_engine(req, builder)
+        n_theta, n_phi = 46, 73
+        del_theta = 90.0 / (n_theta - 1)
+        del_phi = 360.0 / (n_phi - 1)
+        t0 = time.perf_counter()
+        text = eng._run(
+            eng.deck([meas_freq], rp=(n_theta, n_phi - 1, del_theta, del_phi))
+        )
+        gains_by_angle = eng._parse_radiation_patterns(text)
+        pattern_ms = (time.perf_counter() - t0) * 1e3
+        thetas = [ti * del_theta for ti in range(n_theta)]
+        phis = [pi * del_phi for pi in range(n_phi)]
+        gains = [
+            [gains_by_angle[(round(th, 2), round(ph, 2))] for ph in phis]
+            for th in thetas
+        ]
+        return {
+            "available": True,
+            "geometry": name,
+            "ground": bool(req.get("ground", False)),
+            "ground_fast": bool(req.get("ground_fast", False)),
+            "height_m": 0.0,
+            "measurement_freq_mhz": meas_freq,
+            "theta_deg": thetas,
+            "phi_deg": phis,
+            "gain_dbi": gains,
+            "pattern_ms": pattern_ms,
+        }
+
     def params_source(req: dict) -> str:
         # Overlay the request's live knob values onto the chosen variant's
         # params (which still carry ui_params and the design's real nesting —
@@ -2807,6 +2970,8 @@ def _make_example(name: str, cls, *, defer_hints: bool = False) -> AntennaExampl
         pynec_solve=pynec_solve,
         pynec_build=pynec_build,
         pynec_pattern_excite=pynec_pattern_excite,
+        nec5_solve=nec5_solve,
+        nec5_pattern=nec5_pattern,
         nec_export=nec_export,
         schematic_svg=schematic_svg,
         params_source=params_source,

--- a/src/antennaknobs/web/examples/_base.py
+++ b/src/antennaknobs/web/examples/_base.py
@@ -328,6 +328,10 @@ class AntennaExample:
     converged_feed_suggested: bool = False
     pynec_build: Optional[PynecBuildFn] = None
     pynec_solve: Optional[SolveFn] = None
+    #: NEC-5 twins (issue #825): same request/response contracts as the
+    #: pynec pair, backed by the user's licensed binary via $NEC5_EXE.
+    nec5_solve: Optional[SolveFn] = None
+    nec5_pattern: Optional[SolveFn] = None
     # Render the geometry as a NEC2 .nec card deck (str) for the current
     # request (params/variant/freq/ground). None when the design has no
     # faithful native-NEC representation (TL/virtual-driver networks).

--- a/src/antennaknobs/web/frontend/src/__tests__/backendFixtures.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/backendFixtures.ts
@@ -89,6 +89,21 @@ export const ROSTER_NO_PYNEC: BackendRoster = SERVED_ROSTER.filter(
   (b) => b.kind !== "pynec",
 );
 
+/** The roster a machine with a licensed NEC-5 binary serves (issue #825):
+ *  the nec5 entry appears only when the server resolves $NEC5_EXE, so the
+ *  DEFAULT SERVED_ROSTER above deliberately omits it — absence is the
+ *  hosted-simulator shape. Python twin pin: test_backend_roster.py. */
+export const ROSTER_WITH_NEC5: BackendRoster = [
+  ...SERVED_ROSTER,
+  backendEntry({
+    name: "nec5",
+    label: "NEC-5",
+    kind: "nec5",
+    panel: "nec5",
+    default_n_per_wire: 20,
+  }),
+];
+
 export function entry(name: string, roster: BackendRoster = SERVED_ROSTER): BackendEntry {
   const found = roster.find((b) => b.name === name);
   if (!found) throw new Error(`no fixture backend named ${name}`);

--- a/src/antennaknobs/web/frontend/src/__tests__/nec5Backend.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/nec5Backend.test.ts
@@ -1,0 +1,29 @@
+// NEC-5 as a served backend (issue #825): the entry rides the same
+// roster-membership availability contract as pynec, with kind "nec5"
+// steering the solver request field and suppressing momwire_model.
+import { describe, expect, it } from "vitest";
+
+import {
+  backendDisplayLabel,
+  defaultOptsFor,
+  findBackend,
+  modelOptionsForRequest,
+} from "../lib/backends";
+import { ROSTER_WITH_NEC5, SERVED_ROSTER } from "./backendFixtures";
+
+describe("nec5 backend entry", () => {
+  it("is absent from the default served roster (hosted shape)", () => {
+    expect(SERVED_ROSTER.some((b) => b.kind === "nec5")).toBe(false);
+  });
+
+  it("resolves by name when served and labels its chip plainly", () => {
+    const b = findBackend(ROSTER_WITH_NEC5, "nec5");
+    expect(b?.kind).toBe("nec5");
+    expect(backendDisplayLabel(b!, defaultOptsFor(b!))).toContain("NEC-5");
+  });
+
+  it("contributes no momwire model options", () => {
+    const b = findBackend(ROSTER_WITH_NEC5, "nec5");
+    expect(modelOptionsForRequest(b!, defaultOptsFor(b!))).toEqual({});
+  });
+});

--- a/src/antennaknobs/web/frontend/src/components/results/StageOverlays.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/StageOverlays.tsx
@@ -304,7 +304,7 @@ export function FarFieldOverlayControls({
           norm check
         </label>
       )}
-      {!isMobile && backend === "pynec" && (
+      {!isMobile && (backend === "pynec" || backend === "nec5") && (
         <label
           className="overlay-checkbox"
           style={

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -719,7 +719,7 @@ function DesignSessionBody({
       _session: sessionId,
       geometry,
       variant: currentVariant,
-      solver: backend.kind === "pynec" ? "pynec" : "momwire",
+      solver: backend.kind === "momwire" ? "momwire" : backend.kind,
       n_per_wire: nPerWire,
       design_freq_mhz: designFreq,
       measurement_freq_mhz: measFreq,
@@ -739,7 +739,7 @@ function DesignSessionBody({
     if (base.ground_model === "terrain") {
       base.terrain = { preset: terrainPreset, ...terrainParams };
     }
-    if (backend.kind !== "pynec") {
+    if (backend.kind === "momwire") {
       base.momwire_model = backend.name;
       const opts = modelOptionsForRequest(backend, currentOpts);
       // Enrichment now solves over ground (momwire #167: PEC image reaction,

--- a/src/antennaknobs/web/frontend/src/components/session/GroundPanel.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/GroundPanel.tsx
@@ -111,7 +111,9 @@ export function GroundPanel({
                         "refl-coef (fast)",
                         backend.name === "pynec"
                           ? "Reflection-coefficient approximation (NEC ITYPE=0), the default. ~2x faster per solve; impedance degrades below ~0.1λ height."
-                          : "Reflection-coefficient model, the default. Fast; matches Sommerfeld above ~0.1λ heights.",
+                          : backend.name === "nec5"
+                            ? "NEC-5 has no reflection-coefficient model (its IPERF 0 is full Sommerfeld) — this choice is served by the full Sommerfeld solve, and the applied-model readout says so."
+                            : "Reflection-coefficient model, the default. Fast; matches Sommerfeld above ~0.1λ heights.",
                       ],
                       [
                         "sommerfeld",

--- a/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
@@ -494,7 +494,7 @@ export function useAnalysisRunners({
     setPattern(null);
     if (
       !autoSim || // Paused holds the engine (issue #612) — no NEC re-solve.
-      backend.name !== "pynec" ||
+      (backend.name !== "pynec" && backend.name !== "nec5") ||
       !active ||
       !necOverlayEnabled ||
       !patternResident || // issue #715: gated on the azimuth/elevation cuts

--- a/src/antennaknobs/web/frontend/src/lib/api.ts
+++ b/src/antennaknobs/web/frontend/src/lib/api.ts
@@ -250,7 +250,7 @@ export type SolveRequest = {
   /** Which `<name>_params` dict on the Builder to seed from. Omitted
    *  → backend falls back to default_params. */
   variant?: string;
-  solver: "momwire" | "pynec";
+  solver: "momwire" | "pynec" | "nec5";
   /** A momwire model name from the served roster (#628) — a plain string,
    *  not a union: the server owns the registry and validates it, and a
    *  third copy of the roster here is exactly the drift #628 removes. */

--- a/src/antennaknobs/web/frontend/src/lib/backends.ts
+++ b/src/antennaknobs/web/frontend/src/lib/backends.ts
@@ -26,9 +26,11 @@ export type BackendOptionField = {
 export type BackendEntry = {
   name: string;
   label: string;
-  /** "pynec" rides the separate `solver: "pynec"` request field and never
-   *  `momwire_model`; everything else is a momwire model name. */
-  kind: "momwire" | "pynec";
+  /** Non-momwire kinds ("pynec", "nec5") ride the `solver` request field
+   *  and never `momwire_model`; everything else is a momwire model name.
+   *  "nec5" appears only when the serving machine resolves $NEC5_EXE — a
+   *  licensed, user-supplied binary (issue #825), never the hosted box. */
+  kind: "momwire" | "pynec" | "nec5";
   supports_ground: boolean;
   options_schema: BackendOptionField[];
   /** Bespoke panel hint — the knobs no numeric renderer can carry. Null for
@@ -370,7 +372,7 @@ export function modelOptionsForRequest(
   b: BackendEntry,
   opts: BackendOpts,
 ): Record<string, unknown> {
-  if (b.kind === "pynec") return {};
+  if (b.kind !== "momwire") return {};
   const out: Record<string, unknown> = {};
   for (const f of b.options_schema) out[f.key] = opts.schema[f.key] ?? f.default;
   if (b.panel === PANEL_BSPLINE) {

--- a/src/antennaknobs/web/nec5_backend.py
+++ b/src/antennaknobs/web/nec5_backend.py
@@ -1,0 +1,62 @@
+"""NEC-5 drop-in backend for the web UI (issue #825 follow-up).
+
+Mirrors the response shape of `web.server`'s momwire solver paths so the
+frontend can swap a slot to NEC-5 via the `solver` request field, exactly
+like the PyNEC backend.
+
+NEC-5 is licensed, user-supplied software: the backend exists in the
+roster only when the serving machine resolves ``$NEC5_EXE`` (see
+`engines.nec5.find_nec5`). The hosted simulator never defines it, so the
+slot chooser can never offer NEC-5 hosted — running a local web instance
+against a personally licensed binary is the supported use, and network
+exposure of that instance is the operator's responsibility. Availability
+is a runtime binary probe, not an import probe, so it is re-checked per
+request (`have_nec5()`), unlike PyNEC's import-time ``HAVE_PYNEC``.
+"""
+
+from __future__ import annotations
+
+from ..engines.nec5 import find_nec5
+from .examples import REGISTRY as EXAMPLES
+
+
+def have_nec5() -> bool:
+    """True when a licensed NEC-5 binary is resolvable right now."""
+    return find_nec5() is not None
+
+
+def solve(req: dict) -> dict:
+    geometry = req.get("geometry", next(iter(EXAMPLES)))
+    ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
+    if ex.nec5_solve is None:
+        raise ValueError(f"NEC-5 solve not implemented for geometry {ex.name!r}")
+    return ex.nec5_solve(req)
+
+
+def pattern(req: dict) -> dict:
+    geometry = req.get("geometry", next(iter(EXAMPLES)))
+    ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
+    if ex.nec5_pattern is None:
+        raise ValueError(f"NEC-5 pattern not implemented for geometry {ex.name!r}")
+    return ex.nec5_pattern(req)
+
+
+def _sweep_at(req: dict, freq_mhz: float) -> complex:
+    """Single-frequency Z, one binary run per point (the streamed sweep
+    endpoints call per-point; NEC5Engine's batched FR stepping is a future
+    optimisation for uniform grids)."""
+    req2 = dict(req)
+    req2["measurement_freq_mhz"] = freq_mhz
+    res = solve(req2)
+    return complex(res["z_in_re"], res["z_in_im"])
+
+
+def _sweep_at_multifeed(req: dict, freq_mhz: float):
+    """(primary_z, per-feed z list) at one frequency — the multi-feed
+    NDJSON contract, same as the PyNEC twin."""
+    req2 = dict(req)
+    req2["measurement_freq_mhz"] = freq_mhz
+    res = solve(req2)
+    primary = complex(res["z_in_re"], res["z_in_im"])
+    feeds_z = [complex(f["z_re"], f["z_im"]) for f in res.get("feeds", [])]
+    return primary, feeds_z

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -43,7 +43,7 @@ from threadpoolctl import threadpool_limits
 from antennaknobs.terrain import Facet, Sector, Terrain, specular_cut
 
 from . import cost as _cost
-from . import pynec_backend, user_designs
+from . import nec5_backend, pynec_backend, user_designs
 from .examples import REGISTRY as EXAMPLES
 from .lane import LaneRegistry, Superseded, cancel_on_disconnect
 from .progress_stream import ProgressStream, ProgressStreamClosed
@@ -1202,7 +1202,19 @@ def _canonical_solve_key(req: dict) -> str:
             return [quantise(v) for v in x]
         return x
 
-    blob = json.dumps(quantise(req), sort_keys=True, default=str).encode()
+    canon = quantise(req)
+    # The RESOLVED backend, not the requested one: a solver the machine
+    # can't serve falls back to momwire, and for NEC-5 availability is a
+    # runtime $NEC5_EXE probe that can differ between requests — caching
+    # under the requested name would serve a momwire fallback as a NEC-5
+    # answer (or vice versa) after the environment changes.
+    backend = _external_backend(req)
+    canon["_resolved_solver"] = (
+        "momwire"
+        if backend is None
+        else ("pynec" if backend is pynec_backend else "nec5")
+    )
+    blob = json.dumps(canon, sort_keys=True, default=str).encode()
     return hashlib.blake2b(blob, digest_size=16).hexdigest()
 
 
@@ -1232,17 +1244,33 @@ def _shed(fn, *args, **kwargs):
         raise exc
 
 
+def _external_backend(req: dict):
+    """The non-momwire backend module a request selects (pynec / nec5), or
+    None for the momwire path. Availability is re-checked here per request;
+    a requested-but-unavailable engine falls back to momwire — the existing
+    pynec contract, which the nec5 entry (a runtime $NEC5_EXE probe, issue
+    #825) inherits."""
+    s = req.get("solver")
+    if s == "pynec" and pynec_backend.HAVE_PYNEC:
+        return pynec_backend
+    if s == "nec5" and nec5_backend.have_nec5():
+        return nec5_backend
+    return None
+
+
 def _solve_uncached(req: dict, cancel=None) -> dict:
     geometry = req.get("geometry", next(iter(EXAMPLES)))
-    use_pynec = req.get("solver") == "pynec" and pynec_backend.HAVE_PYNEC
-    _check_solve_size(req, use_pynec=use_pynec)
-    if use_pynec:
-        # PyNEC start-gate only: a request already superseded before its solve
-        # begins dies for free here; the native solve is one opaque call with no
-        # mid-solve abort, so an in-flight one runs to completion (as today).
+    backend = _external_backend(req)
+    _check_solve_size(req, use_pynec=backend is not None)
+    if backend is not None:
+        # External-engine start-gate only: a request already superseded before
+        # its solve begins dies for free here; the native solve is one opaque
+        # call with no mid-solve abort (PyNEC in-process, NEC-5 a subprocess),
+        # so an in-flight one runs to completion (as today).
         if cancel is not None:
             cancel.raise_if_cancelled()
-        out = pynec_backend.solve(req)
+        out = backend.solve(req)
+        out["solver"] = "pynec" if backend is pynec_backend else "nec5"
     else:
         ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
         out = ex.momwire_solve(req, cancel=cancel)
@@ -1330,8 +1358,9 @@ async def sweep_endpoint(req: dict, request: Request):
         )
     geometry = req.get("geometry", next(iter(EXAMPLES)))
     sweep_ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
-    use_pynec = req.get("solver") == "pynec" and pynec_backend.HAVE_PYNEC
-    solver_name = "pynec" if use_pynec else "momwire"
+    ext_backend = _external_backend(req)
+    use_pynec = ext_backend is not None
+    solver_name = req.get("solver") if use_pynec else "momwire"
     # Admission by cost (issue #382), before the stream starts: over-cap
     # matrix or point count → clean 413 (as before); a dense-family batch on
     # a benchmark-class mesh → 403 unless the request carries the client
@@ -1391,7 +1420,7 @@ async def sweep_endpoint(req: dict, request: Request):
                         async with _LANES.turn(session, lane_kind, lane_gen) as token:
                             if is_multifeed:
                                 primary, feeds_z = await run_in_threadpool(
-                                    _shed, pynec_backend._sweep_at_multifeed, req, f
+                                    _shed, ext_backend._sweep_at_multifeed, req, f
                                 )
                                 cached = (
                                     float(primary.real),
@@ -1401,7 +1430,7 @@ async def sweep_endpoint(req: dict, request: Request):
                                 )
                             else:
                                 z = await run_in_threadpool(
-                                    _shed, pynec_backend._sweep_at, req, f
+                                    _shed, ext_backend._sweep_at, req, f
                                 )
                                 cached = (float(z.real), float(z.imag), None, None)
                             superseded_mid_point = token.cancelled
@@ -1536,12 +1565,12 @@ def _solve_z_only(req: dict, cancel=None) -> tuple[complex, list[complex] | None
     norm) — for the /converge sweep we only need Z(N).
     """
     geometry = req.get("geometry", next(iter(EXAMPLES)))
-    use_pynec = req.get("solver") == "pynec" and pynec_backend.HAVE_PYNEC
-    if use_pynec:
-        # Start-gate only: PyNEC's native solve has no mid-solve abort.
+    backend = _external_backend(req)
+    if backend is not None:
+        # Start-gate only: the external solve has no mid-solve abort.
         if cancel is not None:
             cancel.raise_if_cancelled()
-        res = pynec_backend.solve(req)
+        res = backend.solve(req)
     else:
         ex = EXAMPLES.get(geometry) or next(iter(EXAMPLES.values()))
         res = ex.momwire_solve(req, cancel=cancel)
@@ -1575,8 +1604,8 @@ async def converge_endpoint(req: dict, request: Request):
         raise HTTPException(
             status_code=422, detail="n_values must be a list of integers"
         ) from None
-    use_pynec = req.get("solver") == "pynec" and pynec_backend.HAVE_PYNEC
-    solver_name = "pynec" if use_pynec else "momwire"
+    use_pynec = _external_backend(req) is not None
+    solver_name = req.get("solver") if use_pynec else "momwire"
     # Admission by cost (issue #382): point-count refuse (413) and the
     # poor-match warn (403 without approval). The per-N matrix-size refuse
     # stays inside the loop — est_basis moves with N.
@@ -1642,8 +1671,9 @@ async def converge_endpoint(req: dict, request: Request):
 
 @app.post("/pattern")
 async def pattern_endpoint(req: dict):
-    """NEC's rp_card-computed gain pattern. PyNEC-only."""
-    if req.get("solver") != "pynec" or not pynec_backend.HAVE_PYNEC:
+    """NEC's rp_card-computed gain pattern (PyNEC or NEC-5)."""
+    pat_backend = _external_backend(req)
+    if pat_backend is None:
         return {"available": False}
     # rp_card needs a full NEC solve first, so the hosted matrix-size cap
     # applies here exactly like the /ws solve path.
@@ -1656,7 +1686,7 @@ async def pattern_endpoint(req: dict):
         # PyNEC-only, so the token is a start gate: a queued pattern that a
         # knob drag overtook dies here instead of grinding a stale solve.
         async with _LANES.turn(session, "pattern", lane_gen):
-            return await run_in_threadpool(_shed, pynec_backend.pattern, req)
+            return await run_in_threadpool(_shed, pat_backend.pattern, req)
     except Superseded:
         return {"available": False}
 
@@ -2447,7 +2477,10 @@ def capabilities_endpoint():
 
     return {
         "have_pynec": pynec_backend.HAVE_PYNEC,
-        "backends": backend_roster(have_pynec=pynec_backend.HAVE_PYNEC),
+        "backends": backend_roster(
+            have_pynec=pynec_backend.HAVE_PYNEC,
+            have_nec5=nec5_backend.have_nec5(),
+        ),
         "terrain_presets": terrain_presets_schema(),
     }
 

--- a/tests/test_backend_roster.py
+++ b/tests/test_backend_roster.py
@@ -36,8 +36,8 @@ def client() -> TestClient:
     return TestClient(_server.app)
 
 
-def _roster(have_pynec: bool = True) -> list[dict]:
-    return backend_roster(have_pynec=have_pynec)
+def _roster(have_pynec: bool = True, have_nec5: bool = False) -> list[dict]:
+    return backend_roster(have_pynec=have_pynec, have_nec5=have_nec5)
 
 
 # ---------------------------------------------------------------------------
@@ -60,7 +60,7 @@ def test_momwire_entries_carry_a_solver_class_and_pynec_does_not():
     serve the wrong solver's numbers under the right tab. PyNEC is the one
     entry with no momwire class — it rides `solver: "pynec"`."""
     for spec in _BACKENDS:
-        assert (spec.solver is None) == (spec.kind == "pynec"), spec.name
+        assert (spec.solver is None) == (spec.kind in ("pynec", "nec5")), spec.name
     assert all(cls is not None for cls in _MOMWIRE_MODELS.values())
 
 
@@ -117,7 +117,7 @@ def test_backend_roster_served_shape(client):
     """The catalog the frontend renders its whole solver picker from: order,
     labels, ground support, panel hints and the generic knob schema. Pinned
     here the way the terrain preset catalog is (issue #560)."""
-    roster = _roster()
+    roster = _roster(have_nec5=True)
     assert [e["name"] for e in roster] == [
         "sinusoidal",
         "sinusoidal-galerkin",
@@ -125,6 +125,7 @@ def test_backend_roster_served_shape(client):
         "hmatrix",
         "arrayblock",
         "pynec",
+        "nec5",
     ]
     by_name = {e["name"]: e for e in roster}
     assert [e["label"] for e in roster] == [
@@ -134,6 +135,7 @@ def test_backend_roster_served_shape(client):
         "H-matrix (ACA)",
         "Array-block",
         "PyNEC",
+        "NEC-5",
     ]
     # Every current solver models a ground; the flag exists so a future one
     # that doesn't can say so without a frontend change.
@@ -145,6 +147,7 @@ def test_backend_roster_served_shape(client):
         "hmatrix": "bspline",
         "arrayblock": "bspline",
         "pynec": "pynec",
+        "nec5": "nec5",
     }
     # Generic numeric knobs: only the two sinusoidal bases carry one today —
     # every other backend's knobs are non-numeric (degree tabs, gated
@@ -156,6 +159,7 @@ def test_backend_roster_served_shape(client):
         "hmatrix": [],
         "arrayblock": [],
         "pynec": [],
+        "nec5": [],
     }
     assert by_name["sinusoidal"]["options_schema"][0] == {
         "key": "n_qp_const",
@@ -174,6 +178,9 @@ def test_backend_roster_served_shape(client):
         "hmatrix": 30,
         "arrayblock": 21,
         "pynec": 21,
+        # NEC-5 sources sit at segment ends: an EVEN count puts the feed
+        # knot at the wire's exact middle (issue #825).
+        "nec5": 20,
     }
     # comboInappropriate policy, served as capabilities instead of the
     # frontend's old name lists.
@@ -191,8 +198,12 @@ def test_backend_roster_served_shape(client):
     # mount, exactly like terrain_presets.
     from antennaknobs.web import pynec_backend
 
+    from antennaknobs.web import nec5_backend
+
     served = client.get("/capabilities").json()["backends"]
-    assert served == _roster(have_pynec=pynec_backend.HAVE_PYNEC)
+    assert served == _roster(
+        have_pynec=pynec_backend.HAVE_PYNEC, have_nec5=nec5_backend.have_nec5()
+    )
 
 
 def test_recommendable_backends_are_roster_members():
@@ -222,3 +233,23 @@ def test_adapter_module_import_is_the_one_registry():
     and the existing web tests that import it."""
     assert adapter._MOMWIRE_MODELS is _MOMWIRE_MODELS
     assert _MOMWIRE_MODELS["bspline"].__name__ == "BSplineSolver"
+
+
+def test_nec5_entry_is_gated_on_the_binary_probe_at_request_time(client, monkeypatch):
+    """NEC-5 is licensed, user-supplied software (issue #825): the entry
+    appears exactly when the serving machine resolves $NEC5_EXE — a runtime
+    probe per request, so the hosted simulator (which never defines it) can
+    never offer NEC-5, while a local instance with the env var set always
+    does."""
+    import sys
+
+    assert "nec5" in {e["name"] for e in _roster(have_nec5=True)}
+    assert "nec5" not in {e["name"] for e in _roster(have_nec5=False)}
+
+    monkeypatch.delenv("NEC5_EXE", raising=False)
+    served = client.get("/capabilities").json()
+    assert "nec5" not in {e["name"] for e in served["backends"]}
+
+    monkeypatch.setenv("NEC5_EXE", sys.executable)
+    served = client.get("/capabilities").json()
+    assert "nec5" in {e["name"] for e in served["backends"]}

--- a/tests/test_web_nec5_backend.py
+++ b/tests/test_web_nec5_backend.py
@@ -1,0 +1,97 @@
+"""Unit + live tests for web/nec5_backend.py (issue #825 follow-up).
+
+The delegation layer and availability probe are covered everywhere; the
+end-to-end web solves run only where $NEC5_EXE resolves a licensed binary
+(the same skip contract as the engine tests)."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from antennaknobs.web import server as _server
+
+from antennaknobs.web import nec5_backend  # noqa: E402
+from antennaknobs.web.examples._base import AntennaExample  # noqa: E402
+
+from conftest import needs_nec5
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    return TestClient(_server.app)
+
+
+def test_have_nec5_is_a_runtime_probe(monkeypatch):
+    monkeypatch.delenv("NEC5_EXE", raising=False)
+    assert nec5_backend.have_nec5() is False
+    monkeypatch.setenv("NEC5_EXE", sys.executable)
+    assert nec5_backend.have_nec5() is True
+
+
+def test_solve_raises_when_example_has_no_nec5_solve():
+    stub = AntennaExample(
+        name="stub_no_nec5",
+        label="stub",
+        momwire_solve=lambda req: {},
+        momwire_sweep=lambda req, freqs: ([], []),
+        nec5_solve=None,
+    )
+    with patch.dict(nec5_backend.EXAMPLES, {"stub_no_nec5": stub}, clear=False):
+        with pytest.raises(ValueError, match="NEC-5 solve not implemented"):
+            nec5_backend.solve({"geometry": "stub_no_nec5"})
+
+
+def _ws_solve(client, req: dict) -> dict:
+    import json
+
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text(json.dumps(req))
+        return json.loads(ws.receive_text())
+
+
+def test_unavailable_nec5_falls_back_to_momwire(client, monkeypatch):
+    """A solver:'nec5' request on a machine without the binary takes the
+    momwire path — the existing unavailable-pynec contract."""
+    monkeypatch.delenv("NEC5_EXE", raising=False)
+    res = _ws_solve(client, {"geometry": "dipoles.invvee", "solver": "nec5"})
+    assert res["solver"] == "momwire"
+
+
+@needs_nec5
+def test_live_web_solve_via_nec5(client):
+    res = _ws_solve(client, {"geometry": "dipoles.invvee", "solver": "nec5"})
+    assert res["solver"] == "nec5"
+    assert res["z_in_re"] > 0
+    assert res["wires"] and res["power_budget"] is not None
+    assert 0.0 < res["radiation_efficiency"] <= 1.0
+
+
+@needs_nec5
+def test_live_web_solve_fast_ground_served_as_sommerfeld(client):
+    # NEC-5 has no reflection-coefficient model: the UI's "fast" request is
+    # served by the full Sommerfeld solve and the applied label says so.
+    res = _ws_solve(
+        client,
+        {
+            "geometry": "dipoles.invvee",
+            "solver": "nec5",
+            "ground": True,
+            "ground_model": "fast",
+        },
+    )
+    assert res["solver"] == "nec5"
+    assert res["ground_model_applied"] == "sommerfeld"
+
+
+@needs_nec5
+def test_live_web_pattern_via_nec5(client):
+    res = client.post(
+        "/pattern", json={"geometry": "dipoles.invvee", "solver": "nec5"}
+    ).json()
+    assert res["available"] is True
+    assert len(res["theta_deg"]) == 46 and len(res["phi_deg"]) == 73
+    assert len(res["gain_dbi"]) == 46 and len(res["gain_dbi"][0]) == 73


### PR DESCRIPTION
Follow-up to #825: NEC-5 joins the web workbench's slot A/B/C chooser — **only on machines that resolve `$NEC5_EXE`**.

## Trust model
The roster is computed per request from a runtime binary probe. The Fly machines never define `NEC5_EXE`, so the hosted simulator can never offer NEC-5 (the #824 EULA's no-SaaS term); a local instance against the operator's own licensed binary always does, and network exposure of that instance is the operator's responsibility.

## What lands
- `NEC5Engine.solve_snapshot()`: one subprocess run serves Z + currents + power budget together (three separate calls would spawn three processes per solve).
- `web/nec5_backend.py`: thin delegation twin of `pynec_backend` (solve / pattern / per-point sweeps).
- Adapter: roster entry (`default_n_per_wire` **20** — even, the feed-at-knot parity), per-example `nec5_solve`/`nec5_pattern` closures with the full response contract (budget, efficiency, terrain hybrid, multi-feed `feeds[]`), and the ground mapping: **NEC-5 has no reflection-coefficient model**, so the UI's "fast" choice is served by the full Sommerfeld solve and `ground_model_applied` reports `sommerfeld` (the ground panel tooltip says so too).
- Server: the pynec dispatch boolean generalises to `_external_backend()` across solve/sweep/converge/pattern, and the **solve-cache key carries the resolved backend** — a momwire fallback cached while the binary was absent must not be replayed as a NEC-5 answer after `NEC5_EXE` appears (caught live by the test suite).
- Frontend: `kind` union widened (unknown kinds were *not* graceful — they silently solved as B-spline), solver mapping, NEC pattern overlay + ground tooltips for nec5, roster fixtures with the new variant.

## Tests
59 backend tests green in both modes (binary present/absent), 737 frontend tests + tsc + build green. Live: websocket solve through the real binary, fast-ground-served-as-Sommerfeld label, 46×73 pattern grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)