### PR TITLE
feat(web): opt-in base-sweep read-through of the per-freq Z cache (#763)

### DIFF
--- a/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
@@ -557,9 +557,18 @@ export function useAnalysisRunners({
       refineEnabled,
     });
 
+    const base = buildRequest();
     const body = {
-      ...buildRequest(),
+      ...base,
       freqs_mhz: freqs,
+      // Opt-in cache read-through (issue #763): a knob scrub back to an
+      // already-swept state may reuse the per-freq Z this session itself
+      // wrote. User designs are excluded — their file can change on disk
+      // under an unchanged request key (the server enforces both gates
+      // again regardless).
+      reuse_cached_z:
+        !String(base.geometry ?? "").startsWith("user.") &&
+        !String(base.geometry ?? "").startsWith("@"),
       // Lane metadata (issue #382): issued-at generation (a newer knob drag
       // supersedes this batch server-side) + the gate's approval, which the
       // server requires for a warned batch (poor-match combo backstop).

--- a/src/antennaknobs/web/server.py
+++ b/src/antennaknobs/web/server.py
@@ -988,6 +988,10 @@ _SOLVE_CACHE_MAX = 100
 # megabyte, and holds ~50 full sweeps of design history.
 _SWEEP_Z_CACHE: "OrderedDict[tuple[str, int], tuple]" = OrderedDict()
 _SWEEP_Z_CACHE_MAX = 4096
+# issue #763: which session last wrote each design's entries. A base sweep
+# may read the cache ONLY back for its own writes (see
+# _base_sweep_may_read_cache) — this map is what "its own" means.
+_SWEEP_Z_WRITER: dict[str, str] = {}
 # Hit/miss counters — observability, and the only honest way to assert "this
 # request performed zero engine solves" in a test.
 _SWEEP_Z_STATS = {"hits": 0, "misses": 0}
@@ -1009,6 +1013,31 @@ def _sweep_design_key(req: dict) -> str:
     otherwise be silently mis-cached.
     """
     return _canonical_solve_key({k: v for k, v in req.items() if k != "freqs_mhz"})
+
+
+def _base_sweep_may_read_cache(req: dict, design_key: str) -> bool:
+    """Issue #763: opt-in read-through for BASE sweeps, so a knob scrub
+    A→B→A stops re-solving the ~41 points the cache already holds.
+
+    Three gates, each preserving a documented ``_SWEEP_Z_CACHE`` property:
+
+    * ``reuse_cached_z`` — the client asserts freshness for its own
+      session (it knows whether the design changed since it last swept);
+    * same-session writer — a session only ever reads back its OWN
+      writes, so two sessions issuing the same sweep still both compute
+      (the #382 lane contract stays testable);
+    * never for user designs — the edited-on-disk exposure stays closed
+      server-side, whatever the client asserts.
+    """
+    if not req.get("reuse_cached_z"):
+        return False
+    geometry = str(req.get("geometry", ""))
+    if geometry.startswith("user.") or geometry.startswith("@"):
+        return False
+    session, _gen = _lane_key(req)
+    if session is None:
+        return False
+    return _SWEEP_Z_WRITER.get(design_key) == session
 
 
 def _sweep_z_get(design_key: str, freq: float) -> tuple | None:
@@ -1148,6 +1177,10 @@ _CACHE_KEY_BLOCKLIST = frozenset(
         # request asks for extra frequencies of the same design, so it has
         # to land on the same per-freq cache entries a base sweep would.
         "_refine",
+        # Base-sweep read-through opt-in (issue #763): pure cache policy —
+        # a refinement request without the flag must land on the same
+        # per-freq entries the flagged base sweep wrote.
+        "reuse_cached_z",
         # Polar-cut angles (issue #547): cuts are attached per-request AFTER
         # the cache, so the cached entry is angle-independent by design.
         # Leaving these in the key meant every cut-dial drag silently
@@ -1380,7 +1413,17 @@ async def sweep_endpoint(req: dict, request: Request):
     # for the same deterministic plan it asked for last time), every sweep
     # writes it. See _SWEEP_Z_CACHE for why the read side is asymmetric.
     design_key = _sweep_design_key(req)
-    read_cache = lane_kind == "sweep_refine"
+    read_cache = lane_kind == "sweep_refine" or _base_sweep_may_read_cache(
+        req, design_key
+    )
+    # Every sweep writes the cache, so record the writing session (checked
+    # first, stamped second: another session's scrub must miss THIS time
+    # and only start hitting once its own sweep has written).
+    _writer_session, _ = _lane_key(req)
+    if _writer_session is not None:
+        _SWEEP_Z_WRITER[design_key] = _writer_session
+        while len(_SWEEP_Z_WRITER) > _SWEEP_Z_CACHE_MAX:
+            _SWEEP_Z_WRITER.pop(next(iter(_SWEEP_Z_WRITER)))
     # Validate the client's solver kwargs up front: this endpoint streams, so
     # an error surfacing mid-generator can't become a clean status code.
     # Imported here (like /optimize's optimizer import): adapter ↔ examples

--- a/tests/test_sweep_cache_readthrough.py
+++ b/tests/test_sweep_cache_readthrough.py
@@ -1,0 +1,85 @@
+"""Opt-in base-sweep read-through of the per-freq Z cache (issue #763).
+
+The cache's two documented properties survive: two sessions issuing the
+same sweep still both compute (a session only reads back its OWN writes),
+and user designs never read through (the edited-on-disk exposure)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from antennaknobs.web import server as _server
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(_server.app)
+
+
+FREQS = [28.0, 28.25, 28.5]
+
+
+def _sweep(client, session: str, *, reuse: bool = True) -> int:
+    """Run one streamed sweep; returns how many points came from the cache
+    (a get is only attempted when read-through is active, so hits are the
+    honest zero-engine-solves count)."""
+    before = dict(_server._SWEEP_Z_STATS)
+    body = {
+        "geometry": "dipoles.invvee",
+        "momwire_model": "bspline",
+        "freqs_mhz": FREQS,
+        "_session": session,
+        "reuse_cached_z": reuse,
+    }
+    with client.stream("POST", "/sweep", json=body) as resp:
+        assert resp.status_code == 200
+        points = [
+            json.loads(line)
+            for line in resp.iter_lines()
+            if line.strip() and not json.loads(line).get("done")
+        ]
+    assert len(points) == len(FREQS)
+    return _server._SWEEP_Z_STATS["hits"] - before["hits"]
+
+
+def test_same_session_scrub_reads_its_own_writes(client):
+    assert _sweep(client, "s763-a") == 0  # first pass computes everything
+    assert _sweep(client, "s763-a") == len(FREQS)  # scrub back: all cached
+
+
+def test_two_sessions_both_compute(client):
+    """The #382 lane contract: a second session issuing the same sweep must
+    compute — it only starts hitting once its OWN sweep has written."""
+    assert _sweep(client, "s763-b1") == 0
+    assert _sweep(client, "s763-b2") == 0  # other session: computes
+    assert _sweep(client, "s763-b2") == len(FREQS)  # its own write serves it
+
+
+def test_without_the_flag_every_sweep_computes(client):
+    assert _sweep(client, "s763-c", reuse=False) == 0
+    assert _sweep(client, "s763-c", reuse=False) == 0  # still no read path
+
+
+def test_gate_refuses_user_designs_and_anonymous_sessions():
+    key = "any-design-key"
+    _server._SWEEP_Z_WRITER[key] = "s763-d"
+    base = {"reuse_cached_z": True, "_session": "s763-d"}
+    assert _server._base_sweep_may_read_cache(
+        dict(base, geometry="dipoles.invvee"), key
+    )
+    # User designs: the file can change on disk under an unchanged key.
+    assert not _server._base_sweep_may_read_cache(
+        dict(base, geometry="user.mydesign"), key
+    )
+    assert not _server._base_sweep_may_read_cache(dict(base, geometry="@deck.nec"), key)
+    # No session identity -> no "own writes" to speak of.
+    assert not _server._base_sweep_may_read_cache(
+        {"reuse_cached_z": True, "geometry": "dipoles.invvee"}, key
+    )
+    # Another session's writes are invisible.
+    assert not _server._base_sweep_may_read_cache(
+        dict(base, _session="s763-other", geometry="dipoles.invvee"), key
+    )


### PR DESCRIPTION
Closes #763 — the design the issue sketched, implemented with each documented `_SWEEP_Z_CACHE` property preserved:

- **`reuse_cached_z` opt-in** from the client (sent for catalog designs, omitted for `user.`/`@file` geometries);
- **same-session writer gate** (`_SWEEP_Z_WRITER`): a session only reads back its own writes, so two sessions issuing the same sweep still both compute — the #382 lane contract, pinned by `test_two_sessions_both_compute`;
- **server-side user-design refusal** regardless of the client's claim — the edited-on-disk exposure stays closed.

`reuse_cached_z` joins the cache-key blocklist (policy, not physics — refinement requests without the flag must land on the flagged base sweep's entries).

Acceptance: `test_same_session_scrub_reads_its_own_writes` — the scrub-back sweep serves every point from cache (asserted via the hit counters, the suite's honest zero-engine-solves measure). 216 web tests + 734 frontend tests + tsc green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)