### PR TITLE
chore: release v0.49.0 (the third-oracle release)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antennaknobs"
-version = "0.48.0"
+version = "0.49.0"
 authors = [
   { name="Steven M. Burns", email="smburns47@gmail.com" },
 ]

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -105,6 +105,7 @@ export default defineConfig({
             { label: "The solver & accuracy", slug: "reference/solver" },
             { label: "Loading NEC decks", slug: "reference/nec-import" },
             { label: "SimNEC round-trip", slug: "reference/simnec" },
+            { label: "NEC-5 engine", slug: "reference/nec5" },
             { label: "Web workbench", slug: "reference/web" },
             { label: "Drone & Transform API", slug: "reference/drone-transform" },
             { label: "Command line", slug: "reference/cli" },

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -68,6 +68,20 @@ by dragging, and read out in real time.
   ></iframe>
 </div>
 
+And the other half of the story — writing an antenna *as code*: a full
+tutorial building a parameterized single-wire dipole from an empty file to
+knobs turning in the workbench.
+
+<div style={{ position: "relative", paddingBottom: "56.25%", height: 0, overflow: "hidden", borderRadius: "0.5rem", marginTop: "1rem" }}>
+  <iframe
+    src="https://www.youtube-nocookie.com/embed/5lxzkic8pnA"
+    title="First AntennaKNoBs Python Coding Tutorial for a Fully Parameterized Single-Wire Dipole"
+    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
+    allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+  ></iframe>
+</div>
+
 <CardGrid stagger>
   <Card title="Antennas as Python code" icon="pencil">
     Describe an antenna once as a small parametric builder — geometry computed

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,22 +25,23 @@ import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
 {/* What's-new box: refresh as part of the release ritual (bump the version,
     swap the highlights) — a stale "new" box is worse than none. */}
 
-<Card title="New in v0.48.0" icon="star">
-  **The extended-kernel release.** NEC's **`EK` card** — the extended
-  thin-wire kernel, the correction that matters when a wire is fat relative
-  to its own segments — is now honoured end to end, powered by momwire
-  0.26.0's C++ implementation. An imported deck's `EK` card **changes the
-  solve instead of being advisory** (and `EK 1` is no longer a refusal), the
-  CLI grows **`--extended-kernel`**, and every momwire slot in the web
-  workbench carries a per-slot **extended kernel (EK)** check — put the same
-  basis in two slots, one with the kernel and one without (the chip reads
-  **+EK**), and read the difference side by side. It runs on four of the
-  five solver families, in free space and over every ground model, at about
-  1.0–1.3× the ordinary solve; on a Δ/a = 2.27 dipole it moves the impedance
-  the same 8% step NEC takes, tracked to 0.5%/3.1% on the two sides of the
-  card. The two combinations that can't serve it refuse loudly rather than
-  quietly answering with the reduced kernel. Start at
-  [The extended thin-wire kernel](/reference/solver/#the-extended-thin-wire-kernel-ek).
+<Card title="New in v0.49.0" icon="star">
+  **The third-oracle release.** With a licensed binary and one environment
+  variable, **NEC-5 runs as a full antennaknobs engine** — impedance,
+  currents, native-Sommerfeld grounds, radiation patterns, network ports
+  (including NEC-5's native current sources), loads and power budgets —
+  closing a **cross-validation triangle** of three independently written
+  solvers: momwire's basis families, NEC-2's kernels, NEC-5's
+  mixed-potential formulation. `--engines nec5` on the CLI, a slot in the
+  workbench picker on your own machine (never the hosted simulator — the
+  license stays personal), honest refusals for everything unserved, and
+  one genuine physics finding already logged from the triangle. Also in
+  this release: knob-scrub **sweeps reuse their own cached points**,
+  refining charts draw **honest dots until the curve settles**, a
+  **reload button** for the user design you're editing, NEC-5 edge-source
+  decks are **detected on import** instead of silently misread, and the
+  portal retires SimNEC's abandoned `YY` directive. Start at
+  [NEC-5 as a third engine](/reference/nec5/).
 </Card>
 
 ## The whole pitch, in one line
@@ -83,8 +84,9 @@ by dragging, and read out in real time.
     O(N²). Demonstrated O(N log N) on a 2142-segment Yagi.
   </Card>
   <Card title="Cross-checked physics" icon="approve-check">
-    A NEC-2 reference engine runs alongside the in-house solver, so you get a
-    built-in accuracy check most tools lack.
+    A NEC-2 reference engine runs alongside the in-house solver — and a
+    licensed NEC-5 can join as a third — so you get a built-in accuracy
+    check most tools lack.
   </Card>
   <Card title="No platform lock-in" icon="laptop">
     A web UI by default — works anywhere a browser does, while the competition

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -291,6 +291,18 @@ python -m antennaknobs compare_patterns \
   --engines pynec momwire:bspline --fn check.png
 ```
 
+With a licensed NEC-5 binary on the machine (`export NEC5_EXE=...`), `nec5`
+joins the roster and the comparison becomes a three-way triangle of
+independently written solvers — see [NEC-5 as a third
+engine](/reference/nec5/) for setup, capabilities, and the license terms
+that keep it strictly local:
+
+```bash
+python -m antennaknobs compare_patterns \
+  --builders beams.moxon beams.moxon beams.moxon \
+  --engines momwire pynec nec5 --fn triangle.png
+```
+
 Alongside the overlaid plot, `compare_patterns` prints a metrics table — peak
 gain (dBi), takeoff angle, front-to-back, and −3 dB azimuth/elevation
 beamwidths — one row per antenna, so the comparison comes with numbers, not just

--- a/site/src/content/docs/reference/nec-import.md
+++ b/site/src/content/docs/reference/nec-import.md
@@ -255,6 +255,20 @@ substitution is named in `skipped_note()`). This dialect support was
 validated against a 3,146-deck corpus of published models — ARRL course
 material, 4nec2's own library, and the wider web.
 
+## The NEC-5 dialect
+
+NEC-5 changed one thing the importer must not guess about: **sources can sit
+at a segment end** (a knot) rather than a segment center — `EX` grows an
+end-selector field, and a negative segment number selects an end too. NEC-2
+uses that same field position for print-control flags, so the two dialects
+genuinely collide. The importer resolves it conservatively: the spellings
+that can only be NEC-5 (a negative segment, or the end-selector value NEC-2
+never defines) are **refused with the dialect named** — never silently read
+as a NEC-2 center feed half a segment away — while the one ambiguous value
+keeps its legal NEC-2 meaning. Decks that need the edge-source form solve
+natively on [the NEC-5 engine](/reference/nec5/), which speaks it as a
+first-class citizen.
+
 ## Programmatic use
 
 Outside a design, `parse_nec(text, name=...)` takes raw deck text and returns

--- a/site/src/content/docs/reference/nec5.md
+++ b/site/src/content/docs/reference/nec5.md
@@ -1,0 +1,115 @@
+---
+title: NEC-5 as a third engine
+description: Run your licensed NEC-5 binary as an antennaknobs engine — deck generation, grounds, patterns, ports and loads — and close the cross-validation triangle.
+---
+
+NEC-5 is LLNL's modern rewrite of the NEC lineage — a mixed-potential
+formulation with basis functions in the RWG family, released in 2019 and
+distributed under an individual license. antennaknobs can drive it as a
+**third engine** beside momwire and PyNEC: it writes NEC-5-dialect decks,
+runs your licensed executable, and parses the printout back into the same
+impedance, current, pattern and power-budget readouts every other engine
+serves.
+
+Why bother, when two engines already cross-check each other? Because the
+three implementations share almost nothing: momwire's sinusoidal and
+B-spline families, NEC-2's reduced/extended thin-wire kernels, and NEC-5's
+mixed-potential formulation are independently derived and independently
+coded. When all three agree, the agreement means something — and when they
+split, the split is a finding (see [the solver
+page](/reference/solver/) for how antennaknobs treats cross-engine
+differences as data, not noise).
+
+## Licensing, and where the engine will not run
+
+NEC-5 is licensed software. antennaknobs **never bundles, downloads, or
+hosts it**: the engine activates only when you point it at a binary you
+license yourself, and the hosted simulator can never offer it (the license
+forbids service use, and the hosted machines simply have no binary). What
+antennaknobs generates and parses — decks and printouts — are yours to keep;
+captured printouts in the test suite carry the LLNL-CODE-746721 citation as
+End-User Reports.
+
+Point the engine at your executable with one environment variable:
+
+```bash
+export NEC5_EXE=~/nec5/nec5cl        # your licensed binary
+```
+
+Everything below lights up exactly when `NEC5_EXE` resolves — the CLI
+engine name, the workbench slot entry — and disappears when it doesn't.
+If you run a local web instance with the variable set, the NEC-5 slot is
+available to anyone who can reach that instance; keeping it off the open
+internet is your call to make, the same as for any local service.
+
+## From the command line
+
+`nec5` joins the `--engines` roster:
+
+```bash
+# The triangle: momwire vs PyNEC vs NEC-5 on one design
+python -m antennaknobs compare_patterns \
+  --builders beams.moxon beams.moxon beams.moxon \
+  --engines momwire pynec nec5 --fn triangle.png
+```
+
+Every solve is one run of the binary in a scratch directory — deck in,
+printout out, parsed and discarded. Sweeps batch uniformly-spaced
+frequencies into a single run using NEC-5's linear `FR` stepping.
+
+## What is served, what refuses
+
+| capability | status |
+| --- | --- |
+| Impedance, currents, frequency sweeps | served |
+| Grounds | free space, PEC, and NEC-5's **native Sommerfeld** (`("finite", eps_r, sigma)`) |
+| Radiation patterns | served (`compare_patterns`, the web far-field views) |
+| Feeds | plain `Wire.ex`, network `Driven`, and `DrivenCurrent` via NEC-5's **native current source** (`EX 4` — NEC-2 has no equivalent) |
+| Loads | `Load` branches (fixed-Z and series/parallel RLC) at the port |
+| Wire material | conductor loss natively; insulation via the same distributed-inductance emulation momwire uses — NEC-5 dropped NEC-4's insulated-wire card |
+| Power budget | input/radiated/wire-loss/efficiency, plus hemisphere average gain (the ground-absorption readout) |
+| Transmission lines, two-ports, `ql`/`qc` loads, distributed ports, buried wires | **refuse loudly**, each naming what is unsupported |
+
+Refusals are the design: NEC-5 either solves exactly what you asked or
+tells you precisely why not — never a silently simplified model.
+
+Two conventions worth knowing, both pinned from the NEC-5 User's Manual
+during development:
+
+- **Sources sit at segment ends** (knots), not segment centers as in
+  NEC-2. The deck writer meshes fed wires with even segment counts so the
+  feed lands exactly at the wire's middle knot — the same physical point
+  the other engines drive.
+- **The "fast" ground model is served as full Sommerfeld.** NEC-5 has no
+  reflection-coefficient approximation (its `IPERF 0` *is* the Sommerfeld
+  solution), so asking for the fast model gets the accurate one, and the
+  applied-model readout says so.
+
+## In the workbench
+
+With `NEC5_EXE` set on the machine serving the web UI, **NEC-5 appears in
+the slot A/B/C solver picker** like any other backend. The natural use is
+A/B: the same design and mesh in two slots, momwire against NEC-5, readouts
+side by side. NEC-5 solves are one subprocess per request with no resident
+state — fine for check-this-snapshot comparisons, heavier than momwire's
+in-process solves for live knob-dragging.
+
+## Honest numbers
+
+Cross-engine agreement on reference designs runs a few ohms of impedance
+(the different formulations' genuine spread) and ~0.01 dB RMS on far-field
+patterns. One documented exception, found the day the engine landed: at
+very low heights over lossy Sommerfeld ground (≈0.05 λ), NEC-5's reactance
+sits ~7 Ω away from the mutually-agreeing NEC-2 lineage while resistances
+match — a real formulation difference in the close-ground interaction,
+pinned in the test suite as a measured gap rather than averaged into a
+tolerance. That is the cross-validation triangle doing its job.
+
+## Importing NEC-5 decks
+
+`@file.nec` import recognises NEC-5's edge-source `EX` spellings (a
+negative segment number, or the end-selector field NEC-2 never uses) and
+refuses them with the dialect named rather than silently shifting the feed
+half a segment to the NEC-2 reading — the [NEC deck
+import](/reference/nec-import/) page has the details. Decks in the common
+NEC-2 subset load normally, and NEC5Engine itself accepts them as-is.

--- a/site/src/content/docs/reference/solver.mdx
+++ b/site/src/content/docs/reference/solver.mdx
@@ -224,7 +224,8 @@ the limits are env-configurable (see `docs/deploy.md`).
 
 ## Accuracy & validation
 
-- A NEC-2 reference engine (`pynec-accel`) runs alongside momwire, so any design
+- A NEC-2 reference engine (`pynec-accel`) runs alongside momwire — and a
+  licensed [NEC-5](/reference/nec5/) can make it a three-way triangle — so any design
   can be solved two ways and compared — a built-in sanity check most tools lack.
 - The repo carries the benchmark above plus per-design solver comparisons.
 

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -174,9 +174,13 @@ What you'll notice:
   *detect* features, so it opens at 17 log-spaced points instead of 41 and the
   S11/VSWR/Smith views fill in sooner; the refinement rounds then sharpen
   whatever the base grid straddled.
-- **The Smith locus is a connected curve.** Refinement removes the sparse-
-  sample kinks that made a polyline dishonest, so the per-feed sweep trail
-  draws as a stroke instead of a dot cloud.
+- **The Smith locus is a connected curve — once it has earned it.** While
+  refinement is still landing points, the Smith, VSWR and |Γ| views draw
+  **unconnected dots**: a polyline through a half-refined set shows kinks
+  that are artifacts of sampling, not physics. When the refinement pass
+  settles, the views switch to the connected stroke. (Toggling refinement
+  off mid-run deliberately keeps the dots — the accumulated set is uneven,
+  and the charts keep saying so.)
 - **Only what's on screen refines.** Like the sweeps themselves
   (view-residency gating, above), refinement spends solves only on the
   projections and cuts whose views are pinned or open.
@@ -253,11 +257,17 @@ A **solver selector** offers a few preset slots so you can flip between engines
 without re-entering options — e.g. a fast dense basis, an accelerated array
 engine, and the PyNEC reference. The available engines are the momwire bases
 (**Sinusoidal**, **Sin-Galerkin**, **B-spline**), the accelerators
-(**H-matrix (ACA)**, **Array-block**), and the optional **PyNEC** backend — see
-[The solver & accuracy](/reference/solver/) for what each is good at. The list
-is **served by the backend you're pointed at**, so a server built without
-PyNEC simply doesn't offer it, rather than offering a slot that fails on the
-first solve.
+(**H-matrix (ACA)**, **Array-block**), the optional **PyNEC** backend — see
+[The solver & accuracy](/reference/solver/) for what each is good at — and,
+on a machine with a licensed binary, **NEC-5**
+([setup and terms](/reference/nec5/)): the slot appears exactly when the
+server resolves `NEC5_EXE`, which is why the hosted simulator never shows
+it while your own local instance can. The list is **served by the backend
+you're pointed at**, so a server without an optional engine simply doesn't
+offer it, rather than offering a slot that fails on the first solve. NEC-5
+solves are one external run per request — right for A/B snapshot checks
+against momwire in the next slot, heavier than the in-process engines for
+live dragging.
 
 The solver's gear menu also exposes **segments / wire (N)** — how finely each
 wire is discretized. More segments = more accurate (up to convergence) but a
@@ -452,6 +462,13 @@ that computes physical diagnostics — the catenary inverted vee reports its
 them as self-describing rows the readout renders generically, so a new
 design idea (including a user design in `~/.antennaknobs/designs/`) gets its
 numbers on screen with no frontend change.
+
+When the design you're iterating **is** a user design — editor in one
+window, workbench in the other — a **reload button** next to the design
+picker re-reads the file and re-solves in place. Your tuned knob values
+always survive the reload; a parameter the edited file just *grew* appears
+with the file's default. One click instead of a page reload per edit
+cycle.
 
 ## Power budget
 


### PR DESCRIPTION
Release PR for **v0.49.0 — the third-oracle release**.

- Version bump `0.48.0` → `0.49.0`
- **NEC-5 documentation** (the arc shipped src+tests only): new [reference/nec5] page — licensing and the strictly-local rule, `NEC5_EXE` setup, capability/refusal table, the knot-feed and fast-ground-served-as-Sommerfeld conventions, the honest 0.048 λ finding — plus the sidebar entry, cli.md's three-way triangle, web.md's slot section, and nec-import.md's NEC-5 dialect section
- **De-stale**: web.md's adaptive-resolution section now describes #866's dots-until-settled honestly; the #867 reload button documented (merge semantics verified against `mergeSeededDefaults`); the front-page pitch and solver.mdx cross-check bullet acknowledge the third engine
- What's-new card rewritten; site builds clean (28 pages)
- momwire pin **unchanged at 0.26.0** (the Galerkin-EK work is next release's story)

**DRAFT until the user's new video (which relies on this release) is uploaded and placed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)