### PR TITLE
Add a reload button for user designs in the web UI

### DIFF
--- a/src/antennaknobs/web/frontend/src/__tests__/CatalogPanel.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/CatalogPanel.test.tsx
@@ -67,6 +67,7 @@ type PanelOverrides = Partial<{
   examplesError: string | null;
   loadErrors: DesignLoadError[];
   trustBusy: string | null;
+  reloadBusy: boolean;
 }>;
 
 function renderPanel(overrides: PanelOverrides = {}) {
@@ -75,6 +76,7 @@ function renderPanel(overrides: PanelOverrides = {}) {
     setGeometry: vi.fn(),
     selectVariant: vi.fn(),
     trustDesign: vi.fn(),
+    onReloadDesign: vi.fn(),
   };
   const defaultExample = example();
   const props = {
@@ -86,6 +88,7 @@ function renderPanel(overrides: PanelOverrides = {}) {
     examplesError: null,
     loadErrors: [],
     trustBusy: null,
+    reloadBusy: false,
     ...overrides,
     ...spies,
   };
@@ -134,6 +137,47 @@ describe("CatalogPanel — variant select", () => {
     await user.selectOptions(variantSelect()!, "opt");
     expect(selectVariant).toHaveBeenCalledWith("opt");
     expect(selectVariant).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("CatalogPanel — reload button (issue #867)", () => {
+  const reloadButton = () =>
+    screen.queryByRole("button", { name: "reload design file" });
+
+  it("shows the button for a user design", () => {
+    renderPanel({
+      currentExample: example({ name: "user.my_dipole" }),
+      geometry: "user.my_dipole",
+    });
+    expect(reloadButton()).not.toBeNull();
+  });
+
+  it("hides the button for a built-in design", () => {
+    renderPanel(); // dipole.test
+    expect(reloadButton()).toBeNull();
+  });
+
+  it("hides the button when currentExample is undefined", () => {
+    renderPanel({ currentExample: undefined });
+    expect(reloadButton()).toBeNull();
+  });
+
+  it("fires onReloadDesign on click", async () => {
+    const { user, onReloadDesign } = renderPanel({
+      currentExample: example({ name: "user.my_dipole" }),
+      geometry: "user.my_dipole",
+    });
+    await user.click(reloadButton()!);
+    expect(onReloadDesign).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the button while a reload is in flight", () => {
+    renderPanel({
+      currentExample: example({ name: "user.my_dipole" }),
+      geometry: "user.my_dipole",
+      reloadBusy: true,
+    });
+    expect((reloadButton() as HTMLButtonElement).disabled).toBe(true);
   });
 });
 

--- a/src/antennaknobs/web/frontend/src/__tests__/params.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/params.test.ts
@@ -16,6 +16,7 @@ import {
   isGroup,
   linkedMeasFreqFor,
   matchesQuery,
+  mergeSeededDefaults,
   overlaySchemaForVariant,
   seedDefaults,
   setValueAtPath,
@@ -217,6 +218,65 @@ describe("seedDefaults", () => {
       expect(innerInstances).toHaveLength(1);
       expect(innerInstances[0]).toEqual({ x: 1 });
     }
+  });
+});
+
+// --- mergeSeededDefaults (issue #867) ---------------------------------
+
+describe("mergeSeededDefaults", () => {
+  it("keeps existing tuned values over seeded defaults", () => {
+    const out = mergeSeededDefaults({ len: 12.5 }, { len: 9.9 });
+    expect(out).toEqual({ len: 9.9 });
+  });
+
+  it("fills in keys the existing bag lacks (a newly added param)", () => {
+    const out = mergeSeededDefaults({ len: 12.5, gap: 0.1 }, { len: 9.9 });
+    expect(out).toEqual({ len: 9.9, gap: 0.1 });
+  });
+
+  it("returns the existing bag by identity when nothing merged", () => {
+    const existing = { len: 9.9 };
+    expect(mergeSeededDefaults({ len: 12.5 }, existing)).toBe(existing);
+  });
+
+  it("merges a new scalar into existing group instances, keeping tuned values", () => {
+    const seeded = {
+      bands: [
+        { freq: 14.1, q: 5 },
+        { freq: 14.1, q: 5 },
+      ],
+    };
+    const existing = { bands: [{ freq: 7.05 }, { freq: 21.2 }] };
+    const out = mergeSeededDefaults(seeded, existing);
+    expect(out).toEqual({
+      bands: [
+        { freq: 7.05, q: 5 },
+        { freq: 21.2, q: 5 },
+      ],
+    });
+  });
+
+  it("grows a group to the seeded max_repeats, seeding the new instances", () => {
+    const seeded = { bands: [{ freq: 14.1 }, { freq: 14.1 }, { freq: 14.1 }] };
+    const existing = { bands: [{ freq: 7.05 }] };
+    const out = mergeSeededDefaults(seeded, existing);
+    expect(out.bands).toEqual([{ freq: 7.05 }, { freq: 14.1 }, { freq: 14.1 }]);
+  });
+
+  it("shrinks a group to the seeded max_repeats, dropping surplus instances", () => {
+    const seeded = { bands: [{ freq: 14.1 }] };
+    const existing = { bands: [{ freq: 7.05 }, { freq: 21.2 }] };
+    const out = mergeSeededDefaults(seeded, existing);
+    expect(out.bands).toEqual([{ freq: 7.05 }]);
+  });
+
+  it("returns identity when group instances need no merging", () => {
+    const existing = { bands: [{ freq: 7.05 }, { freq: 21.2 }] };
+    const out = mergeSeededDefaults(
+      { bands: [{ freq: 14.1 }, { freq: 14.1 }] },
+      existing,
+    );
+    expect(out).toBe(existing);
   });
 });
 

--- a/src/antennaknobs/web/frontend/src/__tests__/reloadDesign.session.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/reloadDesign.session.test.tsx
@@ -1,0 +1,102 @@
+// The user-design reload button, end to end through a real <DesignSession>
+// (issue #867). The unit pins live in CatalogPanel.test.tsx (visibility
+// gating + click wiring) and params.test.ts (mergeSeededDefaults); what those
+// cannot show is the reload actually reloading: a click re-fetches /examples
+// (the server re-registers user designs on every GET — that fetch IS the
+// reload) and re-runs the /geometry preview for the SAME selected design, and
+// a param the edited file just grew shows up seeded without touching the
+// selection. The solve leg past the preview rides the previewReady release
+// (the design-switch path) and lives on the /ws socket, which setup.ts's
+// InertWebSocket keeps silent — same non-goal as the harness documents.
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { mountDesignSession, HARNESS_EXAMPLE } from "./designSessionHarness";
+import type { ExampleDescriptor, SchemaParamSpec } from "../lib/params";
+
+const GAP_PARAM: SchemaParamSpec = {
+  name: "gap",
+  label: "Gap",
+  default: 0.25,
+  kind: "float",
+  min: 0,
+  max: 1,
+  step: 0.05,
+  precision: 2,
+  unit: null,
+  visible_when: null,
+};
+
+// The same design served twice: as first loaded, and as re-served after an
+// "edit" added the Gap param. Which one /examples returns is the test's knob.
+const USER_EXAMPLE: ExampleDescriptor = {
+  ...HARNESS_EXAMPLE,
+  name: "user.probe",
+  label: "Probe (user file)",
+};
+const USER_EXAMPLE_EDITED: ExampleDescriptor = {
+  ...USER_EXAMPLE,
+  param_schema: [GAP_PARAM],
+};
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("user-design reload (issue #867)", () => {
+  it("re-fetches /examples, re-previews the same design, and seeds a new param", async () => {
+    let examplesCalls = 0;
+    let geometryCalls = 0;
+    mountDesignSession({
+      examples: [USER_EXAMPLE],
+      routes: {
+        "/examples": () => {
+          examplesCalls += 1;
+          // First serve: the design as first loaded. Every later serve: the
+          // edited file, one param richer.
+          return jsonResponse({
+            examples: [examplesCalls === 1 ? USER_EXAMPLE : USER_EXAMPLE_EDITED],
+            errors: [],
+          });
+        },
+        "/geometry": () => {
+          geometryCalls += 1;
+          return jsonResponse({ wires: [] });
+        },
+      },
+    });
+
+    // Catalog resolved, the user design auto-selected, the button gated in.
+    const reload = await screen.findByRole("button", {
+      name: "reload design file",
+    });
+    expect(examplesCalls).toBe(1);
+    // The design-switch preview for the auto-selected design.
+    await waitFor(() => expect(geometryCalls).toBe(1));
+    expect(screen.queryByText("Gap")).toBeNull();
+
+    await userEvent.setup().click(reload);
+
+    // The reload re-fetched the catalog and re-ran the preview effect for the
+    // same (still-selected) geometry.
+    await waitFor(() => expect(examplesCalls).toBe(2));
+    await waitFor(() => expect(geometryCalls).toBe(2));
+
+    // The param the edit added rendered, seeded from its schema default —
+    // merge-seed, not the old skip-if-seen (which would leave the bag without
+    // a `gap` entry).
+    const gapLabel = await screen.findByText("Gap");
+    expect(gapLabel).toBeTruthy();
+    const slider = screen.getByRole("slider", { name: "Gap" });
+    expect(slider.getAttribute("aria-valuenow")).toBe("0.25");
+  });
+});

--- a/src/antennaknobs/web/frontend/src/components/session/CatalogPanel.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/CatalogPanel.tsx
@@ -18,6 +18,8 @@ export function CatalogPanel({
   loadErrors,
   trustBusy,
   trustDesign,
+  onReloadDesign,
+  reloadBusy,
 }: {
   geomGroups: ExampleGroup[];
   geometry: string;
@@ -31,6 +33,8 @@ export function CatalogPanel({
   loadErrors: DesignLoadError[];
   trustBusy: string | null;
   trustDesign: (stem: string, allowEdits: boolean) => void;
+  onReloadDesign: () => void;
+  reloadBusy: boolean;
 }) {
   return (
     <>
@@ -43,6 +47,18 @@ export function CatalogPanel({
           setFilter={setGeomFilter}
           onSelect={setGeometry}
         />
+        {currentExample?.name.startsWith("user.") && (
+          <button
+            type="button"
+            className="design-reload-btn"
+            onClick={onReloadDesign}
+            disabled={reloadBusy}
+            aria-label="reload design file"
+            title="Reload this design file from disk and re-solve (trust it in “always” mode so edits keep loading)"
+          >
+            ⟳
+          </button>
+        )}
         {currentExample && currentExample.variants.length > 1 && (
           <select
             id="variant-select"

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -1,4 +1,11 @@
-import { useContext, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   backendAllowed,
   backendDisplayLabel,
@@ -175,7 +182,27 @@ function DesignSessionBody({
     loadErrors,
     trustBusy,
     trustDesign,
+    reloadCatalog,
   } = useDesignCatalog({ geometry, setGeometry, setParamValues });
+
+  // Reload the selected user design from disk (issue #867). Re-fetching
+  // /examples makes the server re-register user designs; bumping the nonce
+  // re-runs the preview effect below for the SAME geometry, and its
+  // previewReady release then re-fires the live solve — exactly the design-
+  // switch path, minus the selection change. Load errors and awaiting-trust
+  // states ride along on the same fetch, so a broken edit surfaces in the
+  // usual panels.
+  const [reloadNonce, setReloadNonce] = useState(0);
+  const [reloadBusy, setReloadBusy] = useState(false);
+  const reloadDesigns = useCallback(async () => {
+    setReloadBusy(true);
+    try {
+      await reloadCatalog();
+      setReloadNonce((n) => n + 1);
+    } finally {
+      setReloadBusy(false);
+    }
+  }, [reloadCatalog]);
 
   const currentExample = examples.find((e) => e.name === geometry);
   // currentValues is deliberately a fresh reference whenever paramValues[geometry]
@@ -1231,7 +1258,8 @@ function DesignSessionBody({
           setPreview(data as SolveResponse);
           // A deferred (user) design derives its natural view only when the
           // builder first runs — which is this preview. Snap the camera to it
-          // here, once per selection (this effect is keyed on `geometry`).
+          // here, once per selection or user-design reload (this effect is
+          // keyed on `geometry` + `reloadNonce`).
           const dv = (data as SolveResponse).default_view;
           if (dv) setCameraProjection(dv);
         }
@@ -1246,8 +1274,11 @@ function DesignSessionBody({
         if (!controller.signal.aborted) setPreviewReady(forGeometry);
       });
     return () => controller.abort();
+    // reloadNonce (issue #867): a user-design reload re-runs this full
+    // switch path for the same geometry — fresh preview from the re-loaded
+    // builder, gate reset, then the live solve re-fires on release.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [geometry]);
+  }, [geometry, reloadNonce]);
 
   // The four background analyses (#642 seam 5b-3): freq sweep, convergence
   // sweep, far-field norm check and the NEC rp_card pattern. Called here, at
@@ -1343,6 +1374,8 @@ function DesignSessionBody({
           loadErrors={loadErrors}
           trustBusy={trustBusy}
           trustDesign={trustDesign}
+          onReloadDesign={reloadDesigns}
+          reloadBusy={reloadBusy}
         />
 
         {currentExample && (

--- a/src/antennaknobs/web/frontend/src/components/session/useDesignCatalog.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useDesignCatalog.ts
@@ -6,6 +6,7 @@ import {
   type SetStateAction,
 } from "react";
 import {
+  mergeSeededDefaults,
   seedDefaults,
   type ExampleDescriptor,
   type ParamValueBag,
@@ -49,12 +50,16 @@ export function useDesignCatalog({
       setLoadErrors(Array.isArray(j.errors) ? j.errors : []);
       // Walk each example's schema and pre-seed defaults — including
       // pre-allocated group instance arrays — so the sliders have
-      // something to render against on first show.
+      // something to render against on first show. Designs already seen
+      // merge-seed instead (issue #867): tuned values survive, but params
+      // an edited user design just grew get their defaults filled in.
       setParamValues((prev) => {
         const next = { ...prev };
         for (const ex of list) {
-          if (next[ex.name]) continue;
-          next[ex.name] = seedDefaults(ex.param_schema);
+          const seeded = seedDefaults(ex.param_schema);
+          next[ex.name] = next[ex.name]
+            ? mergeSeededDefaults(seeded, next[ex.name])
+            : seeded;
         }
         return next;
       });
@@ -124,5 +129,8 @@ export function useDesignCatalog({
     loadErrors,
     trustBusy,
     trustDesign,
+    // For the user-design reload button (issue #867): the server re-registers
+    // user designs on every GET /examples, so a bare re-fetch IS the reload.
+    reloadCatalog: loadExamples,
   };
 }

--- a/src/antennaknobs/web/frontend/src/lib/params.ts
+++ b/src/antennaknobs/web/frontend/src/lib/params.ts
@@ -296,6 +296,40 @@ export function seedDefaults(
   return out;
 }
 
+// Overlay freshly seeded defaults UNDER an existing bag (issue #867): tuned
+// values always win; only keys the bag lacks — a param the design's author
+// just added, seen when reloading an edited user design — take the seeded
+// default. Group instance arrays merge per index, so a new scalar inside an
+// existing group instance lands too; a shrunk max_repeats drops the surplus
+// instances with it. Returns `existing` by identity when nothing merged, so
+// unchanged bags don't churn state identity on every /examples fetch.
+export function mergeSeededDefaults(
+  seeded: ParamValueBag,
+  existing: ParamValueBag,
+): ParamValueBag {
+  let changed = false;
+  const out: ParamValueBag = { ...existing };
+  for (const [key, seedVal] of Object.entries(seeded)) {
+    const cur = existing[key];
+    if (cur === undefined) {
+      out[key] = seedVal;
+      changed = true;
+    } else if (Array.isArray(seedVal) && Array.isArray(cur)) {
+      const merged = seedVal.map((inst, i) =>
+        cur[i] !== undefined ? mergeSeededDefaults(inst, cur[i]) : inst,
+      );
+      if (
+        merged.length !== cur.length ||
+        merged.some((m, i) => m !== cur[i])
+      ) {
+        out[key] = merged;
+        changed = true;
+      }
+    }
+  }
+  return changed ? out : existing;
+}
+
 // Walk the schema collecting (param, value) pairs for every leaf marked
 // `linked_to_design_freq`. Fan_dipole's first band's freq is the
 // canonical example: when it changes, the global design frequency

--- a/src/antennaknobs/web/frontend/src/styles.css
+++ b/src/antennaknobs/web/frontend/src/styles.css
@@ -832,6 +832,29 @@ button:focus-visible,
   padding: var(--space-4) var(--space-3);
 }
 
+/* Reload the selected user design file from disk (issue #867). Only rendered
+   for user.* designs, inline in the antenna row after the picker; same chrome
+   as .geometry-select so the row reads as one control strip. */
+.design-reload-btn {
+  flex: 0 0 auto;
+  padding: 0 var(--space-3);
+  font: inherit;
+  font-size: var(--text-base);
+  line-height: 1;
+  background: var(--inset);
+  color: var(--fg);
+  border: 1px solid var(--border-control);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+}
+.design-reload-btn:hover:not(:disabled) {
+  border-color: var(--border-hover);
+}
+.design-reload-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 .geometry-filter-hint {
   color: var(--muted);
   font-family: var(--font-mono);


### PR DESCRIPTION
## Summary
- Adds a ⟳ button next to the design picker, shown only when the selected design is a user design (`user.*`), that reloads the design file from disk without a page refresh (closes #867)
- The button re-fetches `/examples` (the server re-registers user designs on every GET), then bumps a nonce that re-runs the preview effect for the same geometry; the `previewReady` release re-fires the live solve — the existing design-switch path, minus the selection change
- Catalog seeding switches from skip-if-seen to merge-seed (`mergeSeededDefaults`): tuned slider values always survive, while params an edit just added get their schema defaults, top-level or inside existing group instances; bag identity is preserved when nothing merges
- Broken edits surface through the existing load-error / awaiting-trust panels, which ride along on the same fetch

## Test plan
- [x] `mergeSeededDefaults` unit tests: tuned-wins, new-key seeding, per-instance group merge, grow/shrink to `max_repeats`, identity preservation (params.test.ts)
- [x] CatalogPanel tests: button gated to `user.*` designs, hidden for built-ins/undefined, click wiring, disabled while in flight (CatalogPanel.test.tsx)
- [x] Session-level test through the real `<DesignSession>`: click → `/examples` re-fetch → `/geometry` re-preview for the same design → newly added param renders seeded at its default (reloadDesign.session.test.tsx)
- [x] Full frontend lane: `tsc --noEmit`, eslint (0 errors), vitest 54 files / 747 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)