### PR TITLE
Pin census feed-position exactness for the NEC-5 lane (#872 phase 1 follow-up)

### DIFF
--- a/docs/status/2026-08-12-nec5-feed-model-phase1.md
+++ b/docs/status/2026-08-12-nec5-feed-model-phase1.md
@@ -31,6 +31,21 @@ p. 47: sources exist at "a segment end or patch edge" — there is no
 center option); the identity triple proves there is no hidden center DOF.
 On this coarse mesh the shift is worth ~34 Ω in R.
 
+**Census-pipeline immunity (verified 2026-08-12, follow-up to this
+study):** the trap bites RAW decks fed to the binary, not the translated
+census lane. `wire_tuples` isolates an off-center fed segment on its own
+1-segment wire, and `NEC5Engine`'s even-parity coercion makes that
+segment's center a knot — so the emitted `EX` lands at exactly the NEC-2
+delta-gap position (off-center case: isolated wire, 1→2 segments;
+middle-of-odd-wire case: whole wire, N→N+1). Pinned by the
+`test_corpus_*_feed_lands_on_exact_gap_position` tests. Census
+comparisons therefore carry no feed-POSITION offset; their residual
+NEC-5 systematic is the knot-source feed-MODEL march of section B alone
+— which also means the corpus splits (e.g. the 2m yagi family) are
+feed-model/formulation, not position. The cost of exactness is a local
+mesh perturbation only: the fed segment becomes two half-length segments
+(a 2:1 neighbor-length ratio at the source).
+
 ## B. Ladder decomposition at feed = L/4
 
 Aligned = NS 4k, fed knot pinned exactly at L/4 every rung. Walking =

--- a/tests/test_nec5_engine.py
+++ b/tests/test_nec5_engine.py
@@ -746,3 +746,72 @@ def test_live_ex_sources_live_at_knots():
     # The two knots bracket a steep dZ/ds region — they must differ a lot,
     # or the identity assertions above would be vacuous.
     assert abs(z_k3_e2 - z_k2_e2) > 0.1 * abs(z_k2_e2)
+
+
+# --------------------------------- corpus feed-position exactness (#872 ph 1)
+
+
+def _deck_feed_positions(deck_text: str):
+    """The NEC-5 source's z position for a corpus-style deck translated
+    through the census pipeline (parse_nec -> wire_tuples ->
+    NEC5Engine.deck). Vertical single-axis geometry so z alone locates
+    the feed."""
+    from types import MappingProxyType
+
+    from antennaknobs.nec_import import parse_nec
+
+    deck = parse_nec(deck_text, name="t.nec", network=True)
+    net = deck.network()
+    tups = deck.wire_tuples(specs=True)
+
+    class _B(AntennaBuilder):
+        default_params = MappingProxyType({"freq": 27.0})
+
+        def build_wires(self):
+            return tups
+
+        def build_network(self):
+            return net
+
+    eng = NEC5Engine(_B())
+    lines = eng.deck([27.0]).splitlines()
+    gw = {}
+    for ln in lines:
+        t = ln.split()
+        if t[0] == "GW":
+            gw[int(t[1])] = (int(t[2]), float(t[5]), float(t[8]))  # n_seg, z1, z2
+    ex = next(t for t in map(str.split, lines) if t[0] == "EX")
+    tag, seg, end = int(ex[2]), int(ex[3]), int(ex[4])
+    assert end == 2
+    n_seg, z1, z2 = gw[tag]
+    return z1 + (z2 - z1) * seg / n_seg
+
+
+def test_corpus_offcenter_feed_lands_on_exact_gap_position(monkeypatch):
+    """#872 phase 1: the importer isolates an off-center fed segment on its
+    own 1-segment wire, and even-parity coercion makes that segment's
+    center a knot — so the NEC-5 source sits at EXACTLY the NEC-2
+    delta-gap position. Census comparisons carry no feed-position offset;
+    the residual NEC-5 systematic is the knot-source feed-MODEL march
+    alone (bench_nec5_feed_model.py measures it)."""
+    monkeypatch.setenv("NEC5_EXE", sys.executable)
+    z = _deck_feed_positions(
+        "CM x\nCE\nGW 1 9 0 0 10. 0 0 15.2 .001\nGE 0\n"
+        "EX 0 1 3 0 1. 0.\nFR 0 1 0 0 27. 0\nXQ\nEN\n"
+    )
+    # abs tolerance = the deck text's %.6E print granularity (~1e-5 m
+    # here), not solver precision: the geometry is exact, the printed
+    # coordinate is rounded.
+    assert z == pytest.approx(10 + (3 - 0.5) / 9 * 5.2, abs=1e-4)
+
+
+def test_corpus_middle_feed_of_odd_wire_lands_on_exact_gap_position(monkeypatch):
+    """The stays-whole case: a feed at the middle segment of an odd-count
+    wire keeps the wire intact; parity coercion (9 -> 10) puts a knot at
+    the wire's physical middle = the original segment's center."""
+    monkeypatch.setenv("NEC5_EXE", sys.executable)
+    z = _deck_feed_positions(
+        "CM x\nCE\nGW 1 9 0 0 10. 0 0 15.2 .001\nGE 0\n"
+        "EX 0 1 5 0 1. 0.\nFR 0 1 0 0 27. 0\nXQ\nEN\n"
+    )
+    assert z == pytest.approx(12.6, abs=1e-4)


### PR DESCRIPTION
## Summary
- Verified end-to-end that the census pipeline already places NEC-5 sources at the deck's exact NEC-2 delta-gap position: `wire_tuples` isolates an off-center fed segment on its own 1-segment wire and even-parity coercion makes its center a knot (off-center case), and a middle-of-odd-wire feed stays whole with N→N+1 coercion landing the knot on the wire's physical middle.
- Two regression tests pin the emitted `EX` position against the deck's true gap position (tolerance = the deck text's `%.6E` print granularity, ~10 µm — the geometry itself is exact).
- Phase-1 status doc gains a "census-pipeline immunity" note: the half-segment backward-compatibility trap bites raw decks fed to the binary, not the translated lane, so corpus splits are feed-model/formulation — not position.

## Test plan
- [x] `tests/test_nec5_engine.py`: 44 passed (live binary)
- [x] ruff check + format clean

Part of #872 (phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)