### PR TITLE
chore: adopt momwire 0.27.0 — the Galerkin EK un-refusal (#849)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ COPY --from=frontend /app/src/antennaknobs/web/static ./src/antennaknobs/web/sta
 # install below sees its requirement already satisfied, then the package with the
 # web extra. All from PyPI (the default index).
 RUN pip install --upgrade pip \
- && pip install "momwire==0.26.0" \
+ && pip install "momwire==0.27.0" \
  && pip install -e ".[web]"
 
 # Optional NEC2 solver (PyNEC) — not a dependency of antennaknobs, installed in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 # `pynec-accel` distribution; see README) and must never be declared a
 # dependency of this MIT package.
 dependencies = [
-    "momwire==0.26.0",
+    "momwire==0.27.0",
     "numpy>=1.21",
     "scipy>=1.7",
     "matplotlib>=3.5",

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -270,11 +270,11 @@ python -m antennaknobs sweep --builder wire.dipole --extended-kernel
 It matters for **fat wires** — segments not much longer than the wire radius —
 and is a fraction of a percent on ordinary thin wire; see
 [the extended thin-wire kernel](/reference/solver/#the-extended-thin-wire-kernel-ek).
-Every momwire basis serves it except `sinusoidal-galerkin`, which refuses
-(momwire#246), as does the combination with `use_singular_enrichment`
-(momwire#271) — both exit with a named message rather than a reduced-kernel
-answer under an extended-kernel request. The flag applies only to momwire:
-passing it with `--engine pynec` is an error.
+Every momwire basis serves it, `sinusoidal-galerkin` included since momwire
+0.27.0 (momwire#246/#287/#299). The one refusal left is the combination with
+`use_singular_enrichment` (momwire#271), which exits with a named message
+rather than a reduced-kernel answer under an extended-kernel request. The
+flag applies only to momwire: passing it with `--engine pynec` is an error.
 
 An imported deck brings its own: a `@file.nec` design whose deck carries an
 `EK` card is solved with the kernel on without the flag, and either source

--- a/site/src/content/docs/reference/simnec.md
+++ b/site/src/content/docs/reference/simnec.md
@@ -270,7 +270,7 @@ Everything SimNEC's portal actually emits for wire antennas:
 | Cliffs | `RP 2` linear and `RP 3` circular cliffs — the second medium and edge geometry from a `GD` card (or from `GN`'s own `F3`–`F6`), selected per segment at its own reflection point |
 | Near fields | `NE` / `NH` rectangular grids in free space or over perfect ground |
 | Networks | `NT` two-port admittance branches and `TL` transmission lines between segments |
-| Kernel | `EK` — the extended thin-wire kernel, honoured per execute group: the group's solver is built with momwire's own O(a²) tube expansion, and `EK -1` (like an absent card) stays reduced. The Galerkin basis refuses it as a `NEC ERROR` rather than answering reduced under an extended-kernel request (momwire#246) — `--basis sinusoidal` is the point-matched sibling that carries it |
+| Kernel | `EK` — the extended thin-wire kernel, honoured per execute group: the group's solver is built with momwire's own O(a²) tube expansion, and `EK -1` (like an absent card) stays reduced. Every basis serves it, the Galerkin entries included (momwire 0.27.0: momwire#246/#287/#299 — every ground model, non-collinear geometry sound) |
 | Housekeeping | `MP` multicore hints, `PT` print control — accepted and echoed exactly as nec2c does (advisory where momwire's own physics governs) |
 
 One thing is faster than the engine it replaces, structurally. SimNEC probes an

--- a/site/src/content/docs/reference/solver.mdx
+++ b/site/src/content/docs/reference/solver.mdx
@@ -68,14 +68,15 @@ dipole, nec2c reads 123.7+28.6 j reduced and 113.6+29.0 j extended — an 8 %
 step — and momwire's sinusoidal basis tracks both sides of the card to 0.5 %
 and 3.1 % respectively.
 
-momwire serves it on four of its five solver families — **`sinusoidal`**,
-**`bspline`**, **`hmatrix`** and **`arrayblock`**, in free space and over
-every ground model, at about 1.0–1.3× the reduced-kernel solve. Two
-combinations refuse, loudly rather than silently:
+momwire serves it on all five solver families — **`sinusoidal`**,
+**`sinusoidal-galerkin`**, **`bspline`**, **`hmatrix`** and
+**`arrayblock`** — in free space and over every ground model, at about
+1.0–1.3× the reduced-kernel solve. The Galerkin family joined with momwire
+0.27.0: momwire#246 built its extended kernel, momwire#287 measured the
+Sommerfeld ground in, and momwire#299 made non-collinear geometry (vees,
+bent elements, junctions, radius steps) sound. One combination refuses,
+loudly rather than silently:
 
-- **`sinusoidal-galerkin`** — NEC's `EKSCX` has no counterpart for the
-  Galerkin fill's folded third source shape (momwire#246). Reach for the
-  point-matched `sinusoidal` sibling instead.
 - **singular enrichment** — the enrichment degrees of freedom carry their own
   quadrature and bypass the moment kernels the extended kernel corrects
   (momwire#271).

--- a/src/antennaknobs/engines/momwire.py
+++ b/src/antennaknobs/engines/momwire.py
@@ -154,37 +154,28 @@ def _solver_supports_wire_loading(solver):
 
 
 # NEC's extended thin-wire kernel — the `EK` card — on the momwire bases that
-# implement it (momwire 0.26.0: BSpline + its HMatrix/ArrayBlock subclasses,
-# and the point-matched SinusoidalSolver; issues momwire#249/#259/#269/#270).
-# Two combinations REFUSE upstream, both at solver construction, both with a
-# NotImplementedError. They are re-raised here — same type, same shape — for
-# one reason: the engine can say no BEFORE a fill is attempted, so the caller's
-# error path (the portal's `NEC ERROR` frame, the web solve's error envelope)
-# reports a named refusal instead of a traceback out of the middle of a solve.
+# implement it (momwire 0.27.0: every basis — BSpline + its HMatrix/ArrayBlock
+# subclasses, the point-matched SinusoidalSolver, and since momwire#246/#287
+# the SinusoidalGalerkinSolver on every ground model; issues
+# momwire#249/#259/#269/#270/#246/#287/#299). One combination REFUSES
+# upstream, at solver construction, with a NotImplementedError. It is
+# re-raised here — same type, same shape — for one reason: the engine can say
+# no BEFORE a fill is attempted, so the caller's error path (the portal's
+# `NEC ERROR` frame, the web solve's error envelope) reports a named refusal
+# instead of a traceback out of the middle of a solve.
 def _extended_kernel_refusal(solver, solver_kwargs):
     """Why this solver + kwargs pair cannot run the extended kernel, or None.
 
-    * ``SinusoidalGalerkinSolver`` — momwire#246/#233: NEC's ``EKSCX`` has no
-      counterpart for the Galerkin fill's folded third source shape, so momwire
-      ships EK on the point-matched sibling only and refuses rather than
-      silently serving a reduced-kernel answer under an EK request.
     * ``use_singular_enrichment=True`` — momwire#271/#249 follow-up C: the
       enrichment DOFs carry their own singular quadrature and bypass the moment
       kernels entirely, and the O(a²) tube expansion was never derived for the
       s^(-1/2) shapes.
 
-    Everything else — including finite ground, which momwire#269 lifted — is
-    served.
+    Everything else is served: finite ground (momwire#269), the Galerkin
+    family on every ground model including Sommerfeld (momwire#246/#287,
+    with the node-gated end brackets of momwire#299 making non-collinear
+    decks sound).
     """
-    name = getattr(solver, "__name__", str(solver))
-    if name == "SinusoidalGalerkinSolver":
-        return (
-            "the extended thin-wire kernel is not available on the "
-            "sinusoidal-galerkin basis: momwire implements NEC's extended "
-            "kernel on the point-matched SinusoidalSolver only (momwire#246). "
-            "Use the sinusoidal basis for an extended-kernel run, or drop the "
-            "kernel request for the reduced-kernel Galerkin fill"
-        )
     if (solver_kwargs or {}).get("use_singular_enrichment"):
         return (
             "the extended thin-wire kernel and singular enrichment cannot be "
@@ -239,9 +230,9 @@ class MomwireEngine(SimulationEngine):
           `solver_kwargs={"extended_kernel": ...}` is accepted as the same
           knob (a local web instance forwards model_options verbatim) and is
           folded into this option rather than reaching the constructor twice.
-          Two combinations refuse — see `_extended_kernel_refusal`; the
-          refusal is raised HERE, at engine construction, not from inside a
-          fill.
+          One combination refuses (singular enrichment) — see
+          `_extended_kernel_refusal`; the refusal is raised HERE, at engine
+          construction, not from inside a fill.
         ground:
           None or "free"           — no ground (default)
           "pec"                    — PEC plane at z=ground_z (image method)

--- a/src/antennaknobs/nec_portal.py
+++ b/src/antennaknobs/nec_portal.py
@@ -3272,11 +3272,13 @@ def render_deck(body: str) -> tuple[list[str], list[str]]:
         except (
             PortalError,
             ValueError,
-            # A basis that cannot serve this group's kernel (issue #849:
-            # sinusoidal-galerkin under EK, momwire#246). momwire raises it,
-            # and `MomwireEngine` re-raises it before the fill; either way it
-            # is a refusal SimNEC must see as a NEC ERROR, not as a daemon
-            # traceback that costs the deck its NX sentinel.
+            # A basis that cannot serve this group's kernel (issue #849 —
+            # since momwire 0.27.0 the only such combination is EK with
+            # singular enrichment; the Galerkin refusal fell with
+            # momwire#246/#287/#299). momwire raises it, and `MomwireEngine`
+            # re-raises it before the fill; either way it is a refusal SimNEC
+            # must see as a NEC ERROR, not as a daemon traceback that costs
+            # the deck its NX sentinel.
             NotImplementedError,
             np.linalg.LinAlgError,
         ) as exc:
@@ -3424,17 +3426,16 @@ def _selftest(stdout) -> int:
             and suffix in alt.stdout
             and "ANTENNA INPUT PARAMETERS" in alt.stdout
         )
-    # The Galerkin entries are the exception, and the check is deliberately
-    # two-sided rather than dropped (issue #849). momwire#246 leaves NEC's
-    # extended kernel unimplemented on the Galerkin fill, and deck 1 carries
-    # `EK` precisely because the live NECSource path always sends it — so
-    # honouring the card for real means these two roster entries cannot answer
-    # a live SimNEC deck at all. What a deployment gate can still prove, and
-    # what a box must never get wrong, is that the refusal is the DOCUMENTED
-    # one: a named `ERROR:` line and the NX sentinel behind it (a hang here is
-    # what stalls SimNEC's readLine forever) — and that the SESSION survives
-    # it, which is why both decks go down ONE process: the EK deck refuses,
-    # the same deck without the card answers, from the same resident engine.
+    # The Galerkin entries used to be the exception: until momwire 0.27.0 the
+    # Galerkin fill refused NEC's extended kernel, and deck 1 carries `EK`
+    # precisely because the live NECSource path always sends it, so this check
+    # gated the DOCUMENTED refusal frame. momwire#246/#287/#299 implemented
+    # the kernel on the Galerkin family (every ground model, non-collinear
+    # decks included), so the same two-deck, one-process probe now proves the
+    # positive statement: the EK deck ANSWERS, the plain deck answers after it
+    # from the same resident engine, and both sentinels survive. Keeping both
+    # decks (with and without the card) preserves the session-survival half of
+    # the old gate — a traceback on either would cost its NX sentinel.
     galerkin = _alt(
         "sinusoidal-galerkin-converged",
         _SELFTEST_DECKS[0] + _SELFTEST_DECKS[0].replace("EK\n", ""),
@@ -3444,15 +3445,12 @@ def _selftest(stdout) -> int:
         for ln in galerkin.stdout.splitlines()
         if ln.lstrip().startswith("DATA CARD No:") and " NX " in ln
     )
-    checks["galerkin refuses EK by name, session survives"] = (
+    checks["galerkin serves EK, session survives"] = (
         galerkin.returncode == 0
-        and any(
-            ln.split()[:1] == ["ERROR:"] and "extended thin-wire kernel" in ln
-            for ln in galerkin.stdout.splitlines()
-        )
+        and not any(ln.split()[:1] == ["ERROR:"] for ln in galerkin.stdout.splitlines())
         and sentinels == 2
         and "+sgc" in galerkin.stdout
-        and galerkin.stdout.count("ANTENNA INPUT PARAMETERS") == 1
+        and galerkin.stdout.count("ANTENNA INPUT PARAMETERS") == 2
     )
     for name, ok in checks.items():
         stdout.write(f"  {'ok  ' if ok else 'FAIL'} {name}\n")

--- a/tests/test_engine_spec.py
+++ b/tests/test_engine_spec.py
@@ -339,15 +339,32 @@ def test_make_factory_deck_extended_kernel_silently_ignored_for_non_momwire():
     assert factory is PyNECEngine
 
 
-def test_make_factory_extended_kernel_refuses_sinusoidal_galerkin_at_construction():
-    """momwire#246: no EKSCX counterpart for the Galerkin fill's folded
-    testing shape, so the solver refuses at construction — the same
-    NotImplementedError the engine raises directly (issue #849)."""
+def test_make_factory_extended_kernel_serves_sinusoidal_galerkin():
+    """momwire 0.27.0 un-refusal (issue #849): momwire#246 implemented NEC's
+    extended kernel on the Galerkin fill (#287 lifted the last ground refusal,
+    #299 fixed non-collinear decks), so the factory that used to raise
+    NotImplementedError at construction now builds a working engine, and the
+    kernel is honoured: the fat deck's EK answer differs measurably from the
+    reduced one."""
     factory = make_engine_factory(
         "momwire:sinusoidal-galerkin", _GROUND_UNSET, extended_kernel=True
     )
-    with pytest.raises(NotImplementedError, match="sinusoidal-galerkin"):
-        factory(_fat_dipole_builder())
+    z_ek = factory(_fat_dipole_builder()).impedance()[0]
+    reduced = make_engine_factory("momwire:sinusoidal-galerkin", _GROUND_UNSET)
+    z_red = reduced(_fat_dipole_builder()).impedance()[0]
+    assert abs(z_ek - z_red) / abs(z_red) >= 0.02, f"{z_ek} vs {z_red}"
+
+
+def test_make_factory_extended_kernel_still_refuses_singular_enrichment():
+    """The one EK refusal left (momwire#271): enrichment DOFs bypass the
+    moment kernels the extended kernel corrects. Same NotImplementedError,
+    same at-construction timing — this is the coverage the retired Galerkin
+    refusal test used to provide for the engine's refusal path."""
+    factory = make_engine_factory(
+        "momwire:sinusoidal-galerkin", _GROUND_UNSET, extended_kernel=True
+    )
+    with pytest.raises(NotImplementedError, match="enrichment"):
+        factory(_fat_dipole_builder(), solver_kwargs={"use_singular_enrichment": True})
 
 
 def test_cli_extended_kernel_flag_runs():
@@ -357,17 +374,19 @@ def test_cli_extended_kernel_flag_runs():
     )
 
 
-def test_cli_extended_kernel_galerkin_refusal_is_a_clean_systemexit(capsys):
-    """The CLI must print the refusal and exit cleanly (exit code 1, the
-    message on stdout), not dump a traceback (cli()'s NotImplementedError
-    handler, issue #849)."""
-    with pytest.raises(SystemExit) as exc:
-        ant.cli(
-            f"pattern --builder dipoles.invvee:dipole "
-            f"--engine momwire:sinusoidal-galerkin --extended-kernel{O}".split()
-        )
-    assert exc.value.code == 1
-    assert "sinusoidal-galerkin" in capsys.readouterr().out
+def test_cli_extended_kernel_galerkin_runs():
+    """momwire 0.27.0 (issue #849): the exact invocation that used to be the
+    CLI's documented clean-refusal case now just runs — the Galerkin fill
+    serves the extended kernel on every ground, non-collinear invvee included
+    (momwire#246/#287/#299). The cli() NotImplementedError→SystemExit handler
+    this test used to cover keeps its coverage at the web layer
+    (test_geometry_extended_kernel_enrichment_refusal_is_structured) and the
+    factory layer (…still_refuses_singular_enrichment above); no basis name
+    reachable from the CLI refuses EK anymore."""
+    ant.cli(
+        f"pattern --builder dipoles.invvee:dipole "
+        f"--engine momwire:sinusoidal-galerkin --extended-kernel{O}".split()
+    )
 
 
 @needs_pynec

--- a/tests/test_nec_portal.py
+++ b/tests/test_nec_portal.py
@@ -2640,32 +2640,33 @@ def test_two_groups_of_one_deck_under_two_kernels_get_two_operators():
 @pytest.mark.parametrize(
     "basis", ["sinusoidal-galerkin", "sinusoidal-galerkin-converged"]
 )
-def test_a_galerkin_basis_refuses_an_ek_deck_as_a_nec_error(basis, restore_basis):
-    """The refusal path, on the class of deck that reaches it in real life.
+def test_a_galerkin_basis_serves_an_ek_deck(basis, restore_basis):
+    """The un-refusal (momwire 0.27.0), on the class of deck that reaches it
+    in real life.
 
-    momwire#246 leaves NEC's extended kernel unimplemented on the Galerkin fill
-    — its folded third source shape has no EKSCX counterpart — so the solver
-    refuses at construction with a NotImplementedError. The live `NECSource`
-    path sends `EK` on EVERY deck (grammar doc §17), so a SimNEC user who picks
-    a Galerkin portal entry hits this on their first solve, and what they must
-    get is the documented refusal frame: a token-0 `ERROR:` line naming the
-    kernel, the oracle-shaped `ERROR-NEC2C:` line behind it, and — the one that
-    decides whether the session survives — the NX sentinel. A traceback out of
-    `main` would cost the sentinel and stall `Execute.readLine` forever.
+    Until momwire 0.27.0 the Galerkin fill refused NEC's extended kernel and
+    this test pinned the documented refusal frame. momwire#246 implemented the
+    kernel on the Galerkin family, #287 lifted the last (Sommerfeld) ground
+    refusal and #299 made non-collinear decks sound, so the live `NECSource`
+    path — which sends `EK` on EVERY deck (grammar doc §17) — now gets an
+    ANSWER from the Galerkin portal entries. The deck is the fat Δ/a ≈ 2.4
+    dipole, where the kernel is a real correction: the EK answer must differ
+    measurably from the reduced one (same 2 % floor the sinusoidal EK test
+    uses), and both frames must keep their NX sentinels.
     """
     rc, out, err = _run_main(["--basis", basis], deck=_fat_deck("EK"))
     assert rc == 0 and err == ""
-    assert "Traceback" not in out
-    errors = [ln for ln in out.splitlines() if ln.split()[:1] == ["ERROR:"]]
-    assert errors, out[-800:]
-    assert "extended thin-wire kernel" in errors[0]
-    assert "sinusoidal-galerkin" in errors[0]
-    assert "ERROR-NEC2C: " in out
-    assert NX_ECHO.search(out), "no NX sentinel on the kernel-refusal path"
-    # ... and the same basis answers the same deck once the card is gone, so
-    # the refusal is the KERNEL's and not the basis failing on a fat wire.
+    assert "Traceback" not in out and "ERROR-NEC2C" not in out
+    assert NX_ECHO.search(out), "no NX sentinel on the EK-served path"
+    ek_rows = aip_impedances(out)
+    assert ek_rows, out[-800:]
+    # ... and the reduced answer on the same deck differs by a real margin,
+    # so the card is being honoured rather than silently dropped.
     rc, plain, _err = _run_main(["--basis", basis], deck=_fat_deck())
-    assert rc == 0 and "ERROR-NEC2C" not in plain and aip_impedances(plain)
+    assert rc == 0 and "ERROR-NEC2C" not in plain
+    z_ek = complex(*map(float, ek_rows[0]))
+    z_plain = complex(*map(float, aip_impedances(plain)[0]))
+    assert _relative(z_ek, z_plain) >= 0.02, f"{z_ek} vs {z_plain}"
 
 
 def test_the_thin_wire_ek_fixtures_barely_move_and_move_towards_nec2c():

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -3173,12 +3173,12 @@ def test_extended_kernel_moves_impedance_and_matches_direct_engine():
     assert z_on["z_in_im"] == pytest.approx(z_direct.imag)
 
 
-def test_geometry_extended_kernel_galerkin_refusal_is_structured(client: TestClient):
-    """issue #849: EK + sinusoidal-galerkin refuses at engine construction
-    (momwire#246 — no EKSCX counterpart for the Galerkin fill). The web path
-    must surface this as a clean {"error": ...} body (200), not a
-    500/traceback — the same structured-error contract as a broken user
-    design (test_geometry_endpoint_surfaces_build_error)."""
+def test_geometry_extended_kernel_galerkin_serves(client: TestClient):
+    """momwire 0.27.0 (issue #849): EK + sinusoidal-galerkin — the request
+    that used to be the structured-refusal case — now solves. The invvee is a
+    deliberately NON-COLLINEAR deck: momwire#299's node-gated end brackets
+    are what make this answer sound, so this doubles as the web-path pin on
+    that fix."""
     resp = client.post(
         "/geometry",
         json={
@@ -3189,11 +3189,38 @@ def test_geometry_extended_kernel_galerkin_refusal_is_structured(client: TestCli
     )
     assert resp.status_code == 200
     body = resp.json()
+    assert "error" not in body
+
+
+def test_geometry_extended_kernel_enrichment_refusal_is_structured(
+    client: TestClient,
+):
+    """The one EK refusal left (momwire#271: enrichment DOFs bypass the
+    moment kernels). The web path must surface it as a clean {"error": ...}
+    body (200), not a 500/traceback — the same structured-error contract as a
+    broken user design (test_geometry_endpoint_surfaces_build_error). This
+    carries the refusal-contract coverage the retired galerkin case used to
+    provide."""
+    resp = client.post(
+        "/geometry",
+        json={
+            "geometry": "dipoles.invvee",
+            "momwire_model": "sinusoidal-galerkin",
+            "model_options": {
+                "extended_kernel": True,
+                "use_singular_enrichment": True,
+            },
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
     assert "error" in body
-    assert "sinusoidal-galerkin" in body["error"]
+    assert "enrichment" in body["error"]
 
 
-def test_ws_extended_kernel_galerkin_refusal_keeps_socket_alive(client: TestClient):
+def test_ws_extended_kernel_enrichment_refusal_keeps_socket_alive(
+    client: TestClient,
+):
     """Same refusal on the live /ws solve path: an error frame, not a torn
     down socket — the next (healthy) request on the same socket must still
     solve (mirrors test_ws_solve_error_keeps_socket_alive)."""
@@ -3203,12 +3230,15 @@ def test_ws_extended_kernel_galerkin_refusal_keeps_socket_alive(client: TestClie
                 {
                     "geometry": "dipoles.invvee",
                     "momwire_model": "sinusoidal-galerkin",
-                    "model_options": {"extended_kernel": True},
+                    "model_options": {
+                        "extended_kernel": True,
+                        "use_singular_enrichment": True,
+                    },
                 }
             )
         )
         bad = json.loads(ws.receive_text())
-        assert "sinusoidal-galerkin" in bad["error"]
+        assert "enrichment" in bad["error"]
         ws.send_text(json.dumps({"geometry": "dipoles.invvee"}))
         ok = json.loads(ws.receive_text())
         assert "error" not in ok


### PR DESCRIPTION
Adopts momwire 0.27.0 ("the Galerkin extended kernel, end to end") — the release carrying the five-issue queue (#246 Galerkin EK, #282 contact convergence, #258 per-pair IRA, #263 swept memory bound, #262 swept dispatch) plus the followup slate (#292 EK contact twin, #273 oracle fallback coverage, #287 EK under Sommerfeld, #299 node-gated end brackets).

## The pin (three places, one commit)
- `pyproject.toml` → `momwire==0.27.0`
- `Dockerfile` → `pip install "momwire==0.27.0"`
- submodule pointer → 9768a41 (the 0.27.0 bump commit)

## The un-refusal (issue #849)
With 0.27.0 the Galerkin family serves NEC's extended kernel on every ground model, non-collinear decks included, so:
- `_extended_kernel_refusal`'s galerkin branch removed — the one refusal left is EK + singular enrichment (momwire#271).
- Portal selftest check flipped: "galerkin refuses EK by name" → "galerkin serves EK, session survives" (same two-deck one-process probe, now proving the positive statement; verified live, selftest PASS).
- Refusal-pinned tests flipped to service: portal (`test_a_galerkin_basis_serves_an_ek_deck` — EK vs reduced ≥ 2% on the fat deck), engine factory, CLI clean run, web /geometry + /ws. The structured-refusal contract keeps coverage on the enrichment vehicle (new geometry/ws/factory refusal tests).
- Site pages de-staled: simnec.md dialect table, solver.mdx EK section (five families now), cli.md.

## Verification
- momwire v0.27.0 published (wheels workflow green, PyPI serves 0.27.0, GitHub release auto-created).
- Full antennaknobs suite against the pinned submodule: 4583 passed + 20 skipped; site builds.
- Portal selftest PASS including the flipped galerkin check.
- The junction-ports-over-finite-ground refusal (momwire#182, unrelated boundary) still pins — 0.27.0 did not move it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163HVuvMSt5iYuA7gfTQWRT