### PR TITLE
NEC-5 corpus census lane: dialect scoping + printout capture-cache (#872 phase 0)

### DIFF
--- a/scripts/bench_nec_corpus.py
+++ b/scripts/bench_nec_corpus.py
@@ -7,11 +7,19 @@ For every deck in the xnec2c examples corpus this script:
   2. Runs the *original* deck through the ``nec2c`` CLI and reads the driving-
      point impedance from its first ANTENNA INPUT PARAMETERS block, at the
      frequency nec2c actually used (robust to sweep direction / FR start).
-  3. Solves the translated geometry at that same frequency with four engines:
+  3. Solves the translated geometry at that same frequency with the engines
+     selected by --engines:
        pynec  — PyNECEngine
        sin    — MomwireEngine(SinusoidalSolver)
        bs1    — MomwireEngine(BSplineSolver, degree=1)   (tent basis)
        bs2    — MomwireEngine(BSplineSolver, degree=2)   (quadratic)
+       nec5   — NEC5Engine (opt-in, #872 phase 0): needs $NEC5_EXE; decks
+                asking for dialect the engine deliberately refuses (TL/NT,
+                ql/qc loads, distributed ports, buried/in-plane wires,
+                refl-coef ground) are counted OOS (out-of-scope), not as
+                failures, and printouts are captured-and-cached by deck
+                content hash under --nec5-capture-dir so re-analysis never
+                re-solves.
   4. Scores each engine against nec2c by reflection-coefficient distance
      ΔΓ = |Γ_eng − Γ_nec2c| with Γ = (Z − 50)/(Z + 50), and records solve
      wall-time and peak RSS. ΔΓ is bounded on [0, 2], so decks whose |Z| passes
@@ -88,19 +96,21 @@ Z0 = 50.0  # system impedance for the reflection-coefficient metric (issue #407)
 # Every engine key the benchmark scripts can dispatch. "sing" (momwire#182)
 # is the SAME three-term basis as "sin" tested variationally instead of
 # point-matched, so the pair isolates the TESTING scheme with the basis held
-# fixed — that is what it is here for.
-ENGINE_KEYS = ("pynec", "sin", "sing", "bs1", "bs2")
+# fixed — that is what it is here for. "nec5" (#872 phase 0) drives the
+# licensed NEC-5 binary through NEC5Engine and needs $NEC5_EXE resolved.
+ENGINE_KEYS = ("pynec", "sin", "sing", "bs1", "bs2", "nec5")
 ENGINE_LABEL = {
     "pynec": "PyNEC",
     "sin": "Sinusoidal",
     "sing": "Sinusoidal-Gal",
     "bs1": "BSpline d=1",
     "bs2": "BSpline d=2",
+    "nec5": "NEC-5",
 }
 # What `--engines` defaults to. Deliberately NOT all of ENGINE_KEYS: the
 # corpus/catalog sweeps are long-running, and silently adding a fifth column
 # to every historical benchmark would change what those runs cost and mean.
-# Ask for "sing" explicitly.
+# Ask for "sing" or "nec5" explicitly.
 DEFAULT_ENGINE_KEYS = ("pynec", "sin", "bs1", "bs2")
 
 
@@ -346,7 +356,6 @@ def worker_main(engine: str, deck_path: str, freq: float, ground_json: str):
         cores = apply_server_thread_policy()
 
         from antennaknobs import AntennaBuilder, WireSpec
-        from antennaknobs.engines.pynec import PyNECEngine
         from antennaknobs.engines.momwire import MomwireEngine
         from momwire import BSplineSolver, SinusoidalSolver
 
@@ -386,6 +395,10 @@ def worker_main(engine: str, deck_path: str, freq: float, ground_json: str):
 
         t0 = time.perf_counter()
         if engine == "pynec":
+            # Imported per-branch so the nec5 lane runs without PyNEC
+            # installed (the nec5 study boxes need only the licensed binary).
+            from antennaknobs.engines.pynec import PyNECEngine
+
             eng = PyNECEngine(
                 builder,
                 ground=ground,
@@ -415,10 +428,25 @@ def worker_main(engine: str, deck_path: str, freq: float, ground_json: str):
                 solver_kwargs={"degree": 2},
                 ground=ground,
             )
+        elif engine == "nec5":
+            from antennaknobs.engines.nec5 import NEC5Engine
+
+            # Env-passed like PYNEC_ALLOW_INTERSECTIONS to keep the --worker
+            # argv arity fixed at 4. The capture dir gives the sweep the
+            # phase-0 printout cache (#872): a deck already captured is
+            # served from disk, so re-analysis never re-solves.
+            eng = NEC5Engine(
+                builder,
+                ground=ground,
+                timeout=float(os.environ.get("NEC5_BENCH_TIMEOUT") or 120.0),
+                capture_dir=os.environ.get("NEC5_CAPTURE_DIR") or None,
+            )
         else:
             raise ValueError(f"unknown engine {engine!r}")
         zs = eng.impedance()
         solve_s = time.perf_counter() - t0
+        if engine == "nec5":
+            result["nec5_runs"] = eng.run_log
 
         # ru_maxrss is the process-lifetime peak (KiB on Linux).
         peak_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
@@ -436,7 +464,31 @@ def worker_main(engine: str, deck_path: str, freq: float, ground_json: str):
 
         result["error"] = f"{type(e).__name__}: {e}"
         result["traceback"] = traceback.format_exc()[-800:]
+        if engine == "nec5" and nec5_out_of_scope(e):
+            result["out_of_scope"] = True
     print(json.dumps(result))
+
+
+# NEC5Engine refusal messages that mean "the deck asks for something the
+# stage-1..5 dialect deliberately does not serve" (#872 phase 0): the census
+# counts these as out-of-scope, not engine failures. NotImplementedError is
+# the engine's designed refusal channel (TL/NT branches, distributed or
+# virtual ports, finite-fast ground, buried wires); the two ValueError
+# messages are hard NEC-5 dialect rules the engine enforces at construction.
+_NEC5_SCOPE_VALUEERROR_SNIPPETS = (
+    "lies in the ground plane (z=0)",
+    "too close to free space for NEC-5's Sommerfeld tables",
+)
+
+
+def nec5_out_of_scope(e: BaseException) -> bool:
+    """True when a nec5-lane exception is a dialect-scope refusal rather
+    than a solve failure."""
+    if isinstance(e, NotImplementedError):
+        return True
+    return isinstance(e, ValueError) and any(
+        s in str(e) for s in _NEC5_SCOPE_VALUEERROR_SNIPPETS
+    )
 
 
 def run_engine(
@@ -447,11 +499,18 @@ def run_engine(
     timeout,
     allow_intersections=False,
     mem_bytes=None,
+    nec5_capture_dir=None,
 ):
     """Dispatch a worker subprocess for one (deck, engine); parse its JSON."""
     env = dict(os.environ)
     if allow_intersections:
         env["PYNEC_ALLOW_INTERSECTIONS"] = "1"
+    if engine == "nec5":
+        # Env-passed to keep the --worker argv arity fixed at 4.
+        if nec5_capture_dir:
+            env["NEC5_CAPTURE_DIR"] = str(nec5_capture_dir)
+        if timeout is not None:
+            env["NEC5_BENCH_TIMEOUT"] = repr(float(timeout))
     try:
         proc = subprocess.run(
             [
@@ -518,10 +577,14 @@ _TIMEOUT_RE = re.compile(r"solve timeout")
 def engine_error_kind(res):
     """Classify an engine result's error: ``None`` (no error), ``"geo"``
     (nec2++ geometry-intersection rejection — documented kernel limitation,
-    issue #409), ``"mem"`` (hit the --mem-limit-gb cap), ``"timeout"`` (hit
-    the --timeout wall-clock cap), or ``"err"`` (any other failure)."""
+    issue #409), ``"scope"`` (outside the engine's served dialect — the
+    nec5 lane's designed refusals, #872 phase 0), ``"mem"`` (hit the
+    --mem-limit-gb cap), ``"timeout"`` (hit the --timeout wall-clock cap),
+    or ``"err"`` (any other failure)."""
     if res is None:
         return "err"
+    if res.get("out_of_scope"):
+        return "scope"
     err = res.get("error")
     if not err:
         return None
@@ -1189,6 +1252,7 @@ def bench_deck(
     allow_intersections=False,
     mem_bytes=None,
     rel_name=None,
+    nec5_capture_dir=None,
 ):
     # rel_name (corpus-relative path) disambiguates wild trees where the same
     # stem appears under several sources.
@@ -1317,7 +1381,14 @@ def bench_deck(
     row["engines"] = {}
     for e in engines:
         res = run_engine(
-            e, deck_path, freq, eng_ground, timeout, allow_intersections, mem_bytes
+            e,
+            deck_path,
+            freq,
+            eng_ground,
+            timeout,
+            allow_intersections,
+            mem_bytes,
+            nec5_capture_dir=nec5_capture_dir,
         )
         if res.get("error") is None and "z" in res:
             res["cmp"] = compare(res["z"], ref["z"])
@@ -1333,6 +1404,8 @@ def fmt_dg(res):
     kind = engine_error_kind(res)
     if kind == "geo":
         return "GEO"  # nec2++ geometry-intersection rejection (issue #409)
+    if kind == "scope":
+        return "OOS"  # outside the engine's served dialect (#872 phase 0)
     if kind == "mem":
         return "MEM"  # hit --mem-limit-gb
     if kind == "timeout":
@@ -1461,12 +1534,21 @@ def print_report(rows, engines):
     ]
     if eng_errs:
         geo = [x for x in eng_errs if x[2] == "geo"]
+        scope = [x for x in eng_errs if x[2] == "scope"]
         mem = [x for x in eng_errs if x[2] == "mem"]
         tmo = [x for x in eng_errs if x[2] == "timeout"]
         other = [x for x in eng_errs if x[2] == "err"]
         print("\n" + "=" * 72)
         print(f"ENGINE ERRORS ON REFERENCED DECKS ({len(eng_errs)})")
         print("=" * 72)
+        if scope:
+            print(
+                f"OOS — outside the engine's served dialect ({len(scope)}); "
+                "designed refusal (TL/NT, ql/qc loads, distributed ports, "
+                "buried/in-plane wires, refl-coef ground), not a failure:"
+            )
+            for deck, e, _k, why in scope:
+                print(f"  {deck:<28} {ENGINE_LABEL[e]:<12} {(why or '')[:70]}")
         if geo:
             print(
                 f"GEO — nec2++ geometry-intersection rejection ({len(geo)}); "
@@ -1697,6 +1779,16 @@ def main(argv=None):
         "(issue #409; needs pynec-accel >=1.7.5)",
     )
     ap.add_argument(
+        "--nec5-capture-dir",
+        type=Path,
+        default=Path.home() / ".antennaknobs" / "nec5-captures",
+        help="printout capture-and-cache for the nec5 lane (#872 phase 0): "
+        "each solve's deck and printout are stored keyed by deck content "
+        "hash, and an already-captured deck is served from disk without "
+        "re-running the binary. Captured printouts are End-User Reports "
+        "under the NEC-5 license (LLNL-CODE-746721)",
+    )
+    ap.add_argument(
         "--out",
         type=Path,
         default=None,
@@ -1768,6 +1860,16 @@ def main(argv=None):
     )
     if nec2c_id.get("path") is None:
         sys.exit("nec2c not on PATH — build it and symlink into ~/.local/bin")
+    if "nec5" in args.engines:
+        from antennaknobs.engines.nec5 import find_nec5
+
+        nec5_exe = find_nec5()
+        if nec5_exe is None:
+            sys.exit(
+                "nec5 lane requested but $NEC5_EXE does not resolve to an "
+                "executable — point it at your licensed nec5cl binary"
+            )
+        print(f"nec5 lane: {nec5_exe}   captures: {args.nec5_capture_dir}")
 
     # Incremental JSONL mode: resume by skipping decks already recorded.
     jsonl = args.out if args.out and args.out.suffix == ".jsonl" else None
@@ -1809,6 +1911,9 @@ def main(argv=None):
                 allow_intersections=args.allow_wire_intersections,
                 mem_bytes=mem_bytes,
                 rel_name=rel,
+                nec5_capture_dir=(
+                    args.nec5_capture_dir if "nec5" in args.engines else None
+                ),
             )
         except Exception as e:  # noqa: BLE001 — a 20 h sweep must survive any
             # single deck (first bite: nec2c emitting raw 0xff into its output)

--- a/src/antennaknobs/engines/nec5.py
+++ b/src/antennaknobs/engines/nec5.py
@@ -26,10 +26,12 @@ pinned by captured printouts committed under ``tests/fixtures/nec5/``
 
 from __future__ import annotations
 
+import hashlib
 import os
 import re
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 
 import numpy as np
@@ -98,7 +100,15 @@ class NEC5Engine(SimulationEngine):
     # fed wire's midpoint (see module docstring).
     segment_parity = "even"
 
-    def __init__(self, builder, *, ground=None, nec5_exe=None, timeout=120.0):
+    def __init__(
+        self,
+        builder,
+        *,
+        ground=None,
+        nec5_exe=None,
+        timeout=120.0,
+        capture_dir=None,
+    ):
         super().__init__(builder)
         self.ground = self._normalise_ground(ground)
         exe = find_nec5(nec5_exe)
@@ -110,6 +120,19 @@ class NEC5Engine(SimulationEngine):
             )
         self._exe = exe
         self._timeout = float(timeout)
+        # Printout capture-and-cache (issue #872 phase 0): with capture_dir
+        # set, every run stores its deck and printout keyed by the deck
+        # text's content hash, and a run whose printout is already captured
+        # is served from disk without invoking the binary — re-analysis
+        # never re-solves. The stored printouts are End-User Reports under
+        # the NEC-5 license (LLNL-CODE-746721); the binary itself is never
+        # copied or distributed.
+        self._capture_dir = Path(capture_dir).expanduser() if capture_dir else None
+        if self._capture_dir is not None:
+            self._capture_dir.mkdir(parents=True, exist_ok=True)
+        # One dict per _run call: {"hash", "cached", "seconds"} — the
+        # per-solve time log the census machinery records (#872 phase 0).
+        self.run_log: list[dict] = []
         if builder.build_tls():
             raise NotImplementedError(
                 "NEC5Engine stage 1 does not model transmission lines"
@@ -379,12 +402,39 @@ class NEC5Engine(SimulationEngine):
 
     # ---------- run ----------
 
+    @staticmethod
+    def _deck_hash(deck: str) -> str:
+        """Content key for the capture cache: the deck text fully determines
+        a run (same binary), so its hash names the printout."""
+        return hashlib.sha256(deck.encode()).hexdigest()[:16]
+
     def _run(self, deck: str) -> str:
         """Run one deck through the binary and return the printout text.
 
         NEC-5 reads the input and output file names from stdin and works
         in intermediate files; exit codes are not trusted (Fortran STOP) —
-        the printout's presence and parseability are the health signal."""
+        the printout's presence and parseability are the health signal.
+
+        With ``capture_dir`` set, a previously captured printout for this
+        exact deck is returned without invoking the binary, and fresh
+        printouts are captured beside their decks (``<hash>.nec`` /
+        ``<hash>.out``)."""
+        h = self._deck_hash(deck)
+        if self._capture_dir is not None:
+            cached = self._capture_dir / f"{h}.out"
+            if cached.is_file():
+                self.run_log.append({"hash": h, "cached": True, "seconds": 0.0})
+                return cached.read_text(errors="replace")
+        t0 = time.perf_counter()
+        text = self._run_binary(deck)
+        seconds = time.perf_counter() - t0
+        self.run_log.append({"hash": h, "cached": False, "seconds": seconds})
+        if self._capture_dir is not None:
+            (self._capture_dir / f"{h}.nec").write_text(deck)
+            (self._capture_dir / f"{h}.out").write_text(text)
+        return text
+
+    def _run_binary(self, deck: str) -> str:
         with tempfile.TemporaryDirectory(prefix="nec5_") as td:
             tdp = Path(td)
             (tdp / "model.nec").write_text(deck)

--- a/tests/test_bench_catalog.py
+++ b/tests/test_bench_catalog.py
@@ -114,8 +114,9 @@ def test_bench_one_guard_skips_finite_grounds_for_oversized_meshes():
 
 def test_engine_keys_cover_every_dispatchable_solver():
     # "sing" (momwire#182) is the sinusoidal basis tested variationally — the
-    # same basis as "sin", so the pair isolates the testing scheme.
-    assert set(bc.ENGINE_KEYS) == {"pynec", "sin", "sing", "bs1", "bs2"}
+    # same basis as "sin", so the pair isolates the testing scheme. "nec5"
+    # (#872 phase 0) drives the licensed NEC-5 binary; opt-in like "sing".
+    assert set(bc.ENGINE_KEYS) == {"pynec", "sin", "sing", "bs1", "bs2", "nec5"}
     assert all(k in bc.ENGINE_LABEL for k in bc.ENGINE_KEYS)
 
 

--- a/tests/test_bench_nec5_lane.py
+++ b/tests/test_bench_nec5_lane.py
@@ -1,0 +1,141 @@
+"""The corpus bench's nec5 lane (#872 phase 0): engine roster, dialect
+scoping (designed refusals count as out-of-scope, not failures), and the
+worker-level tagging that carries the classification into the census JSON.
+
+None of these tests need the licensed binary: scope refusals fire at
+NEC5Engine construction, before any subprocess."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from bench_nec_corpus import (  # noqa: E402
+    DEFAULT_ENGINE_KEYS,
+    ENGINE_KEYS,
+    ENGINE_LABEL,
+    engine_error_kind,
+    fmt_dg,
+    nec5_out_of_scope,
+    worker_main,
+)
+
+
+def test_nec5_is_dispatchable_but_not_default():
+    # Same treatment as "sing": silently adding a column to every historical
+    # sweep would change what those runs cost and mean — ask for it.
+    assert "nec5" in ENGINE_KEYS
+    assert "nec5" not in DEFAULT_ENGINE_KEYS
+    assert ENGINE_LABEL["nec5"] == "NEC-5"
+
+
+def test_scope_classification():
+    # NotImplementedError is the engine's designed refusal channel.
+    assert nec5_out_of_scope(NotImplementedError("no TL on this path"))
+    # The two hard NEC-5 dialect rules enforced as ValueError at construction.
+    assert nec5_out_of_scope(
+        ValueError("wire 3 lies in the ground plane (z=0), which ...")
+    )
+    assert nec5_out_of_scope(
+        ValueError(
+            "eps_r=1.0 is too close to free space for NEC-5's Sommerfeld "
+            "tables (degenerate limit); ..."
+        )
+    )
+    # Anything else is a real failure.
+    assert not nec5_out_of_scope(ValueError("design has no excitation"))
+    assert not nec5_out_of_scope(RuntimeError("NEC-5 timed out after 120s"))
+
+
+def test_error_kind_and_report_cell():
+    res = {"error": "NotImplementedError: ...", "out_of_scope": True}
+    assert engine_error_kind(res) == "scope"
+    assert fmt_dg(res) == "OOS"
+    # out_of_scope wins over the error-message regexes (a refusal mentioning
+    # "memory" or "timeout" in prose must still count as scope).
+    res = {"error": "NotImplementedError: timeout memory", "out_of_scope": True}
+    assert engine_error_kind(res) == "scope"
+    # And plain errors are untouched.
+    assert engine_error_kind({"error": "NEC5Error: boom"}) == "err"
+
+
+def _run_worker(capsys, deck_text, tmp_path, ground="free"):
+    deck = tmp_path / "deck.nec"
+    deck.write_text(deck_text)
+    worker_main("nec5", str(deck), 28.5, json.dumps(ground))
+    return json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+
+
+def test_worker_tags_tl_deck_out_of_scope(capsys, monkeypatch, tmp_path):
+    """A TL deck refuses at NEC5Engine construction (stage-1 dialect) and
+    the worker tags the row out_of_scope — the census counts it OOS, not
+    as an engine failure. NEC5_EXE is python: never invoked, any
+    executable satisfies the constructor's gate."""
+    monkeypatch.setenv("NEC5_EXE", sys.executable)
+    res = _run_worker(
+        capsys,
+        "CM tl deck\nCE\n"
+        "GW 1 9 0 0 1 0 0 11 .001\n"
+        "GW 2 9 5 0 1 5 0 11 .001\n"
+        "TL 1 5 2 5 50. 5.\n"
+        "EX 0 1 5 0 1 0\n"
+        "XQ\nEN\n",
+        tmp_path,
+    )
+    assert res["out_of_scope"] is True
+    assert "NotImplementedError" in res["error"]
+    assert engine_error_kind(res) == "scope"
+
+
+def test_worker_tags_refl_coef_ground_out_of_scope(capsys, monkeypatch, tmp_path):
+    """GN 0 maps to ("finite-fast", ...) which NEC-5 cannot express (its
+    IPERF 0 is full Sommerfeld — no refl-coef option exists)."""
+    monkeypatch.setenv("NEC5_EXE", sys.executable)
+    res = _run_worker(
+        capsys,
+        "CM gn0\nCE\nGW 1 10 0 -2.5 5 0 2.5 5 .001\nGN 0 0 0 0 13 .005\n"
+        "EX 0 1 5 0 1 0\nXQ\nEN\n",
+        tmp_path,
+        ground=["finite-fast", 13.0, 0.005],
+    )
+    assert res["out_of_scope"] is True
+    assert engine_error_kind(res) == "scope"
+
+
+def test_worker_real_failure_is_not_scope(capsys, monkeypatch, tmp_path):
+    """A missing binary is a failure, not dialect scope."""
+    monkeypatch.delenv("NEC5_EXE", raising=False)
+    res = _run_worker(
+        capsys,
+        "CM d\nCE\nGW 1 10 0 -2.5 5 0 2.5 5 .001\nEX 0 1 5 0 1 0\nXQ\nEN\n",
+        tmp_path,
+    )
+    assert res.get("out_of_scope") is None
+    assert engine_error_kind(res) == "err"
+
+
+def test_worker_wires_capture_dir_through_env(capsys, monkeypatch, tmp_path):
+    """NEC5_CAPTURE_DIR (how run_engine passes --nec5-capture-dir with the
+    --worker argv arity fixed at 4) reaches the engine: the run's deck and
+    printout land in the capture dir. The stub 'binary' copies a fixture
+    printout whose feed rows don't match this model — the worker therefore
+    reports the row-mismatch NEC5Error (a real failure, not scope), but the
+    capture is written regardless, because _run captures before parsing."""
+    fixtures = Path(__file__).parent / "fixtures" / "nec5"
+    stub = tmp_path / "nec5-stub.sh"
+    stub.write_text(
+        "#!/bin/sh\nread inp\nread outp\n"
+        f'cp "{(fixtures / "invvee_dipole_single.out").resolve()}" "$outp"\n'
+    )
+    stub.chmod(0o755)
+    captures = tmp_path / "captures"
+    monkeypatch.setenv("NEC5_EXE", str(stub))
+    monkeypatch.setenv("NEC5_CAPTURE_DIR", str(captures))
+    res = _run_worker(
+        capsys,
+        "CM d\nCE\nGW 1 10 0 -2.5 5 0 2.5 5 .001\nEX 0 1 5 0 1 0\nXQ\nEN\n",
+        tmp_path,
+    )
+    assert res["error"] and "NEC5Error" in res["error"]
+    assert res.get("out_of_scope") is None
+    assert sorted(p.suffix for p in captures.iterdir()) == [".nec", ".out"]

--- a/tests/test_nec5_engine.py
+++ b/tests/test_nec5_engine.py
@@ -623,3 +623,67 @@ def test_live_average_gain_reads_ground_absorption():
     avg, omega = e.average_power_gain()
     assert 0.2 < avg < 2.0
     assert 0.9 * np.pi < omega < 2.1 * np.pi
+
+
+# ------------------------------------------------- capture cache (#872 ph 0)
+
+
+def test_capture_cache_hit_skips_binary(monkeypatch, tmp_path):
+    """A printout already captured for this exact deck is served from disk:
+    NEC5_EXE points at python (which could never produce a printout), so a
+    successful impedance() proves the binary was not invoked."""
+    monkeypatch.setenv("NEC5_EXE", sys.executable)
+    eng = NEC5Engine(_invvee_builder(), capture_dir=tmp_path)
+    deck = eng.deck([eng.builder.freq])
+    h = NEC5Engine._deck_hash(deck)
+    (tmp_path / f"{h}.out").write_text(
+        (FIXTURES / "invvee_dipole_single.out").read_text()
+    )
+    (z,) = eng.impedance()
+    assert z == pytest.approx(70.746 - 8.5699j, rel=1e-3)
+    assert eng.run_log == [{"hash": h, "cached": True, "seconds": 0.0}]
+
+
+def test_capture_writes_deck_and_printout(monkeypatch, tmp_path):
+    """A fresh run captures <hash>.nec + <hash>.out and logs its solve time;
+    a second engine over the same capture dir is then served from cache.
+    The 'binary' is a stub that copies the pinned fixture printout."""
+    fixture_out = FIXTURES / "invvee_dipole_single.out"
+    stub = tmp_path / "nec5-stub.sh"
+    stub.write_text(
+        f'#!/bin/sh\nread inp\nread outp\ncp "{fixture_out.resolve()}" "$outp"\n'
+    )
+    stub.chmod(0o755)
+    captures = tmp_path / "captures"
+
+    eng = NEC5Engine(_invvee_builder(), nec5_exe=str(stub), capture_dir=captures)
+    (z,) = eng.impedance()
+    assert z == pytest.approx(70.746 - 8.5699j, rel=1e-3)
+    h = NEC5Engine._deck_hash(eng.deck([eng.builder.freq]))
+    assert (captures / f"{h}.nec").read_text() == eng.deck([eng.builder.freq])
+    assert (captures / f"{h}.out").read_text() == fixture_out.read_text()
+    assert len(eng.run_log) == 1
+    (entry,) = eng.run_log
+    assert entry["hash"] == h and entry["cached"] is False
+    assert entry["seconds"] > 0.0
+
+    # Re-analysis path: a second engine never re-solves.
+    eng2 = NEC5Engine(_invvee_builder(), nec5_exe=str(stub), capture_dir=captures)
+    eng2.impedance()
+    assert eng2.run_log[0]["cached"] is True
+
+
+def test_no_capture_dir_means_no_cache(monkeypatch, tmp_path):
+    """Without capture_dir the engine behaves exactly as before: every run
+    invokes the binary and nothing is written anywhere."""
+    fixture_out = FIXTURES / "invvee_dipole_single.out"
+    stub = tmp_path / "nec5-stub.sh"
+    stub.write_text(
+        f'#!/bin/sh\nread inp\nread outp\ncp "{fixture_out.resolve()}" "$outp"\n'
+    )
+    stub.chmod(0o755)
+    eng = NEC5Engine(_invvee_builder(), nec5_exe=str(stub))
+    eng.impedance()
+    eng.impedance()
+    assert [e["cached"] for e in eng.run_log] == [False, False]
+    assert list(tmp_path.iterdir()) == [stub]


### PR DESCRIPTION
## Summary
- Adds a `nec5` engine key to `scripts/bench_nec_corpus.py` driving `NEC5Engine` — opt-in like `sing`, never in `DEFAULT_ENGINE_KEYS`, with a $NEC5_EXE preflight before the sweep starts.
- Dialect scoping (phase 0 of #872): decks the engine deliberately refuses (TL/NT branches, ql/qc loads, distributed/virtual ports, buried or in-plane wires, refl-coef ground, near-unity eps_r) are tagged `out_of_scope` by the worker and classified as a new `scope` error kind — reported as `OOS` in their own bucket, not counted as engine failures.
- `NEC5Engine` grows `capture_dir=`: every run stores its deck and printout keyed by deck content hash (captures are End-User Reports, LLNL-CODE-746721), and a deck already captured is served from disk without invoking the binary — re-analysis never re-solves. Per-run timing/cache provenance lands in `run_log` and is carried into the census JSON as `nec5_runs`. `--nec5-capture-dir` defaults to `~/.antennaknobs/nec5-captures`.
- The worker imports PyNEC lazily (only in the `pynec` branch), so the nec5 lane runs on boxes with just the licensed binary.

## Test plan
- [x] `make test` (PR fast lane): 4417 passed
- [x] `ruff check` + `ruff format --check` clean
- [x] Live binary: full `tests/test_nec5_engine.py` + `tests/test_bench_nec5_lane.py` (47 passed)
- [x] Live corpus smoke: `--engines nec5 bs2 --decks 40m-moxon 20m_quad` — 20m_quad solves (feed-0 ΔΓ 0.054 vs nec2c), 40m-moxon counts OOS (TL branch); re-run served from capture cache (`cached: true`)

Closes nothing — this is phase 0 of #872; later phases ride on this lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)