### PR TITLE
Draw sweep traces as dots while refining, connect only once settled

### DIFF
--- a/src/antennaknobs/web/frontend/src/__tests__/useAnalysisRunners.refine.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/useAnalysisRunners.refine.test.tsx
@@ -333,3 +333,74 @@ describe("adaptive sweep refinement (issue #744)", () => {
     expect(refineBodies()).toHaveLength(0);
   });
 });
+
+// What the charts key dots-vs-polyline on (issue #866): a sweep is settled
+// only when its rendered shape is final. The transitions pinned here are the
+// contract viewRegistry consumes; the planner's own criterion stays pinned
+// in refine.test.ts.
+describe("sweep settledness (issue #866)", () => {
+  it("is unsettled from the base sweep under refinement until the pass concludes", async () => {
+    const { result } = renderRunners(BASE);
+    await settle();
+    // Base sweep streamed, refinement still owed (dwell pending): the lean
+    // grid is provisional — a polyline through it would kink and shift.
+    expect(result.current.sweepSettled).toBe(false);
+    await settle(500, 400); // run every round it wants to conclusion
+    expect(refineBodies().length).toBeGreaterThan(0);
+    expect(result.current.sweepSettled).toBe(true);
+  });
+
+  it("stays settled throughout when refinement is disabled (the dense grid IS the shape)", async () => {
+    const { result } = renderRunners({ ...BASE, refineEnabled: false });
+    await settle();
+    expect(result.current.sweepSettled).toBe(true);
+    await settle();
+    await settle();
+    expect(result.current.sweepSettled).toBe(true);
+  });
+
+  it("a smooth sweep settles via the empty plan, without spending a solve", async () => {
+    fetchMock.mockImplementation((url: string, init?: { body?: string }) => {
+      if (url !== "/sweep")
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      const body = JSON.parse(init?.body ?? "{}");
+      sweepBodies.push(body);
+      const freqs: number[] = body.freqs_mhz ?? [];
+      return ndjson(
+        freqs.map((f) => JSON.stringify({ freq_mhz: f, z_re: 50, z_im: 0 })),
+      );
+    });
+    const { result } = renderRunners(BASE);
+    await settle();
+    expect(result.current.sweepSettled).toBe(false);
+    await settle();
+    expect(refineBodies()).toHaveLength(0);
+    expect(result.current.sweepSettled).toBe(true);
+  });
+
+  it("toggling refinement off mid-run leaves the sweep unsettled — dots, not a faked line", async () => {
+    const { result, rerender } = renderRunners(BASE);
+    await settle();
+    expect(result.current.sweepSettled).toBe(false);
+    // The user switches adaptive resolution off before the pass concludes.
+    rerender({ ...BASE, refineEnabled: false });
+    await settle(500, 400);
+    // The accumulated set is uneven; it never settles, so the charts keep
+    // rendering honest dots instead of a polyline through it.
+    expect(result.current.sweepSettled).toBe(false);
+  });
+
+  it("a knob change mid-refinement hands settledness to the superseding sweep", async () => {
+    const { result, rerender } = renderRunners(BASE);
+    await settle();
+    await settle(500, 400);
+    expect(result.current.sweepSettled).toBe(true);
+    // New knob state: a fresh lean base sweep begins — provisional again —
+    // and its own refinement pass settles it.
+    rerender({ ...BASE, req: { geometry: "g", length_factor: 1.01 } });
+    await settle();
+    expect(result.current.sweepSettled).toBe(false);
+    await settle(500, 400);
+    expect(result.current.sweepSettled).toBe(true);
+  });
+});

--- a/src/antennaknobs/web/frontend/src/__tests__/viewRegistry.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/viewRegistry.test.tsx
@@ -165,6 +165,34 @@ describe("dispatch", () => {
     expect(mount("antenna").querySelector(".viewport-fit")).not.toBeNull();
   });
 
+  it("keys the smith trail on refinement enabled AND settled (issue #866)", () => {
+    const connect = (o: Partial<React.ComponentProps<typeof ViewPanel>>) =>
+      mount("smith", o).querySelector("canvas.smith")!.getAttribute("data-connect");
+    // Refinement disabled (or omitted, the thumbnail case): dot cloud, as
+    // before #744 — regardless of settledness (the refinement-disabled
+    // rendering path must not change).
+    expect(connect({})).toBe("0");
+    expect(connect({ refineEnabled: false, sweepSettled: true })).toBe("0");
+    // Enabled + settled (or settledness omitted): the connected locus.
+    expect(connect({ refineEnabled: true })).toBe("1");
+    expect(connect({ refineEnabled: true, sweepSettled: true })).toBe("1");
+    // Enabled but still refining: dots — no polyline through a set whose
+    // points are still landing.
+    expect(connect({ refineEnabled: true, sweepSettled: false })).toBe("0");
+    // Toggled off mid-run (enabled false, unsettled): still dots.
+    expect(connect({ refineEnabled: false, sweepSettled: false })).toBe("0");
+  });
+
+  for (const view of ["gamma", "vswr"] as const) {
+    it(`passes settledness through to the ${view} chart (issue #866)`, () => {
+      const settledAttr = (o: Partial<React.ComponentProps<typeof ViewPanel>>) =>
+        mount(view, o).querySelector(MARKERS[view])!.getAttribute("data-settled");
+      expect(settledAttr({})).toBe("1"); // omitted: settled, today's line
+      expect(settledAttr({ sweepSettled: true })).toBe("1");
+      expect(settledAttr({ sweepSettled: false })).toBe("0");
+    });
+  }
+
   it("passes the schematic view its own props", () => {
     const svg = '<svg viewBox="0 0 10 10"><path d="M 0,0 L 10,10" /></svg>';
     expect(mount("schematic", { schematicSvg: svg }).innerHTML).toContain("viewBox");

--- a/src/antennaknobs/web/frontend/src/components/charts/SmithChart.tsx
+++ b/src/antennaknobs/web/frontend/src/components/charts/SmithChart.tsx
@@ -614,5 +614,10 @@ export function SmithChart({
     // leave the last trial ring on screen after a run settled.
   }, [r, x, z0, size, sweep, converge, measured, measFreqMhz, running, convergeRunning, feeds, multiFeed, connectSweep, trial, theme]);
 
-  return <canvas ref={canvasRef} className="smith" />;
+  // data-connect mirrors the trail mode (locus vs. dot cloud) for tests —
+  // canvas pixels are invisible to jsdom, the attribute is not (the same
+  // seam SweepChart's data-* attributes provide).
+  return (
+    <canvas ref={canvasRef} className="smith" data-connect={connectSweep ? "1" : "0"} />
+  );
 }

--- a/src/antennaknobs/web/frontend/src/components/charts/SweepChart.tsx
+++ b/src/antennaknobs/web/frontend/src/components/charts/SweepChart.tsx
@@ -42,6 +42,7 @@ export function SweepChart({
   sweep,
   measFreqMhz,
   running,
+  settled = true,
   feeds,
   multiFeed,
 }: {
@@ -53,6 +54,12 @@ export function SweepChart({
   sweep: SweepData | null;
   measFreqMhz: number;
   running: boolean;
+  /** The sweep's shape is final (issue #866). While a refinement pass is
+   *  still inserting points (or was cut short mid-run), the trail renders as
+   *  unconnected dots — a polyline through a still-densifying set draws
+   *  transient kinks that then shift as points land. Defaults true so
+   *  refinement-free call sites keep today's connected line. */
+  settled?: boolean;
   /** Multi-feed geometries pass the per-feed Z list from the latest solve so
    *  the chart can mark N current points, one per port (same prop SmithChart
    *  takes for the same reason). */
@@ -198,21 +205,41 @@ export function SweepChart({
       // dim = sweep trail, bright = current-Z marker). Unlike the Smith
       // chart's 2-D Γ-plane locus, frequency is a natural ordering axis
       // here, so — unlike that chart's unconnected scatter — a connected
-      // line is the correct read, not an artifact of interpolation.
+      // line is the correct read, not an artifact of interpolation. Except
+      // while refinement is still densifying the set (issue #866): then the
+      // line's kinks are transients about to shift, so draw honest dots and
+      // connect only once `settled`.
       for (let fi = 0; fi < nFeeds; fi++) {
-        ctx.strokeStyle = feedSweepColor(fi);
-        ctx.lineWidth = 1.3;
-        ctx.beginPath();
-        let started = false;
-        for (let i = 0; i < freqs.length; i++) {
-          const z = zAt(fi, i);
-          const v = valueFor(mode, z.re, z.im, z0);
-          const px = xOf(freqs[i]);
-          const py = offScale(v) ? marginT : yOf(v);
-          if (!started) { ctx.moveTo(px, py); started = true; }
-          else ctx.lineTo(px, py);
+        if (settled) {
+          ctx.strokeStyle = feedSweepColor(fi);
+          ctx.lineWidth = 1.3;
+          ctx.beginPath();
+          let started = false;
+          for (let i = 0; i < freqs.length; i++) {
+            const z = zAt(fi, i);
+            const v = valueFor(mode, z.re, z.im, z0);
+            const px = xOf(freqs[i]);
+            const py = offScale(v) ? marginT : yOf(v);
+            if (!started) { ctx.moveTo(px, py); started = true; }
+            else ctx.lineTo(px, py);
+          }
+          ctx.stroke();
+        } else {
+          // Same dot radius as SmithChart's unconnected trail, same color
+          // grammar (off-scale samples still get the pinned-needle tick
+          // below, not a dot on the frame).
+          ctx.fillStyle = feedSweepColor(fi);
+          for (let i = 0; i < freqs.length; i++) {
+            const z = zAt(fi, i);
+            const v = valueFor(mode, z.re, z.im, z0);
+            if (offScale(v)) continue;
+            const px = xOf(freqs[i]);
+            const py = yOf(v);
+            ctx.beginPath();
+            ctx.arc(px, py, 1.5, 0, 2 * Math.PI);
+            ctx.fill();
+          }
         }
-        ctx.stroke();
 
         // Off-scale samples get an upward tick at the top edge instead of a
         // dot sitting exactly on the frame — a real VSWR meter's pinned
@@ -292,13 +319,14 @@ export function SweepChart({
     // memoization this dep array exists for. mode is listed directly since
     // it's the one prop dom/valueFor key off that isn't otherwise present.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mode, r, x, z0, size, sweep, measFreqMhz, running, feeds, multiFeed, theme]);
+  }, [mode, r, x, z0, size, sweep, measFreqMhz, running, settled, feeds, multiFeed, theme]);
 
   return (
     <canvas
       ref={canvasRef}
       className={`sweep sweep-${mode}`}
       data-mode={mode}
+      data-settled={settled ? "1" : "0"}
       data-points={hasSweep ? sweep!.freqs_mhz.length : 0}
       data-feeds={nFeeds}
       data-y-values={traceY.map((v) => v.toFixed(4)).join(",")}

--- a/src/antennaknobs/web/frontend/src/components/results/viewRegistry.tsx
+++ b/src/antennaknobs/web/frontend/src/components/results/viewRegistry.tsx
@@ -41,6 +41,12 @@ export type ViewRenderProps = {
    *  frequency-sorted samples finally support one). Optional: thumbnail
    *  call sites omit it and keep the dot trail. */
   refineEnabled?: boolean;
+  /** The sweep's shape is final (issue #866): no refinement pass is running
+   *  or was cut short. While false, the sweep-trace views (smith / vswr /
+   *  gamma) draw unconnected dots — a polyline through a still-densifying
+   *  set renders transient kinks that shift as points land. Optional so
+   *  thumbnail call sites can omit it (defaults settled, today's look). */
+  sweepSettled?: boolean;
   // A trial impedance to plot INSTEAD of `result`'s, while something drives
   // the design faster than the solve channel can follow — today the streamed
   // optimizer (#773), whose per-eval frames carry Z but do not touch the
@@ -126,7 +132,7 @@ export const VIEW_RENDERERS: Record<View, (p: ViewRenderProps) => ReactElement> 
       convergeRunning={p.convergeRunning}
       feeds={p.result?.feeds}
       multiFeed={p.multiFeed}
-      connectSweep={p.refineEnabled ?? false}
+      connectSweep={(p.refineEnabled ?? false) && (p.sweepSettled ?? true)}
     />
   ),
   schematic: (p) => (
@@ -151,6 +157,7 @@ export const VIEW_RENDERERS: Record<View, (p: ViewRenderProps) => ReactElement> 
       sweep={p.sweep}
       measFreqMhz={p.measFreqMhz}
       running={p.sweepRunning}
+      settled={p.sweepSettled ?? true}
       feeds={p.result?.feeds}
       multiFeed={p.multiFeed}
     />
@@ -165,6 +172,7 @@ export const VIEW_RENDERERS: Record<View, (p: ViewRenderProps) => ReactElement> 
       sweep={p.sweep}
       measFreqMhz={p.measFreqMhz}
       running={p.sweepRunning}
+      settled={p.sweepSettled ?? true}
       feeds={p.result?.feeds}
       multiFeed={p.multiFeed}
     />

--- a/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
+++ b/src/antennaknobs/web/frontend/src/components/session/DesignSession.tsx
@@ -1284,8 +1284,15 @@ function DesignSessionBody({
   // sweep, far-field norm check and the NEC rp_card pattern. Called here, at
   // the debounce effects' old position, so all four keep their global order
   // behind the solve and preview effects above.
-  const { sweep, sweepRunning, converge, convergeRunning, normCheck, pattern } =
-    useAnalysisRunners({
+  const {
+    sweep,
+    sweepRunning,
+    sweepSettled,
+    converge,
+    convergeRunning,
+    normCheck,
+    pattern,
+  } = useAnalysisRunners({
       backend,
       currentVariant,
       currentExample,
@@ -1649,6 +1656,7 @@ function DesignSessionBody({
             multiFeed={effectiveMultiFeed}
             fineNorm={normCheck?.pattern_norm ?? null}
             refineEnabled={refineEnabled}
+            sweepSettled={sweepSettled}
             schematicSvg={schematicSvg}
             schematicUnavailable={schematicUnavailable}
           />
@@ -1810,6 +1818,7 @@ function DesignSessionBody({
                       pinnedPatterns={[]}
                       measFreqMhz={measFreq}
                       sweepRunning={sweepRunning}
+                      sweepSettled={sweepSettled}
                       convergeRunning={convergeRunning}
                       azElevDeg={azElevDeg}
                       elevAzDeg={elevAzDeg}

--- a/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
+++ b/src/antennaknobs/web/frontend/src/components/session/useAnalysisRunners.ts
@@ -241,6 +241,16 @@ export function useAnalysisRunners({
 
   const [sweep, setSweep] = useState<SweepData | null>(null);
   const [sweepRunning, setSweepRunning] = useState(false);
+  // Whether the current sweep's shape is final (issue #866). False from the
+  // moment a base sweep starts under refinement (its lean grid is destined
+  // to be densified — a polyline through it would draw the transient kinks
+  // refinement exists to remove) until a refinement pass concludes on its
+  // own terms (plan empty or budget spent). Toggling refinement off mid-run
+  // deliberately does NOT settle: the accumulated set is uneven, so the
+  // charts keep rendering dots rather than faking a finished curve. A sweep
+  // run with refinement disabled settles immediately — its uniform grid is
+  // the rendering, unchanged from the pre-#744 behavior.
+  const [sweepSettled, setSweepSettled] = useState(true);
   const [converge, setConverge] = useState<ConvergeData | null>(null);
   const [convergeRunning, setConvergeRunning] = useState(false);
   const [normCheck, setNormCheck] = useState<NormCheckData | null>(null);
@@ -576,6 +586,10 @@ export function useAnalysisRunners({
       _approved: approvedComboRef.current,
     };
     setSweepRunning(true);
+    // Settledness for this sweep (issue #866): with refinement on, the lean
+    // base grid is provisional until the refine pass lands; with it off, the
+    // dense grid IS the final shape.
+    setSweepSettled(!refineEnabledRef.current);
     let planned: SweepData | null = null;
     try {
       // New object per point so React re-renders the Smith chart as the
@@ -628,6 +642,16 @@ export function useAnalysisRunners({
     sweepRefineAbortRef.current = controller;
     let acc = base;
     let spent = 0;
+    // Unsettle here too, not just in runSweep (issue #866): a pass triggered
+    // by a chart becoming resident refines a sweep whose base flow settled
+    // long ago (or ran refine-disabled), and its insertions are about to
+    // reshape the curve.
+    setSweepSettled(false);
+    // Set exactly when the pass concludes on its own terms — the budget runs
+    // out or the planner finds nothing left to fix. A mid-run toggle-off
+    // (the break below) leaves it false: the accumulated set is uneven and
+    // the charts should keep saying so (dots, not a polyline).
+    let concluded = false;
     try {
       while (spent < SWEEP_REFINE_BUDGET && !controller.signal.aborted) {
         // The toggle and the resident-projection set are read per ROUND:
@@ -641,7 +665,10 @@ export function useAnalysisRunners({
           Math.min(SWEEP_REFINE_ROUND_BUDGET, SWEEP_REFINE_BUDGET - spent),
           residentSweepViewsRef.current,
         );
-        if (want.length === 0) break; // no visible kink left to remove
+        if (want.length === 0) {
+          concluded = true; // no visible kink left to remove
+          break;
+        }
         spent += want.length;
         const settled = acc; // merge target for this round's snapshots
         const extra = await streamSweep(
@@ -664,10 +691,18 @@ export function useAnalysisRunners({
         if (controller.signal.aborted) return;
         setSweep(acc);
       }
+      // Exiting because the budget ran dry is as final as an empty plan —
+      // best-so-far is the shape we will render from here on. An abort
+      // (superseded by a new sweep) is not: that sweep resets settledness
+      // itself.
+      if (spent >= SWEEP_REFINE_BUDGET && !controller.signal.aborted) {
+        concluded = true;
+      }
     } catch (e: unknown) {
       if (e instanceof DOMException && e.name === "AbortError") return;
       console.error("sweep refine error", e);
     } finally {
+      if (concluded) setSweepSettled(true);
       if (sweepRefineAbortRef.current === controller) {
         sweepRefineAbortRef.current = null;
       }
@@ -861,6 +896,7 @@ export function useAnalysisRunners({
   return {
     sweep,
     sweepRunning,
+    sweepSettled,
     converge,
     convergeRunning,
     normCheck,


### PR DESCRIPTION
## Summary
- Adds a `sweepSettled` lifecycle signal to `useAnalysisRunners` (closes #866): false from the start of a base sweep under adaptive refinement until a refine pass concludes on its own terms (empty plan or budget spent); a pass triggered by a chart gaining residency unsettles too
- The Smith chart's connected locus now keys on refinement being enabled **and** settled (previously enabled alone), so an in-flight refinement renders the honest dot cloud instead of a polyline with transient kinks
- `SweepChart` (VSWR and |Γ| views) gains a `settled` prop: unconnected dots while unsettled, today's polyline otherwise; off-scale samples keep their pinned-needle tick
- Toggling refinement off mid-run deliberately never settles — the accumulated set is uneven, so the views keep drawing dots rather than faking a finished curve; refinement-disabled sessions settle immediately and render exactly as before
- Settling is pure client state: the switch from dots to polyline needs no re-solve

## Test plan
- [x] Hook lifecycle tests: unsettled through base sweep + dwell, settled on conclusion; settled throughout with refinement disabled; empty-plan settle without spending a solve; mid-run toggle-off stays unsettled; knob change mid-refinement hands settledness to the superseding sweep (useAnalysisRunners.refine.test.tsx)
- [x] Registry keying tests: smith `data-connect` truth table over refineEnabled × sweepSettled; `data-settled` passthrough for gamma/vswr (viewRegistry.test.tsx)
- [x] Full frontend lane: `tsc --noEmit`, eslint (0 errors), vitest 54 files / 755 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)