### PR TITLE
feat(nec_import): detect and refuse the NEC-5 edge-source EX form (#824)

### DIFF
--- a/src/antennaknobs/nec_import.py
+++ b/src/antennaknobs/nec_import.py
@@ -1836,6 +1836,24 @@ def parse_nec(
                     f"{where}: EX excitation type {ex_type} is not a voltage "
                     f"source; antennaknobs can only drive voltage feeds"
                 )
+            # NEC-5 edge-source dialect detection (#824, semantics pinned by
+            # the NEC-5 Users Manual during #825): NEC-5 places a source at a
+            # segment END — I4 = 1/2 picks the end, and with I4 = 0 the SIGN
+            # of I3 does (negative → end 1). NEC-2's EX I4 is a print-control
+            # field instead (legal values 0/1/10/11), so a negative segment
+            # or I4 = 2 can only be the NEC-5 form — refuse it precisely
+            # rather than silently shifting the feed half a segment to the
+            # NEC-2 center-gap reading. I4 = 1 is genuinely ambiguous
+            # (legal NEC-2 print flag) and keeps its NEC-2 meaning.
+            if card.i(2) < 0 or card.i(3) == 2:
+                raise card.error(
+                    "this is the NEC-5 edge-source form (a source at a "
+                    "segment END — I4 selects the end, or a negative "
+                    "segment number selects end 1): antennaknobs' port "
+                    "model has no wire-end port yet, so the feed cannot "
+                    "be represented faithfully (issue #824). NEC5Engine "
+                    "solves such decks directly."
+                )
             feeds_raw.append(
                 (
                     card.i(1),

--- a/tests/test_nec_import_dialects.py
+++ b/tests/test_nec_import_dialects.py
@@ -1,0 +1,45 @@
+"""Dialect-detection tests for nec_import (#824): the NEC-5 edge-source
+EX form must be recognised and refused precisely, never silently misread
+as an NEC-2 center-gap feed."""
+
+import pytest
+
+from antennaknobs.nec_import import parse_nec
+
+
+# --------------------------------------------------------------------------
+# NEC-5 edge-source EX form (#824)
+# --------------------------------------------------------------------------
+
+_EDGE_DECK = """CM nec5 edge source
+CE
+GW 1 20 0 0 -2.5 0 0 2.5 .001
+GE 0
+EX 0 1 {seg} {i4} 1 0
+FR 0 1 0 0 28.5 0
+EN
+"""
+
+
+def test_nec5_edge_source_i4_refuses_precisely():
+    """NEC-5 puts sources at segment ENDS: I4=2 selects end 2 (and is not a
+    legal NEC-2 print-flag value, so it is unambiguous). The importer must
+    refuse with the dialect named — never silently shift the feed half a
+    segment to the NEC-2 center-gap reading (#824)."""
+    with pytest.raises(ValueError, match="NEC-5 edge-source"):
+        parse_nec(_EDGE_DECK.format(seg=10, i4=2))
+
+
+def test_nec5_edge_source_negative_segment_refuses_precisely():
+    """The I4=0 spelling: a NEGATIVE segment number selects end 1."""
+    with pytest.raises(ValueError, match="NEC-5 edge-source"):
+        parse_nec(_EDGE_DECK.format(seg=-10, i4=0))
+
+
+def test_nec2_print_flag_i4_still_imports():
+    """I4=1 is a legal NEC-2 print-control value (and only ambiguously the
+    NEC-5 end-1 form) — it keeps its NEC-2 meaning: the feed imports as the
+    ordinary center gap."""
+    deck = parse_nec(_EDGE_DECK.format(seg=10, i4=1))
+    assert len(deck.feeds) == 1
+    assert deck.feeds[0].seg == 10


### PR DESCRIPTION
Progress on #824 — the research half is done and the silent-misread hole is closed.

## Verification (the issue's three questions, answered during #825)
- **TagElementEdge hypothesis confirmed** from the NEC-5 Users Manual §3.3 (license landed): `EX` I4 = 1/2 is an explicit end selector; with I4 = 0 the **sign of I3** picks (negative → end 1). The 0/N+1 sentinel guess is dead.
- Empirically pinned against the real Linux `nec5cl` during #825 stages 1/4 (captures in `tests/fixtures/nec5/`).

## The importer hole
`parse_nec` never read I4 — correct for NEC-2 (a print-control field, legal values 0/1/10/11) but a NEC-5 edge-source deck was **silently misread as a center-gap feed half a segment away**. Now:
- **negative segment** or **I4 = 2** (never legal NEC-2; exactly what our own `NEC5Engine` writer emits) → precise refusal naming the dialect and pointing at `NEC5Engine`, which solves such decks natively.
- **I4 = 1** (legal NEC-2 print flag, only ambiguously NEC-5's end-1) keeps its NEC-2 meaning — no regression for real NEC-2 decks.

## Left open on #824
The faithful import — a wire-end port in the network model (`PortOnWire` is a mid-wire gap today) — is a real design question worth your steer: whether to grow an end-port type in the network layer, or leave edge-source decks NEC5Engine-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)