### PR TITLE
docs(site): de-stale for momwire 0.27.0 + the corpus findings (frontend EK un-grey included)

### DIFF
--- a/site/src/content/docs/reference/nec5.md
+++ b/site/src/content/docs/reference/nec5.md
@@ -98,12 +98,20 @@ in-process solves for live knob-dragging.
 
 Cross-engine agreement on reference designs runs a few ohms of impedance
 (the different formulations' genuine spread) and ~0.01 dB RMS on far-field
-patterns. One documented exception, found the day the engine landed: at
-very low heights over lossy Sommerfeld ground (≈0.05 λ), NEC-5's reactance
-sits ~7 Ω away from the mutually-agreeing NEC-2 lineage while resistances
-match — a real formulation difference in the close-ground interaction,
-pinned in the test suite as a measured gap rather than averaged into a
-tolerance. That is the cross-validation triangle doing its job.
+patterns. The one apparent exception closed under study, and the closing is
+worth telling: the day the engine landed, NEC-5's reactance at very low
+heights over lossy Sommerfeld ground (≈0.05 λ) sat ~7 Ω away from the
+mutually-agreeing NEC-2 lineage, and was documented here as a formulation
+difference. The full corpus comparison then swept a dipole from 0.02 λ to
+1.0 λ and found the offset is height-*independent* — a feed-model term from
+NEC-5's knot-source mesh march, not close-ground physics — and that
+Richardson-extrapolating NEC-5's (N, 2N) pair dissolves it entirely:
+extrapolated NEC-5 agrees with the NEC-2 lineage to ≤ 0.17 Ω in reactance
+at every height. Both halves are pinned in the test suite — the raw
+single-mesh offset and its extrapolated resolution. That is the
+cross-validation triangle doing its job twice: first flagging a real
+discrepancy, then identifying it as convergence behaviour rather than
+physics.
 
 ## Importing NEC-5 decks
 

--- a/site/src/content/docs/reference/web.md
+++ b/site/src/content/docs/reference/web.md
@@ -304,13 +304,11 @@ basis and mesh, one slot with the kernel and one without**, and the readouts
 side by side. A slot running it is labelled **+EK** on its chip
 (e.g. `B-spline d=2 +EK`), so the pair stays tellable apart.
 
-Two combinations are unavailable, and the check greys out and says which:
+Every momwire basis serves it — the Galerkin family joined with momwire
+0.27.0 (momwire#246/#287/#299: every ground model, bent and stepped
+geometry included). One combination is unavailable, and the check greys out
+and says which:
 
-- **Sin-Galerkin** cannot run it — momwire implements the extended kernel on
-  the point-matched Sinusoidal solver and the B-spline family, and refuses on
-  the Galerkin sibling rather than quietly serving a reduced-kernel answer
-  (momwire#246). Use the **Sinusoidal** slot for an extended-kernel run on
-  that basis family.
 - **K≥3 junction singular enrichment** (the validation-only B-spline knob)
   cannot run alongside it: the enrichment degrees of freedom bypass the very
   kernels the extended kernel corrects (momwire#271). The two grey each other

--- a/src/antennaknobs/web/frontend/src/__tests__/BackendConfigModal.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/BackendConfigModal.test.tsx
@@ -20,7 +20,6 @@ import {
 import {
   BSPLINE_DEFAULT_OPTS,
   EK_ENRICHMENT_REASON,
-  EK_GALERKIN_REASON,
   RESTRICTED_BACKEND_REASON,
   defaultOptsFor,
   type BackendOpts,
@@ -238,20 +237,10 @@ describe("BackendConfigModal — extended kernel (#849)", () => {
     expect(on.onPatch).toHaveBeenCalledWith({ extendedKernel: false });
   });
 
-  it("greys the toggle out on Sin-Galerkin and says why on the page", () => {
-    renderModal({ backend: "sinusoidal-galerkin" });
-    const box = screen.getByRole("checkbox", { name: EK });
-    expect(box).toHaveProperty("disabled", true);
-    expect(box).toHaveProperty("checked", false);
-    // The reason is visible, not tooltip-only: a greyed box with no
-    // explanation is the silence #849 is about.
-    expect(screen.getByText(EK_GALERKIN_REASON)).toBeTruthy();
-    expect(within(screen.getByTitle(EK_GALERKIN_REASON)).getByRole("checkbox")).toBe(box);
-  });
-
-  it("shows a set flag as UNCHECKED on the basis that refuses it", async () => {
-    // A slot cannot normally reach this (a backend swap resets the flag), but
-    // the row must never claim a kernel that isn't running.
+  it("serves the toggle on Sin-Galerkin (momwire 0.27.0 un-refusal)", async () => {
+    // The exact modal state that used to grey out with the momwire#246
+    // reason: since momwire#246/#287/#299 the Galerkin family serves the
+    // kernel, so the box is live and patches like any other basis.
     const { user, onPatch } = renderModal({
       backend: "sinusoidal-galerkin",
       opts: {
@@ -260,15 +249,15 @@ describe("BackendConfigModal — extended kernel (#849)", () => {
       },
     });
     const box = screen.getByRole("checkbox", { name: EK });
-    expect(box).toHaveProperty("checked", false);
+    expect(box).toHaveProperty("disabled", false);
+    expect(box).toHaveProperty("checked", true);
     await user.click(box);
-    expect(onPatch).not.toHaveBeenCalled(); // disabled: the click does nothing
+    expect(onPatch).toHaveBeenCalledWith({ extendedKernel: false });
   });
 
   it("keeps the Δ/a hint on the servable backends", () => {
     renderModal({ backend: "bspline" });
     expect(screen.getByText(/Δ\/a/)).toBeTruthy();
-    expect(screen.queryByText(EK_GALERKIN_REASON)).toBeNull();
   });
 
   // momwire#271: the two are mutually exclusive, and the exclusion is

--- a/src/antennaknobs/web/frontend/src/__tests__/backends.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/backends.test.ts
@@ -15,8 +15,6 @@ import {
   defaultOptsFor,
   defaultSlots,
   EK_ENRICHMENT_REASON,
-  EK_GALERKIN_REASON,
-  EK_UNSUPPORTED_BACKEND,
   extendedKernelActive,
   extendedKernelRefusal,
   findBackend,
@@ -112,21 +110,18 @@ describe("extendedKernelRefusal (#849)", () => {
   const on = (name: string) => ({ ...defaultOptsFor(entry(name)), extendedKernel: true });
 
   it("passes every backend that momwire serves the kernel on", () => {
-    for (const name of ["sinusoidal", "bspline", "hmatrix", "arrayblock"]) {
+    // Every momwire basis serves the kernel since momwire 0.27.0 — the
+    // Galerkin family joined with momwire#246/#287/#299.
+    for (const name of [
+      "sinusoidal",
+      "sinusoidal-galerkin",
+      "bspline",
+      "hmatrix",
+      "arrayblock",
+    ]) {
       expect(extendedKernelRefusal(entry(name), on(name))).toBeNull();
       expect(extendedKernelActive(entry(name), on(name))).toBe(true);
     }
-  });
-
-  it("refuses the Galerkin basis by name, citing momwire#246", () => {
-    const b = entry("sinusoidal-galerkin");
-    expect(b.name).toBe(EK_UNSUPPORTED_BACKEND); // the constant IS the roster name
-    expect(extendedKernelRefusal(b, on(b.name))).toBe(EK_GALERKIN_REASON);
-    expect(EK_GALERKIN_REASON).toContain("momwire#246");
-    // …and it refuses whether or not the flag is set: the predicate describes
-    // the backend, and the toggle greys out before anything is armed.
-    expect(extendedKernelRefusal(b, defaultOptsFor(b))).toBe(EK_GALERKIN_REASON);
-    expect(extendedKernelActive(b, on(b.name))).toBe(false);
   });
 
   it("refuses alongside singular enrichment, citing momwire#271", () => {
@@ -362,15 +357,15 @@ describe("backendDisplayLabel", () => {
     expect(
       backendDisplayLabel(entry("bspline"), defaultOptsFor(entry("bspline"))),
     ).toBe("B-spline d=2");
-    // Refused by basis — a set flag on a Galerkin slot is not a running
-    // kernel, and the chip must not claim it is.
+    // Served on Galerkin since momwire 0.27.0 — the flag on that slot IS a
+    // running kernel now, and the chip says so.
     expect(
       backendDisplayLabel(entry("sinusoidal-galerkin"), {
         ...defaultOptsFor(entry("sinusoidal-galerkin")),
         feedModel: "point",
         extendedKernel: true,
       }),
-    ).toBe("Sin-Galerkin (converged)");
+    ).toBe("Sin-Galerkin (converged) +EK");
     // Refused by enrichment.
     expect(
       backendDisplayLabel(entry("bspline"), {

--- a/src/antennaknobs/web/frontend/src/__tests__/extendedKernel.session.test.tsx
+++ b/src/antennaknobs/web/frontend/src/__tests__/extendedKernel.session.test.tsx
@@ -146,13 +146,15 @@ describe("the extended-kernel toggle, slot by slot (#849)", () => {
     );
 
     // Swapping the backend resets that slot's model kwargs to the new
-    // backend's defaults, the kernel among them — so the Galerkin basis that
-    // cannot serve it never inherits an armed flag.
+    // backend's defaults, the kernel among them — a new basis never inherits
+    // an armed flag it wasn't configured with. (Sin-Galerkin serves EK since
+    // momwire 0.27.0, so the box arrives live and unchecked rather than
+    // greyed out.)
     await user.click(screen.getByRole("button", { name: "Slot A options" }));
     await user.click(screen.getByRole("tab", { name: "Sin-Galerkin" }));
-    expect(
-      screen.getByRole("checkbox", { name: /extended kernel \(EK\)/ }),
-    ).toHaveProperty("disabled", true);
+    const box = screen.getByRole("checkbox", { name: /extended kernel \(EK\)/ });
+    expect(box).toHaveProperty("disabled", false);
+    expect(box).toHaveProperty("checked", false);
     await user.click(screen.getByRole("button", { name: "Close" }));
 
     await waitFor(() => {

--- a/src/antennaknobs/web/frontend/src/__tests__/modelOptions.test.ts
+++ b/src/antennaknobs/web/frontend/src/__tests__/modelOptions.test.ts
@@ -186,14 +186,15 @@ describe("modelOptionsForRequest", () => {
       }
     });
 
-    it("never reaches the wire on a basis that refuses it (momwire#246/#271)", () => {
-      // Galerkin: momwire#246.
+    it("reaches the wire on Galerkin, never alongside enrichment (momwire#271)", () => {
+      // Galerkin serves the kernel since momwire 0.27.0 (momwire#246/#287/
+      // #299) — an armed slot sends it like any other basis.
       expect(
         modelOptionsForRequest(
           entry("sinusoidal-galerkin"),
           armed("sinusoidal-galerkin"),
         ),
-      ).toEqual({ n_qp_const: 8, feed_model: "segment" });
+      ).toEqual({ n_qp_const: 8, feed_model: "segment", extended_kernel: true });
       // Singular enrichment: momwire#271. Sending both would be a refusal at
       // engine construction; the UI greys the pair out, and this is the lock
       // behind that.

--- a/src/antennaknobs/web/frontend/src/lib/backends.ts
+++ b/src/antennaknobs/web/frontend/src/lib/backends.ts
@@ -237,20 +237,13 @@ export const EK_HINT =
   "and costs about 1.0–1.3× the reduced-kernel solve.";
 
 // The one basis that cannot serve the kernel. Named here rather than read off
-// the roster because the roster carries no capability field for it: momwire
-// implements EK on the point-matched SinusoidalSolver and the B-spline family,
-// and refuses on the Galerkin sibling (momwire#246). This is the frontend twin
-// of engines/momwire.py::_extended_kernel_refusal, which raises the same two
-// refusals server-side — so a stale name here costs a clear error dialog, not
-// a wrong answer. If a second basis ever refuses, that is the moment to serve
-// the capability as a roster field instead of extending this constant.
-export const EK_UNSUPPORTED_BACKEND = "sinusoidal-galerkin";
-
-export const EK_GALERKIN_REASON =
-  "The Sin-Galerkin basis cannot run the extended kernel: NEC's EKSCX has no " +
-  "counterpart for its folded testing shape (momwire#246). Use the " +
-  "Sinusoidal or B-spline slots for an extended-kernel run.";
-
+// Since momwire 0.27.0 every momwire basis serves the extended kernel — the
+// Galerkin family joined with momwire#246/#287/#299 — so the one refusal left
+// is the enrichment combination below. This is the frontend twin of
+// engines/momwire.py::_extended_kernel_refusal, which raises the same refusal
+// server-side — a stale rule here costs a clear error dialog, not a wrong
+// answer. If a second refusal ever appears, that is the moment to serve the
+// capability as a roster field instead of another local rule.
 export const EK_ENRICHMENT_REASON =
   "The extended kernel and K≥3 junction singular enrichment cannot be used " +
   "together (momwire#271): the enrichment DOFs bypass the moment kernels the " +
@@ -260,10 +253,9 @@ export const EK_ENRICHMENT_REASON =
  *  the engine-side refusals so the gear menu can grey the toggle out and say
  *  why, instead of letting the solve come back as an error dialog. */
 export function extendedKernelRefusal(
-  b: BackendEntry,
+  _b: BackendEntry,
   opts: BackendOpts,
 ): string | null {
-  if (b.name === EK_UNSUPPORTED_BACKEND) return EK_GALERKIN_REASON;
   if (opts.bspline?.useSingularEnrichment) return EK_ENRICHMENT_REASON;
   return null;
 }


### PR DESCRIPTION
Pre-release de-staling so tomorrow's v0.50 release PR is just the version bump + what's-new card.

## The frontend fix that fell out of the sweep

`web.md` documents that the EK check "greys out and says which" on Sin-Galerkin — and the frontend still hard-codes that: `EK_UNSUPPORTED_BACKEND = "sinusoidal-galerkin"` in `lib/backends.ts`, missed by #882's un-refusal. The UI was greying out a toggle the backend now serves. Removed the rule (the enrichment exclusion remains, generic `extendedKernelRefusal` machinery unchanged), flipped the five refusal-pinned frontend tests to the serving behaviour (toggle live + patching, `+EK` chip affix on Galerkin, `extended_kernel` reaches the wire, backend-swap reset arrives live-and-unchecked). 753 frontend tests green, `tsc --noEmit` clean, lint 0 errors.

## Docs

- **reference/nec5.md "Honest numbers"** — the v0.49-published "~7 Ω formulation difference at 0.05 λ" is overturned by the #872 corpus height sweep (phase 3a): the offset is height-independent (knot-source feed-model term) and Richardson-extrapolating NEC-5's (N, 2N) pair dissolves it to ≤ 0.17 Ω at every height. Rewritten as the triangle-closing story; both halves are pinned in the suite (`test_live_low_height_sommerfeld_documented_gap`).
- **reference/web.md EK section** — "two combinations are unavailable" → every momwire basis serves it since 0.27.0; enrichment is the one exclusion left.
- Sweep found nothing else stale (simnec.md / solver.mdx / cli.md were already de-staled in #882; no lingering 0.26 or point-matched-only claims).

Site builds (28 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163HVuvMSt5iYuA7gfTQWRT